### PR TITLE
Add documentation for JsonRpcProxyFactory

### DIFF
--- a/src/messaging/common/proxy-factory.ts
+++ b/src/messaging/common/proxy-factory.ts
@@ -9,12 +9,67 @@ import { DisposableCollection } from '../../application/common';
 import { ConnectionHandler } from './handler';
 import { MessageConnection } from "vscode-jsonrpc";
 
+/**
+ * Factory for JSON-RPC proxy objects.
+ *
+ * A JSON-RPC proxy exposes the programmatic interface of an object through
+ * JSON-RPC.  This allows remote programs to call methods of this objects by
+ * sending JSON-RPC requests.  This takes place over a bi-directional stream,
+ * where both ends can expose an object and both can call methods each other's
+ * exposed object.
+ *
+ * For example, assuming we have an object of the following type on one end:
+ *
+ *     class Foo {
+ *         bar(baz: number): number { return baz + 1 }
+ *     }
+ *
+ * which we want to expose through a JSON-RPC interface.  We would do:
+ *
+ *     let target = new Foo()
+ *     let factory = new JsonRpcProxyFactory<Foo>('/foo', target)
+ *     factory.onConnection(connection)
+ *
+ * The party at the other end of the `connection`, in order to remotely call
+ * methods on this object would do:
+ *
+ *     let factory = new JsonRpcProxyFactory<Foo>('/foo')
+ *     factory.onConnection(connection)
+ *     let proxy = factory.createProxy();
+ *     let result = proxy.bar(42)
+ *     // result is equal to 43
+ *
+ * One the wire, it would look like this:
+ *
+ *     --> {"jsonrpc": "2.0", "id": 0, "method": "bar", "params": {"baz": 42}}
+ *     <-- {"jsonrpc": "2.0", "id": 0, "result": 43}
+ *
+ * Note that in the code of the caller, we didn't pass a target object to
+ * JsonRpcProxyFactory, because we don't want/need to expose an object.
+ * If we had passed a target object, the other side could've called methods on
+ * it.
+ *
+ * @param <T> - The type of the object to expose to JSON-RPC.
+ */
 export class JsonRpcProxyFactory<T extends object> implements ConnectionHandler, ProxyHandler<T> {
 
     protected readonly connectionListeners = new DisposableCollection();
 
+    /**
+     * Build a new JsonRpcProxyFactory.
+     *
+     * @param path - The HTTP path to which this proxy will respond.
+     * @param target - The object to expose to JSON-RPC methods calls.  If this
+     *   is omitted, the proxy won't be able to handle requests, only send them.
+     */
     constructor(readonly path: string, private readonly target?: any) {}
 
+    /**
+     * Connect a MessageConnection to the factory.
+     *
+     * This connection will be used to send/receive JSON-RPC requests and
+     * response.
+     */
     onConnection(connection: MessageConnection) {
         this.connectionListeners.dispose();
         connection.onError( error => {
@@ -45,6 +100,18 @@ export class JsonRpcProxyFactory<T extends object> implements ConnectionHandler,
     private connectionPromiseResolve: (connection: MessageConnection) => void;
     private connectionPromise: Promise<MessageConnection> = new Promise(resolve => {this.connectionPromiseResolve = resolve})
 
+    /**
+     * Process an incoming JSON-RPC method call.
+     *
+     * onRequest is called when the JSON-RPC connection received a method call
+     * request.  It calls the corresponding method on [[target]].
+     *
+     * The return value is a Promise object that is resolved with the return
+     * value of the method call, if it is successful.  The promise is rejected
+     * if the called method does not exist or if it throws.
+     *
+     * @returns A promise of the method call completion.
+     */
     protected onRequest(method: string, ...args: any[]): Promise<any> {
         return new Promise<any>((resolve, reject) => {
             try {
@@ -58,15 +125,48 @@ export class JsonRpcProxyFactory<T extends object> implements ConnectionHandler,
         })
     }
 
+    /**
+     * Process an incoming JSON-RPC notification.
+     *
+     * Same as [[onRequest]], but called on incoming notifications rather than
+     * methods calls.
+     */
     protected onNotification(method: string, ...args: any[]): void {
         this.target[method](...args)
     }
 
+    /**
+     * Create a Proxy exposing the interface of an object of type T.  This Proxy
+     * can be used to do JSON-RPC method calls on the remote target object as
+     * if it was local.
+     */
     createProxy(): T {
         const result = new Proxy<T>(this as any, this)
         return result as any
     }
 
+    /**
+     * Get a callable object that executes a JSON-RPC method call.
+     *
+     * Getting a property on the Proxy object returns a callable that, when
+     * called, executes a JSON-RPC call.  The name of the property defines the
+     * method to be called.  The callable takes a variable number of arguments,
+     * which are passed in the JSON-RPC method call.
+     *
+     * For example, if you have a Proxy object:
+     *
+     *     let fooProxyFactory = JsonRpcProxyFactory<Foo>('/foo')
+     *     let fooProxy = fooProxyFactory.createProxy()
+     *
+     * accessing `fooProxy.bar` will return a callable that, when called,
+     * executes a JSON-RPC method call to method `bar`.  Therefore, doing
+     * `fooProxy.bar()` will call the `bar` method on the remote Foo object.
+     *
+     * @param target - unused.
+     * @param p - The property accessed on the Proxy object.
+     * @param receiver - unused.
+     * @returns A callable that executes the JSON-RPC call.
+     */
     get(target: T, p: PropertyKey, receiver: any): any {
         const isNotify = this.isNotification(p)
         return (...args: any[]) => {
@@ -90,6 +190,15 @@ export class JsonRpcProxyFactory<T extends object> implements ConnectionHandler,
         }
     }
 
+    /**
+     * Return whether the given property represents a notification.
+     *
+     * A property leads to a notification rather than a method call if its name
+     * begins with `notifiy` or `on`.
+     *
+     * @param p - The property being called on the proxy.
+     * @return Whether `p` represents a notification.
+     */
     protected isNotification(p: PropertyKey): boolean {
         return p.toString().startsWith("notify") || p.toString().startsWith("on")
     }


### PR DESCRIPTION
This is an attempt at documenting the JsonRpcProxyFactory class, which
is at the heart of the front-end/back-end communication.  This will
hopefully help others understand the control flow of JSON-RPC calls.