### PR TITLE
[preferences] prevent closing preference editor with the middle mouse click

### DIFF
--- a/packages/preferences/src/browser/preference-editor-widget.ts
+++ b/packages/preferences/src/browser/preference-editor-widget.ts
@@ -56,6 +56,7 @@ export class PreferenceEditorTabHeaderRenderer extends TabBar.Renderer {
 
     renderTab(data: TabBar.IRenderData<PreferencesEditorWidget>): VirtualElement {
         const title = data.title;
+        title.closable = false;
         const key = this.createTabKey(data);
         const style = this.createTabStyle(data);
         const className = this.createTabClass(data);


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

Fixes #2639

- prevent closing preference editors using the middle mouse click by
setting the `title.closable` to `false`.


#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
1. open the preferences widget (<kbd>F1</kbd> > `Settings: Open Preferences`)
2. attempt to close the `User` preference editor using the middle-mouse click
 (the editor should not be closable)
3. close the preferences widget, the `User` tab should properly close

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

Signed-off-by: Vincent Fugnitto <vincent.fugnitto@ericsson.com>
