### PR TITLE
register Monaco keybindings in reverse order

### DIFF
--- a/packages/monaco/src/browser/monaco-keybinding.ts
+++ b/packages/monaco/src/browser/monaco-keybinding.ts
@@ -20,7 +20,6 @@ import { EditorKeybindingContexts } from '@theia/editor/lib/browser';
 import { MonacoCommands } from './monaco-command';
 import { MonacoCommandRegistry } from './monaco-command-registry';
 import { KEY_CODE_MAP } from './monaco-keycode-map';
-import KeybindingsRegistry = monaco.keybindings.KeybindingsRegistry;
 import { isOSX } from '@theia/core';
 
 function monaco2BrowserKeyCode(keyCode: monaco.KeyCode): number {
@@ -39,7 +38,11 @@ export class MonacoKeybindingContribution implements KeybindingContribution {
     protected readonly commands: MonacoCommandRegistry;
 
     registerKeybindings(registry: KeybindingRegistry): void {
-        for (const item of KeybindingsRegistry.getDefaultKeybindings()) {
+        const defaultKeybindings = monaco.keybindings.KeybindingsRegistry.getDefaultKeybindings();
+        // register in reverse order to align with Monaco dispatch logic:
+        // https://github.com/TypeFox/vscode/blob/70b8db24a37fafc77247de7f7cb5bb0195120ed0/src/vs/platform/keybinding/common/keybindingResolver.ts#L302
+        for (let i = defaultKeybindings.length - 1; i >= 0; i--) {
+            const item = defaultKeybindings[i];
             const command = this.commands.validate(item.command);
             if (command) {
                 const raw = item.keybinding;


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

fix #6168: register Monaco keybindings in reverse order in order to match to Monaco keybindings dispatch logic

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

- try to navigate between suggest candidates with a keyboard, i.e. with up and down keys
- also check what there is not regression with escaping from the reference peek widget after following a referenc

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

