### PR TITLE
Filter debug console outputs by severity

### DIFF
--- a/packages/console/src/browser/ansi-console-item.tsx
+++ b/packages/console/src/browser/ansi-console-item.tsx
@@ -15,9 +15,9 @@
  ********************************************************************************/
 
 import * as React from 'react';
-import { MessageType } from '@theia/core/lib/common';
 import { ConsoleItem } from './console-session';
 import { ansiToHtml } from 'anser';
+import { Severity } from '@theia/core/lib/common/severity';
 
 export class AnsiConsoleItem implements ConsoleItem {
 
@@ -25,7 +25,7 @@ export class AnsiConsoleItem implements ConsoleItem {
 
     constructor(
         public readonly content: string,
-        public readonly severity?: MessageType
+        public readonly severity?: Severity
     ) {
         this.htmlContent = ansiToHtml(this.content, {
             use_classes: true,

--- a/packages/console/src/browser/console-content-widget.tsx
+++ b/packages/console/src/browser/console-content-widget.tsx
@@ -16,11 +16,12 @@
 
 import { Message } from '@phosphor/messaging';
 import { interfaces, Container, injectable } from 'inversify';
-import { MenuPath, MessageType } from '@theia/core';
+import { MenuPath } from '@theia/core';
 import { TreeProps } from '@theia/core/lib/browser/tree';
 import { TreeSourceNode } from '@theia/core/lib/browser/source-tree';
 import { SourceTreeWidget, TreeElementNode } from '@theia/core/lib/browser/source-tree';
 import { ConsoleItem } from './console-session';
+import { Severity } from '@theia/core/lib/common/severity';
 
 @injectable()
 export class ConsoleContentWidget extends SourceTreeWidget {
@@ -73,16 +74,16 @@ export class ConsoleContentWidget extends SourceTreeWidget {
         return classNames;
     }
     protected toClassName(item: ConsoleItem): string | undefined {
-        if (item.severity === MessageType.Error) {
+        if (item.severity === Severity.Error) {
             return ConsoleItem.errorClassName;
         }
-        if (item.severity === MessageType.Warning) {
+        if (item.severity === Severity.Warning) {
             return ConsoleItem.warningClassName;
         }
-        if (item.severity === MessageType.Info) {
+        if (item.severity === Severity.Info) {
             return ConsoleItem.infoClassName;
         }
-        if (item.severity === MessageType.Log) {
+        if (item.severity === Severity.Log) {
             return ConsoleItem.logClassName;
         }
         return undefined;

--- a/packages/core/src/common/severity.ts
+++ b/packages/core/src/common/severity.ts
@@ -1,0 +1,96 @@
+/********************************************************************************
+ * Copyright (C) 2019 Ericsson and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { DiagnosticSeverity } from 'vscode-languageserver-types';
+
+export enum Severity {
+    Ignore = 0,
+    Error = 1,
+    Warning = 2,
+    Info = 3,
+    Log = 4
+}
+
+export namespace Severity {
+    const error = 'Errors';
+    const warning = 'Warnings';
+    const info = 'Info';
+    const log = 'Log';
+    const ignore = 'All';
+
+    export function fromValue(value: string | undefined): Severity {
+        value = value && value.toLowerCase();
+
+        if (!value) {
+            return Severity.Ignore;
+        }
+        if (['error', 'errors'].indexOf(value) !== -1) {
+            return Severity.Error;
+        }
+        if (['warn', 'warning', 'warnings'].indexOf(value) !== -1) {
+            return Severity.Warning;
+        }
+        if (value === 'info') {
+            return Severity.Info;
+        }
+        if (value === 'log') {
+            return Severity.Log;
+        }
+
+        return Severity.Ignore;
+    }
+
+    export function toDiagnosticSeverity(value: Severity): DiagnosticSeverity {
+        switch (value) {
+            case Severity.Ignore:
+                return DiagnosticSeverity.Hint;
+            case Severity.Info:
+                return DiagnosticSeverity.Information;
+            case Severity.Log:
+                return DiagnosticSeverity.Information;
+            case Severity.Warning:
+                return DiagnosticSeverity.Warning;
+            case Severity.Error:
+                return DiagnosticSeverity.Error;
+            default:
+                return DiagnosticSeverity.Error;
+        }
+    }
+
+    export function toString(severity: Severity | undefined): string {
+        switch (severity) {
+            case Severity.Error:
+                return error;
+            case Severity.Warning:
+                return warning;
+            case Severity.Info:
+                return info;
+            case Severity.Log:
+                return log;
+            default:
+                return ignore;
+        }
+    }
+
+    export function toArray(): string[] {
+        return [ignore, error, warning, info, log];
+    }
+}

--- a/packages/debug/src/browser/console/debug-console-items.tsx
+++ b/packages/debug/src/browser/console/debug-console-items.tsx
@@ -16,10 +16,10 @@
 
 import * as React from 'react';
 import { DebugProtocol } from 'vscode-debugprotocol/lib/debugProtocol';
-import { MessageType } from '@theia/core/lib/common';
 import { SingleTextInputDialog } from '@theia/core/lib/browser';
 import { ConsoleItem, CompositeConsoleItem } from '@theia/console/lib/browser/console-session';
 import { DebugSession } from '../debug-session';
+import { Severity } from '@theia/core/lib/common/severity';
 
 export class ExpressionContainer implements CompositeConsoleItem {
 
@@ -104,7 +104,7 @@ export class ExpressionContainer implements CompositeConsoleItem {
             }
         } catch (e) {
             result.push({
-                severity: MessageType.Error,
+                severity: Severity.Error,
                 visible: !!e.message,
                 render: () => e.message
             });
@@ -256,6 +256,7 @@ export namespace VirtualVariableItem {
 
 export class ExpressionItem extends ExpressionContainer {
 
+    severity?: Severity;
     static notAvailable = 'not available';
 
     protected _value = ExpressionItem.notAvailable;
@@ -299,14 +300,17 @@ export class ExpressionItem extends ExpressionContainer {
                     this.namedVariables = body.namedVariables;
                     this.indexedVariables = body.indexedVariables;
                     this.elements = undefined;
+                    this.severity = Severity.Log;
                 }
             } catch (err) {
                 this._value = err.message;
                 this._available = false;
+                this.severity = Severity.Error;
             }
         } else {
             this._value = 'Please start a debug session to evaluate';
             this._available = false;
+            this.severity = Severity.Error;
         }
     }
 

--- a/packages/task/src/browser/task-problem-matcher-registry.ts
+++ b/packages/task/src/browser/task-problem-matcher-registry.ts
@@ -23,10 +23,11 @@ import { inject, injectable, postConstruct } from 'inversify';
 import { Event, Emitter } from '@theia/core/lib/common';
 import { Disposable, DisposableCollection } from '@theia/core/lib/common/disposable';
 import {
-    ApplyToKind, FileLocationKind, NamedProblemMatcher, Severity,
+    ApplyToKind, FileLocationKind, NamedProblemMatcher,
     ProblemPattern, ProblemMatcher, ProblemMatcherContribution, WatchingMatcher
 } from '../common';
 import { ProblemPatternRegistry } from './task-problem-pattern-registry';
+import { Severity } from '@theia/core/lib/common/severity';
 
 @injectable()
 export class ProblemMatcherRegistry {

--- a/packages/task/src/common/problem-matcher-protocol.ts
+++ b/packages/task/src/common/problem-matcher-protocol.ts
@@ -21,7 +21,8 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { Diagnostic, DiagnosticSeverity } from 'vscode-languageserver-types';
+import { Severity } from '@theia/core/lib/common/severity';
+import { Diagnostic } from 'vscode-languageserver-types';
 import vscodeURI from 'vscode-uri/lib/umd';
 import { ProblemPatternContribution, WatchingMatcherContribution } from './task-protocol';
 
@@ -62,56 +63,6 @@ export namespace FileLocationKind {
             return FileLocationKind.Relative;
         } else {
             return undefined;
-        }
-    }
-}
-
-export enum Severity {
-    Ignore = 0,
-    Info = 1,
-    Warning = 2,
-    Error = 3
-}
-
-export namespace Severity {
-
-    const _error = 'error';
-    const _warning = 'warning';
-    const _warn = 'warn';
-    const _info = 'info';
-
-    // Parses 'error', 'warning', 'warn', 'info' in call casings and falls back to ignore.
-    export function fromValue(value: string | undefined): Severity {
-        if (!value) {
-            return Severity.Ignore;
-        }
-
-        if (value.toLowerCase() === _error) {
-            return Severity.Error;
-        }
-
-        if (value.toLowerCase() === _warning || value.toLowerCase() === _warn) {
-            return Severity.Warning;
-        }
-
-        if (value.toLowerCase() === _info) {
-            return Severity.Info;
-        }
-        return Severity.Ignore;
-    }
-
-    export function toDiagnosticSeverity(value: Severity): DiagnosticSeverity {
-        switch (value) {
-            case Severity.Ignore:
-                return DiagnosticSeverity.Hint;
-            case Severity.Info:
-                return DiagnosticSeverity.Information;
-            case Severity.Warning:
-                return DiagnosticSeverity.Warning;
-            case Severity.Error:
-                return DiagnosticSeverity.Error;
-            default:
-                return DiagnosticSeverity.Error;
         }
     }
 }

--- a/packages/task/src/node/task-abstract-line-matcher.ts
+++ b/packages/task/src/node/task-abstract-line-matcher.ts
@@ -23,10 +23,11 @@ import { isWindows } from '@theia/core/lib/common/os';
 import { Diagnostic, DiagnosticSeverity, Range } from 'vscode-languageserver-types';
 import {
     FileLocationKind, ProblemMatcher, ProblemPattern,
-    ProblemMatch, ProblemMatchData, ProblemLocationKind, Severity
+    ProblemMatch, ProblemMatchData, ProblemLocationKind
 } from '../common/problem-matcher-protocol';
 import URI from '@theia/core/lib/common/uri';
 import vscodeURI from 'vscode-uri/lib/umd';
+import { Severity } from '@theia/core/lib/common/severity';
 
 const endOfLine: string = isWindows ? '\r\n' : '\n';
 

--- a/packages/task/src/node/task-problem-collector.spec.ts
+++ b/packages/task/src/node/task-problem-collector.spec.ts
@@ -17,7 +17,8 @@
 import { expect } from 'chai';
 import { DiagnosticSeverity } from 'vscode-languageserver-types';
 import { ProblemCollector } from './task-problem-collector';
-import { ApplyToKind, FileLocationKind, ProblemLocationKind, ProblemMatch, ProblemMatchData, ProblemMatcher, Severity } from '../common/problem-matcher-protocol';
+import { ApplyToKind, FileLocationKind, ProblemLocationKind, ProblemMatch, ProblemMatchData, ProblemMatcher } from '../common/problem-matcher-protocol';
+import { Severity } from '@theia/core/lib/common/severity';
 
 const startStopMatcher1: ProblemMatcher = {
     owner: 'test1',


### PR DESCRIPTION
Signed-off-by: Anatoliy Bazko <abazko@redhat.com>

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

### Reference issue
https://github.com/eclipse-theia/theia/issues/6067

#### What it does
It supports filtering in debug console by severity.

#### How to test
1. Add some sample.
2. Add debug configuration and launch it
3. Go into debug console and try to filter output.
4. Close/Open debug console, recheck `#3`

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)


![screencast-localhost_3000-2019 11 04-11_09_12](https://user-images.githubusercontent.com/1640675/68111513-f0181c80-fef7-11e9-9688-d1e08f532367.gif)
