### PR TITLE
[cpp] Update clangd install snippet to clangd-10 in README.md

### DIFF
--- a/packages/cpp/README.md
+++ b/packages/cpp/README.md
@@ -7,8 +7,7 @@ To install Clangd on Ubuntu 18.04:
 
     $ wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
     $ echo "deb http://apt.llvm.org/bionic/ llvm-toolchain-bionic main" | sudo tee /etc/apt/sources.list.d/llvm.list
-    $ sudo apt-get update && sudo apt-get install -y clang-tools-8
-    $ sudo ln -s /usr/bin/clangd-8 /usr/bin/clangd
+    $ sudo apt-get update && sudo apt-get install -y clangd
 
 See [here](https://clang.llvm.org/extra/clangd.html#id4) for detailed
 installation instructions.


### PR DESCRIPTION
Because that's what's in the 'llvm-toolchain-bionic' repository now: https://apt.llvm.org/

Thanks to @sylvestre for catching the outdated snippet!

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
Fixes the `clangd` install snippet in the default C++ extension's README.md.

#### How to test
Run the snippet in a fresh Ubuntu 18.04 Bionic install (e.g. using the `ubuntu:bionic` Docker image).

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

