### PR TITLE
[WIP] Added a VS Code task to watch a specific extension with all dependencies

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,46 @@
+{
+    // See https://go.microsoft.com/fwlink/?LinkId=733558
+    // for the documentation about the tasks.json format
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "label": "Theia - Watch Extension...",
+            "type": "shell",
+            "group": "build",
+            "command": "npx run watch ${input:watchTheia} --include-filtered-dependencies --parallel",
+            "presentation": {
+                "reveal": "always",
+                "panel": "new",
+                "clear": false
+            }
+        },
+        {
+            "label": "Theia - Watch Example...",
+            "type": "shell",
+            "group": "build",
+            "command": "yarn --cwd ./examples/browser watch",
+            "presentation": {
+                "reveal": "always",
+                "panel": "new",
+                "clear": false
+            }
+        },
+        {
+            "label": "Theia - Watch All...",
+            "type": "shell",
+            "group": "build",
+            "dependsOn": [
+                "Theia - Watch Extension...",
+                "Theia - Watch Example..."
+            ]
+        }
+    ],
+    "inputs": [
+        {
+            "id": "watchTheia",
+            "type": "promptString",
+            "default": "@theia/core",
+            "description": "The name of the Theia extension to watch with all its dependencies."
+        }
+    ],
+}


### PR DESCRIPTION
I am doing `npx run watch @theia/my-extension --include-filtered-dependencies --parallel` and `yarn --cwd ./examples/browser watch` multiple times a day, this task helps speeding up things. Once [Theia is compatible with VS Code tasks](https://github.com/theia-ide/theia/issues/4212), we can use this in Theia too.

![screencast 2019-02-15 08-57-32](https://user-images.githubusercontent.com/1405703/52844121-30cecc00-3104-11e9-9cc3-2926c6a7c06c.gif)


Signed-off-by: Akos Kitta <kittaakos@typefox.io>

<!-- Please provide a clear and meaningful description to the CHANGELOG.md file if this PR contributes some significant changes -->