### PR TITLE
[core] Don't reject schemas with issues, but add valid properties.

### DIFF
--- a/packages/core/src/browser/preferences/preference-proxy.ts
+++ b/packages/core/src/browser/preferences/preference-proxy.ts
@@ -86,15 +86,7 @@ export function createPreferenceProxy<T>(preferences: PreferenceService, schema:
         const preferenceName = OverridePreferenceName.is(arg) ?
             preferences.overridePreferenceName(arg) :
             <string>arg;
-        const value = preferences.get(preferenceName, defaultValue, resourceUri || opts.resourceUri);
-        if (preferences.validate(preferenceName, value)) {
-            return value;
-        }
-        if (defaultValue !== undefined) {
-            return defaultValue;
-        }
-        const values = preferences.inspect(preferenceName, resourceUri);
-        return values && values.defaultValue;
+        return preferences.get(preferenceName, defaultValue, resourceUri || opts.resourceUri);
     };
 
     const ownKeys: () => string[] = () => {
@@ -163,11 +155,7 @@ export function createPreferenceProxy<T>(preferences: PreferenceService, schema:
                 if (value === undefined) {
                     value = preferences.get(fullProperty, undefined, opts.resourceUri);
                 }
-                if (preferences.validate(fullProperty, value)) {
-                    return value;
-                }
-                const values = preferences.inspect(fullProperty, opts.resourceUri);
-                return values && values.defaultValue;
+                return value;
             }
         }
         if (property === 'onPreferenceChanged') {

--- a/packages/core/src/browser/preferences/preference-service.spec.ts
+++ b/packages/core/src/browser/preferences/preference-service.spec.ts
@@ -220,8 +220,6 @@ describe('Preference Service', () => {
         })), 'events before');
         assert.strictEqual(prefService.get('editor.insertSpaces'), true, 'get before');
         assert.strictEqual(prefService.get('[go].editor.insertSpaces'), false, 'get before overridden');
-        assert.strictEqual(prefSchema.validate('editor.insertSpaces', false), true, 'validate before');
-        assert.strictEqual(prefSchema.validate('[go].editor.insertSpaces', true), true, 'validate before overridden');
 
         events.length = 0;
         toUnset.dispose();
@@ -241,8 +239,6 @@ describe('Preference Service', () => {
         })), 'events after');
         assert.strictEqual(prefService.get('editor.insertSpaces'), undefined, 'get after');
         assert.strictEqual(prefService.get('[go].editor.insertSpaces'), undefined, 'get after overridden');
-        assert.strictEqual(prefSchema.validate('editor.insertSpaces', true), false, 'validate after');
-        assert.strictEqual(prefSchema.validate('[go].editor.insertSpaces', true), false, 'validate after overridden');
     });
 
     describe('overridden preferences', () => {

--- a/packages/core/src/browser/preferences/preference-service.ts
+++ b/packages/core/src/browser/preferences/preference-service.ts
@@ -88,7 +88,6 @@ export interface PreferenceService extends Disposable {
     overriddenPreferenceName(preferenceName: string): OverridePreferenceName | undefined;
 
     resolve<T>(preferenceName: string, defaultValue?: T, resourceUri?: string): PreferenceResolveResult<T>;
-    validate(name: string, value: any): boolean;
 }
 
 /**
@@ -357,9 +356,5 @@ export class PreferenceServiceImpl implements PreferenceService {
             configUri: result.configUri,
             value: result.value !== undefined ? deepFreeze(result.value) : defaultValue
         };
-    }
-
-    validate(name: string, value: any): boolean {
-        return this.schema.validate(name, value);
     }
 }

--- a/packages/editor-preview/src/browser/editor-preview-manager.spec.ts
+++ b/packages/editor-preview/src/browser/editor-preview-manager.spec.ts
@@ -87,12 +87,10 @@ describe('editor-preview-manager', () => {
 
     it('should handle preview requests if editor.enablePreview enabled', async () => {
         (mockPreference.get as sinon.SinonStub).returns(true);
-        (mockPreference.validate as sinon.SinonStub).returns(true);
         expect(await previewManager.canHandle(new URI(), { preview: true })).to.be.greaterThan(0);
     });
     it('should not handle preview requests if editor.enablePreview disabled', async () => {
         (mockPreference.get as sinon.SinonStub).returns(false);
-        (mockPreference.validate as sinon.SinonStub).returns(true);
         expect(await previewManager.canHandle(new URI(), { preview: true })).to.equal(0);
     });
     it('should not handle requests that are not preview or currently being previewed', async () => {


### PR DESCRIPTION
#### What it does

Allows configuration schemas to have issues. 
Some vs code extensions have schema validation issues in their `configuration` section. 
Instead of rejecting the full contribution, which will effectively break the extension, this PR just logs the validation message as a warning. Moreover the PR removes the runtime validation of actual preference values and leaves this to the user and the preference consumer.

#### How to test
Install gitlens.

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

