### PR TITLE
Make Theia data folder name configurable

### DIFF
--- a/packages/core/src/browser/preferences/preference-configurations.ts
+++ b/packages/core/src/browser/preferences/preference-configurations.ts
@@ -45,6 +45,7 @@ export class PreferenceConfigurations {
 
     /* prefer Theia over VS Code by default */
     getPaths(): string[] {
+        console.log('========================:', this.DATA_FOLDER_NAME);
         return [this.DATA_FOLDER_NAME, '.vscode'];
     }
 

--- a/packages/core/src/browser/preferences/preference-configurations.ts
+++ b/packages/core/src/browser/preferences/preference-configurations.ts
@@ -35,7 +35,7 @@ export class PreferenceConfigurations {
     protected readonly provider: ContributionProvider<PreferenceConfiguration>;
 
     /* prefer Theia over VS Code by default */
-    getPaths(): string[] {
+    async getPaths(): Promise<string[]> {
         return ['.theia', '.vscode'];
     }
 
@@ -71,7 +71,10 @@ export class PreferenceConfigurations {
         return configUri.parent.path.base;
     }
 
-    createUri(folder: URI, configPath: string = this.getPaths()[0], configName: string = this.getConfigName()): URI {
+    async createUri(folder: URI, configPath: string, configName: string = this.getConfigName()): Promise<URI> {
+        if (!configPath) {
+            configPath = (await this.getPaths())[0];
+        }
         return folder.resolve(configPath).resolve(configName + '.json');
     }
 

--- a/packages/core/src/browser/preferences/test/mock-preference-provider.ts
+++ b/packages/core/src/browser/preferences/test/mock-preference-provider.ts
@@ -20,6 +20,8 @@ import { interfaces } from 'inversify';
 import { PreferenceProvider } from '../';
 import { PreferenceScope } from '../preference-scope';
 import { PreferenceProviderDataChanges, PreferenceProviderDataChange } from '../preference-provider';
+import { EnvVariablesServer } from '../../../common/env-variables/env-variables-protocol';
+import { MockEnvVariablesServerImpl } from '../../test/mock-env-variables-server';
 
 export class MockPreferenceProvider extends PreferenceProvider {
     readonly prefs: { [p: string]: any } = {};
@@ -49,6 +51,9 @@ export class MockPreferenceProvider extends PreferenceProvider {
 
 export function bindMockPreferenceProviders(bind: interfaces.Bind, unbind: interfaces.Unbind): void {
     unbind(PreferenceProvider);
+
+    // Needed for PreferenceConfigurations in PreferenceSchemaProvider
+    bind(EnvVariablesServer).to(MockEnvVariablesServerImpl).inSingletonScope();
 
     bind(PreferenceProvider).toDynamicValue(ctx => new MockPreferenceProvider(PreferenceScope.User)).inSingletonScope().whenTargetNamed(PreferenceScope.User);
     bind(PreferenceProvider).toDynamicValue(ctx => new MockPreferenceProvider(PreferenceScope.Workspace)).inSingletonScope().whenTargetNamed(PreferenceScope.Workspace);

--- a/packages/core/src/browser/test/mock-env-variables-server.ts
+++ b/packages/core/src/browser/test/mock-env-variables-server.ts
@@ -23,12 +23,12 @@ export class MockEnvVariablesServerImpl implements EnvVariablesServer {
         return '.theia';
     }
 
-    async getUserHomeFolderPath(): Promise<string> {
-        return '/home/test';
+    async getUserHomeFolder(): Promise<string> {
+        return 'file:///home/test';
     }
 
-    async getUserDataFolderPath(): Promise<string> {
-        return '/home/test/.theia';
+    async getUserDataFolder(): Promise<string> {
+        return 'file:///home/test/.theia';
     }
 
     getExecPath(): Promise<string> {
@@ -40,7 +40,7 @@ export class MockEnvVariablesServerImpl implements EnvVariablesServer {
     getValue(key: string): Promise<EnvVariable | undefined> {
         throw new Error('Method not implemented.');
     }
-    getAppDataPath(): Promise<string> {
+    getAppDataFolder(): Promise<string> {
         throw new Error('Method not implemented.');
     }
 }

--- a/packages/core/src/browser/test/mock-env-variables-server.ts
+++ b/packages/core/src/browser/test/mock-env-variables-server.ts
@@ -1,0 +1,46 @@
+/********************************************************************************
+ * Copyright (C) 2020 Red Hat, Inc. and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import { injectable } from 'inversify';
+import { EnvVariablesServer, EnvVariable } from '../../common/env-variables';
+
+@injectable()
+export class MockEnvVariablesServerImpl implements EnvVariablesServer {
+    async getDataFolderName(): Promise<string> {
+        return '.theia';
+    }
+
+    async getUserHomeFolderPath(): Promise<string> {
+        return '/home/test';
+    }
+
+    async getUserDataFolderPath(): Promise<string> {
+        return '/home/test/.theia';
+    }
+
+    getExecPath(): Promise<string> {
+        throw new Error('Method not implemented.');
+    }
+    getVariables(): Promise<EnvVariable[]> {
+        throw new Error('Method not implemented.');
+    }
+    getValue(key: string): Promise<EnvVariable | undefined> {
+        throw new Error('Method not implemented.');
+    }
+    getAppDataPath(): Promise<string> {
+        throw new Error('Method not implemented.');
+    }
+}

--- a/packages/core/src/common/env-variables/env-variables-protocol.ts
+++ b/packages/core/src/common/env-variables/env-variables-protocol.ts
@@ -21,6 +21,10 @@ export interface EnvVariablesServer {
     getExecPath(): Promise<string>
     getVariables(): Promise<EnvVariable[]>
     getValue(key: string): Promise<EnvVariable | undefined>
+    getUserHomeFolderPath(): Promise<string>
+    getDataFolderName(): Promise<string>
+    getUserDataFolderPath(): Promise<string>
+    getAppDataPath(): Promise<string>
 }
 
 export interface EnvVariable {

--- a/packages/core/src/common/env-variables/env-variables-protocol.ts
+++ b/packages/core/src/common/env-variables/env-variables-protocol.ts
@@ -21,10 +21,11 @@ export interface EnvVariablesServer {
     getExecPath(): Promise<string>
     getVariables(): Promise<EnvVariable[]>
     getValue(key: string): Promise<EnvVariable | undefined>
-    getUserHomeFolderPath(): Promise<string>
+    getUserHomeFolder(): Promise<string>
     getDataFolderName(): Promise<string>
-    getUserDataFolderPath(): Promise<string>
-    getAppDataPath(): Promise<string>
+    getUserDataFolder(): Promise<string>
+    /** Windows specific. Returns system data folder of Theia. On other than Windows systems is the same as getUserDataFolder */
+    getAppDataFolder(): Promise<string>
 }
 
 export interface EnvVariable {

--- a/packages/core/src/node/env-variables/env-variables-server.ts
+++ b/packages/core/src/node/env-variables/env-variables-server.ts
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (C) 2018 Red Hat, Inc. and others.
+ * Copyright (C) 2018-2019 Red Hat, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -14,9 +14,17 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
+import * as path from 'path';
+import * as os from 'os';
 import { injectable } from 'inversify';
 import { EnvVariable, EnvVariablesServer } from '../../common/env-variables';
 import { isWindows } from '../../common/os';
+
+const THEIA_DATA_FOLDER = '.theia';
+
+const WINDOWS_APP_DATA_DIR = 'AppData';
+const WINDOWS_ROAMING_DIR = 'Roaming';
+const WINDOWS_DATA_FOLDERS = [WINDOWS_APP_DATA_DIR, WINDOWS_ROAMING_DIR];
 
 @injectable()
 export class EnvVariablesServerImpl implements EnvVariablesServer {
@@ -43,5 +51,25 @@ export class EnvVariablesServerImpl implements EnvVariablesServer {
             key = key.toLowerCase();
         }
         return this.envs[key];
+    }
+
+    async getUserHomeFolderPath(): Promise<string> {
+        return os.homedir();
+    }
+
+    async getDataFolderName(): Promise<string> {
+        return THEIA_DATA_FOLDER;
+    }
+
+    async getUserDataFolderPath(): Promise<string> {
+        return path.join(os.homedir(), THEIA_DATA_FOLDER);
+    }
+
+    async getAppDataPath(): Promise<string> {
+        return path.join(
+            os.homedir(),
+            ...(isWindows ? WINDOWS_DATA_FOLDERS : ['']),
+            THEIA_DATA_FOLDER
+        );
     }
 }

--- a/packages/core/src/node/env-variables/env-variables-server.ts
+++ b/packages/core/src/node/env-variables/env-variables-server.ts
@@ -53,23 +53,35 @@ export class EnvVariablesServerImpl implements EnvVariablesServer {
         return this.envs[key];
     }
 
-    async getUserHomeFolderPath(): Promise<string> {
+    getUserHomeFolderPathSync(): string {
         return os.homedir();
     }
 
-    async getDataFolderName(): Promise<string> {
+    async getUserHomeFolderPath(): Promise<string> {
+        return this.getUserHomeFolderPathSync();
+    }
+
+    getDataFolderNameSync(): string {
         return THEIA_DATA_FOLDER;
     }
 
+    async getDataFolderName(): Promise<string> {
+        return this.getDataFolderNameSync();
+    }
+
+    getUserDataFolderPathSync(): string {
+        return path.join(this.getUserHomeFolderPathSync(), this.getDataFolderNameSync());
+    }
+
     async getUserDataFolderPath(): Promise<string> {
-        return path.join(os.homedir(), THEIA_DATA_FOLDER);
+        return this.getUserDataFolderPathSync();
     }
 
     async getAppDataPath(): Promise<string> {
         return path.join(
-            os.homedir(),
+            this.getUserHomeFolderPathSync(),
             ...(isWindows ? WINDOWS_DATA_FOLDERS : ['']),
-            THEIA_DATA_FOLDER
+            this.getDataFolderNameSync()
         );
     }
 }

--- a/packages/core/src/node/env-variables/env-variables-server.ts
+++ b/packages/core/src/node/env-variables/env-variables-server.ts
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (C) 2018-2019 Red Hat, Inc. and others.
+ * Copyright (C) 2018-2020 Red Hat, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -53,35 +53,24 @@ export class EnvVariablesServerImpl implements EnvVariablesServer {
         return this.envs[key];
     }
 
-    getUserHomeFolderPathSync(): string {
+    async getUserHomeFolderPath(): Promise<string> {
         return os.homedir();
     }
 
-    async getUserHomeFolderPath(): Promise<string> {
-        return this.getUserHomeFolderPathSync();
-    }
-
-    getDataFolderNameSync(): string {
+    async getDataFolderName(): Promise<string> {
         return THEIA_DATA_FOLDER;
     }
 
-    async getDataFolderName(): Promise<string> {
-        return this.getDataFolderNameSync();
-    }
-
-    getUserDataFolderPathSync(): string {
-        return path.join(this.getUserHomeFolderPathSync(), this.getDataFolderNameSync());
-    }
-
     async getUserDataFolderPath(): Promise<string> {
-        return this.getUserDataFolderPathSync();
+        return path.join(await this.getUserHomeFolderPath(), await this.getDataFolderName());
     }
 
     async getAppDataPath(): Promise<string> {
         return path.join(
-            this.getUserHomeFolderPathSync(),
+            await this.getUserHomeFolderPath(),
             ...(isWindows ? WINDOWS_DATA_FOLDERS : ['']),
-            this.getDataFolderNameSync()
+            await this.getDataFolderName()
         );
     }
+
 }

--- a/packages/core/src/node/file-uri.ts
+++ b/packages/core/src/node/file-uri.ts
@@ -54,6 +54,9 @@ export namespace FileUri {
                     return fsPathFromVsCodeUri + '\\';
                 }
             }
+            if (fsPathFromVsCodeUri.startsWith('/file:')) {
+                return fsPathFromVsCodeUri.substring('/file:'.length);
+            }
             return fsPathFromVsCodeUri;
         }
     }

--- a/packages/debug/src/browser/debug-configuration-manager.ts
+++ b/packages/debug/src/browser/debug-configuration-manager.ts
@@ -268,7 +268,7 @@ export class DebugConfigurationManager {
         if (configUri && configUri.path.base === 'launch.json') {
             uri = configUri;
         } else { // fallback
-            uri = new URI(model.workspaceFolderUri).resolve((await this.preferenceConfigurations.getPaths())[0] + '/launch.json');
+            uri = new URI(model.workspaceFolderUri).resolve(`${this.preferenceConfigurations.getPaths()[0]}/launch.json`);
         }
         const debugType = await this.selectDebugType();
         const configurations = debugType ? await this.provideDebugConfigurations(debugType, model.workspaceFolderUri) : [];

--- a/packages/debug/src/browser/debug-configuration-manager.ts
+++ b/packages/debug/src/browser/debug-configuration-manager.ts
@@ -268,7 +268,7 @@ export class DebugConfigurationManager {
         if (configUri && configUri.path.base === 'launch.json') {
             uri = configUri;
         } else { // fallback
-            uri = new URI(model.workspaceFolderUri).resolve(`${this.preferenceConfigurations.getPaths()[0]}/launch.json`);
+            uri = new URI(model.workspaceFolderUri).resolve((await this.preferenceConfigurations.getPaths())[0] + '/launch.json');
         }
         const debugType = await this.selectDebugType();
         const configurations = debugType ? await this.provideDebugConfigurations(debugType, model.workspaceFolderUri) : [];

--- a/packages/java/src/node/java-contribution.ts
+++ b/packages/java/src/node/java-contribution.ts
@@ -14,7 +14,6 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
-import * as os from 'os';
 import * as path from 'path';
 import * as glob from 'glob';
 import { Socket } from 'net';
@@ -23,6 +22,7 @@ import { Message, isRequestMessage } from 'vscode-ws-jsonrpc';
 import { InitializeParams, InitializeRequest } from 'vscode-languageserver-protocol';
 import { createSocketConnection } from 'vscode-ws-jsonrpc/lib/server';
 import { DEBUG_MODE } from '@theia/core/lib/node';
+import { EnvVariablesServer } from '@theia/core/lib/common/env-variables';
 import { IConnection, BaseLanguageServerContribution, LanguageServerStartOptions } from '@theia/languages/lib/node';
 import { JAVA_LANGUAGE_ID, JAVA_LANGUAGE_NAME, JavaStartParams } from '../common';
 import { JavaCliContribution } from './java-cli-contribution';
@@ -52,6 +52,7 @@ export class JavaContribution extends BaseLanguageServerContribution {
     protected readonly ready: Promise<void>;
 
     constructor(
+        @inject(EnvVariablesServer) protected readonly envServer: EnvVariablesServer,
         @inject(JavaCliContribution) protected readonly cli: JavaCliContribution,
         @inject(ContributionProvider) @named(JavaExtensionContribution)
         protected readonly contributions: ContributionProvider<JavaExtensionContribution>
@@ -103,7 +104,7 @@ export class JavaContribution extends BaseLanguageServerContribution {
         this.activeDataFolders.add(dataFolderSuffix);
         clientConnection.onClose(() => this.activeDataFolders.delete(dataFolderSuffix));
 
-        const workspacePath = path.resolve(os.homedir(), '.theia', 'jdt.ls', '_ws_' + dataFolderSuffix);
+        const workspacePath = path.resolve(await this.envServer.getUserDataFolderPath(), 'jdt.ls', '_ws_' + dataFolderSuffix);
         const configuration = configurations.get(process.platform);
         if (!configuration) {
             throw new Error('Cannot find Java server configuration for ' + process.platform);

--- a/packages/java/src/node/java-contribution.ts
+++ b/packages/java/src/node/java-contribution.ts
@@ -21,7 +21,7 @@ import { injectable, inject, named } from 'inversify';
 import { Message, isRequestMessage } from 'vscode-ws-jsonrpc';
 import { InitializeParams, InitializeRequest } from 'vscode-languageserver-protocol';
 import { createSocketConnection } from 'vscode-ws-jsonrpc/lib/server';
-import { DEBUG_MODE } from '@theia/core/lib/node';
+import { DEBUG_MODE, FileUri } from '@theia/core/lib/node';
 import { EnvVariablesServer } from '@theia/core/lib/common/env-variables';
 import { IConnection, BaseLanguageServerContribution, LanguageServerStartOptions } from '@theia/languages/lib/node';
 import { JAVA_LANGUAGE_ID, JAVA_LANGUAGE_NAME, JavaStartParams } from '../common';
@@ -104,7 +104,7 @@ export class JavaContribution extends BaseLanguageServerContribution {
         this.activeDataFolders.add(dataFolderSuffix);
         clientConnection.onClose(() => this.activeDataFolders.delete(dataFolderSuffix));
 
-        const workspacePath = path.resolve(await this.envServer.getUserDataFolderPath(), 'jdt.ls', '_ws_' + dataFolderSuffix);
+        const workspacePath = path.resolve(FileUri.fsPath(await this.envServer.getUserDataFolder()), 'jdt.ls', '_ws_' + dataFolderSuffix);
         const configuration = configurations.get(process.platform);
         if (!configuration) {
             throw new Error('Cannot find Java server configuration for ' + process.platform);

--- a/packages/plugin-ext/src/common/plugin-api-rpc.ts
+++ b/packages/plugin-ext/src/common/plugin-api-rpc.ts
@@ -79,6 +79,7 @@ import { ArgumentProcessor } from '../plugin/command-registry';
 import { MaybePromise } from '@theia/core/lib/common/types';
 import { QuickOpenItem, QuickOpenItemOptions } from '@theia/core/lib/common/quick-open-model';
 import { QuickTitleButton } from '@theia/core/lib/common/quick-open-model';
+import { EnvVariable } from '@theia/core/lib/common/env-variables';
 
 export interface PreferenceData {
     [scope: number]: any;
@@ -972,11 +973,6 @@ export interface ModelChangedEvent {
     readonly eol: string;
 
     readonly versionId: number;
-}
-
-export interface EnvVariable {
-    readonly name: string
-    readonly value: string | undefined
 }
 
 export interface DocumentsExt {

--- a/packages/plugin-ext/src/common/plugin-api-rpc.ts
+++ b/packages/plugin-ext/src/common/plugin-api-rpc.ts
@@ -96,7 +96,7 @@ export interface Plugin {
 export interface ConfigStorage {
     hostLogPath: string;
     hostStoragePath?: string;
-    hostGlobalStoragePath?: string;
+    hostGlobalStoragePath: string;
 }
 
 export interface EnvInit {

--- a/packages/plugin-ext/src/common/plugin-api-rpc.ts
+++ b/packages/plugin-ext/src/common/plugin-api-rpc.ts
@@ -974,6 +974,11 @@ export interface ModelChangedEvent {
     readonly versionId: number;
 }
 
+export interface EnvVariable {
+    readonly name: string
+    readonly value: string | undefined
+}
+
 export interface DocumentsExt {
     $acceptModelModeChanged(startUrl: UriComponents, oldModeId: string, newModeId: string): void;
     $acceptModelSaved(strUrl: UriComponents): void;
@@ -992,7 +997,13 @@ export interface DocumentsMain {
 
 export interface EnvMain {
     $getEnvVariable(envVarName: string): Promise<string | undefined>;
+    $getAllEnvVariables(): Promise<EnvVariable[]>
     $getClientOperatingSystem(): Promise<theia.OperatingSystem>;
+    $getExecPath(): Promise<string>
+    $getUserHomeFolderPath(): Promise<string>
+    $getDataFolderName(): Promise<string>
+    $getUserDataFolderPath(): Promise<string>
+    $getAppDataPath(): Promise<string>
 }
 
 export interface PreferenceRegistryMain {

--- a/packages/plugin-ext/src/hosted/browser/hosted-plugin.ts
+++ b/packages/plugin-ext/src/hosted/browser/hosted-plugin.ts
@@ -470,7 +470,8 @@ export class HostedPluginSupport {
     }
 
     protected async getHostGlobalStoragePath(): Promise<string> {
-        const globalStorageFolderPath = new Path(await this.envServer.getUserDataFolderPath()).join('globalStorage').toString();
+        const userDataFolderPath: string = (await this.fileSystem.getFsPath(await this.envServer.getUserDataFolder()))!;
+        const globalStorageFolderPath = new Path(userDataFolderPath).join('globalStorage').toString();
 
         // Make sure that folder by the path exists
         if (! await this.fileSystem.exists(globalStorageFolderPath)) {

--- a/packages/plugin-ext/src/hosted/browser/hosted-plugin.ts
+++ b/packages/plugin-ext/src/hosted/browser/hosted-plugin.ts
@@ -27,13 +27,13 @@ import { injectable, inject, interfaces, named, postConstruct } from 'inversify'
 import { PluginWorker } from '../../main/browser/plugin-worker';
 import { PluginMetadata, getPluginId, HostedPluginServer, DeployedPlugin } from '../../common/plugin-protocol';
 import { HostedPluginWatcher } from './hosted-plugin-watcher';
-import { MAIN_RPC_CONTEXT, PluginManagerExt } from '../../common/plugin-api-rpc';
+import { MAIN_RPC_CONTEXT, PluginManagerExt, ConfigStorage } from '../../common/plugin-api-rpc';
 import { setUpPluginApi } from '../../main/browser/main-context';
 import { RPCProtocol, RPCProtocolImpl } from '../../common/rpc-protocol';
 import {
     Disposable, DisposableCollection,
     ILogger, ContributionProvider, CommandRegistry, WillExecuteCommandEvent,
-    CancellationTokenSource, JsonRpcProxy, ProgressService
+    CancellationTokenSource, JsonRpcProxy, ProgressService, Path
 } from '@theia/core';
 import { PreferenceServiceImpl, PreferenceProviderProvider } from '@theia/core/lib/browser/preferences';
 import { WorkspaceService } from '@theia/workspace/lib/browser';
@@ -47,6 +47,7 @@ import { Deferred } from '@theia/core/lib/common/promise-util';
 import { DebugSessionManager } from '@theia/debug/lib/browser/debug-session-manager';
 import { DebugConfigurationManager } from '@theia/debug/lib/browser/debug-configuration-manager';
 import { WaitUntilEvent } from '@theia/core/lib/common/event';
+import { FileSystem } from '@theia/filesystem/lib/common';
 import { FileSearchService } from '@theia/file-search/lib/common/file-search-service';
 import { Emitter, isCancelled } from '@theia/core';
 import { FrontendApplicationStateService } from '@theia/core/lib/browser/frontend-application-state';
@@ -56,6 +57,7 @@ import { WebviewEnvironment } from '../../main/browser/webview/webview-environme
 import { WebviewWidget } from '../../main/browser/webview/webview';
 import { WidgetManager } from '@theia/core/lib/browser/widget-manager';
 import { TerminalService } from '@theia/terminal/lib/browser/base/terminal-service';
+import { EnvVariablesServer } from '@theia/core/lib/common/env-variables';
 
 export type PluginHost = 'frontend' | string;
 export type DebugActivationEvent = 'onDebugResolve' | 'onDebugInitialConfigurations' | 'onDebugAdapterProtocolTracker';
@@ -109,6 +111,9 @@ export class HostedPluginSupport {
     @inject(DebugConfigurationManager)
     protected readonly debugConfigurationManager: DebugConfigurationManager;
 
+    @inject(FileSystem)
+    protected readonly fileSystem: FileSystem;
+
     @inject(FileSearchService)
     protected readonly fileSearchService: FileSearchService;
 
@@ -135,6 +140,9 @@ export class HostedPluginSupport {
 
     @inject(TerminalService)
     protected readonly terminalService: TerminalService;
+
+    @inject(EnvVariablesServer)
+    protected readonly envServer: EnvVariablesServer;
 
     private theiaReadyPromise: Promise<any>;
 
@@ -330,15 +338,20 @@ export class HostedPluginSupport {
         let started = 0;
         const startPluginsMeasurement = this.createMeasurement('startPlugins');
 
-        const [hostLogPath, hostStoragePath] = await Promise.all([
+        const [hostLogPath, hostStoragePath, hostGlobalStoragePath] = await Promise.all([
             this.pluginPathsService.getHostLogPath(),
-            this.getStoragePath()
+            this.getStoragePath(),
+            this.getHostGlobalStoragePath()
         ]);
         if (toDisconnect.disposed) {
             return;
         }
         const thenable: Promise<void>[] = [];
-        const configStorage = { hostLogPath, hostStoragePath };
+        const configStorage: ConfigStorage = {
+            hostLogPath: hostLogPath!,
+            hostStoragePath: hostStoragePath,
+            hostGlobalStoragePath: hostGlobalStoragePath!
+        };
         for (const [host, hostContributions] of contributionsByHost) {
             const manager = await this.obtainManager(host, hostContributions, toDisconnect);
             if (!manager) {
@@ -454,6 +467,17 @@ export class HostedPluginSupport {
     protected async getStoragePath(): Promise<string | undefined> {
         const roots = await this.workspaceService.roots;
         return this.pluginPathsService.getHostStoragePath(this.workspaceService.workspace, roots);
+    }
+
+    protected async getHostGlobalStoragePath(): Promise<string> {
+        const globalStorageFolderPath = new Path(await this.envServer.getUserDataFolderPath()).join('globalStorage').toString();
+
+        // Make sure that folder by the path exists
+        if (! await this.fileSystem.exists(globalStorageFolderPath)) {
+            await this.fileSystem.createFolder(globalStorageFolderPath);
+        }
+
+        return globalStorageFolderPath;
     }
 
     async activateByEvent(activationEvent: string): Promise<void> {

--- a/packages/plugin-ext/src/hosted/browser/worker/worker-main.ts
+++ b/packages/plugin-ext/src/hosted/browser/worker/worker-main.ts
@@ -31,6 +31,7 @@ import { WorkerEnvExtImpl } from './worker-env-ext';
 import { ClipboardExt } from '../../../plugin/clipboard-ext';
 import { KeyValueStorageProxy } from '../../../plugin/plugin-storage';
 import { WebviewsExtImpl } from '../../../plugin/webviews';
+import { EnvVariablesServerExt } from '../../../plugin/env-variables-server-ext';
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const ctx = self as any;
@@ -61,6 +62,7 @@ const preferenceRegistryExt = new PreferenceRegistryExtImpl(rpc, workspaceExt);
 const debugExt = createDebugExtStub(rpc);
 const clipboardExt = new ClipboardExt(rpc);
 const webviewExt = new WebviewsExtImpl(rpc, workspaceExt);
+const envServerExt = new EnvVariablesServerExt(rpc);
 
 const pluginManager = new PluginManagerExtImpl({
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -133,7 +135,7 @@ const pluginManager = new PluginManagerExtImpl({
             }
         }
     }
-}, envExt, storageProxy, preferenceRegistryExt, webviewExt, rpc);
+}, envExt, storageProxy, preferenceRegistryExt, webviewExt, envServerExt, rpc);
 
 const apiFactory = createAPIFactory(
     rpc,

--- a/packages/plugin-ext/src/hosted/browser/worker/worker-main.ts
+++ b/packages/plugin-ext/src/hosted/browser/worker/worker-main.ts
@@ -31,7 +31,6 @@ import { WorkerEnvExtImpl } from './worker-env-ext';
 import { ClipboardExt } from '../../../plugin/clipboard-ext';
 import { KeyValueStorageProxy } from '../../../plugin/plugin-storage';
 import { WebviewsExtImpl } from '../../../plugin/webviews';
-import { EnvVariablesServerExt } from '../../../plugin/env-variables-server-ext';
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const ctx = self as any;
@@ -62,7 +61,6 @@ const preferenceRegistryExt = new PreferenceRegistryExtImpl(rpc, workspaceExt);
 const debugExt = createDebugExtStub(rpc);
 const clipboardExt = new ClipboardExt(rpc);
 const webviewExt = new WebviewsExtImpl(rpc, workspaceExt);
-const envServerExt = new EnvVariablesServerExt(rpc);
 
 const pluginManager = new PluginManagerExtImpl({
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -135,7 +133,7 @@ const pluginManager = new PluginManagerExtImpl({
             }
         }
     }
-}, envExt, storageProxy, preferenceRegistryExt, webviewExt, envServerExt, rpc);
+}, envExt, storageProxy, preferenceRegistryExt, webviewExt, rpc);
 
 const apiFactory = createAPIFactory(
     rpc,

--- a/packages/plugin-ext/src/hosted/node/plugin-host-rpc.ts
+++ b/packages/plugin-ext/src/hosted/node/plugin-host-rpc.ts
@@ -30,6 +30,7 @@ import { ClipboardExt } from '../../plugin/clipboard-ext';
 import { loadManifest } from './plugin-manifest-loader';
 import { KeyValueStorageProxy } from '../../plugin/plugin-storage';
 import { WebviewsExtImpl } from '../../plugin/webviews';
+import { EnvVariablesServerExt as EnvVariablesServerExtImpl } from '../../plugin/env-variables-server-ext';
 
 /**
  * Handle the RPC calls.
@@ -54,7 +55,8 @@ export class PluginHostRPC {
         const preferenceRegistryExt = new PreferenceRegistryExtImpl(this.rpc, workspaceExt);
         const clipboardExt = new ClipboardExt(this.rpc);
         const webviewExt = new WebviewsExtImpl(this.rpc, workspaceExt);
-        this.pluginManager = this.createPluginManager(envExt, storageProxy, preferenceRegistryExt, webviewExt, this.rpc);
+        const envServer = new EnvVariablesServerExtImpl(this.rpc);
+        this.pluginManager = this.createPluginManager(envExt, storageProxy, preferenceRegistryExt, webviewExt, envServer, this.rpc);
         this.rpc.set(MAIN_RPC_CONTEXT.HOSTED_PLUGIN_MANAGER_EXT, this.pluginManager);
         this.rpc.set(MAIN_RPC_CONTEXT.EDITORS_AND_DOCUMENTS_EXT, editorsAndDocumentsExt);
         this.rpc.set(MAIN_RPC_CONTEXT.WORKSPACE_EXT, workspaceExt);
@@ -89,7 +91,7 @@ export class PluginHostRPC {
     }
 
     createPluginManager(
-        envExt: EnvExtImpl, storageProxy: KeyValueStorageProxy, preferencesManager: PreferenceRegistryExtImpl, webview: WebviewsExtImpl,
+        envExt: EnvExtImpl, storageProxy: KeyValueStorageProxy, preferencesManager: PreferenceRegistryExtImpl, webview: WebviewsExtImpl, envServer: EnvVariablesServerExtImpl,
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         rpc: any): PluginManagerExtImpl {
         const { extensionTestsPath } = process.env;
@@ -222,7 +224,7 @@ export class PluginHostRPC {
                     `Path ${extensionTestsPath} does not point to a valid extension test runner.`
                 );
             } : undefined
-        }, envExt, storageProxy, preferencesManager, webview, rpc);
+        }, envExt, storageProxy, preferencesManager, webview, envServer, rpc);
         return pluginManager;
     }
 }

--- a/packages/plugin-ext/src/hosted/node/plugin-host-rpc.ts
+++ b/packages/plugin-ext/src/hosted/node/plugin-host-rpc.ts
@@ -30,7 +30,6 @@ import { ClipboardExt } from '../../plugin/clipboard-ext';
 import { loadManifest } from './plugin-manifest-loader';
 import { KeyValueStorageProxy } from '../../plugin/plugin-storage';
 import { WebviewsExtImpl } from '../../plugin/webviews';
-import { EnvVariablesServerExt as EnvVariablesServerExtImpl } from '../../plugin/env-variables-server-ext';
 
 /**
  * Handle the RPC calls.
@@ -55,8 +54,7 @@ export class PluginHostRPC {
         const preferenceRegistryExt = new PreferenceRegistryExtImpl(this.rpc, workspaceExt);
         const clipboardExt = new ClipboardExt(this.rpc);
         const webviewExt = new WebviewsExtImpl(this.rpc, workspaceExt);
-        const envServer = new EnvVariablesServerExtImpl(this.rpc);
-        this.pluginManager = this.createPluginManager(envExt, storageProxy, preferenceRegistryExt, webviewExt, envServer, this.rpc);
+        this.pluginManager = this.createPluginManager(envExt, storageProxy, preferenceRegistryExt, webviewExt, this.rpc);
         this.rpc.set(MAIN_RPC_CONTEXT.HOSTED_PLUGIN_MANAGER_EXT, this.pluginManager);
         this.rpc.set(MAIN_RPC_CONTEXT.EDITORS_AND_DOCUMENTS_EXT, editorsAndDocumentsExt);
         this.rpc.set(MAIN_RPC_CONTEXT.WORKSPACE_EXT, workspaceExt);
@@ -91,7 +89,7 @@ export class PluginHostRPC {
     }
 
     createPluginManager(
-        envExt: EnvExtImpl, storageProxy: KeyValueStorageProxy, preferencesManager: PreferenceRegistryExtImpl, webview: WebviewsExtImpl, envServer: EnvVariablesServerExtImpl,
+        envExt: EnvExtImpl, storageProxy: KeyValueStorageProxy, preferencesManager: PreferenceRegistryExtImpl, webview: WebviewsExtImpl,
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         rpc: any): PluginManagerExtImpl {
         const { extensionTestsPath } = process.env;
@@ -224,7 +222,7 @@ export class PluginHostRPC {
                     `Path ${extensionTestsPath} does not point to a valid extension test runner.`
                 );
             } : undefined
-        }, envExt, storageProxy, preferencesManager, webview, envServer, rpc);
+        }, envExt, storageProxy, preferencesManager, webview, rpc);
         return pluginManager;
     }
 }

--- a/packages/plugin-ext/src/main/browser/env-main.ts
+++ b/packages/plugin-ext/src/main/browser/env-main.ts
@@ -15,7 +15,7 @@
  ********************************************************************************/
 
 import { interfaces } from 'inversify';
-import { EnvVariablesServer } from '@theia/core/lib/common/env-variables';
+import { EnvVariablesServer, EnvVariable } from '@theia/core/lib/common/env-variables';
 import { RPCProtocol } from '../../common/rpc-protocol';
 import { EnvMain } from '../../common/plugin-api-rpc';
 import { QueryParameters } from '../../common/env';
@@ -23,6 +23,7 @@ import { isWindows, isOSX } from '@theia/core';
 import { OperatingSystem } from '../../plugin/types-impl';
 
 export class EnvMainImpl implements EnvMain {
+
     private envVariableServer: EnvVariablesServer;
 
     constructor(rpc: RPCProtocol, container: interfaces.Container) {
@@ -33,6 +34,10 @@ export class EnvMainImpl implements EnvMain {
         return this.envVariableServer.getValue(envVarName).then(result => result ? result.value : undefined);
     }
 
+    $getAllEnvVariables(): Promise<EnvVariable[]> {
+        return this.envVariableServer.getVariables();
+    }
+
     async $getClientOperatingSystem(): Promise<OperatingSystem> {
         if (isWindows) {
             return OperatingSystem.Windows;
@@ -41,6 +46,26 @@ export class EnvMainImpl implements EnvMain {
             return OperatingSystem.OSX;
         }
         return OperatingSystem.Linux;
+    }
+
+    $getExecPath(): Promise<string> {
+        return this.envVariableServer.getExecPath();
+    }
+
+    $getUserHomeFolderPath(): Promise<string> {
+        return this.envVariableServer.getUserHomeFolderPath();
+    }
+
+    $getDataFolderName(): Promise<string> {
+        return this.envVariableServer.getDataFolderName();
+    }
+
+    $getUserDataFolderPath(): Promise<string> {
+        return this.envVariableServer.getUserDataFolderPath();
+    }
+
+    $getAppDataPath(): Promise<string> {
+        return this.envVariableServer.getAppDataPath();
     }
 }
 

--- a/packages/plugin-ext/src/main/browser/env-main.ts
+++ b/packages/plugin-ext/src/main/browser/env-main.ts
@@ -53,7 +53,7 @@ export class EnvMainImpl implements EnvMain {
     }
 
     $getUserHomeFolderPath(): Promise<string> {
-        return this.envVariableServer.getUserHomeFolderPath();
+        return this.envVariableServer.getUserHomeFolder();
     }
 
     $getDataFolderName(): Promise<string> {
@@ -61,11 +61,11 @@ export class EnvMainImpl implements EnvMain {
     }
 
     $getUserDataFolderPath(): Promise<string> {
-        return this.envVariableServer.getUserDataFolderPath();
+        return this.envVariableServer.getUserDataFolder();
     }
 
     $getAppDataPath(): Promise<string> {
-        return this.envVariableServer.getAppDataPath();
+        return this.envVariableServer.getAppDataFolder();
     }
 }
 

--- a/packages/plugin-ext/src/main/common/plugin-paths-protocol.ts
+++ b/packages/plugin-ext/src/main/common/plugin-paths-protocol.ts
@@ -25,6 +25,4 @@ export interface PluginPathsService {
     getHostLogPath(): Promise<string>;
     /** Returns storage path for given workspace */
     getHostStoragePath(workspace: FileStat | undefined, roots: FileStat[]): Promise<string | undefined>;
-    /** Returns Theia data directory (one for all Theia workspaces, so doesn't change) */
-    getTheiaDirPath(): Promise<string>;
 }

--- a/packages/plugin-ext/src/main/node/paths/const.ts
+++ b/packages/plugin-ext/src/main/node/paths/const.ts
@@ -15,10 +15,6 @@
  ********************************************************************************/
 
 export namespace PluginPaths {
-    export const WINDOWS_APP_DATA_DIR = 'AppData';
-    export const WINDOWS_ROAMING_DIR = 'Roaming';
-
-    export const THEIA_DIR = '.theia';
     export const PLUGINS_LOGS_DIR = 'logs';
     export const PLUGINS_GLOBAL_STORAGE_DIR = 'plugin-storage';
     export const PLUGINS_WORKSPACE_STORAGE_DIR = 'workspace-storage';

--- a/packages/plugin-ext/src/main/node/paths/plugin-paths-service.ts
+++ b/packages/plugin-ext/src/main/node/paths/plugin-paths-service.ts
@@ -20,6 +20,7 @@ import * as path from 'path';
 import { readdir, remove } from 'fs-extra';
 import * as crypto from 'crypto';
 import URI from '@theia/core/lib/common/uri';
+import { FileUri } from '@theia/core/lib/node';
 import { ILogger } from '@theia/core';
 import { PluginPaths } from './const';
 import { PluginPathsService } from '../../common/plugin-paths-protocol';
@@ -84,8 +85,7 @@ export class PluginPathsServiceImpl implements PluginPathsService {
     }
 
     protected async buildWorkspaceId(workspace: FileStat, roots: FileStat[]): Promise<string> {
-        const userDataDirPath = await this.envServer.getUserDataFolderPath();
-        const untitledWorkspace = getTemporaryWorkspaceFileUri(userDataDirPath);
+        const untitledWorkspace = getTemporaryWorkspaceFileUri(await this.envServer.getUserDataFolder());
 
         if (untitledWorkspace.toString() === workspace.uri) {
             // if workspace is temporary
@@ -105,13 +105,13 @@ export class PluginPathsServiceImpl implements PluginPathsService {
     }
 
     private async getLogsDirPath(): Promise<string> {
-        const theiaDir = await this.envServer.getUserDataFolderPath();
-        return path.join(theiaDir, PluginPaths.PLUGINS_LOGS_DIR);
+        const theiaDirPath = FileUri.fsPath(await this.envServer.getUserDataFolder());
+        return path.join(theiaDirPath, PluginPaths.PLUGINS_LOGS_DIR);
     }
 
     private async getWorkspaceStorageDirPath(): Promise<string> {
-        const theiaDir = await this.envServer.getUserDataFolderPath();
-        return path.join(theiaDir, PluginPaths.PLUGINS_WORKSPACE_STORAGE_DIR);
+        const theiaDirPath = FileUri.fsPath(await this.envServer.getUserDataFolder());
+        return path.join(theiaDirPath, PluginPaths.PLUGINS_WORKSPACE_STORAGE_DIR);
     }
 
     /**

--- a/packages/plugin-ext/src/main/node/paths/plugin-paths-service.ts
+++ b/packages/plugin-ext/src/main/node/paths/plugin-paths-service.ts
@@ -20,10 +20,11 @@ import * as path from 'path';
 import { readdir, remove } from 'fs-extra';
 import * as crypto from 'crypto';
 import URI from '@theia/core/lib/common/uri';
-import { ILogger, isWindows } from '@theia/core';
+import { ILogger } from '@theia/core';
 import { PluginPaths } from './const';
 import { PluginPathsService } from '../../common/plugin-paths-protocol';
 import { THEIA_EXT, VSCODE_EXT, getTemporaryWorkspaceFileUri } from '@theia/workspace/lib/common';
+import { EnvVariablesServer } from '@theia/core/lib/common/env-variables';
 import { PluginCliContribution } from '../plugin-cli-contribution';
 
 const SESSION_TIMESTAMP_PATTERN = /^\d{8}T\d{6}$/;
@@ -32,13 +33,14 @@ const SESSION_TIMESTAMP_PATTERN = /^\d{8}T\d{6}$/;
 @injectable()
 export class PluginPathsServiceImpl implements PluginPathsService {
 
-    private readonly windowsDataFolders = [PluginPaths.WINDOWS_APP_DATA_DIR, PluginPaths.WINDOWS_ROAMING_DIR];
-
     @inject(ILogger)
     protected readonly logger: ILogger;
 
     @inject(FileSystem)
     protected readonly fileSystem: FileSystem;
+
+    @inject(EnvVariablesServer)
+    protected readonly envServer: EnvVariablesServer;
 
     @inject(PluginCliContribution)
     protected readonly cliContribution: PluginCliContribution;
@@ -82,8 +84,8 @@ export class PluginPathsServiceImpl implements PluginPathsService {
     }
 
     protected async buildWorkspaceId(workspace: FileStat, roots: FileStat[]): Promise<string> {
-        const homeDir = await this.getUserHomeDir();
-        const untitledWorkspace = getTemporaryWorkspaceFileUri(new URI(homeDir));
+        const userDataDirPath = await this.envServer.getUserDataFolderPath();
+        const untitledWorkspace = getTemporaryWorkspaceFileUri(userDataDirPath);
 
         if (untitledWorkspace.toString() === workspace.uri) {
             // if workspace is temporary
@@ -102,6 +104,16 @@ export class PluginPathsServiceImpl implements PluginPathsService {
         }
     }
 
+    private async getLogsDirPath(): Promise<string> {
+        const theiaDir = await this.envServer.getUserDataFolderPath();
+        return path.join(theiaDir, PluginPaths.PLUGINS_LOGS_DIR);
+    }
+
+    private async getWorkspaceStorageDirPath(): Promise<string> {
+        const theiaDir = await this.envServer.getUserDataFolderPath();
+        return path.join(theiaDir, PluginPaths.PLUGINS_WORKSPACE_STORAGE_DIR);
+    }
+
     /**
      * Generate time folder name in format: YYYYMMDDTHHMMSS, for example: 20181205T093828
      */
@@ -115,34 +127,6 @@ export class PluginPathsServiceImpl implements PluginPathsService {
         return timeStamp;
     }
 
-    private async getLogsDirPath(): Promise<string> {
-        const theiaDir = await this.getTheiaDirPath();
-        return path.join(theiaDir, PluginPaths.PLUGINS_LOGS_DIR);
-    }
-
-    private async getWorkspaceStorageDirPath(): Promise<string> {
-        const theiaDir = await this.getTheiaDirPath();
-        return path.join(theiaDir, PluginPaths.PLUGINS_WORKSPACE_STORAGE_DIR);
-    }
-
-    async getTheiaDirPath(): Promise<string> {
-        const homeDir = await this.getUserHomeDir();
-        return path.join(
-            homeDir,
-            ...(isWindows ? this.windowsDataFolders : ['']),
-            PluginPaths.THEIA_DIR
-        );
-    }
-
-    private async getUserHomeDir(): Promise<string> {
-        const homeDirStat = await this.fileSystem.getCurrentUserHome();
-        if (!homeDirStat) {
-            throw new Error('Unable to get user home directory');
-        }
-        const homeDirPath = await this.fileSystem.getFsPath(homeDirStat.uri);
-        return homeDirPath!;
-    }
-
     private async cleanupOldLogs(parentLogsDir: string): Promise<void> {
         // @ts-ignore - fs-extra types (Even latest version) is not updated with the `withFileTypes` option.
         const dirEntries = await readdir(parentLogsDir, { withFileTypes: true });
@@ -150,7 +134,7 @@ export class PluginPathsServiceImpl implements PluginPathsService {
         // However, upgrading the @types/node in theia to 10.11 (as defined in engine field)
         // Causes other packages to break in compilation, so we are using the infamous `any` type...
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        const subDirEntries = dirEntries.filter((dirent: any) => dirent.isDirectory() );
+        const subDirEntries = dirEntries.filter((dirent: any) => dirent.isDirectory());
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         const subDirNames = subDirEntries.map((dirent: any) => dirent.name);
         // We never clean a folder that is not a Theia logs session folder.

--- a/packages/plugin-ext/src/main/node/plugins-key-value-storage.ts
+++ b/packages/plugin-ext/src/main/node/plugins-key-value-storage.ts
@@ -19,6 +19,7 @@ import * as fs from 'fs-extra';
 import * as path from 'path';
 import { Deferred } from '@theia/core/lib/common/promise-util';
 import { FileSystem } from '@theia/filesystem/lib/common';
+import { EnvVariablesServer } from '@theia/core/lib/common/env-variables';
 import { PluginPaths } from './paths/const';
 import { PluginPathsService } from '../common/plugin-paths-protocol';
 import { KeysToAnyValues, KeysToKeysToAnyValue } from '../../common/types';
@@ -32,13 +33,16 @@ export class PluginsKeyValueStorage {
     @inject(PluginPathsService)
     private readonly pluginPathsService: PluginPathsService;
 
+    @inject(EnvVariablesServer)
+    protected readonly envServer: EnvVariablesServer;
+
     @inject(FileSystem)
     protected readonly fileSystem: FileSystem;
 
     @postConstruct()
     protected async init(): Promise<void> {
         try {
-            const theiaDirPath = await this.pluginPathsService.getTheiaDirPath();
+            const theiaDirPath = await this.envServer.getUserDataFolderPath();
             await this.fileSystem.createFolder(theiaDirPath);
             const globalDataPath = path.join(theiaDirPath, PluginPaths.PLUGINS_GLOBAL_STORAGE_DIR, 'global-state.json');
             await this.fileSystem.createFolder(path.dirname(globalDataPath));

--- a/packages/plugin-ext/src/main/node/plugins-key-value-storage.ts
+++ b/packages/plugin-ext/src/main/node/plugins-key-value-storage.ts
@@ -17,6 +17,7 @@
 import { injectable, inject, postConstruct } from 'inversify';
 import * as fs from 'fs-extra';
 import * as path from 'path';
+import { FileUri } from '@theia/core/lib/node/file-uri';
 import { Deferred } from '@theia/core/lib/common/promise-util';
 import { FileSystem } from '@theia/filesystem/lib/common';
 import { EnvVariablesServer } from '@theia/core/lib/common/env-variables';
@@ -42,9 +43,9 @@ export class PluginsKeyValueStorage {
     @postConstruct()
     protected async init(): Promise<void> {
         try {
-            const theiaDirPath = await this.envServer.getUserDataFolderPath();
-            await this.fileSystem.createFolder(theiaDirPath);
-            const globalDataPath = path.join(theiaDirPath, PluginPaths.PLUGINS_GLOBAL_STORAGE_DIR, 'global-state.json');
+            const theiaDataFolderPath = FileUri.fsPath(await this.envServer.getUserDataFolder());
+            await this.fileSystem.createFolder(theiaDataFolderPath);
+            const globalDataPath = path.join(theiaDataFolderPath, PluginPaths.PLUGINS_GLOBAL_STORAGE_DIR, 'global-state.json');
             await this.fileSystem.createFolder(path.dirname(globalDataPath));
             this.deferredGlobalDataPath.resolve(globalDataPath);
         } catch (e) {

--- a/packages/plugin-ext/src/plugin/env-variables-server-ext.ts
+++ b/packages/plugin-ext/src/plugin/env-variables-server-ext.ts
@@ -1,0 +1,62 @@
+/********************************************************************************
+ * Copyright (C) 2019 Red Hat, Inc. and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import { RPCProtocol } from '../common/rpc-protocol';
+import { PLUGIN_RPC_CONTEXT, EnvMain } from '../common';
+import { EnvVariablesServer, EnvVariable } from '@theia/core/lib/common/env-variables';
+
+export class EnvVariablesServerExt implements EnvVariablesServer {
+
+    protected readonly proxy: EnvMain;
+
+    constructor(rpc: RPCProtocol) {
+        this.proxy = rpc.getProxy(PLUGIN_RPC_CONTEXT.ENV_MAIN);
+    }
+
+    getExecPath(): Promise<string> {
+        return this.proxy.$getExecPath();
+    }
+
+    getVariables(): Promise<EnvVariable[]> {
+        return this.proxy.$getAllEnvVariables();
+    }
+
+    $getAllEnvVariables(): Promise<EnvVariable[]> {
+        return this.proxy.$getAllEnvVariables();
+    }
+
+    async getValue(name: string): Promise<EnvVariable | undefined> {
+        const value = await this.proxy.$getEnvVariable(name);
+        return { name, value };
+    }
+
+    getUserHomeFolderPath(): Promise<string> {
+        return this.proxy.$getUserHomeFolderPath();
+    }
+
+    getDataFolderName(): Promise<string> {
+        return this.proxy.$getDataFolderName();
+    }
+
+    getUserDataFolderPath(): Promise<string> {
+        return this.proxy.$getUserDataFolderPath();
+    }
+
+    getAppDataPath(): Promise<string> {
+        return this.proxy.$getAppDataPath();
+    }
+
+}

--- a/packages/plugin-ext/src/plugin/env-variables-server-ext.ts
+++ b/packages/plugin-ext/src/plugin/env-variables-server-ext.ts
@@ -34,10 +34,6 @@ export class EnvVariablesServerExt implements EnvVariablesServer {
         return this.proxy.$getAllEnvVariables();
     }
 
-    $getAllEnvVariables(): Promise<EnvVariable[]> {
-        return this.proxy.$getAllEnvVariables();
-    }
-
     async getValue(name: string): Promise<EnvVariable | undefined> {
         const value = await this.proxy.$getEnvVariable(name);
         return { name, value };

--- a/packages/plugin-ext/src/plugin/env-variables-server-ext.ts
+++ b/packages/plugin-ext/src/plugin/env-variables-server-ext.ts
@@ -39,7 +39,7 @@ export class EnvVariablesServerExt implements EnvVariablesServer {
         return { name, value };
     }
 
-    getUserHomeFolderPath(): Promise<string> {
+    getUserHomeFolder(): Promise<string> {
         return this.proxy.$getUserHomeFolderPath();
     }
 
@@ -47,11 +47,11 @@ export class EnvVariablesServerExt implements EnvVariablesServer {
         return this.proxy.$getDataFolderName();
     }
 
-    getUserDataFolderPath(): Promise<string> {
+    getUserDataFolder(): Promise<string> {
         return this.proxy.$getUserDataFolderPath();
     }
 
-    getAppDataPath(): Promise<string> {
+    getAppDataFolder(): Promise<string> {
         return this.proxy.$getAppDataPath();
     }
 

--- a/packages/plugin-ext/src/plugin/plugin-manager.ts
+++ b/packages/plugin-ext/src/plugin/plugin-manager.ts
@@ -38,9 +38,7 @@ import { Memento, KeyValueStorageProxy } from './plugin-storage';
 import { ExtPluginApi } from '../common/plugin-ext-api-contribution';
 import { RPCProtocol } from '../common/rpc-protocol';
 import { Emitter } from '@theia/core/lib/common/event';
-import * as fs from 'fs-extra';
 import { WebviewsExtImpl } from './webviews';
-import { EnvVariablesServer } from '@theia/core/lib/common/env-variables';
 
 export interface PluginHost {
 
@@ -99,7 +97,6 @@ export class PluginManagerExtImpl implements PluginManagerExt, PluginManager {
         private readonly storageProxy: KeyValueStorageProxy,
         private readonly preferencesManager: PreferenceRegistryExtImpl,
         private readonly webview: WebviewsExtImpl,
-        private readonly envServer: EnvVariablesServer,
         private readonly rpc: RPCProtocol
     ) {
         this.messageRegistryProxy = this.rpc.getProxy(PLUGIN_RPC_CONTEXT.MESSAGE_REGISTRY_MAIN);
@@ -281,12 +278,7 @@ export class PluginManagerExtImpl implements PluginManagerExt, PluginManager {
         const asAbsolutePath = (relativePath: string): string => join(plugin.pluginFolder, relativePath);
         const logPath = join(configStorage.hostLogPath, plugin.model.id); // todo check format
         const storagePath = join(configStorage.hostStoragePath || '', plugin.model.id);
-        const defaultGlobalStorage = async () => {
-            const globalStorageFolderPath = join(await this.envServer.getUserDataFolderPath(), 'globalStorage');
-            await fs.ensureDir(globalStorageFolderPath);
-            return globalStorageFolderPath;
-        };
-        const globalStoragePath = join(configStorage.hostGlobalStoragePath || (await defaultGlobalStorage()), plugin.model.id);
+        const globalStoragePath = join(configStorage.hostGlobalStoragePath, plugin.model.id);
         const pluginContext: theia.PluginContext = {
             extensionPath: plugin.pluginFolder,
             globalState: new Memento(plugin.model.id, true, this.storageProxy),

--- a/packages/preferences/src/browser/folders-preferences-provider.ts
+++ b/packages/preferences/src/browser/folders-preferences-provider.ts
@@ -41,7 +41,7 @@ export class FoldersPreferencesProvider extends PreferenceProvider {
     protected async init(): Promise<void> {
         await this.workspaceService.roots;
 
-        await this.updateProviders();
+        this.updateProviders();
         this.workspaceService.onWorkspaceChanged(() => this.updateProviders());
 
         const readyPromises: Promise<void>[] = [];
@@ -51,13 +51,13 @@ export class FoldersPreferencesProvider extends PreferenceProvider {
         Promise.all(readyPromises).then(() => this._ready.resolve());
     }
 
-    protected async updateProviders(): Promise<void> {
+    protected updateProviders(): void {
         const roots = this.workspaceService.tryGetRoots();
         const toDelete = new Set(this.providers.keys());
         for (const folder of roots) {
-            for (const configPath of await this.configurations.getPaths()) {
+            for (const configPath of this.configurations.getPaths()) {
                 for (const configName of [...this.configurations.getSectionNames(), this.configurations.getConfigName()]) {
-                    const configUri = await this.configurations.createUri(new URI(folder.uri), configPath, configName);
+                    const configUri = this.configurations.createUri(new URI(folder.uri), configPath, configName);
                     const key = configUri.toString();
                     toDelete.delete(key);
                     if (!this.providers.has(key)) {

--- a/packages/preferences/src/browser/folders-preferences-provider.ts
+++ b/packages/preferences/src/browser/folders-preferences-provider.ts
@@ -41,7 +41,7 @@ export class FoldersPreferencesProvider extends PreferenceProvider {
     protected async init(): Promise<void> {
         await this.workspaceService.roots;
 
-        this.updateProviders();
+        await this.updateProviders();
         this.workspaceService.onWorkspaceChanged(() => this.updateProviders());
 
         const readyPromises: Promise<void>[] = [];
@@ -51,13 +51,13 @@ export class FoldersPreferencesProvider extends PreferenceProvider {
         Promise.all(readyPromises).then(() => this._ready.resolve());
     }
 
-    protected updateProviders(): void {
+    protected async updateProviders(): Promise<void> {
         const roots = this.workspaceService.tryGetRoots();
         const toDelete = new Set(this.providers.keys());
         for (const folder of roots) {
-            for (const configPath of this.configurations.getPaths()) {
+            for (const configPath of await this.configurations.getPaths()) {
                 for (const configName of [...this.configurations.getSectionNames(), this.configurations.getConfigName()]) {
-                    const configUri = this.configurations.createUri(new URI(folder.uri), configPath, configName);
+                    const configUri = await this.configurations.createUri(new URI(folder.uri), configPath, configName);
                     const key = configUri.toString();
                     toDelete.delete(key);
                     if (!this.providers.has(key)) {

--- a/packages/preferences/src/browser/preferences-tree-widget.ts
+++ b/packages/preferences/src/browser/preferences-tree-widget.ts
@@ -45,11 +45,12 @@ import { EditorWidget, EditorManager } from '@theia/editor/lib/browser';
 import { DisposableCollection, Emitter, Event, MessageService } from '@theia/core';
 import { Deferred } from '@theia/core/lib/common/promise-util';
 import { FileSystem, FileSystemUtils } from '@theia/filesystem/lib/common';
-import { UserStorageUri, THEIA_USER_STORAGE_FOLDER } from '@theia/userstorage/lib/browser';
+import { UserStorageUri } from '@theia/userstorage/lib/browser';
 import { WorkspaceService } from '@theia/workspace/lib/browser/workspace-service';
 import URI from '@theia/core/lib/common/uri';
 import { FoldersPreferencesProvider } from './folders-preferences-provider';
 import { PreferenceConfigurations } from '@theia/core/lib/browser/preferences/preference-configurations';
+import { EnvVariablesServer } from '@theia/core/lib/common/env-variables';
 
 @injectable()
 export class PreferencesContainer extends SplitPanel implements ApplicationShell.TrackableWidgetProvider, Saveable {
@@ -264,6 +265,9 @@ export class PreferencesEditorsContainer extends DockPanel {
     @inject(PreferenceProvider) @named(PreferenceScope.Workspace)
     protected readonly workspacePreferenceProvider: WorkspacePreferenceProvider;
 
+    @inject(EnvVariablesServer)
+    protected readonly envServer: EnvVariablesServer;
+
     private userPreferenceEditorWidget: PreferencesEditorWidget;
     private workspacePreferenceEditorWidget: PreferencesEditorWidget | undefined;
     private foldersPreferenceEditorWidget: PreferencesEditorWidget | undefined;
@@ -450,7 +454,7 @@ export class PreferencesEditorsContainer extends DockPanel {
 
         let uri = preferenceUri;
         if (preferenceUri.scheme === UserStorageUri.SCHEME && homeUri) {
-            uri = homeUri.resolve(THEIA_USER_STORAGE_FOLDER).resolve(preferenceUri.path);
+            uri = homeUri.resolve(await this.envServer.getDataFolderName()).resolve(preferenceUri.path);
         }
         return homeUri
             ? FileSystemUtils.tildifyPath(uri.path.toString(), homeUri.path.toString())

--- a/packages/task/src/browser/task-configuration-manager.ts
+++ b/packages/task/src/browser/task-configuration-manager.ts
@@ -171,7 +171,7 @@ export class TaskConfigurationManager {
             if (configUri && configUri.path.base === 'tasks.json') {
                 uri = configUri;
             } else { // fallback
-                uri = new URI(model.workspaceFolderUri).resolve(`${this.preferenceConfigurations.getPaths()[0]}/tasks.json`);
+                uri = new URI(model.workspaceFolderUri).resolve((await this.preferenceConfigurations.getPaths())[0] + '/tasks.json');
             }
 
             const fileStat = await this.filesystem.getFileStat(uri.toString());

--- a/packages/task/src/browser/task-configuration-manager.ts
+++ b/packages/task/src/browser/task-configuration-manager.ts
@@ -171,7 +171,7 @@ export class TaskConfigurationManager {
             if (configUri && configUri.path.base === 'tasks.json') {
                 uri = configUri;
             } else { // fallback
-                uri = new URI(model.workspaceFolderUri).resolve((await this.preferenceConfigurations.getPaths())[0] + '/tasks.json');
+                uri = new URI(model.workspaceFolderUri).resolve(`${this.preferenceConfigurations.getPaths()[0]}/tasks.json`);
             }
 
             const fileStat = await this.filesystem.getFileStat(uri.toString());

--- a/packages/task/src/browser/task-configurations.ts
+++ b/packages/task/src/browser/task-configurations.ts
@@ -110,7 +110,7 @@ export class TaskConfigurations implements Disposable {
     }
 
     @postConstruct()
-    protected async init(): Promise<void> {
+    protected init(): void {
         this.toDispose.push(
             this.taskConfigurationManager.onDidChangeTaskConfig(async change => {
                 try {

--- a/packages/task/src/browser/task-configurations.ts
+++ b/packages/task/src/browser/task-configurations.ts
@@ -33,6 +33,7 @@ import URI from '@theia/core/lib/common/uri';
 import { FileChange, FileChangeType } from '@theia/filesystem/lib/common/filesystem-watcher-protocol';
 import { WorkspaceService } from '@theia/workspace/lib/browser';
 import { OpenerService } from '@theia/core/lib/browser';
+import { EnvVariablesServer } from '@theia/core/lib/common/env-variables';
 
 export interface TaskConfigurationClient {
     /**
@@ -60,7 +61,7 @@ export class TaskConfigurations implements Disposable {
     protected taskCustomizationMap = new Map<string, TaskCustomization[]>();
 
     /** last directory element under which we look for task config */
-    protected readonly TASKFILEPATH = '.theia';
+    protected taskFilePath: string;
     /** task configuration file name */
     protected readonly TASKFILE = 'tasks.json';
 
@@ -96,6 +97,9 @@ export class TaskConfigurations implements Disposable {
     @inject(TaskSourceResolver)
     protected readonly taskSourceResolver: TaskSourceResolver;
 
+    @inject(EnvVariablesServer)
+    protected readonly envServer: EnvVariablesServer;
+
     constructor() {
         this.toDispose.push(Disposable.create(() => {
             this.tasksMap.clear();
@@ -106,7 +110,7 @@ export class TaskConfigurations implements Disposable {
     }
 
     @postConstruct()
-    protected init(): void {
+    protected async init(): Promise<void> {
         this.toDispose.push(
             this.taskConfigurationManager.onDidChangeTaskConfig(async change => {
                 try {
@@ -241,7 +245,7 @@ export class TaskConfigurations implements Disposable {
 
     /** returns the string uri of where the config file would be, if it existed under a given root directory */
     protected getConfigFileUri(rootDir: string): string {
-        return new URI(rootDir).resolve(this.TASKFILEPATH).resolve(this.TASKFILE).toString();
+        return new URI(rootDir).resolve(this.taskFilePath).resolve(this.TASKFILE).toString();
     }
 
     /**

--- a/packages/task/src/browser/task-configurations.ts
+++ b/packages/task/src/browser/task-configurations.ts
@@ -110,7 +110,7 @@ export class TaskConfigurations implements Disposable {
     }
 
     @postConstruct()
-    protected init(): void {
+    protected async init(): Promise<void> {
         this.toDispose.push(
             this.taskConfigurationManager.onDidChangeTaskConfig(async change => {
                 try {
@@ -123,6 +123,7 @@ export class TaskConfigurations implements Disposable {
                 }
             })
         );
+        this.taskFilePath = await this.envServer.getDataFolderName();
         this.reorganizeTasks();
         this.toDispose.push(this.taskSchemaUpdater.onDidChangeTaskSchema(() => this.reorganizeTasks()));
     }

--- a/packages/userstorage/src/browser/user-storage-service-filesystem.spec.ts
+++ b/packages/userstorage/src/browser/user-storage-service-filesystem.spec.ts
@@ -29,6 +29,8 @@ import { PreferenceService } from '@theia/core/lib/browser/preferences';
 import { MockPreferenceService } from '@theia/core/lib/browser/preferences/test/mock-preference-service';
 import { FileSystemWatcherServer } from '@theia/filesystem/lib/common/filesystem-watcher-protocol';
 import { MockFilesystem, MockFilesystemWatcherServer } from '@theia/filesystem/lib/common/test';
+import { EnvVariablesServer } from '@theia/core/lib/common/env-variables';
+import { MockEnvVariablesServerImpl } from '@theia/core/lib/browser/test/mock-env-variables-server';
 import { UserStorageUri } from './user-storage-uri';
 import URI from '@theia/core/lib/common/uri';
 
@@ -105,6 +107,7 @@ before(async () => {
 
         return fs;
     }).inSingletonScope();
+    testContainer.bind(EnvVariablesServer).to(MockEnvVariablesServerImpl).inSingletonScope();
     testContainer.bind(UserStorageService).to(UserStorageServiceFilesystemImpl);
 });
 

--- a/packages/userstorage/src/browser/user-storage-service-filesystem.ts
+++ b/packages/userstorage/src/browser/user-storage-service-filesystem.ts
@@ -50,7 +50,6 @@ export class UserStorageServiceFilesystemImpl implements UserStorageService {
         });
 
         this.toDispose.push(this.onUserStorageChangedEmitter);
-
     }
 
     dispose(): void {

--- a/packages/userstorage/src/browser/user-storage-service-filesystem.ts
+++ b/packages/userstorage/src/browser/user-storage-service-filesystem.ts
@@ -36,17 +36,13 @@ export class UserStorageServiceFilesystemImpl implements UserStorageService {
         @inject(ILogger) protected readonly logger: ILogger,
         @inject(EnvVariablesServer) protected readonly envServer: EnvVariablesServer
     ) {
-        this.envServer.getDataFolderName().then(userStorageFolder => {
-            this.userStorageFolder = this.fileSystem.getCurrentUserHome().then(home => {
-                if (home) {
-                    const userStorageFolderUri = new URI(home.uri).resolve(userStorageFolder);
-                    watcher.watchFileChanges(userStorageFolderUri).then(disposable =>
-                        this.toDispose.push(disposable)
-                    );
-                    this.toDispose.push(this.watcher.onFilesChanged(changes => this.onDidFilesChanged(changes)));
-                    return new URI(home.uri).resolve(userStorageFolder);
-                }
-            });
+        this.userStorageFolder = this.envServer.getUserDataFolderPath().then(userDataFolderPath => {
+            const userStorageFolderUri = new URI('file://' + userDataFolderPath);
+            watcher.watchFileChanges(userStorageFolderUri).then(disposable =>
+                this.toDispose.push(disposable)
+            );
+            this.toDispose.push(this.watcher.onFilesChanged(changes => this.onDidFilesChanged(changes)));
+            return userStorageFolderUri;
         });
 
         this.toDispose.push(this.onUserStorageChangedEmitter);

--- a/packages/userstorage/src/browser/user-storage-service-filesystem.ts
+++ b/packages/userstorage/src/browser/user-storage-service-filesystem.ts
@@ -36,13 +36,13 @@ export class UserStorageServiceFilesystemImpl implements UserStorageService {
         @inject(ILogger) protected readonly logger: ILogger,
         @inject(EnvVariablesServer) protected readonly envServer: EnvVariablesServer
     ) {
-        this.userStorageFolder = this.envServer.getUserDataFolderPath().then(userDataFolderPath => {
-            const userStorageFolderUri = new URI('file://' + userDataFolderPath);
-            watcher.watchFileChanges(userStorageFolderUri).then(disposable =>
+        this.userStorageFolder = this.envServer.getUserDataFolder().then(userDataFolder => {
+            const userDataFolderUri = new URI(userDataFolder);
+            watcher.watchFileChanges(userDataFolderUri).then(disposable =>
                 this.toDispose.push(disposable)
             );
             this.toDispose.push(this.watcher.onFilesChanged(changes => this.onDidFilesChanged(changes)));
-            return userStorageFolderUri;
+            return userDataFolderUri;
         });
 
         this.toDispose.push(this.onUserStorageChangedEmitter);

--- a/packages/workspace/src/browser/quick-open-workspace.ts
+++ b/packages/workspace/src/browser/quick-open-workspace.ts
@@ -16,6 +16,7 @@
 
 import { injectable, inject } from 'inversify';
 import { QuickOpenService, QuickOpenModel, QuickOpenItem, QuickOpenGroupItem, QuickOpenMode, LabelProvider } from '@theia/core/lib/browser';
+import { EnvVariablesServer } from '@theia/core/lib/common/env-variables';
 import { WorkspaceService } from './workspace-service';
 import { getTemporaryWorkspaceFileUri } from '../common';
 import { WorkspacePreferences } from './workspace-preferences';
@@ -34,15 +35,13 @@ export class QuickOpenWorkspace implements QuickOpenModel {
     @inject(FileSystem) protected readonly fileSystem: FileSystem;
     @inject(LabelProvider) protected readonly labelProvider: LabelProvider;
     @inject(WorkspacePreferences) protected preferences: WorkspacePreferences;
+    @inject(EnvVariablesServer) protected readonly envServer: EnvVariablesServer;
 
     async open(workspaces: string[]): Promise<void> {
         this.items = [];
-        const homeStat = await this.fileSystem.getCurrentUserHome();
-        const home = (homeStat) ? new URI(homeStat.uri).path.toString() : undefined;
-        let tempWorkspaceFile: URI | undefined;
-        if (home) {
-            tempWorkspaceFile = getTemporaryWorkspaceFileUri(new URI(home));
-        }
+        const homeDirPath = await this.envServer.getUserHomeFolderPath();
+        const userDataDirPath = await this.envServer.getUserDataFolderPath();
+        const tempWorkspaceFile = getTemporaryWorkspaceFileUri(userDataDirPath);
         await this.preferences.ready;
         if (!workspaces.length) {
             this.items.push(new QuickOpenGroupItem({
@@ -64,7 +63,7 @@ export class QuickOpenWorkspace implements QuickOpenModel {
             const iconClass = icon === '' ? undefined : icon + ' file-icon';
             this.items.push(new QuickOpenGroupItem({
                 label: uri.path.base,
-                description: (home) ? FileSystemUtils.tildifyPath(uri.path.toString(), home) : uri.path.toString(),
+                description: (homeDirPath) ? FileSystemUtils.tildifyPath(uri.path.toString(), homeDirPath) : uri.path.toString(),
                 groupLabel: `last modified ${moment(stat.lastModification).fromNow()}`,
                 iconClass,
                 run: (mode: QuickOpenMode): boolean => {

--- a/packages/workspace/src/browser/quick-open-workspace.ts
+++ b/packages/workspace/src/browser/quick-open-workspace.ts
@@ -39,9 +39,8 @@ export class QuickOpenWorkspace implements QuickOpenModel {
 
     async open(workspaces: string[]): Promise<void> {
         this.items = [];
-        const homeDirPath = await this.envServer.getUserHomeFolderPath();
-        const userDataDirPath = await this.envServer.getUserDataFolderPath();
-        const tempWorkspaceFile = getTemporaryWorkspaceFileUri(userDataDirPath);
+        const homeDirPath: string = (await this.fileSystem.getFsPath(await this.envServer.getUserHomeFolder()))!;
+        const tempWorkspaceFile = getTemporaryWorkspaceFileUri(await this.envServer.getUserDataFolder());
         await this.preferences.ready;
         if (!workspaces.length) {
             this.items.push(new QuickOpenGroupItem({

--- a/packages/workspace/src/browser/workspace-service.spec.ts
+++ b/packages/workspace/src/browser/workspace-service.spec.ts
@@ -25,6 +25,8 @@ import { FileSystemNode } from '@theia/filesystem/lib/node/node-filesystem';
 import { FileSystemWatcher, FileChangeEvent, FileChangeType } from '@theia/filesystem/lib/browser/filesystem-watcher';
 import { WindowService } from '@theia/core/lib/browser/window/window-service';
 import { DefaultWindowService } from '@theia/core/lib/browser/window/default-window-service';
+import { EnvVariablesServer } from '@theia/core/lib/common/env-variables';
+import { MockEnvVariablesServerImpl } from '@theia/core/lib/browser/test/mock-env-variables-server';
 import { WorkspaceServer } from '../common';
 import { DefaultWorkspaceServer } from '../node/default-workspace-server';
 import { Emitter, Disposable, DisposableCollection, ILogger, Logger } from '@theia/core';
@@ -107,6 +109,7 @@ describe('WorkspaceService', () => {
         testContainer.bind(WindowService).toConstantValue(mockWindowService);
         testContainer.bind(ILogger).toConstantValue(mockILogger);
         testContainer.bind(WorkspacePreferences).toConstantValue(mockPref);
+        testContainer.bind(EnvVariablesServer).to(MockEnvVariablesServerImpl);
         testContainer.bind(PreferenceServiceImpl).toConstantValue(mockPreferenceServiceImpl);
         testContainer.bind(PreferenceSchemaProvider).toConstantValue(mockPreferenceSchemaProvider);
 

--- a/packages/workspace/src/browser/workspace-service.ts
+++ b/packages/workspace/src/browser/workspace-service.ts
@@ -24,6 +24,7 @@ import {
     FrontendApplicationContribution, PreferenceServiceImpl, PreferenceScope, PreferenceSchemaProvider
 } from '@theia/core/lib/browser';
 import { Deferred } from '@theia/core/lib/common/promise-util';
+import { EnvVariablesServer } from '@theia/core/lib/common/env-variables';
 import { ILogger, Disposable, DisposableCollection, Emitter, Event, MaybePromise } from '@theia/core';
 import { WorkspacePreferences } from './workspace-preferences';
 import * as jsoncparser from 'jsonc-parser';
@@ -64,6 +65,9 @@ export class WorkspaceService implements FrontendApplicationContribution {
 
     @inject(PreferenceSchemaProvider)
     protected readonly schemaProvider: PreferenceSchemaProvider;
+
+    @inject(EnvVariablesServer)
+    protected readonly envServer: EnvVariablesServer;
 
     protected applicationName: string;
 
@@ -376,8 +380,8 @@ export class WorkspaceService implements FrontendApplicationContribution {
     }
 
     protected async getUntitledWorkspace(): Promise<URI | undefined> {
-        const home = await this.fileSystem.getCurrentUserHome();
-        return home && getTemporaryWorkspaceFileUri(new URI(home.uri));
+        const userDataDirPath = await this.envServer.getUserDataFolderPath();
+        return getTemporaryWorkspaceFileUri(userDataDirPath);
     }
 
     private async writeWorkspaceFile(workspaceFile: FileStat | undefined, workspaceData: WorkspaceData): Promise<FileStat | undefined> {

--- a/packages/workspace/src/browser/workspace-service.ts
+++ b/packages/workspace/src/browser/workspace-service.ts
@@ -380,8 +380,7 @@ export class WorkspaceService implements FrontendApplicationContribution {
     }
 
     protected async getUntitledWorkspace(): Promise<URI | undefined> {
-        const userDataDirPath = await this.envServer.getUserDataFolderPath();
-        return getTemporaryWorkspaceFileUri(userDataDirPath);
+        return getTemporaryWorkspaceFileUri(await this.envServer.getUserDataFolder());
     }
 
     private async writeWorkspaceFile(workspaceFile: FileStat | undefined, workspaceData: WorkspaceData): Promise<FileStat | undefined> {

--- a/packages/workspace/src/common/utils.ts
+++ b/packages/workspace/src/common/utils.ts
@@ -19,6 +19,13 @@ import URI from '@theia/core/lib/common/uri';
 export const THEIA_EXT = 'theia-workspace';
 export const VSCODE_EXT = 'code-workspace';
 
-export function getTemporaryWorkspaceFileUri(home: URI): URI {
-    return home.resolve('.theia').resolve(`Untitled.${THEIA_EXT}`).withScheme('file');
+export function getTemporaryWorkspaceFileUri(userDataFolder: string | URI): URI {
+    let userDataFolderUri: URI;
+    if (typeof userDataFolder === 'string') {
+        userDataFolderUri = new URI(userDataFolder);
+    } else {
+        userDataFolderUri = userDataFolder;
+    }
+
+    return userDataFolderUri.resolve(`Untitled.${THEIA_EXT}`).withScheme('file');
 }

--- a/packages/workspace/src/node/default-workspace-server.ts
+++ b/packages/workspace/src/node/default-workspace-server.ts
@@ -166,7 +166,7 @@ export class DefaultWorkspaceServer implements WorkspaceServer {
     }
 
     protected async getUserStoragePath(): Promise<string> {
-        return path.resolve(await this.envServer.getUserDataFolderPath(), 'recentworkspace.json');
+        return path.resolve(FileUri.fsPath(await this.envServer.getUserDataFolder()), 'recentworkspace.json');
     }
 }
 


### PR DESCRIPTION
Signed-off-by: Mykola Morhun <mmorhun@redhat.com>

#### What it does
Makes Theia data folder configurable, so it could be redefined to another than `.theia`.

Resolves https://github.com/eclipse-theia/theia/issues/4488

#### Review checklist

- [X] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

