### PR TITLE
fix #6767: don't reuse integrated terminal that has child processes

### DIFF
--- a/packages/debug/src/browser/debug-session.tsx
+++ b/packages/debug/src/browser/debug-session.tsx
@@ -374,7 +374,14 @@ export class DebugSession implements CompositeTreeElement {
     }
 
     protected async doCreateTerminal(options: TerminalWidgetOptions): Promise<TerminalWidget> {
-        let terminal = this.terminalServer.all.find(t => t.title.label === options.title || t.title.caption === options.title);
+        let terminal = undefined;
+        for (const t of this.terminalServer.all) {
+            if ((t.title.label === options.title || t.title.caption === options.title) && (await t.hasChildProcesses()) === false) {
+                terminal = t;
+                break;
+            }
+        }
+
         if (!terminal) {
             terminal = await this.terminalServer.newTerminal(options);
             await terminal.start();

--- a/packages/debug/src/browser/debug-session.tsx
+++ b/packages/debug/src/browser/debug-session.tsx
@@ -368,7 +368,7 @@ export class DebugSession implements CompositeTreeElement {
     }
 
     protected async runInTerminal({ arguments: { title, cwd, args, env } }: DebugProtocol.RunInTerminalRequest): Promise<DebugProtocol.RunInTerminalResponse['body']> {
-        const terminal = await this.doCreateTerminal({ title, cwd, env });
+        const terminal = await this.doCreateTerminal({ title, cwd, env, useServerTitle: false });
         terminal.sendText(args.join(' ') + '\n');
         return { processId: await terminal.processId };
     }

--- a/packages/terminal/src/browser/base/terminal-widget.ts
+++ b/packages/terminal/src/browser/base/terminal-widget.ts
@@ -47,6 +47,11 @@ export abstract class TerminalWidget extends BaseWidget {
      * Cleat terminal output.
      */
     abstract clearOutput(): void;
+
+    /**
+     * Whether the terminal process has child processes.
+     */
+    abstract hasChildProcesses(): Promise<boolean>;
 }
 
 /**

--- a/packages/terminal/src/browser/terminal-widget-impl.ts
+++ b/packages/terminal/src/browser/terminal-widget-impl.ts
@@ -263,6 +263,10 @@ export class TerminalWidgetImpl extends TerminalWidget implements StatefulWidget
         this.term.clear();
     }
 
+    async hasChildProcesses(): Promise<boolean> {
+        return this.shellTerminalServer.hasChildProcesses(await this.processId);
+    }
+
     storeState(): object {
         this.closeOnDispose = false;
         return { terminalId: this.terminalId, titleLabel: this.title.label };

--- a/packages/terminal/src/common/shell-terminal-protocol.ts
+++ b/packages/terminal/src/common/shell-terminal-protocol.ts
@@ -20,6 +20,7 @@ import { IBaseTerminalServer, IBaseTerminalServerOptions } from './base-terminal
 export const IShellTerminalServer = Symbol('IShellTerminalServer');
 
 export interface IShellTerminalServer extends IBaseTerminalServer {
+    hasChildProcesses(processId: number | undefined): Promise<boolean>;
 }
 
 export const shellTerminalPath = '/services/shell-terminal';


### PR DESCRIPTION
Signed-off-by: Cai Xuye <a1994846931931@gmail.com>

#### What it does
Fix #6767.

#### How to test
1. Check whether the reuse of the integrated terminal is still working.
2. Check if an integrated terminal is in use, it won't be reused.
Demo gif for the 1st commit (propose 1 in #6767):
![integrated-terminal-fixed](https://user-images.githubusercontent.com/17487291/71081277-d55ce700-21c9-11ea-8874-cf01b3705914.gif)
3. Check if the title of the integrated terminal keeps its original value
Update gif for the 2nd commit (propose 2 in #6767):
![integrated-terminal-fixed2](https://user-images.githubusercontent.com/17487291/71082949-f2df8000-21cc-11ea-9e8f-336675ff01d3.gif)

I've tested in only on Linux. Could anyone test it on windows as well? Thanks!

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
- [x] CQ approval needed before merge https://dev.eclipse.org/ipzilla/show_bug.cgi?id=21340
