### PR TITLE
Allow amending of the initial commit in the repository

### DIFF
--- a/packages/scm/src/browser/scm-provider.ts
+++ b/packages/scm/src/browser/scm-provider.ts
@@ -78,7 +78,7 @@ export interface ScmCommit {
 }
 
 export interface ScmAmendSupport {
-    getInitialAmendingCommits(amendingHeadCommitSha: string, latestCommitSha: string): Promise<ScmCommit[]>
+    getInitialAmendingCommits(amendingHeadCommitId: string, latestCommitId: string | undefined): Promise<ScmCommit[]>
     getMessage(commit: string): Promise<string>;
     reset(commit: string): Promise<void>;
     getLastCommit(): Promise<ScmCommit | undefined>;


### PR DESCRIPTION
This fixes https://github.com/theia-ide/theia/issues/4972

This fix is not a high priority as the problem has always existed.  However I thought I would submit the fix so that we don't keep finding the problem or wondering if this is the cause of other issues.

To test this, use a repository with few commits and amend back to the initial commit.  One should not be able to amend the initial commit.