### PR TITLE
[messages] add tooltip to notification statusbar item

### DIFF
--- a/packages/messages/src/browser/notifications-contribution.ts
+++ b/packages/messages/src/browser/notifications-contribution.ts
@@ -51,11 +51,20 @@ export class NotificationsContribution implements FrontendApplicationContributio
             text: this.getStatusBarItemText(count),
             alignment: StatusBarAlignment.RIGHT,
             priority: -900,
-            command: NotificationsCommands.TOGGLE.id
+            command: NotificationsCommands.TOGGLE.id,
+            tooltip: this.getStatusBarItemTooltip(count)
         });
     }
     protected getStatusBarItemText(count: number): string {
-        return `$(bell) ${count ? ` ${count}` : '' }`;
+        return `$(bell) ${count ? ` ${count}` : ''}`;
+    }
+    protected getStatusBarItemTooltip(count: number): string {
+        if (this.manager.centerVisible) {
+            return 'Hide Notifications';
+        }
+        return count === 0
+            ? 'No Notifications'
+            : count === 1 ? '1 Notification' : `${count} Notifications`;
     }
 
     registerCommands(commands: CommandRegistry): void {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

Minor enhancement adding a tooltip to the **Notification** statusbar item:
- displays `Hide Notifications` when the notification center is expanded.
- displays `No Notifications` when the notification center is collapsed and no notifications are present.
- displays `{count} Notifications` when the notification center is collapsed and notifications are present.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
1. test tooltip when no notifications are present.
2. test tooltip when 1 or more notifications are present.
3. test tooltip when the notification center is opened.

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

Signed-off-by: vince-fugnitto <vincent.fugnitto@ericsson.com>

