### PR TITLE
[core] don't scroll when closing a dialog

### DIFF
--- a/packages/core/src/browser/dialogs.ts
+++ b/packages/core/src/browser/dialogs.ts
@@ -243,7 +243,7 @@ export abstract class AbstractDialog<T> extends BaseWidget {
     close(): void {
         if (this.resolve) {
             if (this.activeElement) {
-                this.activeElement.focus();
+                this.activeElement.focus({ preventScroll: true });
             }
             this.resolve(undefined);
         }


### PR DESCRIPTION
When a dialog gets closed, the previously
active element gets focus again. We don't
want the default scroll to top behavior.

#### How to test

Expand the navigator to a state where you scrolled down a bit.
Now right click and choose new file so the dialog appears.
Close the dialog the navigator should have focus again without scrolling to the top.

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

