### PR TITLE
fix reconnection of native language servers

### DIFF
--- a/packages/cpp/src/browser/cpp-language-client-contribution.ts
+++ b/packages/cpp/src/browser/cpp-language-client-contribution.ts
@@ -82,11 +82,7 @@ export class CppLanguageClientContribution extends BaseLanguageClientContributio
     @postConstruct()
     protected init(): void {
         this.cppBuildConfigurations.onActiveConfigChange2(() => this.onActiveBuildConfigChanged());
-        this.cppPreferences.onPreferenceChanged(e => {
-            if (this.running) {
-                this.restart();
-            }
-        });
+        this.cppPreferences.onPreferenceChanged(() => this.restart());
     }
 
     protected onReady(languageClient: ILanguageClient): void {
@@ -147,9 +143,7 @@ export class CppLanguageClientContribution extends BaseLanguageClientContributio
     }
 
     protected onActiveBuildConfigChanged(): void {
-        if (this.running) {
-            this.restart();
-        }
+        this.restart();
     }
 
     protected get documentSelector(): string[] {

--- a/packages/languages/src/browser/language-client-contribution.ts
+++ b/packages/languages/src/browser/language-client-contribution.ts
@@ -160,8 +160,9 @@ export abstract class BaseLanguageClientContribution implements LanguageClientCo
                         }
                     })()));
                     toStop.push(messageConnection.onClose(() => this.forceRestart()));
-                    this.onWillStart(this._languageClient!);
                     this._languageClient!.start();
+                    // it should be called after `start` that `onReady` promise gets reinitialized
+                    this.onWillStart(this._languageClient!, toStop);
                 }
             }, { reconnecting: false });
         } catch (e) {
@@ -189,11 +190,11 @@ export abstract class BaseLanguageClientContribution implements LanguageClientCo
         this.activate();
     }
 
-    protected onWillStart(languageClient: ILanguageClient): void {
-        languageClient.onReady().then(() => this.onReady(languageClient));
+    protected onWillStart(languageClient: ILanguageClient, toStop?: DisposableCollection): void {
+        languageClient.onReady().then(() => this.onReady(languageClient, toStop));
     }
 
-    protected onReady(languageClient: ILanguageClient): void {
+    protected onReady(languageClient: ILanguageClient, toStop?: DisposableCollection): void {
         this._languageClient = languageClient;
         this.resolveReady(this._languageClient);
         this.waitForReady();

--- a/packages/languages/src/browser/language-client-contribution.ts
+++ b/packages/languages/src/browser/language-client-contribution.ts
@@ -159,7 +159,7 @@ export abstract class BaseLanguageClientContribution implements LanguageClientCo
                             } catch { /* no-op */ }
                         }
                     })()));
-                    toStop.push(messageConnection.onClose(() => this.restart()));
+                    toStop.push(messageConnection.onClose(() => this.forceRestart()));
                     this.onWillStart(this._languageClient!);
                     this._languageClient!.start();
                 }
@@ -167,7 +167,7 @@ export abstract class BaseLanguageClientContribution implements LanguageClientCo
         } catch (e) {
             console.error(e);
             if (!toStop.disposed) {
-                this.restart();
+                this.forceRestart();
             }
         }
     }
@@ -181,6 +181,10 @@ export abstract class BaseLanguageClientContribution implements LanguageClientCo
         if (!this.running) {
             return;
         }
+        this.forceRestart();
+    }
+
+    protected forceRestart(): void {
         this.deactivate();
         this.activate();
     }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

fix #6200:
- Force restart language client contribution on reconnect: Since restart skips if a server is not running, on reconnection a server has to be restarted forcefully if it was running before.
- Don't wait when a stopped json language server is ready: Timing of resolving `LanguageClient.onReady` promise is changed in never version of `vscode-languageclient`. It could lead to a situation that clients still use `onReady` of a language client before reconnection.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

- cause connection issues either with system proxy or by stopping a server
- make sure that json language server is running after reconnection and proper configuration snippets are available in launch.json
- make sure that other native language servers are restarted on reconnect as well, for example for typescript

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

