### PR TITLE
[fs][plugin] fix #6661: map editor icon paths to external URIs

### DIFF
--- a/packages/filesystem/src/node/download/file-download-endpoint.ts
+++ b/packages/filesystem/src/node/download/file-download-endpoint.ts
@@ -16,11 +16,13 @@
 
 // tslint:disable:no-any
 
+import * as url from 'url';
 import { injectable, inject, named } from 'inversify';
 import { json } from 'body-parser';
 // tslint:disable-next-line:no-implicit-dependencies
 import { Application, Router } from 'express';
 import { BackendApplicationContribution } from '@theia/core/lib/node/backend-application';
+import { FileUri } from '@theia/core/lib/node/file-uri';
 import { FileDownloadHandler } from './file-download-handler';
 
 @injectable()
@@ -48,6 +50,15 @@ export class FileDownloadEndpoint implements BackendApplicationContribution {
         // Content-Type: application/json
         app.use(json());
         app.use(FileDownloadEndpoint.PATH, router);
+        app.get('/file', (request, response) => {
+            const uri = url.parse(request.url).query;
+            if (!uri) {
+                response.status(400).send('invalid uri');
+                return;
+            }
+            const fsPath = FileUri.fsPath(decodeURIComponent(uri));
+            response.sendFile(fsPath);
+        });
     }
 
 }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

fix #6661: VS Code extensions are using absolute paths to load editor icons. It does not work in remote environments. Instead we rewrite  files URIs to external URIs to make it work.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

- Install vscode-bookmarks extension: https://marketplace.visualstudio.com/items?itemName=alefragnani.Bookmarks
- try to toggle bookmars in any file
  - test in local setup
  - test in remote setup, i.e. with Gitpod

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

