### PR TITLE
update task schema for installed extensions & plugins

### DIFF
--- a/packages/cpp/src/browser/cpp-task-provider.ts
+++ b/packages/cpp/src/browser/cpp-task-provider.ts
@@ -174,7 +174,16 @@ export class CppTaskProvider implements TaskContribution, TaskProvider, TaskReso
             source: 'cpp',
             properties: {
                 required: ['label'],
-                all: ['label']
+                all: ['label'],
+                schema: {
+                    type: CPP_BUILD_TASK_TYPE_KEY,
+                    required: ['label'],
+                    properties: {
+                        label: {
+                            type: 'string'
+                        }
+                    }
+                }
             }
         });
     }

--- a/packages/plugin-ext/src/hosted/node/scanners/scanner-theia.ts
+++ b/packages/plugin-ext/src/hosted/node/scanners/scanner-theia.ts
@@ -450,7 +450,8 @@ export class TheiaPluginScanner implements PluginScanner {
             source: pluginName,
             properties: {
                 required: definitionContribution.required,
-                all: propertyKeys
+                all: propertyKeys,
+                schema: definitionContribution
             }
         };
     }

--- a/packages/task/src/browser/task-definition-registry.spec.ts
+++ b/packages/task/src/browser/task-definition-registry.spec.ts
@@ -26,7 +26,15 @@ describe('TaskDefinitionRegistry', () => {
         required: ['extensionType'],
         properties: {
             required: ['extensionType'],
-            all: ['extensionType', 'taskLabel']
+            all: ['extensionType', 'taskLabel'],
+            schema: {
+                type: 'extA',
+                required: ['extensionType'],
+                properties: {
+                    extensionType: {},
+                    taskLabel: {}
+                }
+            }
         }
     };
     const definitonContributionB = {
@@ -34,7 +42,16 @@ describe('TaskDefinitionRegistry', () => {
         source: 'extA',
         properties: {
             required: ['extensionType', 'taskLabel', 'taskDetailedLabel'],
-            all: ['extensionType', 'taskLabel', 'taskDetailedLabel']
+            all: ['extensionType', 'taskLabel', 'taskDetailedLabel'],
+            schema: {
+                type: 'extA',
+                required: ['extensionType', 'taskLabel', 'taskDetailedLabel'],
+                properties: {
+                    extensionType: {},
+                    taskLabel: {},
+                    taskDetailedLabel: {}
+                }
+            }
         }
     };
 

--- a/packages/task/src/common/task-protocol.ts
+++ b/packages/task/src/common/task-protocol.ts
@@ -15,6 +15,7 @@
  ********************************************************************************/
 
 import { JsonRpcServer } from '@theia/core/lib/common/messaging/proxy-factory';
+import { IJSONSchema } from '@theia/core/lib/common/json-schema';
 import { ProblemMatcher, ProblemMatch, WatchingPattern } from './problem-matcher-protocol';
 
 export const taskPath = '/services/task';
@@ -133,6 +134,7 @@ export interface TaskDefinition {
     properties: {
         required: string[];
         all: string[];
+        schema: IJSONSchema;
     }
 }
 


### PR DESCRIPTION
- With this change, Theia processes task definitions contributed by extensions and plugins, and updates the task schema.
- resolves #6485

Signed-off-by: Liang Huang <liang.huang@ericsson.com>

#### How to test

- Install vscode extensions that make contributions to the task definitions. Here are a few candidates: npm, grunt, typescript-language-features, jake, & gulp.
- Open tasks.json file.
- Start to manually enter a new configuration, and check the information from the content assist.

![Peek 2019-11-04 21-33](https://user-images.githubusercontent.com/37082801/68174099-da801280-ff4a-11e9-97f1-fc137bec9239.gif)


#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)
