### PR TITLE
[vscode] support `globalStoragePath`

### DIFF
--- a/packages/plugin-ext/src/common/plugin-api-rpc.ts
+++ b/packages/plugin-ext/src/common/plugin-api-rpc.ts
@@ -88,7 +88,8 @@ export interface Plugin {
 
 export interface ConfigStorage {
     hostLogPath: string;
-    hostStoragePath?: string,
+    hostStoragePath?: string;
+    hostGlobalStoragePath?: string;
 }
 
 export interface EnvInit {

--- a/packages/plugin-ext/src/plugin/plugin-manager.ts
+++ b/packages/plugin-ext/src/plugin/plugin-manager.ts
@@ -37,6 +37,8 @@ import { Memento, KeyValueStorageProxy } from './plugin-storage';
 import { ExtPluginApi } from '../common/plugin-ext-api-contribution';
 import { RPCProtocol } from '../common/rpc-protocol';
 import { Emitter } from '@theia/core/lib/common/event';
+import * as os from 'os';
+import * as fs from 'fs-extra';
 
 export interface PluginHost {
 
@@ -266,6 +268,12 @@ export class PluginManagerExtImpl implements PluginManagerExt, PluginManager {
         const asAbsolutePath = (relativePath: string): string => join(plugin.pluginFolder, relativePath);
         const logPath = join(configStorage.hostLogPath, plugin.model.id); // todo check format
         const storagePath = join(configStorage.hostStoragePath || '', plugin.model.id);
+        async function defaultGlobalStorage(): Promise<string> {
+            const globalStorage = join(os.homedir(), '.theia', 'globalStorage');
+            await fs.ensureDir(globalStorage);
+            return globalStorage;
+        }
+        const globalStoragePath = join(configStorage.hostGlobalStoragePath || (await defaultGlobalStorage()), plugin.model.id);
         const pluginContext: theia.PluginContext = {
             extensionPath: plugin.pluginFolder,
             globalState: new Memento(plugin.model.id, true, this.storageProxy),
@@ -274,6 +282,7 @@ export class PluginManagerExtImpl implements PluginManagerExt, PluginManager {
             asAbsolutePath: asAbsolutePath,
             logPath: logPath,
             storagePath: storagePath,
+            globalStoragePath: globalStoragePath
         };
         this.pluginContextsMap.set(plugin.model.id, pluginContext);
 

--- a/packages/plugin/src/theia.d.ts
+++ b/packages/plugin/src/theia.d.ts
@@ -2649,11 +2649,6 @@ declare module '@theia/plugin' {
         asAbsolutePath(relativePath: string): string;
 
         /**
-         * Return log path for current of the extension.
-         */
-        logPath: string;
-
-        /**
         * An absolute file path of a workspace specific directory in which the extension
         * can store private state. The directory might not exist on disk and creation is
         * up to the extension. However, the parent directory is guaranteed to be existent.
@@ -2662,6 +2657,22 @@ declare module '@theia/plugin' {
         * [`globalState`](#ExtensionContext.globalState) to store key value data.
         */
         storagePath: string | undefined;
+
+        /**
+         * An absolute file path in which the extension can store global state.
+         * The directory might not exist on disk and creation is
+         * up to the extension. However, the parent directory is guaranteed to be existent.
+         *
+         * Use [`globalState`](#ExtensionContext.globalState) to store key value data.
+         */
+        readonly globalStoragePath: string;
+
+        /**
+         * An absolute file path of a directory in which the extension can create log files.
+         * The directory might not exist on disk and creation is up to the extension. However,
+         * the parent directory is guaranteed to be existent.
+         */
+        readonly logPath: string;
     }
 
     /**


### PR DESCRIPTION
#### What it does
Added `globalStoragePath` to the ExtensionContext object.

#### How to test
Install an extension that accesses this property (e.g. git graph).

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

