### PR TITLE
support presentation.reveal and presentation.focus in task config

### DIFF
--- a/packages/task/src/browser/task-schema-updater.ts
+++ b/packages/task/src/browser/task-schema-updater.ts
@@ -532,6 +532,34 @@ const problemMatcher = {
     ]
 };
 
+const presentation: IJSONSchema = {
+    type: 'object',
+    default: {
+        reveal: 'always',
+        focus: false
+    },
+    description: 'Configures the panel that is used to present the task\'s output and reads its input.',
+    additionalProperties: true,
+    properties: {
+        focus: {
+            type: 'boolean',
+            default: false,
+            description: 'Controls whether the panel takes focus. Default is false. If set to true the panel is revealed as well.'
+        },
+        reveal: {
+            type: 'string',
+            enum: ['always', 'silent', 'never'],
+            enumDescriptions: [
+                'Always reveals the terminal when this task is executed.',
+                'Only reveals the terminal if the task exits with an error or the problem matcher finds an error.',
+                'Never reveals the terminal when this task is executed.'
+            ],
+            default: 'always',
+            description: 'Controls whether the terminal running the task is revealed or not. May be overridden by option \"revealProblems\". Default is \"always\".'
+        }
+    }
+};
+
 const taskIdentifier: IJSONSchema = {
     type: 'object',
     additionalProperties: true,
@@ -603,7 +631,8 @@ const processTaskConfigurationSchema: IJSONSchema = {
             properties: commandAndArgs
         },
         group,
-        problemMatcher
+        problemMatcher,
+        presentation
     },
     additionalProperties: true
 };

--- a/packages/task/src/common/task-protocol.ts
+++ b/packages/task/src/common/task-protocol.ts
@@ -27,10 +27,45 @@ export enum DependsOrder {
     Parallel = 'parallel',
 }
 
+export enum RevealKind {
+    Always,
+    Silent,
+    Never
+}
+
+export interface TaskOutputPresentation {
+    focus?: boolean;
+    reveal?: RevealKind;
+    // tslint:disable-next-line:no-any
+    [name: string]: any;
+}
+export namespace TaskOutputPresentation {
+    // tslint:disable-next-line:no-any
+    export function fromJson(task: any): TaskOutputPresentation {
+        if (task && task.presentation) {
+            let reveal = RevealKind.Always;
+            if (task.presentation.reveal === 'silent') {
+                reveal = RevealKind.Silent;
+            } else if (task.presentation.reveal === 'never') {
+                reveal = RevealKind.Never;
+            }
+            return {
+                reveal,
+                focus: !!task.presentation.focus
+            };
+        }
+        return {
+            reveal: RevealKind.Always,
+            focus: false
+        };
+    }
+}
+
 export interface TaskCustomization {
     type: string;
     group?: 'build' | 'test' | 'none' | { kind: 'build' | 'test' | 'none', isDefault: true };
     problemMatcher?: string | ProblemMatcherContribution | (string | ProblemMatcherContribution)[];
+    presentation?: TaskOutputPresentation;
 
     /** Whether the task is a background task or not. */
     isBackground?: boolean;
@@ -154,6 +189,7 @@ export interface TaskOutputEvent {
 
 export interface TaskOutputProcessedEvent {
     readonly taskId: number;
+    readonly config: TaskConfiguration;
     readonly ctx?: string;
     readonly problems?: ProblemMatch[];
 }

--- a/packages/task/src/node/task-server.ts
+++ b/packages/task/src/node/task-server.ts
@@ -123,6 +123,7 @@ export class TaskServerImpl implements TaskServer, Disposable {
                     if (problems.length > 0) {
                         this.fireTaskOutputProcessedEvent({
                             taskId: event.taskId,
+                            config: taskConfiguration,
                             ctx: event.ctx,
                             problems
                         });


### PR DESCRIPTION
- put focus on the terminal if presentation.reveal = "always",
- do not activate the terminal if presentation.reveal = "never",
- when presentation.reveal = "silent", activate the terminal only if errors are found from the task output by the parser

- when users start a task that is already active, put focus on the
terminal if presentation.focus = true, or presentation.reveal = "always"

Signed-off-by: Liang Huang <liang.huang@ericsson.com>




#### How to test

1. Open a workspace and add some tasks
2. Try adding "presentation" into the task config, and see if getting any content assist.
3. Verify the following scenarios:
3.1 adding "presentation": { "reveal": "always", "focus": false } to task config shouldn't change the behavior of Theia
3.2 having "presentation": { "reveal": "never", "focus": false } in task config should leave the terminal for the task not-focused
3.3 adding "presentation": { "reveal": "never", "focus": false } in a long running task, start the long running task, and start it one more time - the terminal should not be activated throughout all steps
3.4 adding "presentation": { "reveal": "never", "focus": true }, or "presentation": { "reveal": "always", "focus": false } in a long running task, and try the rest of 3.3 - the terminal should have the focus.
3.5 adding "presentation": { "reveal": "silent", "focus": false } in a task, run the task, if the task has no problem matcher defined, or finishes without having errors (warnings and infos are not considered errors), the terminal should not get focus
3.6 Replicate 3.5 with a task whose problem matcher finds errors from the task output - the terminal should get focus immediately after the first error is found.

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)
