### PR TITLE
[markdown-preview] resolve relative links properly

### DIFF
--- a/packages/preview/src/browser/preview-uri.ts
+++ b/packages/preview/src/browser/preview-uri.ts
@@ -26,7 +26,11 @@ export namespace PreviewUri {
         if (match(uri)) {
             return uri;
         }
-        const query = [param, ...uri.query.split('&')].join('&');
+        const params = [param];
+        if (uri.query) {
+            params.push(...uri.query.split('&'));
+        }
+        const query = params.join('&');
         return uri.withQuery(query);
     }
     export function decode(uri: URI): URI {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

fix #6396: resolve relative links properly

Latest version of vscode-uri makes sure that URI always has a scheme  or falls back to `file` scheme and that URI is always absolute by adding leading `/` to the relative path. It broke an assumption that a URI can be relative in the markdown preview.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

- Try to navigate from README file using relative links, for example to docs.
- Make sure to test such links with fragments.
- Make sure to test links to external websites as well, i.e. absolute and with not file scheme.

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

