### PR TITLE
Hide notification center when last item is removed

### DIFF
--- a/packages/messages/src/browser/notification-component.tsx
+++ b/packages/messages/src/browser/notification-component.tsx
@@ -53,7 +53,6 @@ export class NotificationComponent extends React.Component<NotificationComponent
             const action = event.target.dataset.action;
             if (messageId && action) {
                 this.props.manager.accept(messageId, action);
-                this.props.manager.toggleExpansion(messageId);
             }
         }
     }

--- a/packages/messages/src/browser/notifications-manager.ts
+++ b/packages/messages/src/browser/notifications-manager.ts
@@ -121,6 +121,9 @@ export class NotificationManager extends MessageClient {
             return;
         }
         this.deferredResults.delete(messageId);
+        if (this.centerVisible && this.notifications.size === 0) {
+            this.visibilityState = 'hidden';
+        }
         result.resolve(action);
         this.fireUpdatedEvent();
     }


### PR DESCRIPTION
Fixes https://github.com/eclipse-theia/theia/issues/6355

#### How to test
 - install https://github.com/AlexTugarev/txt/blob/master/txt-0.0.1.vsix 
 - call e.g. `TXT: info` command to show a message; toggle the center
 - remove the message (`X` button)
    - see the center is closed as well

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

