### PR TITLE
Don't throw an error if access to the clipboard is denied.

### DIFF
--- a/packages/core/src/browser/browser-clipboard-service.ts
+++ b/packages/core/src/browser/browser-clipboard-service.ts
@@ -56,13 +56,13 @@ export class BrowserClipboardService implements ClipboardService {
                     It can be enabled by 'dom.events.testing.asyncClipboard' preference on 'about:config' page. Then reload Theia.
                     Note, it will allow FireFox getting full access to the system clipboard.`);
                 }
-                throw new Error('Failed reading clipboard content.');
+                return '';
             }
         }
         if (permission.state === 'denied') {
             // most likely, the user intentionally denied the access
-            this.messageService.error("Access to the clipboard is denied. Check your browser's permission.");
-            throw new Error('Access to the clipboard is denied.');
+            this.messageService.warn("Access to the clipboard is denied. Check your browser's permission.");
+            return '';
         }
         return this.getClipboardAPI().readText();
     }
@@ -84,13 +84,13 @@ export class BrowserClipboardService implements ClipboardService {
                     It can be enabled by 'dom.events.testing.asyncClipboard' preference on 'about:config' page. Then reload Theia.
                     Note, it will allow FireFox getting full access to the system clipboard.`);
                 }
-                throw new Error('Failed writing the the clipboard.');
+                return;
             }
         }
         if (permission.state === 'denied') {
             // most likely, the user intentionally denied the access
-            this.messageService.error("Access to the clipboard is denied. Check your browser's permission.");
-            throw new Error('Access to the clipboard is denied.');
+            this.messageService.warn("Access to the clipboard is denied. Check your browser's permission.");
+            return;
         }
         return this.getClipboardAPI().writeText(value);
     }


### PR DESCRIPTION
Signed-off-by: Artem Zatsarynnyi <azatsary@redhat.com>

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->
When the user has denied access to the clipboard, it should not be treated as an error, by Theia.
The user just needs to be warned about it.

fixes https://github.com/eclipse/che/issues/15093

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
1/ Run Theia with the test extension https://github.com/azatsarynnyy/test-clipboard-api/blob/master/clipboard-api-test-0.0.1.vsix
2/ Deny the browser accessing the clipboard from Theia page.
3/ Call `Clipboard: read from clipboard` command from the commands palette.

w/o the patch
![image](https://user-images.githubusercontent.com/1636395/68476899-b2d3c780-0234-11ea-9de9-6b67d624626e.png)

w/ the patch
![image](https://user-images.githubusercontent.com/1636395/68477218-8a000200-0235-11ea-9e09-d1eaa1743cf0.png)


#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

