### PR TITLE
support "group" in the task config

### DIFF
--- a/packages/task/src/browser/task-configurations.ts
+++ b/packages/task/src/browser/task-configurations.ts
@@ -136,7 +136,7 @@ export class TaskConfigurations implements Disposable {
             for (const cus of customizations) {
                 const detected = await this.providedTaskConfigurations.getTaskToCustomize(cus, rootFolder);
                 if (detected) {
-                    detectedTasksAsConfigured.push(detected);
+                    detectedTasksAsConfigured.push({ ...detected, ...cus });
                 }
             }
         }
@@ -280,7 +280,7 @@ export class TaskConfigurations implements Disposable {
 
         const configuredAndCustomizedTasks = await this.getTasks();
         if (!configuredAndCustomizedTasks.some(t => this.taskDefinitionRegistry.compareTasks(t, task))) {
-            await this.saveTask(sourceFolderUri, task);
+            await this.saveTask(sourceFolderUri, { ...task, problemMatcher: [] });
         }
 
         try {
@@ -302,8 +302,8 @@ export class TaskConfigurations implements Disposable {
                 customization[p] = task[p];
             }
         });
-        const problemMatcher: string[] = [];
-        if (task.problemMatcher) {
+        if ('problemMatcher' in task) {
+            const problemMatcher: string[] = [];
             if (Array.isArray(task.problemMatcher)) {
                 problemMatcher.push(...task.problemMatcher.map(t => {
                     if (typeof t === 'string') {
@@ -314,14 +314,15 @@ export class TaskConfigurations implements Disposable {
                 }));
             } else if (typeof task.problemMatcher === 'string') {
                 problemMatcher.push(task.problemMatcher);
-            } else {
+            } else if (task.problemMatcher) {
                 problemMatcher.push(task.problemMatcher.name!);
             }
+            customization.problemMatcher = problemMatcher.map(name => name.startsWith('$') ? name : `$${name}`);
         }
-        return {
-            ...customization,
-            problemMatcher: problemMatcher.map(name => name.startsWith('$') ? name : `$${name}`)
-        };
+        if (task.group) {
+            customization.group = task.group;
+        }
+        return { ...customization };
     }
 
     /** Writes the task to a config file. Creates a config file if this one does not exist */
@@ -370,11 +371,14 @@ export class TaskConfigurations implements Disposable {
     }
 
     /**
-     * saves the names of the problem matchers to be used to parse the output of the given task to `tasks.json`
-     * @param task task that the problem matcher(s) are applied to
-     * @param problemMatchers name(s) of the problem matcher(s)
+     * Updates the task config in the `tasks.json`.
+     * The task config, together with updates, will be written into the `tasks.json` if it is not found in the file.
+     *
+     * @param task task that the updates will be applied to
+     * @param update the updates to be appplied
      */
-    async saveProblemMatcherForTask(task: TaskConfiguration, problemMatchers: string[]): Promise<void> {
+    // tslint:disable-next-line:no-any
+    async updateTaskConfig(task: TaskConfiguration, update: { [name: string]: any }): Promise<void> {
         const sourceFolderUri: string | undefined = this.getSourceFolderUriFromTask(task);
         if (!sourceFolderUri) {
             console.error('Global task cannot be customized');
@@ -396,12 +400,14 @@ export class TaskConfigurations implements Disposable {
                 });
                 jsonTasks[ind] = {
                     ...jsonTasks[ind],
-                    problemMatcher: problemMatchers.map(name => name.startsWith('$') ? name : `$${name}`)
+                    ...update
                 };
             }
             this.taskConfigurationManager.setTaskConfigurations(sourceFolderUri, jsonTasks);
         } else { // task is not in `tasks.json`
-            task.problemMatcher = problemMatchers;
+            Object.keys(update).forEach(taskProperty => {
+                task[taskProperty] = update[taskProperty];
+            });
             this.saveTask(sourceFolderUri, task);
         }
     }

--- a/packages/task/src/browser/task-frontend-contribution.ts
+++ b/packages/task/src/browser/task-frontend-contribution.ts
@@ -29,6 +29,7 @@ import { TerminalMenus } from '@theia/terminal/lib/browser/terminal-frontend-con
 import { TaskSchemaUpdater } from './task-schema-updater';
 import { TaskConfiguration, TaskWatcher } from '../common';
 import { EditorManager } from '@theia/editor/lib/browser';
+import { WorkspaceService } from '@theia/workspace/lib/browser/workspace-service';
 
 export namespace TaskCommands {
     const TASK_CATEGORY = 'Task';
@@ -36,6 +37,18 @@ export namespace TaskCommands {
         id: 'task:run',
         category: TASK_CATEGORY,
         label: 'Run Task...'
+    };
+
+    export const TASK_RUN_BUILD: Command = {
+        id: 'task:run:build',
+        category: TASK_CATEGORY,
+        label: 'Run Build Task...'
+    };
+
+    export const TASK_RUN_TEST: Command = {
+        id: 'task:run:test',
+        category: TASK_CATEGORY,
+        label: 'Run Test Task...'
     };
 
     export const WORKBENCH_RUN_TASK: Command = {
@@ -135,6 +148,9 @@ export class TaskFrontendContribution implements CommandContribution, MenuContri
     @inject(StatusBar)
     protected readonly statusBar: StatusBar;
 
+    @inject(WorkspaceService)
+    protected readonly workspaceService: WorkspaceService;
+
     @postConstruct()
     protected async init(): Promise<void> {
         this.taskWatcher.onTaskCreated(() => this.updateRunningTasksItem());
@@ -210,6 +226,24 @@ export class TaskFrontendContribution implements CommandContribution, MenuContri
             }
         );
         registry.registerCommand(
+            TaskCommands.TASK_RUN_BUILD,
+            {
+                isEnabled: () => this.workspaceService.opened,
+                // tslint:disable-next-line:no-any
+                execute: (...args: any[]) =>
+                    this.quickOpenTask.runBuildOrTestTask('build')
+            }
+        );
+        registry.registerCommand(
+            TaskCommands.TASK_RUN_TEST,
+            {
+                isEnabled: () => this.workspaceService.opened,
+                // tslint:disable-next-line:no-any
+                execute: (...args: any[]) =>
+                    this.quickOpenTask.runBuildOrTestTask('test')
+            }
+        );
+        registry.registerCommand(
             TaskCommands.TASK_ATTACH,
             {
                 isEnabled: () => true,
@@ -268,18 +302,28 @@ export class TaskFrontendContribution implements CommandContribution, MenuContri
         });
 
         menus.registerMenuAction(TerminalMenus.TERMINAL_TASKS, {
-            commandId: TaskCommands.TASK_RUN_LAST.id,
+            commandId: TaskCommands.TASK_RUN_BUILD.id,
             order: '1'
         });
 
         menus.registerMenuAction(TerminalMenus.TERMINAL_TASKS, {
-            commandId: TaskCommands.TASK_ATTACH.id,
+            commandId: TaskCommands.TASK_RUN_TEST.id,
             order: '2'
         });
 
         menus.registerMenuAction(TerminalMenus.TERMINAL_TASKS, {
-            commandId: TaskCommands.TASK_RUN_TEXT.id,
+            commandId: TaskCommands.TASK_RUN_LAST.id,
             order: '3'
+        });
+
+        menus.registerMenuAction(TerminalMenus.TERMINAL_TASKS, {
+            commandId: TaskCommands.TASK_ATTACH.id,
+            order: '4'
+        });
+
+        menus.registerMenuAction(TerminalMenus.TERMINAL_TASKS, {
+            commandId: TaskCommands.TASK_RUN_TEXT.id,
+            order: '5'
         });
 
         menus.registerMenuAction(TerminalMenus.TERMINAL_TASKS_INFO, {

--- a/packages/task/src/browser/task-schema-updater.ts
+++ b/packages/task/src/browser/task-schema-updater.ts
@@ -99,6 +99,7 @@ export class TaskSchemaUpdater {
             });
             customizedDetectedTask.properties!.problemMatcher = problemMatcher;
             customizedDetectedTask.properties!.options = commandOptionsSchema;
+            customizedDetectedTask.properties!.group = group;
             customizedDetectedTasks.push(customizedDetectedTask);
         });
 
@@ -227,6 +228,44 @@ const problemMatcher = {
         }
     ]
 };
+const group = {
+    oneOf: [
+        {
+            type: 'string'
+        },
+        {
+            type: 'object',
+            properties: {
+                kind: {
+                    type: 'string',
+                    default: 'none',
+                    description: 'The task\'s execution group.'
+                },
+                isDefault: {
+                    type: 'boolean',
+                    default: false,
+                    description: 'Defines if this task is the default task in the group.'
+                }
+            }
+        }
+    ],
+    enum: [
+        { kind: 'build', isDefault: true },
+        { kind: 'test', isDefault: true },
+        'build',
+        'test',
+        'none'
+    ],
+    enumDescriptions: [
+        'Marks the task as the default build task.',
+        'Marks the task as the default test task.',
+        'Marks the task as a build task accessible through the \'Run Build Task\' command.',
+        'Marks the task as a test task accessible through the \'Run Test Task\' command.',
+        'Assigns the task to no group'
+    ],
+    // tslint:disable-next-line:max-line-length
+    description: 'Defines to which execution group this task belongs to. It supports "build" to add it to the build group and "test" to add it to the test group.'
+};
 
 const processTaskConfigurationSchema: IJSONSchema = {
     type: 'object',
@@ -250,6 +289,7 @@ const processTaskConfigurationSchema: IJSONSchema = {
             description: 'Linux specific command configuration that overrides the default command, args, and options',
             properties: commandAndArgs
         },
+        group,
         problemMatcher
     }
 };

--- a/packages/task/src/common/task-protocol.ts
+++ b/packages/task/src/common/task-protocol.ts
@@ -25,9 +25,27 @@ export const TaskClient = Symbol('TaskClient');
 
 export interface TaskCustomization {
     type: string;
+    group?: 'build' | 'test' | 'none' | { kind: 'build' | 'test' | 'none', isDefault: true };
     problemMatcher?: string | ProblemMatcherContribution | (string | ProblemMatcherContribution)[];
     // tslint:disable-next-line:no-any
     [name: string]: any;
+}
+export namespace TaskCustomization {
+    export function isBuildTask(task: TaskCustomization): boolean {
+        return task.group === 'build' || !!task.group && typeof task.group === 'object' && task.group.kind === 'build';
+    }
+
+    export function isDefaultBuildTask(task: TaskCustomization): boolean {
+        return !!task.group && typeof task.group === 'object' && task.group.kind === 'build' && task.group.isDefault;
+    }
+
+    export function isTestTask(task: TaskCustomization): boolean {
+        return task.group === 'test' || !!task.group && typeof task.group === 'object' && task.group.kind === 'test';
+    }
+
+    export function isDefaultTestTask(task: TaskCustomization): boolean {
+        return !!task.group && typeof task.group === 'object' && task.group.kind === 'test' && task.group.isDefault;
+    }
 }
 
 export interface TaskConfiguration extends TaskCustomization {


### PR DESCRIPTION
- With this change users would be able to define and run build tasks,
test tasks, default build tasks, and default test tasks.
- resolves #6144

Signed-off-by: Liang Huang <liang.huang@ericsson.com>


#### How to test

Use case 1:
- prepare a workspace where configured and detected tasks are defined
- add `"group": "build"` to task configs in `tasks.json`
- start "run build task" from the top menu bar "Terminal -> Run build task..."
- check if all task configs that are marked as "build tasks" are available from the list populated by the previous step, and if they can be run.

![Peek 2019-11-10 09-53](https://user-images.githubusercontent.com/37082801/68546085-285ca680-03a1-11ea-8a04-97f42e928c8b.gif)


Use case 2:
- prepare a workspace where configured and detected tasks are defined
- ensure there are no task configs marked as "build tasks"
- start "run build task" from the top menu bar "Terminal -> Run build task..."
- Check if an action populated - once clicked there should be a list of tasks presented for the user to select which task would be configured as the "default build task"
- Once the "default build task" is chosen, and "run build task" is started, the default build task should be run automatically.

![Peek 2019-11-10 09-54](https://user-images.githubusercontent.com/37082801/68546232-542c5c00-03a2-11ea-84c8-880da8aa82d9.gif)



#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

- [x] Approval of CQ https://dev.eclipse.org/ipzilla/show_bug.cgi?id=20967

