### PR TITLE
Left border for popup menu

### DIFF
--- a/packages/core/src/browser/style/menus.css
+++ b/packages/core/src/browser/style/menus.css
@@ -103,6 +103,12 @@
   color: var(--theia-ui-font-color1);
   font-size: var(--theia-ui-font-size1);
   box-shadow: 0px 1px 6px rgba(0, 0, 0, 0.2);
+  border-left: var(--theia-border-width) solid var(--theia-border-color1);
+}
+
+
+.p-Menu:focus {
+  border-left: var(--theia-border-width) solid var(--theia-border-color1) !important;
 }
 
 

--- a/packages/core/src/browser/style/menus.css
+++ b/packages/core/src/browser/style/menus.css
@@ -40,6 +40,12 @@
 
 .p-MenuBar-menu {
   transform: translateY(calc(-2*var(--theia-border-width)));
+  border-left: var(--theia-border-width) solid var(--theia-border-color1);
+}
+
+
+.p-MenuBar-menu:focus {
+  border-left: var(--theia-border-width) solid var(--theia-border-color1) !important;
 }
 
 
@@ -103,12 +109,6 @@
   color: var(--theia-ui-font-color1);
   font-size: var(--theia-ui-font-size1);
   box-shadow: 0px 1px 6px rgba(0, 0, 0, 0.2);
-  border-left: var(--theia-border-width) solid var(--theia-border-color1);
-}
-
-
-.p-Menu:focus {
-  border-left: var(--theia-border-width) solid var(--theia-border-color1) !important;
 }
 
 


### PR DESCRIPTION
Improves left border of popup menus.

Popup menu without left border:
![to 1](https://user-images.githubusercontent.com/1655894/56809046-9a253680-683b-11e9-8ee9-94f85631db01.png)

With left border it looks consistently with highlighted item in top menu.

![after 1](https://user-images.githubusercontent.com/1655894/56809069-aa3d1600-683b-11e9-93d5-4cd6ab088504.png)

We need to add `!important` suffix for focused menu to prevent popup trembling when it loses focus.

Signed-off-by: Vitaliy Gulyy <vgulyy@redhat.com>

<!-- Please provide a clear and meaningful description to the CHANGELOG.md file if this PR contributes some significant changes -->
