### PR TITLE
Fix the type and initial value of 'editor.quickSuggestions', fix #5227 #5228

### DIFF
--- a/packages/editor/src/browser/editor-preferences.ts
+++ b/packages/editor/src/browser/editor-preferences.ts
@@ -259,9 +259,25 @@ export const editorPreferenceSchema: PreferenceSchema = {
             'description': "Configure the editor's accessibility support."
         },
         'editor.quickSuggestions': {
-            'type': 'boolean',
-            'default': true,
-            'description': 'Enable quick suggestions (shadow suggestions).'
+            'type': ['object', 'boolean'],
+            'default': { strings: false, comments: false, other: true },
+            'properties': {
+                'strings': {
+                    'type': 'boolean',
+                    'default': false,
+                    'description': 'Enable quick suggestions inside strings.'
+                },
+                'comments': {
+                    'type': 'boolean',
+                    'default': false,
+                    'description': 'Enable quick suggestions inside comments.'
+                },
+                'other': {
+                    'type': 'boolean',
+                    'default': true,
+                    'description': 'Enable quick suggestions outside of strings and comments.'
+                },
+            }
         },
         'editor.quickSuggestionsDelay': {
             'type': 'number',
@@ -557,7 +573,7 @@ export interface EditorConfiguration {
     'editor.mouseWheelScrollSensitivity'?: number
     'editor.multiCursorModifier'?: 'ctrlCmd' | 'alt'
     'editor.accessibilitySupport'?: 'auto' | 'off' | 'on'
-    'editor.quickSuggestions'?: boolean
+    'editor.quickSuggestions'?: { other: boolean, comments: boolean, strings: boolean } | boolean;
     'editor.quickSuggestionsDelay'?: number
     'editor.suggestSelection'?: 'first' | 'recentlyUsed' | 'recentlyUsedByPrefix'
     'editor.iconsInSuggestions'?: boolean

--- a/packages/monaco/src/browser/monaco-editor-provider.ts
+++ b/packages/monaco/src/browser/monaco-editor-provider.ts
@@ -19,7 +19,7 @@ import URI from '@theia/core/lib/common/uri';
 import { EditorPreferenceChange, EditorPreferences, TextEditor, DiffNavigator, EndOfLinePreference } from '@theia/editor/lib/browser';
 import { DiffUris } from '@theia/core/lib/browser/diff-uris';
 import { inject, injectable } from 'inversify';
-import { DisposableCollection } from '@theia/core/lib/common';
+import { DisposableCollection, deepClone } from '@theia/core/lib/common';
 import { MonacoToProtocolConverter, ProtocolToMonacoConverter, TextDocumentSaveReason } from 'monaco-languageclient';
 import { MonacoCommandServiceFactory } from './monaco-command-service';
 import { MonacoContextMenuService } from './monaco-context-menu';
@@ -239,7 +239,7 @@ export class MonacoEditorProvider {
     protected createOptions(prefixes: string[], uri: string, overrideIdentifier?: string): { [name: string]: any } {
         return Object.keys(this.editorPreferences).reduce((options, preferenceName) => {
             const value = (<any>this.editorPreferences).get({ preferenceName, overrideIdentifier }, undefined, uri);
-            return this.setOption(preferenceName, value, prefixes, options);
+            return this.setOption(preferenceName, deepClone(value), prefixes, options);
         }, {});
     }
 


### PR DESCRIPTION

Signed-off-by: Brokun <brokun0128@gmail.com>

#### What it does
Fix the type and initial value of 'editor.quickSuggestions', suggestions won't be seen by default in string and comment.

#### How to test
Modifying preferences, we can now control whether suggestions should be displayed in comments and strings.

