### PR TITLE
[scm] open 'diff-editors' with a single-click

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,10 @@
 
 ## v0.13.0
 
-Breaking changes:
+- [scm] added handling when opening diff-editors to respect preference `workbench.list.openMode` [#6481](https://github.com/eclipse-theia/theia/pull/6481)
 
+Breaking changes:
+- [core] renamed preference `list.openMode` to `workbench.list.openMode` [#6481](https://github.com/eclipse-theia/theia/pull/6481)
 - [task] changed `TaskSchemaUpdater.update()` from asynchronous to synchronous [#6483](https://github.com/eclipse-theia/theia/pull/6483)
 - [monaco] monaco prefix has been removed from commands [#5590](https://github.com/eclipse-theia/theia/pull/5590)
 

--- a/packages/core/src/browser/core-preferences.ts
+++ b/packages/core/src/browser/core-preferences.ts
@@ -20,7 +20,7 @@ import { createPreferenceProxy, PreferenceProxy, PreferenceService, PreferenceCo
 export const corePreferenceSchema: PreferenceSchema = {
     'type': 'object',
     properties: {
-        'list.openMode': {
+        'workbench.list.openMode': {
             type: 'string',
             enum: [
                 'singleClick',
@@ -50,7 +50,7 @@ export const corePreferenceSchema: PreferenceSchema = {
 
 export interface CoreConfiguration {
     'application.confirmExit': 'never' | 'ifRequired' | 'always';
-    'list.openMode': 'singleClick' | 'doubleClick';
+    'workbench.list.openMode': 'singleClick' | 'doubleClick';
     'workbench.commandPalette.history': number;
 }
 

--- a/packages/navigator/src/browser/navigator-widget.tsx
+++ b/packages/navigator/src/browser/navigator-widget.tsx
@@ -249,7 +249,7 @@ export class FileNavigatorWidget extends FileTreeWidget {
 
     protected handleClickEvent(node: TreeNode | undefined, event: React.MouseEvent<HTMLElement>): void {
         const modifierKeyCombined: boolean = isOSX ? (event.shiftKey || event.metaKey) : (event.shiftKey || event.ctrlKey);
-        if (!modifierKeyCombined && node && this.corePreferences['list.openMode'] === 'singleClick') {
+        if (!modifierKeyCombined && node && this.corePreferences['workbench.list.openMode'] === 'singleClick') {
             this.model.previewNode(node);
         }
         super.handleClickEvent(node, event);


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

Fixes #6479

- updated the opening of `diff-editors` through the `scm` widget to respect the preference `workbench.list.openMode`. The following preference describes two possible values `singleClick` and `doubleClick`. When `singleClick` is enabled, clicking the change in the `scm` widget opens the diff-editor directly while `doubleClick` preference requires two clicks.
- renamed the preference `list.openMode` to `workbench.list.openMode`.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

- start the application using a workspace under Git version control
- verify the behavior of opening diff-editor changes with the preference:
  - `"workbench.list.openMode": "singleClick"` - diff-editor is opened with one click
  - `"workbench.list.openMode": "doubleClick"` - diff-editor is opened with two clicks

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

Signed-off-by: vince-fugnitto <vincent.fugnitto@ericsson.com>
