### PR TITLE
Fixes for Vscode emacs extension

### DIFF
--- a/packages/core/src/browser/keyboard/keys.ts
+++ b/packages/core/src/browser/keyboard/keys.ts
@@ -236,7 +236,7 @@ export class KeyCode {
         }
 
         const schema: KeyCodeSchema = {};
-        const keys = keybinding.trim().toLowerCase().split('+');
+        const keys = keybinding.trim().toLowerCase().split(/[-+]/g);
         /* If duplicates i.e ctrl+ctrl+a or alt+alt+b or b+alt+b it is invalid */
         if (keys.length !== new Set(keys).size) {
             throw new Error(`Can't parse keybinding ${keybinding} Duplicate modifiers`);

--- a/packages/plugin-ext-vscode/src/browser/plugin-vscode-commands-contribution.ts
+++ b/packages/plugin-ext-vscode/src/browser/plugin-vscode-commands-contribution.ts
@@ -15,7 +15,15 @@
  ********************************************************************************/
 
 import { Command, CommandContribution, CommandRegistry, ResourceProvider } from '@theia/core';
-import { ApplicationShell, NavigatableWidget, open, OpenerService, Saveable } from '@theia/core/lib/browser';
+import {
+    ApplicationShell,
+    CommonCommands,
+    NavigatableWidget,
+    open,
+    OpenerService,
+    PrefixQuickOpenService,
+    Saveable
+} from '@theia/core/lib/browser';
 import { ContextKeyService } from '@theia/core/lib/browser/context-key-service';
 import { ApplicationShellMouseTracker } from '@theia/core/lib/browser/shell/application-shell-mouse-tracker';
 import { CommandService } from '@theia/core/lib/common/command';
@@ -64,6 +72,8 @@ export class PluginVscodeCommandsContribution implements CommandContribution {
     protected readonly openerService: OpenerService;
     @inject(ApplicationShellMouseTracker)
     protected readonly mouseTracker: ApplicationShellMouseTracker;
+    @inject(PrefixQuickOpenService)
+    protected readonly quickOpen: PrefixQuickOpenService;
 
     registerCommands(commands: CommandRegistry): void {
         commands.registerCommand(VscodeCommands.OPEN, {
@@ -137,6 +147,21 @@ export class PluginVscodeCommandsContribution implements CommandContribution {
         });
         commands.registerCommand({ id: 'workbench.action.files.openFolder' }, {
             execute: () => commands.executeCommand(WorkspaceCommands.OPEN_FOLDER.id)
+        });
+        commands.registerCommand({ id: 'workbench.action.gotoLine' }, {
+            execute: () => commands.executeCommand('editor.action.gotoLine')
+        });
+        commands.registerCommand({ id: 'actions.find' }, {
+            execute: () => commands.executeCommand(CommonCommands.FIND.id)
+        });
+        commands.registerCommand({ id: 'undo' }, {
+            execute: () => commands.executeCommand(CommonCommands.UNDO.id)
+        });
+        commands.registerCommand({ id: 'editor.action.startFindReplaceAction' }, {
+            execute: () => commands.executeCommand(CommonCommands.REPLACE.id)
+        });
+        commands.registerCommand({ id: 'workbench.action.quickOpen' }, {
+            execute: () => this.quickOpen.open('')
         });
         commands.registerCommand({ id: 'default:type' }, {
             execute: args => {

--- a/packages/plugin-ext/src/common/known-commands.ts
+++ b/packages/plugin-ext/src/common/known-commands.ts
@@ -199,8 +199,10 @@ export namespace KnownCommands {
     mappings['scrollPageUp'] = ['scrollPageUp', MONACO_CONVERSION_IDENTITY];
     mappings['tab'] = ['tab', MONACO_CONVERSION_IDENTITY];
     mappings['removeSecondaryCursors'] = ['removeSecondaryCursors', MONACO_CONVERSION_IDENTITY];
+    mappings['cursorWordRight'] = ['cursorWordEndRight', MONACO_CONVERSION_IDENTITY];
     mappings['cursorWordEndRight'] = ['cursorWordEndRight', MONACO_CONVERSION_IDENTITY];
     mappings['cursorWordEndRightSelect'] = ['cursorWordEndRightSelect', MONACO_CONVERSION_IDENTITY];
+    mappings['cursorWordLeft'] = ['cursorWordStartLeft', MONACO_CONVERSION_IDENTITY];
     mappings['cursorWordStartLeft'] = ['cursorWordStartLeft', MONACO_CONVERSION_IDENTITY];
     mappings['cursorWordStartLeftSelect'] = ['cursorWordStartLeftSelect', MONACO_CONVERSION_IDENTITY];
     mappings['deleteWordLeft'] = ['deleteWordLeft', MONACO_CONVERSION_IDENTITY];

--- a/packages/plugin-ext/src/main/browser/keybindings/keybindings-contribution-handler.ts
+++ b/packages/plugin-ext/src/main/browser/keybindings/keybindings-contribution-handler.ts
@@ -36,7 +36,7 @@ export class KeybindingsContributionPointHandler {
         for (const raw of contributions.keybindings) {
             const keybinding = this.toKeybinding(raw);
             if (keybinding) {
-                toDispose.push(this.keybindingRegistry.registerKeybinding(keybinding));
+                toDispose.push(this.keybindingRegistry.registerKeybinding(keybinding, true));
             }
         }
         return toDispose;


### PR DESCRIPTION
Several fixes and adaptions that allow to use [VsCode Emacs Keymap extension](https://marketplace.visualstudio.com/items?itemName=lfs.vscode-emacs-friendly)

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

- Do not throw an error if contributed keybinding is already registered. It would be added to map that can hold several keybindings with the same id.
- Iterate collision keybindings list from the last element like in VsCode: https://github.com/microsoft/vscode/blob/c2c643947bf18030c1af595e590cce6806aae0a5/src/vs/platform/keybinding/common/keybindingResolver.ts#L303
- If a partial keybinding is detected, use it in the higher priority https://github.com/eclipse-theia/theia/compare/che-9244?expand=1#diff-0291e1b92ff01c13c0dc1c98263ac426R624
- Allow to contribute keybindings separated by `-`  https://github.com/eclipse-theia/theia/compare/che-9244?expand=1#diff-d076eb706720290d617fb0fd6f99c707R239
- Add necessary VsCode commands.
#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
Apply [VsCode Emacs Keymap extension](https://marketplace.visualstudio.com/items?itemName=lfs.vscode-emacs-friendly)
Tested Commands:

Move commands

- [x] C-f | Move forward
- [x] C-b | Move backward
- [ ] C-n | Move to the next line (in collision with browser keybinding)
- [x] C-p | Move to the previous line
- [x] C-a | Move to the beginning of line
- [x] C-e | Move to the end of line
- [x] M-f | Move forward by one word unit
- [x] M-b | Move backward by one word unit
- [x] M-> | Move to the end of buffer
- [x] M-< | Move to the beginning of buffer
- [x] C-v | Scroll down by one screen unit
- [x] M-v | Scroll up by one screen unit
- [x] M-g g | Jump to line (command palette)
- [x] M-g n | Jump to next error
- [x] M-g p | Jump to previous error
- [x] C-l | Center screen on current line

Search Commands

- [x] C-s | Search forward
- [x] C-r | Search backward
- [x] A-% | Replace
- [x] C-Enter | Replace One Match (In replace dialog)
- [x] C-M-n | Add selection to next find match

Edit commands

- [x] C-d | Delete right (DEL)
- [x] C-h | Delete left (BACKSPACE)
- [x] M-d | Delete word
- [x] M-Bksp | Delete word left
- [ ] C-k | Kill to line end (requires vscode `cursorMove` built-in command)
- [ ] C-S-Bksp | Kill entire line (requires vscode `cursorMove` built-in command)
- [x] C-o | open-line
- [ ] C-w | Kill region (in collision with browser keybinding)
- [x] M-w | Copy region to kill ring
- [ ] C-y | Yank (requires vscode `lineBreakInsert` built-in command)
- [ ] C-j | Enter (requires vscode `lineBreakInsert` built-in command)
- [ ] C-m | Enter (requires vscode `lineBreakInsert` built-in command)
- [x] C-x C-o | Delete blank lines around
- [x] C-x h | Select All
- [x] C-x u (C-/, C-_) | Undo
- [x] C-; | Toggle line comment in and out
- [x] M-; | Toggle region comment in and out
- [x] C-x C-l | Convert to lower case
- [x] C-x C-u | Convert to upper case

Other Commands

- [x] C-g | Cancel
- [x] C-space | Set mark
- [x] C-quote | IntelliSense Suggestion
- [x] M-x | Open command palette
- [ ] C-M-SPC | Toggle SideBar visibility (requires vscode `workbench.action.toggleSidebarVisibility` built-in command)
- [ ] C-x z |  (requires vscode `workbench.action.toggleZenMode` built-in command)
- [ ] C-x r (requires vscode `workbench.action.openRecent` built-in command)

File Commands

- [x] C-x C-s | Save
- [ ] C-x C-w | Save as (in collision with browser keybinding)
- [ ] C-x C-n | Open new window (in collision with browser keybinding)

Tab / Buffer Manipulation Commands

- [x] C-x b | Switch to another open buffer
- [x] C-x C-f | QuickOpen a file
- [x] C-x k | Close current tab (buffer)
- [x] C-x C-k | Close all tabs
- [x] C-x 0 | Close editors in the current group.
- [x] C-x 1 | Close editors in other (split) group.
- [ ] C-x 2 | Split editor horizontal (requires vscode `workbench.action.splitEditorDown` built-in command)
- [ ] C-x 3 | Split editor vertical (requires vscode `workbench.action.splitEditorRight` built-in command)
- [ ] C-x 4 | Toggle split layout (vertical to horizontal) (requires vscode `workbench.action.toggleEditorGroupLayout` built-in command)
- [ ] C-x o | Focus other split editor (requires vscode `workbench.action.navigateEditorGroups` built-in command)


#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

