### PR TITLE
Fixed #5937, #1344: added `Copy (Relative) Path` to the context menu of navigator node & tabbar tab.

### DIFF
--- a/packages/core/src/browser/common-frontend-contribution.ts
+++ b/packages/core/src/browser/common-frontend-contribution.ts
@@ -25,7 +25,7 @@ import { SelectionService } from '../common/selection-service';
 import { MessageService } from '../common/message-service';
 import { OpenerService, open } from '../browser/opener-service';
 import { ApplicationShell } from './shell/application-shell';
-import { SHELL_TABBAR_CONTEXT_MENU } from './shell/tab-bars';
+import { ShellTabBarContextMenu } from './shell/tab-bars';
 import { AboutDialog } from './about-dialog';
 import * as browser from './browser';
 import URI from '../common/uri';
@@ -326,36 +326,38 @@ export class CommonFrontendContribution implements FrontendApplicationContributi
             order: '1'
         });
 
-        registry.registerMenuAction(SHELL_TABBAR_CONTEXT_MENU, {
+        registry.registerMenuAction(ShellTabBarContextMenu.CLOSE, {
             commandId: CommonCommands.CLOSE_TAB.id,
             label: 'Close',
             order: '0'
         });
-        registry.registerMenuAction(SHELL_TABBAR_CONTEXT_MENU, {
+        registry.registerMenuAction(ShellTabBarContextMenu.CLOSE, {
             commandId: CommonCommands.CLOSE_OTHER_TABS.id,
             label: 'Close Others',
             order: '1'
         });
-        registry.registerMenuAction(SHELL_TABBAR_CONTEXT_MENU, {
+        registry.registerMenuAction(ShellTabBarContextMenu.CLOSE, {
             commandId: CommonCommands.CLOSE_RIGHT_TABS.id,
             label: 'Close to the Right',
             order: '2'
         });
-        registry.registerMenuAction(SHELL_TABBAR_CONTEXT_MENU, {
+        registry.registerMenuAction(ShellTabBarContextMenu.CLOSE, {
             commandId: CommonCommands.CLOSE_ALL_TABS.id,
             label: 'Close All',
             order: '3'
         });
-        registry.registerMenuAction(SHELL_TABBAR_CONTEXT_MENU, {
+
+        registry.registerMenuAction(ShellTabBarContextMenu.ACTIONS, {
             commandId: CommonCommands.COLLAPSE_PANEL.id,
             label: 'Collapse',
-            order: '4'
+            order: '0'
         });
-        registry.registerMenuAction(SHELL_TABBAR_CONTEXT_MENU, {
+        registry.registerMenuAction(ShellTabBarContextMenu.ACTIONS, {
             commandId: CommonCommands.TOGGLE_MAXIMIZED.id,
             label: 'Toggle Maximized',
-            order: '5'
+            order: '1'
         });
+
         registry.registerMenuAction(CommonMenus.HELP, {
             commandId: CommonCommands.ABOUT_COMMAND.id,
             label: 'About',

--- a/packages/core/src/browser/shell/tab-bars.ts
+++ b/packages/core/src/browser/shell/tab-bars.ts
@@ -32,6 +32,12 @@ const HIDDEN_CONTENT_CLASS = 'theia-TabBar-hidden-content';
 /** Menu path for tab bars used throughout the application shell. */
 export const SHELL_TABBAR_CONTEXT_MENU: MenuPath = ['shell-tabbar-context-menu'];
 
+export namespace ShellTabBarContextMenu {
+    export const CLOSE = [...SHELL_TABBAR_CONTEXT_MENU, '1_close'];
+    export const COPY = [...SHELL_TABBAR_CONTEXT_MENU, '2_copy'];
+    export const ACTIONS = [...SHELL_TABBAR_CONTEXT_MENU, '3_toggle'];
+}
+
 export const TabBarRendererFactory = Symbol('TabBarRendererFactory');
 
 /**

--- a/packages/navigator/src/browser/navigator-contribution.ts
+++ b/packages/navigator/src/browser/navigator-contribution.ts
@@ -18,11 +18,10 @@ import { injectable, inject, postConstruct } from 'inversify';
 import { AbstractViewContribution } from '@theia/core/lib/browser/shell/view-contribution';
 import {
     Navigatable, SelectableTreeNode, Widget, KeybindingRegistry, CommonCommands,
-    OpenerService, FrontendApplicationContribution, FrontendApplication, CompositeTreeNode
+    OpenerService, FrontendApplicationContribution, FrontendApplication, CompositeTreeNode, ShellTabBarContextMenu
 } from '@theia/core/lib/browser';
 import { FileDownloadCommands } from '@theia/filesystem/lib/browser/download/file-download-command-contribution';
 import { CommandRegistry, MenuModelRegistry, MenuPath, isOSX, Command, DisposableCollection } from '@theia/core/lib/common';
-import { SHELL_TABBAR_CONTEXT_MENU } from '@theia/core/lib/browser';
 import { WorkspaceCommands, WorkspaceService, WorkspacePreferences } from '@theia/workspace/lib/browser';
 import { FILE_NAVIGATOR_ID, FileNavigatorWidget, EXPLORER_VIEW_CONTAINER_ID } from './navigator-widget';
 import { FileNavigatorPreferences } from './navigator-preferences';
@@ -76,8 +75,8 @@ export namespace NavigatorContextMenu {
 
     export const SEARCH = [...NAVIGATOR_CONTEXT_MENU, '4_search'];
     export const CLIPBOARD = [...NAVIGATOR_CONTEXT_MENU, '5_cutcopypaste'];
-
-    export const MODIFICATION = [...NAVIGATOR_CONTEXT_MENU, '7_modification'];
+    export const COPYPATH = [...NAVIGATOR_CONTEXT_MENU, '6_copypath'];
+    export const MODIFICATION = [...NAVIGATOR_CONTEXT_MENU, '8_modification'];
     /** @deprecated use MODIFICATION */
     export const MOVE = MODIFICATION;
     /** @deprecated use MODIFICATION */
@@ -103,7 +102,7 @@ export class FileNavigatorContribution extends AbstractViewContribution<FileNavi
         @inject(OpenerService) protected readonly openerService: OpenerService,
         @inject(FileNavigatorFilter) protected readonly fileNavigatorFilter: FileNavigatorFilter,
         @inject(WorkspaceService) protected readonly workspaceService: WorkspaceService,
-        @inject(WorkspacePreferences) protected readonly workspacePreferences: WorkspacePreferences
+        @inject(WorkspacePreferences) protected readonly workspacePreferences: WorkspacePreferences,
     ) {
         super({
             viewContainerId: EXPLORER_VIEW_CONTAINER_ID,
@@ -200,10 +199,10 @@ export class FileNavigatorContribution extends AbstractViewContribution<FileNavi
 
     registerMenus(registry: MenuModelRegistry): void {
         super.registerMenus(registry);
-        registry.registerMenuAction(SHELL_TABBAR_CONTEXT_MENU, {
+        registry.registerMenuAction(ShellTabBarContextMenu.ACTIONS, {
             commandId: FileNavigatorCommands.REVEAL_IN_NAVIGATOR.id,
             label: FileNavigatorCommands.REVEAL_IN_NAVIGATOR.label,
-            order: '5'
+            order: '2'
         });
 
         registry.registerMenuAction(NavigatorContextMenu.NAVIGATION, {
@@ -236,6 +235,15 @@ export class FileNavigatorContribution extends AbstractViewContribution<FileNavi
         registry.registerMenuAction(NavigatorContextMenu.CLIPBOARD, {
             commandId: FileDownloadCommands.COPY_DOWNLOAD_LINK.id,
             order: 'z'
+        });
+
+        registry.registerMenuAction(NavigatorContextMenu.COPYPATH, {
+            commandId: WorkspaceCommands.COPY_PATH.id,
+            order: 'a',
+        });
+        registry.registerMenuAction(NavigatorContextMenu.COPYPATH, {
+            commandId: WorkspaceCommands.COPY_RELATIVE_PATH.id,
+            order: 'b'
         });
 
         registry.registerMenuAction(NavigatorContextMenu.MODIFICATION, {


### PR DESCRIPTION
#### What it does
Fixed #5937.
Fixed #1344.
- Added `Copy Path` and `Copy Relative Path` options to the context menu of the navigator tree node & tabbar tab.

#### How to test
- In a workspace, right-click on any navigator tree node or tab bar.
- In the context menu, click on `Copy Path`. The appropriate path of the file should be added to the clipboard.
- In the context menu, click on `Copy Relative Path`. The appropriate relative path (relative to the workspace root) of the file should be added to the clipboard.

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

