### PR TITLE
[electron] Use VS Code's keychord for the 'Close All' command

### DIFF
--- a/packages/core/src/browser/common-frontend-contribution.ts
+++ b/packages/core/src/browser/common-frontend-contribution.ts
@@ -612,7 +612,7 @@ export class CommonFrontendContribution implements FrontendApplicationContributi
             },
             {
                 command: CommonCommands.CLOSE_ALL_TABS.id,
-                keybinding: 'alt+shift+w'
+                keybinding: this.isElectron() ? 'ctrlCmd+k ctrlCmd+w' : 'alt+shift+w'
             },
             // Panels
             {


### PR DESCRIPTION
Signed-off-by: Akos Kitta <kittaakos@typefox.io>

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

Closes the ~editors~ widgets in the `'main'` area with [VS Code's keychord](https://github.com/microsoft/vscode/blob/bf78b9b6c02cce9121026a9fe0641057d71a86c4/src/vs/workbench/browser/parts/editor/editor.contribution.ts#L331) if running in electron environment.
The new binding is: <kbd>Ctrl/Cmd</kbd>+<kbd>K</kbd> | <kbd>Ctrl/Cmd</kbd>+<kbd>W</kbd>.

![close-all-electron](https://user-images.githubusercontent.com/1405703/70307426-6f578380-1809-11ea-8a6e-cc244fdb384d.gif)


#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

