### PR TITLE
GH-79: Fixed electron app defect due to mismatching binary versions.

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,6 @@
     "@types/ws": "0.0.38",
     "@types/xterm": "^2.0.2",
     "chokidar": "^1.6.1",
-    "detect-character-encoding": "^0.3.1",
     "electron": "^1.6.2",
     "express": "^4.15.2",
     "fs-extra": "^2.1.2",
@@ -55,6 +54,7 @@
     "circular-dependency-plugin": "^2.0.0",
     "copy-webpack-plugin": "^4.0.1",
     "css-loader": "^0.26.2",
+    "electron-rebuild": "^1.5.10",
     "file-loader": "^0.10.1",
     "karma": "^1.5.0",
     "karma-chrome-launcher": "^2.0.0",
@@ -79,6 +79,7 @@
   },
   "scripts": {
     "prepublish": "npm run clean && npm run build && npm run test",
+    "postinstall": "./node_modules/.bin/electron-rebuild",
     "lint": "./node_modules/.bin/tslint -c ./config/tslint/tslint.json --project ./tsconfig.json",
     "build": "./node_modules/.bin/tsc && npm run lint",
     "watch": "./node_modules/.bin/tsc-watch --onSuccess \"npm run lint\"",

--- a/src/filesystem/node/node-filesystem.spec.ts
+++ b/src/filesystem/node/node-filesystem.spec.ts
@@ -748,7 +748,7 @@ describe("NodeFileSystem", () => {
             fs.writeFileSync(uri.path, "foo");
             expect(fs.statSync(uri.path).isFile()).to.be.true;
 
-            return createFileSystem().getEncoding(uri.toString()).should.be.eventually.be.equal("UTF-8");
+            return createFileSystem().getEncoding(uri.toString()).should.be.eventually.be.equal("utf8");
         });
 
     });

--- a/src/filesystem/node/node-filesystem.ts
+++ b/src/filesystem/node/node-filesystem.ts
@@ -14,7 +14,6 @@ import { FileStat, FileSystem, FileSystemClient, FileChange, FileChangeType, Fil
 
 const trash: (paths: Iterable<string>) => Promise<void> = require("trash");
 const chokidar: { watch(paths: string | string[], options?: WatchOptions): FSWatcher } = require("chokidar");
-const detectCharacterEncoding: (buffer: Buffer) => { encoding: string, confidence: number } = require("detect-character-encoding");
 
 type EventType =
     "all" |
@@ -283,7 +282,7 @@ export class FileSystemNode implements FileSystem {
         });
     }
 
-    getEncoding(uri: string, options?: { preferredEncoding?: string }): Promise<string> {
+    getEncoding(uri: string): Promise<string> {
         return new Promise<string>((resolve, reject) => {
             const _uri = new URI(uri);
             const stat = this.doGetStat(_uri, 0);
@@ -293,17 +292,7 @@ export class FileSystemNode implements FileSystem {
             if (stat.isDirectory) {
                 return reject(new Error(`Cannot get the encoding of a director. URI: ${uri}.`));
             }
-            fs.readFile(_uri.path, {}, (error, buffer) => {
-                if (error) {
-                    return reject(error);
-                }
-                const encoding = detectCharacterEncoding(buffer);
-                if (encoding && encoding.encoding) {
-                    resolve(encoding.encoding);
-                } else {
-                    resolve(options && typeof (options.preferredEncoding) !== "undefined" ? options.preferredEncoding : this.defaults.encoding);
-                }
-            });
+            return resolve(this.defaults.encoding);
         });
     }
 


### PR DESCRIPTION
- Removed `detect-character-encoding` dependency. Made sure FS alls back
to default `utf8`.
- Added `electron`rebuild` dev-dependency, made sure it is executed
after `npm install`.

Signed-off-by: Akos Kitta <kittaakos@gmail.com>