### PR TITLE
[plugin] dispose webview by a handle, not a widget id

### DIFF
--- a/packages/plugin-ext/src/main/browser/webviews-main.ts
+++ b/packages/plugin-ext/src/main/browser/webviews-main.ts
@@ -119,7 +119,7 @@ export class WebviewsMainImpl implements WebviewsMain, Disposable {
             this.mouseTracker);
         view.disposed.connect(() => {
             toDisposeOnClose.dispose();
-            this.proxy.$onDidDisposeWebviewPanel(viewId);
+            this.proxy.$onDidDisposeWebviewPanel(panelId);
         });
         this.toDispose.push(view);
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

- fix #6288: dispose webview by a handle, not a widget id

Otherwise the webview is not disposed in the plugin host process.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

- ext install `vscode:extension/humao.rest-client`
- create simple http file
```
GET https://www.google.com
```
- send request
- close webivew
- send request again
- webview should show again
- there should not be errors about not found webview in the backend logs

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

