### PR TITLE
[safari] fix incorrect command palette cursor position

### DIFF
--- a/packages/monaco/src/browser/monaco-quick-open-service.ts
+++ b/packages/monaco/src/browser/monaco-quick-open-service.ts
@@ -135,6 +135,10 @@ export class MonacoQuickOpenService extends QuickOpenService {
         const widget = this.widget;
         if (widget.inputBox) {
             widget.inputBox.inputElement.tabIndex = 1;
+            // Position the cursor at the end of the input unless a user has made a selection.
+            if (widget.inputBox.inputElement.selectionStart === widget.inputBox.inputElement.selectionEnd) {
+                widget.inputBox.inputElement.selectionStart = widget.inputBox.inputElement.value.length;
+            }
         }
     }
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

Fixes #6011

Fixes incorrect command palette cursor position especially on Safari browser.
Added additional handling to verify that if no selection is currently present,
force the cursor at the end of the input. Inspired by a similar implementation
in VS Code.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
1. open the command palette <kbd>ctrlcmd</kbd>+<kbd>shift</kbd>+<kbd>p</kdp>
2. ensure that the cursor is placed at the end of the `prefix`
3. verify in multiple browsers (ex: Safari, Chrome, Firefox)

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)
- [x] [CQ registered](https://dev.eclipse.org/ipzilla/show_bug.cgi?id=21005)
- [x] CQ approved

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

Signed-off-by: Vincent Fugnitto <vincent.fugnitto@ericsson.com>
