### PR TITLE
update decorations when clearing search fix #6498

### DIFF
--- a/packages/search-in-workspace/src/browser/search-in-workspace-result-tree-widget.tsx
+++ b/packages/search-in-workspace/src/browser/search-in-workspace-result-tree-widget.tsx
@@ -315,9 +315,13 @@ export class SearchInWorkspaceResultTreeWidget extends TreeWidget {
             if (currentTitle && currentTitle.owner instanceof EditorWidget) {
                 const widget = currentTitle.owner;
                 const fileNodes = this.getFileNodesByUri(widget.editor.uri);
-                fileNodes.forEach(node => {
-                    this.decorateEditor(node, widget);
-                });
+                if (fileNodes.length > 0) {
+                    fileNodes.forEach(node => {
+                        this.decorateEditor(node, widget);
+                    });
+                } else {
+                    this.decorateEditor(undefined, widget);
+                }
             }
         });
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
This fixes the issue #6498 describing that the decorations in Theia still highlight the last search result when clicking 'Clear Search Results' or clearing the search input manually.

#### How to test
- Open a workspace
- Press Ctrl + Shift + F
- Search for anything
- Click on a file in the result tree
- Press 'Clear Search Results' or clear search input completely 

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

