### PR TITLE
Reuse jdt.ls workspace

### DIFF
--- a/packages/java/src/browser/java-client-contribution.ts
+++ b/packages/java/src/browser/java-client-contribution.ts
@@ -27,13 +27,14 @@ import {
     LanguageClientFactory,
     LanguageClientOptions
 } from '@theia/languages/lib/browser';
-import { JAVA_LANGUAGE_ID, JAVA_LANGUAGE_NAME } from '../common';
+import { JAVA_LANGUAGE_ID, JAVA_LANGUAGE_NAME, JavaStartParams } from '../common';
 import {
     ActionableNotification,
     ActionableMessage,
     StatusReport,
     StatusNotification,
 } from './java-protocol';
+import { MaybePromise } from '@theia/core';
 
 @injectable()
 export class JavaClientContribution extends BaseLanguageClientContribution {
@@ -114,6 +115,11 @@ export class JavaClientContribution extends BaseLanguageClientContribution {
             }
         };
         return options;
+    }
+
+    protected getStartParameters(): MaybePromise<JavaStartParams> {
+        const workspace = this.workspace.rootUri ? this.workspace.rootUri : undefined;
+        return { workspace };
     }
 
 }

--- a/packages/java/src/common/index.ts
+++ b/packages/java/src/common/index.ts
@@ -17,3 +17,7 @@
 export const JAVA_SCHEME = 'jdt';
 export const JAVA_LANGUAGE_ID = 'java';
 export const JAVA_LANGUAGE_NAME = 'Java';
+
+export interface JavaStartParams {
+    workspace?: string
+}

--- a/packages/java/src/node/java-contribution.ts
+++ b/packages/java/src/node/java-contribution.ts
@@ -23,11 +23,12 @@ import { Message, isRequestMessage } from 'vscode-ws-jsonrpc';
 import { InitializeParams, InitializeRequest } from 'vscode-languageserver-protocol';
 import { createSocketConnection } from 'vscode-ws-jsonrpc/lib/server';
 import { DEBUG_MODE } from '@theia/core/lib/node';
-import { IConnection, BaseLanguageServerContribution } from '@theia/languages/lib/node';
-import { JAVA_LANGUAGE_ID, JAVA_LANGUAGE_NAME } from '../common';
+import { IConnection, BaseLanguageServerContribution, LanguageServerStartOptions } from '@theia/languages/lib/node';
+import { JAVA_LANGUAGE_ID, JAVA_LANGUAGE_NAME, JavaStartParams } from '../common';
 import { JavaCliContribution } from './java-cli-contribution';
 import { ContributionProvider } from '@theia/core';
 import { JavaExtensionContribution } from './java-extension-model';
+const sha1 = require('sha1');
 
 export type ConfigurationType = 'config_win' | 'config_mac' | 'config_linux';
 export const configurations = new Map<typeof process.platform, ConfigurationType>();
@@ -35,12 +36,17 @@ configurations.set('darwin', 'config_mac');
 configurations.set('win32', 'config_win');
 configurations.set('linux', 'config_linux');
 
+export interface JavaStartOptions extends LanguageServerStartOptions {
+    parameters?: JavaStartParams
+}
+
 @injectable()
 export class JavaContribution extends BaseLanguageServerContribution {
 
     readonly id = JAVA_LANGUAGE_ID;
     readonly name = JAVA_LANGUAGE_NAME;
 
+    private activeDataFolders: Set<string>;
     private javaBundles: string[] = [];
     protected readonly ready: Promise<void>;
 
@@ -50,6 +56,7 @@ export class JavaContribution extends BaseLanguageServerContribution {
         protected readonly contributions: ContributionProvider<JavaExtensionContribution>
     ) {
         super();
+        this.activeDataFolders = new Set<string>();
         this.ready = this.collectExtensionBundles();
     }
 
@@ -64,7 +71,7 @@ export class JavaContribution extends BaseLanguageServerContribution {
         }
     }
 
-    async start(clientConnection: IConnection): Promise<void> {
+    async start(clientConnection: IConnection, { parameters }: JavaStartOptions): Promise<void> {
         await this.ready;
 
         const socketPort = this.cli.lsPort();
@@ -81,9 +88,20 @@ export class JavaContribution extends BaseLanguageServerContribution {
         if (jarPaths.length === 0) {
             throw new Error('The Java server launcher is not found.');
         }
-
         const jarPath = path.resolve(serverPath, jarPaths[0]);
-        const workspacePath = path.resolve(os.tmpdir(), '_ws_' + new Date().getTime());
+
+        let workspaceUri: string;
+        if (!parameters || !parameters.workspace) {
+            workspaceUri = 'default';
+        } else {
+            workspaceUri = parameters.workspace;
+        }
+
+        const dataFolderSuffix = this.generateDataFolderSuffix(workspaceUri);
+        this.activeDataFolders.add(dataFolderSuffix);
+        clientConnection.onClose(() => this.activeDataFolders.delete(dataFolderSuffix));
+
+        const workspacePath = path.resolve(os.homedir(), '.theia', 'jdt.ls', '_ws_' + dataFolderSuffix);
         const configuration = configurations.get(process.platform);
         if (!configuration) {
             throw new Error('Cannot find Java server configuration for ' + process.platform);
@@ -123,6 +141,17 @@ export class JavaContribution extends BaseLanguageServerContribution {
             this.createProcessSocketConnection(socket, socket, command, args, { env })
                 .then(serverConnection => this.forward(clientConnection, serverConnection));
         });
+    }
+
+    protected generateDataFolderSuffix(workspaceUri: string): string {
+        const shaValue = sha1(workspaceUri);
+        let instanceCounter = 0;
+        let dataFolderName = shaValue + '_' + instanceCounter;
+        while (this.activeDataFolders.has(dataFolderName)) {
+            instanceCounter++;
+            dataFolderName = shaValue + '_' + instanceCounter;
+        }
+        return dataFolderName;
     }
 
     protected map(message: Message): Message {


### PR DESCRIPTION
Signed-off-by: Valeriy Svydenko <vsvydenk@redhat.com>

The PR suggests to reuse jdt.ls' workspace multiple times. 
The jdt.ls workspace has schema: `_ws_<opened-theia-workspace-sha1>_<0..n>`

If we have 2 opened instances of Theia with same workspace, we'll have 2 jdt.ls' workspaces:
`/tmp/_ws_sha1ValueOfTheiaWs_0`
`/tmp/_ws_sha1ValueOfTheiaWs_1`

Related issue: https://github.com/eclipse/che/issues/10325

<!-- Please provide a clear and meaningful description to the CHANGELOG.md file if this PR contributes some significant changes -->
