### PR TITLE
[task] add ability to restart running task

### DIFF
--- a/packages/task/src/browser/task-frontend-contribution.ts
+++ b/packages/task/src/browser/task-frontend-contribution.ts
@@ -16,7 +16,7 @@
 
 import { inject, injectable, named, postConstruct } from 'inversify';
 import { ILogger, ContributionProvider } from '@theia/core/lib/common';
-import { QuickOpenTask, TaskTerminateQuickOpen, TaskRunningQuickOpen } from './quick-open-task';
+import { QuickOpenTask, TaskTerminateQuickOpen, TaskRunningQuickOpen, TaskRestartRunningQuickOpen } from './quick-open-task';
 import { CommandContribution, Command, CommandRegistry, MenuContribution, MenuModelRegistry } from '@theia/core/lib/common';
 import {
     FrontendApplication, FrontendApplicationContribution, QuickOpenContribution,
@@ -97,6 +97,12 @@ export namespace TaskCommands {
         category: TASK_CATEGORY,
         label: 'Terminate Task'
     };
+
+    export const TASK_RESTART_RUNNING: Command = {
+        id: 'task:restart-running',
+        category: TASK_CATEGORY,
+        label: 'Restart Running Task...'
+    };
 }
 
 const TASKS_STORAGE_KEY = 'tasks';
@@ -141,6 +147,9 @@ export class TaskFrontendContribution implements CommandContribution, MenuContri
 
     @inject(TaskTerminateQuickOpen)
     protected readonly taskTerminateQuickOpen: TaskTerminateQuickOpen;
+
+    @inject(TaskRestartRunningQuickOpen)
+    protected readonly taskRestartRunningQuickOpen: TaskRestartRunningQuickOpen;
 
     @inject(TaskWatcher)
     protected readonly taskWatcher: TaskWatcher;
@@ -293,6 +302,13 @@ export class TaskFrontendContribution implements CommandContribution, MenuContri
                 execute: () => this.taskTerminateQuickOpen.open()
             }
         );
+
+        registry.registerCommand(
+            TaskCommands.TASK_RESTART_RUNNING,
+            {
+                execute: () => this.taskRestartRunningQuickOpen.open()
+            }
+        );
     }
 
     registerMenus(menus: MenuModelRegistry): void {
@@ -333,9 +349,15 @@ export class TaskFrontendContribution implements CommandContribution, MenuContri
         });
 
         menus.registerMenuAction(TerminalMenus.TERMINAL_TASKS_INFO, {
+            commandId: TaskCommands.TASK_RESTART_RUNNING.id,
+            label: TaskCommands.TASK_RESTART_RUNNING.label,
+            order: '1'
+        });
+
+        menus.registerMenuAction(TerminalMenus.TERMINAL_TASKS_INFO, {
             commandId: TaskCommands.TASK_TERMINATE.id,
             label: 'Terminate Task...',
-            order: '1'
+            order: '2'
         });
 
         menus.registerMenuAction(TerminalMenus.TERMINAL_TASKS_CONFIG, {

--- a/packages/task/src/browser/task-frontend-module.ts
+++ b/packages/task/src/browser/task-frontend-module.ts
@@ -18,7 +18,7 @@ import { ContainerModule } from 'inversify';
 import { FrontendApplicationContribution, QuickOpenContribution, KeybindingContribution } from '@theia/core/lib/browser';
 import { CommandContribution, MenuContribution, bindContributionProvider } from '@theia/core/lib/common';
 import { WebSocketConnectionProvider } from '@theia/core/lib/browser/messaging';
-import { QuickOpenTask, TaskTerminateQuickOpen, TaskRunningQuickOpen, TaskActionProvider, ConfigureTaskAction } from './quick-open-task';
+import { QuickOpenTask, TaskTerminateQuickOpen, TaskRestartRunningQuickOpen, TaskRunningQuickOpen, TaskActionProvider, ConfigureTaskAction } from './quick-open-task';
 import { TaskContribution, TaskProviderRegistry, TaskResolverRegistry } from './task-contribution';
 import { TaskService } from './task-service';
 import { TaskConfigurations } from './task-configurations';
@@ -53,6 +53,7 @@ export default new ContainerModule(bind => {
     bind(QuickOpenTask).toSelf().inSingletonScope();
     bind(TaskRunningQuickOpen).toSelf().inSingletonScope();
     bind(TaskTerminateQuickOpen).toSelf().inSingletonScope();
+    bind(TaskRestartRunningQuickOpen).toSelf().inSingletonScope();
     bind(TaskConfigurations).toSelf().inSingletonScope();
     bind(ProvidedTaskConfigurations).toSelf().inSingletonScope();
     bind(TaskConfigurationManager).toSelf().inSingletonScope();

--- a/packages/task/src/browser/task-service.ts
+++ b/packages/task/src/browser/task-service.ts
@@ -674,7 +674,7 @@ export class TaskService implements TaskConfigurationClient {
      * Terminates a task that is actively running.
      * @param activeTaskInfo the TaskInfo of the task that is actively running
      */
-    protected async terminateTask(activeTaskInfo: TaskInfo): Promise<void> {
+    async terminateTask(activeTaskInfo: TaskInfo): Promise<void> {
         const taskId = activeTaskInfo.taskId;
         return this.kill(taskId);
     }
@@ -683,7 +683,7 @@ export class TaskService implements TaskConfigurationClient {
      * Terminates a task that is actively running, and restarts it.
      * @param activeTaskInfo the TaskInfo of the task that is actively running
      */
-    protected async restartTask(activeTaskInfo: TaskInfo, option?: RunTaskOption): Promise<TaskInfo | undefined> {
+    async restartTask(activeTaskInfo: TaskInfo, option?: RunTaskOption): Promise<TaskInfo | undefined> {
         await this.terminateTask(activeTaskInfo);
         return this.doRunTask(activeTaskInfo.config, option);
     }


### PR DESCRIPTION
Signed-off-by: vince-fugnitto <vincent.fugnitto@ericsson.com>

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

Fixes #5330

- adds a new command and menu item to `restart running task`.
- updates the task-service methods `restartTask` and `terminateTask` to make them public so
others may call them.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

1. start the application using `theia/packages/task/test-resources` as a workspace.
2. start the `long running test task`.
3. use the command or menu item `restart running task` to restart the task.
4. the task should terminate and a new terminal should be opened with the restarted task.

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

