### PR TITLE
Aligned the default message with VS Code

### DIFF
--- a/packages/messages/src/browser/notification-center-component.tsx
+++ b/packages/messages/src/browser/notification-center-component.tsx
@@ -55,7 +55,7 @@ export class NotificationCenterComponent extends React.Component<NotificationCen
 
     render(): React.ReactNode {
         const empty = this.state.notifications.length === 0;
-        const title = empty ? 'NO NOTIFICATIONS' : 'NOTIFICATIONS';
+        const title = empty ? 'NO NEW NOTIFICATIONS' : 'NOTIFICATIONS';
         return (
             <div className={`theia-notifications-container theia-notification-center ${this.state.visibilityState === 'center' ? 'open' : 'closed'}`}>
                 <div className='theia-notification-center-header'>


### PR DESCRIPTION
Signed-off-by: Akos Kitta <kittaakos@typefox.io>

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->
Aligns the default notification center title with VS Code. I do not know if this is needed at all, if no, please close the PR.

VS Code:
![Screen Shot 2019-10-08 at 10 26 55](https://user-images.githubusercontent.com/1405703/66379878-a4388d00-e9b6-11e9-9e98-9d6b9a706503.jpg)

Theia:
![Screen Shot 2019-10-08 at 10 33 50](https://user-images.githubusercontent.com/1405703/66380165-2628b600-e9b7-11e9-952d-dd78cb6bef38.jpg)


#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
Open the notification center in Theia when there are no new notifications.

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

