### PR TITLE
#6308: Close websocket channel when a language server connection is closed

### DIFF
--- a/packages/core/src/common/messaging/web-socket-channel.ts
+++ b/packages/core/src/common/messaging/web-socket-channel.ts
@@ -93,6 +93,20 @@ export class WebSocketChannel implements IWebSocket {
         this.fireClose(code, reason);
     }
 
+    tryClose(code: number = 1000, reason: string = ''): void {
+        if (this.closing || this.toDispose.disposed) {
+            // Do not try to close the channel if it is already closing or disposed.
+            return;
+        }
+        this.doSend(JSON.stringify(<WebSocketChannel.CloseMessage>{
+            kind: 'close',
+            id: this.id,
+            code,
+            reason
+        }));
+        this.fireClose(code, reason);
+    }
+
     protected fireOpen: () => void = () => { };
     onOpen(cb: () => void): void {
         this.checkNotDisposed();

--- a/packages/core/src/node/messaging/messaging-contribution.ts
+++ b/packages/core/src/node/messaging/messaging-contribution.ts
@@ -27,7 +27,7 @@ import * as launch from 'vscode-ws-jsonrpc/lib/server/launch';
 import { ContributionProvider, ConnectionHandler, bindContributionProvider } from '../../common';
 import { WebSocketChannel } from '../../common/messaging/web-socket-channel';
 import { BackendApplicationContribution } from '../backend-application';
-import { MessagingService } from './messaging-service';
+import { MessagingService, WebSocketChannelConnection } from './messaging-service';
 import { ConsoleLogger } from './logger';
 import { ConnectionContainerModule } from './connection-container-module';
 
@@ -68,7 +68,7 @@ export class MessagingContribution implements BackendApplicationContribution, Me
     forward(spec: string, callback: (params: MessagingService.PathParams, connection: IConnection) => void): void {
         this.wsChannel(spec, (params, channel) => {
             const connection = launch.createWebSocketConnection(channel);
-            callback(params, connection);
+            callback(params, WebSocketChannelConnection.create(connection, channel));
         });
     }
 

--- a/packages/core/src/node/messaging/messaging-service.ts
+++ b/packages/core/src/node/messaging/messaging-service.ts
@@ -54,3 +54,18 @@ export namespace MessagingService {
         configure(service: MessagingService): void;
     }
 }
+
+export interface WebSocketChannelConnection extends IConnection {
+    channel: WebSocketChannel;
+}
+export namespace WebSocketChannelConnection {
+    export function is(connection: IConnection): connection is WebSocketChannelConnection {
+        return (connection as WebSocketChannelConnection).channel instanceof WebSocketChannel;
+    }
+
+    export function create(connection: IConnection, channel: WebSocketChannel): WebSocketChannelConnection {
+        const result = connection as WebSocketChannelConnection;
+        result.channel = channel;
+        return result;
+    }
+}

--- a/packages/languages/src/node/language-server-contribution.ts
+++ b/packages/languages/src/node/language-server-contribution.ts
@@ -26,6 +26,7 @@ import {
     IConnection
 } from 'vscode-ws-jsonrpc/lib/server';
 import { MaybePromise } from '@theia/core/lib/common';
+import { WebSocketChannelConnection } from '@theia/core/lib/node/messaging';
 import { LanguageContribution } from '../common';
 import { RawProcess, RawProcessFactory } from '@theia/process/lib/node/raw-process';
 import { ProcessManager } from '@theia/process/lib/node/process-manager';
@@ -61,6 +62,9 @@ export abstract class BaseLanguageServerContribution implements LanguageServerCo
     abstract start(clientConnection: IConnection, options: LanguageServerStartOptions): void;
     protected forward(clientConnection: IConnection, serverConnection: IConnection): void {
         forward(clientConnection, serverConnection, this.map.bind(this));
+        if (WebSocketChannelConnection.is(clientConnection)) {
+            serverConnection.onClose(() => clientConnection.channel.tryClose());
+        }
     }
 
     protected map(message: Message): Message {


### PR DESCRIPTION
#### What it does
Fixes #6308.

#### How to test
Add the following line to `json-starter.ts`
```typescript
setTimeout(() => process.exit(1), 5000);
```
Without this fix, the JSON language server stops working after 5 seconds. With the fix, the server is restarted every 5 seconds.

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

