### PR TITLE
support input variables for tasks

### DIFF
--- a/packages/task/src/browser/process/process-task-resolver.ts
+++ b/packages/task/src/browser/process/process-task-resolver.ts
@@ -42,7 +42,9 @@ export class ProcessTaskResolver implements TaskResolver {
             throw new Error('Unsupported task configuration type.');
         }
         const context = new URI(this.taskDefinitionRegistry.getDefinition(taskConfig) ? taskConfig.scope : taskConfig._source).withScheme('file');
-        const variableResolverOptions = { context };
+        const variableResolverOptions = {
+            context, configurationSection: 'tasks'
+        };
         const processTaskConfig = taskConfig as ProcessTaskConfiguration;
         const result: ProcessTaskConfiguration = {
             ...processTaskConfig,

--- a/packages/task/src/browser/task-service.ts
+++ b/packages/task/src/browser/task-service.ts
@@ -364,7 +364,10 @@ export class TaskService implements TaskConfigurationClient {
                 if (resolvedMatcher) {
                     const scope = task._scope || task._source;
                     if (resolvedMatcher.filePrefix && scope) {
-                        const options = { context: new URI(scope).withScheme('file') };
+                        const options = {
+                            context: new URI(scope).withScheme('file'),
+                            configurationSection: 'tasks'
+                        };
                         const resolvedPrefix = await this.variableResolverService.resolve(resolvedMatcher.filePrefix, options);
                         Object.assign(resolvedMatcher, { filePrefix: resolvedPrefix });
                     }

--- a/packages/variable-resolver/src/browser/common-variable-contribution.ts
+++ b/packages/variable-resolver/src/browser/common-variable-contribution.ts
@@ -85,7 +85,7 @@ export class CommonVariableContribution implements VariableContribution {
                 const inputs = !!configuration && 'inputs' in configuration ? configuration.inputs : undefined;
                 const input = Array.isArray(inputs) && inputs.find(item => !!item && item.id === variable);
                 if (!input) {
-                    return undefined;
+                    throw new Error(`Undefined input variable "${variable}" encountered. Remove or define "${variable}" to continue.`);
                 }
                 if (input.type === 'promptString') {
                     if (typeof input.description !== 'string') {

--- a/packages/variable-resolver/src/browser/variable-resolver-service.ts
+++ b/packages/variable-resolver/src/browser/variable-resolver-service.ts
@@ -150,6 +150,7 @@ export namespace VariableResolverService {
             } catch (e) {
                 console.error(`Failed to resolved '${name}' variable`, e);
                 this.resolved.set(name, undefined);
+                throw e;
             }
         }
 


### PR DESCRIPTION
- add support to input variables which have the syntax: ${input:variableID}, where the variableID refers to entries in the inputs section of `tasks.json`. Check https://code.visualstudio.com/docs/editor/variables-reference#_input-variables for more of how this feature works in vsCode.
- resolves #5836

Signed-off-by: Liang Huang <liang.huang@ericsson.com>


#### How to test

![Peek 2019-10-04 16-53](https://user-images.githubusercontent.com/37082801/66239324-94276180-e6c7-11e9-87a1-df6899f951f9.gif)


Please kindly note, the input variable resolution is not supported in all properties under the task config. 
Properties include
- `type` & `label` for configured tasks, 
- the ones that are invovled in the task definition, such as `script` for detected npm tasks, and
- name of `problemMatchers`
cannot have input variables. (vsCode does the same)

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

