### PR TITLE
Add info about processId and terminalId to TaskExitedEvent

### DIFF
--- a/packages/task/src/common/task-protocol.ts
+++ b/packages/task/src/common/task-protocol.ts
@@ -144,6 +144,9 @@ export interface TaskExitedEvent {
     readonly signal?: string;
 
     readonly config?: TaskConfiguration;
+
+    readonly terminalId?: number;
+    readonly processId?: number;
 }
 
 export interface TaskOutputEvent {

--- a/packages/task/src/node/process/process-task.ts
+++ b/packages/task/src/node/process/process-task.ts
@@ -115,7 +115,9 @@ export class ProcessTask extends Task {
             ctx: this.context,
             code: evt.code,
             signal: evt.signal,
-            config: this.options.config
+            config: this.options.config,
+            terminalId: this.process.id,
+            processId: this.process.id
         };
     }
 


### PR DESCRIPTION
#### What it does
Add `processId` and `terminalId` to `TaskExitedEvent`.
These fields [are available](https://github.com/eclipse-theia/theia/blob/2d9ebcf95b01a5f24bd05b543bedd9e93eb49519/packages/task/src/node/process/process-task.ts#L129-L130) in `TaskInfo` while a task is running, would be nice to have this info when a task is completed. It can be useful to find the corresponding terminal widget, for example. 


#### How to test
The PR changes do not provide a new functionality.
The fields are optional, so I think the PR doesn't bring the breaking changes.   

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

Signed-off-by: Roman Nikitenko <rnikiten@redhat.com>