### PR TITLE
Styling issues in the debug hover

### DIFF
--- a/packages/debug/src/browser/style/index.css
+++ b/packages/debug/src/browser/style/index.css
@@ -369,6 +369,7 @@
 .theia-debug-hover-content {
     display: flex;
     flex: 1;
+    overflow-y: auto;
 }
 
 /** Breakpoint Widget */


### PR DESCRIPTION
Fixes #6278 

#### What it does
- Prevent the debug hover from overflowing into the debug console
- There is no longer a scrollbar overlapping the menu options

#### How to test
  - Hover over a symbol while in debug mode. Please refer to the screenshot in #6278 for more details.

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

