### PR TITLE
Workaround `anser` wrong typings.

### DIFF
--- a/packages/console/src/browser/ansi-console-item.tsx
+++ b/packages/console/src/browser/ansi-console-item.tsx
@@ -17,7 +17,10 @@
 import * as React from 'react';
 import { ConsoleItem } from './console-session';
 import { Severity } from '@theia/core/lib/common/severity';
-import Anser from 'anser';
+
+// TODO: Remove this workaround once issue is fixed by anser.
+// REF: https://github.com/IonicaBizau/anser/issues/52
+const { ansiToHtml } = (require('anser') as import('anser').default);
 
 export class AnsiConsoleItem implements ConsoleItem {
 
@@ -27,7 +30,7 @@ export class AnsiConsoleItem implements ConsoleItem {
         public readonly content: string,
         public readonly severity?: Severity
     ) {
-        this.htmlContent = Anser.ansiToHtml(this.content, {
+        this.htmlContent = ansiToHtml(this.content, {
             use_classes: true,
             remove_empty: true
         });


### PR DESCRIPTION
#### What it does

The .d.ts definition file distributed along the `anser` package is
bogus, but the issue is minimal: It declares that the module exports a
namespace as `export default` when it does not.

Fixes https://github.com/eclipse-theia/theia/issues/6551

#### How to test

See https://github.com/eclipse-theia/theia/issues/6551

#### Review checklist

- [ ] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)