### PR TITLE
[tasks] prompt users to configure tasks

### DIFF
--- a/packages/task/src/browser/quick-open-task.ts
+++ b/packages/task/src/browser/quick-open-task.ts
@@ -111,17 +111,22 @@ export class QuickOpenTask implements QuickOpenModel, QuickOpenHandler {
         );
 
         this.actionProvider = this.items.length ? this.taskActionProvider : undefined;
-
-        if (!this.items.length) {
-            this.items.push(new QuickOpenItem({
-                label: 'No tasks found',
-                run: (mode: QuickOpenMode): boolean => false
-            }));
-        }
     }
 
     async open(): Promise<void> {
         await this.init();
+        if (!this.items.length) {
+            this.items.push(new QuickOpenItem({
+                label: 'No task to run found. Configure Tasks...',
+                run: (mode: QuickOpenMode): boolean => {
+                    if (mode !== QuickOpenMode.OPEN) {
+                        return false;
+                    }
+                    this.configure();
+                    return true;
+                }
+            }));
+        }
         this.quickOpenService.open(this, {
             placeholder: 'Select the task to run',
             fuzzyMatchLabel: true,
@@ -290,7 +295,7 @@ export class QuickOpenTask implements QuickOpenModel, QuickOpenHandler {
 
             } else { // no build / test tasks, display an action item to configure the build / test task
                 this.items = [new QuickOpenItem({
-                    label: `No ${buildOrTestType} task to run found. Configure ${buildOrTestType} task...`,
+                    label: `No ${buildOrTestType} task to run found. Configure ${buildOrTestType.charAt(0).toUpperCase() + buildOrTestType.slice(1)} Task...`,
                     run: (mode: QuickOpenMode): boolean => {
                         if (mode !== QuickOpenMode.OPEN) {
                             return false;
@@ -322,6 +327,19 @@ export class QuickOpenTask implements QuickOpenModel, QuickOpenHandler {
                     }
                 })];
             }
+        } else { // no tasks are currently present, prompt users if they'd like to configure a task.
+            this.items = [
+                new QuickOpenItem({
+                    label: `No ${buildOrTestType} task to run found. Configure ${buildOrTestType.charAt(0).toUpperCase() + buildOrTestType.slice(1)} Task...`,
+                    run: (mode: QuickOpenMode): boolean => {
+                        if (mode !== QuickOpenMode.OPEN) {
+                            return false;
+                        }
+                        this.configure();
+                        return true;
+                    }
+                })
+            ];
         }
 
         this.quickOpenService.open(this, {


### PR DESCRIPTION


<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

Fixes #6525
Fixes #1017

- adjust the `run task` to display an item which prompts users to configure tasks when
no tasks are currently available.
- adjusts the `run build task` to display an item which prompts users to configure tasks when no tasks are currently available.
- adjusts the `run test task` to display an item which prompts users to configure tasks when no tasks are currently available.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

1. open a workspace without any tasks
2. attempt to `run task` (users should be prompted to configure a task)
3. attempt to `run build task` (users should be prompted to configure a task)
4. attempt to `run test task` (users should be prompted to configure a task)
5. open a workspace with tasks
6. task execution for (`run task`, `run build task`, and `run test task` should work as before)

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

Signed-off-by: vince-fugnitto <vincent.fugnitto@ericsson.com>
