### PR TITLE
Made Preferences widget rebindable

### DIFF
--- a/packages/preferences/src/browser/preference-frontend-module.ts
+++ b/packages/preferences/src/browser/preference-frontend-module.ts
@@ -25,6 +25,8 @@ import { bindPreferenceProviders } from './preference-bindings';
 
 import './preferences-monaco-contribution';
 
+export const PreferencesWidgetFactory = Symbol('PreferencesWidgetFactory');
+
 export function bindPreferences(bind: interfaces.Bind, unbind: interfaces.Unbind): void {
     bindPreferenceProviders(bind, unbind);
 
@@ -36,10 +38,11 @@ export function bindPreferences(bind: interfaces.Bind, unbind: interfaces.Unbind
         createWidget: () => container.get(PreferencesContainer)
     }));
 
-    bind(WidgetFactory).toDynamicValue(({ container }) => ({
+    bind(PreferencesWidgetFactory).toDynamicValue(({ container }) => ({
         id: PreferencesTreeWidget.ID,
         createWidget: () => createPreferencesTreeWidget(container)
     })).inSingletonScope();
+    bind(WidgetFactory).toService(PreferencesWidgetFactory);
 
     bind(PreferencesEditorsContainer).toSelf();
     bind(WidgetFactory).toDynamicValue(({ container }) => ({


### PR DESCRIPTION
Made Preferences widget rebindable.

Signed-off-by: Nicholas Stenbeck <nicholas@stenbecks.com>

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
This change makes the Preferences widget rebindable to allow custom Preferences widgets.

#### How to test
1. Create new widget with `yo thea-extension`
2. Copy browser widget to packages/ in main repo
3. Change the code to include the following:


##### In my-widget/package.json

```
"dependencies": {
  "@theia/core": "^0.10.0",
  "@theia/preferences": "^0.10.0”
}
```

Versions may differ. Use the versions the rest of your repo uses.


##### In my-widget-frontend-module.ts
```
import { PreferencesWidgetFactory } from '@theia/preferences/lib/browser/preference-frontend-module’;
```

Remove unused imports and style import if it creates issues; it’s not important for this test

```
export default new ContainerModule((bind, unbind, isbound, rebind) => {
    ...
    rebind(PreferencesWidgetFactory).toDynamicValue(ctx => ({
        id: MyWidget.ID,
        createWidget: () => ctx.container.get<MyWidget>(MyWidget)
    })).inSingletonScope();
}
```

##### In my-widget.tsx
```
import { PreferencesContainer } from ‘@theia/preferences/lib/browser/preferences-tree-widget’;
...
static readonly ID = PreferencesContainer.ID;
```
```
// tslint:disable-next-line: no-any
public async activatePreferenceEditor(preferenceScope: any): Promise<void> {
    return new Promise(() => { });
}
```

##### In my-widget-contribution.ts
```
registerCommands(commands: CommandRegistry): void {
    commands.registerCommand(CommonCommands.OPEN_PREFERENCES, {
        execute: () => super.openView({ activate: false, reveal: true })
    });
}
```

##### In examples/browser/package.json
```
"dependencies": {
  ...
  "hello-world-widget": "^0.0.0"
}
```

4. Run `yarn` in project rootc
5. Run `yarn start` in examples/browser/
6. The preferences widget should now be replaced when you open it

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
