### PR TITLE
remove the terminal id, use the auto-generated one.

### DIFF
--- a/packages/terminal/src/browser/terminal-frontend-module.ts
+++ b/packages/terminal/src/browser/terminal-frontend-module.ts
@@ -49,12 +49,33 @@ export default new ContainerModule(bind => {
     bind(WidgetFactory).toDynamicValue(ctx => ({
         id: TERMINAL_WIDGET_FACTORY_ID,
         createWidget: (options: TerminalWidgetOptions) => {
+            let counter = terminalNum;
+            let domId = options.id || 'terminal-' + counter;
+            let termWidget: TerminalWidget | undefined;
+            if (options.id) {
+                termWidget = ctx.container.get(TerminalFrontendContribution).getById(options.id);
+                if (termWidget !== undefined) {
+                    while (termWidget !== undefined) {
+                        counter = terminalNum++;
+                        domId = 'terminal-' + counter;
+                        termWidget = ctx.container.get(TerminalFrontendContribution).getById(domId);
+                    }
+                }
+            } else {
+                counter = terminalNum++;
+                domId = 'terminal-' + counter;
+                termWidget = ctx.container.get(TerminalFrontendContribution).getById(domId);
+                while (termWidget !== undefined) {
+                    counter = terminalNum++;
+                    domId = 'terminal-' + counter;
+                    termWidget = ctx.container.get(TerminalFrontendContribution).getById(domId);
+                }
+            }
+
             const child = new Container({ defaultScope: 'Singleton' });
             child.parent = ctx.container;
-            const counter = terminalNum++;
-            const domId = options.id || 'terminal-' + counter;
             const widgetOptions: TerminalWidgetOptions = {
-                title: 'Terminal ' + counter,
+                title: domId,
                 useServerTitle: true,
                 destroyTermOnClose: true,
                 ...options


### PR DESCRIPTION
**What it does**
Fixes #5668 

The defined terminal.id was conflicting with the generated id. Now whether you start a task or open a new terminal, the id is using consecutive number

**How to test**
Start a workspace: (theia/packages/task/test-resources
Open some terminal
Start the long running test task
Check the terminal id (CTRL+ P  -> type term )
==> the list of terminal are shown with different label (terminal-<XX> )
Stop the BACK-end + restart BE + restart FE
Create new terminal  and new task and it should show different {terminal-<xx>
Start a new task (Select the long running task)
Select any other terminal
Select: Terminal-> Show running task...
Select the running task and it will show the right terminal with the running task 

**Review checklist**
 as an author, I have thoroughly tested my changes and carefully followed the review guidelines

**Reminder for reviewers**
as a reviewer, I agree to behave in accordance with the review guidelines

Signed-off-by: Jacques Bouthillier <jacques.bouthillier@ericsson.com>
