### PR TITLE
[search-in-workspace] update resizing css for result list

### DIFF
--- a/packages/search-in-workspace/src/browser/styles/index.css
+++ b/packages/search-in-workspace/src/browser/styles/index.css
@@ -248,7 +248,6 @@
 
 .t-siw-search-container .resultLine .match {
     background: var(--theia-word-highlight-match-color1);
-    display: inline-block;
     line-height: normal;
     white-space: pre;
 }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

Fixes #6569

- fixes issue where long search strings are not properly displayed
in the `search-in-workspace` result list.
- removed unnecessary `inline-block` to instead use inherited `display: flex`.


#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

1. search for a very long string, the result list should display properly as compared to `master`.

_Example_:

<div align='center'>

![a](https://user-images.githubusercontent.com/40359487/69085335-d73d5a00-0a13-11ea-9b0b-a61e797eb28f.gif)


</div>

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

Signed-off-by: Vincent Fugnitto <vincent.fugnitto@ericsson.com>
