### PR TITLE
Support Compound Tasks

### DIFF
--- a/packages/debug/src/browser/debug-session-manager.ts
+++ b/packages/debug/src/browser/debug-session-manager.ts
@@ -22,7 +22,7 @@ import { ContextKey, ContextKeyService } from '@theia/core/lib/browser/context-k
 import URI from '@theia/core/lib/common/uri';
 import { EditorManager } from '@theia/editor/lib/browser';
 import { QuickOpenTask } from '@theia/task/lib/browser/quick-open-task';
-import { TaskService } from '@theia/task/lib/browser/task-service';
+import { TaskService, TaskEndedInfo, TaskEndedTypes } from '@theia/task/lib/browser/task-service';
 import { VariableResolverService } from '@theia/variable-resolver/lib/browser';
 import { inject, injectable, postConstruct } from 'inversify';
 import { DebugConfiguration } from '../common/debug-common';
@@ -35,6 +35,7 @@ import { DebugSessionOptions, InternalDebugSessionOptions } from './debug-sessio
 import { DebugBreakpoint } from './model/debug-breakpoint';
 import { DebugStackFrame } from './model/debug-stack-frame';
 import { DebugThread } from './model/debug-thread';
+import { TaskIdentifier } from '@theia/task/lib/common';
 
 export interface WillStartDebugSession extends WaitUntilEvent {
 }
@@ -410,7 +411,7 @@ export class DebugSessionManager {
      * @param taskName the task name to run, see [TaskNameResolver](#TaskNameResolver)
      * @return true if it allowed to continue debugging otherwise it returns false
      */
-    protected async runTask(workspaceFolderUri: string | undefined, taskName: string | undefined, checkErrors?: boolean): Promise<boolean> {
+    protected async runTask(workspaceFolderUri: string | undefined, taskName: string | TaskIdentifier | undefined, checkErrors?: boolean): Promise<boolean> {
         if (!taskName) {
             return true;
         }
@@ -424,11 +425,22 @@ export class DebugSessionManager {
             return this.doPostTaskAction(`Could not run the task '${taskName}'.`);
         }
 
-        const code = await this.taskService.getExitCode(taskInfo.taskId);
-        if (code === 0) {
+        const getExitCodePromise: Promise<TaskEndedInfo> = this.taskService.getExitCode(taskInfo.taskId).then(result =>
+            ({ taskEndedType: TaskEndedTypes.TaskExited, value: result }));
+        const isBackgroundTaskEndedPromise: Promise<TaskEndedInfo> = this.taskService.isBackgroundTaskEnded(taskInfo.taskId).then(result =>
+            ({ taskEndedType: TaskEndedTypes.BackgroundTaskEnded, value: result }));
+
+        // After start running the task, we wait for the task process to exit and if it is a background task, we also wait for a feedback
+        // that a background task is active, as soon as one of the promises fulfills, we can continue and analyze the results.
+        const taskEndedInfo: TaskEndedInfo = await Promise.race([getExitCodePromise, isBackgroundTaskEndedPromise]);
+
+        if (taskEndedInfo.taskEndedType === TaskEndedTypes.BackgroundTaskEnded && taskEndedInfo.value) {
             return true;
-        } else if (code !== undefined) {
-            return this.doPostTaskAction(`Task '${taskName}' terminated with exit code ${code}.`);
+        }
+        if (taskEndedInfo.taskEndedType === TaskEndedTypes.TaskExited && taskEndedInfo.value === 0) {
+            return true;
+        } else if (taskEndedInfo.taskEndedType === TaskEndedTypes.TaskExited && taskEndedInfo.value !== undefined) {
+            return this.doPostTaskAction(`Task '${taskName}' terminated with exit code ${taskEndedInfo.value}.`);
         } else {
             const signal = await this.taskService.getTerminateSignal(taskInfo.taskId);
             if (signal !== undefined) {

--- a/packages/debug/src/common/debug-configuration.ts
+++ b/packages/debug/src/common/debug-configuration.ts
@@ -13,7 +13,7 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
-
+import { TaskIdentifier } from '@theia/task/lib/common';
 // tslint:disable:no-any
 
 export type DebugViewLocation = 'default' | 'left' | 'right' | 'bottom';
@@ -64,10 +64,10 @@ export interface DebugConfiguration {
     internalConsoleOptions?: 'neverOpen' | 'openOnSessionStart' | 'openOnFirstSessionStart'
 
     /** Task to run before debug session starts */
-    preLaunchTask?: string;
+    preLaunchTask?: string | TaskIdentifier;
 
     /** Task to run after debug session ends */
-    postDebugTask?: string;
+    postDebugTask?: string | TaskIdentifier;
 }
 export namespace DebugConfiguration {
     export function is(arg: DebugConfiguration | any): arg is DebugConfiguration {

--- a/packages/task/src/browser/task-node.ts
+++ b/packages/task/src/browser/task-node.ts
@@ -1,0 +1,37 @@
+/********************************************************************************
+ * Copyright (c) 2019 SAP SE or an SAP affiliate company and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+import { TaskConfiguration } from '../common';
+
+export class TaskNode {
+
+    taskId: TaskConfiguration;
+    childTasks: TaskNode[];
+    parentsID: TaskConfiguration[];
+
+    constructor(taskId: TaskConfiguration, childTasks: TaskNode[], parentsID: TaskConfiguration[]) {
+        this.taskId = taskId;
+        this.childTasks = childTasks;
+        this.parentsID = parentsID;
+    }
+
+    addChildDependency(node: TaskNode): void {
+        this.childTasks.push(node);
+    }
+
+    addParentDependency(parentId: TaskConfiguration): void {
+        this.parentsID.push(parentId);
+    }
+}

--- a/packages/task/src/browser/task-schema-updater.ts
+++ b/packages/task/src/browser/task-schema-updater.ts
@@ -532,6 +532,17 @@ const problemMatcher = {
     ]
 };
 
+const taskIdentifier: IJSONSchema = {
+    type: 'object',
+    additionalProperties: true,
+    properties: {
+        type: {
+            type: 'string',
+            description: 'The task identifier.'
+        }
+    }
+};
+
 const processTaskConfigurationSchema: IJSONSchema = {
     type: 'object',
     required: ['type', 'label', 'command'],
@@ -539,6 +550,43 @@ const processTaskConfigurationSchema: IJSONSchema = {
         label: taskLabel,
         type: defaultTaskType,
         ...commandAndArgs,
+        isBackground: {
+            type: 'boolean',
+            default: false,
+            description: 'Whether the executed task is kept alive and is running in the background.'
+        },
+        dependsOn: {
+            anyOf: [
+                {
+                    type: 'string',
+                    description: 'Another task this task depends on.'
+                },
+                taskIdentifier,
+                {
+                    type: 'array',
+                    description: 'The other tasks this task depends on.',
+                    items: {
+                        anyOf: [
+                            {
+                                type: 'string'
+                            },
+                            taskIdentifier
+                        ]
+                    }
+                }
+            ],
+            description: 'Either a string representing another task or an array of other tasks that this task depends on.'
+        },
+        dependsOrder: {
+            type: 'string',
+            enum: ['parallel', 'sequence'],
+            enumDescriptions: [
+                'Run all dependsOn tasks in parallel.',
+                'Run all dependsOn tasks in sequence.'
+            ],
+            default: 'parallel',
+            description: 'Determines the order of the dependsOn tasks for this task. Note that this property is not recursive.'
+        },
         windows: {
             type: 'object',
             description: 'Windows specific command configuration that overrides the command, args, and options',

--- a/packages/task/src/common/task-watcher.ts
+++ b/packages/task/src/common/task-watcher.ts
@@ -16,7 +16,7 @@
 
 import { injectable } from 'inversify';
 import { Emitter, Event } from '@theia/core/lib/common/event';
-import { TaskClient, TaskExitedEvent, TaskInfo, TaskOutputProcessedEvent } from './task-protocol';
+import { TaskClient, TaskExitedEvent, TaskInfo, TaskOutputProcessedEvent, BackgroundTaskEndedEvent } from './task-protocol';
 
 @injectable()
 export class TaskWatcher {
@@ -27,6 +27,7 @@ export class TaskWatcher {
         const taskProcessStartedEmitter = this.onDidStartTaskProcessEmitter;
         const taskProcessEndedEmitter = this.onDidEndTaskProcessEmitter;
         const outputProcessedEmitter = this.onOutputProcessedEmitter;
+        const backgroundTaskEndedEmitter = this.onBackgroundTaskEndedEmitter;
         return {
             onTaskCreated(event: TaskInfo): void {
                 newTaskEmitter.fire(event);
@@ -42,6 +43,9 @@ export class TaskWatcher {
             },
             onDidProcessTaskOutput(event: TaskOutputProcessedEvent): void {
                 outputProcessedEmitter.fire(event);
+            },
+            onBackgroundTaskEnded(event: BackgroundTaskEndedEvent): void {
+                backgroundTaskEndedEmitter.fire(event);
             }
         };
     }
@@ -51,6 +55,7 @@ export class TaskWatcher {
     protected onDidStartTaskProcessEmitter = new Emitter<TaskInfo>();
     protected onDidEndTaskProcessEmitter = new Emitter<TaskExitedEvent>();
     protected onOutputProcessedEmitter = new Emitter<TaskOutputProcessedEvent>();
+    protected onBackgroundTaskEndedEmitter = new Emitter<BackgroundTaskEndedEvent>();
 
     get onTaskCreated(): Event<TaskInfo> {
         return this.onTaskCreatedEmitter.event;
@@ -66,5 +71,8 @@ export class TaskWatcher {
     }
     get onOutputProcessed(): Event<TaskOutputProcessedEvent> {
         return this.onOutputProcessedEmitter.event;
+    }
+    get onBackgroundTaskEnded(): Event<BackgroundTaskEndedEvent> {
+        return this.onBackgroundTaskEndedEmitter.event;
     }
 }

--- a/packages/task/src/node/task-line-matchers.ts
+++ b/packages/task/src/node/task-line-matchers.ts
@@ -67,7 +67,7 @@ export class WatchModeLineMatcher extends StartStopLineMatcher {
 
     private beginsPattern: WatchingPattern;
     private endsPattern: WatchingPattern;
-    private activeOnStart: boolean = false;
+    activeOnStart: boolean = false;
 
     constructor(
         protected matcher: ProblemMatcher
@@ -108,7 +108,7 @@ export class WatchModeLineMatcher extends StartStopLineMatcher {
         return undefined;
     }
 
-    private matchBegin(line: string): boolean {
+    matchBegin(line: string): boolean {
         const beginRegexp = new RegExp(this.beginsPattern.regexp);
         const regexMatches = beginRegexp.exec(line);
         if (regexMatches) {
@@ -119,7 +119,7 @@ export class WatchModeLineMatcher extends StartStopLineMatcher {
         return false;
     }
 
-    private matchEnd(line: string): boolean {
+    matchEnd(line: string): boolean {
         const endRegexp = new RegExp(this.endsPattern.regexp);
         const match = endRegexp.exec(line);
         if (match) {

--- a/packages/task/src/node/task-problem-collector.ts
+++ b/packages/task/src/node/task-problem-collector.ts
@@ -23,7 +23,7 @@ export class ProblemCollector {
     private lineMatchers: AbstractLineMatcher[] = [];
 
     constructor(
-        protected problemMatchers: ProblemMatcher[]
+        public problemMatchers: ProblemMatcher[]
     ) {
         for (const matcher of problemMatchers) {
             if (ProblemMatcher.isWatchModeWatcher(matcher)) {
@@ -43,5 +43,20 @@ export class ProblemCollector {
             }
         });
         return markers;
+    }
+
+    isTaskActiveOnStart(): boolean {
+        const activeOnStart = this.lineMatchers.some(lineMatcher => (lineMatcher instanceof WatchModeLineMatcher) && lineMatcher.activeOnStart);
+        return activeOnStart;
+    }
+
+    matchBeginMatcher(line: string): boolean {
+        const match = this.lineMatchers.some(lineMatcher => (lineMatcher instanceof WatchModeLineMatcher) && lineMatcher.matchBegin(line));
+        return match;
+    }
+
+    matchEndMatcher(line: string): boolean {
+        const match = this.lineMatchers.some(lineMatcher => (lineMatcher instanceof WatchModeLineMatcher) && lineMatcher.matchEnd(line));
+        return match;
     }
 }

--- a/packages/variable-resolver/src/browser/variable-resolver-service.ts
+++ b/packages/variable-resolver/src/browser/variable-resolver-service.ts
@@ -109,13 +109,13 @@ export class VariableResolverService {
     }
 
     protected async resolveVariables(value: string, context: VariableResolverService.Context): Promise<void> {
+        const variableRegExp = new RegExp(VariableResolverService.VAR_REGEXP);
         let match;
-        while ((match = VariableResolverService.VAR_REGEXP.exec(value)) !== null) {
+        while ((match = variableRegExp.exec(value)) !== null) {
             const variableName = match[1];
             await context.resolve(variableName);
         }
     }
-
 }
 export namespace VariableResolverService {
     export class Context {


### PR DESCRIPTION
Signed-off-by: Shimon Ben Yair <shimon.ben.yair@sap.com>

#### What it does

With changes in this pull request, Theia offers users to create compound tasks ( to create tasks that depends on other tasks).
The user can run the tasks ( that his tasks depends on) in sequence or in parallel.And after those tasks will end , the main task will start.
In addition the user can create a task that depends on a background task.

#### How to test

1. Extract this project on your file system :  [mytask.zip](https://github.com/eclipse-theia/theia/files/3916679/mytask.zip)
2. run "npm install"
3. **Check compound tasks in sequence order :** change the "dependsOn" and "dependsOrder" properties of "task1" to the following ( as in the gif animate) : 
        "dependsOn": [
                 "subTask2",
                 "subTask3"
         ],
         "dependsOrder": "sequence"

and run "task1" ==> it should first run "subTask2" and then "subTask3" and when they are finished,  "task1" will start.

![CompoundTasks_run_in_sequence](https://user-images.githubusercontent.com/18531202/70054631-967f3c80-15e0-11ea-8025-f1e636b50382.gif)


4. **Check compound tasks in parallel order :** change the "dependsOn" and "dependsOrder" properties of "task1" to the following ( as in the gif animate) : 
        "dependsOn": [
                 "subTask2",
                 "subTask3"
         ],
         "dependsOrder": "parallel"

and run "task1" ==> it should run in parallel "subTask2" and "subTask3" and when they are finished, 
"task1" will start.

![CompoundTasks_run_in_parallel](https://user-images.githubusercontent.com/18531202/70054641-9d0db400-15e0-11ea-9e7f-c6e714e42295.gif)

5. **Check compound tasks with background task :** change the "dependsOn" and "dependsOrder" properties of "task1" to the following ( as in the gif animate) : 
        "dependsOn": [
            "testBackgroundTask"
         ],
         "dependsOrder": "sequence"

and run "task1" ==> it should run first the "testBackgroundTask" task and when the ends pattern matches ( it will not wait until the whole task is finished and exited) "task1" will start.

![CompoundTasks_run_task_in_background](https://user-images.githubusercontent.com/18531202/70054910-22916400-15e1-11ea-80f7-faec0f3e01c6.gif)

6. **Check compound tasks with taskIdentifier :** change the "dependsOn" and "dependsOrder" properties of "task1" to the following ( as in the gif animate) : 
        "dependsOn": [
            {"type":"npm", "script":"runsample"}
         ],
         "dependsOrder": "sequence"

(Please notify that in the package.json file , there is a script named "runsample").

and run "task1" ==> it should run the script "runsample" before "task1" will start.

![CompoundTasks_run_task_in_by_taskIdentifier](https://user-images.githubusercontent.com/18531202/70055012-566c8980-15e1-11ea-827b-7666856c3768.gif)



       




#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)
- [x] CQ Approved: https://dev.eclipse.org/ipzilla/show_bug.cgi?id=21228


