### PR TITLE
Follow-up on refactoring on plugin metadatas

### DIFF
--- a/packages/plugin-ext/src/common/plugin-protocol.ts
+++ b/packages/plugin-ext/src/common/plugin-protocol.ts
@@ -685,9 +685,15 @@ export interface ServerPluginRunner {
     clientClosed(): void;
 
     /**
-     * Provides additional metadata.
+     * Provides additional deployed plugins.
      */
-    getExtraPluginMetadata(): Promise<PluginMetadata[]>;
+    getExtraDeployedPlugins(): Promise<DeployedPlugin[]>;
+
+    /**
+     * Provides additional plugin ids.
+     */
+    getExtraDeployedPluginIds(): Promise<string[]>;
+
 }
 
 export const PluginHostEnvironmentVariable = Symbol('PluginHostEnvironmentVariable');

--- a/packages/plugin-ext/src/hosted/node/hosted-plugin-process.ts
+++ b/packages/plugin-ext/src/hosted/node/hosted-plugin-process.ts
@@ -20,7 +20,7 @@ import { injectable, inject, named } from 'inversify';
 import { ILogger, ConnectionErrorHandler, ContributionProvider, MessageService } from '@theia/core/lib/common';
 import { Emitter } from '@theia/core/lib/common/event';
 import { createIpcEnv } from '@theia/core/lib/node/messaging/ipc-protocol';
-import { HostedPluginClient, ServerPluginRunner, PluginMetadata, PluginHostEnvironmentVariable } from '../../common/plugin-protocol';
+import { HostedPluginClient, ServerPluginRunner, PluginHostEnvironmentVariable, DeployedPlugin } from '../../common/plugin-protocol';
 import { RPCProtocolImpl } from '../../common/rpc-protocol';
 import { MAIN_RPC_CONTEXT } from '../../common/plugin-api-rpc';
 import { HostedPluginCliContribution } from './hosted-plugin-cli-contribution';
@@ -192,7 +192,17 @@ export class HostedPluginProcess implements ServerPluginRunner {
         this.logger.error(`Error from plugin host: ${err.message}`);
     }
 
-    async getExtraPluginMetadata(): Promise<PluginMetadata[]> {
+    /**
+     * Provides additional plugin ids.
+     */
+    public async getExtraDeployedPluginIds(): Promise<string[]> {
+        return [];
+    }
+
+    /**
+     * Provides additional deployed plugins.
+     */
+    public async getExtraDeployedPlugins(): Promise<DeployedPlugin[]> {
         return [];
     }
 

--- a/packages/plugin-ext/src/hosted/node/hosted-plugin.ts
+++ b/packages/plugin-ext/src/hosted/node/hosted-plugin.ts
@@ -16,7 +16,7 @@
 
 import { injectable, inject, multiInject, postConstruct, optional } from 'inversify';
 import { ILogger, ConnectionErrorHandler } from '@theia/core/lib/common';
-import { HostedPluginClient, PluginModel, ServerPluginRunner, PluginMetadata } from '../../common/plugin-protocol';
+import { HostedPluginClient, PluginModel, ServerPluginRunner, DeployedPlugin } from '../../common/plugin-protocol';
 import { LogPart } from '../../common/types';
 import { HostedPluginProcess } from './hosted-plugin-process';
 
@@ -98,8 +98,18 @@ export class HostedPluginSupport {
         }
     }
 
-    public async getExtraPluginMetadata(): Promise<PluginMetadata[]> {
-        return [].concat.apply([], await Promise.all(this.pluginRunners.map(runner => runner.getExtraPluginMetadata())));
+    /**
+     * Provides additional plugin ids.
+     */
+    public async getExtraDeployedPluginIds(): Promise<string[]> {
+        return [].concat.apply([], await Promise.all(this.pluginRunners.map(runner => runner.getExtraDeployedPluginIds())));
+    }
+
+    /**
+     * Provides additional deployed plugins.
+     */
+    public async getExtraDeployedPlugins(): Promise<DeployedPlugin[]> {
+        return [].concat.apply([], await Promise.all(this.pluginRunners.map(runner => runner.getExtraDeployedPlugins())));
     }
 
     public sendLog(logPart: LogPart): void {


### PR DESCRIPTION
#### What it does

PR https://github.com/eclipse-theia/theia/pull/6252 introduces a refactoring about metadata introducing pluginIds, deployedPlugins, etc.

Update the extra information to match the real expectations of methods (string ids in some case, DeployedPlugin in the other case)

#### How to test
try to deploy a plug-in/vs code extension and it should work as expected as before

#### Review checklist

- [X] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)


Change-Id: I82b5e5cdad2e42cba9e1dd469eadbeb0fac29e3e
Signed-off-by: Florent Benoit <fbenoit@redhat.com>
