### PR TITLE
fix #5659, Unify the icon color settings for Menu and Toolbar, and fixed some strange places

### DIFF
--- a/packages/core/src/browser/style/index.css
+++ b/packages/core/src/browser/style/index.css
@@ -78,7 +78,7 @@ body {
 }
 
 .theia-mod-disabled {
-  opacity: 0.4;
+  opacity: var(--theia-mod-disabled-opacity);
 }
 
 .theia-header {

--- a/packages/core/src/browser/style/menus.css
+++ b/packages/core/src/browser/style/menus.css
@@ -68,7 +68,7 @@
 
 
 .p-MenuBar-item.p-mod-disabled {
-  opacity: 0.4;
+  opacity: var(--theia-mod-disabled-opacity);;
 }
 
 
@@ -123,7 +123,7 @@
 
 
 .p-Menu-item.p-mod-disabled {
-  opacity: 0.4;
+  opacity: var(--theia-mod-disabled-opacity);;
 }
 
 

--- a/packages/core/src/browser/style/menus.css
+++ b/packages/core/src/browser/style/menus.css
@@ -54,6 +54,7 @@
 .p-MenuBar-item.p-mod-active {
   background: var(--theia-menu-color2);
   color: var(--theia-ui-bar-font-color0);
+  opacity: 1;
 }
 
 
@@ -67,7 +68,7 @@
 
 
 .p-MenuBar-item.p-mod-disabled {
-  color: var(--theia-ui-font-color2);
+  opacity: 0.4;
 }
 
 
@@ -117,11 +118,12 @@
 .p-Menu-item.p-mod-active {
   background: var(--theia-menu-color2);
   color: var(--theia-ui-bar-font-color0);
+  opacity: 1;
 }
 
 
 .p-Menu-item.p-mod-disabled {
-  color: var(--theia-ui-font-color2);
+  opacity: 0.4;
 }
 
 

--- a/packages/core/src/browser/style/tabs.css
+++ b/packages/core/src/browser/style/tabs.css
@@ -269,7 +269,7 @@
   display: flex;
   align-items: center;
   margin-left: 8px; /* `padding` + `margin-right` from the container toolbar */
-  opacity: 0.25;
+  opacity: var(--theia-mod-disabled-opacity);;
   cursor: default;
 }
 

--- a/packages/core/src/browser/style/tabs.css
+++ b/packages/core/src/browser/style/tabs.css
@@ -132,16 +132,14 @@
 }
 
 .p-TabBar.theia-app-centers .p-TabBar-tabIcon {
-    height: 15px;
+    height: 14px;
     background-size: 13px;
     background-position-y: 3px;
     background-color: var(--theia-tab-icon-color);
     -webkit-mask-repeat: no-repeat;
     -webkit-mask-size: 13px;
-    -webkit-mask-position-y: 1px;
     mask-repeat: no-repeat;
     mask-size: 13px;
-    mask-position: 0 1px;
     padding-right: 2px;
 }
 

--- a/packages/core/src/browser/style/tree.css
+++ b/packages/core/src/browser/style/tree.css
@@ -124,7 +124,7 @@
 .theia-tree-source-node-placeholder {
     text-align: center;
     font-style: italic;
-    opacity: 0.4;
+    opacity: var(--theia-mod-disabled-opacity);;
 }
 
 .theia-tree-element-node {

--- a/packages/core/src/browser/style/variables-bright.useable.css
+++ b/packages/core/src/browser/style/variables-bright.useable.css
@@ -263,4 +263,6 @@ is not optimized for dense, information rich UIs.
   /* Output */
   --theia-output-font-color: var(--theia-ui-font-color1);
   
+  /* Opacity for disabled mod  */
+  --theia-mod-disabled-opacity: 0.4;
 }

--- a/packages/core/src/browser/style/variables-dark.useable.css
+++ b/packages/core/src/browser/style/variables-dark.useable.css
@@ -263,4 +263,6 @@ is not optimized for dense, information rich UIs.
   /* Output */
   --theia-output-font-color: var(--theia-ui-font-color1);
 
+  /* Opacity for disabled mod  */
+  --theia-mod-disabled-opacity: 0.4;
 }

--- a/packages/output/src/browser/style/output.css
+++ b/packages/output/src/browser/style/output.css
@@ -51,7 +51,7 @@
     background-repeat: no-repeat;
     display: inline-block;
     width: 21px;
-    opacity: 0.25;
+    opacity: var(--theia-mod-disabled-opacity);;
 }
 
 #outputView #outputClear.enabled {

--- a/packages/search-in-workspace/src/browser/styles/index.css
+++ b/packages/search-in-workspace/src/browser/styles/index.css
@@ -160,11 +160,9 @@
 }
 
 .t-siw-search-container .searchHeader .button-container {
-    text-align: right;
-    padding-right: 5px;
-    padding-top: 5px;
+    text-align: center;
     display: flex;
-    justify-content: flex-end;
+    justify-content: center;
 }
 
 .t-siw-search-container .searchHeader .search-field .option,
@@ -187,8 +185,16 @@
     justify-content: center;
 }
 
+.t-siw-search-container .searchHeader .search-details {
+    position: relative;
+    padding-top: 5px;
+}
+
 .t-siw-search-container .searchHeader .search-details .button-container {
-    height: 5px;
+    position: absolute;
+    width: 25px;
+    top:0;
+    right:0;
 }
 
 .t-siw-search-container .searchHeader .search-details .button-container .btn{
@@ -201,7 +207,7 @@
 
 .t-siw-search-container .searchHeader .glob-field-container .glob-field {
     margin-bottom: 8px;
-    margin-left: 17px;
+    margin-left: 14px;
     display: flex;
     flex-direction: column;
 }
@@ -373,6 +379,7 @@
     height: 100%;
     display: inline-block;
     background: var(--theia-icon-replace-all) no-repeat center;
+    cursor: pointer;
 }
 
 .result-node-buttons .replace-result {

--- a/packages/search-in-workspace/src/browser/styles/index.css
+++ b/packages/search-in-workspace/src/browser/styles/index.css
@@ -383,7 +383,8 @@
 }
 
 .replace-all-button.disabled {
-    opacity: 0.5;
+    opacity: var(--theia-mod-disabled-opacity);;
+    cursor: default;
 }
 
 .search-in-workspace-tab-icon {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->
fix #5659

- Use the opacity property to display the availability of the menu, which is better for colored icons.
- Use the same opacity value when disabled.
- Make sure the bottom tabbar icon is vertically aligned with the text.
- Improved UI of search-in-workspace
  - Use pointer cursor when replace-all button is available.
  - Search-detail and search-header are horizontally aligned.
  - Use absolute position to make the clickable area of the toggle button larger.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
1. The menu bar should look the same.
2. Use a colored icon in the menu bar, and the icon color should change if the menu is disabled.
3. The icons in the bottom tab-bar should always be vertically aligned with the text.
4. search-in-workspace
    1. The disabled icons should look the same grayscale.
    2. Input box are horizontally left aligned.
    3. The show-detail button is always clickable.
    4. When the replace-all button is enable, the cursor should be pointer.

#### Review checklist
- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)
- [x]  I have thoroughly tested my changes in  Chrome 76.0.3809.132 and FireFox 69.0 on macOS 10.14.5.
#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

