### PR TITLE
[Fylesystem] Fixed error on handling of nsfw RENAMED event

### DIFF
--- a/packages/core/src/typings/nsfw/index.d.ts
+++ b/packages/core/src/typings/nsfw/index.d.ts
@@ -31,6 +31,7 @@ declare module 'nsfw' {
         export interface ChangeEvent {
             action: number;
             directory: string;
+            newDirectory?: string;
             file?: string;
             oldFile?: string;
             newFile?: string;

--- a/packages/filesystem/src/node/nsfw-watcher/nsfw-filesystem-watcher.ts
+++ b/packages/filesystem/src/node/nsfw-watcher/nsfw-filesystem-watcher.ts
@@ -121,7 +121,7 @@ export class NsfwFileSystemWatcherServer implements FileSystemWatcherServer {
                 }
                 if (event.action === nsfw.actions.RENAMED) {
                     this.pushDeleted(watcherId, this.resolvePath(event.directory, event.oldFile!));
-                    this.pushAdded(watcherId, this.resolvePath(event.directory, event.newFile!));
+                    this.pushAdded(watcherId, this.resolvePath(event.newDirectory || event.directory, event.newFile!));
                 }
             }
         }, {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->
The typing of a nsfw RENAMED event is incomplete. When a file is moved, Theia handles the event incorrectly.

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->
This PR fixes the typing of the nfws events and handles the file moving correctly.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
Open Theia with a debugger and move a file. It's possible to see that the nfws event received has a newDirectory property that at the moment was not used.

#### Review checklist

- [X] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

