### PR TITLE
Fix `cancellable` option for `withProgress`

### DIFF
--- a/packages/plugin-ext/src/common/plugin-api-rpc.ts
+++ b/packages/plugin-ext/src/common/plugin-api-rpc.ts
@@ -686,7 +686,7 @@ export interface DecorationProvider {
 }
 
 export interface NotificationMain {
-    $startProgress(options: string | NotificationMain.StartProgressOptions): Promise<string>;
+    $startProgress(options: NotificationMain.StartProgressOptions): Promise<string>;
     $stopProgress(id: string): void;
     $updateProgress(id: string, report: NotificationMain.ProgressReport): void;
 }
@@ -694,6 +694,7 @@ export namespace NotificationMain {
     export interface StartProgressOptions {
         title: string;
         location?: string;
+        cancellable?: boolean;
     }
     export interface ProgressReport {
         message?: string;

--- a/packages/plugin-ext/src/main/browser/notification-main.ts
+++ b/packages/plugin-ext/src/main/browser/notification-main.ts
@@ -38,7 +38,7 @@ export class NotificationMainImpl implements NotificationMain, Disposable {
         this.toDispose.dispose();
     }
 
-    async $startProgress(options: string | NotificationMain.StartProgressOptions): Promise<string> {
+    async $startProgress(options: NotificationMain.StartProgressOptions): Promise<string> {
         const progressMessage = this.mapOptions(options);
         const progress = await this.progressService.showProgress(progressMessage);
         const id = progress.id;
@@ -51,10 +51,9 @@ export class NotificationMainImpl implements NotificationMain, Disposable {
         }
         return id;
     }
-    protected mapOptions(options: string | NotificationMain.StartProgressOptions): ProgressMessage {
-        const text = typeof options === 'string' ? options : options.title;
-        const location = typeof options === 'string' ? 'notification' : options.location;
-        return { text, options: { location, cancelable: true } };
+    protected mapOptions(options: NotificationMain.StartProgressOptions): ProgressMessage {
+        const { title, location, cancellable } = options;
+        return { text: title, options: { location, cancelable: cancellable } };
     }
 
     $stopProgress(id: string): void {

--- a/packages/plugin-ext/src/plugin/notification.ts
+++ b/packages/plugin-ext/src/plugin/notification.ts
@@ -37,7 +37,8 @@ export class NotificationExtImpl implements NotificationExt {
         const progress = task({ report: async item => this.proxy.$updateProgress(await id.promise, item)}, tokenSource.token);
         const title = options.title ? options.title : '';
         const location = this.mapLocation(options.location);
-        id.resolve(await this.proxy.$startProgress({ title, location }));
+        const cancellable = options.cancellable;
+        id.resolve(await this.proxy.$startProgress({ title, location, cancellable }));
         const stop = async () => this.proxy.$stopProgress(await id.promise);
         const promise = Promise.all([
             progress,


### PR DESCRIPTION
#### What it does

This PR makes the `cancellable` option being considered for `withProgress` notifications.

Fixes #5578

#### How to test

- install https://github.com/AlexTugarev/txt/blob/master/txt-0.0.1.vsix
- call `TXT: Progress` command

<img width="550" alt="Screen Shot 2019-10-10 at 22 40 41" src="https://user-images.githubusercontent.com/914497/66605081-b3365f80-ebaf-11e9-85dd-b6344698fdea.png">

now the `cancellable: false` option should have the same effect as in vscode

![Screen Shot 2019-10-10 at 22 10 26](https://user-images.githubusercontent.com/914497/66605080-b29dc900-ebaf-11e9-9aaf-174b6b78a024.png)


#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

