### PR TITLE
process: use defaults when spawning a child_process

### DIFF
--- a/packages/process/src/node/raw-process.ts
+++ b/packages/process/src/node/raw-process.ts
@@ -102,13 +102,13 @@ export class RawProcess extends Process {
             if (this.isForkOptions(options)) {
                 this.process = fork(
                     options.modulePath,
-                    options.args,
-                    options.options);
+                    options.args || [],
+                    options.options || {});
             } else {
                 this.process = spawn(
                     options.command,
-                    options.args,
-                    options.options);
+                    options.args || [],
+                    options.options || {});
             }
 
             this.process.on('error', (error: NodeJS.ErrnoException) => {


### PR DESCRIPTION
#### What it does

While the typings allow for undefined values, the behavior is actually
nasty: If you leave `args` undefined, then `options` are ignored. This
could lead to stdio pipes not being set correctly.

#### How to test

It happened to me when contributing a debug adapter using our internal contribution points:

```ts
@injectable()
export class SomeDebugAdapterContribution implements DebugAdapterContribution {
    provideDebugAdapterExecutable(): DebugAdapterExecutable {
        return {
            modulePath: 'somePath',
            // no `args` field, typings are ok with that.
        };
    }
}
```

In this case, the debug adapter was spawned, but nothing was happening. No errors too.

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)