### PR TITLE
[preview] fix transparent preview widget background

### DIFF
--- a/packages/core/src/browser/style/dockpanel.css
+++ b/packages/core/src/browser/style/dockpanel.css
@@ -37,6 +37,11 @@
   border-left: var(--theia-border-width) solid var(--theia-border-color1);
 }
 
+.p-DockPanel-handle[data-orientation='horizontal']:after {
+  background-color: var(--theia-layout-color0);
+  border-left: var(--theia-border-width) solid var(--theia-border-color1);
+}
+
 .p-DockPanel-overlay {
   background: rgba(33, 150, 243, 0.1);
   border: var(--theia-border-width) dashed var(--theia-brand-color1);

--- a/packages/core/src/browser/style/tabs.css
+++ b/packages/core/src/browser/style/tabs.css
@@ -75,6 +75,10 @@
 | Tabs in the center area (main and bottom)
 |----------------------------------------------------------------------------*/
 
+#theia-main-content-panel .p-Widget.p-DockPanel-widget {
+  background-color: var(--theia-layout-color0);
+}
+
 /* This is a current tab of a tab bar: each tab bar has 1. */
 .p-TabBar .p-TabBar-tab.p-mod-current {
   min-height: calc(var(--theia-private-horizontal-tab-height) + var(--theia-border-width));


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

Fixes #6194

- Fixes an issue where widgets present in the main area had transparent backgrounds which interfered with custom branding. With the change, widgets now have default background colors.
- Adjusts the styling of the dockpanel to be more consistent with VSCode

| Before (`master`) | After (`pr`) |
|:---:|:---:|
|![image](https://user-images.githubusercontent.com/40359487/64954964-03dac700-d855-11e9-8454-08754f158b72.png)|![image](https://user-images.githubusercontent.com/40359487/64954732-77c89f80-d854-11e9-82f7-535eaf7904f1.png)|

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
I made the following changes locally in the [`index.css`](https://github.com/eclipse-theia/theia/blob/master/packages/core/src/browser/style/index.css) so I can visualize the changes:

```css
#theia-main-content-panel {
  background-image: url('https://assets.webiconspng.com/uploads/2017/09/Simpsons-PNG-Image-19701.png');
  background-position: center center;
  background-repeat: no-repeat;
  background-size: 50%;
}
```

1. with the local changes, open a workspace (ex: 'theia')
2. open a `README.md` or any markdown file
3. click on _preview_ in the markdown's tabbar toolbar
4. confirm that the contributed image is not visible
5. open any widget in the main area (ex: _explorer_, _scm_, _getting-started_, _search_) and ensure that styling is correct and the background image does not display

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

Signed-off-by: Vincent Fugnitto <vincent.fugnitto@ericsson.com>
