### PR TITLE
[WIP] GH-2992: Changed the way we resolve an extension.

### DIFF
--- a/dev-packages/application-package/src/extension-package-collector.ts
+++ b/dev-packages/application-package/src/extension-package-collector.ts
@@ -64,6 +64,7 @@ export class ExtensionPackageCollector {
         try {
             packagePath = this.resolveModule(name + '/package.json');
         } catch (error) {
+            console.error(error);
             console.warn(`Failed to resolve module: ${name}`);
         }
         if (!packagePath) {

--- a/dev-packages/application-package/src/node-require.ts
+++ b/dev-packages/application-package/src/node-require.ts
@@ -1,0 +1,42 @@
+/********************************************************************************
+ * Copyright (C) 2019 TypeFox and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+/**
+ * This is a hack to help `webpack` locating the Theia extensions with dynamic `require`.
+ * See: https://github.com/theia-ide/theia/pull/4983#issuecomment-486145220
+ *
+ * Instead of doing:
+ * ```ts
+ * const myModule = require.resolve(getMyModuleName());
+ * ```
+ *
+ * You're supposed to do:
+ * ```ts
+ * import nodeRequire from './node-require';
+ * const myModule = nodeRequire.resolve(getMyModuleName());
+ * ```
+ *
+ * Then, in your `webpack.config.js`, you have to make sure, `webpack` does not parse this module:
+ * ```js
+ * module.exports = (options = {}) => ({
+ *      // Your configuration comes here.
+ *      module: {
+ *          noParse: /\/node-require.js$/,
+ *      }
+ * });
+ * ```
+ */
+export default require;

--- a/packages/core/src/node/messaging/ipc-connection-provider.ts
+++ b/packages/core/src/node/messaging/ipc-connection-provider.ts
@@ -14,12 +14,12 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
-import * as path from 'path';
 import * as cp from 'child_process';
 import { injectable, inject } from 'inversify';
 import { Trace, IPCMessageReader, IPCMessageWriter, createMessageConnection, MessageConnection, Message } from 'vscode-jsonrpc';
 import { ILogger, ConnectionErrorHandler, DisposableCollection, Disposable } from '../../common';
 import { createIpcEnv } from './ipc-protocol';
+import nodeRequire from '@theia/application-package/lib/node-require';
 
 export interface ResolvedIPCConnectionOptions {
     readonly serverName: string
@@ -100,7 +100,8 @@ export class IPCConnectionProvider {
             forkOptions.execArgv = ['--nolazy', `--inspect${inspectArg.substr(inspectArgPrefix.length)}`];
         }
 
-        const childProcess = cp.fork(path.resolve(__dirname, 'ipc-bootstrap.js'), options.args, forkOptions);
+        const modulePath = nodeRequire.resolve('./ipc-bootstrap.js', { paths: [__dirname] });
+        const childProcess = cp.fork(modulePath, options.args, forkOptions);
         childProcess.stdout.on('data', data => this.logger.info(`[${options.serverName}: ${childProcess.pid}] ${data.toString().trim()}`));
         childProcess.stderr.on('data', data => this.logger.error(`[${options.serverName}: ${childProcess.pid}] ${data.toString().trim()}`));
 


### PR DESCRIPTION
Instead of creating a new file on the fly with the corresponding resolve
code, we use `require.resolve`'s
`paths` option.

It was introduced in Node.js `v8.9.0`.
https://nodejs.org/api/modules.html#modules_require_resolve_paths_request

Closes #2992.

Signed-off-by: Akos Kitta <kittaakos@typefox.io>

<!-- Please provide a clear and meaningful description to the CHANGELOG.md file if this PR contributes some significant changes -->
