### PR TITLE
[monaco] Fix bad preference initialization

### DIFF
--- a/packages/monaco/src/browser/monaco-frontend-application-contribution.ts
+++ b/packages/monaco/src/browser/monaco-frontend-application-contribution.ts
@@ -35,8 +35,9 @@ export class MonacoFrontendApplicationContribution implements FrontendApplicatio
         }
         const registerLanguage = monaco.languages.register.bind(monaco.languages);
         monaco.languages.register = language => {
-            registerLanguage(language);
+            // first register override identifier, because monaco will immediately update already opened documents and then initialize with bad preferences.
             this.preferenceSchema.registerOverrideIdentifier(language.id);
+            registerLanguage(language);
         };
     }
 


### PR DESCRIPTION
first register override identifier, because monaco will immediately
update already  opened documents and then initialize with
bad preferences.

Fixes #6449

#### What it does
The plug-in initialization happens slightly after the editors have been created. 
When a new language is registered, monaco will update the options of matching editors immediately.
But our preferenceService doesn't know yet about the override identifier and returns a bad preference model (undefined values).

This change registers the override identifier first.

#### How to test
 - Run Theia with built-in VS Code extensions.
 - Open an editor and make sure minimaps are disabled.
 - now reload and see if the editor has a minimap (not with this fix).

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

