### PR TITLE
[dev] Add electron backend and composite electron launch

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -31,6 +31,7 @@
         "--hostname=localhost",
         "--no-cluster",
         "--app-project-path=${workspaceRoot}/examples/electron",
+        "--remote-debugging-port=9222",
         "--no-app-auto-install"
       ],
       "env": {
@@ -51,7 +52,7 @@
     {
       "type": "node",
       "request": "launch",
-      "name": "Launch Backend",
+      "name": "Launch Browser Backend",
       "program": "${workspaceRoot}/examples/browser/src-gen/backend/main.js",
       "args": [
         "--hostname=0.0.0.0",
@@ -93,7 +94,7 @@
     {
       "type": "node",
       "request": "launch",
-      "name": "Launch Backend (eclipse.jdt.ls)",
+      "name": "Launch Browser Backend (eclipse.jdt.ls)",
       "program": "${workspaceRoot}/examples/browser/src-gen/backend/main.js",
       "args": [
         "--log-level=debug",
@@ -120,7 +121,7 @@
       "type": "node",
       "request": "launch",
       "protocol": "inspector",
-      "name": "Run Mocha Test",
+      "name": "Run Mocha Tests",
       "program": "${workspaceRoot}/node_modules/mocha/bin/_mocha",
       "args": [
         "--no-timeouts",
@@ -138,11 +139,17 @@
       "outputCapture": "std"
     },
     {
-      "name": "Launch Frontend",
+      "name": "Launch Browser Frontend",
       "type": "chrome",
       "request": "launch",
       "url": "http://localhost:3000/",
       "webRoot": "${workspaceRoot}"
+    },
+    {
+      "type": "chrome",
+      "request": "attach",
+      "name": "Attach to Electron Frontend",
+      "port": 9222
     },
     {
       "name": "Launch VS Code Tests",
@@ -165,6 +172,15 @@
       "sourceMaps": true,
       "outFiles": [
         "${workspaceFolder}/../.js"
+      ]
+    }
+  ],
+  "compounds": [
+    {
+      "name": "Launch Electron Backend & Frontend",
+      "configurations": [
+        "Launch Electron Backend",
+        "Attach to Electron Frontend"
       ]
     }
   ]


### PR DESCRIPTION
Signed-off-by: thegecko <rob.moran@arm.com>

#### What it does

- Adds ability to attach to the electron frontend
- Adds composite launch config for electron backend and frontend together
- Some minor launch name changes to align nomenclature

#### How to test

- Open in VSCode
- Select one of the new launch configs
- Start debug 

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

