### PR TITLE
Fix #6380: Add configuration attribute to DebugSession

### DIFF
--- a/packages/plugin-ext/src/plugin/node/debug/debug.ts
+++ b/packages/plugin-ext/src/plugin/node/debug/debug.ts
@@ -209,6 +209,7 @@ export class DebugExtImpl implements DebugExt {
             id: sessionId,
             type: debugConfiguration.type,
             name: debugConfiguration.name,
+            configuration: debugConfiguration,
             customRequest: (command: string, args?: any) => this.proxy.$customRequest(sessionId, command, args)
         };
 

--- a/packages/plugin-ext/src/plugin/node/debug/plugin-debug-adapter-session.ts
+++ b/packages/plugin-ext/src/plugin/node/debug/plugin-debug-adapter-session.ts
@@ -27,6 +27,7 @@ import { IWebSocket } from 'vscode-ws-jsonrpc/lib/socket/socket';
 export class PluginDebugAdapterSession extends DebugAdapterSessionImpl implements theia.DebugSession {
     readonly type: string;
     readonly name: string;
+    readonly configuration: theia.DebugConfiguration;
 
     constructor(
         protected readonly communicationProvider: CommunicationProvider,
@@ -37,6 +38,7 @@ export class PluginDebugAdapterSession extends DebugAdapterSessionImpl implement
 
         this.type = theiaSession.type;
         this.name = theiaSession.name;
+        this.configuration = theiaSession.configuration;
     }
 
     async start(channel: IWebSocket): Promise<void> {

--- a/packages/plugin/src/theia.d.ts
+++ b/packages/plugin/src/theia.d.ts
@@ -7523,6 +7523,11 @@ declare module '@theia/plugin' {
          */
         readonly name: string;
 
+		/**
+		 * The "resolved" [debug configuration](#DebugConfiguration) of this session.
+		 */
+        readonly configuration: DebugConfiguration;
+
         /**
          * Send a custom request to the debug adapter.
          */


### PR DESCRIPTION
Signed-off-by: Brokun <brokun0128@gmail.com>

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
Add configuration attribute to DebugSession

#### How to test
1. Add the latest version of the `vscode-python` plugin
2. Debugging Python files

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

Since I only know that the `vscode-python` plugin uses related APIs, I have not tested the performance of other plugins.

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

