### PR TITLE
[filesystem] Increase may number of file watchers.

### DIFF
--- a/packages/filesystem/src/browser/filesystem-watcher.ts
+++ b/packages/filesystem/src/browser/filesystem-watcher.ts
@@ -88,7 +88,7 @@ export class FileSystemWatcher implements Disposable {
     protected readonly toRestartAll = new DisposableCollection();
 
     protected readonly onFileChangedEmitter = new Emitter<FileChangeEvent>();
-    readonly onFilesChanged: Event<FileChangeEvent> = this.onFileChangedEmitter.event;
+    readonly onFilesChanged: Event<FileChangeEvent> = Object.assign(this.onFileChangedEmitter.event, { maxListeners: 200 });
 
     protected readonly onDidMoveEmitter = new Emitter<FileMoveEvent>();
     readonly onDidMove: Event<FileMoveEvent> = this.onDidMoveEmitter.event;


### PR DESCRIPTION
#### What it does
Increase the number of allowed listeners for filechanges

We have regularly more than 30 file watchers, as
there are already 6 watchers per workspace root,
to watch the settings, launch config and tasks for
both .theia and .vscode.


#### How to test
create a multi-root workspace (>5 roots) and see how there are no more emiitter leak warnings.

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

