### PR TITLE
[debug] fix typos present in 'debug' extension

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ Breaking changes:
 
 - [core] new browser windows spawned through opener-service have noopener set, preventing them from accessing window.opener and giving them their own event loop. openNewWindow will no longer return a Window as a result.
 - [terminal] renamed `TerminalCopyOnSelectionHander` to `TerminalCopyOnSelectionHandler` [#6692](https://github.com/eclipse-theia/theia/pull/6692)
+- [debug] renamed command `COPY_VARAIBLE_AS_EXPRESSION` to `COPY_VARIABLE_AS_EXPRESSION` [#6698](https://github.com/eclipse-theia/theia/pull/6698)
+- [debug] renamed command `COPY_VARAIBLE_VALUE` to `COPY_VARIABLE_VALUE` [#6698](https://github.com/eclipse-theia/theia/pull/6698)
+- [debug] renamed getter method `multiSesssion` to `multiSession` [#6698](https://github.com/eclipse-theia/theia/pull/6698)
 
 ## v0.13.0
 

--- a/packages/debug/src/browser/debug-frontend-application-contribution.ts
+++ b/packages/debug/src/browser/debug-frontend-application-contribution.ts
@@ -205,12 +205,12 @@ export namespace DebugCommands {
         category: DEBUG_CATEGORY,
         label: 'Set Value',
     };
-    export const COPY_VAIRABLE_VALUE: Command = {
+    export const COPY_VARIABLE_VALUE: Command = {
         id: 'debug.variable.copyValue',
         category: DEBUG_CATEGORY,
         label: 'Copy Value',
     };
-    export const COPY_VAIRABLE_AS_EXPRESSION: Command = {
+    export const COPY_VARIABLE_AS_EXPRESSION: Command = {
         id: 'debug.variable.copyAsExpression',
         category: DEBUG_CATEGORY,
         label: 'Copy As Expression',
@@ -477,8 +477,8 @@ export class DebugFrontendApplicationContribution extends AbstractViewContributi
 
         registerMenuActions(DebugVariablesWidget.CONTEXT_MENU,
             DebugCommands.SET_VARIABLE_VALUE,
-            DebugCommands.COPY_VAIRABLE_VALUE,
-            DebugCommands.COPY_VAIRABLE_AS_EXPRESSION
+            DebugCommands.COPY_VARIABLE_VALUE,
+            DebugCommands.COPY_VARIABLE_AS_EXPRESSION
         );
 
         registerMenuActions(DebugBreakpointsWidget.EDIT_MENU,
@@ -737,12 +737,12 @@ export class DebugFrontendApplicationContribution extends AbstractViewContributi
             isEnabled: () => !!this.selectedVariable && this.selectedVariable.supportSetVariable,
             isVisible: () => !!this.selectedVariable && this.selectedVariable.supportSetVariable
         });
-        registry.registerCommand(DebugCommands.COPY_VAIRABLE_VALUE, {
+        registry.registerCommand(DebugCommands.COPY_VARIABLE_VALUE, {
             execute: () => this.selectedVariable && this.selectedVariable.copyValue(),
             isEnabled: () => !!this.selectedVariable && this.selectedVariable.supportCopyValue,
             isVisible: () => !!this.selectedVariable && this.selectedVariable.supportCopyValue
         });
-        registry.registerCommand(DebugCommands.COPY_VAIRABLE_AS_EXPRESSION, {
+        registry.registerCommand(DebugCommands.COPY_VARIABLE_AS_EXPRESSION, {
             execute: () => this.selectedVariable && this.selectedVariable.copyAsExpression(),
             isEnabled: () => !!this.selectedVariable && this.selectedVariable.supportCopyAsExpression,
             isVisible: () => !!this.selectedVariable && this.selectedVariable.supportCopyAsExpression

--- a/packages/debug/src/browser/preferences/launch-preferences.spec.ts
+++ b/packages/debug/src/browser/preferences/launch-preferences.spec.ts
@@ -489,7 +489,7 @@ describe('Launch Preferences', () => {
                 assert.deepStrictEqual(JSON.parse(JSON.stringify(config)), expectation);
             });
 
-            testIt('get from undefind', () => {
+            testIt('get from undefined', () => {
                 const config = preferences.get('launch', undefined, undefined);
                 assert.deepStrictEqual(JSON.parse(JSON.stringify(config)), expectation);
             });

--- a/packages/debug/src/browser/view/debug-threads-source.tsx
+++ b/packages/debug/src/browser/view/debug-threads-source.tsx
@@ -36,7 +36,7 @@ export class DebugThreadsSource extends TreeSource {
         this.toDispose.push(this.model.onDidChange(() => this.fireDidChange()));
     }
 
-    get multiSesssion(): boolean {
+    get multiSession(): boolean {
         return this.model.sessionCount > 1;
     }
 

--- a/packages/debug/src/browser/view/debug-threads-widget.ts
+++ b/packages/debug/src/browser/view/debug-threads-widget.ts
@@ -114,7 +114,7 @@ export class DebugThreadsWidget extends SourceTreeWidget {
     }
 
     protected getDefaultNodeStyle(node: TreeNode, props: NodeProps): React.CSSProperties | undefined {
-        if (this.threads.multiSesssion) {
+        if (this.threads.multiSession) {
             return super.getDefaultNodeStyle(node, props);
         }
         return undefined;

--- a/packages/debug/src/common/debug-model.ts
+++ b/packages/debug/src/common/debug-model.ts
@@ -29,7 +29,7 @@ import { IJSONSchema, IJSONSchemaSnippet } from '@theia/core/lib/common/json-sch
 import { Disposable } from '@theia/core/lib/common/disposable';
 import { MaybePromise } from '@theia/core/lib/common/types';
 
-// FXIME: break down this file to debug adapter and debug adapter contribution (see Theia file naming conventions)
+// FIXME: break down this file to debug adapter and debug adapter contribution (see Theia file naming conventions)
 
 /**
  * DebugAdapterSession symbol for DI.


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

- renamed command `COPY_VAIRABLE_VALUE` to `COPY_VARIABLE_VALUE`.
- renamed command `COPY_VAIRABLE_AS_EXPRESSION` to `COPY_VARIABLE_AS_EXPRESSION`.
- renamed getter method `multiSesssion` to `multiSession`.
- fixed additional typos.


#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

- verify that CI successfully passes (build & test of the `@theia/debug` extension)

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

Signed-off-by: vince-fugnitto <vincent.fugnitto@ericsson.com>
