### PR TITLE
Add 'Toggle Minimap' menu item

### DIFF
--- a/packages/editor/src/browser/editor-menu.ts
+++ b/packages/editor/src/browser/editor-menu.ts
@@ -16,7 +16,7 @@
 
 import { injectable } from 'inversify';
 import { MenuContribution, MenuModelRegistry, MenuPath, MAIN_MENU_BAR } from '@theia/core';
-import { CommonCommands } from '@theia/core/lib/browser';
+import { CommonCommands, CommonMenus } from '@theia/core/lib/browser';
 import { EditorCommands } from './editor-command';
 
 export const EDITOR_CONTEXT_MENU: MenuPath = ['editor_context_menu'];
@@ -84,6 +84,11 @@ export class EditorMenuContribution implements MenuContribution {
         registry.registerMenuAction(EditorMainMenu.NAVIGATION_GROUP, {
             commandId: EditorCommands.GO_LAST_EDIT.id,
             label: 'Last Edit Location'
+        });
+
+        registry.registerMenuAction(CommonMenus.VIEW_LAYOUT, {
+            commandId: EditorCommands.TOGGLE_MINIMAP.id,
+            label: 'Show Minimap'
         });
     }
 

--- a/packages/editor/src/browser/editor-navigation-contribution.ts
+++ b/packages/editor/src/browser/editor-navigation-contribution.ts
@@ -79,7 +79,8 @@ export class EditorNavigationContribution implements Disposable, FrontendApplica
         });
         this.commandRegistry.registerHandler(EditorCommands.TOGGLE_MINIMAP.id, {
             execute: () => this.toggleMinimap(),
-            isEnabled: () => true
+            isEnabled: () => true,
+            isToggled: () => this.isMinimapEnabled()
         });
     }
 
@@ -165,6 +166,10 @@ export class EditorNavigationContribution implements Disposable, FrontendApplica
             }
             this.locationStack.register(...locations);
         }
+    }
+
+    private isMinimapEnabled(): boolean {
+        return !!this.preferenceService.get('editor.minimap.enabled');
     }
 
 }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

- adds the `toggle minimap` menu item to the view menu.
- updates the existing command to display `toggle` (checkmark) icon when the minimap is enabled/disabled.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
1. open an editor
2. click `View` > `Toggle Minimap`
2.1 the command should work properly (update the editor with minimap on/off)
2.2 the command should properly display toggle (checkmark to reflect on/off)

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

Signed-off-by: Vincent Fugnitto <vincent.fugnitto@ericsson.com>
