### PR TITLE
fix bug:The datas of Complete exists repeatedly

### DIFF
--- a/packages/plugin-ext/package.json
+++ b/packages/plugin-ext/package.json
@@ -33,7 +33,8 @@
     "request": "^2.82.0",
     "uuid": "^3.2.1",
     "vscode-debugprotocol": "^1.32.0",
-    "vscode-textmate": "^4.0.1"
+    "vscode-textmate": "^4.0.1",
+    "ts-md5": "^1.2.2"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/plugin-ext/src/main/browser/languages-main.ts
+++ b/packages/plugin-ext/src/main/browser/languages-main.ts
@@ -99,6 +99,9 @@ export class LanguagesMainImpl implements LanguagesMain {
     }
 
     $registerCompletionSupport(handle: number, selector: SerializedDocumentFilter[], triggerCharacters: string[], supportsResolveDetails: boolean): void {
+        if (this.disposables.has(handle)) {
+            return;
+        }
         this.disposables.set(handle, monaco.modes.SuggestRegistry.register(fromLanguageSelector(selector)!, {
             triggerCharacters,
             provideCompletionItems: (model: monaco.editor.ITextModel,


### PR DESCRIPTION
Signed-off-by: xieyuanhu <xieyuanhuata@163.com>

#### What it does
fix #6128  If the selectors and triggerCharacters of the two plugins are the same, then the datas of Complete will be duplicated.So,it is no need to generate two adapters for plugins with the same selector and triggerCharacters.

#### How to test
1、Install vscode plugins and the hello-plugin into theia，and then start theia;
redhat.java-0.46.0.vsix --- https://marketplace.visualstudio.com/items?itemName=redhat.java
vscjava.vscode-java-debug-0.20.0.vsix --- https://marketplace.visualstudio.com/items?itemName=vscjava.vscode-java-debug
vscjava.vscode-java-dependency-0.4.0.vsix -- https://marketplace.visualstudio.com/items?itemName=vscjava.vscode-java-dependency
vscjava.vscode-maven-0.17.0.vsix --- https://marketplace.visualstudio.com/items?itemName=vscjava.vscode-maven
vscode-java-test-0.18.2.vsix --- https://marketplace.visualstudio.com/items?itemName=vscjava.vscode-java-test
2、Open a java project，and insert a chart;

#### Review checklist

- [ ] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

