### PR TITLE
Give React tab toolbar items access to the current widget instance

### DIFF
--- a/packages/core/src/browser/shell/tab-bar-toolbar.tsx
+++ b/packages/core/src/browser/shell/tab-bar-toolbar.tsx
@@ -106,7 +106,7 @@ export class TabBarToolbar extends ReactWidget {
     protected render(): React.ReactNode {
         return <React.Fragment>
             {this.renderMore()}
-            {[...this.inline.values()].map(item => TabBarToolbarItem.is(item) ? this.renderItem(item) : item.render())}
+            {[...this.inline.values()].map(item => TabBarToolbarItem.is(item) ? this.renderItem(item) : item.render(this.current))}
         </React.Fragment>;
     }
 
@@ -288,7 +288,7 @@ export interface TabBarToolbarItem {
  */
 export interface ReactTabBarToolbarItem {
     readonly id: string;
-    render(): React.ReactNode;
+    render(widget?: Widget): React.ReactNode;
 
     readonly onDidChange?: Event<void>;
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

This PR passes the current widget to the render method of React tab bar toolbar items.

This allows extension authors to create toolbar items that show content specific to the current widget instance. This is useful when there can be more instance of a Widget class at a time. For example, a toolbar item for the terminal could show a message specific to the currently displayed terminal tab.

This change brings the signature for `render` in to line with `isVisible`: https://github.com/eclipse-theia/theia/blob/master/packages/core/src/browser/shell/tab-bar-toolbar.tsx#L297.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
Add a tab toolbar item with a render method that uses the input widget. Test that the item content changes appropriately as different widgets are selected.

See https://github.com/mcgordonite/theia/commit/d713b49d977a5835ca55c00acd489e449100881b.

#### Review checklist

- [X] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)