### PR TITLE
[SCM] Fix SCM status bar commands

### DIFF
--- a/packages/plugin-ext/src/common/plugin-api-rpc.ts
+++ b/packages/plugin-ext/src/common/plugin-api-rpc.ts
@@ -70,7 +70,6 @@ import { IJSONSchema, IJSONSchemaSnippet } from '@theia/core/lib/common/json-sch
 import { DebuggerDescription } from '@theia/debug/lib/common/debug-service';
 import { DebugProtocol } from 'vscode-debugprotocol';
 import { SymbolInformation } from 'vscode-languageserver-types';
-import { ScmCommand } from '@theia/scm/lib/browser/scm-provider';
 import { ArgumentProcessor } from '../plugin/command-registry';
 import { MaybePromise } from '@theia/core/lib/common/types';
 import { QuickOpenItem, QuickOpenItemOptions } from '@theia/core/lib/common/quick-open-model';
@@ -607,8 +606,8 @@ export interface SourceControlProviderFeatures {
     hasQuickDiffProvider?: boolean;
     count?: number;
     commitTemplate?: string;
-    acceptInputCommand?: ScmCommand;
-    statusBarCommands?: ScmCommand[];
+    acceptInputCommand?: Command;
+    statusBarCommands?: Command[];
 }
 
 export interface SourceControlGroupFeatures {

--- a/packages/plugin-ext/src/main/browser/scm-main.ts
+++ b/packages/plugin-ext/src/main/browser/scm-main.ts
@@ -189,11 +189,23 @@ export class PluginScmProvider implements ScmProvider {
     }
 
     get acceptInputCommand(): ScmCommand | undefined {
-        return this.features.acceptInputCommand;
+        const command = this.features.acceptInputCommand;
+        if (command) {
+            const scmCommand: ScmCommand = command;
+            scmCommand.command = command.id;
+            return command;
+        }
     }
 
     get statusBarCommands(): ScmCommand[] | undefined {
-        return this.features.statusBarCommands;
+        const commands = this.features.statusBarCommands;
+        if (commands) {
+            return commands.map(command => {
+                const scmCommand: ScmCommand = command;
+                scmCommand.command = command.id;
+                return scmCommand;
+            });
+        }
     }
 
     get count(): number | undefined {

--- a/packages/plugin-ext/src/plugin/scm.ts
+++ b/packages/plugin-ext/src/plugin/scm.ts
@@ -22,8 +22,8 @@ import { DisposableCollection, Disposable } from '@theia/core/lib/common/disposa
 import { UriComponents } from '../common/uri-components';
 import URI from '@theia/core/lib/common/uri';
 import { CommandRegistryImpl } from './command-registry';
-import { ScmCommand } from '@theia/scm/lib/browser/scm-provider';
 import { Emitter } from '@theia/core/lib/common/event';
+import { Command } from '../common/plugin-api-rpc-model';
 
 export class ScmExtImpl implements ScmExt {
     private handle: number = 0;
@@ -254,7 +254,7 @@ class SourceControlImpl implements theia.SourceControl {
 
         this._statusBarCommands = statusBarCommands;
 
-        let safeStatusBarCommands: ScmCommand[] | undefined;
+        let safeStatusBarCommands: Command[] | undefined;
         if (statusBarCommands) {
             safeStatusBarCommands = statusBarCommands.map(statusBarCommand => this.commands.converter.toSafeCommand(statusBarCommand, this.toDisposeOnStatusBarCommands));
         }

--- a/packages/scm/src/browser/scm-contribution.ts
+++ b/packages/scm/src/browser/scm-contribution.ts
@@ -169,6 +169,7 @@ export class ScmContribution extends AbstractViewContribution<ScmWidget> impleme
             text: value.title,
             tooltip: label + (value.tooltip ? ` - ${value.tooltip}` : ''),
             command: value.command,
+            arguments: value.arguments,
             alignment: StatusBarAlignment.LEFT,
             priority: 100
         }));


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->
Pass command arguments to SCM status bar commands. Map `command.id` to `command.command` in `statusBarCommands` and `acceptInputCommand`

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
1. Clone the test plugin: https://github.com/vinokurig/Test.git
2. Compile the plugin and start it as a hosted instance. 
3. Select the `/` SCM repository (this is a view of a dummy SCM repository):
![screenshot-localhost-3030-2019 09 06-17-34-24](https://user-images.githubusercontent.com/7668752/64436695-892fe000-d0cd-11e9-8f13-ccd7492bcbb7.png)
4. Click `title` button in the status bar:
![screenshot-localhost-3030-2019 09 18-15-18-52](https://user-images.githubusercontent.com/7668752/65147946-d7c36f80-da27-11e9-81bd-70dcc5f1b4c9.png)

See the notification

fixes https://github.com/eclipse/che/issues/13974
#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

