### PR TITLE
Fixed #5110, #5223: re-implemented "open source" to work with image/pdf files

### DIFF
--- a/packages/core/src/browser/widget-open-handler.ts
+++ b/packages/core/src/browser/widget-open-handler.ts
@@ -36,6 +36,13 @@ export interface WidgetOpenerOptions extends OpenerOptions {
      * By default to the main area.
      */
     widgetOptions?: ApplicationShell.WidgetOptions;
+    /**
+     * Specify what the widget is opened for
+     * preview: preview of image/pdf/etc.
+     * edit: source file
+     * By default to `edit`
+     */
+    openFor?: 'preview' | 'edit';
 }
 
 @injectable()

--- a/packages/editor/src/browser/editor-manager.ts
+++ b/packages/editor/src/browser/editor-manager.ts
@@ -98,6 +98,10 @@ export class EditorManager extends NavigatableWidgetOpenHandler<EditorWidget> {
     }
 
     canHandle(uri: URI, options?: WidgetOpenerOptions): number {
+        // Set the priority negative if an open handler is called for 'preview' (not for 'edit)
+        if (options && options.openFor === 'preview') {
+            return -100;
+        }
         return 100;
     }
 

--- a/packages/mini-browser/src/browser/mini-browser-open-handler.ts
+++ b/packages/mini-browser/src/browser/mini-browser-open-handler.ts
@@ -97,11 +97,15 @@ export class MiniBrowserOpenHandler extends NavigatableWidgetOpenHandler<MiniBro
         }))();
     }
 
-    canHandle(uri: URI): number {
+    canHandle(uri: URI, options?: WidgetOpenerOptions): number {
         // It does not guard against directories. For instance, a folder with this name: `Hahahah.html`.
         // We could check with the FS, but then, this method would become async again.
         const extension = uri.toString().split('.').pop();
         if (extension) {
+            // Set the priority negative if an open handler is called for 'edit' (not for 'preview')
+            if (options && options.openFor === 'edit') {
+                return -100;
+            }
             return this.supportedExtensions.get(extension.toLocaleLowerCase()) || 0;
         }
         return 0;
@@ -237,7 +241,8 @@ export class MiniBrowserOpenHandler extends NavigatableWidgetOpenHandler<MiniBro
         const uri = this.getSourceUri(ref);
         if (uri) {
             await open(this.openerService, uri, {
-                widgetOptions: { ref, mode: 'open-to-left' }
+                widgetOptions: { ref, mode: 'open-to-left' },
+                openFor: 'edit'
             });
         }
     }
@@ -275,7 +280,8 @@ export class MiniBrowserOpenHandler extends NavigatableWidgetOpenHandler<MiniBro
                 area: 'right'
             },
             resetBackground,
-            iconClass: 'theia-mini-browser-icon'
+            iconClass: 'theia-mini-browser-icon',
+            openFor: 'preview'
         };
     }
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

Fixed #5110 
Fixed #5223

Re-implemented `openSource` function so that files with image (jpg, png, ...) and pdf extensions can have the source open from preview. 

Previously the implementation of `openSource` function is flawed. It would always call the open handler with the highest priority (`ImageHandler`/`PdfHandler`), which would not open the source of image/pdf files. 

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

_Master_
1. right-click a `jpg` image in the explorer, select `Open with` -> `Preview`
2. attempt to open the source of the image using the toolbar item `Open Source`
3. nothing happens

_PR_
1. right-click a `jpg` image in the explorer, select `Open with` -> `Preview`
2. attempt to open the source of the image using the toolbar item `Open Source`
3. the source of the image is displayed


#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)









