### PR TITLE
Set 'noopener' when opening windows to avoid sharing event loops

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 - [bunyan] removed [`@theia/bunyan`](https://github.com/eclipse-theia/theia/tree/b92a5673de1e9d1bdc85e6200486b92394200579/packages/bunyan) extension [#6651](https://github.com/eclipse-theia/theia/pull/6651)
 
+Breaking changes:
+
+- [core] new browser windows spawned through opener-service have noopener set, preventing them from accessing window.opener and giveing them their own event loop. openNewWindow will no longer return a Window as a result.
+
 ## v0.13.0
 
 - [console] added filtering support based on severity [#6486](https://github.com/eclipse-theia/theia/pull/6486)

--- a/packages/core/src/browser/http-open-handler.ts
+++ b/packages/core/src/browser/http-open-handler.ts
@@ -35,7 +35,7 @@ export class HttpOpenHandler implements OpenHandler {
         return (uri.scheme.startsWith('http') || uri.scheme.startsWith('mailto')) ? 500 : 0;
     }
 
-    async open(uri: URI): Promise<Window | undefined> {
+    async open(uri: URI): Promise<undefined> {
         const resolvedUri = await this.externalUriService.resolve(uri);
         return this.windowService.openNewWindow(resolvedUri.toString(true), { external: true });
     }

--- a/packages/core/src/browser/window/default-window-service.ts
+++ b/packages/core/src/browser/window/default-window-service.ts
@@ -41,12 +41,9 @@ export class DefaultWindowService implements WindowService, FrontendApplicationC
         });
     }
 
-    openNewWindow(url: string): Window | undefined {
-        const newWindow = window.open(url);
-        if (newWindow === null) {
-            throw new Error('Cannot open a new window for URL: ' + url);
-        }
-        return newWindow;
+    openNewWindow(url: string): undefined {
+        window.open(url, undefined, 'noopener');
+        return undefined;
     }
 
     canUnload(): boolean {

--- a/packages/core/src/browser/window/window-service.ts
+++ b/packages/core/src/browser/window/window-service.ts
@@ -29,7 +29,7 @@ export interface WindowService {
      * In a browser, opening a new Theia tab or open a link is the same thing.
      * But in Electron, we want to open links in a browser, not in Electron.
      */
-    openNewWindow(url: string, options?: NewWindowOptions): Window | undefined;
+    openNewWindow(url: string, options?: NewWindowOptions): undefined;
 
     /**
      * Called when the `window` is about to `unload` its resources.


### PR DESCRIPTION
Prevents the web UI pausing when an app opened with window.open is paused in the browsers debugger.

Fixes https://github.com/eclipse-theia/theia/issues/5857.

Note: I'm not sure how to test this from source. I tested it on GitPod by replacing `window.open` with a wrapper using the dev tools like this:

```
var oldWO = window.open; window.open = function(url) {console.log(url); oldWO(url, undefined, 'noopener');}
```

This resolved the issue of the GitPod UI hanging when my web app stopped at a breakpoint. If this is something I should be able to test locally, please provide some pointers (and ofc, I'm happy to re-test on staging once it gets there).