### PR TITLE
fix #6618: Reuse terminal based both on label and caption of the term…

### DIFF
--- a/packages/debug/src/browser/debug-session.tsx
+++ b/packages/debug/src/browser/debug-session.tsx
@@ -374,7 +374,7 @@ export class DebugSession implements CompositeTreeElement {
     }
 
     protected async doCreateTerminal(options: TerminalWidgetOptions): Promise<TerminalWidget> {
-        let terminal = this.terminalServer.all.find(t => t.title.label === options.title);
+        let terminal = this.terminalServer.all.find(t => t.title.label === options.title || t.title.caption === options.title);
         if (!terminal) {
             terminal = await this.terminalServer.newTerminal(options);
             await terminal.start();


### PR DESCRIPTION
…inal title

Signed-off-by: Cai Xuye <a1994846931931@gmail.com>

#### What it does
A simple approach to fix #6618 - may not be the best solution, but does what it does.

#### How to test
1. Install VSCode's python plugin
2. Debug with the following configuration ( console should be integratedTerminal )
```
    {
      "name": "Python: Current File",
      "type": "python",
      "request": "launch",
      "program": "${file}",
      "console": "integratedTerminal"
    }
```
3. End the debug session but keep the integrated terminal. Then run another debug session and see how theia lanches it in the same terminal launched before.

![python-integrated-fix](https://user-images.githubusercontent.com/17487291/69525321-d58b0d80-0fa2-11ea-9456-3968e04e7b10.gif)

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

