### PR TITLE
fix #5229: Add language configuration items for js, ts and jsx

### DIFF
--- a/packages/textmate-grammars/src/browser/js.ts
+++ b/packages/textmate-grammars/src/browser/js.ts
@@ -13,6 +13,10 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
 
 import { injectable } from 'inversify';
 import { LanguageGrammarDefinitionContribution, TextmateRegistry, getEncodedLanguageId, GrammarDefinition } from '@theia/monaco/lib/browser/textmate';
@@ -117,6 +121,45 @@ export class JavascriptContribution implements LanguageGrammarDefinitionContribu
     }
 
     protected configuration: monaco.languages.LanguageConfiguration = {
+        // copied and modified from https://github.com/microsoft/vscode/blob/master/extensions/typescript-language-features/src/features/languageConfiguration.ts
+        'indentationRules': {
+            'decreaseIndentPattern': /^((?!.*?\/\*).*\*\/)?\s*[\}\]].*$/,
+            'increaseIndentPattern': /^((?!\/\/).)*(\{[^}"'`]*|\([^)"'`]*|\[[^\]"'`]*)$/
+        },
+        'wordPattern': /(-?\d*\.\d\w*)|([^\`\~\!\@\#\%\^\&\*\(\)\-\=\+\[\{\]\}\\\|\;\:\'\"\,\.\<\>\/\?\s]+)/g,
+        'onEnterRules': [
+            {
+                // e.g. /** | */
+                'beforeText': /^\s*\/\*\*(?!\/)([^\*]|\*(?!\/))*$/,
+                'afterText': /^\s*\*\/$/,
+                'action': { indentAction: monaco.languages.IndentAction.IndentOutdent, appendText: ' * ' },
+            },
+            {
+                // e.g. /** ...|
+                'beforeText': /^\s*\/\*\*(?!\/)([^\*]|\*(?!\/))*$/,
+                'action': { indentAction: monaco.languages.IndentAction.None, appendText: ' * ' },
+            },
+            {
+                // e.g.  * ...|
+                'beforeText': /^(\t|[ ])*[ ]\*([ ]([^\*]|\*(?!\/))*)?$/,
+                'action': { indentAction: monaco.languages.IndentAction.None, appendText: '* ' },
+            },
+            {
+                // e.g.  */|
+                'beforeText': /^(\t|[ ])*[ ]\*\/\s*$/,
+                'action': { indentAction: monaco.languages.IndentAction.None, removeText: 1 },
+            },
+            {
+                // e.g.  *-----*/|
+                'beforeText': /^(\t|[ ])*[ ]\*[^/]*\*\/\s*$/,
+                'action': { indentAction: monaco.languages.IndentAction.None, removeText: 1 },
+            },
+            {
+                'beforeText': /^\s*(\bcase\s.+:|\bdefault:)$/,
+                'afterText': /^(?!\s*(\bcase\b|\bdefault\b))/,
+                'action': { indentAction: monaco.languages.IndentAction.Indent },
+            }
+        ],
         'comments': {
             'lineComment': '//',
             'blockComment': ['/*', '*/']

--- a/packages/textmate-grammars/src/browser/jsx-tags.ts
+++ b/packages/textmate-grammars/src/browser/jsx-tags.ts
@@ -13,6 +13,10 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
 
 import { injectable } from 'inversify';
 import { LanguageGrammarDefinitionContribution, TextmateRegistry } from '@theia/monaco/lib/browser/textmate';
@@ -20,6 +24,8 @@ import { LanguageGrammarDefinitionContribution, TextmateRegistry } from '@theia/
 @injectable()
 export class JsxTagsContribution implements LanguageGrammarDefinitionContribution {
     private readonly id = 'jsx-tags';
+    // copied and modified from https://github.com/microsoft/vscode/blob/master/extensions/typescript-language-features/src/features/languageConfiguration.ts
+    static EMPTY_ELEMENTS: string[] = ['area', 'base', 'br', 'col', 'embed', 'hr', 'img', 'input', 'keygen', 'link', 'menuitem', 'meta', 'param', 'source', 'track', 'wbr'];
 
     registerTextmateLanguage(registry: TextmateRegistry): void {
         this.registerJsxTags();
@@ -36,6 +42,31 @@ export class JsxTagsContribution implements LanguageGrammarDefinitionContributio
     }
 
     protected configuration: monaco.languages.LanguageConfiguration = {
+        // copied and modified from https://github.com/microsoft/vscode/blob/master/extensions/typescript-language-features/src/features/languageConfiguration.ts
+        'wordPattern': /(-?\d*\.\d\w*)|([^\`\~\!\@\$\^\&\*\(\)\=\+\[\{\]\}\\\|\;\:\'\"\,\.\<\>\/\s]+)/g,
+        'onEnterRules': [
+            {
+                'beforeText': new RegExp(`<(?!(?:${JsxTagsContribution.EMPTY_ELEMENTS.join('|')}))([_:\\w][_:\\w\\-.\\d]*)([^/>]*(?!/)>)[^<]*$`, 'i'),
+                'afterText': /^<\/([_:\w][_:\w-.\d]*)\s*>$/i,
+                'action': { indentAction: monaco.languages.IndentAction.IndentOutdent }
+            },
+            {
+                'beforeText': new RegExp(`<(?!(?:${JsxTagsContribution.EMPTY_ELEMENTS.join('|')}))([_:\\w][_:\\w\\-.\\d]*)([^/>]*(?!/)>)[^<]*$`, 'i'),
+                'action': { indentAction: monaco.languages.IndentAction.Indent }
+            },
+            {
+                // `beforeText` only applies to tokens of a given language. Since we are dealing with jsx-tags,
+                // make sure we apply to the closing `>` of a tag so that mixed language spans
+                // such as `<div onclick={1}>` are handled properly.
+                'beforeText': /^>$/,
+                'afterText': /^<\/([_:\w][_:\w-.\d]*)\s*>$/i,
+                'action': { indentAction: monaco.languages.IndentAction.IndentOutdent }
+            },
+            {
+                'beforeText': /^>$/,
+                'action': { indentAction: monaco.languages.IndentAction.Indent }
+            },
+        ],
         'comments': {
             'blockComment': ['{/*', '*/}']
         },

--- a/packages/textmate-grammars/src/browser/ts.ts
+++ b/packages/textmate-grammars/src/browser/ts.ts
@@ -13,6 +13,10 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
 
 import { injectable, inject } from 'inversify';
 import { LanguageGrammarDefinitionContribution, TextmateRegistry, GrammarDefinition } from '@theia/monaco/lib/browser/textmate';
@@ -106,6 +110,45 @@ export class TypescriptContribution implements LanguageGrammarDefinitionContribu
     }
 
     protected configuration: monaco.languages.LanguageConfiguration = {
+        // copied and modified from https://github.com/microsoft/vscode/blob/master/extensions/typescript-language-features/src/features/languageConfiguration.ts
+        'indentationRules': {
+            'decreaseIndentPattern': /^((?!.*?\/\*).*\*\/)?\s*[\}\]].*$/,
+            'increaseIndentPattern': /^((?!\/\/).)*(\{[^}"'`]*|\([^)"'`]*|\[[^\]"'`]*)$/
+        },
+        'wordPattern': /(-?\d*\.\d\w*)|([^\`\~\!\@\#\%\^\&\*\(\)\-\=\+\[\{\]\}\\\|\;\:\'\"\,\.\<\>\/\?\s]+)/g,
+        'onEnterRules': [
+            {
+                // e.g. /** | */
+                'beforeText': /^\s*\/\*\*(?!\/)([^\*]|\*(?!\/))*$/,
+                'afterText': /^\s*\*\/$/,
+                'action': { indentAction: monaco.languages.IndentAction.IndentOutdent, appendText: ' * ' },
+            },
+            {
+                // e.g. /** ...|
+                'beforeText': /^\s*\/\*\*(?!\/)([^\*]|\*(?!\/))*$/,
+                'action': { indentAction: monaco.languages.IndentAction.None, appendText: ' * ' },
+            },
+            {
+                // e.g.  * ...|
+                'beforeText': /^(\t|[ ])*[ ]\*([ ]([^\*]|\*(?!\/))*)?$/,
+                'action': { indentAction: monaco.languages.IndentAction.None, appendText: '* ' },
+            },
+            {
+                // e.g.  */|
+                'beforeText': /^(\t|[ ])*[ ]\*\/\s*$/,
+                'action': { indentAction: monaco.languages.IndentAction.None, removeText: 1 },
+            },
+            {
+                // e.g.  *-----*/|
+                'beforeText': /^(\t|[ ])*[ ]\*[^/]*\*\/\s*$/,
+                'action': { indentAction: monaco.languages.IndentAction.None, removeText: 1 },
+            },
+            {
+                'beforeText': /^\s*(\bcase\s.+:|\bdefault:)$/,
+                'afterText': /^(?!\s*(\bcase\b|\bdefault\b))/,
+                'action': { indentAction: monaco.languages.IndentAction.Indent },
+            }
+        ],
         'comments': {
             'lineComment': '//',
             'blockComment': ['/*', '*/']


### PR DESCRIPTION
Signed-off-by: Brokun <brokun0128@gmail.com>

#### What it does
Added some configuration items that only exist in vscode, some may not be used yet. 
There are still some differences, we can handle them when we upgrade the editor.

#### How to test
Type a multi-line comment, and the `enter` key will bring the right code.

