### PR TITLE
[keybinding] parse minus as key

### DIFF
--- a/packages/core/src/browser/keyboard/keys.spec.ts
+++ b/packages/core/src/browser/keyboard/keys.spec.ts
@@ -227,4 +227,29 @@ describe('keys api', () => {
         expect(first.key).is.equal(Key.F10);
         expect(second.key).is.equal(Key.KEY_B);
     });
+
+    it('should parse minus as key', () => {
+        const keycode = KeyCode.parse('ctrl+-');
+        expect(keycode.ctrl).to.be.true;
+        expect(keycode.key).is.equal(Key.MINUS);
+    });
+
+    it('should parse minus as key and seprator', () => {
+        const keycode = KeyCode.parse('ctrl--');
+        expect(keycode.ctrl).to.be.true;
+        expect(keycode.key).is.equal(Key.MINUS);
+    });
+
+    it('should parse plus as separator', () => {
+        const keycode = KeyCode.parse('ctrl-+-');
+        expect(keycode.ctrl).to.be.true;
+        expect(keycode.key).is.equal(Key.MINUS);
+    });
+
+    it('should not parse plus as key but separator', () => {
+        const keycode = KeyCode.parse('ctrl++-');
+        expect(keycode.ctrl).to.be.true;
+        expect(keycode.key).is.equal(Key.MINUS);
+    });
+
 });

--- a/packages/core/src/browser/keyboard/keys.ts
+++ b/packages/core/src/browser/keyboard/keys.ts
@@ -236,7 +236,19 @@ export class KeyCode {
         }
 
         const schema: KeyCodeSchema = {};
-        const keys = keybinding.trim().toLowerCase().split(/[-+]/g);
+        const keys = [];
+        let currentKey = '';
+        for (const character of keybinding.trim().toLowerCase()) {
+            if (currentKey && (character === '-' || character === '+')) {
+                keys.push(currentKey);
+                currentKey = '';
+            } else if (character !== '+') {
+                currentKey += character;
+            }
+        }
+        if (currentKey) {
+            keys.push(currentKey);
+        }
         /* If duplicates i.e ctrl+ctrl+a or alt+alt+b or b+alt+b it is invalid */
         if (keys.length !== new Set(keys).size) {
             throw new Error(`Can't parse keybinding ${keybinding} Duplicate modifiers`);


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

- fix #6826 Fix regression which broke parsing minus as a key

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

- try to use keybindings with minus, like to go back

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

