### PR TITLE
[plugin] don't wrap promise in promise

### DIFF
--- a/packages/plugin-ext/src/main/browser/command-registry-main.ts
+++ b/packages/plugin-ext/src/main/browser/command-registry-main.ts
@@ -73,11 +73,7 @@ export class CommandRegistryMainImpl implements CommandRegistryMain, Disposable 
 
     // tslint:disable-next-line:no-any
     $executeCommand<T>(id: string, ...args: any[]): PromiseLike<T | undefined> {
-        try {
-            return Promise.resolve(this.delegate.executeCommand(id, ...args));
-        } catch (e) {
-            return Promise.reject(e);
-        }
+        return this.delegate.executeCommand(id, ...args);
     }
 
     $getKeyBinding(commandId: string): PromiseLike<theia.CommandKeyBinding[] | undefined> {


### PR DESCRIPTION
#### What it does

Fixes a bug where command execution result was wrapped in an extra promise.

#### How to test
Install a vscode extension that executes a command expecting a result. 
E.g. built-in emmet runs unsupported `vscode.executeDocumentSymbolProvider` https://github.com/microsoft/vscode/blob/8cafaf5900ac9765a6946ce9c660da54846d9d07/extensions/emmet/src/defaultCompletionProvider.ts#L166

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

