### PR TITLE
Use StorageService interface instead of its implementation

### DIFF
--- a/packages/core/src/browser/keyboard/browser-keyboard-layout-provider.spec.ts
+++ b/packages/core/src/browser/keyboard/browser-keyboard-layout-provider.spec.ts
@@ -20,7 +20,7 @@ import * as chai from 'chai';
 import * as sinon from 'sinon';
 import * as os from '../../common/os';
 import { ILogger, Loggable } from '../../common/logger';
-import { LocalStorageService } from '../storage-service';
+import { StorageService, LocalStorageService } from '../storage-service';
 import { MessageService } from '../../common/message-service';
 import { WindowService } from '../window/window-service';
 import { BrowserKeyboardLayoutProvider } from './browser-keyboard-layout-provider';
@@ -51,7 +51,7 @@ describe('browser keyboard layout provider', function (): void {
         const container = new Container();
         container.bind(BrowserKeyboardLayoutProvider).toSelf();
         container.bind(ILogger).to(MockLogger);
-        container.bind(LocalStorageService).toSelf().inSingletonScope();
+        container.bind(StorageService).to(LocalStorageService).inSingletonScope();
         container.bind(MessageService).toConstantValue({} as MessageService);
         container.bind(WindowService).toConstantValue({} as WindowService);
         const service = container.get(BrowserKeyboardLayoutProvider);

--- a/packages/core/src/browser/keyboard/browser-keyboard-layout-provider.ts
+++ b/packages/core/src/browser/keyboard/browser-keyboard-layout-provider.ts
@@ -23,7 +23,7 @@ import { Deferred } from '../../common/promise-util';
 import {
     NativeKeyboardLayout, KeyboardLayoutProvider, KeyboardLayoutChangeNotifier, KeyValidator, KeyValidationInput
 } from '../../common/keyboard/keyboard-layout-provider';
-import { LocalStorageService } from '../storage-service';
+import { StorageService } from '../storage-service';
 
 export type KeyboardLayoutSource = 'navigator.keyboard' | 'user-choice' | 'pressed-keys';
 
@@ -33,8 +33,8 @@ export class BrowserKeyboardLayoutProvider implements KeyboardLayoutProvider, Ke
     @inject(ILogger)
     protected readonly logger: ILogger;
 
-    @inject(LocalStorageService)
-    protected readonly storageService: LocalStorageService;
+    @inject(StorageService)
+    protected readonly storageService: StorageService;
 
     protected readonly initialized = new Deferred();
     protected readonly nativeLayoutChanged = new Emitter<NativeKeyboardLayout>();


### PR DESCRIPTION
#### What it does
This changes proposal uses `StorageService` interface instead of its implementation. The problem of using implementation may occur, when there is a rebind of default StorageService, when all data stores in rebind implementation and this one stores in local storage.

Signed-off-by: Vladyslav Zhukovskyi <vzhukovs@redhat.com>

#### How to test
Create a new one implementation of `StorageService` and rebind it in extension in which it locates.

Test extension is located in following branch https://github.com/eclipse-theia/theia/compare/master...vzhukovskii:reproduceStorageService?expand=1

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

