### PR TITLE
[terminal] Move hover tooltip zIndex above the xterm.js canvas layers

### DIFF
--- a/packages/terminal/src/browser/terminal-widget-impl.ts
+++ b/packages/terminal/src/browser/terminal-widget-impl.ts
@@ -126,8 +126,10 @@ export class TerminalWidgetImpl extends TerminalWidget implements StatefulWidget
         this.hoverMessage.style.borderWidth = '0.5px';
         this.hoverMessage.style.borderStyle = 'solid';
         this.hoverMessage.style.padding = '5px';
-        this.hoverMessage.style.zIndex = '1';
-        // initially invisible
+        // Above the xterm.js canvas layers:
+        // https://github.com/xtermjs/xterm.js/blob/ff790236c1b205469f17a21246141f512d844295/src/renderer/Renderer.ts#L41-L46
+        this.hoverMessage.style.zIndex = '10';
+        // Initially invisible:
         this.hoverMessage.style.display = 'none';
         this.node.appendChild(this.hoverMessage);
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does

Currently, the link `Cmd + click` tooltip appears behind the Xterm canvas border:

<img width="451" alt="Screenshot 2019-10-03 at 10 30 29" src="https://user-images.githubusercontent.com/599268/66116606-49c4b880-e5d3-11e9-9279-95b8b1545d63.png">

That's because it has a `z-index` of `1`, while Xterm canvas layers have `z-index`es of `0`, `1`, `2` and `3`.

In this Pull Request, I've set the tooltip `z-index` to `10`, which makes it appear above the Xterm canvas border:

<img width="452" alt="Screenshot 2019-10-03 at 10 40 13" src="https://user-images.githubusercontent.com/599268/66116970-ef782780-e5d3-11e9-95ec-b1eff16712dc.png">

#### How to test
1. Run Theia
2. Run `echo "https://www.google.com" in the Terminal
3. Hover over the output link with your mouse

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

