### PR TITLE
Fix `Task.execution` instantiation

### DIFF
--- a/packages/plugin-ext/src/plugin/type-converters.spec.ts
+++ b/packages/plugin-ext/src/plugin/type-converters.spec.ts
@@ -20,7 +20,7 @@ import * as theia from '@theia/plugin';
 import * as types from './types-impl';
 import * as model from '../common/plugin-api-rpc-model';
 import { MarkdownString, isMarkdownString } from './markdown-string';
-import { ProcessTaskDto, TaskDto } from '../common/plugin-api-rpc';
+import { TaskDto } from '../common/plugin-api-rpc';
 
 describe('Type converters:', () => {
 
@@ -179,13 +179,23 @@ describe('Type converters:', () => {
         const cwd = '/projects/theia';
         const additionalProperty = 'some property';
 
-        const shellTaskDto: ProcessTaskDto = {
+        const shellTaskDto: TaskDto = {
             type: shellType,
             label,
             source,
             scope: undefined,
             command,
             args,
+            options: { cwd },
+            additionalProperty
+        };
+
+        const shellTaskDtoWithCommandLine: TaskDto = {
+            type: shellType,
+            label,
+            source,
+            scope: undefined,
+            command: commandLine,
             options: { cwd },
             additionalProperty
         };
@@ -221,7 +231,9 @@ describe('Type converters:', () => {
             }
         };
 
-        const customTaskDto: ProcessTaskDto = { ...shellTaskDto, type: customType };
+        const customTaskDto: TaskDto = { ...shellTaskDto, type: customType };
+
+        const customTaskDtoWithCommandLine: TaskDto = { ...shellTaskDtoWithCommandLine, type: customType };
 
         const customPluginTask: theia.Task = {
             ...shellPluginTask, definition: {
@@ -258,6 +270,18 @@ describe('Type converters:', () => {
             // when
             const result: theia.Task = Converter.toTask(shellTaskDto);
 
+            assert.strictEqual(result.execution instanceof types.ShellExecution, true);
+
+            if (result.execution instanceof types.ShellExecution) {
+                assert.strictEqual(result.execution.commandLine, undefined);
+
+                result.execution = {
+                    args: result.execution.args,
+                    options: result.execution.options,
+                    command: result.execution.command
+                };
+            }
+
             // then
             assert.notEqual(result, undefined);
             assert.deepEqual(result, shellPluginTask);
@@ -269,7 +293,7 @@ describe('Type converters:', () => {
 
             // then
             assert.notEqual(result, undefined);
-            assert.deepEqual(result, shellTaskDto);
+            assert.deepEqual(result, shellTaskDtoWithCommandLine);
         });
 
         it('should convert task with custom type to dto', () => {
@@ -285,8 +309,19 @@ describe('Type converters:', () => {
             // when
             const result: theia.Task = Converter.toTask(customTaskDto);
 
+            assert.strictEqual(result.execution instanceof types.ShellExecution, true);
+
+            if (result.execution instanceof types.ShellExecution) {
+                assert.strictEqual(result.execution.commandLine, undefined);
+
+                result.execution = {
+                    args: result.execution.args,
+                    options: result.execution.options,
+                    command: result.execution.command
+                };
+            }
+
             // then
-            assert.notEqual(result, undefined);
             assert.deepEqual(result, customPluginTask);
         });
 
@@ -296,7 +331,7 @@ describe('Type converters:', () => {
 
             // then
             assert.notEqual(result, undefined);
-            assert.deepEqual(result, customTaskDto);
+            assert.deepEqual(result, customTaskDtoWithCommandLine);
         });
     });
 


### PR DESCRIPTION
Signed-off-by: Anatoliy Bazko <abazko@redhat.com>

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
Fix `Task.execution` instantiation. 
`ShellExecution` and `ProcessExecution` contain additional logic in their constructors.
 That's why is it necessary to use them.

[1] https://github.com/theia-ide/theia/blob/ab/fixTaskExecution/packages/plugin-ext/src/plugin/types-impl.ts#L1461
[2] https://github.com/eclipse-theia/theia/blob/ab/fixTaskExecution/packages/plugin-ext/src/plugin/types-impl.ts#L1368

#### How to test
The following tasks should work:
1. https://github.com/tolusha/vscode-test-extensions/blob/master/task-test-0.0.1.vsix?raw=true
2. 

```json
{
    // comment
    "tasks": [
        {
            "label": "config_task#1",
            "type": "shell",
            "command": "echo",
            "args": [
                "test"
            ]
        },
        {
            "label": "config_task#2",
            "type": "shell",
            "command": "echo test"
        }        
    ]
}
```



#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

