### PR TITLE
plugin-ext-metrics extension for creating metrics from language plugins

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -48,6 +48,7 @@ cache:
   - packages/plugin-dev/node_modules
   - packages/plugin-ext-vscode/node_modules
   - packages/plugin-ext/node_modules
+  - packages/plugin-metrics/node_modules
   - packages/plugin/node_modules
   - packages/preferences/node_modules
   - packages/preview/node_modules

--- a/examples/browser/package.json
+++ b/examples/browser/package.json
@@ -44,6 +44,7 @@
     "@theia/plugin-dev": "^0.12.0",
     "@theia/plugin-ext": "^0.12.0",
     "@theia/plugin-ext-vscode": "^0.12.0",
+    "@theia/plugin-metrics": "^0.12.0",
     "@theia/preferences": "^0.12.0",
     "@theia/preview": "^0.12.0",
     "@theia/process": "^0.12.0",

--- a/packages/plugin-metrics/README.md
+++ b/packages/plugin-metrics/README.md
@@ -1,0 +1,38 @@
+
+# Theia Plugin Extension Metrics
+This extension provides metrics for the theia plugin extension in the prometheus format.
+
+### What Metrics it Detects
+1. Detects errors in languages that are registered directly with monaco (E.g. if an error happens here: https://github.com/microsoft/vscode-extension-samples/blob/master/completions-sample/src/extension.ts#L11 it will be reported).
+
+2. Detects errors that are logged directly to the output channel for a specific vscode extension that uses a language server. These errors can only be reported via their id that is registered with the vscode-languageclient library. E.g. "YAML Support", "XML Support", etc
+
+### Limitations & Drawbacks
+Due to the limitations of the vscode-languageclient library (see https://github.com/microsoft/vscode-languageserver-node/issues/517) we are unable to process errors that come from the language server directly, instead we need to use the output channel. The output channel is great because it allows us to work around limitations of the vscode-languageclient library and still get metrics but it still has some drawbacks:
+
+1. Every time a language server request is resolved it counts as a success. This is because the vscode-languageclient always sends back a resolved promise even when the promise is actually rejected. The only time you can get an error is by extracting data from the output channel using a regex and connecting it back to the successes that were counted earlier. This has a few consequences:
+    1. If the errors logged are not matched by the regex we have no way to know where the error occured and thus we can't link the error back to a language server method. That means that the metric we created will always show that its working 100% correctly, even though it's not.
+
+2. You need to manually add a mapping of the output channel id to the vscode extension id, otherwise when the request is logged to the output channel it doesn't know which vscode extension it should associate itself with. There is no way around this because the output channel id is registered in the vscode-languageclient library inside of the vscode extension and not in something like the vscode-extensions package.json.
+
+### Implementation
+The browser side of this extension rebinds key parts of the plugin-ext allowing us to abstract relevant metrics at certain points.
+
+The browser then collects all these key metrics in the plugin-metrics-creator class.
+
+Once we have all the data we want, we need to transfer the data from the frontend to the backend so that our new metrics are displayed on /metrics endpoint. This communication is done via JSON-RPC where the PluginMetrics interface acts as a way to pass information between the frontend and the backend. To learn more see [1]
+
+The plugin-metrics-extractor will set the plugin metrics every 5 seconds [2] via pluginMetrics.setMetrics(metrics: string).
+
+Then, every 5 seconds [2] the backend will check the plugin metrics via pluginMetrics.getMetrics() to see what the contents of the metrics are at that time.
+
+Then, when you load up the /metrics endpoint you will see the new language metrics.
+
+[1] - [https://www.theia-ide.org/docs/json_rpc](https://www.theia-ide.org/docs/json_rpc)
+
+[2] - This is configurable and lives in common/metrics-protocol.ts 
+
+## License
+
+-  [Eclipse Public License 2.0](http://www.eclipse.org/legal/epl-2.0/)
+-  [一 (Secondary) GNU General Public License, version 2 with the GNU Classpath Exception](https://projects.eclipse.org/license/secondary-gpl-2.0-cp)

--- a/packages/plugin-metrics/compile.tsconfig.json
+++ b/packages/plugin-metrics/compile.tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../configs/base.tsconfig",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "lib"
+  },
+  "include": [
+    "src"
+  ]
+}

--- a/packages/plugin-metrics/package.json
+++ b/packages/plugin-metrics/package.json
@@ -1,0 +1,51 @@
+{
+  "name": "@theia/plugin-metrics",
+  "version": "0.12.0",
+  "description": "Theia - Plugin Metrics",
+  "dependencies": {
+    "@theia/core": "^0.12.0",
+    "@theia/languages": "^0.12.0",
+    "@theia/metrics": "^0.12.0",
+    "@theia/plugin-ext": "^0.12.0",
+    "vscode-languageserver-protocol": "^3.15.0-next.8",
+    "@theia/plugin": "^0.12.0"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "theiaExtensions": [
+    {
+      "frontend": "lib/browser/plugin-metrics-frontend-module",
+      "backend": "lib/node/plugin-metrics-backend-module"
+    }
+  ],
+  "keywords": [
+    "theia-extension"
+  ],
+  "license": "EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/theia-ide/theia.git"
+  },
+  "bugs": {
+    "url": "https://github.com/theia-ide/theia/issues"
+  },
+  "homepage": "https://github.com/theia-ide/theia",
+  "files": [
+    "lib",
+    "src"
+  ],
+  "scripts": {
+    "prepare": "yarn run clean && yarn run build",
+    "clean": "theiaext clean",
+    "build": "theiaext build",
+    "watch": "theiaext watch",
+    "test": "theiaext test"
+  },
+  "devDependencies": {
+    "@theia/ext-scripts": "^0.12.0"
+  },
+  "nyc": {
+    "extends": "../../configs/nyc.json"
+  }
+}

--- a/packages/plugin-metrics/src/browser/plugin-metrics-creator.ts
+++ b/packages/plugin-metrics/src/browser/plugin-metrics-creator.ts
@@ -1,0 +1,190 @@
+/********************************************************************************
+ * Copyright (C) 2019 Red Hat, Inc. and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import { inject, injectable } from 'inversify';
+import { PluginMetrics, METRICS_TIMEOUT } from '../common/metrics-protocol';
+import { AnalyticsFromRequests, DataFromRequest, createRequestData, createDefaultAnalytics, MetricsMap } from '../common/plugin-metrics-types';
+
+@injectable()
+export class PluginMetricsCreator {
+
+    @inject(PluginMetrics)
+    private pluginMetrics: PluginMetrics;
+
+    private _extensionIDAnalytics: MetricsMap;
+
+    private NODE_BASED_REGEX = /(?<=Request)(.*?)(?=failed)/;
+
+    constructor() {
+        this.setPluginMetrics();
+        this._extensionIDAnalytics = {};
+    }
+
+    /**
+     * Create an error metric for requestData.pluginID by attempting to extract the erroring
+     * language server method from the requestData.errorContentsOrMethod. If it cannot extract the
+     * error language server method from requestData.errorContentsOrMethod then it will not
+     * create a metric.
+     *
+     * @param pluginID The id of the plugin
+     * @param errorContents The contents that the langauge server error has produced
+     */
+    async createErrorMetric(requestData: DataFromRequest): Promise<void> {
+        if (!requestData.pluginID) {
+            return;
+        }
+
+        const method = this.extractMethodFromValue(requestData.errorContentsOrMethod);
+
+        // only log the metric if we can find the method that it occured in
+        if (method) {
+            const createdMetric = createRequestData(requestData.pluginID, method, requestData.timeTaken);
+            this.createMetric(createdMetric, false);
+
+            this.decreaseExtensionRequests(requestData.pluginID, method);
+        }
+    }
+
+    /**
+     * Decreases the total requests and the successful responses for pluginID with method by 1.
+     *
+     * This is needed because an error and a successful language server request aren't currently
+     * associated together because of https://github.com/microsoft/vscode-languageserver-node/issues/517.
+     * That means that every language server request that resolves counts as a successful language server request.
+     * Therefore, we need to decrease the extension requests for pluginID when we know there is an error.
+     * Otherwise, for every language server request that errors we would count it as both a success and a failure.
+     *
+     * @param pluginID The id of the plugin that should have the decreased requests
+     */
+    private decreaseExtensionRequests(pluginID: string, method: string): void {
+        const thisExtension = this._extensionIDAnalytics[pluginID];
+        if (thisExtension) {
+            const currentAnalytics = thisExtension[method];
+            if (currentAnalytics) {
+                currentAnalytics.totalRequests -= 1;
+                currentAnalytics.succesfulResponses -= 1;
+            }
+        }
+    }
+
+    /**
+     * Update the internal metrics structure for pluginID with method when a request is made
+     *
+     * @param requestData The data from the request that was made
+     * @param isRequestSuccessful If the language server request was successful or not
+     */
+    async createMetric(requestData: DataFromRequest, isRequestSuccessful: boolean): Promise<void> {
+        if (!requestData.pluginID) {
+            return;
+        }
+
+        // When we are in this function we know its a method so we can make it clearer
+        const method = requestData.errorContentsOrMethod;
+        const defaultAnalytic = createDefaultAnalytics(requestData.timeTaken, isRequestSuccessful);
+
+        this.createExtensionIDAnalyticIfNotFound(requestData, defaultAnalytic);
+        this.createExtensionIDMethodIfNotFound(requestData, defaultAnalytic);
+
+        const thisExtension = this._extensionIDAnalytics[requestData.pluginID];
+        if (thisExtension) {
+            const currentAnalytic = thisExtension[method];
+            if (currentAnalytic) {
+                currentAnalytic.totalRequests += 1;
+                if (isRequestSuccessful) {
+                    currentAnalytic.succesfulResponses += 1;
+                }
+                if (isRequestSuccessful) {
+                    currentAnalytic.sumOfTimeForSuccess = currentAnalytic.sumOfTimeForSuccess + requestData.timeTaken;
+                } else {
+                    currentAnalytic.sumOfTimeForFailure = currentAnalytic.sumOfTimeForFailure + requestData.timeTaken;
+                }
+            }
+        }
+    }
+
+    /**
+     * Create an entry in _extensionIDAnalytics with createdAnalytic if there does not exist one
+     *
+     * @param requestData data that we will turn into metrics
+     * @param createdAnalytic the analytic being created
+     */
+    private createExtensionIDAnalyticIfNotFound(requestData: DataFromRequest, createdAnalytic: AnalyticsFromRequests): void {
+        const method = requestData.errorContentsOrMethod; // We know its a metric if this is being called
+
+        if (!this._extensionIDAnalytics[requestData.pluginID]) {
+            this._extensionIDAnalytics[requestData.pluginID] = {
+                [method]: createdAnalytic
+            };
+        }
+    }
+
+    /**
+     * Create an entry in _extensionIDAnalytics for requestData.pluginID with requestData.errorContentsOrMethod as the method
+     * if there does not exist one
+     *
+     * @param requestData data that we will turn into metrics
+     * @param createdAnalytic the analytic being created
+     */
+    private createExtensionIDMethodIfNotFound(requestData: DataFromRequest, createdAnalytic: AnalyticsFromRequests): void {
+        const method = requestData.errorContentsOrMethod; // We know its a metric if this is being called
+
+        if (this._extensionIDAnalytics[requestData.pluginID]) {
+            const methodToAnalyticMap = this._extensionIDAnalytics[requestData.pluginID];
+            if (!methodToAnalyticMap[method]) {
+                methodToAnalyticMap[method] = createdAnalytic;
+            }
+        }
+    }
+
+    /**
+     * setPluginMetrics is a constant running function that sets
+     * pluginMetrics every {$METRICS_TIMEOUT} seconds so that it doesn't
+     * update /metrics on every request
+     */
+    private setPluginMetrics(): void {
+        const self = this;
+        setInterval(() => {
+            if (Object.keys(self._extensionIDAnalytics).length !== 0) {
+                self.pluginMetrics.setMetrics(JSON.stringify(self._extensionIDAnalytics));
+            }
+        }, METRICS_TIMEOUT);
+    }
+
+    // Map of plugin extension id to method to analytic
+    get extensionIDAnalytics(): MetricsMap {
+        return this._extensionIDAnalytics;
+    }
+
+    /**
+     * Attempts to extract the method name from the current errorContents using the
+     * vscode-languageclient matching regex.
+     *
+     * If it cannot find a match in the errorContents it returns undefined
+     *
+     * @param errorContents The contents of the current error or undefined
+     */
+    private extractMethodFromValue(errorContents: string | undefined): string | undefined {
+        if (!errorContents) {
+            return undefined;
+        }
+        const matches = errorContents.match(this.NODE_BASED_REGEX);
+        if (matches) {
+            return matches[0].trim();
+        }
+        return undefined;
+    }
+
+}

--- a/packages/plugin-metrics/src/browser/plugin-metrics-frontend-module.ts
+++ b/packages/plugin-metrics/src/browser/plugin-metrics-frontend-module.ts
@@ -1,0 +1,38 @@
+/********************************************************************************
+ * Copyright (C) 2019 Red Hat and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import { ContainerModule } from 'inversify';
+import { LanguagesMainPluginMetrics } from './plugin-metrics-languages-main';
+import { PluginMetrics, metricsJsonRpcPath } from '../common/metrics-protocol';
+import { WebSocketConnectionProvider } from '@theia/core/lib/browser/messaging/ws-connection-provider';
+import { PluginMetricsCreator } from './plugin-metrics-creator';
+import { PluginMetricsResolver } from './plugin-metrics-resolver';
+import { PluginMetricsOutputChannelRegistry } from './plugin-metrics-output-registry';
+import { LanguagesMainImpl } from '@theia/plugin-ext/lib/main/browser/languages-main';
+import { OutputChannelRegistryMainImpl } from '@theia/plugin-ext/lib/main/browser/output-channel-registry-main';
+
+export default new ContainerModule((bind, unbind, isBound, rebind) => {
+    bind(PluginMetricsResolver).toSelf().inSingletonScope();
+    bind(PluginMetricsCreator).toSelf().inSingletonScope();
+
+    rebind(LanguagesMainImpl).to(LanguagesMainPluginMetrics).inTransientScope();
+    rebind(OutputChannelRegistryMainImpl).to(PluginMetricsOutputChannelRegistry).inTransientScope();
+
+    bind(PluginMetrics).toDynamicValue(ctx => {
+        const connection = ctx.container.get(WebSocketConnectionProvider);
+        return connection.createProxy<PluginMetrics>(metricsJsonRpcPath);
+    }).inSingletonScope();
+});

--- a/packages/plugin-metrics/src/browser/plugin-metrics-languages-main.ts
+++ b/packages/plugin-metrics/src/browser/plugin-metrics-languages-main.ts
@@ -1,0 +1,324 @@
+/********************************************************************************
+ * Copyright (C) 2019 Red Hat and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import { Range, WorkspaceSymbolParams } from '@theia/plugin-ext/lib/common/plugin-api-rpc-model';
+import { PluginMetricsResolver } from './plugin-metrics-resolver';
+import { LanguagesMainImpl } from '@theia/plugin-ext/lib/main/browser/languages-main';
+import { SymbolInformation } from '@theia/languages/lib/browser';
+import { injectable, inject } from 'inversify';
+import * as vst from 'vscode-languageserver-protocol';
+import { PluginInfo } from '@theia/plugin-ext/lib/common/plugin-api-rpc';
+import { SerializedDocumentFilter } from '@theia/plugin-ext/lib/common/plugin-api-rpc-model';
+import * as theia from '@theia/plugin';
+
+@injectable()
+export class LanguagesMainPluginMetrics extends LanguagesMainImpl {
+
+    @inject(PluginMetricsResolver)
+    private pluginMetricsResolver: PluginMetricsResolver;
+
+    // Map of handle to extension id
+    protected readonly handleToExtensionID = new Map<number, string>();
+
+    $unregister(handle: number): void {
+        this.handleToExtensionID.delete(handle);
+        super.$unregister(handle);
+    }
+
+    protected provideCompletionItems(handle: number, model: monaco.editor.ITextModel, position: monaco.Position,
+        context: monaco.languages.CompletionContext, token: monaco.CancellationToken): monaco.languages.ProviderResult<monaco.languages.CompletionList> {
+        return this.pluginMetricsResolver.resolveRequest(this.handleToExtensionName(handle),
+            vst.CompletionRequest.type.method,
+            super.provideCompletionItems(handle, model, position, context, token));
+    }
+
+    protected resolveCompletionItem(handle: number, model: monaco.editor.ITextModel, position: monaco.Position,
+        item: monaco.languages.CompletionItem, token: monaco.CancellationToken): monaco.languages.ProviderResult<monaco.languages.CompletionItem> {
+        return this.pluginMetricsResolver.resolveRequest(this.handleToExtensionName(handle),
+            vst.CompletionRequest.type.method,
+            super.resolveCompletionItem(handle, model, position, item, token));
+    }
+
+    protected provideReferences(handle: number, model: monaco.editor.ITextModel, position: monaco.Position,
+        context: monaco.languages.ReferenceContext, token: monaco.CancellationToken): monaco.languages.ProviderResult<monaco.languages.Location[]> {
+        return this.pluginMetricsResolver.resolveRequest(this.handleToExtensionName(handle),
+            vst.ReferencesRequest.type.method,
+            super.provideReferences(handle, model, position, context, token));
+    }
+
+    protected provideImplementation(handle: number, model: monaco.editor.ITextModel,
+        position: monaco.Position, token: monaco.CancellationToken): monaco.languages.ProviderResult<monaco.languages.Definition> {
+        return this.pluginMetricsResolver.resolveRequest(this.handleToExtensionName(handle),
+            vst.ImplementationRequest.type.method,
+            super.provideImplementation(handle, model, position, token));
+    }
+
+    protected provideTypeDefinition(handle: number, model: monaco.editor.ITextModel,
+        position: monaco.Position, token: monaco.CancellationToken): monaco.languages.ProviderResult<monaco.languages.Definition> {
+        return this.pluginMetricsResolver.resolveRequest(this.handleToExtensionName(handle),
+            vst.TypeDefinitionRequest.type.method,
+            super.provideTypeDefinition(handle, model, position, token));
+    }
+
+    protected provideHover(handle: number, model: monaco.editor.ITextModel, position: monaco.Position,
+        token: monaco.CancellationToken): monaco.languages.ProviderResult<monaco.languages.Hover> {
+        return this.pluginMetricsResolver.resolveRequest(this.handleToExtensionName(handle),
+            vst.HoverRequest.type.method,
+            super.provideHover(handle, model, position, token));
+    }
+
+    protected provideDocumentHighlights(handle: number, model: monaco.editor.ITextModel, position: monaco.Position,
+        token: monaco.CancellationToken): monaco.languages.ProviderResult<monaco.languages.DocumentHighlight[]> {
+        return this.pluginMetricsResolver.resolveRequest(this.handleToExtensionName(handle),
+            vst.DocumentHighlightRequest.type.method,
+            super.provideDocumentHighlights(handle, model, position, token));
+    }
+
+    protected provideWorkspaceSymbols(handle: number, params: WorkspaceSymbolParams, token: monaco.CancellationToken): Thenable<SymbolInformation[]> {
+        return this.pluginMetricsResolver.resolveRequest(this.handleToExtensionName(handle),
+            vst.WorkspaceSymbolRequest.type.method,
+            super.provideWorkspaceSymbols(handle, params, token));
+    }
+
+    protected resolveWorkspaceSymbol(handle: number, symbol: SymbolInformation, token: monaco.CancellationToken): Thenable<SymbolInformation> {
+        return this.pluginMetricsResolver.resolveRequest(this.handleToExtensionName(handle),
+            vst.WorkspaceSymbolRequest.type.method,
+            super.resolveWorkspaceSymbol(handle, symbol, token));
+    }
+
+    protected async provideLinks(handle: number, model: monaco.editor.ITextModel,
+        token: monaco.CancellationToken): Promise<monaco.languages.ProviderResult<monaco.languages.ILinksList>> {
+        return this.pluginMetricsResolver.resolveRequest(this.handleToExtensionName(handle),
+            vst.DocumentLinkRequest.type.method,
+            super.provideLinks(handle, model, token));
+    }
+
+    protected async resolveLink(handle: number, link: monaco.languages.ILink,
+        token: monaco.CancellationToken): Promise<monaco.languages.ProviderResult<monaco.languages.ILink>> {
+        return this.pluginMetricsResolver.resolveRequest(this.handleToExtensionName(handle),
+            vst.DocumentLinkRequest.type.method,
+            super.resolveLink(handle, link, token));
+    }
+
+    protected async provideCodeLenses(handle: number, model: monaco.editor.ITextModel,
+        token: monaco.CancellationToken): Promise<monaco.languages.ProviderResult<monaco.languages.CodeLensList>> {
+        return this.pluginMetricsResolver.resolveRequest(this.handleToExtensionName(handle),
+            vst.CodeLensRequest.type.method,
+            super.provideCodeLenses(handle, model, token));
+    }
+
+    protected resolveCodeLens(handle: number, model: monaco.editor.ITextModel,
+        codeLens: monaco.languages.CodeLens, token: monaco.CancellationToken): monaco.languages.ProviderResult<monaco.languages.CodeLens> {
+        return this.pluginMetricsResolver.resolveRequest(this.handleToExtensionName(handle),
+            vst.CodeLensResolveRequest.type.method,
+            super.resolveCodeLens(handle, model, codeLens, token));
+    }
+
+    protected provideDocumentSymbols(handle: number, model: monaco.editor.ITextModel,
+        token: monaco.CancellationToken): monaco.languages.ProviderResult<monaco.languages.DocumentSymbol[]> {
+        return this.pluginMetricsResolver.resolveRequest(this.handleToExtensionName(handle),
+            vst.DocumentSymbolRequest.type.method,
+            super.provideDocumentSymbols(handle, model, token));
+    }
+
+    protected provideDefinition(handle: number, model: monaco.editor.ITextModel,
+        position: monaco.Position, token: monaco.CancellationToken): monaco.languages.ProviderResult<monaco.languages.Definition> {
+        return this.pluginMetricsResolver.resolveRequest(this.handleToExtensionName(handle),
+            vst.DefinitionRequest.type.method,
+            super.provideDefinition(handle, model, position, token));
+    }
+
+    protected async provideSignatureHelp(handle: number, model: monaco.editor.ITextModel,
+        position: monaco.Position, token: monaco.CancellationToken,
+        context: monaco.languages.SignatureHelpContext): Promise<monaco.languages.ProviderResult<monaco.languages.SignatureHelpResult>> {
+        return this.pluginMetricsResolver.resolveRequest(this.handleToExtensionName(handle),
+            vst.SignatureHelpRequest.type.method,
+            super.provideSignatureHelp(handle, model, position, token, context));
+    }
+
+    protected provideDocumentFormattingEdits(handle: number, model: monaco.editor.ITextModel,
+        options: monaco.languages.FormattingOptions, token: monaco.CancellationToken): monaco.languages.ProviderResult<monaco.languages.TextEdit[]> {
+        return this.pluginMetricsResolver.resolveRequest(this.handleToExtensionName(handle),
+            vst.DocumentFormattingRequest.type.method,
+            super.provideDocumentFormattingEdits(handle, model, options, token));
+    }
+
+    protected provideDocumentRangeFormattingEdits(handle: number, model: monaco.editor.ITextModel,
+        range: Range, options: monaco.languages.FormattingOptions, token: monaco.CancellationToken): monaco.languages.ProviderResult<monaco.languages.TextEdit[]> {
+        return this.pluginMetricsResolver.resolveRequest(this.handleToExtensionName(handle),
+            vst.DocumentRangeFormattingRequest.type.method,
+            super.provideDocumentRangeFormattingEdits(handle, model, range, options, token));
+    }
+
+    protected provideOnTypeFormattingEdits(handle: number, model: monaco.editor.ITextModel, position: monaco.Position,
+        ch: string, options: monaco.languages.FormattingOptions, token: monaco.CancellationToken): monaco.languages.ProviderResult<monaco.languages.TextEdit[]> {
+        return this.pluginMetricsResolver.resolveRequest(this.handleToExtensionName(handle),
+            vst.DocumentOnTypeFormattingRequest.type.method,
+            super.provideOnTypeFormattingEdits(handle, model, position, ch, options, token));
+    }
+
+    protected provideFoldingRanges(handle: number, model: monaco.editor.ITextModel,
+        context: monaco.languages.FoldingContext, token: monaco.CancellationToken): monaco.languages.ProviderResult<monaco.languages.FoldingRange[]> {
+        return this.pluginMetricsResolver.resolveRequest(this.handleToExtensionName(handle),
+            vst.FoldingRangeRequest.type.method,
+            super.provideFoldingRanges(handle, model, context, token));
+    }
+
+    protected provideDocumentColors(handle: number, model: monaco.editor.ITextModel,
+        token: monaco.CancellationToken): monaco.languages.ProviderResult<monaco.languages.IColorInformation[]> {
+        return this.pluginMetricsResolver.resolveRequest(this.handleToExtensionName(handle),
+            vst.DocumentColorRequest.type.method,
+            super.provideDocumentColors(handle, model, token));
+    }
+
+    protected provideColorPresentations(handle: number, model: monaco.editor.ITextModel,
+        colorInfo: monaco.languages.IColorInformation, token: monaco.CancellationToken): monaco.languages.ProviderResult<monaco.languages.IColorPresentation[]> {
+        return this.pluginMetricsResolver.resolveRequest(this.handleToExtensionName(handle),
+            vst.ColorPresentationRequest.type.method,
+            super.provideColorPresentations(handle, model, colorInfo, token));
+    }
+
+    protected async provideCodeActions(handle: number, model: monaco.editor.ITextModel,
+        rangeOrSelection: Range, context: monaco.languages.CodeActionContext,
+        token: monaco.CancellationToken): Promise<monaco.languages.CodeActionList | Promise<monaco.languages.CodeActionList>> {
+        return this.pluginMetricsResolver.resolveRequest(this.handleToExtensionName(handle),
+            vst.CodeActionRequest.type.method,
+            super.provideCodeActions(handle, model, rangeOrSelection, context, token));
+    }
+
+    protected provideRenameEdits(handle: number, model: monaco.editor.ITextModel,
+        position: monaco.Position, newName: string, token: monaco.CancellationToken): monaco.languages.ProviderResult<monaco.languages.WorkspaceEdit & monaco.languages.Rejection> {
+        return this.pluginMetricsResolver.resolveRequest(this.handleToExtensionName(handle),
+            vst.RenameRequest.type.method,
+            super.provideRenameEdits(handle, model, position, newName, token));
+    }
+
+    protected resolveRenameLocation(handle: number, model: monaco.editor.ITextModel,
+        position: monaco.Position, token: monaco.CancellationToken): monaco.languages.ProviderResult<monaco.languages.RenameLocation> {
+        return this.pluginMetricsResolver.resolveRequest(this.handleToExtensionName(handle),
+            vst.RenameRequest.type.method,
+            super.resolveRenameLocation(handle, model, position, token));
+    }
+
+    $registerCompletionSupport(handle: number, pluginInfo: PluginInfo,
+        selector: SerializedDocumentFilter[], triggerCharacters: string[], supportsResolveDetails: boolean): void {
+        this.registerPluginWithFeatureHandle(handle, pluginInfo.id);
+        super.$registerCompletionSupport(handle, pluginInfo, selector, triggerCharacters, supportsResolveDetails);
+    }
+
+    $registerDefinitionProvider(handle: number, pluginInfo: PluginInfo, selector: SerializedDocumentFilter[]): void {
+        this.registerPluginWithFeatureHandle(handle, pluginInfo.id);
+        super.$registerDefinitionProvider(handle, pluginInfo, selector);
+    }
+
+    $registerDeclarationProvider(handle: number, pluginInfo: PluginInfo, selector: SerializedDocumentFilter[]): void {
+        this.registerPluginWithFeatureHandle(handle, pluginInfo.id);
+        super.$registerDeclarationProvider(handle, pluginInfo, selector);
+    }
+
+    $registerReferenceProvider(handle: number, pluginInfo: PluginInfo, selector: SerializedDocumentFilter[]): void {
+        this.registerPluginWithFeatureHandle(handle, pluginInfo.id);
+        super.$registerReferenceProvider(handle, pluginInfo, selector);
+    }
+
+    $registerSignatureHelpProvider(handle: number, pluginInfo: PluginInfo, selector: SerializedDocumentFilter[], metadata: theia.SignatureHelpProviderMetadata): void {
+        this.registerPluginWithFeatureHandle(handle, pluginInfo.id);
+        super.$registerSignatureHelpProvider(handle, pluginInfo, selector, metadata);
+    }
+
+    $registerImplementationProvider(handle: number, pluginInfo: PluginInfo, selector: SerializedDocumentFilter[]): void {
+        this.registerPluginWithFeatureHandle(handle, pluginInfo.id);
+        super.$registerImplementationProvider(handle, pluginInfo, selector);
+    }
+
+    $registerTypeDefinitionProvider(handle: number, pluginInfo: PluginInfo, selector: SerializedDocumentFilter[]): void {
+        this.registerPluginWithFeatureHandle(handle, pluginInfo.id);
+        super.$registerTypeDefinitionProvider(handle, pluginInfo, selector);
+    }
+
+    $registerHoverProvider(handle: number, pluginInfo: PluginInfo, selector: SerializedDocumentFilter[]): void {
+        this.registerPluginWithFeatureHandle(handle, pluginInfo.id);
+        super.$registerHoverProvider(handle, pluginInfo, selector);
+    }
+
+    $registerDocumentHighlightProvider(handle: number, pluginInfo: PluginInfo, selector: SerializedDocumentFilter[]): void {
+        this.registerPluginWithFeatureHandle(handle, pluginInfo.id);
+        super.$registerDocumentHighlightProvider(handle, pluginInfo, selector);
+    }
+
+    $registerWorkspaceSymbolProvider(handle: number, pluginInfo: PluginInfo): void {
+        this.registerPluginWithFeatureHandle(handle, pluginInfo.id);
+        super.$registerWorkspaceSymbolProvider(handle, pluginInfo);
+    }
+
+    $registerDocumentLinkProvider(handle: number, pluginInfo: PluginInfo, selector: SerializedDocumentFilter[]): void {
+        this.registerPluginWithFeatureHandle(handle, pluginInfo.id);
+        super.$registerDocumentLinkProvider(handle, pluginInfo, selector);
+    }
+
+    $registerCodeLensSupport(handle: number, pluginInfo: PluginInfo, selector: SerializedDocumentFilter[], eventHandle: number): void {
+        this.registerPluginWithFeatureHandle(handle, pluginInfo.id);
+        super.$registerCodeLensSupport(handle, pluginInfo, selector, eventHandle);
+    }
+
+    $registerOutlineSupport(handle: number, pluginInfo: PluginInfo, selector: SerializedDocumentFilter[]): void {
+        this.registerPluginWithFeatureHandle(handle, pluginInfo.id);
+        super.$registerOutlineSupport(handle, pluginInfo, selector);
+    }
+
+    $registerDocumentFormattingSupport(handle: number, pluginInfo: PluginInfo, selector: SerializedDocumentFilter[]): void {
+        this.registerPluginWithFeatureHandle(handle, pluginInfo.id);
+        super.$registerDocumentFormattingSupport(handle, pluginInfo, selector);
+    }
+
+    $registerRangeFormattingProvider(handle: number, pluginInfo: PluginInfo, selector: SerializedDocumentFilter[]): void {
+        this.registerPluginWithFeatureHandle(handle, pluginInfo.id);
+        super.$registerRangeFormattingProvider(handle, pluginInfo, selector);
+    }
+
+    $registerOnTypeFormattingProvider(handle: number, pluginInfo: PluginInfo, selector: SerializedDocumentFilter[], autoFormatTriggerCharacters: string[]): void {
+        this.registerPluginWithFeatureHandle(handle, pluginInfo.id);
+        super.$registerOnTypeFormattingProvider(handle, pluginInfo, selector, autoFormatTriggerCharacters);
+    }
+
+    $registerFoldingRangeProvider(handle: number, pluginInfo: PluginInfo, selector: SerializedDocumentFilter[]): void {
+        this.registerPluginWithFeatureHandle(handle, pluginInfo.id);
+        super.$registerFoldingRangeProvider(handle, pluginInfo, selector);
+    }
+
+    $registerDocumentColorProvider(handle: number, pluginInfo: PluginInfo, selector: SerializedDocumentFilter[]): void {
+        this.registerPluginWithFeatureHandle(handle, pluginInfo.id);
+        super.$registerDocumentColorProvider(handle, pluginInfo, selector);
+    }
+
+    $registerQuickFixProvider(handle: number, pluginInfo: PluginInfo, selector: SerializedDocumentFilter[], codeActionKinds?: string[]): void {
+        this.registerPluginWithFeatureHandle(handle, pluginInfo.id);
+        super.$registerQuickFixProvider(handle, pluginInfo, selector);
+    }
+
+    $registerRenameProvider(handle: number, pluginInfo: PluginInfo, selector: SerializedDocumentFilter[], supportsResolveLocation: boolean): void {
+        this.registerPluginWithFeatureHandle(handle, pluginInfo.id);
+        super.$registerRenameProvider(handle, pluginInfo, selector, supportsResolveLocation);
+    }
+
+    private registerPluginWithFeatureHandle(handle: number, pluginID: string): void {
+        this.handleToExtensionID.set(handle, pluginID);
+    }
+
+    private handleToExtensionName(handle: number): string {
+        return this.handleToExtensionID.get(handle) as string;
+    }
+}

--- a/packages/plugin-metrics/src/browser/plugin-metrics-output-registry.ts
+++ b/packages/plugin-metrics/src/browser/plugin-metrics-output-registry.ts
@@ -1,0 +1,37 @@
+/********************************************************************************
+ * Copyright (C) 2019 Red Hat, Inc. and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import { injectable, inject } from 'inversify';
+import { OutputChannelRegistryMainImpl } from '@theia/plugin-ext/lib/main/browser/output-channel-registry-main';
+import { PluginMetricsCreator } from './plugin-metrics-creator';
+import { createDefaultRequestData } from '../common/plugin-metrics-types';
+import { PluginInfo } from '@theia/plugin-ext/lib/common/plugin-api-rpc';
+
+@injectable()
+export class PluginMetricsOutputChannelRegistry extends OutputChannelRegistryMainImpl {
+
+    @inject(PluginMetricsCreator)
+    protected readonly pluginMetricsCreator: PluginMetricsCreator;
+
+    $append(channelName: string, errorOrValue: string, pluginInfo: PluginInfo): PromiseLike<void> {
+        if (errorOrValue.startsWith('[Error')) {
+            const createdMetric = createDefaultRequestData(pluginInfo.id, errorOrValue);
+            this.pluginMetricsCreator.createErrorMetric(createdMetric);
+        }
+        return super.$append(channelName, errorOrValue, pluginInfo);
+    }
+
+}

--- a/packages/plugin-metrics/src/browser/plugin-metrics-resolver.ts
+++ b/packages/plugin-metrics/src/browser/plugin-metrics-resolver.ts
@@ -1,0 +1,57 @@
+/********************************************************************************
+ * Copyright (C) 2019 Red Hat, Inc. and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+// tslint:disable:no-any
+
+import { injectable, inject } from 'inversify';
+import { PluginMetricsCreator } from './plugin-metrics-creator';
+import { createRequestData } from '../common/plugin-metrics-types';
+
+/**
+ * This class helps resolve language server requests into successess or failures
+ * and sends the data to the metricsExtractor
+ */
+@injectable()
+export class PluginMetricsResolver {
+
+    @inject(PluginMetricsCreator)
+    private metricsCreator: PluginMetricsCreator;
+
+    /**
+     * Resolve a request for pluginID and create a metric based on whether or not
+     * the language server errored.
+     *
+     * @param pluginID the ID of the plugin that made the request
+     * @param method  the method that was request
+     * @param request the result of the language server request
+     */
+    async resolveRequest(pluginID: string, method: string, request: PromiseLike<any> | Promise<any> | Thenable<any> | any): Promise<any> {
+        const currentTime = performance.now();
+        try {
+            const value = await request;
+            this.createAndSetMetric(pluginID, method, performance.now() - currentTime, true);
+            return value;
+        } catch (error) {
+            this.createAndSetMetric(pluginID, method, performance.now() - currentTime, false);
+            return Promise.reject(error);
+        }
+    }
+
+    private createAndSetMetric(pluginID: string, method: string, time: number, successful: boolean): void {
+        const createdSuccessMetric = createRequestData(pluginID, method, time);
+        this.metricsCreator.createMetric(createdSuccessMetric, successful);
+    }
+}

--- a/packages/plugin-metrics/src/common/metrics-protocol.ts
+++ b/packages/plugin-metrics/src/common/metrics-protocol.ts
@@ -1,0 +1,27 @@
+/********************************************************************************
+ * Copyright (C) 2019 Red Hat, Inc. and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+/**
+ * The JSON-RPC interface for plugin metrics
+ */
+export const metricsJsonRpcPath = '/services/plugin-ext/metrics';
+export const PluginMetrics = Symbol('PluginMetrics');
+export interface PluginMetrics {
+    setMetrics(metrics: string): void;
+    getMetrics(): string;
+}
+
+export const METRICS_TIMEOUT = 10000;

--- a/packages/plugin-metrics/src/common/plugin-metrics-types.ts
+++ b/packages/plugin-metrics/src/common/plugin-metrics-types.ts
@@ -1,0 +1,80 @@
+/********************************************************************************
+ * Copyright (C) 2019 Red Hat, Inc. and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+// Define common interfaces that multiple classes can use
+
+export interface MetricsMap {
+    [extensionID: string]: MethodToAnalytics
+}
+
+export interface MethodToAnalytics {
+    [methodID: string]: AnalyticsFromRequests;
+}
+
+export interface AnalyticsFromRequests {
+    totalRequests: number;
+    succesfulResponses: number;
+    sumOfTimeForSuccess: number;
+    sumOfTimeForFailure: number;
+}
+
+export interface DataFromRequest {
+    pluginID: string;
+    errorContentsOrMethod: string;
+    timeTaken: number;
+}
+
+export interface MetricOutput {
+    header: string;
+    createMetricOutput(pluginID: string, method: string, requestAnalytics: AnalyticsFromRequests): string;
+}
+
+/**
+ * Helper functions for creating an object that corresponds to the DataFromRequest interface
+ */
+export function createRequestData(pluginID: string, errorContentsOrMethod: string, timeTaken: number): DataFromRequest {
+    return {
+        pluginID,
+        errorContentsOrMethod,
+        timeTaken
+    };
+}
+
+export function createDefaultRequestData(pluginID: string, errorContentsOrMethod: string): DataFromRequest {
+    return {
+        pluginID,
+        errorContentsOrMethod,
+        timeTaken: 0
+    };
+}
+
+export function createDefaultAnalytics(timeTaken: number, isRequestSuccessful: boolean): AnalyticsFromRequests {
+    if (isRequestSuccessful) {
+        return {
+            sumOfTimeForSuccess: timeTaken,
+            sumOfTimeForFailure: 0,
+            succesfulResponses: 0,
+            totalRequests: 0
+        };
+    } else {
+        return {
+            sumOfTimeForSuccess: 0,
+            sumOfTimeForFailure: timeTaken,
+            succesfulResponses: 0,
+            totalRequests: 0
+        };
+    }
+}

--- a/packages/plugin-metrics/src/node/metric-output/plugin-metrics-time-count.ts
+++ b/packages/plugin-metrics/src/node/metric-output/plugin-metrics-time-count.ts
@@ -1,0 +1,36 @@
+/********************************************************************************
+ * Copyright (C) 2019 Red Hat, Inc. and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import { MetricOutput, AnalyticsFromRequests } from '../../common/plugin-metrics-types';
+import { injectable } from 'inversify';
+
+@injectable()
+export class PluginMetricTimeCount implements MetricOutput {
+
+    public header = '# HELP language_server_time_count Number of language server requests\n# TYPE language_server_time_count gauge\n';
+
+    createMetricOutput(id: string, method: string, requestAnalytics: AnalyticsFromRequests): string {
+        if (requestAnalytics.succesfulResponses < 0) {
+            requestAnalytics.succesfulResponses = 0;
+        }
+        const successMetric = `language_server_time_count{id="${id}" method="${method}" result="success"} ${requestAnalytics.succesfulResponses}\n`;
+
+        const failedRequests = requestAnalytics.totalRequests - requestAnalytics.succesfulResponses;
+        const failureMetric = `language_server_time_count{id="${id}" method="${method}" result="fail"} ${failedRequests}\n`;
+        return successMetric + failureMetric;
+    }
+
+}

--- a/packages/plugin-metrics/src/node/metric-output/plugin-metrics-time-sum.ts
+++ b/packages/plugin-metrics/src/node/metric-output/plugin-metrics-time-sum.ts
@@ -1,0 +1,36 @@
+/********************************************************************************
+ * Copyright (C) 2019 Red Hat, Inc. and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import { MetricOutput, AnalyticsFromRequests } from '../../common/plugin-metrics-types';
+import { injectable } from 'inversify';
+
+@injectable()
+export class PluginMetricTimeSum implements MetricOutput {
+
+    public header =
+        '# HELP language_server_time_sum Sum of time in milliseconds that language server requests take\n# TYPE language_server_time_sum gauge\n';
+
+    createMetricOutput(id: string, method: string, requestAnalytics: AnalyticsFromRequests): string {
+        const successTime = requestAnalytics.sumOfTimeForSuccess;
+        const success = `language_server_time_sum{id="${id}" method="${method}" result="success"} ${successTime}\n`;
+
+        const failureTime = requestAnalytics.sumOfTimeForFailure;
+        const failure = `language_server_time_sum{id="${id}" method="${method}" result="failure"} ${failureTime}\n`;
+
+        return success + failure;
+    }
+
+}

--- a/packages/plugin-metrics/src/node/metric-string-generator.ts
+++ b/packages/plugin-metrics/src/node/metric-string-generator.ts
@@ -1,0 +1,70 @@
+/********************************************************************************
+ * Copyright (C) 2019 Red Hat, Inc. and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+import { PluginMetricTimeCount } from './metric-output/plugin-metrics-time-count';
+import { PluginMetricTimeSum } from './metric-output/plugin-metrics-time-sum';
+import { MetricsMap } from '../common/plugin-metrics-types';
+import { injectable, inject } from 'inversify';
+
+@injectable()
+export class PluginMetricStringGenerator {
+
+    @inject(PluginMetricTimeCount)
+    private pluginMetricsTimeCount: PluginMetricTimeCount;
+
+    @inject(PluginMetricTimeSum)
+    private pluginMetricsTimeSum: PluginMetricTimeSum;
+
+    getMetricsString(extensionIDAnalytics: MetricsMap): string {
+
+        if (Object.keys(extensionIDAnalytics).length === 0) {
+            return '';
+        }
+
+        let metricString = this.pluginMetricsTimeCount.header;
+        for (const extensionID in extensionIDAnalytics) {
+            if (!extensionIDAnalytics.hasOwnProperty(extensionID)) {
+                continue;
+            }
+
+            const methodToAnalytic = extensionIDAnalytics[extensionID];
+            for (const method in methodToAnalytic) {
+                if (!methodToAnalytic.hasOwnProperty(method)) {
+                    continue;
+                }
+                const analytic = methodToAnalytic[method];
+                metricString += this.pluginMetricsTimeCount.createMetricOutput(extensionID, method, analytic);
+            }
+        }
+
+        metricString += this.pluginMetricsTimeSum.header;
+        for (const extensionID in extensionIDAnalytics) {
+            if (!extensionIDAnalytics.hasOwnProperty(extensionID)) {
+                continue;
+            }
+
+            const methodToAnalytic = extensionIDAnalytics[extensionID];
+            for (const method in methodToAnalytic) {
+                if (!methodToAnalytic.hasOwnProperty(method)) {
+                    continue;
+                }
+                const analytic = methodToAnalytic[method];
+                metricString += this.pluginMetricsTimeSum.createMetricOutput(extensionID, method, analytic);
+            }
+        }
+
+        return metricString;
+    }
+}

--- a/packages/plugin-metrics/src/node/metrics-contributor.spec.ts
+++ b/packages/plugin-metrics/src/node/metrics-contributor.spec.ts
@@ -1,0 +1,234 @@
+/********************************************************************************
+ * Copyright (C) 2019 Red Hat, Inc. and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import { AnalyticsFromRequests } from '../common/plugin-metrics-types';
+import { PluginMetricsContributor } from './metrics-contributor';
+import { Container, ContainerModule } from 'inversify';
+import { PluginMetricsImpl } from './plugin-metrics-impl';
+import { PluginMetrics } from '../common/metrics-protocol';
+import * as assert from 'assert';
+
+describe('Metrics contributor:', () => {
+    let testContainer: Container;
+    before(() => {
+        testContainer = new Container();
+
+        const module = new ContainerModule(bind => {
+            bind(PluginMetrics).to(PluginMetricsImpl).inTransientScope();
+            bind(PluginMetricsContributor).toSelf().inTransientScope();
+        });
+
+        testContainer.load(module);
+    });
+
+    describe('reconcile:', () => {
+        it('Reconcile with one client connected', async () => {
+            // given
+            const analytics = {
+                sumOfTimeForFailure: 0,
+                sumOfTimeForSuccess: 5,
+                succesfulResponses: 10,
+                totalRequests: 15
+            } as AnalyticsFromRequests;
+            const metricExtensionID = 'my_test_metric.test_metric';
+            const metricMethod = 'textDocument/testMethod';
+
+            const metricsMap = {
+                [metricExtensionID]: {
+                    [metricMethod]: analytics
+                }
+            };
+
+            const metricsContributor = testContainer.get(PluginMetricsContributor);
+            const pluginMetrics = testContainer.get(PluginMetrics) as PluginMetrics;
+            pluginMetrics.setMetrics(JSON.stringify(metricsMap));
+            metricsContributor.clients.add(pluginMetrics);
+
+            // when
+            const reconciledMap = metricsContributor.reconcile();
+
+            // then
+            assert.deepStrictEqual(reconciledMap, metricsMap);
+
+        });
+
+        it('Reconcile same extension id and method with two clients connected', async () => {
+            // given
+
+            // first client
+            const firstClientAnalytics = {
+                sumOfTimeForFailure: 0,
+                sumOfTimeForSuccess: 5,
+                succesfulResponses: 10,
+                totalRequests: 15
+            } as AnalyticsFromRequests;
+            const firstClientMetricExtensionID = 'my_test_metric.test_metric';
+            const firstClientMetricMethod = 'textDocument/testMethod';
+            const firstClientMetricsMap = {
+                [firstClientMetricExtensionID]: {
+                    [firstClientMetricMethod]: firstClientAnalytics
+                }
+            };
+
+            const secondClientAnalytics = {
+                sumOfTimeForFailure: 0,
+                sumOfTimeForSuccess: 15,
+                succesfulResponses: 20,
+                totalRequests: 18
+            } as AnalyticsFromRequests;
+            const secondClientMetricsMap = {
+                [firstClientMetricExtensionID]: {
+                    [firstClientMetricMethod]: secondClientAnalytics
+                }
+            };
+            const metricsContributor = testContainer.get(PluginMetricsContributor);
+            const firstClientPluginMetric = testContainer.get(PluginMetrics) as PluginMetrics;
+            firstClientPluginMetric.setMetrics(JSON.stringify(firstClientMetricsMap));
+            metricsContributor.clients.add(firstClientPluginMetric);
+
+            const secondClientPluginMetric = testContainer.get(PluginMetrics) as PluginMetrics;
+            secondClientPluginMetric.setMetrics(JSON.stringify(secondClientMetricsMap));
+            metricsContributor.clients.add(secondClientPluginMetric);
+
+            // when
+            const reconciledMap = metricsContributor.reconcile();
+
+            // then
+            const expectedAnalytics = {
+                sumOfTimeForFailure: 0,
+                sumOfTimeForSuccess: 20,
+                succesfulResponses: 30,
+                totalRequests: 33
+            } as AnalyticsFromRequests;
+
+            const expectedMap = {
+                [firstClientMetricExtensionID]: {
+                    [firstClientMetricMethod]: expectedAnalytics
+                }
+            };
+
+            assert.deepStrictEqual(reconciledMap, expectedMap);
+        });
+
+        it('Reconcile different extension id and method with two clients connected', async () => {
+            // given
+
+            // first client
+            const firstClientAnalytics = {
+                sumOfTimeForFailure: 0,
+                sumOfTimeForSuccess: 5,
+                succesfulResponses: 10,
+                totalRequests: 15
+            } as AnalyticsFromRequests;
+            const firstClientMetricExtensionID = 'my_test_metric.test_metric';
+            const firstClientMetricMethod = 'textDocument/testMethod';
+            const firstClientMetricsMap = {
+                [firstClientMetricExtensionID]: {
+                    [firstClientMetricMethod]: firstClientAnalytics
+                }
+            };
+
+            const secondClientAnalytics = {
+                sumOfTimeForFailure: 0,
+                sumOfTimeForSuccess: 15,
+                succesfulResponses: 20,
+                totalRequests: 18
+            } as AnalyticsFromRequests;
+            const secondClientMetricExtensionID = 'my_other_test_metric.test_metric';
+            const secondClientMetricsMap = {
+                [secondClientMetricExtensionID]: {
+                    [firstClientMetricMethod]: secondClientAnalytics
+                }
+            };
+            const metricsContributor = testContainer.get(PluginMetricsContributor);
+            const firstClientPluginMetric = testContainer.get(PluginMetrics) as PluginMetrics;
+            firstClientPluginMetric.setMetrics(JSON.stringify(firstClientMetricsMap));
+            metricsContributor.clients.add(firstClientPluginMetric);
+
+            const secondClientPluginMetric = testContainer.get(PluginMetrics) as PluginMetrics;
+            secondClientPluginMetric.setMetrics(JSON.stringify(secondClientMetricsMap));
+            metricsContributor.clients.add(secondClientPluginMetric);
+
+            // when
+            const reconciledMap = metricsContributor.reconcile();
+
+            // then
+            const expectedMap = {
+                [firstClientMetricExtensionID]: {
+                    [firstClientMetricMethod]: firstClientAnalytics
+                },
+                [secondClientMetricExtensionID]: {
+                    [firstClientMetricMethod]: secondClientAnalytics
+                }
+            };
+
+            assert.deepStrictEqual(reconciledMap, expectedMap);
+        });
+
+        it('Reconcile same extension id and different method with two clients connected', async () => {
+            // given
+
+            // first client
+            const firstClientAnalytics = {
+                sumOfTimeForFailure: 0,
+                sumOfTimeForSuccess: 5,
+                succesfulResponses: 10,
+                totalRequests: 15
+            } as AnalyticsFromRequests;
+            const firstClientMetricExtensionID = 'my_test_metric.test_metric';
+            const firstClientMetricMethod = 'textDocument/testMethod';
+            const firstClientMetricsMap = {
+                [firstClientMetricExtensionID]: {
+                    [firstClientMetricMethod]: firstClientAnalytics
+                }
+            };
+            const secondClientAnalytics = {
+                sumOfTimeForFailure: 0,
+                sumOfTimeForSuccess: 15,
+                succesfulResponses: 20,
+                totalRequests: 18
+            } as AnalyticsFromRequests;
+            const secondClientMetricMethod = 'textDocument/myOthertestMethod';
+            const secondClientMetricsMap = {
+                [firstClientMetricExtensionID]: {
+                    [secondClientMetricMethod]: secondClientAnalytics
+                }
+            };
+            const metricsContributor = testContainer.get(PluginMetricsContributor);
+            const firstClientPluginMetric = testContainer.get(PluginMetrics) as PluginMetrics;
+            firstClientPluginMetric.setMetrics(JSON.stringify(firstClientMetricsMap));
+            metricsContributor.clients.add(firstClientPluginMetric);
+
+            const secondClientPluginMetric = testContainer.get(PluginMetrics) as PluginMetrics;
+            secondClientPluginMetric.setMetrics(JSON.stringify(secondClientMetricsMap));
+            metricsContributor.clients.add(secondClientPluginMetric);
+
+            // when
+            const reconciledMap = metricsContributor.reconcile();
+
+            // then
+            const expectedMap = {
+                [firstClientMetricExtensionID]: {
+                    [firstClientMetricMethod]: firstClientAnalytics,
+                    [secondClientMetricMethod]: secondClientAnalytics
+                }
+            };
+
+            assert.deepStrictEqual(reconciledMap, expectedMap);
+        });
+    });
+
+});

--- a/packages/plugin-metrics/src/node/metrics-contributor.ts
+++ b/packages/plugin-metrics/src/node/metrics-contributor.ts
@@ -1,0 +1,70 @@
+/********************************************************************************
+ * Copyright (C) 2019 Red Hat, Inc. and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import { PluginMetrics } from '../common/metrics-protocol';
+import { injectable } from 'inversify';
+import { AnalyticsFromRequests, MetricsMap } from '../common/plugin-metrics-types';
+
+@injectable()
+export class PluginMetricsContributor {
+    clients: Set<PluginMetrics> = new Set();
+
+    reconcile(): MetricsMap {
+        const reconciledMap: MetricsMap = {};
+        this.clients.forEach(c => {
+            const extensionIDtoMap = JSON.parse(c.getMetrics()) as MetricsMap;
+
+            for (const vscodeExtensionID in extensionIDtoMap) {
+                if (!extensionIDtoMap.hasOwnProperty(vscodeExtensionID)) {
+                    continue;
+                }
+
+                if (!reconciledMap[vscodeExtensionID]) {
+                    reconciledMap[vscodeExtensionID] = extensionIDtoMap[vscodeExtensionID];
+                } else {
+                    const methodToAnalytics = extensionIDtoMap[vscodeExtensionID];
+                    for (const method in methodToAnalytics) {
+
+                        if (!methodToAnalytics.hasOwnProperty(method)) {
+                            continue;
+                        }
+
+                        if (!reconciledMap[vscodeExtensionID][method]) {
+                            reconciledMap[vscodeExtensionID][method] = methodToAnalytics[method];
+                        } else {
+                            const currentAnalytic = reconciledMap[vscodeExtensionID][method];
+                            if (!methodToAnalytics[method]) {
+                                reconciledMap[vscodeExtensionID][method] = currentAnalytic;
+                            } else {
+                                // It does have the method
+                                // Then we need to reconcile the two analytics from requests
+                                const newAnalytic = methodToAnalytics[method] as AnalyticsFromRequests;
+                                newAnalytic.sumOfTimeForSuccess = newAnalytic.sumOfTimeForSuccess + currentAnalytic.sumOfTimeForSuccess;
+                                newAnalytic.sumOfTimeForFailure = newAnalytic.sumOfTimeForFailure + currentAnalytic.sumOfTimeForFailure;
+                                newAnalytic.totalRequests += currentAnalytic.totalRequests;
+                                newAnalytic.succesfulResponses += currentAnalytic.succesfulResponses;
+
+                                reconciledMap[vscodeExtensionID][method] = newAnalytic;
+                            }
+                        }
+                    }
+                }
+            }
+        });
+        return reconciledMap;
+    }
+
+}

--- a/packages/plugin-metrics/src/node/plugin-metrics-backend-module.ts
+++ b/packages/plugin-metrics/src/node/plugin-metrics-backend-module.ts
@@ -1,0 +1,49 @@
+/********************************************************************************
+ * Copyright (C) 2019 Red Hat, Inc. and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import { MetricsContribution } from '@theia/metrics/lib/node/metrics-contribution';
+import { PluginMetricsContribution } from './plugin-metrics';
+import { PluginMetrics, metricsJsonRpcPath } from '../common/metrics-protocol';
+import { PluginMetricsImpl } from './plugin-metrics-impl';
+import { ConnectionHandler } from '@theia/core/lib/common/messaging/handler';
+import { JsonRpcConnectionHandler } from '@theia/core';
+import { ContainerModule } from 'inversify';
+import { PluginMetricsContributor } from './metrics-contributor';
+import { PluginMetricTimeSum } from './metric-output/plugin-metrics-time-sum';
+import { PluginMetricTimeCount } from './metric-output/plugin-metrics-time-count';
+import { PluginMetricStringGenerator } from './metric-string-generator';
+
+export default new ContainerModule((bind, unbind, isBound, rebind) => {
+    bind(PluginMetricTimeSum).toSelf().inSingletonScope();
+    bind(PluginMetricTimeCount).toSelf().inSingletonScope();
+    bind(PluginMetrics).to(PluginMetricsImpl).inTransientScope();
+    bind(PluginMetricStringGenerator).toSelf().inSingletonScope();
+    bind(PluginMetricsContributor).toSelf().inSingletonScope();
+    bind(ConnectionHandler).toDynamicValue(ctx => {
+        const clients = ctx.container.get(PluginMetricsContributor);
+        return new JsonRpcConnectionHandler(metricsJsonRpcPath, client => {
+            const pluginMetricsHandler: PluginMetrics = ctx.container.get(PluginMetrics);
+            clients.clients.add(pluginMetricsHandler);
+            client.onDidCloseConnection(() => {
+                clients.clients.delete(pluginMetricsHandler);
+            });
+            return pluginMetricsHandler;
+        });
+    }
+    ).inSingletonScope();
+
+    bind(MetricsContribution).to(PluginMetricsContribution).inSingletonScope();
+});

--- a/packages/plugin-metrics/src/node/plugin-metrics-impl.ts
+++ b/packages/plugin-metrics/src/node/plugin-metrics-impl.ts
@@ -1,0 +1,38 @@
+/********************************************************************************
+ * Copyright (C) 2019 Red Hat, Inc. and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import { injectable } from 'inversify';
+import { PluginMetrics } from '../common/metrics-protocol';
+
+@injectable()
+export class PluginMetricsImpl implements PluginMetrics {
+
+    private metrics: string = '{}';
+
+    // tslint:disable-next-line:typedef
+    setMetrics(metrics: string) {
+        this.metrics = metrics;
+    }
+
+    /**
+     * This sends all the information about metrics inside of the plugins to the backend
+     * where it is served on the /metrics endpoint
+     */
+    getMetrics(): string {
+        return this.metrics;
+    }
+
+}

--- a/packages/plugin-metrics/src/node/plugin-metrics.ts
+++ b/packages/plugin-metrics/src/node/plugin-metrics.ts
@@ -1,0 +1,44 @@
+/********************************************************************************
+ * Copyright (C) 2019 Red Hat, Inc. and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import { injectable, inject } from 'inversify';
+import { MetricsContribution } from '@theia/metrics/lib/node/metrics-contribution';
+import { METRICS_TIMEOUT } from '../common/metrics-protocol';
+import { PluginMetricsContributor } from './metrics-contributor';
+import { PluginMetricStringGenerator } from './metric-string-generator';
+
+@injectable()
+export class PluginMetricsContribution implements MetricsContribution {
+
+    @inject(PluginMetricsContributor)
+    protected readonly metricsContributor: PluginMetricsContributor;
+
+    @inject(PluginMetricStringGenerator)
+    protected readonly stringGenerator: PluginMetricStringGenerator;
+
+    private metrics: string;
+
+    getMetrics(): string {
+        return this.metrics;
+    }
+
+    startCollecting(): void {
+        setInterval(() => {
+            const reconciledMetrics = this.metricsContributor.reconcile();
+            this.metrics = this.stringGenerator.getMetricsString(reconciledMetrics);
+        }, METRICS_TIMEOUT);
+    }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -124,6 +124,9 @@
       "@theia/plugin-ext-vscode/lib/*": [
         "packages/plugin-ext-vscode/src/*"
       ],
+      "@theia/plugin-metrics/lib/*": [
+        "packages/plugin-metrics/src/*"
+      ],
       "@theia/userstorage/lib/*": [
         "packages/userstorage/src/*"
       ],


### PR DESCRIPTION
#### What it does
<!-- Include relevant issues and describe how they are addressed. -->
This PR introduces a new extension that creates metrics from language plugins. It creates metrics for two specific instances:
- The time it takes for a language server request to be made for a specific request for a specific plugin
E.g. vscode-yaml -> document symbols -> 13 ms

- The percentage of success made for a specific request for a specific plugin
E.g. vscode-yaml -> document symbols -> 99% successful

Spectrum discussion: https://spectrum.chat/theia/dev/current-state-of-metrics-in-theia~8efd05d2-a25b-4629-a1b1-1dd8a0ccef96
Related issues:
https://github.com/eclipse/che/issues/14245

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

For testing I used a modified version of vscode-yaml that errors randomly in document symbols (just so you don't have to go out and find a plugin that errors on a language server request): you can download from https://github.com/JPinkney/Sample-vsix-repo/blob/master/0.5.2-beta7.vsix

You can actually use anything in this list though: https://github.com/eclipse-theia/theia/compare/master...JPinkney:plugin-ext-metrics?expand=1#diff-fb56011c00b860bfb7d05eedd825006eR33 it's just easier to verify that the percentage of successes is working when you know how to generate an error in the plugin.

Play around with the extension (autocompletion, document symbols, etc, etc) just so that we can get some data for metrics.

After you've played around with it go to ${yourUrl}/metrics and you should see the updated analytics for language_server_success_metrics and language_server_time_metrics.


#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

