### PR TITLE
Reorganize tasks when task schema is updated

### DIFF
--- a/packages/task/src/browser/task-configurations.ts
+++ b/packages/task/src/browser/task-configurations.ts
@@ -110,10 +110,7 @@ export class TaskConfigurations implements Disposable {
             })
         );
         this.reorgnizeTasks();
-        this.toDispose.pushAll([
-            this.taskDefinitionRegistry.onDidRegisterTaskDefinition(() => this.reorgnizeTasks()),
-            this.taskDefinitionRegistry.onDidUnregisterTaskDefinition(() => this.reorgnizeTasks())
-        ]);
+        this.toDispose.push(this.taskSchemaUpdater.onDidChangeTaskSchema(() => this.reorgnizeTasks()));
     }
 
     setClient(client: TaskConfigurationClient): void {


### PR DESCRIPTION
#### What it does
Rely on `onTaskSchemaChanged` event to reorganize tasks configurations.
Fixes https://github.com/eclipse-theia/theia/issues/6640

#### How to test
1. Use vs code extensions with tasks (like `typescript`, `npm`).
Tasks should be available for running from `Terminal -> Run task` menu.
Try to run them, configure and run, refresh page and run again.

2. Please use my forked repo for testing, it contains:
- the current PR [changes](https://github.com/RomanNikitenko/theia/commit/bf5dbc2af16feb65df2a2e189adfd712d6a3da58)
- the [test extension](https://github.com/RomanNikitenko/theia/commit/2f9c8943858477b6a63f6fa14cbeb701887a623f) which allows to add/remove schemes for custom types
- tasks with custom type for testing 

1. `git clone https://github.com/RomanNikitenko/theia.git`
2. `cd theia/` and `git checkout reorganizeTasks`.
3. Build the project and run it.
4. The project contains prepared tasks in `tasks.json` file, so please open the cloned project: `File=>Open...` and select the project.   
4. Go to `Terminal => Run Task` menu: 
you can see that only `SHELL task` is available for running 
5. Go to `Help` menu and select `Add CHE task schema`
you can see that now `CHE task` is available for running as well as `SHELL task`.
6. Try the same for `EXEC task`
7. You can try to remove subschema for `CHE task` and `EXEC task` using `Help` menu
you can see that the corresponding tasks are not available for running after that.
 

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

Signed-off-by: Roman Nikitenko <rnikiten@redhat.com>
