### PR TITLE
support having multiple user-defined problem matchers in tasks.json

### DIFF
--- a/packages/task/src/common/problem-matcher-protocol.ts
+++ b/packages/task/src/common/problem-matcher-protocol.ts
@@ -167,9 +167,9 @@ export namespace ProblemPattern {
             message: value.message,
             location: value.location,
             line: value.line,
-            character: value.character,
+            character: value.column || value.character,
             endLine: value.endLine,
-            endCharacter: value.endCharacter,
+            endCharacter: value.endColumn || value.endCharacter,
             code: value.code,
             severity: value.severity,
             loop: value.loop

--- a/packages/task/src/common/task-protocol.ts
+++ b/packages/task/src/common/task-protocol.ts
@@ -189,8 +189,10 @@ export interface ProblemPatternContribution {
     location?: number;
     line?: number;
     character?: number;
+    column?: number;
     endLine?: number;
     endCharacter?: number;
+    endColumn?: number;
     code?: number;
     severity?: number;
     loop?: boolean;


### PR DESCRIPTION
- resolved #6567: With this change Theia supports users defining ***a collection of*** problem matchers in tasks.json
- added json schemas to validate the user-defined problem matchers in tasks.json
- fixed the bug with task's schema to allow configured tasks and customized detected tasks in the same tasks.json

The code duplication from VS Code was approved in [CQ 19787](https://dev.eclipse.org/ipzilla/show_bug.cgi?id=19787)

Signed-off-by: Liang Huang <liang.huang@ericsson.com>


#### How to test

- prepare a workspace in a Theia setup that has detected tasks. When I tested this change I installed `npm` extension that contributes npm tasks.

- Open / create `.theia/tasks.json`, and create a config to customize a detected task. Add a user defined `problemMatcher` to the config, and make sure use the array. Mine was 
```json
      {
          "type": "npm",
          "script": "lintAAA",
          "problemMatcher": [{
            "owner": "eslint2",
            "source": "eslint2",
            "applyTo": "allDocuments",
            "fileLocation": "absolute",
            "pattern": [
                {
                    "regexp": "^([^\\s].*)$",
                    "kind":  "location",
                    "file": 1
                },
                {
                    "regexp": "^\\s+(\\d+):(\\d+)\\s+(error|warning|info)\\s+(.+?)(?:\\s\\s+(.*))?$",
                    "line": 1,
                    "column": 2,
                    "severity": 3,
                    "message": 4,
                    "code": 5,
                    "loop": true
                }
            ]
          }]
      }
```
- Run the customized detected task, and check if the problem matcher works.


#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)
