### PR TITLE
Add option to only allow a single instance of the Electron app

### DIFF
--- a/dev-packages/application-manager/src/generator/frontend-generator.ts
+++ b/dev-packages/application-manager/src/generator/frontend-generator.ts
@@ -128,6 +128,13 @@ const { fork } = require('child_process');
 const { app, shell, BrowserWindow, ipcMain, Menu } = electron;
 
 const applicationName = \`${this.pck.props.frontend.config.applicationName}\`;
+const isSingleInstance = ${this.pck.props.backend.config.singleInstance === true ? 'true' : 'false'};
+
+if (isSingleInstance && !app.requestSingleInstanceLock()) {
+    // There is another instance running, exit now. The other instance will request focus.
+    app.quit();
+    return;
+}
 
 const nativeKeymap = require('native-keymap');
 const Storage = require('electron-store');
@@ -285,6 +292,19 @@ app.on('ready', () => {
     // @ts-ignore
     const devMode = process.defaultApp || /node_modules[\/]electron[\/]/.test(process.execPath);
     const mainWindow = createNewWindow();
+
+    if (isSingleInstance) {
+        app.on('second-instance', (event, commandLine, workingDirectory) => {
+            // Someone tried to run a second instance, we should focus our window.
+            if (mainWindow && !mainWindow.isDestroyed()) {
+                if (mainWindow.isMinimized()) {
+                    mainWindow.restore();
+                }
+                mainWindow.focus()
+            }
+        })
+    }
+
     const loadMainWindow = (port) => {
         if (!mainWindow.isDestroyed()) {
             mainWindow.loadURL('file://' + join(__dirname, '../../lib/index.html') + '?port=' + port);

--- a/dev-packages/application-package/src/application-props.ts
+++ b/dev-packages/application-package/src/application-props.ts
@@ -116,6 +116,11 @@ export interface FrontendApplicationConfig extends ApplicationConfig {
  */
 export interface BackendApplicationConfig extends ApplicationConfig {
 
+    /**
+     * If true and in Electron mode, only one instance of the application is allowed to run at a time.
+     */
+    singleInstance?: boolean;
+
 }
 
 /**


### PR DESCRIPTION
<!--
If a second instance is opened, it closes immediately and the original
instance receives focus.

Signed-off-by: Matthew Gordon <matthew.gordon@arm.com>

Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

Added an option to the backend config: `singleInstance`. If true and in Electron mode, only one instance of the application is allowed to run at a time. If a second is started, it terminates itself and the original instance's window is focused.

See: https://electronjs.org/docs/api/app#apprequestsingleinstancelock.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

Add the following to the "theia" section of the electron example's package.json: https://github.com/eclipse-theia/theia/blob/master/examples/electron/package.json#L6.

```json
    "backend": {
      "config": {
        "singleInstance": true
      }
    }
```

Then build the example.

With `singleInstance` set to true, only one instance of the application can be started. A second instance will exit immediately and the first instance will receive focus.

With `singleInstance` false or not set, any number of instances can be run (as before).

#### Review checklist

- [X] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

