### PR TITLE
[plugin] start document listening when all clients are ready

### DIFF
--- a/packages/plugin-ext/src/main/browser/editors-and-documents-main.ts
+++ b/packages/plugin-ext/src/main/browser/editors-and-documents-main.ts
@@ -70,6 +70,10 @@ export class EditorsAndDocumentsMain implements Disposable {
         this.toDispose.push(this.onDocumentRemoveEmitter);
     }
 
+    listen(): void {
+        this.stateComputer.listen();
+    }
+
     dispose(): void {
         this.toDispose.dispose();
     }
@@ -177,17 +181,22 @@ class EditorAndDocumentStateComputer implements Disposable {
         private callback: (delta: EditorAndDocumentStateDelta) => void,
         private readonly editorService: TextEditorService,
         private readonly modelService: EditorModelService
-    ) {
-        this.toDispose.push(editorService.onTextEditorAdd(e => {
+    ) { }
+
+    listen(): void {
+        if (this.toDispose.disposed) {
+            return;
+        }
+        this.toDispose.push(this.editorService.onTextEditorAdd(e => {
             this.onTextEditorAdd(e);
         }));
-        this.toDispose.push(editorService.onTextEditorRemove(e => {
+        this.toDispose.push(this.editorService.onTextEditorRemove(e => {
             this.onTextEditorRemove(e);
         }));
-        this.toDispose.push(modelService.onModelAdded(this.onModelAdded, this));
-        this.toDispose.push(modelService.onModelRemoved(() => this.update()));
+        this.toDispose.push(this.modelService.onModelAdded(this.onModelAdded, this));
+        this.toDispose.push(this.modelService.onModelRemoved(() => this.update()));
 
-        editorService.listTextEditors().forEach(e => this.onTextEditorAdd(e));
+        this.editorService.listTextEditors().forEach(e => this.onTextEditorAdd(e));
         this.update();
     }
 

--- a/packages/plugin-ext/src/main/browser/main-context.ts
+++ b/packages/plugin-ext/src/main/browser/main-context.ts
@@ -68,6 +68,7 @@ export function setUpPluginApi(rpc: RPCProtocol, container: interfaces.Container
     rpc.set(PLUGIN_RPC_CONTEXT.PREFERENCE_REGISTRY_MAIN, preferenceRegistryMain);
 
     const editorsAndDocuments = new EditorsAndDocumentsMain(rpc, container);
+
     const modelService = container.get(EditorModelService);
     const editorManager = container.get(EditorManager);
     const openerService = container.get<OpenerService>(OpenerService);
@@ -79,6 +80,9 @@ export function setUpPluginApi(rpc: RPCProtocol, container: interfaces.Container
     const monacoEditorService = container.get(MonacoEditorService);
     const editorsMain = new TextEditorsMainImpl(editorsAndDocuments, rpc, bulkEditService, monacoEditorService);
     rpc.set(PLUGIN_RPC_CONTEXT.TEXT_EDITORS_MAIN, editorsMain);
+
+    // start listening only after all clients are subscribed to events
+    editorsAndDocuments.listen();
 
     const statusBarMessageRegistryMain = new StatusBarMessageRegistryMainImpl(container);
     rpc.set(PLUGIN_RPC_CONTEXT.STATUS_BAR_MESSAGE_REGISTRY_MAIN, statusBarMessageRegistryMain);


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

- fix #6319: start document listening when all clients are ready

Otherwise events for already opened document can be missed.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

- install vscode go extension
- install some go project, i.e. `go get github.com/petar/GoLLRB/llrb`
- configure preference to use go LS and see its tracing information:
```json
{
  "gopls.trace.server": "verbose",
  "go.useLanguageServer": true
}
```
- open go project and open a file
- open `gopls` output view
- check that `didOpen`, `didChange`, `didClose` events are delivered whenever you do a corresponding action
- make sure to test it after reload with preserved editors
- also test it with reconnections by restarting the backend

Hint: you can clean the output view when an event should be at the top

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

