### PR TITLE
access tasks configs as preferences

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ Breaking changes:
   - `PluginHost.init` can initialize plugins asynchronous, synchronous initialization is still supported.
   - `HostedPluginReader.doGetPluginMetadata` is renamed to `HostedPluginReader.getPluginMetadata`.
   - `PluginDebugAdapterContribution.languages`, `PluginDebugAdapterContribution.getSchemaAttributes` and `PluginDebugAdapterContribution.getConfigurationSnippets` are removed to prevent sending the contributions second time to the frontend. Debug contributions are loaded statically from the deployed plugin metadata instead. The same for corresponding methods in `DebugExtImpl`.
+- [task] removed `watchedConfigFileUris`, `watchersMap` `watcherServer`, `fileSystem`, `configFileUris`, `watchConfigurationFile()` and `unwatchConfigurationFile()` from `TaskConfigurations` class. [6268](https://github.com/eclipse-theia/theia/pull/6268)
+- [task] removed `configurationFileFound` from `TaskService` class. [6268](https://github.com/eclipse-theia/theia/pull/6268)
 
 ## v0.11.0
 

--- a/packages/task/package.json
+++ b/packages/task/package.json
@@ -8,11 +8,13 @@
     "@theia/filesystem": "^0.11.0",
     "@theia/markers": "^0.11.0",
     "@theia/monaco": "^0.11.0",
+    "@theia/preferences": "^0.11.0",
     "@theia/process": "^0.11.0",
     "@theia/terminal": "^0.11.0",
     "@theia/variable-resolver": "^0.11.0",
     "@theia/workspace": "^0.11.0",
     "jsonc-parser": "^2.0.2",
+    "p-debounce": "^2.1.0",
     "vscode-uri": "^1.0.8"
   },
   "publishConfig": {

--- a/packages/task/src/browser/task-action-provider.ts
+++ b/packages/task/src/browser/task-action-provider.ts
@@ -17,7 +17,8 @@
 import { injectable, inject } from 'inversify';
 import { TaskService } from './task-service';
 import { TaskRunQuickOpenItem } from './quick-open-task';
-import { QuickOpenBaseAction, QuickOpenItem, QuickOpenActionProvider, QuickOpenAction } from '@theia/core/lib/browser/quick-open';
+import { QuickOpenBaseAction, QuickOpenItem } from '@theia/core/lib/browser/quick-open';
+import { QuickOpenAction, QuickOpenActionProvider } from '@theia/core/lib/common/quick-open-model';
 import { ThemeService } from '@theia/core/lib/browser/theming';
 
 @injectable()

--- a/packages/task/src/browser/task-configuration-manager.ts
+++ b/packages/task/src/browser/task-configuration-manager.ts
@@ -1,0 +1,198 @@
+/********************************************************************************
+ * Copyright (C) 2019 Ericsson and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import debounce = require('p-debounce');
+import { inject, injectable, postConstruct } from 'inversify';
+import URI from '@theia/core/lib/common/uri';
+import { Emitter, Event } from '@theia/core/lib/common/event';
+import { EditorManager, EditorWidget } from '@theia/editor/lib/browser';
+import { PreferenceService } from '@theia/core/lib/browser';
+import { QuickPickService } from '@theia/core/lib/common/quick-pick-service';
+import { WorkspaceService } from '@theia/workspace/lib/browser/workspace-service';
+import { TaskConfigurationModel } from './task-configuration-model';
+import { TaskCustomization, TaskConfiguration } from '../common/task-protocol';
+import { WorkspaceVariableContribution } from '@theia/workspace/lib/browser/workspace-variable-contribution';
+import { FileSystem, FileSystemError } from '@theia/filesystem/lib/common';
+import { FileChange, FileChangeType } from '@theia/filesystem/lib/common/filesystem-watcher-protocol';
+import { PreferenceConfigurations } from '@theia/core/lib/browser/preferences/preference-configurations';
+
+@injectable()
+export class TaskConfigurationManager {
+
+    @inject(WorkspaceService)
+    protected readonly workspaceService: WorkspaceService;
+
+    @inject(EditorManager)
+    protected readonly editorManager: EditorManager;
+
+    @inject(QuickPickService)
+    protected readonly quickPick: QuickPickService;
+
+    @inject(FileSystem)
+    protected readonly filesystem: FileSystem;
+
+    @inject(PreferenceService)
+    protected readonly preferences: PreferenceService;
+
+    @inject(PreferenceConfigurations)
+    protected readonly preferenceConfigurations: PreferenceConfigurations;
+
+    @inject(WorkspaceVariableContribution)
+    protected readonly workspaceVariables: WorkspaceVariableContribution;
+
+    protected readonly onDidChangeTaskConfigEmitter = new Emitter<FileChange>();
+    readonly onDidChangeTaskConfig: Event<FileChange> = this.onDidChangeTaskConfigEmitter.event;
+
+    @postConstruct()
+    protected async init(): Promise<void> {
+        this.updateModels();
+        this.preferences.onPreferenceChanged(e => {
+            if (e.preferenceName === 'tasks') {
+                this.updateModels();
+            }
+        });
+    }
+
+    protected readonly models = new Map<string, TaskConfigurationModel>();
+    protected updateModels = debounce(async () => {
+        const roots = await this.workspaceService.roots;
+        const toDelete = new Set(this.models.keys());
+        for (const rootStat of roots) {
+            const key = rootStat.uri;
+            toDelete.delete(key);
+            if (!this.models.has(key)) {
+                const model = new TaskConfigurationModel(key, this.preferences);
+                model.onDidChange(() => this.onDidChangeTaskConfigEmitter.fire({ uri: key, type: FileChangeType.UPDATED }));
+                model.onDispose(() => this.models.delete(key));
+                this.models.set(key, model);
+                this.onDidChangeTaskConfigEmitter.fire({ uri: key, type: FileChangeType.UPDATED });
+            }
+        }
+        for (const uri of toDelete) {
+            const model = this.models.get(uri);
+            if (model) {
+                model.dispose();
+            }
+            this.onDidChangeTaskConfigEmitter.fire({ uri, type: FileChangeType.DELETED });
+        }
+    }, 500);
+
+    getTasks(sourceFolderUri: string): (TaskCustomization | TaskConfiguration)[] {
+        if (this.models.has(sourceFolderUri)) {
+            const taskPrefModel = this.models.get(sourceFolderUri)!;
+            return taskPrefModel.configurations;
+        }
+        return [];
+    }
+
+    getTask(name: string, sourceFolderUri: string | undefined): TaskCustomization | TaskConfiguration | undefined {
+        const taskPrefModel = this.getModel(sourceFolderUri);
+        if (taskPrefModel) {
+            for (const configuration of taskPrefModel.configurations) {
+                if (configuration.name === name) {
+                    return configuration;
+                }
+            }
+        }
+    }
+
+    async openConfiguration(sourceFolderUri: string): Promise<void> {
+        const taskPrefModel = this.getModel(sourceFolderUri);
+        if (taskPrefModel) {
+            await this.doOpen(taskPrefModel);
+        }
+    }
+
+    async addTaskConfiguration(sourceFolderUri: string, taskConfig: TaskCustomization): Promise<void> {
+        const taskPrefModel = this.getModel(sourceFolderUri);
+        if (taskPrefModel) {
+            const configurations = taskPrefModel.configurations;
+            return this.setTaskConfigurations(sourceFolderUri, [...configurations, taskConfig]);
+        }
+    }
+
+    async setTaskConfigurations(sourceFolderUri: string, taskConfigs: (TaskCustomization | TaskConfiguration)[]): Promise<void> {
+        const taskPrefModel = this.getModel(sourceFolderUri);
+        if (taskPrefModel) {
+            return taskPrefModel.setConfigurations(taskConfigs);
+        }
+    }
+
+    private getModel(sourceFolderUri: string | undefined): TaskConfigurationModel | undefined {
+        if (!sourceFolderUri) {
+            return undefined;
+        }
+        for (const model of this.models.values()) {
+            if (model.workspaceFolderUri === sourceFolderUri) {
+                return model;
+            }
+        }
+    }
+
+    protected async doOpen(model: TaskConfigurationModel): Promise<EditorWidget> {
+        let uri = model.uri;
+        if (!uri) {
+            uri = await this.doCreate(model);
+        }
+        return this.editorManager.open(uri, {
+            mode: 'activate'
+        });
+    }
+
+    protected async doCreate(model: TaskConfigurationModel): Promise<URI> {
+        await this.preferences.set('tasks', {}); // create dummy tasks.json in the correct place
+        const { configUri } = this.preferences.resolve('tasks'); // get uri to write content to it
+        let uri: URI;
+        if (configUri && configUri.path.base === 'tasks.json') {
+            uri = configUri;
+        } else { // fallback
+            uri = new URI(model.workspaceFolderUri).resolve(`${this.preferenceConfigurations.getPaths()[0]}/tasks.json`);
+        }
+        const content = this.getInitialConfigurationContent();
+        const fileStat = await this.filesystem.getFileStat(uri.toString());
+        if (!fileStat) {
+            throw new Error(`file not found: ${uri.toString()}`);
+        }
+        try {
+            await this.filesystem.setContent(fileStat, content);
+        } catch (e) {
+            if (!FileSystemError.FileExists.is(e)) {
+                throw e;
+            }
+        }
+        return uri;
+    }
+
+    protected getInitialConfigurationContent(): string {
+        return `{
+  // Use IntelliSense to learn about possible attributes.
+  // Hover to view descriptions of existing attributes.
+  "version": "2.0.0",
+  "tasks": ${JSON.stringify([], undefined, '  ').split('\n').map(line => '  ' + line).join('\n').trim()}
+}
+`;
+    }
+
+}
+
+export namespace TaskConfigurationManager {
+    export interface Data {
+        current?: {
+            name: string
+            workspaceFolderUri?: string
+        }
+    }
+}

--- a/packages/task/src/browser/task-configuration-model.ts
+++ b/packages/task/src/browser/task-configuration-model.ts
@@ -1,0 +1,93 @@
+/********************************************************************************
+ * Copyright (C) 2019 Ericsson and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import URI from '@theia/core/lib/common/uri';
+import { Emitter, Event } from '@theia/core/lib/common/event';
+import { Disposable, DisposableCollection } from '@theia/core/lib/common/disposable';
+import { TaskCustomization, TaskConfiguration } from '../common/task-protocol';
+import { PreferenceService, PreferenceScope } from '@theia/core/lib/browser/preferences/preference-service';
+
+export class TaskConfigurationModel implements Disposable {
+
+    protected json: TaskConfigurationModel.JsonContent;
+
+    protected readonly onDidChangeEmitter = new Emitter<void>();
+    readonly onDidChange: Event<void> = this.onDidChangeEmitter.event;
+
+    protected readonly toDispose = new DisposableCollection(
+        this.onDidChangeEmitter
+    );
+
+    constructor(
+        public readonly workspaceFolderUri: string,
+        protected readonly preferences: PreferenceService
+    ) {
+        this.reconcile();
+        this.toDispose.push(this.preferences.onPreferenceChanged(e => {
+            if (e.preferenceName === 'tasks' && e.affects(workspaceFolderUri)) {
+                this.reconcile();
+            }
+        }));
+    }
+
+    get uri(): URI | undefined {
+        return this.json.uri;
+    }
+
+    dispose(): void {
+        this.toDispose.dispose();
+    }
+    get onDispose(): Event<void> {
+        return this.toDispose.onDispose;
+    }
+
+    get configurations(): (TaskCustomization | TaskConfiguration)[] {
+        return this.json.configurations;
+    }
+
+    protected reconcile(): void {
+        this.json = this.parseConfigurations();
+        this.onDidChangeEmitter.fire(undefined);
+    }
+
+    setConfigurations(value: object): Promise<void> {
+        return this.preferences.set('tasks.tasks', value, PreferenceScope.Folder, this.workspaceFolderUri);
+    }
+
+    protected parseConfigurations(): TaskConfigurationModel.JsonContent {
+        const configurations: (TaskCustomization | TaskConfiguration)[] = [];
+        // tslint:disable-next-line:no-any
+        const { configUri, value } = this.preferences.resolve<any>('tasks', undefined, this.workspaceFolderUri);
+        if (value && typeof value === 'object' && 'tasks' in value) {
+            if (Array.isArray(value.tasks)) {
+                for (const taskConfig of value.tasks) {
+                    configurations.push(taskConfig);
+                }
+            }
+        }
+        return {
+            uri: configUri,
+            configurations
+        };
+    }
+
+}
+export namespace TaskConfigurationModel {
+    export interface JsonContent {
+        uri?: URI;
+        configurations: (TaskCustomization | TaskConfiguration)[];
+    }
+}

--- a/packages/task/src/browser/task-folder-preference-provider.ts
+++ b/packages/task/src/browser/task-folder-preference-provider.ts
@@ -1,0 +1,42 @@
+/********************************************************************************
+ * Copyright (C) 2019 Ericsson and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import { injectable } from 'inversify';
+import { FolderPreferenceProvider } from '@theia/preferences/lib/browser/folder-preference-provider';
+
+@injectable()
+export class TaskFolderPreferenceProvider extends FolderPreferenceProvider {
+
+    // tslint:disable-next-line:no-any
+    protected parse(content: string): any {
+        const tasks = super.parse(content);
+        if (tasks === undefined) {
+            return undefined;
+        }
+        return { tasks: { ...tasks } };
+    }
+
+    protected getPath(preferenceName: string): string[] | undefined {
+        if (preferenceName === 'tasks') {
+            return [];
+        }
+        if (preferenceName.startsWith('tasks.')) {
+            return [preferenceName.substr('tasks.'.length)];
+        }
+        return undefined;
+    }
+
+}

--- a/packages/task/src/browser/task-frontend-module.ts
+++ b/packages/task/src/browser/task-frontend-module.ts
@@ -33,6 +33,8 @@ import { TaskActionProvider, ConfigureTaskAction } from './task-action-provider'
 import { TaskDefinitionRegistry } from './task-definition-registry';
 import { ProblemMatcherRegistry } from './task-problem-matcher-registry';
 import { ProblemPatternRegistry } from './task-problem-pattern-registry';
+import { TaskConfigurationManager } from './task-configuration-manager';
+import { bindTaskPreferences } from './task-preferences';
 import '../../src/browser/style/index.css';
 import './tasks-monaco-contribution';
 
@@ -51,6 +53,7 @@ export default new ContainerModule(bind => {
     bind(TaskTerminateQuickOpen).toSelf().inSingletonScope();
     bind(TaskConfigurations).toSelf().inSingletonScope();
     bind(ProvidedTaskConfigurations).toSelf().inSingletonScope();
+    bind(TaskConfigurationManager).toSelf().inSingletonScope();
 
     bind(TaskServer).toDynamicValue(ctx => {
         const connection = ctx.container.get(WebSocketConnectionProvider);
@@ -70,4 +73,5 @@ export default new ContainerModule(bind => {
     bind(TaskSchemaUpdater).toSelf().inSingletonScope();
 
     bindProcessTaskModule(bind);
+    bindTaskPreferences(bind);
 });

--- a/packages/task/src/browser/task-preferences.ts
+++ b/packages/task/src/browser/task-preferences.ts
@@ -1,0 +1,42 @@
+/********************************************************************************
+ * Copyright (C) 2019 Ericsson and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import { interfaces } from 'inversify';
+import { PreferenceContribution, PreferenceSchema } from '@theia/core/lib/browser/preferences/preference-contribution';
+import { taskSchemaId } from './task-schema-updater';
+import { TaskFolderPreferenceProvider } from './task-folder-preference-provider';
+import { FolderPreferenceProvider } from '@theia/preferences/lib/browser';
+import { PreferenceConfiguration } from '@theia/core/lib/browser/preferences/preference-configurations';
+
+export const taskPreferencesSchema: PreferenceSchema = {
+    type: 'object',
+    scope: 'resource',
+    properties: {
+        tasks: {
+            $ref: taskSchemaId,
+            description: 'Task definition file',
+            defaultValue: {
+                tasks: []
+            }
+        }
+    }
+};
+
+export function bindTaskPreferences(bind: interfaces.Bind): void {
+    bind(PreferenceContribution).toConstantValue({ schema: taskPreferencesSchema });
+    bind(FolderPreferenceProvider).to(TaskFolderPreferenceProvider).inTransientScope().whenTargetNamed('tasks');
+    bind(PreferenceConfiguration).toConstantValue({ name: 'tasks' });
+}

--- a/packages/task/src/browser/task-schema-updater.ts
+++ b/packages/task/src/browser/task-schema-updater.ts
@@ -20,6 +20,8 @@ import { IJSONSchema } from '@theia/core/lib/common/json-schema';
 import URI from '@theia/core/lib/common/uri';
 import { TaskService } from './task-service';
 
+export const taskSchemaId = 'vscode://schemas/tasks';
+
 @injectable()
 export class TaskSchemaUpdater {
     @inject(JsonSchemaStore)
@@ -45,15 +47,15 @@ export class TaskSchemaUpdater {
         };
         const taskTypes = await this.taskService.getRegisteredTaskTypes();
         taskSchema.properties.tasks.items.oneOf![0].allOf![0].properties!.type.enum = taskTypes;
-        const taskSchemaUrl = new URI('vscode://task/tasks.json');
+        const taskSchemaUri = new URI(taskSchemaId);
         const contents = JSON.stringify(taskSchema);
         try {
-            this.inmemoryResources.update(taskSchemaUrl, contents);
+            this.inmemoryResources.update(taskSchemaUri, contents);
         } catch (e) {
-            this.inmemoryResources.add(taskSchemaUrl, contents);
+            this.inmemoryResources.add(taskSchemaUri, contents);
             this.jsonSchemaStore.registerSchema({
                 fileMatch: ['tasks.json'],
-                url: taskSchemaUrl.toString()
+                url: taskSchemaUri.toString()
             });
         }
     }
@@ -107,6 +109,7 @@ const commandOptionsSchema: IJSONSchema = {
 };
 
 const taskConfigurationSchema: IJSONSchema = {
+    $id: taskSchemaId,
     oneOf: [
         {
             allOf: [

--- a/packages/task/src/browser/task-service.ts
+++ b/packages/task/src/browser/task-service.ts
@@ -55,11 +55,6 @@ export interface QuickPickProblemMatcherItem {
 
 @injectable()
 export class TaskService implements TaskConfigurationClient {
-    /**
-     * Reflects whether a valid task configuration file was found
-     * in the current workspace, and is being watched for changes.
-     */
-    protected configurationFileFound: boolean = false;
 
     /**
      * The last executed task.
@@ -132,18 +127,6 @@ export class TaskService implements TaskConfigurationClient {
 
     @postConstruct()
     protected init(): void {
-        this.workspaceService.onWorkspaceChanged(async roots => {
-            this.configurationFileFound = (await Promise.all(roots.map(r => this.taskConfigurations.watchConfigurationFile(r.uri)))).some(result => !!result);
-            const rootUris = roots.map(r => new URI(r.uri));
-            const taskConfigFileUris = this.taskConfigurations.configFileUris.map(strUri => new URI(strUri));
-            for (const taskConfigUri of taskConfigFileUris) {
-                if (!rootUris.some(rootUri => !!rootUri.relative(taskConfigUri))) {
-                    this.taskConfigurations.unwatchConfigurationFile(taskConfigUri.toString());
-                    this.taskConfigurations.removeTasks(taskConfigUri.toString());
-                }
-            }
-        });
-
         // notify user that task has started
         this.taskWatcher.onTaskCreated((event: TaskInfo) => {
             if (this.isEventForThisClient(event.ctx)) {


### PR DESCRIPTION
- In current Theia, the task extension is responsible for reading,
writing, and watching `tasks.json` files. With this change, the task
extension does not access `tasks.json` files directly, and leaves the
work to the preference extension.
- resolves #5013


#### How to test
There are no changes in terms of functionalities. Therefore, to verify this change, we would need to go through the use cases that are already supported by Theia, and  check if they are still properly functional. Those use cases include but not limit to:

As a Theia user I am able to

- run tasks defined in `tasks.json`
- run detected tasks contributed by Theia plugins
- run detected tasks contributed by Theia extensions (Please note, this is broken on master branch and reported in https://github.com/eclipse-theia/theia/issues/6204)
- configure tasks defined in `tasks.json`
- configure detected tasks (Please note, "configuring tasks" by clicking the gear icons in tasks' quick open menu is broken on master branch and reported in https://github.com/eclipse-theia/theia/issues/6212. In order to test this feature we would have to use the top menu bar `Terminal` -> `Configure Tasks ...`)
- see the recently used tasks be grouped together and show up at the top of the tasks' quick open menu
- see the "detected tasks" displayed as "configured tasks", if they are configured / customized in the `tasks.json`
- see the problem matcher items show up in the prompt, if a task that is not associated with any problem matchers is started
   - and see the selected problem matcher item written into `tasks.json` 
- do all the items described above in both single root and multi root workspace.
