### PR TITLE
Keep node expanded

### DIFF
--- a/packages/core/src/browser/tree/tree-model.ts
+++ b/packages/core/src/browser/tree/tree-model.ts
@@ -169,8 +169,11 @@ export class TreeModelImpl implements TreeModel, SelectionProvider<ReadonlyArray
         this.toDispose.dispose();
     }
 
-    protected handleExpansion(node: Readonly<ExpandableTreeNode>): void {
+    handleExpansion(node: Readonly<ExpandableTreeNode>): void {
         this.selectIfAncestorOfSelected(node);
+        if (this.tree.handleExpansion) {
+            this.tree.handleExpansion(node);
+        }
     }
 
     /**

--- a/packages/core/src/browser/tree/tree.ts
+++ b/packages/core/src/browser/tree/tree.ts
@@ -16,6 +16,7 @@
 
 import { injectable } from 'inversify';
 import { Event, Emitter, Disposable, DisposableCollection, WaitUntilEvent, Mutable } from '../../common';
+import { ExpandableTreeNode } from './tree-expansion';
 
 export const Tree = Symbol('Tree');
 
@@ -53,6 +54,8 @@ export interface Tree extends Disposable {
      * Return a valid refreshed composite node or `undefined` if such does not exist.
      */
     refresh(parent: Readonly<CompositeTreeNode>): Promise<Readonly<CompositeTreeNode> | undefined>;
+
+    handleExpansion?(node: Readonly<ExpandableTreeNode>): void;
     /**
      * Emit when the children of the given node are refreshed.
      */

--- a/packages/debug/src/browser/view/debug-variables-source.ts
+++ b/packages/debug/src/browser/view/debug-variables-source.ts
@@ -38,7 +38,7 @@ export class DebugVariablesSource extends TreeSource {
         this.toDispose.push(this.model.onDidChange(() => this.refresh()));
     }
 
-    protected readonly refresh = debounce(() => this.fireDidChange(), 400);
+    protected readonly refresh = debounce(() => this.fireDidChange(), 1);
 
     async getElements(): Promise<IterableIterator<DebugScope>> {
         const { currentSession } = this.model;

--- a/packages/outline-view/src/browser/outline-view-tree.ts
+++ b/packages/outline-view/src/browser/outline-view-tree.ts
@@ -28,7 +28,7 @@ export class OutlineViewTreeModel extends TreeModelImpl {
      * after attempting to perform a `collapse-all`.
      * @param node the expandable tree node.
      */
-    protected handleExpansion(node: Readonly<ExpandableTreeNode>): void {
+    handleExpansion(node: Readonly<ExpandableTreeNode>): void {
         // no-op
     }
 


### PR DESCRIPTION
Signed-off-by: Anatoliy Bazko <abazko@redhat.com>

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->
### Reference issue
https://github.com/eclipse-theia/theia/issues/6580
 
#### What it does
Keeps nodes expanded over time.

`protected readonly refresh = debounce(() => this.fireDidChange(), 1);`
It was intentionally committed to test the changes. It will be removed once PR is approved.

#### How to test
1. Try to debug any file.
2. Expand some nodes in a variable list
3. Do step/in/out
4. Nodes should be collapsed.

#### Review checklist

- [ ] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

