### PR TITLE
[plugin] initialize ext storage proxy earlier

### DIFF
--- a/packages/plugin-ext/src/hosted/browser/worker/worker-main.ts
+++ b/packages/plugin-ext/src/hosted/browser/worker/worker-main.ts
@@ -29,6 +29,7 @@ import { WorkspaceExtImpl } from '../../../plugin/workspace';
 import { MessageRegistryExt } from '../../../plugin/message-registry';
 import { WorkerEnvExtImpl } from './worker-env-ext';
 import { ClipboardExt } from '../../../plugin/clipboard-ext';
+import { KeyValueStorageProxy } from '../../../plugin/plugin-storage';
 
 // tslint:disable-next-line:no-any
 const ctx = self as any;
@@ -51,6 +52,7 @@ function initialize(contextPath: string, pluginMetadata: PluginMetadata): void {
     ctx.importScripts('/context/' + contextPath);
 }
 const envExt = new WorkerEnvExtImpl(rpc);
+const storageProxy = new KeyValueStorageProxy(rpc);
 const editorsAndDocuments = new EditorsAndDocumentsExtImpl(rpc);
 const messageRegistryExt = new MessageRegistryExt(rpc);
 const workspaceExt = new WorkspaceExtImpl(rpc, editorsAndDocuments, messageRegistryExt);
@@ -129,7 +131,7 @@ const pluginManager = new PluginManagerExtImpl({
             }
         }
     }
-}, envExt, preferenceRegistryExt, rpc);
+}, envExt, storageProxy, preferenceRegistryExt, rpc);
 
 const apiFactory = createAPIFactory(
     rpc,

--- a/packages/plugin-ext/src/plugin/plugin-manager.ts
+++ b/packages/plugin-ext/src/plugin/plugin-manager.ts
@@ -16,7 +16,6 @@
 
 import {
     PLUGIN_RPC_CONTEXT,
-    MAIN_RPC_CONTEXT,
     MainMessageType,
     MessageRegistryMain,
     PluginManagerExt,
@@ -81,7 +80,6 @@ export class PluginManagerExtImpl implements PluginManagerExt, PluginManager {
     private readonly activatedPlugins = new Map<string, ActivatedPlugin>();
     private readonly pluginActivationPromises = new Map<string, Deferred<void>>();
     private readonly pluginContextsMap = new Map<string, theia.PluginContext>();
-    private storageProxy: KeyValueStorageProxy;
 
     private onDidChangeEmitter = new Emitter<void>();
     private messageRegistryProxy: MessageRegistryMain;
@@ -92,6 +90,7 @@ export class PluginManagerExtImpl implements PluginManagerExt, PluginManager {
     constructor(
         private readonly host: PluginHost,
         private readonly envExt: EnvExtImpl,
+        private readonly storageProxy: KeyValueStorageProxy,
         private readonly preferencesManager: PreferenceRegistryExtImpl,
         private readonly rpc: RPCProtocol
     ) {
@@ -138,12 +137,7 @@ export class PluginManagerExtImpl implements PluginManagerExt, PluginManager {
     }
 
     async $init(params: PluginManagerInitializeParams): Promise<void> {
-        this.storageProxy = this.rpc.set(
-            MAIN_RPC_CONTEXT.STORAGE_EXT,
-            new KeyValueStorageProxy(this.rpc.getProxy(PLUGIN_RPC_CONTEXT.STORAGE_MAIN),
-                params.globalState,
-                params.workspaceState)
-        );
+        this.storageProxy.init(params.globalState, params.workspaceState);
 
         this.envExt.setQueryParameters(params.env.queryParams);
         this.envExt.setLanguage(params.env.language);

--- a/packages/plugin-ext/src/plugin/plugin-storage.ts
+++ b/packages/plugin-ext/src/plugin/plugin-storage.ts
@@ -18,6 +18,8 @@ import * as theia from '@theia/plugin';
 import { Event, Emitter } from '@theia/core/lib/common/event';
 import { StorageMain, StorageExt } from '../common/plugin-api-rpc';
 import { KeysToAnyValues, KeysToKeysToAnyValue } from '../common/types';
+import { RPCProtocol } from '../common/rpc-protocol';
+import { PLUGIN_RPC_CONTEXT } from '../common/plugin-api-rpc';
 
 export class Memento implements theia.Memento {
 
@@ -68,13 +70,11 @@ export class KeyValueStorageProxy implements StorageExt {
     private globalDataCache: KeysToKeysToAnyValue;
     private workspaceDataCache: KeysToKeysToAnyValue;
 
-    constructor(
-        proxy: StorageMain,
-        initGlobalData: KeysToKeysToAnyValue,
-        initWorkspaceData: KeysToKeysToAnyValue
-    ) {
-        this.proxy = proxy;
+    constructor(rpc: RPCProtocol) {
+        this.proxy = rpc.getProxy<StorageMain>(PLUGIN_RPC_CONTEXT.STORAGE_MAIN);
+    }
 
+    init(initGlobalData: KeysToKeysToAnyValue, initWorkspaceData: KeysToKeysToAnyValue): void {
         this.globalDataCache = initGlobalData;
         this.workspaceDataCache = initWorkspaceData;
     }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

- fix #6305: Initialize ext storage proxy earlier. Otherwise the main side can send events before the plugin manager is initialized leading to exceptions.


#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

- install some vs code extension, i.e. go
- open a project
- check that console dose not have unknown ext storage service errors

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

