### PR TITLE
#6401 Support to "alwaysSignOff" commits

### DIFF
--- a/packages/git/src/browser/git-contribution.ts
+++ b/packages/git/src/browser/git-contribution.ts
@@ -29,6 +29,7 @@ import { GitErrorHandler } from '../browser/git-error-handler';
 import { ScmWidget } from '@theia/scm/lib/browser/scm-widget';
 import { ScmResource, ScmCommand } from '@theia/scm/lib/browser/scm-provider';
 import { ProgressService } from '@theia/core/lib/common/progress-service';
+import { GitPreferences } from './git-preferences';
 
 export const EDITOR_CONTEXT_MENU_GIT = [...EDITOR_CONTEXT_MENU, '3_git'];
 
@@ -207,6 +208,7 @@ export class GitContribution implements CommandContribution, MenuContribution, T
     @inject(GitErrorHandler) protected readonly gitErrorHandler: GitErrorHandler;
     @inject(CommandRegistry) protected readonly commands: CommandRegistry;
     @inject(ProgressService) protected readonly progressService: ProgressService;
+    @inject(GitPreferences) protected readonly gitPreferences: GitPreferences;
 
     onStart(): void {
         this.updateStatusBar();
@@ -690,7 +692,8 @@ export class GitContribution implements CommandContribution, MenuContribution, T
         scmRepository.input.issue = undefined;
         try {
             // We can make sure, repository exists, otherwise we would not have this button.
-            const { signOff, amend } = options;
+            const amend = options.amend;
+            const signOff = options.signOff || this.gitPreferences['git.alwaysSignOff'];
             const repository = scmRepository.provider.repository;
             await this.git.commit(repository, message, { signOff, amend });
             scmRepository.input.value = '';

--- a/packages/git/src/browser/git-preferences.ts
+++ b/packages/git/src/browser/git-preferences.ts
@@ -39,6 +39,11 @@ export const GitConfigSchema: PreferenceSchema = {
             'type': 'number',
             'description': 'Do not show dirty diff decorations, if editor\'s line count exceeds this limit.',
             'default': 1000
+        },
+        'git.alwaysSignOff': {
+            'type': 'boolean',
+            'description': 'Always sign off commits.',
+            'default': false
         }
     }
 };
@@ -48,6 +53,7 @@ export interface GitConfiguration {
     'git.decorations.colors': boolean,
     'git.editor.decorations.enabled': boolean,
     'git.editor.dirtyDiff.linesLimit': number,
+    'git.alwaysSignOff': boolean
 }
 
 export const GitPreferences = Symbol('GitPreferences');

--- a/packages/git/src/browser/git-repository-provider.spec.ts
+++ b/packages/git/src/browser/git-repository-provider.spec.ts
@@ -37,6 +37,7 @@ import { ContextKeyService } from '@theia/core/lib/browser/context-key-service';
 import { GitScmProvider } from './git-scm-provider';
 import { EditorManager } from '@theia/editor/lib/browser';
 import { GitErrorHandler } from './git-error-handler';
+import { GitPreferences } from './git-preferences';
 const expect = chai.expect;
 
 disableJSDOM();
@@ -106,6 +107,7 @@ describe('GitRepositoryProvider', () => {
         testContainer.bind(GitErrorHandler).toConstantValue(<GitErrorHandler>{});
         testContainer.bind(CommandService).toConstantValue(<CommandService>{});
         testContainer.bind(LabelProvider).toConstantValue(<LabelProvider>{});
+        testContainer.bind(GitPreferences).toConstantValue(<GitPreferences>{});
 
         sinon.stub(mockWorkspaceService, 'onWorkspaceChanged').value(mockRootChangeEmitter.event);
         sinon.stub(mockFileSystemWatcher, 'onFilesChanged').value(mockFileChangeEmitter.event);


### PR DESCRIPTION
Signed-off-by: Jonas Helming <jhelming@eclipsesource.com>

#### What it does
- fix https://github.com/eclipse-theia/theia/issues/6401: It add a preference to "auto sign off" on CTRL+ENTER in the SCM view

#### How to test
turn the preference on (under Git) and commit via CTRL+ENTER. Check the the commit is signed off

#### Review checklist

- [X] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

