### PR TITLE
Make `yarn rebuild:electron` fail explicitly on Windows

### DIFF
--- a/dev-packages/application-manager/src/rebuild.ts
+++ b/dev-packages/application-manager/src/rebuild.ts
@@ -16,7 +16,6 @@
 
 import fs = require('fs-extra');
 import path = require('path');
-import cp = require('child_process');
 
 export function rebuild(target: 'electron' | 'browser', modules: string[]): void {
     const nodeModulesPath = path.join(process.cwd(), 'node_modules');
@@ -43,12 +42,8 @@ export function rebuild(target: 'electron' | 'browser', modules: string[]): void
         try {
             pack.dependencies = Object.assign({}, pack.dependencies, dependencies);
             fs.writeFileSync(packFile, JSON.stringify(pack, undefined, '  '));
-            const electronRebuildPath = path.join(process.cwd(), 'node_modules', '.bin', 'electron-rebuild');
-            if (process.platform === 'win32') {
-                cp.spawnSync('cmd', ['/c', electronRebuildPath]);
-            } else {
-                require(electronRebuildPath);
-            }
+            const electronRebuildPackageJson = require('electron-rebuild/package.json');
+            require(`electron-rebuild/${electronRebuildPackageJson['bin']['electron-rebuild']}`);
         } finally {
             setTimeout(() => {
                 fs.writeFile(packFile, packageText);


### PR DESCRIPTION
#### What it does

Before this commit, the `yarn rebuild:electron` used to fail silently.
We now get a proper output and exit code.

#### How to test

On Windows, try to run `yarn rebuild:electron`. Apparently there is a failure due to some http 403 error when downloading node-gyp build dependencies.

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)