### PR TITLE
fix cpp task labels and ensure they can be run

### DIFF
--- a/packages/cpp/src/browser/cpp-task-provider.spec.ts
+++ b/packages/cpp/src/browser/cpp-task-provider.spec.ts
@@ -99,7 +99,7 @@ describe('CppTaskProvider', function (): void {
 
         const resolvedTask = await taskProvider.resolveTask(tasks[0]);
         expect(resolvedTask.type === 'shell');
-        expect((<ProcessTaskConfiguration>resolvedTask).cwd).to.be.equal('/tmp/build2');
+        expect((<ProcessTaskConfiguration>resolvedTask).options!.cwd).to.be.equal('/tmp/build2');
         expect((<ProcessTaskConfiguration>resolvedTask).command).to.be.equal('very');
         expect((<ProcessTaskConfiguration>resolvedTask).args).to.deep.equal(['complex', 'command']);
     });

--- a/packages/cpp/src/browser/cpp-task-provider.ts
+++ b/packages/cpp/src/browser/cpp-task-provider.ts
@@ -124,7 +124,9 @@ export class CppTaskProvider implements TaskContribution, TaskProvider, TaskReso
             type: 'shell',
             command,
             args,
-            cwd: task.config.directory,
+            options: {
+                cwd: task.config.directory,
+            }
         };
         return resolver.resolveTask(resolvedTask);
     }

--- a/packages/task/src/browser/quick-open-task.ts
+++ b/packages/task/src/browser/quick-open-task.ts
@@ -283,7 +283,7 @@ export class TaskRunQuickOpenItem extends QuickOpenGroupItem {
         }
 
         if (this.taskDefinitionRegistry && !!this.taskDefinitionRegistry.getDefinition(this.task)) {
-            this.taskService.run(this.task.source, this.task.label);
+            this.taskService.run(this.task.source || this.task._source, this.task.label);
         } else {
             this.taskService.run(this.task._source, this.task.label);
         }

--- a/packages/task/src/browser/task-name-resolver.ts
+++ b/packages/task/src/browser/task-name-resolver.ts
@@ -15,7 +15,7 @@
  ********************************************************************************/
 
 import { inject, injectable } from 'inversify';
-import { TaskConfiguration } from '../common';
+import { TaskConfiguration, ContributedTaskConfiguration } from '../common';
 import { TaskDefinitionRegistry } from './task-definition-registry';
 
 @injectable()
@@ -28,11 +28,15 @@ export class TaskNameResolver {
      * It is aligned with VS Code.
      */
     resolve(task: TaskConfiguration): string {
-        if (this.taskDefinitionRegistry.getDefinition(task)) {
-            return `${task.source}: ${task.label}`;
+        if (this.isDetectedTask(task)) {
+            return `${task.source || task._source}: ${task.label}`;
         }
 
         // it is a hack, when task is customized but extension is absent
         return task.label || `${task.type}: ${task.task}`;
+    }
+
+    private isDetectedTask(task: TaskConfiguration): task is ContributedTaskConfiguration {
+        return !!this.taskDefinitionRegistry.getDefinition(task);
     }
 }


### PR DESCRIPTION
This pull request fixes the following problems:
- cpp task labels are displayed as "undefined: xxxx" and it is wrong
- Theia always fails to run tasks defined in cpp extension. When they are started from the "Run Task", users either get "launch config not found" error, or an exception that says "Error attaching to terminal".

fixed #6204

#### How to test

1. define cpp build task(s) in the preference editor
2. open the "Terminal -> Run Task" from top menu bar and check if the task label(s) are correct
3. start the defined cpp build task(s) to check if they can be run 

![Peek 2019-10-20 10-02](https://user-images.githubusercontent.com/37082801/67160644-19924f00-f321-11e9-9233-a49459ecaa48.gif)


#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

