### PR TITLE
Lazily update frames of all threads in all-stop mode

### DIFF
--- a/packages/debug/src/browser/model/debug-thread.tsx
+++ b/packages/debug/src/browser/model/debug-thread.tsx
@@ -140,7 +140,9 @@ export class DebugThread extends DebugThreadData implements TreeElement {
     }
 
     protected pendingFetch = Promise.resolve<DebugStackFrame[]>([]);
+    protected _pendingFetchCount: number = 0;
     async fetchFrames(levels: number = 20): Promise<DebugStackFrame[]> {
+        this._pendingFetchCount += 1;
         return this.pendingFetch = this.pendingFetch.then(async () => {
             try {
                 const start = this.frameCount;
@@ -149,8 +151,13 @@ export class DebugThread extends DebugThreadData implements TreeElement {
             } catch (e) {
                 console.error(e);
                 return [];
+            } finally {
+                this._pendingFetchCount -= 1;
             }
         });
+    }
+    get pendingFrameCount(): number {
+        return this._pendingFetchCount;
     }
     protected async doFetchFrames(startFrame: number, levels: number): Promise<DebugProtocol.StackFrame[]> {
         try {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

When a breakpoint occurs in a thread in all-stop mode, all other
threads have outdated/missing stackframes which means no variables
show up and can be inspected. This fixes the issue by marking each
thread as potentially having "dirty" frames: frames that need to be
re-fetched when the user selects them.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

Testing is unfortunately quite complex at the moment. This is because `@theia/cpp-debug` is using an outdated version of a vscode extension. If you test these changes before and after, you'll see that before, you could only access the current thread's frames. After, you'll see that you can play around with all your frames as expected.

**Step 1: Build the debugger vscode extension manually**

The latest release of our fork is using an outdated adapter.

1. Clone https://github.com/theia-ide/cdt-gdb-vscode
1. Build the vscode extension `yarn && yarn vsce:package`
1. Launch a simple webserver serving this file.  
   Python 2: `python -m SimpleHTTPServer`  
   Python 3: `python -m http.server`  

**Step 2: Add the extension to theia**

1. Add `"cdt-gdb-vscode": "http://localhost:8000/cdt-gdb-vscode-0.0.90.vsix"` to the root `package.json` under `"theiaPlugins"`.
1. Make sure you don't have a `plugins/cdt-gdb-vscode` laying around.
1. `yarn` at the root, then `yarn start:browser`. If you've only updated the plugin, it's fine to just run `yarn download:plugins` instead of `yarn`.

**Step 3: Get an example workspace**

Debug a multi-threaded program with the GDB support, an example is https://github.com/zappala/pthreads-examples-c

1. Clone https://github.com/zappala/pthreads-examples-c
1. Compile with `make -B CPPFLAGS=-ggdb`
1. Add the following `.theia/tasks.json`:

```json
{
  "version": "0.2.0",
  "configurations": [
    {
      "type": "gdb",
      "request": "launch",
      "name": "Example",
      "program": "${workspaceFolder}/example"
    }
  ]
}
```

**Step 4: Play around with threads, both before and after this PR!**

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)