### PR TITLE
Add vertical lines to files/folders in tree

### DIFF
--- a/packages/core/src/browser/style/tree.css
+++ b/packages/core/src/browser/style/tree.css
@@ -79,7 +79,7 @@
     font-family: FontAwesome;
     font-size: calc(var(--theia-content-font-size) * 0.8);
     content: "\f0da";
-    transform: rotate(45deg);
+    transform: rotate(90deg);
 }
 
 .theia-Tree:focus .theia-TreeNode.theia-mod-selected,
@@ -138,4 +138,12 @@
 
 .theia-tree-element-node {
     width: 100%
+}
+
+.theia-tree-folder-vertical-line .theia-TreeNodeContent {
+    border-left: 1px solid #f0f0f0;
+}
+
+.theia-tree-file-extra-padding .theia-TreeNodeContent {
+    padding-left: 5px;
 }

--- a/packages/core/src/browser/tree/tree-widget.tsx
+++ b/packages/core/src/browser/tree/tree-widget.tsx
@@ -844,7 +844,7 @@ export class TreeWidget extends ReactWidget implements StatefulWidget {
     }
 
     protected getPaddingLeft(node: TreeNode, props: NodeProps): number {
-        return props.depth * this.props.leftPadding + (this.needsExpansionTogglePadding(node) ? this.props.expansionTogglePadding : 0);
+        return props.depth * this.props.leftPadding;
     }
 
     /**


### PR DESCRIPTION
Solves first half of issue: #6586 

#### What it does
- When a file is highlighted, add vertical lines for all its sibling files/folders in the tree
- When a folder is highlighted/expanded, add vertical lines for all its child files/folders in the tree

#### How to test
Please refer to the first screenshot in issue: #6586 for steps to test

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

