### PR TITLE
fix problem matcher items in the prompt before task is started

### DIFF
--- a/packages/task/src/browser/task-problem-matcher-registry.ts
+++ b/packages/task/src/browser/task-problem-matcher-registry.ts
@@ -88,7 +88,7 @@ export class ProblemMatcherRegistry {
      */
     getAll(): NamedProblemMatcher[] {
         const all: NamedProblemMatcher[] = [];
-        for (const matcherName of Object.keys(this.matchers)) {
+        for (const matcherName of this.matchers.keys()) {
             all.push(this.get(matcherName)!);
         }
         all.sort((one, other) => one.name.localeCompare(other.name));


### PR DESCRIPTION
When the user starts a task that is not associated with any problem
matchers, s/he should be prompted with a list of problem matchers that
are already defined in Theia. In the current version of Theia, the
problem matcher list is broken by 657bda85aeedcc91cd295d4a4eba967ed0fb79c3, and this change fixes the problem.

#### How to test
1. prepare a workspace where a number of tasks are defined in tasks.json. Make sure the tasks are not associated with any problem matchers.
2. start Theia, start a task defined in tasks.json, and watch closely on the items in the quick open

expected: Theia should prompts users with a list of problem matchers
what happens on the master branch of Theia: users don't see the list of problem matchers

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)



