### PR TITLE
Add ability to configure borders in quick pick items list on plugin side

### DIFF
--- a/packages/plugin-ext/src/common/plugin-api-rpc.ts
+++ b/packages/plugin-ext/src/common/plugin-api-rpc.ts
@@ -286,6 +286,8 @@ export interface PickOpenItem {
     description?: string;
     detail?: string;
     picked?: boolean;
+    groupLabel?: string;
+    showBorder?: boolean;
 }
 
 export enum MainMessageType {

--- a/packages/plugin-ext/src/plugin/type-converters.ts
+++ b/packages/plugin-ext/src/plugin/type-converters.ts
@@ -954,17 +954,22 @@ export function quickPickItemToPickOpenItem(items: Item[]): PickOpenItem[] {
         let description: string | undefined;
         let detail: string | undefined;
         let picked: boolean | undefined;
+        let groupLabel: string | undefined;
+        let showBorder: boolean | undefined;
         if (typeof item === 'string') {
             label = item;
         } else {
-            ({ label, description, detail, picked } = item);
+            ({ label, description, detail, picked, groupLabel, showBorder } = item);
         }
+
         pickItems.push({
             label,
             description,
             handle,
             detail,
-            picked
+            picked,
+            groupLabel,
+            showBorder
         });
     }
     return pickItems;

--- a/packages/plugin/src/theia.d.ts
+++ b/packages/plugin/src/theia.d.ts
@@ -1991,6 +1991,16 @@ declare module '@theia/plugin' {
          * not implemented yet
          */
         picked?: boolean;
+
+        /**
+         * Used to display the group label in the right corner of item
+         */
+        groupLabel?: string;
+
+        /**
+         * Used to display border after item
+         */
+        showBorder?: boolean;
     }
 
     /**


### PR DESCRIPTION
#### What it does
This changes proposal adds ability to create quick open item configured with border and group label used in plugins.

When new terminal opens _(mechanism used to create quick open items in extension)_: 
<img width="873" alt="Снимок экрана 2019-11-04 в 14 34 23" src="https://user-images.githubusercontent.com/1968177/68121764-3f1e7b80-ff11-11e9-9d89-38a8cd013e44.png">

When new task starts _(mechanism used to create quick open items in plugin)_:
<img width="848" alt="Снимок экрана 2019-11-04 в 14 34 41" src="https://user-images.githubusercontent.com/1968177/68121773-45145c80-ff11-11e9-8ea2-1d34d172645b.png">

Signed-off-by: Vlad Zhukovskyi <vzhukovs@redhat.com>

#### How to test
Devfile to test changes: https://gist.github.com/vzhukovskii/23b275d18af208629648430df251a78e/raw/6451e1d0589cb435bf58208d560fb8006e338cd8/che-dev-workspace.yaml

Steps to test changes manually:
* clone `che-theia` and `theia`
* checkout to `quick_pick_items_ext` in `che-theia` and `theia` repo
* build `che-theia`, then go to dockerfile/theia and build docker image: `./build.sh --build-args:GITHUB_TOKEN=${GITHUB_TOKEN},THEIA_VERSION=master --tag:next --branch:quick_pick_items_ext --git-ref:refs\\/heads\\/quick_pick_items_ext --skip-tests`
* use built docker image `eclipse/che-theia:next` as image for the main editor in che.

Need for: https://github.com/eclipse/che/issues/13390
Linked Che-Theia PR: https://github.com/eclipse/che-theia/pull/532

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

