### PR TITLE
Add terminal renderer option into terminal preferences

### DIFF
--- a/packages/terminal/src/browser/terminal-preferences.ts
+++ b/packages/terminal/src/browser/terminal-preferences.ts
@@ -68,7 +68,13 @@ export const TerminalConfigSchema: PreferenceSchema = {
         'terminal.integrated.scrollback': {
             description: 'Controls the maximum amount of lines the terminal keeps in its buffer.',
             type: 'number',
-            default: 1000,
+            default: 1000
+        },
+        'terminal.integrated.rendererType': {
+            description: 'Controls how the terminal is rendered.',
+            type: 'string',
+            enum: ['canvas', 'dom'],
+            default: 'canvas'
         }
     }
 };
@@ -83,9 +89,17 @@ export interface TerminalConfiguration {
     'terminal.integrated.letterSpacing': number
     'terminal.integrated.lineHeight': number,
     'terminal.integrated.scrollback': number,
+    'terminal.integrated.rendererType': TerminalRendererType
 }
 
 type FontWeight = 'normal' | 'bold' | '100' | '200' | '300' | '400' | '500' | '600' | '700' | '800' | '900';
+
+export type TerminalRendererType = 'canvas' | 'dom';
+export const DEFAULT_TERMINAL_RENDERER_TYPE = 'canvas';
+// tslint:disable-next-line:no-any
+export function isTerminalRendererType(arg: any): arg is TerminalRendererType {
+    return typeof arg === 'string' && (arg === 'canvas' || arg === 'dom');
+}
 
 export const TerminalPreferences = Symbol('TerminalPreferences');
 export type TerminalPreferences = PreferenceProxy<TerminalConfiguration>;


### PR DESCRIPTION
Signed-off-by: Mykola Morhun <mmorhun@redhat.com>

#### What it does
Adds a new `rendererType` option in terminal settings group.
The option changes the way of terminal renderer: `canvas` (default) or `dom`.
In case of invalid option value the default `canvas` renderer is used.

#### How to test
Change the renderer type, open a new terminal and select the terminal form developers tools in browser.