### PR TITLE
Allow to use HTTP resources for webview tabs

### DIFF
--- a/packages/plugin-ext/src/plugin/webviews.ts
+++ b/packages/plugin-ext/src/plugin/webviews.ts
@@ -271,7 +271,11 @@ export class WebviewPanelImpl implements theia.WebviewPanel {
     set iconPath(iconPath: theia.Uri | { light: theia.Uri; dark: theia.Uri }) {
         this.checkIsDisposed();
         if (URI.isUri(iconPath)) {
-            this.proxy.$setIconPath(this.viewId, (<theia.Uri>iconPath).path);
+            if ('http' === iconPath.scheme || 'https' === iconPath.scheme) {
+                this.proxy.$setIconPath(this.viewId, iconPath.toString());
+            } else {
+                this.proxy.$setIconPath(this.viewId, (<theia.Uri>iconPath).path);
+            }
         } else {
             this.proxy.$setIconPath(this.viewId, {
                 light: (<{ light: theia.Uri; dark: theia.Uri }>iconPath).light.path,


### PR DESCRIPTION
Signed-off-by: Vitaliy Gulyy <vgulyy@redhat.com>

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

Makes it possible to use HTTP icons for webview tabs opened by plugins.
Adds unimplemented functionality. WebView plugin API describes that any URI referencing on an image can be used for tab icon.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

It's a part of the plugin system.
To test you have to
- open a webview from your plugin
- update tab icon with an URI referencing on a remote HTTP image resource

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

