### PR TITLE
[Filesystem] Allow overwriting of icon and name for cached file tree nodes

### DIFF
--- a/packages/filesystem/src/browser/file-tree/file-tree.ts
+++ b/packages/filesystem/src/browser/file-tree/file-tree.ts
@@ -54,14 +54,14 @@ export class FileTree extends TreeImpl {
             return [];
         }
         const result = await Promise.all(fileStat.children.map(async child =>
-            await this.toNode(child, parent)
+            this.toNode(child, parent)
         ));
         return result.sort(DirNode.compare);
     }
 
     protected async toNode(fileStat: FileStat, parent: CompositeTreeNode): Promise<FileNode | DirNode> {
         const uri = new URI(fileStat.uri);
-        const name = await this.labelProvider.getName(uri);
+        const name = this.labelProvider.getName(uri);
         const icon = await this.labelProvider.getIcon(fileStat);
         const id = this.toNodeId(uri, parent);
         const node = this.getNode(id);

--- a/packages/filesystem/src/browser/file-tree/file-tree.ts
+++ b/packages/filesystem/src/browser/file-tree/file-tree.ts
@@ -66,7 +66,7 @@ export class FileTree extends TreeImpl {
         const id = this.toNodeId(uri, parent);
         const node = this.getNode(id);
         if (fileStat.isDirectory) {
-            if (DirNode.is(node)) {
+            if (DirNode.is(node) && icon === node.icon && name === node.name) {
                 node.fileStat = fileStat;
                 return node;
             }
@@ -77,7 +77,7 @@ export class FileTree extends TreeImpl {
                 children: []
             };
         }
-        if (FileNode.is(node)) {
+        if (FileNode.is(node) && icon === node.icon && name === node.name) {
             node.fileStat = fileStat;
             return node;
         }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

Allow overwriting of icon and name for cached file tree nodes
It fixes #6747

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

Create a new contribution that changes the icon or name for a specific file extension. Move that file/folder. The default icon might be cached and cannot be overwritten anymore

#### Review checklist

- [X] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

