### PR TITLE
[core] fix display of toolbar item icons

### DIFF
--- a/packages/core/src/browser/style/tabs.css
+++ b/packages/core/src/browser/style/tabs.css
@@ -290,3 +290,19 @@
     background-repeat: no-repeat;
     line-height: 18px;
 }
+
+.p-TabBar-toolbar .item .collapse-all {
+  background: var(--theia-icon-collapse-all) no-repeat;
+}
+
+.p-TabBar-toolbar .item .close {
+  background: var(--theia-icon-collapse-all) no-repeat;
+}
+
+.p-TabBar-toolbar .item .clear-all {
+  background: var(--theia-icon-clear) no-repeat;
+}
+
+.p-TabBar-toolbar .item .refresh {
+  background: var(--theia-icon-refresh) no-repeat;
+}

--- a/packages/search-in-workspace/src/browser/styles/index.css
+++ b/packages/search-in-workspace/src/browser/styles/index.css
@@ -65,18 +65,6 @@
     margin-bottom: 5px;
 }
 
-.p-TabBar-toolbar .item .refresh {
-    background: var(--theia-icon-refresh) no-repeat;
-}
-
-.p-TabBar-toolbar .item .collapse-all {
-    background: var(--theia-icon-collapse-all) no-repeat;
-}
-
-.p-TabBar-toolbar .item .clear-all {
-    background: var(--theia-icon-clear) no-repeat;
-}
-
 .t-siw-search-container .searchHeader .search-field-container {
     background: var(--theia-layout-color2);
     border-style: solid;


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

Fixes #6513

- fixes the display of toolbar item icons when applications are created
with a subset of available extensions. The common icons are added to core
for others to use.

The following limited example application was used during testing:

<details>
<summary>package.json</summary>

```json
{
  "private": true,
  "name": "@theia/example-browser",
  "version": "0.12.0",
  "license": "EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0",
  "theia": {
    "frontend": {
      "config": {
        "applicationName": "Theia Browser Example",
        "preferences": {
          "files.enableTrash": false
        }
      }
    }
  },
  "dependencies": {
    "@theia/console": "^0.12.0",
    "@theia/core": "^0.12.0",
    "@theia/debug": "^0.12.0",
    "@theia/editor": "^0.12.0",
    "@theia/filesystem": "^0.12.0",
    "@theia/getting-started": "^0.12.0",
    "@theia/keymaps": "^0.12.0",
    "@theia/languages": "^0.12.0",
    "@theia/monaco": "^0.12.0",
    "@theia/navigator": "^0.12.0",
    "@theia/outline-view": "^0.12.0",
    "@theia/preferences": "^0.12.0",
    "@theia/terminal": "^0.12.0",
    "@theia/workspace": "^0.12.0"
  },
  "scripts": {
    "prepare": "yarn run clean && yarn build",
    "clean": "theia clean && rimraf errorShots",
    "build": "theiaext compile && theia build --mode development",
    "watch": "concurrently -n compile,bundle \"theiaext watch --preserveWatchOutput\" \"theia build --watch --mode development\"",
    "start": "theia start --plugins=local-dir:../../plugins",
    "start:debug": "yarn start --log-level=debug",
    "test": "wdio wdio.conf.js",
    "test-non-headless": "wdio wdio-non-headless.conf.js",
    "coverage:compile": "yarn build --config coverage-webpack.config.js",
    "coverage:remap": "remap-istanbul -i coverage/coverage.json -o coverage/coverage-final.json --exclude 'frontend/index.js' && rimraf coverage/coverage.json",
    "coverage:report:html": "istanbul report --root coverage --format html",
    "coverage:report:lcov": "istanbul report --root coverage --format lcov",
    "coverage": "yarn coverage:compile && yarn test && yarn coverage:remap && yarn coverage:report:lcov && yarn coverage:report:html"
  },
  "devDependencies": {
    "@theia/cli": "^0.12.0"
  }
}

```

</details>



#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

- verify that existing toolbar icons are displayed properly

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

Signed-off-by: Vincent Fugnitto <vincent.fugnitto@ericsson.com>

