### PR TITLE
Allow label providers to notify that changes require a refresh

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ cache:
   - dev-packages/application-manager/node_modules
   - dev-packages/application-package/node_modules
   - dev-packages/electron/node_modules
+  - examples/api-samples/node_modules
   - examples/browser/node_modules
   - examples/electron/node_modules
   - node_modules

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## v0.13.0
 
 - [core] Switched the frontend application's shutdown hook from `window.unload` to `window.beforeunload`. [#6530](https://github.com/eclipse-theia/theia/issues/6530)
+- [core] label providers can now notify that element labels and icons may have changed and should be refreshed [#5884](https://github.com/theia-ide/theia/pull/5884)
 - [scm] added handling when opening diff-editors to respect preference `workbench.list.openMode` [#6481](https://github.com/eclipse-theia/theia/pull/6481)
 
 Breaking changes:

--- a/examples/api-samples/README.md
+++ b/examples/api-samples/README.md
@@ -1,0 +1,9 @@
+# Theia - Examples - API Samples - Label Provider
+
+This package contains examples of how to use Theia's internal API.  The examples here can provide code that enables new features to be tested.  The examples also show how to use certain API.
+
+The examples here are all deactivated by default.  Commands are provided that toggles on the example behavior.  These commands are prefixed with "API Sample".
+
+## License
+- [Eclipse Public License 2.0](http://www.eclipse.org/legal/epl-2.0/)
+- [一 (Secondary) GNU General Public License, version 2 with the GNU Classpath Exception](https://projects.eclipse.org/license/secondary-gpl-2.0-cp)

--- a/examples/api-samples/compile.tsconfig.json
+++ b/examples/api-samples/compile.tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../configs/base.tsconfig",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "lib"
+  },
+  "include": [
+    "src"
+  ]
+}

--- a/examples/api-samples/package.json
+++ b/examples/api-samples/package.json
@@ -1,0 +1,39 @@
+{
+  "private": true,
+  "name": "@theia/api-samples",
+  "version": "0.12.0",
+  "description": "Theia - Example code to demonstrate Theia API",
+  "dependencies": {
+    "@theia/core": "^0.12.0"
+  },
+  "theiaExtensions": [
+    {
+      "frontend": "lib/browser/api-samples-frontend-module"
+    }
+  ],
+  "keywords": [
+    "theia-extension"
+  ],
+  "license": "EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/eclipse-theia/theia.git"
+  },
+  "bugs": {
+    "url": "https://github.com/eclipse-theia/theia/issues"
+  },
+  "homepage": "https://github.com/eclipse-theia/theia",
+  "files": [
+    "lib",
+    "src"
+  ],
+  "scripts": {
+    "prepare": "yarn run clean && yarn run build",
+    "clean": "theiaext clean",
+    "build": "theiaext build",
+    "watch": "theiaext watch"
+  },
+  "devDependencies": {
+    "@theia/ext-scripts": "^0.12.0"
+  }
+}

--- a/examples/api-samples/src/browser/api-samples-contribution.ts
+++ b/examples/api-samples/src/browser/api-samples-contribution.ts
@@ -1,0 +1,55 @@
+/********************************************************************************
+ * Copyright (C) 2019 Arm and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import { injectable, inject } from 'inversify';
+import { Command, CommandContribution, CommandRegistry, CommandHandler } from '@theia/core';
+import { FrontendApplicationContribution } from '@theia/core/lib/browser';
+import { SampleDynamicLabelProviderContribution } from './sample-dynamic-label-provider-contribution';
+
+export namespace ExampleLabelProviderCommands {
+    const EXAMPLE_CATEGORY = 'Examples';
+    export const TOGGLE_SAMPLE: Command = {
+        id: 'example_label_provider.toggle',
+        category: EXAMPLE_CATEGORY,
+        label: 'Toggle Dynamically-Changing Labels'
+    };
+}
+
+@injectable()
+export class ApiSamplesContribution implements FrontendApplicationContribution, CommandContribution {
+
+    @inject(SampleDynamicLabelProviderContribution)
+    protected readonly labelProviderContribution: SampleDynamicLabelProviderContribution;
+
+    initialize(): void { }
+
+    registerCommands(commands: CommandRegistry): void {
+        commands.registerCommand(ExampleLabelProviderCommands.TOGGLE_SAMPLE, new ExampleLabelProviderCommandHandler(this.labelProviderContribution));
+    }
+
+}
+
+export class ExampleLabelProviderCommandHandler implements CommandHandler {
+
+    constructor(private readonly labelProviderContribution: SampleDynamicLabelProviderContribution) {
+    }
+
+    // tslint:disable-next-line:no-any
+    execute(...args: any[]): any {
+        this.labelProviderContribution.toggle();
+    }
+
+}

--- a/examples/api-samples/src/browser/api-samples-frontend-module.ts
+++ b/examples/api-samples/src/browser/api-samples-frontend-module.ts
@@ -1,0 +1,28 @@
+/********************************************************************************
+ * Copyright (C) 2019 Arm and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import { ContainerModule } from 'inversify';
+import { CommandContribution } from '@theia/core';
+import { LabelProviderContribution } from '@theia/core/lib/browser/label-provider';
+import { ApiSamplesContribution } from './api-samples-contribution';
+import { SampleDynamicLabelProviderContribution } from './sample-dynamic-label-provider-contribution';
+
+export default new ContainerModule(bind => {
+    bind(CommandContribution).to(ApiSamplesContribution).inSingletonScope();
+
+    bind(SampleDynamicLabelProviderContribution).toSelf().inSingletonScope();
+    bind(LabelProviderContribution).toService(SampleDynamicLabelProviderContribution);
+});

--- a/examples/api-samples/src/browser/sample-dynamic-label-provider-contribution.ts
+++ b/examples/api-samples/src/browser/sample-dynamic-label-provider-contribution.ts
@@ -1,0 +1,91 @@
+/********************************************************************************
+ * Copyright (C) 2019 Arm and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import { DefaultUriLabelProviderContribution, DidChangeLabelEvent, FILE_ICON } from '@theia/core/lib/browser/label-provider';
+import URI from '@theia/core/lib/common/uri';
+import { injectable } from 'inversify';
+import { Emitter, Event } from '@theia/core';
+
+@injectable()
+export class SampleDynamicLabelProviderContribution extends DefaultUriLabelProviderContribution {
+
+    protected isActive: boolean = false;
+
+    constructor() {
+        super();
+        const outer = this;
+
+        setInterval(() => {
+            if (this.isActive) {
+                outer.x++;
+                outer.fireLabelsDidChange();
+            }
+        }, 1000);
+    }
+
+    canHandle(element: object): number {
+        if (element.toString().includes('test')) {
+            return 30;
+        }
+        return 0;
+    }
+
+    toggle(): void {
+        this.isActive = !this.isActive;
+        this.fireLabelsDidChange();
+    }
+
+    private fireLabelsDidChange(): void {
+        this.onDidChangeEmitter.fire({
+            affects: (element: URI) => element.toString().includes('test')
+        });
+    }
+
+    private getUri(element: URI): URI {
+        return new URI(element.toString());
+    }
+
+    async getIcon(element: URI): Promise<string> {
+        const uri = this.getUri(element);
+        const icon = super.getFileIcon(uri);
+        if (!icon) {
+            return FILE_ICON;
+        }
+        return icon;
+    }
+
+    protected readonly onDidChangeEmitter = new Emitter<DidChangeLabelEvent>();
+    private x: number = 0;
+
+    getName(element: URI): string {
+        const uri = this.getUri(element);
+        if (this.isActive && uri.toString().includes('test')) {
+            return super.getName(uri) + '-' + this.x.toString(10);
+        } else {
+            return super.getName(uri);
+        }
+    }
+
+    getLongName(element: URI): string {
+        const uri = this.getUri(element);
+        return super.getLongName(uri);
+    }
+
+    get onDidChange(): Event<DidChangeLabelEvent> {
+        return this.onDidChangeEmitter.event;
+    }
+
+}

--- a/examples/browser/package.json
+++ b/examples/browser/package.json
@@ -14,6 +14,7 @@
     }
   },
   "dependencies": {
+    "@theia/api-samples": "^0.12.0",
     "@theia/callhierarchy": "^0.12.0",
     "@theia/console": "^0.12.0",
     "@theia/core": "^0.12.0",

--- a/examples/electron/package.json
+++ b/examples/electron/package.json
@@ -12,6 +12,7 @@
     }
   },
   "dependencies": {
+    "@theia/api-samples": "^0.12.0",
     "@theia/callhierarchy": "^0.12.0",
     "@theia/console": "^0.12.0",
     "@theia/core": "^0.12.0",

--- a/packages/callhierarchy/src/browser/callhierarchy-tree/callhierarchy-tree-widget.tsx
+++ b/packages/callhierarchy/src/browser/callhierarchy-tree/callhierarchy-tree-widget.tsx
@@ -59,6 +59,9 @@ export class CallHierarchyTreeWidget extends TreeWidget {
         this.toDispose.push(this.model.onOpenNode((node: TreeNode) => {
             this.openEditor(node, false);
         }));
+        this.toDispose.push(
+            this.labelProvider.onDidChange(() => this.update())
+        );
     }
 
     initializeModel(selection: Location | undefined, languageId: string | undefined): void {

--- a/packages/core/src/browser/diff-uris.ts
+++ b/packages/core/src/browser/diff-uris.ts
@@ -102,4 +102,9 @@ export class DiffUriLabelProviderContribution implements LabelProviderContributi
     getIcon(uri: URI): string {
         return 'fa fa-columns';
     }
+
+    getConstituentUris(uri: URI): URI[] {
+        return DiffUris.decode(uri);
+    }
+
 }

--- a/packages/core/src/browser/label-provider.ts
+++ b/packages/core/src/browser/label-provider.ts
@@ -19,6 +19,7 @@ import * as fileIcons from 'file-icons-js';
 import URI from '../common/uri';
 import { ContributionProvider } from '../common/contribution-provider';
 import { Prioritizeable, MaybePromise } from '../common/types';
+import { Event, Emitter } from '../common';
 
 export const FOLDER_ICON = 'fa fa-folder';
 export const FILE_ICON = 'fa fa-file';
@@ -48,6 +49,17 @@ export interface LabelProviderContribution {
      */
     getLongName?(element: object): string;
 
+    /**
+     * Emit when something has changed that may result in this label provider returning a different
+     * value for one or more properties (name, icon etc).
+     */
+    readonly onDidChange?: Event<DidChangeLabelEvent>;
+
+    readonly getConstituentUris?: (compositeElement: object) => URI[];
+}
+
+export interface DidChangeLabelEvent {
+    affects(element: object): boolean;
 }
 
 @injectable()
@@ -88,10 +100,67 @@ export class DefaultUriLabelProviderContribution implements LabelProviderContrib
 @injectable()
 export class LabelProvider {
 
+    protected readonly onDidChangeEmitter = new Emitter<DidChangeLabelEvent>();
+
     constructor(
         @inject(ContributionProvider) @named(LabelProviderContribution)
         protected readonly contributionProvider: ContributionProvider<LabelProviderContribution>
-    ) { }
+    ) {
+        const contributions = this.contributionProvider.getContributions();
+        for (const contribution of contributions) {
+            if (contribution.onDidChange) {
+                contribution.onDidChange(event => {
+                    const affects = (uri: URI) => this.affects(uri, event, contribution);
+                    this.onDidChangeEmitter.fire({ affects });
+                });
+            }
+        }
+    }
+
+    /**
+     * When the given event occurs, determine if the given URI could in any
+     * way be affected.
+     *
+     * If the event directly indicates that it affects the URI then of course we
+     * return `true`.  However there may be label provider contributions that delegate
+     * back to the label provider.  These contributors do not, and should not, listen for
+     * label provider events because that would cause infinite recursion.
+     *
+     * @param uri
+     * @param event
+     */
+    protected affects(element: object, event: DidChangeLabelEvent, originatingContribution: LabelProviderContribution): boolean {
+
+        const contribs = this.findContribution(element);
+        const possibleContribsWithDups = [
+            contribs.find(c => c.getIcon !== undefined),
+            contribs.find(c => c.getName !== undefined),
+            contribs.find(c => c.getLongName !== undefined),
+        ];
+        const possibleContribsWithoutDups = [...new Set(possibleContribsWithDups)];
+        for (const possibleContrib of possibleContribsWithoutDups) {
+            if (possibleContrib) {
+                if (possibleContrib === originatingContribution) {
+                    if (event.affects(element)) {
+                        return true;
+                    }
+                }
+                if (possibleContrib.getConstituentUris) {
+                    const constituentUris: URI[] = possibleContrib.getConstituentUris(element);
+                    for (const constituentUri of constituentUris) {
+                        if (this.affects(constituentUri, event, originatingContribution)) {
+                            return true;
+                        }
+                    }
+                }
+            }
+        }
+        return false;
+    }
+
+    get onDidChange(): Event<DidChangeLabelEvent> {
+        return this.onDidChangeEmitter.event;
+    }
 
     async getIcon(element: object): Promise<string> {
         const contribs = this.findContribution(element);
@@ -117,7 +186,7 @@ export class LabelProvider {
         if (!contrib) {
             return '';
         }
-        return contrib!.getLongName!(element);
+        return contrib.getLongName!(element);
     }
 
     protected findContribution(element: object): LabelProviderContribution[] {
@@ -126,5 +195,4 @@ export class LabelProvider {
         );
         return prioritized.map(c => c.value);
     }
-
 }

--- a/packages/core/src/browser/tree/tree.ts
+++ b/packages/core/src/browser/tree/tree.ts
@@ -15,7 +15,7 @@
  ********************************************************************************/
 
 import { injectable } from 'inversify';
-import { Event, Emitter, Disposable, DisposableCollection, WaitUntilEvent } from '../../common';
+import { Event, Emitter, Disposable, DisposableCollection, WaitUntilEvent, Mutable } from '../../common';
 
 export const Tree = Symbol('Tree');
 
@@ -206,7 +206,7 @@ export class TreeImpl implements Tree {
     protected readonly toDispose = new DisposableCollection();
 
     protected nodes: {
-        [id: string]: TreeNode | undefined
+        [id: string]: Mutable<TreeNode> | undefined
     } = {};
 
     constructor() {

--- a/packages/debug/src/browser/debug-session-manager.ts
+++ b/packages/debug/src/browser/debug-session-manager.ts
@@ -147,6 +147,14 @@ export class DebugSessionManager {
         this.debugTypeKey = this.contextKeyService.createKey<string>('debugType', undefined);
         this.inDebugModeKey = this.contextKeyService.createKey<boolean>('inDebugMode', this.inDebugMode);
         this.breakpoints.onDidChangeMarkers(uri => this.fireDidChangeBreakpoints({ uri }));
+        this.labelProvider.onDidChange(event => {
+            for (const uriString of this.breakpoints.getUris()) {
+                const uri = new URI(uriString);
+                if (event.affects(uri)) {
+                    this.fireDidChangeBreakpoints({ uri });
+                }
+            }
+        });
     }
 
     get inDebugMode(): boolean {

--- a/packages/editor/src/browser/editor-widget.ts
+++ b/packages/editor/src/browser/editor-widget.ts
@@ -14,7 +14,7 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
-import { Disposable, SelectionService } from '@theia/core/lib/common';
+import { Disposable, SelectionService, Event } from '@theia/core/lib/common';
 import { Widget, BaseWidget, Message, Saveable, SaveableSource, Navigatable, StatefulWidget } from '@theia/core/lib/browser';
 import URI from '@theia/core/lib/common/uri';
 import { TextEditor } from './editor';
@@ -82,6 +82,10 @@ export class EditorWidget extends BaseWidget implements SaveableSource, Navigata
 
     restoreState(oldState: object): void {
         this.editor.restoreViewState(oldState);
+    }
+
+    get onDispose(): Event<void> {
+        return this.toDispose.onDispose;
     }
 
 }

--- a/packages/git/src/browser/diff/git-diff-widget.tsx
+++ b/packages/git/src/browser/diff/git-diff-widget.tsx
@@ -68,6 +68,12 @@ export class GitDiffWidget extends GitNavigableListWidget<GitFileChangeNode> imp
                 this.setContent(this.options);
             }
         }));
+        this.toDispose.push(this.labelProvider.onDidChange(event => {
+            const affectsFiles = this.fileChangeNodes.some(node => event.affects(new URI(node.uri)));
+            if (this.options && affectsFiles) {
+                this.setContent(this.options);
+            }
+        }));
     }
 
     protected getScrollContainer(): MaybePromise<HTMLElement> {

--- a/packages/git/src/browser/git-uri-label-contribution.ts
+++ b/packages/git/src/browser/git-uri-label-contribution.ts
@@ -23,7 +23,7 @@ import { MaybePromise } from '@theia/core';
 @injectable()
 export class GitUriLabelProviderContribution implements LabelProviderContribution {
 
-    constructor( @inject(LabelProvider) protected labelProvider: LabelProvider) {
+    constructor(@inject(LabelProvider) protected labelProvider: LabelProvider) {
     }
 
     canHandle(element: object): number {
@@ -43,6 +43,14 @@ export class GitUriLabelProviderContribution implements LabelProviderContributio
 
     getIcon(uri: URI): MaybePromise<string> {
         return this.labelProvider.getIcon(this.toFileUri(uri));
+    }
+
+    getConstituentUris(element: URI): URI[] {
+        const fileUri = this.toFileUri(element);
+        return [
+            fileUri,
+            fileUri.withoutQuery().withoutFragment(),
+        ];
     }
 
     protected toFileUri(uri: URI): URI {

--- a/packages/markers/src/browser/marker-tree.ts
+++ b/packages/markers/src/browser/marker-tree.ts
@@ -39,6 +39,24 @@ export abstract class MarkerTree<T extends object> extends TreeImpl {
         super();
 
         this.toDispose.push(markerManager.onDidChangeMarkers(uri => this.refreshMarkerInfo(uri)));
+        this.toDispose.push(labelProvider.onDidChange(async event => {
+            let isAnyAffectedNodes = false;
+            for (const nodeId of Object.keys(this.nodes)) {
+                const node = this.nodes[nodeId];
+                const markerInfoNode = node;
+                if (node && MarkerInfoNode.is(markerInfoNode)) {
+                    const uri = markerInfoNode.uri;
+                    if (event.affects(uri)) {
+                        node.name = this.labelProvider.getName(uri);
+                        node.icon = await this.labelProvider.getIcon(uri);
+                        isAnyAffectedNodes = true;
+                    }
+                }
+            }
+            if (isAnyAffectedNodes) {
+                this.fireChanged();
+            }
+        }));
 
         this.root = <MarkerRootNode>{
             visible: false,

--- a/packages/navigator/src/browser/navigator-tree.spec.ts
+++ b/packages/navigator/src/browser/navigator-tree.spec.ts
@@ -69,6 +69,7 @@ describe('FileNavigatorTree', () => {
     let mockLabelProvider: LabelProvider;
 
     const mockFilterChangeEmitter: Emitter<void> = new Emitter();
+    const mockLabelChangeEmitter: Emitter<void> = new Emitter();
 
     let navigatorTree: FileNavigatorTree;
 
@@ -91,6 +92,7 @@ describe('FileNavigatorTree', () => {
         testContainer.bind(LabelProvider).toConstantValue(mockLabelProvider);
 
         sinon.stub(mockFileNavigatorFilter, 'onFilterChanged').value(mockFilterChangeEmitter.event);
+        sinon.stub(mockLabelProvider, 'onDidChange').value(mockLabelChangeEmitter.event);
         setup();
 
         navigatorTree = testContainer.get<FileNavigatorTree>(FileNavigatorTree);

--- a/packages/navigator/src/browser/navigator-tree.ts
+++ b/packages/navigator/src/browser/navigator-tree.ts
@@ -28,6 +28,7 @@ export class FileNavigatorTree extends FileTree {
 
     @postConstruct()
     protected init(): void {
+        super.initFileTree();
         this.toDispose.push(this.filter.onFilterChanged(() => this.refresh()));
     }
 

--- a/packages/scm/src/browser/scm-contribution.ts
+++ b/packages/scm/src/browser/scm-contribution.ts
@@ -93,6 +93,7 @@ export class ScmContribution extends AbstractViewContribution<ScmWidget> impleme
         this.scmService.onDidRemoveRepository(() => this.updateStatusBar());
         this.scmService.onDidChangeSelectedRepository(() => this.updateStatusBar());
         this.scmService.onDidChangeStatusBarCommands(() => this.updateStatusBar());
+        this.labelProvider.onDidChange(() => this.updateStatusBar());
 
         this.updateContextKeys();
         this.shell.currentChanged.connect(() => this.updateContextKeys());

--- a/packages/scm/src/browser/scm-widget.tsx
+++ b/packages/scm/src/browser/scm-widget.tsx
@@ -88,6 +88,7 @@ export class ScmWidget extends ReactWidget implements StatefulWidget {
     protected init(): void {
         this.refresh();
         this.toDispose.push(this.scmService.onDidChangeSelectedRepository(() => this.refresh()));
+        this.toDispose.push(this.labelProvider.onDidChange(() => this.update()));
     }
 
     protected readonly toDisposeOnRefresh = new DisposableCollection();

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -129,6 +129,9 @@
       ],
       "@theia/task/lib/*": [
         "packages/task/src/*"
+      ],
+      "@theia/api-samples/lib/*": [
+        "examples/api-samples/src/*"
       ]
     },
     "plugins": [
@@ -140,6 +143,7 @@
   "include": [
     "dev-packages/*/src",
     "packages/*/src",
+    "examples/*/src",
     "examples/*/test"
   ]
 }


### PR DESCRIPTION
Currently label providers can provide names, descriptions, and icons.  However the result is cached so once the provider has provided a property, the tree cannot be refreshed with a changed value.

We need to be able to refresh the navigation tree with changed values because we have an icon we set to a directory, but the icon depends on other files next to the directory.  These other files may change and this requires updating the icon for the directory.  Note that the Eclipse label providers provide a listener so that label providers can notify the UI components that they must refresh (see https://help.eclipse.org/neon/topic/org.eclipse.platform.doc.isv/reference/api/org/eclipse/jface/viewers/IBaseLabelProvider.html#addListener-org.eclipse.jface.viewers.ILabelProviderListener- ).  The navigation tree already has an emitter to force a refresh so it is not that much more code to connect this to the label providers.

#### How to test
There is no easy way to test this.  I have tested it in our application where I can rename a file back and forth and see the icon for a folder change back and forth.

To test it, one would have to modify a label provider to provide a name or icon that depends on something other than the uri.  Perhaps it could depend on the existence of another file.  Then add a file watcher to the label provider and fire the event.  Here are some bits of code that may help:

```
import { FileChangeType, FileSystemWatcher } from '@theia/filesystem/lib/browser';
```
and
```
    protected readonly onElementUpdatedEmitter = new Emitter<URI>();
```
and

```
        @inject(FileSystem) protected fileSystem: FileSystem;
        @inject(FileSystemWatcher) protected readonly fileWatcher: FileSystemWatcher;
```
and code to put in init:
```
        this.fileWatcher.onFilesChanged(async changes => {
            for (const change of changes) {
                const uriString = change.uri.toString();
                if (uriString.endsWith('.foo')
                    && (change.type === FileChangeType.ADDED
                        || change.type === FileChangeType.DELETED)) {
                    const fooUri = uriString.substring(0, uriString.length - 4);
                    this.onElementUpdatedEmitter.fire(new URI(fooUri));
                }
            }
        });
```
which will need this
```
    get onElementUpdated(): Event<URI> {
        return this.onElementUpdatedEmitter.event;
    }
```
and the code to get the name could be something like:
```
   public async getName(element: URI | FileStat): Promise<string> {
         let name = <previous way of getting name>;
         const elementUri = this.getUri(element);
          const elementStat = await this.getStat(element);
          if (elementStat && elementStat.isDirectory) {
            const fooFileUri = `${elementStat.uri}.foo`;
            const fooFileStat = await this.fileSystem.getFileStat(fooFileUri);
            if (fooFileStat) {
                name = name + '-with-foo';
            }
            return name;
    }
```
Sorry, it's a lot of work to test.  Alternatively just test that nothing is broken with this PR which will not require any extra code.

#### Review checklist

- [x ] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
