### PR TITLE
Add ability to handle vscode.openFolder command

### DIFF
--- a/packages/plugin-ext-vscode/src/browser/plugin-vscode-commands-contribution.ts
+++ b/packages/plugin-ext-vscode/src/browser/plugin-vscode-commands-contribution.ts
@@ -29,7 +29,7 @@ import { ApplicationShellMouseTracker } from '@theia/core/lib/browser/shell/appl
 import { CommandService } from '@theia/core/lib/common/command';
 import TheiaURI from '@theia/core/lib/common/uri';
 import { EditorManager } from '@theia/editor/lib/browser';
-import { TextDocumentShowOptions, IOpenFolderAPICommandOptions } from '@theia/plugin-ext/lib/common/plugin-api-rpc-model';
+import { TextDocumentShowOptions } from '@theia/plugin-ext/lib/common/plugin-api-rpc-model';
 import { DocumentsMainImpl } from '@theia/plugin-ext/lib/main/browser/documents-main';
 import { createUntitledResource } from '@theia/plugin-ext/lib/main/browser/editor/untitled-resource';
 import { toDocumentSymbol } from '@theia/plugin-ext/lib/plugin/type-converters';
@@ -107,6 +107,12 @@ export class PluginVscodeCommandsContribution implements CommandContribution {
                 await open(this.openerService, new TheiaURI(resource), editorOptions);
             }
         });
+
+        interface IOpenFolderAPICommandOptions {
+            forceNewWindow?: boolean;
+            forceReuseWindow?: boolean;
+            noRecentEntry?: boolean;
+        }
 
         commands.registerCommand(VscodeCommands.OPEN_FOLDER, {
             isVisible: () => false,

--- a/packages/plugin-ext/src/common/plugin-api-rpc-model.ts
+++ b/packages/plugin-ext/src/common/plugin-api-rpc-model.ts
@@ -434,6 +434,12 @@ export interface WorkspaceFolder {
     index: number;
 }
 
+export interface IOpenFolderAPICommandOptions {
+    forceNewWindow?: boolean;
+    forceReuseWindow?: boolean;
+    noRecentEntry?: boolean;
+}
+
 export interface Breakpoint {
     readonly id: string;
     readonly enabled: boolean;

--- a/packages/plugin-ext/src/common/plugin-api-rpc-model.ts
+++ b/packages/plugin-ext/src/common/plugin-api-rpc-model.ts
@@ -434,12 +434,6 @@ export interface WorkspaceFolder {
     index: number;
 }
 
-export interface IOpenFolderAPICommandOptions {
-    forceNewWindow?: boolean;
-    forceReuseWindow?: boolean;
-    noRecentEntry?: boolean;
-}
-
 export interface Breakpoint {
     readonly id: string;
     readonly enabled: boolean;


### PR DESCRIPTION
Signed-off-by: Tomer Epstein <tomer.epstein@sap.com>

Issue: https://github.com/eclipse-theia/theia/issues/4050

#### What it does
This change proposal adds ability to handle vscode.openFolder command.

#### How to test

1.  git clone https://github.com/tomer-epstein/vscode-open-folder.git
2. cd vscode-open-folder
3. npm run compile && npm run pacage
4. copy vscode-open-folder-0.0.1.vsix to plugins folder
5. Right click on a folder in the Explorer, choose 'Open Folder New Instance' /  'Open Folder Here' or 'Open Folder Dialog'.

![image](https://user-images.githubusercontent.com/57438361/72806941-f0a29280-3c5e-11ea-8a69-9c63e2f57cee.png)


#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

