### PR TITLE
fix command execution for inline editors

### DIFF
--- a/packages/monaco/src/browser/monaco-command-registry.ts
+++ b/packages/monaco/src/browser/monaco-command-registry.ts
@@ -16,8 +16,9 @@
 
 import { injectable, inject } from 'inversify';
 import { Command, CommandHandler, CommandRegistry, SelectionService } from '@theia/core';
-import { EditorManager, TextEditorSelection } from '@theia/editor/lib/browser';
+import { TextEditorSelection } from '@theia/editor/lib/browser';
 import { MonacoEditor } from './monaco-editor';
+import { MonacoEditorProvider } from './monaco-editor-provider';
 
 export interface MonacoEditorCommandHandler {
     // tslint:disable-next-line:no-any
@@ -30,11 +31,12 @@ export class MonacoCommandRegistry {
 
     public static MONACO_COMMAND_PREFIX = 'monaco.';
 
-    constructor(
-        @inject(CommandRegistry) protected readonly commands: CommandRegistry,
-        @inject(EditorManager) protected readonly editorManager: EditorManager,
-        @inject(SelectionService) protected readonly selectionService: SelectionService
-    ) { }
+    @inject(MonacoEditorProvider)
+    protected readonly monacoEditors: MonacoEditorProvider;
+
+    @inject(CommandRegistry) protected readonly commands: CommandRegistry;
+
+    @inject(SelectionService) protected readonly selectionService: SelectionService;
 
     protected prefix(command: string): string {
         return MonacoCommandRegistry.MONACO_COMMAND_PREFIX + command;
@@ -66,7 +68,7 @@ export class MonacoCommandRegistry {
 
     // tslint:disable-next-line:no-any
     protected execute(monacoHandler: MonacoEditorCommandHandler, ...args: any[]): any {
-        const editor = MonacoEditor.getCurrent(this.editorManager);
+        const editor = this.monacoEditors.current;
         if (editor) {
             editor.focus();
             return Promise.resolve(monacoHandler.execute(editor, ...args));
@@ -76,7 +78,7 @@ export class MonacoCommandRegistry {
 
     // tslint:disable-next-line:no-any
     protected isEnabled(monacoHandler: MonacoEditorCommandHandler, ...args: any[]): boolean {
-        const editor = MonacoEditor.getCurrent(this.editorManager);
+        const editor = this.monacoEditors.current;
         return !!editor && (!monacoHandler.isEnabled || monacoHandler.isEnabled(editor, ...args));
     }
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

- fix #6325: fix command execution for inline editors

Since migrating to Monaco 0.18 we handle monaco keybindings to avoid some bugs, like inability to close the reference widget. It led to a regression for inline editors, since they are not tracked by editor managers.

This PR tracks the last focused Monaco editor regardless whether it is inline or not and apply Monaco commands to it.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

- Use inline editors, like input in the debug console and breakpoint expression editor, and make sure that keys applied to them when they are focused.
- Check that there is no regressions for editors widgets by typing and using features as content assist and find references.

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

