### PR TITLE
No one package should depend on @theia/json

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,6 +76,8 @@ Breaking changes:
   `webpack.config.js` is generated only once. It can be edited by users to custoimze bundling,
   but should be based on `gen-webpack.config.js` to pick any changes in the generated config.
   If it does not have a reference to `gen-webpack.config.js` then it will be regenerated.
+- [debug] removed `@theia/json` dependency. Applications should explicitly depend on `@theia/json` instead [#6647](https://github.com/eclipse-theia/theia/pull/6647)
+- [preferences] removed `@theia/json` dependency. Applications should explicitly depend on `@theia/json` instead [#6647](https://github.com/eclipse-theia/theia/pull/6647)
 
 ## v0.14.0
 

--- a/packages/debug/package.json
+++ b/packages/debug/package.json
@@ -8,7 +8,6 @@
     "@theia/core": "^0.14.0",
     "@theia/editor": "^0.14.0",
     "@theia/filesystem": "^0.14.0",
-    "@theia/json": "^0.14.0",
     "@theia/languages": "^0.14.0",
     "@theia/markers": "^0.14.0",
     "@theia/monaco": "^0.14.0",

--- a/packages/preferences/package.json
+++ b/packages/preferences/package.json
@@ -6,7 +6,6 @@
     "@theia/core": "^0.14.0",
     "@theia/editor": "^0.14.0",
     "@theia/filesystem": "^0.14.0",
-    "@theia/json": "^0.14.0",
     "@theia/monaco": "^0.14.0",
     "@theia/userstorage": "^0.14.0",
     "@theia/workspace": "^0.14.0",

--- a/packages/preferences/src/browser/preferences-tree-widget.ts
+++ b/packages/preferences/src/browser/preferences-tree-widget.ts
@@ -41,7 +41,6 @@ import { UserPreferenceProvider } from './user-preference-provider';
 import { WorkspacePreferenceProvider } from './workspace-preference-provider';
 import { PreferencesEditorWidget, PreferenceEditorContainerTabBarRenderer } from './preference-editor-widget';
 import { EditorWidget, EditorManager } from '@theia/editor/lib/browser';
-import { JSONC_LANGUAGE_ID } from '@theia/json/lib/common';
 import { DisposableCollection, Emitter, Event, MessageService } from '@theia/core';
 import { Deferred } from '@theia/core/lib/common/promise-util';
 import { FileSystem, FileSystemUtils } from '@theia/filesystem/lib/common';
@@ -346,7 +345,7 @@ export class PreferencesEditorsContainer extends DockPanel {
             workspacePreferences.title.label = 'Workspace';
             workspacePreferences.title.caption = `Workspace Preferences: ${await this.getPreferenceEditorCaption(workspacePreferenceUri!)}`;
             workspacePreferences.title.iconClass = 'database-icon medium-yellow file-icon';
-            workspacePreferences.editor.setLanguage(JSONC_LANGUAGE_ID);
+            workspacePreferences.editor.setLanguage('jsonc');
             workspacePreferences.scope = PreferenceScope.Workspace;
         }
         return workspacePreferences;


### PR DESCRIPTION
Signed-off-by: Anatoliy Bazko <abazko@redhat.com>

#### What it does
PR removes dependency on `@theia/json`. It is allows to replace it with builtin extension.
https://www.npmjs.com/package/@theia/vscode-builtin-json-language-features

#### How to test
1. Built Theia
2. Open `launch.json` and `preferences.json`.
3. Check if auto-completion works.

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

