### PR TITLE
Pass pluginInfo through to output channel append method

### DIFF
--- a/packages/plugin-ext/src/common/plugin-api-rpc.ts
+++ b/packages/plugin-ext/src/common/plugin-api-rpc.ts
@@ -991,7 +991,7 @@ export interface PreferenceRegistryExt {
 }
 
 export interface OutputChannelRegistryMain {
-    $append(channelName: string, value: string): PromiseLike<void>;
+    $append(channelName: string, value: string, pluginInfo: PluginInfo): PromiseLike<void>;
     $clear(channelName: string): PromiseLike<void>;
     $dispose(channelName: string): PromiseLike<void>;
     $reveal(channelName: string, preserveFocus: boolean): PromiseLike<void>;

--- a/packages/plugin-ext/src/main/browser/output-channel-registry-main.ts
+++ b/packages/plugin-ext/src/main/browser/output-channel-registry-main.ts
@@ -18,7 +18,7 @@ import { injectable, inject } from 'inversify';
 import { OutputWidget } from '@theia/output/lib/browser/output-widget';
 import { OutputContribution } from '@theia/output/lib/browser/output-contribution';
 import { OutputChannel, OutputChannelManager } from '@theia/output/lib/common/output-channel';
-import { OutputChannelRegistryMain } from '../../common/plugin-api-rpc';
+import { OutputChannelRegistryMain, PluginInfo } from '../../common/plugin-api-rpc';
 
 @injectable()
 export class OutputChannelRegistryMainImpl implements OutputChannelRegistryMain {
@@ -33,7 +33,7 @@ export class OutputChannelRegistryMainImpl implements OutputChannelRegistryMain 
 
     private channels: Map<string, OutputChannel> = new Map();
 
-    $append(channelName: string, value: string): PromiseLike<void> {
+    $append(channelName: string, value: string, pluginInfo: PluginInfo): PromiseLike<void> {
         const outputChannel = this.getChannel(channelName);
         if (outputChannel) {
             outputChannel.append(value);

--- a/packages/plugin-ext/src/plugin/output-channel-registry.ts
+++ b/packages/plugin-ext/src/plugin/output-channel-registry.ts
@@ -14,7 +14,7 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 import {
-    PLUGIN_RPC_CONTEXT as Ext, OutputChannelRegistryMain
+    PLUGIN_RPC_CONTEXT as Ext, OutputChannelRegistryMain, PluginInfo
 } from '../common/plugin-api-rpc';
 import { RPCProtocol } from '../common/rpc-protocol';
 import * as theia from '@theia/plugin';
@@ -28,12 +28,12 @@ export class OutputChannelRegistryExt {
         this.proxy = rpc.getProxy(Ext.OUTPUT_CHANNEL_REGISTRY_MAIN);
     }
 
-    createOutputChannel(name: string): theia.OutputChannel {
+    createOutputChannel(name: string, pluginInfo: PluginInfo): theia.OutputChannel {
         name = name.trim();
         if (!name) {
             throw new Error('illegal argument \'name\'. must not be falsy');
         } else {
-            return new OutputChannelImpl(name, this.proxy);
+            return new OutputChannelImpl(name, this.proxy, pluginInfo);
         }
     }
 }

--- a/packages/plugin-ext/src/plugin/output-channel/output-channel-item.ts
+++ b/packages/plugin-ext/src/plugin/output-channel/output-channel-item.ts
@@ -14,13 +14,13 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 import * as theia from '@theia/plugin';
-import {OutputChannelRegistryMain} from '../../common/plugin-api-rpc';
+import { OutputChannelRegistryMain, PluginInfo } from '../../common/plugin-api-rpc';
 
 export class OutputChannelImpl implements theia.OutputChannel {
 
     private disposed: boolean;
 
-    constructor(readonly name: string, private proxy: OutputChannelRegistryMain) {
+    constructor(readonly name: string, private proxy: OutputChannelRegistryMain, private readonly pluginInfo: PluginInfo) {
     }
 
     dispose(): void {
@@ -33,7 +33,7 @@ export class OutputChannelImpl implements theia.OutputChannel {
 
     append(value: string): void {
         this.validate();
-        this.proxy.$append(this.name, value);
+        this.proxy.$append(this.name, value, this.pluginInfo);
     }
 
     appendLine(value: string): void {

--- a/packages/plugin-ext/src/plugin/plugin-context.ts
+++ b/packages/plugin-ext/src/plugin/plugin-context.ts
@@ -333,7 +333,7 @@ export function createAPIFactory(
                 return statusBarMessageRegistryExt.createStatusBarItem(alignment, priority);
             },
             createOutputChannel(name: string): theia.OutputChannel {
-                return outputChannelRegistryExt.createOutputChannel(name);
+                return outputChannelRegistryExt.createOutputChannel(name, pluginToPluginInfo(plugin));
             },
             createWebviewPanel(viewType: string,
                 title: string,


### PR DESCRIPTION
Signed-off-by: Josh Pinkney <joshpinkney@gmail.com>

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->
This PR passes the pluginInfo through to the output-channel-registry-main $append method.

This is needed for https://github.com/eclipse-theia/theia/pull/6303/files#r330382601 to make the language plugins we can get metrics from more dynamic. 

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
Put a breakpoint https://github.com/eclipse-theia/theia/compare/master...JPinkney:pass-plugin-info-output-registry?expand=1#diff-11ebe3cff728b3126a471050a7378864L37 and launch the browser backend/frontend. Then install vscode java. When it's installed and starts outputting to the output channel the breakpoint will be hit. Inspect the pluginInfo variable and you will find the pluginInfo that was passed through.

#### Review checklist

- [X] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

