### PR TITLE
Add additional prop to support spellcheck

### DIFF
--- a/packages/core/src/browser/dialogs.ts
+++ b/packages/core/src/browser/dialogs.ts
@@ -369,6 +369,7 @@ export class SingleTextInputDialogProps extends DialogProps {
         end: number
         direction?: 'forward' | 'backward' | 'none'
     };
+    readonly spellCheck?: boolean;
     readonly validate?: (input: string, mode: DialogMode) => MaybePromise<DialogError>;
 }
 
@@ -385,6 +386,7 @@ export class SingleTextInputDialog extends AbstractDialog<string> {
         this.inputField.type = 'text';
         this.inputField.setAttribute('style', 'flex: 0;');
         this.inputField.value = props.initialValue || '';
+        this.inputField.spellcheck = props.spellCheck !== undefined ? props.spellCheck : true;
         if (props.initialSelectionRange) {
             this.inputField.setSelectionRange(
                 props.initialSelectionRange.start,

--- a/packages/workspace/src/browser/workspace-commands.ts
+++ b/packages/workspace/src/browser/workspace-commands.ts
@@ -204,6 +204,7 @@ export class WorkspaceCommandContribution implements CommandContribution {
                     const dialog = new SingleTextInputDialog({
                         title: 'New File',
                         initialValue: vacantChildUri.path.base,
+                        spellCheck: false,
                         validate: name => this.validateFileName(name, parent, true)
                     });
 
@@ -226,6 +227,7 @@ export class WorkspaceCommandContribution implements CommandContribution {
                     const dialog = new SingleTextInputDialog({
                         title: 'New Folder',
                         initialValue: vacantChildUri.path.base,
+                        spellCheck: false,
                         validate: name => this.validateFileName(name, parent, true)
                     });
                     dialog.open().then(name => {
@@ -256,6 +258,7 @@ export class WorkspaceCommandContribution implements CommandContribution {
                                 start: 0,
                                 end: uri.path.name.length
                             },
+                            spellCheck: false,
                             validate: (name, mode) => {
                                 if (initialValue === name && mode === 'preview') {
                                     return false;


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

Fixes #6439

- added additional prop to `SingleTextInputDialogProps` in order to control the behavior of the spellcheck.
- updated the dialogs for `New File`, `New Folder` and `File Rename` to disable spellcheck.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

1. execute the command `New File`, and add random characters (ex: sdadadsasd) - the spellcheck should not display the red underline
2. repeat step 1 for both the `New Folder` and `Rename` commands.

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

Signed-off-by: vince-fugnitto <vincent.fugnitto@ericsson.com>

