### PR TITLE
Avoid URL escaping request path when building a websocket URI

### DIFF
--- a/packages/core/src/browser/messaging/ws-connection-provider.ts
+++ b/packages/core/src/browser/messaging/ws-connection-provider.ts
@@ -160,7 +160,7 @@ export class WebSocketConnectionProvider {
      */
     protected createWebSocketUrl(path: string): string {
         const endpoint = new Endpoint({ path });
-        return endpoint.getWebSocketUrl().toString();
+        return endpoint.getWebSocketUrl().toString(true);
     }
 
     /**


### PR DESCRIPTION
By default, theia will urlescape the url request path.  In the situation of running theia under JupyterHub (and perhaps also Che?) the url contains an `@` from the user's email address.  This will get encoded to `%40` by theia, which is technically a different url and therefore the websocket will fail.

This PR simply disables url encoding for websocket urls