### PR TITLE
[on-hold]: Updated the `vscode-uri` version.

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -40,7 +40,7 @@
     "reflect-metadata": "^0.1.10",
     "route-parser": "^0.0.5",
     "vscode-languageserver-types": "^3.15.0-next",
-    "vscode-uri": "^1.0.8",
+    "vscode-uri": "^2.1.1",
     "vscode-ws-jsonrpc": "^0.1.1",
     "ws": "^7.1.2",
     "yargs": "^11.1.0"

--- a/packages/core/src/browser/resource-context-key.ts
+++ b/packages/core/src/browser/resource-context-key.ts
@@ -16,7 +16,7 @@
 
 import { injectable, inject, postConstruct } from 'inversify';
 import URI from '../common/uri';
-import Uri from 'vscode-uri';
+import { URI as Uri } from 'vscode-uri';
 import { ContextKeyService, ContextKey } from './context-key-service';
 
 @injectable()

--- a/packages/core/src/common/uri.ts
+++ b/packages/core/src/common/uri.ts
@@ -15,7 +15,7 @@
  ********************************************************************************/
 
 import { setUriThrowOnMissingScheme } from 'vscode-uri';
-import Uri from 'vscode-uri';
+import { URI as Uri } from 'vscode-uri';
 import { Path } from './path';
 
 // TODO: disable it because of #4487

--- a/packages/core/src/common/uri.ts
+++ b/packages/core/src/common/uri.ts
@@ -14,12 +14,8 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
-import { setUriThrowOnMissingScheme } from 'vscode-uri';
 import { URI as Uri } from 'vscode-uri';
 import { Path } from './path';
-
-// TODO: disable it because of #4487
-setUriThrowOnMissingScheme(false);
 
 export default class URI {
 

--- a/packages/core/src/node/file-uri.ts
+++ b/packages/core/src/node/file-uri.ts
@@ -14,7 +14,7 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
-import Uri from 'vscode-uri';
+import { URI as Uri } from 'vscode-uri';
 import URI from '../common/uri';
 import { isWindows } from '../common/os';
 

--- a/packages/debug/src/browser/model/debug-source.ts
+++ b/packages/debug/src/browser/model/debug-source.ts
@@ -19,7 +19,7 @@ import { EditorManager, EditorOpenerOptions, EditorWidget } from '@theia/editor/
 import URI from '@theia/core/lib/common/uri';
 import { DebugProtocol } from 'vscode-debugprotocol/lib/debugProtocol';
 import { DebugSession } from '../debug-session';
-import Uri from 'vscode-uri';
+import { URI as Uri } from 'vscode-uri';
 
 export class DebugSourceData {
     readonly raw: DebugProtocol.Source;

--- a/packages/monaco/src/browser/monaco-workspace.ts
+++ b/packages/monaco/src/browser/monaco-workspace.ts
@@ -16,7 +16,7 @@
 
 // tslint:disable:no-null-keyword
 
-import Uri from 'vscode-uri';
+import { URI as Uri } from 'vscode-uri';
 import { injectable, inject, postConstruct } from 'inversify';
 import { ProtocolToMonacoConverter, MonacoToProtocolConverter, testGlob } from 'monaco-languageclient';
 import URI from '@theia/core/lib/common/uri';

--- a/packages/plugin-ext-vscode/src/browser/plugin-vscode-commands-contribution.ts
+++ b/packages/plugin-ext-vscode/src/browser/plugin-vscode-commands-contribution.ts
@@ -29,7 +29,7 @@ import { ViewColumn } from '@theia/plugin-ext/lib/plugin/types-impl';
 import { WorkspaceCommands } from '@theia/workspace/lib/browser';
 import { DiffService } from '@theia/workspace/lib/browser/diff-service';
 import { inject, injectable } from 'inversify';
-import URI from 'vscode-uri';
+import { URI } from 'vscode-uri';
 
 export namespace VscodeCommands {
     export const OPEN: Command = {

--- a/packages/plugin-ext/src/common/known-commands.ts
+++ b/packages/plugin-ext/src/common/known-commands.ts
@@ -15,7 +15,7 @@
  ********************************************************************************/
 
 import { Range as R, Position as P, Location as L } from 'vscode-languageserver-types';
-import URI from 'vscode-uri';
+import { URI } from 'vscode-uri';
 import * as theia from '@theia/plugin';
 import { cloneAndChange } from './objects';
 import { Position, Range, Location } from '../plugin/types-impl';

--- a/packages/plugin-ext/src/common/rpc-protocol.ts
+++ b/packages/plugin-ext/src/common/rpc-protocol.ts
@@ -25,7 +25,7 @@
 import { Event } from '@theia/core/lib/common/event';
 import { DisposableCollection, Disposable } from '@theia/core/lib/common/disposable';
 import { Deferred } from '@theia/core/lib/common/promise-util';
-import VSCodeURI from 'vscode-uri';
+import { URI as VSCodeURI } from 'vscode-uri';
 import URI from '@theia/core/lib/common/uri';
 import { CancellationToken, CancellationTokenSource } from 'vscode-languageserver-protocol';
 import { Range, Position } from '../plugin/types-impl';

--- a/packages/plugin-ext/src/main/browser/debug/debug-main.ts
+++ b/packages/plugin-ext/src/main/browser/debug/debug-main.ts
@@ -29,7 +29,7 @@ import { LabelProvider } from '@theia/core/lib/browser';
 import { EditorManager } from '@theia/editor/lib/browser';
 import { BreakpointManager } from '@theia/debug/lib/browser/breakpoint/breakpoint-manager';
 import { DebugBreakpoint } from '@theia/debug/lib/browser/model/debug-breakpoint';
-import Uri from 'vscode-uri';
+import { URI as Uri } from 'vscode-uri';
 import { DebugConsoleSession } from '@theia/debug/lib/browser/console/debug-console-session';
 import { SourceBreakpoint } from '@theia/debug/lib/browser/breakpoint/breakpoint-marker';
 import { DebugConfiguration } from '@theia/debug/lib/common/debug-configuration';

--- a/packages/plugin-ext/src/main/browser/documents-main.ts
+++ b/packages/plugin-ext/src/main/browser/documents-main.ts
@@ -23,7 +23,7 @@ import { EditorModelService } from './text-editor-model-service';
 import { createUntitledResource } from './editor/untitled-resource';
 import { EditorManager, EditorOpenerOptions } from '@theia/editor/lib/browser';
 import URI from '@theia/core/lib/common/uri';
-import CodeURI from 'vscode-uri';
+import { URI as CodeURI } from 'vscode-uri';
 import { ApplicationShell, Saveable } from '@theia/core/lib/browser';
 import { TextDocumentShowOptions } from '../../common/plugin-api-rpc-model';
 import { Range } from 'vscode-languageserver-types';

--- a/packages/plugin-ext/src/main/browser/file-system-main.ts
+++ b/packages/plugin-ext/src/main/browser/file-system-main.ts
@@ -15,7 +15,7 @@
  ********************************************************************************/
 
 import { interfaces, injectable } from 'inversify';
-import Uri from 'vscode-uri';
+import { URI as Uri } from 'vscode-uri';
 import { Disposable, ResourceResolver, DisposableCollection } from '@theia/core';
 import { Resource } from '@theia/core/lib/common/resource';
 import URI from '@theia/core/lib/common/uri';

--- a/packages/plugin-ext/src/main/browser/menus/menus-contribution-handler.ts
+++ b/packages/plugin-ext/src/main/browser/menus/menus-contribution-handler.ts
@@ -16,7 +16,7 @@
 
 // tslint:disable:no-any
 
-import CodeUri from 'vscode-uri';
+import { URI as CodeUri } from 'vscode-uri';
 import { injectable, inject } from 'inversify';
 import { MenuPath, ILogger, CommandRegistry, Command, Mutable, MenuAction, SelectionService, CommandHandler, Disposable, DisposableCollection } from '@theia/core';
 import { EDITOR_CONTEXT_MENU, EditorWidget } from '@theia/editor/lib/browser';

--- a/packages/plugin-ext/src/main/browser/quick-open-main.ts
+++ b/packages/plugin-ext/src/main/browser/quick-open-main.ts
@@ -36,7 +36,7 @@ import {
 import { MonacoQuickOpenService } from '@theia/monaco/lib/browser/monaco-quick-open-service';
 import { QuickInputService, FOLDER_ICON, FILE_ICON } from '@theia/core/lib/browser';
 import { PluginSharedStyle } from './plugin-shared-style';
-import URI from 'vscode-uri';
+import { URI } from 'vscode-uri';
 import { ThemeIcon, QuickInputButton } from '../../plugin/types-impl';
 import { QuickPickService, QuickPickItem, QuickPickValue } from '@theia/core/lib/common/quick-pick-service';
 import { QuickTitleBar } from '@theia/core/lib/browser/quick-open/quick-title-bar';

--- a/packages/plugin-ext/src/main/browser/text-editors-main.ts
+++ b/packages/plugin-ext/src/main/browser/text-editors-main.ts
@@ -14,7 +14,7 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
-import URI from 'vscode-uri';
+import { URI } from 'vscode-uri';
 import {
     TextEditorsMain,
     MAIN_RPC_CONTEXT,

--- a/packages/plugin-ext/src/main/browser/webviews-main.ts
+++ b/packages/plugin-ext/src/main/browser/webviews-main.ts
@@ -15,7 +15,7 @@
  ********************************************************************************/
 
 import debounce = require('lodash.debounce');
-import URI from 'vscode-uri';
+import { URI } from 'vscode-uri';
 import { interfaces } from 'inversify';
 import { WebviewsMain, MAIN_RPC_CONTEXT, WebviewsExt, WebviewPanelViewState } from '../../common/plugin-api-rpc';
 import { RPCProtocol } from '../../common/rpc-protocol';

--- a/packages/plugin-ext/src/main/browser/window-state-main.ts
+++ b/packages/plugin-ext/src/main/browser/window-state-main.ts
@@ -14,7 +14,7 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
-import URI from 'vscode-uri';
+import { URI } from 'vscode-uri';
 import CoreURI from '@theia/core/lib/common/uri';
 import { interfaces } from 'inversify';
 import { WindowStateExt, MAIN_RPC_CONTEXT, WindowMain } from '../../common/plugin-api-rpc';

--- a/packages/plugin-ext/src/main/browser/workspace-main.ts
+++ b/packages/plugin-ext/src/main/browser/workspace-main.ts
@@ -18,7 +18,7 @@ import * as theia from '@theia/plugin';
 import { interfaces, injectable } from 'inversify';
 import { WorkspaceExt, StorageExt, MAIN_RPC_CONTEXT, WorkspaceMain, WorkspaceFolderPickOptionsMain } from '../../common/plugin-api-rpc';
 import { RPCProtocol } from '../../common/rpc-protocol';
-import Uri from 'vscode-uri';
+import { URI as Uri } from 'vscode-uri';
 import { UriComponents } from '../../common/uri-components';
 import { QuickOpenModel, QuickOpenItem, QuickOpenMode } from '@theia/core/lib/browser/quick-open/quick-open-model';
 import { MonacoQuickOpenService } from '@theia/monaco/lib/browser/monaco-quick-open-service';

--- a/packages/plugin-ext/src/plugin/decorations.ts
+++ b/packages/plugin-ext/src/plugin/decorations.ts
@@ -24,7 +24,7 @@ import {
 } from '../common/plugin-api-rpc';
 import { Event } from '@theia/core/lib/common/event';
 import { RPCProtocol } from '../common/rpc-protocol';
-import URI from 'vscode-uri';
+import { URI } from 'vscode-uri';
 import { Disposable } from './types-impl';
 
 export class DecorationsExtImpl implements DecorationsExt {
@@ -39,7 +39,7 @@ export class DecorationsExtImpl implements DecorationsExt {
     }
 
     registerDecorationProvider(provider: theia.DecorationProvider): Disposable {
-        const id = DecorationsExtImpl.PROVIDER_ID ++;
+        const id = DecorationsExtImpl.PROVIDER_ID++;
         provider.onDidChangeDecorations(arg => {
             let argument;
             if (Array.isArray(arg)) {
@@ -72,7 +72,7 @@ export class DecorationsExtImpl implements DecorationsExt {
         };
         this.proxy.$registerDecorationProvider(id, providerMain);
         this.providersMap.set(id, providerMain);
-        return new Disposable( () => {
+        return new Disposable(() => {
             this.proxy.$dispose(id);
         });
     }

--- a/packages/plugin-ext/src/plugin/dialogs.ts
+++ b/packages/plugin-ext/src/plugin/dialogs.ts
@@ -16,7 +16,7 @@
 import { PLUGIN_RPC_CONTEXT as Ext, OpenDialogOptionsMain, DialogsMain, SaveDialogOptionsMain, UploadDialogOptionsMain } from '../common/plugin-api-rpc';
 import { OpenDialogOptions, SaveDialogOptions, UploadDialogOptions } from '@theia/plugin';
 import { RPCProtocol } from '../common/rpc-protocol';
-import Uri from 'vscode-uri';
+import { URI as Uri } from 'vscode-uri';
 
 export class DialogsExtImpl {
     private proxy: DialogsMain;

--- a/packages/plugin-ext/src/plugin/document-data.ts
+++ b/packages/plugin-ext/src/plugin/document-data.ts
@@ -17,7 +17,7 @@
 import * as theia from '@theia/plugin';
 import { ModelChangedEvent, DocumentsMain } from '../common/plugin-api-rpc';
 import { Range as ARange } from '../common/plugin-api-rpc-model';
-import URI from 'vscode-uri';
+import { URI } from 'vscode-uri';
 import { ok } from '../common/assert';
 import { Range, Position, EndOfLine } from './types-impl';
 import { PrefixSumComputer } from './prefix-sum-computer';

--- a/packages/plugin-ext/src/plugin/documents.ts
+++ b/packages/plugin-ext/src/plugin/documents.ts
@@ -21,7 +21,7 @@
  * based on https://github.com/Microsoft/vscode/blob/bf9a27ec01f2ef82fc45f69e0c946c7d74a57d3e/src/vs/workbench/api/node/extHostDocumentSaveParticipant.ts
  */
 import { DocumentsExt, ModelChangedEvent, PLUGIN_RPC_CONTEXT, DocumentsMain, SingleEditOperation } from '../common/plugin-api-rpc';
-import URI from 'vscode-uri';
+import { URI } from 'vscode-uri';
 import { UriComponents } from '../common/uri-components';
 import { RPCProtocol } from '../common/rpc-protocol';
 import { Emitter, Event } from '@theia/core/lib/common/event';
@@ -124,11 +124,11 @@ export class DocumentsExtImpl implements DocumentsExt {
     protected async fireTextDocumentWillSaveEvent({
         document, reason, fireEvent, accept
     }: {
-            document: theia.TextDocument,
-            reason: theia.TextDocumentSaveReason,
-            fireEvent: (e: theia.TextDocumentWillSaveEvent) => any,
-            accept: (operation: SingleEditOperation) => void
-        }): Promise<void> {
+        document: theia.TextDocument,
+        reason: theia.TextDocumentSaveReason,
+        fireEvent: (e: theia.TextDocumentWillSaveEvent) => any,
+        accept: (operation: SingleEditOperation) => void
+    }): Promise<void> {
 
         const promises: PromiseLike<TextEdit[] | any>[] = [];
         fireEvent(Object.freeze({

--- a/packages/plugin-ext/src/plugin/editors-and-documents.ts
+++ b/packages/plugin-ext/src/plugin/editors-and-documents.ts
@@ -22,7 +22,7 @@ import { DocumentDataExt } from './document-data';
 import { ok } from '../common/assert';
 import * as Converter from './type-converters';
 import { dispose } from '../common/disposable-util';
-import URI from 'vscode-uri';
+import { URI } from 'vscode-uri';
 
 export class EditorsAndDocumentsExtImpl implements EditorsAndDocumentsExt {
     private activeEditorId: string | undefined;

--- a/packages/plugin-ext/src/plugin/file-system.ts
+++ b/packages/plugin-ext/src/plugin/file-system.ts
@@ -14,7 +14,7 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
-import URI from 'vscode-uri';
+import { URI } from 'vscode-uri';
 import * as theia from '@theia/plugin';
 import { PLUGIN_RPC_CONTEXT, FileSystemExt, FileSystemMain } from '../common/plugin-api-rpc';
 import { RPCProtocol } from '../common/rpc-protocol';

--- a/packages/plugin-ext/src/plugin/in-plugin-filesystem-watcher-proxy.ts
+++ b/packages/plugin-ext/src/plugin/in-plugin-filesystem-watcher-proxy.ts
@@ -18,7 +18,7 @@ import * as theia from '@theia/plugin';
 import { Emitter, Event } from '@theia/core/lib/common/event';
 import { WorkspaceMain } from '../common/plugin-api-rpc';
 import { FileWatcherSubscriberOptions, FileChangeEventType } from '../common/plugin-api-rpc-model';
-import URI from 'vscode-uri';
+import { URI } from 'vscode-uri';
 
 /**
  * This class is responsible for file watchers subscription registering and file system events proxying.

--- a/packages/plugin-ext/src/plugin/known-commands.spec.ts
+++ b/packages/plugin-ext/src/plugin/known-commands.spec.ts
@@ -16,7 +16,7 @@
 
 import * as assert from 'assert';
 import { KnownCommands } from '../common/known-commands';
-import URI from 'vscode-uri';
+import { URI } from 'vscode-uri';
 import { Position } from './types-impl';
 import { fromPosition } from './type-converters';
 

--- a/packages/plugin-ext/src/plugin/languages.ts
+++ b/packages/plugin-ext/src/plugin/languages.ts
@@ -33,7 +33,7 @@ import * as theia from '@theia/plugin';
 import { DocumentsExtImpl } from './documents';
 import { PluginModel } from '../common/plugin-protocol';
 import { Disposable } from './types-impl';
-import URI from 'vscode-uri/lib/umd';
+import { URI } from 'vscode-uri';
 import { match as matchGlobPattern } from '../common/glob';
 import { UriComponents } from '../common/uri-components';
 import {

--- a/packages/plugin-ext/src/plugin/languages/code-action.ts
+++ b/packages/plugin-ext/src/plugin/languages/code-action.ts
@@ -15,7 +15,7 @@
  ********************************************************************************/
 
 import * as theia from '@theia/plugin';
-import URI from 'vscode-uri/lib/umd';
+import { URI } from 'vscode-uri';
 import { Selection } from '../../common/plugin-api-rpc';
 import { Range, CodeActionContext, CodeAction } from '../../common/plugin-api-rpc-model';
 import * as Converter from '../type-converters';

--- a/packages/plugin-ext/src/plugin/languages/color.ts
+++ b/packages/plugin-ext/src/plugin/languages/color.ts
@@ -15,7 +15,7 @@
  ********************************************************************************/
 
 import * as theia from '@theia/plugin';
-import URI from 'vscode-uri/lib/umd';
+import { URI } from 'vscode-uri';
 import { DocumentsExtImpl } from '../documents';
 import * as Converter from '../type-converters';
 import { RawColorInfo } from '../../common/plugin-api-rpc';

--- a/packages/plugin-ext/src/plugin/languages/completion.ts
+++ b/packages/plugin-ext/src/plugin/languages/completion.ts
@@ -14,7 +14,7 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
-import URI from 'vscode-uri/lib/umd';
+import { URI } from 'vscode-uri';
 import * as theia from '@theia/plugin';
 import { CompletionList, Range, SnippetString } from '../types-impl';
 import { DocumentsExtImpl } from '../documents';

--- a/packages/plugin-ext/src/plugin/languages/declaration.ts
+++ b/packages/plugin-ext/src/plugin/languages/declaration.ts
@@ -14,7 +14,7 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
-import URI from 'vscode-uri/lib/umd';
+import { URI } from 'vscode-uri';
 import * as theia from '@theia/plugin';
 import { DocumentsExtImpl } from '../documents';
 import * as types from '../types-impl';

--- a/packages/plugin-ext/src/plugin/languages/definition.ts
+++ b/packages/plugin-ext/src/plugin/languages/definition.ts
@@ -14,7 +14,7 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
-import URI from 'vscode-uri/lib/umd';
+import { URI } from 'vscode-uri';
 import * as theia from '@theia/plugin';
 import { DocumentsExtImpl } from '../documents';
 import * as types from '../types-impl';

--- a/packages/plugin-ext/src/plugin/languages/diagnostics.ts
+++ b/packages/plugin-ext/src/plugin/languages/diagnostics.ts
@@ -21,7 +21,7 @@ import { DiagnosticSeverity, MarkerSeverity } from '../types-impl';
 import { MarkerData } from '../../common/plugin-api-rpc-model';
 import { RPCProtocol } from '../../common/rpc-protocol';
 import { PLUGIN_RPC_CONTEXT, LanguagesMain } from '../../common/plugin-api-rpc';
-import URI from 'vscode-uri';
+import { URI } from 'vscode-uri';
 import { v4 } from 'uuid';
 
 export class DiagnosticCollection implements theia.DiagnosticCollection {

--- a/packages/plugin-ext/src/plugin/languages/document-formatting.ts
+++ b/packages/plugin-ext/src/plugin/languages/document-formatting.ts
@@ -17,7 +17,7 @@
 import * as theia from '@theia/plugin';
 import { DocumentsExtImpl } from '../documents';
 import * as Converter from '../type-converters';
-import URI from 'vscode-uri/lib/umd';
+import { URI } from 'vscode-uri';
 import { FormattingOptions, TextEdit } from '../../common/plugin-api-rpc-model';
 
 export class DocumentFormattingAdapter {

--- a/packages/plugin-ext/src/plugin/languages/document-highlight.ts
+++ b/packages/plugin-ext/src/plugin/languages/document-highlight.ts
@@ -14,7 +14,7 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
-import URI from 'vscode-uri/lib/umd';
+import { URI } from 'vscode-uri';
 import * as theia from '@theia/plugin';
 import { DocumentsExtImpl } from '../documents';
 import * as types from '../types-impl';

--- a/packages/plugin-ext/src/plugin/languages/folding.ts
+++ b/packages/plugin-ext/src/plugin/languages/folding.ts
@@ -16,7 +16,7 @@
 
 import * as theia from '@theia/plugin';
 import { DocumentsExtImpl } from '../documents';
-import URI from 'vscode-uri/lib/umd';
+import { URI } from 'vscode-uri';
 import * as Converter from '../type-converters';
 import * as model from '../../common/plugin-api-rpc-model';
 

--- a/packages/plugin-ext/src/plugin/languages/hover.ts
+++ b/packages/plugin-ext/src/plugin/languages/hover.ts
@@ -15,7 +15,7 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
-import URI from 'vscode-uri/lib/umd';
+import { URI } from 'vscode-uri';
 import * as theia from '@theia/plugin';
 import { DocumentsExtImpl } from '../documents';
 import { Hover } from '../../common/plugin-api-rpc-model';

--- a/packages/plugin-ext/src/plugin/languages/implementation.ts
+++ b/packages/plugin-ext/src/plugin/languages/implementation.ts
@@ -14,7 +14,7 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
-import URI from 'vscode-uri/lib/umd';
+import { URI } from 'vscode-uri';
 import * as theia from '@theia/plugin';
 import { DocumentsExtImpl } from '../documents';
 import * as types from '../types-impl';

--- a/packages/plugin-ext/src/plugin/languages/lens.ts
+++ b/packages/plugin-ext/src/plugin/languages/lens.ts
@@ -14,7 +14,7 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
-import URI from 'vscode-uri/lib/umd';
+import { URI } from 'vscode-uri';
 import * as theia from '@theia/plugin';
 import { DocumentsExtImpl } from '../documents';
 import { CodeLensSymbol } from '../../common/plugin-api-rpc-model';

--- a/packages/plugin-ext/src/plugin/languages/link-provider.ts
+++ b/packages/plugin-ext/src/plugin/languages/link-provider.ts
@@ -14,7 +14,7 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
-import URI from 'vscode-uri/lib/umd';
+import { URI } from 'vscode-uri';
 import * as theia from '@theia/plugin';
 import { DocumentsExtImpl } from '../documents';
 import { DocumentLink } from '../../common/plugin-api-rpc-model';

--- a/packages/plugin-ext/src/plugin/languages/on-type-formatting.ts
+++ b/packages/plugin-ext/src/plugin/languages/on-type-formatting.ts
@@ -17,7 +17,7 @@
 import * as theia from '@theia/plugin';
 import { DocumentsExtImpl } from '../documents';
 import * as Converter from '../type-converters';
-import URI from 'vscode-uri/lib/umd';
+import { URI } from 'vscode-uri';
 import { FormattingOptions, TextEdit } from '../../common/plugin-api-rpc-model';
 import { Position } from '../../common/plugin-api-rpc';
 

--- a/packages/plugin-ext/src/plugin/languages/outline.ts
+++ b/packages/plugin-ext/src/plugin/languages/outline.ts
@@ -14,7 +14,7 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
-import URI from 'vscode-uri/lib/umd';
+import { URI } from 'vscode-uri';
 import * as theia from '@theia/plugin';
 import { DocumentsExtImpl } from '../documents';
 import * as Converter from '../type-converters';

--- a/packages/plugin-ext/src/plugin/languages/range-formatting.ts
+++ b/packages/plugin-ext/src/plugin/languages/range-formatting.ts
@@ -17,7 +17,7 @@
 import * as theia from '@theia/plugin';
 import { DocumentsExtImpl } from '../documents';
 import * as Converter from '../type-converters';
-import URI from 'vscode-uri/lib/umd';
+import { URI } from 'vscode-uri';
 import { FormattingOptions, TextEdit, Range } from '../../common/plugin-api-rpc-model';
 
 export class RangeFormattingAdapter {

--- a/packages/plugin-ext/src/plugin/languages/reference.ts
+++ b/packages/plugin-ext/src/plugin/languages/reference.ts
@@ -14,7 +14,7 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
-import URI from 'vscode-uri/lib/umd';
+import { URI } from 'vscode-uri';
 import * as theia from '@theia/plugin';
 import { DocumentsExtImpl } from '../documents';
 import { ReferenceContext, Location } from '../../common/plugin-api-rpc-model';

--- a/packages/plugin-ext/src/plugin/languages/rename.ts
+++ b/packages/plugin-ext/src/plugin/languages/rename.ts
@@ -14,7 +14,7 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
-import URI from 'vscode-uri/lib/umd';
+import { URI } from 'vscode-uri';
 import * as theia from '@theia/plugin';
 import * as Converter from '../type-converters';
 import * as model from '../../common/plugin-api-rpc-model';

--- a/packages/plugin-ext/src/plugin/languages/signature.ts
+++ b/packages/plugin-ext/src/plugin/languages/signature.ts
@@ -20,7 +20,7 @@
 
 // copied and modified from https://github.com/TypeFox/vscode/blob/70b8db24a37fafc77247de7f7cb5bb0195120ed0/src/vs/workbench/api/common/extHostLanguageFeatures.ts#L771
 
-import URI from 'vscode-uri/lib/umd';
+import { URI } from 'vscode-uri';
 import * as theia from '@theia/plugin';
 import { DocumentsExtImpl } from '../documents';
 import * as Converter from '../type-converters';

--- a/packages/plugin-ext/src/plugin/languages/type-definition.ts
+++ b/packages/plugin-ext/src/plugin/languages/type-definition.ts
@@ -14,7 +14,7 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
-import URI from 'vscode-uri/lib/umd';
+import { URI } from 'vscode-uri';
 import * as theia from '@theia/plugin';
 import { DocumentsExtImpl } from '../documents';
 import * as types from '../types-impl';

--- a/packages/plugin-ext/src/plugin/node/debug/debug.ts
+++ b/packages/plugin-ext/src/plugin/node/debug/debug.ts
@@ -17,7 +17,7 @@ import { Emitter } from '@theia/core/lib/common/event';
 import { Path } from '@theia/core/lib/common/path';
 import { CommunicationProvider } from '@theia/debug/lib/common/debug-model';
 import * as theia from '@theia/plugin';
-import URI from 'vscode-uri';
+import { URI } from 'vscode-uri';
 import { Breakpoint } from '../../../common/plugin-api-rpc-model';
 import { DebugExt, DebugMain, PLUGIN_RPC_CONTEXT as Ext, TerminalOptionsExt } from '../../../common/plugin-api-rpc';
 import { PluginPackageDebuggersContribution } from '../../../common/plugin-protocol';

--- a/packages/plugin-ext/src/plugin/plugin-context.ts
+++ b/packages/plugin-ext/src/plugin/plugin-context.ts
@@ -116,7 +116,7 @@ import { SymbolKind } from '../common/plugin-api-rpc-model';
 import { EditorsAndDocumentsExtImpl } from './editors-and-documents';
 import { TextEditorsExtImpl } from './text-editors';
 import { DocumentsExtImpl } from './documents';
-import Uri from 'vscode-uri';
+import { URI as Uri } from 'vscode-uri';
 import { TextEditorCursorStyle } from '../common/editor-options';
 import { PreferenceRegistryExtImpl } from './preference-registry';
 import { OutputChannelRegistryExtImpl } from './output-channel-registry';

--- a/packages/plugin-ext/src/plugin/plugin-icon-path.ts
+++ b/packages/plugin-ext/src/plugin/plugin-icon-path.ts
@@ -15,7 +15,7 @@
  ********************************************************************************/
 
 import * as path from 'path';
-import Uri from 'vscode-uri';
+import { URI as Uri } from 'vscode-uri';
 import { IconUrl, PluginPackage } from '../common/plugin-protocol';
 import { Plugin } from '../common/plugin-api-rpc';
 

--- a/packages/plugin-ext/src/plugin/preferences/configuration.spec.ts
+++ b/packages/plugin-ext/src/plugin/preferences/configuration.spec.ts
@@ -19,7 +19,7 @@ import { Configuration, ConfigurationModel } from './configuration';
 import { PreferenceData } from '../../common';
 import { PreferenceScope } from '@theia/core/lib/common/preferences/preference-scope';
 import { WorkspaceExtImpl } from '../workspace';
-import URI from 'vscode-uri';
+import { URI } from 'vscode-uri';
 
 const expect = chai.expect;
 

--- a/packages/plugin-ext/src/plugin/preferences/configuration.ts
+++ b/packages/plugin-ext/src/plugin/preferences/configuration.ts
@@ -17,7 +17,7 @@
 import { WorkspaceExtImpl } from '../workspace';
 import { isObject } from '../../common/types';
 import cloneDeep = require('lodash.clonedeep');
-import URI from 'vscode-uri';
+import { URI } from 'vscode-uri';
 
 /* tslint:disable:no-any */
 

--- a/packages/plugin-ext/src/plugin/quick-open.ts
+++ b/packages/plugin-ext/src/plugin/quick-open.ts
@@ -22,7 +22,7 @@ import { hookCancellationToken } from '../common/async-util';
 import { Emitter, Event } from '@theia/core/lib/common/event';
 import { DisposableCollection } from '@theia/core/lib/common/disposable';
 import { QuickInputButtons, QuickInputButton, ThemeIcon } from './types-impl';
-import URI from 'vscode-uri';
+import { URI } from 'vscode-uri';
 import * as path from 'path';
 import { quickPickItemToPickOpenItem } from './type-converters';
 import { QuickOpenItem, QuickOpenItemOptions } from '@theia/core/lib/browser/quick-open/quick-open-model';

--- a/packages/plugin-ext/src/plugin/type-converters.ts
+++ b/packages/plugin-ext/src/plugin/type-converters.ts
@@ -33,7 +33,7 @@ import * as theia from '@theia/plugin';
 import * as types from './types-impl';
 import { LanguageSelector, LanguageFilter, RelativePattern } from './languages';
 import { isMarkdownString, MarkdownString } from './markdown-string';
-import URI from 'vscode-uri';
+import { URI } from 'vscode-uri';
 
 const SIDE_GROUP = -2;
 const ACTIVE_GROUP = -1;

--- a/packages/plugin-ext/src/plugin/types-impl.ts
+++ b/packages/plugin-ext/src/plugin/types-impl.ts
@@ -23,7 +23,7 @@ import { UUID } from '@phosphor/coreutils/lib/uuid';
 import { illegalArgument } from '../common/errors';
 import * as theia from '@theia/plugin';
 import * as crypto from 'crypto';
-import URI from 'vscode-uri';
+import { URI } from 'vscode-uri';
 import { relative } from '../common/paths-util';
 import { startsWithIgnoreCase } from '../common/strings';
 import { MarkdownString, isMarkdownString } from './markdown-string';

--- a/packages/plugin-ext/src/plugin/webviews.ts
+++ b/packages/plugin-ext/src/plugin/webviews.ts
@@ -19,7 +19,7 @@ import { WebviewsExt, WebviewPanelViewState, WebviewsMain, PLUGIN_RPC_CONTEXT, W
 import * as theia from '@theia/plugin';
 import { RPCProtocol } from '../common/rpc-protocol';
 import { Plugin } from '../common/plugin-api-rpc';
-import URI from 'vscode-uri';
+import { URI } from 'vscode-uri';
 import { Emitter, Event } from '@theia/core/lib/common/event';
 import { fromViewColumn, toViewColumn, toWebviewPanelShowOptions } from './type-converters';
 import { Disposable, WebviewPanelTargetArea } from './types-impl';

--- a/packages/plugin-ext/src/plugin/window-state.ts
+++ b/packages/plugin-ext/src/plugin/window-state.ts
@@ -14,7 +14,7 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
-import URI from 'vscode-uri';
+import { URI } from 'vscode-uri';
 import { WindowState } from '@theia/plugin';
 import { WindowStateExt, WindowMain, PLUGIN_RPC_CONTEXT } from '../common/plugin-api-rpc';
 import { Event, Emitter } from '@theia/core/lib/common/event';

--- a/packages/plugin-ext/src/plugin/workspace.ts
+++ b/packages/plugin-ext/src/plugin/workspace.ts
@@ -35,7 +35,7 @@ import { RPCProtocol } from '../common/rpc-protocol';
 import { WorkspaceRootsChangeEvent, FileChangeEvent, FileMoveEvent, FileWillMoveEvent } from '../common/plugin-api-rpc-model';
 import { EditorsAndDocumentsExtImpl } from './editors-and-documents';
 import { InPluginFileSystemWatcherProxy } from './in-plugin-filesystem-watcher-proxy';
-import URI from 'vscode-uri';
+import { URI } from 'vscode-uri';
 import { FileStat } from '@theia/filesystem/lib/common';
 import { normalize } from '../common/paths';
 import { relative } from '../common/paths-util';

--- a/packages/task/package.json
+++ b/packages/task/package.json
@@ -16,7 +16,7 @@
     "ajv": "^6.5.3",
     "jsonc-parser": "^2.0.2",
     "p-debounce": "^2.1.0",
-    "vscode-uri": "^1.0.8"
+    "vscode-uri": "^2.1.1"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/task/src/common/problem-matcher-protocol.ts
+++ b/packages/task/src/common/problem-matcher-protocol.ts
@@ -23,7 +23,7 @@
 
 import { Severity } from '@theia/core/lib/common/severity';
 import { Diagnostic } from 'vscode-languageserver-types';
-import vscodeURI from 'vscode-uri/lib/umd';
+import { URI as vscodeURI } from 'vscode-uri';
 import { ProblemPatternContribution, WatchingMatcherContribution } from './task-protocol';
 
 export enum ApplyToKind {

--- a/packages/task/src/node/task-abstract-line-matcher.ts
+++ b/packages/task/src/node/task-abstract-line-matcher.ts
@@ -26,7 +26,7 @@ import {
     ProblemMatch, ProblemMatchData, ProblemLocationKind
 } from '../common/problem-matcher-protocol';
 import URI from '@theia/core/lib/common/uri';
-import vscodeURI from 'vscode-uri/lib/umd';
+import { URI as vscodeURI } from 'vscode-uri';
 import { Severity } from '@theia/core/lib/common/severity';
 
 const endOfLine: string = isWindows ? '\r\n' : '\n';

--- a/yarn.lock
+++ b/yarn.lock
@@ -12659,12 +12659,12 @@ vscode-textmate@^4.0.1:
   dependencies:
     oniguruma "^7.2.0"
 
-vscode-uri@^1.0.5, vscode-uri@^1.0.8:
+vscode-uri@^1.0.5:
   version "1.0.8"
   resolved "https://registry.yarnpkg.com/vscode-uri/-/vscode-uri-1.0.8.tgz#9769aaececae4026fb6e22359cb38946580ded59"
   integrity sha512-obtSWTlbJ+a+TFRYGaUumtVwb+InIUVI0Lu0VBUAPmj2cU5JutEXg3xUE0c2J5Tcy7h2DEKVJBFi+Y9ZSFzzPQ==
 
-vscode-uri@^2.0.3, vscode-uri@^2.1.0:
+vscode-uri@^2.0.3, vscode-uri@^2.1.0, vscode-uri@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/vscode-uri/-/vscode-uri-2.1.1.tgz#5aa1803391b6ebdd17d047f51365cf62c38f6e90"
   integrity sha512-eY9jmGoEnVf8VE8xr5znSah7Qt1P/xsCdErz+g8HYZtJ7bZqKH5E3d+6oVNm1AC/c6IHUDokbmVXKOi4qPAC9A==


### PR DESCRIPTION
## on-hold: https://github.com/eclipse-theia/theia/issues/4874#issuecomment-562829134

To fix the dependency hoisting in the `node_modules`.

Signed-off-by: Akos Kitta <kittaakos@typefox.io>

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->
It updates the `vscode-uri` version. Otherwise, the old, `1.x.x` version is hoisted to the main `node_modules` folder.

```
yarn why vscode-uri
yarn why v1.19.1
[1/4] Why do we have the module "vscode-uri"...?
[2/4] Initialising dependency graph...
[3/4] Finding dependency...
[4/4] Calculating file sizes...
=> Found "vscode-uri@1.0.8"
info Has been hoisted to "vscode-uri"
info Reasons this module exists
   - "workspace-aggregator-071b277d-a6f4-4569-90f5-3d9422efaa2a" depends on it
   - Hoisted from "_project_#@theia#core#vscode-uri"
   - Hoisted from "_project_#@theia#task#vscode-uri"
   - Hoisted from "_project_#@theia#typescript#typescript-language-server#vscode-uri"
   - Hoisted from "_project_#@theia#languages#monaco-languageclient#vscode-uri"
info Disk size without dependencies: "104KB"
info Disk size with unique dependencies: "104KB"
info Disk size with transitive dependencies: "104KB"
info Number of shared dependencies: 0
=> Found "vscode-json-languageserver#vscode-uri@2.1.1"
info This module exists because "_project_#@theia#json#vscode-json-languageserver" depends on it.
info Disk size without dependencies: "104KB"
info Disk size with unique dependencies: "104KB"
info Disk size with transitive dependencies: "104KB"
info Number of shared dependencies: 0
=> Found "vscode-json-languageservice#vscode-uri@2.1.1"
info This module exists because "_project_#@theia#json#vscode-json-languageserver#vscode-json-languageservice" depends on it.
info Disk size without dependencies: "104KB"
info Disk size with unique dependencies: "104KB"
info Disk size with transitive dependencies: "104KB"
info Number of shared dependencies: 0
Done in 1.83s.
```

```
=> Found "vscode-uri@1.0.8"
info Has been hoisted to "vscode-uri"
```

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
Run `yarn why` you should see:
```
yarn why vscode-uri          
yarn why v1.19.1
[1/4] 🤔  Why do we have the module "vscode-uri"...?
[2/4] 🚚  Initialising dependency graph...
[3/4] 🔍  Finding dependency...
[4/4] 🚡  Calculating file sizes...
=> Found "vscode-uri@2.1.1"
info Has been hoisted to "vscode-uri"
info Reasons this module exists
   - "workspace-aggregator-9bb122b1-d1b9-438f-8bca-64068c9cc66d" depends on it
   - Hoisted from "_project_#@theia#core#vscode-uri"
   - Hoisted from "_project_#@theia#task#vscode-uri"
   - Hoisted from "_project_#@theia#json#vscode-json-languageserver#vscode-uri"
   - Hoisted from "_project_#@theia#json#vscode-json-languageserver#vscode-json-languageservice#vscode-uri"
info Disk size without dependencies: "104KB"
info Disk size with unique dependencies: "104KB"
info Disk size with transitive dependencies: "104KB"
info Number of shared dependencies: 0
=> Found "typescript-language-server#vscode-uri@1.0.8"
info This module exists because "_project_#@theia#typescript#typescript-language-server" depends on it.
info Disk size without dependencies: "104KB"
info Disk size with unique dependencies: "104KB"
info Disk size with transitive dependencies: "104KB"
info Number of shared dependencies: 0
=> Found "monaco-languageclient#vscode-uri@1.0.8"
info This module exists because "_project_#@theia#languages#monaco-languageclient" depends on it.
info Disk size without dependencies: "104KB"
info Disk size with unique dependencies: "104KB"
info Disk size with transitive dependencies: "104KB"
info Number of shared dependencies: 0
✨  Done in 1.05s.
```

```
=> Found "vscode-uri@2.1.1"
info Has been hoisted to "vscode-uri"
```

Or just check the content of the `./node_modules/vscode-uri/package.json` file before and after this PR change; you can see the difference.

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

