### PR TITLE
Generalized `onDidChange` for the toolbar.

### DIFF
--- a/packages/core/src/browser/shell/tab-bar-toolbar.tsx
+++ b/packages/core/src/browser/shell/tab-bar-toolbar.tsx
@@ -283,7 +283,7 @@ export interface TabBarToolbarItem {
      *
      * Note: currently, each item of the container toolbar will be re-rendered if any of the items have changed.
      */
-    readonly onDidChange?: Event<void>;
+    readonly onDidChange?: Event<any>; // tslint:disable-line:no-any
 
 }
 
@@ -295,7 +295,7 @@ export interface ReactTabBarToolbarItem {
     readonly id: string;
     render(widget?: Widget): React.ReactNode;
 
-    readonly onDidChange?: Event<void>;
+    readonly onDidChange?: Event<any>; // tslint:disable-line:no-any
 
     // For the rest, see `TabBarToolbarItem`.
     // For conditional visibility.


### PR DESCRIPTION
From now on, the `Event` can have `any` type,
not just `void` on both `TabBarToolbarItem` and `ReactTabBarToolbarItem`

Signed-off-by: Akos Kitta <kittaakos@typefox.io>

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->
See the commit message above 👆

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
Check if the CI is greenn.

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

