### PR TITLE
handles invalid task configurations

### DIFF
--- a/packages/task/package.json
+++ b/packages/task/package.json
@@ -13,6 +13,7 @@
     "@theia/terminal": "^0.12.0",
     "@theia/variable-resolver": "^0.12.0",
     "@theia/workspace": "^0.12.0",
+    "ajv": "^6.5.3",
     "jsonc-parser": "^2.0.2",
     "p-debounce": "^2.1.0",
     "vscode-uri": "^1.0.8"

--- a/packages/task/src/browser/task-schema-updater.ts
+++ b/packages/task/src/browser/task-schema-updater.ts
@@ -100,6 +100,7 @@ export class TaskSchemaUpdater {
             customizedDetectedTask.properties!.problemMatcher = problemMatcher;
             customizedDetectedTask.properties!.options = commandOptionsSchema;
             customizedDetectedTask.properties!.group = group;
+            customizedDetectedTask.additionalProperties = true;
             customizedDetectedTasks.push(customizedDetectedTask);
         });
 
@@ -112,6 +113,9 @@ export class TaskSchemaUpdater {
         return {
             type: 'object',
             properties: {
+                version: {
+                    type: 'string'
+                },
                 tasks: {
                     type: 'array',
                     items: {
@@ -119,7 +123,8 @@ export class TaskSchemaUpdater {
                     }
                 },
                 inputs: inputsSchema.definitions!.inputs
-            }
+            },
+            additionalProperties: false
         };
     }
 
@@ -291,7 +296,8 @@ const processTaskConfigurationSchema: IJSONSchema = {
         },
         group,
         problemMatcher
-    }
+    },
+    additionalProperties: true
 };
 
 const customizedDetectedTasks: IJSONSchema[] = [];


### PR DESCRIPTION
- not display the invalid task configurations in the list of tasks.
- displays a warning message to inform users if Theia finds invalid task
configuration(s) in tasks.json.
- fixes #6482

Signed-off-by: Liang Huang <liang.huang@ericsson.com>


#### How to test

As the GIF shows,

- enter an invalid task configuration into tasks.json. 
  FYI, it would be helpful to keep the Problem View open, as it would display the schema errors Theia finds from task configuration. With the information from the Problems View, we know if we are truely entering an invalid config.

- Open the list of tasks from the top menu bar "Termimal -> Run Tasks"
  At this point of time, the list of tasks should NOT have the task config that was entered most recently, because it's invalid. Also, there should be a warning populated that reminds us to open the Problems view to get what the errors are.

- Go back to tasks.json and fix the invalid configuration
  After the config is fixed, it should show up as one item in the list of tasks.

![Peek 2019-11-07 22-56](https://user-images.githubusercontent.com/37082801/68448581-f89b7c00-01b1-11ea-89bd-12ffd852fda8.gif)


#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)
