### PR TITLE
[monaco] fix incorrect color from editor peek widget

### DIFF
--- a/packages/monaco/src/browser/style/index.css
+++ b/packages/monaco/src/browser/style/index.css
@@ -90,3 +90,7 @@
 .monaco-scrollable-element > .scrollbar.horizontal > .slider {
     height: var(--theia-scrollbar-width) !important;
 }
+
+.monaco-editor .reference-zone-widget .ref-tree .referenceMatch .highlight {
+    color: unset !important;
+}


### PR DESCRIPTION

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

Fixes #6827

Fixes an issue from the `peek` widget for the highlighted match.

<div align='center'>

![image](https://user-images.githubusercontent.com/40359487/71832048-1e40e680-3078-11ea-9be2-5e0a4c718289.png)

</div>


#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

Signed-off-by: Vincent Fugnitto <vincent.fugnitto@ericsson.com>

---

For reference, https://github.com/microsoft/vscode/blob/67acfd62e1f28e19ae5027f31e864e8ead103bc3/src/vs/workbench/browser/parts/views/customView.ts#L678-L681