### PR TITLE
search detected tasks by scope

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ Breaking changes:
 - [debug] renamed command `COPY_VARAIBLE_AS_EXPRESSION` to `COPY_VARIABLE_AS_EXPRESSION` [#6698](https://github.com/eclipse-theia/theia/pull/6698)
 - [debug] renamed command `COPY_VARAIBLE_VALUE` to `COPY_VARIABLE_VALUE` [#6698](https://github.com/eclipse-theia/theia/pull/6698)
 - [debug] renamed getter method `multiSesssion` to `multiSession` [#6698](https://github.com/eclipse-theia/theia/pull/6698)
+- [task] changed the data structure of `ProvidedTaskConfigurations.tasksMap` [#6718](https://github.com/eclipse-theia/theia/pull/6718)
+- [task] added `taskDefinitionRegistry` and `taskSourceResolver` to the constructor of `TaskRunQuickOpenItem` and `ConfigureBuildOrTestTaskQuickOpenItem` [#6718](https://github.com/eclipse-theia/theia/pull/6718)
 
 ## v0.13.0
 

--- a/packages/task/src/browser/provided-task-configurations.spec.ts
+++ b/packages/task/src/browser/provided-task-configurations.spec.ts
@@ -38,7 +38,7 @@ describe('provided-task-configurations', () => {
             }
         });
 
-        const task = await container.get(ProvidedTaskConfigurations).getTask('test', 'task from test');
+        const task = await container.get(ProvidedTaskConfigurations).getTask('test', 'task from test', 'test');
         assert.isOk(task);
         assert.equal(task!.type, 'test');
         assert.equal(task!.label, 'task from test');

--- a/packages/task/src/browser/task-frontend-contribution.ts
+++ b/packages/task/src/browser/task-frontend-contribution.ts
@@ -217,9 +217,9 @@ export class TaskFrontendContribution implements CommandContribution, MenuContri
                 isEnabled: () => true,
                 // tslint:disable-next-line:no-any
                 execute: (...args: any[]) => {
-                    const [source, label] = args;
+                    const [source, label, scope] = args;
                     if (source && label) {
-                        return this.taskService.run(source, label);
+                        return this.taskService.run(source, label, scope);
                     }
                     return this.quickOpenTask.open();
                 }

--- a/packages/task/src/browser/task-service.ts
+++ b/packages/task/src/browser/task-service.ts
@@ -318,8 +318,8 @@ export class TaskService implements TaskConfigurationClient {
      * Returns a task configuration provided by an extension by task source and label.
      * If there are no task configuration, returns undefined.
      */
-    async getProvidedTask(source: string, label: string): Promise<TaskConfiguration | undefined> {
-        return this.providedTaskConfigurations.getTask(source, label);
+    async getProvidedTask(source: string, label: string, scope?: string): Promise<TaskConfiguration | undefined> {
+        return this.providedTaskConfigurations.getTask(source, label, scope);
     }
 
     /** Returns an array of running tasks 'TaskInfo' objects */
@@ -370,8 +370,8 @@ export class TaskService implements TaskConfigurationClient {
      * Runs a task, by the source and label of the task configuration.
      * It looks for configured and detected tasks.
      */
-    async run(source: string, taskLabel: string): Promise<TaskInfo | undefined> {
-        let task = await this.getProvidedTask(source, taskLabel);
+    async run(source: string, taskLabel: string, scope?: string): Promise<TaskInfo | undefined> {
+        let task = await this.getProvidedTask(source, taskLabel, scope);
         if (!task) { // if a detected task cannot be found, search from tasks.json
             task = this.taskConfigurations.getTask(source, taskLabel);
             if (!task) {


### PR DESCRIPTION
This pull request adds the support of detected tasks that have
- same label, and
- different scopes
in a multi-root workspace. This change fixes #6715.

Signed-off-by: Liang Huang <liang.huang@ericsson.com>

#### How to test

1) Prepare a multi root workspace. Make sure two or more root folders contribute detected tasks that have the same name. In the GIF below, both of my root folders (i.e., `test-dir` and `test-resource_B` have `npm: myWatch` defined in their `package.json` files)

2) Run `npm: myWatch` from root folder `test-dir`.


3) Check which `npm: myWatch` was started. In the GIF below, I started `npm: myWatch` in `test-dir`, and the task history and populated messages showed that the task was started in the right root folder.

![Peek 2019-12-07 23-45](https://user-images.githubusercontent.com/37082801/70384384-ca918f00-194b-11ea-9e0b-1e5997fed968.gif)


#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

