### PR TITLE
GH-4723: Added support for `ResourceFileEdit`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Breaking changes:
 - [core][monaco][plugin] reload plugins on reconnection [6159](https://github.com/eclipse-theia/theia/pull/6159)
   - Extenders should implement `Disposable` for plugin main services to handle reconnection properly.
   - Many APIs are refactored to return `Disposable`.
+- [monaco] Added support for `monaco.languages.ResourceFileEdit`. [#4723](https://github.com/eclipse-theia/theia/issues/4723)
 
 Misc:
 


### PR DESCRIPTION
Closes #4723

Signed-off-by: Akos Kitta <kittaakos@typefox.io>

#### What it does
 - Added support for file and folder operations (create, rename, move) to workspace edits to be compatible with [the `3.13.0` LSP specification](https://microsoft.github.io/language-server-protocol/specification#version_3_13_0).
 - I have exported all interfaces from the `packages/monaco/src/browser/monaco-workspace.ts` module. It was a bug before. Extending clients had to redefine the interfaces previously; such as `EditsByEditor`.

#### How to test

 - If your LS supports `CreateFile`, `RenameFile`, and `DeleteFile`, you are ready to go and try it with your LS. Otherwise, I am happy to give you instructions offline.

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

🌞

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)