### PR TITLE
[Filesystem] Added option to set the All Files position in file dialog

### DIFF
--- a/packages/filesystem/src/browser/file-dialog/file-dialog-tree-filters-renderer.tsx
+++ b/packages/filesystem/src/browser/file-dialog/file-dialog-tree-filters-renderer.tsx
@@ -17,6 +17,7 @@
 import { ReactRenderer } from '@theia/core/lib/browser/widgets/react-renderer';
 import { FileDialogTree } from './file-dialog-tree';
 import * as React from 'react';
+import { FileDialogTreeAllFilesPosition } from './file-dialog';
 
 export const FILE_TREE_FILTERS_LIST_CLASS = 'theia-FileTreeFiltersList';
 
@@ -38,6 +39,7 @@ export class FileDialogTreeFiltersRenderer extends ReactRenderer {
 
     constructor(
         readonly filters: FileDialogTreeFilters,
+        readonly allFilesPosition: FileDialogTreeAllFilesPosition | undefined,
         readonly fileDialogTree: FileDialogTree
     ) {
         super();
@@ -50,10 +52,17 @@ export class FileDialogTreeFiltersRenderer extends ReactRenderer {
             return undefined;
         }
 
-        const fileTypes = ['All Files'];
+        const allFilesElement = 'All Files';
+        const fileTypes: string[] = [];
+        if (this.allFilesPosition === undefined || this.allFilesPosition === FileDialogTreeAllFilesPosition.FIRST) {
+            fileTypes.push(allFilesElement);
+        }
         Object.keys(this.filters).forEach(element => {
             fileTypes.push(element);
         });
+        if (this.allFilesPosition === FileDialogTreeAllFilesPosition.LAST) {
+            fileTypes.push(allFilesElement);
+        }
 
         const options = fileTypes.map(value => this.renderLocation(value));
         return <select className={FILE_TREE_FILTERS_LIST_CLASS} onChange={this.handleFilterChanged}>{...options}</select>;

--- a/packages/filesystem/src/browser/file-dialog/file-dialog-tree-filters-renderer.tsx
+++ b/packages/filesystem/src/browser/file-dialog/file-dialog-tree-filters-renderer.tsx
@@ -17,7 +17,7 @@
 import { ReactRenderer } from '@theia/core/lib/browser/widgets/react-renderer';
 import { FileDialogTree } from './file-dialog-tree';
 import * as React from 'react';
-import { FileDialogTreeAllFilesPosition } from './file-dialog';
+import { FileDialogTreeAllFilesPosition, FileDialogProps } from './file-dialog';
 
 export const FILE_TREE_FILTERS_LIST_CLASS = 'theia-FileTreeFiltersList';
 
@@ -39,8 +39,8 @@ export class FileDialogTreeFiltersRenderer extends ReactRenderer {
 
     constructor(
         readonly filters: FileDialogTreeFilters,
-        readonly allFilesPosition: FileDialogTreeAllFilesPosition | undefined,
-        readonly fileDialogTree: FileDialogTree
+        readonly fileDialogTree: FileDialogTree,
+        readonly fileDialogOptions?: FileDialogProps
     ) {
         super();
     }
@@ -54,13 +54,13 @@ export class FileDialogTreeFiltersRenderer extends ReactRenderer {
 
         const allFilesElement = 'All Files';
         const fileTypes: string[] = [];
-        if (this.allFilesPosition === undefined || this.allFilesPosition === FileDialogTreeAllFilesPosition.FIRST) {
+        if (this.fileDialogOptions === undefined || this.fileDialogOptions.allFilesPosition === FileDialogTreeAllFilesPosition.FIRST) {
             fileTypes.push(allFilesElement);
         }
         Object.keys(this.filters).forEach(element => {
             fileTypes.push(element);
         });
-        if (this.allFilesPosition === FileDialogTreeAllFilesPosition.LAST) {
+        if (this.fileDialogOptions !== undefined && this.fileDialogOptions.allFilesPosition === FileDialogTreeAllFilesPosition.LAST) {
             fileTypes.push(allFilesElement);
         }
 

--- a/packages/filesystem/src/browser/file-dialog/file-dialog-tree-filters-renderer.tsx
+++ b/packages/filesystem/src/browser/file-dialog/file-dialog-tree-filters-renderer.tsx
@@ -52,15 +52,17 @@ export class FileDialogTreeFiltersRenderer extends ReactRenderer {
             return undefined;
         }
 
+        const isAllFilePositionDefined = this.fileDialogOptions !== undefined && this.fileDialogOptions.allFilesPosition !== undefined;
+        const allFilesPosition = isAllFilePositionDefined ? this.fileDialogOptions!.allFilesPosition : FileDialogTreeAllFilesPosition.FIRST;
         const allFilesElement = 'All Files';
         const fileTypes: string[] = [];
-        if (this.fileDialogOptions === undefined || this.fileDialogOptions.allFilesPosition === FileDialogTreeAllFilesPosition.FIRST) {
+        if (allFilesPosition === FileDialogTreeAllFilesPosition.FIRST) {
             fileTypes.push(allFilesElement);
         }
         Object.keys(this.filters).forEach(element => {
             fileTypes.push(element);
         });
-        if (this.fileDialogOptions !== undefined && this.fileDialogOptions.allFilesPosition === FileDialogTreeAllFilesPosition.LAST) {
+        if (allFilesPosition === FileDialogTreeAllFilesPosition.LAST) {
             fileTypes.push(allFilesElement);
         }
 

--- a/packages/filesystem/src/browser/file-dialog/file-dialog.ts
+++ b/packages/filesystem/src/browser/file-dialog/file-dialog.ts
@@ -55,6 +55,12 @@ export const FILENAME_TEXTFIELD_CLASS = 'theia-FileNameTextField';
 
 export const CONTROL_PANEL_CLASS = 'theia-ControlPanel';
 
+export enum FileDialogTreeAllFilesPosition {
+    FIRST,
+    LAST,
+    HIDDEN
+}
+
 export class FileDialogProps extends DialogProps {
 
     /**
@@ -68,6 +74,11 @@ export class FileDialogProps extends DialogProps {
      * ```
      */
     filters?: FileDialogTreeFilters;
+
+    /**
+     * Allow to decide where the 'All Files' selector appears relative to the other filters
+     */
+    allFilesPosition?: FileDialogTreeAllFilesPosition;
 
 }
 
@@ -158,7 +169,7 @@ export abstract class FileDialog<T> extends AbstractDialog<T> {
 
     protected createFileTreeFiltersRenderer(): FileDialogTreeFiltersRenderer | undefined {
         if (this.props.filters) {
-            return new FileDialogTreeFiltersRenderer(this.props.filters, this.widget.model.tree);
+            return new FileDialogTreeFiltersRenderer(this.props.filters, this.props.allFilesPosition, this.widget.model.tree);
         }
 
         return undefined;

--- a/packages/filesystem/src/browser/file-dialog/file-dialog.ts
+++ b/packages/filesystem/src/browser/file-dialog/file-dialog.ts
@@ -169,7 +169,7 @@ export abstract class FileDialog<T> extends AbstractDialog<T> {
 
     protected createFileTreeFiltersRenderer(): FileDialogTreeFiltersRenderer | undefined {
         if (this.props.filters) {
-            return new FileDialogTreeFiltersRenderer(this.props.filters, this.props.allFilesPosition, this.widget.model.tree);
+            return new FileDialogTreeFiltersRenderer(this.props.filters, this.widget.model.tree, this.props);
         }
 
         return undefined;

--- a/packages/filesystem/src/electron-browser/file-dialog/electron-file-dialog-service.ts
+++ b/packages/filesystem/src/electron-browser/file-dialog/electron-file-dialog-service.ts
@@ -22,7 +22,7 @@ import { MaybeArray } from '@theia/core/lib/common/types';
 import { MessageService } from '@theia/core/lib/common/message-service';
 import { FileStat } from '../../common';
 import { FileAccess } from '../../common/filesystem';
-import { DefaultFileDialogService, OpenFileDialogProps, SaveFileDialogProps } from '../../browser/file-dialog';
+import { DefaultFileDialogService, OpenFileDialogProps, SaveFileDialogProps, FileDialogTreeAllFilesPosition } from '../../browser/file-dialog';
 
 //
 // We are OK to use this here because the electron backend and frontend are on the same host.
@@ -94,9 +94,16 @@ export class ElectronFileDialogService extends DefaultFileDialogService {
     protected toDialogOptions(uri: URI, props: SaveFileDialogProps | OpenFileDialogProps, dialogTitle: string): electron.FileDialogProps {
         const title = props.title || dialogTitle;
         const defaultPath = FileUri.fsPath(uri);
-        const filters: FileFilter[] = [{ name: 'All Files', extensions: ['*'] }];
+        const allFilesFilter = { name: 'All Files', extensions: ['*'] };
+        const filters: FileFilter[] = [];
+        if (props.allFilesPosition === undefined || props.allFilesPosition === FileDialogTreeAllFilesPosition.FIRST) {
+            filters.push(allFilesFilter);
+        }
         if (props.filters) {
             filters.push(...Object.keys(props.filters).map(key => ({ name: key, extensions: props.filters![key] })));
+        }
+        if (props.allFilesPosition === FileDialogTreeAllFilesPosition.LAST) {
+            filters.push(allFilesFilter);
         }
         return { title, defaultPath, filters };
     }


### PR DESCRIPTION
Added an option in the `FileDialog` props to allow the user to decide if the "All Files" filter should appear as the first option, last option, or not appear at all.

By default "All Files" appears as the first option to guarantee backward compatibility.

Fix #2812 