### PR TITLE
[terminal] Fix terminal scrolling in some browsers

### DIFF
--- a/packages/terminal/src/browser/terminal-widget-impl.ts
+++ b/packages/terminal/src/browser/terminal-widget-impl.ts
@@ -18,7 +18,7 @@ import * as Xterm from 'xterm';
 import { proposeGeometry } from 'xterm/lib/addons/fit/fit';
 import { inject, injectable, named, postConstruct } from 'inversify';
 import { ContributionProvider, Disposable, Event, Emitter, ILogger, DisposableCollection } from '@theia/core';
-import { Widget, Message, WebSocketConnectionProvider, StatefulWidget, isFirefox, MessageLoop, KeyCode } from '@theia/core/lib/browser';
+import { Widget, Message, WebSocketConnectionProvider, StatefulWidget, MessageLoop, KeyCode } from '@theia/core/lib/browser';
 import { isOSX } from '@theia/core/lib/common';
 import { WorkspaceService } from '@theia/workspace/lib/browser';
 import { ShellTerminalServerProxy } from '../common/shell-terminal-protocol';
@@ -434,11 +434,6 @@ export class TerminalWidgetImpl extends TerminalWidget implements StatefulWidget
         }
         this.termOpened = true;
         this.initialData = '';
-
-        if (isFirefox) {
-            // The software scrollbars don't work with xterm.js, so we disable the scrollbar if we are on firefox.
-            (this.term.element.children.item(0) as HTMLElement).style.overflow = 'hidden';
-        }
     }
     protected write(data: string): void {
         if (this.termOpened) {

--- a/packages/terminal/src/browser/terminal.css
+++ b/packages/terminal/src/browser/terminal.css
@@ -20,6 +20,11 @@
     padding: var(--theia-code-padding);
 }
 
+.xterm .xterm-viewport {
+  /* fix partly-hidden terminal scrollbar. */
+  scrollbar-width: none;
+}
+
 .xterm .xterm-screen canvas {
   /* fix random 1px white border on terminal in Firefox. See https://github.com/eclipse-theia/theia/issues/4665 */
   border: 1px solid var(--theia-layout-color0);


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does

In some browsers (e.g. Firefox on some older systems), it's impossible to scroll the Terminal output.

- I believe that it's because of the Firefox-specific `overflow: hidden`.
- I first tried removing it, but that caused a sometimes partially hidden scrollbar to appear in `.xterm-viewport` (at some widths, the scrollbar was hidden behind the `xterm` canvases).
- Thus I hid the scrollbar, by styling its width to zero, to align with the Terminal's current appearance/behavior everwhere.

Here is a screencast showing Terminal scrolling on OS X, in both Firefox Nightly and Google Chrome, with my change: https://www.youtube.com/watch?v=QiIuv4bo9aY

I've also tested on iPad with iOS 12.

#### How to test
1. Run Theia
2. Open a Terminal
3. `cat README.md`
4. Try scrolling (it should work well)

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

