### PR TITLE
Fixes for VsCode Vim extension

### DIFF
--- a/packages/core/src/common/command.ts
+++ b/packages/core/src/common/command.ts
@@ -281,7 +281,7 @@ export class CommandRegistry implements CommandService {
             return result;
         }
         const argsMessage = args && args.length > 0 ? ` (args: ${JSON.stringify(args)})` : '';
-        throw new Error(`The command '${commandId}' cannot be executed. There are no active handlers available for the command.${argsMessage}`);
+        throw Object.assign(new Error(`The command '${commandId}' cannot be executed. There are no active handlers available for the command.${argsMessage}`), { code: 'NO_ACTIVE_HANDLER' });
     }
 
     protected async fireWillExecuteCommand(commandId: string): Promise<void> {

--- a/packages/monaco/src/browser/monaco-editor.ts
+++ b/packages/monaco/src/browser/monaco-editor.ts
@@ -322,6 +322,11 @@ export class MonacoEditor extends MonacoEditorServices implements TextEditor {
         this.toDispose.dispose();
     }
 
+    // tslint:disable-next-line:no-any
+    trigger(source: string, handlerId: string, payload: any): void {
+        this.editor.trigger(source, handlerId, payload);
+    }
+
     getControl(): IStandaloneCodeEditor {
         return this.editor;
     }

--- a/packages/monaco/src/typings/monaco/index.d.ts
+++ b/packages/monaco/src/typings/monaco/index.d.ts
@@ -47,6 +47,7 @@ declare module monaco.editor {
     export interface IStandaloneCodeEditor extends CommonCodeEditor {
         setDecorations(decorationTypeKey: string, ranges: IDecorationOptions[]): void;
         setDecorationsFast(decorationTypeKey: string, ranges: IRange[]): void;
+        trigger(source: string, handlerId: string, payload: any): void
     }
 
     // https://github.com/TypeFox/vscode/blob/monaco/0.18.0/src/vs/editor/browser/widget/codeEditorWidget.ts#L107

--- a/packages/plugin-ext-vscode/package.json
+++ b/packages/plugin-ext-vscode/package.json
@@ -5,6 +5,7 @@
   "dependencies": {
     "@theia/core": "^0.13.0",
     "@theia/editor": "^0.13.0",
+    "@theia/monaco": "^0.13.0",
     "@theia/plugin": "^0.13.0",
     "@theia/plugin-ext": "^0.13.0",
     "@theia/workspace": "^0.13.0",

--- a/packages/plugin-ext-vscode/src/browser/plugin-vscode-commands-contribution.ts
+++ b/packages/plugin-ext-vscode/src/browser/plugin-vscode-commands-contribution.ts
@@ -28,6 +28,7 @@ import { fromViewColumn, toDocumentSymbol } from '@theia/plugin-ext/lib/plugin/t
 import { ViewColumn } from '@theia/plugin-ext/lib/plugin/types-impl';
 import { WorkspaceCommands } from '@theia/workspace/lib/browser';
 import { DiffService } from '@theia/workspace/lib/browser/diff-service';
+import { MonacoEditor } from '@theia/monaco/lib/browser/monaco-editor';
 import { inject, injectable } from 'inversify';
 import URI from 'vscode-uri';
 
@@ -136,6 +137,14 @@ export class PluginVscodeCommandsContribution implements CommandContribution {
         });
         commands.registerCommand({ id: 'workbench.action.files.openFolder' }, {
             execute: () => commands.executeCommand(WorkspaceCommands.OPEN_FOLDER.id)
+        });
+        commands.registerCommand({ id: 'default:type' }, {
+            execute: args => {
+                const editor = MonacoEditor.getCurrent(this.editorManager);
+                if (editor) {
+                    editor.trigger('keyboard', 'type', args);
+                }
+            }
         });
         commands.registerCommand({ id: 'workbench.action.files.save', }, {
             execute: (uri?: monaco.Uri) => {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->
Several fixes and adaptations that allow to use [VsCode Vim extension](https://marketplace.visualstudio.com/items?itemName=vscodevim.vim)
#### What it does
<!-- Include relevant issues and describe how they are addressed. -->
- Do not throw an error if no active handler has been found during command execution.
- Add monaco `trigger` transit command.
- Register built-in VsCode command: `default:type`.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
Apply  [VsCode Vim extension](https://marketplace.visualstudio.com/items?itemName=vscodevim.vim)

Available commands:

Key | Action | Followed by
-- | -- | --
a | enter insertion mode after current character | text, ESC
b | back word
c | change command | cursor motion command
d | delete command | cursor motion command
e | end of word
f | find character after cursor in current line | character to find
h | move left one character
i | enter insertion mode before current character | text, ESC
j | move down one line
k | move up one line
l | move right one character
m | mark current line and position | mark character tag (a-z)
n | repeat last search
o | open line below and enter insertion mode | text, ESC
p | put buffer after cursor
r | replace single character at cursor | replacement character expected
s | substitute single character with new text | text, ESC
t | same as "f" but cursor moves to just before found character | character to find
u | undo
w | move foreward one word
x | delete single character
y | yank command | cursor motion command
z | position current line | CR = top; "." = center; "-"=bottom
A | enter insertion mode after end of line | text, ESC
B | move back one Word
C | change to end of line | text, ESC
D | delete to end of line
E | move to end of Word
F | backwards version of "f" | character to find
G | goto line number prefixed, or goto end if none
H | home cursor - goto first line on screen (requires vscode `cursorMove` built-in command)
I | enter insertion mode before first non-whitespace character | text, ESC
J | join current line with next line
L | goto last line on screen (requires vscode `cursorMove` built-in command)
M | goto middle line on screen (requires vscode `cursorMove` built-in command)
N | repeat last search, but in opposite direction of original search
O | open line above and enter insertion mode | text, ESC
P | put buffer before cursor
Q | leave visual mode (go into "ex" mode)
R | replace mode - replaces through end of current line, then inserts | text, ESC
S | substitute entire line - deletes line, enters insertion mode | text, ESC (requires vscode `editor.action.reindentselectedlines` built-in command)
T | backwards version of "t" | character to find
U | restores line to state when cursor was moved into it
W | foreward Word
X | delete backwards single character
Y | yank entire line
Z | first half of quick save-and-exit | "Z"
0 | move to column zero
1-9 | numeric precursor to other commands | [additional numbers (0-9)] command
  | (SPACE) move right one character
$ | move to end of line
% | match nearest [],(),{} on line, to its match (same line or others)
^ | move to first non-whitespace character of line
& | repeat last ex substitution (":s ...") not including modifiers
( | move to previous sentence
) | move to next sentence
\| | move to column zero
`-` | move to first non-whitespace of previous line
_ | similar to "^" but uses numeric prefix oddly
`+` | move to first non-whitespace of next line
[ | move to previous "{...}" section | "["
] | move to next "{...}" section | "]"
{ | move to previous blank-line separated section | "{"
} | move to next blank-line separated section | "}"
; | repeat last "f", "F", "t", or "T" command
' | move to marked line, first non-whitespace | character tag (a-z)
` | move to marked line, memorized column | character tag (a-z)
: | ex-submode | ex command
" | access numbered buffer; load or access lettered buffer | 1-9,a-z
~ | reverse case of current character and move cursor forward
, | reverse direction of last "f", "F", "t", or "T" command
. | repeat last text-changing command
/ | search forward | search string, ESC or CR
< | unindent command | cursor motion command
`>` | indent command | cursor motion command
? | search backward | search string, ESC or CR


#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

