### PR TITLE
debug: make allThreadStop reason generic

### DIFF
--- a/packages/debug/src/browser/debug-session.tsx
+++ b/packages/debug/src/browser/debug-session.tsx
@@ -419,8 +419,17 @@ export class DebugSession implements CompositeTreeElement {
             const thread = existing.get(id) || new DebugThread(this);
             this._threads.set(id, thread);
             const data: Partial<Mutable<DebugThreadData>> = { raw };
-            if (stoppedDetails && (stoppedDetails.allThreadsStopped || stoppedDetails.threadId === id)) {
-                data.stoppedDetails = stoppedDetails;
+            if (stoppedDetails) {
+                if (stoppedDetails.threadId === id) {
+                    data.stoppedDetails = stoppedDetails;
+                } else if (stoppedDetails.allThreadsStopped) {
+                    data.stoppedDetails = {
+                        // When a debug adapter notifies us that all threads are stopped,
+                        // we do not know why the others are stopped, so we should default
+                        // to something generic.
+                        reason: '',
+                    };
+                }
             }
             thread.update(data);
         }


### PR DESCRIPTION
#### What it does

When we receive a stopped event from a debug adapter, a
`allThreadStopped` flag can be set. When doing so, it feels weird to
display the reason of the thread that caused it on other threads.

This commit reports "PAUSED" for all the paused threads, but keeps
displaying the reason for the thread that caused the event.

#### How to test

Run a multi-threaded debug session that pauses every thread when one hit a breakpoint hit. The latter should be stopped with reason "PAUSED ON BREAKPOINT", while all the others threads should just display "PAUSED".

I used the following vscode extension and workspace (linux/mac? only)
- [cdt-gdb-vscode-0.0.90.vsix.zip](https://github.com/eclipse-theia/theia/files/3887999/cdt-gdb-vscode-0.0.90.vsix.zip)
- [cpp-threading.zip](https://github.com/eclipse-theia/theia/files/3888034/cpp-threading.zip)

Run the task "Build C++", then you should be able to debug using the "Debug C++" configuration. Place a breakpoint on line 6 to break inside a function that runs in a separate thread.

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)