### PR TITLE
break DI cycle between LabelProvider and its contributions

### DIFF
--- a/packages/core/src/browser/frontend-application-module.ts
+++ b/packages/core/src/browser/frontend-application-module.ts
@@ -226,6 +226,7 @@ export const frontendApplicationModule = new ContainerModule((bind, unbind, isBo
 
     bindContributionProvider(bind, LabelProviderContribution);
     bind(LabelProvider).toSelf().inSingletonScope();
+    bind(FrontendApplicationContribution).toService(LabelProvider);
     bind(LabelProviderContribution).to(DefaultUriLabelProviderContribution).inSingletonScope();
     bind(LabelProviderContribution).to(DiffUriLabelProviderContribution).inSingletonScope();
 

--- a/packages/core/src/browser/label-provider.ts
+++ b/packages/core/src/browser/label-provider.ts
@@ -20,6 +20,7 @@ import URI from '../common/uri';
 import { ContributionProvider } from '../common/contribution-provider';
 import { Prioritizeable, MaybePromise } from '../common/types';
 import { Event, Emitter } from '../common';
+import { FrontendApplicationContribution } from './frontend-application';
 
 export const FOLDER_ICON = 'fa fa-folder';
 export const FILE_ICON = 'fa fa-file';
@@ -98,14 +99,20 @@ export class DefaultUriLabelProviderContribution implements LabelProviderContrib
 }
 
 @injectable()
-export class LabelProvider {
+export class LabelProvider implements FrontendApplicationContribution {
 
     protected readonly onDidChangeEmitter = new Emitter<DidChangeLabelEvent>();
 
-    constructor(
-        @inject(ContributionProvider) @named(LabelProviderContribution)
-        protected readonly contributionProvider: ContributionProvider<LabelProviderContribution>
-    ) {
+    @inject(ContributionProvider) @named(LabelProviderContribution)
+    protected readonly contributionProvider: ContributionProvider<LabelProviderContribution>;
+
+    /**
+     * Start listening to contributions.
+     *
+     * Don't call this method directly!
+     * It's called by the frontend application during initialization.
+     */
+    initialize(): void {
         const contributions = this.contributionProvider.getContributions();
         for (const contribution of contributions) {
             if (contribution.onDidChange) {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

See https://github.com/eclipse-theia/theia/pull/5884#issuecomment-557603264

LabelProvider tries to create contributions during instantiation, but some contributions need `LabelProvider`, so it goes forever.

The cycle is broken by moving creation of contributions to the frontend application initialization, so after an instance of `LabelProvider` is created.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

Build, start the app and check that the browser console does not 

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

