### PR TITLE
[merge-conflicts] fix 'merge-conflicts' command category

### DIFF
--- a/packages/merge-conflicts/src/browser/merge-conflict.ts
+++ b/packages/merge-conflicts/src/browser/merge-conflict.ts
@@ -35,20 +35,20 @@ export interface MergeConflictCommandArgument {
 }
 
 export namespace MergeConflictsCommands {
-    const MERGE_CONFLIC_PREFIX = 'Merge Conflict';
+    export const MERGE_CONFLICT_PREFIX = 'Merge Conflict';
     export const AcceptCurrent: Command = {
         id: 'merge-conflicts:accept.current',
-        category: MERGE_CONFLIC_PREFIX,
+        category: MERGE_CONFLICT_PREFIX,
         label: 'Accept Current Change'
     };
     export const AcceptIncoming: Command = {
         id: 'merge-conflicts:accept.incoming',
-        category: MERGE_CONFLIC_PREFIX,
+        category: MERGE_CONFLICT_PREFIX,
         label: 'Accept Incoming Change'
     };
     export const AcceptBoth: Command = {
         id: 'merge-conflicts:accept.both',
-        category: MERGE_CONFLIC_PREFIX,
+        category: MERGE_CONFLICT_PREFIX,
         label: 'Accept Both Changes'
     };
 }


### PR DESCRIPTION


<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

- fixed the typo present in the command category prefix.
- made the command prefix exportable so it can be resued by others.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

- verify that CI passes for `@theia/merge-conflicts` (build & tests)
- verify that the typo is renamed properly

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

Signed-off-by: Vincent Fugnitto <vincent.fugnitto@ericsson.com>
