### PR TITLE
Added ApplicationError to inherit from

### DIFF
--- a/packages/core/src/common/error.spec.ts
+++ b/packages/core/src/common/error.spec.ts
@@ -1,0 +1,65 @@
+/*
+ * Copyright (C) 2018 Ericsson and others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+import { expect } from 'chai';
+import { ApplicationError } from "./error";
+
+enum TestErrorCode {
+    FRONTEND = "ERR_THEIA_FRONTEND",
+    BACKEND = "ERR_THEIA_BACKEND",
+}
+
+describe("Application Errors", () => {
+
+    it("throw custom error code", () => {
+        const errorCode = "ERR_TEST";
+        const backendError = new ApplicationError(errorCode);
+        const frontendError = new ApplicationError(errorCode);
+
+        try {
+            throw backendError;
+        } catch (e) {
+            expect(backendError).to.be.instanceof(ApplicationError);
+            expect(backendError.code).to.be.equal(errorCode);
+        }
+
+        try {
+            throw frontendError;
+        } catch (e) {
+            expect(frontendError).to.be.instanceof(ApplicationError);
+            expect(frontendError.code).to.be.equal(errorCode);
+        }
+
+    });
+
+    it("error serialization should still allow us to test errors", () => {
+        const frontendError = new ApplicationError(TestErrorCode.FRONTEND, "TEST: no error actually happened in the frontend");
+        const backendError = new ApplicationError(TestErrorCode.BACKEND, "TEST: no error actually happened in the backend");
+
+        const serializedFrontendError = JSON.stringify(frontendError);
+        const serializedBackendError = JSON.stringify(backendError);
+
+        console.log(serializedBackendError);
+        console.log(serializedFrontendError);
+
+        const deserializedFrontendError: ApplicationError = JSON.parse(serializedFrontendError);
+        const deserializedBackendError: ApplicationError = JSON.parse(serializedBackendError);
+
+        expect(deserializedFrontendError).to.not.be.instanceof(ApplicationError);
+        expect(deserializedFrontendError).to.have.property("message");
+        expect(deserializedFrontendError).to.have.property("stack");
+        expect(deserializedFrontendError).to.have.property("code");
+        expect(deserializedFrontendError.code).to.be.equal(frontendError.code);
+
+        expect(deserializedBackendError).to.not.be.instanceof(ApplicationError);
+        expect(deserializedBackendError).to.have.property("message");
+        expect(deserializedBackendError).to.have.property("stack");
+        expect(deserializedBackendError).to.have.property("code");
+        expect(deserializedBackendError.code).to.be.equal(backendError.code);
+    });
+
+});

--- a/packages/core/src/common/error.ts
+++ b/packages/core/src/common/error.ts
@@ -1,0 +1,33 @@
+/*
+ * Copyright (C) 2018 Ericsson and others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+export class ApplicationError extends Error {
+
+    /**
+     * Static code member representing the error
+     */
+    static readonly CODE: string = "ERR_THEIA";
+
+    /**
+     * Instance property representing the error
+     */
+    code: string;
+
+    constructor(code?: string, message?: string) {
+        super(message);
+        this.code = code || new.target.CODE; // Applying default
+        Object.setPrototypeOf(this, new.target.prototype);
+    }
+
+    toJSON() {
+        return {
+            message: this.message,
+            stack: this.stack,
+            code: this.code,
+        };
+    }
+}


### PR DESCRIPTION
Very simple PR that adds an `error.js` package to `@theia/core/common` so that we can easily define errors:

```ts
import { ApplicationError } from '@theia/core/lib/common/error';

export enum MyErrorCode {
    CODE1 = "ERR_THEIA_CODE1",
    CODE2 = "ERR_THEIA_CODE2",
}

const error = new ApplicationError(MyErrorCode.CODE1, "my message");
```

Talk?: #1535