### PR TITLE
[core] Remove perfect scrollbar

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -33,7 +33,6 @@
     "lodash.debounce": "^4.0.8",
     "lodash.throttle": "^4.1.1",
     "nsfw": "^1.2.2",
-    "perfect-scrollbar": "^1.3.0",
     "react": "^16.4.1",
     "react-dom": "^16.4.1",
     "react-virtualized": "^9.20.0",

--- a/packages/core/src/browser/shell/application-shell.ts
+++ b/packages/core/src/browser/shell/application-shell.ts
@@ -80,12 +80,7 @@ export class DockPanelRenderer implements DockLayout.IRenderer {
     createTabBar(): TabBar<Widget> {
         const renderer = this.tabBarRendererFactory();
         const tabBar = new ToolbarAwareTabBar(this.tabBarToolbarRegistry, this.tabBarToolbarFactory, {
-            renderer,
-            // Scroll bar options
-            handlers: ['drag-thumb', 'keyboard', 'wheel', 'touch'],
-            useBothWheelAxes: true,
-            scrollXMarginOffset: 4,
-            suppressScrollY: true
+            renderer
         });
         this.tabBarClasses.forEach(c => tabBar.addClass(c));
         renderer.tabBar = tabBar;

--- a/packages/core/src/browser/shell/side-panel-handler.ts
+++ b/packages/core/src/browser/shell/side-panel-handler.ts
@@ -129,12 +129,7 @@ export class SidePanelHandler {
             removeBehavior: 'select-previous-tab',
             allowDeselect: false,
             tabsMovable: true,
-            renderer: tabBarRenderer,
-            // Scroll bar options
-            handlers: ['drag-thumb', 'keyboard', 'wheel', 'touch'],
-            useBothWheelAxes: true,
-            scrollYMarginOffset: 8,
-            suppressScrollX: true
+            renderer: tabBarRenderer
         });
         tabBarRenderer.tabBar = sideBar;
         tabBarRenderer.contextMenuPath = SHELL_TABBAR_CONTEXT_MENU;

--- a/packages/core/src/browser/shell/tab-bars.ts
+++ b/packages/core/src/browser/shell/tab-bars.ts
@@ -14,7 +14,6 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
-import PerfectScrollbar from 'perfect-scrollbar';
 import { TabBar, Title, Widget } from '@phosphor/widgets';
 import { VirtualElement, h, VirtualDOM, ElementInlineStyle } from '@phosphor/virtualdom';
 import { Disposable, DisposableCollection, MenuPath, notEmpty } from '../../common';
@@ -433,45 +432,16 @@ export class TabBarRenderer extends TabBar.Renderer {
  */
 export class ScrollableTabBar extends TabBar<Widget> {
 
-    protected scrollBar?: PerfectScrollbar;
-
-    private scrollBarFactory: () => PerfectScrollbar;
     private pendingReveal?: Promise<void>;
 
-    constructor(options?: TabBar.IOptions<Widget> & PerfectScrollbar.Options) {
+    constructor(options?: TabBar.IOptions<Widget>) {
         super(options);
-        this.scrollBarFactory = () => new PerfectScrollbar(this.scrollbarHost, options);
-    }
-
-    protected onAfterAttach(msg: Message): void {
-        if (!this.scrollBar) {
-            this.scrollBar = this.scrollBarFactory();
-        }
-        super.onAfterAttach(msg);
-    }
-
-    protected onBeforeDetach(msg: Message): void {
-        super.onBeforeDetach(msg);
-        if (this.scrollBar) {
-            this.scrollBar.destroy();
-            this.scrollBar = undefined;
-        }
-    }
-
-    protected onUpdateRequest(msg: Message): void {
-        super.onUpdateRequest(msg);
-        if (this.scrollBar) {
-            this.scrollBar.update();
-        }
     }
 
     protected onResize(msg: Widget.ResizeMessage): void {
         super.onResize(msg);
-        if (this.scrollBar) {
-            if (this.currentIndex >= 0) {
-                this.revealTab(this.currentIndex);
-            }
-            this.scrollBar.update();
+        if (this.currentIndex >= 0) {
+            this.revealTab(this.currentIndex);
         }
     }
 
@@ -488,7 +458,7 @@ export class ScrollableTabBar extends TabBar<Widget> {
             window.requestAnimationFrame(() => {
                 const tab = this.contentNode.children[index] as HTMLElement;
                 if (tab && this.isVisible) {
-                    const parent = this.scrollbarHost;
+                    const parent = this.node;
                     if (this.orientation === 'horizontal') {
                         const scroll = parent.scrollLeft;
                         const left = tab.offsetLeft;
@@ -523,10 +493,6 @@ export class ScrollableTabBar extends TabBar<Widget> {
         return result;
     }
 
-    protected get scrollbarHost(): HTMLElement {
-        return this.node;
-    }
-
 }
 
 /**
@@ -537,7 +503,7 @@ export class ScrollableTabBar extends TabBar<Widget> {
  * |[TAB_0][TAB_1][TAB_2][TAB|
  * +-------------Scrollable--+
  *
- * There is a dedicated HTML element for toolbar which does **not** contained in the scrollable element.
+ * There is a dedicated HTML element for toolbar which is **not** contained in the scrollable element.
  *
  * +-------------------------+-----------------+
  * |[TAB_0][TAB_1][TAB_2][TAB|         Toolbar |
@@ -552,7 +518,7 @@ export class ToolbarAwareTabBar extends ScrollableTabBar {
     constructor(
         protected readonly tabBarToolbarRegistry: TabBarToolbarRegistry,
         protected readonly tabBarToolbarFactory: () => TabBarToolbar,
-        protected readonly options?: TabBar.IOptions<Widget> & PerfectScrollbar.Options) {
+        protected readonly options?: TabBar.IOptions<Widget>) {
 
         super(options);
         this.rewireDOM();
@@ -564,13 +530,6 @@ export class ToolbarAwareTabBar extends ScrollableTabBar {
      */
     get contentNode(): HTMLUListElement {
         return this.tabBarContainer.getElementsByClassName(ToolbarAwareTabBar.Styles.TAB_BAR_CONTENT)[0] as HTMLUListElement;
-    }
-
-    /**
-     * Overrides the scrollable host from the parent class.
-     */
-    protected get scrollbarHost(): HTMLElement {
-        return this.tabBarContainer;
     }
 
     protected get tabBarContainer(): HTMLElement {
@@ -673,7 +632,7 @@ export class SideTabBar extends ScrollableTabBar {
         mouseDownTabIndex: number
     };
 
-    constructor(options?: TabBar.IOptions<Widget> & PerfectScrollbar.Options) {
+    constructor(options?: TabBar.IOptions<Widget>) {
         super(options);
 
         // Create the hidden content node (see `hiddenContentNode` for explanation)
@@ -709,9 +668,6 @@ export class SideTabBar extends ScrollableTabBar {
 
     protected onUpdateRequest(msg: Message): void {
         this.renderTabBar();
-        if (this.scrollBar) {
-            this.scrollBar.update();
-        }
     }
 
     /**

--- a/packages/core/src/browser/status-bar/status-bar.tsx
+++ b/packages/core/src/browser/status-bar/status-bar.tsx
@@ -81,7 +81,6 @@ export class StatusBarImpl extends ReactWidget implements StatusBar {
         @inject(FrontendApplicationStateService) protected readonly applicationStateService: FrontendApplicationStateService
     ) {
         super();
-        delete this.scrollOptions;
         this.id = 'theia-statusBar';
         this.addClass('noselect');
     }

--- a/packages/core/src/browser/style/scrollbars.css
+++ b/packages/core/src/browser/style/scrollbars.css
@@ -14,12 +14,14 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
-@import url('~perfect-scrollbar/css/perfect-scrollbar.css');
-
 ::-webkit-scrollbar {
     height: var(--theia-scrollbar-width);
     width: var(--theia-scrollbar-width);
-    background: var(--theia-scrollbar-rail-color);
+    background: transparent;
+}
+
+::-webkit-scrollbar-track {
+    background: transparent;
 }
 
 ::-webkit-scrollbar-thumb {
@@ -38,98 +40,10 @@
     background: transparent;
 }
 
-
-/*-----------------------------------------------------------------------------
-| Perfect scrollbar
-|----------------------------------------------------------------------------*/
-
-#theia-app-shell .ps__rail-x,
-#theia-dialog-shell .ps__rail-x {
-    height: var(--theia-scrollbar-rail-width);
-    background: var(--theia-scrollbar-rail-color);
+* {
+    scrollbar-width: thin;
+    scrollbar-color: var(--theia-scrollbar-rail-color) var(--theia-scrollbar-thumb-color);
 }
-
-#theia-app-shell .ps__rail-x > .ps__thumb-x,
-#theia-dialog-shell .ps__rail-x > .ps__thumb-x {
-    height: var(--theia-scrollbar-width);
-    bottom: calc((var(--theia-scrollbar-rail-width) - var(--theia-scrollbar-width)) / 2);
-    background: var(--theia-scrollbar-thumb-color);
-    border-radius: 0px;
-}
-
-#theia-app-shell .ps__rail-x:hover,
-#theia-app-shell .ps__rail-x:focus,
-#theia-dialog-shell .ps__rail-x:hover,
-#theia-dialog-shell .ps__rail-x:focus {
-    height: var(--theia-scrollbar-rail-width);
-}
-
-#theia-app-shell .ps__rail-x:hover > .ps__thumb-x,
-#theia-app-shell .ps__rail-x:focus > .ps__thumb-x,
-#theia-app-shell .ps__rail-x.ps--clicking .ps__thumb-x,
-#theia-dialog-shell .ps__rail-x:hover > .ps__thumb-x,
-#theia-dialog-shell .ps__rail-x:focus > .ps__thumb-x,
-#theia-dialog-shell .ps__rail-x.ps--clicking .ps__thumb-x  {
-    height: var(--theia-scrollbar-width);
-}
-
-#theia-app-shell .ps__rail-y,
-#theia-dialog-shell .ps__rail-y {
-    width: var(--theia-scrollbar-rail-width);
-    background: var(--theia-scrollbar-rail-color);
-}
-
-#theia-app-shell .ps__rail-y > .ps__thumb-y,
-#theia-dialog-shell .ps__rail-y > .ps__thumb-y {
-    width: var(--theia-scrollbar-width);
-    right: calc((var(--theia-scrollbar-rail-width) - var(--theia-scrollbar-width)) / 2);
-    background: var(--theia-scrollbar-thumb-color);
-    border-radius: 0px;
-}
-
-#theia-app-shell .ps__rail-y:hover,
-#theia-app-shell .ps__rail-y:focus,
-#theia-dialog-shell .ps__rail-y:hover,
-#theia-dialog-shell .ps__rail-y:focus {
-    width: var(--theia-scrollbar-rail-width);
-}
-
-#theia-app-shell .ps__rail-y:hover > .ps__thumb-y,
-#theia-app-shell .ps__rail-y:focus > .ps__thumb-y,
-#theia-app-shell .ps__rail-y.ps--clicking .ps__thumb-y,
-#theia-dialog-shell .ps__rail-y:hover > .ps__thumb-y,
-#theia-dialog-shell .ps__rail-y:focus > .ps__thumb-y,
-#theia-dialog-shell .ps__rail-y.ps--clicking .ps__thumb-y  {
-    right: calc((var(--theia-scrollbar-rail-width) - var(--theia-scrollbar-width)) / 2);
-    width: var(--theia-scrollbar-width);
-}
-
-#theia-app-shell .ps [class^='ps__rail']:hover,
-#theia-app-shell .ps [class^='ps__rail']:focus,
-#theia-app-shell .ps [class^='ps__rail'].ps--clicking,
-#theia-dialog-shell .ps [class^='ps__rail']:hover,
-#theia-dialog-shell .ps [class^='ps__rail']:focus,
-#theia-dialog-shell .ps [class^='ps__rail'].ps--clicking {
-    background-color: var(--theia-scrollbar-active-rail-color);
-}
-
-#theia-app-shell .ps [class^='ps__rail']:hover > [class^='ps__thumb'],
-#theia-app-shell .ps [class^='ps__rail']:focus > [class^='ps__thumb'],
-#theia-dialog-shell .ps [class^='ps__rail']:hover > [class^='ps__thumb'],
-#theia-dialog-shell .ps [class^='ps__rail']:focus > [class^='ps__thumb']
- {
-    background: var(--theia-scrollbar-active-thumb-color);
-}
-
-#theia-app-shell .ps:hover > [class^='ps__rail'],
-#theia-app-shell .ps--focus > [class^='ps__rail'],
-#theia-app-shell .ps--scrolling-y > [class^='ps__rail'],
-#theia-dialog-shell .ps:hover > [class^='ps__rail'],
-#theia-dialog-shell .ps--focus > [class^='ps__rail'],
-#theia-dialog-shell .ps--scrolling-y > [class^='ps__rail'] {
-    opacity: 1;
-}
-
 
 /*-----------------------------------------------------------------------------
 | Monaco

--- a/packages/core/src/browser/style/sidepanel.css
+++ b/packages/core/src/browser/style/sidepanel.css
@@ -144,33 +144,6 @@
   background-color: var(--theia-layout-color1);
 }
 
-
-/*-----------------------------------------------------------------------------
-| Perfect scrollbar
-|----------------------------------------------------------------------------*/
-
-.p-TabBar.theia-app-sides > .ps__rail-y {
-  width: var(--theia-private-sidebar-scrollbar-rail-width);
-  z-index: 1000;
-}
-
-.p-TabBar.theia-app-sides > .ps__rail-y  >.ps__thumb-y {
-  width: var(--theia-private-sidebar-scrollbar-width);
-  right: calc((var(--theia-private-sidebar-scrollbar-rail-width) - var(--theia-private-sidebar-scrollbar-width)) / 2);
-}
-
-.p-TabBar.theia-app-sides > .ps__rail-y:hover,
-.p-TabBar.theia-app-sides > .ps__rail-y:focus {
-  width: var(--theia-private-sidebar-scrollbar-rail-width);
-}
-
-.p-TabBar.theia-app-sides > .ps__rail-y:hover > .ps__thumb-y,
-.p-TabBar.theia-app-sides > .ps__rail-y:focus > .ps__thumb-y {
-  width: var(--theia-private-sidebar-scrollbar-width);
-  right: calc((var(--theia-private-sidebar-scrollbar-rail-width) - var(--theia-private-sidebar-scrollbar-width)) / 2);
-}
-
-
 /*-----------------------------------------------------------------------------
 | Bottom content panel
 |----------------------------------------------------------------------------*/

--- a/packages/core/src/browser/style/tabs.css
+++ b/packages/core/src/browser/style/tabs.css
@@ -42,6 +42,21 @@
   min-height: calc(var(--theia-private-horizontal-tab-height) + var(--theia-private-horizontal-tab-scrollbar-rail-height) / 2);
 }
 
+/* the default overflow for all browsers */
+.p-TabBar:hover {
+    overflow-x: auto;
+}
+
+.p-TabBar[data-orientation='horizontal']:hover {
+    /* use overlay, which only works in webkit browsers. IF not supported will fall back to the value set above (i.e. auto) */
+    overflow-x: overlay;
+    scrollbar-width: none;
+}
+
+.p-TabBar[data-orientation='horizontal']:hover::-webkit-scrollbar {
+    height: 5px;
+}
+
 .p-TabBar .p-TabBar-content {
   cursor: pointer;
 }
@@ -192,32 +207,6 @@
 .p-TabBar.theia-app-centers .p-TabBar-tab > .p-TabBar-tabIcon.no-icon {
   display: none;
 }
-
-/*-----------------------------------------------------------------------------
-| Perfect scrollbar
-|----------------------------------------------------------------------------*/
-
-.p-TabBar[data-orientation='horizontal'] > .p-TabBar-content-container > .ps__rail-x {
-  height: var(--theia-private-horizontal-tab-scrollbar-rail-height);
-  z-index: 1000;
-}
-
-.p-TabBar[data-orientation='horizontal'] > .p-TabBar-content-container > .ps__rail-x  > .ps__thumb-x {
-  height: var(--theia-private-horizontal-tab-scrollbar-height) !important;
-  bottom: calc((var(--theia-private-horizontal-tab-scrollbar-rail-height) - var(--theia-private-horizontal-tab-scrollbar-height)) / 2);
-}
-
-.p-TabBar[data-orientation='horizontal'] > .p-TabBar-content-container > .ps__rail-x:hover,
-.p-TabBar[data-orientation='horizontal'] > .p-TabBar-content-container > .ps__rail-x:focus {
-  height: var(--theia-private-horizontal-tab-scrollbar-rail-height) !important;
-}
-
-.p-TabBar[data-orientation='horizontal'] > .p-TabBar-content-container > .ps__rail-x:hover > .ps__thumb-x,
-.p-TabBar[data-orientation='horizontal'] > .p-TabBar-content-container > .ps__rail-x:focus > .ps__thumb-x {
-  height: calc(var(--theia-private-horizontal-tab-scrollbar-height) / 2) !important;
-  bottom: calc((var(--theia-private-horizontal-tab-scrollbar-rail-height) - var(--theia-private-horizontal-tab-scrollbar-height)) / 2);
-}
-
 
 /*-----------------------------------------------------------------------------
 | Dragged tabs

--- a/packages/core/src/browser/style/tree.css
+++ b/packages/core/src/browser/style/tree.css
@@ -22,6 +22,10 @@
     position: relative;
 }
 
+.theia-Tree:hover {
+    overflow-y: auto;
+}
+
 .theia-Tree:focus .theia-TreeContainer.empty {
     outline-width: 1px;
     outline-style: solid;

--- a/packages/core/src/browser/tree/tree-widget.tsx
+++ b/packages/core/src/browser/tree/tree-widget.tsx
@@ -163,10 +163,6 @@ export class TreeWidget extends ReactWidget implements StatefulWidget {
         @inject(ContextMenuRenderer) protected readonly contextMenuRenderer: ContextMenuRenderer,
     ) {
         super();
-        this.scrollOptions = {
-            suppressScrollX: true,
-            minScrollbarLength: 35
-        };
         this.addClass(TREE_CLASS);
         this.node.tabIndex = 0;
     }
@@ -953,7 +949,7 @@ export class TreeWidget extends ReactWidget implements StatefulWidget {
         this.addKeyListener(this.node, down, event => this.handleDown(event));
         this.addKeyListener(this.node, Key.ENTER, event => this.handleEnter(event));
         // tslint:disable-next-line:no-any
-        this.addEventListener<any>(this.node, 'ps-scroll-y', (e: Event & { target: { scrollTop: number } }) => {
+        this.addEventListener<any>(this.node, 'scroll', (e: Event & { target: { scrollTop: number } }) => {
             if (this.view && this.view.list && this.view.list.Grid) {
                 const { scrollTop } = e.target;
                 this.view.list.Grid.handleScrollEvent({ scrollTop });

--- a/packages/core/src/browser/view-container.ts
+++ b/packages/core/src/browser/view-container.ts
@@ -707,10 +707,6 @@ export class ViewContainerPart extends BaseWidget {
             // focus event does not bubble, capture it
             addEventListener(this.node, 'focus', () => this.onDidFocusEmitter.fire(this), true)
         ]);
-        this.scrollOptions = {
-            suppressScrollX: true,
-            minScrollbarLength: 35
-        };
         this.collapsed = !!options.initiallyCollapsed;
         if (options.initiallyHidden && this.canHide) {
             this.hide();

--- a/packages/core/src/browser/widgets/react-widget.tsx
+++ b/packages/core/src/browser/widgets/react-widget.tsx
@@ -27,10 +27,6 @@ export abstract class ReactWidget extends BaseWidget {
 
     constructor() {
         super();
-        this.scrollOptions = {
-            suppressScrollX: true,
-            minScrollbarLength: 35,
-        };
         this.toDispose.push(Disposable.create(() => {
             ReactDOM.unmountComponentAtNode(this.node);
         }));

--- a/packages/core/src/browser/widgets/virtual-widget.ts
+++ b/packages/core/src/browser/widgets/virtual-widget.ts
@@ -28,21 +28,12 @@ export class VirtualWidget extends BaseWidget {
 
     protected readonly onRender = new DisposableCollection();
     protected childContainer?: HTMLElement;
-    protected scrollOptions = {
-        suppressScrollX: true
-    };
 
     protected onUpdateRequest(msg: Message): void {
         super.onUpdateRequest(msg);
         const child = this.render();
         if (!this.childContainer) {
-            // if we are adding scrolling, we need to wrap the contents in its own div, to not conflict with the virtual dom algo.
-            if (this.scrollOptions) {
-                this.childContainer = this.createChildContainer();
-                this.node.appendChild(this.childContainer);
-            } else {
-                this.childContainer = this.node;
-            }
+            this.childContainer = this.node;
         }
         VirtualRenderer.render(child, this.childContainer);
         this.onRender.dispose();

--- a/packages/debug/src/browser/view/debug-configuration-widget.tsx
+++ b/packages/debug/src/browser/view/debug-configuration-widget.tsx
@@ -56,7 +56,6 @@ export class DebugConfigurationWidget extends ReactWidget {
         this.toDispose.push(this.manager.onDidChange(() => this.update()));
         this.toDispose.push(this.workspaceService.onWorkspaceChanged(() => this.update()));
         this.toDispose.push(this.workspaceService.onWorkspaceLocationChanged(() => this.update()));
-        this.scrollOptions = undefined;
         this.update();
     }
 

--- a/packages/debug/src/browser/view/debug-toolbar-widget.tsx
+++ b/packages/debug/src/browser/view/debug-toolbar-widget.tsx
@@ -34,7 +34,6 @@ export class DebugToolBar extends ReactWidget {
         this.addClass('debug-toolbar');
         this.toDispose.push(this.model);
         this.toDispose.push(this.model.onDidChange(() => this.update()));
-        this.scrollOptions = undefined;
         this.update();
     }
 

--- a/packages/git/src/browser/history/git-history-widget.tsx
+++ b/packages/git/src/browser/history/git-history-widget.tsx
@@ -118,7 +118,7 @@ export class GitHistoryWidget extends GitNavigableListWidget<GitHistoryListNode>
         super.onAfterAttach(msg);
         this.addGitListNavigationKeyListeners(this.node);
         // tslint:disable-next-line:no-any
-        this.addEventListener<any>(this.node, 'ps-scroll-y', (e: Event & { target: { scrollTop: number } }) => {
+        this.addEventListener<any>(this.node, 'scroll', (e: Event & { target: { scrollTop: number } }) => {
             if (this.listView && this.listView.list && this.listView.list.Grid) {
                 const { scrollTop } = e.target;
                 this.listView.list.Grid.handleScrollEvent({ scrollTop });

--- a/packages/messages/package.json
+++ b/packages/messages/package.json
@@ -6,7 +6,6 @@
     "@theia/core": "^0.12.0",
     "lodash.throttle": "^4.1.1",
     "markdown-it": "^8.4.0",
-    "react-perfect-scrollbar": "^1.5.3",
     "ts-md5": "^1.2.2"
   },
   "publishConfig": {

--- a/packages/messages/src/browser/notification-center-component.tsx
+++ b/packages/messages/src/browser/notification-center-component.tsx
@@ -19,8 +19,6 @@ import { DisposableCollection } from '@theia/core';
 import { NotificationManager, NotificationUpdateEvent } from './notifications-manager';
 import { NotificationComponent } from './notification-component';
 
-const PerfectScrollbar = require('react-perfect-scrollbar');
-
 export interface NotificationCenterComponentProps {
     readonly manager: NotificationManager;
 }
@@ -67,13 +65,11 @@ export class NotificationCenterComponent extends React.Component<NotificationCen
                         </ul>
                     </div>
                 </div>
-                <PerfectScrollbar className='theia-notification-list-scroll-container'>
-                    <div className='theia-notification-list'>
-                        {this.state.notifications.map(notification =>
-                            <NotificationComponent key={notification.messageId} notification={notification} manager={this.props.manager} />
-                        )}
-                    </div>
-                </PerfectScrollbar>
+                <div className='theia-notification-list'>
+                    {this.state.notifications.map(notification =>
+                        <NotificationComponent key={notification.messageId} notification={notification} manager={this.props.manager} />
+                    )}
+                </div>
             </div>
         );
     }

--- a/packages/messages/src/browser/style/notifications.css
+++ b/packages/messages/src/browser/style/notifications.css
@@ -266,24 +266,3 @@
     background-color: var(--theia-brand-color0);
     width: 66%;
 }
-
-/* Perfect scrollbar */
-
-.theia-notification-list-scroll-container .ps__rail-y {
-    width: var(--theia-scrollbar-rail-width);
-    background: var(--theia-scrollbar-rail-color);
-}
-
-.theia-notification-list-scroll-container .ps__rail-y:hover > .ps__thumb-y,
-.theia-notification-list-scroll-container .ps__rail-y:focus > .ps__thumb-y,
-.theia-notification-list-scroll-container .ps__rail-y.ps--clicking .ps__thumb-y {
-    right: calc((var(--theia-scrollbar-rail-width) - var(--theia-scrollbar-width)) / 2);
-    width: var(--theia-scrollbar-width);
-}
-
-.theia-notification-list-scroll-container .ps__rail-y > .ps__thumb-y {
-    width: var(--theia-scrollbar-width);
-    right: calc((var(--theia-scrollbar-rail-width) - var(--theia-scrollbar-width)) / 2);
-    background: var(--theia-scrollbar-thumb-color);
-    border-radius: 0px;
-}

--- a/yarn.lock
+++ b/yarn.lock
@@ -9504,11 +9504,6 @@ pend@~1.2.0:
   resolved "https://registry.yarnpkg.com/pend/-/pend-1.2.0.tgz#7a57eb550a6783f9115331fcf4663d5c8e007a50"
   integrity sha1-elfrVQpng/kRUzH89GY9XI4AelA=
 
-perfect-scrollbar@^1.3.0, perfect-scrollbar@^1.4.0:
-  version "1.4.0"
-  resolved "https://registry.yarnpkg.com/perfect-scrollbar/-/perfect-scrollbar-1.4.0.tgz#5d014ef9775e1f43058a1dbae9ed1daf0e7091f1"
-  integrity sha512-/2Sk/khljhdrsamjJYS5NjrH+GKEHEwh7zFSiYyxROyYKagkE4kSn2zDQDRTOMo8mpT2jikxx6yI1dG7lNP/hw==
-
 performance-now@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/performance-now/-/performance-now-2.1.0.tgz#6309f4e0e5fa913ec1c69307ae364b4b377c9e7b"
@@ -10221,14 +10216,6 @@ react-lifecycles-compat@^3.0.4:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz#4f1a273afdfc8f3488a8c516bfda78f872352362"
   integrity sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA==
-
-react-perfect-scrollbar@^1.5.3:
-  version "1.5.3"
-  resolved "https://registry.yarnpkg.com/react-perfect-scrollbar/-/react-perfect-scrollbar-1.5.3.tgz#a8a0051a5f737801d4f73d48af5369724c595787"
-  integrity sha512-2fVqbDJgOb1siCCJozGbv22cAHnh6TI9HFHRpM0lBJTPPM0ajgmsU75mBnI3k0ndryo+JiwUbLKACrurx1BjBw==
-  dependencies:
-    perfect-scrollbar "^1.4.0"
-    prop-types "^15.6.1"
 
 react-virtualized@^9.20.0:
   version "9.21.2"


### PR DESCRIPTION
#### What it does

Removes perfect-scrollbar.

The reason we introduced it was because of the limited
styling capabilities in Friefox. This has changed end of last year,
as it now supports the properties `scrollbar-color`
and `scrollbar-width`.

#### How to test
Check scrolling behavior and visual experience in chrome and firefox.

#### Review checklist

- [ ] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

