### PR TITLE
Made Preferences Widget Rebindable

### DIFF
--- a/packages/preferences/src/browser/index.ts
+++ b/packages/preferences/src/browser/index.ts
@@ -20,3 +20,5 @@ export * from './user-preference-provider';
 export * from './workspace-preference-provider';
 export * from './folders-preferences-provider';
 export * from './folder-preference-provider';
+export { PreferencesWidgetFactory } from './preference-frontend-module';
+export { PREFERENCE_IDS } from './preferences-tree-widget';

--- a/packages/preferences/src/browser/index.ts
+++ b/packages/preferences/src/browser/index.ts
@@ -20,5 +20,3 @@ export * from './user-preference-provider';
 export * from './workspace-preference-provider';
 export * from './folders-preferences-provider';
 export * from './folder-preference-provider';
-export { PreferencesWidgetFactory } from './preference-frontend-module';
-export { PREFERENCE_IDS } from './preferences-tree-widget';

--- a/packages/preferences/src/browser/preference-frontend-module.ts
+++ b/packages/preferences/src/browser/preference-frontend-module.ts
@@ -25,6 +25,8 @@ import { bindPreferenceProviders } from './preference-bindings';
 
 import './preferences-monaco-contribution';
 
+export const PreferencesWidgetFactory = Symbol('PreferencesWidgetFactory');
+
 export function bindPreferences(bind: interfaces.Bind, unbind: interfaces.Unbind): void {
     bindPreferenceProviders(bind, unbind);
 
@@ -36,10 +38,11 @@ export function bindPreferences(bind: interfaces.Bind, unbind: interfaces.Unbind
         createWidget: () => container.get(PreferencesContainer)
     }));
 
-    bind(WidgetFactory).toDynamicValue(({ container }) => ({
+    bind(PreferencesWidgetFactory).toDynamicValue(({ container }) => ({
         id: PreferencesTreeWidget.ID,
         createWidget: () => createPreferencesTreeWidget(container)
     })).inSingletonScope();
+    bind(WidgetFactory).toService(PreferencesWidgetFactory);
 
     bind(PreferencesEditorsContainer).toSelf();
     bind(WidgetFactory).toDynamicValue(({ container }) => ({

--- a/packages/preferences/src/browser/preferences-tree-widget.ts
+++ b/packages/preferences/src/browser/preferences-tree-widget.ts
@@ -608,3 +608,9 @@ export class PreferencesTreeWidget extends TreeWidget {
         return a.localeCompare(b, undefined, { ignorePunctuation: true });
     }
 }
+
+export const PREFERENCE_IDS = {
+    TREE_WIDGET: PreferencesTreeWidget.ID,
+    CONTAINER: PreferencesContainer.ID,
+    EDITORS_CONTAINER: PreferencesEditorsContainer.ID
+};


### PR DESCRIPTION
Exported a PreferencesWidgetFactory to make preferences widget rebindable.

Exported preferences widget IDs to make rebinding easier.

Signed-off-by: Nicholas Stenbeck <nicholas@stenbecks.com>

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
This change makes the Preferences widget rebindable to allow custom Preferences widgets

#### How to test
1. Create new widget with `yo thea-extension`
2. Copy browser widget to packages/ in main repo
3. Change the code to include the following:


##### In my-widget/package.json

```
"dependencies": {
  "@theia/core": "^0.10.0",
  "@theia/preferences": "^0.10.0”
}
```

Versions may differ. Use the versions the rest of your repo uses.


##### In my-widget-frontend-module.ts
```
import { PreferencesWidgetFactory } from '@theia/preferences/lib/browser/preference-frontend-module’;
```

Remove unused imports and style import if it creates issues; it’s not important for this test

```
export default new ContainerModule((bind, unbind, isbound, rebind) => {
    ...
    rebind(PreferencesWidgetFactory).toDynamicValue(ctx => ({
        id: MyWidget.ID,
        createWidget: () => ctx.container.get<MyWidget>(MyWidget)
    })).inSingletonScope();
}
```

##### In my-widget.tsx
```
import { PREFERENCE_IDS } from ‘@theia/preferences/lib/browser/preferences-tree-widget’;
```
Choose an ID to use
```
static readonly ID = PREFERENCE_IDS.CONTAINER;
```
```
// tslint:disable-next-line: no-any
public async activatePreferenceEditor(preferenceScope: any): Promise<void> {
    return new Promise(() => { });
}
```

##### In my-widget-contribution.ts
```
registerCommands(commands: CommandRegistry): void {
    commands.registerCommand(CommonCommands.OPEN_PREFERENCES, {
        execute: () => super.openView({ activate: false, reveal: true })
    });
}
```

##### In examples/browser/package.json
```
"dependencies": {
  ...
  "hello-world-widget": "^0.0.0"
}
```

4. Run `yarn` in project root
5. Run `yarn start` in examples/browser/
6. The preferences widget should now be replaced when you open it

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

