### PR TITLE
Use argument processor for the commands called from plugins

### DIFF
--- a/packages/plugin-ext/src/plugin/command-registry.ts
+++ b/packages/plugin-ext/src/plugin/command-registry.ts
@@ -100,6 +100,7 @@ export class CommandRegistryImpl implements CommandRegistryExt {
 
     // tslint:disable:no-any
     executeCommand<T>(id: string, ...args: any[]): PromiseLike<T | undefined> {
+        args = args.map(arg => this.argumentProcessors.reduce((r, p) => p.processArgument(r), arg));
         if (this.handlers.has(id)) {
             return this.executeLocalCommand(id, ...args);
         } else if (KnownCommands.mapped(id)) {


### PR DESCRIPTION
#### What it does
Use process argument before command executes. This changes proposal allows command registry use mechanism of argument processor.

This PR fixes https://github.com/eclipse/che/issues/13044

Signed-off-by: Vladyslav Zhukovskyi <vzhukovs@redhat.com>

#### How to test
Register custom argument processor and call any command from plug-in.

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

