### PR TITLE
Catch schema change event in order to have actual representation of user preferences

### DIFF
--- a/packages/preferences/src/browser/preferences-tree-widget.ts
+++ b/packages/preferences/src/browser/preferences-tree-widget.ts
@@ -443,7 +443,7 @@ export class PreferencesTreeWidget extends TreeWidget {
 
     private activeFolderUri: string | undefined;
     private preferencesGroupNames = new Set<string>();
-    private readonly properties: { [name: string]: PreferenceDataProperty };
+    private properties: { [name: string]: PreferenceDataProperty };
     private readonly onPreferenceSelectedEmitter: Emitter<{ [key: string]: string }>;
     readonly onPreferenceSelected: Event<{ [key: string]: string }>;
 
@@ -468,17 +468,6 @@ export class PreferencesTreeWidget extends TreeWidget {
         this.toDispose.push(this.onPreferenceSelectedEmitter);
 
         this.id = PreferencesTreeWidget.ID;
-
-        this.properties = this.preferenceSchemaProvider.getCombinedSchema().properties;
-        for (const property in this.properties) {
-            if (property) {
-                // Compute preference group name and accept those which have the proper format.
-                const group: string = property.substring(0, property.indexOf('.'));
-                if (property.split('.').length > 1) {
-                    this.preferencesGroupNames.add(group);
-                }
-            }
-        }
     }
 
     dispose(): void {
@@ -488,6 +477,9 @@ export class PreferencesTreeWidget extends TreeWidget {
 
     protected onAfterAttach(msg: Message): void {
         this.initializeModel();
+        this.toDisposeOnDetach.push(this.preferenceSchemaProvider.onDidPreferenceSchemaChanged(() => {
+            this.initializeModel();
+        }));
         super.onAfterAttach(msg);
     }
 
@@ -538,6 +530,17 @@ export class PreferencesTreeWidget extends TreeWidget {
     }
 
     protected initializeModel(): void {
+        this.properties = this.preferenceSchemaProvider.getCombinedSchema().properties;
+        for (const property in this.properties) {
+            if (property) {
+                // Compute preference group name and accept those which have the proper format.
+                const group: string = property.substring(0, property.indexOf('.'));
+                if (property.split('.').length > 1) {
+                    this.preferencesGroupNames.add(group);
+                }
+            }
+        }
+
         type GroupNode = SelectableTreeNode & ExpandableTreeNode;
         const preferencesGroups: GroupNode[] = [];
         const nodes: { [id: string]: PreferenceDataProperty }[] = [];


### PR DESCRIPTION
#### What it does
This changes proposal fixes the problem, when user preference tree wasn't respect preference schema change event. The problem was in initializer [code fragment](https://github.com/eclipse-theia/theia/blob/master/packages/preferences/src/browser/preferences-tree-widget.ts#L472-L481) that collect combined preference scheme during tree create. Here is a sample of plugin, that has [definition](https://github.com/eclipse/che-theia/blob/master/plugins/welcome-plugin/package.json#L17-L29) of preference in package.json. The flow of representing problem. HostedPluginSupport [initialize](https://github.com/eclipse-theia/theia/blob/master/packages/plugin-ext/src/hosted/browser/hosted-plugin.ts#L168) and calls [load](https://github.com/eclipse-theia/theia/blob/master/packages/plugin-ext/src/hosted/browser/hosted-plugin.ts#L174) function  and then [doLoad](https://github.com/eclipse-theia/theia/blob/master/packages/plugin-ext/src/hosted/browser/hosted-plugin.ts#L182) where [loads contribution](https://github.com/eclipse-theia/theia/blob/master/packages/plugin-ext/src/hosted/browser/hosted-plugin.ts#L198) and [handle it](https://github.com/eclipse-theia/theia/blob/master/packages/plugin-ext/src/hosted/browser/hosted-plugin.ts#L272), calling this [function](https://github.com/eclipse-theia/theia/blob/master/packages/plugin-ext/src/main/browser/plugin-contribution-handler.ts#L94). Then it [takes](https://github.com/eclipse-theia/theia/blob/master/packages/plugin-ext/src/main/browser/plugin-contribution-handler.ts#L108-L113) contribution configuration and operates with scheme, [setting it up](https://github.com/eclipse-theia/theia/blob/master/packages/plugin-ext/src/main/browser/plugin-contribution-handler.ts#L331) into preference provider where [preference changed event fires](https://github.com/eclipse-theia/theia/blob/master/packages/core/src/browser/preferences/preference-contribution.ts#L259) and nothing appears. So there is a reason to subscribe preference tree listen to [this kind of event](https://github.com/eclipse-theia/theia/compare/user_preferences#diff-babf136e87e3791f9dd8560dbc828e21R472-R474) to be able to update the representation of preference tree when schema changes.

There is a linked issue for this problem: https://github.com/eclipse/che/issues/15001

Signed-off-by: Vladyslav Zhukovskyi <vzhukovs@redhat.com>

#### How to test
Clone [this](https://github.com/vzhukovskii/test-plugin) sample plugin, build it and place in `theia/plugin` directory and start theia. In master branch there is a problem, when user refreshes the page where opened preference editor and after refresh configuration from the custom contribution disappears.

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

