### PR TITLE
[keybinding] Align Electron keybindings for 'Open File' and 'Open Workspace Symbol' with VS Code

### DIFF
--- a/packages/languages/package.json
+++ b/packages/languages/package.json
@@ -3,6 +3,7 @@
   "version": "0.13.0",
   "description": "Theia - Languages Extension",
   "dependencies": {
+    "@theia/application-package": "^0.13.0",
     "@theia/core": "^0.13.0",
     "@theia/output": "^0.13.0",
     "@theia/process": "^0.13.0",

--- a/packages/languages/src/browser/workspace-symbols.ts
+++ b/packages/languages/src/browser/workspace-symbols.ts
@@ -15,6 +15,7 @@
  ********************************************************************************/
 
 import { injectable, inject } from 'inversify';
+import { environment } from '@theia/application-package/lib/environment';
 import {
     PrefixQuickOpenService, QuickOpenModel, QuickOpenItem, OpenerService,
     QuickOpenMode, KeybindingContribution, KeybindingRegistry, QuickOpenHandler, QuickOpenOptions, QuickOpenContribution, QuickOpenHandlerRegistry
@@ -67,10 +68,14 @@ export class WorkspaceSymbolCommand implements QuickOpenModel, CommandContributi
         commands.registerCommand(this.command, this);
     }
 
+    private isElectron(): boolean {
+        return environment.electron.is();
+    }
+
     registerKeybindings(keybindings: KeybindingRegistry): void {
         keybindings.registerKeybinding({
             command: this.command.id,
-            keybinding: 'ctrlcmd+o',
+            keybinding: this.isElectron() ? 'ctrlcmd+t' : 'ctrlcmd+o',
         });
     }
 

--- a/packages/workspace/src/browser/workspace-frontend-contribution.ts
+++ b/packages/workspace/src/browser/workspace-frontend-contribution.ts
@@ -147,7 +147,7 @@ export class WorkspaceFrontendContribution implements CommandContribution, Keybi
         });
         keybindings.registerKeybinding({
             command: isOSX || !this.isElectron() ? WorkspaceCommands.OPEN.id : WorkspaceCommands.OPEN_FILE.id,
-            keybinding: 'ctrlcmd+alt+o',
+            keybinding: this.isElectron() ? 'ctrlcmd+o' : 'ctrlcmd+alt+o',
         });
         if (!isOSX && this.isElectron()) {
             keybindings.registerKeybinding({


### PR DESCRIPTION
#### What it does

Fixes #6633.

In **browsers**, the keybindings remain unchanged:

- <kbd>Ctrl/Cmd</kbd> + <kbd>Alt/Opt</kbd> + <kbd>O</kbd>: `File` > `Open...`
- <kbd>Ctrl/Cmd</kbd> + <kbd>O</kbd>: `F1` > `Open Workspace Symbol...`

<img width="414" alt="Screenshot 2019-12-04 at 18 11 41" src="https://user-images.githubusercontent.com/599268/70164550-a884dc00-16c1-11ea-847c-2fc76b1cec92.png">

<img width="783" alt="Screenshot 2019-12-04 at 18 12 12" src="https://user-images.githubusercontent.com/599268/70164543-a3c02800-16c1-11ea-9374-241de26a677c.png">

---

However, in **Electron** the bindings are now aligned with VS Code across all 3 platforms:

- <kbd>Ctrl/Cmd</kbd> + <kbd>O</kbd>: `File` > `Open...`
- <kbd>Ctrl/Cmd</kbd> + <kbd>T</kbd>: `F1` > `Open Workspace Symbol...`

<img width="380" alt="Screenshot 2019-12-04 at 17 36 29" src="https://user-images.githubusercontent.com/599268/70162376-d8ca7b80-16bd-11ea-80f6-475cede97604.png">

<img width="816" alt="Screenshot 2019-12-04 at 17 37 30" src="https://user-images.githubusercontent.com/599268/70164394-5f348c80-16c1-11ea-8e62-13f0c984b612.png">

#### How to test

Open Theia/Electron on Windows, Mac OS and Linux. The `Open File` and `Open Workspace Symbol` keybindings should be the same as VS Code.

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

