### PR TITLE
[plugin-ext] Fix WorkspaceEdits for rename providers

### DIFF
--- a/packages/plugin-ext/src/common/plugin-api-rpc.ts
+++ b/packages/plugin-ext/src/common/plugin-api-rpc.ts
@@ -1057,6 +1057,11 @@ export interface ResourceTextEditDto {
     modelVersionId?: number;
     edits: TextEdit[];
 }
+export namespace ResourceTextEditDto {
+    export function is(arg: Object): arg is ResourceTextEditDto {
+        return !!arg && typeof arg === 'object' && 'resource' in arg && 'edits' in arg;
+    }
+}
 
 export interface WorkspaceEditDto {
     edits: (ResourceFileEditDto | ResourceTextEditDto)[];

--- a/packages/plugin-ext/src/main/browser/text-editors-main.ts
+++ b/packages/plugin-ext/src/main/browser/text-editors-main.ts
@@ -34,7 +34,7 @@ import { RPCProtocol } from '../../common/rpc-protocol';
 import { Disposable, DisposableCollection } from '@theia/core/lib/common/disposable';
 import { TextEditorMain } from './text-editor-main';
 import { disposed } from '../../common/errors';
-import { reviveWorkspaceEditDto } from './languages-main';
+import { toMonacoWorkspaceEdit } from './languages-main';
 import { MonacoBulkEditService } from '@theia/monaco/lib/browser/monaco-bulk-edit-service';
 import { MonacoEditorService } from '@theia/monaco/lib/browser/monaco-editor-service';
 
@@ -113,7 +113,7 @@ export class TextEditorsMainImpl implements TextEditorsMain, Disposable {
     }
 
     $tryApplyWorkspaceEdit(dto: WorkspaceEditDto): Promise<boolean> {
-        const edits = reviveWorkspaceEditDto(dto);
+        const edits = toMonacoWorkspaceEdit(dto);
         return new Promise(resolve => {
             this.bulkEditService.apply(edits).then(() => resolve(true), err => resolve(false));
         });

--- a/packages/plugin-ext/src/plugin/languages/rename.ts
+++ b/packages/plugin-ext/src/plugin/languages/rename.ts
@@ -57,7 +57,7 @@ export class RenameAdapter {
             if (rejectReason) {
                 return <WorkspaceEditDto>{
                     rejectReason,
-                    edits: undefined!
+                    edits: []
                 };
             } else {
                 return Promise.reject<WorkspaceEditDto>(error);


### PR DESCRIPTION
#### What it does
`WorkspaceEdit`s created in `languages-main.ts` should include `monaco.Uri`s instead of `require("vscode-uri").URI`s. "Rename Symbol" is broken due to this, and this PR fixes it.

Fixes eclipse-theia/theia#6295

#### How to test
- try to use vscode extension for python 
- run "Rename Symbol" and see it working; without this change you would see `Error applying workspace edits: Error: Unexpected edit type: {}`

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

