### PR TITLE
open minibrowser without url encode

### DIFF
--- a/packages/mini-browser/src/browser/mini-browser-open-handler.ts
+++ b/packages/mini-browser/src/browser/mini-browser-open-handler.ts
@@ -132,7 +132,7 @@ export class MiniBrowserOpenHandler extends NavigatableWidgetOpenHandler<MiniBro
         let result = await this.defaultOptions();
         if (uri) {
             // Decorate it with a few properties inferred from the URI.
-            const startPage = uri.toString();
+            const startPage = uri.toString(true);
             const name = this.labelProvider.getName(uri);
             const iconClass = `${await this.labelProvider.getIcon(uri)} file-icon`;
             // The background has to be reset to white only for "real" web-pages but not for images, for instance.


### PR DESCRIPTION
Signed-off-by: 二凢 <dingyu.wdy@alibaba-inc.com>

#### What it does
open minibrowser without url encode

#### How to test
inject a MiniBrowserOpenHandler as miniBrowserOpenHandler

this.miniBrowserOpenHandler.open(new URI('https://your.site.com?q=test'), options);

expect open a minibrowser with url "https://your.site.com?q=test" but got "https://your.site.com?q%3Dtest"

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

