### PR TITLE
[debug] automatically create 'launch.json'

### DIFF
--- a/packages/debug/src/browser/debug-frontend-application-contribution.ts
+++ b/packages/debug/src/browser/debug-frontend-application-contribution.ts
@@ -42,6 +42,7 @@ import { DebugService } from '../common/debug-service';
 import { DebugSchemaUpdater } from './debug-schema-updater';
 import { DebugPreferences } from './debug-preferences';
 import { TabBarToolbarContribution, TabBarToolbarRegistry, TabBarToolbarItem } from '@theia/core/lib/browser/shell/tab-bar-toolbar';
+import { DebugSessionOptions } from './debug-session-options';
 
 export namespace DebugMenus {
     export const DEBUG = [...MAIN_MENU_BAR, '6_debug'];
@@ -512,10 +513,10 @@ export class DebugFrontendApplicationContribution extends AbstractViewContributi
     registerCommands(registry: CommandRegistry): void {
         super.registerCommands(registry);
         registry.registerCommand(DebugCommands.START, {
-            execute: () => this.start()
+            execute: (config?: DebugSessionOptions) => this.start(false, config)
         });
         registry.registerCommand(DebugCommands.START_NO_DEBUG, {
-            execute: () => this.start(true)
+            execute: (config?: DebugSessionOptions) => this.start(true, config)
         });
         registry.registerCommand(DebugCommands.STOP, {
             execute: () => this.manager.currentSession && this.manager.currentSession.terminate(),
@@ -945,8 +946,13 @@ export class DebugFrontendApplicationContribution extends AbstractViewContributi
         return widget;
     }
 
-    async start(noDebug?: boolean): Promise<void> {
-        let { current } = this.configurations;
+    async start(noDebug?: boolean, debugSessionOptions?: DebugSessionOptions): Promise<void> {
+        let current = debugSessionOptions ? debugSessionOptions : this.configurations.current;
+        // If no configurations are currently present, create the `launch.json` and prompt users to select the config.
+        if (!current) {
+            await this.configurations.addConfiguration();
+            return;
+        }
         if (current) {
             if (noDebug !== undefined) {
                 current = {

--- a/packages/debug/src/browser/view/debug-configuration-widget.tsx
+++ b/packages/debug/src/browser/view/debug-configuration-widget.tsx
@@ -26,9 +26,14 @@ import { DebugSessionManager } from '../debug-session-manager';
 import { DebugAction } from './debug-action';
 import { DebugViewModel } from './debug-view-model';
 import { DebugSessionOptions } from '../debug-session-options';
+import { DebugCommands } from '../debug-frontend-application-contribution';
+import { CommandRegistry } from '@theia/core/lib/common';
 
 @injectable()
 export class DebugConfigurationWidget extends ReactWidget {
+
+    @inject(CommandRegistry)
+    protected readonly commandRegistry: CommandRegistry;
 
     @inject(DebugViewModel)
     protected readonly viewModel: DebugViewModel;
@@ -118,11 +123,7 @@ export class DebugConfigurationWidget extends ReactWidget {
 
     protected readonly start = () => {
         const configuration = this.manager.current;
-        if (configuration) {
-            this.sessionManager.start(configuration);
-        } else {
-            this.manager.addConfiguration();
-        }
+        this.commandRegistry.executeCommand(DebugCommands.START.id, configuration);
     }
 
     protected readonly openConfiguration = () => this.manager.openConfiguration();


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

Currently, when attempting to execute the command `Start Debugging` without a `launch.json` present under `.theia` or `.vscode` nothing occurs. The change ensures that if no configurations are found, the `launch.json` is automatically created and users are then prompted to select their debug configuration type template.

Additional steps will need to be done in the future to prompt the quick-open described in #6489.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

1. start the application with a workspace that currently does not have a `.launch.json`
2. attempt to execute the command `Start Debugging`
3. the command will automatically create the `launch.json` if not present, and will prompt users in the editor to select the type of config
4. the same scenario should work with a `launch.json` except the debugging should begin

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

Signed-off-by: Vincent Fugnitto <vincent.fugnitto@ericsson.com>

