### PR TITLE
Send log messages to output view when Electron

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## v0.15.0
 
 - [terminal] always open terminal links on touchevents (e.g. when tapping a link on iPad) [#6875](https://github.com/eclipse-theia/theia/pull/6875)
+- [electron] send log output to the output view (desktop version only) [#5039](https://github.com/theia-ide/theia/pull/5039)
 
 Breaking changes:
 
@@ -71,6 +72,7 @@ Breaking changes:
   Before these attributes have to be computed for all nodes and stored as a part of the layout.
   From now on they will be computed only on demand for visible nodes.
   It decreases requirements to the local storage and allows to invalidate node appearance by simply rerendering a tree.
+- [output] functions to read channel contents moved from OutputChannelManager to OutputChannelReaders [#5039](https://github.com/theia-ide/theia/pull/5039)
 - [application-manager] `ApplicationPackageManager.start*` methods return an instance of a server child process instead of promise.
 - [cli] Generated webpack config is renamed to `gen-webpack.config.js`.
   `webpack.config.js` is generated only once. It can be edited by users to custoimze bundling,

--- a/packages/output/package.json
+++ b/packages/output/package.json
@@ -10,7 +10,11 @@
   },
   "theiaExtensions": [
     {
-      "frontend": "lib/browser/output-frontend-module"
+      "frontend": "lib/browser/output-frontend-module",
+      "backend": "lib/node/output-backend-module"
+    },
+    {
+      "backendElectron": "lib/electron-node/output-backend-electron-module"
     }
   ],
   "keywords": [

--- a/packages/output/src/browser/output-channel-manager-client.ts
+++ b/packages/output/src/browser/output-channel-manager-client.ts
@@ -1,0 +1,54 @@
+/********************************************************************************
+ * Copyright (C) 2018 TypeFox and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import { Emitter } from '@theia/core';
+import { injectable, inject } from 'inversify';
+import { OutputPreferences } from '../common/output-preferences';
+import { OutputChannel, OutputChannelManager, OutputOptions } from '../common/output-channel';
+
+@injectable()
+export class OutputChannelManagerClient implements OutputChannelManager {
+    protected readonly channels = new Map<string, OutputChannel>();
+
+    protected readonly channelDeleteEmitter = new Emitter<{ channelName: string }>();
+    protected readonly channelAddedEmitter = new Emitter<OutputChannel>();
+    readonly onDidDeleteChannel = this.channelDeleteEmitter.event;
+    readonly onDidAddChannel = this.channelAddedEmitter.event;
+
+    constructor(
+        @inject(OutputPreferences) protected preferences: OutputPreferences) {
+    }
+
+    getChannel(name: string, options: OutputOptions = { group: 'default' }): OutputChannel {
+        const existing = this.channels.get(name);
+        if (existing) {
+            return existing;
+        }
+        const channel = new OutputChannel(name, this.preferences, options);
+        this.channels.set(name, channel);
+        this.channelAddedEmitter.fire(channel);
+        return channel;
+    }
+
+    deleteChannel(name: string): void {
+        this.channels.delete(name);
+        this.channelDeleteEmitter.fire({ channelName: name });
+    }
+
+    getChannels(): OutputChannel[] {
+        return Array.from(this.channels.values());
+    }
+}

--- a/packages/output/src/browser/output-channel-readers.ts
+++ b/packages/output/src/browser/output-channel-readers.ts
@@ -1,0 +1,146 @@
+/********************************************************************************
+ * Copyright (C) 2019 Arm and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import { Disposable, DisposableCollection, Emitter } from '@theia/core';
+import { injectable, inject, postConstruct } from 'inversify';
+import { OutputChannelBackendService, OutputChannelFrontendService } from '../common/output-protocol';
+import { OutputPreferences } from '../common/output-preferences';
+import { OutputChannel } from '../common/output-channel';
+import { OutputChannelManagerClient } from './output-channel-manager-client';
+
+export interface OutputChannelMetadata {
+    name: string,
+    group: string
+}
+
+/**
+ * Class that will receive output data from the server.  This is separate
+ * from the OutputChannelReaders class only to avoid a cycle in the
+ * dependency injection.
+ */
+
+@injectable()
+export class OutputChannelReadersClient implements OutputChannelFrontendService {
+    private service: OutputChannelFrontendService;
+
+    onChannelAdded(channelName: string, group: string): void {
+        this.service.onChannelAdded(channelName, group);
+    }
+    onChannelDeleted(channelName: string): void {
+        this.service.onChannelDeleted(channelName);
+    }
+
+    onProcessOutput(line: string, channelName: string): void {
+        this.service.onProcessOutput(line, channelName);
+    }
+
+    setService(service: OutputChannelFrontendService): void {
+        this.service = service;
+    }
+}
+
+@injectable()
+export class OutputChannelReaders implements OutputChannelFrontendService, Disposable {
+    protected readonly backendChannels = new Map<string, OutputChannel>();
+    protected selectedChannelValue: OutputChannel | undefined;
+
+    protected readonly channelDeleteEmitter = new Emitter<{ channelName: string }>();
+    protected readonly channelAddedEmitter = new Emitter<OutputChannel>();
+    protected readonly selectedChannelEmitter: Emitter<void> = new Emitter<void>();
+    protected readonly listOrSelectionEmitter: Emitter<void> = new Emitter<void>();
+    readonly onDidDeleteChannel = this.channelDeleteEmitter.event;
+    readonly onDidAddChannel = this.channelAddedEmitter.event;
+    readonly onDidChangeSelection = this.selectedChannelEmitter.event;
+    readonly onDidChangeListOrSelection = this.listOrSelectionEmitter.event;
+
+    protected toDispose: DisposableCollection = new DisposableCollection();
+
+    @inject(OutputChannelReadersClient) protected readonly client: OutputChannelReadersClient;
+    @inject(OutputChannelManagerClient) protected frontendChannels: OutputChannelManagerClient;
+    @inject(OutputChannelBackendService) protected remoteChannelService: OutputChannelBackendService;
+    @inject(OutputPreferences) protected preferences: OutputPreferences;
+
+    @postConstruct()
+    async init(): Promise<void> {
+        this.client.setService(this);
+
+        this.toDispose.push(this.frontendChannels.onDidAddChannel(channel => {
+            this.channelAddedEmitter.fire(channel);
+        }));
+        this.toDispose.push(this.frontendChannels.onDidDeleteChannel(channel => {
+            this.channelDeleteEmitter.fire(channel);
+        }));
+
+        const backendChannels = await this.remoteChannelService.getChannels();
+        backendChannels.forEach(channelInfo => {
+            const backendChannel = new OutputChannel(channelInfo.name, this.preferences, { group: channelInfo.group });
+            this.backendChannels.set(channelInfo.name, backendChannel);
+            this.remoteChannelService.requestToSendContent(channelInfo.name);
+        });
+    }
+
+    getChannel(name: string): OutputChannel {
+        const backendChannel = this.backendChannels.get(name);
+        if (backendChannel) {
+            return backendChannel;
+        }
+        return this.frontendChannels.getChannel(name);
+    }
+
+    getChannels(): OutputChannel[] {
+        return [
+            ...this.frontendChannels.getChannels(),
+            ...this.backendChannels.values()
+        ];
+    }
+
+    getVisibleChannels(): OutputChannel[] {
+        return this.getChannels()
+            .filter(channel => channel.isVisible);
+    }
+
+    onChannelAdded(channelName: string, group: string): void {
+        const channel = new OutputChannel(channelName, this.preferences, { group });
+        this.backendChannels.set(channelName, channel);
+        this.channelAddedEmitter.fire(channel);
+    }
+
+    onChannelDeleted(channelName: string): void {
+        this.backendChannels.delete(channelName);
+        this.channelDeleteEmitter.fire({ channelName });
+    }
+
+    onProcessOutput(line: string, channelName: string): void {
+        const channel = this.backendChannels.get(channelName);
+        if (channel) {
+            channel.appendLine(line);
+        }
+    }
+
+    get selectedChannel(): OutputChannel | undefined {
+        return this.selectedChannelValue;
+    }
+
+    set selectedChannel(channel: OutputChannel | undefined) {
+        this.selectedChannelValue = channel;
+        this.selectedChannelEmitter.fire(undefined);
+        this.listOrSelectionEmitter.fire(undefined);
+    }
+
+    dispose(): void {
+        this.toDispose.dispose();
+    }
+}

--- a/packages/output/src/common/output-channel.ts
+++ b/packages/output/src/common/output-channel.ts
@@ -15,94 +15,18 @@
  ********************************************************************************/
 
 import { Emitter, Event } from '@theia/core';
-import { injectable, inject, postConstruct } from 'inversify';
 import { OutputPreferences } from './output-preferences';
-import { Disposable, DisposableCollection } from 'vscode-ws-jsonrpc';
 
-@injectable()
-export class OutputChannelManager implements Disposable {
-    protected readonly channels = new Map<string, OutputChannel>();
-    protected selectedChannelValue: OutputChannel | undefined;
+export const OutputChannelManager = Symbol('OutputChannelManager');
 
-    protected readonly channelDeleteEmitter = new Emitter<{ channelName: string }>();
-    protected readonly channelAddedEmitter = new Emitter<OutputChannel>();
-    protected readonly selectedChannelEmitter: Emitter<void> = new Emitter<void>();
-    protected readonly listOrSelectionEmitter: Emitter<void> = new Emitter<void>();
-    readonly onChannelDelete = this.channelDeleteEmitter.event;
-    readonly onChannelAdded = this.channelAddedEmitter.event;
-    readonly onSelectedChannelChange = this.selectedChannelEmitter.event;
-    readonly onListOrSelectionChange = this.listOrSelectionEmitter.event;
+export interface OutputChannelManager {
+    getChannel(name: string, options?: { group: string }): OutputChannel;
+    deleteChannel(name: string): void;
+    getChannels(): OutputChannel[];
+}
 
-    protected toDispose = new DisposableCollection();
-
-    @inject(OutputPreferences)
-    protected readonly preferences: OutputPreferences;
-
-    @postConstruct()
-    protected init(): void {
-        this.getChannels().forEach(this.registerListener.bind(this));
-        this.toDispose.push(this.onChannelAdded(channel => {
-            this.listOrSelectionEmitter.fire(undefined);
-            this.registerListener(channel);
-        }));
-        this.toDispose.push(this.onChannelDelete(event => {
-            this.listOrSelectionEmitter.fire(undefined);
-            if (this.selectedChannel && this.selectedChannel.name === event.channelName) {
-                this.selectedChannel = this.getVisibleChannels()[0];
-            }
-        }));
-    }
-
-    protected registerListener(outputChannel: OutputChannel): void {
-        if (!this.selectedChannel) {
-            this.selectedChannel = outputChannel;
-        }
-        this.toDispose.push(outputChannel.onVisibilityChange(event => {
-            if (event.visible) {
-                this.selectedChannel = outputChannel;
-            } else if (outputChannel === this.selectedChannel) {
-                this.selectedChannel = this.getVisibleChannels()[0];
-            }
-        }));
-    }
-
-    getChannel(name: string): OutputChannel {
-        const existing = this.channels.get(name);
-        if (existing) {
-            return existing;
-        }
-        const channel = new OutputChannel(name, this.preferences);
-        this.channels.set(name, channel);
-        this.channelAddedEmitter.fire(channel);
-        return channel;
-    }
-
-    deleteChannel(name: string): void {
-        this.channels.delete(name);
-        this.channelDeleteEmitter.fire({ channelName: name });
-    }
-
-    getChannels(): OutputChannel[] {
-        return Array.from(this.channels.values());
-    }
-
-    getVisibleChannels(): OutputChannel[] {
-        return this.getChannels().filter(channel => channel.isVisible);
-    }
-
-    public dispose(): void {
-        this.toDispose.dispose();
-    }
-
-    get selectedChannel(): OutputChannel | undefined {
-        return this.selectedChannelValue;
-    }
-
-    set selectedChannel(channel: OutputChannel | undefined) {
-        this.selectedChannelValue = channel;
-        this.selectedChannelEmitter.fire(undefined);
-        this.listOrSelectionEmitter.fire(undefined);
-    }
+export interface OutputOptions {
+    group: string
 }
 
 export class OutputChannel {
@@ -116,7 +40,7 @@ export class OutputChannel {
     readonly onVisibilityChange: Event<{ visible: boolean }> = this.visibilityChangeEmitter.event;
     readonly onContentChange: Event<OutputChannel> = this.contentChangeEmitter.event;
 
-    constructor(readonly name: string, readonly preferences: OutputPreferences) { }
+    constructor(readonly name: string, readonly preferences: OutputPreferences, readonly options: OutputOptions = { group: 'default' }) { }
 
     append(value: string): void {
         if (this.currentLine === undefined) {
@@ -162,5 +86,9 @@ export class OutputChannel {
 
     get isVisible(): boolean {
         return this.visible;
+    }
+
+    get group(): string {
+        return this.options.group;
     }
 }

--- a/packages/output/src/common/output-protocol.ts
+++ b/packages/output/src/common/output-protocol.ts
@@ -1,0 +1,32 @@
+/********************************************************************************
+ * Copyright (C) 2019 Arm and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+export const OutputChannelBackendService = Symbol('OutputChannelBackendService');
+export const outputChannelBackendServicePath = '/services/outputChannelBackendService';
+
+export interface OutputChannelBackendService {
+    getChannels(): Promise<{ name: string, group: string }[]>;
+    requestToSendContent(channelName: string): Promise<void>;
+}
+
+export const OutputChannelFrontendService = Symbol('OutputChannelFrontendService');
+export const outputChannelFrontendServicePath = '/services/outputChannelFrontendService';
+
+export interface OutputChannelFrontendService {
+    onChannelAdded(channelName: string, group: string): void;
+    onChannelDeleted(channelName: string): void;
+    onProcessOutput(line: string, channelName: string): void;
+}

--- a/packages/output/src/electron-node/output-backend-electron-module.ts
+++ b/packages/output/src/electron-node/output-backend-electron-module.ts
@@ -1,0 +1,23 @@
+/********************************************************************************
+ * Copyright (C) 2019 Arm and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import { interfaces, ContainerModule } from 'inversify';
+import { ILoggerServer } from '@theia/core/lib/common/logger-protocol';
+import { OutputChannelLoggerServer } from './output-channel-logger-server';
+
+export default new ContainerModule((bind: interfaces.Bind, unbind: interfaces.Unbind, isBound: interfaces.IsBound, rebind: interfaces.Rebind) => {
+    rebind(ILoggerServer).to(OutputChannelLoggerServer).inSingletonScope();
+});

--- a/packages/output/src/electron-node/output-channel-logger-server.ts
+++ b/packages/output/src/electron-node/output-channel-logger-server.ts
@@ -1,0 +1,69 @@
+/********************************************************************************
+ * Copyright (C) 2017 Ericsson and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import { inject, injectable, postConstruct } from 'inversify';
+import { LoggerWatcher } from '@theia/core/lib/common/logger-watcher';
+import { LogLevelCliContribution } from '@theia/core/lib/node/logger-cli-contribution';
+import { ILoggerClient, ConsoleLogger } from '@theia/core/lib/common/logger-protocol';
+import { ConsoleLoggerServer } from '@theia/core/lib/node/console-logger-server';
+import { OutputChannelBackendManager, LogOutputChannel } from '../node/output-channel-backend-manager';
+
+@injectable()
+export class OutputChannelLoggerServer extends ConsoleLoggerServer {
+
+    protected client: ILoggerClient | undefined = undefined;
+
+    @inject(LoggerWatcher)
+    protected watcher: LoggerWatcher;
+
+    @inject(LogLevelCliContribution)
+    protected cli: LogLevelCliContribution;
+
+    @inject(OutputChannelBackendManager)
+    protected loggerService: OutputChannelBackendManager;
+
+    @postConstruct()
+    protected init(): void {
+        super.init();
+    }
+
+    // tslint:disable:no-any
+    async log(name: string, logLevel: number, message: any, params: any[]): Promise<void> {
+        const configuredLogLevel = await this.getLogLevel(name);
+        if (logLevel >= configuredLogLevel) {
+            ConsoleLogger.log(name, logLevel, message, params);
+            this.logToOutput(name, message, params);
+        }
+    }
+
+    protected logToOutput(name: string, message: any, params: any[]): void {
+
+        const outputChannel: LogOutputChannel = this.loggerService.getChannel(`Log (${name})`, 'log');
+
+        if (typeof message === 'string') {
+            outputChannel.appendLine(message);
+        } else if (Array.isArray(message)) {
+            // TODO pass in outputChannel so we don't look it up each time?
+            message.forEach(line =>
+                this.logToOutput(name, line, params)
+            );
+        } else {
+            const line = JSON.stringify(message);
+            outputChannel.appendLine(line);
+        }
+    }
+
+}

--- a/packages/output/src/node/output-backend-module.ts
+++ b/packages/output/src/node/output-backend-module.ts
@@ -1,0 +1,38 @@
+/********************************************************************************
+ * Copyright (C) 2019 Arm and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import { interfaces, ContainerModule } from 'inversify';
+import { OutputChannelBackendManager } from './output-channel-backend-manager';
+import { OutputChannelBackendServiceImpl } from './output-channel-backend-service-impl';
+import { OutputChannelBackendService, outputChannelBackendServicePath, outputChannelFrontendServicePath, OutputChannelFrontendService } from '../common/output-protocol';
+import { ConnectionContainerModule } from '@theia/core/lib/node/messaging/connection-container-module';
+
+export default new ContainerModule((bind: interfaces.Bind, unbind: interfaces.Unbind, isBound: interfaces.IsBound, rebind: interfaces.Rebind) => {
+    bind(OutputChannelBackendManager).toSelf().inSingletonScope();
+    bind(OutputChannelBackendService).toDynamicValue(ctx => {
+        const server = ctx.container.get(OutputChannelBackendManager);
+        return server;
+    }).inSingletonScope();
+
+    bind(ConnectionContainerModule).toConstantValue(outputChannelConnectionModule);
+});
+
+const outputChannelConnectionModule = ConnectionContainerModule.create(({ bind, bindFrontendService, bindBackendService }) => {
+    bind(OutputChannelBackendServiceImpl).toSelf().inSingletonScope();
+    bindBackendService(outputChannelBackendServicePath, OutputChannelBackendServiceImpl);
+
+    bindFrontendService(outputChannelFrontendServicePath, OutputChannelFrontendService);
+});

--- a/packages/output/src/node/output-channel-backend-manager.ts
+++ b/packages/output/src/node/output-channel-backend-manager.ts
@@ -1,0 +1,91 @@
+/********************************************************************************
+ * Copyright (C) 2019 Arm and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import { injectable } from 'inversify';
+import { Emitter, Event } from '@theia/core/lib/common/event';
+
+export interface LogOutputChannel {
+    appendLine(line: string): void;
+}
+
+interface ChannelNameAndGroup {
+    channelName: string;
+    group: string;
+}
+
+interface ChannelNameAndLine {
+    channelName: string;
+    line: string;
+}
+
+interface ChannelData {
+    group: string;
+    lines: string[];
+}
+
+@injectable()
+export class OutputChannelBackendManager {
+    protected static LINES_TO_KEEP = 5000;
+    protected static REMOVAL_SIZE = 100;
+
+    protected readonly channelAdded = new Emitter<ChannelNameAndGroup>();
+    get onChannelAdded(): Event<ChannelNameAndGroup> {
+        return this.channelAdded.event;
+    }
+
+    protected readonly lineAdded = new Emitter<ChannelNameAndLine>();
+    get onLineAdded(): Event<ChannelNameAndLine> {
+        return this.lineAdded.event;
+    }
+
+    private channels: Map<string, ChannelData> = new Map();
+
+    getChannelData(channelName: string): ChannelData | undefined {
+        return this.channels.get(channelName);
+    }
+
+    async getChannels(): Promise<{ name: string, group: string }[]> {
+        return Array.from(this.channels.entries()).map(([key, value]) =>
+            ({ name: key, group: value.group })
+        );
+    }
+
+    getChannel(channelName: string, group: string = 'default'): LogOutputChannel {
+        const outer = this;
+        return {
+            appendLine(line: string): void {
+                outer.appendLine(line, channelName, group);
+            }
+        };
+    }
+
+    protected appendLine(line: string, channelName: string, group: string): void {
+        let data = this.channels.get(channelName);
+        if (!data) {
+            data = { group, lines: [] };
+            this.channels.set(channelName, data);
+            this.channelAdded.fire({ channelName, group });
+        }
+
+        this.lineAdded.fire({ channelName, line });
+
+        // Store on the backend for future clients
+        data.lines.push(line);
+        if (data.lines.length > OutputChannelBackendManager.LINES_TO_KEEP + OutputChannelBackendManager.REMOVAL_SIZE) {
+            data.lines = data.lines.slice(OutputChannelBackendManager.REMOVAL_SIZE);
+        }
+    }
+}

--- a/packages/output/src/node/output-channel-backend-service-impl.ts
+++ b/packages/output/src/node/output-channel-backend-service-impl.ts
@@ -1,0 +1,63 @@
+/********************************************************************************
+ * Copyright (C) 2019 Arm and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import { injectable, inject, postConstruct } from 'inversify';
+import { Disposable, DisposableCollection } from '@theia/core';
+import { OutputChannelBackendService, OutputChannelFrontendService } from '../common/output-protocol';
+import { OutputChannelBackendManager } from './output-channel-backend-manager';
+
+@injectable()
+export class OutputChannelBackendServiceImpl implements OutputChannelBackendService, Disposable {
+    @inject(OutputChannelFrontendService) protected readonly frontendService: OutputChannelFrontendService;
+    @inject(OutputChannelBackendManager) protected readonly underlyingServiceImpl: OutputChannelBackendManager;
+
+    protected toDispose = new DisposableCollection();
+
+    protected visibleChannels = new Set<string>();
+
+    @postConstruct()
+    init(): void {
+        this.toDispose.push(this.underlyingServiceImpl.onChannelAdded(event => {
+            this.frontendService.onChannelAdded(event.channelName, event.group);
+        }));
+        this.toDispose.push(this.underlyingServiceImpl.onLineAdded(event => {
+            if (this.visibleChannels.has(event.channelName)) {
+                this.frontendService.onProcessOutput(event.line, event.channelName);
+            }
+        }));
+    }
+
+    async getChannels(): Promise<{ name: string, group: string }[]> {
+        return this.underlyingServiceImpl.getChannels();
+    }
+
+    async requestToSendContent(channelName: string): Promise<void> {
+        const data = this.underlyingServiceImpl.getChannelData(channelName);
+        if (data) {
+            const linesToReturn = data.lines;
+            data.lines = [];
+            linesToReturn.forEach(line => {
+                this.frontendService.onProcessOutput(line, channelName);
+            });
+            this.visibleChannels.add(channelName);
+        }
+    }
+
+    dispose(): void {
+        this.toDispose.dispose();
+    }
+
+}


### PR DESCRIPTION
Here are the changes as discussed in issue 4297.  With these changes you will see a separate section in the output channel drop-down for logs, though with this default implementation one will only see a single log listed there.

This PR includes support for writing to an output channel from the node side.  I assume this was always the intention because you had put OutputChannel in common.

I have not included the log4js logging package in this PR.  Instead the output package rebinds the logger and sends log messages directly to the output view without going through Bunyan.  This removes a dependency on a specific logger.  If one rebinds again to a specific logger such as our log4js logging package then logs can be formatted before being sent to the output view, so one can get color-coded text in the output view.

You will see that there is support to get past log messages when opening the channel.  This can be done when logging to files, as the log file could be read and sent to the client.  However the default implementation sends log messages as they are logged so this support is not used.

I'll create another PR for the log4js package if you think you may want that in the core repository.
