### PR TITLE
[plugin] fix executeCommand arguments passing

### DIFF
--- a/packages/plugin-ext/src/hosted/node/plugin-host.ts
+++ b/packages/plugin-ext/src/hosted/node/plugin-host.ts
@@ -50,8 +50,8 @@ process.on('unhandledRejection', (reason: any, promise: Promise<any>) => {
         if (index >= 0) {
             promise.catch(err => {
                 unhandledPromises.splice(index, 1);
-                console.error(`Promise rejection not handled in one second: ${err}`);
-                if (err.stack) {
+                console.error(`Promise rejection not handled in one second: ${err} , reason: ${reason}`);
+                if (err && err.stack) {
                     console.error(`With stack trace: ${err.stack}`);
                 }
             });

--- a/packages/plugin-ext/src/plugin/command-registry.ts
+++ b/packages/plugin-ext/src/plugin/command-registry.ts
@@ -107,7 +107,7 @@ export class CommandRegistryImpl implements CommandRegistryExt {
             return KnownCommands.map(id, args, (mappedId: string, mappedArgs: any[] | undefined) =>
                 this.proxy.$executeCommand(mappedId, ...mappedArgs));
         } else {
-            return this.proxy.$executeCommand(id, args);
+            return this.proxy.$executeCommand(id, ...args);
         }
     }
     // tslint:enable:no-any


### PR DESCRIPTION
#### What it does

Fixes passing of arguments for `executeCommand`.

#### How to test
Install typescript-language-features builtin and see how the commands (prefixed with 'TypeScript:' do not appear when a ts file is active without this change.

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

