### PR TITLE
Add out of memory hint in case of plugins node crash

### DIFF
--- a/packages/plugin-ext/src/hosted/node/hosted-plugin-process.ts
+++ b/packages/plugin-ext/src/hosted/node/hosted-plugin-process.ts
@@ -181,7 +181,11 @@ export class HostedPluginProcess implements ServerPluginRunner {
             return;
         }
         this.logger.error(`[${serverName}: ${pid}] IPC exited, with signal: ${signal}, and exit code: ${code}`);
-        this.messageService.error('Plugin runtime crashed unexpectedly, all plugins are not working, please reload...', { timeout: 15 * 60 * 1000 });
+        this.messageService.error(
+            'Plugin runtime crashed unexpectedly, all plugins are not working, please reload the page. ' +
+            'It might happen if there is not enough memory for the plugins.',
+            { timeout: 15 * 60 * 1000 }
+        );
     }
 
     private onChildProcessError(err: Error): void {


### PR DESCRIPTION
Signed-off-by: Mykola Morhun <mmorhun@redhat.com>

#### What it does
Gives hint about out of memory if the node instance with plugins was terminated. In the most cases the node instance with plugins is terminated because of OOM or by sending the signal manually.

As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)
