### PR TITLE
GH-6707: Fixed a timeout issue for notifications

### DIFF
--- a/packages/messages/src/browser/notifications-manager.ts
+++ b/packages/messages/src/browser/notifications-manager.ts
@@ -202,7 +202,8 @@ export class NotificationManager extends MessageClient {
         }
     }
     protected getTimeout(plainMessage: PlainMessage): number {
-        if (plainMessage.actions && !plainMessage.actions.length) {
+        if (plainMessage.actions && plainMessage.actions.length > 0) {
+            // Ignore the timeout if at least one action is set, and we wait for user interaction.
             return 0;
         }
         return plainMessage.options && plainMessage.options.timeout || this.preferences['notification.timeout'];


### PR DESCRIPTION
Timeout was ignored when no `actions` were set.
The corrected logic ignores the `timeout` if any action was set.

Closes #6707

Signed-off-by: Akos Kitta <kittaakos@typefox.io>

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->
Fixes the `no-timeout` issue when `actions` are not set.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

