### PR TITLE
wip: fix view container 'null' error

### DIFF
--- a/packages/core/src/browser/view-container.ts
+++ b/packages/core/src/browser/view-container.ts
@@ -57,6 +57,7 @@ export class ViewContainerIdentifier {
 @injectable()
 export class ViewContainer extends BaseWidget implements StatefulWidget, ApplicationShell.TrackableWidgetProvider {
 
+    protected _containerLayout: ViewContainerLayout;
     protected panel: SplitPanel;
     protected attached = new Deferred<void>();
 
@@ -101,15 +102,14 @@ export class ViewContainer extends BaseWidget implements StatefulWidget, Applica
         this.addClass('theia-view-container');
         const layout = new PanelLayout();
         this.layout = layout;
-        this.panel = new SplitPanel({
-            layout: new ViewContainerLayout({
-                renderer: SplitPanel.defaultRenderer,
-                orientation: this.orientation,
-                spacing: 2,
-                headerSize: ViewContainerPart.HEADER_HEIGHT,
-                animationDuration: 200
-            }, this.splitPositionHandler)
-        });
+        this._containerLayout = new ViewContainerLayout({
+            renderer: SplitPanel.defaultRenderer,
+            orientation: this.orientation,
+            spacing: 2,
+            headerSize: ViewContainerPart.HEADER_HEIGHT,
+            animationDuration: 200
+        }, this.splitPositionHandler);
+        this.panel = new SplitPanel({ layout: this._containerLayout });
         this.panel.node.tabIndex = -1;
         layout.addWidget(this.panel);
 
@@ -330,7 +330,7 @@ export class ViewContainer extends BaseWidget implements StatefulWidget, Applica
     }
 
     get containerLayout(): ViewContainerLayout {
-        return this.panel.layout as ViewContainerLayout;
+        return this._containerLayout as ViewContainerLayout;
     }
 
     protected get orientation(): SplitLayout.Orientation {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

Fixes #6231

Set the `ViewContainerLayout` explicitly so it is not `null` when it is being used.


#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

Re-test the following functionality present in https://github.com/eclipse-theia/theia/pull/5665

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

Signed-off-by: Vincent Fugnitto <vincent.fugnitto@ericsson.com>
