### PR TITLE
[navigator] fix 'collapseAll' command

### DIFF
--- a/packages/navigator/src/browser/navigator-model.ts
+++ b/packages/navigator/src/browser/navigator-model.ts
@@ -186,4 +186,12 @@ export class FileNavigatorModel extends FileTreeModel {
                 node1.id.length >= node2.id.length ? node1 : node2
             ) : undefined;
     }
+
+    async collapseAll(raw: CompositeTreeNode): Promise<boolean> {
+        const node = raw || this.selectedNodes[0];
+        if (CompositeTreeNode.is(node)) {
+            return this.expansionService.collapseAll(node);
+        }
+        return false;
+    }
 }


### PR DESCRIPTION

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

Fixes #6936

Fixes an issue when triggering the `collapseAll` command for the **navigator/explorer** which would unnecessarily fire `onSelectionChanged` events for each node. Anyone who would listen to the event would get notified many times making it expensive and difficult to perform handling. 

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
- verify that the command `collapseAll` works correctly for the explorer in a single-root workspace
- verify that the command `collapseAll` works correctly for the explorer in a multi-root workspace (roots are collapsed and the first node is selected)
- verify that when triggering `collapseAll`, multiple `onSelectionChanged` events are not triggered

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

Signed-off-by: Vincent Fugnitto <vincent.fugnitto@ericsson.com>
