### PR TITLE
Expose output from processes on frontend

### DIFF
--- a/packages/task/src/browser/task-contribution.ts
+++ b/packages/task/src/browser/task-contribution.ts
@@ -16,7 +16,7 @@
 
 import { injectable, postConstruct } from 'inversify';
 import { Disposable } from '@theia/core/lib/common/disposable';
-import { TaskConfiguration } from '../common/task-protocol';
+import { TaskInfo, TaskConfiguration, TaskExitedEvent } from '../common/task-protocol';
 
 export const TaskContribution = Symbol('TaskContribution');
 
@@ -31,9 +31,24 @@ export interface TaskResolver {
     resolveTask(taskConfig: TaskConfiguration): Promise<TaskConfiguration>;
 }
 
+export interface ProcessOutputLines {
+    /** Called for each line from the process written to stdout */
+    processLine(line: string): void;
+    /** Called before output starts, typically used to show a 'start' message */
+    notifyStart(taskId: number, config: TaskConfiguration): void;
+    /** Called after the process has exited, typically used to show a 'completed' message */
+    notifyExit(event: TaskExitedEvent): void;
+    /** Always called last */
+    close(): void;
+}
+
 export interface TaskProvider {
     /** Returns the Task Configurations which are provides programmatically to the system. */
     provideTasks(): Promise<TaskConfiguration[]>;
+
+    /** Attaches a process to its frontend UI components */
+    attach?(taskInfo: TaskInfo, doKill?: () => Promise<void>): Promise<ProcessOutputLines>;
+
 }
 
 @injectable()

--- a/packages/task/src/common/task-protocol.ts
+++ b/packages/task/src/common/task-protocol.ts
@@ -18,6 +18,7 @@ import { JsonRpcServer } from '@theia/core/lib/common/messaging/proxy-factory';
 import { ProblemMatcher, ProblemMatch, WatchingPattern } from './problem-matcher-protocol';
 
 export const taskPath = '/services/task';
+export const tasksPath = '/services/tasks';
 
 export const TaskServer = Symbol('TaskServer');
 export const TaskClient = Symbol('TaskClient');

--- a/packages/task/src/node/process/process-task-runner-backend-module.ts
+++ b/packages/task/src/node/process/process-task-runner-backend-module.ts
@@ -19,6 +19,8 @@ import { ProcessTask, TaskFactory, TaskProcessOptions } from './process-task';
 import { ProcessTaskRunner } from './process-task-runner';
 import { ProcessTaskRunnerContribution } from './process-task-runner-contribution';
 import { TaskRunnerContribution } from '../task-runner';
+import { TaskBackendMessagingContribution } from './task-backend-messaging-contribution';
+import { MessagingService } from '@theia/core/lib/node/messaging/messaging-service';
 
 export function bindProcessTaskRunnerModule(bind: interfaces.Bind) {
 
@@ -34,4 +36,6 @@ export function bindProcessTaskRunnerModule(bind: interfaces.Bind) {
     bind(ProcessTaskRunner).toSelf().inSingletonScope();
     bind(ProcessTaskRunnerContribution).toSelf().inSingletonScope();
     bind(TaskRunnerContribution).toService(ProcessTaskRunnerContribution);
+
+    bind(MessagingService.Contribution).to(TaskBackendMessagingContribution).inSingletonScope();
 }

--- a/packages/task/src/node/process/task-backend-messaging-contribution.ts
+++ b/packages/task/src/node/process/task-backend-messaging-contribution.ts
@@ -1,0 +1,47 @@
+/********************************************************************************
+ * Copyright (C) 2017 TypeFox and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import { injectable, inject, named } from 'inversify';
+import { ILogger } from '@theia/core/lib/common';
+import { TaskManager } from '..';
+import { tasksPath } from '../../common/task-protocol';
+import { MessagingService } from '@theia/core/lib/node/messaging/messaging-service';
+import { TaskRunnerRegistry } from '../task-runner';
+
+@injectable()
+export class TaskBackendMessagingContribution implements MessagingService.Contribution {
+
+    @inject(TaskManager)
+    protected readonly taskManager: TaskManager;
+
+    @inject(TaskRunnerRegistry)
+    protected readonly taskRunnerRegistry: TaskRunnerRegistry;
+
+    @inject(ILogger) @named('terminal')
+    protected readonly logger: ILogger;
+
+    configure(service: MessagingService): void {
+        service.listen(`${tasksPath}/:id`, (params: MessagingService.PathParams, connection) => {
+            const id = parseInt(params.id, 10);
+            const task = this.taskManager.get(id);
+            if (task) {
+                task.initClientConnection(connection);
+            } else {
+                connection.dispose();
+            }
+        });
+    }
+}

--- a/packages/task/src/node/task.ts
+++ b/packages/task/src/node/task.ts
@@ -18,6 +18,7 @@ import { injectable } from 'inversify';
 import { ILogger, Disposable, DisposableCollection, Emitter, Event, MaybePromise } from '@theia/core/lib/common/';
 import { TaskManager } from './task-manager';
 import { TaskInfo, TaskExitedEvent, TaskConfiguration, TaskOutputEvent } from '../common/task-protocol';
+import { MessageConnection } from 'vscode-jsonrpc';
 
 export interface TaskOptions {
     label: string;
@@ -47,6 +48,19 @@ export abstract class Task implements Disposable {
 
     /** Terminates the task. */
     abstract kill(): Promise<void>;
+
+    /**
+     * Initializes a connection between this task and the client.
+     *
+     * The connection may be used to provide feedback and progress monitoring
+     * to the client.  It can also be used to send  data from the client to the executing
+     * task.  Tasks do not need to create a connection with the client.
+     */
+    initClientConnection(connection: MessageConnection): void {
+        // By default, no feedback through a client connection is provided.
+        // For an example implementation of this function, see ProcessTask which
+        // connects a task based on a Process to the client.
+    }
 
     get onExit(): Event<TaskExitedEvent> {
         return this.exitEmitter.event;


### PR DESCRIPTION
I have been looking at moving various tasks into Theia's task framework.  We have a number of tasks that provide feedback to progress monitors, output channels, and other destinations in the UI.  Currently tasks that are run as processes (ie not terminals) do not provide support for extenders to do this (just start and exit messages courtesy of @elaihau in #5155).

These changes provide the required support.  The changes involved are:
- Output from processes are sent to the client.  These are converted from 'chunks' to 'lines' before sending to the client.
- Previously all tasks show a message both when the task starts and when it completes.  If a process shows alternative feedback to the user then those messages may not be wanted.  It is possible to change that behavior by rebinding TaskWatcher but that is very messy.   This code therefore outputs the start and exit messages only if no custom code is bound to the process output.
- The `kill` message is supported.  This is easily invoked from the `cancel` token in progress monitors.

I have kept the changes fairly minimal.  Ideally the 'process' and 'task' packages should be more decoupled.  For example, although 'task' depends on 'process', there is lot code in 'process' that is supporting terminals.  If that code were refactored out into the 'terminal' package then it would also be easy for extenders to extend stuff in 'process'.

ProgressManager currently maps ids to Process objects.  Ideally it would map ids to objects (eg TaskInfo)  that contain at least Process and the task type.   For many uses of Process it is not necessary to put in the ProcessManager, so it makes more sense if ProcessManager were TaskManager in the tasks package.  This would avoid the need to hook `initClientConnection` off Process as is done in this PR.

I am very happy to do the further changes too.  However I cannot do that without guidance on how I can know what is considered API that can't be changed.


