### PR TITLE
[editor] add command to 'toggle render whitespace'

### DIFF
--- a/packages/editor/src/browser/editor-command.ts
+++ b/packages/editor/src/browser/editor-command.ts
@@ -117,6 +117,14 @@ export namespace EditorCommands {
         category: 'View',
         label: 'Toggle Minimap'
     };
+    /**
+     * Command that toggles the rendering of whitespace.
+     */
+    export const TOGGLE_RENDER_WHITESPACE: Command = {
+        id: 'editor.action.toggleRenderWhitespace',
+        category: 'View',
+        label: 'Toggle Render Whitespace'
+    };
 }
 
 @injectable()
@@ -169,6 +177,7 @@ export class EditorCommandContribution implements CommandContribution {
         registry.registerCommand(EditorCommands.GO_LAST_EDIT);
         registry.registerCommand(EditorCommands.CLEAR_EDITOR_HISTORY);
         registry.registerCommand(EditorCommands.TOGGLE_MINIMAP);
+        registry.registerCommand(EditorCommands.TOGGLE_RENDER_WHITESPACE);
 
         registry.registerCommand(CommonCommands.AUTO_SAVE, {
             isToggled: () => this.isAutoSaveOn(),

--- a/packages/editor/src/browser/editor-menu.ts
+++ b/packages/editor/src/browser/editor-menu.ts
@@ -16,7 +16,7 @@
 
 import { injectable } from 'inversify';
 import { MenuContribution, MenuModelRegistry, MenuPath, MAIN_MENU_BAR } from '@theia/core';
-import { CommonCommands } from '@theia/core/lib/browser';
+import { CommonCommands, CommonMenus } from '@theia/core/lib/browser';
 import { EditorCommands } from './editor-command';
 
 export const EDITOR_CONTEXT_MENU: MenuPath = ['editor_context_menu'];
@@ -84,6 +84,11 @@ export class EditorMenuContribution implements MenuContribution {
         registry.registerMenuAction(EditorMainMenu.NAVIGATION_GROUP, {
             commandId: EditorCommands.GO_LAST_EDIT.id,
             label: 'Last Edit Location'
+        });
+
+        registry.registerMenuAction(CommonMenus.VIEW_LAYOUT, {
+            commandId: EditorCommands.TOGGLE_RENDER_WHITESPACE.id,
+            label: 'Render Whitespace',
         });
     }
 

--- a/packages/editor/src/browser/editor-navigation-contribution.ts
+++ b/packages/editor/src/browser/editor-navigation-contribution.ts
@@ -81,6 +81,11 @@ export class EditorNavigationContribution implements Disposable, FrontendApplica
             execute: () => this.toggleMinimap(),
             isEnabled: () => true
         });
+        this.commandRegistry.registerHandler(EditorCommands.TOGGLE_RENDER_WHITESPACE.id, {
+            execute: () => this.toggleRenderWhitespace(),
+            isEnabled: () => true,
+            isToggled: () => this.isRenderWhitespaceEnabled()
+        });
     }
 
     async onStart(): Promise<void> {
@@ -102,6 +107,20 @@ export class EditorNavigationContribution implements Disposable, FrontendApplica
     protected async toggleMinimap(): Promise<void> {
         const value: boolean | undefined = this.preferenceService.get('editor.minimap.enabled');
         this.preferenceService.set('editor.minimap.enabled', !value, PreferenceScope.User);
+    }
+
+    /**
+     * Toggle the rendering of whitespace in the editor.
+     */
+    protected async toggleRenderWhitespace(): Promise<void> {
+        const renderWhitespace: string | undefined = this.preferenceService.get('editor.renderWhitespace');
+        let updatedRenderWhitespace: string;
+        if (renderWhitespace === 'none') {
+            updatedRenderWhitespace = 'all';
+        } else {
+            updatedRenderWhitespace = 'none';
+        }
+        this.preferenceService.set('editor.renderWhitespace', updatedRenderWhitespace, PreferenceScope.User);
     }
 
     protected onCurrentEditorChanged(editorWidget: EditorWidget | undefined): void {
@@ -165,6 +184,11 @@ export class EditorNavigationContribution implements Disposable, FrontendApplica
             }
             this.locationStack.register(...locations);
         }
+    }
+
+    private isRenderWhitespaceEnabled(): boolean {
+        const renderWhitespace = this.preferenceService.get('editor.renderWhitespace');
+        return renderWhitespace === 'none' ? false : true;
     }
 
 }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

Added a new command `Toggle Render Whitespace` which controls the rendering of whitespaces in the editor. The command also includes a menu item present in the `View` menu and displays the toggle.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
1. open an editor
2. execute the command `Toggle Render Whitespace` which updates the rendering of whitespace present in the editor.

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

Signed-off-by: Vincent Fugnitto <vincent.fugnitto@ericsson.com>
