### PR TITLE
process: refine exit type

### DIFF
--- a/packages/process/src/node/process.ts
+++ b/packages/process/src/node/process.ts
@@ -23,11 +23,16 @@ import { Readable, Writable } from 'stream';
 import { exec } from 'child_process';
 import * as fs from 'fs';
 
-export interface IProcessExitEvent {
-    // Exactly one of code and signal will be set.
-    readonly code?: number,
-    readonly signal?: string
-}
+/**
+ * Exactly one of `code` and `signal` will be set.
+ */
+export type IProcessExitEvent = {
+    readonly code: number
+    readonly signal: undefined
+} | {
+    readonly code: undefined
+    readonly signal: string
+};
 
 /**
  * Data emitted when a process has been successfully started.
@@ -39,7 +44,7 @@ export interface IProcessStartEvent {
  * Data emitted when a process has failed to start.
  */
 export interface ProcessErrorEvent extends Error {
-    /** An errno-like error string (e.g. ENOENT).  */
+    /** An errno-like error string (e.g. ENOENT). */
     code: string;
 }
 
@@ -155,7 +160,10 @@ export abstract class Process {
      * Emit the onExit event for this process.  Only one of code and signal
      * should be defined.
      */
-    protected emitOnExit(code?: number, signal?: string): void {
+    protected emitOnExit(code: number, signal: undefined): void;
+    protected emitOnExit(code: undefined, signal: string): void;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    protected emitOnExit(code: any, signal: any): void {
         const exitEvent: IProcessExitEvent = { code, signal };
         this.handleOnExit(exitEvent);
         this.exitEmitter.fire(exitEvent);
@@ -165,7 +173,10 @@ export abstract class Process {
      * Emit the onClose event for this process.  Only one of code and signal
      * should be defined.
      */
-    protected emitOnClose(code?: number, signal?: string): void {
+    protected emitOnClose(code: number, signal: undefined): void;
+    protected emitOnClose(code: undefined, signal: string): void;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    protected emitOnClose(code: any, signal: any): void {
         this.closeEmitter.fire({ code, signal });
     }
 

--- a/packages/process/src/node/raw-process.ts
+++ b/packages/process/src/node/raw-process.ts
@@ -124,19 +124,25 @@ export class RawProcess extends Process {
             this.process.on('exit', (exitCode, signal) => {
                 // node's child_process exit sets the unused parameter to null,
                 // but we want it to be undefined instead.
-                this.emitOnExit(
-                    typeof exitCode === 'number' ? exitCode : undefined,
-                    typeof signal === 'string' ? signal : undefined,
-                );
+                if (typeof exitCode === 'number') {
+                    this.emitOnClose(exitCode, undefined);
+                } else if (typeof signal === 'string') {
+                    this.emitOnClose(undefined, signal);
+                } else {
+                    throw new Error(`exit: nor exitCode(${typeof exitCode}) nor signal(${typeof signal}) has a valid type.`);
+                }
             });
 
             this.process.on('close', (exitCode, signal) => {
                 // node's child_process exit sets the unused parameter to null,
                 // but we want it to be undefined instead.
-                this.emitOnClose(
-                    typeof exitCode === 'number' ? exitCode : undefined,
-                    typeof signal === 'string' ? signal : undefined,
-                );
+                if (typeof exitCode === 'number') {
+                    this.emitOnExit(exitCode, undefined);
+                } else if (typeof signal === 'string') {
+                    this.emitOnExit(undefined, signal);
+                } else {
+                    throw new Error(`close: nor exitCode(${typeof exitCode}) nor signal(${typeof signal}) has a valid type.`);
+                }
             });
 
             if (this.process.pid !== undefined) {

--- a/packages/process/src/node/terminal-process.spec.ts
+++ b/packages/process/src/node/terminal-process.spec.ts
@@ -117,9 +117,9 @@ if (process.platform !== 'win32' || process.env.THEIA_PROCESS_TEST_OVERRIDE) {
 
         this.timeout(20_000);
 
-        interface ProcessExit extends IProcessExitEvent {
+        type ProcessExit = IProcessExitEvent & {
             output: string;
-        }
+        };
 
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         async function checkOutput(proc: TerminalProcess, pattern?: RegExp): Promise<ProcessExit> {

--- a/packages/process/src/node/terminal-process.spec.ts
+++ b/packages/process/src/node/terminal-process.spec.ts
@@ -126,7 +126,7 @@ if (process.platform !== 'win32' || process.env.THEIA_PROCESS_TEST_OVERRIDE) {
             return new Promise<ProcessExit>((resolve, reject) => {
                 let output = '';
                 proc.outputStream.on('data', chunk => output += chunk);
-                proc.onExit(async exit => {
+                proc.onClose(async exit => {
                     if (pattern) {
                         expect(output).match(pattern, output);
                     }


### PR DESCRIPTION
#### What it does

IProcessExitEvent can have both fields left undefined, or have both
fields defined. This commit refines the typings so that only one of the
fields should be set.

Fixes https://github.com/eclipse-theia/theia/issues/6741

#### How to test

`yarn run test`

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)