### PR TITLE
Check partial keybindings to match current context

### DIFF
--- a/packages/core/src/browser/keybinding.ts
+++ b/packages/core/src/browser/keybinding.ts
@@ -627,7 +627,7 @@ export class KeybindingRegistry {
             this.keySequence = [];
             this.statusBar.removeElement('keybinding-status');
 
-        } else if (bindings.partial.length > 0) {
+        } else if (bindings.partial.some(binding => this.isEnabled(binding, event))) {
 
             /* Accumulate the keysequence */
             event.preventDefault();


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->
Check partial keybindings to match current context. VsCode uses the same approach: https://github.com/microsoft/vscode/blob/1bf341e6d2b0963e6260853e570d2655f987ffcb/src/vs/platform/keybinding/common/keybindingResolver.ts#L279-L292
They look for a suitable command by checking the context before viewing partial keybinding notification in the status bar
#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
1. Apply  [VsCode Vim extension](https://marketplace.visualstudio.com/items?itemName=vscodevim.vim)
2. Disable the `Vim` plugin by executing `F1 => Vim: Toggle Vim Mode`
3. Press `g` key.
See that the status bar didn't change.
Theia at current master state shows a notification in the the status bar, that the first part of the keybinding was pressed.
#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

