### PR TITLE
[electron] Added @theia/scm dependency explicitly

### DIFF
--- a/examples/electron/package.json
+++ b/examples/electron/package.json
@@ -46,6 +46,7 @@
     "@theia/preview": "^0.11.0",
     "@theia/process": "^0.11.0",
     "@theia/python": "^0.11.0",
+    "@theia/scm": "^0.11.0",
     "@theia/search-in-workspace": "^0.11.0",
     "@theia/task": "^0.11.0",
     "@theia/terminal": "^0.11.0",


### PR DESCRIPTION
Issue: #5387

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
For the sake of beginner friendliness, `theia` dependencies are mentioned explicitly even though they are imported via `treia/git`
This adds `theia/scm` explicitly to `package.json`

<!-- Include relevant issues and describe how they are addressed. -->

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)
