### PR TITLE
Fix loss of local storage in Electron

### DIFF
--- a/packages/core/src/browser/storage-service.ts
+++ b/packages/core/src/browser/storage-service.ts
@@ -18,6 +18,7 @@ import { inject, injectable, postConstruct } from 'inversify';
 import { ILogger } from '../common/logger';
 import { MessageService } from '../common/message-service';
 import { WindowService } from './window/window-service';
+import { environment } from '@theia/application-package/lib/environment';
 
 export const StorageService = Symbol('IStorageService');
 /**
@@ -83,6 +84,9 @@ export class LocalStorageService implements StorageService {
     }
 
     protected prefix(key: string): string {
+        if (environment.electron.is()) {
+            return `theia:${key}`;
+        }
         const pathname = typeof window === 'undefined' ? '' : window.location.pathname;
         return `theia:${pathname}:${key}`;
     }


### PR DESCRIPTION
#### What it does
As a result of https://github.com/eclipse-theia/theia/issues/904 the window path name is prefixed to the local storage key.  However in the Electron version this can break the persistence of local storage.  This is because the window path name changes each time the program is run (when run in production mode).   Therefore I suggest reverting to exclude pathname if running in Electron.

#### How to test
Run an Electron app on Linux.  Change something that is persisted in local storage.  Exit the app, closing down Electron and restart (do not just refresh).  Run in production because in development the path name is the path to index.html for the desktop app.

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

