### PR TITLE
[keybinding] Align more Electron/browser keybindings with VS Code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - [core] updated handling when access is denied to the clipboard [#6516](https://github.com/eclipse-theia/theia/pull/6516)
 - [core] updated scrolling of widgets when re-setting their focus [#6621](https://github.com/eclipse-theia/theia/pull/6621)
 - [core] upgraded `reconnecting-websocket` to latest version [#6512](https://github.com/eclipse-theia/theia/pull/6512)
+- [core] aligned `New File`, `Close Editor` and `Close Window` keybindings with VS Code across OSes [#6635](https://github.com/eclipse-theia/theia/pull/6635)
 - [cpp] moved the `cpp` extension to the [`theia-cpp-extensions`](https://github.com/eclipse-theia/theia-cpp-extensions) repo [#6505](https://github.com/eclipse-theia/theia/pull/6505)
 - [debug] added ability to re-use the terminal based on label and caption [#6619](https://github.com/eclipse-theia/theia/pull/6619)
 - [debug] added reloading of child variable nodes on `setValue` call [#6555](https://github.com/eclipse-theia/theia/pull/6555)

--- a/packages/core/src/browser/common-frontend-contribution.ts
+++ b/packages/core/src/browser/common-frontend-contribution.ts
@@ -30,13 +30,14 @@ import { AboutDialog } from './about-dialog';
 import * as browser from './browser';
 import URI from '../common/uri';
 import { ContextKeyService } from './context-key-service';
-import { OS, isOSX } from '../common/os';
+import { OS, isOSX, isWindows } from '../common/os';
 import { ResourceContextKey } from './resource-context-key';
 import { UriSelection } from '../common/selection';
 import { StorageService } from './storage-service';
 import { Navigatable } from './navigatable';
 import { QuickViewService } from './quick-view-service';
 import { PrefixQuickOpenService } from './quick-open';
+import { environment } from '@theia/application-package/lib/environment';
 
 export namespace CommonMenus {
 
@@ -543,6 +544,10 @@ export class CommonFrontendContribution implements FrontendApplicationContributi
         return tabBar.currentTitle || undefined;
     }
 
+    private isElectron(): boolean {
+        return environment.electron.is();
+    }
+
     registerKeybindings(registry: KeybindingRegistry): void {
         if (supportCut) {
             registry.registerKeybinding({
@@ -599,7 +604,7 @@ export class CommonFrontendContribution implements FrontendApplicationContributi
             },
             {
                 command: CommonCommands.CLOSE_TAB.id,
-                keybinding: 'alt+w'
+                keybinding: (!this.isElectron() ? 'alt+w' : (isWindows ? 'ctrl+f4' : 'ctrlcmd+w'))
             },
             {
                 command: CommonCommands.CLOSE_OTHER_TABS.id,

--- a/packages/core/src/electron-browser/menu/electron-menu-contribution.ts
+++ b/packages/core/src/electron-browser/menu/electron-menu-contribution.ts
@@ -18,7 +18,7 @@ import * as electron from 'electron';
 import { inject, injectable } from 'inversify';
 import {
     Command, CommandContribution, CommandRegistry,
-    isOSX, MenuModelRegistry, MenuContribution, Disposable
+    isOSX, isWindows, MenuModelRegistry, MenuContribution, Disposable
 } from '../../common';
 import { KeybindingContribution, KeybindingRegistry } from '../../browser';
 import { FrontendApplication, FrontendApplicationContribution, CommonMenus } from '../../browser';
@@ -196,7 +196,7 @@ export class ElectronMenuContribution implements FrontendApplicationContribution
             },
             {
                 command: ElectronCommands.CLOSE_WINDOW.id,
-                keybinding: 'ctrlcmd+shift+w'
+                keybinding: (isOSX ? 'cmd+shift+w' : (isWindows ? 'ctrl+w' : /* Linux */ 'ctrl+q'))
             }
         );
     }

--- a/packages/workspace/src/browser/workspace-frontend-contribution.ts
+++ b/packages/workspace/src/browser/workspace-frontend-contribution.ts
@@ -142,6 +142,10 @@ export class WorkspaceFrontendContribution implements CommandContribution, Keybi
 
     registerKeybindings(keybindings: KeybindingRegistry): void {
         keybindings.registerKeybinding({
+            command: WorkspaceCommands.NEW_FILE.id,
+            keybinding: this.isElectron() ? 'ctrlcmd+n' : 'alt+n',
+        });
+        keybindings.registerKeybinding({
             command: isOSX || !this.isElectron() ? WorkspaceCommands.OPEN.id : WorkspaceCommands.OPEN_FILE.id,
             keybinding: 'ctrlcmd+alt+o',
         });


### PR DESCRIPTION
#### What it does

- [x] Add <kbd>Ctrl/Cmd</kbd> + <kbd>N</kbd> = `File` > `New File`
- ~~Fix <kbd>Ctrl/Cmd</kbd> + <kbd>O</kbd> = `File` > `Open...` (currently discussed in #6633)~~ (EDIT: let's do that later)
- [x] Align <kbd>Ctrl/Cmd</kbd> + <kbd>W</kbd> with VS Code on all OSes

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

