### PR TITLE
[cli] add explicit 'yargs' dependency

### DIFF
--- a/dev-packages/cli/package.json
+++ b/dev-packages/cli/package.json
@@ -31,6 +31,7 @@
   },
   "dependencies": {
     "@theia/application-manager": "^0.11.0",
-    "@theia/application-package": "^0.11.0"
+    "@theia/application-package": "^0.11.0",
+    "yargs": "^11.1.0"
   }
 }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

Added explicit `yargs` dependency to `@theia/cli` under `dev-packages`. Fixes an issue where users/extenders cannot successfully use the `@theia/cli` package when working outside of the main repository monorepo.

Originally from @cortopy #6418.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)


Signed-off-by: vince-fugnitto <vincent.fugnitto@ericsson.com>
Co-authored-by: Juan Jimenez-Anca <cortopy@users.noreply.github.com>
