### PR TITLE
Disabled `tslint` in the `node_modules` folder.

### DIFF
--- a/configs/errors.tslint.json
+++ b/configs/errors.tslint.json
@@ -1,5 +1,10 @@
 {
   "defaultSeverity": "error",
+  "linterOptions": {
+    "exclude": [
+      "node_modules/**"
+    ]
+  },
   "rules": {
     "arrow-parens": [
       true,


### PR DESCRIPTION
Signed-off-by: Akos Kitta <kittaakos@typefox.io>

Somebody, please review. The linter rules should be the same as they were in the Theia source, but when you open a 3rd party lib from the `node_modules`, you won't see, missing copyright, `max-line-length` and other issues.
