### PR TITLE
[markers] add problem color decoration preference

### DIFF
--- a/packages/markers/src/browser/problem/problem-decorator.ts
+++ b/packages/markers/src/browser/problem/problem-decorator.ts
@@ -47,7 +47,8 @@ export class ProblemDecorator implements TreeDecorator {
     protected init(): void {
         this.problemPreferences.onPreferenceChanged((event: PreferenceChangeEvent<ProblemConfiguration>) => {
             const { preferenceName } = event;
-            if (preferenceName === 'problems.decorations.enabled') {
+            if (preferenceName === 'problems.decorations.enabled' ||
+                preferenceName === 'problems.decorations.colors.enabled') {
                 this.fireDidChangeDecorations((tree: Tree) => this.collectDecorators(tree));
             }
         });
@@ -130,6 +131,9 @@ export class ProblemDecorator implements TreeDecorator {
         const icon = this.getOverlayIcon(marker);
         const color = this.getOverlayIconColor(marker);
         return {
+            fontData: {
+                color: !!this.problemPreferences['problems.decorations.colors.enabled'] ? color : '',
+            },
             iconOverlay: {
                 position,
                 icon,

--- a/packages/markers/src/browser/problem/problem-preferences.ts
+++ b/packages/markers/src/browser/problem/problem-preferences.ts
@@ -25,6 +25,11 @@ export const ProblemConfigSchema: PreferenceSchema = {
             'description': 'Show problem decorators (diagnostic markers) in tree widgets.',
             'default': true,
         },
+        'problems.decorations.colors.enabled': {
+            'type': 'boolean',
+            'description': 'Show problem color decorations in tree widgets.',
+            'default': false,
+        },
         'problems.decorations.tabbar.enabled': {
             'type': 'boolean',
             'description': 'Show problem decorators (diagnostic markers) in the tab bars.',
@@ -35,7 +40,8 @@ export const ProblemConfigSchema: PreferenceSchema = {
 
 export interface ProblemConfiguration {
     'problems.decorations.enabled': boolean,
-    'problems.decorations.tabbar.enabled': boolean
+    'problems.decorations.colors.enabled': boolean,
+    'problems.decorations.tabbar.enabled': boolean,
 }
 
 export const ProblemPreferences = Symbol('ProblemPreferences');


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

- added a new preference `problems.decorations.colors.enabled` which controls whether to update tree widget nodes with foreground colors based on available diagnostic markers.
- the new preference is set to `false` as to not break behavior of existing applications (breaking behavior is now displaying markers differently in tree nodes).
- the new preference is listened to in order to provide instant effect when updating the value in the `settings.json`.

| Preference Off (Default) | Preference On |
|:---:|:---:|
| <img width="1316" alt="Screen Shot 2020-01-06 at 7 38 34 PM" src="https://user-images.githubusercontent.com/40359487/71859592-6b937700-30bd-11ea-817d-edcb973df2de.png"> | <img width="1316" alt="Screen Shot 2020-01-06 at 7 38 06 PM" src="https://user-images.githubusercontent.com/40359487/71859610-7f3edd80-30bd-11ea-8db5-13c333bd0758.png"> |

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
1. start the application, add problem markers to existing files (errors, warnings).
2. open the explorer
3. update the preference value `problems.decorations.colors.enabled` and verify that the file nodes containing the markers are successfully updated with their colors similarly to their icons.

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

Signed-off-by: vince-fugnitto <vincent.fugnitto@ericsson.com>
