### PR TITLE
[theming] fix sidebar icons

### DIFF
--- a/packages/core/src/browser/style/sidepanel.css
+++ b/packages/core/src/browser/style/sidepanel.css
@@ -57,7 +57,7 @@
 }
 
 .p-TabBar.theia-app-left .p-TabBar-tab {
-    margin-right: var(--theia-panel-border-width);
+    border-left: var(--theia-panel-border-width) solid transparent;
 }
 
 .p-TabBar.theia-app-left.theia-app-sides {
@@ -65,7 +65,7 @@
 }
 
 .p-TabBar.theia-app-right .p-TabBar-tab {
-    margin-left: var(--theia-panel-border-width);
+    border-right: var(--theia-panel-border-width) solid transparent;
 }
 
 .p-Widget.p-TabBar.theia-app-right.theia-app-sides {
@@ -114,8 +114,8 @@
   text-align: center;
   color: inherit;
   background-color: var(--theia-activityBar-inactiveForeground);
-  
-  /* svg */ 
+
+  /* svg */
   width: var(--theia-private-sidebar-icon-size);
   height: var(--theia-private-sidebar-icon-size);
   mask-repeat: no-repeat;


### PR DESCRIPTION

Signed-off-by: vince-fugnitto <vincent.fugnitto@ericsson.com>

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

Fixes #6808

Fixes issue where the active widget icon in the sidebar is not consistent with inactive icons. The fix includes adding the same border as the active widget but with a transparent background.


#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

1. start the application
2. toggle widgets present in the left and right sidebars, the active icon should not shift

| Before | After |
|:---:|:---:|
| ![2](https://user-images.githubusercontent.com/40359487/71679503-b62b9100-2d55-11ea-889a-67323d4f3144.gif) | ![3](https://user-images.githubusercontent.com/40359487/71679514-bb88db80-2d55-11ea-9531-a12dae686eda.gif) |



#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

