### PR TITLE
[terminal] Always open terminal links on touch events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## v0.15.0
 
+- [terminal] always open terminal links on touchevents (e.g. when tapping a link on iPad) [#6875](https://github.com/eclipse-theia/theia/pull/6875)
+
 Breaking changes:
 
 - [task] renamed method `getStrigifiedTaskSchema()` has been renamed to `getStringifiedTaskSchema()` [#6780](https://github.com/eclipse-theia/theia/pull/6780)

--- a/packages/terminal/src/browser/terminal-linkmatcher.ts
+++ b/packages/terminal/src/browser/terminal-linkmatcher.ts
@@ -37,16 +37,18 @@ export abstract class AbstractCmdClickTerminalContribution implements TerminalCo
         const validate = this.getValidate(terminalWidget);
         const wrappedHandler = (event: MouseEvent, match: string) => {
             event.preventDefault();
-            if (this.isCommandPressed(event)) {
+            if (this.isCommandPressed(event) || this.wasTouchEvent(event, terminalWidget.lastTouchEndEvent)) {
                 handler(event, match);
             } else {
                 term.focus();
             }
         };
         const matcherId = term.registerLinkMatcher(regexp, wrappedHandler, {
-            willLinkActivate: (event: MouseEvent, uri: string) => this.isCommandPressed(event),
+            willLinkActivate: (event: MouseEvent, uri: string) => this.isCommandPressed(event) || this.wasTouchEvent(event, terminalWidget.lastTouchEndEvent),
             tooltipCallback: (event: MouseEvent, uri: string) => {
-                terminalWidget.showHoverMessage(event.clientX, event.clientY, this.getHoverMessage());
+                if (!this.wasTouchEvent(event, terminalWidget.lastTouchEndEvent)) {
+                    terminalWidget.showHoverMessage(event.clientX, event.clientY, this.getHoverMessage());
+                }
             },
             leaveCallback: (event: MouseEvent, uri: string) => {
                 terminalWidget.hideHover();
@@ -62,6 +64,26 @@ export abstract class AbstractCmdClickTerminalContribution implements TerminalCo
 
     protected isCommandPressed(event: MouseEvent): boolean {
         return isOSX ? event.metaKey : event.ctrlKey;
+    }
+
+    protected wasTouchEvent(event: MouseEvent, lastTouchEnd: TouchEvent | undefined): boolean {
+        if (!lastTouchEnd) {
+            return false;
+        }
+        if ((event.timeStamp - lastTouchEnd.timeStamp) > 400) {
+            // A 'touchend' event typically precedes a matching 'click' event by 50ms.
+            return false;
+        }
+        if (Math.abs(event.pageX - (lastTouchEnd as unknown as MouseEvent).pageX) > 5) {
+            // Matching 'touchend' and 'click' events typically have the same page coordinates,
+            // plus or minus 1 pixel.
+            return false;
+        }
+        if (Math.abs(event.pageY - (lastTouchEnd as unknown as MouseEvent).pageY) > 5) {
+            return false;
+        }
+        // We have a match! This link was tapped.
+        return true;
     }
 
     protected getHoverMessage(): string {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

Fixes #6320.

This PR attempts to detect whether a `click` event on an XtermJS link was from a touch screen (should always open) or not (should only open if <kbd>Cmd</kbd> was also pressed).

This is achieved by keeping track of the last `touchend` event, and comparing times / coordinates.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

1. `yarn`
2. `cd examples/browser && yarn start --hostname=0.0.0.0`
3. Open port `3000` in desktop browser: run `echo http://perdu.com`
    - Simple click on link (should not open)
    - <kbd>Cmd</kbd> + click on link (should open)
4. Open port `3000` on touch device, e.g. iPad: run `echo http://perdu.com`
    - Tap on link (should open)

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

