### PR TITLE
remove uneeded commands

### DIFF
--- a/examples/browser/Dockerfile
+++ b/examples/browser/Dockerfile
@@ -36,7 +36,7 @@ FROM node:8
 RUN useradd --create-home theia
 WORKDIR /home/theia
 RUN rm -rf /opt/yarn && rm -f /usr/local/bin/yarn && rm -f /usr/local/bin/yarnpkg
-RUN apt-get update && apt-get install -y npm && npm install -g yarn@1.3.2
+RUN npm install -g yarn@1.3.2
 USER theia
 RUN git clone --depth 1 https://github.com/eclipse-theia/theia && \
     cd theia && \


### PR DESCRIPTION
npm is already installed in node:8

Signed-off-by: João Daniel <jotaf.daniel@gmail.com>

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

It cleans an installation command `apt install npm -y` -- npm already comes installed in node:8

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

Run `docker image build . -t theia` and note that it'll not fail


#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

