### PR TITLE
[markers] add problem decorator fontData

### DIFF
--- a/packages/markers/src/browser/problem/problem-decorator.ts
+++ b/packages/markers/src/browser/problem/problem-decorator.ts
@@ -130,7 +130,12 @@ export class ProblemDecorator implements TreeDecorator {
         const position = TreeDecoration.IconOverlayPosition.BOTTOM_RIGHT;
         const icon = this.getOverlayIcon(marker);
         const color = this.getOverlayIconColor(marker);
+        const priority = this.getPriority(marker);
         return {
+            priority,
+            fontData: {
+                color,
+            },
             iconOverlay: {
                 position,
                 icon,
@@ -139,7 +144,7 @@ export class ProblemDecorator implements TreeDecorator {
                     shape: 'circle',
                     color: 'transparent'
                 }
-            }
+            },
         };
     }
 
@@ -160,6 +165,21 @@ export class ProblemDecorator implements TreeDecorator {
             case 2: return 'var(--theia-editorWarning-foreground)';
             case 3: return 'var(--theia-editorInfo-foreground)';
             default: return 'var(--theia-successBackground)';
+        }
+    }
+
+    /**
+     * Get the decoration for a given marker diagnostic.
+     * Markers with higher severity have a higher priority and should be displayed.
+     * @param marker the diagnostic marker.
+     */
+    protected getPriority(marker: Marker<Diagnostic>): number {
+        const { severity } = marker.data;
+        switch (severity) {
+            case 1: return 30; // Errors.
+            case 2: return 20; // Warnings.
+            case 3: return 10; // Infos.
+            default: return 0;
         }
     }
 


### PR DESCRIPTION


Signed-off-by: vince-fugnitto <vincent.fugnitto@ericsson.com>

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

- added `fontData` to the problem decorators in the explorer which decorates the node with a foreground color with the highest marker severity.
- added a new method `getPriority()` which takes as argument a marker diagnostic and returns it's priority which is used when decorating. Markers with a higher severity have a higher priority.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
1. start the application with a given workspace
2. create problem markers
3. ensure that the explorer view is opened, verify that nodes for the given files with problems are correctly decorated.

<img width="1316" alt="Screen Shot 2020-01-10 at 2 41 48 PM" src="https://user-images.githubusercontent.com/40359487/72181442-59fce880-33b7-11ea-8a6f-b681d99e26dd.png">



#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

