### PR TITLE
Add implementation copy text on selection for terminal

### DIFF
--- a/packages/terminal/src/browser/terminal-copy-on-selection-handler.ts
+++ b/packages/terminal/src/browser/terminal-copy-on-selection-handler.ts
@@ -1,0 +1,92 @@
+/********************************************************************************
+ * Copyright (C) 2019 Red Hat, Inc. and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import { injectable, postConstruct } from 'inversify';
+import { isFirefox } from '@theia/core/lib/browser';
+
+@injectable()
+export class TerminalCopyOnSelectionHander {
+
+    private textToCopy: string;
+    private interceptCopy: boolean;
+
+    private copyListener = (ev: ClipboardEvent) => {
+        if (this.interceptCopy && ev.clipboardData) {
+            ev.clipboardData.setData('text/plain', this.textToCopy);
+            ev.preventDefault();
+        }
+    }
+
+    @postConstruct()
+    protected init(): void {
+        document.addEventListener('copy', this.copyListener);
+    }
+
+    private async clipBoardCopyIsGranted(): Promise<boolean> {
+          // Unfortunately Firefox doesn't support permission check `clipboard-write`, so let try to copy anyway,
+          if (isFirefox) {
+            return true;
+        }
+        try {
+            // tslint:disable-next-line:no-any
+            const permissions = (navigator as any).permissions;
+            const { state } = await permissions.query({name: 'clipboard-write'});
+            if (state === 'granted') {
+                return true;
+            }
+        } catch (e) {}
+
+        return false;
+    }
+
+    private executeCommandCopy(): void {
+        try {
+            this.interceptCopy = true;
+            document.execCommand('copy');
+            this.interceptCopy = false;
+        } catch (e) {
+            // do nothing
+        }
+    }
+
+    private async writeToClipBoard(): Promise<void> {
+        // tslint:disable-next-line:no-any
+        const clipboard = (navigator as any).clipboard;
+
+        if (!clipboard) {
+            this.executeCommandCopy();
+            return;
+        }
+
+        try {
+            await clipboard.writeText(this.textToCopy);
+        } catch (e) {
+            this.executeCommandCopy();
+        }
+    }
+
+    async copy(text: string): Promise<void> {
+        this.textToCopy = text;
+
+        // tslint:disable-next-line:no-any
+        const permissions = (navigator as any).permissions;
+        if (permissions && permissions.query && await this.clipBoardCopyIsGranted()) {
+            await this.writeToClipBoard();
+        } else {
+            this.executeCommandCopy();
+        }
+    }
+}

--- a/packages/terminal/src/browser/terminal-frontend-module.ts
+++ b/packages/terminal/src/browser/terminal-frontend-module.ts
@@ -37,6 +37,7 @@ import { TerminalQuickOpenService, TerminalQuickOpenContribution } from './termi
 
 import '../../src/browser/terminal.css';
 import 'xterm/lib/xterm.css';
+import { TerminalCopyOnSelectionHander } from './terminal-copy-on-selection-handler';
 
 export default new ContainerModule(bind => {
     bindTerminalPreferences(bind);
@@ -67,6 +68,7 @@ export default new ContainerModule(bind => {
     }));
 
     bind(TerminalQuickOpenService).toSelf().inSingletonScope();
+    bind(TerminalCopyOnSelectionHander).toSelf().inSingletonScope();
 
     bind(TerminalQuickOpenContribution).toSelf().inSingletonScope();
     for (const identifier of [CommandContribution, QuickOpenContribution]) {

--- a/packages/terminal/src/browser/terminal-preferences.ts
+++ b/packages/terminal/src/browser/terminal-preferences.ts
@@ -75,6 +75,11 @@ export const TerminalConfigSchema: PreferenceSchema = {
             type: 'string',
             enum: ['canvas', 'dom'],
             default: 'canvas'
+        },
+        'terminal.integrated.copyOnSelection': {
+            description: 'Controls whether text selected in the terminal will be copied to the clipboard.',
+            type: 'boolean',
+            default: false,
         }
     }
 };
@@ -89,7 +94,8 @@ export interface TerminalConfiguration {
     'terminal.integrated.letterSpacing': number
     'terminal.integrated.lineHeight': number,
     'terminal.integrated.scrollback': number,
-    'terminal.integrated.rendererType': TerminalRendererType
+    'terminal.integrated.rendererType': TerminalRendererType,
+    'terminal.integrated.copyOnSelection': boolean,
 }
 
 type FontWeight = 'normal' | 'bold' | '100' | '200' | '300' | '400' | '500' | '600' | '700' | '800' | '900';

--- a/packages/terminal/src/browser/terminal-widget-impl.ts
+++ b/packages/terminal/src/browser/terminal-widget-impl.ts
@@ -33,6 +33,7 @@ import { TerminalPreferences, TerminalRendererType, isTerminalRendererType, DEFA
 import { TerminalContribution } from './terminal-contribution';
 import URI from '@theia/core/lib/common/uri';
 import { TerminalService } from './base/terminal-service';
+import { TerminalCopyOnSelectionHander } from './terminal-copy-on-selection-handler';
 
 export const TERMINAL_WIDGET_FACTORY_ID = 'terminal';
 
@@ -75,6 +76,7 @@ export class TerminalWidgetImpl extends TerminalWidget implements StatefulWidget
     @inject(TerminalPreferences) protected readonly preferences: TerminalPreferences;
     @inject(ContributionProvider) @named(TerminalContribution) protected readonly terminalContributionProvider: ContributionProvider<TerminalContribution>;
     @inject(TerminalService) protected readonly terminalService: TerminalService;
+    @inject(TerminalCopyOnSelectionHander) protected readonly copyOnSelectionHandler: TerminalCopyOnSelectionHander;
 
     protected readonly onDidOpenEmitter = new Emitter<void>();
     readonly onDidOpen: Event<void> = this.onDidOpenEmitter.event;
@@ -196,6 +198,12 @@ export class TerminalWidgetImpl extends TerminalWidget implements StatefulWidget
         }));
         this.toDispose.push(this.onTermDidClose);
         this.toDispose.push(this.onDidOpenEmitter);
+
+        this.toDispose.push(this.term.onSelectionChange(() => {
+            if (this.copyOnSelection) {
+                this.copyOnSelectionHandler.copy(this.term.getSelection());
+            }
+        }));
 
         for (const contribution of this.terminalContributionProvider.getContributions()) {
             contribution.onCreate(this);
@@ -532,6 +540,11 @@ export class TerminalWidgetImpl extends TerminalWidget implements StatefulWidget
         }
         return true;
     }
+
+    protected get copyOnSelection(): boolean {
+        return this.preferences['terminal.integrated.copyOnSelection'];
+    }
+
     protected attachCustomKeyEventHandler(): void {
         this.term.attachCustomKeyEventHandler(e => this.customKeyHandler(e));
     }


### PR DESCRIPTION
#### What it does
Add implementation copy text on selection for terminal and add option to enable/disable feature to align with VSCode. Works with Google Chrome, Firefox. 
With Safary seems an issue: https://bugs.webkit.org/show_bug.cgi?id=156529
 
### Referenced issue:
https://github.com/eclipse/che/issues/15106

#### How to test
1. Open terminal preferences, find option `terminal.integrated.copyOnSelection`, set value true to enable feature.
2. Open new terminal select some text(**Don't use** Ctrl +C).
3. Open some text editor, gedit, atom or so on, and paste text by Ctrl + V.

#### Review checklist

- [ ] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

Signed-off-by: Oleksandr Andriienko <oandriie@redhat.com>