### PR TITLE
support creating tasks.json from template

### DIFF
--- a/packages/task/src/browser/task-frontend-module.ts
+++ b/packages/task/src/browser/task-frontend-module.ts
@@ -38,6 +38,7 @@ import { bindTaskPreferences } from './task-preferences';
 import '../../src/browser/style/index.css';
 import './tasks-monaco-contribution';
 import { TaskNameResolver } from './task-name-resolver';
+import { TaskTemplateSelector } from './task-templates';
 
 export default new ContainerModule(bind => {
     bind(TaskFrontendContribution).toSelf().inSingletonScope();
@@ -73,6 +74,7 @@ export default new ContainerModule(bind => {
     bindContributionProvider(bind, TaskContribution);
     bind(TaskSchemaUpdater).toSelf().inSingletonScope();
     bind(TaskNameResolver).toSelf().inSingletonScope();
+    bind(TaskTemplateSelector).toSelf().inSingletonScope();
 
     bindProcessTaskModule(bind);
     bindTaskPreferences(bind);

--- a/packages/task/src/browser/task-templates.ts
+++ b/packages/task/src/browser/task-templates.ts
@@ -1,0 +1,168 @@
+/********************************************************************************
+ * Copyright (C) 2019 Ericsson and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { injectable } from 'inversify';
+import { QuickPickItem } from '@theia/core/lib/common/quick-pick-service';
+
+/** The representation of a task template used in the auto-generation of `tasks.json` */
+export interface TaskTemplateEntry {
+    id: string;
+    label: string;
+    description: string;
+    sort?: string; // string used in the sorting. If `undefined` the label is used in sorting.
+    autoDetect: boolean; // not supported in Theia
+    content: string;
+}
+
+const dotnetBuild: TaskTemplateEntry = {
+    id: 'dotnetCore',
+    label: '.NET Core',
+    sort: 'NET Core',
+    autoDetect: false, // not supported in Theia
+    description: 'Executes .NET Core build command',
+    content: [
+        '{',
+        '\t// See https://go.microsoft.com/fwlink/?LinkId=733558',
+        '\t// for the documentation about the tasks.json format',
+        '\t"version": "2.0.0",',
+        '\t"tasks": [',
+        '\t\t{',
+        '\t\t\t"label": "build",',
+        '\t\t\t"command": "dotnet",',
+        '\t\t\t"type": "shell",',
+        '\t\t\t"args": [',
+        '\t\t\t\t"build",',
+        '\t\t\t\t// Ask dotnet build to generate full paths for file names.',
+        '\t\t\t\t"/property:GenerateFullPaths=true",',
+        '\t\t\t\t// Do not generate summary otherwise it leads to duplicate errors in Problems panel',
+        '\t\t\t\t"/consoleloggerparameters:NoSummary"',
+        '\t\t\t],',
+        '\t\t\t"group": "build",',
+        '\t\t\t"presentation": {',
+        '\t\t\t\t"reveal": "silent"',
+        '\t\t\t},',
+        '\t\t\t"problemMatcher": "$msCompile"',
+        '\t\t}',
+        '\t]',
+        '}'
+    ].join('\n')
+};
+
+const msbuild: TaskTemplateEntry = {
+    id: 'msbuild',
+    label: 'MSBuild',
+    autoDetect: false, // not supported in Theia
+    description: 'Executes the build target',
+    content: [
+        '{',
+        '\t// See https://go.microsoft.com/fwlink/?LinkId=733558',
+        '\t// for the documentation about the tasks.json format',
+        '\t"version": "2.0.0",',
+        '\t"tasks": [',
+        '\t\t{',
+        '\t\t\t"label": "build",',
+        '\t\t\t"type": "shell",',
+        '\t\t\t"command": "msbuild",',
+        '\t\t\t"args": [',
+        '\t\t\t\t// Ask msbuild to generate full paths for file names.',
+        '\t\t\t\t"/property:GenerateFullPaths=true",',
+        '\t\t\t\t"/t:build",',
+        '\t\t\t\t// Do not generate summary otherwise it leads to duplicate errors in Problems panel',
+        '\t\t\t\t"/consoleloggerparameters:NoSummary"',
+        '\t\t\t],',
+        '\t\t\t"group": "build",',
+        '\t\t\t"presentation": {',
+        '\t\t\t\t// Reveal the output only if unrecognized errors occur.',
+        '\t\t\t\t"reveal": "silent"',
+        '\t\t\t},',
+        '\t\t\t// Use the standard MS compiler pattern to detect errors, warnings and infos',
+        '\t\t\t"problemMatcher": "$msCompile"',
+        '\t\t}',
+        '\t]',
+        '}'
+    ].join('\n')
+};
+
+const maven: TaskTemplateEntry = {
+    id: 'maven',
+    label: 'maven',
+    sort: 'MVN',
+    autoDetect: false, // not supported in Theia
+    description: 'Executes common maven commands',
+    content: [
+        '{',
+        '\t// See https://go.microsoft.com/fwlink/?LinkId=733558',
+        '\t// for the documentation about the tasks.json format',
+        '\t"version": "2.0.0",',
+        '\t"tasks": [',
+        '\t\t{',
+        '\t\t\t"label": "verify",',
+        '\t\t\t"type": "shell",',
+        '\t\t\t"command": "mvn -B verify",',
+        '\t\t\t"group": "build"',
+        '\t\t},',
+        '\t\t{',
+        '\t\t\t"label": "test",',
+        '\t\t\t"type": "shell",',
+        '\t\t\t"command": "mvn -B test",',
+        '\t\t\t"group": "test"',
+        '\t\t}',
+        '\t]',
+        '}'
+    ].join('\n')
+};
+
+const command: TaskTemplateEntry = {
+    id: 'externalCommand',
+    label: 'Others',
+    autoDetect: false, // not supported in Theia
+    description: 'Example to run an arbitrary external command',
+    content: [
+        '{',
+        '\t// See https://go.microsoft.com/fwlink/?LinkId=733558',
+        '\t// for the documentation about the tasks.json format',
+        '\t"version": "2.0.0",',
+        '\t"tasks": [',
+        '\t\t{',
+        '\t\t\t"label": "echo",',
+        '\t\t\t"type": "shell",',
+        '\t\t\t"command": "echo Hello"',
+        '\t\t}',
+        '\t]',
+        '}'
+    ].join('\n')
+};
+
+@injectable()
+export class TaskTemplateSelector {
+    selectTemplates(): QuickPickItem<TaskTemplateEntry>[] {
+        const templates: TaskTemplateEntry[] = [
+            dotnetBuild, msbuild, maven
+        ].sort((a, b) =>
+            (a.sort || a.label).localeCompare(b.sort || b.label)
+        );
+        templates.push(command);
+        return templates.map(t => ({
+            label: t.label,
+            description: t.description,
+            value: t
+        }));
+    }
+}


### PR DESCRIPTION
- group the tasks by workspace folder in the quick open item list populated by "Terminal" -> "Configure Tasks..."
- when "Configure Tasks" is started, check if tasks.json exists:
    - "Create tasks.json file from template" is displayed if 1) there are no detected or configured tasks, and 2) tasks.json does not exist
    - "Open tasks.json file" is displayed, if 1) tasks.json exists, and 2) no detected or configured tasks are found, display "Open tasks.json file".
- add VS Code Task templates to Theia. CQ created http://dev.eclipse.org/ipzilla/show_bug.cgi?id=20967
- part of #4212

Signed-off-by: Liang Huang <liang.huang@ericsson.com>


#### How to test

- In a multi root workspace, quick open items of "Tasks: Configure Tasks" (or "Terminal -> Configure tasks") should be grouped by the names of root folders
![1_group_by_folder](https://user-images.githubusercontent.com/37082801/66826147-c338a100-ef19-11e9-8a26-d73a4d483875.gif)


- When tasks.json does not exist in the root folder, "Create tasks.json file from template" should show up as an option, and users should be prompted to select which template to to generate the tasks.json from
![2_no_tasks_or_config_file](https://user-images.githubusercontent.com/37082801/66826154-c764be80-ef19-11e9-9088-e86735a5ded0.gif)


- If a non-empty tasks.json exists and there are no configured or detected tasks in the root folder, "Open tasks.json file" should show up as an option. Clicking that option opens the tasks.json by the editor.
![3_show_open_if_config_exists](https://user-images.githubusercontent.com/37082801/66826162-cb90dc00-ef19-11e9-9638-af5cf5350abd.gif)


#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

- [ ] CQ http://dev.eclipse.org/ipzilla/show_bug.cgi?id=20967 approved
