### PR TITLE
fix(QuickPickInput): result should always be array if canPickAny is enabled

### DIFF
--- a/packages/plugin-ext/src/plugin/quick-open.ts
+++ b/packages/plugin-ext/src/plugin/quick-open.ts
@@ -88,7 +88,12 @@ export class QuickOpenExtImpl implements QuickOpenExt {
 
                 return widgetPromise.then(handle => {
                     if (typeof handle === 'number') {
-                        return items[handle];
+                        if (options && options.canPickMany) {
+                            return Array.of(items[handle]);
+                        } else {
+                            return items[handle];
+                        }
+
                     } else if (Array.isArray(handle)) {
                         return handle.map(h => items[h]);
                     }


### PR DESCRIPTION
#### What it does
Ensure to provide array result when `canPickAny` flag is used on QuickPickInput
Fixes https://github.com/eclipse-theia/theia/issues/6557

#### How to test
Use this VS Code extension:
https://marketplace.visualstudio.com/items?itemName=MicroProfile-Community.mp-starter-vscode-ext

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

Change-Id: I1de65f41c049fb7909f91afa0a69e98b0b8b2294
Signed-off-by: Florent Benoit <fbenoit@redhat.com>
