### PR TITLE
[theming] fix hardcoded search result overview ruler color

### DIFF
--- a/packages/search-in-workspace/src/browser/search-in-workspace-result-tree-widget.tsx
+++ b/packages/search-in-workspace/src/browser/search-in-workspace-result-tree-widget.tsx
@@ -41,6 +41,7 @@ import URI from '@theia/core/lib/common/uri';
 import * as React from 'react';
 import { SearchInWorkspacePreferences } from './search-in-workspace-preferences';
 import { ProgressService } from '@theia/core';
+import { ColorRegistry } from '@theia/core/lib/browser/color-registry';
 
 const ROOT_ID = 'ResultTree';
 
@@ -118,6 +119,7 @@ export class SearchInWorkspaceResultTreeWidget extends TreeWidget {
     @inject(TreeExpansionService) protected readonly expansionService: TreeExpansionService;
     @inject(SearchInWorkspacePreferences) protected readonly searchInWorkspacePreferences: SearchInWorkspacePreferences;
     @inject(ProgressService) protected readonly progressService: ProgressService;
+    @inject(ColorRegistry) protected readonly colorRegistry: ColorRegistry;
 
     constructor(
         @inject(TreeProps) readonly props: TreeProps,
@@ -759,8 +761,8 @@ export class SearchInWorkspaceResultTreeWidget extends TreeWidget {
                     },
                     options: {
                         overviewRuler: {
-                            color: 'rgba(230, 0, 0, 1)',
-                            position: OverviewRulerLane.Full
+                            color: this.colorRegistry.getCurrentColor('editor.findMatchHighlightBackground') || '',
+                            position: OverviewRulerLane.Center
                         },
                         className: res.selected ? 'current-search-in-workspace-editor-match' : 'search-in-workspace-editor-match',
                         stickiness: TrackedRangeStickiness.GrowsOnlyWhenTypingBefore


### PR DESCRIPTION



<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

Fixes #6819

- fixes the hardcoded value for the `overviewRuler` to instead use theme color when a search result is present.
- aligns the `overviewRuler` decoration position with VS Code.

| Before | After |
|:---:|:---:|
| <img width="194" alt="Screen Shot 2020-01-03 at 4 19 19 PM" src="https://user-images.githubusercontent.com/40359487/71750244-d8044100-2e45-11ea-9467-41a676ea68ef.png"> | <img width="196" alt="Screen Shot 2020-01-03 at 4 22 29 PM" src="https://user-images.githubusercontent.com/40359487/71750254-dcc8f500-2e45-11ea-921c-d2620b4c463d.png"> |

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
1. verify with multiple themes
2. perform a search through the `search-in-workspace` widget, the decoration should be fixed

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

Signed-off-by: vince-fugnitto <vincent.fugnitto@ericsson.com>
