### PR TITLE
[terminal] map localhost to external links

### DIFF
--- a/packages/terminal/src/browser/terminal-linkmatcher.ts
+++ b/packages/terminal/src/browser/terminal-linkmatcher.ts
@@ -16,9 +16,10 @@
 
 import { injectable, inject } from 'inversify';
 import { isOSX, } from '@theia/core';
-import { WindowService } from '@theia/core/lib/browser/window/window-service';
 import { TerminalContribution } from './terminal-contribution';
 import { TerminalWidgetImpl } from './terminal-widget-impl';
+import { open, OpenerService } from '@theia/core/lib/browser/opener-service';
+import URI from '@theia/core/lib/common/uri';
 
 @injectable()
 export abstract class AbstractCmdClickTerminalContribution implements TerminalContribution {
@@ -76,25 +77,24 @@ export abstract class AbstractCmdClickTerminalContribution implements TerminalCo
 @injectable()
 export class URLMatcher extends AbstractCmdClickTerminalContribution {
 
-    @inject(WindowService)
-    protected readonly windowService: WindowService;
+    @inject(OpenerService)
+    protected readonly openerService: OpenerService;
 
     async getRegExp(): Promise<RegExp> {
         return /https?:\/\/(www\.)?[-a-zA-Z0-9@:%._\+~#=]{2,256}\.[a-z]{2,4}\b([-a-zA-Z0-9@:%_\+.~#?&//=]*)/;
     }
 
     getHandler(): (event: MouseEvent, uri: string) => void {
-        return (event: MouseEvent, uri: string) => {
-            this.windowService.openNewWindow(uri);
-        };
+        return (event: MouseEvent, uri: string) =>
+            open(this.openerService, new URI(uri));
     }
 }
 
 @injectable()
 export class LocalhostMatcher extends AbstractCmdClickTerminalContribution {
 
-    @inject(WindowService)
-    protected readonly windowService: WindowService;
+    @inject(OpenerService)
+    protected readonly openerService: OpenerService;
 
     async getRegExp(): Promise<RegExp> {
         return /(https?:\/\/)?(localhost|127\.0\.0\.1|0\.0\.0\.0)(:[0-9]{1,5})?([-a-zA-Z0-9@:%_\+.~#?&//=]*)/;
@@ -103,7 +103,7 @@ export class LocalhostMatcher extends AbstractCmdClickTerminalContribution {
     getHandler(): (event: MouseEvent, uri: string) => void {
         return (event: MouseEvent, matched: string) => {
             const uri = matched.startsWith('http') ? matched : `http://${matched}`;
-            this.windowService.openNewWindow(uri);
+            open(this.openerService, new URI(uri));
         };
     }
 }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

It allows to open localhost links from terminal as external. 

Generally we should always use `OpenerService` to apply complete logic. Don't take shortcuts to concrete handlers or try to implement them using `WindowService`.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

- for regressions tests that it still works locally
- if possible test in remote environments, but obviously with some changes to `ExternalUriService.toRemoteHost`
  - for Gitpod:  
```ts
return `${localhost.port}-${window.location.hostname.substr(window.location.hostname.indexOf('-') + 1)}`;
```

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

