### PR TITLE
[core] Don't scroll when re-setting focus on widgets.

### DIFF
--- a/packages/core/src/browser/menu/browser-menu-plugin.ts
+++ b/packages/core/src/browser/menu/browser-menu-plugin.ts
@@ -173,7 +173,7 @@ class DynamicMenuWidget extends MenuWidget {
         // we want to restore the focus after the menu closes.
         const previouslyActive = window.document.activeElement as HTMLElement;
         const cb = () => {
-            previouslyActive.focus();
+            previouslyActive.focus({ preventScroll: true });
             this.aboutToClose.disconnect(cb);
         };
         this.aboutToClose.connect(cb);

--- a/packages/core/src/browser/quick-open/quick-command-service.ts
+++ b/packages/core/src/browser/quick-open/quick-command-service.ts
@@ -246,7 +246,7 @@ export class CommandQuickOpenItem extends QuickOpenGroupItem {
         // allow the quick open widget to close itself
         setTimeout(() => {
             // reset focus on the previously active element.
-            this.activeElement.focus();
+            this.activeElement.focus({ preventScroll: true });
             this.commands.executeCommand(this.command.id);
         }, 50);
         return true;

--- a/packages/core/src/browser/tree/tree-widget.tsx
+++ b/packages/core/src/browser/tree/tree-widget.tsx
@@ -331,7 +331,7 @@ export class TreeWidget extends ReactWidget implements StatefulWidget {
 
     protected onActivateRequest(msg: Message): void {
         super.onActivateRequest(msg);
-        this.node.focus();
+        this.node.focus({ preventScroll: true });
     }
 
     /**

--- a/packages/core/src/browser/view-container.ts
+++ b/packages/core/src/browser/view-container.ts
@@ -528,7 +528,7 @@ export class ViewContainer extends BaseWidget implements StatefulWidget, Applica
         if (this.currentPart) {
             this.currentPart.activate();
         } else {
-            this.panel.node.focus();
+            this.panel.node.focus({ preventScroll: true });
         }
     }
 

--- a/packages/git/src/browser/diff/git-diff-widget.tsx
+++ b/packages/git/src/browser/diff/git-diff-widget.tsx
@@ -437,7 +437,7 @@ export class GitDiffListContainer extends React.Component<GitDiffListContainer.P
 
     focus(): void {
         if (this.listContainer) {
-            this.listContainer.focus();
+            this.listContainer.focus({ preventScroll: true });
         }
     }
 }

--- a/packages/monaco/src/browser/monaco-quick-open-service.ts
+++ b/packages/monaco/src/browser/monaco-quick-open-service.ts
@@ -219,7 +219,7 @@ export class MonacoQuickOpenService extends QuickOpenService {
             },
             onCancel: () => {
                 if (this.previousActiveElement instanceof HTMLElement) {
-                    this.previousActiveElement.focus();
+                    this.previousActiveElement.focus({ preventScroll: true });
                 }
                 this.previousActiveElement = undefined;
                 this.contextKeyService.activeContext = undefined;

--- a/packages/plugin-ext/src/main/browser/quick-open-main.ts
+++ b/packages/plugin-ext/src/main/browser/quick-open-main.ts
@@ -77,7 +77,7 @@ export class QuickOpenMainImpl implements QuickOpenMain, QuickOpenModel, Disposa
         this.items = undefined;
         this.acceptor = undefined;
         if (this.activeElement) {
-            this.activeElement.focus();
+            this.activeElement.focus({ preventScroll: true });
         }
         this.activeElement = undefined;
     }

--- a/packages/plugin-ext/src/main/browser/workspace-main.ts
+++ b/packages/plugin-ext/src/main/browser/workspace-main.ts
@@ -150,7 +150,7 @@ export class WorkspaceMainImpl implements WorkspaceMain, Disposable {
                 placeholder: options.placeHolder,
                 onClose: () => {
                     if (activeElement) {
-                        activeElement.focus();
+                        activeElement.focus({ preventScroll: true });
                     }
 
                     resolve(returnValue);


### PR DESCRIPTION
#### What it does

Fixes annoying scrolling issues in scrollable widgets, that occur when using context menu or the quick open functionality.

Fixes #4901

#### How to test
In navigator scroll down, so you no longer see the first item.
Then open context menu or quick open and escape again (or choose an action). In current master the navigator will be scrolled back to zero. With this PR the scrolling state doesn't change.


#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

