### PR TITLE
Stop dispatching to keybindings in editing coposition text.

### DIFF
--- a/packages/core/src/browser/frontend-application.ts
+++ b/packages/core/src/browser/frontend-application.ts
@@ -157,17 +157,42 @@ export class FrontendApplication {
         return startupElements.length === 0 ? undefined : startupElements[0] as HTMLElement;
     }
 
+    /* vvv HOTFIX begin vvv
+     *
+     * This is a hotfix against issues eclipse/theia#6459 and gitpod-io/gitpod#875 .
+     * It should be reverted after Theia was updated to the newer Monaco.
+     */
+    protected inComposition = false;
+    /**
+     * Register composition related event listeners.
+     */
+    protected registerComositionEventListeners(): void {
+        window.document.addEventListener('compositionstart', event => {
+            this.inComposition = true;
+        });
+        window.document.addEventListener('compositionend', event => {
+            this.inComposition = false;
+        });
+    }
+    /* ^^^ HOTFIX end ^^^ */
+
     /**
      * Register global event listeners.
      */
     protected registerEventListeners(): void {
+        this.registerComositionEventListeners(); /* Hotfix. See above. */
+
         window.addEventListener('beforeunload', () => {
             this.stateService.state = 'closing_window';
             this.layoutRestorer.storeLayout(this);
             this.stopContributions();
         });
         window.addEventListener('resize', () => this.shell.update());
-        document.addEventListener('keydown', event => this.keybindings.run(event), true);
+        document.addEventListener('keydown', event => {
+            if (this.inComposition !== true) {
+                this.keybindings.run(event);
+            }
+        }, true);
         document.addEventListener('touchmove', event => { event.preventDefault(); }, { passive: false });
         // Prevent forward/back navigation by scrolling in OS X
         if (isOSX) {


### PR DESCRIPTION
Signed-off-by: Masaki Muranaka <monaka@monami-ya.com>

#### What it does

Ignores `keydown` event when [IME](https://developer.mozilla.org/en-US/docs/Glossary/Input_method_editor) is working.
This will fix #6459 and gitpod-io/gitpod#875 .

#### How to test

Editing texts like the description of #6459. 


#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

This patch was tested on my Chrome only.
I suppose this will work also on another modern browsers, but not tested on them.