### PR TITLE
tsconfig: transpile to es6

### DIFF
--- a/configs/base.tsconfig.json
+++ b/configs/base.tsconfig.json
@@ -14,7 +14,7 @@
         "resolveJsonModule": true,
         "module": "commonjs",
         "moduleResolution": "node",
-        "target": "es5",
+        "target": "es6",
         "jsx": "react",
         "lib": [
             "es6",

--- a/packages/core/src/browser/navigatable.ts
+++ b/packages/core/src/browser/navigatable.ts
@@ -45,14 +45,14 @@ export namespace NavigatableWidget {
         return arg instanceof BaseWidget && Navigatable.is(arg);
     }
     export function* getAffected<T extends Widget>(
-        widgets: IterableIterator<T> | ArrayLike<T>,
+        widgets: Iterable<T>,
         context: MaybeArray<URI>
     ): IterableIterator<[URI, T & NavigatableWidget]> {
         const uris = Array.isArray(context) ? context : [context];
         return get(widgets, resourceUri => uris.some(uri => uri.isEqualOrParent(resourceUri)));
     }
     export function* get<T extends Widget>(
-        widgets: IterableIterator<T> | ArrayLike<T>,
+        widgets: Iterable<T>,
         filter: (resourceUri: URI) => boolean = () => true
     ): IterableIterator<[URI, T & NavigatableWidget]> {
         for (const widget of widgets) {

--- a/packages/core/src/browser/saveable.ts
+++ b/packages/core/src/browser/saveable.ts
@@ -122,11 +122,11 @@ export namespace SaveableWidget {
     export function is(widget: Widget | undefined): widget is SaveableWidget {
         return !!widget && 'closeWithoutSaving' in widget;
     }
-    export function getDirty<T extends Widget>(widgets: IterableIterator<T> | ArrayLike<T>): IterableIterator<SaveableWidget & T> {
+    export function getDirty<T extends Widget>(widgets: Iterable<T>): IterableIterator<SaveableWidget & T> {
         return get(widgets, Saveable.isDirty);
     }
     export function* get<T extends Widget>(
-        widgets: IterableIterator<T> | ArrayLike<T>,
+        widgets: Iterable<T>,
         filter: (widget: T) => boolean = () => true
     ): IterableIterator<SaveableWidget & T> {
         for (const widget of widgets) {

--- a/packages/core/src/browser/shell/tab-bars.ts
+++ b/packages/core/src/browser/shell/tab-bars.ts
@@ -192,7 +192,7 @@ export class TabBarRenderer extends TabBar.Renderer {
         if (this.tabBar && this.decoratorService) {
             const allDecorations = this.decoratorService.getDecorations([...this.tabBar.titles]);
             if (allDecorations.has(tab)) {
-                tabDecorations.push(...allDecorations.get(tab));
+                tabDecorations.push(...allDecorations.get(tab)!);
             }
         }
         return tabDecorations;

--- a/packages/core/src/browser/tree/tree-widget.tsx
+++ b/packages/core/src/browser/tree/tree-widget.tsx
@@ -697,7 +697,7 @@ export class TreeWidget extends ReactWidget implements StatefulWidget {
             decorations.push(node.decorationData);
         }
         if (this.decorations.has(node.id)) {
-            decorations.push(...this.decorations.get(node.id));
+            decorations.push(...this.decorations.get(node.id)!);
         }
         return decorations.sort(TreeDecoration.Data.comparePriority);
     }

--- a/packages/java/src/browser/java-client-contribution.ts
+++ b/packages/java/src/browser/java-client-contribution.ts
@@ -80,7 +80,7 @@ export class JavaClientContribution extends BaseLanguageClientContribution {
     protected onReady(languageClient: ILanguageClient): void {
         languageClient.onNotification(ActionableNotification.type, this.showActionableMessage.bind(this));
         languageClient.onNotification(StatusNotification.type, this.showStatusMessage.bind(this));
-        languageClient.onRequest(ExecuteClientCommand.type, params => this.commandService.executeCommand(params.command, ...params.arguments));
+        languageClient.onRequest(ExecuteClientCommand.type, params => this.commandService.executeCommand(params.command, ...params.arguments || []));
         super.onReady(languageClient);
     }
 

--- a/packages/monaco/src/browser/monaco-bulk-edit-service.ts
+++ b/packages/monaco/src/browser/monaco-bulk-edit-service.ts
@@ -24,7 +24,7 @@ export class MonacoBulkEditService implements monaco.editor.IBulkEditService {
     protected readonly workspace: MonacoWorkspace;
 
     apply(edit: monaco.languages.WorkspaceEdit): monaco.Promise<monaco.editor.IBulkEditResult> {
-        return this.workspace.applyBulkEdit(edit);
+        return monaco.Promise.wrap(this.workspace.applyBulkEdit(edit));
     }
 
 }

--- a/packages/monaco/src/browser/monaco-quick-open-service.ts
+++ b/packages/monaco/src/browser/monaco-quick-open-service.ts
@@ -527,10 +527,10 @@ export class MonacoQuickOpenActionProvider implements monaco.quickOpen.IActionPr
     }
 
     // tslint:disable-next-line:no-any
-    async getActions(element: any, entry: QuickOpenEntry | QuickOpenEntryGroup): monaco.Promise<monaco.quickOpen.IAction[]> {
-        const actions = await this.provider.getActions(entry.item);
-        const monacoActions = actions.map(action => new MonacoQuickOpenAction(action));
-        return monaco.Promise.wrap(monacoActions);
+    getActions(element: any, entry: QuickOpenEntry | QuickOpenEntryGroup): monaco.Promise<monaco.quickOpen.IAction[]> {
+        return monaco.Promise.wrap(
+            this.provider.getActions(entry.item)
+                .then(actions => actions.map(action => new MonacoQuickOpenAction(action))));
     }
 
     hasSecondaryActions(): boolean {

--- a/packages/monaco/src/browser/monaco-workspace.ts
+++ b/packages/monaco/src/browser/monaco-workspace.ts
@@ -268,7 +268,7 @@ export class MonacoWorkspace implements lang.Workspace {
         return true;
     }
 
-    async applyBulkEdit(workspaceEdit: monaco.languages.WorkspaceEdit, options?: EditorOpenerOptions): monaco.Promise<monaco.editor.IBulkEditResult> {
+    async applyBulkEdit(workspaceEdit: monaco.languages.WorkspaceEdit, options?: EditorOpenerOptions): Promise<monaco.editor.IBulkEditResult> {
         try {
             const unresolvedEditorEdits = this.groupEdits(workspaceEdit);
             const editorEdits = await this.openEditors(unresolvedEditorEdits, options);

--- a/packages/plugin-ext/src/plugin/command-registry.ts
+++ b/packages/plugin-ext/src/plugin/command-registry.ts
@@ -103,7 +103,7 @@ export class CommandRegistryImpl implements CommandRegistryExt {
             return this.executeLocalCommand(id, ...args);
         } else {
             return KnownCommands.map(id, args, (mappedId: string, mappedArgs: any[] | undefined) =>
-                this.proxy.$executeCommand(mappedId, ...mappedArgs));
+                this.proxy.$executeCommand(mappedId, ...mappedArgs || []));
         }
     }
     // tslint:enable:no-any

--- a/packages/plugin-ext/src/plugin/scm.ts
+++ b/packages/plugin-ext/src/plugin/scm.ts
@@ -319,7 +319,7 @@ class SourceControlResourceGroupImpl implements theia.SourceControlResourceGroup
         if (state && state.command) {
             const command = state.command;
             if (command.command) {
-                await this.commands.$executeCommand(command.command, ...command.arguments);
+                await this.commands.$executeCommand(command.command, ...command.arguments || []);
             }
         }
     }


### PR DESCRIPTION
#### What it does

Transpile from es5 to es6 to accomodate libraries written in es6.

Reason is that es6 is backward compatible with es5 but it is not forward
compatible.

Closes https://github.com/theia-ide/theia/issues/5902.

#### How to test

To be defined? `yarn test` should terminate successfully.

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)