### PR TITLE
[editor] add misc toggle commands to the view menu

### DIFF
--- a/packages/core/src/browser/common-frontend-contribution.ts
+++ b/packages/core/src/browser/common-frontend-contribution.ts
@@ -68,6 +68,7 @@ export namespace CommonMenus {
     export const VIEW_PRIMARY = [...VIEW, '0_primary'];
     export const VIEW_VIEWS = [...VIEW, '1_views'];
     export const VIEW_LAYOUT = [...VIEW, '2_layout'];
+    export const VIEW_TOGGLE = [...VIEW, '3_toggle'];
 
     // last menu item
     export const HELP = [...MAIN_MENU_BAR, '9_help'];

--- a/packages/editor/src/browser/editor-command.ts
+++ b/packages/editor/src/browser/editor-command.ts
@@ -117,6 +117,14 @@ export namespace EditorCommands {
         category: 'View',
         label: 'Toggle Minimap'
     };
+    /**
+     * Command that toggles the rendering of whitespace characters in the editor.
+     */
+    export const TOGGLE_RENDER_WHITESPACE: Command = {
+        id: 'editor.action.toggleRenderWhitespace',
+        category: 'View',
+        label: 'Toggle Render Whitespace'
+    };
 }
 
 @injectable()
@@ -169,6 +177,7 @@ export class EditorCommandContribution implements CommandContribution {
         registry.registerCommand(EditorCommands.GO_LAST_EDIT);
         registry.registerCommand(EditorCommands.CLEAR_EDITOR_HISTORY);
         registry.registerCommand(EditorCommands.TOGGLE_MINIMAP);
+        registry.registerCommand(EditorCommands.TOGGLE_RENDER_WHITESPACE);
 
         registry.registerCommand(CommonCommands.AUTO_SAVE, {
             isToggled: () => this.isAutoSaveOn(),

--- a/packages/editor/src/browser/editor-command.ts
+++ b/packages/editor/src/browser/editor-command.ts
@@ -125,6 +125,14 @@ export namespace EditorCommands {
         category: 'View',
         label: 'Toggle Render Whitespace'
     };
+    /**
+     * Command that toggles the word wrap.
+     */
+    export const TOGGLE_WORD_WRAP: Command = {
+        id: 'editor.action.toggleWordWrap',
+        category: 'View',
+        label: 'Toggle Word Wrap'
+    };
 }
 
 @injectable()
@@ -178,6 +186,7 @@ export class EditorCommandContribution implements CommandContribution {
         registry.registerCommand(EditorCommands.CLEAR_EDITOR_HISTORY);
         registry.registerCommand(EditorCommands.TOGGLE_MINIMAP);
         registry.registerCommand(EditorCommands.TOGGLE_RENDER_WHITESPACE);
+        registry.registerCommand(EditorCommands.TOGGLE_WORD_WRAP);
 
         registry.registerCommand(CommonCommands.AUTO_SAVE, {
             isToggled: () => this.isAutoSaveOn(),

--- a/packages/editor/src/browser/editor-keybinding.ts
+++ b/packages/editor/src/browser/editor-keybinding.ts
@@ -35,6 +35,10 @@ export class EditorKeybindingContribution implements KeybindingContribution {
             {
                 command: EditorCommands.GO_LAST_EDIT.id,
                 keybinding: 'ctrl+alt+q'
+            },
+            {
+                command: EditorCommands.TOGGLE_WORD_WRAP.id,
+                keybinding: 'alt+z'
             }
         );
     }

--- a/packages/editor/src/browser/editor-menu.ts
+++ b/packages/editor/src/browser/editor-menu.ts
@@ -88,6 +88,11 @@ export class EditorMenuContribution implements MenuContribution {
 
         // Toggle Commands.
         registry.registerMenuAction(CommonMenus.VIEW_TOGGLE, {
+            commandId: EditorCommands.TOGGLE_WORD_WRAP.id,
+            label: EditorCommands.TOGGLE_WORD_WRAP.label,
+            order: '0'
+        });
+        registry.registerMenuAction(CommonMenus.VIEW_TOGGLE, {
             commandId: EditorCommands.TOGGLE_MINIMAP.id,
             label: 'Show Minimap',
             order: '1',

--- a/packages/editor/src/browser/editor-menu.ts
+++ b/packages/editor/src/browser/editor-menu.ts
@@ -16,7 +16,7 @@
 
 import { injectable } from 'inversify';
 import { MenuContribution, MenuModelRegistry, MenuPath, MAIN_MENU_BAR } from '@theia/core';
-import { CommonCommands } from '@theia/core/lib/browser';
+import { CommonCommands, CommonMenus } from '@theia/core/lib/browser';
 import { EditorCommands } from './editor-command';
 
 export const EDITOR_CONTEXT_MENU: MenuPath = ['editor_context_menu'];
@@ -84,6 +84,12 @@ export class EditorMenuContribution implements MenuContribution {
         registry.registerMenuAction(EditorMainMenu.NAVIGATION_GROUP, {
             commandId: EditorCommands.GO_LAST_EDIT.id,
             label: 'Last Edit Location'
+        });
+
+        // Toggle Commands.
+        registry.registerMenuAction(CommonMenus.VIEW_TOGGLE, {
+            commandId: EditorCommands.TOGGLE_MINIMAP.id,
+            label: 'Show Minimap'
         });
     }
 

--- a/packages/editor/src/browser/editor-menu.ts
+++ b/packages/editor/src/browser/editor-menu.ts
@@ -89,7 +89,13 @@ export class EditorMenuContribution implements MenuContribution {
         // Toggle Commands.
         registry.registerMenuAction(CommonMenus.VIEW_TOGGLE, {
             commandId: EditorCommands.TOGGLE_MINIMAP.id,
-            label: 'Show Minimap'
+            label: 'Show Minimap',
+            order: '1',
+        });
+        registry.registerMenuAction(CommonMenus.VIEW_TOGGLE, {
+            commandId: EditorCommands.TOGGLE_RENDER_WHITESPACE.id,
+            label: 'Render Whitespace',
+            order: '2'
         });
     }
 

--- a/packages/editor/src/browser/editor-navigation-contribution.ts
+++ b/packages/editor/src/browser/editor-navigation-contribution.ts
@@ -82,6 +82,11 @@ export class EditorNavigationContribution implements Disposable, FrontendApplica
             isEnabled: () => true,
             isToggled: () => this.isMinimapEnabled()
         });
+        this.commandRegistry.registerHandler(EditorCommands.TOGGLE_RENDER_WHITESPACE.id, {
+            execute: () => this.toggleRenderWhitespace(),
+            isEnabled: () => true,
+            isToggled: () => this.isRenderWhitespaceEnabled()
+        });
     }
 
     async onStart(): Promise<void> {
@@ -103,6 +108,20 @@ export class EditorNavigationContribution implements Disposable, FrontendApplica
     protected async toggleMinimap(): Promise<void> {
         const value: boolean | undefined = this.preferenceService.get('editor.minimap.enabled');
         this.preferenceService.set('editor.minimap.enabled', !value, PreferenceScope.User);
+    }
+
+    /**
+     * Toggle the rendering of whitespace in the editor.
+     */
+    protected async toggleRenderWhitespace(): Promise<void> {
+        const renderWhitespace: string | undefined = this.preferenceService.get('editor.renderWhitespace');
+        let updatedRenderWhitespace: string;
+        if (renderWhitespace === 'none') {
+            updatedRenderWhitespace = 'all';
+        } else {
+            updatedRenderWhitespace = 'none';
+        }
+        this.preferenceService.set('editor.renderWhitespace', updatedRenderWhitespace, PreferenceScope.User);
     }
 
     protected onCurrentEditorChanged(editorWidget: EditorWidget | undefined): void {
@@ -170,6 +189,11 @@ export class EditorNavigationContribution implements Disposable, FrontendApplica
 
     private isMinimapEnabled(): boolean {
         return !!this.preferenceService.get('editor.minimap.enabled');
+    }
+
+    private isRenderWhitespaceEnabled(): boolean {
+        const renderWhitespace = this.preferenceService.get('editor.renderWhitespace');
+        return renderWhitespace === 'none' ? false : true;
     }
 
 }

--- a/packages/editor/src/browser/editor-navigation-contribution.ts
+++ b/packages/editor/src/browser/editor-navigation-contribution.ts
@@ -87,6 +87,10 @@ export class EditorNavigationContribution implements Disposable, FrontendApplica
             isEnabled: () => true,
             isToggled: () => this.isRenderWhitespaceEnabled()
         });
+        this.commandRegistry.registerHandler(EditorCommands.TOGGLE_WORD_WRAP.id, {
+            execute: () => this.toggleWordWrap(),
+            isEnabled: () => true,
+        });
     }
 
     async onStart(): Promise<void> {
@@ -100,6 +104,24 @@ export class EditorNavigationContribution implements Disposable, FrontendApplica
 
     dispose(): void {
         this.toDispose.dispose();
+    }
+
+    /**
+     * Toggle the editor word wrap behavior.
+     */
+    protected async toggleWordWrap(): Promise<void> {
+        // Get the current word wrap.
+        const wordWrap: string | undefined = this.preferenceService.get('editor.wordWrap');
+        if (wordWrap === undefined) {
+            return;
+        }
+        // The list of allowed word wrap values.
+        const values: string[] = ['off', 'on', 'wordWrapColumn', 'bounded'];
+        // Get the index of the current value, and toggle to the next available value.
+        const index = values.indexOf(wordWrap) + 1;
+        if (index > -1) {
+            this.preferenceService.set('editor.wordWrap', values[index % values.length], PreferenceScope.User);
+        }
     }
 
     /**

--- a/packages/editor/src/browser/editor-navigation-contribution.ts
+++ b/packages/editor/src/browser/editor-navigation-contribution.ts
@@ -79,7 +79,8 @@ export class EditorNavigationContribution implements Disposable, FrontendApplica
         });
         this.commandRegistry.registerHandler(EditorCommands.TOGGLE_MINIMAP.id, {
             execute: () => this.toggleMinimap(),
-            isEnabled: () => true
+            isEnabled: () => true,
+            isToggled: () => this.isMinimapEnabled()
         });
     }
 
@@ -165,6 +166,10 @@ export class EditorNavigationContribution implements Disposable, FrontendApplica
             }
             this.locationStack.register(...locations);
         }
+    }
+
+    private isMinimapEnabled(): boolean {
+        return !!this.preferenceService.get('editor.minimap.enabled');
     }
 
 }


### PR DESCRIPTION
#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

**`View: Toggle Word Wrap`:**
 
Fixes #2433

Adds the command, menu item, and keybinding which is used to toggle between the available word wrap values: (off, on, wordWrapColumn, bounded).

**`View Toggle Minimap`:** 

Adds the missing view menu item to toggle the display of the minimap.
Adds the `isToggled` property to display the checkmark when the setting is `on`/`off`. 

**`View: Toggle Render Whitespace`:**

Adds the command, and menu item to control the rendering of whitespace characters in the editor.
Adds the `isToggled` property to display the checkmark when the setting is `on`/`off`. 

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
- verify the command `toggle word wrap` (should properly cycle between possible values)
- verify the command `toggle minimap` (should properly turn the minimap on/off)
- verify the command `toggle render whitespace` (should properly turn the rendering of whitespace characters on/off)

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

