### PR TITLE
[editor-preview] remove unnecessary 'navigator' dependency

### DIFF
--- a/packages/editor-preview/package.json
+++ b/packages/editor-preview/package.json
@@ -4,8 +4,7 @@
   "description": "Theia - Editor Preview Extension",
   "dependencies": {
     "@theia/core": "^0.12.0",
-    "@theia/editor": "^0.12.0",
-    "@theia/navigator": "^0.12.0"
+    "@theia/editor": "^0.12.0"
   },
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
#### What it does

Fixes #6639

- removes the unused `navigator` from the `editor-preview` extension.
- the `navigator` was needlessly pulled by the `editor-preview` as it was never used and is likely to be a leftover of 00e7d9d.

#### How to test

- verify that CI passes (`editor-preview` builds and the tests pass)

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

Signed-off-by: vince-fugnitto <vincent.fugnitto@ericsson.com>
