### PR TITLE
Rebind Go to Definition to ctrl+f11

### DIFF
--- a/packages/monaco/src/browser/monaco-command.ts
+++ b/packages/monaco/src/browser/monaco-command.ts
@@ -56,6 +56,8 @@ export namespace MonacoCommands {
     export const SELECTION_ADD_PREVIOUS_OCCURRENCE = 'editor.action.addSelectionToPreviousFindMatch';
     export const SELECTION_SELECT_ALL_OCCURRENCES = 'editor.action.selectHighlights';
 
+    export const GO_TO_DEFINITION = 'editor.action.revealDefinition';
+
     export const ACTIONS = new Map<string, MonacoCommand>();
     ACTIONS.set(SELECTION_SELECT_ALL, { id: SELECTION_SELECT_ALL, label: 'Select All', delegate: 'editor.action.selectAll' });
     export const EXCLUDE_ACTIONS = new Set([

--- a/packages/monaco/src/browser/monaco-keybinding.ts
+++ b/packages/monaco/src/browser/monaco-keybinding.ts
@@ -20,7 +20,7 @@ import { EditorKeybindingContexts } from '@theia/editor/lib/browser';
 import { MonacoCommands } from './monaco-command';
 import { MonacoCommandRegistry } from './monaco-command-registry';
 import { KEY_CODE_MAP } from './monaco-keycode-map';
-import { isOSX } from '@theia/core';
+import { isOSX, environment } from '@theia/core';
 
 function monaco2BrowserKeyCode(keyCode: monaco.KeyCode): number {
     for (let i = 0; i < KEY_CODE_MAP.length; i++) {
@@ -47,9 +47,14 @@ export class MonacoKeybindingContribution implements KeybindingContribution {
             if (command) {
                 const raw = item.keybinding;
                 const when = item.when && item.when.serialize();
-                const keybinding = raw instanceof monaco.keybindings.SimpleKeybinding
-                    ? this.keyCode(raw).toString()
-                    : this.keySequence(raw as monaco.keybindings.ChordKeybinding).join(' ');
+                let keybinding;
+                if (item.command === MonacoCommands.GO_TO_DEFINITION && !environment.electron.is()) {
+                    keybinding = 'ctrlcmd+f11';
+                } else {
+                    keybinding = raw instanceof monaco.keybindings.SimpleKeybinding
+                        ? this.keyCode(raw).toString()
+                        : this.keySequence(raw as monaco.keybindings.ChordKeybinding).join(' ');
+                }
                 registry.registerKeybinding({ command, keybinding, when });
             }
         }


### PR DESCRIPTION
Signed-off-by: svor <vsvydenk@redhat.com>

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
Sets `ctrl+f11` as a default shortcut for **Go to Definition** command to avoid collision with **Go to Implementation** command. 

Related issues:
- https://github.com/eclipse-theia/theia/issues/6410
- https://github.com/eclipse/che/issues/14520

#### How to test
- Start Theia in the browser
- Open some java class and make sure that Java LS started
- Try to execute Go to Definition via `ctrl+f11` and Go to Implementation via `ctrl+f12`

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

