### PR TITLE
[plugin] support `vscode.executeDocumentSymbol` command.

### DIFF
--- a/packages/monaco/src/typings/monaco/index.d.ts
+++ b/packages/monaco/src/typings/monaco/index.d.ts
@@ -19,6 +19,7 @@
 
 declare module monaco.instantiation {
     export interface IInstantiationService {
+        invokeFunction: (fn: any, ...args: any) => any
     }
 }
 
@@ -273,6 +274,10 @@ declare module monaco.editor {
 
 declare module monaco.commands {
 
+    export const CommandsRegistry: {
+        getCommands(): Map<string, { id: string, handler: (...args: any) => any }>;
+    };
+
     export interface ICommandEvent {
         commandId: string;
     }
@@ -514,6 +519,7 @@ declare module monaco.services {
         export const codeEditorService: LazyStaticService<monaco.editor.ICodeEditorService>;
         export const configurationService: LazyStaticService<IConfigurationService>;
         export const resourcePropertiesService: LazyStaticService<ITextResourcePropertiesService>;
+        export const instantiationService: LazyStaticService<monaco.instantiation.IInstantiationService>;
     }
 }
 

--- a/packages/plugin-ext-vscode/src/browser/plugin-vscode-commands-contribution.ts
+++ b/packages/plugin-ext-vscode/src/browser/plugin-vscode-commands-contribution.ts
@@ -14,24 +14,23 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
-import { injectable, inject } from 'inversify';
-import { CommandContribution, CommandRegistry, Command } from '@theia/core';
+import { Command, CommandContribution, CommandRegistry, ResourceProvider } from '@theia/core';
+import { ApplicationShell, NavigatableWidget, open, OpenerService, Saveable } from '@theia/core/lib/browser';
+import { ContextKeyService } from '@theia/core/lib/browser/context-key-service';
+import { ApplicationShellMouseTracker } from '@theia/core/lib/browser/shell/application-shell-mouse-tracker';
 import { CommandService } from '@theia/core/lib/common/command';
 import TheiaURI from '@theia/core/lib/common/uri';
-import URI from 'vscode-uri';
-import { ContextKeyService } from '@theia/core/lib/browser/context-key-service';
-import { DiffService } from '@theia/workspace/lib/browser/diff-service';
 import { EditorManager } from '@theia/editor/lib/browser';
-import { WebviewWidget } from '@theia/plugin-ext/lib/main/browser/webview/webview';
-import { ApplicationShell, NavigatableWidget, OpenerService, open, Saveable } from '@theia/core/lib/browser';
-import { ResourceProvider } from '@theia/core';
-import { ViewColumn } from '@theia/plugin-ext/lib/plugin/types-impl';
 import { TextDocumentShowOptions } from '@theia/plugin-ext/lib/common/plugin-api-rpc-model';
-import { fromViewColumn } from '@theia/plugin-ext/lib/plugin/type-converters';
-import { WorkspaceCommands } from '@theia/workspace/lib/browser';
-import { createUntitledResource } from '@theia/plugin-ext/lib/main/browser/editor/untitled-resource';
 import { DocumentsMainImpl } from '@theia/plugin-ext/lib/main/browser/documents-main';
-import { ApplicationShellMouseTracker } from '@theia/core/lib/browser/shell/application-shell-mouse-tracker';
+import { createUntitledResource } from '@theia/plugin-ext/lib/main/browser/editor/untitled-resource';
+import { WebviewWidget } from '@theia/plugin-ext/lib/main/browser/webview/webview';
+import { fromViewColumn, toDocumentSymbol } from '@theia/plugin-ext/lib/plugin/type-converters';
+import { ViewColumn } from '@theia/plugin-ext/lib/plugin/types-impl';
+import { WorkspaceCommands } from '@theia/workspace/lib/browser';
+import { DiffService } from '@theia/workspace/lib/browser/diff-service';
+import { inject, injectable } from 'inversify';
+import URI from 'vscode-uri';
 
 export namespace VscodeCommands {
     export const OPEN: Command = {
@@ -315,6 +314,27 @@ export class PluginVscodeCommandsContribution implements CommandContribution {
          * Show Opened File in New Window	workbench.action.files.showOpenedFileInNewWindow
          * Compare Opened File With	workbench.files.action.compareFileWith
          */
+
+        // Register built-in language service commands
+        // see https://code.visualstudio.com/api/references/commands
+        // tslint:disable: no-any
+        commands.registerCommand(
+            {
+                id: 'vscode.executeDocumentSymbolProvider'
+            },
+            {
+                execute: (resource: URI) => commands.executeCommand('monaco._executeDocumentSymbolProvider',
+                    { resource: monaco.Uri.parse(resource.toString()) }
+                ).then((value: any) => {
+                    if (!Array.isArray(value) || value === undefined) {
+                        return undefined;
+                    }
+                    return value.map(loc => toDocumentSymbol(loc));
+                })
+            }
+        );
+        // TODO register other `vscode.execute...` commands.
+        // see https://github.com/microsoft/vscode/blob/master/src/vs/workbench/api/common/extHostApiCommands.ts
     }
 
     private getHtml(body: String): string {

--- a/packages/plugin-ext/src/plugin/type-converters.ts
+++ b/packages/plugin-ext/src/plugin/type-converters.ts
@@ -642,6 +642,17 @@ export function fromDocumentSymbol(info: theia.DocumentSymbol): model.DocumentSy
     return result;
 }
 
+export function toDocumentSymbol(symbol: model.DocumentSymbol): theia.DocumentSymbol {
+    return {
+        name: symbol.name,
+        detail: symbol.detail,
+        range: toRange(symbol.range)!,
+        selectionRange: toRange(symbol.selectionRange)!,
+        children: symbol.children ? symbol.children.map(toDocumentSymbol) : [],
+        kind: SymbolKind.toSymbolKind(symbol.kind)
+    };
+}
+
 export function toWorkspaceFolder(folder: model.WorkspaceFolder): theia.WorkspaceFolder {
     return {
         uri: URI.revive(folder.uri),


### PR DESCRIPTION
#### What it does
Registers the `vscode.executeDocumentSymbol` command, which is one of the commands vscode extensions might use. 
See https://code.visualstudio.com/api/references/commands for the full list.

#### How to test
Install the emmet extension (https://registry.npmjs.org/@theia/vscode-builtin-emmet/-/vscode-builtin-emmet-0.2.1.tgz)
 - Start theia
 - change preferences, adding the following property:
```json
"emmet.includeLanguages": {
    "typescript": "typescriptreact"
  }
```
 - open a TS file
 - start using content assist.

Without this change, there will be an error in the console.

see also https://github.com/eclipse-theia/theia/issues/4050
fixes https://github.com/eclipse-theia/theia/issues/4048

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

