### PR TITLE
Ability to add task subschema

### DIFF
--- a/packages/task/src/browser/index.ts
+++ b/packages/task/src/browser/index.ts
@@ -19,3 +19,4 @@ export * from './task-contribution';
 export * from './task-definition-registry';
 export * from './task-problem-matcher-registry';
 export * from './task-problem-pattern-registry';
+export * from './task-schema-updater';


### PR DESCRIPTION
#### What it does
At the moment default schema and schemes of customized `detected` tasks are registered, so only these tasks are available for running.

The PR provides ability to add  task subschema from an extension for a custom task type to get ability run it from `Terminal => Run Task` menu.

#### How to test

Please use my forked repo for testing, it contains:
- the current PR [changes](https://github.com/eclipse-theia/theia/compare/master...RomanNikitenko:task-extension?expand=1#diff-e2e18ebe0bda942957153944df4a3fb7)
- the [test extension](https://github.com/RomanNikitenko/theia/commit/af59b6502a7ada8bef2f4c05e2d094aa29311c5b) which allows to add/remove schemes for custom types
- tasks with custom type for testing 

1. `git clone https://github.com/RomanNikitenko/theia.git`
2. `cd theia/` and `git checkout task-extension`.
3. Build the project and run it.
4. The project contains prepared tasks in `tasks.json` file, so please open the cloned project: `File=>Open...` and select the project.   
4. Go to `Terminal => Run Task` menu: 
you can see that only `SHELL task` is available for running 
5. Go to `Help` menu and select `Add CHE task schema`
you can see that now `CHE task` is available for running as well as `SHELL task`.
6. Try the same for `EXEC task`
7. You can try to remove subschema for `CHE task` and `EXEC task` using `Help` menu
you can see that the corresponding tasks are not available for running after that.

Please see https://youtu.be/VOuFi9M2Q2k    
#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

Signed-off-by: Roman Nikitenko <rnikiten@redhat.com>
