### PR TITLE
Changed font family in monaco editor

### DIFF
--- a/packages/monaco/src/browser/style/index.css
+++ b/packages/monaco/src/browser/style/index.css
@@ -7,7 +7,7 @@
 
 .monaco-editor {
     padding-bottom: 5.6px;
-    font-family: monospace !important;
+    font-family: var(--theia-ui-font-family);
     font-size: inherit !important;
 }
 


### PR DESCRIPTION
<img width="447" alt="screen shot 2018-04-27 at 09 19 52" src="https://user-images.githubusercontent.com/28291421/39349800-807b04fc-49fc-11e8-8eab-5acddd81378a.png">

instead of

<img width="440" alt="screen shot 2018-04-27 at 09 20 58" src="https://user-images.githubusercontent.com/28291421/39349801-8097cc5e-49fc-11e8-84fe-28f23e6c161a.png">
