### PR TITLE
[terminal] improve the display of 'new terminal'

### DIFF
--- a/packages/terminal/src/browser/terminal-frontend-contribution.ts
+++ b/packages/terminal/src/browser/terminal-frontend-contribution.ts
@@ -368,7 +368,7 @@ export class TerminalFrontendContribution implements TerminalService, CommandCon
     protected async selectTerminalCwd(): Promise<string | undefined> {
         const roots = this.workspaceService.tryGetRoots();
         return this.quickPick.show(roots.map(
-            ({ uri }) => ({ label: this.labelProvider.getLongName(new URI(uri)), value: uri })
+            ({ uri }) => ({ label: this.labelProvider.getName(new URI(uri)), description: this.labelProvider.getLongName(new URI(uri)), value: uri })
         ), { placeholder: 'Select current working directory for new terminal' });
     }
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

Fixes #6874

- improves the display of `new terminal` items when running in a multi-root workspace.
- adds the `root name` as a label, and displays the `uri` as a description.

Signed-off-by: Vincent Fugnitto <vincent.fugnitto@ericsson.com>

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

1. open a multiple-root workspace with more than one root
2. run the command `New Terminal` (the quick open should display the root names as a labels, and the uri as descriptions)

<div align='center'>

![image](https://user-images.githubusercontent.com/40359487/72279707-b30d8c00-3604-11ea-8d30-b464c50a3ccc.png)

</div>

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

