### PR TITLE
[keymaps] remove internal commands from keybindings widget

### DIFF
--- a/packages/keymaps/src/browser/keybindings-widget.tsx
+++ b/packages/keymaps/src/browser/keybindings-widget.tsx
@@ -455,6 +455,10 @@ export class KeybindingWidget extends ReactWidget {
         const items: KeybindingItem[] = [];
         // Build the keybinding items.
         for (let i = 0; i < commands.length; i++) {
+            // Skip internal commands prefixed by `_`.
+            if (commands[i].id.startsWith('_')) {
+                continue;
+            }
             // Obtain the keybinding for the given command.
             const keybindings = this.keybindingRegistry.getKeybindingsForCommand(commands[i].id);
             const item: KeybindingItem = {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

Fixes #6368

- remove internal commands (commands prefixed by `_`) from the keybindings widget. These commands should not be displayed to end users as they should not be updated.

| Master | PR |
|:---:|:---:|
| <img width="1402" alt="Screen Shot 2019-11-20 at 3 45 02 PM" src="https://user-images.githubusercontent.com/40359487/69276733-fb806e80-0bac-11ea-8b52-bd3b1c80a4f6.png">| <img width="1402" alt="Screen Shot 2019-11-20 at 3 42 22 PM" src="https://user-images.githubusercontent.com/40359487/69276749-01764f80-0bad-11ea-8cab-7e90244c50a2.png"> |

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

- verify that internal commands are not present in the keybindings widget UI and when searching

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

Signed-off-by: vince-fugnitto <vincent.fugnitto@ericsson.com>

