### PR TITLE
process: add onClose event

### DIFF
--- a/dev-packages/electron/scripts/post-install.js
+++ b/dev-packages/electron/scripts/post-install.js
@@ -32,7 +32,7 @@ async function fork(script, args = [], options = {}, callback) {
     return new Promise((resolve, reject) => {
         const subprocess = cp.fork(script, args, options);
         subprocess.once('error', reject);
-        subprocess.once('exit', (code, signal) => {
+        subprocess.once('close', (code, signal) => {
             if (signal || code) reject(new Error(`"${script}" exited with ${signal || code}`));
             else resolve();
         });

--- a/packages/process/src/node/dev-null-stream.ts
+++ b/packages/process/src/node/dev-null-stream.ts
@@ -22,6 +22,19 @@ import stream = require('stream');
  * Writing goes to a black hole, reading returns `EOF`.
  */
 export class DevNullStream extends stream.Duplex {
+
+    constructor(options: {
+        /**
+         * Makes this stream call `destroy` on itself, emitting the `close` event.
+         */
+        autoDestroy?: boolean,
+    } = {}) {
+        super();
+        if (options.autoDestroy) {
+            this.destroy();
+        }
+    }
+
     // tslint:disable-next-line:no-any
     _write(chunk: any, encoding: string, callback: (err?: Error) => void): void {
         callback();

--- a/packages/task/src/node/process/process-task.ts
+++ b/packages/task/src/node/process/process-task.ts
@@ -64,7 +64,7 @@ export class ProcessTask extends Task {
     ) {
         super(taskManager, logger, options);
 
-        const toDispose = this.process.onExit(async event => {
+        const toDispose = this.process.onClose(async event => {
             toDispose.dispose();
             this.fireTaskExited(await this.getTaskExitedEvent(event));
         });
@@ -100,7 +100,7 @@ export class ProcessTask extends Task {
             if (this.process.killed) {
                 resolve();
             } else {
-                const toDispose = this.process.onExit(event => {
+                const toDispose = this.process.onClose(event => {
                     toDispose.dispose();
                     resolve();
                 });


### PR DESCRIPTION
#### What it does

WIP

Add a `onClose` convenience event on processes, fired when all the
streams are supposed to be closed.

Fixes https://github.com/eclipse-theia/theia/issues/6587

#### How to test

- `yarn run test` should pass
- Run tasks and make sure it stops correctly
- Open terminals, reload frontend and check if you can keep using it.

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

