### PR TITLE
Add new `package.json` scripts for yarn start

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,7 +67,9 @@
     "publish:latest": "lerna publish && yarn publish:check",
     "publish:next": "yarn next:publish && yarn next:publish --skip-npm && yarn publish:check",
     "next:publish": "lerna publish --exact --canary=next --npm-tag=next --yes",
-    "publish:check": "node scripts/check-publish.js"
+    "publish:check": "node scripts/check-publish.js",
+    "start:browser": "yarn rebuild:browser && run start \"@theia/example-browser\"",
+    "start:electron": "yarn rebuild:electron && run start \"@theia/example-electron\""
   },
   "workspaces": [
     "dev-packages/*",


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

As a developer, I'd like the option to quickly start the
`example-browser` and `example-electron` applications from
the root of the main repo. Added the `rebuild` for both
cases to seemingly switch between the two targets.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
1. build the application (ex: `yarn`)
2. start the browser app from the root (`yarn start:browser`)
3. start the electron app from the root (`yarn start:electron`)

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

Signed-off-by: Vincent Fugnitto <vincent.fugnitto@ericsson.com>
