### PR TITLE
fix infinity recursion when tree root is change during refresh

### DIFF
--- a/packages/core/src/browser/tree/test/tree-test-container.ts
+++ b/packages/core/src/browser/tree/test/tree-test-container.ts
@@ -1,0 +1,45 @@
+/********************************************************************************
+ * Copyright (C) 2019 TypeFox and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import { TreeImpl, Tree } from '../tree';
+import { TreeModel, TreeModelImpl } from '../tree-model';
+import { Container } from 'inversify';
+import { TreeSelectionServiceImpl } from '../tree-selection-impl';
+import { TreeSelectionService } from '../tree-selection';
+import { TreeExpansionServiceImpl, TreeExpansionService } from '../tree-expansion';
+import { TreeNavigationService } from '../tree-navigation';
+import { TreeSearch } from '../tree-search';
+import { FuzzySearch } from '../fuzzy-search';
+import { MockLogger } from '../../../common/test/mock-logger';
+import { ILogger } from '../../../common';
+
+export function createTreeTestContainer(): Container {
+    const container = new Container({ defaultScope: 'Singleton' });
+    container.bind(TreeImpl).toSelf();
+    container.bind(Tree).toService(TreeImpl);
+    container.bind(TreeSelectionServiceImpl).toSelf();
+    container.bind(TreeSelectionService).toService(TreeSelectionServiceImpl);
+    container.bind(TreeExpansionServiceImpl).toSelf();
+    container.bind(TreeExpansionService).toService(TreeExpansionServiceImpl);
+    container.bind(TreeNavigationService).toSelf();
+    container.bind(TreeModelImpl).toSelf();
+    container.bind(TreeModel).toService(TreeModelImpl);
+    container.bind(TreeSearch).toSelf();
+    container.bind(FuzzySearch).toSelf();
+    container.bind(MockLogger).toSelf();
+    container.bind(ILogger).to(MockLogger);
+    return container;
+}

--- a/packages/core/src/browser/tree/tree-consistency.spec.ts
+++ b/packages/core/src/browser/tree/tree-consistency.spec.ts
@@ -1,0 +1,101 @@
+/********************************************************************************
+ * Copyright (C) 2019 TypeFox and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import * as assert from 'assert';
+import { injectable } from 'inversify';
+import { createTreeTestContainer } from './test/tree-test-container';
+import { TreeImpl, CompositeTreeNode, TreeNode } from './tree';
+import { TreeModel } from './tree-model';
+import { ExpandableTreeNode } from './tree-expansion';
+
+@injectable()
+class ConsistencyTestTree extends TreeImpl {
+
+    public resolveCounter = 0;
+
+    protected async resolveChildren(parent: CompositeTreeNode): Promise<TreeNode[]> {
+        if (parent.id === 'expandable') {
+            const step: () => Promise<TreeNode[]> = async () => {
+                // a predicate to emulate bad timing, i.e.
+                // children of a node gets resolved when a root is changed
+                if (this.root && this.root !== parent.parent) {
+                    this.resolveCounter++;
+                    return [];
+                } else {
+                    await new Promise(resolve => setTimeout(resolve, 10));
+                    return step();
+                }
+            };
+            return step();
+        }
+        return super.resolveChildren(parent);
+    }
+
+}
+
+/**
+ * Return roots having the same id, but not object identity.
+ */
+function createConsistencyTestRoot(rootName: string): CompositeTreeNode {
+    const children: TreeNode[] = [];
+    const root: CompositeTreeNode = {
+        id: 'root',
+        name: rootName,
+        parent: undefined,
+        children
+    };
+    const parent: ExpandableTreeNode = {
+        id: 'expandable',
+        name: 'expandable',
+        parent: root,
+        expanded: true,
+        children: []
+    };
+    children.push(parent);
+    return root;
+}
+
+describe('Tree Consistency', () => {
+
+    it('setting different tree roots should finish', async () => {
+        const container = createTreeTestContainer();
+        container.bind(ConsistencyTestTree).toSelf();
+        container.rebind(TreeImpl).toService(ConsistencyTestTree);
+        const tree = container.get(ConsistencyTestTree);
+
+        const model = container.get<TreeModel>(TreeModel);
+
+        model.root = createConsistencyTestRoot('Foo');
+        await new Promise(resolve => setTimeout(resolve, 50));
+
+        model.root = createConsistencyTestRoot('Bar');
+        await new Promise(resolve => setTimeout(resolve, 50));
+
+        let resolveCounter = tree.resolveCounter;
+        assert.deepStrictEqual(tree.resolveCounter, 1);
+        for (let i = 0; i < 10; i++) {
+            await new Promise(resolve => setTimeout(resolve, 50));
+            if (resolveCounter === tree.resolveCounter) {
+                assert.deepStrictEqual(tree.resolveCounter, 1);
+                assert.deepStrictEqual(model.root!.name, 'Bar');
+                return;
+            }
+            resolveCounter = tree.resolveCounter;
+        }
+        assert.ok(false, 'Resolving does not stop, attempts: ' + tree.resolveCounter);
+    });
+
+});

--- a/packages/core/src/browser/tree/tree-expansion.spec.ts
+++ b/packages/core/src/browser/tree/tree-expansion.spec.ts
@@ -16,143 +16,123 @@
 
 import { expect } from 'chai';
 import { MockTreeModel } from './test/mock-tree-model';
-import { TreeModelImpl, TreeModel } from './tree-model';
-import { TreeImpl, Tree, TreeNode, CompositeTreeNode } from './tree';
-import { Container } from 'inversify';
-import { TreeSelectionServiceImpl } from './tree-selection-impl';
-import { TreeSelectionService } from './tree-selection';
-import { TreeExpansionServiceImpl, TreeExpansionService, ExpandableTreeNode } from './tree-expansion';
-import { TreeNavigationService } from './tree-navigation';
-import { TreeSearch } from './tree-search';
-import { FuzzySearch } from './fuzzy-search';
-import { MockLogger } from '../../common/test/mock-logger';
-import { ILogger } from '../../common';
+import { TreeModel } from './tree-model';
+import { TreeNode, CompositeTreeNode } from './tree';
+import { ExpandableTreeNode } from './tree-expansion';
+import { createTreeTestContainer } from './test/tree-test-container';
 
 // tslint:disable:no-unused-expression
 describe('TreeExpansionService', () => {
-  let model: TreeModel;
-  beforeEach(() => {
-    model = createTreeModel();
-    model.root = MockTreeModel.HIERARCHICAL_MOCK_ROOT();
-  });
-  describe('expandNode', () => {
-    it('won\'t expand an already expanded node', done => {
-      const node: ExpandableTreeNode = retrieveNode<ExpandableTreeNode>('1');
-      model.expandNode(node).then(result => {
-        expect(result).to.be.false;
-        done();
-      });
+    let model: TreeModel;
+    beforeEach(() => {
+        model = createTreeModel();
+        model.root = MockTreeModel.HIERARCHICAL_MOCK_ROOT();
     });
-
-    it('will expand a collapsed node', done => {
-      const node: ExpandableTreeNode = retrieveNode<ExpandableTreeNode>('1');
-      model.collapseNode(node).then(() => {
-        model.expandNode(node).then(result => {
-          expect(result).to.be.true;
-          done();
+    describe('expandNode', () => {
+        it("won't expand an already expanded node", done => {
+            const node: ExpandableTreeNode = retrieveNode<ExpandableTreeNode>('1');
+            model.expandNode(node).then(result => {
+                expect(result).to.be.undefined;
+                done();
+            });
         });
-      });
-    });
 
-    it('won\'t expand an undefined node', done => {
-      model.expandNode(undefined).then(result => {
-        expect(result).to.be.false;
-        done();
-      });
-    });
-  });
-
-  describe('collapseNode', () => {
-    it('will collapse an expanded node', done => {
-      const node: ExpandableTreeNode = retrieveNode<ExpandableTreeNode>('1');
-      model.collapseNode(node).then(result => {
-        expect(result).to.be.true;
-        done();
-      });
-    });
-
-    it('won\'t collapse an already collapsed node', done => {
-      const node: ExpandableTreeNode = retrieveNode<ExpandableTreeNode>('1');
-      model.collapseNode(node).then(() => {
-        model.collapseNode(node).then(result => {
-          expect(result).to.be.false;
-          done();
+        it('will expand a collapsed node', done => {
+            const node: ExpandableTreeNode = retrieveNode<ExpandableTreeNode>('1');
+            model.collapseNode(node).then(() => {
+                model.expandNode(node).then(result => {
+                    expect(result).to.be.eq(result);
+                    done();
+                });
+            });
         });
-      });
-    });
 
-    it('cannot collapse a leaf node', done => {
-      const node: ExpandableTreeNode = retrieveNode<ExpandableTreeNode>('1.1.2');
-      model.collapseNode(node).then(result => {
-        expect(result).to.be.false;
-        done();
-      });
-    });
-  });
-
-  describe('collapseAll', () => {
-    it('will collapse all nodes recursively', done => {
-      model.collapseAll(retrieveNode<CompositeTreeNode>('1')).then(result => {
-        expect(result).to.be.true;
-        done();
-      });
-    });
-
-    it('won\'t collapse nodes recursively if the root node is collapsed already', done => {
-      model.collapseNode(retrieveNode<ExpandableTreeNode>('1')).then(() => {
-        model.collapseAll(retrieveNode<CompositeTreeNode>('1')).then(result => {
-          expect(result).to.be.true;
-          done();
+        it("won't expand an undefined node", done => {
+            model.expandNode(undefined).then(result => {
+                expect(result).to.be.undefined;
+                done();
+            });
         });
-      });
-    });
-  });
-
-  describe('toggleNodeExpansion', () => {
-    it('changes the expansion state from expanded to collapsed', done => {
-      const node = retrieveNode<ExpandableTreeNode>('1');
-      model.onExpansionChanged((e: Readonly<ExpandableTreeNode>) => {
-        expect(e).to.be.equal(node);
-        expect(e.expanded).to.be.false;
-      });
-      model.toggleNodeExpansion(node).then(() => {
-        done();
-      });
     });
 
-    it('changes the expansion state from collapsed to expanded', done => {
-      const node = retrieveNode<ExpandableTreeNode>('1');
-      model.collapseNode(node).then(() => {
-      });
-      model.onExpansionChanged((e: Readonly<ExpandableTreeNode>) => {
-        expect(e).to.be.equal(node);
-        expect(e.expanded).to.be.true;
-      });
-      model.toggleNodeExpansion(node).then(() => {
-        done();
-      });
-    });
-  });
+    describe('collapseNode', () => {
+        it('will collapse an expanded node', done => {
+            const node: ExpandableTreeNode = retrieveNode<ExpandableTreeNode>('1');
+            model.collapseNode(node).then(result => {
+                expect(result).to.be.eq(result);
+                done();
+            });
+        });
 
-  function createTreeModel(): TreeModel {
-    const container = new Container({ defaultScope: 'Singleton' });
-    container.bind(TreeImpl).toSelf();
-    container.bind(Tree).toService(TreeImpl);
-    container.bind(TreeSelectionServiceImpl).toSelf();
-    container.bind(TreeSelectionService).toService(TreeSelectionServiceImpl);
-    container.bind(TreeExpansionServiceImpl).toSelf();
-    container.bind(TreeExpansionService).toService(TreeExpansionServiceImpl);
-    container.bind(TreeNavigationService).toSelf();
-    container.bind(TreeModelImpl).toSelf();
-    container.bind(TreeModel).toService(TreeModelImpl);
-    container.bind(TreeSearch).toSelf();
-    container.bind(FuzzySearch).toSelf();
-    container.bind(MockLogger).toSelf();
-    container.bind(ILogger).to(MockLogger).inSingletonScope();
-    return container.get(TreeModel);
-  }
-  function retrieveNode<T extends TreeNode>(id: string): Readonly<T> {
-    const readonlyNode: Readonly<T> = model.getNode(id) as T;
-    return readonlyNode;
-  }
+        it("won't collapse an already collapsed node", done => {
+            const node: ExpandableTreeNode = retrieveNode<ExpandableTreeNode>('1');
+            model.collapseNode(node).then(() => {
+                model.collapseNode(node).then(result => {
+                    expect(result).to.be.false;
+                    done();
+                });
+            });
+        });
+
+        it('cannot collapse a leaf node', done => {
+            const node: ExpandableTreeNode = retrieveNode<ExpandableTreeNode>('1.1.2');
+            model.collapseNode(node).then(result => {
+                expect(result).to.be.false;
+                done();
+            });
+        });
+    });
+
+    describe('collapseAll', () => {
+        it('will collapse all nodes recursively', done => {
+            model.collapseAll(retrieveNode<CompositeTreeNode>('1')).then(result => {
+                expect(result).to.be.eq(result);
+                done();
+            });
+        });
+
+        it("won't collapse nodes recursively if the root node is collapsed already", done => {
+            model.collapseNode(retrieveNode<ExpandableTreeNode>('1')).then(() => {
+                model.collapseAll(retrieveNode<CompositeTreeNode>('1')).then(result => {
+                    expect(result).to.be.eq(result);
+                    done();
+                });
+            });
+        });
+    });
+
+    describe('toggleNodeExpansion', () => {
+        it('changes the expansion state from expanded to collapsed', done => {
+            const node = retrieveNode<ExpandableTreeNode>('1');
+            model.onExpansionChanged((e: Readonly<ExpandableTreeNode>) => {
+                expect(e).to.be.equal(node);
+                expect(e.expanded).to.be.false;
+            });
+            model.toggleNodeExpansion(node).then(() => {
+                done();
+            });
+        });
+
+        it('changes the expansion state from collapsed to expanded', done => {
+            const node = retrieveNode<ExpandableTreeNode>('1');
+            model.collapseNode(node).then(() => {
+            });
+            model.onExpansionChanged((e: Readonly<ExpandableTreeNode>) => {
+                expect(e).to.be.equal(node);
+                expect(e.expanded).to.be.true;
+            });
+            model.toggleNodeExpansion(node).then(() => {
+                done();
+            });
+        });
+    });
+
+    function createTreeModel(): TreeModel {
+        const container = createTreeTestContainer();
+        return container.get(TreeModel);
+    }
+    function retrieveNode<T extends TreeNode>(id: string): Readonly<T> {
+        const readonlyNode: Readonly<T> = model.getNode(id) as T;
+        return readonlyNode;
+    }
 });

--- a/packages/core/src/browser/tree/tree-model.ts
+++ b/packages/core/src/browser/tree/tree-model.ts
@@ -33,7 +33,7 @@ export interface TreeModel extends Tree, TreeSelectionService, TreeExpansionServ
      * Expands the given node. If the `node` argument is `undefined`, then expands the currently selected tree node.
      * If multiple tree nodes are selected, expands the most recently selected tree node.
      */
-    expandNode(node?: Readonly<ExpandableTreeNode>): Promise<boolean>;
+    expandNode(node?: Readonly<ExpandableTreeNode>): Promise<Readonly<ExpandableTreeNode> | undefined>;
 
     /**
      * Collapses the given node. If the `node` argument is `undefined`, then collapses the currently selected tree node.
@@ -216,12 +216,11 @@ export class TreeModelImpl implements TreeModel, SelectionProvider<ReadonlyArray
         return this.tree.validateNode(node);
     }
 
-    async refresh(parent?: Readonly<CompositeTreeNode>): Promise<void> {
+    async refresh(parent?: Readonly<CompositeTreeNode>): Promise<CompositeTreeNode | undefined> {
         if (parent) {
-            await this.tree.refresh(parent);
-        } else {
-            await this.tree.refresh();
+            return this.tree.refresh(parent);
         }
+        return this.tree.refresh();
     }
 
     // tslint:disable-next-line:typedef
@@ -238,19 +237,19 @@ export class TreeModelImpl implements TreeModel, SelectionProvider<ReadonlyArray
         return this.expansionService.onExpansionChanged;
     }
 
-    async expandNode(raw?: Readonly<ExpandableTreeNode>): Promise<boolean> {
+    async expandNode(raw?: Readonly<ExpandableTreeNode>): Promise<ExpandableTreeNode | undefined> {
         for (const node of raw ? [raw] : this.selectedNodes) {
             if (ExpandableTreeNode.is(node)) {
-                return await this.expansionService.expandNode(node);
+                return this.expansionService.expandNode(node);
             }
         }
-        return false;
+        return undefined;
     }
 
     async collapseNode(raw?: Readonly<ExpandableTreeNode>): Promise<boolean> {
         for (const node of raw ? [raw] : this.selectedNodes) {
             if (ExpandableTreeNode.is(node)) {
-                return await this.expansionService.collapseNode(node);
+                return this.expansionService.collapseNode(node);
             }
         }
         return false;
@@ -262,7 +261,7 @@ export class TreeModelImpl implements TreeModel, SelectionProvider<ReadonlyArray
             this.selectNode(node);
         }
         if (CompositeTreeNode.is(node)) {
-            return await this.expansionService.collapseAll(node);
+            return this.expansionService.collapseAll(node);
         }
         return false;
     }

--- a/packages/core/src/browser/tree/tree.spec.ts
+++ b/packages/core/src/browser/tree/tree.spec.ts
@@ -15,19 +15,11 @@
  ********************************************************************************/
 
 import * as assert from 'assert';
-import { TreeNode, CompositeTreeNode, TreeImpl, Tree } from './tree';
-import { TreeModel, TreeModelImpl } from './tree-model';
+import { TreeNode, CompositeTreeNode } from './tree';
+import { TreeModel } from './tree-model';
 import { MockTreeModel } from './test/mock-tree-model';
 import { expect } from 'chai';
-import { Container } from 'inversify';
-import { TreeSelectionServiceImpl } from './tree-selection-impl';
-import { TreeSelectionService } from './tree-selection';
-import { TreeExpansionServiceImpl, TreeExpansionService } from './tree-expansion';
-import { TreeNavigationService } from './tree-navigation';
-import { TreeSearch } from './tree-search';
-import { FuzzySearch } from './fuzzy-search';
-import { MockLogger } from '../../common/test/mock-logger';
-import { ILogger } from '../../common';
+import { createTreeTestContainer } from './test/tree-test-container';
 
 // tslint:disable:no-unused-expression
 describe('Tree', () => {
@@ -230,7 +222,7 @@ describe('Tree', () => {
 
     function assertTreeNode(expectation: string, node: TreeNode): void {
         // tslint:disable-next-line:no-any
-        assert.deepEqual(expectation, JSON.stringify(node, (key: keyof CompositeTreeNode, value: any) => {
+        assert.deepStrictEqual(expectation, JSON.stringify(node, (key: keyof CompositeTreeNode, value: any) => {
             if (key === 'parent' || key === 'previousSibling' || key === 'nextSibling') {
                 return value && value.id;
             }
@@ -239,20 +231,7 @@ describe('Tree', () => {
     }
 
     function createTreeModel(): TreeModel {
-        const container = new Container({ defaultScope: 'Singleton' });
-        container.bind(TreeImpl).toSelf();
-        container.bind(Tree).toService(TreeImpl);
-        container.bind(TreeSelectionServiceImpl).toSelf();
-        container.bind(TreeSelectionService).toService(TreeSelectionServiceImpl);
-        container.bind(TreeExpansionServiceImpl).toSelf();
-        container.bind(TreeExpansionService).toService(TreeExpansionServiceImpl);
-        container.bind(TreeNavigationService).toSelf();
-        container.bind(TreeModelImpl).toSelf();
-        container.bind(TreeModel).toService(TreeModelImpl);
-        container.bind(TreeSearch).toSelf();
-        container.bind(FuzzySearch).toSelf();
-        container.bind(MockLogger).toSelf();
-        container.bind(ILogger).to(MockLogger).inSingletonScope();
+        const container = createTreeTestContainer();
         return container.get(TreeModel);
     }
     function retrieveNode<T extends TreeNode>(id: string): Readonly<T> {

--- a/packages/navigator/src/browser/navigator-model.spec.ts
+++ b/packages/navigator/src/browser/navigator-model.spec.ts
@@ -195,13 +195,6 @@ describe('FileNavigatorModel', () => {
         toRestore.length = 0;
     });
 
-    it('should update the root(s) on receiving a WorkspaceChanged event from the WorkspaceService', done => {
-        sinon.stub(navigatorModel, 'updateRoot').callsFake(() => {
-            done(); // This test would time out if updateRoot() is not called
-        });
-        mockWorkspaceServiceEmitter.fire([]);
-    }).timeout(2000);
-
     describe('updateRoot() function', () => {
         it('should assign "this.root" a WorkspaceNode with WorkspaceRootNodes (one for each root folder in the workspace) as its children', async () => {
             sinon.stub(mockWorkspaceService, 'roots').value([folderA, folderB]);
@@ -215,7 +208,7 @@ describe('FileNavigatorModel', () => {
                 })
             );
 
-            await navigatorModel.updateRoot();
+            await navigatorModel['updateRoot']();
             const thisRoot = navigatorModel['root'] as WorkspaceNode;
             expect(thisRoot).not.to.be.undefined;
             expect(thisRoot.children.length).to.eq(2);
@@ -226,7 +219,7 @@ describe('FileNavigatorModel', () => {
         it('should assign "this.root" undefined if there is no workspace open', async () => {
             sinon.stub(mockWorkspaceService, 'opened').value(false);
 
-            await navigatorModel.updateRoot();
+            await navigatorModel['updateRoot']();
             const thisRoot = navigatorModel['root'] as WorkspaceNode;
             expect(thisRoot).to.be.undefined;
         });

--- a/packages/navigator/src/browser/navigator-model.ts
+++ b/packages/navigator/src/browser/navigator-model.ts
@@ -130,14 +130,14 @@ export class FileNavigatorModel extends FileTreeModel {
         if (!uri.path.isAbsolute) {
             return undefined;
         }
-        let node = await this.getNodeClosestToRootByUri(uri);
+        let node = this.getNodeClosestToRootByUri(uri);
 
         // success stop condition
         // we have to reach workspace root because expanded node could be inside collapsed one
         if (WorkspaceRootNode.is(node)) {
             if (ExpandableTreeNode.is(node)) {
                 if (!node.expanded) {
-                    await this.expandNode(node);
+                    node = await this.expandNode(node);
                 }
                 return node;
             }
@@ -155,10 +155,10 @@ export class FileNavigatorModel extends FileTreeModel {
         if (await this.revealFile(uri.parent)) {
             if (node === undefined) {
                 // get node if it wasn't mounted into navigator tree before expansion
-                node = await this.getNodeClosestToRootByUri(uri);
+                node = this.getNodeClosestToRootByUri(uri);
             }
             if (ExpandableTreeNode.is(node) && !node.expanded) {
-                await this.expandNode(node);
+                node = await this.expandNode(node);
             }
             return node;
         }

--- a/packages/navigator/src/browser/navigator-widget.tsx
+++ b/packages/navigator/src/browser/navigator-widget.tsx
@@ -21,8 +21,7 @@ import { CommandService, SelectionService } from '@theia/core/lib/common';
 import { CommonCommands, CorePreferences, LabelProvider, ViewContainerTitleOptions, Key } from '@theia/core/lib/browser';
 import {
     ContextMenuRenderer, ExpandableTreeNode,
-    TreeProps, TreeModel, TreeNode,
-    SelectableTreeNode, CompositeTreeNode
+    TreeProps, TreeModel, TreeNode
 } from '@theia/core/lib/browser';
 import { FileTreeWidget, FileNode, DirNode } from '@theia/filesystem/lib/browser';
 import { WorkspaceService, WorkspaceCommands } from '@theia/workspace/lib/browser';
@@ -68,7 +67,6 @@ export class FileNavigatorWidget extends FileTreeWidget {
         super(props, model, contextMenuRenderer);
         this.id = FILE_NAVIGATOR_ID;
         this.addClass(CLASS);
-        this.initialize();
     }
 
     @postConstruct()
@@ -89,21 +87,6 @@ export class FileNavigatorWidget extends FileTreeWidget {
 
             })
         ]);
-    }
-
-    protected async initialize(): Promise<void> {
-        await this.model.updateRoot();
-        if (this.model.selectedNodes.length) {
-            return;
-        }
-        const root = this.model.root;
-        if (CompositeTreeNode.is(root) && root.children.length === 1) {
-            const child = root.children[0];
-            if (SelectableTreeNode.is(child) && !child.selected && ExpandableTreeNode.is(child)) {
-                this.model.selectNode(child);
-                this.model.expandNode(child);
-            }
-        }
     }
 
     protected doUpdateRows(): void {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

The navigator model root gets initialized too eagerly before the workspace service is ready to provide roots. And then the second time by an event then the workspace service is initialized. It causes 2 parallel refreshes and with bad timing on workspaces with multiple roots can lead to infinity loop and eventually max call stack error.

This PR:
- [x] resolves the issue generically for trees by allowing parallel refreshes without resetting a root
- [x] avoid initializing the navigator model root eagerly

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

- There is a unit test reproducing it.
- Test for regressions in the navigator and outline for example.
  - In the navigator try with multi-root workspaces with many roots and a single root. Check that files are revealed when an editor is selected and so on. Check that keyboard navigation is not broken.
  - In the outline switch between editors and check that outline is updated.
- Check logs for `Child node does not belong to this tree` error.

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

