### PR TITLE
Make webview resources path relative

### DIFF
--- a/packages/plugin-ext-vscode/src/node/plugin-vscode-init.ts
+++ b/packages/plugin-ext-vscode/src/node/plugin-vscode-init.ts
@@ -61,7 +61,7 @@ export const doInitialization: BackendInitializationFn = (apiFactory: PluginAPIF
         // redefine property
         Object.defineProperty(panel.webview, 'html', {
             set: function (html: string): void {
-                const newHtml = html.replace(new RegExp('vscode-resource:/', 'g'), '/webview/');
+                const newHtml = html.replace(new RegExp('vscode-resource:/', 'g'), 'webview/');
                 this.checkIsDisposed();
                 if (this._html !== newHtml) {
                     this._html = newHtml;
@@ -74,7 +74,7 @@ export const doInitialization: BackendInitializationFn = (apiFactory: PluginAPIF
         const originalPostMessage = panel.webview.postMessage;
         panel.webview.postMessage = (message: any): PromiseLike<boolean> => {
             const decoded = JSON.stringify(message);
-            const newMessage = decoded.replace(new RegExp('vscode-resource:/', 'g'), '/webview/');
+            const newMessage = decoded.replace(new RegExp('vscode-resource:/', 'g'), 'webview/');
             return originalPostMessage.call(panel.webview, JSON.parse(newMessage));
         };
 

--- a/packages/plugin-ext/src/main/browser/webview/theme-rules-service.ts
+++ b/packages/plugin-ext/src/main/browser/webview/theme-rules-service.ts
@@ -135,7 +135,7 @@ export class ThemeRulesService {
                 path = this.isDark() ? value.dark : value.light;
             }
             if (path.startsWith('/')) {
-                path = `/webview${path}`;
+                path = `webview${path}`;
             }
             cssRules.push(`.webview-icon.${key}-file-icon::before { background-image: url(${path}); }`);
         });

--- a/packages/plugin-ext/src/plugin/webviews.ts
+++ b/packages/plugin-ext/src/plugin/webviews.ts
@@ -150,7 +150,7 @@ export class WebviewImpl implements theia.Webview {
         this.checkIsDisposed();
         // replace theia-resource: content in the given message
         const decoded = JSON.stringify(message);
-        let newMessage = decoded.replace(new RegExp('theia-resource:/', 'g'), '/webview/');
+        let newMessage = decoded.replace(new RegExp('theia-resource:/', 'g'), 'webview/');
         if (this._options && this._options.localResourceRoots) {
             newMessage = this.filterLocalRoots(newMessage, this._options.localResourceRoots);
         }
@@ -158,7 +158,7 @@ export class WebviewImpl implements theia.Webview {
     }
 
     protected filterLocalRoots(content: string, localResourceRoots: ReadonlyArray<theia.Uri>): string {
-        const webViewsRegExp = /"(\/webview\/.*?)\"/g;
+        const webViewsRegExp = /"(webview\/.*?)\"/g;
         let m;
         while ((m = webViewsRegExp.exec(content)) !== null) {
             if (m.index === webViewsRegExp.lastIndex) {
@@ -166,9 +166,9 @@ export class WebviewImpl implements theia.Webview {
             }
             // take group 1 which is webview URL
             const url = m[1];
-            const isIncluded = localResourceRoots.some((uri): boolean => url.substring('/webview'.length).startsWith(uri.fsPath));
+            const isIncluded = localResourceRoots.some((uri): boolean => url.substring('webview'.length).startsWith(uri.fsPath));
             if (!isIncluded) {
-                content = content.replace(url, url.replace('/webview', '/webview-disallowed-localroot'));
+                content = content.replace(url, url.replace('webview', 'webview-disallowed-localroot'));
             }
         }
         return content;
@@ -191,7 +191,7 @@ export class WebviewImpl implements theia.Webview {
     }
 
     set html(html: string) {
-        let newHtml = html.replace(new RegExp('theia-resource:/', 'g'), '/webview/');
+        let newHtml = html.replace(new RegExp('theia-resource:/', 'g'), 'webview/');
         if (this._options && this._options.localResourceRoots) {
             newHtml = this.filterLocalRoots(newHtml, this._options.localResourceRoots);
         }


### PR DESCRIPTION
Signed-off-by: Mykola Morhun <mmorhun@redhat.com>

#### What it does
Makes links to webview resources of plugins relative. This is needed to have resources loaded if one need to run Theia on path different than root, e.g. `https//host.net/theia/.

#### How to test
Run a plugin which uses webview API with resources (css, js, images).
For example, [dependency analytics extension](https://marketplace.visualstudio.com/items?itemName=redhat.fabric8-analytics)