### PR TITLE
Fix add missing await on workspace edits file create

### DIFF
--- a/packages/monaco/src/browser/monaco-workspace.ts
+++ b/packages/monaco/src/browser/monaco-workspace.ts
@@ -363,7 +363,7 @@ export class MonacoWorkspace implements lang.Workspace {
                     totalFiles += 1;
                     totalEdits += editOperations.length;
                 } else if (CreateResourceEdit.is(edit) || DeleteResourceEdit.is(edit) || RenameResourceEdit.is(edit)) {
-                    this.performResourceEdit(edit);
+                    await this.performResourceEdit(edit);
                 } else {
                     throw new Error(`Unexpected edit type: ${JSON.stringify(edit)}`);
                 }


### PR DESCRIPTION
Signed-off-by: Amiram Wingarten <amiram.wingarten@sap.com>

#### What it does
Fixes a missing await for file creation done as part of workspace edits.

#### How to test

VS Code extension containing code like the below will create an empty file as the promise does not wait for the file to be created.

 ```javascript
let we = new vscode.WorkspaceEdit();
let pathUri = vscode.Uri.file(path);
we.createFile(pathUri);
vscode.workspace.applyEdit(we).then(function() {
  writeFileSync(tasksPathUri.fsPath, "some content");
});
```

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

