### PR TITLE
[plugin] wait for workspace to be ready

### DIFF
--- a/packages/plugin-ext/src/hosted/browser/hosted-plugin.ts
+++ b/packages/plugin-ext/src/hosted/browser/hosted-plugin.ts
@@ -350,8 +350,9 @@ export class HostedPluginSupport {
         }
     }
 
-    protected getStoragePath(): Promise<string | undefined> {
-        return this.pluginPathsService.getHostStoragePath(this.workspaceService.workspace, this.workspaceService.tryGetRoots());
+    protected async getStoragePath(): Promise<string | undefined> {
+        const roots = await this.workspaceService.roots;
+        return this.pluginPathsService.getHostStoragePath(this.workspaceService.workspace, roots);
     }
 
     async activateByEvent(activationEvent: string): Promise<void> {


### PR DESCRIPTION
#### What it does
Awaits for workspace service to be initialized before computing the storage path for plugins.
With slow workspace initialization sometime the first call to storage path resolved to `undefined`.
As a result plugins get loaded and activated with a bad storage path and fail.

#### How to test
Deploy redhat-vscode java extension and make workspace initialization slow (or block though  breakpoint). See how the extension fails on activate becasue it tries to create directory withinn the storagePath.

#### Review checklist

- [ ] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

