### PR TITLE
[WIP][process] Kill child processes when the parent process exits or is terminated

### DIFF
--- a/dev-packages/application-manager/src/application-package-manager.ts
+++ b/dev-packages/application-manager/src/application-package-manager.ts
@@ -85,7 +85,10 @@ export class ApplicationPackageManager {
 
     async startBrowser(args: string[]): Promise<void> {
         const { mainArgs, options } = this.adjustArgs(args);
-        this.__process.fork(this.pck.backend('main.js'), mainArgs, options);
+        const child = this.__process.fork(this.pck.backend('main.js'), mainArgs, options);
+        process.on('exit', () => child.kill());
+        process.on('SIGINT', () => child.kill());
+        process.on('SIGTERM', () => child.kill());
     }
 
     private adjustArgs(args: string[], forkOptions: cp.ForkOptions = {}): Readonly<{ mainArgs: string[]; options: cp.ForkOptions }> {

--- a/packages/core/src/node/messaging/ipc-connection-provider.ts
+++ b/packages/core/src/node/messaging/ipc-connection-provider.ts
@@ -109,6 +109,10 @@ export class IPCConnectionProvider {
         this.logger.debug(`[${options.serverName}: ${childProcess.pid}] IPC started`);
         childProcess.once('exit', () => this.logger.debug(`[${options.serverName}: ${childProcess.pid}] IPC exited`));
 
+        process.on('exit', () => childProcess.kill());
+        process.on('SIGINT', () => childProcess.kill());
+        process.on('SIGTERM', () => childProcess.kill());
+
         return childProcess;
     }
 

--- a/packages/languages/src/node/language-server-contribution.ts
+++ b/packages/languages/src/node/language-server-contribution.ts
@@ -86,13 +86,13 @@ export abstract class BaseLanguageServerContribution implements LanguageServerCo
      * Otherwise, the backend cannot notify the client if the LS has failed at start-up.
      */
     protected createProcessStreamConnection(command: string, args?: string[], options?: cp.SpawnOptions): IConnection {
-        const process = this.spawnProcess(command, args, options);
-        return createStreamConnection(process.output, process.input, () => process.kill());
+        const childProcess = this.spawnProcess(command, args, options);
+        return createStreamConnection(childProcess.output, childProcess.input, () => childProcess.kill());
     }
 
     protected async createProcessStreamConnectionAsync(command: string, args?: string[], options?: cp.SpawnOptions): Promise<IConnection> {
-        const process = await this.spawnProcessAsync(command, args, options);
-        return createStreamConnection(process.outputStream, process.inputStream, () => process.kill());
+        const childProcess = await this.spawnProcessAsync(command, args, options);
+        return createStreamConnection(childProcess.outputStream, childProcess.inputStream, () => childProcess.kill());
     }
 
     /**

--- a/packages/process/src/node/raw-process.ts
+++ b/packages/process/src/node/raw-process.ts
@@ -139,6 +139,10 @@ export class RawProcess extends Process {
                 );
             });
 
+            process.on('exit', () => this.kill());
+            process.on('SIGINT', () => this.kill());
+            process.on('SIGTERM', () => this.kill());
+
             if (this.process.pid !== undefined) {
                 process.nextTick(this.emitOnStarted.bind(this));
             }


### PR DESCRIPTION
I'm not quite sure how this is supposed to work, but in my testing, this fixes most "defunct" zombie processes left behind when you stop Theia.

It may not be the best or cleanest approach, and I'm not sure if this can have unintended side effects. Please review carefully.

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
Fixes most zombie processes listed in https://github.com/eclipse-theia/theia/issues/6685.

#### How to test
1. Start Theia
2. Run `ps axjf > ps1`
3. Stop Theia
4. Run `ps axjf > ps2`
5. Compare `ps1` and `ps2`. There should be no new zombie processes (indicated as "defunct") in `ps2`.

Note: If there are new zombie processes in `ps2`, you can find their full command and original parent by looking up their PID in `ps1`.

#### Review checklist

- [ ] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

