### PR TITLE
Add ability to use upload service on plugin side

### DIFF
--- a/packages/plugin-ext/src/common/plugin-api-rpc.ts
+++ b/packages/plugin-ext/src/common/plugin-api-rpc.ts
@@ -399,6 +399,20 @@ export interface SaveDialogOptionsMain {
 }
 
 /**
+ * Options to configure the behaviour of a file upload dialog.
+ */
+export interface UploadDialogOptionsMain {
+    /**
+     * The resource, where files should be uploaded.
+     */
+    defaultUri?: string;
+}
+
+export interface FileUploadResultMain {
+    uploaded: string[]
+}
+
+/**
  * Options to configure the behaviour of the [workspace folder](#WorkspaceFolder) pick UI.
  */
 export interface WorkspaceFolderPickOptionsMain {
@@ -484,6 +498,7 @@ export interface WorkspaceExt {
 export interface DialogsMain {
     $showOpenDialog(options: OpenDialogOptionsMain): Promise<string[] | undefined>;
     $showSaveDialog(options: SaveDialogOptionsMain): Promise<string | undefined>;
+    $showUploadDialog(options: UploadDialogOptionsMain): Promise<string[] | undefined>;
 }
 
 export interface TreeViewsMain {

--- a/packages/plugin-ext/src/plugin/dialogs.ts
+++ b/packages/plugin-ext/src/plugin/dialogs.ts
@@ -13,8 +13,8 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
-import { PLUGIN_RPC_CONTEXT as Ext, OpenDialogOptionsMain, DialogsMain, SaveDialogOptionsMain } from '../common/plugin-api-rpc';
-import { OpenDialogOptions, SaveDialogOptions } from '@theia/plugin';
+import { PLUGIN_RPC_CONTEXT as Ext, OpenDialogOptionsMain, DialogsMain, SaveDialogOptionsMain, UploadDialogOptionsMain } from '../common/plugin-api-rpc';
+import { OpenDialogOptions, SaveDialogOptions, UploadDialogOptions } from '@theia/plugin';
 import { RPCProtocol } from '../common/rpc-protocol';
 import Uri from 'vscode-uri';
 
@@ -64,6 +64,24 @@ export class DialogsExtImpl {
             this.proxy.$showSaveDialog(optionsMain).then(result => {
                 if (result) {
                     resolve(Uri.parse('file://' + result));
+                } else {
+                    resolve(undefined);
+                }
+            }).catch(reason => {
+                reject(reason);
+            });
+        });
+    }
+
+    showUploadDialog(options: UploadDialogOptions): PromiseLike<Uri[] | undefined> {
+        const optionsMain = {
+            defaultUri: options.defaultUri ? options.defaultUri.path : undefined
+        } as UploadDialogOptionsMain;
+
+        return new Promise((resolve, reject) => {
+            this.proxy.$showUploadDialog(optionsMain).then(result => {
+                if (result) {
+                    resolve(result.map(uri => Uri.parse(uri)));
                 } else {
                     resolve(undefined);
                 }

--- a/packages/plugin-ext/src/plugin/plugin-context.ts
+++ b/packages/plugin-ext/src/plugin/plugin-context.ts
@@ -316,6 +316,9 @@ export function createAPIFactory(
             showSaveDialog(options: theia.SaveDialogOptions): PromiseLike<Uri | undefined> {
                 return dialogsExt.showSaveDialog(options);
             },
+            showUploadDialog(options: theia.UploadDialogOptions): PromiseLike<Uri[] | undefined> {
+                return dialogsExt.showUploadDialog(options);
+            },
             // tslint:disable-next-line:no-any
             setStatusBarMessage(text: string, arg?: number | PromiseLike<any>): Disposable {
                 return statusBarMessageRegistryExt.setStatusBarMessage(text, arg);

--- a/packages/plugin/src/theia.d.ts
+++ b/packages/plugin/src/theia.d.ts
@@ -2546,6 +2546,17 @@ declare module '@theia/plugin' {
     }
 
     /**
+     * Options to configure the behaviour of a file upload dialog.
+     */
+    export interface UploadDialogOptions {
+
+        /**
+         * The resource, where files should be uploaded.
+         */
+        defaultUri?: Uri;
+    }
+
+    /**
      * Definition of the terminal emulator.
      */
     export interface Terminal {
@@ -3322,6 +3333,15 @@ declare module '@theia/plugin' {
          * @returns A promise that resolves to the selected resource or `undefined`.
          */
         export function showSaveDialog(options: SaveDialogOptions): PromiseLike<Uri | undefined>;
+
+        /**
+         * Shows a file upload dialog to the user which allows to upload files
+         * for various purposes.
+         * 
+         * @param options Options, that control the dialog.
+         * @returns A promise that resolves the paths of uploaded files or `undefined`.
+         */
+        export function showUploadDialog(options: UploadDialogOptions): PromiseLike<Uri[] | undefined>;
 
         /**
          * Create and show a new webview panel.


### PR DESCRIPTION
#### What it does
This changes proposal adds an ability to call upload service from plugin side.

Real world example of usage this api in che-theia. This sample shows how user can upload private ssh key from plugin:
![upload_ssh_key](https://user-images.githubusercontent.com/1968177/68931356-03997200-0799-11ea-8516-190e02c0c520.gif)

Linked issue in che-theia: https://github.com/eclipse/che-theia/pull/547

Signed-off-by: Vladyslav Zhukovskyi <vzhukovs@redhat.com>

#### How to test
Clone this [example](https://github.com/vzhukovskii/test-plugin) into plugins folder. After theia and plugin build run theia and call action `Upload File`.

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

