### PR TITLE
Don't use  lookbehind regex

### DIFF
--- a/packages/plugin-metrics/src/browser/plugin-metrics-creator.ts
+++ b/packages/plugin-metrics/src/browser/plugin-metrics-creator.ts
@@ -26,7 +26,7 @@ export class PluginMetricsCreator {
 
     private _extensionIDAnalytics: MetricsMap;
 
-    private NODE_BASED_REGEX = /(?<=Request)(.*?)(?=failed)/;
+    private NODE_BASED_REGEX = /Request(.*?)failed/;
 
     constructor() {
         this.setPluginMetrics();
@@ -182,9 +182,8 @@ export class PluginMetricsCreator {
         }
         const matches = errorContents.match(this.NODE_BASED_REGEX);
         if (matches) {
-            return matches[0].trim();
+            return matches[1].trim();
         }
         return undefined;
     }
-
 }


### PR DESCRIPTION
Signed-off-by: Thomas Mäder <tmader@redhat.com>

#### What it does
Uses a Regex that does not include look-behind syntax. Fix for plugin metrics breaks application start up in Firefox #6582

#### How to test
Instructions are here: https://github.com/eclipse-theia/theia/pull/6303

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

