### PR TITLE
Support progress indicators in trees

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## v0.8.0
 
+- [navigator] added support for progress indicators to items in navigation and other trees
+
 Breaking changes:
 
 - [plugin] 'Hosted mode' extracted in `plugin-dev` extension

--- a/packages/core/src/browser/style/tree-decorators.css
+++ b/packages/core/src/browser/style/tree-decorators.css
@@ -65,3 +65,23 @@
     bottom: 40%;
     right: 25%;
 }
+
+.theia-TreeNodeProgress {
+    -webkit-animation: fa-spin 2s infinite linear;
+    animation: fa-spin 2s infinite linear;
+    width: 13px;
+    height: 13px;
+    background-position: center;
+    position: absolute;
+    left: -9px;
+    top: 4px;
+}
+
+.theia-TreeNodeProgress:before {
+    content: "\f110";
+    font-family: FontAwesome;
+    font-size:10px;
+    position: absolute;
+    top: -4px;
+    left: 1px; 
+}

--- a/packages/core/src/browser/tree/index.ts
+++ b/packages/core/src/browser/tree/index.ts
@@ -23,4 +23,5 @@ export * from './tree-model';
 export * from './tree-widget';
 export * from './tree-container';
 export * from './tree-decorator';
+export * from './tree-progress';
 export * from './tree-search';

--- a/packages/core/src/browser/tree/tree-container.ts
+++ b/packages/core/src/browser/tree/tree-container.ts
@@ -23,6 +23,7 @@ import { TreeSelectionServiceImpl } from './tree-selection-impl';
 import { TreeExpansionService, TreeExpansionServiceImpl } from './tree-expansion';
 import { TreeNavigationService } from './tree-navigation';
 import { TreeDecoratorService, NoopTreeDecoratorService } from './tree-decorator';
+import { TreeProgressService, NoopTreeProgressService } from './tree-progress';
 import { TreeSearch } from './tree-search';
 import { FuzzySearch } from './fuzzy-search';
 import { SearchBox, SearchBoxFactory, SearchBoxProps } from './search-box';
@@ -62,5 +63,6 @@ export function createTreeContainer(parent: interfaces.Container, props?: Partia
     );
 
     child.bind(TreeDecoratorService).to(NoopTreeDecoratorService).inSingletonScope();
+    child.bind(TreeProgressService).to(NoopTreeProgressService).inSingletonScope();
     return child;
 }

--- a/packages/core/src/browser/tree/tree-progress.ts
+++ b/packages/core/src/browser/tree/tree-progress.ts
@@ -1,0 +1,132 @@
+/********************************************************************************
+ * Copyright (C) 2019 Arm and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import { injectable } from 'inversify';
+import { Event, Emitter, Disposable, DisposableCollection } from '../../common';
+import { TreeNode } from './tree';
+
+/**
+ * Progress indicator that contributes indicators to a tree.
+ */
+export interface TreeProgress {
+
+    /**
+     * Fired when a change has occured to any of the progress data.
+     */
+    readonly onDidChangeProgress: Event<void>;
+
+    /**
+     * Given a tree node, returns progress data associated with the node, or undefined
+     * if nothing to progress for the node.
+     */
+    getProgressIndicator(node: TreeNode): TreeProgressData | undefined;
+
+}
+
+/**
+ * Progress service which emits events from all known tree progress indicators.
+ * This service consolidates progress indicator data collected from all the progress contributors known by this service.
+ */
+export const TreeProgressService = Symbol('TreeProgressService');
+export interface TreeProgressService extends Disposable {
+
+    /**
+     * Fired when any of the progress indicators have changes.
+     */
+    readonly onDidChangeProgress: Event<void>;
+
+    /**
+     * Returns with the progress data for the given tree node, consolidating data from all progress contributors.
+     */
+    getProgressIndicators(node: TreeNode): TreeProgressData[];
+
+}
+
+/**
+ * The default tree progress indicator service. Does nothing at all. One has to rebind to a concrete implementation
+ * if progress indicators are to be supported in the tree widget.
+ */
+@injectable()
+export class NoopTreeProgressService implements TreeProgressService {
+
+    protected readonly emitter = new Emitter<void>();
+    readonly onDidChangeProgress = this.emitter.event;
+
+    dispose(): void {
+        this.emitter.dispose();
+    }
+
+    getProgressIndicators(node: TreeNode) {
+        return [];
+    }
+}
+
+@injectable()
+export class NoopTreeProgressContribution implements TreeProgress {
+
+    protected readonly emitter = new Emitter<void>();
+    readonly onDidChangeProgress = this.emitter.event;
+
+    getProgressIndicator(node: TreeNode) {
+        return undefined;
+    }
+}
+
+/**
+ * Abstract progress indicator service implementation which emits events from all known progress contributors.
+ */
+@injectable()
+export abstract class AbstractTreeProgressService implements TreeProgressService {
+
+    protected readonly onDidChangeProgressEmitter = new Emitter<void>();
+    readonly onDidChangeProgress = this.onDidChangeProgressEmitter.event;
+
+    protected readonly toDispose = new DisposableCollection();
+
+    constructor(protected readonly progressContributors: ReadonlyArray<TreeProgress>) {
+        this.toDispose.push(this.onDidChangeProgressEmitter);
+        this.toDispose.pushAll(this.progressContributors.map(progressContributor =>
+            progressContributor.onDidChangeProgress(() =>
+                this.onDidChangeProgressEmitter.fire(undefined)
+            ))
+        );
+    }
+
+    dispose(): void {
+        this.toDispose.dispose();
+    }
+
+    getProgressIndicators(node: TreeNode) {
+        const progressIndicators: TreeProgressData[] = [];
+        for (const progressContributor of this.progressContributors) {
+            const progressIndicator = progressContributor.getProgressIndicator(node);
+            if (progressIndicator) {
+                progressIndicators.push(progressIndicator);
+            }
+        }
+        return progressIndicators;
+    }
+
+}
+
+export interface TreeProgressData {
+
+    /**
+     * A title to indentify the task to the user
+     */
+    readonly title?: string;
+
+}

--- a/packages/core/src/browser/tree/tree-widget-selection.ts
+++ b/packages/core/src/browser/tree/tree-widget-selection.ts
@@ -29,7 +29,7 @@ export namespace TreeWidgetSelection {
     }
     export function is(selection: Object | undefined): selection is TreeWidgetSelection {
         // tslint:disable-next-line:no-any
-        return Array.isArray(selection) && ('source' in selection) && <any>selection['source'] instanceof TreeWidget;
+        return Array.isArray(selection) && ('source' in selection) /*&& <any>selection['source'] instanceof TreeWidget*/;
     }
     export function create(source: TreeWidget): TreeWidgetSelection {
         return Object.assign(source.model.selectedNodes, { source });

--- a/packages/navigator/src/browser/index.ts
+++ b/packages/navigator/src/browser/index.ts
@@ -17,3 +17,4 @@
 export * from './navigator-model';
 export * from './navigator-widget';
 export * from './navigator-decorator-service';
+export * from './navigator-progress-service';

--- a/packages/navigator/src/browser/navigator-container.ts
+++ b/packages/navigator/src/browser/navigator-container.ts
@@ -26,6 +26,9 @@ import { NavigatorDecoratorService, NavigatorTreeDecorator } from './navigator-d
 import { NavigatorProgressService, NavigatorTreeProgress } from './navigator-progress-service';
 import { NoopTreeProgressContribution } from '@theia/core/lib/browser/tree/tree-progress';
 
+// Nigel
+import { TestTreeProgressContribution } from './navigator-contribution';
+
 export const FILE_NAVIGATOR_PROPS = <TreeProps>{
     ...defaultTreeProps,
     contextMenuPath: NAVIGATOR_CONTEXT_MENU,
@@ -58,6 +61,7 @@ export function createFileNavigatorContainer(parent: interfaces.Container): Cont
     child.rebind(TreeProgressService).toService(NavigatorProgressService);
     bindContributionProvider(child, NavigatorTreeProgress);
     child.bind(NavigatorTreeProgress).to(NoopTreeProgressContribution);
+    child.bind(NavigatorTreeProgress).to(TestTreeProgressContribution);
 
     return child;
 }

--- a/packages/navigator/src/browser/navigator-container.ts
+++ b/packages/navigator/src/browser/navigator-container.ts
@@ -15,7 +15,7 @@
  ********************************************************************************/
 
 import { Container, interfaces } from 'inversify';
-import { Tree, TreeModel, TreeProps, defaultTreeProps, TreeDecoratorService } from '@theia/core/lib/browser';
+import { Tree, TreeModel, TreeProps, defaultTreeProps, TreeDecoratorService, TreeProgressService } from '@theia/core/lib/browser';
 import { createFileTreeContainer, FileTree, FileTreeModel, FileTreeWidget } from '@theia/filesystem/lib/browser';
 import { bindContributionProvider } from '@theia/core/lib/common/contribution-provider';
 import { FileNavigatorTree } from './navigator-tree';
@@ -23,6 +23,8 @@ import { FileNavigatorModel } from './navigator-model';
 import { FileNavigatorWidget } from './navigator-widget';
 import { NAVIGATOR_CONTEXT_MENU } from './navigator-contribution';
 import { NavigatorDecoratorService, NavigatorTreeDecorator } from './navigator-decorator-service';
+import { NavigatorProgressService, NavigatorTreeProgress } from './navigator-progress-service';
+import { NoopTreeProgressContribution } from '@theia/core/lib/browser/tree/tree-progress';
 
 export const FILE_NAVIGATOR_PROPS = <TreeProps>{
     ...defaultTreeProps,
@@ -51,6 +53,11 @@ export function createFileNavigatorContainer(parent: interfaces.Container): Cont
     child.bind(NavigatorDecoratorService).toSelf().inSingletonScope();
     child.rebind(TreeDecoratorService).toService(NavigatorDecoratorService);
     bindContributionProvider(child, NavigatorTreeDecorator);
+
+    child.bind(NavigatorProgressService).toSelf().inSingletonScope();
+    child.rebind(TreeProgressService).toService(NavigatorProgressService);
+    bindContributionProvider(child, NavigatorTreeProgress);
+    child.bind(NavigatorTreeProgress).to(NoopTreeProgressContribution);
 
     return child;
 }

--- a/packages/navigator/src/browser/navigator-contribution.ts
+++ b/packages/navigator/src/browser/navigator-contribution.ts
@@ -34,6 +34,11 @@ import { TabBarToolbarContribution, TabBarToolbarRegistry } from '@theia/core/li
 import { FileSystemCommands } from '@theia/filesystem/lib/browser/filesystem-frontend-contribution';
 import { NavigatorDiff, NavigatorDiffCommands } from './navigator-diff';
 
+// Nigel
+import { FileStatNode } from '@theia/filesystem/lib/browser';
+import { Emitter } from '@theia/core/lib/common';
+import { TreeNode, TreeProgress } from '@theia/core/lib/browser/tree';
+
 export namespace FileNavigatorCommands {
     export const REVEAL_IN_NAVIGATOR: Command = {
         id: 'navigator.reveal',
@@ -362,4 +367,19 @@ export class FileNavigatorContribution extends AbstractViewContribution<FileNavi
         }
     }
 
+}
+
+@injectable()
+export class TestTreeProgressContribution implements TreeProgress {
+
+    protected readonly emitter = new Emitter<void>();
+    readonly onDidChangeProgress = this.emitter.event;
+
+    getProgressIndicator(node: TreeNode) {
+        if (FileStatNode.is(node)) {
+            if (node.fileStat.uri.endsWith('docs')) {
+                return { title: 'my test' };
+            }
+        }
+    }
 }

--- a/packages/navigator/src/browser/navigator-progress-service.ts
+++ b/packages/navigator/src/browser/navigator-progress-service.ts
@@ -1,0 +1,36 @@
+/********************************************************************************
+ * Copyright (C) 2019 Arm and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import { inject, injectable, named } from 'inversify';
+import { ContributionProvider } from '@theia/core/lib/common/contribution-provider';
+import { TreeProgress, AbstractTreeProgressService } from '@theia/core/lib/browser/tree/tree-progress';
+
+/**
+ * Symbol for all progress indicator contributors that would like to contribute into the navigator.
+ */
+export const NavigatorTreeProgress = Symbol('NavigatorTreeProgress');
+
+/**
+ * Progress indicator service for the navigator.
+ */
+@injectable()
+export class NavigatorProgressService extends AbstractTreeProgressService {
+
+    constructor(@inject(ContributionProvider) @named(NavigatorTreeProgress) protected readonly contributions: ContributionProvider<TreeProgress>) {
+        super(contributions.getContributions());
+    }
+
+}


### PR DESCRIPTION
Often tasks can be executing against a project that will temporarily disable actions against that project.  Also projects may take a while to clone and initialize before the project is ready.  Our UX team asked for a progress indicator to appear beside a project when it is in such a state.

This PR adds support for such indicators.

![image](https://user-images.githubusercontent.com/87310/59829289-ee78fe00-9334-11e9-81c5-0802492560a1.png)

