### PR TITLE
[markers] add problems statusbar tooltip

### DIFF
--- a/packages/markers/src/browser/problem/problem-contribution.ts
+++ b/packages/markers/src/browser/problem/problem-contribution.ts
@@ -87,8 +87,36 @@ export class ProblemContribution extends AbstractViewContribution<ProblemWidget>
                 : `$(times-circle) ${problemStat.errors} $(exclamation-triangle) ${problemStat.warnings} $(info-circle) ${problemStat.infos}`,
             alignment: StatusBarAlignment.LEFT,
             priority: 10,
-            command: this.toggleCommand ? this.toggleCommand.id : undefined
+            command: this.toggleCommand ? this.toggleCommand.id : undefined,
+            tooltip: this.getStatusBarTooltip(problemStat)
         });
+    }
+
+    /**
+     * Get the tooltip to be displayed when hovering over the problem statusbar item.
+     * - Displays `No Problems` when no problems are present.
+     * - Displays a human-readable label which describes for each type of problem stat properties,
+     * their overall count and type when any one of these properties has a positive count.
+     * @param stat the problem stat describing the number of `errors`, `warnings` and `infos`.
+     *
+     * @return the tooltip to be displayed in the statusbar.
+     */
+    protected getStatusBarTooltip(stat: ProblemStat): string {
+        if (stat.errors <= 0 && stat.warnings <= 0 && stat.infos <= 0) {
+            return 'No Problems';
+        }
+        const tooltip: string[] = [];
+        if (stat.errors > 0) {
+            tooltip.push(`${stat.errors} Errors`);
+        }
+        if (stat.warnings > 0) {
+            tooltip.push(`${stat.warnings} Warnings`);
+        }
+        if (stat.infos > 0) {
+            tooltip.push(`${stat.infos} Infos`);
+        }
+        return tooltip.join(', ');
+
     }
 
     registerCommands(commands: CommandRegistry): void {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

- adds a tooltip to the problems statusbar when hovering over the item.
- displays `No Problems` when no problems are present.
- displays the count and type of a problem for each problem stat property when problems are present.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

- verify the problem statusbar item tooltip for a collection of different scenarios:
    - multiple errors, warnings, infos
    - no errors

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

Signed-off-by: Vincent Fugnitto <vincent.fugnitto@ericsson.com>
