### PR TITLE
[WIP][search-in-workspace] improve performance

### DIFF
--- a/packages/search-in-workspace/src/browser/search-in-workspace-service.ts
+++ b/packages/search-in-workspace/src/browser/search-in-workspace-service.ts
@@ -29,8 +29,8 @@ import { ILogger } from '@theia/core';
 export class SearchInWorkspaceClientImpl implements SearchInWorkspaceClient {
     private service: SearchInWorkspaceClient;
 
-    onResult(searchId: number, result: SearchInWorkspaceResult): void {
-        this.service.onResult(searchId, result);
+    onResult(searchId: number, results: SearchInWorkspaceResult[]): void {
+        this.service.onResult(searchId, results);
     }
     onDone(searchId: number, error?: string): void {
         this.service.onDone(searchId, error);
@@ -78,11 +78,11 @@ export class SearchInWorkspaceService implements SearchInWorkspaceClient {
         return this.workspaceService.opened;
     }
 
-    onResult(searchId: number, result: SearchInWorkspaceResult): void {
+    onResult(searchId: number, results: SearchInWorkspaceResult[]): void {
         const callbacks = this.pendingSearches.get(searchId);
 
         if (callbacks) {
-            callbacks.onResult(searchId, result);
+            callbacks.onResult(searchId, results);
         }
     }
 

--- a/packages/search-in-workspace/src/browser/search-in-workspace-widget.tsx
+++ b/packages/search-in-workspace/src/browser/search-in-workspace-widget.tsx
@@ -127,7 +127,11 @@ export class SearchInWorkspaceWidget extends BaseWidget implements StatefulWidge
             includeIgnored: false,
             include: [],
             exclude: [],
-            maxResults: 2000
+            maxResults: 1000,
+            shortenLineText: {
+                before: 20,
+                after: 40
+            }
         };
         this.toDispose.push(this.resultTreeWidget.onChange(r => {
             this.hasResults = r.size > 0;
@@ -355,6 +359,7 @@ export class SearchInWorkspaceWidget extends BaseWidget implements StatefulWidge
         this.update();
     }
 
+    protected previousSearchTerm = '';
     protected readonly search = (e: React.KeyboardEvent) => this.doSearch(e);
     protected doSearch(e: React.KeyboardEvent): void {
         if (e.target) {
@@ -362,7 +367,10 @@ export class SearchInWorkspaceWidget extends BaseWidget implements StatefulWidge
                 this.resultTreeWidget.focusFirstResult();
             } else {
                 this.searchTerm = (e.target as HTMLInputElement).value;
-                this.resultTreeWidget.search(this.searchTerm, (this.searchInWorkspaceOptions || {}));
+                if (this.previousSearchTerm !== this.searchTerm) {
+                    this.previousSearchTerm = this.searchTerm;
+                    this.resultTreeWidget.search(this.searchTerm, (this.searchInWorkspaceOptions || {}));
+                }
             }
         }
     }
@@ -401,7 +409,6 @@ export class SearchInWorkspaceWidget extends BaseWidget implements StatefulWidge
         if (e.target) {
             this.replaceTerm = (e.target as HTMLInputElement).value;
             this.resultTreeWidget.replaceTerm = this.replaceTerm;
-            this.resultTreeWidget.search(this.searchTerm, (this.searchInWorkspaceOptions || {}));
             this.update();
         }
     }

--- a/packages/search-in-workspace/src/common/search-in-workspace-interface.ts
+++ b/packages/search-in-workspace/src/common/search-in-workspace-interface.ts
@@ -22,6 +22,15 @@ export interface SearchInWorkspaceOptions {
      */
     maxResults?: number;
     /**
+     * Maximum number of results per message.  Defaults to 20.
+     */
+    maxResultsPerMessage?: number;
+    /**
+     * If provided, the `lineText` will be shortened around the match,
+     * based on the given before and after values.
+     */
+    shortenLineText?: { before: number, after: number };
+    /**
      * Search case sensitively if true.
      */
     matchCase?: boolean;
@@ -76,7 +85,13 @@ export interface SearchInWorkspaceResult {
     length: number;
 
     /**
-     * The text of the line containing the result.
+     * The character offset of the match in `significantLineText`.
+     * If `undefine` the `significantLineText` starts at 0, hence `character` denotes the offset.
+     */
+    significantLineCharacter?: number;
+
+    /**
+     * The text of the line around the result. If `significantLineCharacter` is defined this might not be the full line.
      */
     lineText: string;
 }
@@ -106,9 +121,9 @@ export namespace SearchInWorkspaceResult {
 export const SearchInWorkspaceClient = Symbol('SearchInWorkspaceClient');
 export interface SearchInWorkspaceClient {
     /**
-     * Called by the server for every search match.
+     * Called by the server for found search matches.
      */
-    onResult(searchId: number, result: SearchInWorkspaceResult): void;
+    onResult(searchId: number, results: SearchInWorkspaceResult[]): void;
 
     /**
      * Called when no more search matches will come.

--- a/packages/search-in-workspace/src/node/ripgrep-search-in-workspace-server.slow-spec.ts
+++ b/packages/search-in-workspace/src/node/ripgrep-search-in-workspace-server.slow-spec.ts
@@ -54,8 +54,8 @@ class ResultAccumulator implements SearchInWorkspaceClient {
         this.onDoneCallback = onDoneCallback;
     }
 
-    onResult(searchId: number, result: SearchInWorkspaceResult): void {
-        this.results.push(result);
+    onResult(searchId: number, results: SearchInWorkspaceResult[]): void {
+        this.results.push(...results);
     }
 
     onDone(searchId: number): void {
@@ -751,7 +751,7 @@ describe('ripgrep-search-in-workspace-server', function (): void {
             const rgServer = createInstance('/non-existent/rg');
 
             rgServer.setClient({
-                onResult: (searchId: number, result: SearchInWorkspaceResult): void => {
+                onResult: (searchId: number, results: SearchInWorkspaceResult[]): void => {
                     reject();
                 },
                 onDone: (searchId: number, error?: string): void => {
@@ -775,7 +775,7 @@ describe('ripgrep-search-in-workspace-server', function (): void {
             const rgServer = createInstance(rg.path);
 
             rgServer.setClient({
-                onResult: (searchId: number, result: SearchInWorkspaceResult): void => {
+                onResult: (searchId: number, results: SearchInWorkspaceResult[]): void => {
                     reject();
                 },
                 onDone: (searchId: number, error?: string): void => {


### PR DESCRIPTION
#### What it does

Optimizes search in workspace performance through the following changes:

 - set default limit of results to 1000
 - shorten lineText to what is displayed (matches in long lines, e.g. bundle.js, are no longer sent completely)
 - buffer file changes to 50 results per message
 - add a bit of timeout between search result processing to allow server processing other things in between. E.g. allows the server to answer the offline/online ping so we don't get a yellow status bar on big searches.
 - avoid search when the text has not changed
 - don't search on replace text change
 - user service side sort (rg)
 - update tree on every 50 search result.

TODO:
 - improve protocol (contains lots of redundent URIs)

#### How to test
- try search with include all in large workspaces.

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

