### PR TITLE
[vscode] allow installation of extension packs

### DIFF
--- a/packages/plugin-ext-vscode/src/node/scanner-vscode.ts
+++ b/packages/plugin-ext-vscode/src/node/scanner-vscode.ts
@@ -52,15 +52,20 @@ export class VsCodePluginScanner extends TheiaPluginScanner implements PluginSca
      * Maps extension dependencies to deployable extension dependencies.
      */
     getDependencies(plugin: PluginPackage): Map<string, string> | undefined {
-        if (!plugin.extensionDependencies || !plugin.extensionDependencies.length) {
-            return undefined;
-        }
+        // Store the list of dependencies.
         const dependencies = new Map<string, string>();
-        for (const dependency of plugin.extensionDependencies) {
-            const dependencyId = dependency.toLowerCase();
-            dependencies.set(dependencyId, this.VSCODE_PREFIX + dependencyId);
+        // Iterate through the list of dependencies from `extensionDependencies` and `extensionPack`.
+        for (const dependency of [plugin.extensionDependencies, plugin.extensionPack]) {
+            if (dependency !== undefined) {
+                // Iterate over the list of dependencies present, and add them to the collection.
+                dependency.forEach((dep: string) => {
+                    const dependencyId = dep.toLowerCase();
+                    dependencies.set(dependencyId, this.VSCODE_PREFIX + dependencyId);
+                });
+            }
         }
-        return dependencies;
+        // Return the map of dependencies if present, else `undefined`.
+        return dependencies.size > 0 ? dependencies : undefined ;
     }
 
     getLifecycle(plugin: PluginPackage): PluginLifecycle {

--- a/packages/plugin-ext/src/common/plugin-protocol.ts
+++ b/packages/plugin-ext/src/common/plugin-protocol.ts
@@ -53,6 +53,7 @@ export interface PluginPackage {
     packagePath: string;
     activationEvents?: string[];
     extensionDependencies?: string[];
+    extensionPack?: string[];
 }
 export namespace PluginPackage {
     export function toPluginUrl(pck: PluginPackage, relativePath: string): string {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

Fixes #6611

- added `extensionPack` property to `PluginPackage` interface.
- when getting dependencies, ensure that `extensionPack` dependencies are also loaded. Extensions packs can now be unloaded and their bundled extensions installed.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

1. start the application
    - for test purposes a minimal application was used:
        - no `@theia/java`, `@theia/java-debug`, `@theia/textmate-grammars`
        - added `@theia/vscode-builtin-java`
2. install the `java extension pack`: https://marketplace.visualstudio.com/items?itemName=vscjava.vscode-java-pack
3. should notice the extensions present in the pack unloaded



#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

Signed-off-by: Vincent Fugnitto <vincent.fugnitto@ericsson.com>

cc @eclipse-theia/plugin-system 