### PR TITLE
Navigator:Select Folder when user creates one.

### DIFF
--- a/packages/navigator/src/browser/navigator-tree.ts
+++ b/packages/navigator/src/browser/navigator-tree.ts
@@ -25,7 +25,6 @@ import { FileNavigatorFilter } from './navigator-filter';
 export class FileNavigatorTree extends FileTree {
 
     @inject(FileNavigatorFilter) protected readonly filter: FileNavigatorFilter;
-
     @postConstruct()
     protected init(): void {
         this.toDispose.push(this.filter.onFilterChanged(() => this.refresh()));
@@ -57,6 +56,7 @@ export class FileNavigatorTree extends FileTree {
         });
         return node;
     }
+
 }
 
 export interface WorkspaceNode extends CompositeTreeNode, SelectableTreeNode {

--- a/packages/workspace/src/browser/workspace-commands.ts
+++ b/packages/workspace/src/browser/workspace-commands.ts
@@ -213,7 +213,7 @@ export class WorkspaceCommandContribution implements CommandContribution {
                     dialog.open().then(name => {
                         if (name) {
                             const fileUri = parentUri.resolve(name);
-                            this.fileSystem.createFile(fileUri.toString()).then(() => {
+                            this.workspaceService.createFile(fileUri.toString()).then(() => {
                                 open(this.openerService, fileUri);
                             });
                         }
@@ -234,7 +234,7 @@ export class WorkspaceCommandContribution implements CommandContribution {
                     }, this.labelProvider);
                     dialog.open().then(name => {
                         if (name) {
-                            this.fileSystem.createFolder(parentUri.resolve(name).toString());
+                            this.workspaceService.createFolder(parentUri.resolve(name).toString());
                         }
                     });
                 }

--- a/packages/workspace/src/browser/workspace-service.ts
+++ b/packages/workspace/src/browser/workspace-service.ts
@@ -66,7 +66,9 @@ export class WorkspaceService implements FrontendApplicationContribution {
     protected readonly schemaProvider: PreferenceSchemaProvider;
 
     protected applicationName: string;
-
+    protected readonly onDidCreateFileFolderEmitter = new Emitter<string>();
+    readonly onDidCreateFileFolder = this.onDidCreateFileFolderEmitter.event;
+    readonly onDidReveal = new Emitter<void>().event;
     @postConstruct()
     protected async init(): Promise<void> {
         this.applicationName = FrontendApplicationConfigProvider.get().applicationName;
@@ -581,6 +583,22 @@ export class WorkspaceService implements FrontendApplicationContribution {
         }
         const rootUris = new Set(this.tryGetRoots().map(root => root.uri));
         return uris.every(uri => rootUris.has(uri.toString()));
+    }
+    /**
+     * Creates a file at the given URI.
+     * @param uri the file URI.
+     */
+    async createFile(uri: string): Promise<void> {
+        await this.fileSystem.createFile(uri);
+        this.onDidCreateFileFolderEmitter.fire(uri);
+    }
+    /**
+     * Creates a folder at the given URI.
+     * @param uri the folder URI.
+     */
+    async createFolder(uri: string): Promise<void> {
+        await this.fileSystem.createFolder(uri);
+        this.onDidCreateFileFolderEmitter.fire(uri);
     }
 
 }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
Problem Before: When you create a new folder, the folder is not selected. However, in VSCode it is.
Solution: Updated the Workspace service to contain the createFile and createFolder methods, which would call the filesystem to create it for us, then an event is fired so that the navigator-widget would know about it, once the file receives the uri. It will then create a URI, get the nodes by that URI, and then select that specific node.


Issue ID: [6190](https://github.com/eclipse-theia/theia/issues/6190)

Signed-off-by: [Muhammad Anas Shahid <Muhammad Anas Shahid>](https://github.com/Anasshahidd21)

#### How to test
Create a new folder, checks to see if the folder is highlighted.
Create a new file, check to see if the file is highlighted and opened up as well. 

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

