### PR TITLE
Prevent default browser context-menu

### DIFF
--- a/packages/core/src/browser/frontend-application.ts
+++ b/packages/core/src/browser/frontend-application.ts
@@ -180,6 +180,9 @@ export class FrontendApplication {
         window.addEventListener('drop', event => {
             event.preventDefault();
         }, false);
+        window.addEventListener('contextmenu', event => {
+            event.preventDefault();
+        }, false);
 
     }
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

Fixes #4007

_Current Behavior_
- When right-clicking certain content (ex: the application without any editors opened) the default browser menu is displayed. This breaks up the user experience and can become quite annoying.

<div align='center'>

![contextmenu](https://user-images.githubusercontent.com/40359487/67231675-c649fa80-f40d-11e9-9721-81b6a130a5ab.gif)

</div>

_PR_
- The PR adds additional handling to the `window` `contextmenu` event to prevent the default browser behavior. Existing context menus such as for an editor, or widgets remain unchanged.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

_Verify Default Behavior_
1. open the application
2. ensure that no editors are opened
3. attempt to right-click in the empty area (nothing should happen) - previously the browser context menu was displayed

_Verify Regression_
1. open the application
2. open an editor
3. right-click within the editor, the editor context menu should be visible
4. do the same as step 3 with a widget tab

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

Signed-off-by: Vincent Fugnitto <vincent.fugnitto@ericsson.com>
