### PR TITLE
[preferences] improve the display of preference descriptions

### DIFF
--- a/packages/core/src/common/preferences/preference-schema.ts
+++ b/packages/core/src/common/preferences/preference-schema.ts
@@ -80,11 +80,13 @@ export interface PreferenceItem {
 
 export interface PreferenceSchemaProperty extends PreferenceItem {
     description?: string;
+    markdownDescription?: string;
     scope?: 'application' | 'window' | 'resource' | PreferenceScope;
 }
 
 export interface PreferenceDataProperty extends PreferenceItem {
     description?: string;
+    markdownDescription?: string;
     scope?: PreferenceScope;
 }
 export namespace PreferenceDataProperty {

--- a/packages/editor/src/browser/editor-preferences.ts
+++ b/packages/editor/src/browser/editor-preferences.ts
@@ -205,7 +205,7 @@ export const EDITOR_DEFAULTS = {
         codeActionsOnSaveTimeout: 750
     },
 };
-// tslint:eanble:no-null-keyword
+// tslint:enable:no-null-keyword
 
 // tslint:disable:max-line-length
 // should be in sync with https://github.com/TypeFox/vscode/blob/70b8db24a37fafc77247de7f7cb5bb0195120ed0/src/vs/editor/common/config/commonEditorConfig.ts#L232

--- a/packages/preferences/src/browser/preferences-decorator.ts
+++ b/packages/preferences/src/browser/preferences-decorator.ts
@@ -49,6 +49,7 @@ export class PreferencesDecorator implements TreeDecorator {
             const preferenceName = Object.keys(m)[0];
             const preferenceValue = m[preferenceName];
             const storedValue = this.preferencesService.get(preferenceName, undefined, this.activeFolderUri);
+            const description = this.getDescription(preferenceValue);
             return [preferenceName, {
                 tooltip: this.buildTooltip(preferenceValue),
                 captionSuffixes: [
@@ -56,7 +57,7 @@ export class PreferencesDecorator implements TreeDecorator {
                         data: `: ${this.getPreferenceDisplayValue(storedValue, preferenceValue.defaultValue)}`
                     },
                     {
-                        data: ' ' + preferenceValue.description,
+                        data: ' ' + description,
                         fontData: { color: 'var(--theia-ui-font-color2)' }
                     }]
             }] as [string, TreeDecoration.Data];
@@ -101,5 +102,35 @@ export class PreferencesDecorator implements TreeDecorator {
             tooltips += `\nAccepted Values: ${data.enum.join(', ')}`;
         }
         return tooltips;
+    }
+
+    /**
+     * Get the description for the preference for display purposes.
+     * @param value {PreferenceDataProperty} the preference data property.
+     * @returns the description if available.
+     */
+    private getDescription(value: PreferenceDataProperty): string {
+
+        /**
+         * Format the string for consistency and display purposes.
+         * Formatting includes:
+         * - capitalizing the string.
+         * - ensuring it ends in punctuation (`.`).
+         * @param str {string} the string to format.
+         * @returns the formatted string.
+         */
+        function format(str: string): string {
+            if (str.endsWith('.')) {
+                return str.charAt(0).toUpperCase() + str.slice(1);
+            }
+            return `${str.charAt(0).toUpperCase() + str.slice(1)}.`;
+        }
+
+        if (value.description) {
+            return format(value.description);
+        } else if (value.markdownDescription) {
+            return format(value.markdownDescription);
+        }
+        return '';
     }
 }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

Fixes #6250

Improve the display of preference descriptions.
Improvements include:
- using the `description` if available
- using the `markdownDescription` if available and `description` is unavailable
- fallback to an empty string instead of displaying `undefined`
- formatting the descriptions for consistency (capitalize, and ensure it ends in punctuation)
- fixed minor typo with `tslint` rule check

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
1. open the `preferences` widget
2. ensure that descriptions look consistent (capitalized first letters, end in punctuation)
3. ensure that monaco preferences have descriptions and are not `undefined` anymore (ex: `editor.tabSize`, editor.suggestLineHeight, ...)

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

Signed-off-by: vince-fugnitto <vincent.fugnitto@ericsson.com>
