### PR TITLE
[travis] remove 'allow_failures' from config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -121,9 +121,6 @@ notifications:
     on_start: never
 jobs:
   fast_finish: true
-  allow_failures:
-    - os: osx
-    - os: windows
   include:
   - stage: test
     os: linux


### PR DESCRIPTION

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

Fixes #6468

- removes `allow_failures` from Travis CI.
- ensures that every operating system (`windows`, `osx`, and `linux`) must pass their respective CIs.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
- ensure that Travis CI is mandatory for every operating system.

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

Signed-off-by: Vincent Fugnitto <vincent.fugnitto@ericsson.com>

