### PR TITLE
Fixes to default selected SCM code

### DIFF
--- a/packages/git/src/browser/git-repository-provider.ts
+++ b/packages/git/src/browser/git-repository-provider.ts
@@ -87,10 +87,15 @@ export class GitRepositoryProvider {
     }
 
     /**
-     * Sets or un-sets the repository.
+     * Sets the selected repository, but do nothing if the given repository is not a Git repository
+     * registered with the SCM service.  We must be sure not to clear the selection if the selected
+     * repository is managed by an SCM other than Git.
      */
     set selectedRepository(repository: Repository | undefined) {
-        this.scmService.selectedRepository = this.toScmRepository(repository);
+        const scmRepository = this.toScmRepository(repository);
+        if (scmRepository) {
+            this.scmService.selectedRepository = scmRepository;
+        }
     }
 
     get selectedScmRepository(): GitScmRepository | undefined {

--- a/packages/scm/src/browser/scm-service.ts
+++ b/packages/scm/src/browser/scm-service.ts
@@ -65,9 +65,6 @@ export class ScmService {
         }
         this.toDisposeOnSelected.dispose();
         this._selectedRepository = repository;
-        if (!repository) {
-            this._selectedRepository = this._repositories.values().next().value;
-        }
         this.updateContextKeys();
         if (this._selectedRepository) {
             this.toDisposeOnSelected.push(this._selectedRepository.onDidChange(() => this.updateContextKeys()));
@@ -91,7 +88,7 @@ export class ScmService {
             dispose.bind(repository)();
             this.onDidRemoveRepositoryEmitter.fire(repository);
             if (this._selectedRepository === repository) {
-                this.selectedRepository = undefined;
+                this.selectedRepository = this._repositories.values().next().value;
             }
         };
         this._repositories.set(key, repository);


### PR DESCRIPTION
#### What it does
There are a couple of related issues here that are fixed.

1) When setting the selected repository in ScmService to `undefined`, it does not set it to `undefined` but sets it to the first repository in its list.  This prevents extenders from setting the selection to be 'no selection'.  It is generally considered bad practice to put business logic in setters so I moved this out of the setter.

2) When one has two or more SCM provider implementations then the setting of the selection fails.  This is because if the selected repository is not a Git repository then the Git provider sets the repository to `undefined` (because toScmRepository will return `undefined` for repositories other than Git repositories).  This forces the selected repository to the first repository in the list, overwriting the selection set by any other SCM provider.

#### How to test
You can test that all works the same as before when there is only the Git provider.  If you want to see a problem that is fixed by this change then the steps are as follows:
- install a second SCM provider.
- create two projects, one in an SCM repository of each type.
- select one and restart.  Check which is shown in the SCM view.
- select the other and restart.  Check which is shown in the SCM view.

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

