### PR TITLE
[travis] fix failing windows CI due to ffmpeg

### DIFF
--- a/dev-packages/electron/native/src/ffmpeg.c
+++ b/dev-packages/electron/native/src/ffmpeg.c
@@ -69,9 +69,6 @@ napi_value codecs(napi_env env, napi_callback_info info)
         goto error;
     }
 
-    // Register all codecs contained in the library.
-    ffmpeg.av_register_all();
-
     // Iterate over the codec descriptions.
     // It includes descriptions for codecs that may not be present in the library.
     struct AVCodecDescriptor *descriptor = ffmpeg.avcodec_descriptor_next(NULL);

--- a/dev-packages/electron/native/src/ffmpeg.h
+++ b/dev-packages/electron/native/src/ffmpeg.h
@@ -49,11 +49,6 @@ struct FFMPEG_Library
     void *handle;
 
     /**
-     * https://github.com/FFmpeg/FFmpeg/blob/release/3.2/libavformat/avformat.h#L1982
-     */
-    void (*av_register_all)(void);
-
-    /**
      * https://github.com/FFmpeg/FFmpeg/blob/release/3.2/libavcodec/avcodec.h#L6228
      *
      * We use AVCodecDescriptor because it is the only structure that we can
@@ -70,7 +65,7 @@ struct FFMPEG_Library
 };
 
 #define NULL_FFMPEG_LIBRARY \
-    (struct FFMPEG_Library) { NULL, NULL, NULL, NULL }
+    (struct FFMPEG_Library) { NULL, NULL, NULL }
 
 /**
  * Loader that will inject the loaded functions into a FFMPEG_Library structure.

--- a/dev-packages/electron/native/src/linux-ffmpeg.c
+++ b/dev-packages/electron/native/src/linux-ffmpeg.c
@@ -30,14 +30,7 @@ char *load_ffmpeg_library(struct FFMPEG_Library *library, char *library_path)
     {
         goto error;
     }
-
-    void (*av_register_all)(void) = dlsym(handle, "av_register_all");
-    error = dlerror();
-    if (error != NULL)
-    {
-        goto error;
-    }
-
+   
     struct AVCodecDescriptor *(*avcodec_descriptor_next)(const struct AVCodecDescriptor *) = dlsym(handle, "avcodec_descriptor_next");
     error = dlerror();
     if (error != NULL)
@@ -53,7 +46,6 @@ char *load_ffmpeg_library(struct FFMPEG_Library *library, char *library_path)
     }
 
     library->handle = handle;
-    library->av_register_all = av_register_all;
     library->avcodec_descriptor_next = avcodec_descriptor_next;
     library->avcodec_find_decoder = avcodec_find_decoder;
     return NULL;

--- a/dev-packages/electron/native/src/win-ffmpeg.c
+++ b/dev-packages/electron/native/src/win-ffmpeg.c
@@ -35,14 +35,6 @@ char *load_ffmpeg_library(struct FFMPEG_Library *library, char *library_path)
         goto error;
     }
 
-    void (*av_register_all)(void) = (void (*)(void))
-        GetProcAddress(handle, "av_register_all");
-    if (!av_register_all)
-    {
-        error = error_function_not_found;
-        goto error;
-    }
-
     struct AVCodecDescriptor *(*av_codec_next)(const struct AVCodecDescriptor *) = (struct AVCodecDescriptor * (*)(const struct AVCodecDescriptor *))
         GetProcAddress(handle, "avcodec_descriptor_next");
     if (!av_codec_next)
@@ -60,7 +52,6 @@ char *load_ffmpeg_library(struct FFMPEG_Library *library, char *library_path)
     }
 
     library->handle = handle;
-    library->av_register_all = av_register_all;
     library->avcodec_descriptor_next = av_codec_next;
     library->avcodec_find_decoder = avcodec_find_decoder;
     return NULL;


### PR DESCRIPTION


<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

Fixes #6399

- Fixes failing Travis CI for Windows build due to the deprecated ffmpeg `av_register_all` property. The CI would fail due to not finding the function in the library.


#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

- Verify that CI successfully passes for each operating system (`Linux`, `macOS` and `Windows`)

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

Signed-off-by: Vincent Fugnitto <vincent.fugnitto@ericsson.com>

