### PR TITLE
Remove trailing whitespace

### DIFF
--- a/src/navigator/browser/navigator-command.ts
+++ b/src/navigator/browser/navigator-command.ts
@@ -57,7 +57,7 @@ export class NavigatorCommandHandler implements CommandHandler {
     }
 
     execute(arg?: any): Promise<any> {
-        
+
         return Promise.resolve();
     }
 


### PR DESCRIPTION
I am getting this error while trying to run the examples:

.../Theia/src/navigator/browser/navigator-command.ts[60, 1]: trailing whitespace