### PR TITLE
[plugin] map dependencies to vscode builtins properly

### DIFF
--- a/packages/plugin-ext-vscode/src/node/scanner-vscode.ts
+++ b/packages/plugin-ext-vscode/src/node/scanner-vscode.ts
@@ -28,6 +28,11 @@ export class VsCodePluginScanner extends TheiaPluginScanner implements PluginSca
     }
 
     getModel(plugin: PluginPackage): PluginModel {
+        // translate vscode builtins, as they are published with a prefix. See https://github.com/theia-ide/vscode-builtin-extensions/blob/master/src/republish.js#L50
+        const built_prefix = '@theia/vscode-builtin-';
+        if (plugin && plugin.name && plugin.name.startsWith(built_prefix)) {
+            plugin.name = plugin.name.substr(built_prefix.length);
+        }
         const result: PluginModel = {
             // see id definition: https://github.com/microsoft/vscode/blob/15916055fe0cb9411a5f36119b3b012458fe0a1d/src/vs/platform/extensions/common/extensions.ts#L167-L169
             id: `${plugin.publisher.toLowerCase()}.${plugin.name.toLowerCase()}`,


### PR DESCRIPTION
#### What it does

The builtin extension from vscode that we hare releasing to npm.js need to have an altered package name because the simple names would conflict. Unfortunately there are a few extensions outthere, that have specified dependencies to these extensions using their original name.

For example, [ionide](https://github.com/ionide/ionide-vscode-fsharp/blob/master/release/package.json#L1609) asks for `vscode.fsharp` while we have `vscode.@theia/vscode-built-fsharp`

#### How to test
Use this gitpod snapshot, which has both extensions in the plugins folder already.
Try with and without the change.

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io#snapshot/075ac736-f856-49c9-a9e4-084e8a862e5c)

Or download those extensions manually and try to reproduce locally.

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

