### PR TITLE
Make process creation asynchronous, improve error reporting

### DIFF
--- a/packages/cpp/src/node/cpp-contribution.ts
+++ b/packages/cpp/src/node/cpp-contribution.ts
@@ -37,7 +37,8 @@ export class CppContribution extends BaseLanguageServerContribution {
             args = parseArgs(envArgs);
         }
 
-        const serverConnection = this.createProcessStreamConnection(command, args);
-        this.forward(clientConnection, serverConnection);
+        this.createProcessStreamConnection(command, args).then(serverConnection => {
+            this.forward(clientConnection, serverConnection);
+        });
     }
 }

--- a/packages/debug/src/node/debug-adapter.ts
+++ b/packages/debug/src/node/debug-adapter.ts
@@ -50,19 +50,19 @@ export class LaunchBasedDebugAdapterFactory implements DebugAdapterFactory {
     @inject(ProcessManager)
     protected readonly processManager: ProcessManager;
 
-    start(executable: DebugAdapterExecutable): CommunicationProvider {
-        const process = this.spawnProcess(executable);
+    async start(executable: DebugAdapterExecutable): Promise<CommunicationProvider> {
+        const process = await this.spawnProcess(executable);
         // FIXME: propagate onError + onExit
         return {
-            input: process.input,
-            output: process.output,
+            input: process.stdin,
+            output: process.stdout,
             dispose: () => process.kill()
         };
     }
 
-    private spawnProcess(executable: DebugAdapterExecutable): RawProcess {
+    private spawnProcess(executable: DebugAdapterExecutable): Promise<RawProcess> {
         const { command, args } = executable;
-        return this.processFactory({ command, args, options: { stdio: ['pipe', 'pipe', 2] } });
+        return this.processFactory.create({ command, args, options: { stdio: ['pipe', 'pipe', 2] } });
     }
 
     connect(debugServerPort: number): CommunicationProvider {

--- a/packages/debug/src/node/debug-model.ts
+++ b/packages/debug/src/node/debug-model.ts
@@ -90,7 +90,7 @@ export const DebugAdapterFactory = Symbol('DebugAdapterFactory');
  * Factory to start debug adapter.
  */
 export interface DebugAdapterFactory {
-    start(executable: DebugAdapterExecutable): CommunicationProvider;
+    start(executable: DebugAdapterExecutable): Promise<CommunicationProvider>;
     connect(debugServerPort: number): CommunicationProvider;
 }
 

--- a/packages/debug/src/node/debug-service-impl.ts
+++ b/packages/debug/src/node/debug-service-impl.ts
@@ -207,7 +207,7 @@ export class DebugAdapterSessionManager {
             communicationProvider = this.debugAdapterFactory.connect(config.debugServer);
         } else {
             const executable = await this.registry.provideDebugAdapterExecutable(config);
-            communicationProvider = this.debugAdapterFactory.start(executable);
+            communicationProvider = await this.debugAdapterFactory.start(executable);
         }
 
         const sessionFactory = this.registry.debugAdapterSessionFactory(config.type) || this.debugAdapterSessionFactory;

--- a/packages/file-search/src/node/file-search-service-impl.ts
+++ b/packages/file-search/src/node/file-search-service-impl.ts
@@ -48,7 +48,7 @@ export class FileSearchServiceImpl implements FileSearchService {
         if (!options.useGitIgnore) {
             args.push('-uu');
         }
-        const process = this.rawProcessFactory({
+        const process = await this.rawProcessFactory.create({
             command: rgPath,
             args,
             options: {
@@ -71,8 +71,8 @@ export class FileSearchServiceImpl implements FileSearchService {
             }
         }
         const lineReader = readline.createInterface({
-            input: process.output,
-            output: process.input
+            input: process.stdout,
+            output: process.stdin,
         });
         lineReader.on('line', line => {
             if (result.length >= opts.limit) {
@@ -84,9 +84,6 @@ export class FileSearchServiceImpl implements FileSearchService {
                     fuzzyMatches.push(line);
                 }
             }
-        });
-        process.onError(e => {
-            resultDeferred.reject(e);
         });
         process.onExit(e => {
             const left = opts.limit - result.length;

--- a/packages/java/src/node/java-contribution.ts
+++ b/packages/java/src/node/java-contribution.ts
@@ -109,7 +109,7 @@ export class JavaContribution extends BaseLanguageServerContribution {
             const address = server.address();
             env.CLIENT_HOST = address.address;
             env.CLIENT_PORT = address.port;
-            this.createProcessSocketConnection(socket, socket, command, args, { env })
+            return this.createProcessSocketConnection(socket, socket, command, args, { env })
                 .then(serverConnection => this.forward(clientConnection, serverConnection));
         });
     }

--- a/packages/json/src/node/json-contribution.ts
+++ b/packages/json/src/node/json-contribution.ts
@@ -31,16 +31,13 @@ export class JsonContribution extends BaseLanguageServerContribution {
             path.resolve(__dirname, './json-starter'),
             '--stdio'
         ];
-        try {
-            const serverConnection = this.createProcessStreamConnection(command, args);
+
+        this.createProcessStreamConnection(command, args).then(serverConnection => {
             serverConnection.reader.onError(err => {
                 console.log(err);
             });
             this.forward(clientConnection, serverConnection);
-        } catch (e) {
-            console.log(e);
-            throw e;
-        }
+        }).catch(e => console.log(e));
     }
 
     protected onDidFailSpawnProcess(error: Error): void {

--- a/packages/process/src/node/multi-ring-buffer.ts
+++ b/packages/process/src/node/multi-ring-buffer.ts
@@ -15,7 +15,6 @@
  ********************************************************************************/
 
 import * as stream from 'stream';
-import { inject, injectable } from 'inversify';
 import { Disposable } from '@theia/core/lib/common';
 
 /**
@@ -73,7 +72,6 @@ export class MultiRingBufferReadableStream extends stream.Readable implements Di
     }
 }
 
-export const MultiRingBufferOptions = Symbol('MultiRingBufferOptions');
 export interface MultiRingBufferOptions {
     readonly size: number,
     readonly encoding?: string,
@@ -81,7 +79,6 @@ export interface MultiRingBufferOptions {
 
 export interface WrappedPosition { newPos: number, wrap: boolean }
 
-@injectable()
 export class MultiRingBuffer {
 
     protected readonly buffer: Buffer;
@@ -97,7 +94,7 @@ export class MultiRingBuffer {
     protected readerId = 0;
 
     constructor(
-        @inject(MultiRingBufferOptions) protected readonly options: MultiRingBufferOptions
+        protected readonly options: MultiRingBufferOptions
     ) {
         this.maxSize = options.size;
         if (options.encoding !== undefined) {

--- a/packages/process/src/node/process-backend-module.ts
+++ b/packages/process/src/node/process-backend-module.ts
@@ -14,44 +14,21 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
-import { ContainerModule, Container } from 'inversify';
-import { RawProcess, RawProcessOptions, RawProcessFactory } from './raw-process';
-import { TerminalProcess, TerminalProcessOptions, TerminalProcessFactory } from './terminal-process';
+import { ContainerModule } from 'inversify';
+import { RawProcessFactory, RawProcessFactoryImpl } from './raw-process';
+import { TerminalProcessFactory, TerminalProcessFactoryImpl } from './terminal-process';
 import { BackendApplicationContribution } from '@theia/core/lib/node';
 import { ProcessManager } from './process-manager';
 import { ILogger } from '@theia/core/lib/common';
-import { MultiRingBuffer, MultiRingBufferOptions } from './multi-ring-buffer';
 
 export default new ContainerModule(bind => {
-    bind(RawProcess).toSelf().inTransientScope();
     bind(ProcessManager).toSelf().inSingletonScope();
     bind(BackendApplicationContribution).toDynamicValue(ctx => ctx.container.get(ProcessManager)).inSingletonScope();
     bind(ILogger).toDynamicValue(ctx => {
         const parentLogger = ctx.container.get<ILogger>(ILogger);
         return parentLogger.child('process');
     }).inSingletonScope().whenTargetNamed('process');
-    bind(RawProcessFactory).toFactory(ctx =>
-        (options: RawProcessOptions) => {
-            const child = new Container({ defaultScope: 'Singleton' });
-            child.parent = ctx.container;
 
-            child.bind(RawProcessOptions).toConstantValue(options);
-            return child.get(RawProcess);
-        }
-    );
-
-    bind(TerminalProcess).toSelf().inTransientScope();
-    bind(TerminalProcessFactory).toFactory(ctx =>
-        (options: TerminalProcessOptions) => {
-            const child = new Container({ defaultScope: 'Singleton' });
-            child.parent = ctx.container;
-
-            child.bind(TerminalProcessOptions).toConstantValue(options);
-            return child.get(TerminalProcess);
-        }
-    );
-
-    bind(MultiRingBuffer).toSelf().inTransientScope();
-    /* 1MB size, TODO should be a user preference. */
-    bind(MultiRingBufferOptions).toConstantValue({ size: 1048576 });
+    bind(RawProcessFactory).to(RawProcessFactoryImpl);
+    bind(TerminalProcessFactory).to(TerminalProcessFactoryImpl);
 });

--- a/packages/process/src/node/process-manager.ts
+++ b/packages/process/src/node/process-manager.ts
@@ -18,6 +18,7 @@ import { Process } from './process';
 import { Emitter, Event } from '@theia/core/lib/common';
 import { ILogger } from '@theia/core/lib/common/logger';
 import { BackendApplicationContribution } from '@theia/core/lib/node';
+import * as assert from 'assert';
 
 @injectable()
 export class ProcessManager implements BackendApplicationContribution {
@@ -39,13 +40,14 @@ export class ProcessManager implements BackendApplicationContribution {
      *
      * @param process the process to register.
      */
-    register(process: Process): number {
+    register(process: Process): void {
+        assert(process.pid > 0);
         const id = this.id;
+        this.id++;
+
+        process.setId(id);
         this.processes.set(id, process);
         process.onExit(() => this.unregister(process));
-        process.onError(() => this.unregister(process));
-        this.id++;
-        return id;
     }
 
     /**

--- a/packages/process/src/node/raw-process.ts
+++ b/packages/process/src/node/raw-process.ts
@@ -19,7 +19,6 @@ import { ProcessManager } from './process-manager';
 import { ILogger } from '@theia/core/lib/common';
 import { Process, ProcessType, ProcessOptions } from './process';
 import { ChildProcess, spawn } from 'child_process';
-import * as stream from 'stream';
 
 export const RawProcessOptions = Symbol('RawProcessOptions');
 export interface RawProcessOptions extends ProcessOptions {
@@ -27,75 +26,64 @@ export interface RawProcessOptions extends ProcessOptions {
 
 export const RawProcessFactory = Symbol('RawProcessFactory');
 export interface RawProcessFactory {
-    (options: RawProcessOptions): RawProcess;
-}
-
-/* A Node stream like /dev/null.
-
-   Writing goes to a black hole, reading returns EOF.  */
-class DevNullStream extends stream.Duplex {
-    // tslint:disable-next-line:no-any
-    _write(chunk: any, encoding: string, callback: (err?: Error) => void): void {
-        callback();
-    }
-
-    _read(size: number): void {
-        // tslint:disable-next-line:no-null-keyword
-        this.push(null);
-    }
+    create(options: RawProcessOptions): Promise<RawProcess>;
 }
 
 @injectable()
+export class RawProcessFactoryImpl implements RawProcessFactory {
+
+    @inject(ProcessManager)
+    processManager: ProcessManager;
+
+    @inject(ILogger) @named('process')
+    logger: ILogger;
+
+    create(options: RawProcessOptions): Promise<RawProcess> {
+        return new Promise<RawProcess>((resolve, reject) => {
+            this.logger.debug(`Starting raw process: ${options.command},`
+                + ` with args: ${options.args ? options.args.join(' ') : ''}, `
+                + ` with options: ${JSON.stringify(options.options)}`);
+
+            // About catching errors: spawn will sometimes throw directly
+            // (EACCES on Linux), sometimes return a Process object with the pid
+            // property undefined (ENOENT on Linux).  In the latter case, wait
+            // for the error event to reject the Promise.
+            const process: ChildProcess = spawn(options.command, options.args, options.options);
+            if (process.pid === undefined) {
+                process.on('error', (err: Error) => {
+                    reject(err);
+                });
+            } else {
+                const rawProcess = new RawProcess(process, this.logger);
+                this.processManager.register(rawProcess);
+                resolve(rawProcess);
+            }
+        });
+    }
+}
+
 export class RawProcess extends Process {
 
-    readonly input: stream.Writable;
-    readonly output: stream.Readable;
-    readonly errorOutput: stream.Readable;
-    readonly process: ChildProcess;
+    constructor(readonly process: ChildProcess, logger: ILogger) {
+        super(logger, ProcessType.Raw);
 
-    constructor(
-        @inject(RawProcessOptions) options: RawProcessOptions,
-        @inject(ProcessManager) processManager: ProcessManager,
-        @inject(ILogger) @named('process') logger: ILogger
-    ) {
-        super(processManager, logger, ProcessType.Raw, options);
-
-        this.logger.debug(`Starting raw process: ${options.command},`
-            + ` with args: ${options.args ? options.args.join(' ') : ''}, `
-            + ` with options: ${JSON.stringify(options.options)}`);
-
-        /* spawn can throw exceptions, for example if the file is not
-           executable, it throws an error with EACCES.  Here, we try to
-           normalize the error handling by calling the error handler
-           instead.  */
-        try {
-            this.process = spawn(
-                options.command,
-                options.args,
-                options.options);
-
-            this.process.on('error', this.emitOnError.bind(this));
-            this.process.on('exit', this.emitOnExit.bind(this));
-
-            this.output = this.process.stdout;
-            this.input = this.process.stdin;
-            this.errorOutput = this.process.stderr;
-        } catch (error) {
-            /* When an error is thrown, set up some fake streams, so the client
-               code doesn't break because these field are undefined.  */
-            this.output = new DevNullStream();
-            this.input = new DevNullStream();
-            this.errorOutput = new DevNullStream();
-
-            /* Call the client error handler, but first give them a chance to register it.  */
-            process.nextTick(() => {
-                this.errorEmitter.fire(error);
-            });
-        }
+        this.process.on('exit', this.emitOnExit.bind(this));
     }
 
     get pid() {
         return this.process.pid;
+    }
+
+    get stdin() {
+        return this.process.stdin;
+    }
+
+    get stdout() {
+        return this.process.stdout;
+    }
+
+    get stderr() {
+        return this.process.stderr;
     }
 
     kill(signal?: string) {

--- a/packages/process/src/node/terminal-process.spec.ts
+++ b/packages/process/src/node/terminal-process.spec.ts
@@ -40,9 +40,16 @@ describe('TerminalProcess', function () {
         /* Strangely, Linux returns exited with code 1 when using a non existing path but Windows throws an error.
         This would need to be investigated more.  */
         if (isWindows) {
-            return expect(() => terminalProcessFactory({ command: '/non-existent' })).to.throw();
+            let error: Error | undefined = undefined;
+            try {
+                await terminalProcessFactory.create({ command: '/non-existent' });
+            } catch (err) {
+                error = err;
+            }
+
+            expect(error).not.eq(undefined);
         } else {
-            const terminalProcess = terminalProcessFactory({ command: '/non-existant' });
+            const terminalProcess = await terminalProcessFactory.create({ command: '/non-existant' });
             const p = new Promise(resolve => {
                 terminalProcess.onExit(event => {
                     if (event.code > 0) { resolve(); }
@@ -55,11 +62,8 @@ describe('TerminalProcess', function () {
 
     it('test exit', async function () {
         const args = ['--version'];
-        const terminalProcess = terminalProcessFactory({ command: process.execPath, 'args': args });
+        const terminalProcess = await terminalProcessFactory.create({ command: process.execPath, 'args': args });
         const p = new Promise((resolve, reject) => {
-            terminalProcess.onError(error => {
-                reject();
-            });
             terminalProcess.onExit(event => {
                 if (event.code === 0) {
                     resolve();
@@ -74,7 +78,7 @@ describe('TerminalProcess', function () {
 
     it('test pipe stream', async function () {
         const args = ['--version'];
-        const terminalProcess = terminalProcessFactory({ command: process.execPath, 'args': args });
+        const terminalProcess = await terminalProcessFactory.create({ command: process.execPath, 'args': args });
 
         const outStream = new stream.PassThrough();
 

--- a/packages/python/src/node/python-contribution.ts
+++ b/packages/python/src/node/python-contribution.ts
@@ -34,8 +34,10 @@ export class PythonContribution extends BaseLanguageServerContribution {
             command = pythonLsCommand;
             args = parseArgs(process.env.PYTHON_LS_ARGS || '');
         }
-        const serverConnection = this.createProcessStreamConnection(command, args, this.getSpawnOptions());
-        this.forward(clientConnection, serverConnection);
+
+        this.createProcessStreamConnection(command, args, this.getSpawnOptions()).then(serverConnection => {
+            this.forward(clientConnection, serverConnection);
+        });
     }
 
     protected getSpawnOptions(): SpawnOptions | undefined {

--- a/packages/search-in-workspace/src/common/search-in-workspace-interface.ts
+++ b/packages/search-in-workspace/src/common/search-in-workspace-interface.ts
@@ -108,7 +108,7 @@ export interface SearchInWorkspaceClient {
     /**
      * Called when no more search matches will come.
      */
-    onDone(searchId: number, error?: string): void;
+    onDone(searchId: number): void;
 }
 
 export const SearchInWorkspaceServer = Symbol('SearchInWorkspaceServer');

--- a/packages/search-in-workspace/src/node/ripgrep-search-in-workspace-server.ts
+++ b/packages/search-in-workspace/src/node/ripgrep-search-in-workspace-server.ts
@@ -79,7 +79,7 @@ export class RipgrepSearchInWorkspaceServer implements SearchInWorkspaceServer {
     }
 
     // Search for the string WHAT in directory ROOT.  Return the assigned search id.
-    search(what: string, rootUri: string, opts?: SearchInWorkspaceOptions): Promise<number> {
+    async search(what: string, rootUri: string, opts?: SearchInWorkspaceOptions): Promise<number> {
         // Start the rg process.  Use --vimgrep to get one result per
         // line, --color=always to get color control characters that
         // we'll use to parse the lines.
@@ -104,23 +104,9 @@ export class RipgrepSearchInWorkspaceServer implements SearchInWorkspaceServer {
             command: rgPath,
             args: [...args, what, ...globs, FileUri.fsPath(rootUri)]
         };
-        const process: RawProcess = this.rawProcessFactory(processOptions);
+
+        const process: RawProcess = await this.rawProcessFactory.create(processOptions);
         this.ongoingSearches.set(searchId, process);
-
-        process.onError(error => {
-            // tslint:disable-next-line:no-any
-            let errorCode = (error as any).code;
-
-            // Try to provide somewhat clearer error messages, if possible.
-            if (errorCode === 'ENOENT') {
-                errorCode = 'could not find the ripgrep (rg) binary';
-            } else if (errorCode === 'EACCES') {
-                errorCode = 'could not execute the ripgrep (rg) binary';
-            }
-
-            const errorStr = `An error happened while searching (${errorCode}).`;
-            this.wrapUpSearch(searchId, errorStr);
-        });
 
         // Running counter of results.
         let numResults = 0;
@@ -134,7 +120,7 @@ export class RipgrepSearchInWorkspaceServer implements SearchInWorkspaceServer {
             index: 0,
         };
 
-        process.output.on('data', (chunk: string) => {
+        process.stdout.on('data', (chunk: string) => {
             // We might have already reached the max number of
             // results, sent a TERM signal to rg, but we still get
             // the data that was already output in the mean time.
@@ -271,7 +257,7 @@ export class RipgrepSearchInWorkspaceServer implements SearchInWorkspaceServer {
             }
         });
 
-        process.output.on('end', () => {
+        process.stdout.on('end', () => {
             // If we reached maxResults, we should have already
             // wrapped up the search.  Returning early avoids
             // logging a warning message in wrapUpSearch.
@@ -282,7 +268,7 @@ export class RipgrepSearchInWorkspaceServer implements SearchInWorkspaceServer {
             this.wrapUpSearch(searchId);
         });
 
-        return Promise.resolve(searchId);
+        return searchId;
     }
 
     // Cancel an ongoing search.  Trying to cancel a search that doesn't exist isn't an
@@ -299,11 +285,11 @@ export class RipgrepSearchInWorkspaceServer implements SearchInWorkspaceServer {
     }
 
     // Send onDone to the client and clean up what we know about search searchId.
-    private wrapUpSearch(searchId: number, error?: string) {
+    private wrapUpSearch(searchId: number) {
         if (this.ongoingSearches.delete(searchId)) {
             if (this.client) {
-                this.logger.debug('Sending onDone for ' + searchId, error);
-                this.client.onDone(searchId, error);
+                this.logger.debug('Sending onDone for ' + searchId);
+                this.client.onDone(searchId);
             } else {
                 this.logger.debug('Wrapping up search ' + searchId + ' but no client');
             }

--- a/packages/task/src/node/process/process-task-runner.ts
+++ b/packages/task/src/node/process/process-task-runner.ts
@@ -102,7 +102,7 @@ export class ProcessTaskRunner implements TaskRunner {
             const processType = taskConfig.type === 'process' ? 'process' : 'shell';
             if (processType === 'process') {
                 this.logger.debug('Task: creating underlying raw process');
-                proc = this.rawProcessFactory(<RawProcessOptions>{
+                proc = await this.rawProcessFactory.create(<RawProcessOptions>{
                     command: command,
                     args: args,
                     options: options
@@ -110,7 +110,7 @@ export class ProcessTaskRunner implements TaskRunner {
             } else {
                 // all Task types without specific TaskRunner will be run as a shell process e.g.: npm, gulp, etc.
                 this.logger.debug('Task: creating underlying terminal process');
-                proc = this.terminalProcessFactory(<TerminalProcessOptions>{
+                proc = await this.terminalProcessFactory.create(<TerminalProcessOptions>{
                     command: command,
                     args: args,
                     options: options

--- a/packages/terminal/src/node/base-terminal-server.ts
+++ b/packages/terminal/src/node/base-terminal-server.ts
@@ -78,18 +78,6 @@ export abstract class BaseTerminalServer implements IBaseTerminalServer {
 
     protected postCreate(term: TerminalProcess): void {
         const toDispose = new DisposableCollection();
-
-        toDispose.push(term.onError(error => {
-            this.logger.error(`Terminal pid: ${term.pid} error: ${error}, closing it.`);
-
-            if (this.client !== undefined) {
-                this.client.onTerminalError({
-                    'terminalId': term.id,
-                    'error': error
-                });
-            }
-        }));
-
         toDispose.push(term.onExit(event => {
             if (this.client !== undefined) {
                 this.client.onTerminalExitChanged({

--- a/packages/terminal/src/node/shell-terminal-server.ts
+++ b/packages/terminal/src/node/shell-terminal-server.ts
@@ -31,11 +31,11 @@ export class ShellTerminalServer extends BaseTerminalServer {
         super(processManager, logger);
     }
 
-    create(options: IShellTerminalServerOptions): Promise<number> {
+    async create(options: IShellTerminalServerOptions): Promise<number> {
         try {
-            const term = this.shellFactory(options);
-            this.postCreate(term);
-            return Promise.resolve(term.id);
+            const process = await this.shellFactory.create(options);
+            this.postCreate(process);
+            return Promise.resolve(process.id);
         } catch (error) {
             this.logger.error('Error while creating terminal', error);
             return Promise.resolve(-1);

--- a/packages/terminal/src/node/terminal-backend-module.ts
+++ b/packages/terminal/src/node/terminal-backend-module.ts
@@ -14,10 +14,10 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
-import { ContainerModule, Container, interfaces } from 'inversify';
+import { ContainerModule, interfaces } from 'inversify';
 import { TerminalBackendContribution } from './terminal-backend-contribution';
 import { ConnectionHandler, JsonRpcConnectionHandler } from '@theia/core/lib/common/messaging';
-import { ShellProcess, ShellProcessFactory, ShellProcessOptions } from './shell-process';
+import { ShellProcessFactory, ShellProcessFactoryImpl } from './shell-process';
 import { ITerminalServer, terminalPath } from '../common/terminal-protocol';
 import { IBaseTerminalClient, DispatchingBaseTerminalClient, IBaseTerminalServer } from '../common/base-terminal-protocol';
 import { TerminalServer } from './terminal-server';
@@ -56,16 +56,7 @@ export function bindTerminalServer(bind: interfaces.Bind, { path, identifier, co
 export default new ContainerModule(bind => {
     bind(MessagingService.Contribution).to(TerminalBackendContribution).inSingletonScope();
 
-    bind(ShellProcess).toSelf().inTransientScope();
-    bind(ShellProcessFactory).toFactory(ctx =>
-        (options: ShellProcessOptions) => {
-            const child = new Container({ defaultScope: 'Singleton' });
-            child.parent = ctx.container;
-            child.bind(ShellProcessOptions).toConstantValue(options);
-            return child.get(ShellProcess);
-        }
-    );
-
+    bind(ShellProcessFactory).to(ShellProcessFactoryImpl).inSingletonScope();
     bind(TerminalWatcher).toSelf().inSingletonScope();
     bindTerminalServer(bind, {
         path: terminalPath,

--- a/packages/terminal/src/node/terminal-server.ts
+++ b/packages/terminal/src/node/terminal-server.ts
@@ -36,9 +36,9 @@ export class TerminalServer extends BaseTerminalServer implements ITerminalServe
 
     async create(options: ITerminalServerOptions): Promise<number> {
         try {
-            const term = this.terminalFactory(options);
-            this.postCreate(term);
-            return term.id;
+            const process = await this.terminalFactory.create(options);
+            this.postCreate(process);
+            return process.id;
         } catch (error) {
             this.logger.error('Error while creating terminal', error);
             return -1;

--- a/packages/typescript/src/node/typescript-contribution.ts
+++ b/packages/typescript/src/node/typescript-contribution.ts
@@ -54,8 +54,9 @@ export class TypeScriptContribution extends BaseLanguageServerContribution {
             __dirname + '/startserver.js',
             '--stdio'
         ];
-        const serverConnection = this.createProcessStreamConnection(command, args);
-        this.forward(clientConnection, serverConnection);
+        this.createProcessStreamConnection(command, args).then(serverConnection => {
+            this.forward(clientConnection, serverConnection);
+        });
     }
 
     protected map(message: Message): Message {


### PR DESCRIPTION
The error reporting when spawning a process fails (notably ENOENT and
EACCES) is not very good currently.

For example, after trying to execute a non-executable file, we get a
RawProcess object with the `process` property undefined.  When we try to
execute a non-existent file, we get a RawProcess.process with an
undefined pid.  I think it's not very practical to be able to receive
RawProcess objects that represent processes that we failed to start.

With this patch, I propose to extract the actual process spawn from the
RawProcess and TerminalProcess constructors and move that in some
factory methods that return Promises.  The RawProcess and
TerminalProcess objects will be created to wrap successfully started
processes.  Errors will be propagated by returning rejected Promises.

Doing this change has quite a bit of impact on other modules, but I
think that in the end it's an API that's harder to misuse.

Change-Id: I76bc0cc5ab0664c04ddc73e4d68e78948780f9d0
Signed-off-by: Simon Marchi <simon.marchi@ericsson.com>

<!-- Please provide a clear and meaningful description to the CHANGELOG.md file if this PR contributes some significant changes -->
