### PR TITLE
[core] Update reconnecting-websocket to latest version

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -37,7 +37,7 @@
     "react": "^16.4.1",
     "react-dom": "^16.4.1",
     "react-virtualized": "^9.20.0",
-    "reconnecting-websocket": "^3.0.7",
+    "reconnecting-websocket": "^4.2.0",
     "reflect-metadata": "^0.1.10",
     "route-parser": "^0.0.5",
     "vscode-languageserver-types": "^3.15.0-next",

--- a/packages/core/src/browser/messaging/ws-connection-provider.ts
+++ b/packages/core/src/browser/messaging/ws-connection-provider.ts
@@ -19,7 +19,7 @@ import { createWebSocketConnection, Logger, ConsoleLogger } from 'vscode-ws-json
 import { ConnectionHandler, JsonRpcProxyFactory, JsonRpcProxy, Emitter, Event } from '../../common';
 import { WebSocketChannel } from '../../common/messaging/web-socket-channel';
 import { Endpoint } from '../endpoint';
-const ReconnectingWebSocket = require('reconnecting-websocket');
+import ReconnectingWebSocket from 'reconnecting-websocket';
 
 decorate(injectable(), JsonRpcProxyFactory);
 decorate(unmanaged(), JsonRpcProxyFactory, 0);
@@ -52,7 +52,7 @@ export class WebSocketConnectionProvider {
     }
 
     protected channelIdSeq = 0;
-    protected readonly socket: WebSocket;
+    protected readonly socket: ReconnectingWebSocket;
     protected readonly channels = new Map<number, WebSocketChannel>();
 
     protected readonly onIncomingMessageActivityEmitter: Emitter<void> = new Emitter();
@@ -166,7 +166,7 @@ export class WebSocketConnectionProvider {
     /**
      * Creates a web socket for the given url
      */
-    protected createWebSocket(url: string): WebSocket {
+    protected createWebSocket(url: string): ReconnectingWebSocket {
         return new ReconnectingWebSocket(url, undefined, {
             maxReconnectionDelay: 10000,
             minReconnectionDelay: 1000,

--- a/yarn.lock
+++ b/yarn.lock
@@ -9209,9 +9209,10 @@ rechoir@^0.6.2:
   dependencies:
     resolve "^1.1.6"
 
-reconnecting-websocket@^3.0.7:
-  version "3.2.2"
-  resolved "https://registry.yarnpkg.com/reconnecting-websocket/-/reconnecting-websocket-3.2.2.tgz#8097514e926e9855e03c39e76efa2e3d1f371bee"
+reconnecting-websocket@^4.2.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/reconnecting-websocket/-/reconnecting-websocket-4.2.0.tgz#2395f84b5d0acee439ff5df34c3fd0853d11be7c"
+  integrity sha512-HMD8A0sv40xhkHf/T4qxktyOvHx7K3d2A9i1QG2wRIYdMecxQJMhTIBH4aQ8KfQLfQW4UOqNSfxTgv0C+MbPIA==
 
 redent@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
#### What it does
Updates the `reconnecting-websocket` library to its latest version.

The newer version was reimplemented in TypeScript and has a lot of fixes.
For instance, before the initial connection would always be delayed by the reconnection delay.


#### How to test

Just test if everything still works. :-)

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

