### PR TITLE
Support preLaunchTask and postDebugTask

### DIFF
--- a/packages/debug/package.json
+++ b/packages/debug/package.json
@@ -19,6 +19,7 @@
     "@theia/userstorage": "^0.11.0",
     "@theia/variable-resolver": "^0.11.0",
     "@theia/workspace": "^0.11.0",
+    "@theia/task": "^0.11.0",
     "@types/p-debounce": "^1.0.1",
     "jsonc-parser": "^2.0.2",
     "mkdirp": "^0.5.0",

--- a/packages/debug/src/common/debug-configuration.ts
+++ b/packages/debug/src/common/debug-configuration.ts
@@ -62,6 +62,12 @@ export interface DebugConfiguration {
 
     /** default: neverOpen */
     internalConsoleOptions?: 'neverOpen' | 'openOnSessionStart' | 'openOnFirstSessionStart'
+
+    /** Task to run before debug session starts */
+    preLaunchTask?: string;
+
+    /** Task to run after debug session ends */
+    postDebugTask?: string;
 }
 export namespace DebugConfiguration {
     export function is(arg: DebugConfiguration | any): arg is DebugConfiguration {

--- a/packages/debug/src/node/vscode/vscode-debug-adapter-contribution.ts
+++ b/packages/debug/src/node/vscode/vscode-debug-adapter-contribution.ts
@@ -170,16 +170,18 @@ export abstract class AbstractVSCodeDebugAdapterContribution implements DebugAda
             };
             properties['preLaunchTask'] = {
                 anyOf: [taskSchema, {
-                    type: ['string', 'null'],
+                    type: ['string'],
                 }],
                 default: '',
+                defaultSnippets: [{ body: { task: '', type: '' } }],
                 description: nls.localize('debugPrelaunchTask', 'Task to run before debug session starts.')
             };
             properties['postDebugTask'] = {
                 anyOf: [taskSchema, {
-                    type: ['string', 'null'],
+                    type: ['string', ],
                 }],
                 default: '',
+                defaultSnippets: [{ body: { task: '', type: '' } }],
                 description: nls.localize('debugPostDebugTask', 'Task to run after debug session ends.')
             };
             properties['internalConsoleOptions'] = INTERNAL_CONSOLE_OPTIONS_SCHEMA;

--- a/packages/plugin-ext/src/hosted/node/scanners/scanner-theia.ts
+++ b/packages/plugin-ext/src/hosted/node/scanners/scanner-theia.ts
@@ -493,14 +493,14 @@ export class TheiaPluginScanner implements PluginScanner {
             };
             properties['preLaunchTask'] = {
                 anyOf: [taskSchema, {
-                    type: ['string', 'null'],
+                    type: ['string'],
                 }],
                 default: '',
                 description: nls.localize('debugPrelaunchTask', 'Task to run before debug session starts.')
             };
             properties['postDebugTask'] = {
                 anyOf: [taskSchema, {
-                    type: ['string', 'null'],
+                    type: ['string'],
                 }],
                 default: '',
                 description: nls.localize('debugPostDebugTask', 'Task to run after debug session ends.')

--- a/packages/task/src/browser/task-configurations.ts
+++ b/packages/task/src/browser/task-configurations.ts
@@ -257,7 +257,8 @@ export class TaskConfigurations implements Disposable {
             }
             return {
                 ...config,
-                _source: rootFolderUri
+                _source: rootFolderUri,
+                _scope: rootFolderUri
             };
         });
         this.rawTaskConfigurations.set(rootFolderUri, tasks);

--- a/packages/task/src/browser/task-frontend-module.ts
+++ b/packages/task/src/browser/task-frontend-module.ts
@@ -37,6 +37,7 @@ import { TaskConfigurationManager } from './task-configuration-manager';
 import { bindTaskPreferences } from './task-preferences';
 import '../../src/browser/style/index.css';
 import './tasks-monaco-contribution';
+import { TaskNameResolver } from './task-name-resolver';
 
 export default new ContainerModule(bind => {
     bind(TaskFrontendContribution).toSelf().inSingletonScope();
@@ -71,6 +72,7 @@ export default new ContainerModule(bind => {
     bind(TaskResolverRegistry).toSelf().inSingletonScope();
     bindContributionProvider(bind, TaskContribution);
     bind(TaskSchemaUpdater).toSelf().inSingletonScope();
+    bind(TaskNameResolver).toSelf().inSingletonScope();
 
     bindProcessTaskModule(bind);
     bindTaskPreferences(bind);

--- a/packages/task/src/browser/task-name-resolver.ts
+++ b/packages/task/src/browser/task-name-resolver.ts
@@ -1,0 +1,38 @@
+/********************************************************************************
+ * Copyright (C) 2019 Red Hat, Inc. and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import { inject, injectable } from 'inversify';
+import { TaskConfiguration } from '../common';
+import { TaskDefinitionRegistry } from './task-definition-registry';
+
+@injectable()
+export class TaskNameResolver {
+    @inject(TaskDefinitionRegistry)
+    protected taskDefinitionRegistry: TaskDefinitionRegistry;
+
+    /**
+     * Returns task name to display.
+     * It is aligned with VS Code.
+     */
+    resolve(task: TaskConfiguration): string {
+        if (this.taskDefinitionRegistry.getDefinition(task)) {
+            return `${task.source}: ${task.label}`;
+        }
+
+        // it is a hack, when task is customized but extension is absent
+        return task.label || `${task.type}: ${task.task}`;
+    }
+}

--- a/packages/task/src/common/task-protocol.ts
+++ b/packages/task/src/common/task-protocol.ts
@@ -32,6 +32,12 @@ export interface TaskCustomization {
 export interface TaskConfiguration extends TaskCustomization {
     /** A label that uniquely identifies a task configuration per source */
     readonly label: string;
+    /**
+     * For a provided task, it is the string representation of the URI where the task is supposed to run from. It is `undefined` for global tasks.
+     * For a configured task, it is workspace URI that task belongs to.
+     * This field is not supposed to be used in `tasks.json`
+     */
+    readonly _scope: string | undefined;
 }
 
 export interface ContributedTaskConfiguration extends TaskConfiguration {
@@ -41,11 +47,6 @@ export interface ContributedTaskConfiguration extends TaskConfiguration {
      * This field is not supposed to be used in `tasks.json`
      */
     readonly _source: string;
-    /**
-     * For a provided task, it is the string representation of the URI where the task is supposed to run from. It is `undefined` for global tasks.
-     * This field is not supposed to be used in `tasks.json`
-     */
-    readonly _scope: string | undefined;
 }
 
 /** Runtime information about Task. */


### PR DESCRIPTION
Signed-off-by: Anatoliy Bazko <abazko@redhat.com>

#### What it does
It adds support for `preLaunchTask` and `postDebugTask`
https://code.visualstudio.com/docs/editor/debugging#_launchjson-attributes

- [x] If task is configured the label of the task is used to identify and to display.

### Reference issue
https://github.com/eclipse-theia/theia/issues/3409

#### How to test
1. Add any debug configuration
2. Add `preLaunchTask` and `postDebugTask`
```
            "preLaunchTask": "taskStart",
            "postDebugTask": "taskEnd"
```
3.  Configure tasks, for instance:
```json
{
    "tasks": [
        {
            "type": "shell",
            "label": "taskStart",
            "command": "sleep 1s && echo Start"

        },
        {
            "type": "shell",
            "label": "taskEnd",
            "command": "sleep 1s && echo End"
        }
    ]
}
```


#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

