### PR TITLE
[Electron] Disable Dev Tools when mode is not development

### DIFF
--- a/dev-packages/application-manager/src/generator/abstract-generator.ts
+++ b/dev-packages/application-manager/src/generator/abstract-generator.ts
@@ -84,4 +84,8 @@ export abstract class AbstractGenerator {
         return JSON.stringify(object, null, 4);
     }
 
+    protected get hasDevTools(): boolean {
+        return mode === 'development';
+    }
+
 }

--- a/dev-packages/application-manager/src/generator/frontend-generator.ts
+++ b/dev-packages/application-manager/src/generator/frontend-generator.ts
@@ -138,7 +138,7 @@ if (isMaster) {
             const y = Math.floor(bounds.y + (bounds.height - height) / 2);
             const x = Math.floor(bounds.x + (bounds.width - width) / 2);
 
-            const newWindow = new BrowserWindow({ width, height, x, y, show: !!theUrl, title: applicationName });
+            const newWindow = new BrowserWindow({ width, height, x, y, show: !!theUrl, title: applicationName, webPreferences: { devTools: ${this.hasDevTools} } });
 
             if (windows.length === 0) {
                 newWindow.webContents.on('new-window', (event, url, frameName, disposition, options) => {

--- a/packages/core/src/electron-browser/menu/electron-menu-contribution.ts
+++ b/packages/core/src/electron-browser/menu/electron-menu-contribution.ts
@@ -52,10 +52,6 @@ export namespace ElectronMenus {
     export const VIEW_ZOOM = [...CommonMenus.VIEW, 'zoom'];
 }
 
-export namespace ElectronMenus {
-    export const HELP_TOGGLE = [...CommonMenus.HELP, 'z_toggle'];
-}
-
 @injectable()
 export class ElectronMenuContribution implements FrontendApplicationContribution, CommandContribution, MenuContribution, KeybindingContribution {
 
@@ -173,10 +169,6 @@ export class ElectronMenuContribution implements FrontendApplicationContribution
     }
 
     registerMenus(registry: MenuModelRegistry) {
-        registry.registerMenuAction(ElectronMenus.HELP_TOGGLE, {
-            commandId: ElectronCommands.TOGGLE_DEVELOPER_TOOLS.id
-        });
-
         registry.registerMenuAction(ElectronMenus.VIEW_WINDOW, {
             commandId: ElectronCommands.RELOAD.id,
             order: 'z0'


### PR DESCRIPTION
- Check mode and update webPreferences accordingly
- When in production, Dev Tools cannot be accessed

Signed-off-by: Matt Oster <matthew.oster@arm.com>

<!-- Please provide a clear and meaningful description to the CHANGELOG.md file if this PR contributes some significant changes -->
