### PR TITLE
Support integrated terminal

### DIFF
--- a/packages/debug/src/browser/debug-session.tsx
+++ b/packages/debug/src/browser/debug-session.tsx
@@ -36,7 +36,7 @@ import { DebugSessionOptions, InternalDebugSessionOptions } from './debug-sessio
 import { DebugConfiguration } from '../common/debug-common';
 import { SourceBreakpoint } from './breakpoint/breakpoint-marker';
 import { FileSystem } from '@theia/filesystem/lib/common';
-import { TerminalWidgetOptions } from '@theia/terminal/lib/browser/base/terminal-widget';
+import { TerminalWidgetOptions, TerminalWidget } from '@theia/terminal/lib/browser/base/terminal-widget';
 
 export enum DebugState {
     Inactive,
@@ -368,14 +368,19 @@ export class DebugSession implements CompositeTreeElement {
     }
 
     protected async runInTerminal({ arguments: { title, cwd, args, env } }: DebugProtocol.RunInTerminalRequest): Promise<DebugProtocol.RunInTerminalResponse['body']> {
-        return this.doRunInTerminal({ title, cwd, shellPath: args[0], shellArgs: args.slice(1), env });
+        const terminal = await this.doCreateTerminal({ title, cwd, env });
+        terminal.sendText(args.join(' ') + '\n');
+        return { processId: await terminal.processId };
     }
 
-    protected async doRunInTerminal(options: TerminalWidgetOptions): Promise<DebugProtocol.RunInTerminalResponse['body']> {
-        const terminal = await this.terminalServer.newTerminal(options);
-        this.terminalServer.activateTerminal(terminal);
-        const processId = await terminal.start();
-        return { processId };
+    protected async doCreateTerminal(options: TerminalWidgetOptions): Promise<TerminalWidget> {
+        let terminal = this.terminalServer.all.find(t => t.title.label === options.title);
+        if (!terminal) {
+            terminal = await this.terminalServer.newTerminal(options);
+            await terminal.start();
+        }
+        this.terminalServer.open(terminal);
+        return terminal;
     }
 
     protected clearThreads(): void {

--- a/packages/plugin-ext/src/main/browser/debug/plugin-debug-session-factory.ts
+++ b/packages/plugin-ext/src/main/browser/debug/plugin-debug-session-factory.ts
@@ -27,8 +27,7 @@ import { DebugSession } from '@theia/debug/lib/browser/debug-session';
 import { DebugSessionConnection } from '@theia/debug/lib/browser/debug-session-connection';
 import { IWebSocket } from 'vscode-ws-jsonrpc/lib/socket/socket';
 import { FileSystem } from '@theia/filesystem/lib/common';
-import { DebugProtocol } from 'vscode-debugprotocol';
-import { TerminalWidgetOptions } from '@theia/terminal/lib/browser/base/terminal-widget';
+import { TerminalWidgetOptions, TerminalWidget } from '@theia/terminal/lib/browser/base/terminal-widget';
 import { TerminalOptionsExt } from '../../../common/plugin-api-rpc';
 
 export class PluginDebugSession extends DebugSession {
@@ -46,9 +45,9 @@ export class PluginDebugSession extends DebugSession {
         super(id, options, connection, terminalServer, editorManager, breakpoints, labelProvider, messages, fileSystem);
     }
 
-    protected async doRunInTerminal(terminalWidgetOptions: TerminalWidgetOptions): Promise<DebugProtocol.RunInTerminalResponse['body']> {
+    protected async doCreateTerminal(terminalWidgetOptions: TerminalWidgetOptions): Promise<TerminalWidget> {
         terminalWidgetOptions = Object.assign({}, terminalWidgetOptions, this.terminalOptionsExt);
-        return super.doRunInTerminal(terminalWidgetOptions);
+        return super.doCreateTerminal(terminalWidgetOptions);
     }
 }
 


### PR DESCRIPTION
Signed-off-by: Anatoliy Bazko <abazko@redhat.com>

### Reference issue
https://github.com/eclipse-theia/theia/issues/6103

#### What it does
It creates terminal in a proper way.

#### How to test
1. Add VS Code Python extension https://github.com/Microsoft/vscode-python/releases/download/2019.5.18875/ms-python-release.vsix
2. Open any python file
3. Add debug configuration
```json
{
            "name": "Python: Current File",
            "type": "python",
            "request": "launch",
            "program": "${file}",
            "console": "integratedTerminal"
        }
```
4. Add some breakponits
5. Start debugging
6. Check that console is opened and all debug features work well


#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

