### PR TITLE
Pass plugin information through to languages-main

### DIFF
--- a/packages/plugin-ext/src/common/plugin-api-rpc.ts
+++ b/packages/plugin-ext/src/common/plugin-api-rpc.ts
@@ -1086,6 +1086,11 @@ export interface ProcessTaskDto extends TaskDto, CommandProperties {
     windows?: CommandProperties;
 }
 
+export interface PluginInfo {
+    id: string;
+    name: string;
+}
+
 export interface LanguagesExt {
     $provideCompletionItems(handle: number, resource: UriComponents, position: Position,
         context: CompletionContext, token: CancellationToken): Promise<CompletionResultDto | undefined>;
@@ -1155,29 +1160,30 @@ export interface LanguagesMain {
     $changeLanguage(resource: UriComponents, languageId: string): Promise<void>;
     $setLanguageConfiguration(handle: number, languageId: string, configuration: SerializedLanguageConfiguration): void;
     $unregister(handle: number): void;
-    $registerCompletionSupport(handle: number, selector: SerializedDocumentFilter[], triggerCharacters: string[], supportsResolveDetails: boolean): void;
-    $registerImplementationProvider(handle: number, selector: SerializedDocumentFilter[]): void;
-    $registerTypeDefinitionProvider(handle: number, selector: SerializedDocumentFilter[]): void;
-    $registerDefinitionProvider(handle: number, selector: SerializedDocumentFilter[]): void;
-    $registerDeclarationProvider(handle: number, selector: SerializedDocumentFilter[]): void;
-    $registerReferenceProvider(handle: number, selector: SerializedDocumentFilter[]): void;
-    $registerSignatureHelpProvider(handle: number, selector: SerializedDocumentFilter[], metadata: theia.SignatureHelpProviderMetadata): void;
-    $registerHoverProvider(handle: number, selector: SerializedDocumentFilter[]): void;
-    $registerDocumentHighlightProvider(handle: number, selector: SerializedDocumentFilter[]): void;
-    $registerQuickFixProvider(handle: number, selector: SerializedDocumentFilter[], codeActionKinds?: string[]): void;
+    $registerCompletionSupport(handle: number, pluginInfo: PluginInfo,
+        selector: SerializedDocumentFilter[], triggerCharacters: string[], supportsResolveDetails: boolean): void;
+    $registerImplementationProvider(handle: number, pluginInfo: PluginInfo, selector: SerializedDocumentFilter[]): void;
+    $registerTypeDefinitionProvider(handle: number, pluginInfo: PluginInfo, selector: SerializedDocumentFilter[]): void;
+    $registerDefinitionProvider(handle: number, pluginInfo: PluginInfo, selector: SerializedDocumentFilter[]): void;
+    $registerDeclarationProvider(handle: number, pluginInfo: PluginInfo, selector: SerializedDocumentFilter[]): void;
+    $registerReferenceProvider(handle: number, pluginInfo: PluginInfo, selector: SerializedDocumentFilter[]): void;
+    $registerSignatureHelpProvider(handle: number, pluginInfo: PluginInfo, selector: SerializedDocumentFilter[], metadata: theia.SignatureHelpProviderMetadata): void;
+    $registerHoverProvider(handle: number, pluginInfo: PluginInfo, selector: SerializedDocumentFilter[]): void;
+    $registerDocumentHighlightProvider(handle: number, pluginInfo: PluginInfo, selector: SerializedDocumentFilter[]): void;
+    $registerQuickFixProvider(handle: number, pluginInfo: PluginInfo, selector: SerializedDocumentFilter[], codeActionKinds?: string[]): void;
     $clearDiagnostics(id: string): void;
     $changeDiagnostics(id: string, delta: [string, MarkerData[]][]): void;
-    $registerDocumentFormattingSupport(handle: number, selector: SerializedDocumentFilter[]): void;
-    $registerRangeFormattingProvider(handle: number, selector: SerializedDocumentFilter[]): void;
-    $registerOnTypeFormattingProvider(handle: number, selector: SerializedDocumentFilter[], autoFormatTriggerCharacters: string[]): void;
-    $registerDocumentLinkProvider(handle: number, selector: SerializedDocumentFilter[]): void;
-    $registerCodeLensSupport(handle: number, selector: SerializedDocumentFilter[], eventHandle?: number): void;
+    $registerDocumentFormattingSupport(handle: number, pluginInfo: PluginInfo, selector: SerializedDocumentFilter[]): void;
+    $registerRangeFormattingProvider(handle: number, pluginInfo: PluginInfo, selector: SerializedDocumentFilter[]): void;
+    $registerOnTypeFormattingProvider(handle: number, pluginInfo: PluginInfo, selector: SerializedDocumentFilter[], autoFormatTriggerCharacters: string[]): void;
+    $registerDocumentLinkProvider(handle: number, pluginInfo: PluginInfo, selector: SerializedDocumentFilter[]): void;
+    $registerCodeLensSupport(handle: number, pluginInfo: PluginInfo, selector: SerializedDocumentFilter[], eventHandle?: number): void;
     $emitCodeLensEvent(eventHandle: number, event?: any): void;
-    $registerOutlineSupport(handle: number, selector: SerializedDocumentFilter[]): void;
-    $registerWorkspaceSymbolProvider(handle: number): void;
-    $registerFoldingRangeProvider(handle: number, selector: SerializedDocumentFilter[]): void;
-    $registerDocumentColorProvider(handle: number, selector: SerializedDocumentFilter[]): void;
-    $registerRenameProvider(handle: number, selector: SerializedDocumentFilter[], supportsResoveInitialValues: boolean): void;
+    $registerOutlineSupport(handle: number, pluginInfo: PluginInfo, selector: SerializedDocumentFilter[]): void;
+    $registerWorkspaceSymbolProvider(handle: number, pluginInfo: PluginInfo): void;
+    $registerFoldingRangeProvider(handle: number, pluginInfo: PluginInfo, selector: SerializedDocumentFilter[]): void;
+    $registerDocumentColorProvider(handle: number, pluginInfo: PluginInfo, selector: SerializedDocumentFilter[]): void;
+    $registerRenameProvider(handle: number, pluginInfo: PluginInfo, selector: SerializedDocumentFilter[], supportsResoveInitialValues: boolean): void;
 }
 
 export interface WebviewPanelViewState {

--- a/packages/plugin-ext/src/main/browser/languages-main.ts
+++ b/packages/plugin-ext/src/main/browser/languages-main.ts
@@ -33,6 +33,7 @@ import {
     WorkspaceEditDto,
     ResourceTextEditDto,
     ResourceFileEditDto,
+    PluginInfo
 } from '../../common/plugin-api-rpc';
 import { injectable, inject } from 'inversify';
 import {
@@ -114,7 +115,7 @@ export class LanguagesMainImpl implements LanguagesMain, Disposable {
         this.register(handle, monaco.languages.setLanguageConfiguration(languageId, config));
     }
 
-    $registerCompletionSupport(handle: number, selector: SerializedDocumentFilter[], triggerCharacters: string[], supportsResolveDetails: boolean): void {
+    $registerCompletionSupport(handle: number, pluginInfo: PluginInfo, selector: SerializedDocumentFilter[], triggerCharacters: string[], supportsResolveDetails: boolean): void {
         this.register(handle, monaco.modes.CompletionProviderRegistry.register(fromLanguageSelector(selector), {
             triggerCharacters,
             provideCompletionItems: (model, position, context, token) => this.provideCompletionItems(handle, model, position, context, token),
@@ -143,19 +144,19 @@ export class LanguagesMainImpl implements LanguagesMain, Disposable {
         return this.proxy.$resolveCompletionItem(handle, model.uri, position, item, token);
     }
 
-    $registerDefinitionProvider(handle: number, selector: SerializedDocumentFilter[]): void {
+    $registerDefinitionProvider(handle: number, pluginInfo: PluginInfo, selector: SerializedDocumentFilter[]): void {
         const languageSelector = fromLanguageSelector(selector);
         const definitionProvider = this.createDefinitionProvider(handle);
         this.register(handle, monaco.languages.registerDefinitionProvider(languageSelector, definitionProvider));
     }
 
-    $registerDeclarationProvider(handle: number, selector: SerializedDocumentFilter[]): void {
+    $registerDeclarationProvider(handle: number, pluginInfo: PluginInfo, selector: SerializedDocumentFilter[]): void {
         const languageSelector = fromLanguageSelector(selector);
         const declarationProvider = this.createDeclarationProvider(handle);
         this.register(handle, monaco.languages.registerDeclarationProvider(languageSelector, declarationProvider));
     }
 
-    $registerReferenceProvider(handle: number, selector: SerializedDocumentFilter[]): void {
+    $registerReferenceProvider(handle: number, pluginInfo: PluginInfo, selector: SerializedDocumentFilter[]): void {
         const languageSelector = fromLanguageSelector(selector);
         const referenceProvider = this.createReferenceProvider(handle);
         this.register(handle, monaco.languages.registerReferenceProvider(languageSelector, referenceProvider));
@@ -186,7 +187,7 @@ export class LanguagesMainImpl implements LanguagesMain, Disposable {
         });
     }
 
-    $registerSignatureHelpProvider(handle: number, selector: SerializedDocumentFilter[], metadata: theia.SignatureHelpProviderMetadata): void {
+    $registerSignatureHelpProvider(handle: number, pluginInfo: PluginInfo, selector: SerializedDocumentFilter[], metadata: theia.SignatureHelpProviderMetadata): void {
         const languageSelector = fromLanguageSelector(selector);
         const signatureHelpProvider = this.createSignatureHelpProvider(handle, metadata);
         this.register(handle, monaco.languages.registerSignatureHelpProvider(languageSelector, signatureHelpProvider));
@@ -205,7 +206,7 @@ export class LanguagesMainImpl implements LanguagesMain, Disposable {
         }
     }
 
-    $registerImplementationProvider(handle: number, selector: SerializedDocumentFilter[]): void {
+    $registerImplementationProvider(handle: number, pluginInfo: PluginInfo, selector: SerializedDocumentFilter[]): void {
         const languageSelector = fromLanguageSelector(selector);
         const implementationProvider = this.createImplementationProvider(handle);
         this.register(handle, monaco.languages.registerImplementationProvider(languageSelector, implementationProvider));
@@ -241,7 +242,7 @@ export class LanguagesMainImpl implements LanguagesMain, Disposable {
         });
     }
 
-    $registerTypeDefinitionProvider(handle: number, selector: SerializedDocumentFilter[]): void {
+    $registerTypeDefinitionProvider(handle: number, pluginInfo: PluginInfo, selector: SerializedDocumentFilter[]): void {
         const languageSelector = fromLanguageSelector(selector);
         const typeDefinitionProvider = this.createTypeDefinitionProvider(handle);
         this.register(handle, monaco.languages.registerTypeDefinitionProvider(languageSelector, typeDefinitionProvider));
@@ -277,7 +278,7 @@ export class LanguagesMainImpl implements LanguagesMain, Disposable {
         });
     }
 
-    $registerHoverProvider(handle: number, selector: SerializedDocumentFilter[]): void {
+    $registerHoverProvider(handle: number, pluginInfo: PluginInfo, selector: SerializedDocumentFilter[]): void {
         const languageSelector = fromLanguageSelector(selector);
         const hoverProvider = this.createHoverProvider(handle);
         this.register(handle, monaco.languages.registerHoverProvider(languageSelector, hoverProvider));
@@ -294,7 +295,7 @@ export class LanguagesMainImpl implements LanguagesMain, Disposable {
         return this.proxy.$provideHover(handle, model.uri, position, token);
     }
 
-    $registerDocumentHighlightProvider(handle: number, selector: SerializedDocumentFilter[]): void {
+    $registerDocumentHighlightProvider(handle: number, pluginInfo: PluginInfo, selector: SerializedDocumentFilter[]): void {
         const languageSelector = fromLanguageSelector(selector);
         const documentHighlightProvider = this.createDocumentHighlightProvider(handle);
         this.register(handle, monaco.languages.registerDocumentHighlightProvider(languageSelector, documentHighlightProvider));
@@ -329,7 +330,7 @@ export class LanguagesMainImpl implements LanguagesMain, Disposable {
         });
     }
 
-    $registerWorkspaceSymbolProvider(handle: number): void {
+    $registerWorkspaceSymbolProvider(handle: number, pluginInfo: PluginInfo): void {
         const workspaceSymbolProvider = this.createWorkspaceSymbolProvider(handle);
         this.register(handle, this.monacoLanguages.registerWorkspaceSymbolProvider(workspaceSymbolProvider));
     }
@@ -349,7 +350,7 @@ export class LanguagesMainImpl implements LanguagesMain, Disposable {
         return this.proxy.$resolveWorkspaceSymbol(handle, symbol, token);
     }
 
-    $registerDocumentLinkProvider(handle: number, selector: SerializedDocumentFilter[]): void {
+    $registerDocumentLinkProvider(handle: number, pluginInfo: PluginInfo, selector: SerializedDocumentFilter[]): void {
         const languageSelector = fromLanguageSelector(selector);
         const linkProvider = this.createLinkProvider(handle);
         this.register(handle, monaco.languages.registerLinkProvider(languageSelector, linkProvider));
@@ -389,7 +390,7 @@ export class LanguagesMainImpl implements LanguagesMain, Disposable {
         };
     }
 
-    $registerCodeLensSupport(handle: number, selector: SerializedDocumentFilter[], eventHandle: number): void {
+    $registerCodeLensSupport(handle: number, pluginInfo: PluginInfo, selector: SerializedDocumentFilter[], eventHandle: number): void {
         const languageSelector = fromLanguageSelector(selector);
         const lensProvider = this.createCodeLensProvider(handle);
 
@@ -436,7 +437,7 @@ export class LanguagesMainImpl implements LanguagesMain, Disposable {
         }
     }
 
-    $registerOutlineSupport(handle: number, selector: SerializedDocumentFilter[]): void {
+    $registerOutlineSupport(handle: number, pluginInfo: PluginInfo, selector: SerializedDocumentFilter[]): void {
         const languageSelector = fromLanguageSelector(selector);
         const symbolProvider = this.createDocumentSymbolProvider(handle);
         this.register(handle, monaco.modes.DocumentSymbolProviderRegistry.register(languageSelector, symbolProvider));
@@ -538,7 +539,7 @@ export class LanguagesMainImpl implements LanguagesMain, Disposable {
         };
     }
 
-    $registerDocumentFormattingSupport(handle: number, selector: SerializedDocumentFilter[]): void {
+    $registerDocumentFormattingSupport(handle: number, pluginInfo: PluginInfo, selector: SerializedDocumentFilter[]): void {
         const languageSelector = fromLanguageSelector(selector);
         const documentFormattingEditSupport = this.createDocumentFormattingSupport(handle);
         this.register(handle, monaco.languages.registerDocumentFormattingEditProvider(languageSelector, documentFormattingEditSupport));
@@ -555,7 +556,7 @@ export class LanguagesMainImpl implements LanguagesMain, Disposable {
         return this.proxy.$provideDocumentFormattingEdits(handle, model.uri, options, token);
     }
 
-    $registerRangeFormattingProvider(handle: number, selector: SerializedDocumentFilter[]): void {
+    $registerRangeFormattingProvider(handle: number, pluginInfo: PluginInfo, selector: SerializedDocumentFilter[]): void {
         const languageSelector = fromLanguageSelector(selector);
         const rangeFormattingEditProvider = this.createRangeFormattingProvider(handle);
         this.register(handle, monaco.languages.registerDocumentRangeFormattingEditProvider(languageSelector, rangeFormattingEditProvider));
@@ -572,7 +573,7 @@ export class LanguagesMainImpl implements LanguagesMain, Disposable {
         return this.proxy.$provideDocumentRangeFormattingEdits(handle, model.uri, range, options, token);
     }
 
-    $registerOnTypeFormattingProvider(handle: number, selector: SerializedDocumentFilter[], autoFormatTriggerCharacters: string[]): void {
+    $registerOnTypeFormattingProvider(handle: number, pluginInfo: PluginInfo, selector: SerializedDocumentFilter[], autoFormatTriggerCharacters: string[]): void {
         const languageSelector = fromLanguageSelector(selector);
         const onTypeFormattingProvider = this.createOnTypeFormattingProvider(handle, autoFormatTriggerCharacters);
         this.register(handle, monaco.languages.registerOnTypeFormattingEditProvider(languageSelector, onTypeFormattingProvider));
@@ -593,7 +594,7 @@ export class LanguagesMainImpl implements LanguagesMain, Disposable {
         return this.proxy.$provideOnTypeFormattingEdits(handle, model.uri, position, ch, options, token);
     }
 
-    $registerFoldingRangeProvider(handle: number, selector: SerializedDocumentFilter[]): void {
+    $registerFoldingRangeProvider(handle: number, pluginInfo: PluginInfo, selector: SerializedDocumentFilter[]): void {
         const languageSelector = fromLanguageSelector(selector);
         const provider = this.createFoldingRangeProvider(handle);
         this.register(handle, monaco.languages.registerFoldingRangeProvider(languageSelector, provider));
@@ -610,7 +611,7 @@ export class LanguagesMainImpl implements LanguagesMain, Disposable {
         return this.proxy.$provideFoldingRange(handle, model.uri, context, token);
     }
 
-    $registerDocumentColorProvider(handle: number, selector: SerializedDocumentFilter[]): void {
+    $registerDocumentColorProvider(handle: number, pluginInfo: PluginInfo, selector: SerializedDocumentFilter[]): void {
         const languageSelector = fromLanguageSelector(selector);
         const colorProvider = this.createColorProvider(handle);
         this.register(handle, monaco.languages.registerColorProvider(languageSelector, colorProvider));
@@ -656,7 +657,7 @@ export class LanguagesMainImpl implements LanguagesMain, Disposable {
         }, token);
     }
 
-    $registerQuickFixProvider(handle: number, selector: SerializedDocumentFilter[], codeActionKinds?: string[]): void {
+    $registerQuickFixProvider(handle: number, pluginInfo: PluginInfo, selector: SerializedDocumentFilter[], codeActionKinds?: string[]): void {
         const languageSelector = fromLanguageSelector(selector);
         const quickFixProvider = this.createQuickFixProvider(handle, codeActionKinds);
         this.register(handle, monaco.languages.registerCodeActionProvider(languageSelector, quickFixProvider));
@@ -683,7 +684,7 @@ export class LanguagesMainImpl implements LanguagesMain, Disposable {
         };
     }
 
-    $registerRenameProvider(handle: number, selector: SerializedDocumentFilter[], supportsResolveLocation: boolean): void {
+    $registerRenameProvider(handle: number, pluginInfo: PluginInfo, selector: SerializedDocumentFilter[], supportsResolveLocation: boolean): void {
         const languageSelector = fromLanguageSelector(selector);
         const renameProvider = this.createRenameProvider(handle, supportsResolveLocation);
         this.register(handle, monaco.languages.registerRenameProvider(languageSelector, renameProvider));

--- a/packages/plugin-ext/src/plugin/languages.ts
+++ b/packages/plugin-ext/src/plugin/languages.ts
@@ -26,6 +26,7 @@ import {
     Selection,
     RawColorInfo,
     WorkspaceEditDto,
+    PluginInfo
 } from '../common/plugin-api-rpc';
 import { RPCProtocol } from '../common/rpc-protocol';
 import * as theia from '@theia/plugin';
@@ -231,9 +232,10 @@ export class LanguagesExtImpl implements LanguagesExt {
         this.withAdapter(handle, CompletionAdapter, async adapter => adapter.releaseCompletionItems(id));
     }
 
-    registerCompletionItemProvider(selector: theia.DocumentSelector, provider: theia.CompletionItemProvider, triggerCharacters: string[]): theia.Disposable {
+    registerCompletionItemProvider(selector: theia.DocumentSelector, provider: theia.CompletionItemProvider, triggerCharacters: string[],
+        pluginInfo: PluginInfo): theia.Disposable {
         const callId = this.addNewAdapter(new CompletionAdapter(provider, this.documents, this.commands));
-        this.proxy.$registerCompletionSupport(callId, this.transformDocumentSelector(selector), triggerCharacters, CompletionAdapter.hasResolveSupport(provider));
+        this.proxy.$registerCompletionSupport(callId, pluginInfo, this.transformDocumentSelector(selector), triggerCharacters, CompletionAdapter.hasResolveSupport(provider));
         return this.createDisposable(callId);
     }
     // ### Completion end
@@ -243,9 +245,9 @@ export class LanguagesExtImpl implements LanguagesExt {
         return this.withAdapter(handle, DefinitionAdapter, adapter => adapter.provideDefinition(URI.revive(resource), position, token));
     }
 
-    registerDefinitionProvider(selector: theia.DocumentSelector, provider: theia.DefinitionProvider): theia.Disposable {
+    registerDefinitionProvider(selector: theia.DocumentSelector, provider: theia.DefinitionProvider, pluginInfo: PluginInfo): theia.Disposable {
         const callId = this.addNewAdapter(new DefinitionAdapter(provider, this.documents));
-        this.proxy.$registerDefinitionProvider(callId, this.transformDocumentSelector(selector));
+        this.proxy.$registerDefinitionProvider(callId, pluginInfo, this.transformDocumentSelector(selector));
         return this.createDisposable(callId);
     }
     // ### Definition provider end
@@ -255,9 +257,9 @@ export class LanguagesExtImpl implements LanguagesExt {
         return this.withAdapter(handle, DeclarationAdapter, adapter => adapter.provideDeclaration(URI.revive(resource), position, token));
     }
 
-    registerDeclarationProvider(selector: theia.DocumentSelector, provider: theia.DeclarationProvider): theia.Disposable {
+    registerDeclarationProvider(selector: theia.DocumentSelector, provider: theia.DeclarationProvider, pluginInfo: PluginInfo): theia.Disposable {
         const callId = this.addNewAdapter(new DeclarationAdapter(provider, this.documents));
-        this.proxy.$registerDeclarationProvider(callId, this.transformDocumentSelector(selector));
+        this.proxy.$registerDeclarationProvider(callId, pluginInfo, this.transformDocumentSelector(selector));
         return this.createDisposable(callId);
     }
     // ### Declaration provider end
@@ -273,9 +275,10 @@ export class LanguagesExtImpl implements LanguagesExt {
         this.withAdapter(handle, SignatureHelpAdapter, async adapter => adapter.releaseSignatureHelp(id));
     }
 
-    registerSignatureHelpProvider(selector: theia.DocumentSelector, provider: theia.SignatureHelpProvider, metadata: theia.SignatureHelpProviderMetadata): theia.Disposable {
+    registerSignatureHelpProvider(selector: theia.DocumentSelector, provider: theia.SignatureHelpProvider, metadata: theia.SignatureHelpProviderMetadata,
+        pluginInfo: PluginInfo): theia.Disposable {
         const callId = this.addNewAdapter(new SignatureHelpAdapter(provider, this.documents));
-        this.proxy.$registerSignatureHelpProvider(callId, this.transformDocumentSelector(selector), metadata);
+        this.proxy.$registerSignatureHelpProvider(callId, pluginInfo, this.transformDocumentSelector(selector), metadata);
         return this.createDisposable(callId);
     }
     // ### Signature help end
@@ -295,9 +298,9 @@ export class LanguagesExtImpl implements LanguagesExt {
         return this.withAdapter(handle, ImplementationAdapter, adapter => adapter.provideImplementation(URI.revive(resource), position, token));
     }
 
-    registerImplementationProvider(selector: theia.DocumentSelector, provider: theia.ImplementationProvider): theia.Disposable {
+    registerImplementationProvider(selector: theia.DocumentSelector, provider: theia.ImplementationProvider, pluginInfo: PluginInfo): theia.Disposable {
         const callId = this.addNewAdapter(new ImplementationAdapter(provider, this.documents));
-        this.proxy.$registerImplementationProvider(callId, this.transformDocumentSelector(selector));
+        this.proxy.$registerImplementationProvider(callId, pluginInfo, this.transformDocumentSelector(selector));
         return this.createDisposable(callId);
     }
     // ### Implementation provider end
@@ -307,17 +310,17 @@ export class LanguagesExtImpl implements LanguagesExt {
         return this.withAdapter(handle, TypeDefinitionAdapter, adapter => adapter.provideTypeDefinition(URI.revive(resource), position, token));
     }
 
-    registerTypeDefinitionProvider(selector: theia.DocumentSelector, provider: theia.TypeDefinitionProvider): theia.Disposable {
+    registerTypeDefinitionProvider(selector: theia.DocumentSelector, provider: theia.TypeDefinitionProvider, pluginInfo: PluginInfo): theia.Disposable {
         const callId = this.addNewAdapter(new TypeDefinitionAdapter(provider, this.documents));
-        this.proxy.$registerTypeDefinitionProvider(callId, this.transformDocumentSelector(selector));
+        this.proxy.$registerTypeDefinitionProvider(callId, pluginInfo, this.transformDocumentSelector(selector));
         return this.createDisposable(callId);
     }
     // ### Type Definition provider end
 
     // ### Hover Provider begin
-    registerHoverProvider(selector: theia.DocumentSelector, provider: theia.HoverProvider): theia.Disposable {
+    registerHoverProvider(selector: theia.DocumentSelector, provider: theia.HoverProvider, pluginInfo: PluginInfo): theia.Disposable {
         const callId = this.addNewAdapter(new HoverAdapter(provider, this.documents));
-        this.proxy.$registerHoverProvider(callId, this.transformDocumentSelector(selector));
+        this.proxy.$registerHoverProvider(callId, pluginInfo, this.transformDocumentSelector(selector));
         return this.createDisposable(callId);
     }
 
@@ -327,9 +330,9 @@ export class LanguagesExtImpl implements LanguagesExt {
     // ### Hover Provider end
 
     // ### Document Highlight Provider begin
-    registerDocumentHighlightProvider(selector: theia.DocumentSelector, provider: theia.DocumentHighlightProvider): theia.Disposable {
+    registerDocumentHighlightProvider(selector: theia.DocumentSelector, provider: theia.DocumentHighlightProvider, pluginInfo: PluginInfo): theia.Disposable {
         const callId = this.addNewAdapter(new DocumentHighlightAdapter(provider, this.documents));
-        this.proxy.$registerDocumentHighlightProvider(callId, this.transformDocumentSelector(selector));
+        this.proxy.$registerDocumentHighlightProvider(callId, pluginInfo, this.transformDocumentSelector(selector));
         return this.createDisposable(callId);
     }
 
@@ -339,9 +342,9 @@ export class LanguagesExtImpl implements LanguagesExt {
     // ### Document Highlight Provider end
 
     // ### WorkspaceSymbol Provider begin
-    registerWorkspaceSymbolProvider(provider: theia.WorkspaceSymbolProvider): theia.Disposable {
+    registerWorkspaceSymbolProvider(provider: theia.WorkspaceSymbolProvider, pluginInfo: PluginInfo): theia.Disposable {
         const callId = this.addNewAdapter(new WorkspaceSymbolAdapter(provider));
-        this.proxy.$registerWorkspaceSymbolProvider(callId);
+        this.proxy.$registerWorkspaceSymbolProvider(callId, pluginInfo);
         return this.createDisposable(callId);
     }
 
@@ -355,9 +358,9 @@ export class LanguagesExtImpl implements LanguagesExt {
     // ### WorkspaceSymbol Provider end
 
     // ### Document Formatting Edit begin
-    registerDocumentFormattingEditProvider(selector: theia.DocumentSelector, provider: theia.DocumentFormattingEditProvider): theia.Disposable {
+    registerDocumentFormattingEditProvider(selector: theia.DocumentSelector, provider: theia.DocumentFormattingEditProvider, pluginInfo: PluginInfo): theia.Disposable {
         const callId = this.addNewAdapter(new DocumentFormattingAdapter(provider, this.documents));
-        this.proxy.$registerDocumentFormattingSupport(callId, this.transformDocumentSelector(selector));
+        this.proxy.$registerDocumentFormattingSupport(callId, pluginInfo, this.transformDocumentSelector(selector));
         return this.createDisposable(callId);
     }
 
@@ -368,9 +371,10 @@ export class LanguagesExtImpl implements LanguagesExt {
     // ### Document Formatting Edit end
 
     // ### Document Range Formatting Edit begin
-    registerDocumentRangeFormattingEditProvider(selector: theia.DocumentSelector, provider: theia.DocumentRangeFormattingEditProvider): theia.Disposable {
+    registerDocumentRangeFormattingEditProvider(selector: theia.DocumentSelector, provider: theia.DocumentRangeFormattingEditProvider,
+        pluginInfo: PluginInfo): theia.Disposable {
         const callId = this.addNewAdapter(new RangeFormattingAdapter(provider, this.documents));
-        this.proxy.$registerRangeFormattingProvider(callId, this.transformDocumentSelector(selector));
+        this.proxy.$registerRangeFormattingProvider(callId, pluginInfo, this.transformDocumentSelector(selector));
         return this.createDisposable(callId);
     }
 
@@ -384,10 +388,11 @@ export class LanguagesExtImpl implements LanguagesExt {
     registerOnTypeFormattingEditProvider(
         selector: theia.DocumentSelector,
         provider: theia.OnTypeFormattingEditProvider,
-        triggerCharacters: string[]
+        triggerCharacters: string[],
+        pluginInfo: PluginInfo
     ): theia.Disposable {
         const callId = this.addNewAdapter(new OnTypeFormattingAdapter(provider, this.documents));
-        this.proxy.$registerOnTypeFormattingProvider(callId, this.transformDocumentSelector(selector), triggerCharacters);
+        this.proxy.$registerOnTypeFormattingProvider(callId, pluginInfo, this.transformDocumentSelector(selector), triggerCharacters);
         return this.createDisposable(callId);
     }
 
@@ -406,9 +411,9 @@ export class LanguagesExtImpl implements LanguagesExt {
         return this.withAdapter(handle, LinkProviderAdapter, adapter => adapter.resolveLink(link, token));
     }
 
-    registerLinkProvider(selector: theia.DocumentSelector, provider: theia.DocumentLinkProvider): theia.Disposable {
+    registerLinkProvider(selector: theia.DocumentSelector, provider: theia.DocumentLinkProvider, pluginInfo: PluginInfo): theia.Disposable {
         const callId = this.addNewAdapter(new LinkProviderAdapter(provider, this.documents));
-        this.proxy.$registerDocumentLinkProvider(callId, this.transformDocumentSelector(selector));
+        this.proxy.$registerDocumentLinkProvider(callId, pluginInfo, this.transformDocumentSelector(selector));
         return this.createDisposable(callId);
     }
     // ### Document Link Provider end
@@ -418,11 +423,13 @@ export class LanguagesExtImpl implements LanguagesExt {
         selector: theia.DocumentSelector,
         provider: theia.CodeActionProvider,
         pluginModel: PluginModel,
+        pluginInfo: PluginInfo,
         metadata?: theia.CodeActionProviderMetadata
     ): theia.Disposable {
         const callId = this.addNewAdapter(new CodeActionAdapter(provider, this.documents, this.diagnostics, pluginModel ? pluginModel.id : '', this.commands));
         this.proxy.$registerQuickFixProvider(
             callId,
+            pluginInfo,
             this.transformDocumentSelector(selector),
             metadata && metadata.providedCodeActionKinds ? metadata.providedCodeActionKinds.map(kind => kind.value!) : undefined
         );
@@ -440,10 +447,10 @@ export class LanguagesExtImpl implements LanguagesExt {
     // ### Code Actions Provider end
 
     // ### Code Lens Provider begin
-    registerCodeLensProvider(selector: theia.DocumentSelector, provider: theia.CodeLensProvider): theia.Disposable {
+    registerCodeLensProvider(selector: theia.DocumentSelector, provider: theia.CodeLensProvider, pluginInfo: PluginInfo): theia.Disposable {
         const callId = this.addNewAdapter(new CodeLensAdapter(provider, this.documents, this.commands));
         const eventHandle = typeof provider.onDidChangeCodeLenses === 'function' ? this.nextCallId() : undefined;
-        this.proxy.$registerCodeLensSupport(callId, this.transformDocumentSelector(selector), eventHandle);
+        this.proxy.$registerCodeLensSupport(callId, pluginInfo, this.transformDocumentSelector(selector), eventHandle);
         let result = this.createDisposable(callId);
 
         if (eventHandle !== undefined && provider.onDidChangeCodeLenses) {
@@ -468,17 +475,17 @@ export class LanguagesExtImpl implements LanguagesExt {
         return this.withAdapter(handle, ReferenceAdapter, adapter => adapter.provideReferences(URI.revive(resource), position, context, token));
     }
 
-    registerReferenceProvider(selector: theia.DocumentSelector, provider: theia.ReferenceProvider): theia.Disposable {
+    registerReferenceProvider(selector: theia.DocumentSelector, provider: theia.ReferenceProvider, pluginInfo: PluginInfo): theia.Disposable {
         const callId = this.addNewAdapter(new ReferenceAdapter(provider, this.documents));
-        this.proxy.$registerReferenceProvider(callId, this.transformDocumentSelector(selector));
+        this.proxy.$registerReferenceProvider(callId, pluginInfo, this.transformDocumentSelector(selector));
         return this.createDisposable(callId);
     }
     // ### Code Reference Provider end
 
     // ### Document Symbol Provider begin
-    registerDocumentSymbolProvider(selector: theia.DocumentSelector, provider: theia.DocumentSymbolProvider): theia.Disposable {
+    registerDocumentSymbolProvider(selector: theia.DocumentSelector, provider: theia.DocumentSymbolProvider, pluginInfo: PluginInfo): theia.Disposable {
         const callId = this.addNewAdapter(new OutlineAdapter(this.documents, provider));
-        this.proxy.$registerOutlineSupport(callId, this.transformDocumentSelector(selector));
+        this.proxy.$registerOutlineSupport(callId, pluginInfo, this.transformDocumentSelector(selector));
         return this.createDisposable(callId);
     }
 
@@ -488,9 +495,9 @@ export class LanguagesExtImpl implements LanguagesExt {
     // ### Document Symbol Provider end
 
     // ### Color Provider begin
-    registerColorProvider(selector: theia.DocumentSelector, provider: theia.DocumentColorProvider): theia.Disposable {
+    registerColorProvider(selector: theia.DocumentSelector, provider: theia.DocumentColorProvider, pluginInfo: PluginInfo): theia.Disposable {
         const callId = this.addNewAdapter(new ColorProviderAdapter(this.documents, provider));
-        this.proxy.$registerDocumentColorProvider(callId, this.transformDocumentSelector(selector));
+        this.proxy.$registerDocumentColorProvider(callId, pluginInfo, this.transformDocumentSelector(selector));
         return this.createDisposable(callId);
     }
 
@@ -504,9 +511,9 @@ export class LanguagesExtImpl implements LanguagesExt {
     // ### Color Provider end
 
     // ### Folding Range Provider begin
-    registerFoldingRangeProvider(selector: theia.DocumentSelector, provider: theia.FoldingRangeProvider): theia.Disposable {
+    registerFoldingRangeProvider(selector: theia.DocumentSelector, provider: theia.FoldingRangeProvider, pluginInfo: PluginInfo): theia.Disposable {
         const callId = this.addNewAdapter(new FoldingProviderAdapter(provider, this.documents));
-        this.proxy.$registerFoldingRangeProvider(callId, this.transformDocumentSelector(selector));
+        this.proxy.$registerFoldingRangeProvider(callId, pluginInfo, this.transformDocumentSelector(selector));
         return this.createDisposable(callId);
     }
 
@@ -521,9 +528,9 @@ export class LanguagesExtImpl implements LanguagesExt {
     // ### Folging Range Provider end
 
     // ### Rename Provider begin
-    registerRenameProvider(selector: theia.DocumentSelector, provider: theia.RenameProvider): theia.Disposable {
+    registerRenameProvider(selector: theia.DocumentSelector, provider: theia.RenameProvider, pluginInfo: PluginInfo): theia.Disposable {
         const callId = this.addNewAdapter(new RenameAdapter(provider, this.documents));
-        this.proxy.$registerRenameProvider(callId, this.transformDocumentSelector(selector), RenameAdapter.supportsResolving(provider));
+        this.proxy.$registerRenameProvider(callId, pluginInfo, this.transformDocumentSelector(selector), RenameAdapter.supportsResolving(provider));
         return this.createDisposable(callId);
     }
 

--- a/packages/plugin-ext/src/plugin/plugin-context.ts
+++ b/packages/plugin-ext/src/plugin/plugin-context.ts
@@ -122,7 +122,7 @@ import { PreferenceRegistryExtImpl } from './preference-registry';
 import { OutputChannelRegistryExt } from './output-channel-registry';
 import { TerminalServiceExtImpl, TerminalExtImpl } from './terminal-ext';
 import { LanguagesExtImpl, score } from './languages';
-import { fromDocumentSelector } from './type-converters';
+import { fromDocumentSelector, pluginToPluginInfo } from './type-converters';
 import { DialogsExtImpl } from './dialogs';
 import { NotificationExtImpl } from './notification';
 import { CancellationToken } from '@theia/core/lib/common/cancellation';
@@ -545,13 +545,13 @@ export function createAPIFactory(
                 return languagesExt.setLanguageConfiguration(language, configuration);
             },
             registerCompletionItemProvider(selector: theia.DocumentSelector, provider: theia.CompletionItemProvider, ...triggerCharacters: string[]): theia.Disposable {
-                return languagesExt.registerCompletionItemProvider(selector, provider, triggerCharacters);
+                return languagesExt.registerCompletionItemProvider(selector, provider, triggerCharacters, pluginToPluginInfo(plugin));
             },
             registerDefinitionProvider(selector: theia.DocumentSelector, provider: theia.DefinitionProvider): theia.Disposable {
-                return languagesExt.registerDefinitionProvider(selector, provider);
+                return languagesExt.registerDefinitionProvider(selector, provider, pluginToPluginInfo(plugin));
             },
             registerDeclarationProvider(selector: theia.DocumentSelector, provider: theia.DeclarationProvider): theia.Disposable {
-                return languagesExt.registerDeclarationProvider(selector, provider);
+                return languagesExt.registerDeclarationProvider(selector, provider, pluginToPluginInfo(plugin));
             },
             registerSignatureHelpProvider(
                 selector: theia.DocumentSelector, provider: theia.SignatureHelpProvider, first?: string | theia.SignatureHelpProviderMetadata, ...remaining: string[]
@@ -566,28 +566,28 @@ export function createAPIFactory(
                         triggerCharacters.push(first, ...remaining);
                     }
                 }
-                return languagesExt.registerSignatureHelpProvider(selector, provider, metadata);
+                return languagesExt.registerSignatureHelpProvider(selector, provider, metadata, pluginToPluginInfo(plugin));
             },
             registerTypeDefinitionProvider(selector: theia.DocumentSelector, provider: theia.TypeDefinitionProvider): theia.Disposable {
-                return languagesExt.registerTypeDefinitionProvider(selector, provider);
+                return languagesExt.registerTypeDefinitionProvider(selector, provider, pluginToPluginInfo(plugin));
             },
             registerImplementationProvider(selector: theia.DocumentSelector, provider: theia.ImplementationProvider): theia.Disposable {
-                return languagesExt.registerImplementationProvider(selector, provider);
+                return languagesExt.registerImplementationProvider(selector, provider, pluginToPluginInfo(plugin));
             },
             registerHoverProvider(selector: theia.DocumentSelector, provider: theia.HoverProvider): theia.Disposable {
-                return languagesExt.registerHoverProvider(selector, provider);
+                return languagesExt.registerHoverProvider(selector, provider, pluginToPluginInfo(plugin));
             },
             registerDocumentHighlightProvider(selector: theia.DocumentSelector, provider: theia.DocumentHighlightProvider): theia.Disposable {
-                return languagesExt.registerDocumentHighlightProvider(selector, provider);
+                return languagesExt.registerDocumentHighlightProvider(selector, provider, pluginToPluginInfo(plugin));
             },
             registerWorkspaceSymbolProvider(provider: theia.WorkspaceSymbolProvider): theia.Disposable {
-                return languagesExt.registerWorkspaceSymbolProvider(provider);
+                return languagesExt.registerWorkspaceSymbolProvider(provider, pluginToPluginInfo(plugin));
             },
             registerDocumentFormattingEditProvider(selector: theia.DocumentSelector, provider: theia.DocumentFormattingEditProvider): theia.Disposable {
-                return languagesExt.registerDocumentFormattingEditProvider(selector, provider);
+                return languagesExt.registerDocumentFormattingEditProvider(selector, provider, pluginToPluginInfo(plugin));
             },
             registerDocumentRangeFormattingEditProvider(selector: theia.DocumentSelector, provider: theia.DocumentRangeFormattingEditProvider): theia.Disposable {
-                return languagesExt.registerDocumentRangeFormattingEditProvider(selector, provider);
+                return languagesExt.registerDocumentRangeFormattingEditProvider(selector, provider, pluginToPluginInfo(plugin));
             },
             registerOnTypeFormattingEditProvider(
                 selector: theia.DocumentSelector,
@@ -595,31 +595,31 @@ export function createAPIFactory(
                 firstTriggerCharacter: string,
                 ...moreTriggerCharacters: string[]
             ): theia.Disposable {
-                return languagesExt.registerOnTypeFormattingEditProvider(selector, provider, [firstTriggerCharacter].concat(moreTriggerCharacters));
+                return languagesExt.registerOnTypeFormattingEditProvider(selector, provider, [firstTriggerCharacter].concat(moreTriggerCharacters), pluginToPluginInfo(plugin));
             },
             registerDocumentLinkProvider(selector: theia.DocumentSelector, provider: theia.DocumentLinkProvider): theia.Disposable {
-                return languagesExt.registerLinkProvider(selector, provider);
+                return languagesExt.registerLinkProvider(selector, provider, pluginToPluginInfo(plugin));
             },
             registerCodeActionsProvider(selector: theia.DocumentSelector, provider: theia.CodeActionProvider, metadata?: theia.CodeActionProviderMetadata): theia.Disposable {
-                return languagesExt.registerCodeActionsProvider(selector, provider, plugin.model, metadata);
+                return languagesExt.registerCodeActionsProvider(selector, provider, plugin.model, pluginToPluginInfo(plugin), metadata);
             },
             registerCodeLensProvider(selector: theia.DocumentSelector, provider: theia.CodeLensProvider): theia.Disposable {
-                return languagesExt.registerCodeLensProvider(selector, provider);
+                return languagesExt.registerCodeLensProvider(selector, provider, pluginToPluginInfo(plugin));
             },
             registerReferenceProvider(selector: theia.DocumentSelector, provider: theia.ReferenceProvider): theia.Disposable {
-                return languagesExt.registerReferenceProvider(selector, provider);
+                return languagesExt.registerReferenceProvider(selector, provider, pluginToPluginInfo(plugin));
             },
             registerDocumentSymbolProvider(selector: theia.DocumentSelector, provider: theia.DocumentSymbolProvider): theia.Disposable {
-                return languagesExt.registerDocumentSymbolProvider(selector, provider);
+                return languagesExt.registerDocumentSymbolProvider(selector, provider, pluginToPluginInfo(plugin));
             },
             registerColorProvider(selector: theia.DocumentSelector, provider: theia.DocumentColorProvider): theia.Disposable {
-                return languagesExt.registerColorProvider(selector, provider);
+                return languagesExt.registerColorProvider(selector, provider, pluginToPluginInfo(plugin));
             },
             registerFoldingRangeProvider(selector: theia.DocumentSelector, provider: theia.FoldingRangeProvider): theia.Disposable {
-                return languagesExt.registerFoldingRangeProvider(selector, provider);
+                return languagesExt.registerFoldingRangeProvider(selector, provider, pluginToPluginInfo(plugin));
             },
             registerRenameProvider(selector: theia.DocumentSelector, provider: theia.RenameProvider): theia.Disposable {
-                return languagesExt.registerRenameProvider(selector, provider);
+                return languagesExt.registerRenameProvider(selector, provider, pluginToPluginInfo(plugin));
             },
         };
 

--- a/packages/plugin-ext/src/plugin/type-converters.ts
+++ b/packages/plugin-ext/src/plugin/type-converters.ts
@@ -24,7 +24,8 @@ import {
     ResourceFileEditDto,
     TaskDto,
     ProcessTaskDto,
-    PickOpenItem
+    PickOpenItem,
+    Plugin
 } from '../common/plugin-api-rpc';
 import * as rpc from '../common/plugin-api-rpc';
 import * as model from '../common/plugin-api-rpc-model';
@@ -1076,4 +1077,11 @@ export function pathOrURIToURI(value: string | URI): URI {
     } else {
         return value;
     }
+}
+
+export function pluginToPluginInfo(plugin: Plugin): rpc.PluginInfo {
+    return {
+        id: plugin.model.id,
+        name: plugin.model.name
+    };
 }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->
This PR passes some plugin info through to languages-main and establishes a map that allows one to get a handle for a specific vscode extension's language server call.

An example of this map is:
```
{
    "redhat.vscode-yaml": {
        "completion": 0,
        "outline": 1
    },
    "redhat.java": {
        "completion": 2,
        "outline": 3,
        "codeLens": 4
   }
}
```

Related issue: https://github.com/eclipse-theia/theia/issues/6151

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
I've created a sample theia extension https://github.com/JPinkney/Theia-Test-Extension that you clone into theia/packages/ and then add `"@theia/test-extension": "^.0.10.0"` to the package.json. Then add a plugin to the plugins folder such as vscode-java, vscode-xml. Inside of theia open a java and xml file (so the vscode extensions get activated). Then open up the browsers console and after 10 seconds you should see a printout of the map.

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

