### PR TITLE
[keybinding] Align 'Open Preferences' and 'Save As' keybindings with VS Code on Mac OS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 - [core] Switched the frontend application's shutdown hook from `window.unload` to `window.beforeunload`. [#6530](https://github.com/eclipse-theia/theia/issues/6530)
 - [core] label providers can now notify that element labels and icons may have changed and should be refreshed [#5884](https://github.com/theia-ide/theia/pull/5884)
-- [core] added <kbd>cmd</kbd> + <kbd>,</kbd> as default keybinding for 'Open Preferences' on Mac to align with VS Code [#6620](https://github.com/eclipse-theia/theia/pull/6620)
+- [core] aligned 'Open Preferences' and 'Save As' keybindings with VS Code on Mac OS [#6620](https://github.com/eclipse-theia/theia/pull/6620)
 - [scm] added handling when opening diff-editors to respect preference `workbench.list.openMode` [#6481](https://github.com/eclipse-theia/theia/pull/6481)
 
 Breaking changes:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - [core] Switched the frontend application's shutdown hook from `window.unload` to `window.beforeunload`. [#6530](https://github.com/eclipse-theia/theia/issues/6530)
 - [core] label providers can now notify that element labels and icons may have changed and should be refreshed [#5884](https://github.com/theia-ide/theia/pull/5884)
+- [core] added <kbd>cmd</kbd> + <kbd>,</kbd> as default keybinding for 'Open Preferences' on Mac to align with VS Code [#6620](https://github.com/eclipse-theia/theia/pull/6620)
 - [scm] added handling when opening diff-editors to respect preference `workbench.list.openMode` [#6481](https://github.com/eclipse-theia/theia/pull/6481)
 
 Breaking changes:

--- a/packages/preferences/src/browser/preferences-contribution.ts
+++ b/packages/preferences/src/browser/preferences-contribution.ts
@@ -29,6 +29,8 @@ import { FileSystem } from '@theia/filesystem/lib/common';
 import { UserStorageService } from '@theia/userstorage/lib/browser';
 import { PreferencesContainer } from './preferences-tree-widget';
 import { EditorManager } from '@theia/editor/lib/browser';
+import { isFirefox } from '@theia/core/lib/browser';
+import { isOSX } from '@theia/core/lib/common/os';
 
 @injectable()
 export class PreferencesContribution extends AbstractViewContribution<PreferencesContainer> {
@@ -61,6 +63,12 @@ export class PreferencesContribution extends AbstractViewContribution<Preference
     }
 
     registerKeybindings(keybindings: KeybindingRegistry): void {
+        if (isOSX && !isFirefox) {
+            keybindings.registerKeybinding({
+                command: CommonCommands.OPEN_PREFERENCES.id,
+                keybinding: 'cmd+,'
+            });
+        }
         keybindings.registerKeybinding({
             command: CommonCommands.OPEN_PREFERENCES.id,
             keybinding: 'ctrl+,'

--- a/packages/workspace/src/browser/workspace-frontend-contribution.ts
+++ b/packages/workspace/src/browser/workspace-frontend-contribution.ts
@@ -161,7 +161,7 @@ export class WorkspaceFrontendContribution implements CommandContribution, Keybi
         });
         keybindings.registerKeybinding({
             command: WorkspaceCommands.SAVE_AS.id,
-            keybinding: 'ctrl+shift+s',
+            keybinding: 'ctrlcmd+shift+s',
         });
     }
 


### PR DESCRIPTION
Fixes https://github.com/eclipse-theia/theia/issues/6606.

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does

In VS Code, the default keybinding to open Settings is:
- <kbd>Cmd</kbd> + <kbd>,</kbd> on Mac OS, and
- <kbd>Ctrl</kbd> + <kbd>,</kbd> on Linux and Windows

In Theia, it is currently <kbd>Ctrl</kbd> + <kbd>,</kbd> everywhere. While this works everywhere, it's perceived as surprising on Mac OS.

Thus, on Mac OS we want the default keybinding to be <kbd>Cmd</kbd> + <kbd>,</kbd>. However:
- The previous keybinding should still work, in order to avoid nasty surprises for users who got used to it
- While the new keybinding works in Electron and in browser/Chrome, it doesn't work in browser/Firefox. So on Firefox Mac, the default keybinding should remain <kbd>Ctrl</kbd> + <kbd>,</kbd>

#### How to test

- In Electron and in Chrome:
  - both <kbd>Ctrl</kbd> + <kbd>,</kbd> and <kbd>Ctrl</kbd> + <kbd>,</kbd> should open the Preferences
  - the menu entry `File` > `Settings` > `Open Preferences` should show `⌘,` as the default keybinding
- In Firefox:
  - only <kbd>Ctrl</kbd> + <kbd>,</kbd> can open the Preferences
  - thus the menu entry should still show `^,` as the default keybinding
- On Linux and Windows:
  - the default keybinding should remain <kbd>Ctrl</kbd> + <kbd>,</kbd> everywhere (like VS Code)

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

