### PR TITLE
Broadcast Framework: Create Multi-client Broadcast Framework

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ cache:
   - examples/browser/node_modules
   - examples/electron/node_modules
   - node_modules
+  - packages/broadcast/node_modules
   - packages/bunyan/node_modules
   - packages/callhierarchy/node_modules
   - packages/console/node_modules

--- a/packages/broadcast/README.md
+++ b/packages/broadcast/README.md
@@ -1,0 +1,3 @@
+# Broadcast Messaging
+
+Work In Progress

--- a/packages/broadcast/compile.tsconfig.json
+++ b/packages/broadcast/compile.tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../configs/base.tsconfig",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "lib",
+    "baseUrl": "."
+  },
+  "include": [
+    "src"
+  ]
+}

--- a/packages/broadcast/package.json
+++ b/packages/broadcast/package.json
@@ -1,0 +1,48 @@
+{
+  "name": "@theia/broadcast",
+  "version": "0.5.0",
+  "description": "Theia - Broadcast Messaging Extension",
+  "dependencies": {
+    "@theia/core": "^0.5.0"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "theiaExtensions": [
+    {
+      "backend": "lib/node/broadcast-backend-module"
+    },
+    {
+      "frontend": "lib/browser/broadcast-frontend-module"
+    }
+  ],
+  "keywords": [
+    "theia-extension"
+  ],
+  "license": "EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/theia-ide/theia.git"
+  },
+  "bugs": {
+    "url": "https://github.com/theia-ide/theia/issues"
+  },
+  "homepage": "https://github.com/theia-ide/theia",
+  "files": [
+    "lib",
+    "src"
+  ],
+  "scripts": {
+    "prepare": "yarn run clean && yarn run build",
+    "clean": "theiaext clean",
+    "build": "theiaext build",
+    "watch": "theiaext watch",
+    "test": "theiaext test"
+  },
+  "devDependencies": {
+    "@theia/ext-scripts": "^0.5.0"
+  },
+  "nyc": {
+    "extends": "../../configs/nyc.json"
+  }
+}

--- a/packages/broadcast/src/browser/broadcast-frontend-module.ts
+++ b/packages/broadcast/src/browser/broadcast-frontend-module.ts
@@ -1,0 +1,29 @@
+/********************************************************************************
+ * Copyright (C) 2019 Progyan Bhattacharya
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import { ContainerModule } from 'inversify';
+import { WebSocketConnectionProvider } from '@theia/core/lib/browser';
+import { servicePath, IBroadcastClientDispatch, BroadcastClientDispatch, IBroadcastServer, BroadcastWatcher } from '../common';
+
+export default new ContainerModule(bind => {
+    bind(IBroadcastClientDispatch).to(BroadcastClientDispatch).inSingletonScope();
+    bind(BroadcastWatcher).toSelf().inSingletonScope();
+    bind(IBroadcastServer).toDynamicValue(({ container }) => {
+        const watcher = container.get(BroadcastWatcher);
+        const connection = container.get(WebSocketConnectionProvider);
+        return connection.createProxy<IBroadcastServer>(servicePath, watcher.getConnectedClient());
+    }).inSingletonScope();
+});

--- a/packages/broadcast/src/common/broadcast-client.ts
+++ b/packages/broadcast/src/common/broadcast-client.ts
@@ -1,0 +1,45 @@
+/********************************************************************************
+ * Copyright (C) 2019 Progyan Bhattacharya
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import { inject, injectable, postConstruct } from 'inversify';
+import { IBroadcastProtocol, IBroadcastClientDispatch, IBroadcastServer, IBroadcastState, onStateUpdateHandler } from './broadcast-protocol';
+import { BroadcastWatcher } from './broadcast-watcher';
+
+@injectable()
+export class BroadcastClientDispatch implements IBroadcastClientDispatch {
+
+    @inject(BroadcastWatcher)
+    private readonly watcher: BroadcastWatcher;
+
+    @inject(IBroadcastServer)
+    private readonly server: IBroadcastServer;
+
+    @postConstruct()
+    onStateUpdate(callback: onStateUpdateHandler) {
+        this.watcher.onStateUpdate(callback);
+    }
+
+    @postConstruct()
+    getState(): Promise<IBroadcastState> {
+        return this.server.getState();
+    }
+
+    @postConstruct()
+    async setState(state: IBroadcastState): Promise<IBroadcastProtocol> {
+        await this.server.getState();
+        return this.server.setState(state);
+    }
+}

--- a/packages/broadcast/src/common/broadcast-protocol.ts
+++ b/packages/broadcast/src/common/broadcast-protocol.ts
@@ -1,0 +1,59 @@
+/********************************************************************************
+ * Copyright (C) 2019 Progyan Bhattacharya
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+/** Interface for Broadcast Message State */
+export const IBroadcastState = Symbol('IBroadcastState');
+
+export type IBroadcastState = string | Object;
+
+/** Interface for Broadcast Message Protocol */
+export const IBroadcastProtocol = Symbol('IBroadcastProtocol');
+
+export interface IBroadcastProtocol {
+    prevState: IBroadcastState;
+    state: IBroadcastState;
+}
+
+/** Interface for Broadcast Client */
+export const IBroadcastClient = Symbol('IBroadcastClient');
+
+export interface IBroadcastClient {
+    onStateUpdate(event: IBroadcastProtocol): void;
+}
+
+/** Interface for Broadcast Server */
+export const IBroadcastServer = Symbol('IBroadcastServer');
+
+export interface IBroadcastServer {
+    addClient(client: IBroadcastClient): void;
+    removeClient(client: IBroadcastClient): void;
+    setState(state: IBroadcastState): Promise<IBroadcastProtocol>;
+    getState(): Promise<IBroadcastState>;
+}
+
+/** Interface for Broadcast Dispatcher Client */
+export const IBroadcastClientDispatch = Symbol('IBroadcastClientDispatch');
+
+export type onStateUpdateHandler = (event: IBroadcastProtocol) => void;
+
+export interface IBroadcastClientDispatch {
+    onStateUpdate(callback: onStateUpdateHandler): void;
+    getState(): Promise<IBroadcastState>;
+    setState(state: IBroadcastState): Promise<IBroadcastProtocol>;
+}
+
+/** API Endpoint for the Broadcast Service */
+export const servicePath = '/services/broadcast';

--- a/packages/broadcast/src/common/broadcast-server.ts
+++ b/packages/broadcast/src/common/broadcast-server.ts
@@ -1,0 +1,50 @@
+/********************************************************************************
+ * Copyright (C) 2019 Progyan Bhattacharya
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import { injectable } from 'inversify';
+import { IBroadcastServer, IBroadcastClient, IBroadcastState, IBroadcastProtocol } from './broadcast-protocol';
+
+@injectable()
+export class BroadcastServer implements IBroadcastServer {
+
+    private readonly clients: Set<IBroadcastClient>;
+    private state: string | Object;
+
+    constructor() {
+        this.clients = new Set<IBroadcastClient>();
+        this.state = {};
+    }
+
+    addClient(client: IBroadcastClient) {
+        this.clients.add(client);
+    }
+
+    removeClient(client: IBroadcastClient) {
+        this.clients.delete(client);
+    }
+
+    setState(state: IBroadcastState): Promise<IBroadcastProtocol> {
+        const prevState = this.state;
+        this.state = state;
+        const stateUpdateMetadata: IBroadcastProtocol = { prevState, state };
+        this.clients.forEach(client => client.onStateUpdate(stateUpdateMetadata));
+        return Promise.resolve(stateUpdateMetadata);
+    }
+
+    getState(): Promise<IBroadcastState> {
+        return Promise.resolve(this.state);
+    }
+}

--- a/packages/broadcast/src/common/broadcast-watcher.ts
+++ b/packages/broadcast/src/common/broadcast-watcher.ts
@@ -1,0 +1,42 @@
+/********************************************************************************
+ * Copyright (C) 2019 Progyan Bhattacharya
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import { injectable } from 'inversify';
+import { Emitter, Event } from '@theia/core/lib/common';
+import { IBroadcastClient, IBroadcastProtocol } from './broadcast-protocol';
+
+@injectable()
+export class BroadcastWatcher {
+
+    private readonly emitter: Emitter<IBroadcastProtocol>;
+
+    constructor() {
+        this.emitter = new Emitter<IBroadcastProtocol>();
+    }
+
+    getConnectedClient(): IBroadcastClient {
+        const { emitter } = this;
+        return {
+            onStateUpdate(event: IBroadcastProtocol) {
+                emitter.fire(event);
+            }
+        };
+    }
+
+    get onStateUpdate(): Event<IBroadcastProtocol> {
+        return this.emitter.event;
+    }
+}

--- a/packages/broadcast/src/common/index.ts
+++ b/packages/broadcast/src/common/index.ts
@@ -1,0 +1,20 @@
+/********************************************************************************
+ * Copyright (C) 2019 Progyan Bhattacharya
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+export * from './broadcast-client';
+export * from './broadcast-protocol';
+export * from './broadcast-server';
+export * from './broadcast-watcher';

--- a/packages/broadcast/src/node/broadcast-backend-module.ts
+++ b/packages/broadcast/src/node/broadcast-backend-module.ts
@@ -1,0 +1,34 @@
+/********************************************************************************
+ * Copyright (C) 2019 Progyan Bhattacharya
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import { ContainerModule } from 'inversify';
+import { ConnectionHandler, JsonRpcConnectionHandler } from '@theia/core/lib/common';
+import { servicePath, IBroadcastClientDispatch, BroadcastClientDispatch, IBroadcastClient, IBroadcastServer, BroadcastServer, BroadcastWatcher } from '../common';
+
+export default new ContainerModule(bind => {
+    bind(IBroadcastClientDispatch).to(BroadcastClientDispatch).inSingletonScope();
+    bind(BroadcastWatcher).toSelf().inSingletonScope();
+    bind(BroadcastServer).toSelf().inSingletonScope();
+    bind(IBroadcastServer).toService(BroadcastServer);
+    bind(ConnectionHandler).toDynamicValue(({ container }) =>
+        new JsonRpcConnectionHandler<IBroadcastClient>(servicePath, client => {
+            const server = container.get<IBroadcastServer>(IBroadcastServer);
+            client.onDidOpenConnection(() => server.addClient(client));
+            client.onDidCloseConnection(() => server.removeClient(client));
+            return container.get<IBroadcastServer>(IBroadcastServer);
+        })
+    ).inSingletonScope();
+});

--- a/packages/broadcast/src/package.spec.ts
+++ b/packages/broadcast/src/package.spec.ts
@@ -1,0 +1,21 @@
+/********************************************************************************
+ * Copyright (C) 2019 Progyan Bhattacharya
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+describe('broadcast package', () => {
+
+    it('support code coverage statistics', () => true);
+
+});


### PR DESCRIPTION
Work In Progress: Proof of Concept for VS Liveshare equivalent in Theia

The broadcast framework is required to perform operation on collaborative editing. To create similar functionalities as VS Liveshare, all kind of events and event metadata need to be sent to every client connected to same server workspace.

Signed-off-by: Progyan Bhattacharya <bprogyan@gmail.com>

<!-- Please provide a clear and meaningful description to the CHANGELOG.md file if this PR contributes some significant changes -->
