### PR TITLE
[quick-open] Do not validate input on start

### DIFF
--- a/packages/core/src/browser/quick-open/quick-input-service.ts
+++ b/packages/core/src/browser/quick-open/quick-input-service.ts
@@ -119,11 +119,17 @@ export class QuickInputService {
         let label = prompt;
         let currentText = '';
         const validateInput = options && options.validateInput;
+        let initial: boolean = true;
 
         this.quickOpenService.open({
             onType: async (lookFor, acceptor) => {
-                this.onDidChangeValueEmitter.fire(lookFor);
-                const error = validateInput && lookFor !== undefined ? await validateInput(lookFor) : undefined;
+                let error: string | undefined;
+                if (initial) {
+                    initial = false;
+                } else {
+                    this.onDidChangeValueEmitter.fire(lookFor);
+                    error = validateInput && lookFor !== undefined ? await validateInput(lookFor) : undefined;
+                }
                 label = error || prompt;
                 if (error) {
                     this.quickOpenService.showDecoration(MessageType.Error);


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->
Check if the `onType` handler is fired at first time, ignore validating the input. As `QuickInputService` wraps `QuickOpenServece`:
https://github.com/eclipse-theia/theia/blob/5e50106058fd05d76e8e18010aff3ec398c48e45/packages/core/src/browser/quick-open/quick-input-service.ts#L123
 such workaround can resolve the problem.
fixes #6245 
#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
1. Clone and compile the [test plugin](https://github.com/vinokurig/Test.git)
2. Start the plugin as a Hosted Plugin
3. `F1` => `Hello World`

**See**: The validation is not called on the start.
#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

