### PR TITLE
Fixed #5609: supported workspace search in dirty (unsaved) file content

### DIFF
--- a/packages/search-in-workspace/package.json
+++ b/packages/search-in-workspace/package.json
@@ -9,6 +9,7 @@
     "@theia/navigator": "^0.10.0",
     "@theia/process": "^0.10.0",
     "@theia/workspace": "^0.10.0",
+    "minimatch": "^3.0.4",
     "vscode-ripgrep": "^1.2.4"
   },
   "publishConfig": {


### PR DESCRIPTION
#### What it does
Fixed #5609.
- The `Search-in-Workspace` now can correctly search content in dirty files (file with unsaved changes).
- Search results in dirty files will be replaced in correct line and character position.
- Implemented by conducting a search in all currently tracked dirty files, before the backend ripgrep search.

#### How to test
- Open editor files in a workspace.
- Make changes in the editors without saving.
- Open `Search-in-Workspace` (`ctrl`+`shift`+`f`) and search for a certain keyword. The results should correctly reflect the current state of the dirty editors. The unsaved content in the editors should be shown in the search results, and properly highlighted in the editors.
- Try with the search options. All the `SearchInWorkspaceOptions` are supported, including:
    - [x] Match Regex (on/off)
    - [x] Match Case (on/off)
    - [x] Match Whole Word (on/off)
    - [x] Include ignored files (on/off)
    - [x] Files to include
    - [x] Files to exclude
    - [x] Maximum number of results
- Do `Replace` or `Replace All`. Matches in the dirty file (files with unsaved changes) should be replaced correctly.

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to review in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
