### PR TITLE
[vscode] fixed bad type conversion with code actions

### DIFF
--- a/packages/plugin-ext/src/common/plugin-api-rpc-model.ts
+++ b/packages/plugin-ext/src/common/plugin-api-rpc-model.ts
@@ -353,14 +353,8 @@ export interface CodeAction {
     kind?: string;
 }
 
-export enum CodeActionTrigger {
-    Automatic = 1,
-    Manual = 2,
-}
-
 export interface CodeActionContext {
     only?: string;
-    trigger: CodeActionTrigger;
 }
 
 export interface CodeActionProvider {

--- a/packages/plugin-ext/src/common/plugin-api-rpc.ts
+++ b/packages/plugin-ext/src/common/plugin-api-rpc.ts
@@ -61,7 +61,11 @@ import {
     RenameLocation,
     FileMoveEvent,
     FileWillMoveEvent,
-    SignatureHelpContext
+    SignatureHelpContext,
+    CodeAction,
+    CodeActionContext,
+    FoldingContext,
+    FoldingRange
 } from './plugin-api-rpc-model';
 import { ExtPluginApi } from './plugin-ext-api-contribution';
 import { KeysToAnyValues, KeysToKeysToAnyValue } from './types';
@@ -1155,18 +1159,18 @@ export interface LanguagesExt {
         handle: number,
         resource: UriComponents,
         rangeOrSelection: Range | Selection,
-        context: monaco.languages.CodeActionContext,
+        context: CodeActionContext,
         token: CancellationToken
-    ): Promise<monaco.languages.CodeAction[] | undefined>;
+    ): Promise<CodeAction[] | undefined>;
     $provideDocumentSymbols(handle: number, resource: UriComponents, token: CancellationToken): Promise<DocumentSymbol[] | undefined>;
     $provideWorkspaceSymbols(handle: number, query: string, token: CancellationToken): PromiseLike<SymbolInformation[]>;
     $resolveWorkspaceSymbol(handle: number, symbol: SymbolInformation, token: CancellationToken): PromiseLike<SymbolInformation>;
     $provideFoldingRange(
         handle: number,
         resource: UriComponents,
-        context: monaco.languages.FoldingContext,
+        context: FoldingContext,
         token: CancellationToken
-    ): PromiseLike<monaco.languages.FoldingRange[] | undefined>;
+    ): PromiseLike<FoldingRange[] | undefined>;
     $provideDocumentColors(handle: number, resource: UriComponents, token: CancellationToken): PromiseLike<RawColorInfo[]>;
     $provideColorPresentations(handle: number, resource: UriComponents, colorInfo: RawColorInfo, token: CancellationToken): PromiseLike<ColorPresentation[]>;
     $provideRenameEdits(handle: number, resource: UriComponents, position: Position, newName: string, token: CancellationToken): PromiseLike<WorkspaceEditDto | undefined>;

--- a/packages/plugin-ext/src/plugin/languages.ts
+++ b/packages/plugin-ext/src/plugin/languages.ts
@@ -57,6 +57,9 @@ import {
     ColorPresentation,
     RenameLocation,
     SignatureHelpContext,
+    CodeActionContext,
+    CodeAction,
+    FoldingRange,
 } from '../common/plugin-api-rpc-model';
 import { CompletionAdapter } from './languages/completion';
 import { Diagnostics } from './languages/diagnostics';
@@ -439,9 +442,9 @@ export class LanguagesExtImpl implements LanguagesExt {
     $provideCodeActions(handle: number,
         resource: UriComponents,
         rangeOrSelection: Range | Selection,
-        context: monaco.languages.CodeActionContext,
+        context: CodeActionContext,
         token: theia.CancellationToken
-    ): Promise<monaco.languages.CodeAction[] | undefined> {
+    ): Promise<CodeAction[] | undefined> {
         return this.withAdapter(handle, CodeActionAdapter, adapter => adapter.provideCodeAction(URI.revive(resource), rangeOrSelection, context, token));
     }
     // ### Code Actions Provider end
@@ -522,7 +525,7 @@ export class LanguagesExtImpl implements LanguagesExt {
         resource: UriComponents,
         context: theia.FoldingContext,
         token: theia.CancellationToken
-    ): Promise<monaco.languages.FoldingRange[] | undefined> {
+    ): Promise<FoldingRange[] | undefined> {
         return this.withAdapter(callId, FoldingProviderAdapter, adapter => adapter.provideFoldingRanges(URI.revive(resource), context, token));
     }
     // ### Folging Range Provider end

--- a/packages/plugin-ext/src/plugin/languages/code-action.ts
+++ b/packages/plugin-ext/src/plugin/languages/code-action.ts
@@ -17,7 +17,7 @@
 import * as theia from '@theia/plugin';
 import URI from 'vscode-uri/lib/umd';
 import { Selection } from '../../common/plugin-api-rpc';
-import { Range } from '../../common/plugin-api-rpc-model';
+import { Range, CodeActionContext, CodeAction } from '../../common/plugin-api-rpc-model';
 import * as Converter from '../type-converters';
 import { DocumentsExtImpl } from '../documents';
 import { Diagnostics } from './diagnostics';
@@ -35,8 +35,8 @@ export class CodeActionAdapter {
         private readonly commands: CommandRegistryImpl
     ) { }
 
-    provideCodeAction(resource: URI, rangeOrSelection: Range | Selection,
-        context: monaco.languages.CodeActionContext, token: theia.CancellationToken): Promise<monaco.languages.CodeAction[] | undefined> {
+    async provideCodeAction(resource: URI, rangeOrSelection: Range | Selection,
+        context: CodeActionContext, token: theia.CancellationToken): Promise<CodeAction[] | undefined> {
         const document = this.document.getDocumentData(resource);
         if (!document) {
             return Promise.reject(new Error(`There are no document for ${resource}`));
@@ -59,46 +59,45 @@ export class CodeActionAdapter {
             only: context.only ? new CodeActionKind(context.only) : undefined
         };
 
-        return Promise.resolve(this.provider.provideCodeActions(doc, ran, codeActionContext, token)).then(commandsOrActions => {
-            if (!Array.isArray(commandsOrActions) || commandsOrActions.length === 0) {
-                return undefined;
+        const commandsOrActions = await this.provider.provideCodeActions(doc, ran, codeActionContext, token);
+
+        if (!Array.isArray(commandsOrActions) || commandsOrActions.length === 0) {
+            return undefined;
+        }
+        // TODO cache toDispose and dispose it
+        const toDispose = new DisposableCollection();
+        const result: CodeAction[] = [];
+        for (const candidate of commandsOrActions) {
+            if (!candidate) {
+                continue;
             }
-            // TODO cache toDispose and dispose it
-            const toDispose = new DisposableCollection();
-            const result: monaco.languages.CodeAction[] = [];
-            for (const candidate of commandsOrActions) {
-                if (!candidate) {
-                    continue;
-                }
-                if (CodeActionAdapter._isCommand(candidate)) {
-                    result.push({
-                        title: candidate.title || '',
-                        command: this.commands.converter.toSafeCommand(candidate, toDispose)
-                    });
-                } else {
-                    if (codeActionContext.only) {
-                        if (!candidate.kind) {
-                            /* tslint:disable-next-line:max-line-length */
-                            console.warn(`${this.pluginId} - Code actions of kind '${codeActionContext.only.value}' requested but returned code action does not have a 'kind'. Code action will be dropped. Please set 'CodeAction.kind'.`);
-                        } else if (!codeActionContext.only.contains(candidate.kind)) {
-                            /* tslint:disable-next-line:max-line-length */
-                            console.warn(`${this.pluginId} - Code actions of kind '${codeActionContext.only.value}' requested but returned code action is of kind '${candidate.kind.value}'. Code action will be dropped. Please check 'CodeActionContext.only' to only return requested code action.`);
-                        }
+            if (CodeActionAdapter._isCommand(candidate)) {
+                result.push({
+                    title: candidate.title || '',
+                    command: this.commands.converter.toSafeCommand(candidate, toDispose)
+                });
+            } else {
+                if (codeActionContext.only) {
+                    if (!candidate.kind) {
+                        /* tslint:disable-next-line:max-line-length */
+                        console.warn(`${this.pluginId} - Code actions of kind '${codeActionContext.only.value}' requested but returned code action does not have a 'kind'. Code action will be dropped. Please set 'CodeAction.kind'.`);
+                    } else if (!codeActionContext.only.contains(candidate.kind)) {
+                        /* tslint:disable-next-line:max-line-length */
+                        console.warn(`${this.pluginId} - Code actions of kind '${codeActionContext.only.value}' requested but returned code action is of kind '${candidate.kind.value}'. Code action will be dropped. Please check 'CodeActionContext.only' to only return requested code action.`);
                     }
-
-                    result.push({
-                        title: candidate.title,
-                        command: this.commands.converter.toSafeCommand(candidate.command, toDispose),
-                        diagnostics: candidate.diagnostics && candidate.diagnostics.map(Converter.convertDiagnosticToMarkerData) as monaco.editor.IMarker[],
-                        edit: candidate.edit && Converter.fromWorkspaceEdit(candidate.edit) as monaco.languages.WorkspaceEdit,
-                        kind: candidate.kind && candidate.kind.value
-                    });
                 }
+
+                result.push({
+                    title: candidate.title,
+                    command: this.commands.converter.toSafeCommand(candidate.command, toDispose),
+                    diagnostics: candidate.diagnostics && candidate.diagnostics.map(Converter.convertDiagnosticToMarkerData),
+                    edit: candidate.edit && Converter.fromWorkspaceEdit(candidate.edit),
+                    kind: candidate.kind && candidate.kind.value
+                });
             }
+        }
 
-            return result;
-        });
-
+        return result;
     }
 
     // tslint:disable-next-line:no-any


### PR DESCRIPTION
#### What it does
conversion for some code actions was broken, as we didn't translated the URI properly to monaco.Uri. While at it I freed the plugin host code from any monaco references.

#### How to test
Install typescript-language-features and try 'Implement Interface' quickfix.

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

