### PR TITLE
Remove mini-browser dependency in plugin-ext

### DIFF
--- a/packages/core/src/browser/style/index.css
+++ b/packages/core/src/browser/style/index.css
@@ -175,6 +175,16 @@ textarea {
   font-family: var(--theia-ui-font-family);
 }
 
+.theia-transparent-overlay {
+    background-color: transparent;
+    position: absolute;
+    top: 0;
+    left: 0;
+    height: 100%;
+    width: 100%;
+    z-index: 999;
+}
+
 /*-----------------------------------------------------------------------------
 | Import children style files
 |----------------------------------------------------------------------------*/

--- a/packages/mini-browser/src/browser/mini-browser-content-style.ts
+++ b/packages/mini-browser/src/browser/mini-browser-content-style.ts
@@ -27,6 +27,6 @@ export namespace MiniBrowserContentStyle {
     export const OPEN = 'theia-mini-browser-open';
     export const BUTTON = 'theia-mini-browser-button';
     export const DISABLED = 'theia-mini-browser-button-disabled';
-    export const TRANSPARENT_OVERLAY = 'theia-mini-browser-transparent-overlay';
+    export const TRANSPARENT_OVERLAY = 'theia-transparent-overlay';
     export const ERROR_BAR = 'theia-mini-browser-error-bar';
 }

--- a/packages/mini-browser/src/browser/style/index.css
+++ b/packages/mini-browser/src/browser/style/index.css
@@ -158,13 +158,3 @@
     flex-grow: 1;
     border: none; margin: 0; padding: 0;
 }
-
-.theia-mini-browser-transparent-overlay {
-    background-color: transparent;
-    position: absolute;
-    top: 0;
-    left: 0;
-    height: 100%;
-    width: 100%;
-    z-index: 999;
-}

--- a/packages/plugin-ext/package.json
+++ b/packages/plugin-ext/package.json
@@ -13,7 +13,6 @@
     "@theia/languages": "^0.12.0",
     "@theia/markers": "^0.12.0",
     "@theia/messages": "^0.12.0",
-    "@theia/mini-browser": "^0.12.0",
     "@theia/monaco": "^0.12.0",
     "@theia/navigator": "^0.12.0",
     "@theia/output": "^0.12.0",

--- a/packages/plugin-ext/src/main/browser/webview/webview.ts
+++ b/packages/plugin-ext/src/main/browser/webview/webview.ts
@@ -26,8 +26,6 @@ import { injectable, inject, postConstruct } from 'inversify';
 import { WebviewPanelOptions, WebviewPortMapping } from '@theia/plugin';
 import { BaseWidget, Message } from '@theia/core/lib/browser/widgets/widget';
 import { Disposable, DisposableCollection } from '@theia/core/lib/common/disposable';
-// TODO: get rid of dependencies to the mini browser
-import { MiniBrowserContentStyle } from '@theia/mini-browser/lib/browser/mini-browser-content-style';
 import { ApplicationShellMouseTracker } from '@theia/core/lib/browser/shell/application-shell-mouse-tracker';
 import { StatefulWidget } from '@theia/core/lib/browser/shell/shell-layout-restorer';
 import { WebviewPanelViewState } from '../../../common/plugin-api-rpc';
@@ -48,6 +46,9 @@ import { WebviewPreferences } from './webview-preferences';
 import { WebviewResourceLoader } from '../../common/webview-protocol';
 import { WebviewResourceCache } from './webview-resource-cache';
 import { Endpoint } from '@theia/core/lib/browser/endpoint';
+
+// Style from core
+const TRANSPARENT_OVERLAY_STYLE = 'theia-transparent-overlay';
 
 // tslint:disable:no-any
 
@@ -176,7 +177,7 @@ export class WebviewWidget extends BaseWidget implements StatefulWidget {
         this.toDispose.push(this.onMessageEmitter);
 
         this.transparentOverlay = document.createElement('div');
-        this.transparentOverlay.classList.add(MiniBrowserContentStyle.TRANSPARENT_OVERLAY);
+        this.transparentOverlay.classList.add(TRANSPARENT_OVERLAY_STYLE);
         this.transparentOverlay.style.display = 'none';
         this.node.appendChild(this.transparentOverlay);
 


### PR DESCRIPTION
Signed-off-by: Rob Moran <rob.moran@arm.com>

#### What it does
This PR removes the direct dependency on `mini-browser` from `plugin-ext`.
This means developers can use the `plugin-ext` extension without having to also accept the `mini-browser` functionality.

#### How to test

Clone this branch and remove `@theia/mini-browser` and `@theia/preview` from the example application.

Run the application and confirm the mini-browser functionality no longer appears (e.g. f1 > url preview)

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

