### PR TITLE
revert "Remove leading slash of webview route ..."

### DIFF
--- a/packages/plugin-ext-vscode/src/node/plugin-vscode-init.ts
+++ b/packages/plugin-ext-vscode/src/node/plugin-vscode-init.ts
@@ -61,7 +61,7 @@ export const doInitialization: BackendInitializationFn = (apiFactory: PluginAPIF
         // redefine property
         Object.defineProperty(panel.webview, 'html', {
             set: function (html: string): void {
-                const newHtml = html.replace(new RegExp('vscode-resource:/', 'g'), 'webview/');
+                const newHtml = html.replace(new RegExp('vscode-resource:/', 'g'), '/webview/');
                 this.checkIsDisposed();
                 if (this._html !== newHtml) {
                     this._html = newHtml;
@@ -74,7 +74,7 @@ export const doInitialization: BackendInitializationFn = (apiFactory: PluginAPIF
         const originalPostMessage = panel.webview.postMessage;
         panel.webview.postMessage = (message: any): PromiseLike<boolean> => {
             const decoded = JSON.stringify(message);
-            const newMessage = decoded.replace(new RegExp('vscode-resource:/', 'g'), 'webview/');
+            const newMessage = decoded.replace(new RegExp('vscode-resource:/', 'g'), '/webview/');
             return originalPostMessage.call(panel.webview, JSON.parse(newMessage));
         };
 

--- a/packages/plugin-ext/src/main/browser/webview/theme-rules-service.ts
+++ b/packages/plugin-ext/src/main/browser/webview/theme-rules-service.ts
@@ -135,7 +135,7 @@ export class ThemeRulesService {
                 path = this.isDark() ? value.dark : value.light;
             }
             if (path.startsWith('/')) {
-                path = `webview${path}`;
+                path = `/webview${path}`;
             }
             cssRules.push(`.webview-icon.${key}-file-icon::before { background-image: url(${path}); }`);
         });

--- a/packages/plugin-ext/src/plugin/webviews.ts
+++ b/packages/plugin-ext/src/plugin/webviews.ts
@@ -150,7 +150,7 @@ export class WebviewImpl implements theia.Webview {
         this.checkIsDisposed();
         // replace theia-resource: content in the given message
         const decoded = JSON.stringify(message);
-        let newMessage = decoded.replace(new RegExp('theia-resource:/', 'g'), 'webview/');
+        let newMessage = decoded.replace(new RegExp('theia-resource:/', 'g'), '/webview/');
         if (this._options && this._options.localResourceRoots) {
             newMessage = this.filterLocalRoots(newMessage, this._options.localResourceRoots);
         }
@@ -191,7 +191,7 @@ export class WebviewImpl implements theia.Webview {
     }
 
     set html(html: string) {
-        let newHtml = html.replace(new RegExp('theia-resource:/', 'g'), 'webview/');
+        let newHtml = html.replace(new RegExp('theia-resource:/', 'g'), '/webview/');
         if (this._options && this._options.localResourceRoots) {
             newHtml = this.filterLocalRoots(newHtml, this._options.localResourceRoots);
         }


### PR DESCRIPTION
#### What it does
partially reverting changes from https://github.com/eclipse-theia/theia/pull/5619 which break "html base href" logic in webview for instance in the python extension for vscode.

some vscode extensions like the python extension to load html like this into the webview:

```
<html lang="en">
    <head>
        <!-- ... -->
        <base href="${uriBase}"/>
    </head>
    <body>
        <!-- ... -->
    <script type="text/javascript" src="${uri}"></script></body>
</html>
```
using these values for vars:
```
const uriBasePath = Uri.file(`${path.dirname(mainScriptPath)}/`);
const uriBase = uriBasePath.with({ scheme: 'vscode-resource' });

const uriPath = Uri.file(mainScriptPath);
const uri = uriPath.with({ scheme: 'vscode-resource' });
```

now what happens is that after the change done in PR 5619 we end up with `base href` being a relative path which leads to a bogus concatenation of both URIs when the browser tries to fetch the script resource. in other words: the script resource url was `webview/<path-to-resource-dir>/webview/<path-to-resource>`


#### How to test
- check with python extension for vscode that the "index_bundle.js" is actually loaded.

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

quickly checked that the resources are loaded in the python extension.

<img width="970" alt="Screen Shot 2019-09-27 at 09 39 39" src="https://user-images.githubusercontent.com/914497/65751407-cacf0c00-e10a-11e9-8598-e26d90ad8ce6.png">


#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
