### PR TITLE
GH-6432: Deprecated `getDefaultWorkspacePath`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - [cli] enable static compression of build artifacts [#6266](https://github.com/eclipse-theia/theia/pull/6266)
   - to disable pass `--no-static-compression` to `theia build` or `theia watch`.
+- [workspace] Deprecated `getDefaultWorkspacePath` on the `WorkspaceService` as the method name was misleading. Use `getDefaultWorkspaceUri` instead. [#6432](https://github.com/eclipse-theia/theia/issues/6432)
 
 Breaking changes:
 

--- a/packages/workspace/src/browser/workspace-service.ts
+++ b/packages/workspace/src/browser/workspace-service.ts
@@ -70,9 +70,9 @@ export class WorkspaceService implements FrontendApplicationContribution {
     @postConstruct()
     protected async init(): Promise<void> {
         this.applicationName = FrontendApplicationConfigProvider.get().applicationName;
-        const wpUriString = await this.getDefaultWorkspacePath();
-        const wpStat = await this.toFileStat(wpUriString);
-        await this.setWorkspace(wpStat);
+        const wsUriString = await this.getDefaultWorkspaceUri();
+        const wsStat = await this.toFileStat(wsUriString);
+        await this.setWorkspace(wsStat);
 
         this.watcher.onFilesChanged(event => {
             if (this._workspace && FileChangeEvent.isAffected(event, new URI(this._workspace.uri))) {
@@ -88,9 +88,16 @@ export class WorkspaceService implements FrontendApplicationContribution {
     }
 
     /**
-     * Get the path of the workspace to use initially.
+     * Resolves to the default workspace URI as string.
+     *
+     * The default implementation tries to extract the default workspace location
+     * from the `window.location.hash`, then falls-back to the most recently
+     * used workspace root from the server.
+     *
+     * It is not ensured that the resolved workspace URI is valid, it can point
+     * to a non-existing location.
      */
-    protected getDefaultWorkspacePath(): MaybePromise<string | undefined> {
+    protected getDefaultWorkspaceUri(): MaybePromise<string | undefined> {
         // Prefer the workspace path specified as the URL fragment, if present.
         if (window.location.hash.length > 1) {
             // Remove the leading # and decode the URI.
@@ -101,6 +108,14 @@ export class WorkspaceService implements FrontendApplicationContribution {
             // specified on the CLI, or the most recent).
             return this.server.getMostRecentlyUsedWorkspace();
         }
+    }
+
+    /**
+     * Get the path of the workspace to use initially.
+     * @deprecated use `WorkspaceService#getDefaultWorkspaceUri` instead.
+     */
+    protected getDefaultWorkspacePath(): MaybePromise<string | undefined> {
+        return this.getDefaultWorkspaceUri();
     }
 
     /**


### PR DESCRIPTION
Use `WorkspaceService#getDefaultWorkspaceUri` instead.

Closes #6432

Signed-off-by: Akos Kitta <kittaakos@typefox.io>

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

Deprecates `getDefaultWorkspacePath` on the `WorkspaceService` as the method name was misleading. Use `getDefaultWorkspaceUri` instead.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

Check the CI.

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

