### PR TITLE
Don't show empty debugger list when there isn't any debug config

### DIFF
--- a/packages/core/src/browser/quick-open/quick-pick-service-impl.ts
+++ b/packages/core/src/browser/quick-open/quick-pick-service-impl.ts
@@ -38,6 +38,10 @@ export class QuickPickServiceImpl implements QuickPickService {
     async show(elements: (string | QuickPickItem<Object>)[], options?: QuickPickOptions): Promise<Object | undefined> {
         return new Promise<Object | undefined>(resolve => {
             this.items = this.toItems(elements, resolve);
+            if (this.items.length === 0) {
+                resolve(undefined);
+                return;
+            }
             // Set `runIfSingle` to the value passed through options, else defaults to true.
             const runIfSingle: boolean = (options && options.runIfSingle !== undefined) ? options.runIfSingle : true;
             if (runIfSingle && this.items.length === 1) {


### PR DESCRIPTION
#### What it does
This changes proposal doesn't show empty quick pick popup if there is no any debug configurations, this one:

<img width="740" alt="Снимок экрана 2020-01-13 в 12 00 49" src="https://user-images.githubusercontent.com/1968177/72261676-f0cade80-361d-11ea-9e50-ed104dbb7500.png">

Old behavior:
![debug](https://user-images.githubusercontent.com/1968177/72261708-00e2be00-361e-11ea-85fc-495ad2fa6338.gif)

New behavior:
![debug-fixed](https://user-images.githubusercontent.com/1968177/72261729-0dffad00-361e-11ea-8f7c-f4b0c1262ae3.gif)

Signed-off-by: Vladyslav Zhukovskyi <vzhukovs@redhat.com>

#### How to test
Ensure that your workspace doesn't have `launch.json`, open any file in editor, place focus into editor and try to execute `Debug > Start Debugging`, you'll get empty quick pick popup and when it closes auto generated `launch.json` opens.

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

