### PR TITLE
Fix https://github.com/eclipse-theia/theia/issues/6416 :: .editorconfig trim whitespace config not considered in manual save

### DIFF
--- a/packages/editorconfig/src/browser/editorconfig-document-manager.ts
+++ b/packages/editorconfig/src/browser/editorconfig-document-manager.ts
@@ -202,15 +202,15 @@ export class EditorconfigDocumentManager {
     private getEditsTrimmingTrailingWhitespaces(editor: MonacoEditor, properties: KnownProps, saveReason?: TextDocumentSaveReason): monaco.editor.IIdentifiedSingleEditOperation[] {
         const edits = [];
 
-        if (MonacoEditor.get(this.editorManager.activeEditor) === editor) {
-            const trimReason = (saveReason !== TextDocumentSaveReason.Manual) ? 'auto-save' : undefined;
-            editor.commandService.executeCommand('editor.action.trimTrailingWhitespace', {
-                reason: trimReason
-            });
-            return [];
-        }
-
         if (this.isSet(properties.trim_trailing_whitespace)) {
+            if (MonacoEditor.get(this.editorManager.activeEditor) === editor) {
+                const trimReason = (saveReason !== TextDocumentSaveReason.Manual) ? 'auto-save' : undefined;
+                editor.commandService.executeCommand('editor.action.trimTrailingWhitespace', {
+                    reason: trimReason
+                });
+                return [];
+            }
+
             const lines = editor.document.lineCount;
             for (let i = 1; i <= lines; i++) {
                 const line = editor.document.textEditorModel.getLineContent(i);


### PR DESCRIPTION
#### What it does
Fix for https://github.com/eclipse-theia/theia/issues/6416

#### How to test
Explained in the issue

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
