### PR TITLE
[git] handle attempting to sign-off without configs

### DIFF
--- a/packages/git/src/browser/git-contribution.ts
+++ b/packages/git/src/browser/git-contribution.ts
@@ -704,20 +704,28 @@ export class GitContribution implements CommandContribution, MenuContribution, T
         if (!scmRepository) {
             return;
         }
-        const repository = scmRepository.provider.repository;
-        const [username, email] = (await Promise.all([
-            this.git.exec(repository, ['config', 'user.name']),
-            this.git.exec(repository, ['config', 'user.email'])
-        ])).map(result => result.stdout.trim());
+        try {
+            const repository = scmRepository.provider.repository;
+            const [username, email] = (await Promise.all([
+                this.git.exec(repository, ['config', 'user.name']),
+                this.git.exec(repository, ['config', 'user.email'])
+            ])).map(result => result.stdout.trim());
 
-        const signOff = `\n\nSigned-off-by: ${username} <${email}>`;
-        const value = scmRepository.input.value;
-        if (value.endsWith(signOff)) {
-            scmRepository.input.value = value.substr(0, value.length - signOff.length);
-        } else {
-            scmRepository.input.value = `${value}${signOff}`;
+            const signOff = `\n\nSigned-off-by: ${username} <${email}>`;
+            const value = scmRepository.input.value;
+            if (value.endsWith(signOff)) {
+                scmRepository.input.value = value.substr(0, value.length - signOff.length);
+            } else {
+                scmRepository.input.value = `${value}${signOff}`;
+            }
+            scmRepository.input.focus();
+        } catch (e) {
+            scmRepository.input.issue = {
+                type: 'warning',
+                message: 'Make sure you configure your \'user.name\' and \'user.email\' in git.'
+            };
         }
-        scmRepository.input.focus();
+
     }
 }
 export interface GitOpenFileOptions {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

Fixes #4908

Handle the toolbar action to add a sign-off when the
user does not have their `user.name` and `user.email` configured.

<div align='left'>

<img width="315" alt="Screen Shot 2019-09-19 at 3 30 43 PM" src="https://user-images.githubusercontent.com/40359487/65274937-7fa56f80-daf2-11e9-97d0-b641080b2ecc.png">

</div>


#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
1. ensure that the git config is not set (ex: open `~/.gitconfig` and comment out `user.name` and `user.email` entries
2. attempt to create a commit in the application, and click the sign-off toolbar button
3. a warning should be displayed that no config is set
4. un-comment out the entries in the gitconfig
5. retry step 2, the sign-off should be added in the commit message

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

Signed-off-by: vince-fugnitto <vincent.fugnitto@ericsson.com>

