### PR TITLE
Show in amending commit list only the first parents

### DIFF
--- a/packages/git/src/browser/git-scm-provider.ts
+++ b/packages/git/src/browser/git-scm-provider.ts
@@ -401,6 +401,7 @@ export class GitAmendSupport implements ScmAmendSupport {
             this.repository,
             {
                 range: { toRevision: amendingHeadCommitSha, fromRevision: latestCommitSha },
+                firstParent: true,
                 maxCount: 50
             }
         );

--- a/packages/git/src/common/git.ts
+++ b/packages/git/src/common/git.ts
@@ -547,6 +547,10 @@ export namespace Git {
              */
             readonly shortSha?: boolean;
 
+            /**
+             * Return only commits reached by following the first parent, giving a linear list of commits.
+             */
+            readonly firstParent?: boolean;
         }
 
         /**

--- a/packages/git/src/node/dugite-git.ts
+++ b/packages/git/src/node/dugite-git.ts
@@ -643,6 +643,9 @@ export class DugiteGit implements Git {
         if (options && options.branch) {
             args.push(options.branch);
         }
+        if (options && options.firstParent) {
+            args.push('--first-parent');
+        }
         const range = this.mapRange((options || {}).range);
         args.push(...[range, '-C', '-M', '-m']);
         const maxCount = options && options.maxCount ? options.maxCount : 0;


### PR DESCRIPTION
#### What it does

This fixes a problem that occurs when amending commits where a commit has more than one parent (such as occurs after a merge).  The commits being amended are correctly listed as the commits from the first parent, which would generally be the master branch.  However if refreshed then one sees commits from other branches involved in the merges.

@kittaakos found this problem while reviewing https://github.com/eclipse-theia/theia/pull/5451

#### How to test

- Create or clone a repository that has a merge commit.
- Press 'amend' to go back to a commit prior to the merge commit.
- Note the list of amending commits.
- Press 'refresh'.
- Check that the list of amending commits is the same as before refreshing.

#### Review checklist

- [x ] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers
 
- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

