### PR TITLE
[preferences] fix indentation when updating preferences through the tree

### DIFF
--- a/packages/core/src/browser/preferences/preference-service.ts
+++ b/packages/core/src/browser/preferences/preference-service.ts
@@ -70,7 +70,7 @@ export interface PreferenceService extends Disposable {
     readonly ready: Promise<void>;
     get<T>(preferenceName: string): T | undefined;
     get<T>(preferenceName: string, defaultValue: T): T;
-    get<T>(preferenceName: string, defaultValue: T, resourceUri: string): T;
+    get<T>(preferenceName: string, defaultValue: T, resourceUri?: string): T;
     get<T>(preferenceName: string, defaultValue?: T, resourceUri?: string): T | undefined;
     set(preferenceName: string, value: any, scope?: PreferenceScope, resourceUri?: string): Promise<void>;
     onPreferenceChanged: Event<PreferenceChange>;


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

Fixes #5052

Fixes the inconsistent formatting when attempting to update/set preferences using the `preferences-tree` widget. Since the formatting options passed to `jsoncparser` were hardcoded, the formatting would be inconsistent with whichever formatting the editor currently has:

https://github.com/eclipse-theia/theia/blob/928e1e00b47268c7ea8b8f2889c520e5fa3d5f0a/packages/preferences/src/browser/abstract-resource-preference-provider.ts#L107

In order to fix the issue, the following method `detectIndentation` was implemented which attempts to determine the `tabSize` and `indentType` (`insertSpaces`) directly from the `TextEditorDocument` of the `settings.json` file in question. This is done in order to get a more accurate representation of the actual formatting present in the file.

The following is the before and after when adding a new preference `terminal.enableCopy` through the `preferences-tree`:

| Before (using `tabSize`=8) | After (using `tabSize`=8) |
|:---:|:---:|
|<img width="381" alt="Screen Shot 2019-12-11 at 6 42 54 PM" src="https://user-images.githubusercontent.com/40359487/70670071-13945c80-1c46-11ea-8f9d-0190ed7867c8.png"> | <img width="393" alt="Screen Shot 2019-12-11 at 6 40 30 PM" src="https://user-images.githubusercontent.com/40359487/70670089-1bec9780-1c46-11ea-9e96-8cb40e9eac41.png"> |



#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

1. attempt to add preferences through the preferences-tree widget
2. update the `tabSize` using the statusbar and format the document accordingly (repeat step 1)
3. update the `indentType` (spaces or tabs) using the statusbar, format the document accordingly (repeat step 1)
4. repeat step 1 using both `user` and `workspace` files

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

Signed-off-by: vince-fugnitto <vincent.fugnitto@ericsson.com>
