### PR TITLE
[git] update 'git checkout' statusbar tooltip

### DIFF
--- a/packages/git/src/browser/git-contribution.ts
+++ b/packages/git/src/browser/git-contribution.ts
@@ -638,7 +638,7 @@ export class GitContribution implements CommandContribution, MenuContribution, T
         return {
             command: GIT_COMMANDS.CHECKOUT.id,
             title: `$(code-fork) ${branch}${changes}`,
-            tooltip: 'Checkout...'
+            tooltip: `${branch}${changes}`
         };
     }
     protected getSyncStatusBarCommand(): ScmCommand | undefined {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

Fixes #6765

Updates the statusbar tooltip for the `Git Checkout...` command, aligning the behavior with that present in VS Code. With this change, hovering over the statusbar item now displays the repo name, scm provider, the branch name and the state the branch is in (if the branch has `unstaged`, `staged`, and `merged` changes`).

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

1. start the application with `theia` as a workspace
2. hover over the branch name in the statusbar
3. hovering should now display the repo name, scm provider, branch name, and state

    ```
    ex: theia (Git) - master+
    ```


#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

Signed-off-by: vince-fugnitto <vincent.fugnitto@ericsson.com>
