### PR TITLE
Fix webview undefined exception

### DIFF
--- a/packages/plugin-ext/src/main/browser/webview/webview.ts
+++ b/packages/plugin-ext/src/main/browser/webview/webview.ts
@@ -33,7 +33,7 @@ export interface WebviewEvents {
 
 export class WebviewWidget extends BaseWidget {
     private static readonly ID = new IdGenerator('webview-widget-');
-    private iframe: HTMLIFrameElement;
+    private iframe: HTMLIFrameElement | undefined;
     private state: { [key: string]: any } | undefined = undefined;
     private loadTimeout: number | undefined;
     private scrollY: number;
@@ -60,12 +60,12 @@ export class WebviewWidget extends BaseWidget {
         this.node.appendChild(this.transparentOverlay);
 
         this.toDispose.push(this.mouseTracker.onMousedown(e => {
-            if (this.iframe.style.display !== 'none') {
+            if (this.iframe!.style.display !== 'none') {
                 this.transparentOverlay.style.display = 'block';
             }
         }));
         this.toDispose.push(this.mouseTracker.onMouseup(e => {
-            if (this.iframe.style.display !== 'none') {
+            if (this.iframe!.style.display !== 'none') {
                 this.transparentOverlay.style.display = 'none';
             }
         }));
@@ -84,7 +84,7 @@ export class WebviewWidget extends BaseWidget {
     async postMessage(message: any): Promise<void> {
         // wait message can be delivered
         await this.waitReadyToReceiveMessage();
-        this.iframe.contentWindow!.postMessage(message, '*');
+        this.iframe!.contentWindow!.postMessage(message, '*');
     }
 
     setOptions(options: WebviewWidgetOptions): void {
@@ -186,7 +186,7 @@ export class WebviewWidget extends BaseWidget {
         super.onActivateRequest(msg);
         // restore scrolling if there was one
         if (this.scrollY > 0) {
-            this.iframe.contentWindow!.scrollTo({ top: this.scrollY });
+            this.iframe!.contentWindow!.scrollTo({ top: this.scrollY });
         }
         this.node.focus();
         // unblock messages
@@ -200,7 +200,7 @@ export class WebviewWidget extends BaseWidget {
 
     protected onBeforeHide(msg: Message): void {
         // persist scrolling
-        if (this.iframe.contentWindow) {
+        if (this.iframe && this.iframe.contentWindow) {
             this.scrollY = this.iframe.contentWindow.scrollY;
         }
         super.onBeforeHide(msg);


### PR DESCRIPTION
### Referenced issue:
Part of the https://github.com/eclipse/che/issues/13442

#### What it does
Fix webview undefined exception when webview located in the editor area(top area) and during restore editor tabs hide webview faster than it was rendered. Issue is reproducible on the Firefox.

#### How to test
1. Start theia with test theia plugin https://github.com/AndrienkoAleksandr/che-plugin-registry/releases/download/welcome-plugin-test/eclipse_che_welcome_plugin.theia
2. Open theia and open browser console by F12 (I used latest long term supported Firefox 68.0.1ers)

<details><summary>Exception log:</summary>
<p>

```javascript
root ERROR ../../packages/plugin-ext/lib/main/browser/webview/webview.js/WebviewWidget.prototype.onBeforeHide@http://localhost:3000/43.bundle.js:2262:13
../../node_modules/@phosphor/widgets/lib/widget.js/Widget.prototype.processMessage@http://localhost:3000/bundle.js:26389:22
invokeHandler@http://localhost:3000/bundle.js:10313:21
sendMessage@http://localhost:3000/bundle.js:10049:13
../../node_modules/@phosphor/widgets/lib/widget.js/Widget.prototype.hide@http://localhost:3000/bundle.js:26301:37
../../node_modules/@phosphor/widgets/lib/dockpanel.js/DockPanel.prototype._onCurrentChanged@http://localhost:3000/bundle.js:16634:33
TheiaDockPanel/_this._onCurrentChanged@http://localhost:3000/bundle.js:125349:51
invokeSlot@http://localhost:3000/bundle.js:11098:18
emit@http://localhost:3000/bundle.js:11055:17
../../node_modules/@phosphor/signaling/lib/index.js/</Signal.prototype.emit@http://localhost:3000/bundle.js:10728:17
set@http://localhost:3000/bundle.js:24207:34
set@http://localhost:3000/bundle.js:24165:54
../../node_modules/@phosphor/widgets/lib/dockpanel.js/DockPanel.prototype.selectWidget@http://localhost:3000/bundle.js:16091:9
../../node_modules/@phosphor/widgets/lib/dockpanel.js/DockPanel.prototype.activateWidget@http://localhost:3000/bundle.js:16102:14
../../packages/core/lib/browser/shell/theia-dock-panel.js/TheiaDockPanel.prototype.activateWidget@http://localhost:3000/bundle.js:125394:41
../../packages/core/lib/browser/shell/application-shell.js/ApplicationShell.prototype.doActivateWidget@http://localhost:3000/bundle.js:121718:28
../../packages/core/lib/browser/shell/application-shell.js/ApplicationShell.prototype.activateWidget@http://localhost:3000/bundle.js:121697:30
../../packages/core/lib/browser/widget-open-handler.js/WidgetOpenHandler.prototype.doOpen/</<@http://localhost:3000/bundle.js:133037:40
step@http://localhost:3000/bundle.js:132976:23
verb/<@http://localhost:3000/bundle.js:132957:53
../../packages/core/lib/browser/widget-open-handler.js/__awaiter</<@http://localhost:3000/bundle.js:132951:71
../../packages/core/lib/browser/widget-open-handler.js/__awaiter<@http://localhost:3000/bundle.js:132947:12
../../packages/core/lib/browser/widget-open-handler.js/WidgetOpenHandler.prototype.doOpen@http://localhost:3000/bundle.js:133024:16
../../packages/core/lib/browser/widget-open-handler.js/WidgetOpenHandler.prototype.open/</<@http://localhost:3000/bundle.js:133015:51
step@http://localhost:3000/bundle.js:132976:23
verb/<@http://localhost:3000/bundle.js:132957:53
fulfilled@http://localhost:3000/bundle.js:132948:58
```
</p>
</details>

<img width="960" alt="WebviewException" src="https://user-images.githubusercontent.com/6873095/69148474-12579000-0add-11ea-888a-2473cf885e8d.png">

#### Review checklist
- [ ] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

Signed-off-by: Oleksandr Andriienko <oandriie@redhat.com>

