### PR TITLE
add content assist for input variables in tasks.json

### DIFF
--- a/packages/task/src/browser/task-schema-updater.ts
+++ b/packages/task/src/browser/task-schema-updater.ts
@@ -17,6 +17,7 @@ import { injectable, inject } from 'inversify';
 import { JsonSchemaStore } from '@theia/core/lib/browser/json-schema-store';
 import { InMemoryResources, deepClone } from '@theia/core/lib/common';
 import { IJSONSchema } from '@theia/core/lib/common/json-schema';
+import { inputsSchema } from '@theia/variable-resolver/lib/browser/variable-input-schema';
 import URI from '@theia/core/lib/common/uri';
 import { TaskService } from './task-service';
 
@@ -42,7 +43,8 @@ export class TaskSchemaUpdater {
                     items: {
                         ...deepClone(taskConfigurationSchema)
                     }
-                }
+                },
+                inputs: inputsSchema.definitions!.inputs
             }
         };
         const taskTypes = await this.taskService.getRegisteredTaskTypes();

--- a/packages/variable-resolver/src/browser/common-variable-contribution.ts
+++ b/packages/variable-resolver/src/browser/common-variable-contribution.ts
@@ -85,7 +85,7 @@ export class CommonVariableContribution implements VariableContribution {
                 const inputs = !!configuration && 'inputs' in configuration ? configuration.inputs : undefined;
                 const input = Array.isArray(inputs) && inputs.find(item => !!item && item.id === variable);
                 if (!input) {
-                    throw new Error(`Undefined input variable "${variable}" encountered. Remove or define "${variable}" to continue.`);
+                    return undefined;
                 }
                 if (input.type === 'promptString') {
                     if (typeof input.description !== 'string') {

--- a/packages/variable-resolver/src/browser/variable-resolver-service.ts
+++ b/packages/variable-resolver/src/browser/variable-resolver-service.ts
@@ -150,7 +150,6 @@ export namespace VariableResolverService {
             } catch (e) {
                 console.error(`Failed to resolved '${name}' variable`, e);
                 this.resolved.set(name, undefined);
-                throw e;
             }
         }
 


### PR DESCRIPTION
- content assist is added to help the users of tasks.json input variables.
- changes made to VariableResolverService and CommonVariableContribution
in #6331 are reverted.

Signed-off-by: Liang Huang <liang.huang@ericsson.com>

#### How to test
- Open `.theia/tasks.json`, and enter input variables.
- Check if the editor provides content assist.

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)
