### PR TITLE
Minor fix for the command palette filter

### DIFF
--- a/packages/core/src/common/quick-open-service.ts
+++ b/packages/core/src/common/quick-open-service.ts
@@ -31,7 +31,8 @@ export namespace QuickOpenOptions {
     export interface Resolved {
         readonly enabled: boolean;
 
-        readonly trim: boolean;
+        /** `true` means that input of quick open widget will be trimmed by default. */
+        readonly trimInput: boolean;
         readonly prefix: string;
         readonly placeholder: string;
         readonly ignoreFocusOut: boolean;
@@ -63,7 +64,7 @@ export namespace QuickOpenOptions {
     export const defaultOptions: Resolved = Object.freeze({
         enabled: true,
 
-        trim: true,
+        trimInput: true,
         prefix: '',
         placeholder: '',
         ignoreFocusOut: false,

--- a/packages/core/src/common/quick-open-service.ts
+++ b/packages/core/src/common/quick-open-service.ts
@@ -31,6 +31,7 @@ export namespace QuickOpenOptions {
     export interface Resolved {
         readonly enabled: boolean;
 
+        readonly trim: boolean;
         readonly prefix: string;
         readonly placeholder: string;
         readonly ignoreFocusOut: boolean;
@@ -62,6 +63,7 @@ export namespace QuickOpenOptions {
     export const defaultOptions: Resolved = Object.freeze({
         enabled: true,
 
+        trim: true,
         prefix: '',
         placeholder: '',
         ignoreFocusOut: false,

--- a/packages/monaco/src/browser/monaco-quick-open-service.ts
+++ b/packages/monaco/src/browser/monaco-quick-open-service.ts
@@ -346,7 +346,7 @@ export class MonacoQuickOpenControllerOptsImpl implements MonacoQuickOpenControl
         if (this.options.skipPrefix) {
             lookFor = lookFor.substr(this.options.skipPrefix);
         }
-        if (this.options.trim) {
+        if (this.options.trimInput) {
             lookFor = lookFor.trim();
         }
         const { fuzzyMatchLabel, fuzzyMatchDescription, fuzzyMatchDetail } = this.options;

--- a/packages/monaco/src/browser/monaco-quick-open-service.ts
+++ b/packages/monaco/src/browser/monaco-quick-open-service.ts
@@ -346,6 +346,9 @@ export class MonacoQuickOpenControllerOptsImpl implements MonacoQuickOpenControl
         if (this.options.skipPrefix) {
             lookFor = lookFor.substr(this.options.skipPrefix);
         }
+        if (this.options.trim) {
+            lookFor = lookFor.trim();
+        }
         const { fuzzyMatchLabel, fuzzyMatchDescription, fuzzyMatchDetail } = this.options;
         const labelHighlights = fuzzyMatchLabel ? this.matchesFuzzy(lookFor, item.getLabel(), fuzzyMatchLabel) : item.getLabelHighlights();
         const descriptionHighlights = fuzzyMatchDescription ? this.matchesFuzzy(lookFor, item.getDescription(), fuzzyMatchDescription) : item.getDescriptionHighlights();


### PR DESCRIPTION
Signed-off-by: Oleksii Orel <oorel@redhat.com>

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->
Add the trim options to the command palette filter.
#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
 How to reproduce a bug:
  1. Press 'f1' and try to find 'git' commands. It won't work if you add a space after the prefix.
![Screenshot from 2019-09-20 06-08-51](https://user-images.githubusercontent.com/6310786/65296976-039d3d00-db6f-11e9-81df-88e6ba067512.png)

Visual Studio Code has another behavior:
![Screenshot from 2019-09-20 06-06-14](https://user-images.githubusercontent.com/6310786/65297464-9c808800-db70-11e9-97f9-8f341242e9f0.png)

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

