### PR TITLE
Clipboard API for Plugins

### DIFF
--- a/packages/core/src/browser/browser-clipboard-service.ts
+++ b/packages/core/src/browser/browser-clipboard-service.ts
@@ -1,0 +1,111 @@
+/********************************************************************************
+ * Copyright (C) 2019 RedHat and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import { injectable, inject } from 'inversify';
+import { isFirefox } from './browser';
+import { ClipboardService } from './clipboard-service';
+import { ILogger } from '../common/logger';
+import { MessageService } from '../common/message-service';
+
+export interface NavigatorClipboard {
+    readText(): Promise<string>;
+    writeText(value: string): Promise<void>;
+}
+export interface PermissionStatus {
+    state: 'granted' | 'prompt' | 'denied'
+}
+export interface NavigatorPermissions {
+    query(options: { name: string }): Promise<PermissionStatus>
+}
+
+@injectable()
+export class BrowserClipboardService implements ClipboardService {
+
+    @inject(MessageService)
+    protected readonly messageService: MessageService;
+
+    @inject(ILogger)
+    protected readonly logger: ILogger;
+
+    async readText(): Promise<string> {
+        let permission;
+        try {
+            permission = await this.queryPermission('clipboard-read');
+        } catch (e) {
+            this.logger.error('Failed checking a clipboard-read permission.', e);
+            // in FireFox, Clipboard API isn't gated with the permissions
+            try {
+                return await this.getClipboardAPI().readText();
+            } catch (e) {
+                this.logger.error('Failed reading clipboard content.', e);
+                if (isFirefox) {
+                    this.messageService.warn(`Clipboard API is not available.
+                    It can be enabled by 'dom.events.testing.asyncClipboard' preference on 'about:config' page. Then reload Theia.
+                    Note, it will allow FireFox getting full access to the system clipboard.`);
+                }
+                throw new Error('Failed reading clipboard content.');
+            }
+        }
+        if (permission.state === 'denied') {
+            // most likely, the user intentionally denied the access
+            this.messageService.error("Access to the clipboard is denied. Check your browser's permission.");
+            throw new Error('Access to the clipboard is denied.');
+        }
+        return this.getClipboardAPI().readText();
+    }
+
+    async writeText(value: string): Promise<void> {
+        let permission;
+        try {
+            permission = await this.queryPermission('clipboard-write');
+        } catch (e) {
+            this.logger.error('Failed checking a clipboard-write permission.', e);
+            // in FireFox, Clipboard API isn't gated with the permissions
+            try {
+                await this.getClipboardAPI().writeText(value);
+                return;
+            } catch (e) {
+                this.logger.error('Failed writing to the clipboard.', e);
+                if (isFirefox) {
+                    this.messageService.warn(`Clipboard API is not available.
+                    It can be enabled by 'dom.events.testing.asyncClipboard' preference on 'about:config' page. Then reload Theia.
+                    Note, it will allow FireFox getting full access to the system clipboard.`);
+                }
+                throw new Error('Failed writing the the clipboard.');
+            }
+        }
+        if (permission.state === 'denied') {
+            // most likely, the user intentionally denied the access
+            this.messageService.error("Access to the clipboard is denied. Check your browser's permission.");
+            throw new Error('Access to the clipboard is denied.');
+        }
+        return this.getClipboardAPI().writeText(value);
+    }
+
+    protected async queryPermission(name: string): Promise<PermissionStatus> {
+        if ('permissions' in navigator) {
+            return (<NavigatorPermissions>navigator['permissions']).query({ name: name });
+        }
+        throw new Error('Permissions API unavailable');
+    }
+
+    protected getClipboardAPI(): NavigatorClipboard {
+        if ('clipboard' in navigator) {
+            return (<NavigatorClipboard>navigator['clipboard']);
+        }
+        throw new Error('Async Clipboard API unavailable');
+    }
+}

--- a/packages/core/src/browser/clipboard-service.ts
+++ b/packages/core/src/browser/clipboard-service.ts
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (C) 2017 TypeFox and others.
+ * Copyright (C) 2019 RedHat and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -14,16 +14,10 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
-import { ContainerModule } from 'inversify';
-import { WindowService } from '../../browser/window/window-service';
-import { DefaultWindowService } from '../../browser/window/default-window-service';
-import { FrontendApplicationContribution } from '../frontend-application';
-import { ClipboardService } from '../clipboard-service';
-import { BrowserClipboardService } from '../browser-clipboard-service';
+import { MaybePromise } from '../common/types';
 
-export default new ContainerModule(bind => {
-    bind(DefaultWindowService).toSelf().inSingletonScope();
-    bind(WindowService).toService(DefaultWindowService);
-    bind(FrontendApplicationContribution).toService(DefaultWindowService);
-    bind(ClipboardService).to(BrowserClipboardService).inSingletonScope();
-});
+export const ClipboardService = Symbol('ClipboardService');
+export interface ClipboardService {
+    readText(): MaybePromise<string>;
+    writeText(value: string): MaybePromise<void>;
+}

--- a/packages/core/src/electron-browser/electron-clipboard-service.ts
+++ b/packages/core/src/electron-browser/electron-clipboard-service.ts
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (C) 2017 TypeFox and others.
+ * Copyright (C) 2019 RedHat and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -14,16 +14,19 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
-import { ContainerModule } from 'inversify';
-import { WindowService } from '../../browser/window/window-service';
-import { DefaultWindowService } from '../../browser/window/default-window-service';
-import { FrontendApplicationContribution } from '../frontend-application';
-import { ClipboardService } from '../clipboard-service';
-import { BrowserClipboardService } from '../browser-clipboard-service';
+import { clipboard } from 'electron';
+import { injectable } from 'inversify';
+import { ClipboardService } from '../browser/clipboard-service';
 
-export default new ContainerModule(bind => {
-    bind(DefaultWindowService).toSelf().inSingletonScope();
-    bind(WindowService).toService(DefaultWindowService);
-    bind(FrontendApplicationContribution).toService(DefaultWindowService);
-    bind(ClipboardService).to(BrowserClipboardService).inSingletonScope();
-});
+@injectable()
+export class ElectronClipboardService implements ClipboardService {
+
+    readText(): string {
+        return clipboard.readText();
+    }
+
+    writeText(value: string): void {
+        clipboard.writeText(value);
+    }
+
+}

--- a/packages/core/src/electron-browser/window/electron-window-module.ts
+++ b/packages/core/src/electron-browser/window/electron-window-module.ts
@@ -18,8 +18,11 @@ import { ContainerModule } from 'inversify';
 import { WindowService } from '../../browser/window/window-service';
 import { ElectronWindowService } from './electron-window-service';
 import { FrontendApplicationContribution } from '../../browser/frontend-application';
+import { ElectronClipboardService } from '../electron-clipboard-service';
+import { ClipboardService } from '../../browser/clipboard-service';
 
 export default new ContainerModule(bind => {
     bind(WindowService).to(ElectronWindowService).inSingletonScope();
     bind(FrontendApplicationContribution).toService(WindowService);
+    bind(ClipboardService).to(ElectronClipboardService).inSingletonScope();
 });

--- a/packages/plugin-ext/src/common/plugin-api-rpc.ts
+++ b/packages/plugin-ext/src/common/plugin-api-rpc.ts
@@ -1253,6 +1253,11 @@ export interface FileSystemMain {
     $unregisterProvider(handle: number): void;
 }
 
+export interface ClipboardMain {
+    $readText(): Promise<string>;
+    $writeText(value: string): Promise<void>;
+}
+
 export const PLUGIN_RPC_CONTEXT = {
     COMMAND_REGISTRY_MAIN: <ProxyIdentifier<CommandRegistryMain>>createProxyIdentifier<CommandRegistryMain>('CommandRegistryMain'),
     QUICK_OPEN_MAIN: createProxyIdentifier<QuickOpenMain>('QuickOpenMain'),
@@ -1278,7 +1283,8 @@ export const PLUGIN_RPC_CONTEXT = {
     FILE_SYSTEM_MAIN: createProxyIdentifier<FileSystemMain>('FileSystemMain'),
     SCM_MAIN: createProxyIdentifier<ScmMain>('ScmMain'),
     DECORATIONS_MAIN: createProxyIdentifier<DecorationsMain>('DecorationsMain'),
-    WINDOW_MAIN: createProxyIdentifier<WindowMain>('WindowMain')
+    WINDOW_MAIN: createProxyIdentifier<WindowMain>('WindowMain'),
+    CLIPBOARD_MAIN: <ProxyIdentifier<ClipboardMain>>createProxyIdentifier<ClipboardMain>('ClipboardMain')
 };
 
 export const MAIN_RPC_CONTEXT = {

--- a/packages/plugin-ext/src/hosted/browser/worker/worker-main.ts
+++ b/packages/plugin-ext/src/hosted/browser/worker/worker-main.ts
@@ -28,6 +28,7 @@ import { EditorsAndDocumentsExtImpl } from '../../../plugin/editors-and-document
 import { WorkspaceExtImpl } from '../../../plugin/workspace';
 import { MessageRegistryExt } from '../../../plugin/message-registry';
 import { WorkerEnvExtImpl } from './worker-env-ext';
+import { ClipboardExt } from '../../../plugin/clipboard-ext';
 
 // tslint:disable-next-line:no-any
 const ctx = self as any;
@@ -55,6 +56,7 @@ const messageRegistryExt = new MessageRegistryExt(rpc);
 const workspaceExt = new WorkspaceExtImpl(rpc, editorsAndDocuments, messageRegistryExt);
 const preferenceRegistryExt = new PreferenceRegistryExtImpl(rpc, workspaceExt);
 const debugExt = createDebugExtStub(rpc);
+const clipboardExt = new ClipboardExt(rpc);
 
 const pluginManager = new PluginManagerExtImpl({
     // tslint:disable-next-line:no-any
@@ -133,7 +135,8 @@ const apiFactory = createAPIFactory(
     preferenceRegistryExt,
     editorsAndDocuments,
     workspaceExt,
-    messageRegistryExt
+    messageRegistryExt,
+    clipboardExt
 );
 let defaultApi: typeof theia;
 

--- a/packages/plugin-ext/src/hosted/node/plugin-host-rpc.ts
+++ b/packages/plugin-ext/src/hosted/node/plugin-host-rpc.ts
@@ -26,6 +26,7 @@ import { EditorsAndDocumentsExtImpl } from '../../plugin/editors-and-documents';
 import { WorkspaceExtImpl } from '../../plugin/workspace';
 import { MessageRegistryExt } from '../../plugin/message-registry';
 import { EnvNodeExtImpl } from '../../plugin/node/env-node-ext';
+import { ClipboardExt } from '../../plugin/clipboard-ext';
 
 /**
  * Handle the RPC calls.
@@ -47,6 +48,7 @@ export class PluginHostRPC {
         const messageRegistryExt = new MessageRegistryExt(this.rpc);
         const workspaceExt = new WorkspaceExtImpl(this.rpc, editorsAndDocumentsExt, messageRegistryExt);
         const preferenceRegistryExt = new PreferenceRegistryExtImpl(this.rpc, workspaceExt);
+        const clipboardExt = new ClipboardExt(this.rpc);
         this.pluginManager = this.createPluginManager(envExt, preferenceRegistryExt, this.rpc);
         this.rpc.set(MAIN_RPC_CONTEXT.HOSTED_PLUGIN_MANAGER_EXT, this.pluginManager);
         this.rpc.set(MAIN_RPC_CONTEXT.EDITORS_AND_DOCUMENTS_EXT, editorsAndDocumentsExt);
@@ -61,7 +63,8 @@ export class PluginHostRPC {
             preferenceRegistryExt,
             editorsAndDocumentsExt,
             workspaceExt,
-            messageRegistryExt
+            messageRegistryExt,
+            clipboardExt
         );
     }
 

--- a/packages/plugin-ext/src/main/browser/clipboard-main.ts
+++ b/packages/plugin-ext/src/main/browser/clipboard-main.ts
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (C) 2017 TypeFox and others.
+ * Copyright (C) 2019 RedHat and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -14,16 +14,25 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
-import { ContainerModule } from 'inversify';
-import { WindowService } from '../../browser/window/window-service';
-import { DefaultWindowService } from '../../browser/window/default-window-service';
-import { FrontendApplicationContribution } from '../frontend-application';
-import { ClipboardService } from '../clipboard-service';
-import { BrowserClipboardService } from '../browser-clipboard-service';
+import { interfaces } from 'inversify';
+import { ClipboardMain } from '../../common';
+import { ClipboardService } from '@theia/core/lib/browser/clipboard-service';
 
-export default new ContainerModule(bind => {
-    bind(DefaultWindowService).toSelf().inSingletonScope();
-    bind(WindowService).toService(DefaultWindowService);
-    bind(FrontendApplicationContribution).toService(DefaultWindowService);
-    bind(ClipboardService).to(BrowserClipboardService).inSingletonScope();
-});
+export class ClipboardMainImpl implements ClipboardMain {
+
+    protected readonly clipboardService: ClipboardService;
+
+    constructor(container: interfaces.Container) {
+        this.clipboardService = container.get(ClipboardService);
+    }
+
+    async $readText(): Promise<string> {
+        const result = await this.clipboardService.readText();
+        return result;
+    }
+
+    async $writeText(value: string): Promise<void> {
+        await this.clipboardService.writeText(value);
+    }
+
+}

--- a/packages/plugin-ext/src/main/browser/main-context.ts
+++ b/packages/plugin-ext/src/main/browser/main-context.ts
@@ -40,6 +40,7 @@ import { DebugMainImpl } from './debug/debug-main';
 import { FileSystemMainImpl } from './file-system-main';
 import { ScmMainImpl } from './scm-main';
 import { DecorationsMainImpl } from './decorations/decorations-main';
+import { ClipboardMainImpl } from './clipboard-main';
 
 export function setUpPluginApi(rpc: RPCProtocol, container: interfaces.Container): void {
     const commandRegistryMain = new CommandRegistryMainImpl(rpc, container);
@@ -113,4 +114,7 @@ export function setUpPluginApi(rpc: RPCProtocol, container: interfaces.Container
 
     const windowMain = new WindowStateMain(rpc, container);
     rpc.set(PLUGIN_RPC_CONTEXT.WINDOW_MAIN, windowMain);
+
+    const clipboardMain = new ClipboardMainImpl(container);
+    rpc.set(PLUGIN_RPC_CONTEXT.CLIPBOARD_MAIN, clipboardMain);
 }

--- a/packages/plugin-ext/src/plugin/clipboard-ext.ts
+++ b/packages/plugin-ext/src/plugin/clipboard-ext.ts
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (C) 2017 TypeFox and others.
+ * Copyright (C) 2019 RedHat and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -14,16 +14,24 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
-import { ContainerModule } from 'inversify';
-import { WindowService } from '../../browser/window/window-service';
-import { DefaultWindowService } from '../../browser/window/default-window-service';
-import { FrontendApplicationContribution } from '../frontend-application';
-import { ClipboardService } from '../clipboard-service';
-import { BrowserClipboardService } from '../browser-clipboard-service';
+import * as theia from '@theia/plugin';
+import { RPCProtocol } from '../common/rpc-protocol';
+import { PLUGIN_RPC_CONTEXT, ClipboardMain } from '../common';
 
-export default new ContainerModule(bind => {
-    bind(DefaultWindowService).toSelf().inSingletonScope();
-    bind(WindowService).toService(DefaultWindowService);
-    bind(FrontendApplicationContribution).toService(DefaultWindowService);
-    bind(ClipboardService).to(BrowserClipboardService).inSingletonScope();
-});
+export class ClipboardExt implements theia.Clipboard {
+
+    protected readonly proxy: ClipboardMain;
+
+    constructor(rpc: RPCProtocol) {
+        this.proxy = rpc.getProxy(PLUGIN_RPC_CONTEXT.CLIPBOARD_MAIN);
+    }
+
+    readText(): Promise<string> {
+        return this.proxy.$readText();
+    }
+
+    writeText(value: string): Promise<void> {
+        return this.proxy.$writeText(value);
+    }
+
+}

--- a/packages/plugin-ext/src/plugin/plugin-context.ts
+++ b/packages/plugin-ext/src/plugin/plugin-context.ts
@@ -139,6 +139,7 @@ import { ScmExtImpl } from './scm';
 import { DecorationProvider, LineChange } from '@theia/plugin';
 import { DecorationsExtImpl } from './decorations';
 import { TextEditorExt } from './text-editor';
+import { ClipboardExt } from './clipboard-ext';
 
 export function createAPIFactory(
     rpc: RPCProtocol,
@@ -148,7 +149,8 @@ export function createAPIFactory(
     preferenceRegistryExt: PreferenceRegistryExtImpl,
     editorsAndDocumentsExt: EditorsAndDocumentsExtImpl,
     workspaceExt: WorkspaceExtImpl,
-    messageRegistryExt: MessageRegistryExt
+    messageRegistryExt: MessageRegistryExt,
+    clipboard: ClipboardExt
 ): PluginAPIFactory {
 
     const commandRegistry = rpc.set(MAIN_RPC_CONTEXT.COMMAND_REGISTRY_EXT, new CommandRegistryImpl(rpc));
@@ -491,7 +493,7 @@ export function createAPIFactory(
             get machineId(): string { return envExt.machineId; },
             get sessionId(): string { return envExt.sessionId; },
             get uriScheme(): string { return envExt.uriScheme; },
-
+            clipboard,
             getEnvVariable(envVarName: string): PromiseLike<string | undefined> {
                 return envExt.getEnvVariable(envVarName);
             },

--- a/packages/plugin/src/theia.d.ts
+++ b/packages/plugin/src/theia.d.ts
@@ -2952,6 +2952,24 @@ declare module '@theia/plugin' {
     }
 
     /**
+     * The clipboard provides read and write access to the system's clipboard.
+     */
+    export interface Clipboard {
+
+        /**
+         * Read the current clipboard contents as text.
+         * @returns A thenable that resolves to a string.
+         */
+        readText(): PromiseLike<string>;
+
+        /**
+         * Writes text into the clipboard.
+         * @returns A thenable that resolves when writing happened.
+         */
+        writeText(value: string): PromiseLike<void>;
+    }
+
+    /**
      * A uri handler is responsible for handling system-wide [uris](#Uri).
      *
      * @see [window.registerUriHandler](#window.registerUriHandler).
@@ -4732,6 +4750,11 @@ declare module '@theia/plugin' {
          * Represents the preferred user-language, like `de-CH`, `fr`, or `en-US`.
          */
         export const language: string;
+
+        /**
+         * The system clipboard.
+         */
+        export const clipboard: Clipboard;
 
         /**
          * A unique identifier for the computer.


### PR DESCRIPTION
#### What it does
Adds Clipboard API for Plugins.
Closes #5519 
This PR is based on the code extracted from #5527 

#### Some notes about the implementation
Different browsers and it's native extensions work a bit differently with the APIs around the clipboard: Async Clipboard API, Permissions API, document.execCommand API.
So the PR adds a minimal level of support for Chrome and FireFox browsers. Support for other cases may be added later as needed.

#### How to test
Run Theia with the test VS Code extension https://github.com/azatsarynnyy/test-clipboard-api/blob/master/clipboard-api-test-0.0.1.vsix

To test [`vscode.env.clipboard.readText` API](https://github.com/microsoft/vscode/blob/466c132f5b4362b3be485a1f7a624b3a7316ddb8/src/vs/vscode.d.ts#L5982-L5986):
- copy an arbitrary text to the clipboard
- call `Clipboard: read from clipboard` command
- the text from the clipboard should be shown with a notification

To test [`vscode.env.clipboard.writeText` API](https://github.com/microsoft/vscode/blob/466c132f5b4362b3be485a1f7a624b3a7316ddb8/src/vs/vscode.d.ts#L5988-L5992):
- select an arbitrary text in Theia editor
- call `Clipboard: write selection to clipboard` command
- paste the clipboard content to any place to check that it was really copied

#### Browser-specific behavior:
- Chrome
The user is able to block the access to the clipboard by setting a preference
![perm](https://user-images.githubusercontent.com/1636395/64795077-2daa9a00-d586-11e9-8e6d-5b1c1475f991.png)

In that case, Theia shows the message
![image](https://user-images.githubusercontent.com/1636395/64784274-70fb0d80-d572-11e9-8bf7-fa645c00473b.png)

- FireFox
By default, Async Clipboard API is disabled but it can be enabled by setting `dom.events.testing.asyncClipboard` preference. User will be informed about that with a notification
![image](https://user-images.githubusercontent.com/1636395/64795915-875f9400-d587-11e9-9ecc-fc8d934135d3.png)

Besides that, Async Clipboard API isn't gated with the permissions in FireFox, so it just bypassed.

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

