### PR TITLE
[theming] adjust tree node foreground color when active

### DIFF
--- a/packages/core/src/browser/style/tree.css
+++ b/packages/core/src/browser/style/tree.css
@@ -85,7 +85,14 @@
 .theia-Tree:focus .theia-TreeNode.theia-mod-selected,
 .theia-Tree .ReactVirtualized__List:focus .theia-TreeNode.theia-mod-selected {
     background: var(--theia-list-activeSelectionBackground);
-    color: var(--theia-list-activeSelectionForeground);
+    color: var(--theia-list-activeSelectionForeground) !important;
+}
+
+.theia-Tree:focus .theia-TreeNode.theia-mod-selected .theia-TreeNodeTail,
+.theia-Tree .ReactVirtualized__List:focus .theia-TreeNode.theia-mod-selected .theia-TreeNodeTail,
+.theia-Tree:focus .theia-TreeNode.theia-mod-selected .theia-caption-suffix,
+.theia-Tree .ReactVirtualized__List:focus .theia-TreeNode.theia-mod-selected .theia-caption-suffix {
+    color: var(--theia-list-activeSelectionForeground) !important;
 }
 
 .theia-Tree .theia-TreeNode.theia-mod-selected {


### PR DESCRIPTION

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

Fixes #3960
Fixes #6831

With this change, when a tree node is active, the entire node content, the `tail` and `suffixes` are displayed with the same `activeSelectionForeground` which helps in visibility, the overall look, and also aligns with VS Code. Previously, for certain themes, the colors were difficult to see.

Below are a few examples highlighting the `git` decoration:

_Theia Light_:

<img width="655" alt="Screen Shot 2020-01-08 at 10 13 55 AM" src="https://user-images.githubusercontent.com/40359487/71989544-dfd63380-31ff-11ea-8e94-51c7594ffdf4.png">

_Dark+_:

<img width="660" alt="Screen Shot 2020-01-08 at 10 14 43 AM" src="https://user-images.githubusercontent.com/40359487/71989596-f41a3080-31ff-11ea-997b-edd6ef8852ec.png">

_Horizon_:

<img width="661" alt="Screen Shot 2020-01-08 at 10 14 27 AM" src="https://user-images.githubusercontent.com/40359487/71989613-fb413e80-31ff-11ea-8960-080f2887a7f0.png">


#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

1. open a workspace under source control.
2. make some arbitrary changes (modifications, additions, deletions) to a file.
3. for the file in question, verify that the tree node in the explorer correctly updates it's decoration when the node is active.
4. open the preferences, verify that the description (suffix) is correctly displayed when active.

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

Signed-off-by: vince-fugnitto <vincent.fugnitto@ericsson.com>
