### PR TITLE
Added new color variables for warning alert (as in scm widget)

### DIFF
--- a/packages/core/src/browser/common-frontend-contribution.ts
+++ b/packages/core/src/browser/common-frontend-contribution.ts
@@ -1541,6 +1541,22 @@ export class CommonFrontendContribution implements FrontendApplicationContributi
                     hc: 'editorGutter.addedBackground'
                 }, description: 'Background color of success widgets (like alerts or notifications).'
             },
+            {
+                id: 'warningBackground',
+                defaults: {
+                    dark: 'editorWarning.foreground',
+                    light: 'editorWarning.foreground',
+                    hc: 'editorWarning.border'
+                }, description: 'Background color of warning widgets (like alerts or notifications).'
+            },
+            {
+                id: 'warningForeground',
+                defaults: {
+                    dark: 'inputValidation.warningBackground',
+                    light: 'inputValidation.warningBackground',
+                    hc: 'inputValidation.warningBackground'
+                }, description: 'Foreground color of warning widgets (like alerts or notifications).'
+            },
             // Statusbar
             {
                 id: 'statusBar.offlineBackground',

--- a/packages/core/src/browser/style/alert-messages.css
+++ b/packages/core/src/browser/style/alert-messages.css
@@ -33,8 +33,8 @@
 
 /* warning message */
 .theia-warning-alert {
-    background-color: var(--theia-editorWarning-foreground);
-    color: var(--theia-inputValidation-warningBackground);
+    background-color: var(--theia-warningBackground);
+    color: var(--theia-warningForeground);
     padding: 10px;
 }
 


### PR DESCRIPTION
#### What it does
<!-- Include relevant issues and describe how they are addressed. -->
Added inividual color variables for warning fields as shown in e.g. scm widget if no repository is found. So this color can be overwritten individually now.
Before we used 'inputValidation.warningBackground' as foreground and 'editorWarning.foreground' as background which are used for different purposes.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
Start theia, close workspace and open scm widget. There should be still shown this:
<img width="397" alt="Bildschirmfoto 2020-01-14 um 16 04 42" src="https://user-images.githubusercontent.com/28291421/72355531-f4c33300-36e7-11ea-9f4c-949c40492edb.png">
resp. this
<img width="398" alt="Bildschirmfoto 2020-01-14 um 16 07 49" src="https://user-images.githubusercontent.com/28291421/72355587-0d334d80-36e8-11ea-90ce-9eba23c190c0.png">


#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

