### PR TITLE
POC: Use peer dependencies for @theia dependencies

### DIFF
--- a/dev-packages/application-package/src/extension-package-collector.ts
+++ b/dev-packages/application-package/src/extension-package-collector.ts
@@ -36,13 +36,19 @@ export class ExtensionPackageCollector {
     }
 
     protected collectPackages(pck: NodePackage): void {
-        if (!pck.dependencies) {
-            return;
+        if (pck.peerDependencies) {
+            // tslint:disable-next-line:forin
+            for (const dependency in pck.peerDependencies) {
+                const versionRange = pck.peerDependencies[dependency]!;
+                this.collectPackage(dependency, versionRange);
+            }
         }
-        // tslint:disable-next-line:forin
-        for (const dependency in pck.dependencies) {
-            const versionRange = pck.dependencies[dependency]!;
-            this.collectPackage(dependency, versionRange);
+        if (pck.dependencies) {
+            // tslint:disable-next-line:forin
+            for (const dependency in pck.dependencies) {
+                const versionRange = pck.dependencies[dependency]!;
+                this.collectPackage(dependency, versionRange);
+            }
         }
     }
 

--- a/dev-packages/application-package/src/npm-registry.ts
+++ b/dev-packages/application-package/src/npm-registry.ts
@@ -46,6 +46,7 @@ export interface NodePackage {
     author?: string | Author;
     maintainers?: Maintainer[];
     keywords?: string[];
+    peerDependencies?: Dependencies;
     dependencies?: Dependencies;
     [property: string]: any;
 }

--- a/packages/bunyan/package.json
+++ b/packages/bunyan/package.json
@@ -2,8 +2,10 @@
   "name": "@theia/bunyan",
   "version": "0.9.0",
   "description": "Theia - bunyan Logger Extension",
+  "peerDependencies": {
+    "@theia/core": "^0.9.0"
+  },
   "dependencies": {
-    "@theia/core": "^0.9.0",
     "@types/bunyan": "^1.8.0",
     "bunyan": "^1.8.10"
   },
@@ -39,7 +41,8 @@
     "test": "theiaext test"
   },
   "devDependencies": {
-    "@theia/ext-scripts": "^0.9.0"
+    "@theia/ext-scripts": "*",
+    "@theia/core": "*"
   },
   "nyc": {
     "extends": "../../configs/nyc.json"

--- a/packages/callhierarchy/package.json
+++ b/packages/callhierarchy/package.json
@@ -2,11 +2,13 @@
   "name": "@theia/callhierarchy",
   "version": "0.9.0",
   "description": "Theia - Call Hierarchy Extension",
-  "dependencies": {
+  "peerDependencies": {
     "@theia/core": "^0.9.0",
     "@theia/editor": "^0.9.0",
     "@theia/languages": "^0.9.0",
-    "@theia/monaco": "^0.9.0",
+    "@theia/monaco": "^0.9.0"
+  },
+  "dependencies": {
     "ts-md5": "^1.2.2"
   },
   "publishConfig": {
@@ -41,7 +43,11 @@
     "test": "theiaext test"
   },
   "devDependencies": {
-    "@theia/ext-scripts": "^0.9.0"
+    "@theia/core": "*",
+    "@theia/editor": "*",
+    "@theia/ext-scripts": "*",
+    "@theia/languages": "*",
+    "@theia/monaco": "*"
   },
   "nyc": {
     "extends": "../../configs/nyc.json"

--- a/packages/console/package.json
+++ b/packages/console/package.json
@@ -2,9 +2,11 @@
   "name": "@theia/console",
   "version": "0.9.0",
   "description": "Theia - Console Extension",
-  "dependencies": {
+  "peerDependencies": {
     "@theia/core": "^0.9.0",
-    "@theia/monaco": "^0.9.0",
+    "@theia/monaco": "^0.9.0"
+  },
+  "dependencies": {
     "anser": "^1.4.7"
   },
   "publishConfig": {
@@ -39,7 +41,9 @@
     "test": "theiaext test"
   },
   "devDependencies": {
-    "@theia/ext-scripts": "^0.9.0"
+    "@theia/core": "*",
+    "@theia/ext-scripts": "*",
+    "@theia/monaco": "*"
   },
   "nyc": {
     "extends": "../../configs/nyc.json"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -4,10 +4,12 @@
   "description": "Theia is a cloud & desktop IDE framework implemented in TypeScript.",
   "main": "lib/common/index.js",
   "typings": "lib/common/index.d.ts",
+  "peerDependencies": {
+    "@theia/application-package": "^0.9.0"
+  },
   "dependencies": {
     "@phosphor/widgets": "^1.5.0",
     "@primer/octicons-react": "^9.0.0",
-    "@theia/application-package": "^0.9.0",
     "@types/body-parser": "^1.16.4",
     "@types/bunyan": "^1.8.0",
     "@types/express": "^4.16.0",
@@ -91,7 +93,8 @@
     "generate-layout": "electron ./scripts/generate-layout"
   },
   "devDependencies": {
-    "@theia/ext-scripts": "^0.9.0",
+    "@theia/application-package": "*",
+    "@theia/ext-scripts": "*",
     "minimist": "^1.2.0"
   },
   "nyc": {

--- a/packages/cpp/package.json
+++ b/packages/cpp/package.json
@@ -2,7 +2,7 @@
   "name": "@theia/cpp",
   "version": "0.9.0",
   "description": "Theia - Cpp Extension",
-  "dependencies": {
+  "peerDependencies": {
     "@theia/core": "^0.9.0",
     "@theia/editor": "^0.9.0",
     "@theia/filesystem": "^0.9.0",
@@ -12,7 +12,9 @@
     "@theia/process": "^0.9.0",
     "@theia/task": "^0.9.0",
     "@theia/workspace": "^0.9.0",
-    "@theia/variable-resolver": "0.9.0",
+    "@theia/variable-resolver": "0.9.0"
+  },
+  "dependencies": {
     "string-argv": "^0.1.1"
   },
   "publishConfig": {
@@ -49,7 +51,17 @@
     "test": "theiaext test"
   },
   "devDependencies": {
-    "@theia/ext-scripts": "^0.9.0"
+    "@theia/core": "*",
+    "@theia/editor": "*",
+    "@theia/ext-scripts": "*",
+    "@theia/filesystem": "*",
+    "@theia/languages": "*",
+    "@theia/monaco": "*",
+    "@theia/preferences": "*",
+    "@theia/process": "*",
+    "@theia/task": "*",
+    "@theia/workspace": "*",
+    "@theia/variable-resolver": "*"
   },
   "nyc": {
     "extends": "../../configs/nyc.json"

--- a/packages/debug-nodejs/package.json
+++ b/packages/debug-nodejs/package.json
@@ -2,8 +2,10 @@
   "name": "@theia/debug-nodejs",
   "version": "0.9.0",
   "description": "Theia - NodeJS Debug Extension",
+  "peerDependencies": {
+    "@theia/debug": "^0.9.0"
+  },
   "dependencies": {
-    "@theia/debug": "^0.9.0",
     "ps-list": "5.0.1",
     "vscode-debugprotocol": "^1.32.0"
   },
@@ -43,7 +45,8 @@
     "test": "theiaext test"
   },
   "devDependencies": {
-    "@theia/ext-scripts": "^0.9.0"
+    "@theia/debug": "*",
+    "@theia/ext-scripts": "*"
   },
   "nyc": {
     "extends": "../../configs/nyc.json"

--- a/packages/debug/package.json
+++ b/packages/debug/package.json
@@ -2,7 +2,7 @@
   "name": "@theia/debug",
   "version": "0.9.0",
   "description": "Theia - Debug Extension",
-  "dependencies": {
+  "peerDependencies": {
     "@theia/application-package": "^0.9.0",
     "@theia/console": "^0.9.0",
     "@theia/core": "^0.9.0",
@@ -18,7 +18,9 @@
     "@theia/terminal": "^0.9.0",
     "@theia/userstorage": "^0.9.0",
     "@theia/variable-resolver": "^0.9.0",
-    "@theia/workspace": "^0.9.0",
+    "@theia/workspace": "^0.9.0"
+  },
+  "dependencies": {
     "@types/p-debounce": "^1.0.1",
     "jsonc-parser": "^2.0.2",
     "mkdirp": "^0.5.0",
@@ -66,7 +68,23 @@
     "test": "theiaext test"
   },
   "devDependencies": {
-    "@theia/ext-scripts": "^0.9.0"
+    "@theia/application-package": "*",
+    "@theia/console": "*",
+    "@theia/core": "*",
+    "@theia/editor": "*",
+    "@theia/ext-scripts": "*",
+    "@theia/filesystem": "*",
+    "@theia/json": "*",
+    "@theia/languages": "*",
+    "@theia/markers": "*",
+    "@theia/monaco": "*",
+    "@theia/output": "*",
+    "@theia/preferences": "*",
+    "@theia/process": "*",
+    "@theia/terminal": "*",
+    "@theia/userstorage": "*",
+    "@theia/variable-resolver": "*",
+    "@theia/workspace": "*"
   },
   "nyc": {
     "extends": "../../configs/nyc.json"

--- a/packages/editor-preview/package.json
+++ b/packages/editor-preview/package.json
@@ -2,10 +2,12 @@
   "name": "@theia/editor-preview",
   "version": "0.9.0",
   "description": "Theia - Editor Preview Extension",
-  "dependencies": {
+  "peerDependencies": {
     "@theia/core": "^0.9.0",
     "@theia/editor": "^0.9.0",
     "@theia/navigator": "^0.9.0"
+  },
+  "dependencies": {
   },
   "publishConfig": {
     "access": "public"
@@ -39,7 +41,10 @@
     "test": "theiaext test"
   },
   "devDependencies": {
-    "@theia/ext-scripts": "^0.9.0"
+    "@theia/core": "*",
+    "@theia/editor": "*",
+    "@theia/ext-scripts": "*",
+    "@theia/navigator": "*"
   },
   "nyc": {
     "extends": "../../configs/nyc.json"

--- a/packages/editor/package.json
+++ b/packages/editor/package.json
@@ -2,10 +2,12 @@
   "name": "@theia/editor",
   "version": "0.9.0",
   "description": "Theia - Editor Extension",
-  "dependencies": {
+  "peerDependencies": {
     "@theia/core": "^0.9.0",
     "@theia/languages": "^0.9.0",
-    "@theia/variable-resolver": "^0.9.0",
+    "@theia/variable-resolver": "^0.9.0"
+  },
+  "dependencies": {
     "@types/base64-arraybuffer": "0.1.0",
     "base64-arraybuffer": "^0.1.5"
   },
@@ -41,7 +43,10 @@
     "test": "theiaext test"
   },
   "devDependencies": {
-    "@theia/ext-scripts": "^0.9.0"
+    "@theia/core": "*",
+    "@theia/ext-scripts": "*",
+    "@theia/languages": "*",
+    "@theia/variable-resolver": "*"
   },
   "nyc": {
     "extends": "../../configs/nyc.json"

--- a/packages/editorconfig/package.json
+++ b/packages/editorconfig/package.json
@@ -2,11 +2,13 @@
   "name": "@theia/editorconfig",
   "version": "0.9.0",
   "description": "Theia - Editorconfig Extension",
-  "dependencies": {
+  "peerDependencies": {
     "@theia/core": "^0.9.0",
     "@theia/editor": "^0.9.0",
     "@theia/languages": "^0.9.0",
-    "@theia/monaco": "^0.9.0",
+    "@theia/monaco": "^0.9.0"
+  },
+  "dependencies": {
     "editorconfig": "^0.15.0"
   },
   "publishConfig": {
@@ -42,7 +44,11 @@
     "test": "theiaext test"
   },
   "devDependencies": {
-    "@theia/ext-scripts": "^0.9.0"
+    "@theia/core": "*",
+    "@theia/editor": "*",
+    "@theia/ext-scripts": "*",
+    "@theia/languages": "*",
+    "@theia/monaco": "*"
   },
   "nyc": {
     "extends": "../../configs/nyc.json"

--- a/packages/extension-manager/package.json
+++ b/packages/extension-manager/package.json
@@ -2,11 +2,13 @@
   "name": "@theia/extension-manager",
   "version": "0.9.0",
   "description": "Theia - Extension Manager",
-  "dependencies": {
+  "peerDependencies": {
     "@theia/application-manager": "^0.9.0",
     "@theia/application-package": "^0.9.0",
     "@theia/core": "^0.9.0",
-    "@theia/filesystem": "^0.9.0",
+    "@theia/filesystem": "^0.9.0"
+  },
+  "dependencies": {
     "@types/request": "^2.0.3",
     "@types/sanitize-html": "^1.13.31",
     "@types/showdown": "^1.7.1",
@@ -47,7 +49,11 @@
     "test": "theiaext test"
   },
   "devDependencies": {
-    "@theia/ext-scripts": "^0.9.0"
+    "@theia/application-manager": "*",
+    "@theia/application-package": "*",
+    "@theia/core": "*",
+    "@theia/ext-scripts": "*",
+    "@theia/filesystem": "*"
   },
   "nyc": {
     "extends": "../../configs/nyc.json"

--- a/packages/file-search/package.json
+++ b/packages/file-search/package.json
@@ -2,12 +2,14 @@
   "name": "@theia/file-search",
   "version": "0.9.0",
   "description": "Theia - File Search Extension",
-  "dependencies": {
+  "peerDependencies": {
     "@theia/core": "^0.9.0",
     "@theia/editor": "^0.9.0",
     "@theia/filesystem": "^0.9.0",
     "@theia/process": "^0.9.0",
-    "@theia/workspace": "^0.9.0",
+    "@theia/workspace": "^0.9.0"
+  },
+  "dependencies": {
     "fuzzy": "^0.1.3",
     "vscode-ripgrep": "^1.2.4"
   },
@@ -44,7 +46,12 @@
     "test": "theiaext test"
   },
   "devDependencies": {
-    "@theia/ext-scripts": "^0.9.0"
+    "@theia/core": "*",
+    "@theia/editor": "*",
+    "@theia/ext-scripts": "*",
+    "@theia/filesystem": "*",
+    "@theia/process": "*",
+    "@theia/workspace": "*"
   },
   "nyc": {
     "extends": "../../configs/nyc.json"

--- a/packages/filesystem/package.json
+++ b/packages/filesystem/package.json
@@ -2,9 +2,11 @@
   "name": "@theia/filesystem",
   "version": "0.9.0",
   "description": "Theia - FileSystem Extension",
-  "dependencies": {
+  "peerDependencies": {
     "@theia/application-package": "^0.9.0",
-    "@theia/core": "^0.9.0",
+    "@theia/core": "^0.9.0"
+  },
+  "dependencies": {
     "@types/body-parser": "^1.17.0",
     "@types/rimraf": "^2.0.2",
     "@types/tar-fs": "^1.16.1",
@@ -64,7 +66,9 @@
     "test:watch": "theiaext test:watch"
   },
   "devDependencies": {
-    "@theia/ext-scripts": "^0.9.0"
+    "@theia/application-package": "*",
+    "@theia/core": "*",
+    "@theia/ext-scripts": "*"
   },
   "nyc": {
     "extends": "../../configs/nyc.json"

--- a/packages/getting-started/package.json
+++ b/packages/getting-started/package.json
@@ -2,11 +2,13 @@
   "name": "@theia/getting-started",
   "version": "0.9.0",
   "description": "Theia - GettingStarted Extension",
-  "dependencies": {
+  "peerDependencies": {
     "@theia/core": "^0.9.0",
     "@theia/filesystem": "^0.9.0",
     "@theia/keymaps": "^0.9.0",
     "@theia/workspace": "^0.9.0"
+  },
+  "dependencies": {
   },
   "publishConfig": {
     "access": "public"
@@ -41,7 +43,11 @@
     "test:watch": "theiaext test:watch"
   },
   "devDependencies": {
-    "@theia/ext-scripts": "^0.9.0"
+    "@theia/core": "*",
+    "@theia/ext-scripts": "*",
+    "@theia/filesystem": "*",
+    "@theia/keymaps": "*",
+    "@theia/workspace": "*"
   },
   "nyc": {
     "extends": "../../configs/nyc.json"

--- a/packages/git/package.json
+++ b/packages/git/package.json
@@ -2,14 +2,16 @@
   "name": "@theia/git",
   "version": "0.9.0",
   "description": "Theia - Git Integration",
-  "dependencies": {
+  "peerDependencies": {
     "@theia/core": "^0.9.0",
     "@theia/editor": "^0.9.0",
     "@theia/filesystem": "^0.9.0",
     "@theia/languages": "^0.9.0",
     "@theia/navigator": "^0.9.0",
     "@theia/scm": "^0.9.0",
-    "@theia/workspace": "^0.9.0",
+    "@theia/workspace": "^0.9.0"
+  },
+  "dependencies": {
     "@types/diff": "^3.2.2",
     "@types/p-queue": "^2.3.1",
     "diff": "^3.4.0",
@@ -63,7 +65,14 @@
     "test:watch": "theiaext test:watch"
   },
   "devDependencies": {
-    "@theia/ext-scripts": "^0.9.0",
+    "@theia/core": "*",
+    "@theia/editor": "*",
+    "@theia/ext-scripts": "*",
+    "@theia/filesystem": "*",
+    "@theia/languages": "*",
+    "@theia/navigator": "*",
+    "@theia/scm": "*",
+    "@theia/workspace": "*",
     "upath": "^1.0.2"
   },
   "nyc": {

--- a/packages/java-debug/package.json
+++ b/packages/java-debug/package.json
@@ -2,9 +2,11 @@
   "name": "@theia/java-debug",
   "version": "0.9.0",
   "description": "Theia - Java Debug Extension",
-  "dependencies": {
+  "peerDependencies": {
     "@theia/debug": "^0.9.0",
-    "@theia/java": "^0.9.0",
+    "@theia/java": "^0.9.0"
+  },
+  "dependencies": {
     "lodash": "^4.17.10"
   },
   "publishConfig": {
@@ -44,7 +46,9 @@
     "test": "theiaext test"
   },
   "devDependencies": {
-    "@theia/ext-scripts": "^0.9.0"
+    "@theia/debug": "*",
+    "@theia/ext-scripts": "*",
+    "@theia/java": "*"
   },
   "nyc": {
     "extends": "../../configs/nyc.json"

--- a/packages/java/package.json
+++ b/packages/java/package.json
@@ -2,11 +2,13 @@
   "name": "@theia/java",
   "version": "0.9.0",
   "description": "Theia - Java Extension",
-  "dependencies": {
+  "peerDependencies": {
     "@theia/core": "^0.9.0",
     "@theia/editor": "^0.9.0",
     "@theia/languages": "^0.9.0",
-    "@theia/monaco": "^0.9.0",
+    "@theia/monaco": "^0.9.0"
+  },
+  "dependencies": {
     "@types/glob": "^5.0.30",
     "@types/tar": "4.0.0",
     "glob": "^7.1.2",
@@ -15,7 +17,11 @@
     "tar": "^4.0.0"
   },
   "devDependencies": {
-    "@theia/ext-scripts": "^0.9.0"
+    "@theia/core": "*",
+    "@theia/editor": "*",
+    "@theia/ext-scripts": "*",
+    "@theia/languages": "*",
+    "@theia/monaco": "*"
   },
   "scripts": {
     "prepare": "yarn run clean && yarn run build",

--- a/packages/json/package.json
+++ b/packages/json/package.json
@@ -2,15 +2,21 @@
   "name": "@theia/json",
   "version": "0.9.0",
   "description": "Theia - JSON Extension",
-  "dependencies": {
+  "peerDependencies": {
     "@theia/application-package": "^0.9.0",
     "@theia/core": "^0.9.0",
     "@theia/languages": "^0.9.0",
-    "@theia/monaco": "^0.9.0",
+    "@theia/monaco": "^0.9.0"
+  },
+  "dependencies": {
     "vscode-json-languageserver": "^1.0.1"
   },
   "devDependencies": {
-    "@theia/ext-scripts": "^0.9.0"
+    "@theia/application-package": "*",
+    "@theia/core": "*",
+    "@theia/ext-scripts": "*",
+    "@theia/languages": "*",
+    "@theia/monaco": "*"
   },
   "scripts": {
     "prepare": "yarn run clean && yarn run build",

--- a/packages/keymaps/package.json
+++ b/packages/keymaps/package.json
@@ -2,11 +2,13 @@
   "name": "@theia/keymaps",
   "version": "0.9.0",
   "description": "Theia - Custom Keymaps Extension",
-  "dependencies": {
+  "peerDependencies": {
     "@theia/core": "^0.9.0",
     "@theia/monaco": "^0.9.0",
     "@theia/userstorage": "^0.9.0",
-    "@theia/workspace": "^0.9.0",
+    "@theia/workspace": "^0.9.0"
+  },
+  "dependencies": {
     "@types/lodash.debounce": "4.0.3",
     "ajv": "^6.5.3",
     "fuzzy": "^0.1.3",
@@ -14,7 +16,11 @@
     "lodash.debounce": "^4.0.8"
   },
   "devDependencies": {
-    "@theia/ext-scripts": "^0.9.0",
+    "@theia/core": "*",
+    "@theia/ext-scripts": "*",
+    "@theia/monaco": "*",
+    "@theia/userstorage": "*",
+    "@theia/workspace": "*",
     "@types/temp": "^0.8.29",
     "temp": "^0.8.3"
   },

--- a/packages/languages/package.json
+++ b/packages/languages/package.json
@@ -2,11 +2,13 @@
   "name": "@theia/languages",
   "version": "0.9.0",
   "description": "Theia - Languages Extension",
-  "dependencies": {
+  "peerDependencies": {
     "@theia/core": "^0.9.0",
     "@theia/output": "^0.9.0",
     "@theia/process": "^0.9.0",
-    "@theia/workspace": "^0.9.0",
+    "@theia/workspace": "^0.9.0"
+  },
+  "dependencies": {
     "@typefox/monaco-editor-core": "^0.14.6",
     "@types/uuid": "^3.4.3",
     "monaco-languageclient": "^0.9.0",
@@ -45,7 +47,11 @@
     "test": "theiaext test"
   },
   "devDependencies": {
-    "@theia/ext-scripts": "^0.9.0"
+    "@theia/core": "*",
+    "@theia/ext-scripts": "*",
+    "@theia/output": "*",
+    "@theia/process": "*",
+    "@theia/workspace": "*"
   },
   "nyc": {
     "extends": "../../configs/nyc.json"

--- a/packages/markers/package.json
+++ b/packages/markers/package.json
@@ -2,11 +2,13 @@
   "name": "@theia/markers",
   "version": "0.9.0",
   "description": "Theia - Markers Extension",
-  "dependencies": {
+  "peerDependencies": {
     "@theia/core": "^0.9.0",
     "@theia/filesystem": "^0.9.0",
     "@theia/navigator": "^0.9.0",
     "@theia/workspace": "^0.9.0"
+  },
+  "dependencies": {
   },
   "publishConfig": {
     "access": "public"
@@ -40,7 +42,11 @@
     "test": "theiaext test"
   },
   "devDependencies": {
-    "@theia/ext-scripts": "^0.9.0"
+    "@theia/core": "*",
+    "@theia/ext-scripts": "*",
+    "@theia/filesystem": "*",
+    "@theia/navigator": "*",
+    "@theia/workspace": "*"
   },
   "nyc": {
     "extends": "../../configs/nyc.json"

--- a/packages/merge-conflicts/package.json
+++ b/packages/merge-conflicts/package.json
@@ -2,10 +2,12 @@
   "name": "@theia/merge-conflicts",
   "version": "0.9.0",
   "description": "Theia - Merge Conflicts Extension",
-  "dependencies": {
+  "peerDependencies": {
     "@theia/core": "^0.9.0",
     "@theia/editor": "^0.9.0",
     "@theia/languages": "^0.9.0"
+  },
+  "dependencies": {
   },
   "publishConfig": {
     "access": "public"
@@ -39,7 +41,10 @@
     "test": "theiaext test"
   },
   "devDependencies": {
-    "@theia/ext-scripts": "^0.9.0"
+    "@theia/core": "*",
+    "@theia/editor": "*",
+    "@theia/ext-scripts": "*",
+    "@theia/languages": "*"
   },
   "nyc": {
     "extends": "../../configs/nyc.json"

--- a/packages/messages/package.json
+++ b/packages/messages/package.json
@@ -2,8 +2,10 @@
   "name": "@theia/messages",
   "version": "0.9.0",
   "description": "Theia - Messages Extension",
-  "dependencies": {
+  "peerDependencies": {
     "@theia/core": "^0.9.0"
+  },
+  "dependencies": {
   },
   "publishConfig": {
     "access": "public"
@@ -37,7 +39,8 @@
     "test": "theiaext test"
   },
   "devDependencies": {
-    "@theia/ext-scripts": "^0.9.0"
+    "@theia/core": "*",
+    "@theia/ext-scripts": "*"
   },
   "nyc": {
     "extends": "../../configs/nyc.json"

--- a/packages/metrics/package.json
+++ b/packages/metrics/package.json
@@ -2,9 +2,11 @@
   "name": "@theia/metrics",
   "version": "0.9.0",
   "description": "Theia - Metrics Extension",
-  "dependencies": {
+  "peerDependencies": {
     "@theia/application-package": "^0.9.0",
-    "@theia/core": "^0.9.0",
+    "@theia/core": "^0.9.0"
+  },
+  "dependencies": {
     "prom-client": "^10.2.0"
   },
   "publishConfig": {
@@ -39,7 +41,9 @@
     "test": "theiaext test"
   },
   "devDependencies": {
-    "@theia/ext-scripts": "^0.9.0"
+    "@theia/application-package": "*",
+    "@theia/core": "*",
+    "@theia/ext-scripts": "*"
   },
   "nyc": {
     "extends": "../../configs/nyc.json"

--- a/packages/mini-browser/package.json
+++ b/packages/mini-browser/package.json
@@ -2,9 +2,11 @@
   "name": "@theia/mini-browser",
   "version": "0.9.0",
   "description": "Theia - Mini-Browser Extension",
-  "dependencies": {
+  "peerDependencies": {
     "@theia/core": "^0.9.0",
-    "@theia/filesystem": "^0.9.0",
+    "@theia/filesystem": "^0.9.0"
+  },
+  "dependencies": {
     "@types/mime-types": "^2.1.0",
     "mime-types": "^2.1.18",
     "pdfobject": "^2.0.201604172"
@@ -42,7 +44,9 @@
     "test": "theiaext test"
   },
   "devDependencies": {
-    "@theia/ext-scripts": "^0.9.0"
+    "@theia/core": "*",
+    "@theia/ext-scripts": "*",
+    "@theia/filesystem": "*"
   },
   "nyc": {
     "extends": "../../configs/nyc.json"

--- a/packages/monaco/package.json
+++ b/packages/monaco/package.json
@@ -2,14 +2,16 @@
   "name": "@theia/monaco",
   "version": "0.9.0",
   "description": "Theia - Monaco Extension",
-  "dependencies": {
+  "peerDependencies": {
     "@theia/core": "^0.9.0",
     "@theia/editor": "^0.9.0",
     "@theia/filesystem": "^0.9.0",
     "@theia/languages": "^0.9.0",
     "@theia/markers": "^0.9.0",
     "@theia/outline-view": "^0.9.0",
-    "@theia/workspace": "^0.9.0",
+    "@theia/workspace": "^0.9.0"
+  },
+  "dependencies": {
     "deepmerge": "2.0.1",
     "jsonc-parser": "^2.0.2",
     "monaco-css": "^2.0.1",
@@ -51,7 +53,14 @@
     "test": "theiaext test"
   },
   "devDependencies": {
-    "@theia/ext-scripts": "^0.9.0"
+    "@theia/core": "*",
+    "@theia/editor": "*",
+    "@theia/ext-scripts": "*",
+    "@theia/filesystem": "*",
+    "@theia/languages": "*",
+    "@theia/markers": "*",
+    "@theia/outline-view": "*",
+    "@theia/workspace": "*"
   },
   "nyc": {
     "extends": "../../configs/nyc.json"

--- a/packages/navigator/package.json
+++ b/packages/navigator/package.json
@@ -2,10 +2,12 @@
   "name": "@theia/navigator",
   "version": "0.9.0",
   "description": "Theia - Navigator Extension",
-  "dependencies": {
+  "peerDependencies": {
     "@theia/core": "^0.9.0",
     "@theia/filesystem": "^0.9.0",
-    "@theia/workspace": "^0.9.0",
+    "@theia/workspace": "^0.9.0"
+  },
+  "dependencies": {
     "fuzzy": "^0.1.3",
     "minimatch": "^3.0.4"
   },
@@ -41,7 +43,10 @@
     "test": "theiaext test"
   },
   "devDependencies": {
-    "@theia/ext-scripts": "^0.9.0"
+    "@theia/core": "*",
+    "@theia/ext-scripts": "*",
+    "@theia/filesystem": "*",
+    "@theia/workspace": "*"
   },
   "nyc": {
     "extends": "../../configs/nyc.json"

--- a/packages/outline-view/package.json
+++ b/packages/outline-view/package.json
@@ -2,8 +2,10 @@
   "name": "@theia/outline-view",
   "version": "0.9.0",
   "description": "Theia - Outline View Extension",
-  "dependencies": {
+  "peerDependencies": {
     "@theia/core": "^0.9.0"
+  },
+  "dependencies": {
   },
   "publishConfig": {
     "access": "public"
@@ -37,7 +39,8 @@
     "test": "theiaext test"
   },
   "devDependencies": {
-    "@theia/ext-scripts": "^0.9.0"
+    "@theia/core": "*",
+    "@theia/ext-scripts": "*"
   },
   "nyc": {
     "extends": "../../configs/nyc.json"

--- a/packages/output/package.json
+++ b/packages/output/package.json
@@ -2,8 +2,10 @@
   "name": "@theia/output",
   "version": "0.9.0",
   "description": "Theia - Output Extension",
-  "dependencies": {
+  "peerDependencies": {
     "@theia/core": "^0.9.0"
+  },
+  "dependencies": {
   },
   "publishConfig": {
     "access": "public"
@@ -37,7 +39,8 @@
     "test": "theiaext test"
   },
   "devDependencies": {
-    "@theia/ext-scripts": "^0.9.0"
+    "@theia/core": "*",
+    "@theia/ext-scripts": "*"
   },
   "nyc": {
     "extends": "../../configs/nyc.json"

--- a/packages/plugin-dev/package.json
+++ b/packages/plugin-dev/package.json
@@ -4,14 +4,16 @@
   "description": "Theia - Plugin Development Extension",
   "main": "lib/common/index.js",
   "typings": "lib/common/index.d.ts",
-  "dependencies": {
+  "peerDependencies": {
     "@theia/core": "^0.9.0",
     "@theia/debug": "^0.9.0",
     "@theia/filesystem": "^0.9.0",
     "@theia/output": "^0.9.0",
     "@theia/plugin-ext": "^0.9.0",
     "@theia/preferences": "^0.9.0",
-    "@theia/workspace": "^0.9.0",
+    "@theia/workspace": "^0.9.0"
+  },
+  "dependencies": {
     "@types/request": "^2.0.3",
     "ps-tree": "^1.2.0",
     "request": "^2.82.0"
@@ -50,7 +52,14 @@
     "test": "theiaext test"
   },
   "devDependencies": {
-    "@theia/ext-scripts": "^0.9.0"
+    "@theia/core": "*",
+    "@theia/debug": "*",
+    "@theia/ext-scripts": "*",
+    "@theia/filesystem": "*",
+    "@theia/output": "*",
+    "@theia/plugin-ext": "*",
+    "@theia/preferences": "*",
+    "@theia/workspace": "*"
   },
   "nyc": {
     "extends": "../../configs/nyc.json"

--- a/packages/plugin-ext-vscode/package.json
+++ b/packages/plugin-ext-vscode/package.json
@@ -2,12 +2,14 @@
   "name": "@theia/plugin-ext-vscode",
   "version": "0.9.0",
   "description": "Theia - Plugin Extension for VsCode",
-  "dependencies": {
+  "peerDependencies": {
     "@theia/core": "^0.9.0",
     "@theia/editor": "^0.9.0",
     "@theia/plugin": "^0.9.0",
     "@theia/plugin-ext": "^0.9.0",
-    "@theia/workspace": "^0.9.0",
+    "@theia/workspace": "^0.9.0"
+  },
+  "dependencies": {
     "@types/request": "^2.0.3",
     "request": "^2.82.0"
   },
@@ -44,7 +46,12 @@
     "test": "theiaext test"
   },
   "devDependencies": {
-    "@theia/ext-scripts": "^0.9.0"
+    "@theia/core": "*",
+    "@theia/editor": "*",
+    "@theia/ext-scripts": "*",
+    "@theia/plugin": "*",
+    "@theia/plugin-ext": "*",
+    "@theia/workspace": "*"
   },
   "nyc": {
     "extends": "../../configs/nyc.json"

--- a/packages/plugin-ext/package.json
+++ b/packages/plugin-ext/package.json
@@ -4,7 +4,7 @@
   "description": "Theia - Plugin Extension",
   "main": "lib/common/index.js",
   "typings": "lib/common/index.d.ts",
-  "dependencies": {
+  "peerDependencies": {
     "@theia/core": "^0.9.0",
     "@theia/debug": "^0.9.0",
     "@theia/editor": "^0.9.0",
@@ -23,7 +23,9 @@
     "@theia/search-in-workspace": "^0.9.0",
     "@theia/task": "^0.9.0",
     "@theia/terminal": "^0.9.0",
-    "@theia/workspace": "^0.9.0",
+    "@theia/workspace": "^0.9.0"
+  },
+  "dependencies": {
     "decompress": "^4.2.0",
     "escape-html": "^1.0.3",
     "getmac": "^1.4.6",
@@ -69,7 +71,26 @@
     "test": "theiaext test"
   },
   "devDependencies": {
-    "@theia/ext-scripts": "^0.9.0",
+    "@theia/core": "*",
+    "@theia/debug": "*",
+    "@theia/editor": "*",
+    "@theia/ext-scripts": "*",
+    "@theia/file-search": "*",
+    "@theia/filesystem": "*",
+    "@theia/languages": "*",
+    "@theia/markers": "*",
+    "@theia/messages": "*",
+    "@theia/mini-browser": "*",
+    "@theia/monaco": "*",
+    "@theia/navigator": "*",
+    "@theia/output": "*",
+    "@theia/plugin": "*",
+    "@theia/preferences": "*",
+    "@theia/scm": "*",
+    "@theia/search-in-workspace": "*",
+    "@theia/task": "*",
+    "@theia/terminal": "*",
+    "@theia/workspace": "*",
     "@types/decompress": "^4.2.2",
     "@types/escape-html": "^0.0.20",
     "@types/lodash.clonedeep": "^4.5.3",

--- a/packages/plugin/package.json
+++ b/packages/plugin/package.json
@@ -26,7 +26,7 @@
     "test": "theiaext test"
   },
   "devDependencies": {
-    "@theia/ext-scripts": "^0.9.0"
+    "@theia/ext-scripts": "*"
   },
   "nyc": {
     "extends": "../../configs/nyc.json"

--- a/packages/preferences/package.json
+++ b/packages/preferences/package.json
@@ -2,14 +2,16 @@
   "name": "@theia/preferences",
   "version": "0.9.0",
   "description": "Theia - Preferences Extension",
-  "dependencies": {
+  "peerDependencies": {
     "@theia/core": "^0.9.0",
     "@theia/editor": "^0.9.0",
     "@theia/filesystem": "^0.9.0",
     "@theia/json": "^0.9.0",
     "@theia/monaco": "^0.9.0",
     "@theia/userstorage": "^0.9.0",
-    "@theia/workspace": "^0.9.0",
+    "@theia/workspace": "^0.9.0"
+  },
+  "dependencies": {
     "jsonc-parser": "^2.0.2"
   },
   "publishConfig": {
@@ -44,7 +46,14 @@
     "test": "theiaext test"
   },
   "devDependencies": {
-    "@theia/ext-scripts": "^0.9.0"
+    "@theia/core": "*",
+    "@theia/editor": "*",
+    "@theia/ext-scripts": "*",
+    "@theia/filesystem": "*",
+    "@theia/json": "*",
+    "@theia/monaco": "*",
+    "@theia/userstorage": "*",
+    "@theia/workspace": "*"
   },
   "nyc": {
     "extends": "../../configs/nyc.json"

--- a/packages/preview/package.json
+++ b/packages/preview/package.json
@@ -2,11 +2,13 @@
   "name": "@theia/preview",
   "version": "0.9.0",
   "description": "Theia - Preview Extension",
-  "dependencies": {
+  "peerDependencies": {
     "@theia/core": "^0.9.0",
     "@theia/editor": "^0.9.0",
     "@theia/languages": "^0.9.0",
-    "@theia/mini-browser": "^0.9.0",
+    "@theia/mini-browser": "^0.9.0"
+  },
+  "dependencies": {
     "@types/highlight.js": "^9.12.2",
     "@types/markdown-it": "^0.0.4",
     "@types/markdown-it-anchor": "^4.0.1",
@@ -46,7 +48,11 @@
     "test": "theiaext test"
   },
   "devDependencies": {
-    "@theia/ext-scripts": "^0.9.0"
+    "@theia/core": "*",
+    "@theia/editor": "*",
+    "@theia/ext-scripts": "*",
+    "@theia/languages": "*",
+    "@theia/mini-browser": "*"
   },
   "nyc": {
     "extends": "../../configs/nyc.json"

--- a/packages/process/package.json
+++ b/packages/process/package.json
@@ -2,8 +2,10 @@
   "name": "@theia/process",
   "version": "0.9.0",
   "description": "Theia process support.",
+  "peerDependencies": {
+    "@theia/core": "^0.9.0"
+  },
   "dependencies": {
-    "@theia/core": "^0.9.0",
     "@theia/node-pty": "0.7.8-theia004",
     "string-argv": "^0.1.1"
   },
@@ -39,7 +41,8 @@
     "test": "theiaext test"
   },
   "devDependencies": {
-    "@theia/ext-scripts": "^0.9.0"
+    "@theia/core": "*",
+    "@theia/ext-scripts": "*"
   },
   "nyc": {
     "extends": "../../configs/nyc.json"

--- a/packages/python/package.json
+++ b/packages/python/package.json
@@ -2,11 +2,13 @@
   "name": "@theia/python",
   "version": "0.9.0",
   "description": "Theia - Python Extension",
-  "dependencies": {
+  "peerDependencies": {
     "@theia/core": "^0.9.0",
     "@theia/languages": "^0.9.0",
     "@theia/monaco": "^0.9.0",
     "@theia/process": "^0.9.0"
+  },
+  "dependencies": {
   },
   "publishConfig": {
     "access": "public"
@@ -42,7 +44,11 @@
     "test": "theiaext test"
   },
   "devDependencies": {
-    "@theia/ext-scripts": "^0.9.0"
+    "@theia/core": "*",
+    "@theia/ext-scripts": "*",
+    "@theia/languages": "*",
+    "@theia/monaco": "*",
+    "@theia/process": "*"
   },
   "nyc": {
     "extends": "../../configs/nyc.json"

--- a/packages/scm/package.json
+++ b/packages/scm/package.json
@@ -2,11 +2,13 @@
   "name": "@theia/scm",
   "version": "0.9.0",
   "description": "Theia - Source control Extension",
-  "dependencies": {
+  "peerDependencies": {
     "@theia/core": "^0.9.0",
     "@theia/editor": "^0.9.0",
     "@theia/filesystem": "^0.9.0",
-    "@theia/navigator": "^0.9.0",
+    "@theia/navigator": "^0.9.0"
+  },
+  "dependencies": {
     "@types/diff": "^3.2.2",
     "@types/p-debounce": "^1.0.1",
     "diff": "^3.4.0",
@@ -46,7 +48,11 @@
     "docs": "theiaext docs"
   },
   "devDependencies": {
-    "@theia/ext-scripts": "^0.9.0"
+    "@theia/core": "*",
+    "@theia/editor": "*",
+    "@theia/ext-scripts": "*",
+    "@theia/filesystem": "*",
+    "@theia/navigator": "*"
   },
   "nyc": {
     "extends": "../../configs/nyc.json"

--- a/packages/search-in-workspace/package.json
+++ b/packages/search-in-workspace/package.json
@@ -2,13 +2,15 @@
   "name": "@theia/search-in-workspace",
   "version": "0.9.0",
   "description": "Theia - Search in workspace",
-  "dependencies": {
+  "peerDependencies": {
     "@theia/core": "^0.9.0",
     "@theia/editor": "^0.9.0",
     "@theia/filesystem": "^0.9.0",
     "@theia/navigator": "^0.9.0",
     "@theia/process": "^0.9.0",
-    "@theia/workspace": "^0.9.0",
+    "@theia/workspace": "^0.9.0"
+  },
+  "dependencies": {
     "vscode-ripgrep": "^1.2.4"
   },
   "publishConfig": {
@@ -44,6 +46,12 @@
     "test": "theiaext test"
   },
   "devDependencies": {
-    "@theia/ext-scripts": "^0.9.0"
+    "@theia/core": "*",
+    "@theia/editor": "*",
+    "@theia/ext-scripts": "*",
+    "@theia/filesystem": "*",
+    "@theia/navigator": "*",
+    "@theia/process": "*",
+    "@theia/workspace": "*"
   }
 }

--- a/packages/task/package.json
+++ b/packages/task/package.json
@@ -2,7 +2,7 @@
   "name": "@theia/task",
   "version": "0.9.0",
   "description": "Theia - Task extension. This extension adds support for executing raw or terminal processes in the backend.",
-  "dependencies": {
+  "peerDependencies": {
     "@theia/core": "^0.9.0",
     "@theia/editor": "^0.9.0",
     "@theia/filesystem": "^0.9.0",
@@ -11,7 +11,9 @@
     "@theia/process": "^0.9.0",
     "@theia/terminal": "^0.9.0",
     "@theia/variable-resolver": "^0.9.0",
-    "@theia/workspace": "^0.9.0",
+    "@theia/workspace": "^0.9.0"
+  },
+  "dependencies": {
     "jsonc-parser": "^2.0.2",
     "vscode-uri": "^1.0.8"
   },
@@ -48,7 +50,16 @@
     "test": "theiaext test"
   },
   "devDependencies": {
-    "@theia/ext-scripts": "^0.9.0"
+    "@theia/core": "*",
+    "@theia/editor": "*",
+    "@theia/ext-scripts": "*",
+    "@theia/filesystem": "*",
+    "@theia/markers": "*",
+    "@theia/monaco": "*",
+    "@theia/process": "*",
+    "@theia/terminal": "*",
+    "@theia/variable-resolver": "*",
+    "@theia/workspace": "*"
   },
   "nyc": {
     "extends": "../../configs/nyc.json"

--- a/packages/terminal/package.json
+++ b/packages/terminal/package.json
@@ -2,12 +2,14 @@
   "name": "@theia/terminal",
   "version": "0.9.0",
   "description": "Theia - Terminal Extension",
-  "dependencies": {
+  "peerDependencies": {
     "@theia/core": "^0.9.0",
     "@theia/editor": "^0.9.0",
     "@theia/filesystem": "^0.9.0",
     "@theia/process": "^0.9.0",
-    "@theia/workspace": "^0.9.0",
+    "@theia/workspace": "^0.9.0"
+  },
+  "dependencies": {
     "xterm": "3.13.0"
   },
   "publishConfig": {
@@ -43,7 +45,12 @@
     "test": "theiaext test"
   },
   "devDependencies": {
-    "@theia/ext-scripts": "^0.9.0"
+    "@theia/core": "*",
+    "@theia/editor": "*",
+    "@theia/ext-scripts": "*",
+    "@theia/filesystem": "*",
+    "@theia/process": "*",
+    "@theia/workspace": "*"
   },
   "nyc": {
     "extends": "../../configs/nyc.json"

--- a/packages/textmate-grammars/package.json
+++ b/packages/textmate-grammars/package.json
@@ -2,8 +2,10 @@
   "name": "@theia/textmate-grammars",
   "version": "0.9.0",
   "description": "Theia - Textmate Grammars",
+  "peerDependencies": {
+    "@theia/monaco": "^0.9.0"
+  },
   "dependencies": {
-    "@theia/monaco": "^0.9.0",
     "vscode-textmate": "^4.0.1"
   },
   "publishConfig": {
@@ -39,7 +41,8 @@
     "test": "theiaext test"
   },
   "devDependencies": {
-    "@theia/ext-scripts": "^0.9.0"
+    "@theia/ext-scripts": "*",
+    "@theia/monaco": "*"
   },
   "nyc": {
     "extends": "../../configs/nyc.json"

--- a/packages/tslint/package.json
+++ b/packages/tslint/package.json
@@ -33,7 +33,7 @@
     "test": "theiaext test"
   },
   "devDependencies": {
-    "@theia/ext-scripts": "^0.9.0"
+    "@theia/ext-scripts": "*"
   },
   "nyc": {
     "extends": "../../configs/nyc.json"

--- a/packages/typehierarchy/package.json
+++ b/packages/typehierarchy/package.json
@@ -2,10 +2,12 @@
   "name": "@theia/typehierarchy",
   "version": "0.9.0",
   "description": "Theia - Type Hierarchy Extension",
-  "dependencies": {
+  "peerDependencies": {
     "@theia/core": "^0.9.0",
     "@theia/editor": "^0.9.0",
-    "@theia/languages": "^0.9.0",
+    "@theia/languages": "^0.9.0"
+  },
+  "dependencies": {
     "@types/uuid": "^3.4.3",
     "uuid": "^3.2.1"
   },
@@ -41,7 +43,10 @@
     "test": "theiaext test"
   },
   "devDependencies": {
-    "@theia/ext-scripts": "^0.9.0"
+    "@theia/core": "*",
+    "@theia/editor": "*",
+    "@theia/ext-scripts": "*",
+    "@theia/languages": "*"
   },
   "nyc": {
     "extends": "../../configs/nyc.json"

--- a/packages/typescript/package.json
+++ b/packages/typescript/package.json
@@ -2,7 +2,7 @@
   "name": "@theia/typescript",
   "version": "0.9.0",
   "description": "Theia - Typescript Extension",
-  "dependencies": {
+  "peerDependencies": {
     "@theia/application-package": "^0.9.0",
     "@theia/callhierarchy": "^0.9.0",
     "@theia/core": "^0.9.0",
@@ -10,7 +10,9 @@
     "@theia/filesystem": "^0.9.0",
     "@theia/languages": "^0.9.0",
     "@theia/monaco": "^0.9.0",
-    "@theia/workspace": "^0.9.0",
+    "@theia/workspace": "^0.9.0"
+  },
+  "dependencies": {
     "command-exists": "^1.2.8",
     "typescript-language-server": "^0.3.8"
   },
@@ -48,7 +50,15 @@
     "test": "theiaext test"
   },
   "devDependencies": {
-    "@theia/ext-scripts": "^0.9.0"
+    "@theia/application-package": "*",
+    "@theia/callhierarchy": "*",
+    "@theia/core": "*",
+    "@theia/editor": "*",
+    "@theia/ext-scripts": "*",
+    "@theia/filesystem": "*",
+    "@theia/languages": "*",
+    "@theia/monaco": "*",
+    "@theia/workspace": "*"
   },
   "nyc": {
     "extends": "../../configs/nyc.json"

--- a/packages/userstorage/package.json
+++ b/packages/userstorage/package.json
@@ -2,9 +2,11 @@
   "name": "@theia/userstorage",
   "version": "0.9.0",
   "description": "Theia - User Storage Extension",
-  "dependencies": {
+  "peerDependencies": {
     "@theia/core": "^0.9.0",
     "@theia/filesystem": "^0.9.0"
+  },
+  "dependencies": {
   },
   "publishConfig": {
     "access": "public"
@@ -38,7 +40,9 @@
     "test": "theiaext test"
   },
   "devDependencies": {
-    "@theia/ext-scripts": "^0.9.0"
+    "@theia/core": "*",
+    "@theia/ext-scripts": "*",
+    "@theia/filesystem": "*"
   },
   "nyc": {
     "extends": "../../configs/nyc.json"

--- a/packages/variable-resolver/package.json
+++ b/packages/variable-resolver/package.json
@@ -2,8 +2,10 @@
   "name": "@theia/variable-resolver",
   "version": "0.9.0",
   "description": "Theia - Variable Resolver Extension",
-  "dependencies": {
+  "peerDependencies": {
     "@theia/core": "^0.9.0"
+  },
+  "dependencies": {
   },
   "publishConfig": {
     "access": "public"
@@ -43,7 +45,8 @@
     "test": "theiaext test"
   },
   "devDependencies": {
-    "@theia/ext-scripts": "^0.9.0"
+    "@theia/core": "*",
+    "@theia/ext-scripts": "*"
   },
   "nyc": {
     "extends": "../../configs/nyc.json"

--- a/packages/workspace/package.json
+++ b/packages/workspace/package.json
@@ -2,10 +2,12 @@
   "name": "@theia/workspace",
   "version": "0.9.0",
   "description": "Theia - Workspace Extension",
-  "dependencies": {
+  "peerDependencies": {
     "@theia/core": "^0.9.0",
     "@theia/filesystem": "^0.9.0",
-    "@theia/variable-resolver": "^0.9.0",
+    "@theia/variable-resolver": "^0.9.0"
+  },
+  "dependencies": {
     "ajv": "^6.5.3",
     "jsonc-parser": "^2.0.2",
     "moment": "^2.21.0",
@@ -44,7 +46,10 @@
     "test": "theiaext test"
   },
   "devDependencies": {
-    "@theia/ext-scripts": "^0.9.0"
+    "@theia/core": "*",
+    "@theia/ext-scripts": "*",
+    "@theia/filesystem": "*",
+    "@theia/variable-resolver": "*"
   },
   "nyc": {
     "extends": "../../configs/nyc.json"


### PR DESCRIPTION
#### What it does

It moves all `@theia` dependencies to "peer dependencies". This should allow the dependency tree to only look for one extension version instead of duplicating it. See https://nodejs.org/es/blog/npm/peer-dependencies/

Only quirk is that in order for lerna to understand the package topology, we need to declare the packages as dev dependencies.

#### How to test

Build and run (might be broken for now, since this is a draft/poc)

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

