### PR TITLE
Title: Display Ellipses when content not displayed fully

### DIFF
--- a/packages/plugin-ext/src/main/browser/style/tree.css
+++ b/packages/plugin-ext/src/main/browser/style/tree.css
@@ -30,7 +30,7 @@
     margin-left: var(--theia-ui-padding);
 }
 
-.theia-TreeNodeSegment {
+.theia-tree-view.theia-TreeNodeSegment {
     display: flex;
 }
 
@@ -38,4 +38,3 @@
     align-items: center;
     height: 100%;
 }
-

--- a/packages/plugin-ext/src/main/browser/view/tree-view-widget.tsx
+++ b/packages/plugin-ext/src/main/browser/view/tree-view-widget.tsx
@@ -281,7 +281,8 @@ export class TreeViewWidget extends TreeWidget {
             });
         }
 
-        nodes.push(<div>{work}</div>);
+        const className = [TREE_NODE_SEGMENT_CLASS, TREE_NODE_SEGMENT_GROW_CLASS].join(' ');
+        nodes.push(<div className={className}>{work}</div >);
         if (description) {
             nodes.push(<div className='theia-tree-view-description'>
                 {description}


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
Fixes: [#6711](https://github.com/eclipse-theia/theia/issues/6711)

When the width  of the navigator is reduced and the content cannot be displayed completely, then the file name should show ellipses, which currently is not displayed. Fixing one of the css property, fixed the issue.

#### How to test

- Create a new folder or a file, try to contract the size of the navigator and test to see if the name of the file/folder displays ellipses or not.

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

Signed-off-by: Muhammad Anas Shahid <muhammad.shahid@ericsson.com>