### PR TITLE
[core] fix 'noWrapInfo' CSS class

### DIFF
--- a/packages/core/src/browser/style/sidepanel.css
+++ b/packages/core/src/browser/style/sidepanel.css
@@ -231,3 +231,9 @@
     width: 18px;
     background-repeat: no-repeat;
 }
+
+.noWrapInfo {
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}

--- a/packages/extension-manager/src/browser/style/index.css
+++ b/packages/extension-manager/src/browser/style/index.css
@@ -30,12 +30,6 @@
     display: flex;
 }
 
-.noWrapInfo {
-    white-space: nowrap;
-    overflow: hidden;
-    text-overflow: ellipsis;
-}
-
 .row {
     width: 100%;
 }

--- a/packages/git/src/browser/style/index.css
+++ b/packages/git/src/browser/style/index.css
@@ -31,9 +31,6 @@
 }
 
 .theia-git .noWrapInfo {
-    white-space: nowrap;
-    overflow: hidden;
-    text-overflow: ellipsis;
     width: 100%;
 }
 

--- a/packages/plugin-ext/src/main/browser/style/index.css
+++ b/packages/plugin-ext/src/main/browser/style/index.css
@@ -30,12 +30,6 @@
     display: flex;
 }
 
-.noWrapInfo {
-    white-space: nowrap;
-    overflow: hidden;
-    text-overflow: ellipsis;
-}
-
 .row {
     width: 100%;
 }

--- a/packages/scm/src/browser/style/index.css
+++ b/packages/scm/src/browser/style/index.css
@@ -32,10 +32,7 @@
 
 .theia-scm .noWrapInfo {
     width: 100%;
-    overflow: hidden;
-    white-space: nowrap;
     align-items: center;
-    text-overflow: ellipsis;
 }
 
 .theia-scm .space-between {

--- a/packages/search-in-workspace/src/browser/styles/index.css
+++ b/packages/search-in-workspace/src/browser/styles/index.css
@@ -263,10 +263,7 @@
     background: var(--theia-word-highlight-replace-color0);
 }
 
-.noWrapInfo {
-    white-space: nowrap;
-    overflow: hidden;
-    text-overflow: ellipsis;
+.t-siw-search-container .noWrapInfo {
     width: 100%;
 }
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

Fixes #6592

- fixes the issue where `noWrapInfo` is referenced in `core`
without actually having its CSS defined. The `noWrapInfo` is currently
available from other extensions, and if those extensions are not included
the styling is off.
- removes duplication of CSS properties.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

- verify that previous uses (extensions) of `noWrapInfo` are styled correctly.

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

Signed-off-by: vince-fugnitto <vincent.fugnitto@ericsson.com>
