### PR TITLE
[Eclipse] update references to old GH org

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,13 +2,17 @@
 
 ## v0.11.0
 
-- [task] added `tasks.fetchTasks()` and `tasks.executeTask()` to plugins API [#6058](https://github.com/theia-ide/theia/pull/6058)
-- [task] prompt user to choose parser to parse task output [#5877](https://github.com/theia-ide/theia/pull/5877)
+- [task] added `tasks.fetchTasks()` and `tasks.executeTask()` to plugins API [#6058](https://github.com/eclipse-theia/theia/pull/6058)
+- [task] prompt user to choose parser to parse task output [#5877](https://github.com/eclipse-theia/theia/pull/5877)
 
 Breaking changes:
 
-- [core][plugin] support alternative commands in context menus [6069](https://github.com/theia-ide/theia/pull/6069)
-- [workspace] switched `workspace.supportMultiRootWorkspace` to enabled by default [#6089](https://github.com/theia-ide/theia/pull/6089)
+- [core][plugin] support alternative commands in context menus [6069](https://github.com/eclipse-theia/theia/pull/6069)
+- [workspace] switched `workspace.supportMultiRootWorkspace` to enabled by default [#6089](https://github.com/eclipse-theia/theia/pull/6089)
+
+Misc:
+
+This repo was moved to the `eclipse-theia` organization. Though GitHub automatically redirects from the old repo to the new one, we'll use the new one from now on in this file.
 
 ## v0.10.0
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -43,12 +43,12 @@ that you are willing to do so and how you would approach it. The team will be
 happy to guide you and give feedback.
 
 We follow the contributing and reviewing pull request guidelines described
-[here](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md).
+[here](https://github.com/eclipse-theia/theia/blob/master/doc/pull-requests.md).
 
 ## Coding Guidelines
 
 We follow the coding guidelines described
-[here](https://github.com/theia-ide/theia/wiki/Coding-Guidelines).
+[here](https://github.com/eclipse-theia/theia/wiki/Coding-Guidelines).
 
 ## Eclipse Contributor Agreement
 

--- a/README.md
+++ b/README.md
@@ -1,19 +1,19 @@
 <br/>
 <div id="theia-logo" align="center">
     <br />
-    <img src="https://raw.githubusercontent.com/theia-ide/theia/master/logo/theia-logo.svg?sanitize=true" alt="Theia Logo" width="300"/>
+    <img src="https://raw.githubusercontent.com/eclipse-theia/theia/master/logo/theia-logo.svg?sanitize=true" alt="Theia Logo" width="300"/>
     <h3>Cloud & Desktop IDE Platform</h3>
 </div>
 
 <div id="badges" align="center">
 
-  [![Gitpod - Code Now](https://img.shields.io/badge/Gitpod-code%20now-blue.svg?longCache=true)](https://gitpod.io#https://github.com/theia-ide/theia)
-  [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg?style=flat-curved)](https://github.com/theia-ide/theia/labels/help%20wanted)
+  [![Gitpod - Code Now](https://img.shields.io/badge/Gitpod-code%20now-blue.svg?longCache=true)](https://gitpod.io#https://github.com/eclipse-theia/theia)
+  [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg?style=flat-curved)](https://github.com/eclipse-theia/theia/labels/help%20wanted)
   [![Spectrum](https://img.shields.io/badge/Chat-on%20Spectrum-blue.svg)](https://spectrum.chat/theia)
-  [![Build Status](https://travis-ci.org/theia-ide/theia.svg?branch=master)](https://travis-ci.org/theia-ide/theia)
+  [![Build Status](https://travis-ci.org/eclipse-theia/theia.svg?branch=master)](https://travis-ci.org/eclipse-theia/theia)
   [![Build status](https://ci.appveyor.com/api/projects/status/02s4d40orokl3njl/branch/master?svg=true)](https://ci.appveyor.com/project/kittaakos/theia/branch/master)
-  [![Open questions](https://img.shields.io/badge/Open-questions-blue.svg?style=flat-curved)](https://github.com/theia-ide/theia/labels/question)
-  [![Open bugs](https://img.shields.io/badge/Open-bugs-red.svg?style=flat-curved)](https://github.com/theia-ide/theia/labels/bug)
+  [![Open questions](https://img.shields.io/badge/Open-questions-blue.svg?style=flat-curved)](https://github.com/eclipse-theia/theia/labels/question)
+  [![Open bugs](https://img.shields.io/badge/Open-bugs-red.svg?style=flat-curved)](https://github.com/eclipse-theia/theia/labels/bug)
 
   Eclipse Theia is an extensible platform to develop full-fledged multi-language Cloud & Desktop IDE-like products with state-of-the-art web  technologies.
 
@@ -21,7 +21,7 @@
 
 <div style='margin:0 auto;width:80%;'>
 
-![Theia](https://raw.githubusercontent.com/theia-ide/theia/master/doc/images/theia-screenshot.png)
+![Theia](https://raw.githubusercontent.com/eclipse-theia/theia/master/doc/images/theia-screenshot.png)
 
 </div>
 
@@ -52,25 +52,25 @@ Here you can find guides and examples for common scenarios:
 - [Develop a Theia application - your own IDE](https://www.theia-ide.org/doc/Composing_Applications.html)
 - [Develop a Theia plugin - a VS Code like extension](https://www.theia-ide.org/doc/Authoring_Plugins.html)
 - [Develop a Theia extension](http://www.theia-ide.org/doc/Authoring_Extensions.html)
-- [Test a VS Code extension in Theia](https://github.com/theia-ide/theia/wiki/Testing-VS-Code-extensions)
+- [Test a VS Code extension in Theia](https://github.com/eclipse-theia/theia/wiki/Testing-VS-Code-extensions)
 - [Package a desktop Theia application with Electron](https://github.com/theia-ide/yangster-electron)
 
 ## Contributing
 
 Read below to learn how to take part in improving Theia:
 - Fork the repository and [run the examples from source](doc/Developing.md#quick-start)
-- Get familiar with [the development workflow](doc/Developing.md), [Coding Guidelines](https://github.com/theia-ide/theia/wiki/Coding-Guidelines), [Code of Conduct](CODE_OF_CONDUCT.md) and [learn how to sign your work](CONTRIBUTING.md#sign-your-work)
+- Get familiar with [the development workflow](doc/Developing.md), [Coding Guidelines](https://github.com/eclipse-theia/theia/wiki/Coding-Guidelines), [Code of Conduct](CODE_OF_CONDUCT.md) and [learn how to sign your work](CONTRIBUTING.md#sign-your-work)
 - Find an issue to work on and submit a pull request
-  - First time contributing to open source? Pick a [good first issue](https://github.com/theia-ide/theia/labels/good%20first%20issue) to get you familiar with GitHub contributing process.
-  - First time contributing to Theia? Pick a [beginner friendly issue](https://github.com/theia-ide/theia/labels/beginners) to get you familiar with codebase and our contributing process.
-  - Want to become a Committer? Solve an issue showing that you understand Theia objectives and architecture. [Here](https://github.com/theia-ide/theia/labels/help%20wanted) is a good list to start.
+  - First time contributing to open source? Pick a [good first issue](https://github.com/eclipse-theia/theia/labels/good%20first%20issue) to get you familiar with GitHub contributing process.
+  - First time contributing to Theia? Pick a [beginner friendly issue](https://github.com/eclipse-theia/theia/labels/beginners) to get you familiar with codebase and our contributing process.
+  - Want to become a Committer? Solve an issue showing that you understand Theia objectives and architecture. [Here](https://github.com/eclipse-theia/theia/labels/help%20wanted) is a good list to start.
 - Could not find an issue? Look for bugs, typos, and missing features.
 
 ## Feedback
 
 Read below how to engage with Theia community:
 - Join the discussion on [Spectrum](https://spectrum.chat/theia).
-- Ask a question, request a new feature and file a bug with [GitHub issues](https://github.com/theia-ide/theia/issues/new).
+- Ask a question, request a new feature and file a bug with [GitHub issues](https://github.com/eclipse-theia/theia/issues/new).
 - Star the repository to show your support.
 - Follow Theia on [Twitter](https://twitter.com/theia_ide).
 

--- a/dev-packages/application-manager/package.json
+++ b/dev-packages/application-manager/package.json
@@ -8,12 +8,12 @@
   "license": "EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0",
   "repository": {
     "type": "git",
-    "url": "https://github.com/theia-ide/theia.git"
+    "url": "https://github.com/eclipse-theia/theia.git"
   },
   "bugs": {
-    "url": "https://github.com/theia-ide/theia/issues"
+    "url": "https://github.com/eclipse-theia/theia/issues"
   },
-  "homepage": "https://github.com/theia-ide/theia",
+  "homepage": "https://github.com/eclipse-theia/theia",
   "files": [
     "lib",
     "src"

--- a/dev-packages/application-manager/src/generator/frontend-generator.ts
+++ b/dev-packages/application-manager/src/generator/frontend-generator.ts
@@ -110,7 +110,7 @@ module.exports = Promise.resolve()${this.compileFrontendModuleImports(frontendMo
 // Useful for Electron/NW.js apps as GUI apps on macOS doesn't inherit the \`$PATH\` define
 // in your dotfiles (.bashrc/.bash_profile/.zshrc/etc).
 // https://github.com/electron/electron/issues/550#issuecomment-162037357
-// https://github.com/theia-ide/theia/pull/3534#issuecomment-439689082
+// https://github.com/eclipse-theia/theia/pull/3534#issuecomment-439689082
 require('fix-path')();
 
 // Workaround for https://github.com/electron/electron/issues/9225. Chrome has an issue where
@@ -293,10 +293,10 @@ app.on('ready', () => {
 
     // We cannot use the \`process.cwd()\` as the application project path (the location of the \`package.json\` in other words)
     // in a bundled electron application because it depends on the way we start it. For instance, on OS X, these are a differences:
-    // https://github.com/theia-ide/theia/issues/3297#issuecomment-439172274
+    // https://github.com/eclipse-theia/theia/issues/3297#issuecomment-439172274
     process.env.THEIA_APP_PROJECT_PATH = resolve(__dirname, '..', '..');
 
-    // Set the electron version for both the dev and the production mode. (https://github.com/theia-ide/theia/issues/3254)
+    // Set the electron version for both the dev and the production mode. (https://github.com/eclipse-theia/theia/issues/3254)
     // Otherwise, the forked backend processes will not know that they're serving the electron frontend.
     const { versions } = process;
     // @ts-ignore
@@ -326,7 +326,7 @@ app.on('ready', () => {
         });
         app.on('quit', () => {
             // If we forked the process for the clusters, we need to manually terminate it.
-            // See: https://github.com/theia-ide/theia/issues/835
+            // See: https://github.com/eclipse-theia/theia/issues/835
             process.kill(cp.pid);
         });
     }

--- a/dev-packages/application-manager/src/generator/webpack-generator.ts
+++ b/dev-packages/application-manager/src/generator/webpack-generator.ts
@@ -106,7 +106,7 @@ module.exports = {
                 }
             },
             {
-                // see https://github.com/theia-ide/theia/issues/556
+                // see https://github.com/eclipse-theia/theia/issues/556
                 test: /source-map-support/,
                 loader: 'ignore-loader'
             },

--- a/dev-packages/application-package/package.json
+++ b/dev-packages/application-package/package.json
@@ -8,12 +8,12 @@
   "license": "EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0",
   "repository": {
     "type": "git",
-    "url": "https://github.com/theia-ide/theia.git"
+    "url": "https://github.com/eclipse-theia/theia.git"
   },
   "bugs": {
-    "url": "https://github.com/theia-ide/theia/issues"
+    "url": "https://github.com/eclipse-theia/theia/issues"
   },
-  "homepage": "https://github.com/theia-ide/theia",
+  "homepage": "https://github.com/eclipse-theia/theia",
   "files": [
     "lib",
     "src"

--- a/dev-packages/application-package/src/environment.ts
+++ b/dev-packages/application-package/src/environment.ts
@@ -52,7 +52,7 @@ class ElectronEnv {
     /**
      * Creates and return with a new environment object which always contains the `ELECTRON_RUN_AS_NODE: 1` property pair.
      * This should be used to `spawn` and `fork` a new Node.js process from the Node.js shipped with Electron. Otherwise, a new Electron
-     * process will be spawned which [has side-effects](https://github.com/theia-ide/theia/issues/5385).
+     * process will be spawned which [has side-effects](https://github.com/eclipse-theia/theia/issues/5385).
      *
      * If called from the backend and the `env` argument is not defined, it falls back to `process.env` such as Node.js behaves
      * with the [`SpawnOptions`](https://nodejs.org/api/child_process.html#child_process_child_process_spawn_command_args_options).

--- a/dev-packages/cli/package.json
+++ b/dev-packages/cli/package.json
@@ -8,12 +8,12 @@
   "license": "EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0",
   "repository": {
     "type": "git",
-    "url": "https://github.com/theia-ide/theia.git"
+    "url": "https://github.com/eclipse-theia/theia.git"
   },
   "bugs": {
-    "url": "https://github.com/theia-ide/theia/issues"
+    "url": "https://github.com/eclipse-theia/theia/issues"
   },
-  "homepage": "https://github.com/theia-ide/theia",
+  "homepage": "https://github.com/eclipse-theia/theia",
   "files": [
     "bin",
     "lib",

--- a/dev-packages/cli/src/check-hoisting.ts
+++ b/dev-packages/cli/src/check-hoisting.ts
@@ -19,8 +19,8 @@ import * as path from 'path';
 
 /**
  * This script makes sure all the dependencies are hoisted into the root `node_modules` after running `yarn`.
- *  - https://github.com/theia-ide/theia/pull/2994#issuecomment-425447650
- *  - https://github.com/theia-ide/theia/pull/2994#issuecomment-425649817
+ *  - https://github.com/eclipse-theia/theia/pull/2994#issuecomment-425447650
+ *  - https://github.com/eclipse-theia/theia/pull/2994#issuecomment-425649817
  *
  * If you do not want to bail the execution: `theia check:hoisted -s`
  */

--- a/dev-packages/electron/package.json
+++ b/dev-packages/electron/package.json
@@ -8,12 +8,12 @@
   "license": "EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0",
   "repository": {
     "type": "git",
-    "url": "https://github.com/theia-ide/theia.git"
+    "url": "https://github.com/eclipse-theia/theia.git"
   },
   "bugs": {
-    "url": "https://github.com/theia-ide/theia/issues"
+    "url": "https://github.com/eclipse-theia/theia/issues"
   },
-  "homepage": "https://github.com/theia-ide/theia",
+  "homepage": "https://github.com/eclipse-theia/theia",
   "bin": {
     "electron": "electron-cli.js",
     "electron-h264-test": "electron-h264-test.js",

--- a/doc/Developing.md
+++ b/doc/Developing.md
@@ -54,7 +54,7 @@ For Windows instructions [click here](#building-on-windows).
  - Node.js `>= 10.2.0` **AND** `< 12.x`.
    - Preferably, **use** version `10.15.3`, it has the [active LTS](https://github.com/nodejs/Release).
    - Node.js `11.x` is untested.
-   - Node.js `12.x` is [unsupported](https://github.com/theia-ide/theia/issues/5117).
+   - Node.js `12.x` is [unsupported](https://github.com/eclipse-theia/theia/issues/5117).
  - [Yarn package manager](https://yarnpkg.com/en/docs/install) v1.7.0
  - git (If you would like to use the Git-extension too, you will need to have git version 2.11.0 or higher.)
 
@@ -79,7 +79,7 @@ Some additional tools and libraries are needed depending on your platform:
 
 To build and run the browser example:
 
-    git clone https://github.com/theia-ide/theia \
+    git clone https://github.com/eclipse-theia/theia \
     && cd theia \
     && yarn \
     && cd examples/browser \
@@ -89,7 +89,7 @@ Start your browser on http://localhost:3000.
 
 To build and run the Electron example:
 
-    git clone https://github.com/theia-ide/theia \
+    git clone https://github.com/eclipse-theia/theia \
     && cd theia \
     && yarn \
     && yarn run rebuild:electron \
@@ -100,7 +100,7 @@ To build and run the Electron example:
 
 To run the browser example using SSL use:
 
-    git clone https://github.com/theia-ide/theia \
+    git clone https://github.com/eclipse-theia/theia \
     && cd theia \
     && yarn \
     && cd examples/browser \
@@ -112,7 +112,7 @@ Start your browser on https://localhost:3000.
 
 [Gitpod](http://gitpod.io/) is a Theia-based IDE for GitHub.
 You can start by prefixing any GitHub URL in the Theia repository with `gitpod.io/#`:
-- Open http://gitpod.io/#https://github.com/theia-ide/theia to start development with the master branch.
+- Open http://gitpod.io/#https://github.com/eclipse-theia/theia to start development with the master branch.
 - Gitpod will start a properly configured for Theia development workspace, clone and build the Theia repository.
 - After the build is finished, run from the terminal in Gitpod:
 
@@ -121,7 +121,7 @@ You can start by prefixing any GitHub URL in the Theia repository with `gitpod.i
 
 ## Clone the repository
 
-    git clone https://github.com/theia-ide/theia
+    git clone https://github.com/eclipse-theia/theia
 
 The directory containing the Theia repository will now be referred to as
 `$THEIA`, so if you want to copy-paste the examples, you can set the `THEIA`
@@ -340,7 +340,7 @@ Run PowerShell as an administrator and copy-paste the below command:
 Clone, build and run Theia.
 Using Git Bash as administrator:
 
-    git clone https://github.com/theia-ide/theia.git && cd theia && yarn && cd examples/browser && yarn run start
+    git clone https://github.com/eclipse-theia/theia.git && cd theia && yarn && cd examples/browser && yarn run start
 
 ## Troubleshooting
 
@@ -383,7 +383,7 @@ If you have accidentally installed the wrong `yarn` version, you have to remove 
  - Run: choco install yarn --version 1.7.0 -y
 
 [all-in-one packages]: https://github.com/felixrieseberg/windows-build-tools
-[bug]: https://github.com/theia-ide/theia/issues
+[bug]: https://github.com/eclipse-theia/theia/issues
 
 ### macOS
 

--- a/doc/pull-requests.md
+++ b/doc/pull-requests.md
@@ -2,7 +2,7 @@
 
 This document clarifies rules and expectations of contributing and reviewing pull requests.
 It is structured as a list of rules which can be referenced on a PR to moderate and drive discussions.
-If a rule causes distress during discussions itself, it has to be reviewed on [the dev meeting](https://github.com/theia-ide/theia/wiki/Dev-Meetings) and updated.
+If a rule causes distress during discussions itself, it has to be reviewed on [the dev meeting](https://github.com/eclipse-theia/theia/wiki/Dev-Meetings) and updated.
 
  - [**Opening a Pull Request**](#opening-a-pull-request)
  - [**Requesting a Review**](#requesting-a-review)
@@ -21,7 +21,7 @@ If a rule causes distress during discussions itself, it has to be reviewed on [t
 Thank you for your Pull Request. Please provide a description and review
 the requirements below.
 
-Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
+Contributors guide: https://github.com/eclipse-theia/theia/blob/master/CONTRIBUTING.md
 -->
 
 #### What it does
@@ -32,11 +32,11 @@ Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.
 
 #### Review checklist
 
-- [ ] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)
+- [ ] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/eclipse-theia/theia/blob/master/doc/pull-requests.md#requesting-a-review)
 
 #### Reminder for reviewers
 
-- as a reviewer, I agree to review in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
+- as a reviewer, I agree to review in accordance with [the review guidelines](https://github.com/eclipse-theia/theia/blob/master/doc/pull-requests.md#reviewing)
 
 ```
 
@@ -63,19 +63,19 @@ Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.
 <a name="checklist-build-and-test"></a>
 - [1.](#checklist-build-and-test) The new code is built and tested according to the `How to test` section of a PR description.
 <a name="checklist-project-org"></a>
-- [2.](#checklist-project-org) The new code is aligned with the [project organization](https://github.com/theia-ide/theia/wiki/Code-Organization) and [coding conventions](https://github.com/theia-ide/theia/wiki/Coding-Guidelines).
+- [2.](#checklist-project-org) The new code is aligned with the [project organization](https://github.com/eclipse-theia/theia/wiki/Code-Organization) and [coding conventions](https://github.com/eclipse-theia/theia/wiki/Coding-Guidelines).
 <a name="checklist-changelog"></a>
-- [3.](#checklist-changelog) [Changelog](https://github.com/theia-ide/theia/blob/master/CHANGELOG.md) is updated.
+- [3.](#checklist-changelog) [Changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) is updated.
 <a name="checklist-breaking-changes"></a>
-- [4.](#checklist-breaking-changes) Breaking changes are justified and recorded in the [changelog](https://github.com/theia-ide/theia/blob/master/CHANGELOG.md).
+- [4.](#checklist-breaking-changes) Breaking changes are justified and recorded in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md).
 <a name="checklist-dependencies"></a>
-- [5.](#checklist-dependencies) New dependencies are justified and [verified](https://github.com/theia-ide/theia/wiki/Registering-CQs#wip---new-ecd-theia-intellectual-property-clearance-approach-experimental).
+- [5.](#checklist-dependencies) New dependencies are justified and [verified](https://github.com/eclipse-theia/theia/wiki/Registering-CQs#wip---new-ecd-theia-intellectual-property-clearance-approach-experimental).
 <a name="checklist-copied-code"></a>
-- [6.](#checklist-copied-code) Copied code is justified and [approved via a CQ](https://github.com/theia-ide/theia/wiki/Registering-CQs#case-3rd-party-project-code-copiedforked-from-another-project-into-eclipse-theia-maintained-by-us).
+- [6.](#checklist-copied-code) Copied code is justified and [approved via a CQ](https://github.com/eclipse-theia/theia/wiki/Registering-CQs#case-3rd-party-project-code-copiedforked-from-another-project-into-eclipse-theia-maintained-by-us).
 <a name="checklist-copyright"></a>
 - [7.](#checklist-copyright) Each new file has proper copyright with the current year and the name of contributing entity (individual or company).
 <a name="checklist-sign-off"></a>
-- [8.](#checklist-sign-off) Commits are signed-off: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md#sign-your-work.
+- [8.](#checklist-sign-off) Commits are signed-off: https://github.com/eclipse-theia/theia/blob/master/CONTRIBUTING.md#sign-your-work.
 <a name="checklist-meaningful-commity"></a>
 - [9.](#checklist-meaningful-commit) Each commit has meaningful title and a body that explains what it does. One can take inspiration from the `What it does` section from the PR.
 <a name="checklist-commit-history"></a>
@@ -104,8 +104,8 @@ Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.
 - [3.](#changes-no-out-of-scope) Changes cannot be requested if they address issues out of the scope of a PR.
   - Such change requests should be dismissed and an issue should be filed to address them separately.
 <a name="changes-style-agreement"></a>
-- [4.](#changes-style-agreement) Styles and coding preferences should not be discussed on the PR, but raised in [the dev meeting](https://github.com/theia-ide/theia/wiki/Dev-Meetings),
-  agreed by the team, applied to [the coding guidelines](https://github.com/theia-ide/theia/wiki/Coding-Guidelines) and after that followed by all contributors.
+- [4.](#changes-style-agreement) Styles and coding preferences should not be discussed on the PR, but raised in [the dev meeting](https://github.com/eclipse-theia/theia/wiki/Dev-Meetings),
+  agreed by the team, applied to [the coding guidelines](https://github.com/eclipse-theia/theia/wiki/Coding-Guidelines) and after that followed by all contributors.
 
 ### Approving
 
@@ -122,7 +122,7 @@ then a reviewer should be encouraged to open an alternative PR or collaborate on
 <a name="completing-pr"></a>
 - [2.](#completing-pr) If a PR is important, but an author cannot or does not want to address outstanding issues,
 then maintainers can complete the PR with additional commits
-given that author commits are preserved, [signed-off](https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md#sign-your-work) and an author accepted the [ECA](https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md#eclipse-contributor-agreement).
+given that author commits are preserved, [signed-off](https://github.com/eclipse-theia/theia/blob/master/CONTRIBUTING.md#sign-your-work) and an author accepted the [ECA](https://github.com/eclipse-theia/theia/blob/master/CONTRIBUTING.md#eclipse-contributor-agreement).
 <a name="suggesting-help-on-pr"></a>
 - [3.](#suggesting-help-on-pr) Reviewers have to suggest his help via a comment to avoid intervening in an author work.
 <a name="landing-stale-pr"></a>
@@ -133,7 +133,7 @@ given that author commits are preserved, [signed-off](https://github.com/theia-i
 <a name="landing-pr"></a>
 - [1.](#landing-pr) A PR can be landed when:
   - CI build has succeeded.
-  - The author has accepted the [Eclipse Contributor Agreement](https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md#eclipse-contributor-agreement).
+  - The author has accepted the [Eclipse Contributor Agreement](https://github.com/eclipse-theia/theia/blob/master/CONTRIBUTING.md#eclipse-contributor-agreement).
   - All checks from [the review checklist](#pull-request-review-checklist) are approved by at least one reviewer.
   - There are no unresolved review comments.
 
@@ -154,4 +154,4 @@ then an author and maintainers have 2 days to resolve them after that a PR has t
   Such changes have to be done by an experienced maintainer to avoid regressions and long reviews.
   - It should be a 3rd party component, e.g. Theia is not a logging framework or a proxy server.
   - It changes development infrastructure, e.g. testing frameworks, packaging and so on.
-Such changes have to be done by active maintainers after agreement in [the dev meeting](https://github.com/theia-ide/theia/wiki/Dev-Meetings).
+Such changes have to be done by active maintainers after agreement in [the dev meeting](https://github.com/eclipse-theia/theia/wiki/Dev-Meetings).

--- a/examples/browser/Dockerfile
+++ b/examples/browser/Dockerfile
@@ -12,7 +12,7 @@
 # 2. Next, you will need to download this Dockerfile into your PWD session with
 #    wget.
 # 
-# $ wget https://raw.githubusercontent.com/theia-ide/theia/master/examples/browser/Dockerfile
+# $ wget https://raw.githubusercontent.com/eclipse-theia/theia/master/examples/browser/Dockerfile
 # 
 # 3. Next, ask Docker to build the image. This will take some time.
 # 
@@ -38,7 +38,7 @@ WORKDIR /home/theia
 RUN rm -rf /opt/yarn && rm -f /usr/local/bin/yarn && rm -f /usr/local/bin/yarnpkg
 RUN apt-get update && apt-get install -y npm && npm install -g yarn@1.3.2
 USER theia
-RUN git clone --depth 1 https://github.com/theia-ide/theia && \
+RUN git clone --depth 1 https://github.com/eclipse-theia/theia && \
     cd theia && \
     yarn
 EXPOSE 3000

--- a/packages/bunyan/package.json
+++ b/packages/bunyan/package.json
@@ -21,12 +21,12 @@
   "license": "EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0",
   "repository": {
     "type": "git",
-    "url": "https://github.com/theia-ide/theia.git"
+    "url": "https://github.com/eclipse-theia/theia.git"
   },
   "bugs": {
-    "url": "https://github.com/theia-ide/theia/issues"
+    "url": "https://github.com/eclipse-theia/theia/issues"
   },
-  "homepage": "https://github.com/theia-ide/theia",
+  "homepage": "https://github.com/eclipse-theia/theia",
   "files": [
     "lib",
     "src"

--- a/packages/callhierarchy/package.json
+++ b/packages/callhierarchy/package.json
@@ -23,12 +23,12 @@
   "license": "EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0",
   "repository": {
     "type": "git",
-    "url": "https://github.com/theia-ide/theia.git"
+    "url": "https://github.com/eclipse-theia/theia.git"
   },
   "bugs": {
-    "url": "https://github.com/theia-ide/theia/issues"
+    "url": "https://github.com/eclipse-theia/theia/issues"
   },
-  "homepage": "https://github.com/theia-ide/theia",
+  "homepage": "https://github.com/eclipse-theia/theia",
   "files": [
     "lib",
     "src"

--- a/packages/console/README.md
+++ b/packages/console/README.md
@@ -1,6 +1,6 @@
 # Theia - Console Extension
 
-See [here](https://github.com/theia-ide/theia) for a detailed documentation.
+See [here](https://github.com/eclipse-theia/theia) for a detailed documentation.
 
 ## License
 - [Eclipse Public License 2.0](http://www.eclipse.org/legal/epl-2.0/)

--- a/packages/console/package.json
+++ b/packages/console/package.json
@@ -21,12 +21,12 @@
   "license": "EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0",
   "repository": {
     "type": "git",
-    "url": "https://github.com/theia-ide/theia.git"
+    "url": "https://github.com/eclipse-theia/theia.git"
   },
   "bugs": {
-    "url": "https://github.com/theia-ide/theia/issues"
+    "url": "https://github.com/eclipse-theia/theia/issues"
   },
-  "homepage": "https://github.com/theia-ide/theia",
+  "homepage": "https://github.com/eclipse-theia/theia",
   "files": [
     "lib",
     "src"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -73,12 +73,12 @@
   "license": "EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0",
   "repository": {
     "type": "git",
-    "url": "https://github.com/theia-ide/theia.git"
+    "url": "https://github.com/eclipse-theia/theia.git"
   },
   "bugs": {
-    "url": "https://github.com/theia-ide/theia/issues"
+    "url": "https://github.com/eclipse-theia/theia/issues"
   },
-  "homepage": "https://github.com/theia-ide/theia",
+  "homepage": "https://github.com/eclipse-theia/theia",
   "files": [
     "lib",
     "src"

--- a/packages/core/src/browser/keyboard/keys.ts
+++ b/packages/core/src/browser/keyboard/keys.ts
@@ -336,7 +336,7 @@ export namespace KeyCode {
         const code = event.code;
         if (code) {
             if (isOSX) {
-                // https://github.com/theia-ide/theia/issues/4986
+                // https://github.com/eclipse-theia/theia/issues/4986
                 const char = event.key;
                 if (code === 'IntlBackslash' && (char === '`' || char === '~')) {
                     return Key.BACKQUOTE;

--- a/packages/core/src/browser/storage-service.ts
+++ b/packages/core/src/browser/storage-service.ts
@@ -96,7 +96,7 @@ export class LocalStorageService implements StorageService {
         your browser's local storage or choose to clear all.`;
         this.messageService.warn(ERROR_MESSAGE, READ_INSTRUCTIONS_ACTION, CLEAR_STORAGE_ACTION).then(async selected => {
             if (READ_INSTRUCTIONS_ACTION === selected) {
-                this.windowService.openNewWindow('https://github.com/theia-ide/theia/wiki/Cleaning-Local-Storage', { external: true });
+                this.windowService.openNewWindow('https://github.com/eclipse-theia/theia/wiki/Cleaning-Local-Storage', { external: true });
             } else if (CLEAR_STORAGE_ACTION === selected) {
                 this.clearStorage();
             }

--- a/packages/core/src/common/contribution-provider.ts
+++ b/packages/core/src/common/contribution-provider.ts
@@ -60,7 +60,7 @@ export type Bindable = interfaces.Bind | interfaces.Container;
 export namespace Bindable {
     export function isContainer(arg: Bindable): arg is interfaces.Container {
         return typeof arg !== 'function'
-            // https://github.com/theia-ide/theia/issues/3204#issue-371029654
+            // https://github.com/eclipse-theia/theia/issues/3204#issue-371029654
             // In InversifyJS `4.14.0` containers no longer have a property `guid`.
             && ('guid' in arg || 'parent' in arg);
     }

--- a/packages/core/src/electron-browser/menu/electron-main-menu-factory.ts
+++ b/packages/core/src/electron-browser/menu/electron-main-menu-factory.ts
@@ -151,7 +151,7 @@ export class ElectronMainMenuFactory {
                     label: node.label,
                     type: this.commandRegistry.getToggledHandler(commandId, ...args) ? 'checkbox' : 'normal',
                     checked: this.commandRegistry.isToggled(commandId, ...args),
-                    enabled: true, // https://github.com/theia-ide/theia/issues/446
+                    enabled: true, // https://github.com/eclipse-theia/theia/issues/446
                     visible: true,
                     click: () => this.execute(commandId, args),
                     accelerator
@@ -173,7 +173,7 @@ export class ElectronMainMenuFactory {
         // Key Sequences can't be represented properly in the electron menu.
         //
         // We can do what VS Code does, and append the chords as a suffix to the menu label.
-        // https://github.com/theia-ide/theia/issues/1199#issuecomment-430909480
+        // https://github.com/eclipse-theia/theia/issues/1199#issuecomment-430909480
         if (bindingKeySequence.length > 1) {
             return '';
         }
@@ -184,7 +184,7 @@ export class ElectronMainMenuFactory {
 
     protected async execute(command: string, args: any[]): Promise<void> {
         try {
-            // This is workaround for https://github.com/theia-ide/theia/issues/446.
+            // This is workaround for https://github.com/eclipse-theia/theia/issues/446.
             // Electron menus do not update based on the `isEnabled`, `isVisible` property of the command.
             // We need to check if we can execute it.
             if (this.commandRegistry.isEnabled(command, ...args)) {

--- a/packages/cpp/README.md
+++ b/packages/cpp/README.md
@@ -146,7 +146,7 @@ In .theia/tasks.json, add the following:
    }
 ```
 
-If you want a description for each task field, see [theia/packages/task/src/browser/task-schema-updater.ts]( https://github.com/theia-ide/theia/blob/531aa3bde8dea7f022ea41beaee3aace65ce54de/packages/task/src/browser/task-schema-updater.ts#L62 )
+If you want a description for each task field, see [theia/packages/task/src/browser/task-schema-updater.ts]( https://github.com/eclipse-theia/theia/blob/531aa3bde8dea7f022ea41beaee3aace65ce54de/packages/task/src/browser/task-schema-updater.ts#L62 )
 
 ```bash
 When there is no compilation database, clang-tidy could run but you may need to be more specific which files to select. One way is to replace the "args" from the "*" to

--- a/packages/cpp/package.json
+++ b/packages/cpp/package.json
@@ -30,12 +30,12 @@
   "license": "EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0",
   "repository": {
     "type": "git",
-    "url": "https://github.com/theia-ide/theia.git"
+    "url": "https://github.com/eclipse-theia/theia.git"
   },
   "bugs": {
-    "url": "https://github.com/theia-ide/theia/issues"
+    "url": "https://github.com/eclipse-theia/theia/issues"
   },
-  "homepage": "https://github.com/theia-ide/theia",
+  "homepage": "https://github.com/eclipse-theia/theia",
   "files": [
     "data",
     "lib",

--- a/packages/debug-nodejs/package.json
+++ b/packages/debug-nodejs/package.json
@@ -23,12 +23,12 @@
   "license": "EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0",
   "repository": {
     "type": "git",
-    "url": "https://github.com/theia-ide/theia.git"
+    "url": "https://github.com/eclipse-theia/theia.git"
   },
   "bugs": {
-    "url": "https://github.com/theia-ide/theia/issues"
+    "url": "https://github.com/eclipse-theia/theia/issues"
   },
-  "homepage": "https://github.com/theia-ide/theia",
+  "homepage": "https://github.com/eclipse-theia/theia",
   "files": [
     "lib",
     "src",

--- a/packages/debug/README.md
+++ b/packages/debug/README.md
@@ -1,7 +1,7 @@
 ## Architecture
 `DebugService` is used to initialize a new `DebugSession`. This service provides functionality to configure and to start a new debug session. The workflow is the following. If user wants to debug an application and there is no debug configuration associated with the application then the list of available debuggers is requested to create a suitable debug configuration. When configuration is chosen it is possible to alter the configuration by filling in missing values or by adding/changing/removing attributes.
 
-In most cases the default behavior of the `DebugSession` is enough. But it is possible to provide its own implementation. The `DebugSessionFactory` is used for this purpose via `DebugSessionContribution`. Documented model objects are located [here](https://github.com/theia-ide/theia/tree/master/packages/debug/src/browser/debug-model.ts)
+In most cases the default behavior of the `DebugSession` is enough. But it is possible to provide its own implementation. The `DebugSessionFactory` is used for this purpose via `DebugSessionContribution`. Documented model objects are located [here](https://github.com/eclipse-theia/theia/tree/master/packages/debug/src/browser/debug-model.ts)
 
 ### Debug Session life-cycle API
 `DebugSession` life-cycle is controlled and can be tracked as follows:
@@ -14,14 +14,14 @@ In most cases the default behavior of the `DebugSession` is enough. But it is po
 `ExtDebugProtocol.AggregatedBreakpoint` is used to handle breakpoints on the client side. It covers all three breakpoint types: `DebugProtocol.SourceBreakpoint`, `DebugProtocol.FunctionBreakpoint` and `ExtDebugProtocol.ExceptionBreakpoint`. It is possible to identify a breakpoint type with help of `DebugUtils`. Notification about added, removed, or changed breakpoints is received via `onDidChangeBreakpoints`.
 
 ### Server side
-At the back-end we start a debug adapter using `DebugAdapterFactory` and then a `DebugAdapterSession` is instantiated which works as a proxy between client and debug adapter. If a default implementation of the debug adapter session does not fit needs, it is possible to provide its own implementation using `DebugAdapterSessionFactory`. If so, it is recommended to extend the default implementation of the `DebugAdapterSession`. Documented model objects are located [here](https://github.com/theia-ide/theia/tree/master/packages/debug/src/node/debug-model.ts)
+At the back-end we start a debug adapter using `DebugAdapterFactory` and then a `DebugAdapterSession` is instantiated which works as a proxy between client and debug adapter. If a default implementation of the debug adapter session does not fit needs, it is possible to provide its own implementation using `DebugAdapterSessionFactory`. If so, it is recommended to extend the default implementation of the `DebugAdapterSession`. Documented model objects are located [here](https://github.com/eclipse-theia/theia/tree/master/packages/debug/src/node/debug-model.ts)
 
 `DebugSessionState` accumulates debug adapter events and is used to restore debug session on the client side when page is refreshed. 
 
 ## How to contribute a new debugger
 `DebugAdapterContribution` is a contribution point for all debug adapters to provide and resolve debug configuration.
 
-Here is an example of [debug adapter contribution for node](https://github.com/theia-ide/theia/tree/master/packages/debug-nodejs/src/node/debug-nodejs.ts)
+Here is an example of [debug adapter contribution for node](https://github.com/eclipse-theia/theia/tree/master/packages/debug-nodejs/src/node/debug-nodejs.ts)
 
 ## References
 * [Debug Adapter Protocol](https://github.com/Microsoft/vscode-debugadapter-node/blob/master/protocol/src/debugProtocol.ts)

--- a/packages/debug/package.json
+++ b/packages/debug/package.json
@@ -44,12 +44,12 @@
   "license": "EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0",
   "repository": {
     "type": "git",
-    "url": "https://github.com/theia-ide/theia.git"
+    "url": "https://github.com/eclipse-theia/theia.git"
   },
   "bugs": {
-    "url": "https://github.com/theia-ide/theia/issues"
+    "url": "https://github.com/eclipse-theia/theia/issues"
   },
-  "homepage": "https://github.com/theia-ide/theia",
+  "homepage": "https://github.com/eclipse-theia/theia",
   "bin": {
     "download-debug-adapters": "./bin/download-adapters.js"
   },

--- a/packages/editor-preview/package.json
+++ b/packages/editor-preview/package.json
@@ -21,12 +21,12 @@
   "license": "EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0",
   "repository": {
     "type": "git",
-    "url": "https://github.com/theia-ide/theia.git"
+    "url": "https://github.com/eclipse-theia/theia.git"
   },
   "bugs": {
-    "url": "https://github.com/theia-ide/theia/issues"
+    "url": "https://github.com/eclipse-theia/theia/issues"
   },
-  "homepage": "https://github.com/theia-ide/theia",
+  "homepage": "https://github.com/eclipse-theia/theia",
   "files": [
     "lib",
     "src"

--- a/packages/editor-preview/src/browser/editor-preview-widget.ts
+++ b/packages/editor-preview/src/browser/editor-preview-widget.ts
@@ -182,7 +182,7 @@ export class EditorPreviewWidget extends BaseWidget implements ApplicationShell.
     protected onResize(msg: Widget.ResizeMessage): void {
         if (this.editorWidget_) {
             // Currently autosizing does not work with the Monaco Editor Widget
-            // https://github.com/theia-ide/theia/blob/c86a33b9ee0e5bb1dc49c66def123ffb2cadbfe4/packages/monaco/src/browser/monaco-editor.ts#L461
+            // https://github.com/eclipse-theia/theia/blob/c86a33b9ee0e5bb1dc49c66def123ffb2cadbfe4/packages/monaco/src/browser/monaco-editor.ts#L461
             // After this is supported we can rely on the underlying widget to resize and remove
             // the following if statement. (Without it, the editor will be initialized to its
             // minimum size)

--- a/packages/editor/package.json
+++ b/packages/editor/package.json
@@ -23,12 +23,12 @@
   "license": "EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0",
   "repository": {
     "type": "git",
-    "url": "https://github.com/theia-ide/theia.git"
+    "url": "https://github.com/eclipse-theia/theia.git"
   },
   "bugs": {
-    "url": "https://github.com/theia-ide/theia/issues"
+    "url": "https://github.com/eclipse-theia/theia/issues"
   },
-  "homepage": "https://github.com/theia-ide/theia",
+  "homepage": "https://github.com/eclipse-theia/theia",
   "files": [
     "lib",
     "src"

--- a/packages/editorconfig/package.json
+++ b/packages/editorconfig/package.json
@@ -24,12 +24,12 @@
   "license": "EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0",
   "repository": {
     "type": "git",
-    "url": "https://github.com/theia-ide/theia.git"
+    "url": "https://github.com/eclipse-theia/theia.git"
   },
   "bugs": {
-    "url": "https://github.com/theia-ide/theia/issues"
+    "url": "https://github.com/eclipse-theia/theia/issues"
   },
-  "homepage": "https://github.com/theia-ide/theia",
+  "homepage": "https://github.com/eclipse-theia/theia",
   "files": [
     "lib",
     "src"

--- a/packages/extension-manager/package.json
+++ b/packages/extension-manager/package.json
@@ -29,12 +29,12 @@
   "license": "EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0",
   "repository": {
     "type": "git",
-    "url": "https://github.com/theia-ide/theia.git"
+    "url": "https://github.com/eclipse-theia/theia.git"
   },
   "bugs": {
-    "url": "https://github.com/theia-ide/theia/issues"
+    "url": "https://github.com/eclipse-theia/theia/issues"
   },
-  "homepage": "https://github.com/theia-ide/theia",
+  "homepage": "https://github.com/eclipse-theia/theia",
   "files": [
     "lib",
     "src"

--- a/packages/file-search/package.json
+++ b/packages/file-search/package.json
@@ -26,12 +26,12 @@
   "license": "EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0",
   "repository": {
     "type": "git",
-    "url": "https://github.com/theia-ide/theia.git"
+    "url": "https://github.com/eclipse-theia/theia.git"
   },
   "bugs": {
-    "url": "https://github.com/theia-ide/theia/issues"
+    "url": "https://github.com/eclipse-theia/theia/issues"
   },
-  "homepage": "https://github.com/theia-ide/theia",
+  "homepage": "https://github.com/eclipse-theia/theia",
   "files": [
     "lib",
     "src"

--- a/packages/filesystem/package.json
+++ b/packages/filesystem/package.json
@@ -47,12 +47,12 @@
   "license": "EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0",
   "repository": {
     "type": "git",
-    "url": "https://github.com/theia-ide/theia.git"
+    "url": "https://github.com/eclipse-theia/theia.git"
   },
   "bugs": {
-    "url": "https://github.com/theia-ide/theia/issues"
+    "url": "https://github.com/eclipse-theia/theia/issues"
   },
-  "homepage": "https://github.com/theia-ide/theia",
+  "homepage": "https://github.com/eclipse-theia/theia",
   "files": [
     "lib",
     "src"

--- a/packages/filesystem/src/browser/location/location-renderer.tsx
+++ b/packages/filesystem/src/browser/location/location-renderer.tsx
@@ -69,7 +69,7 @@ export class LocationListRenderer extends ReactRenderer {
                 } else {
                     // This is necessary for Windows to be able to show `/e:/` as a drive and `c:` as "non-drive" in the same way.
                     // `URI.path.toString()` Vs. `URI.displayName` behaves a bit differently on Windows.
-                    // https://github.com/theia-ide/theia/pull/3038#issuecomment-425944189
+                    // https://github.com/eclipse-theia/theia/pull/3038#issuecomment-425944189
                     locations[index].isDrive = true;
                 }
             });

--- a/packages/filesystem/src/node/node-filesystem.spec.ts
+++ b/packages/filesystem/src/node/node-filesystem.spec.ts
@@ -368,7 +368,7 @@ describe('NodeFileSystem', function (): void {
 
         it('Moving a non-empty directory to an empty directory. Source folder and its content should be moved to the target location.', async function (): Promise<void> {
             if (isWindows) {
-                // https://github.com/theia-ide/theia/issues/2088
+                // https://github.com/eclipse-theia/theia/issues/2088
                 this.skip();
                 return;
             }

--- a/packages/getting-started/package.json
+++ b/packages/getting-started/package.json
@@ -22,12 +22,12 @@
   "license": "EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0",
   "repository": {
     "type": "git",
-    "url": "https://github.com/theia-ide/theia.git"
+    "url": "https://github.com/eclipse-theia/theia.git"
   },
   "bugs": {
-    "url": "https://github.com/theia-ide/theia/issues"
+    "url": "https://github.com/eclipse-theia/theia/issues"
   },
-  "homepage": "https://github.com/theia-ide/theia",
+  "homepage": "https://github.com/eclipse-theia/theia",
   "files": [
     "lib",
     "src"

--- a/packages/git/package.json
+++ b/packages/git/package.json
@@ -44,12 +44,12 @@
   "license": "EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0",
   "repository": {
     "type": "git",
-    "url": "https://github.com/theia-ide/theia.git"
+    "url": "https://github.com/eclipse-theia/theia.git"
   },
   "bugs": {
-    "url": "https://github.com/theia-ide/theia/issues"
+    "url": "https://github.com/eclipse-theia/theia/issues"
   },
-  "homepage": "https://github.com/theia-ide/theia",
+  "homepage": "https://github.com/eclipse-theia/theia",
   "files": [
     "lib",
     "src"

--- a/packages/git/src/node/dugite-git.spec.ts
+++ b/packages/git/src/node/dugite-git.spec.ts
@@ -15,7 +15,7 @@
  ********************************************************************************/
 
 // tslint:disable-next-line:no-implicit-dependencies
- import * as upath from 'upath';
+import * as upath from 'upath';
 
 import * as path from 'path';
 import * as temp from 'temp';
@@ -767,7 +767,7 @@ describe('git', async function (): Promise<void> {
 
 describe('log', function (): void {
 
-    // See https://github.com/theia-ide/theia/issues/2143
+    // See https://github.com/eclipse-theia/theia/issues/2143
     it('should not fail when executed from the repository root', async () => {
         const root = await createTestRepository(track.mkdirSync('log-test'));
         const localUri = FileUri.create(root).toString();

--- a/packages/java-debug/package.json
+++ b/packages/java-debug/package.json
@@ -24,12 +24,12 @@
   "license": "EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0",
   "repository": {
     "type": "git",
-    "url": "https://github.com/theia-ide/theia.git"
+    "url": "https://github.com/eclipse-theia/theia.git"
   },
   "bugs": {
-    "url": "https://github.com/theia-ide/theia/issues"
+    "url": "https://github.com/eclipse-theia/theia/issues"
   },
-  "homepage": "https://github.com/theia-ide/theia",
+  "homepage": "https://github.com/eclipse-theia/theia",
   "files": [
     "lib",
     "src",

--- a/packages/java/package.json
+++ b/packages/java/package.json
@@ -41,12 +41,12 @@
   "license": "EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0",
   "repository": {
     "type": "git",
-    "url": "https://github.com/theia-ide/theia.git"
+    "url": "https://github.com/eclipse-theia/theia.git"
   },
   "bugs": {
-    "url": "https://github.com/theia-ide/theia/issues"
+    "url": "https://github.com/eclipse-theia/theia/issues"
   },
-  "homepage": "https://github.com/theia-ide/theia",
+  "homepage": "https://github.com/eclipse-theia/theia",
   "files": [
     "lib",
     "scripts",

--- a/packages/json/package.json
+++ b/packages/json/package.json
@@ -34,12 +34,12 @@
   "license": "EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0",
   "repository": {
     "type": "git",
-    "url": "https://github.com/theia-ide/theia.git"
+    "url": "https://github.com/eclipse-theia/theia.git"
   },
   "bugs": {
-    "url": "https://github.com/theia-ide/theia/issues"
+    "url": "https://github.com/eclipse-theia/theia/issues"
   },
-  "homepage": "https://github.com/theia-ide/theia",
+  "homepage": "https://github.com/eclipse-theia/theia",
   "files": [
     "lib",
     "src",

--- a/packages/json/src/node/json-contribution.ts
+++ b/packages/json/src/node/json-contribution.ts
@@ -27,7 +27,7 @@ export class JsonContribution extends BaseLanguageServerContribution {
     readonly name = JSON_LANGUAGE_NAME;
 
     async start(clientConnection: IConnection): Promise<void> {
-        // Same as https://github.com/theia-ide/theia/commit/de45794a90fc1a1a590578026f8ad527127afa0a
+        // Same as https://github.com/eclipse-theia/theia/commit/de45794a90fc1a1a590578026f8ad527127afa0a
         const command = process.execPath;
         const args: string[] = [
             path.resolve(__dirname, './json-starter'),

--- a/packages/keymaps/package.json
+++ b/packages/keymaps/package.json
@@ -32,12 +32,12 @@
   "license": "EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0",
   "repository": {
     "type": "git",
-    "url": "https://github.com/theia-ide/theia.git"
+    "url": "https://github.com/eclipse-theia/theia.git"
   },
   "bugs": {
-    "url": "https://github.com/theia-ide/theia/issues"
+    "url": "https://github.com/eclipse-theia/theia/issues"
   },
-  "homepage": "https://github.com/theia-ide/theia",
+  "homepage": "https://github.com/eclipse-theia/theia",
   "files": [
     "lib",
     "src"

--- a/packages/languages/package.json
+++ b/packages/languages/package.json
@@ -27,12 +27,12 @@
   "license": "EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0",
   "repository": {
     "type": "git",
-    "url": "https://github.com/theia-ide/theia.git"
+    "url": "https://github.com/eclipse-theia/theia.git"
   },
   "bugs": {
-    "url": "https://github.com/theia-ide/theia/issues"
+    "url": "https://github.com/eclipse-theia/theia/issues"
   },
-  "homepage": "https://github.com/theia-ide/theia",
+  "homepage": "https://github.com/eclipse-theia/theia",
   "files": [
     "lib",
     "src"

--- a/packages/languages/src/browser/language-client-factory.ts
+++ b/packages/languages/src/browser/language-client-factory.ts
@@ -81,7 +81,7 @@ export class LanguageClientFactory {
     }
 
     /**
-     * see https://github.com/theia-ide/theia/issues/4085
+     * see https://github.com/eclipse-theia/theia/issues/4085
      * remove when monaco-languageclient is upgraded to latest vscode-languageclient
      */
     protected patch4085(client: MonacoLanguageClient): MonacoLanguageClient {

--- a/packages/markers/package.json
+++ b/packages/markers/package.json
@@ -22,12 +22,12 @@
   "license": "EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0",
   "repository": {
     "type": "git",
-    "url": "https://github.com/theia-ide/theia.git"
+    "url": "https://github.com/eclipse-theia/theia.git"
   },
   "bugs": {
-    "url": "https://github.com/theia-ide/theia/issues"
+    "url": "https://github.com/eclipse-theia/theia/issues"
   },
-  "homepage": "https://github.com/theia-ide/theia",
+  "homepage": "https://github.com/eclipse-theia/theia",
   "files": [
     "lib",
     "src"

--- a/packages/merge-conflicts/package.json
+++ b/packages/merge-conflicts/package.json
@@ -21,12 +21,12 @@
   "license": "EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0",
   "repository": {
     "type": "git",
-    "url": "https://github.com/theia-ide/theia.git"
+    "url": "https://github.com/eclipse-theia/theia.git"
   },
   "bugs": {
-    "url": "https://github.com/theia-ide/theia/issues"
+    "url": "https://github.com/eclipse-theia/theia/issues"
   },
-  "homepage": "https://github.com/theia-ide/theia",
+  "homepage": "https://github.com/eclipse-theia/theia",
   "files": [
     "lib",
     "src"

--- a/packages/messages/package.json
+++ b/packages/messages/package.json
@@ -23,12 +23,12 @@
   "license": "EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0",
   "repository": {
     "type": "git",
-    "url": "https://github.com/theia-ide/theia.git"
+    "url": "https://github.com/eclipse-theia/theia.git"
   },
   "bugs": {
-    "url": "https://github.com/theia-ide/theia/issues"
+    "url": "https://github.com/eclipse-theia/theia/issues"
   },
-  "homepage": "https://github.com/theia-ide/theia",
+  "homepage": "https://github.com/eclipse-theia/theia",
   "files": [
     "lib",
     "src"

--- a/packages/metrics/package.json
+++ b/packages/metrics/package.json
@@ -21,12 +21,12 @@
   "license": "EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0",
   "repository": {
     "type": "git",
-    "url": "https://github.com/theia-ide/theia.git"
+    "url": "https://github.com/eclipse-theia/theia.git"
   },
   "bugs": {
-    "url": "https://github.com/theia-ide/theia/issues"
+    "url": "https://github.com/eclipse-theia/theia/issues"
   },
-  "homepage": "https://github.com/theia-ide/theia",
+  "homepage": "https://github.com/eclipse-theia/theia",
   "files": [
     "lib",
     "src"

--- a/packages/mini-browser/package.json
+++ b/packages/mini-browser/package.json
@@ -24,12 +24,12 @@
   "license": "EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0",
   "repository": {
     "type": "git",
-    "url": "https://github.com/theia-ide/theia.git"
+    "url": "https://github.com/eclipse-theia/theia.git"
   },
   "bugs": {
-    "url": "https://github.com/theia-ide/theia/issues"
+    "url": "https://github.com/eclipse-theia/theia/issues"
   },
-  "homepage": "https://github.com/theia-ide/theia",
+  "homepage": "https://github.com/eclipse-theia/theia",
   "files": [
     "lib",
     "src"

--- a/packages/mini-browser/src/browser/mini-browser-open-handler.ts
+++ b/packages/mini-browser/src/browser/mini-browser-open-handler.ts
@@ -66,9 +66,9 @@ export class MiniBrowserOpenHandler extends NavigatableWidgetOpenHandler<MiniBro
      * Instead of going to the backend with each file URI to ask whether it can handle the current file or not,
      * we have this map of extension and priority pairs that we populate at application startup.
      * The real advantage of this approach is the following: [Phosphor cannot run async code when invoking `isEnabled`/`isVisible`
-     * for the command handlers](https://github.com/theia-ide/theia/issues/1958#issuecomment-392829371)
+     * for the command handlers](https://github.com/eclipse-theia/theia/issues/1958#issuecomment-392829371)
      * so the menu item would be always visible for the user even if the file type cannot be handled eventually.
-     * Hopefully, we could get rid of this hack once we have migrated the existing Phosphor code to [React](https://github.com/theia-ide/theia/issues/1915).
+     * Hopefully, we could get rid of this hack once we have migrated the existing Phosphor code to [React](https://github.com/eclipse-theia/theia/issues/1915).
      */
     protected readonly supportedExtensions: Map<string, number> = new Map();
 

--- a/packages/mini-browser/src/node/mini-browser-endpoint.ts
+++ b/packages/mini-browser/src/node/mini-browser-endpoint.ts
@@ -204,7 +204,7 @@ export class HtmlHandler implements MiniBrowserEndpointHandler {
 
     priority(): number {
         // Prefer Code Editor over Mini Browser
-        // https://github.com/theia-ide/theia/issues/2051
+        // https://github.com/eclipse-theia/theia/issues/2051
         return 1;
     }
 

--- a/packages/monaco/package.json
+++ b/packages/monaco/package.json
@@ -32,12 +32,12 @@
   "license": "EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0",
   "repository": {
     "type": "git",
-    "url": "https://github.com/theia-ide/theia.git"
+    "url": "https://github.com/eclipse-theia/theia.git"
   },
   "bugs": {
-    "url": "https://github.com/theia-ide/theia/issues"
+    "url": "https://github.com/eclipse-theia/theia/issues"
   },
-  "homepage": "https://github.com/theia-ide/theia",
+  "homepage": "https://github.com/eclipse-theia/theia",
   "files": [
     "lib",
     "src",

--- a/packages/monaco/src/browser/monaco-outline-contribution.ts
+++ b/packages/monaco/src/browser/monaco-outline-contribution.ts
@@ -224,7 +224,7 @@ export class MonacoOutlineContribution implements FrontendApplicationContributio
      * If the argument is a `DocumentSymbol`, then `getFullRange` will be used to retrieve the range of the underlying symbol.
      */
     protected parentContains(candidate: DocumentSymbol | Range, parent: DocumentSymbol | Range, rangeBased: boolean): boolean {
-        // TODO: move this code to the `monaco-languageclient`: https://github.com/theia-ide/theia/pull/2885#discussion_r217800446
+        // TODO: move this code to the `monaco-languageclient`: https://github.com/eclipse-theia/theia/pull/2885#discussion_r217800446
         const candidateRange = Range.is(candidate) ? candidate : this.getFullRange(candidate);
         const parentRange = Range.is(parent) ? parent : this.getFullRange(parent);
         const sameStartLine = candidateRange.start.line === parentRange.start.line;

--- a/packages/navigator/package.json
+++ b/packages/navigator/package.json
@@ -23,12 +23,12 @@
   "license": "EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0",
   "repository": {
     "type": "git",
-    "url": "https://github.com/theia-ide/theia.git"
+    "url": "https://github.com/eclipse-theia/theia.git"
   },
   "bugs": {
-    "url": "https://github.com/theia-ide/theia/issues"
+    "url": "https://github.com/eclipse-theia/theia/issues"
   },
-  "homepage": "https://github.com/theia-ide/theia",
+  "homepage": "https://github.com/eclipse-theia/theia",
   "files": [
     "lib",
     "src"

--- a/packages/outline-view/package.json
+++ b/packages/outline-view/package.json
@@ -19,12 +19,12 @@
   "license": "EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0",
   "repository": {
     "type": "git",
-    "url": "https://github.com/theia-ide/theia.git"
+    "url": "https://github.com/eclipse-theia/theia.git"
   },
   "bugs": {
-    "url": "https://github.com/theia-ide/theia/issues"
+    "url": "https://github.com/eclipse-theia/theia/issues"
   },
-  "homepage": "https://github.com/theia-ide/theia",
+  "homepage": "https://github.com/eclipse-theia/theia",
   "files": [
     "lib",
     "src"

--- a/packages/output/package.json
+++ b/packages/output/package.json
@@ -19,12 +19,12 @@
   "license": "EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0",
   "repository": {
     "type": "git",
-    "url": "https://github.com/theia-ide/theia.git"
+    "url": "https://github.com/eclipse-theia/theia.git"
   },
   "bugs": {
-    "url": "https://github.com/theia-ide/theia/issues"
+    "url": "https://github.com/eclipse-theia/theia/issues"
   },
-  "homepage": "https://github.com/theia-ide/theia",
+  "homepage": "https://github.com/eclipse-theia/theia",
   "files": [
     "lib",
     "src"

--- a/packages/plugin-dev/package.json
+++ b/packages/plugin-dev/package.json
@@ -32,12 +32,12 @@
   "license": "EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0",
   "repository": {
     "type": "git",
-    "url": "https://github.com/theia-ide/theia.git"
+    "url": "https://github.com/eclipse-theia/theia.git"
   },
   "bugs": {
-    "url": "https://github.com/theia-ide/theia/issues"
+    "url": "https://github.com/eclipse-theia/theia/issues"
   },
-  "homepage": "https://github.com/theia-ide/theia",
+  "homepage": "https://github.com/eclipse-theia/theia",
   "files": [
     "lib",
     "src"

--- a/packages/plugin-ext-vscode/package.json
+++ b/packages/plugin-ext-vscode/package.json
@@ -26,12 +26,12 @@
   "license": "EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0",
   "repository": {
     "type": "git",
-    "url": "https://github.com/theia-ide/theia.git"
+    "url": "https://github.com/eclipse-theia/theia.git"
   },
   "bugs": {
-    "url": "https://github.com/theia-ide/theia/issues"
+    "url": "https://github.com/eclipse-theia/theia/issues"
   },
-  "homepage": "https://github.com/theia-ide/theia",
+  "homepage": "https://github.com/eclipse-theia/theia",
   "files": [
     "lib",
     "src"

--- a/packages/plugin-ext/package.json
+++ b/packages/plugin-ext/package.json
@@ -51,12 +51,12 @@
   "license": "EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0",
   "repository": {
     "type": "git",
-    "url": "https://github.com/theia-ide/theia.git"
+    "url": "https://github.com/eclipse-theia/theia.git"
   },
   "bugs": {
-    "url": "https://github.com/theia-ide/theia/issues"
+    "url": "https://github.com/eclipse-theia/theia/issues"
   },
-  "homepage": "https://github.com/theia-ide/theia",
+  "homepage": "https://github.com/eclipse-theia/theia",
   "files": [
     "lib",
     "src"

--- a/packages/plugin-ext/src/main/browser/menus/menus-contribution-handler.spec.ts
+++ b/packages/plugin-ext/src/main/browser/menus/menus-contribution-handler.spec.ts
@@ -36,7 +36,7 @@ import { ResourceContextKey } from '@theia/core/lib/browser/resource-context-key
 
 disableJSDOM();
 
-// TODO: enable tests once the https://github.com/theia-ide/theia/issues/3344 is fixed
+// TODO: enable tests once the https://github.com/eclipse-theia/theia/issues/3344 is fixed
 describe.skip('MenusContributionHandler', () => {
 
     let testContainer: Container;

--- a/packages/plugin-ext/src/main/browser/menus/menus-contribution-handler.ts
+++ b/packages/plugin-ext/src/main/browser/menus/menus-contribution-handler.ts
@@ -328,7 +328,7 @@ export class MenusContributionPointHandler {
             // Registering a menu action requires the related command to be already registered.
             // But Theia plugin registers the commands dynamically via the Commands API.
             // Let's wait for ~2 sec. It should be enough to finish registering all the contributed commands.
-            // FIXME: remove this workaround (timer) once the https://github.com/theia-ide/theia/issues/3344 is fixed
+            // FIXME: remove this workaround (timer) once the https://github.com/eclipse-theia/theia/issues/3344 is fixed
             setTimeout(() => this.onDidRegisterCommand(id, cb), 2000);
         }
     }

--- a/packages/plugin-ext/src/plugin/plugin-context.ts
+++ b/packages/plugin-ext/src/plugin/plugin-context.ts
@@ -475,7 +475,7 @@ export function createAPIFactory(
             registerTaskProvider(type: string, provider: theia.TaskProvider): theia.Disposable {
                 return tasks.registerTaskProvider(type, provider);
             },
-            // Experimental API https://github.com/theia-ide/theia/issues/4167
+            // Experimental API https://github.com/eclipse-theia/theia/issues/4167
             onDidRenameFile(listener, thisArg?, disposables?): theia.Disposable {
                 return workspaceExt.onDidRenameFile(listener, thisArg, disposables);
             },

--- a/packages/plugin-ext/src/plugin/plugin-manager.ts
+++ b/packages/plugin-ext/src/plugin/plugin-manager.ts
@@ -170,7 +170,7 @@ export class PluginManagerExtImpl implements PluginManagerExt, PluginManager {
             this.setActivation(`onPlugin:${plugin.model.id}`, activation);
             const unsupportedActivationEvents = plugin.rawModel.activationEvents.filter(e => !PluginManagerExtImpl.SUPPORTED_ACTIVATION_EVENTS.has(e.split(':')[0]));
             if (unsupportedActivationEvents.length) {
-                console.warn(`Unsupported activation events: ${unsupportedActivationEvents.join(', ')}, please open an issue: https://github.com/theia-ide/theia/issues/new`);
+                console.warn(`Unsupported activation events: ${unsupportedActivationEvents.join(', ')}, please open an issue: https://github.com/eclipse-theia/theia/issues/new`);
                 console.warn(`${plugin.model.id} extension will be activated eagerly.`);
                 this.setActivation('*', activation);
             } else {

--- a/packages/plugin-ext/src/plugin/quick-open.ts
+++ b/packages/plugin-ext/src/plugin/quick-open.ts
@@ -376,7 +376,7 @@ export class QuickInputExt implements QuickInput {
 
 /**
  * Base implementation of {@link InputBox} that uses {@link QuickOpenExt}.
- * Missing functionality is going to be implemented in the scope of https://github.com/theia-ide/theia/issues/5109
+ * Missing functionality is going to be implemented in the scope of https://github.com/eclipse-theia/theia/issues/5109
  */
 export class InputBoxExt extends QuickInputExt implements InputBox {
 
@@ -490,7 +490,7 @@ export class InputBoxExt extends QuickInputExt implements InputBox {
 
 /**
  * Base implementation of {@link QuickPick} that uses {@link QuickOpenExt}.
- * Missing functionality is going to be implemented in the scope of https://github.com/theia-ide/theia/issues/5059
+ * Missing functionality is going to be implemented in the scope of https://github.com/eclipse-theia/theia/issues/5059
  */
 export class QuickPickExt<T extends QuickPickItem> extends QuickInputExt implements QuickPick<T> {
 

--- a/packages/plugin-ext/src/plugin/workspace.ts
+++ b/packages/plugin-ext/src/plugin/workspace.ts
@@ -344,7 +344,7 @@ export class WorkspaceExtImpl implements WorkspaceExt {
         return true;
     }
 
-    // Experimental API https://github.com/theia-ide/theia/issues/4167
+    // Experimental API https://github.com/eclipse-theia/theia/issues/4167
     private workspaceWillRenameFileEmitter = new Emitter<theia.FileWillRenameEvent>();
     private workspaceDidRenameFileEmitter = new Emitter<theia.FileRenameEvent>();
 

--- a/packages/plugin/package.json
+++ b/packages/plugin/package.json
@@ -9,12 +9,12 @@
   "license": "EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0",
   "repository": {
     "type": "git",
-    "url": "https://github.com/theia-ide/theia.git"
+    "url": "https://github.com/eclipse-theia/theia.git"
   },
   "bugs": {
-    "url": "https://github.com/theia-ide/theia/issues"
+    "url": "https://github.com/eclipse-theia/theia/issues"
   },
-  "homepage": "https://github.com/theia-ide/theia",
+  "homepage": "https://github.com/eclipse-theia/theia",
   "files": [
     "src"
   ],

--- a/packages/preferences/package.json
+++ b/packages/preferences/package.json
@@ -26,12 +26,12 @@
   "license": "EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0",
   "repository": {
     "type": "git",
-    "url": "https://github.com/theia-ide/theia.git"
+    "url": "https://github.com/eclipse-theia/theia.git"
   },
   "bugs": {
-    "url": "https://github.com/theia-ide/theia/issues"
+    "url": "https://github.com/eclipse-theia/theia/issues"
   },
-  "homepage": "https://github.com/theia-ide/theia",
+  "homepage": "https://github.com/eclipse-theia/theia",
   "files": [
     "lib",
     "src"

--- a/packages/preview/package.json
+++ b/packages/preview/package.json
@@ -28,12 +28,12 @@
   "license": "EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0",
   "repository": {
     "type": "git",
-    "url": "https://github.com/theia-ide/theia.git"
+    "url": "https://github.com/eclipse-theia/theia.git"
   },
   "bugs": {
-    "url": "https://github.com/theia-ide/theia/issues"
+    "url": "https://github.com/eclipse-theia/theia/issues"
   },
-  "homepage": "https://github.com/theia-ide/theia",
+  "homepage": "https://github.com/eclipse-theia/theia",
   "files": [
     "lib",
     "src"

--- a/packages/preview/src/browser/markdown/markdown-preview-handler.spec.ts
+++ b/packages/preview/src/browser/markdown/markdown-preview-handler.spec.ts
@@ -115,18 +115,18 @@ async function assertRenderedContent(source: string, expectation: string): Promi
 const exampleMarkdown1 = //
     `# Theia - Preview Extension
 Shows a preview of supported resources.
-See [here](https://github.com/theia-ide/theia).
+See [here](https://github.com/eclipse-theia/theia).
 
 ## License
-[Apache-2.0](https://github.com/theia-ide/theia/blob/master/LICENSE)
+[Apache-2.0](https://github.com/eclipse-theia/theia/blob/master/LICENSE)
 `;
 
 const exampleHtml1 = //
     `<h1 id="theia---preview-extension" class="line" data-line="0">Theia - Preview Extension</h1>
 <p class="line" data-line="1">Shows a preview of supported resources.
-See <a href="https://github.com/theia-ide/theia">here</a>.</p>
+See <a href="https://github.com/eclipse-theia/theia">here</a>.</p>
 <h2 id="license" class="line" data-line="4">License</h2>
-<p class="line" data-line="5"><a href="https://github.com/theia-ide/theia/blob/master/LICENSE">Apache-2.0</a></p>
+<p class="line" data-line="5"><a href="https://github.com/eclipse-theia/theia/blob/master/LICENSE">Apache-2.0</a></p>
 `;
 
 const exampleMarkdown2 = //

--- a/packages/process/package.json
+++ b/packages/process/package.json
@@ -21,12 +21,12 @@
   "license": "EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0",
   "repository": {
     "type": "git",
-    "url": "https://github.com/theia-ide/theia.git"
+    "url": "https://github.com/eclipse-theia/theia.git"
   },
   "bugs": {
-    "url": "https://github.com/theia-ide/theia/issues"
+    "url": "https://github.com/eclipse-theia/theia/issues"
   },
-  "homepage": "https://github.com/theia-ide/theia",
+  "homepage": "https://github.com/eclipse-theia/theia",
   "files": [
     "lib",
     "src"

--- a/packages/python/package.json
+++ b/packages/python/package.json
@@ -23,12 +23,12 @@
   "license": "EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0",
   "repository": {
     "type": "git",
-    "url": "https://github.com/theia-ide/theia.git"
+    "url": "https://github.com/eclipse-theia/theia.git"
   },
   "bugs": {
-    "url": "https://github.com/theia-ide/theia/issues"
+    "url": "https://github.com/eclipse-theia/theia/issues"
   },
-  "homepage": "https://github.com/theia-ide/theia",
+  "homepage": "https://github.com/eclipse-theia/theia",
   "files": [
     "data",
     "lib",

--- a/packages/scm/package.json
+++ b/packages/scm/package.json
@@ -28,12 +28,12 @@
   "license": "EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0",
   "repository": {
     "type": "git",
-    "url": "https://github.com/theia-ide/theia.git"
+    "url": "https://github.com/eclipse-theia/theia.git"
   },
   "bugs": {
-    "url": "https://github.com/theia-ide/theia/issues"
+    "url": "https://github.com/eclipse-theia/theia/issues"
   },
-  "homepage": "https://github.com/theia-ide/theia",
+  "homepage": "https://github.com/eclipse-theia/theia",
   "files": [
     "lib",
     "src"

--- a/packages/search-in-workspace/package.json
+++ b/packages/search-in-workspace/package.json
@@ -26,12 +26,12 @@
   "license": "EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0",
   "repository": {
     "type": "git",
-    "url": "https://github.com/theia-ide/theia.git"
+    "url": "https://github.com/eclipse-theia/theia.git"
   },
   "bugs": {
-    "url": "https://github.com/theia-ide/theia/issues"
+    "url": "https://github.com/eclipse-theia/theia/issues"
   },
-  "homepage": "https://github.com/theia-ide/theia",
+  "homepage": "https://github.com/eclipse-theia/theia",
   "files": [
     "lib",
     "src"

--- a/packages/task/package.json
+++ b/packages/task/package.json
@@ -30,12 +30,12 @@
   "license": "EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0",
   "repository": {
     "type": "git",
-    "url": "https://github.com/theia-ide/theia.git"
+    "url": "https://github.com/eclipse-theia/theia.git"
   },
   "bugs": {
-    "url": "https://github.com/theia-ide/theia/issues"
+    "url": "https://github.com/eclipse-theia/theia/issues"
   },
-  "homepage": "https://github.com/theia-ide/theia",
+  "homepage": "https://github.com/eclipse-theia/theia",
   "files": [
     "lib",
     "src"

--- a/packages/terminal/package.json
+++ b/packages/terminal/package.json
@@ -25,12 +25,12 @@
   "license": "EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0",
   "repository": {
     "type": "git",
-    "url": "https://github.com/theia-ide/theia.git"
+    "url": "https://github.com/eclipse-theia/theia.git"
   },
   "bugs": {
-    "url": "https://github.com/theia-ide/theia/issues"
+    "url": "https://github.com/eclipse-theia/theia/issues"
   },
-  "homepage": "https://github.com/theia-ide/theia",
+  "homepage": "https://github.com/eclipse-theia/theia",
   "files": [
     "lib",
     "src"

--- a/packages/terminal/src/browser/terminal.css
+++ b/packages/terminal/src/browser/terminal.css
@@ -21,6 +21,6 @@
 }
 
 .xterm .xterm-screen canvas {
-  /* fix random 1px white border on terminal in Firefox. See https://github.com/theia-ide/theia/issues/4665 */
+  /* fix random 1px white border on terminal in Firefox. See https://github.com/eclipse-theia/theia/issues/4665 */
   border: 1px solid var(--theia-layout-color0);
 }

--- a/packages/textmate-grammars/package.json
+++ b/packages/textmate-grammars/package.json
@@ -20,12 +20,12 @@
   "license": "EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0",
   "repository": {
     "type": "git",
-    "url": "https://github.com/theia-ide/theia.git"
+    "url": "https://github.com/eclipse-theia/theia.git"
   },
   "bugs": {
-    "url": "https://github.com/theia-ide/theia/issues"
+    "url": "https://github.com/eclipse-theia/theia/issues"
   },
-  "homepage": "https://github.com/theia-ide/theia",
+  "homepage": "https://github.com/eclipse-theia/theia",
   "files": [
     "data",
     "lib",

--- a/packages/tslint/package.json
+++ b/packages/tslint/package.json
@@ -14,12 +14,12 @@
   "license": "EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0",
   "repository": {
     "type": "git",
-    "url": "https://github.com/theia-ide/theia.git"
+    "url": "https://github.com/eclipse-theia/theia.git"
   },
   "bugs": {
-    "url": "https://github.com/theia-ide/theia/issues"
+    "url": "https://github.com/eclipse-theia/theia/issues"
   },
-  "homepage": "https://github.com/theia-ide/theia",
+  "homepage": "https://github.com/eclipse-theia/theia",
   "files": [
     "lib",
     "src",

--- a/packages/typehierarchy/package.json
+++ b/packages/typehierarchy/package.json
@@ -23,12 +23,12 @@
   "license": "EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0",
   "repository": {
     "type": "git",
-    "url": "https://github.com/theia-ide/theia.git"
+    "url": "https://github.com/eclipse-theia/theia.git"
   },
   "bugs": {
-    "url": "https://github.com/theia-ide/theia/issues"
+    "url": "https://github.com/eclipse-theia/theia/issues"
   },
-  "homepage": "https://github.com/theia-ide/theia",
+  "homepage": "https://github.com/eclipse-theia/theia",
   "files": [
     "lib",
     "src"

--- a/packages/typescript/package.json
+++ b/packages/typescript/package.json
@@ -29,12 +29,12 @@
   "license": "EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0",
   "repository": {
     "type": "git",
-    "url": "https://github.com/theia-ide/theia.git"
+    "url": "https://github.com/eclipse-theia/theia.git"
   },
   "bugs": {
-    "url": "https://github.com/theia-ide/theia/issues"
+    "url": "https://github.com/eclipse-theia/theia/issues"
   },
-  "homepage": "https://github.com/theia-ide/theia",
+  "homepage": "https://github.com/eclipse-theia/theia",
   "files": [
     "lib",
     "src",

--- a/packages/typescript/src/browser/typescript-client-contribution.ts
+++ b/packages/typescript/src/browser/typescript-client-contribution.ts
@@ -107,7 +107,7 @@ export class TypeScriptClientContribution extends BaseLanguageClientContribution
     }
 
     protected get workspaceContains(): string[] {
-        // FIXME requires https://github.com/theia-ide/theia/issues/2359
+        // FIXME requires https://github.com/eclipse-theia/theia/issues/2359
         // return [
         //     "**/tsconfig.json",
         //     "**/jsconfig.json",

--- a/packages/userstorage/package.json
+++ b/packages/userstorage/package.json
@@ -20,12 +20,12 @@
   "license": "EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0",
   "repository": {
     "type": "git",
-    "url": "https://github.com/theia-ide/theia.git"
+    "url": "https://github.com/eclipse-theia/theia.git"
   },
   "bugs": {
-    "url": "https://github.com/theia-ide/theia/issues"
+    "url": "https://github.com/eclipse-theia/theia/issues"
   },
-  "homepage": "https://github.com/theia-ide/theia",
+  "homepage": "https://github.com/eclipse-theia/theia",
   "files": [
     "lib",
     "src"

--- a/packages/variable-resolver/package.json
+++ b/packages/variable-resolver/package.json
@@ -19,12 +19,12 @@
   "license": "EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0",
   "repository": {
     "type": "git",
-    "url": "https://github.com/theia-ide/theia.git"
+    "url": "https://github.com/eclipse-theia/theia.git"
   },
   "bugs": {
-    "url": "https://github.com/theia-ide/theia/issues"
+    "url": "https://github.com/eclipse-theia/theia/issues"
   },
-  "homepage": "https://github.com/theia-ide/theia",
+  "homepage": "https://github.com/eclipse-theia/theia",
   "contributors": [
     {
       "name": "Artem Zatsarynnyi",

--- a/packages/workspace/package.json
+++ b/packages/workspace/package.json
@@ -26,12 +26,12 @@
   "license": "EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0",
   "repository": {
     "type": "git",
-    "url": "https://github.com/theia-ide/theia.git"
+    "url": "https://github.com/eclipse-theia/theia.git"
   },
   "bugs": {
-    "url": "https://github.com/theia-ide/theia/issues"
+    "url": "https://github.com/eclipse-theia/theia/issues"
   },
-  "homepage": "https://github.com/theia-ide/theia",
+  "homepage": "https://github.com/eclipse-theia/theia",
   "files": [
     "lib",
     "src"

--- a/packages/workspace/src/browser/workspace-commands.ts
+++ b/packages/workspace/src/browser/workspace-commands.ts
@@ -45,7 +45,7 @@ export namespace WorkspaceCommands {
     // On Linux and Windows, both files and folders cannot be opened at the same time in electron.
     // `OPEN_FILE` and `OPEN_FOLDER` must be available only on Linux and Windows in electron.
     // `OPEN` must *not* be available on Windows and Linux in electron.
-    // VS Code does the same. See: https://github.com/theia-ide/theia/pull/3202#issuecomment-430585357
+    // VS Code does the same. See: https://github.com/eclipse-theia/theia/pull/3202#issuecomment-430585357
     export const OPEN: Command & { dialogLabel: string } = {
         id: 'workspace:open',
         category: FILE_CATEGORY,

--- a/packages/workspace/src/browser/workspace-frontend-contribution.ts
+++ b/packages/workspace/src/browser/workspace-frontend-contribution.ts
@@ -251,7 +251,7 @@ export class WorkspaceFrontendContribution implements CommandContribution, Keybi
      * if it was successful. Otherwise, resolves to `undefined`.
      *
      * **Caveat**: this behaves differently on different platforms, the `workspace.supportMultiRootWorkspace` preference value **does** matter,
-     * and `electron`/`browser` version has impact too. See [here](https://github.com/theia-ide/theia/pull/3202#issuecomment-430884195) for more details.
+     * and `electron`/`browser` version has impact too. See [here](https://github.com/eclipse-theia/theia/pull/3202#issuecomment-430884195) for more details.
      *
      * Legend:
      *  - `workspace.supportMultiRootWorkspace` is `false`: => `N`

--- a/scripts/prepare-initial
+++ b/scripts/prepare-initial
@@ -57,7 +57,7 @@ function replaceLicenses() {
         try {
             if (path.basename(fileName) === 'README.md') {
                 const content = fs.readFileSync(fileName, { encoding: 'UTF-8' });
-                const result = content.replace('[Apache-2.0](https://github.com/theia-ide/theia/blob/master/LICENSE)', `- [Eclipse Public License 2.0](http://www.eclipse.org/legal/epl-2.0/)
+                const result = content.replace('[Apache-2.0](https://github.com/eclipse-theia/theia/blob/master/LICENSE)', `- [Eclipse Public License 2.0](http://www.eclipse.org/legal/epl-2.0/)
 - [一 (Secondary) GNU General Public License, version 2 with the GNU Classpath Exception](https://projects.eclipse.org/license/secondary-gpl-2.0-cp)`);
                 fs.writeFileSync(fileName, result);
             }


### PR DESCRIPTION
Update all URLs pointing to the old organization so that they now
refer to "eclipe-theia". GitHub magically redirects but I am not
certain if we can assume this will work forever, so I even updated
links that are part of the code, e.g. that point to an issue or
GH comment.

Fixes #6169

Signed-off-by: Marc Dumais <marc.dumais@ericsson.com>