### PR TITLE
[vscode] support os specific keybindings

### DIFF
--- a/packages/plugin-ext/src/common/plugin-protocol.ts
+++ b/packages/plugin-ext/src/common/plugin-protocol.ts
@@ -83,9 +83,12 @@ export interface PluginPackageMenu {
 }
 
 export interface PluginPackageKeybinding {
-    key: string;
+    key?: string;
     command: string;
     when?: string;
+    mac?: string;
+    linux?: string;
+    win?: string;
 }
 
 export interface PluginPackageGrammarsContribution {
@@ -462,9 +465,12 @@ export interface Menu {
  * Keybinding contribution
  */
 export interface Keybinding {
-    keybinding: string;
+    keybinding?: string;
     command: string;
     when?: string;
+    mac?: string;
+    linux?: string;
+    win?: string;
 }
 
 /**

--- a/packages/plugin-ext/src/hosted/node/scanners/scanner-theia.ts
+++ b/packages/plugin-ext/src/hosted/node/scanners/scanner-theia.ts
@@ -217,7 +217,10 @@ export class TheiaPluginScanner implements PluginScanner {
         return {
             keybinding: rawKeybinding.key,
             command: rawKeybinding.command,
-            when: rawKeybinding.when
+            when: rawKeybinding.when,
+            mac: rawKeybinding.mac,
+            linux: rawKeybinding.linux,
+            win: rawKeybinding.win
         };
     }
 


### PR DESCRIPTION
fix #4203

In order to verify:
- install `node-debug` VS Code extension
- check that the browser log does not have errors like `cannot read property "split" of undefined`