### PR TITLE
[filesystem] fix type check during `uriCompare`

### DIFF
--- a/packages/filesystem/src/browser/file-tree/file-tree.ts
+++ b/packages/filesystem/src/browser/file-tree/file-tree.ts
@@ -121,13 +121,13 @@ export namespace DirNode {
     }
 
     export function uriCompare(node: TreeNode, node2: TreeNode): number {
-        if (FileNode.is(node)) {
-            if (FileNode.is(node2)) {
+        if (FileStatNode.is(node)) {
+            if (FileStatNode.is(node2)) {
                 return node.uri.displayName.localeCompare(node2.uri.displayName);
             }
             return 1;
         }
-        if (FileNode.is(node2)) {
+        if (FileStatNode.is(node2)) {
             return -1;
         }
         return 0;


### PR DESCRIPTION

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

Fixes #6828

Fixes an issue from the filesystem `uriCompare` which was not taking into account if a node was a directory which resulted in inconsistent ordering, for instance from the `Explorer` widget.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

1. start the application using both the browser and electron, the explorer ordering of nodes should be correct

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

Signed-off-by: Vincent Fugnitto <vincent.fugnitto@ericsson.com>
