### PR TITLE
Align 'ActionProvider' related entities with VS Code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ Breaking changes:
   - `PluginDebugAdapterContribution.languages`, `PluginDebugAdapterContribution.getSchemaAttributes` and `PluginDebugAdapterContribution.getConfigurationSnippets` are removed to prevent sending the contributions second time to the frontend. Debug contributions are loaded statically from the deployed plugin metadata instead. The same for corresponding methods in `DebugExtImpl`.
 - [task] removed `watchedConfigFileUris`, `watchersMap` `watcherServer`, `fileSystem`, `configFileUris`, `watchConfigurationFile()` and `unwatchConfigurationFile()` from `TaskConfigurations` class. [6268](https://github.com/eclipse-theia/theia/pull/6268)
 - [task] removed `configurationFileFound` from `TaskService` class. [6268](https://github.com/eclipse-theia/theia/pull/6268)
+- [core][monaco][task] aligh `ActionProvider` related entities with VS Code. [6302](https://github.com/eclipse-theia/theia/pull/6302)
 
 ## v0.11.0
 

--- a/packages/core/src/common/quick-open-model.ts
+++ b/packages/core/src/common/quick-open-model.ts
@@ -111,7 +111,7 @@ export interface QuickOpenModel {
 
 export interface QuickOpenActionProvider {
     hasActions(item: QuickOpenItem): boolean;
-    getActions(item: QuickOpenItem): Promise<QuickOpenAction[]>;
+    getActions(item: QuickOpenItem): ReadonlyArray<QuickOpenAction>;
 }
 
 export interface QuickOpenActionOptions {

--- a/packages/monaco/src/browser/monaco-quick-open-service.ts
+++ b/packages/monaco/src/browser/monaco-quick-open-service.ts
@@ -531,21 +531,9 @@ export class MonacoQuickOpenActionProvider implements monaco.quickOpen.IActionPr
     }
 
     // tslint:disable-next-line:no-any
-    async getActions(element: any, entry: QuickOpenEntry | QuickOpenEntryGroup): Promise<monaco.quickOpen.IAction[]> {
-        const actions = await this.provider.getActions(entry.item);
+    getActions(element: any, entry: QuickOpenEntry | QuickOpenEntryGroup): ReadonlyArray<monaco.quickOpen.IAction> {
+        const actions = this.provider.getActions(entry.item);
         return actions.map(action => new MonacoQuickOpenAction(action));
-    }
-
-    hasSecondaryActions(): boolean {
-        return false;
-    }
-
-    async getSecondaryActions(): Promise<monaco.quickOpen.IAction[]> {
-        return [];
-    }
-
-    getActionItem(): undefined {
-        return undefined;
     }
 }
 

--- a/packages/monaco/src/typings/monaco/index.d.ts
+++ b/packages/monaco/src/typings/monaco/index.d.ts
@@ -747,10 +747,7 @@ declare module monaco.quickOpen {
 
     export interface IActionProvider {
         hasActions(element: any, item: any): boolean;
-        getActions(element: any, item: any): Promise<IAction[]>;
-        hasSecondaryActions(element: any, item: any): boolean;
-        getSecondaryActions(element: any, item: any): Promise<IAction[]>;
-        getActionItem(element: any, item: any, action: IAction): any;
+        getActions(element: any, item: any): ReadonlyArray<IAction>;
     }
 
     export class QuickOpenModel implements IModel<QuickOpenEntry>, IDataSource<QuickOpenEntry>, IFilter<QuickOpenEntry>, IRunner<QuickOpenEntry> {

--- a/packages/task/src/browser/task-action-provider.ts
+++ b/packages/task/src/browser/task-action-provider.ts
@@ -61,7 +61,7 @@ export class TaskActionProvider implements QuickOpenActionProvider {
         return true;
     }
 
-    async getActions(): Promise<QuickOpenAction[]> {
+    getActions(): ReadonlyArray<QuickOpenAction> {
         return [this.configureTaskAction];
     }
 }


### PR DESCRIPTION
#### What it does
- align 'ActionProvider' related entities with VS Code
- fixes https://github.com/eclipse-theia/theia/issues/6212

#### How to test
Go to `Terminal` => `Run Task` menu.
Selected item should contain `Configure Task` action icon (gear wheel)
![gear_wheel](https://user-images.githubusercontent.com/5676062/65952215-389c7000-e44a-11e9-8e36-779d49ee5c58.png)

Clicking cog icon should: 
- for `detected` task - open `tasks.json` file and copy the configuration 
- for `configured` one - just open `tasks.json`

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

Signed-off-by: Roman Nikitenko <rnikiten@redhat.com>