### PR TITLE
ask user to terminate or restart a task if it is active

### DIFF
--- a/packages/task/src/browser/task-configurations.ts
+++ b/packages/task/src/browser/task-configurations.ts
@@ -21,6 +21,7 @@ import { TaskDefinitionRegistry } from './task-definition-registry';
 import { ProvidedTaskConfigurations } from './provided-task-configurations';
 import { TaskConfigurationManager } from './task-configuration-manager';
 import { TaskSchemaUpdater } from './task-schema-updater';
+import { TaskSourceResolver } from './task-source-resolver';
 import { Disposable, DisposableCollection, ResourceProvider } from '@theia/core/lib/common';
 import URI from '@theia/core/lib/common/uri';
 import { FileChange, FileChangeType } from '@theia/filesystem/lib/common/filesystem-watcher-protocol';
@@ -85,6 +86,9 @@ export class TaskConfigurations implements Disposable {
 
     @inject(TaskSchemaUpdater)
     protected readonly taskSchemaUpdater: TaskSchemaUpdater;
+
+    @inject(TaskSourceResolver)
+    protected readonly taskSourceResolver: TaskSourceResolver;
 
     constructor() {
         this.toDispose.push(Disposable.create(() => {
@@ -292,7 +296,7 @@ export class TaskConfigurations implements Disposable {
             return;
         }
 
-        const sourceFolderUri: string | undefined = this.getSourceFolderUriFromTask(task);
+        const sourceFolderUri: string | undefined = this.taskSourceResolver.resolve(task);
         if (!sourceFolderUri) {
             console.error('Global task cannot be customized');
             return;
@@ -414,7 +418,7 @@ export class TaskConfigurations implements Disposable {
      */
     // tslint:disable-next-line:no-any
     async updateTaskConfig(task: TaskConfiguration, update: { [name: string]: any }): Promise<void> {
-        const sourceFolderUri: string | undefined = this.getSourceFolderUriFromTask(task);
+        const sourceFolderUri: string | undefined = this.taskSourceResolver.resolve(task);
         if (!sourceFolderUri) {
             console.error('Global task cannot be customized');
             return;
@@ -463,16 +467,5 @@ export class TaskConfigurations implements Disposable {
             ...task,
             type: task.taskType || task.type
         });
-    }
-
-    private getSourceFolderUriFromTask(task: TaskConfiguration): string | undefined {
-        const isDetectedTask = this.isDetectedTask(task);
-        let sourceFolderUri: string | undefined;
-        if (isDetectedTask) {
-            sourceFolderUri = task._scope;
-        } else {
-            sourceFolderUri = task._source;
-        }
-        return sourceFolderUri;
     }
 }

--- a/packages/task/src/browser/task-frontend-module.ts
+++ b/packages/task/src/browser/task-frontend-module.ts
@@ -38,6 +38,7 @@ import { bindTaskPreferences } from './task-preferences';
 import '../../src/browser/style/index.css';
 import './tasks-monaco-contribution';
 import { TaskNameResolver } from './task-name-resolver';
+import { TaskSourceResolver } from './task-source-resolver';
 import { TaskTemplateSelector } from './task-templates';
 
 export default new ContainerModule(bind => {
@@ -74,6 +75,7 @@ export default new ContainerModule(bind => {
     bindContributionProvider(bind, TaskContribution);
     bind(TaskSchemaUpdater).toSelf().inSingletonScope();
     bind(TaskNameResolver).toSelf().inSingletonScope();
+    bind(TaskSourceResolver).toSelf().inSingletonScope();
     bind(TaskTemplateSelector).toSelf().inSingletonScope();
 
     bindProcessTaskModule(bind);

--- a/packages/task/src/browser/task-source-resolver.ts
+++ b/packages/task/src/browser/task-source-resolver.ts
@@ -1,0 +1,43 @@
+/********************************************************************************
+ * Copyright (C) 2019 Ericsson and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import { inject, injectable } from 'inversify';
+import { TaskConfiguration, ContributedTaskConfiguration } from '../common';
+import { TaskDefinitionRegistry } from './task-definition-registry';
+
+@injectable()
+export class TaskSourceResolver {
+    @inject(TaskDefinitionRegistry)
+    protected taskDefinitionRegistry: TaskDefinitionRegistry;
+
+    /**
+     * Returns task source to display.
+     */
+    resolve(task: TaskConfiguration): string | undefined {
+        const isDetectedTask = this.isDetectedTask(task);
+        let sourceFolderUri: string | undefined;
+        if (isDetectedTask) {
+            sourceFolderUri = task._scope;
+        } else {
+            sourceFolderUri = task._source;
+        }
+        return sourceFolderUri;
+    }
+
+    private isDetectedTask(task: TaskConfiguration): task is ContributedTaskConfiguration {
+        return !!this.taskDefinitionRegistry.getDefinition(task);
+    }
+}


### PR DESCRIPTION
With changes in this pull request, Theia offers users the flexibility of terminating or restarting a task, if the user tries to run a task that is actively running.
This pull request resolves https://github.com/eclipse-theia/theia/issues/6618#issuecomment-558047443, and resolves https://github.com/eclipse-theia/theia/issues/5269

Signed-off-by: Liang Huang <liang.huang@ericsson.com>

#### How to test

1. Start a long running task, or a background task
2. Before the task that is started in step 1 finishes, run it for one more time
    - Expected: Users should see a prompt. From the prompt they are offered 2 options: terminate the task (started in step 1), or restart the task.


![Peek 2019-11-30 19-02](https://user-images.githubusercontent.com/37082801/69908008-e7a7ea00-13ae-11ea-8738-22fa208dd3b6.gif)



#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)
