### PR TITLE
Use C/C++ grammar files from VSCode

### DIFF
--- a/packages/textmate-grammars/data/c.tmLanguage.json
+++ b/packages/textmate-grammars/data/c.tmLanguage.json
@@ -1,10 +1,10 @@
 {
 	"information_for_contributors": [
-		"This file has been converted from https://github.com/atom/language-c/blob/master/grammars/c.cson",
+		"This file has been converted from https://github.com/jeff-hykin/cpp-textmate-grammar/blob/master//syntaxes/c.tmLanguage.json",
 		"If you want to provide a fix or improvement, please create a pull request against the original repository.",
 		"Once accepted there, we are happy to receive an update request."
 	],
-	"version": "https://github.com/atom/language-c/commit/9c0c5f202741a5647025db8d5df5fefba47b036c",
+	"version": "https://github.com/jeff-hykin/cpp-textmate-grammar/commit/72b309aabb63bf14a3cdf0280149121db005d616",
 	"name": "C",
 	"scopeName": "source.c",
 	"patterns": [
@@ -18,14 +18,24 @@
 			"include": "#preprocessor-rule-conditional"
 		},
 		{
+			"include": "#predefined_macros"
+		},
+		{
 			"include": "#comments"
 		},
 		{
-			"match": "\\b(break|case|continue|default|do|else|for|goto|if|_Pragma|return|switch|while)\\b",
+			"include": "#switch_statement"
+		},
+		{
+			"match": "\\b(break|continue|do|else|for|goto|if|_Pragma|return|while)\\b",
 			"name": "keyword.control.c"
 		},
 		{
 			"include": "#storage_types"
+		},
+		{
+			"match": "typedef",
+			"name": "keyword.other.typedef.c"
 		},
 		{
 			"match": "\\b(const|extern|register|restrict|static|volatile|inline)\\b",
@@ -57,32 +67,71 @@
 			"include": "#strings"
 		},
 		{
-			"begin": "(?x)\n^\\s* ((\\#)\\s*define) \\s+    # define\n((?<id>[a-zA-Z_$][\\w$]*))      # macro name\n(?:\n  (\\()\n    (\n      \\s* \\g<id> \\s*         # first argument\n      ((,) \\s* \\g<id> \\s*)*  # additional arguments\n      (?:\\.\\.\\.)?            # varargs ellipsis?\n    )\n  (\\))\n)?",
+			"name": "meta.preprocessor.macro.c",
+			"begin": "((?:(?:(?>\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+?|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z)))((#)\\s*define\\b)\\s+((?<!\\w)[a-zA-Z_]\\w*(?!\\w))(?:(\\()([^()\\\\]+)(\\)))?",
 			"beginCaptures": {
 				"1": {
-					"name": "keyword.control.directive.define.c"
+					"patterns": [
+						{
+							"include": "#inline_comment"
+						}
+					]
 				},
 				"2": {
-					"name": "punctuation.definition.directive.c"
+					"name": "comment.block.c punctuation.definition.comment.begin.c"
 				},
 				"3": {
-					"name": "entity.name.function.preprocessor.c"
+					"name": "comment.block.c"
+				},
+				"4": {
+					"patterns": [
+						{
+							"match": "\\*\\/",
+							"name": "comment.block.c punctuation.definition.comment.end.c"
+						},
+						{
+							"match": "\\*",
+							"name": "comment.block.c"
+						}
+					]
 				},
 				"5": {
-					"name": "punctuation.definition.parameters.begin.c"
+					"name": "keyword.control.directive.define.c"
 				},
 				"6": {
-					"name": "variable.parameter.preprocessor.c"
+					"name": "punctuation.definition.directive.c"
+				},
+				"7": {
+					"name": "entity.name.function.preprocessor.c"
 				},
 				"8": {
-					"name": "punctuation.separator.parameters.c"
+					"name": "punctuation.definition.parameters.begin.c"
 				},
 				"9": {
+					"patterns": [
+						{
+							"match": "(?<=[(,])\\s*((?<!\\w)[a-zA-Z_]\\w*(?!\\w))\\s*",
+							"captures": {
+								"1": {
+									"name": "variable.parameter.preprocessor.c"
+								}
+							}
+						},
+						{
+							"match": ",",
+							"name": "punctuation.separator.parameters.c"
+						},
+						{
+							"match": "\\.\\.\\.",
+							"name": "ellipses.c punctuation.vararg-ellipses.variable.parameter.preprocessor.c"
+						}
+					]
+				},
+				"10": {
 					"name": "punctuation.definition.parameters.end.c"
 				}
 			},
-			"end": "(?=(?://|/\\*))|(?<!\\\\)(?=\\n)",
-			"name": "meta.preprocessor.macro.c",
+			"end": "(?<!\\\\)(?=\\n)",
 			"patterns": [
 				{
 					"include": "#preprocessor-rule-define-line-contents"
@@ -90,8 +139,8 @@
 			]
 		},
 		{
-			"begin": "^\\s*((#)\\s*(error|warning))\\b",
-			"captures": {
+			"begin": "^\\s*((#)\\s*(error|warning))\\b\\s*",
+			"beginCaptures": {
 				"1": {
 					"name": "keyword.control.directive.diagnostic.$3.c"
 				},
@@ -99,17 +148,61 @@
 					"name": "punctuation.definition.directive.c"
 				}
 			},
-			"end": "(?<!\\\\)(?=\\n)|(?=//)|(?=/\\*(?!.*\\\\\\s*\\n))",
+			"end": "(?<!\\\\)(?=\\n)",
 			"name": "meta.preprocessor.diagnostic.c",
 			"patterns": [
 				{
-					"include": "#comments"
+					"begin": "\"",
+					"beginCaptures": {
+						"0": {
+							"name": "punctuation.definition.string.begin.c"
+						}
+					},
+					"end": "\"|(?<!\\\\)(?=\\s*\\n)",
+					"endCaptures": {
+						"0": {
+							"name": "punctuation.definition.string.end.c"
+						}
+					},
+					"name": "string.quoted.double.c",
+					"patterns": [
+						{
+							"include": "#line_continuation_character"
+						}
+					]
 				},
 				{
-					"include": "#strings"
+					"begin": "'",
+					"beginCaptures": {
+						"0": {
+							"name": "punctuation.definition.string.begin.c"
+						}
+					},
+					"end": "'|(?<!\\\\)(?=\\s*\\n)",
+					"endCaptures": {
+						"0": {
+							"name": "punctuation.definition.string.end.c"
+						}
+					},
+					"name": "string.quoted.single.c",
+					"patterns": [
+						{
+							"include": "#line_continuation_character"
+						}
+					]
 				},
 				{
-					"include": "#line_continuation_character"
+					"begin": "[^'\"]",
+					"end": "(?<!\\\\)(?=\\s*\\n)",
+					"name": "string.unquoted.single.c",
+					"patterns": [
+						{
+							"include": "#line_continuation_character"
+						},
+						{
+							"include": "#comments"
+						}
+					]
 				}
 			]
 		},
@@ -269,9 +362,9 @@
 			"include": "#parens"
 		},
 		{
-			"begin": "(?x)\n(?!(?:while|for|do|if|else|switch|catch|enumerate|return|typeid|alignof|alignas|sizeof|[cr]?iterate|asm|__asm__|auto|bool|_Bool|char|_Complex|double|enum|float|_Imaginary|int|long|short|signed|struct|typedef|union|unsigned|void)\\s*\\()\n(?=\n  (?:[A-Za-z_][A-Za-z0-9_]*+|::)++\\s*\\(  # actual name\n  |\n  (?:(?<=operator)(?:[-*&<>=+!]+|\\(\\)|\\[\\]))\\s*\\(\n)",
-			"end": "(?<=\\))(?!\\w)",
 			"name": "meta.function.c",
+			"begin": "(?<!\\w)(?!\\s*(?:atomic_uint_least64_t|atomic_uint_least16_t|atomic_uint_least32_t|atomic_uint_least8_t|atomic_int_least16_t|atomic_uint_fast64_t|atomic_uint_fast32_t|atomic_int_least64_t|atomic_int_least32_t|pthread_rwlockattr_t|atomic_uint_fast16_t|pthread_mutexattr_t|atomic_int_fast16_t|atomic_uint_fast8_t|atomic_int_fast64_t|atomic_int_least8_t|atomic_int_fast32_t|atomic_int_fast8_t|pthread_condattr_t|pthread_rwlock_t|atomic_uintptr_t|atomic_ptrdiff_t|atomic_uintmax_t|atomic_intmax_t|atomic_char32_t|atomic_intptr_t|atomic_char16_t|pthread_mutex_t|pthread_cond_t|atomic_wchar_t|uint_least64_t|uint_least32_t|uint_least16_t|pthread_once_t|pthread_attr_t|uint_least8_t|int_least32_t|int_least16_t|pthread_key_t|uint_fast32_t|uint_fast64_t|uint_fast16_t|atomic_size_t|atomic_ushort|atomic_ullong|int_least64_t|atomic_ulong|int_least8_t|int_fast16_t|int_fast32_t|int_fast64_t|uint_fast8_t|memory_order|atomic_schar|atomic_uchar|atomic_short|atomic_llong|thread_local|atomic_bool|atomic_uint|atomic_long|int_fast8_t|suseconds_t|atomic_char|atomic_int|useconds_t|_Imaginary|uintmax_t|uintmax_t|in_addr_t|in_port_t|_Noreturn|blksize_t|pthread_t|uintptr_t|volatile|u_quad_t|blkcnt_t|intmax_t|intptr_t|_Complex|uint16_t|uint32_t|uint64_t|_Alignof|_Alignas|continue|unsigned|restrict|intmax_t|register|int64_t|qaddr_t|segsz_t|_Atomic|alignas|default|caddr_t|nlink_t|typedef|u_short|fixpt_t|clock_t|swblk_t|ssize_t|alignof|daddr_t|int16_t|int32_t|uint8_t|struct|mode_t|size_t|time_t|ushort|u_long|u_char|int8_t|double|signed|static|extern|inline|return|switch|xor_eq|and_eq|bitand|not_eq|sizeof|quad_t|uid_t|bitor|union|off_t|key_t|ino_t|compl|u_int|short|const|false|while|float|pid_t|break|_Bool|or_eq|div_t|dev_t|gid_t|id_t|long|case|goto|else|bool|auto|id_t|enum|uint|true|NULL|void|char|for|not|int|and|xor|do|or|if)\\s*\\()(?=[a-zA-Z_]\\w*\\s*\\()",
+			"end": "(?<=\\))",
 			"patterns": [
 				{
 					"include": "#function-innards"
@@ -282,15 +375,31 @@
 			"include": "#line_continuation_character"
 		},
 		{
-			"match": "(\\[)|(\\])",
-			"captures": {
+			"name": "meta.bracket.square.access.c",
+			"begin": "([a-zA-Z_][a-zA-Z_0-9]*|(?<=[\\]\\)]))?(\\[)(?!\\])",
+			"beginCaptures": {
 				"1": {
-					"name": "punctuation.definition.begin.bracket.square.c"
+					"name": "variable.object.c"
 				},
 				"2": {
+					"name": "punctuation.definition.begin.bracket.square.c"
+				}
+			},
+			"end": "\\]",
+			"endCaptures": {
+				"0": {
 					"name": "punctuation.definition.end.bracket.square.c"
 				}
-			}
+			},
+			"patterns": [
+				{
+					"include": "#function-call-innards"
+				}
+			]
+		},
+		{
+			"name": "storage.modifier.array.bracket.square.c",
+			"match": "\\[\\s*\\]"
 		},
 		{
 			"match": ";",
@@ -302,8 +411,13 @@
 		}
 	],
 	"repository": {
-		"access": {
-			"captures": {
+		"access-method": {
+			"name": "meta.function-call.member.c",
+			"begin": "([a-zA-Z_][a-zA-Z_0-9]*|(?<=[\\]\\)]))\\s*(?:(\\.)|(->))((?:(?:[a-zA-Z_][a-zA-Z_0-9]*)\\s*(?:(?:\\.)|(?:->)))*)\\s*([a-zA-Z_][a-zA-Z_0-9]*)(\\()",
+			"beginCaptures": {
+				"1": {
+					"name": "variable.object.c"
+				},
 				"2": {
 					"name": "punctuation.separator.dot-access.c"
 				},
@@ -311,10 +425,47 @@
 					"name": "punctuation.separator.pointer-access.c"
 				},
 				"4": {
-					"name": "variable.other.member.c"
+					"patterns": [
+						{
+							"match": "\\.",
+							"name": "punctuation.separator.dot-access.c"
+						},
+						{
+							"match": "->",
+							"name": "punctuation.separator.pointer-access.c"
+						},
+						{
+							"match": "[a-zA-Z_][a-zA-Z_0-9]*",
+							"name": "variable.object.c"
+						},
+						{
+							"name": "everything.else.c",
+							"match": ".+"
+						}
+					]
+				},
+				"5": {
+					"name": "entity.name.function.member.c"
+				},
+				"6": {
+					"name": "punctuation.section.arguments.begin.bracket.round.function.member.c"
 				}
 			},
-			"match": "((\\.)|(->))\\s*(([a-zA-Z_][a-zA-Z_0-9]*)\\b(?!\\s*\\())?"
+			"end": "\\)",
+			"endCaptures": {
+				"0": {
+					"name": "punctuation.section.arguments.end.bracket.round.function.member.c"
+				}
+			},
+			"patterns": [
+				{
+					"include": "#function-call-innards"
+				}
+			]
+		},
+		"backslash_escapes": {
+			"match": "(?x)\\\\ (\n\\\\\t\t\t |\n[abefnprtv'\"?]   |\n[0-3]\\d{,2}\t |\n[4-7]\\d?\t\t|\nx[a-fA-F0-9]{,2} |\nu[a-fA-F0-9]{,4} |\nU[a-fA-F0-9]{,8} )",
+			"name": "constant.character.escape.c"
 		},
 		"block": {
 			"patterns": [
@@ -352,25 +503,36 @@
 					"include": "#preprocessor-rule-conditional-block"
 				},
 				{
-					"include": "#access"
+					"include": "#method_access"
 				},
 				{
-					"include": "#libc"
+					"include": "#member_access"
 				},
 				{
 					"include": "#c_function_call"
 				},
 				{
-					"captures": {
+					"name": "meta.initialization.c",
+					"begin": "(?x)\n(?:\n  (?:\n\t(?=\\s)(?<!else|new|return)\n\t(?<=\\w) \\s+(and|and_eq|bitand|bitor|compl|not|not_eq|or|or_eq|typeid|xor|xor_eq|alignof|alignas)  # or word + space before name\n  )\n)\n(\n  (?:[A-Za-z_][A-Za-z0-9_]*+ | :: )++   # actual name\n  |\n  (?:(?<=operator) (?:[-*&<>=+!]+ | \\(\\) | \\[\\]))\n)\n\\s*(\\() # opening bracket",
+					"beginCaptures": {
 						"1": {
 							"name": "variable.other.c"
 						},
 						"2": {
-							"name": "punctuation.definition.parameters.c"
+							"name": "punctuation.section.parens.begin.bracket.round.initialization.c"
 						}
 					},
-					"match": "(?x)\n(?:\n  (?:\n    (?=\\s)(?<!else|new|return)\n    (?<=\\w) \\s+  # or word + space before name\n  )\n)\n(\n  (?:[A-Za-z_][A-Za-z0-9_]*+ | :: )++   # actual name\n  |\n  (?:(?<=operator) (?:[-*&<>=+!]+ | \\(\\) | \\[\\]))\n)\n\\s*(\\() # opening bracket",
-					"name": "meta.initialization.c"
+					"end": "\\)",
+					"endCaptures": {
+						"0": {
+							"name": "punctuation.section.parens.end.bracket.round.initialization.c"
+						}
+					},
+					"patterns": [
+						{
+							"include": "#function-call-innards"
+						}
+					]
 				},
 				{
 					"begin": "{",
@@ -399,8 +561,18 @@
 				}
 			]
 		},
+		"c_conditional_context": {
+			"patterns": [
+				{
+					"include": "$self"
+				},
+				{
+					"include": "#block_innards"
+				}
+			]
+		},
 		"c_function_call": {
-			"begin": "(?x)\n(?!(?:while|for|do|if|else|switch|catch|enumerate|return|typeid|alignof|alignas|sizeof|[cr]?iterate)\\s*\\()\n(?=\n(?:[A-Za-z_][A-Za-z0-9_]*+|::)++\\s*\\(  # actual name\n|\n(?:(?<=operator)(?:[-*&<>=+!]+|\\(\\)|\\[\\]))\\s*\\(\n)",
+			"begin": "(?x)\n(?!(?:while|for|do|if|else|switch|catch|enumerate|return|typeid|alignof|alignas|sizeof|[cr]?iterate|and|and_eq|bitand|bitor|compl|not|not_eq|or|or_eq|typeid|xor|xor_eq|alignof|alignas)\\s*\\()\n(?=\n(?:[A-Za-z_][A-Za-z0-9_]*+|::)++\\s*\\(  # actual name\n|\n(?:(?<=operator)(?:[-*&<>=+!]+|\\(\\)|\\[\\]))\\s*\\(\n)",
 			"end": "(?<=\\))(?!\\w)",
 			"name": "meta.function-call.c",
 			"patterns": [
@@ -409,63 +581,359 @@
 				}
 			]
 		},
+		"case_statement": {
+			"name": "meta.conditional.case.c",
+			"begin": "((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))((?<!\\w)case(?!\\w))",
+			"beginCaptures": {
+				"1": {
+					"patterns": [
+						{
+							"include": "#inline_comment"
+						}
+					]
+				},
+				"2": {
+					"name": "comment.block.c punctuation.definition.comment.begin.c"
+				},
+				"3": {
+					"name": "comment.block.c"
+				},
+				"4": {
+					"patterns": [
+						{
+							"match": "\\*\\/",
+							"name": "comment.block.c punctuation.definition.comment.end.c"
+						},
+						{
+							"match": "\\*",
+							"name": "comment.block.c"
+						}
+					]
+				},
+				"5": {
+					"name": "keyword.control.case.c"
+				}
+			},
+			"end": "(:)",
+			"endCaptures": {
+				"1": {
+					"name": "punctuation.separator.colon.case.c"
+				}
+			},
+			"patterns": [
+				{
+					"include": "#evaluation_context"
+				},
+				{
+					"include": "#c_conditional_context"
+				}
+			]
+		},
 		"comments": {
 			"patterns": [
 				{
+					"name": "comment.line.double-slash.documentation.c",
+					"begin": "(?:^)(?>\\s*)(\\/\\/[!\\/]+)",
+					"beginCaptures": {
+						"1": {
+							"name": "punctuation.definition.comment.documentation.c"
+						}
+					},
+					"end": "(?<=\\n)(?<!\\\\\\n)",
+					"patterns": [
+						{
+							"include": "#line_continuation_character"
+						},
+						{
+							"match": "(?<=[\\s*!\\/])[\\\\@](?:callergraph|callgraph|else|endif|f\\$|f\\[|f\\]|hidecallergraph|hidecallgraph|hiderefby|hiderefs|hideinitializer|htmlinclude|n|nosubgrouping|private|privatesection|protected|protectedsection|public|publicsection|pure|showinitializer|showrefby|showrefs|tableofcontents|\\$|\\#|<|>|%|\"|\\.|=|::|\\||\\-\\-|\\-\\-\\-)\\b(?:\\{[^}]*\\})?",
+							"name": "storage.type.class.doxygen.c"
+						},
+						{
+							"match": "((?<=[\\s*!\\/])[\\\\@](?:a|em|e))\\s+(\\S+)",
+							"captures": {
+								"1": {
+									"name": "storage.type.class.doxygen.c"
+								},
+								"2": {
+									"name": "markup.italic.doxygen.c"
+								}
+							}
+						},
+						{
+							"match": "((?<=[\\s*!\\/])[\\\\@]b)\\s+(\\S+)",
+							"captures": {
+								"1": {
+									"name": "storage.type.class.doxygen.c"
+								},
+								"2": {
+									"name": "markup.bold.doxygen.c"
+								}
+							}
+						},
+						{
+							"match": "((?<=[\\s*!\\/])[\\\\@](?:c|p))\\s+(\\S+)",
+							"captures": {
+								"1": {
+									"name": "storage.type.class.doxygen.c"
+								},
+								"2": {
+									"name": "markup.inline.raw.string.c"
+								}
+							}
+						},
+						{
+							"match": "(?<=[\\s*!\\/])[\\\\@](?:a|anchor|b|c|cite|copybrief|copydetail|copydoc|def|dir|dontinclude|e|em|emoji|enum|example|extends|file|idlexcept|implements|include|includedoc|includelineno|latexinclude|link|memberof|namespace|p|package|ref|refitem|related|relates|relatedalso|relatesalso|verbinclude)\\b(?:\\{[^}]*\\})?",
+							"name": "storage.type.class.doxygen.c"
+						},
+						{
+							"match": "(?<=[\\s*!\\/])[\\\\@](?:addindex|addtogroup|category|class|defgroup|diafile|dotfile|elseif|fn|headerfile|if|ifnot|image|ingroup|interface|line|mainpage|mscfile|name|overload|page|property|protocol|section|skip|skipline|snippet|snippetdoc|snippetlineno|struct|subpage|subsection|subsubsection|typedef|union|until|vhdlflow|weakgroup)\\b(?:\\{[^}]*\\})?",
+							"name": "storage.type.class.doxygen.c"
+						},
+						{
+							"match": "((?<=[\\s*!\\/])[\\\\@]param)\\s+(\\b\\w+\\b)",
+							"captures": {
+								"1": {
+									"name": "storage.type.class.doxygen.c"
+								},
+								"2": {
+									"name": "variable.parameter.c"
+								}
+							}
+						},
+						{
+							"match": "(?<=[\\s*!\\/])[\\\\@](?:arg|attention|author|authors|brief|bug|copyright|date|deprecated|details|exception|invariant|li|note|par|paragraph|param|post|pre|remark|remarks|result|return|returns|retval|sa|see|short|since|test|throw|todo|tparam|version|warning|xrefitem)\\b(?:\\{[^}]*\\})?",
+							"name": "storage.type.class.doxygen.c"
+						},
+						{
+							"match": "(?<=[\\s*!\\/])[\\\\@](?:code|cond|docbookonly|dot|htmlonly|internal|latexonly|link|manonly|msc|parblock|rtfonly|secreflist|uml|verbatim|xmlonly|endcode|endcond|enddocbookonly|enddot|endhtmlonly|endinternal|endlatexonly|endlink|endmanonly|endmsc|endparblock|endrtfonly|endsecreflist|enduml|endverbatim|endxmlonly)\\b(?:\\{[^}]*\\})?",
+							"name": "storage.type.class.doxygen.c"
+						},
+						{
+							"match": "(?:\\b[A-Z]+:|@[a-z_]+:)",
+							"name": "storage.type.class.gtkdoc"
+						}
+					]
+				},
+				{
+					"match": "(\\/\\*[!*]+(?=\\s))(.+)([!*]*\\*\\/)",
+					"captures": {
+						"1": {
+							"name": "punctuation.definition.comment.begin.documentation.c"
+						},
+						"2": {
+							"patterns": [
+								{
+									"match": "(?<=[\\s*!\\/])[\\\\@](?:callergraph|callgraph|else|endif|f\\$|f\\[|f\\]|hidecallergraph|hidecallgraph|hiderefby|hiderefs|hideinitializer|htmlinclude|n|nosubgrouping|private|privatesection|protected|protectedsection|public|publicsection|pure|showinitializer|showrefby|showrefs|tableofcontents|\\$|\\#|<|>|%|\"|\\.|=|::|\\||\\-\\-|\\-\\-\\-)\\b(?:\\{[^}]*\\})?",
+									"name": "storage.type.class.doxygen.c"
+								},
+								{
+									"match": "((?<=[\\s*!\\/])[\\\\@](?:a|em|e))\\s+(\\S+)",
+									"captures": {
+										"1": {
+											"name": "storage.type.class.doxygen.c"
+										},
+										"2": {
+											"name": "markup.italic.doxygen.c"
+										}
+									}
+								},
+								{
+									"match": "((?<=[\\s*!\\/])[\\\\@]b)\\s+(\\S+)",
+									"captures": {
+										"1": {
+											"name": "storage.type.class.doxygen.c"
+										},
+										"2": {
+											"name": "markup.bold.doxygen.c"
+										}
+									}
+								},
+								{
+									"match": "((?<=[\\s*!\\/])[\\\\@](?:c|p))\\s+(\\S+)",
+									"captures": {
+										"1": {
+											"name": "storage.type.class.doxygen.c"
+										},
+										"2": {
+											"name": "markup.inline.raw.string.c"
+										}
+									}
+								},
+								{
+									"match": "(?<=[\\s*!\\/])[\\\\@](?:a|anchor|b|c|cite|copybrief|copydetail|copydoc|def|dir|dontinclude|e|em|emoji|enum|example|extends|file|idlexcept|implements|include|includedoc|includelineno|latexinclude|link|memberof|namespace|p|package|ref|refitem|related|relates|relatedalso|relatesalso|verbinclude)\\b(?:\\{[^}]*\\})?",
+									"name": "storage.type.class.doxygen.c"
+								},
+								{
+									"match": "(?<=[\\s*!\\/])[\\\\@](?:addindex|addtogroup|category|class|defgroup|diafile|dotfile|elseif|fn|headerfile|if|ifnot|image|ingroup|interface|line|mainpage|mscfile|name|overload|page|property|protocol|section|skip|skipline|snippet|snippetdoc|snippetlineno|struct|subpage|subsection|subsubsection|typedef|union|until|vhdlflow|weakgroup)\\b(?:\\{[^}]*\\})?",
+									"name": "storage.type.class.doxygen.c"
+								},
+								{
+									"match": "((?<=[\\s*!\\/])[\\\\@]param)\\s+(\\b\\w+\\b)",
+									"captures": {
+										"1": {
+											"name": "storage.type.class.doxygen.c"
+										},
+										"2": {
+											"name": "variable.parameter.c"
+										}
+									}
+								},
+								{
+									"match": "(?<=[\\s*!\\/])[\\\\@](?:arg|attention|author|authors|brief|bug|copyright|date|deprecated|details|exception|invariant|li|note|par|paragraph|param|post|pre|remark|remarks|result|return|returns|retval|sa|see|short|since|test|throw|todo|tparam|version|warning|xrefitem)\\b(?:\\{[^}]*\\})?",
+									"name": "storage.type.class.doxygen.c"
+								},
+								{
+									"match": "(?<=[\\s*!\\/])[\\\\@](?:code|cond|docbookonly|dot|htmlonly|internal|latexonly|link|manonly|msc|parblock|rtfonly|secreflist|uml|verbatim|xmlonly|endcode|endcond|enddocbookonly|enddot|endhtmlonly|endinternal|endlatexonly|endlink|endmanonly|endmsc|endparblock|endrtfonly|endsecreflist|enduml|endverbatim|endxmlonly)\\b(?:\\{[^}]*\\})?",
+									"name": "storage.type.class.doxygen.c"
+								},
+								{
+									"match": "(?:\\b[A-Z]+:|@[a-z_]+:)",
+									"name": "storage.type.class.gtkdoc"
+								}
+							]
+						},
+						"3": {
+							"name": "punctuation.definition.comment.end.documentation.c"
+						}
+					},
+					"name": "comment.block.documentation.c"
+				},
+				{
+					"name": "comment.block.documentation.c",
+					"begin": "((?>\\s*)\\/\\*[!*]+(?:(?:\\n|$)|(?=\\s)))",
+					"beginCaptures": {
+						"1": {
+							"name": "punctuation.definition.comment.begin.documentation.c"
+						}
+					},
+					"end": "([!*]*\\*\\/)",
+					"endCaptures": {
+						"1": {
+							"name": "punctuation.definition.comment.end.documentation.c"
+						}
+					},
+					"patterns": [
+						{
+							"match": "(?<=[\\s*!\\/])[\\\\@](?:callergraph|callgraph|else|endif|f\\$|f\\[|f\\]|hidecallergraph|hidecallgraph|hiderefby|hiderefs|hideinitializer|htmlinclude|n|nosubgrouping|private|privatesection|protected|protectedsection|public|publicsection|pure|showinitializer|showrefby|showrefs|tableofcontents|\\$|\\#|<|>|%|\"|\\.|=|::|\\||\\-\\-|\\-\\-\\-)\\b(?:\\{[^}]*\\})?",
+							"name": "storage.type.class.doxygen.c"
+						},
+						{
+							"match": "((?<=[\\s*!\\/])[\\\\@](?:a|em|e))\\s+(\\S+)",
+							"captures": {
+								"1": {
+									"name": "storage.type.class.doxygen.c"
+								},
+								"2": {
+									"name": "markup.italic.doxygen.c"
+								}
+							}
+						},
+						{
+							"match": "((?<=[\\s*!\\/])[\\\\@]b)\\s+(\\S+)",
+							"captures": {
+								"1": {
+									"name": "storage.type.class.doxygen.c"
+								},
+								"2": {
+									"name": "markup.bold.doxygen.c"
+								}
+							}
+						},
+						{
+							"match": "((?<=[\\s*!\\/])[\\\\@](?:c|p))\\s+(\\S+)",
+							"captures": {
+								"1": {
+									"name": "storage.type.class.doxygen.c"
+								},
+								"2": {
+									"name": "markup.inline.raw.string.c"
+								}
+							}
+						},
+						{
+							"match": "(?<=[\\s*!\\/])[\\\\@](?:a|anchor|b|c|cite|copybrief|copydetail|copydoc|def|dir|dontinclude|e|em|emoji|enum|example|extends|file|idlexcept|implements|include|includedoc|includelineno|latexinclude|link|memberof|namespace|p|package|ref|refitem|related|relates|relatedalso|relatesalso|verbinclude)\\b(?:\\{[^}]*\\})?",
+							"name": "storage.type.class.doxygen.c"
+						},
+						{
+							"match": "(?<=[\\s*!\\/])[\\\\@](?:addindex|addtogroup|category|class|defgroup|diafile|dotfile|elseif|fn|headerfile|if|ifnot|image|ingroup|interface|line|mainpage|mscfile|name|overload|page|property|protocol|section|skip|skipline|snippet|snippetdoc|snippetlineno|struct|subpage|subsection|subsubsection|typedef|union|until|vhdlflow|weakgroup)\\b(?:\\{[^}]*\\})?",
+							"name": "storage.type.class.doxygen.c"
+						},
+						{
+							"match": "((?<=[\\s*!\\/])[\\\\@]param)\\s+(\\b\\w+\\b)",
+							"captures": {
+								"1": {
+									"name": "storage.type.class.doxygen.c"
+								},
+								"2": {
+									"name": "variable.parameter.c"
+								}
+							}
+						},
+						{
+							"match": "(?<=[\\s*!\\/])[\\\\@](?:arg|attention|author|authors|brief|bug|copyright|date|deprecated|details|exception|invariant|li|note|par|paragraph|param|post|pre|remark|remarks|result|return|returns|retval|sa|see|short|since|test|throw|todo|tparam|version|warning|xrefitem)\\b(?:\\{[^}]*\\})?",
+							"name": "storage.type.class.doxygen.c"
+						},
+						{
+							"match": "(?<=[\\s*!\\/])[\\\\@](?:code|cond|docbookonly|dot|htmlonly|internal|latexonly|link|manonly|msc|parblock|rtfonly|secreflist|uml|verbatim|xmlonly|endcode|endcond|enddocbookonly|enddot|endhtmlonly|endinternal|endlatexonly|endlink|endmanonly|endmsc|endparblock|endrtfonly|endsecreflist|enduml|endverbatim|endxmlonly)\\b(?:\\{[^}]*\\})?",
+							"name": "storage.type.class.doxygen.c"
+						},
+						{
+							"match": "(?:\\b[A-Z]+:|@[a-z_]+:)",
+							"name": "storage.type.class.gtkdoc"
+						}
+					]
+				},
+				{
+					"match": "^\\/\\* =(\\s*.*?)\\s*= \\*\\/$\\n?",
 					"captures": {
 						"1": {
 							"name": "meta.toc-list.banner.block.c"
 						}
 					},
-					"match": "^/\\* =(\\s*.*?)\\s*= \\*/$\\n?",
-					"name": "comment.block.c"
+					"name": "comment.block.banner.c"
 				},
 				{
-					"begin": "/\\*",
+					"name": "comment.block.c",
+					"begin": "(\\/\\*)",
 					"beginCaptures": {
-						"0": {
+						"1": {
 							"name": "punctuation.definition.comment.begin.c"
 						}
 					},
-					"end": "\\*/",
+					"end": "(\\*\\/)",
 					"endCaptures": {
-						"0": {
+						"1": {
 							"name": "punctuation.definition.comment.end.c"
 						}
-					},
-					"name": "comment.block.c"
+					}
 				},
 				{
-					"match": "\\*/.*\\n",
-					"name": "invalid.illegal.stray-comment-end.c"
-				},
-				{
+					"match": "^\\/\\/ =(\\s*.*?)\\s*=$\\n?",
 					"captures": {
 						"1": {
 							"name": "meta.toc-list.banner.line.c"
 						}
 					},
-					"match": "^// =(\\s*.*?)\\s*=\\s*$\\n?",
-					"name": "comment.line.banner.cpp"
+					"name": "comment.line.banner.c"
 				},
 				{
-					"begin": "(^[ \\t]+)?(?=//)",
+					"begin": "((?:^[ \\t]+)?)(?=\\/\\/)",
 					"beginCaptures": {
 						"1": {
-							"name": "punctuation.whitespace.comment.leading.cpp"
+							"name": "punctuation.whitespace.comment.leading.c"
 						}
 					},
 					"end": "(?!\\G)",
 					"patterns": [
 						{
-							"begin": "//",
+							"name": "comment.line.double-slash.c",
+							"begin": "(\\/\\/)",
 							"beginCaptures": {
-								"0": {
-									"name": "punctuation.definition.comment.cpp"
+								"1": {
+									"name": "punctuation.definition.comment.c"
 								}
 							},
 							"end": "(?=\\n)",
-							"name": "comment.line.double-slash.cpp",
 							"patterns": [
 								{
 									"include": "#line_continuation_character"
@@ -473,6 +941,54 @@
 							]
 						}
 					]
+				}
+			]
+		},
+		"default_statement": {
+			"name": "meta.conditional.case.c",
+			"begin": "((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))((?<!\\w)default(?!\\w))",
+			"beginCaptures": {
+				"1": {
+					"patterns": [
+						{
+							"include": "#inline_comment"
+						}
+					]
+				},
+				"2": {
+					"name": "comment.block.c punctuation.definition.comment.begin.c"
+				},
+				"3": {
+					"name": "comment.block.c"
+				},
+				"4": {
+					"patterns": [
+						{
+							"match": "\\*\\/",
+							"name": "comment.block.c punctuation.definition.comment.end.c"
+						},
+						{
+							"match": "\\*",
+							"name": "comment.block.c"
+						}
+					]
+				},
+				"5": {
+					"name": "keyword.control.default.c"
+				}
+			},
+			"end": "(:)",
+			"endCaptures": {
+				"1": {
+					"name": "punctuation.separator.colon.case.default.c"
+				}
+			},
+			"patterns": [
+				{
+					"include": "#evaluation_context"
+				},
+				{
+					"include": "#c_conditional_context"
 				}
 			]
 		},
@@ -488,16 +1004,165 @@
 				}
 			]
 		},
-		"libc": {
+		"evalutation_context": {
+			"patterns": [
+				{
+					"include": "#function-call-innards"
+				},
+				{
+					"include": "$base"
+				}
+			]
+		},
+		"function-call-innards": {
+			"patterns": [
+				{
+					"include": "#comments"
+				},
+				{
+					"include": "#storage_types"
+				},
+				{
+					"include": "#method_access"
+				},
+				{
+					"include": "#member_access"
+				},
+				{
+					"include": "#operators"
+				},
+				{
+					"begin": "(?x)\n(?!(?:while|for|do|if|else|switch|catch|enumerate|return|typeid|alignof|alignas|sizeof|[cr]?iterate|and|and_eq|bitand|bitor|compl|not|not_eq|or|or_eq|typeid|xor|xor_eq|alignof|alignas)\\s*\\()\n(\n(?:[A-Za-z_][A-Za-z0-9_]*+|::)++  # actual name\n|\n(?:(?<=operator)(?:[-*&<>=+!]+|\\(\\)|\\[\\]))\n)\n\\s*(\\()",
+					"beginCaptures": {
+						"1": {
+							"name": "entity.name.function.c"
+						},
+						"2": {
+							"name": "punctuation.section.arguments.begin.bracket.round.c"
+						}
+					},
+					"end": "\\)",
+					"endCaptures": {
+						"0": {
+							"name": "punctuation.section.arguments.end.bracket.round.c"
+						}
+					},
+					"patterns": [
+						{
+							"include": "#function-call-innards"
+						}
+					]
+				},
+				{
+					"begin": "\\(",
+					"beginCaptures": {
+						"0": {
+							"name": "punctuation.section.parens.begin.bracket.round.c"
+						}
+					},
+					"end": "\\)",
+					"endCaptures": {
+						"0": {
+							"name": "punctuation.section.parens.end.bracket.round.c"
+						}
+					},
+					"patterns": [
+						{
+							"include": "#function-call-innards"
+						}
+					]
+				},
+				{
+					"include": "#block_innards"
+				}
+			]
+		},
+		"function-innards": {
+			"patterns": [
+				{
+					"include": "#comments"
+				},
+				{
+					"include": "#storage_types"
+				},
+				{
+					"include": "#operators"
+				},
+				{
+					"include": "#vararg_ellipses"
+				},
+				{
+					"name": "meta.function.definition.parameters.c",
+					"begin": "(?x)\n(?!(?:while|for|do|if|else|switch|catch|enumerate|return|typeid|alignof|alignas|sizeof|[cr]?iterate|and|and_eq|bitand|bitor|compl|not|not_eq|or|or_eq|typeid|xor|xor_eq|alignof|alignas)\\s*\\()\n(\n(?:[A-Za-z_][A-Za-z0-9_]*+|::)++  # actual name\n|\n(?:(?<=operator)(?:[-*&<>=+!]+|\\(\\)|\\[\\]))\n)\n\\s*(\\()",
+					"beginCaptures": {
+						"1": {
+							"name": "entity.name.function.c"
+						},
+						"2": {
+							"name": "punctuation.section.parameters.begin.bracket.round.c"
+						}
+					},
+					"end": "\\)",
+					"endCaptures": {
+						"0": {
+							"name": "punctuation.section.parameters.end.bracket.round.c"
+						}
+					},
+					"patterns": [
+						{
+							"include": "#probably_a_parameter"
+						},
+						{
+							"include": "#function-innards"
+						}
+					]
+				},
+				{
+					"begin": "\\(",
+					"beginCaptures": {
+						"0": {
+							"name": "punctuation.section.parens.begin.bracket.round.c"
+						}
+					},
+					"end": "\\)",
+					"endCaptures": {
+						"0": {
+							"name": "punctuation.section.parens.end.bracket.round.c"
+						}
+					},
+					"patterns": [
+						{
+							"include": "#function-innards"
+						}
+					]
+				},
+				{
+					"include": "$base"
+				}
+			]
+		},
+		"inline_comment": {
+			"match": "(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/))",
 			"captures": {
 				"1": {
-					"name": "punctuation.whitespace.support.function.leading.c"
+					"name": "comment.block.c punctuation.definition.comment.begin.c"
 				},
 				"2": {
-					"name": "support.function.C99.c"
+					"name": "comment.block.c"
+				},
+				"3": {
+					"patterns": [
+						{
+							"match": "\\*\\/",
+							"name": "comment.block.c punctuation.definition.comment.end.c"
+						},
+						{
+							"match": "\\*",
+							"name": "comment.block.c"
+						}
+					]
 				}
-			},
-			"match": "(?x) (\\s*) \\b\n(_Exit|(?:nearbyint|nextafter|nexttoward|netoward|nan)[fl]?|a(?:cos|sin)h?[fl]?|abort|abs|asctime|assert\n|atan(?:[h2]?[fl]?)?|atexit|ato[ifl]|atoll|bsearch|btowc|cabs[fl]?|cacos|cacos[fl]|cacosh[fl]?\n|calloc|carg[fl]?|casinh?[fl]?|catanh?[fl]?|cbrt[fl]?|ccosh?[fl]?|ceil[fl]?|cexp[fl]?|cimag[fl]?\n|clearerr|clock|clog[fl]?|conj[fl]?|copysign[fl]?|cosh?[fl]?|cpow[fl]?|cproj[fl]?|creal[fl]?\n|csinh?[fl]?|csqrt[fl]?|ctanh?[fl]?|ctime|difftime|div|erfc?[fl]?|exit|fabs[fl]?\n|exp(?:2[fl]?|[fl]|m1[fl]?)?|fclose|fdim[fl]?|fe[gs]et(?:env|exceptflag|round)|feclearexcept\n|feholdexcept|feof|feraiseexcept|ferror|fetestexcept|feupdateenv|fflush|fgetpos|fgetw?[sc]\n|floor[fl]?|fmax?[fl]?|fmin[fl]?|fmod[fl]?|fopen|fpclassify|fprintf|fputw?[sc]|fread|free|freopen\n|frexp[fl]?|fscanf|fseek|fsetpos|ftell|fwide|fwprintf|fwrite|fwscanf|genv|get[sc]|getchar|gmtime\n|gwc|gwchar|hypot[fl]?|ilogb[fl]?|imaxabs|imaxdiv|isalnum|isalpha|isblank|iscntrl|isdigit|isfinite\n|isgraph|isgreater|isgreaterequal|isinf|isless(?:equal|greater)?|isw?lower|isnan|isnormal|isw?print\n|isw?punct|isw?space|isunordered|isw?upper|iswalnum|iswalpha|iswblank|iswcntrl|iswctype|iswdigit|iswgraph\n|isw?xdigit|labs|ldexp[fl]?|ldiv|lgamma[fl]?|llabs|lldiv|llrint[fl]?|llround[fl]?|localeconv|localtime\n|log[2b]?[fl]?|log1[p0][fl]?|longjmp|lrint[fl]?|lround[fl]?|malloc|mbr?len|mbr?towc|mbsinit|mbsrtowcs\n|mbstowcs|memchr|memcmp|memcpy|memmove|memset|mktime|modf[fl]?|perror|pow[fl]?|printf|puts|putw?c(?:har)?\n|qsort|raise|rand|remainder[fl]?|realloc|remove|remquo[fl]?|rename|rewind|rint[fl]?|round[fl]?|scalbl?n[fl]?\n|scanf|setbuf|setjmp|setlocale|setvbuf|signal|signbit|sinh?[fl]?|snprintf|sprintf|sqrt[fl]?|srand|sscanf\n|strcat|strchr|strcmp|strcoll|strcpy|strcspn|strerror|strftime|strlen|strncat|strncmp|strncpy|strpbrk\n|strrchr|strspn|strstr|strto[kdf]|strtoimax|strtol[dl]?|strtoull?|strtoumax|strxfrm|swprintf|swscanf\n|system|tan|tan[fl]|tanh[fl]?|tgamma[fl]?|time|tmpfile|tmpnam|tolower|toupper|trunc[fl]?|ungetw?c|va_arg\n|va_copy|va_end|va_start|vfw?printf|vfw?scanf|vprintf|vscanf|vsnprintf|vsprintf|vsscanf|vswprintf|vswscanf\n|vwprintf|vwscanf|wcrtomb|wcscat|wcschr|wcscmp|wcscoll|wcscpy|wcscspn|wcsftime|wcslen|wcsncat|wcsncmp|wcsncpy\n|wcspbrk|wcsrchr|wcsrtombs|wcsspn|wcsstr|wcsto[dkf]|wcstoimax|wcstol[dl]?|wcstombs|wcstoull?|wcstoumax|wcsxfrm\n|wctom?b|wmem(?:set|chr|cpy|cmp|move)|wprintf|wscanf)\\b"
+			}
 		},
 		"line_continuation_character": {
 			"patterns": [
@@ -511,69 +1176,355 @@
 				}
 			]
 		},
-		"numbers": {
-			"patterns": [
-				{
-					"match": "\\b((0(x|X)[0-9a-fA-F]([0-9a-fA-F']*[0-9a-fA-F])?)|(0(b|B)[01]([01']*[01])?)|(([0-9]([0-9']*[0-9])?\\.?[0-9]*([0-9']*[0-9])?)|(\\.[0-9]([0-9']*[0-9])?))((e|E)(\\+|-)?[0-9]([0-9']*[0-9])?)?)(L|l|UL|ul|u|U|F|f|ll|LL|ull|ULL)?\\b",
-					"name": "constant.numeric.c"
-				}
-			]
-		},
-		"parens": {
-			"begin": "\\(",
-			"beginCaptures": {
-				"0": {
-					"name": "punctuation.section.parens.begin.bracket.round.c"
-				}
-			},
-			"end": "\\)",
-			"endCaptures": {
-				"0": {
-					"name": "punctuation.section.parens.end.bracket.round.c"
-				}
-			},
-			"patterns": [
-				{
-					"include": "$base"
-				}
-			]
-		},
-		"parens-block": {
-			"begin": "\\(",
-			"beginCaptures": {
-				"0": {
-					"name": "punctuation.section.parens.begin.bracket.round.c"
-				}
-			},
-			"end": "\\)",
-			"endCaptures": {
-				"0": {
-					"name": "punctuation.section.parens.end.bracket.round.c"
-				}
-			},
-			"patterns": [
-				{
-					"include": "#block_innards"
-				}
-			]
-		},
-		"pragma-mark": {
+		"member_access": {
+			"match": "((?:[a-zA-Z_]\\w*|(?<=\\]|\\)))\\s*)(?:((?:\\.\\*|\\.))|((?:->\\*|->)))((?:[a-zA-Z_]\\w*\\s*(?:(?:(?:\\.\\*|\\.))|(?:(?:->\\*|->)))\\s*)*)\\s*(\\b(?!(?:atomic_uint_least64_t|atomic_uint_least16_t|atomic_uint_least32_t|atomic_uint_least8_t|atomic_int_least16_t|atomic_uint_fast64_t|atomic_uint_fast32_t|atomic_int_least64_t|atomic_int_least32_t|pthread_rwlockattr_t|atomic_uint_fast16_t|pthread_mutexattr_t|atomic_int_fast16_t|atomic_uint_fast8_t|atomic_int_fast64_t|atomic_int_least8_t|atomic_int_fast32_t|atomic_int_fast8_t|pthread_condattr_t|atomic_uintptr_t|atomic_ptrdiff_t|pthread_rwlock_t|atomic_uintmax_t|pthread_mutex_t|atomic_intmax_t|atomic_intptr_t|atomic_char32_t|atomic_char16_t|pthread_attr_t|atomic_wchar_t|uint_least64_t|uint_least32_t|uint_least16_t|pthread_cond_t|pthread_once_t|uint_fast64_t|uint_fast16_t|atomic_size_t|uint_least8_t|int_least64_t|int_least32_t|int_least16_t|pthread_key_t|atomic_ullong|atomic_ushort|uint_fast32_t|atomic_schar|atomic_short|uint_fast8_t|int_fast64_t|int_fast32_t|int_fast16_t|atomic_ulong|atomic_llong|int_least8_t|atomic_uchar|memory_order|suseconds_t|int_fast8_t|atomic_bool|atomic_char|atomic_uint|atomic_long|atomic_int|useconds_t|_Imaginary|blksize_t|pthread_t|in_addr_t|uintptr_t|in_port_t|uintmax_t|uintmax_t|blkcnt_t|uint16_t|unsigned|_Complex|uint32_t|intptr_t|intmax_t|intmax_t|uint64_t|u_quad_t|int64_t|int32_t|ssize_t|caddr_t|clock_t|uint8_t|u_short|swblk_t|segsz_t|int16_t|fixpt_t|daddr_t|nlink_t|qaddr_t|size_t|time_t|mode_t|signed|quad_t|ushort|u_long|u_char|double|int8_t|ino_t|uid_t|pid_t|_Bool|float|dev_t|div_t|short|gid_t|off_t|u_int|key_t|id_t|uint|long|void|char|bool|id_t|int)\\b)[a-zA-Z_]\\w*\\b(?!\\())",
 			"captures": {
 				"1": {
-					"name": "meta.preprocessor.pragma.c"
+					"name": "variable.other.object.access.c"
 				},
 				"2": {
-					"name": "keyword.control.directive.pragma.pragma-mark.c"
+					"name": "punctuation.separator.dot-access.c"
 				},
 				"3": {
-					"name": "punctuation.definition.directive.c"
+					"name": "punctuation.separator.pointer-access.c"
 				},
 				"4": {
-					"name": "entity.name.tag.pragma-mark.c"
+					"patterns": [
+						{
+							"include": "#member_access"
+						},
+						{
+							"include": "#method_access"
+						},
+						{
+							"match": "((?:[a-zA-Z_]\\w*|(?<=\\]|\\)))\\s*)(?:((?:\\.\\*|\\.))|((?:->\\*|->)))",
+							"captures": {
+								"1": {
+									"name": "variable.other.object.access.c"
+								},
+								"2": {
+									"name": "punctuation.separator.dot-access.c"
+								},
+								"3": {
+									"name": "punctuation.separator.pointer-access.c"
+								}
+							}
+						}
+					]
+				},
+				"5": {
+					"name": "variable.other.member.c"
+				}
+			}
+		},
+		"method_access": {
+			"contentName": "meta.function-call.member.c",
+			"begin": "((?:[a-zA-Z_]\\w*|(?<=\\]|\\)))\\s*)(?:((?:\\.\\*|\\.))|((?:->\\*|->)))((?:[a-zA-Z_]\\w*\\s*(?:(?:(?:\\.\\*|\\.))|(?:(?:->\\*|->)))\\s*)*)\\s*([a-zA-Z_]\\w*)(\\()",
+			"beginCaptures": {
+				"1": {
+					"name": "variable.other.object.access.c"
+				},
+				"2": {
+					"name": "punctuation.separator.dot-access.c"
+				},
+				"3": {
+					"name": "punctuation.separator.pointer-access.c"
+				},
+				"4": {
+					"patterns": [
+						{
+							"include": "#member_access"
+						},
+						{
+							"include": "#method_access"
+						},
+						{
+							"match": "((?:[a-zA-Z_]\\w*|(?<=\\]|\\)))\\s*)(?:((?:\\.\\*|\\.))|((?:->\\*|->)))",
+							"captures": {
+								"1": {
+									"name": "variable.other.object.access.c"
+								},
+								"2": {
+									"name": "punctuation.separator.dot-access.c"
+								},
+								"3": {
+									"name": "punctuation.separator.pointer-access.c"
+								}
+							}
+						}
+					]
+				},
+				"5": {
+					"name": "entity.name.function.member.c"
+				},
+				"6": {
+					"name": "punctuation.section.arguments.begin.bracket.round.function.member.c"
 				}
 			},
-			"match": "^\\s*(((#)\\s*pragma\\s+mark)\\s+(.*))",
-			"name": "meta.section"
+			"end": "(\\))",
+			"endCaptures": {
+				"1": {
+					"name": "punctuation.section.arguments.end.bracket.round.function.member.c"
+				}
+			},
+			"patterns": [
+				{
+					"include": "#function-call-innards"
+				}
+			]
+		},
+		"numbers": {
+			"match": "(?<!\\w)\\.?\\d(?:(?:[0-9a-zA-Z_\\.]|')|(?<=[eEpP])[+-])*",
+			"captures": {
+				"0": {
+					"patterns": [
+						{
+							"begin": "(?=.)",
+							"end": "$",
+							"patterns": [
+								{
+									"match": "(\\G0[xX])([0-9a-fA-F](?:[0-9a-fA-F]|((?<=[0-9a-fA-F])'(?=[0-9a-fA-F])))*)?((?:(?<=[0-9a-fA-F])\\.|\\.(?=[0-9a-fA-F])))([0-9a-fA-F](?:[0-9a-fA-F]|((?<=[0-9a-fA-F])'(?=[0-9a-fA-F])))*)?((?<!')([pP])(\\+?)(\\-?)((?:[0-9](?:[0-9]|(?:(?<=[0-9a-fA-F])'(?=[0-9a-fA-F])))*)))?([lLfF](?!\\w))?$",
+									"captures": {
+										"1": {
+											"name": "keyword.other.unit.hexadecimal.c"
+										},
+										"2": {
+											"name": "constant.numeric.hexadecimal.c",
+											"patterns": [
+												{
+													"match": "(?<=[0-9a-fA-F])'(?=[0-9a-fA-F])",
+													"name": "punctuation.separator.constant.numeric"
+												}
+											]
+										},
+										"3": {
+											"name": "punctuation.separator.constant.numeric"
+										},
+										"4": {
+											"name": "constant.numeric.hexadecimal.c"
+										},
+										"5": {
+											"name": "constant.numeric.hexadecimal.c",
+											"patterns": [
+												{
+													"match": "(?<=[0-9a-fA-F])'(?=[0-9a-fA-F])",
+													"name": "punctuation.separator.constant.numeric"
+												}
+											]
+										},
+										"6": {
+											"name": "punctuation.separator.constant.numeric"
+										},
+										"8": {
+											"name": "keyword.other.unit.exponent.hexadecimal.c"
+										},
+										"9": {
+											"name": "keyword.operator.plus.exponent.hexadecimal.c"
+										},
+										"10": {
+											"name": "keyword.operator.minus.exponent.hexadecimal.c"
+										},
+										"11": {
+											"name": "constant.numeric.exponent.hexadecimal.c",
+											"patterns": [
+												{
+													"match": "(?<=[0-9a-fA-F])'(?=[0-9a-fA-F])",
+													"name": "punctuation.separator.constant.numeric"
+												}
+											]
+										},
+										"12": {
+											"name": "keyword.other.unit.suffix.floating-point.c"
+										}
+									}
+								},
+								{
+									"match": "(\\G(?=[0-9.])(?!0[xXbB]))([0-9](?:[0-9]|((?<=[0-9a-fA-F])'(?=[0-9a-fA-F])))*)?((?:(?<=[0-9])\\.|\\.(?=[0-9])))([0-9](?:[0-9]|((?<=[0-9a-fA-F])'(?=[0-9a-fA-F])))*)?((?<!')([eE])(\\+?)(\\-?)((?:[0-9](?:[0-9]|(?:(?<=[0-9a-fA-F])'(?=[0-9a-fA-F])))*)))?([lLfF](?!\\w))?$",
+									"captures": {
+										"2": {
+											"name": "constant.numeric.decimal.c",
+											"patterns": [
+												{
+													"match": "(?<=[0-9a-fA-F])'(?=[0-9a-fA-F])",
+													"name": "punctuation.separator.constant.numeric"
+												}
+											]
+										},
+										"3": {
+											"name": "punctuation.separator.constant.numeric"
+										},
+										"4": {
+											"name": "constant.numeric.decimal.point.c"
+										},
+										"5": {
+											"name": "constant.numeric.decimal.c",
+											"patterns": [
+												{
+													"match": "(?<=[0-9a-fA-F])'(?=[0-9a-fA-F])",
+													"name": "punctuation.separator.constant.numeric"
+												}
+											]
+										},
+										"6": {
+											"name": "punctuation.separator.constant.numeric"
+										},
+										"8": {
+											"name": "keyword.other.unit.exponent.decimal.c"
+										},
+										"9": {
+											"name": "keyword.operator.plus.exponent.decimal.c"
+										},
+										"10": {
+											"name": "keyword.operator.minus.exponent.decimal.c"
+										},
+										"11": {
+											"name": "constant.numeric.exponent.decimal.c",
+											"patterns": [
+												{
+													"match": "(?<=[0-9a-fA-F])'(?=[0-9a-fA-F])",
+													"name": "punctuation.separator.constant.numeric"
+												}
+											]
+										},
+										"12": {
+											"name": "keyword.other.unit.suffix.floating-point.c"
+										}
+									}
+								},
+								{
+									"match": "(\\G0[bB])([01](?:[01]|((?<=[0-9a-fA-F])'(?=[0-9a-fA-F])))*)((?:(?:(?:(?:(?:[uU]|[uU]ll?)|[uU]LL?)|ll?[uU]?)|LL?[uU]?)|[fF])(?!\\w))?$",
+									"captures": {
+										"1": {
+											"name": "keyword.other.unit.binary.c"
+										},
+										"2": {
+											"name": "constant.numeric.binary.c",
+											"patterns": [
+												{
+													"match": "(?<=[0-9a-fA-F])'(?=[0-9a-fA-F])",
+													"name": "punctuation.separator.constant.numeric"
+												}
+											]
+										},
+										"3": {
+											"name": "punctuation.separator.constant.numeric"
+										},
+										"4": {
+											"name": "keyword.other.unit.suffix.integer.c"
+										}
+									}
+								},
+								{
+									"match": "(\\G0)((?:[0-7]|((?<=[0-9a-fA-F])'(?=[0-9a-fA-F])))+)((?:(?:(?:(?:(?:[uU]|[uU]ll?)|[uU]LL?)|ll?[uU]?)|LL?[uU]?)|[fF])(?!\\w))?$",
+									"captures": {
+										"1": {
+											"name": "keyword.other.unit.octal.c"
+										},
+										"2": {
+											"name": "constant.numeric.octal.c",
+											"patterns": [
+												{
+													"match": "(?<=[0-9a-fA-F])'(?=[0-9a-fA-F])",
+													"name": "punctuation.separator.constant.numeric"
+												}
+											]
+										},
+										"3": {
+											"name": "punctuation.separator.constant.numeric"
+										},
+										"4": {
+											"name": "keyword.other.unit.suffix.integer.c"
+										}
+									}
+								},
+								{
+									"match": "(\\G0[xX])([0-9a-fA-F](?:[0-9a-fA-F]|((?<=[0-9a-fA-F])'(?=[0-9a-fA-F])))*)((?<!')([pP])(\\+?)(\\-?)((?:[0-9](?:[0-9]|(?:(?<=[0-9a-fA-F])'(?=[0-9a-fA-F])))*)))?((?:(?:(?:(?:(?:[uU]|[uU]ll?)|[uU]LL?)|ll?[uU]?)|LL?[uU]?)|[fF])(?!\\w))?$",
+									"captures": {
+										"1": {
+											"name": "keyword.other.unit.hexadecimal.c"
+										},
+										"2": {
+											"name": "constant.numeric.hexadecimal.c",
+											"patterns": [
+												{
+													"match": "(?<=[0-9a-fA-F])'(?=[0-9a-fA-F])",
+													"name": "punctuation.separator.constant.numeric"
+												}
+											]
+										},
+										"3": {
+											"name": "punctuation.separator.constant.numeric"
+										},
+										"5": {
+											"name": "keyword.other.unit.exponent.hexadecimal.c"
+										},
+										"6": {
+											"name": "keyword.operator.plus.exponent.hexadecimal.c"
+										},
+										"7": {
+											"name": "keyword.operator.minus.exponent.hexadecimal.c"
+										},
+										"8": {
+											"name": "constant.numeric.exponent.hexadecimal.c",
+											"patterns": [
+												{
+													"match": "(?<=[0-9a-fA-F])'(?=[0-9a-fA-F])",
+													"name": "punctuation.separator.constant.numeric"
+												}
+											]
+										},
+										"9": {
+											"name": "keyword.other.unit.suffix.integer.c"
+										}
+									}
+								},
+								{
+									"match": "(\\G(?=[0-9.])(?!0[xXbB]))([0-9](?:[0-9]|((?<=[0-9a-fA-F])'(?=[0-9a-fA-F])))*)((?<!')([eE])(\\+?)(\\-?)((?:[0-9](?:[0-9]|(?:(?<=[0-9a-fA-F])'(?=[0-9a-fA-F])))*)))?((?:(?:(?:(?:(?:[uU]|[uU]ll?)|[uU]LL?)|ll?[uU]?)|LL?[uU]?)|[fF])(?!\\w))?$",
+									"captures": {
+										"2": {
+											"name": "constant.numeric.decimal.c",
+											"patterns": [
+												{
+													"match": "(?<=[0-9a-fA-F])'(?=[0-9a-fA-F])",
+													"name": "punctuation.separator.constant.numeric"
+												}
+											]
+										},
+										"3": {
+											"name": "punctuation.separator.constant.numeric"
+										},
+										"5": {
+											"name": "keyword.other.unit.exponent.decimal.c"
+										},
+										"6": {
+											"name": "keyword.operator.plus.exponent.decimal.c"
+										},
+										"7": {
+											"name": "keyword.operator.minus.exponent.decimal.c"
+										},
+										"8": {
+											"name": "constant.numeric.exponent.decimal.c",
+											"patterns": [
+												{
+													"match": "(?<=[0-9a-fA-F])'(?=[0-9a-fA-F])",
+													"name": "punctuation.separator.constant.numeric"
+												}
+											]
+										},
+										"9": {
+											"name": "keyword.other.unit.suffix.integer.c"
+										}
+									}
+								},
+								{
+									"match": "(?:(?:[0-9a-zA-Z_\\.]|')|(?<=[eEpP])[+-])+",
+									"name": "invalid.illegal.constant.numeric"
+								}
+							]
+						}
+					]
+				}
+			}
 		},
 		"operators": {
 			"patterns": [
@@ -622,28 +1573,21 @@
 					"name": "keyword.operator.c"
 				},
 				{
-					"begin": "\\?",
+					"begin": "(\\?)",
 					"beginCaptures": {
-						"0": {
+						"1": {
 							"name": "keyword.operator.ternary.c"
 						}
 					},
-					"end": ":",
-					"applyEndPatternLast": true,
+					"end": "(:)",
 					"endCaptures": {
-						"0": {
+						"1": {
 							"name": "keyword.operator.ternary.c"
 						}
 					},
 					"patterns": [
 						{
-							"include": "#access"
-						},
-						{
-							"include": "#libc"
-						},
-						{
-							"include": "#c_function_call"
+							"include": "#function-call-innards"
 						},
 						{
 							"include": "$base"
@@ -652,98 +1596,83 @@
 				}
 			]
 		},
-		"strings": {
+		"parens": {
+			"name": "meta.parens.c",
+			"begin": "\\(",
+			"beginCaptures": {
+				"0": {
+					"name": "punctuation.section.parens.begin.bracket.round.c"
+				}
+			},
+			"end": "\\)",
+			"endCaptures": {
+				"0": {
+					"name": "punctuation.section.parens.end.bracket.round.c"
+				}
+			},
 			"patterns": [
 				{
-					"begin": "\"",
-					"beginCaptures": {
-						"0": {
-							"name": "punctuation.definition.string.begin.c"
-						}
-					},
-					"end": "\"",
-					"endCaptures": {
-						"0": {
-							"name": "punctuation.definition.string.end.c"
-						}
-					},
-					"name": "string.quoted.double.c",
-					"patterns": [
-						{
-							"include": "#string_escaped_char"
-						},
-						{
-							"include": "#string_placeholder"
-						},
-						{
-							"include": "#line_continuation_character"
-						}
-					]
-				},
-				{
-					"begin": "'",
-					"beginCaptures": {
-						"0": {
-							"name": "punctuation.definition.string.begin.c"
-						}
-					},
-					"end": "'",
-					"endCaptures": {
-						"0": {
-							"name": "punctuation.definition.string.end.c"
-						}
-					},
-					"name": "string.quoted.single.c",
-					"patterns": [
-						{
-							"include": "#string_escaped_char"
-						},
-						{
-							"include": "#line_continuation_character"
-						}
-					]
+					"include": "$base"
 				}
 			]
 		},
-		"string_escaped_char": {
+		"parens-block": {
+			"name": "meta.parens.block.c",
+			"begin": "\\(",
+			"beginCaptures": {
+				"0": {
+					"name": "punctuation.section.parens.begin.bracket.round.c"
+				}
+			},
+			"end": "\\)",
+			"endCaptures": {
+				"0": {
+					"name": "punctuation.section.parens.end.bracket.round.c"
+				}
+			},
 			"patterns": [
 				{
-					"match": "(?x)\\\\ (\n\\\\             |\n[abefnprtv'\"?]   |\n[0-3]\\d{,2}     |\n[4-7]\\d?        |\nx[a-fA-F0-9]{,2} |\nu[a-fA-F0-9]{,4} |\nU[a-fA-F0-9]{,8} )",
-					"name": "constant.character.escape.c"
+					"include": "#block_innards"
 				},
 				{
-					"match": "\\\\.",
-					"name": "invalid.illegal.unknown-escape.c"
+					"match": "(?-mix:(?<!:):(?!:))",
+					"name": "punctuation.range-based.c"
 				}
 			]
 		},
-		"string_placeholder": {
+		"pragma-mark": {
+			"captures": {
+				"1": {
+					"name": "meta.preprocessor.pragma.c"
+				},
+				"2": {
+					"name": "keyword.control.directive.pragma.pragma-mark.c"
+				},
+				"3": {
+					"name": "punctuation.definition.directive.c"
+				},
+				"4": {
+					"name": "entity.name.tag.pragma-mark.c"
+				}
+			},
+			"match": "^\\s*(((#)\\s*pragma\\s+mark)\\s+(.*))",
+			"name": "meta.section.c"
+		},
+		"predefined_macros": {
 			"patterns": [
 				{
-					"match": "(?x) %\n(\\d+\\$)?                           # field (argument #)\n[#0\\- +']*                          # flags\n[,;:_]?                              # separator character (AltiVec)\n((-?\\d+)|\\*(-?\\d+\\$)?)?          # minimum field width\n(\\.((-?\\d+)|\\*(-?\\d+\\$)?)?)?    # precision\n(hh|h|ll|l|j|t|z|q|L|vh|vl|v|hv|hl)? # length modifier\n[diouxXDOUeEfFgGaACcSspn%]           # conversion type",
-					"name": "constant.other.placeholder.c"
-				},
-				{
-					"match": "(%)(?!\"\\s*(PRI|SCN))",
+					"match": "\\b(__cplusplus|__DATE__|__FILE__|__LINE__|__STDC__|__STDC_HOSTED__|__STDC_NO_COMPLEX__|__STDC_VERSION__|__STDCPP_THREADS__|__TIME__|NDEBUG|__OBJC__|__ASSEMBLER__|__ATOM__|__AVX__|__AVX2__|_CHAR_UNSIGNED|__CLR_VER|_CONTROL_FLOW_GUARD|__COUNTER__|__cplusplus_cli|__cplusplus_winrt|_CPPRTTI|_CPPUNWIND|_DEBUG|_DLL|__FUNCDNAME__|__FUNCSIG__|__FUNCTION__|_INTEGRAL_MAX_BITS|__INTELLISENSE__|_ISO_VOLATILE|_KERNEL_MODE|_M_AMD64|_M_ARM|_M_ARM_ARMV7VE|_M_ARM_FP|_M_ARM64|_M_CEE|_M_CEE_PURE|_M_CEE_SAFE|_M_FP_EXCEPT|_M_FP_FAST|_M_FP_PRECISE|_M_FP_STRICT|_M_IX86|_M_IX86_FP|_M_X64|_MANAGED|_MSC_BUILD|_MSC_EXTENSIONS|_MSC_FULL_VER|_MSC_VER|_MSVC_LANG|__MSVC_RUNTIME_CHECKS|_MT|_NATIVE_WCHAR_T_DEFINED|_OPENMP|_PREFAST|__TIMESTAMP__|_VC_NO_DEFAULTLIB|_WCHAR_T_DEFINED|_WIN32|_WIN64|_WINRT_DLL|_ATL_VER|_MFC_VER|__GFORTRAN__|__GNUC__|__GNUC_MINOR__|__GNUC_PATCHLEVEL__|__GNUG__|__STRICT_ANSI__|__BASE_FILE__|__INCLUDE_LEVEL__|__ELF__|__VERSION__|__OPTIMIZE__|__OPTIMIZE_SIZE__|__NO_INLINE__|__GNUC_STDC_INLINE__|__CHAR_UNSIGNED__|__WCHAR_UNSIGNED__|__REGISTER_PREFIX__|__REGISTER_PREFIX__|__SIZE_TYPE__|__PTRDIFF_TYPE__|__WCHAR_TYPE__|__WINT_TYPE__|__INTMAX_TYPE__|__UINTMAX_TYPE__|__SIG_ATOMIC_TYPE__|__INT8_TYPE__|__INT16_TYPE__|__INT32_TYPE__|__INT64_TYPE__|__UINT8_TYPE__|__UINT16_TYPE__|__UINT32_TYPE__|__UINT64_TYPE__|__INT_LEAST8_TYPE__|__INT_LEAST16_TYPE__|__INT_LEAST32_TYPE__|__INT_LEAST64_TYPE__|__UINT_LEAST8_TYPE__|__UINT_LEAST16_TYPE__|__UINT_LEAST32_TYPE__|__UINT_LEAST64_TYPE__|__INT_FAST8_TYPE__|__INT_FAST16_TYPE__|__INT_FAST32_TYPE__|__INT_FAST64_TYPE__|__UINT_FAST8_TYPE__|__UINT_FAST16_TYPE__|__UINT_FAST32_TYPE__|__UINT_FAST64_TYPE__|__INTPTR_TYPE__|__UINTPTR_TYPE__|__CHAR_BIT__|__SCHAR_MAX__|__WCHAR_MAX__|__SHRT_MAX__|__INT_MAX__|__LONG_MAX__|__LONG_LONG_MAX__|__WINT_MAX__|__SIZE_MAX__|__PTRDIFF_MAX__|__INTMAX_MAX__|__UINTMAX_MAX__|__SIG_ATOMIC_MAX__|__INT8_MAX__|__INT16_MAX__|__INT32_MAX__|__INT64_MAX__|__UINT8_MAX__|__UINT16_MAX__|__UINT32_MAX__|__UINT64_MAX__|__INT_LEAST8_MAX__|__INT_LEAST16_MAX__|__INT_LEAST32_MAX__|__INT_LEAST64_MAX__|__UINT_LEAST8_MAX__|__UINT_LEAST16_MAX__|__UINT_LEAST32_MAX__|__UINT_LEAST64_MAX__|__INT_FAST8_MAX__|__INT_FAST16_MAX__|__INT_FAST32_MAX__|__INT_FAST64_MAX__|__UINT_FAST8_MAX__|__UINT_FAST16_MAX__|__UINT_FAST32_MAX__|__UINT_FAST64_MAX__|__INTPTR_MAX__|__UINTPTR_MAX__|__WCHAR_MIN__|__WINT_MIN__|__SIG_ATOMIC_MIN__|__SCHAR_WIDTH__|__SHRT_WIDTH__|__INT_WIDTH__|__LONG_WIDTH__|__LONG_LONG_WIDTH__|__PTRDIFF_WIDTH__|__SIG_ATOMIC_WIDTH__|__SIZE_WIDTH__|__WCHAR_WIDTH__|__WINT_WIDTH__|__INT_LEAST8_WIDTH__|__INT_LEAST16_WIDTH__|__INT_LEAST32_WIDTH__|__INT_LEAST64_WIDTH__|__INT_FAST8_WIDTH__|__INT_FAST16_WIDTH__|__INT_FAST32_WIDTH__|__INT_FAST64_WIDTH__|__INTPTR_WIDTH__|__INTMAX_WIDTH__|__SIZEOF_INT__|__SIZEOF_LONG__|__SIZEOF_LONG_LONG__|__SIZEOF_SHORT__|__SIZEOF_POINTER__|__SIZEOF_FLOAT__|__SIZEOF_DOUBLE__|__SIZEOF_LONG_DOUBLE__|__SIZEOF_SIZE_T__|__SIZEOF_WCHAR_T__|__SIZEOF_WINT_T__|__SIZEOF_PTRDIFF_T__|__BYTE_ORDER__|__ORDER_LITTLE_ENDIAN__|__ORDER_BIG_ENDIAN__|__ORDER_PDP_ENDIAN__|__FLOAT_WORD_ORDER__|__DEPRECATED|__EXCEPTIONS|__GXX_RTTI|__USING_SJLJ_EXCEPTIONS__|__GXX_EXPERIMENTAL_CXX0X__|__GXX_WEAK__|__NEXT_RUNTIME__|__LP64__|_LP64|__SSP__|__SSP_ALL__|__SSP_STRONG__|__SSP_EXPLICIT__|__SANITIZE_ADDRESS__|__SANITIZE_THREAD__|__GCC_HAVE_SYNC_COMPARE_AND_SWAP_1|__GCC_HAVE_SYNC_COMPARE_AND_SWAP_2|__GCC_HAVE_SYNC_COMPARE_AND_SWAP_4|__GCC_HAVE_SYNC_COMPARE_AND_SWAP_8|__GCC_HAVE_SYNC_COMPARE_AND_SWAP_16|__HAVE_SPECULATION_SAFE_VALUE|__GCC_HAVE_DWARF2_CFI_ASM|__FP_FAST_FMA|__FP_FAST_FMAF|__FP_FAST_FMAL|__FP_FAST_FMAF16|__FP_FAST_FMAF32|__FP_FAST_FMAF64|__FP_FAST_FMAF128|__FP_FAST_FMAF32X|__FP_FAST_FMAF64X|__FP_FAST_FMAF128X|__GCC_IEC_559|__GCC_IEC_559_COMPLEX|__NO_MATH_ERRNO__|__has_builtin|__has_feature|__has_extension|__has_cpp_attribute|__has_c_attribute|__has_attribute|__has_declspec_attribute|__is_identifier|__has_include|__has_include_next|__has_warning|__BASE_FILE__|__FILE_NAME__|__clang__|__clang_major__|__clang_minor__|__clang_patchlevel__|__clang_version__|__fp16|_Float16)\\b",
 					"captures": {
 						"1": {
-							"name": "invalid.illegal.placeholder.c"
+							"name": "entity.name.other.preprocessor.macro.predefined.$1.c"
 						}
 					}
-				}
-			]
-		},
-		"storage_types": {
-			"patterns": [
+				},
 				{
-					"match": "\\b(asm|__asm__|auto|bool|_Bool|char|_Complex|double|enum|float|_Imaginary|int|long|short|signed|struct|typedef|union|unsigned|void)\\b",
-					"name": "storage.type.c"
+					"match": "\\b__([A-Z_]+)__\\b",
+					"name": "entity.name.other.preprocessor.macro.predefined.probably.$1.c"
 				}
 			]
-		},
-		"vararg_ellipses": {
-			"match": "(?<!\\.)\\.\\.\\.(?!\\.)",
-			"name": "punctuation.vararg-ellipses.c"
 		},
 		"preprocessor-rule-conditional": {
 			"patterns": [
@@ -975,6 +1904,204 @@
 							"include": "#preprocessor-rule-conditional-line"
 						}
 					]
+				}
+			]
+		},
+		"preprocessor-rule-define-line-blocks": {
+			"patterns": [
+				{
+					"begin": "{",
+					"beginCaptures": {
+						"0": {
+							"name": "punctuation.section.block.begin.bracket.curly.c"
+						}
+					},
+					"end": "}|(?=\\s*#\\s*(?:elif|else|endif)\\b)|(?<!\\\\)(?=\\s*\\n)",
+					"endCaptures": {
+						"0": {
+							"name": "punctuation.section.block.end.bracket.curly.c"
+						}
+					},
+					"patterns": [
+						{
+							"include": "#preprocessor-rule-define-line-blocks"
+						},
+						{
+							"include": "#preprocessor-rule-define-line-contents"
+						}
+					]
+				},
+				{
+					"include": "#preprocessor-rule-define-line-contents"
+				}
+			]
+		},
+		"preprocessor-rule-define-line-contents": {
+			"patterns": [
+				{
+					"include": "#vararg_ellipses"
+				},
+				{
+					"begin": "{",
+					"beginCaptures": {
+						"0": {
+							"name": "punctuation.section.block.begin.bracket.curly.c"
+						}
+					},
+					"end": "}|(?=\\s*#\\s*(?:elif|else|endif)\\b)|(?<!\\\\)(?=\\s*\\n)",
+					"endCaptures": {
+						"0": {
+							"name": "punctuation.section.block.end.bracket.curly.c"
+						}
+					},
+					"name": "meta.block.c",
+					"patterns": [
+						{
+							"include": "#preprocessor-rule-define-line-blocks"
+						}
+					]
+				},
+				{
+					"match": "\\(",
+					"name": "punctuation.section.parens.begin.bracket.round.c"
+				},
+				{
+					"match": "\\)",
+					"name": "punctuation.section.parens.end.bracket.round.c"
+				},
+				{
+					"begin": "(?x)\n(?!(?:while|for|do|if|else|switch|catch|enumerate|return|typeid|alignof|alignas|sizeof|[cr]?iterate|and|and_eq|bitand|bitor|compl|not|not_eq|or|or_eq|typeid|xor|xor_eq|alignof|alignas|asm|__asm__|auto|bool|_Bool|char|_Complex|double|enum|float|_Imaginary|int|long|short|signed|struct|typedef|union|unsigned|void)\\s*\\()\n(?=\n  (?:[A-Za-z_][A-Za-z0-9_]*+|::)++\\s*\\(  # actual name\n  |\n  (?:(?<=operator)(?:[-*&<>=+!]+|\\(\\)|\\[\\]))\\s*\\(\n)",
+					"end": "(?<=\\))(?!\\w)|(?<!\\\\)(?=\\s*\\n)",
+					"name": "meta.function.c",
+					"patterns": [
+						{
+							"include": "#preprocessor-rule-define-line-functions"
+						}
+					]
+				},
+				{
+					"begin": "\"",
+					"beginCaptures": {
+						"0": {
+							"name": "punctuation.definition.string.begin.c"
+						}
+					},
+					"end": "\"|(?<!\\\\)(?=\\s*\\n)",
+					"endCaptures": {
+						"0": {
+							"name": "punctuation.definition.string.end.c"
+						}
+					},
+					"name": "string.quoted.double.c",
+					"patterns": [
+						{
+							"include": "#string_escaped_char"
+						},
+						{
+							"include": "#string_placeholder"
+						},
+						{
+							"include": "#line_continuation_character"
+						}
+					]
+				},
+				{
+					"begin": "'",
+					"beginCaptures": {
+						"0": {
+							"name": "punctuation.definition.string.begin.c"
+						}
+					},
+					"end": "'|(?<!\\\\)(?=\\s*\\n)",
+					"endCaptures": {
+						"0": {
+							"name": "punctuation.definition.string.end.c"
+						}
+					},
+					"name": "string.quoted.single.c",
+					"patterns": [
+						{
+							"include": "#string_escaped_char"
+						},
+						{
+							"include": "#line_continuation_character"
+						}
+					]
+				},
+				{
+					"include": "#method_access"
+				},
+				{
+					"include": "#member_access"
+				},
+				{
+					"include": "$base"
+				}
+			]
+		},
+		"preprocessor-rule-define-line-functions": {
+			"patterns": [
+				{
+					"include": "#comments"
+				},
+				{
+					"include": "#storage_types"
+				},
+				{
+					"include": "#vararg_ellipses"
+				},
+				{
+					"include": "#method_access"
+				},
+				{
+					"include": "#member_access"
+				},
+				{
+					"include": "#operators"
+				},
+				{
+					"begin": "(?x)\n(?!(?:while|for|do|if|else|switch|catch|enumerate|return|typeid|alignof|alignas|sizeof|[cr]?iterate|and|and_eq|bitand|bitor|compl|not|not_eq|or|or_eq|typeid|xor|xor_eq|alignof|alignas)\\s*\\()\n(\n(?:[A-Za-z_][A-Za-z0-9_]*+|::)++  # actual name\n|\n(?:(?<=operator)(?:[-*&<>=+!]+|\\(\\)|\\[\\]))\n)\n\\s*(\\()",
+					"beginCaptures": {
+						"1": {
+							"name": "entity.name.function.c"
+						},
+						"2": {
+							"name": "punctuation.section.arguments.begin.bracket.round.c"
+						}
+					},
+					"end": "(\\))|(?<!\\\\)(?=\\s*\\n)",
+					"endCaptures": {
+						"1": {
+							"name": "punctuation.section.arguments.end.bracket.round.c"
+						}
+					},
+					"patterns": [
+						{
+							"include": "#preprocessor-rule-define-line-functions"
+						}
+					]
+				},
+				{
+					"begin": "\\(",
+					"beginCaptures": {
+						"0": {
+							"name": "punctuation.section.parens.begin.bracket.round.c"
+						}
+					},
+					"end": "(\\))|(?<!\\\\)(?=\\s*\\n)",
+					"endCaptures": {
+						"1": {
+							"name": "punctuation.section.parens.end.bracket.round.c"
+						}
+					},
+					"patterns": [
+						{
+							"include": "#preprocessor-rule-define-line-functions"
+						}
+					]
+				},
+				{
+					"include": "#preprocessor-rule-define-line-contents"
 				}
 			]
 		},
@@ -1636,49 +2763,241 @@
 				}
 			]
 		},
-		"preprocessor-rule-define-line-contents": {
+		"probably_a_parameter": {
+			"match": "(?<=(?:[a-zA-Z_0-9] |[&*>\\]\\)]))\\s*([a-zA-Z_]\\w*)\\s*(?=(?:\\[\\]\\s*)?(?:,|\\)))",
+			"captures": {
+				"1": {
+					"name": "variable.parameter.probably.c"
+				}
+			}
+		},
+		"static_assert": {
+			"begin": "((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))((?<!\\w)static_assert|_Static_assert(?!\\w))((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))(\\()",
+			"beginCaptures": {
+				"1": {
+					"patterns": [
+						{
+							"include": "#inline_comment"
+						}
+					]
+				},
+				"2": {
+					"name": "comment.block.c punctuation.definition.comment.begin.c"
+				},
+				"3": {
+					"name": "comment.block.c"
+				},
+				"4": {
+					"patterns": [
+						{
+							"match": "\\*\\/",
+							"name": "comment.block.c punctuation.definition.comment.end.c"
+						},
+						{
+							"match": "\\*",
+							"name": "comment.block.c"
+						}
+					]
+				},
+				"5": {
+					"name": "keyword.other.static_assert.c"
+				},
+				"6": {
+					"patterns": [
+						{
+							"include": "#inline_comment"
+						}
+					]
+				},
+				"7": {
+					"name": "comment.block.c punctuation.definition.comment.begin.c"
+				},
+				"8": {
+					"name": "comment.block.c"
+				},
+				"9": {
+					"patterns": [
+						{
+							"match": "\\*\\/",
+							"name": "comment.block.c punctuation.definition.comment.end.c"
+						},
+						{
+							"match": "\\*",
+							"name": "comment.block.c"
+						}
+					]
+				},
+				"10": {
+					"name": "punctuation.section.arguments.begin.bracket.round.static_assert.c"
+				}
+			},
+			"end": "(\\))",
+			"endCaptures": {
+				"1": {
+					"name": "punctuation.section.arguments.end.bracket.round.static_assert.c"
+				}
+			},
 			"patterns": [
 				{
-					"include": "#vararg_ellipses"
-				},
-				{
-					"begin": "{",
+					"name": "meta.static_assert.message.c",
+					"begin": "(,)\\s*(?=(?:L|u8|u|U\\s*\\\")?)",
 					"beginCaptures": {
-						"0": {
-							"name": "punctuation.section.block.begin.bracket.curly.c"
+						"1": {
+							"name": "punctuation.separator.delimiter.comma.c"
 						}
 					},
-					"end": "}|(?=\\s*#\\s*(?:elif|else|endif)\\b)|(?<!\\\\)(?=\\s*\\n)",
+					"end": "(?=\\))",
+					"patterns": [
+						{
+							"include": "#string_context"
+						}
+					]
+				},
+				{
+					"include": "#evaluation_context"
+				}
+			]
+		},
+		"storage_types": {
+			"patterns": [
+				{
+					"match": "(?-mix:(?<!\\w)(?:unsigned|signed|double|_Bool|short|float|long|void|char|bool|int)(?!\\w))",
+					"name": "storage.type.built-in.primitive.c"
+				},
+				{
+					"match": "(?-mix:(?<!\\w)(?:atomic_uint_least64_t|atomic_uint_least16_t|atomic_uint_least32_t|pthread_rwlockattr_t|atomic_uint_fast64_t|atomic_uint_fast32_t|atomic_uint_fast16_t|atomic_int_least64_t|atomic_int_least32_t|atomic_int_least16_t|atomic_uint_least8_t|atomic_uint_fast8_t|atomic_int_least8_t|atomic_int_fast16_t|pthread_mutexattr_t|atomic_int_fast32_t|atomic_int_fast64_t|atomic_int_fast8_t|pthread_condattr_t|atomic_ptrdiff_t|pthread_rwlock_t|atomic_uintptr_t|atomic_uintmax_t|atomic_intmax_t|atomic_intptr_t|atomic_char32_t|atomic_char16_t|pthread_mutex_t|pthread_cond_t|atomic_wchar_t|uint_least64_t|uint_least32_t|uint_least16_t|pthread_once_t|pthread_attr_t|int_least32_t|pthread_key_t|int_least16_t|int_least64_t|uint_least8_t|uint_fast16_t|uint_fast32_t|uint_fast64_t|atomic_ushort|atomic_ullong|atomic_size_t|int_fast16_t|int_fast64_t|uint_fast8_t|atomic_short|atomic_uchar|atomic_schar|int_least8_t|memory_order|atomic_llong|atomic_ulong|int_fast32_t|atomic_long|atomic_uint|atomic_char|int_fast8_t|suseconds_t|atomic_bool|atomic_int|_Imaginary|useconds_t|in_port_t|uintmax_t|uintmax_t|pthread_t|blksize_t|in_addr_t|uintptr_t|blkcnt_t|uint16_t|uint32_t|uint64_t|u_quad_t|_Complex|intptr_t|intmax_t|intmax_t|segsz_t|u_short|nlink_t|uint8_t|int64_t|int32_t|int16_t|fixpt_t|daddr_t|caddr_t|qaddr_t|ssize_t|clock_t|swblk_t|u_long|mode_t|int8_t|time_t|ushort|u_char|quad_t|size_t|pid_t|gid_t|uid_t|dev_t|div_t|off_t|u_int|key_t|ino_t|uint|id_t|id_t)(?!\\w))",
+					"name": "storage.type.built-in.c"
+				},
+				{
+					"match": "(?-mix:\\b(enum|struct|union)\\b)",
+					"name": "storage.type.$1.c"
+				},
+				{
+					"name": "meta.asm.c",
+					"begin": "(\\b(?:__asm__|asm)\\b)\\s*((?:volatile)?)\\s*(\\()",
+					"beginCaptures": {
+						"1": {
+							"name": "storage.type.asm.c"
+						},
+						"2": {
+							"name": "storage.modifier.c"
+						},
+						"3": {
+							"name": "punctuation.section.parens.begin.bracket.round.assembly.c"
+						}
+					},
+					"end": "(\\))",
 					"endCaptures": {
-						"0": {
-							"name": "punctuation.section.block.end.bracket.curly.c"
+						"1": {
+							"name": "punctuation.section.parens.end.bracket.round.assembly.c"
 						}
 					},
-					"name": "meta.block.c",
 					"patterns": [
 						{
-							"include": "#preprocessor-rule-define-line-blocks"
-						}
-					]
-				},
-				{
-					"match": "\\(",
-					"name": "punctuation.section.parens.begin.bracket.round.c"
-				},
-				{
-					"match": "\\)",
-					"name": "punctuation.section.parens.end.bracket.round.c"
-				},
-				{
-					"begin": "(?x)\n(?!(?:while|for|do|if|else|switch|catch|enumerate|return|typeid|alignof|alignas|sizeof|[cr]?iterate|asm|__asm__|auto|bool|_Bool|char|_Complex|double|enum|float|_Imaginary|int|long|short|signed|struct|typedef|union|unsigned|void)\\s*\\()\n(?=\n  (?:[A-Za-z_][A-Za-z0-9_]*+|::)++\\s*\\(  # actual name\n  |\n  (?:(?<=operator)(?:[-*&<>=+!]+|\\(\\)|\\[\\]))\\s*\\(\n)",
-					"end": "(?<=\\))(?!\\w)|(?<!\\\\)(?=\\s*\\n)",
-					"name": "meta.function.c",
-					"patterns": [
+							"name": "string.quoted.double.c",
+							"contentName": "meta.embedded.assembly.c",
+							"begin": "(R?)(\")",
+							"beginCaptures": {
+								"1": {
+									"name": "meta.encoding.c"
+								},
+								"2": {
+									"name": "punctuation.definition.string.begin.assembly.c"
+								}
+							},
+							"end": "(\")",
+							"endCaptures": {
+								"1": {
+									"name": "punctuation.definition.string.end.assembly.c"
+								}
+							},
+							"patterns": [
+								{
+									"include": "source.asm"
+								},
+								{
+									"include": "source.x86"
+								},
+								{
+									"include": "source.x86_64"
+								},
+								{
+									"include": "source.arm"
+								},
+								{
+									"include": "#backslash_escapes"
+								},
+								{
+									"include": "#string_escaped_char"
+								},
+								{
+									"match": "(?=not)possible"
+								}
+							]
+						},
 						{
-							"include": "#preprocessor-rule-define-line-functions"
+							"begin": "(\\()",
+							"beginCaptures": {
+								"1": {
+									"name": "punctuation.section.parens.begin.bracket.round.assembly.inner.c"
+								}
+							},
+							"end": "(\\))",
+							"endCaptures": {
+								"1": {
+									"name": "punctuation.section.parens.end.bracket.round.assembly.inner.c"
+								}
+							},
+							"patterns": [
+								{
+									"include": "#evaluation_context"
+								}
+							]
+						},
+						{
+							"match": ":",
+							"name": "punctuation.separator.delimiter.colon.assembly.c"
+						},
+						{
+							"include": "#comments_context"
+						},
+						{
+							"include": "#comments"
 						}
 					]
+				}
+			]
+		},
+		"string_escaped_char": {
+			"patterns": [
+				{
+					"match": "(?x)\\\\ (\n\\\\\t\t\t |\n[abefnprtv'\"?]   |\n[0-3]\\d{,2}\t |\n[4-7]\\d?\t\t|\nx[a-fA-F0-9]{,2} |\nu[a-fA-F0-9]{,4} |\nU[a-fA-F0-9]{,8} )",
+					"name": "constant.character.escape.c"
 				},
+				{
+					"match": "\\\\.",
+					"name": "invalid.illegal.unknown-escape.c"
+				}
+			]
+		},
+		"string_placeholder": {
+			"patterns": [
+				{
+					"match": "(?x) %\n(\\d+\\$)?\t\t\t\t\t\t   # field (argument #)\n[#0\\- +']*\t\t\t\t\t\t  # flags\n[,;:_]?\t\t\t\t\t\t\t  # separator character (AltiVec)\n((-?\\d+)|\\*(-?\\d+\\$)?)?\t\t  # minimum field width\n(\\.((-?\\d+)|\\*(-?\\d+\\$)?)?)?\t# precision\n(hh|h|ll|l|j|t|z|q|L|vh|vl|v|hv|hl)? # length modifier\n[diouxXDOUeEfFgGaACcSspn%]\t\t   # conversion type",
+					"name": "constant.other.placeholder.c"
+				},
+				{
+					"match": "(%)(?!\"\\s*(PRI|SCN))",
+					"captures": {
+						"1": {
+							"name": "invalid.illegal.placeholder.c"
+						}
+					}
+				}
+			]
+		},
+		"strings": {
+			"patterns": [
 				{
 					"begin": "\"",
 					"beginCaptures": {
@@ -1686,7 +3005,7 @@
 							"name": "punctuation.definition.string.begin.c"
 						}
 					},
-					"end": "\"|(?<!\\\\)(?=\\s*\\n)",
+					"end": "\"",
 					"endCaptures": {
 						"0": {
 							"name": "punctuation.definition.string.end.c"
@@ -1712,7 +3031,7 @@
 							"name": "punctuation.definition.string.begin.c"
 						}
 					},
-					"end": "'|(?<!\\\\)(?=\\s*\\n)",
+					"end": "'",
 					"endCaptures": {
 						"0": {
 							"name": "punctuation.definition.string.end.c"
@@ -1727,229 +3046,152 @@
 							"include": "#line_continuation_character"
 						}
 					]
-				},
-				{
-					"include": "#access"
-				},
-				{
-					"include": "#libc"
-				},
-				{
-					"include": "$base"
 				}
 			]
 		},
-		"preprocessor-rule-define-line-blocks": {
-			"patterns": [
-				{
-					"begin": "{",
-					"beginCaptures": {
-						"0": {
-							"name": "punctuation.section.block.begin.bracket.curly.c"
-						}
-					},
-					"end": "}|(?=\\s*#\\s*(?:elif|else|endif)\\b)|(?<!\\\\)(?=\\s*\\n)",
-					"endCaptures": {
-						"0": {
-							"name": "punctuation.section.block.end.bracket.curly.c"
-						}
-					},
+		"switch_conditional_parentheses": {
+			"name": "meta.conditional.switch.c",
+			"begin": "((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))(\\()",
+			"beginCaptures": {
+				"1": {
 					"patterns": [
 						{
-							"include": "#preprocessor-rule-define-line-blocks"
-						},
-						{
-							"include": "#preprocessor-rule-define-line-contents"
+							"include": "#inline_comment"
 						}
 					]
 				},
+				"2": {
+					"name": "comment.block.c punctuation.definition.comment.begin.c"
+				},
+				"3": {
+					"name": "comment.block.c"
+				},
+				"4": {
+					"patterns": [
+						{
+							"match": "\\*\\/",
+							"name": "comment.block.c punctuation.definition.comment.end.c"
+						},
+						{
+							"match": "\\*",
+							"name": "comment.block.c"
+						}
+					]
+				},
+				"5": {
+					"name": "punctuation.section.parens.begin.bracket.round.conditional.switch.c"
+				}
+			},
+			"end": "(\\))",
+			"endCaptures": {
+				"1": {
+					"name": "punctuation.section.parens.end.bracket.round.conditional.switch.c"
+				}
+			},
+			"patterns": [
 				{
-					"include": "#preprocessor-rule-define-line-contents"
+					"include": "#evaluation_context"
+				},
+				{
+					"include": "#c_conditional_context"
 				}
 			]
 		},
-		"preprocessor-rule-define-line-functions": {
+		"switch_statement": {
+			"name": "meta.block.switch.c",
+			"begin": "(((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))((?<!\\w)switch(?!\\w)))",
+			"beginCaptures": {
+				"1": {
+					"name": "meta.head.switch.c"
+				},
+				"2": {
+					"patterns": [
+						{
+							"include": "#inline_comment"
+						}
+					]
+				},
+				"3": {
+					"name": "comment.block.c punctuation.definition.comment.begin.c"
+				},
+				"4": {
+					"name": "comment.block.c"
+				},
+				"5": {
+					"patterns": [
+						{
+							"match": "\\*\\/",
+							"name": "comment.block.c punctuation.definition.comment.end.c"
+						},
+						{
+							"match": "\\*",
+							"name": "comment.block.c"
+						}
+					]
+				},
+				"6": {
+					"name": "keyword.control.switch.c"
+				}
+			},
+			"end": "(?:(?<=\\}|%>|\\?\\?>)|(?=[;>\\[\\]=]))",
 			"patterns": [
 				{
-					"include": "#comments"
-				},
-				{
-					"include": "#storage_types"
-				},
-				{
-					"include": "#vararg_ellipses"
-				},
-				{
-					"include": "#access"
-				},
-				{
-					"include": "#operators"
-				},
-				{
-					"begin": "(?x)\n(?!(?:while|for|do|if|else|switch|catch|enumerate|return|typeid|alignof|alignas|sizeof|[cr]?iterate)\\s*\\()\n(\n(?:[A-Za-z_][A-Za-z0-9_]*+|::)++  # actual name\n|\n(?:(?<=operator)(?:[-*&<>=+!]+|\\(\\)|\\[\\]))\n)\n\\s*(\\()",
-					"beginCaptures": {
+					"name": "meta.head.switch.c",
+					"begin": "\\G ?",
+					"end": "((?:\\{|<%|\\?\\?<|(?=;)))",
+					"endCaptures": {
 						"1": {
-							"name": "entity.name.function.c"
+							"name": "punctuation.section.block.begin.bracket.curly.switch.c"
+						}
+					},
+					"patterns": [
+						{
+							"include": "#switch_conditional_parentheses"
 						},
-						"2": {
-							"name": "punctuation.section.arguments.begin.bracket.round.c"
-						}
-					},
-					"end": "(\\))|(?<!\\\\)(?=\\s*\\n)",
-					"endCaptures": {
-						"1": {
-							"name": "punctuation.section.arguments.end.bracket.round.c"
-						}
-					},
-					"patterns": [
 						{
-							"include": "#preprocessor-rule-define-line-functions"
+							"include": "$self"
 						}
 					]
 				},
 				{
-					"begin": "\\(",
-					"beginCaptures": {
-						"0": {
-							"name": "punctuation.section.parens.begin.bracket.round.c"
-						}
-					},
-					"end": "(\\))|(?<!\\\\)(?=\\s*\\n)",
+					"name": "meta.body.switch.c",
+					"begin": "(?<=\\{|<%|\\?\\?<)",
+					"end": "(\\}|%>|\\?\\?>)",
 					"endCaptures": {
 						"1": {
-							"name": "punctuation.section.parens.end.bracket.round.c"
+							"name": "punctuation.section.block.end.bracket.curly.switch.c"
 						}
 					},
 					"patterns": [
 						{
-							"include": "#preprocessor-rule-define-line-functions"
+							"include": "#default_statement"
+						},
+						{
+							"include": "#case_statement"
+						},
+						{
+							"include": "$self"
+						},
+						{
+							"include": "#block_innards"
 						}
 					]
 				},
 				{
-					"include": "#preprocessor-rule-define-line-contents"
+					"name": "meta.tail.switch.c",
+					"begin": "(?<=\\}|%>|\\?\\?>)[\\s\\n]*",
+					"end": "[\\s\\n]*(?=;)",
+					"patterns": [
+						{
+							"include": "$self"
+						}
+					]
 				}
 			]
 		},
-		"function-innards": {
-			"patterns": [
-				{
-					"include": "#comments"
-				},
-				{
-					"include": "#storage_types"
-				},
-				{
-					"include": "#operators"
-				},
-				{
-					"include": "#vararg_ellipses"
-				},
-				{
-					"begin": "(?x)\n(?!(?:while|for|do|if|else|switch|catch|enumerate|return|typeid|alignof|alignas|sizeof|[cr]?iterate)\\s*\\()\n(\n(?:[A-Za-z_][A-Za-z0-9_]*+|::)++  # actual name\n|\n(?:(?<=operator)(?:[-*&<>=+!]+|\\(\\)|\\[\\]))\n)\n\\s*(\\()",
-					"beginCaptures": {
-						"1": {
-							"name": "entity.name.function.c"
-						},
-						"2": {
-							"name": "punctuation.section.parameters.begin.bracket.round.c"
-						}
-					},
-					"end": "\\)",
-					"endCaptures": {
-						"0": {
-							"name": "punctuation.section.parameters.end.bracket.round.c"
-						}
-					},
-					"patterns": [
-						{
-							"include": "#function-innards"
-						}
-					]
-				},
-				{
-					"begin": "\\(",
-					"beginCaptures": {
-						"0": {
-							"name": "punctuation.section.parens.begin.bracket.round.c"
-						}
-					},
-					"end": "\\)",
-					"endCaptures": {
-						"0": {
-							"name": "punctuation.section.parens.end.bracket.round.c"
-						}
-					},
-					"patterns": [
-						{
-							"include": "#function-innards"
-						}
-					]
-				},
-				{
-					"include": "$base"
-				}
-			]
-		},
-		"function-call-innards": {
-			"patterns": [
-				{
-					"include": "#comments"
-				},
-				{
-					"include": "#storage_types"
-				},
-				{
-					"include": "#access"
-				},
-				{
-					"include": "#operators"
-				},
-				{
-					"begin": "(?x)\n(?!(?:while|for|do|if|else|switch|catch|enumerate|return|typeid|alignof|alignas|sizeof|[cr]?iterate)\\s*\\()\n(\n(?:[A-Za-z_][A-Za-z0-9_]*+|::)++  # actual name\n|\n(?:(?<=operator)(?:[-*&<>=+!]+|\\(\\)|\\[\\]))\n)\n\\s*(\\()",
-					"beginCaptures": {
-						"1": {
-							"name": "entity.name.function.c"
-						},
-						"2": {
-							"name": "punctuation.section.arguments.begin.bracket.round.c"
-						}
-					},
-					"end": "\\)",
-					"endCaptures": {
-						"0": {
-							"name": "punctuation.section.arguments.end.bracket.round.c"
-						}
-					},
-					"patterns": [
-						{
-							"include": "#function-call-innards"
-						}
-					]
-				},
-				{
-					"begin": "\\(",
-					"beginCaptures": {
-						"0": {
-							"name": "punctuation.section.parens.begin.bracket.round.c"
-						}
-					},
-					"end": "\\)",
-					"endCaptures": {
-						"0": {
-							"name": "punctuation.section.parens.end.bracket.round.c"
-						}
-					},
-					"patterns": [
-						{
-							"include": "#function-call-innards"
-						}
-					]
-				},
-				{
-					"include": "#block_innards"
-				}
-			]
+		"vararg_ellipses": {
+			"match": "(?<!\\.)\\.\\.\\.(?!\\.)",
+			"name": "punctuation.vararg-ellipses.c"
 		}
 	}
 }

--- a/packages/textmate-grammars/data/cpp.embedded.macro.tmLanguage.json
+++ b/packages/textmate-grammars/data/cpp.embedded.macro.tmLanguage.json
@@ -1,0 +1,16220 @@
+{
+  "information_for_contributors": [
+    "This file has been converted from https://github.com/jeff-hykin/cpp-textmate-grammar/blob/master//syntaxes/cpp.embedded.macro.tmLanguage.json",
+    "If you want to provide a fix or improvement, please create a pull request against the original repository.",
+    "Once accepted there, we are happy to receive an update request."
+  ],
+  "version": "https://github.com/jeff-hykin/cpp-textmate-grammar/commit/666808cab3907fc91ed4d3901060ee6b045cca58",
+  "name": "C++",
+  "scopeName": "source.cpp.embedded.macro",
+  "patterns": [
+    {
+      "include": "#ever_present_context"
+    },
+    {
+      "include": "#constructor_root"
+    },
+    {
+      "include": "#destructor_root"
+    },
+    {
+      "include": "#function_definition"
+    },
+    {
+      "include": "#operator_overload"
+    },
+    {
+      "include": "#using_namespace"
+    },
+    {
+      "include": "#type_alias"
+    },
+    {
+      "include": "#using_name"
+    },
+    {
+      "include": "#namespace_alias"
+    },
+    {
+      "include": "#namespace_block"
+    },
+    {
+      "include": "#extern_block"
+    },
+    {
+      "include": "#typedef_class"
+    },
+    {
+      "include": "#typedef_struct"
+    },
+    {
+      "include": "#typedef_union"
+    },
+    {
+      "include": "#typedef_keyword"
+    },
+    {
+      "include": "#standard_declares"
+    },
+    {
+      "include": "#class_block"
+    },
+    {
+      "include": "#struct_block"
+    },
+    {
+      "include": "#union_block"
+    },
+    {
+      "include": "#enum_block"
+    },
+    {
+      "include": "#template_isolated_definition"
+    },
+    {
+      "include": "#template_definition"
+    },
+    {
+      "include": "#access_control_keywords"
+    },
+    {
+      "include": "#block"
+    },
+    {
+      "include": "#static_assert"
+    },
+    {
+      "include": "#assembly"
+    },
+    {
+      "include": "#function_pointer"
+    },
+    {
+      "include": "#evaluation_context"
+    }
+  ],
+  "repository": {
+    "access_control_keywords": {
+      "match": "((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))(((?:protected|private|public))\\s*(:))",
+      "captures": {
+        "1": {
+          "patterns": [
+            {
+              "include": "#inline_comment"
+            }
+          ]
+        },
+        "2": {
+          "name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+        },
+        "3": {
+          "name": "comment.block.cpp"
+        },
+        "4": {
+          "patterns": [
+            {
+              "match": "\\*\\/",
+              "name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+            },
+            {
+              "match": "\\*",
+              "name": "comment.block.cpp"
+            }
+          ]
+        },
+        "5": {
+          "name": "storage.type.modifier.access.control.$6.cpp"
+        },
+        "7": {
+          "name": "punctuation.separator.colon.access.control.cpp"
+        }
+      }
+    },
+    "alignas_attribute": {
+      "name": "support.other.attribute.cpp",
+      "begin": "(alignas\\()",
+      "beginCaptures": {
+        "1": {
+          "name": "punctuation.section.attribute.begin.cpp"
+        }
+      },
+      "end": "(\\))|(?=(?<!\\\\)\n)",
+      "endCaptures": {
+        "1": {
+          "name": "punctuation.section.attribute.end.cpp"
+        }
+      },
+      "patterns": [
+        {
+          "include": "#attributes_context"
+        },
+        {
+          "begin": "\\(",
+          "end": "\\)|(?=(?<!\\\\)\n)",
+          "patterns": [
+            {
+              "include": "#attributes_context"
+            },
+            {
+              "include": "#string_context"
+            }
+          ]
+        },
+        {
+          "match": "(using)\\s+((?<!\\w)(?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*(?!\\w))",
+          "captures": {
+            "1": {
+              "name": "keyword.other.using.directive.cpp"
+            },
+            "2": {
+              "name": "entity.name.namespace.cpp"
+            }
+          }
+        },
+        {
+          "match": ",",
+          "name": "punctuation.separator.attribute.cpp"
+        },
+        {
+          "match": ":",
+          "name": "punctuation.accessor.attribute.cpp"
+        },
+        {
+          "match": "(?<!\\w)(?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*(?!\\w)(?=::)",
+          "name": "entity.name.namespace.cpp"
+        },
+        {
+          "match": "(?<!\\w)(?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*(?!\\w)",
+          "name": "entity.other.attribute.$0.cpp"
+        },
+        {
+          "include": "#number_literal"
+        }
+      ]
+    },
+    "alignas_operator": {
+      "contentName": "meta.arguments.operator.alignas.cpp",
+      "begin": "((?<!\\w)alignas(?!\\w))((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))(\\()",
+      "beginCaptures": {
+        "1": {
+          "name": "keyword.operator.functionlike.cpp keyword.operator.alignas.cpp"
+        },
+        "2": {
+          "patterns": [
+            {
+              "include": "#inline_comment"
+            }
+          ]
+        },
+        "3": {
+          "name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+        },
+        "4": {
+          "name": "comment.block.cpp"
+        },
+        "5": {
+          "patterns": [
+            {
+              "match": "\\*\\/",
+              "name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+            },
+            {
+              "match": "\\*",
+              "name": "comment.block.cpp"
+            }
+          ]
+        },
+        "6": {
+          "name": "punctuation.section.arguments.begin.bracket.round.operator.alignas.cpp"
+        }
+      },
+      "end": "(\\))|(?=(?<!\\\\)\n)",
+      "endCaptures": {
+        "1": {
+          "name": "punctuation.section.arguments.end.bracket.round.operator.alignas.cpp"
+        }
+      },
+      "patterns": [
+        {
+          "include": "#evaluation_context"
+        }
+      ]
+    },
+    "alignof_operator": {
+      "contentName": "meta.arguments.operator.alignof.cpp",
+      "begin": "((?<!\\w)alignof(?!\\w))((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))(\\()",
+      "beginCaptures": {
+        "1": {
+          "name": "keyword.operator.functionlike.cpp keyword.operator.alignof.cpp"
+        },
+        "2": {
+          "patterns": [
+            {
+              "include": "#inline_comment"
+            }
+          ]
+        },
+        "3": {
+          "name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+        },
+        "4": {
+          "name": "comment.block.cpp"
+        },
+        "5": {
+          "patterns": [
+            {
+              "match": "\\*\\/",
+              "name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+            },
+            {
+              "match": "\\*",
+              "name": "comment.block.cpp"
+            }
+          ]
+        },
+        "6": {
+          "name": "punctuation.section.arguments.begin.bracket.round.operator.alignof.cpp"
+        }
+      },
+      "end": "(\\))|(?=(?<!\\\\)\n)",
+      "endCaptures": {
+        "1": {
+          "name": "punctuation.section.arguments.end.bracket.round.operator.alignof.cpp"
+        }
+      },
+      "patterns": [
+        {
+          "include": "#evaluation_context"
+        }
+      ]
+    },
+    "assembly": {
+      "name": "meta.asm.cpp",
+      "begin": "(\\b(?:__asm__|asm)\\b)\\s*((?:volatile)?)\\s*(\\()",
+      "beginCaptures": {
+        "1": {
+          "name": "storage.type.asm.cpp"
+        },
+        "2": {
+          "name": "storage.modifier.cpp"
+        },
+        "3": {
+          "name": "punctuation.section.parens.begin.bracket.round.assembly.cpp"
+        }
+      },
+      "end": "(\\))|(?=(?<!\\\\)\n)",
+      "endCaptures": {
+        "1": {
+          "name": "punctuation.section.parens.end.bracket.round.assembly.cpp"
+        }
+      },
+      "patterns": [
+        {
+          "name": "string.quoted.double.cpp",
+          "contentName": "meta.embedded.assembly.cpp",
+          "begin": "(R?)(\")",
+          "beginCaptures": {
+            "1": {
+              "name": "meta.encoding.cpp"
+            },
+            "2": {
+              "name": "punctuation.definition.string.begin.assembly.cpp"
+            }
+          },
+          "end": "(\")|(?=(?<!\\\\)\n)",
+          "endCaptures": {
+            "1": {
+              "name": "punctuation.definition.string.end.assembly.cpp"
+            }
+          },
+          "patterns": [
+            {
+              "include": "source.asm"
+            },
+            {
+              "include": "source.x86"
+            },
+            {
+              "include": "source.x86_64"
+            },
+            {
+              "include": "source.arm"
+            },
+            {
+              "include": "#backslash_escapes"
+            },
+            {
+              "include": "#string_escaped_char"
+            },
+            {
+              "match": "(?=not)possible"
+            }
+          ]
+        },
+        {
+          "begin": "(\\()",
+          "beginCaptures": {
+            "1": {
+              "name": "punctuation.section.parens.begin.bracket.round.assembly.inner.cpp"
+            }
+          },
+          "end": "(\\))|(?=(?<!\\\\)\n)",
+          "endCaptures": {
+            "1": {
+              "name": "punctuation.section.parens.end.bracket.round.assembly.inner.cpp"
+            }
+          },
+          "patterns": [
+            {
+              "include": "#evaluation_context"
+            }
+          ]
+        },
+        {
+          "match": ":",
+          "name": "punctuation.separator.delimiter.colon.assembly.cpp"
+        },
+        {
+          "include": "#comments_context"
+        },
+        {
+          "include": "#comments"
+        }
+      ]
+    },
+    "assignment_operator": {
+      "match": "\\=",
+      "name": "keyword.operator.assignment.cpp"
+    },
+    "attributes_context": {
+      "patterns": [
+        {
+          "include": "#cpp_attributes"
+        },
+        {
+          "include": "#gcc_attributes"
+        },
+        {
+          "include": "#ms_attributes"
+        },
+        {
+          "include": "#alignas_attribute"
+        }
+      ]
+    },
+    "backslash_escapes": {
+      "match": "(?x)\\\\ (\n\\\\\t\t\t |\n[abefnprtv'\"?]   |\n[0-3]\\d{,2}\t |\n[4-7]\\d?\t\t|\nx[a-fA-F0-9]{,2} |\nu[a-fA-F0-9]{,4} |\nU[a-fA-F0-9]{,8} )",
+      "name": "constant.character.escape.cpp"
+    },
+    "block": {
+      "name": "meta.block.cpp",
+      "begin": "({)",
+      "beginCaptures": {
+        "1": {
+          "name": "punctuation.section.block.begin.bracket.curly.cpp"
+        }
+      },
+      "end": "(}|(?=\\s*#\\s*(?:elif|else|endif)\\b))|(?=(?<!\\\\)\n)",
+      "endCaptures": {
+        "1": {
+          "name": "punctuation.section.block.end.bracket.curly.cpp"
+        }
+      },
+      "patterns": [
+        {
+          "include": "#function_body_context"
+        }
+      ]
+    },
+    "block_comment": {
+      "name": "comment.block.cpp",
+      "begin": "\\s*+(\\/\\*)",
+      "beginCaptures": {
+        "1": {
+          "name": "punctuation.definition.comment.begin.cpp"
+        }
+      },
+      "end": "(\\*\\/)|(?=(?<!\\\\)\n)",
+      "endCaptures": {
+        "1": {
+          "name": "punctuation.definition.comment.end.cpp"
+        }
+      }
+    },
+    "builtin_storage_type_initilizer": {
+      "begin": "((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))(?:(?:(?:((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))((?<!\\w)(?:unsigned|wchar_t|double|signed|short|float|auto|void|long|char|bool|int)(?!\\w))|((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))((?<!\\w)(?:uint_least32_t|uint_least64_t|uint_least16_t|int_least16_t|int_least64_t|int_least32_t|uint_fast32_t|uint_fast16_t|uint_fast64_t|uint_least8_t|int_fast64_t|int_fast16_t|uint_fast8_t|int_fast32_t|int_least8_t|int_fast8_t|suseconds_t|useconds_t|uintmax_t|uintptr_t|in_addr_t|uintmax_t|blksize_t|in_port_t|blkcnt_t|intptr_t|intmax_t|uint64_t|u_quad_t|uint16_t|uint32_t|intmax_t|segsz_t|fixpt_t|caddr_t|daddr_t|u_short|int16_t|int32_t|int64_t|uint8_t|nlink_t|qaddr_t|swblk_t|clock_t|ssize_t|time_t|u_long|ushort|quad_t|mode_t|size_t|u_char|int8_t|u_int|uid_t|off_t|pid_t|gid_t|dev_t|div_t|key_t|ino_t|id_t|id_t|uint)(?!\\w)))|((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))((?<!\\w)pthread_attr_t|pthread_cond_t|pthread_condattr_t|pthread_mutex_t|pthread_mutexattr_t|pthread_once_t|pthread_rwlock_t|pthread_rwlockattr_t|pthread_t|pthread_key_t(?!\\w)))|((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))((?<!\\w)[a-zA-Z_]\\w*_t(?!\\w)))((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))(\\()",
+      "beginCaptures": {
+        "1": {
+          "patterns": [
+            {
+              "include": "#inline_comment"
+            }
+          ]
+        },
+        "2": {
+          "name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+        },
+        "3": {
+          "name": "comment.block.cpp"
+        },
+        "4": {
+          "patterns": [
+            {
+              "match": "\\*\\/",
+              "name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+            },
+            {
+              "match": "\\*",
+              "name": "comment.block.cpp"
+            }
+          ]
+        },
+        "5": {
+          "patterns": [
+            {
+              "include": "#inline_comment"
+            }
+          ]
+        },
+        "6": {
+          "name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+        },
+        "7": {
+          "name": "comment.block.cpp"
+        },
+        "8": {
+          "patterns": [
+            {
+              "match": "\\*\\/",
+              "name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+            },
+            {
+              "match": "\\*",
+              "name": "comment.block.cpp"
+            }
+          ]
+        },
+        "9": {
+          "name": "storage.type.primitive.cpp storage.type.built-in.primitive.cpp"
+        },
+        "10": {
+          "patterns": [
+            {
+              "include": "#inline_comment"
+            }
+          ]
+        },
+        "11": {
+          "name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+        },
+        "12": {
+          "name": "comment.block.cpp"
+        },
+        "13": {
+          "patterns": [
+            {
+              "match": "\\*\\/",
+              "name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+            },
+            {
+              "match": "\\*",
+              "name": "comment.block.cpp"
+            }
+          ]
+        },
+        "14": {
+          "name": "storage.type.cpp storage.type.built-in.cpp"
+        },
+        "15": {
+          "patterns": [
+            {
+              "include": "#inline_comment"
+            }
+          ]
+        },
+        "16": {
+          "name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+        },
+        "17": {
+          "name": "comment.block.cpp"
+        },
+        "18": {
+          "patterns": [
+            {
+              "match": "\\*\\/",
+              "name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+            },
+            {
+              "match": "\\*",
+              "name": "comment.block.cpp"
+            }
+          ]
+        },
+        "19": {
+          "name": "support.type.posix-reserved.pthread.cpp support.type.built-in.posix-reserved.pthread.cpp"
+        },
+        "20": {
+          "patterns": [
+            {
+              "include": "#inline_comment"
+            }
+          ]
+        },
+        "21": {
+          "name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+        },
+        "22": {
+          "name": "comment.block.cpp"
+        },
+        "23": {
+          "patterns": [
+            {
+              "match": "\\*\\/",
+              "name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+            },
+            {
+              "match": "\\*",
+              "name": "comment.block.cpp"
+            }
+          ]
+        },
+        "24": {
+          "name": "support.type.posix-reserved.cpp support.type.built-in.posix-reserved.cpp"
+        },
+        "25": {
+          "patterns": [
+            {
+              "include": "#inline_comment"
+            }
+          ]
+        },
+        "26": {
+          "name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+        },
+        "27": {
+          "name": "comment.block.cpp"
+        },
+        "28": {
+          "patterns": [
+            {
+              "match": "\\*\\/",
+              "name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+            },
+            {
+              "match": "\\*",
+              "name": "comment.block.cpp"
+            }
+          ]
+        },
+        "29": {
+          "name": "punctuation.section.arguments.begin.bracket.round.initializer.cpp"
+        }
+      },
+      "end": "(\\))|(?=(?<!\\\\)\n)",
+      "endCaptures": {
+        "1": {
+          "name": "punctuation.section.arguments.end.bracket.round.initializer.cpp"
+        }
+      },
+      "patterns": [
+        {
+          "include": "#evaluation_context"
+        }
+      ]
+    },
+    "case_statement": {
+      "name": "meta.conditional.case.cpp",
+      "begin": "((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))((?<!\\w)case(?!\\w))",
+      "beginCaptures": {
+        "1": {
+          "patterns": [
+            {
+              "include": "#inline_comment"
+            }
+          ]
+        },
+        "2": {
+          "name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+        },
+        "3": {
+          "name": "comment.block.cpp"
+        },
+        "4": {
+          "patterns": [
+            {
+              "match": "\\*\\/",
+              "name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+            },
+            {
+              "match": "\\*",
+              "name": "comment.block.cpp"
+            }
+          ]
+        },
+        "5": {
+          "name": "keyword.control.case.cpp"
+        }
+      },
+      "end": "(:)|(?=(?<!\\\\)\n)",
+      "endCaptures": {
+        "1": {
+          "name": "punctuation.separator.colon.case.cpp"
+        }
+      },
+      "patterns": [
+        {
+          "include": "#evaluation_context"
+        },
+        {
+          "include": "#c_conditional_context"
+        }
+      ]
+    },
+    "class_block": {
+      "name": "meta.block.class.cpp",
+      "begin": "((((?<!\\w)class(?!\\w))(?:(?:((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))|((?:(?:(?:\\[\\[.*?\\]\\]|__attribute(?:__)?\\(\\(.*?\\)\\))|__declspec\\(.*?\\))|alignas\\(.*?\\))(?!\\))))|(?={))(?:((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))(DLLEXPORT)((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z)))))?((?:(?:(?:\\[\\[.*?\\]\\]|__attribute(?:__)?\\(\\(.*?\\)\\))|__declspec\\(.*?\\))|alignas\\(.*?\\))(?!\\)))?((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))((?:(?<!\\w)(?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*(?!\\w))?)(?:((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))(final)((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z)))))?(?:((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))(:)((?>[^{]*)))?))",
+      "beginCaptures": {
+        "1": {
+          "name": "meta.head.class.cpp"
+        },
+        "3": {
+          "name": "storage.type.$3.cpp"
+        },
+        "4": {
+          "patterns": [
+            {
+              "include": "#inline_comment"
+            }
+          ]
+        },
+        "5": {
+          "name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+        },
+        "6": {
+          "name": "comment.block.cpp"
+        },
+        "7": {
+          "patterns": [
+            {
+              "match": "\\*\\/",
+              "name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+            },
+            {
+              "match": "\\*",
+              "name": "comment.block.cpp"
+            }
+          ]
+        },
+        "8": {
+          "patterns": [
+            {
+              "include": "#attributes_context"
+            },
+            {
+              "include": "#number_literal"
+            }
+          ]
+        },
+        "9": {
+          "patterns": [
+            {
+              "include": "#inline_comment"
+            }
+          ]
+        },
+        "10": {
+          "name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+        },
+        "11": {
+          "name": "comment.block.cpp"
+        },
+        "12": {
+          "patterns": [
+            {
+              "match": "\\*\\/",
+              "name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+            },
+            {
+              "match": "\\*",
+              "name": "comment.block.cpp"
+            }
+          ]
+        },
+        "13": {
+          "name": "entity.name.other.preprocessor.macro.predefined.DLLEXPORT.cpp"
+        },
+        "14": {
+          "patterns": [
+            {
+              "include": "#inline_comment"
+            }
+          ]
+        },
+        "15": {
+          "name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+        },
+        "16": {
+          "name": "comment.block.cpp"
+        },
+        "17": {
+          "patterns": [
+            {
+              "match": "\\*\\/",
+              "name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+            },
+            {
+              "match": "\\*",
+              "name": "comment.block.cpp"
+            }
+          ]
+        },
+        "18": {
+          "patterns": [
+            {
+              "include": "#attributes_context"
+            },
+            {
+              "include": "#number_literal"
+            }
+          ]
+        },
+        "19": {
+          "patterns": [
+            {
+              "include": "#inline_comment"
+            }
+          ]
+        },
+        "20": {
+          "name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+        },
+        "21": {
+          "name": "comment.block.cpp"
+        },
+        "22": {
+          "patterns": [
+            {
+              "match": "\\*\\/",
+              "name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+            },
+            {
+              "match": "\\*",
+              "name": "comment.block.cpp"
+            }
+          ]
+        },
+        "23": {
+          "name": "entity.name.type.$3.cpp"
+        },
+        "24": {
+          "patterns": [
+            {
+              "include": "#inline_comment"
+            }
+          ]
+        },
+        "25": {
+          "name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+        },
+        "26": {
+          "name": "comment.block.cpp"
+        },
+        "27": {
+          "patterns": [
+            {
+              "match": "\\*\\/",
+              "name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+            },
+            {
+              "match": "\\*",
+              "name": "comment.block.cpp"
+            }
+          ]
+        },
+        "28": {
+          "name": "storage.type.modifier.final.cpp"
+        },
+        "29": {
+          "patterns": [
+            {
+              "include": "#inline_comment"
+            }
+          ]
+        },
+        "30": {
+          "name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+        },
+        "31": {
+          "name": "comment.block.cpp"
+        },
+        "32": {
+          "patterns": [
+            {
+              "match": "\\*\\/",
+              "name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+            },
+            {
+              "match": "\\*",
+              "name": "comment.block.cpp"
+            }
+          ]
+        },
+        "33": {
+          "patterns": [
+            {
+              "include": "#inline_comment"
+            }
+          ]
+        },
+        "34": {
+          "name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+        },
+        "35": {
+          "name": "comment.block.cpp"
+        },
+        "36": {
+          "patterns": [
+            {
+              "match": "\\*\\/",
+              "name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+            },
+            {
+              "match": "\\*",
+              "name": "comment.block.cpp"
+            }
+          ]
+        },
+        "37": {
+          "name": "punctuation.separator.colon.inheritance.cpp"
+        },
+        "38": {
+          "patterns": [
+            {
+              "include": "#inheritance_context"
+            }
+          ]
+        }
+      },
+      "end": "(?:(?:(?<=\\}|%>|\\?\\?>)\\s*(;)|(;))|(?=[;>\\[\\]=]))|(?=(?<!\\\\)\n)",
+      "endCaptures": {
+        "1": {
+          "name": "punctuation.terminator.statement.cpp"
+        },
+        "2": {
+          "name": "punctuation.terminator.statement.cpp"
+        }
+      },
+      "patterns": [
+        {
+          "name": "meta.head.class.cpp",
+          "begin": "\\G ?",
+          "end": "((?:\\{|<%|\\?\\?<|(?=;)))|(?=(?<!\\\\)\n)",
+          "endCaptures": {
+            "1": {
+              "name": "punctuation.section.block.begin.bracket.curly.class.cpp"
+            }
+          },
+          "patterns": [
+            {
+              "include": "#ever_present_context"
+            },
+            {
+              "include": "#inheritance_context"
+            },
+            {
+              "include": "#template_call_range"
+            }
+          ]
+        },
+        {
+          "name": "meta.body.class.cpp",
+          "begin": "(?<=\\{|<%|\\?\\?<)",
+          "end": "(\\}|%>|\\?\\?>)|(?=(?<!\\\\)\n)",
+          "endCaptures": {
+            "1": {
+              "name": "punctuation.section.block.end.bracket.curly.class.cpp"
+            }
+          },
+          "patterns": [
+            {
+              "include": "#function_pointer"
+            },
+            {
+              "include": "#static_assert"
+            },
+            {
+              "include": "#constructor_inline"
+            },
+            {
+              "include": "#destructor_inline"
+            },
+            {
+              "include": "$self"
+            }
+          ]
+        },
+        {
+          "name": "meta.tail.class.cpp",
+          "begin": "(?<=\\}|%>|\\?\\?>)[\\s\\n]*",
+          "end": "[\\s\\n]*(?=;)|(?=(?<!\\\\)\n)",
+          "patterns": [
+            {
+              "include": "$self"
+            }
+          ]
+        }
+      ]
+    },
+    "class_declare": {
+      "match": "((?<!\\w)class(?!\\w))((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))((?<!\\w)(?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*(?!\\w))(((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))?(?:(?:\\&|\\*)((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z)))))*(?:\\&|\\*))?((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))\\b(?!override\\W|override\\$|final\\W|final\\$)((?<!\\w)(?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*(?!\\w))((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))(?=\\S)(?![:{])",
+      "captures": {
+        "1": {
+          "name": "storage.type.class.declare.cpp"
+        },
+        "2": {
+          "patterns": [
+            {
+              "include": "#inline_comment"
+            }
+          ]
+        },
+        "3": {
+          "name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+        },
+        "4": {
+          "name": "comment.block.cpp"
+        },
+        "5": {
+          "patterns": [
+            {
+              "match": "\\*\\/",
+              "name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+            },
+            {
+              "match": "\\*",
+              "name": "comment.block.cpp"
+            }
+          ]
+        },
+        "6": {
+          "name": "entity.name.type.class.cpp"
+        },
+        "7": {
+          "patterns": [
+            {
+              "match": "\\*",
+              "name": "storage.modifier.pointer.cpp"
+            },
+            {
+              "match": "(?:\\&((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))){2,}\\&",
+              "captures": {
+                "1": {
+                  "patterns": [
+                    {
+                      "include": "#inline_comment"
+                    }
+                  ]
+                },
+                "2": {
+                  "name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+                },
+                "3": {
+                  "name": "comment.block.cpp"
+                },
+                "4": {
+                  "patterns": [
+                    {
+                      "match": "\\*\\/",
+                      "name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+                    },
+                    {
+                      "match": "\\*",
+                      "name": "comment.block.cpp"
+                    }
+                  ]
+                }
+              },
+              "name": "invalid.illegal.reference-type.cpp"
+            },
+            {
+              "match": "\\&",
+              "name": "storage.modifier.reference.cpp"
+            }
+          ]
+        },
+        "8": {
+          "patterns": [
+            {
+              "include": "#inline_comment"
+            }
+          ]
+        },
+        "9": {
+          "name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+        },
+        "10": {
+          "name": "comment.block.cpp"
+        },
+        "11": {
+          "patterns": [
+            {
+              "match": "\\*\\/",
+              "name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+            },
+            {
+              "match": "\\*",
+              "name": "comment.block.cpp"
+            }
+          ]
+        },
+        "12": {
+          "patterns": [
+            {
+              "include": "#inline_comment"
+            }
+          ]
+        },
+        "13": {
+          "name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+        },
+        "14": {
+          "name": "comment.block.cpp"
+        },
+        "15": {
+          "patterns": [
+            {
+              "match": "\\*\\/",
+              "name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+            },
+            {
+              "match": "\\*",
+              "name": "comment.block.cpp"
+            }
+          ]
+        },
+        "16": {
+          "patterns": [
+            {
+              "include": "#inline_comment"
+            }
+          ]
+        },
+        "17": {
+          "name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+        },
+        "18": {
+          "name": "comment.block.cpp"
+        },
+        "19": {
+          "patterns": [
+            {
+              "match": "\\*\\/",
+              "name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+            },
+            {
+              "match": "\\*",
+              "name": "comment.block.cpp"
+            }
+          ]
+        },
+        "20": {
+          "name": "variable.other.object.declare.cpp"
+        },
+        "21": {
+          "patterns": [
+            {
+              "include": "#inline_comment"
+            }
+          ]
+        },
+        "22": {
+          "name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+        },
+        "23": {
+          "name": "comment.block.cpp"
+        },
+        "24": {
+          "patterns": [
+            {
+              "match": "\\*\\/",
+              "name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+            },
+            {
+              "match": "\\*",
+              "name": "comment.block.cpp"
+            }
+          ]
+        }
+      }
+    },
+    "comma": {
+      "match": ",",
+      "name": "punctuation.separator.delimiter.comma.cpp"
+    },
+    "comma_in_template_argument": {
+      "match": ",",
+      "name": "punctuation.separator.delimiter.comma.template.argument.cpp"
+    },
+    "comments": {
+      "patterns": [
+        {
+          "name": "comment.line.double-slash.documentation.cpp",
+          "begin": "(?:^)(?>\\s*)(\\/\\/[!\\/]+)",
+          "beginCaptures": {
+            "1": {
+              "name": "punctuation.definition.comment.documentation.cpp"
+            }
+          },
+          "end": "(?<=\\n)(?<!\\\\\\n)|(?=(?<!\\\\)\n)",
+          "patterns": [
+            {
+              "include": "#line_continuation_character"
+            },
+            {
+              "match": "(?<=[\\s*!\\/])[\\\\@](?:callergraph|callgraph|else|endif|f\\$|f\\[|f\\]|hidecallergraph|hidecallgraph|hiderefby|hiderefs|hideinitializer|htmlinclude|n|nosubgrouping|private|privatesection|protected|protectedsection|public|publicsection|pure|showinitializer|showrefby|showrefs|tableofcontents|\\$|\\#|<|>|%|\"|\\.|=|::|\\||\\-\\-|\\-\\-\\-)\\b(?:\\{[^}]*\\})?",
+              "name": "storage.type.class.doxygen.cpp"
+            },
+            {
+              "match": "((?<=[\\s*!\\/])[\\\\@](?:a|em|e))\\s+(\\S+)",
+              "captures": {
+                "1": {
+                  "name": "storage.type.class.doxygen.cpp"
+                },
+                "2": {
+                  "name": "markup.italic.doxygen.cpp"
+                }
+              }
+            },
+            {
+              "match": "((?<=[\\s*!\\/])[\\\\@]b)\\s+(\\S+)",
+              "captures": {
+                "1": {
+                  "name": "storage.type.class.doxygen.cpp"
+                },
+                "2": {
+                  "name": "markup.bold.doxygen.cpp"
+                }
+              }
+            },
+            {
+              "match": "((?<=[\\s*!\\/])[\\\\@](?:c|p))\\s+(\\S+)",
+              "captures": {
+                "1": {
+                  "name": "storage.type.class.doxygen.cpp"
+                },
+                "2": {
+                  "name": "markup.inline.raw.string.cpp"
+                }
+              }
+            },
+            {
+              "match": "(?<=[\\s*!\\/])[\\\\@](?:a|anchor|b|c|cite|copybrief|copydetail|copydoc|def|dir|dontinclude|e|em|emoji|enum|example|extends|file|idlexcept|implements|include|includedoc|includelineno|latexinclude|link|memberof|namespace|p|package|ref|refitem|related|relates|relatedalso|relatesalso|verbinclude)\\b(?:\\{[^}]*\\})?",
+              "name": "storage.type.class.doxygen.cpp"
+            },
+            {
+              "match": "(?<=[\\s*!\\/])[\\\\@](?:addindex|addtogroup|category|class|defgroup|diafile|dotfile|elseif|fn|headerfile|if|ifnot|image|ingroup|interface|line|mainpage|mscfile|name|overload|page|property|protocol|section|skip|skipline|snippet|snippetdoc|snippetlineno|struct|subpage|subsection|subsubsection|typedef|union|until|vhdlflow|weakgroup)\\b(?:\\{[^}]*\\})?",
+              "name": "storage.type.class.doxygen.cpp"
+            },
+            {
+              "match": "((?<=[\\s*!\\/])[\\\\@]param)\\s+(\\b\\w+\\b)",
+              "captures": {
+                "1": {
+                  "name": "storage.type.class.doxygen.cpp"
+                },
+                "2": {
+                  "name": "variable.parameter.cpp"
+                }
+              }
+            },
+            {
+              "match": "(?<=[\\s*!\\/])[\\\\@](?:arg|attention|author|authors|brief|bug|copyright|date|deprecated|details|exception|invariant|li|note|par|paragraph|param|post|pre|remark|remarks|result|return|returns|retval|sa|see|short|since|test|throw|todo|tparam|version|warning|xrefitem)\\b(?:\\{[^}]*\\})?",
+              "name": "storage.type.class.doxygen.cpp"
+            },
+            {
+              "match": "(?<=[\\s*!\\/])[\\\\@](?:code|cond|docbookonly|dot|htmlonly|internal|latexonly|link|manonly|msc|parblock|rtfonly|secreflist|uml|verbatim|xmlonly|endcode|endcond|enddocbookonly|enddot|endhtmlonly|endinternal|endlatexonly|endlink|endmanonly|endmsc|endparblock|endrtfonly|endsecreflist|enduml|endverbatim|endxmlonly)\\b(?:\\{[^}]*\\})?",
+              "name": "storage.type.class.doxygen.cpp"
+            },
+            {
+              "match": "(?:\\b[A-Z]+:|@[a-z_]+:)",
+              "name": "storage.type.class.gtkdoc.cpp"
+            }
+          ]
+        },
+        {
+          "match": "(\\/\\*[!*]+(?=\\s))(.+)([!*]*\\*\\/)",
+          "captures": {
+            "1": {
+              "name": "punctuation.definition.comment.begin.documentation.cpp"
+            },
+            "2": {
+              "patterns": [
+                {
+                  "match": "(?<=[\\s*!\\/])[\\\\@](?:callergraph|callgraph|else|endif|f\\$|f\\[|f\\]|hidecallergraph|hidecallgraph|hiderefby|hiderefs|hideinitializer|htmlinclude|n|nosubgrouping|private|privatesection|protected|protectedsection|public|publicsection|pure|showinitializer|showrefby|showrefs|tableofcontents|\\$|\\#|<|>|%|\"|\\.|=|::|\\||\\-\\-|\\-\\-\\-)\\b(?:\\{[^}]*\\})?",
+                  "name": "storage.type.class.doxygen.cpp"
+                },
+                {
+                  "match": "((?<=[\\s*!\\/])[\\\\@](?:a|em|e))\\s+(\\S+)",
+                  "captures": {
+                    "1": {
+                      "name": "storage.type.class.doxygen.cpp"
+                    },
+                    "2": {
+                      "name": "markup.italic.doxygen.cpp"
+                    }
+                  }
+                },
+                {
+                  "match": "((?<=[\\s*!\\/])[\\\\@]b)\\s+(\\S+)",
+                  "captures": {
+                    "1": {
+                      "name": "storage.type.class.doxygen.cpp"
+                    },
+                    "2": {
+                      "name": "markup.bold.doxygen.cpp"
+                    }
+                  }
+                },
+                {
+                  "match": "((?<=[\\s*!\\/])[\\\\@](?:c|p))\\s+(\\S+)",
+                  "captures": {
+                    "1": {
+                      "name": "storage.type.class.doxygen.cpp"
+                    },
+                    "2": {
+                      "name": "markup.inline.raw.string.cpp"
+                    }
+                  }
+                },
+                {
+                  "match": "(?<=[\\s*!\\/])[\\\\@](?:a|anchor|b|c|cite|copybrief|copydetail|copydoc|def|dir|dontinclude|e|em|emoji|enum|example|extends|file|idlexcept|implements|include|includedoc|includelineno|latexinclude|link|memberof|namespace|p|package|ref|refitem|related|relates|relatedalso|relatesalso|verbinclude)\\b(?:\\{[^}]*\\})?",
+                  "name": "storage.type.class.doxygen.cpp"
+                },
+                {
+                  "match": "(?<=[\\s*!\\/])[\\\\@](?:addindex|addtogroup|category|class|defgroup|diafile|dotfile|elseif|fn|headerfile|if|ifnot|image|ingroup|interface|line|mainpage|mscfile|name|overload|page|property|protocol|section|skip|skipline|snippet|snippetdoc|snippetlineno|struct|subpage|subsection|subsubsection|typedef|union|until|vhdlflow|weakgroup)\\b(?:\\{[^}]*\\})?",
+                  "name": "storage.type.class.doxygen.cpp"
+                },
+                {
+                  "match": "((?<=[\\s*!\\/])[\\\\@]param)\\s+(\\b\\w+\\b)",
+                  "captures": {
+                    "1": {
+                      "name": "storage.type.class.doxygen.cpp"
+                    },
+                    "2": {
+                      "name": "variable.parameter.cpp"
+                    }
+                  }
+                },
+                {
+                  "match": "(?<=[\\s*!\\/])[\\\\@](?:arg|attention|author|authors|brief|bug|copyright|date|deprecated|details|exception|invariant|li|note|par|paragraph|param|post|pre|remark|remarks|result|return|returns|retval|sa|see|short|since|test|throw|todo|tparam|version|warning|xrefitem)\\b(?:\\{[^}]*\\})?",
+                  "name": "storage.type.class.doxygen.cpp"
+                },
+                {
+                  "match": "(?<=[\\s*!\\/])[\\\\@](?:code|cond|docbookonly|dot|htmlonly|internal|latexonly|link|manonly|msc|parblock|rtfonly|secreflist|uml|verbatim|xmlonly|endcode|endcond|enddocbookonly|enddot|endhtmlonly|endinternal|endlatexonly|endlink|endmanonly|endmsc|endparblock|endrtfonly|endsecreflist|enduml|endverbatim|endxmlonly)\\b(?:\\{[^}]*\\})?",
+                  "name": "storage.type.class.doxygen.cpp"
+                },
+                {
+                  "match": "(?:\\b[A-Z]+:|@[a-z_]+:)",
+                  "name": "storage.type.class.gtkdoc.cpp"
+                }
+              ]
+            },
+            "3": {
+              "name": "punctuation.definition.comment.end.documentation.cpp"
+            }
+          },
+          "name": "comment.block.documentation.cpp"
+        },
+        {
+          "name": "comment.block.documentation.cpp",
+          "begin": "((?>\\s*)\\/\\*[!*]+(?:(?:\\n|$)|(?=\\s)))",
+          "beginCaptures": {
+            "1": {
+              "name": "punctuation.definition.comment.begin.documentation.cpp"
+            }
+          },
+          "end": "([!*]*\\*\\/)|(?=(?<!\\\\)\n)",
+          "endCaptures": {
+            "1": {
+              "name": "punctuation.definition.comment.end.documentation.cpp"
+            }
+          },
+          "patterns": [
+            {
+              "match": "(?<=[\\s*!\\/])[\\\\@](?:callergraph|callgraph|else|endif|f\\$|f\\[|f\\]|hidecallergraph|hidecallgraph|hiderefby|hiderefs|hideinitializer|htmlinclude|n|nosubgrouping|private|privatesection|protected|protectedsection|public|publicsection|pure|showinitializer|showrefby|showrefs|tableofcontents|\\$|\\#|<|>|%|\"|\\.|=|::|\\||\\-\\-|\\-\\-\\-)\\b(?:\\{[^}]*\\})?",
+              "name": "storage.type.class.doxygen.cpp"
+            },
+            {
+              "match": "((?<=[\\s*!\\/])[\\\\@](?:a|em|e))\\s+(\\S+)",
+              "captures": {
+                "1": {
+                  "name": "storage.type.class.doxygen.cpp"
+                },
+                "2": {
+                  "name": "markup.italic.doxygen.cpp"
+                }
+              }
+            },
+            {
+              "match": "((?<=[\\s*!\\/])[\\\\@]b)\\s+(\\S+)",
+              "captures": {
+                "1": {
+                  "name": "storage.type.class.doxygen.cpp"
+                },
+                "2": {
+                  "name": "markup.bold.doxygen.cpp"
+                }
+              }
+            },
+            {
+              "match": "((?<=[\\s*!\\/])[\\\\@](?:c|p))\\s+(\\S+)",
+              "captures": {
+                "1": {
+                  "name": "storage.type.class.doxygen.cpp"
+                },
+                "2": {
+                  "name": "markup.inline.raw.string.cpp"
+                }
+              }
+            },
+            {
+              "match": "(?<=[\\s*!\\/])[\\\\@](?:a|anchor|b|c|cite|copybrief|copydetail|copydoc|def|dir|dontinclude|e|em|emoji|enum|example|extends|file|idlexcept|implements|include|includedoc|includelineno|latexinclude|link|memberof|namespace|p|package|ref|refitem|related|relates|relatedalso|relatesalso|verbinclude)\\b(?:\\{[^}]*\\})?",
+              "name": "storage.type.class.doxygen.cpp"
+            },
+            {
+              "match": "(?<=[\\s*!\\/])[\\\\@](?:addindex|addtogroup|category|class|defgroup|diafile|dotfile|elseif|fn|headerfile|if|ifnot|image|ingroup|interface|line|mainpage|mscfile|name|overload|page|property|protocol|section|skip|skipline|snippet|snippetdoc|snippetlineno|struct|subpage|subsection|subsubsection|typedef|union|until|vhdlflow|weakgroup)\\b(?:\\{[^}]*\\})?",
+              "name": "storage.type.class.doxygen.cpp"
+            },
+            {
+              "match": "((?<=[\\s*!\\/])[\\\\@]param)\\s+(\\b\\w+\\b)",
+              "captures": {
+                "1": {
+                  "name": "storage.type.class.doxygen.cpp"
+                },
+                "2": {
+                  "name": "variable.parameter.cpp"
+                }
+              }
+            },
+            {
+              "match": "(?<=[\\s*!\\/])[\\\\@](?:arg|attention|author|authors|brief|bug|copyright|date|deprecated|details|exception|invariant|li|note|par|paragraph|param|post|pre|remark|remarks|result|return|returns|retval|sa|see|short|since|test|throw|todo|tparam|version|warning|xrefitem)\\b(?:\\{[^}]*\\})?",
+              "name": "storage.type.class.doxygen.cpp"
+            },
+            {
+              "match": "(?<=[\\s*!\\/])[\\\\@](?:code|cond|docbookonly|dot|htmlonly|internal|latexonly|link|manonly|msc|parblock|rtfonly|secreflist|uml|verbatim|xmlonly|endcode|endcond|enddocbookonly|enddot|endhtmlonly|endinternal|endlatexonly|endlink|endmanonly|endmsc|endparblock|endrtfonly|endsecreflist|enduml|endverbatim|endxmlonly)\\b(?:\\{[^}]*\\})?",
+              "name": "storage.type.class.doxygen.cpp"
+            },
+            {
+              "match": "(?:\\b[A-Z]+:|@[a-z_]+:)",
+              "name": "storage.type.class.gtkdoc.cpp"
+            }
+          ]
+        },
+        {
+          "include": "#emacs_file_banner"
+        },
+        {
+          "include": "#block_comment"
+        },
+        {
+          "include": "#line_comment"
+        },
+        {
+          "include": "#invalid_comment_end"
+        }
+      ]
+    },
+    "constructor_inline": {
+      "name": "meta.function.definition.special.constructor.cpp",
+      "begin": "(^((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))((?:(?:constexpr|explicit|mutable|virtual|inline|friend)((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z)))))*)((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))((?:__cdecl|__clrcall|__stdcall|__fastcall|__thiscall|__vectorcall)?)((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))((?<!\\w)(?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*(?!\\w)(?=\\()))",
+      "beginCaptures": {
+        "1": {
+          "name": "meta.head.function.definition.special.constructor.cpp"
+        },
+        "2": {
+          "patterns": [
+            {
+              "include": "#inline_comment"
+            }
+          ]
+        },
+        "3": {
+          "name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+        },
+        "4": {
+          "name": "comment.block.cpp"
+        },
+        "5": {
+          "patterns": [
+            {
+              "match": "\\*\\/",
+              "name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+            },
+            {
+              "match": "\\*",
+              "name": "comment.block.cpp"
+            }
+          ]
+        },
+        "6": {
+          "patterns": [
+            {
+              "include": "#functional_specifiers_pre_parameters"
+            }
+          ]
+        },
+        "7": {
+          "patterns": [
+            {
+              "include": "#inline_comment"
+            }
+          ]
+        },
+        "8": {
+          "name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+        },
+        "9": {
+          "name": "comment.block.cpp"
+        },
+        "10": {
+          "patterns": [
+            {
+              "match": "\\*\\/",
+              "name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+            },
+            {
+              "match": "\\*",
+              "name": "comment.block.cpp"
+            }
+          ]
+        },
+        "11": {
+          "patterns": [
+            {
+              "include": "#inline_comment"
+            }
+          ]
+        },
+        "12": {
+          "name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+        },
+        "13": {
+          "name": "comment.block.cpp"
+        },
+        "14": {
+          "patterns": [
+            {
+              "match": "\\*\\/",
+              "name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+            },
+            {
+              "match": "\\*",
+              "name": "comment.block.cpp"
+            }
+          ]
+        },
+        "15": {
+          "name": "storage.type.modifier.calling-convention.cpp"
+        },
+        "16": {
+          "patterns": [
+            {
+              "include": "#inline_comment"
+            }
+          ]
+        },
+        "17": {
+          "name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+        },
+        "18": {
+          "name": "comment.block.cpp"
+        },
+        "19": {
+          "patterns": [
+            {
+              "match": "\\*\\/",
+              "name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+            },
+            {
+              "match": "\\*",
+              "name": "comment.block.cpp"
+            }
+          ]
+        },
+        "20": {
+          "name": "entity.name.function.constructor.cpp entity.name.function.definition.special.constructor.cpp"
+        }
+      },
+      "end": "(?:(?<=\\}|%>|\\?\\?>)|(?=[;>\\[\\]=]))|(?=(?<!\\\\)\n)",
+      "patterns": [
+        {
+          "name": "meta.head.function.definition.special.constructor.cpp",
+          "begin": "\\G ?",
+          "end": "((?:\\{|<%|\\?\\?<|(?=;)))|(?=(?<!\\\\)\n)",
+          "endCaptures": {
+            "1": {
+              "name": "punctuation.section.block.begin.bracket.curly.function.definition.special.constructor.cpp"
+            }
+          },
+          "patterns": [
+            {
+              "include": "#ever_present_context"
+            },
+            {
+              "patterns": [
+                {
+                  "match": "(\\=)((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))(?:(default)|(delete))",
+                  "captures": {
+                    "1": {
+                      "name": "keyword.operator.assignment.cpp"
+                    },
+                    "2": {
+                      "patterns": [
+                        {
+                          "include": "#inline_comment"
+                        }
+                      ]
+                    },
+                    "3": {
+                      "name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+                    },
+                    "4": {
+                      "name": "comment.block.cpp"
+                    },
+                    "5": {
+                      "patterns": [
+                        {
+                          "match": "\\*\\/",
+                          "name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+                        },
+                        {
+                          "match": "\\*",
+                          "name": "comment.block.cpp"
+                        }
+                      ]
+                    },
+                    "6": {
+                      "name": "keyword.other.default.constructor.cpp"
+                    },
+                    "7": {
+                      "name": "keyword.other.delete.constructor.cpp"
+                    }
+                  }
+                }
+              ]
+            },
+            {
+              "include": "#functional_specifiers_pre_parameters"
+            },
+            {
+              "begin": "(:)",
+              "beginCaptures": {
+                "1": {
+                  "name": "punctuation.separator.initializers.cpp"
+                }
+              },
+              "end": "(?=\\{)|(?=(?<!\\\\)\n)",
+              "patterns": [
+                {
+                  "contentName": "meta.parameter.initialization.cpp",
+                  "begin": "((?<!\\w)(?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*(?!\\w))(((?<!<)<(?!<)(?>(?:(?>[^<>]*)\\g<3>?)+)>)\\s*)?(\\()",
+                  "beginCaptures": {
+                    "1": {
+                      "name": "entity.name.function.call.initializer.cpp"
+                    },
+                    "2": {
+                      "name": "meta.template.call.cpp",
+                      "patterns": [
+                        {
+                          "include": "#template_call_range"
+                        }
+                      ]
+                    },
+                    "4": {
+                      "name": "punctuation.section.arguments.begin.bracket.round.function.call.initializer.cpp"
+                    }
+                  },
+                  "end": "(\\))|(?=(?<!\\\\)\n)",
+                  "endCaptures": {
+                    "1": {
+                      "name": "punctuation.section.arguments.end.bracket.round.function.call.initializer.cpp"
+                    }
+                  },
+                  "patterns": [
+                    {
+                      "include": "#evaluation_context"
+                    }
+                  ]
+                },
+                {
+                  "contentName": "meta.parameter.initialization.cpp",
+                  "begin": "((?<!\\w)(?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*(?!\\w))(\\{)",
+                  "beginCaptures": {
+                    "1": {
+                      "name": "entity.name.function.call.initializer.cpp"
+                    },
+                    "2": {
+                      "name": "punctuation.section.arguments.begin.bracket.round.function.call.initializer.cpp"
+                    }
+                  },
+                  "end": "(\\})|(?=(?<!\\\\)\n)",
+                  "endCaptures": {
+                    "1": {
+                      "name": "punctuation.section.arguments.end.bracket.round.function.call.initializer.cpp"
+                    }
+                  },
+                  "patterns": [
+                    {
+                      "include": "#evaluation_context"
+                    }
+                  ]
+                },
+                {
+                  "include": "#comma"
+                },
+                {
+                  "include": "#comments"
+                }
+              ]
+            },
+            {
+              "contentName": "meta.function.definition.parameters.special.constructor.cpp",
+              "begin": "(\\()",
+              "beginCaptures": {
+                "1": {
+                  "name": "punctuation.section.parameters.begin.bracket.round.special.constructor.cpp"
+                }
+              },
+              "end": "(\\))|(?=(?<!\\\\)\n)",
+              "endCaptures": {
+                "1": {
+                  "name": "punctuation.section.parameters.end.bracket.round.special.constructor.cpp"
+                }
+              },
+              "patterns": [
+                {
+                  "include": "#function_parameter_context"
+                },
+                {
+                  "include": "#evaluation_context"
+                }
+              ]
+            },
+            {
+              "include": "$self"
+            }
+          ]
+        },
+        {
+          "name": "meta.body.function.definition.special.constructor.cpp",
+          "begin": "(?<=\\{|<%|\\?\\?<)",
+          "end": "(\\}|%>|\\?\\?>)|(?=(?<!\\\\)\n)",
+          "endCaptures": {
+            "1": {
+              "name": "punctuation.section.block.end.bracket.curly.function.definition.special.constructor.cpp"
+            }
+          },
+          "patterns": [
+            {
+              "include": "#function_body_context"
+            }
+          ]
+        },
+        {
+          "name": "meta.tail.function.definition.special.constructor.cpp",
+          "begin": "(?<=\\}|%>|\\?\\?>)[\\s\\n]*",
+          "end": "[\\s\\n]*(?=;)|(?=(?<!\\\\)\n)",
+          "patterns": [
+            {
+              "include": "$self"
+            }
+          ]
+        }
+      ]
+    },
+    "constructor_root": {
+      "name": "meta.function.definition.special.constructor.cpp",
+      "begin": "(\\s*+((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))((?:__cdecl|__clrcall|__stdcall|__fastcall|__thiscall|__vectorcall)?)((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))((?:((?-mix:(?!\\b(?:__has_cpp_attribute|reinterpret_cast|atomic_noexcept|atomic_cancel|atomic_commit|__has_include|dynamic_cast|thread_local|synchronized|static_cast|const_cast|consteval|constexpr|protected|namespace|co_return|constexpr|constexpr|continue|explicit|volatile|noexcept|co_yield|noexcept|noexcept|requires|typename|decltype|operator|co_await|template|volatile|register|restrict|reflexpr|alignof|private|default|mutable|include|concept|__asm__|defined|_Pragma|alignas|typedef|warning|virtual|mutable|struct|sizeof|delete|not_eq|bitand|and_eq|xor_eq|typeid|switch|return|static|extern|inline|friend|public|ifndef|define|pragma|export|import|module|catch|throw|const|or_eq|while|compl|bitor|const|union|ifdef|class|undef|error|break|using|endif|goto|line|enum|this|case|else|elif|else|asm|try|for|new|and|xor|not|do|or|if|if)\\b)(?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*))\\s*+(((?<!<)<(?!<)(?>(?:(?>[^<>]*)\\g<14>?)+)>)\\s*)?::)*)(((?>(?<!\\w)(?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*(?!\\w)))((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))::((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))\\16((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))(?=\\()))",
+      "beginCaptures": {
+        "1": {
+          "name": "meta.head.function.definition.special.constructor.cpp"
+        },
+        "2": {
+          "patterns": [
+            {
+              "include": "#inline_comment"
+            }
+          ]
+        },
+        "3": {
+          "name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+        },
+        "4": {
+          "name": "comment.block.cpp"
+        },
+        "5": {
+          "patterns": [
+            {
+              "match": "\\*\\/",
+              "name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+            },
+            {
+              "match": "\\*",
+              "name": "comment.block.cpp"
+            }
+          ]
+        },
+        "6": {
+          "name": "storage.type.modifier.calling-convention.cpp"
+        },
+        "7": {
+          "patterns": [
+            {
+              "include": "#inline_comment"
+            }
+          ]
+        },
+        "8": {
+          "name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+        },
+        "9": {
+          "name": "comment.block.cpp"
+        },
+        "10": {
+          "patterns": [
+            {
+              "match": "\\*\\/",
+              "name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+            },
+            {
+              "match": "\\*",
+              "name": "comment.block.cpp"
+            }
+          ]
+        },
+        "11": {
+          "patterns": [
+            {
+              "match": "::",
+              "name": "punctuation.separator.namespace.access.cpp punctuation.separator.scope-resolution.constructor.cpp"
+            },
+            {
+              "match": "(?<!\\w)(?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*(?!\\w)",
+              "name": "entity.name.scope-resolution.constructor.cpp"
+            },
+            {
+              "include": "#template_call_range"
+            }
+          ]
+        },
+        "13": {
+          "name": "meta.template.call.cpp",
+          "patterns": [
+            {
+              "include": "#template_call_range"
+            }
+          ]
+        },
+        "15": {
+          "patterns": [
+            {
+              "match": "(?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*(?=:)",
+              "name": "entity.name.type.constructor.cpp"
+            },
+            {
+              "match": "(?<=:)(?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*",
+              "name": "entity.name.function.definition.special.constructor.cpp"
+            },
+            {
+              "match": "::",
+              "name": "punctuation.separator.namespace.access.cpp punctuation.separator.scope-resolution.constructor.cpp"
+            }
+          ]
+        },
+        "17": {
+          "patterns": [
+            {
+              "include": "#inline_comment"
+            }
+          ]
+        },
+        "18": {
+          "name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+        },
+        "19": {
+          "name": "comment.block.cpp"
+        },
+        "20": {
+          "patterns": [
+            {
+              "match": "\\*\\/",
+              "name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+            },
+            {
+              "match": "\\*",
+              "name": "comment.block.cpp"
+            }
+          ]
+        },
+        "21": {
+          "patterns": [
+            {
+              "include": "#inline_comment"
+            }
+          ]
+        },
+        "22": {
+          "name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+        },
+        "23": {
+          "name": "comment.block.cpp"
+        },
+        "24": {
+          "patterns": [
+            {
+              "match": "\\*\\/",
+              "name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+            },
+            {
+              "match": "\\*",
+              "name": "comment.block.cpp"
+            }
+          ]
+        },
+        "25": {
+          "patterns": [
+            {
+              "include": "#inline_comment"
+            }
+          ]
+        },
+        "26": {
+          "name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+        },
+        "27": {
+          "name": "comment.block.cpp"
+        },
+        "28": {
+          "patterns": [
+            {
+              "match": "\\*\\/",
+              "name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+            },
+            {
+              "match": "\\*",
+              "name": "comment.block.cpp"
+            }
+          ]
+        }
+      },
+      "end": "(?:(?<=\\}|%>|\\?\\?>)|(?=[;>\\[\\]=]))|(?=(?<!\\\\)\n)",
+      "patterns": [
+        {
+          "name": "meta.head.function.definition.special.constructor.cpp",
+          "begin": "\\G ?",
+          "end": "((?:\\{|<%|\\?\\?<|(?=;)))|(?=(?<!\\\\)\n)",
+          "endCaptures": {
+            "1": {
+              "name": "punctuation.section.block.begin.bracket.curly.function.definition.special.constructor.cpp"
+            }
+          },
+          "patterns": [
+            {
+              "include": "#ever_present_context"
+            },
+            {
+              "patterns": [
+                {
+                  "match": "(\\=)((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))(?:(default)|(delete))",
+                  "captures": {
+                    "1": {
+                      "name": "keyword.operator.assignment.cpp"
+                    },
+                    "2": {
+                      "patterns": [
+                        {
+                          "include": "#inline_comment"
+                        }
+                      ]
+                    },
+                    "3": {
+                      "name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+                    },
+                    "4": {
+                      "name": "comment.block.cpp"
+                    },
+                    "5": {
+                      "patterns": [
+                        {
+                          "match": "\\*\\/",
+                          "name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+                        },
+                        {
+                          "match": "\\*",
+                          "name": "comment.block.cpp"
+                        }
+                      ]
+                    },
+                    "6": {
+                      "name": "keyword.other.default.constructor.cpp"
+                    },
+                    "7": {
+                      "name": "keyword.other.delete.constructor.cpp"
+                    }
+                  }
+                }
+              ]
+            },
+            {
+              "include": "#functional_specifiers_pre_parameters"
+            },
+            {
+              "begin": "(:)",
+              "beginCaptures": {
+                "1": {
+                  "name": "punctuation.separator.initializers.cpp"
+                }
+              },
+              "end": "(?=\\{)|(?=(?<!\\\\)\n)",
+              "patterns": [
+                {
+                  "contentName": "meta.parameter.initialization.cpp",
+                  "begin": "((?<!\\w)(?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*(?!\\w))(((?<!<)<(?!<)(?>(?:(?>[^<>]*)\\g<3>?)+)>)\\s*)?(\\()",
+                  "beginCaptures": {
+                    "1": {
+                      "name": "entity.name.function.call.initializer.cpp"
+                    },
+                    "2": {
+                      "name": "meta.template.call.cpp",
+                      "patterns": [
+                        {
+                          "include": "#template_call_range"
+                        }
+                      ]
+                    },
+                    "4": {
+                      "name": "punctuation.section.arguments.begin.bracket.round.function.call.initializer.cpp"
+                    }
+                  },
+                  "end": "(\\))|(?=(?<!\\\\)\n)",
+                  "endCaptures": {
+                    "1": {
+                      "name": "punctuation.section.arguments.end.bracket.round.function.call.initializer.cpp"
+                    }
+                  },
+                  "patterns": [
+                    {
+                      "include": "#evaluation_context"
+                    }
+                  ]
+                },
+                {
+                  "contentName": "meta.parameter.initialization.cpp",
+                  "begin": "((?<!\\w)(?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*(?!\\w))(\\{)",
+                  "beginCaptures": {
+                    "1": {
+                      "name": "entity.name.function.call.initializer.cpp"
+                    },
+                    "2": {
+                      "name": "punctuation.section.arguments.begin.bracket.round.function.call.initializer.cpp"
+                    }
+                  },
+                  "end": "(\\})|(?=(?<!\\\\)\n)",
+                  "endCaptures": {
+                    "1": {
+                      "name": "punctuation.section.arguments.end.bracket.round.function.call.initializer.cpp"
+                    }
+                  },
+                  "patterns": [
+                    {
+                      "include": "#evaluation_context"
+                    }
+                  ]
+                },
+                {
+                  "include": "#comma"
+                },
+                {
+                  "include": "#comments"
+                }
+              ]
+            },
+            {
+              "contentName": "meta.function.definition.parameters.special.constructor.cpp",
+              "begin": "(\\()",
+              "beginCaptures": {
+                "1": {
+                  "name": "punctuation.section.parameters.begin.bracket.round.special.constructor.cpp"
+                }
+              },
+              "end": "(\\))|(?=(?<!\\\\)\n)",
+              "endCaptures": {
+                "1": {
+                  "name": "punctuation.section.parameters.end.bracket.round.special.constructor.cpp"
+                }
+              },
+              "patterns": [
+                {
+                  "include": "#function_parameter_context"
+                },
+                {
+                  "include": "#evaluation_context"
+                }
+              ]
+            },
+            {
+              "include": "$self"
+            }
+          ]
+        },
+        {
+          "name": "meta.body.function.definition.special.constructor.cpp",
+          "begin": "(?<=\\{|<%|\\?\\?<)",
+          "end": "(\\}|%>|\\?\\?>)|(?=(?<!\\\\)\n)",
+          "endCaptures": {
+            "1": {
+              "name": "punctuation.section.block.end.bracket.curly.function.definition.special.constructor.cpp"
+            }
+          },
+          "patterns": [
+            {
+              "include": "#function_body_context"
+            }
+          ]
+        },
+        {
+          "name": "meta.tail.function.definition.special.constructor.cpp",
+          "begin": "(?<=\\}|%>|\\?\\?>)[\\s\\n]*",
+          "end": "[\\s\\n]*(?=;)|(?=(?<!\\\\)\n)",
+          "patterns": [
+            {
+              "include": "$self"
+            }
+          ]
+        }
+      ]
+    },
+    "control_flow_keywords": {
+      "match": "((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))((?<!\\w)(?:continue|default|switch|return|throw|break|catch|while|case|goto|else|try|for|do|if)(?!\\w))",
+      "captures": {
+        "1": {
+          "patterns": [
+            {
+              "include": "#inline_comment"
+            }
+          ]
+        },
+        "2": {
+          "name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+        },
+        "3": {
+          "name": "comment.block.cpp"
+        },
+        "4": {
+          "patterns": [
+            {
+              "match": "\\*\\/",
+              "name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+            },
+            {
+              "match": "\\*",
+              "name": "comment.block.cpp"
+            }
+          ]
+        },
+        "5": {
+          "name": "keyword.control.$5.cpp"
+        }
+      }
+    },
+    "cpp_attributes": {
+      "name": "support.other.attribute.cpp",
+      "begin": "(\\[\\[)",
+      "beginCaptures": {
+        "1": {
+          "name": "punctuation.section.attribute.begin.cpp"
+        }
+      },
+      "end": "(\\]\\])|(?=(?<!\\\\)\n)",
+      "endCaptures": {
+        "1": {
+          "name": "punctuation.section.attribute.end.cpp"
+        }
+      },
+      "patterns": [
+        {
+          "include": "#attributes_context"
+        },
+        {
+          "begin": "\\(",
+          "end": "\\)|(?=(?<!\\\\)\n)",
+          "patterns": [
+            {
+              "include": "#attributes_context"
+            },
+            {
+              "include": "#string_context"
+            }
+          ]
+        },
+        {
+          "match": "(using)\\s+((?<!\\w)(?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*(?!\\w))",
+          "captures": {
+            "1": {
+              "name": "keyword.other.using.directive.cpp"
+            },
+            "2": {
+              "name": "entity.name.namespace.cpp"
+            }
+          }
+        },
+        {
+          "match": ",",
+          "name": "punctuation.separator.attribute.cpp"
+        },
+        {
+          "match": ":",
+          "name": "punctuation.accessor.attribute.cpp"
+        },
+        {
+          "match": "(?<!\\w)(?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*(?!\\w)(?=::)",
+          "name": "entity.name.namespace.cpp"
+        },
+        {
+          "match": "(?<!\\w)(?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*(?!\\w)",
+          "name": "entity.other.attribute.$0.cpp"
+        },
+        {
+          "include": "#number_literal"
+        }
+      ]
+    },
+    "curly_initializer": {
+      "name": "meta.initialization.cpp",
+      "begin": "(\\s*+((?:(?:(?:\\[\\[.*?\\]\\]|__attribute(?:__)?\\(\\(.*?\\)\\))|__declspec\\(.*?\\))|alignas\\(.*?\\))(?!\\)))?((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))(?:(?:(?:unsigned|signed|short|long)|(?:struct|class|union|enum))((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z)))))*(((::)?(?:((?-mix:(?!\\b(?:__has_cpp_attribute|reinterpret_cast|atomic_noexcept|atomic_cancel|atomic_commit|__has_include|dynamic_cast|thread_local|synchronized|static_cast|const_cast|consteval|constexpr|protected|namespace|co_return|constexpr|constexpr|continue|explicit|volatile|noexcept|co_yield|noexcept|noexcept|requires|typename|decltype|operator|co_await|template|volatile|register|restrict|reflexpr|alignof|private|default|mutable|include|concept|__asm__|defined|_Pragma|alignas|typedef|warning|virtual|mutable|struct|sizeof|delete|not_eq|bitand|and_eq|xor_eq|typeid|switch|return|static|extern|inline|friend|public|ifndef|define|pragma|export|import|module|catch|throw|const|or_eq|while|compl|bitor|const|union|ifdef|class|undef|error|break|using|endif|goto|line|enum|this|case|else|elif|else|asm|try|for|new|and|xor|not|do|or|if|if)\\b)(?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*))\\s*+(((?<!<)<(?!<)(?>(?:(?>[^<>]*)\\g<27>?)+)>)\\s*)?::)*\\s*+)((?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*)\\s*+(((?<!<)<(?!<)(?>(?:(?>[^<>]*)\\g<27>?)+)>)\\s*)?(::))?((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))(?!(?:transaction_safe_dynamic|__has_cpp_attribute|transaction_safe|reinterpret_cast|atomic_noexcept|atomic_commit|atomic_cancel|__has_include|dynamic_cast|thread_local|synchronized|static_cast|const_cast|constexpr|consteval|protected|constexpr|co_return|namespace|constexpr|noexcept|typename|decltype|template|operator|noexcept|co_yield|co_await|continue|volatile|register|restrict|explicit|override|volatile|reflexpr|noexcept|requires|default|typedef|nullptr|alignof|mutable|concept|virtual|defined|__asm__|include|_Pragma|mutable|warning|private|alignas|module|switch|not_eq|bitand|and_eq|ifndef|return|sizeof|xor_eq|export|static|delete|public|define|extern|inline|import|pragma|friend|typeid|const|compl|bitor|throw|or_eq|while|catch|break|false|final|const|endif|ifdef|undef|error|using|audit|axiom|line|else|elif|true|NULL|case|goto|else|this|new|asm|not|and|xor|try|for|if|do|or|if)\\b)((?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*)\\b(((?<!<)<(?!<)(?>(?:(?>[^<>]*)\\g<27>?)+)>)\\s*)?(?![\\w<:.]))((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))(\\{)",
+      "beginCaptures": {
+        "1": {
+          "name": "meta.qualified_type.cpp",
+          "patterns": [
+            {
+              "match": "(?<!\\w)(?:struct|class|union|enum)(?!\\w)",
+              "name": "storage.type.$0.cpp"
+            },
+            {
+              "include": "#attributes_context"
+            },
+            {
+              "include": "#function_type"
+            },
+            {
+              "include": "#storage_types"
+            },
+            {
+              "include": "#number_literal"
+            },
+            {
+              "include": "#string_context"
+            },
+            {
+              "include": "#comma"
+            },
+            {
+              "include": "#scope_resolution_inner_generated"
+            },
+            {
+              "include": "#template_call_range"
+            },
+            {
+              "match": "(?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*",
+              "name": "entity.name.type.cpp"
+            }
+          ]
+        },
+        "2": {
+          "patterns": [
+            {
+              "include": "#attributes_context"
+            },
+            {
+              "include": "#number_literal"
+            }
+          ]
+        },
+        "3": {
+          "patterns": [
+            {
+              "include": "#inline_comment"
+            }
+          ]
+        },
+        "4": {
+          "name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+        },
+        "5": {
+          "name": "comment.block.cpp"
+        },
+        "6": {
+          "patterns": [
+            {
+              "match": "\\*\\/",
+              "name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+            },
+            {
+              "match": "\\*",
+              "name": "comment.block.cpp"
+            }
+          ]
+        },
+        "7": {
+          "patterns": [
+            {
+              "include": "#inline_comment"
+            }
+          ]
+        },
+        "8": {
+          "name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+        },
+        "9": {
+          "name": "comment.block.cpp"
+        },
+        "10": {
+          "patterns": [
+            {
+              "match": "\\*\\/",
+              "name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+            },
+            {
+              "match": "\\*",
+              "name": "comment.block.cpp"
+            }
+          ]
+        },
+        "12": {
+          "patterns": [
+            {
+              "include": "#scope_resolution_inner_generated"
+            }
+          ]
+        },
+        "13": {
+          "name": "punctuation.separator.namespace.access.cpp punctuation.separator.scope-resolution.cpp"
+        },
+        "15": {
+          "name": "meta.template.call.cpp",
+          "patterns": [
+            {
+              "include": "#template_call_range"
+            }
+          ]
+        },
+        "17": {
+          "name": "entity.name.scope-resolution.cpp"
+        },
+        "18": {
+          "name": "meta.template.call.cpp",
+          "patterns": [
+            {
+              "include": "#template_call_range"
+            }
+          ]
+        },
+        "20": {
+          "name": "punctuation.separator.namespace.access.cpp punctuation.separator.scope-resolution.cpp"
+        },
+        "21": {
+          "patterns": [
+            {
+              "include": "#inline_comment"
+            }
+          ]
+        },
+        "22": {
+          "name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+        },
+        "23": {
+          "name": "comment.block.cpp"
+        },
+        "24": {
+          "patterns": [
+            {
+              "match": "\\*\\/",
+              "name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+            },
+            {
+              "match": "\\*",
+              "name": "comment.block.cpp"
+            }
+          ]
+        },
+        "25": {
+          "name": "entity.name.type.cpp"
+        },
+        "26": {
+          "name": "meta.template.call.cpp",
+          "patterns": [
+            {
+              "include": "#template_call_range"
+            }
+          ]
+        },
+        "28": {
+          "patterns": [
+            {
+              "include": "#inline_comment"
+            }
+          ]
+        },
+        "29": {
+          "name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+        },
+        "30": {
+          "name": "comment.block.cpp"
+        },
+        "31": {
+          "patterns": [
+            {
+              "match": "\\*\\/",
+              "name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+            },
+            {
+              "match": "\\*",
+              "name": "comment.block.cpp"
+            }
+          ]
+        },
+        "32": {
+          "name": "punctuation.section.arguments.begin.bracket.curly.initializer.cpp"
+        }
+      },
+      "end": "(\\})|(?=(?<!\\\\)\n)",
+      "endCaptures": {
+        "1": {
+          "name": "punctuation.section.arguments.end.bracket.curly.initializer.cpp"
+        }
+      },
+      "patterns": [
+        {
+          "include": "#evaluation_context"
+        },
+        {
+          "include": "#comma"
+        }
+      ]
+    },
+    "decltype": {
+      "contentName": "meta.arguments.decltype.cpp",
+      "begin": "((?<!\\w)decltype(?!\\w))((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))(\\()",
+      "beginCaptures": {
+        "1": {
+          "name": "keyword.operator.functionlike.cpp keyword.other.decltype.cpp storage.type.decltype.cpp"
+        },
+        "2": {
+          "patterns": [
+            {
+              "include": "#inline_comment"
+            }
+          ]
+        },
+        "3": {
+          "name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+        },
+        "4": {
+          "name": "comment.block.cpp"
+        },
+        "5": {
+          "patterns": [
+            {
+              "match": "\\*\\/",
+              "name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+            },
+            {
+              "match": "\\*",
+              "name": "comment.block.cpp"
+            }
+          ]
+        },
+        "6": {
+          "name": "punctuation.section.arguments.begin.bracket.round.decltype.cpp"
+        }
+      },
+      "end": "(\\))|(?=(?<!\\\\)\n)",
+      "endCaptures": {
+        "1": {
+          "name": "punctuation.section.arguments.end.bracket.round.decltype.cpp"
+        }
+      },
+      "patterns": [
+        {
+          "include": "#evaluation_context"
+        }
+      ]
+    },
+    "decltype_specifier": {
+      "contentName": "meta.arguments.decltype.cpp",
+      "begin": "((?<!\\w)decltype(?!\\w))((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))(\\()",
+      "beginCaptures": {
+        "1": {
+          "name": "keyword.operator.functionlike.cpp keyword.other.decltype.cpp storage.type.decltype.cpp"
+        },
+        "2": {
+          "patterns": [
+            {
+              "include": "#inline_comment"
+            }
+          ]
+        },
+        "3": {
+          "name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+        },
+        "4": {
+          "name": "comment.block.cpp"
+        },
+        "5": {
+          "patterns": [
+            {
+              "match": "\\*\\/",
+              "name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+            },
+            {
+              "match": "\\*",
+              "name": "comment.block.cpp"
+            }
+          ]
+        },
+        "6": {
+          "name": "punctuation.section.arguments.begin.bracket.round.decltype.cpp"
+        }
+      },
+      "end": "(\\))|(?=(?<!\\\\)\n)",
+      "endCaptures": {
+        "1": {
+          "name": "punctuation.section.arguments.end.bracket.round.decltype.cpp"
+        }
+      },
+      "patterns": [
+        {
+          "include": "#evaluation_context"
+        }
+      ]
+    },
+    "default_statement": {
+      "name": "meta.conditional.case.cpp",
+      "begin": "((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))((?<!\\w)default(?!\\w))",
+      "beginCaptures": {
+        "1": {
+          "patterns": [
+            {
+              "include": "#inline_comment"
+            }
+          ]
+        },
+        "2": {
+          "name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+        },
+        "3": {
+          "name": "comment.block.cpp"
+        },
+        "4": {
+          "patterns": [
+            {
+              "match": "\\*\\/",
+              "name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+            },
+            {
+              "match": "\\*",
+              "name": "comment.block.cpp"
+            }
+          ]
+        },
+        "5": {
+          "name": "keyword.control.default.cpp"
+        }
+      },
+      "end": "(:)|(?=(?<!\\\\)\n)",
+      "endCaptures": {
+        "1": {
+          "name": "punctuation.separator.colon.case.default.cpp"
+        }
+      },
+      "patterns": [
+        {
+          "include": "#evaluation_context"
+        },
+        {
+          "include": "#c_conditional_context"
+        }
+      ]
+    },
+    "destructor_inline": {
+      "name": "meta.function.definition.special.member.destructor.cpp",
+      "begin": "(^((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))((?:__cdecl|__clrcall|__stdcall|__fastcall|__thiscall|__vectorcall)?)((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))((?:(?:constexpr|explicit|mutable|virtual|inline|friend)((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z)))))*)(~(?<!\\w)(?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*(?!\\w)(?=\\()))",
+      "beginCaptures": {
+        "1": {
+          "name": "meta.head.function.definition.special.member.destructor.cpp"
+        },
+        "2": {
+          "patterns": [
+            {
+              "include": "#inline_comment"
+            }
+          ]
+        },
+        "3": {
+          "name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+        },
+        "4": {
+          "name": "comment.block.cpp"
+        },
+        "5": {
+          "patterns": [
+            {
+              "match": "\\*\\/",
+              "name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+            },
+            {
+              "match": "\\*",
+              "name": "comment.block.cpp"
+            }
+          ]
+        },
+        "6": {
+          "patterns": [
+            {
+              "include": "#inline_comment"
+            }
+          ]
+        },
+        "7": {
+          "name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+        },
+        "8": {
+          "name": "comment.block.cpp"
+        },
+        "9": {
+          "patterns": [
+            {
+              "match": "\\*\\/",
+              "name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+            },
+            {
+              "match": "\\*",
+              "name": "comment.block.cpp"
+            }
+          ]
+        },
+        "10": {
+          "name": "storage.type.modifier.calling-convention.cpp"
+        },
+        "11": {
+          "patterns": [
+            {
+              "include": "#inline_comment"
+            }
+          ]
+        },
+        "12": {
+          "name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+        },
+        "13": {
+          "name": "comment.block.cpp"
+        },
+        "14": {
+          "patterns": [
+            {
+              "match": "\\*\\/",
+              "name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+            },
+            {
+              "match": "\\*",
+              "name": "comment.block.cpp"
+            }
+          ]
+        },
+        "15": {
+          "patterns": [
+            {
+              "include": "#functional_specifiers_pre_parameters"
+            }
+          ]
+        },
+        "16": {
+          "patterns": [
+            {
+              "include": "#inline_comment"
+            }
+          ]
+        },
+        "17": {
+          "name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+        },
+        "18": {
+          "name": "comment.block.cpp"
+        },
+        "19": {
+          "patterns": [
+            {
+              "match": "\\*\\/",
+              "name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+            },
+            {
+              "match": "\\*",
+              "name": "comment.block.cpp"
+            }
+          ]
+        },
+        "20": {
+          "name": "entity.name.function.destructor.cpp entity.name.function.definition.special.member.destructor.cpp"
+        }
+      },
+      "end": "(?:(?<=\\}|%>|\\?\\?>)|(?=[;>\\[\\]=]))|(?=(?<!\\\\)\n)",
+      "patterns": [
+        {
+          "name": "meta.head.function.definition.special.member.destructor.cpp",
+          "begin": "\\G ?",
+          "end": "((?:\\{|<%|\\?\\?<|(?=;)))|(?=(?<!\\\\)\n)",
+          "endCaptures": {
+            "1": {
+              "name": "punctuation.section.block.begin.bracket.curly.function.definition.special.member.destructor.cpp"
+            }
+          },
+          "patterns": [
+            {
+              "include": "#ever_present_context"
+            },
+            {
+              "patterns": [
+                {
+                  "match": "(\\=)((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))(?:(default)|(delete))",
+                  "captures": {
+                    "1": {
+                      "name": "keyword.operator.assignment.cpp"
+                    },
+                    "2": {
+                      "patterns": [
+                        {
+                          "include": "#inline_comment"
+                        }
+                      ]
+                    },
+                    "3": {
+                      "name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+                    },
+                    "4": {
+                      "name": "comment.block.cpp"
+                    },
+                    "5": {
+                      "patterns": [
+                        {
+                          "match": "\\*\\/",
+                          "name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+                        },
+                        {
+                          "match": "\\*",
+                          "name": "comment.block.cpp"
+                        }
+                      ]
+                    },
+                    "6": {
+                      "name": "keyword.other.default.constructor.cpp"
+                    },
+                    "7": {
+                      "name": "keyword.other.delete.constructor.cpp"
+                    }
+                  }
+                }
+              ]
+            },
+            {
+              "contentName": "meta.function.definition.parameters.special.member.destructor.cpp",
+              "begin": "(\\()",
+              "beginCaptures": {
+                "1": {
+                  "name": "punctuation.section.parameters.begin.bracket.round.special.member.destructor.cpp"
+                }
+              },
+              "end": "(\\))|(?=(?<!\\\\)\n)",
+              "endCaptures": {
+                "1": {
+                  "name": "punctuation.section.parameters.end.bracket.round.special.member.destructor.cpp"
+                }
+              }
+            },
+            {
+              "include": "$self"
+            }
+          ]
+        },
+        {
+          "name": "meta.body.function.definition.special.member.destructor.cpp",
+          "begin": "(?<=\\{|<%|\\?\\?<)",
+          "end": "(\\}|%>|\\?\\?>)|(?=(?<!\\\\)\n)",
+          "endCaptures": {
+            "1": {
+              "name": "punctuation.section.block.end.bracket.curly.function.definition.special.member.destructor.cpp"
+            }
+          },
+          "patterns": [
+            {
+              "include": "#function_body_context"
+            }
+          ]
+        },
+        {
+          "name": "meta.tail.function.definition.special.member.destructor.cpp",
+          "begin": "(?<=\\}|%>|\\?\\?>)[\\s\\n]*",
+          "end": "[\\s\\n]*(?=;)|(?=(?<!\\\\)\n)",
+          "patterns": [
+            {
+              "include": "$self"
+            }
+          ]
+        }
+      ]
+    },
+    "destructor_root": {
+      "name": "meta.function.definition.special.member.destructor.cpp",
+      "begin": "(((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))((?:__cdecl|__clrcall|__stdcall|__fastcall|__thiscall|__vectorcall)?)((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))((?:((?-mix:(?!\\b(?:__has_cpp_attribute|reinterpret_cast|atomic_noexcept|atomic_cancel|atomic_commit|__has_include|dynamic_cast|thread_local|synchronized|static_cast|const_cast|consteval|constexpr|protected|namespace|co_return|constexpr|constexpr|continue|explicit|volatile|noexcept|co_yield|noexcept|noexcept|requires|typename|decltype|operator|co_await|template|volatile|register|restrict|reflexpr|alignof|private|default|mutable|include|concept|__asm__|defined|_Pragma|alignas|typedef|warning|virtual|mutable|struct|sizeof|delete|not_eq|bitand|and_eq|xor_eq|typeid|switch|return|static|extern|inline|friend|public|ifndef|define|pragma|export|import|module|catch|throw|const|or_eq|while|compl|bitor|const|union|ifdef|class|undef|error|break|using|endif|goto|line|enum|this|case|else|elif|else|asm|try|for|new|and|xor|not|do|or|if|if)\\b)(?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*))\\s*+(((?<!<)<(?!<)(?>(?:(?>[^<>]*)\\g<14>?)+)>)\\s*)?::)*)(((?>(?<!\\w)(?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*(?!\\w)))((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))::((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))~\\16((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))(?=\\()))",
+      "beginCaptures": {
+        "1": {
+          "name": "meta.head.function.definition.special.member.destructor.cpp"
+        },
+        "2": {
+          "patterns": [
+            {
+              "include": "#inline_comment"
+            }
+          ]
+        },
+        "3": {
+          "name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+        },
+        "4": {
+          "name": "comment.block.cpp"
+        },
+        "5": {
+          "patterns": [
+            {
+              "match": "\\*\\/",
+              "name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+            },
+            {
+              "match": "\\*",
+              "name": "comment.block.cpp"
+            }
+          ]
+        },
+        "6": {
+          "name": "storage.type.modifier.calling-convention.cpp"
+        },
+        "7": {
+          "patterns": [
+            {
+              "include": "#inline_comment"
+            }
+          ]
+        },
+        "8": {
+          "name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+        },
+        "9": {
+          "name": "comment.block.cpp"
+        },
+        "10": {
+          "patterns": [
+            {
+              "match": "\\*\\/",
+              "name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+            },
+            {
+              "match": "\\*",
+              "name": "comment.block.cpp"
+            }
+          ]
+        },
+        "11": {
+          "patterns": [
+            {
+              "match": "::",
+              "name": "punctuation.separator.namespace.access.cpp punctuation.separator.scope-resolution.destructor.cpp"
+            },
+            {
+              "match": "(?<!\\w)(?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*(?!\\w)",
+              "name": "entity.name.scope-resolution.destructor.cpp"
+            },
+            {
+              "include": "#template_call_range"
+            }
+          ]
+        },
+        "13": {
+          "name": "meta.template.call.cpp",
+          "patterns": [
+            {
+              "include": "#template_call_range"
+            }
+          ]
+        },
+        "15": {
+          "patterns": [
+            {
+              "match": "(?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*(?=:)",
+              "name": "entity.name.type.destructor.cpp"
+            },
+            {
+              "match": "(?<=:)~(?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*",
+              "name": "entity.name.function.definition.special.member.destructor.cpp"
+            },
+            {
+              "match": "::",
+              "name": "punctuation.separator.namespace.access.cpp punctuation.separator.scope-resolution.destructor.cpp"
+            }
+          ]
+        },
+        "17": {
+          "patterns": [
+            {
+              "include": "#inline_comment"
+            }
+          ]
+        },
+        "18": {
+          "name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+        },
+        "19": {
+          "name": "comment.block.cpp"
+        },
+        "20": {
+          "patterns": [
+            {
+              "match": "\\*\\/",
+              "name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+            },
+            {
+              "match": "\\*",
+              "name": "comment.block.cpp"
+            }
+          ]
+        },
+        "21": {
+          "patterns": [
+            {
+              "include": "#inline_comment"
+            }
+          ]
+        },
+        "22": {
+          "name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+        },
+        "23": {
+          "name": "comment.block.cpp"
+        },
+        "24": {
+          "patterns": [
+            {
+              "match": "\\*\\/",
+              "name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+            },
+            {
+              "match": "\\*",
+              "name": "comment.block.cpp"
+            }
+          ]
+        },
+        "25": {
+          "patterns": [
+            {
+              "include": "#inline_comment"
+            }
+          ]
+        },
+        "26": {
+          "name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+        },
+        "27": {
+          "name": "comment.block.cpp"
+        },
+        "28": {
+          "patterns": [
+            {
+              "match": "\\*\\/",
+              "name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+            },
+            {
+              "match": "\\*",
+              "name": "comment.block.cpp"
+            }
+          ]
+        }
+      },
+      "end": "(?:(?<=\\}|%>|\\?\\?>)|(?=[;>\\[\\]=]))|(?=(?<!\\\\)\n)",
+      "patterns": [
+        {
+          "name": "meta.head.function.definition.special.member.destructor.cpp",
+          "begin": "\\G ?",
+          "end": "((?:\\{|<%|\\?\\?<|(?=;)))|(?=(?<!\\\\)\n)",
+          "endCaptures": {
+            "1": {
+              "name": "punctuation.section.block.begin.bracket.curly.function.definition.special.member.destructor.cpp"
+            }
+          },
+          "patterns": [
+            {
+              "include": "#ever_present_context"
+            },
+            {
+              "patterns": [
+                {
+                  "match": "(\\=)((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))(?:(default)|(delete))",
+                  "captures": {
+                    "1": {
+                      "name": "keyword.operator.assignment.cpp"
+                    },
+                    "2": {
+                      "patterns": [
+                        {
+                          "include": "#inline_comment"
+                        }
+                      ]
+                    },
+                    "3": {
+                      "name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+                    },
+                    "4": {
+                      "name": "comment.block.cpp"
+                    },
+                    "5": {
+                      "patterns": [
+                        {
+                          "match": "\\*\\/",
+                          "name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+                        },
+                        {
+                          "match": "\\*",
+                          "name": "comment.block.cpp"
+                        }
+                      ]
+                    },
+                    "6": {
+                      "name": "keyword.other.default.constructor.cpp"
+                    },
+                    "7": {
+                      "name": "keyword.other.delete.constructor.cpp"
+                    }
+                  }
+                }
+              ]
+            },
+            {
+              "contentName": "meta.function.definition.parameters.special.member.destructor.cpp",
+              "begin": "(\\()",
+              "beginCaptures": {
+                "1": {
+                  "name": "punctuation.section.parameters.begin.bracket.round.special.member.destructor.cpp"
+                }
+              },
+              "end": "(\\))|(?=(?<!\\\\)\n)",
+              "endCaptures": {
+                "1": {
+                  "name": "punctuation.section.parameters.end.bracket.round.special.member.destructor.cpp"
+                }
+              }
+            },
+            {
+              "include": "$self"
+            }
+          ]
+        },
+        {
+          "name": "meta.body.function.definition.special.member.destructor.cpp",
+          "begin": "(?<=\\{|<%|\\?\\?<)",
+          "end": "(\\}|%>|\\?\\?>)|(?=(?<!\\\\)\n)",
+          "endCaptures": {
+            "1": {
+              "name": "punctuation.section.block.end.bracket.curly.function.definition.special.member.destructor.cpp"
+            }
+          },
+          "patterns": [
+            {
+              "include": "#function_body_context"
+            }
+          ]
+        },
+        {
+          "name": "meta.tail.function.definition.special.member.destructor.cpp",
+          "begin": "(?<=\\}|%>|\\?\\?>)[\\s\\n]*",
+          "end": "[\\s\\n]*(?=;)|(?=(?<!\\\\)\n)",
+          "patterns": [
+            {
+              "include": "$self"
+            }
+          ]
+        }
+      ]
+    },
+    "diagnostic": {
+      "name": "meta.preprocessor.diagnostic.$reference(directive).cpp",
+      "begin": "((?:^)((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))(#)\\s*((?:error|warning)))\\b\\s*",
+      "beginCaptures": {
+        "1": {
+          "name": "keyword.control.directive.diagnostic.$7.cpp"
+        },
+        "2": {
+          "patterns": [
+            {
+              "include": "#inline_comment"
+            }
+          ]
+        },
+        "3": {
+          "name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+        },
+        "4": {
+          "name": "comment.block.cpp"
+        },
+        "5": {
+          "patterns": [
+            {
+              "match": "\\*\\/",
+              "name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+            },
+            {
+              "match": "\\*",
+              "name": "comment.block.cpp"
+            }
+          ]
+        },
+        "6": {
+          "name": "punctuation.definition.directive.cpp"
+        }
+      },
+      "end": "(?<!\\\\)(?=\\n)|(?=(?<!\\\\)\n)",
+      "patterns": [
+        {
+          "name": "string.quoted.double.cpp",
+          "begin": "(\")",
+          "beginCaptures": {
+            "1": {
+              "name": "punctuation.definition.string.begin.cpp"
+            }
+          },
+          "end": "(?:(\")|(?<!\\\\)(?=\\n))|(?=(?<!\\\\)\n)",
+          "endCaptures": {
+            "1": {
+              "name": "punctuation.definition.string.end.cpp"
+            }
+          },
+          "patterns": [
+            {
+              "include": "#line_continuation_character"
+            }
+          ]
+        },
+        {
+          "name": "string.quoted.single.cpp",
+          "begin": "(')",
+          "beginCaptures": {
+            "1": {
+              "name": "punctuation.definition.string.begin.cpp"
+            }
+          },
+          "end": "(?:(')|(?<!\\\\)(?=\\n))|(?=(?<!\\\\)\n)",
+          "endCaptures": {
+            "1": {
+              "name": "punctuation.definition.string.end.cpp"
+            }
+          },
+          "patterns": [
+            {
+              "include": "#line_continuation_character"
+            }
+          ]
+        },
+        {
+          "name": "string.unquoted.cpp",
+          "begin": "[^'\"]",
+          "end": "(?<!\\\\)(?=\\n)|(?=(?<!\\\\)\n)",
+          "patterns": [
+            {
+              "include": "#line_continuation_character"
+            },
+            {
+              "include": "#comments"
+            }
+          ]
+        }
+      ]
+    },
+    "emacs_file_banner": {
+      "match": "(?:(^\\s*((\\/\\/)\\s*((?>[#;\\/=*C~]+)(?![#;\\/=*C~]))\\s*.+\\s*\\8\\s*(?:\\n|$)))|(^\\s*((\\/\\*)\\s*?((?>[#;\\/=*C~]+)(?![#;\\/=*C~]))\\s*.+\\s*\\8\\s*\\*\\/)))",
+      "captures": {
+        "1": {
+          "name": "meta.toc-list.banner.double-slash.cpp"
+        },
+        "2": {
+          "name": "comment.line.double-slash.cpp"
+        },
+        "3": {
+          "name": "punctuation.definition.comment.cpp"
+        },
+        "4": {
+          "name": "meta.banner.character.cpp"
+        },
+        "5": {
+          "name": "meta.toc-list.banner.block.cpp"
+        },
+        "6": {
+          "name": "comment.line.banner.cpp"
+        },
+        "7": {
+          "name": "punctuation.definition.comment.cpp"
+        },
+        "8": {
+          "name": "meta.banner.character.cpp"
+        }
+      }
+    },
+    "empty_square_brackets": {
+      "name": "storage.modifier.array.bracket.square.cpp",
+      "match": "(?-mix:(?-mix:(?<!delete))\\\\[\\\\s*\\\\])"
+    },
+    "enum_block": {
+      "name": "meta.block.enum.cpp",
+      "begin": "(((?<!\\w)enum(?!\\w))(?:\\s+(class|struct))?(?:(?:\\s+|((?:(?:(?:\\[\\[.*?\\]\\]|__attribute(?:__)?\\(\\(.*?\\)\\))|__declspec\\(.*?\\))|alignas\\(.*?\\))(?!\\))))|(?={))\\s*((?:(?<!\\w)(?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*(?!\\w))?)(?:\\s*(:)\\s*(((::)?(?:((?-mix:(?!\\b(?:__has_cpp_attribute|reinterpret_cast|atomic_noexcept|atomic_cancel|atomic_commit|__has_include|dynamic_cast|thread_local|synchronized|static_cast|const_cast|consteval|constexpr|protected|namespace|co_return|constexpr|constexpr|continue|explicit|volatile|noexcept|co_yield|noexcept|noexcept|requires|typename|decltype|operator|co_await|template|volatile|register|restrict|reflexpr|alignof|private|default|mutable|include|concept|__asm__|defined|_Pragma|alignas|typedef|warning|virtual|mutable|struct|sizeof|delete|not_eq|bitand|and_eq|xor_eq|typeid|switch|return|static|extern|inline|friend|public|ifndef|define|pragma|export|import|module|catch|throw|const|or_eq|while|compl|bitor|const|union|ifdef|class|undef|error|break|using|endif|goto|line|enum|this|case|else|elif|else|asm|try|for|new|and|xor|not|do|or|if|if)\\b)(?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*))\\s*+(((?<!<)<(?!<)(?>(?:(?>[^<>]*)\\g<15>?)+)>)\\s*)?::)*\\s*+)((?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*)\\s*+(((?<!<)<(?!<)(?>(?:(?>[^<>]*)\\g<15>?)+)>)\\s*)?(::))?\\s*((?<!\\w)(?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*(?!\\w)))?)",
+      "beginCaptures": {
+        "1": {
+          "name": "meta.head.enum.cpp"
+        },
+        "2": {
+          "name": "storage.type.enum.cpp"
+        },
+        "3": {
+          "name": "storage.type.enum.enum-key.$3.cpp"
+        },
+        "4": {
+          "patterns": [
+            {
+              "include": "#attributes_context"
+            },
+            {
+              "include": "#number_literal"
+            }
+          ]
+        },
+        "5": {
+          "name": "entity.name.type.enum.cpp"
+        },
+        "6": {
+          "name": "punctuation.separator.colon.type-specifier.cpp"
+        },
+        "8": {
+          "patterns": [
+            {
+              "include": "#scope_resolution_inner_generated"
+            }
+          ]
+        },
+        "9": {
+          "name": "punctuation.separator.namespace.access.cpp punctuation.separator.scope-resolution.cpp"
+        },
+        "11": {
+          "name": "meta.template.call.cpp",
+          "patterns": [
+            {
+              "include": "#template_call_range"
+            }
+          ]
+        },
+        "13": {
+          "name": "entity.name.scope-resolution.cpp"
+        },
+        "14": {
+          "name": "meta.template.call.cpp",
+          "patterns": [
+            {
+              "include": "#template_call_range"
+            }
+          ]
+        },
+        "16": {
+          "name": "punctuation.separator.namespace.access.cpp punctuation.separator.scope-resolution.cpp"
+        },
+        "17": {
+          "name": "storage.type.integral.$17.cpp"
+        }
+      },
+      "end": "(?:(?:(?<=\\}|%>|\\?\\?>)\\s*(;)|(;))|(?=[;>\\[\\]=]))|(?=(?<!\\\\)\n)",
+      "endCaptures": {
+        "1": {
+          "name": "punctuation.terminator.statement.cpp"
+        },
+        "2": {
+          "name": "punctuation.terminator.statement.cpp"
+        }
+      },
+      "patterns": [
+        {
+          "name": "meta.head.enum.cpp",
+          "begin": "\\G ?",
+          "end": "((?:\\{|<%|\\?\\?<|(?=;)))|(?=(?<!\\\\)\n)",
+          "endCaptures": {
+            "1": {
+              "name": "punctuation.section.block.begin.bracket.curly.enum.cpp"
+            }
+          },
+          "patterns": [
+            {
+              "include": "$self"
+            }
+          ]
+        },
+        {
+          "name": "meta.body.enum.cpp",
+          "begin": "(?<=\\{|<%|\\?\\?<)",
+          "end": "(\\}|%>|\\?\\?>)|(?=(?<!\\\\)\n)",
+          "endCaptures": {
+            "1": {
+              "name": "punctuation.section.block.end.bracket.curly.enum.cpp"
+            }
+          },
+          "patterns": [
+            {
+              "include": "#ever_present_context"
+            },
+            {
+              "include": "#enumerator_list"
+            },
+            {
+              "include": "#comments"
+            },
+            {
+              "include": "#comma"
+            },
+            {
+              "include": "#semicolon"
+            }
+          ]
+        },
+        {
+          "name": "meta.tail.enum.cpp",
+          "begin": "(?<=\\}|%>|\\?\\?>)[\\s\\n]*",
+          "end": "[\\s\\n]*(?=;)|(?=(?<!\\\\)\n)",
+          "patterns": [
+            {
+              "include": "$self"
+            }
+          ]
+        }
+      ]
+    },
+    "enum_declare": {
+      "match": "((?<!\\w)enum(?!\\w))((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))((?<!\\w)(?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*(?!\\w))(((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))?(?:(?:\\&|\\*)((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z)))))*(?:\\&|\\*))?((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))\\b(?!override\\W|override\\$|final\\W|final\\$)((?<!\\w)(?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*(?!\\w))((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))(?=\\S)(?![:{])",
+      "captures": {
+        "1": {
+          "name": "storage.type.enum.declare.cpp"
+        },
+        "2": {
+          "patterns": [
+            {
+              "include": "#inline_comment"
+            }
+          ]
+        },
+        "3": {
+          "name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+        },
+        "4": {
+          "name": "comment.block.cpp"
+        },
+        "5": {
+          "patterns": [
+            {
+              "match": "\\*\\/",
+              "name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+            },
+            {
+              "match": "\\*",
+              "name": "comment.block.cpp"
+            }
+          ]
+        },
+        "6": {
+          "name": "entity.name.type.enum.cpp"
+        },
+        "7": {
+          "patterns": [
+            {
+              "match": "\\*",
+              "name": "storage.modifier.pointer.cpp"
+            },
+            {
+              "match": "(?:\\&((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))){2,}\\&",
+              "captures": {
+                "1": {
+                  "patterns": [
+                    {
+                      "include": "#inline_comment"
+                    }
+                  ]
+                },
+                "2": {
+                  "name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+                },
+                "3": {
+                  "name": "comment.block.cpp"
+                },
+                "4": {
+                  "patterns": [
+                    {
+                      "match": "\\*\\/",
+                      "name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+                    },
+                    {
+                      "match": "\\*",
+                      "name": "comment.block.cpp"
+                    }
+                  ]
+                }
+              },
+              "name": "invalid.illegal.reference-type.cpp"
+            },
+            {
+              "match": "\\&",
+              "name": "storage.modifier.reference.cpp"
+            }
+          ]
+        },
+        "8": {
+          "patterns": [
+            {
+              "include": "#inline_comment"
+            }
+          ]
+        },
+        "9": {
+          "name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+        },
+        "10": {
+          "name": "comment.block.cpp"
+        },
+        "11": {
+          "patterns": [
+            {
+              "match": "\\*\\/",
+              "name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+            },
+            {
+              "match": "\\*",
+              "name": "comment.block.cpp"
+            }
+          ]
+        },
+        "12": {
+          "patterns": [
+            {
+              "include": "#inline_comment"
+            }
+          ]
+        },
+        "13": {
+          "name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+        },
+        "14": {
+          "name": "comment.block.cpp"
+        },
+        "15": {
+          "patterns": [
+            {
+              "match": "\\*\\/",
+              "name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+            },
+            {
+              "match": "\\*",
+              "name": "comment.block.cpp"
+            }
+          ]
+        },
+        "16": {
+          "patterns": [
+            {
+              "include": "#inline_comment"
+            }
+          ]
+        },
+        "17": {
+          "name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+        },
+        "18": {
+          "name": "comment.block.cpp"
+        },
+        "19": {
+          "patterns": [
+            {
+              "match": "\\*\\/",
+              "name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+            },
+            {
+              "match": "\\*",
+              "name": "comment.block.cpp"
+            }
+          ]
+        },
+        "20": {
+          "name": "variable.other.object.declare.cpp"
+        },
+        "21": {
+          "patterns": [
+            {
+              "include": "#inline_comment"
+            }
+          ]
+        },
+        "22": {
+          "name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+        },
+        "23": {
+          "name": "comment.block.cpp"
+        },
+        "24": {
+          "patterns": [
+            {
+              "match": "\\*\\/",
+              "name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+            },
+            {
+              "match": "\\*",
+              "name": "comment.block.cpp"
+            }
+          ]
+        }
+      }
+    },
+    "enumerator_list": {
+      "match": "((?<!\\w)(?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*(?!\\w))\\s*((?:(?:(?:\\[\\[.*?\\]\\]|__attribute(?:__)?\\(\\(.*?\\)\\))|__declspec\\(.*?\\))|alignas\\(.*?\\))(?!\\)))?\\s*(?:(\\=)\\s*(.+?)\\s*)?(?:(?:((?:[,;](?!')|\\n))|(?=\\}[^']))|(?=(?:\\/\\/|\\/\\*)))",
+      "captures": {
+        "1": {
+          "name": "variable.other.enummember.cpp"
+        },
+        "2": {
+          "patterns": [
+            {
+              "include": "#attributes_context"
+            },
+            {
+              "include": "#number_literal"
+            }
+          ]
+        },
+        "3": {
+          "name": "keyword.operator.assignment.cpp"
+        },
+        "4": {
+          "patterns": [
+            {
+              "include": "#evaluation_context"
+            }
+          ]
+        },
+        "5": {
+          "patterns": [
+            {
+              "include": "#comma"
+            },
+            {
+              "include": "#semicolon"
+            }
+          ]
+        }
+      },
+      "name": "meta.enum.definition.cpp"
+    },
+    "evaluation_context": {
+      "patterns": [
+        {
+          "include": "#ever_present_context"
+        },
+        {
+          "include": "#string_context"
+        },
+        {
+          "include": "#number_literal"
+        },
+        {
+          "include": "#method_access"
+        },
+        {
+          "include": "#member_access"
+        },
+        {
+          "include": "#predefined_macros"
+        },
+        {
+          "include": "#operators"
+        },
+        {
+          "include": "#memory_operators"
+        },
+        {
+          "include": "#wordlike_operators"
+        },
+        {
+          "include": "#type_casting_operators"
+        },
+        {
+          "include": "#control_flow_keywords"
+        },
+        {
+          "include": "#exception_keywords"
+        },
+        {
+          "include": "#the_this_keyword"
+        },
+        {
+          "include": "#language_constants"
+        },
+        {
+          "include": "#builtin_storage_type_initilizer"
+        },
+        {
+          "include": "#qualifiers_and_specifiers_post_parameters"
+        },
+        {
+          "include": "#functional_specifiers_pre_parameters"
+        },
+        {
+          "include": "#storage_types"
+        },
+        {
+          "include": "#misc_storage_modifiers"
+        },
+        {
+          "include": "#lambdas"
+        },
+        {
+          "include": "#attributes_context"
+        },
+        {
+          "include": "#parentheses"
+        },
+        {
+          "include": "#function_call"
+        },
+        {
+          "include": "#scope_resolution_inner_generated"
+        },
+        {
+          "include": "#square_brackets"
+        },
+        {
+          "include": "#empty_square_brackets"
+        },
+        {
+          "include": "#semicolon"
+        },
+        {
+          "include": "#comma"
+        }
+      ]
+    },
+    "ever_present_context": {
+      "patterns": [
+        {
+          "include": "#pragma_mark"
+        },
+        {
+          "include": "#pragma"
+        },
+        {
+          "include": "#include"
+        },
+        {
+          "include": "#module_import"
+        },
+        {
+          "include": "#line"
+        },
+        {
+          "include": "#diagnostic"
+        },
+        {
+          "include": "#undef"
+        },
+        {
+          "include": "#preprocessor_conditional_range"
+        },
+        {
+          "include": "#single_line_macro"
+        },
+        {
+          "include": "#macro"
+        },
+        {
+          "include": "#preprocessor_conditional_standalone"
+        },
+        {
+          "include": "#macro_argument"
+        },
+        {
+          "include": "#comments"
+        },
+        {
+          "include": "#line_continuation_character"
+        }
+      ]
+    },
+    "exception_keywords": {
+      "match": "((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))((?<!\\w)(?:throw|catch|try)(?!\\w))",
+      "captures": {
+        "1": {
+          "patterns": [
+            {
+              "include": "#inline_comment"
+            }
+          ]
+        },
+        "2": {
+          "name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+        },
+        "3": {
+          "name": "comment.block.cpp"
+        },
+        "4": {
+          "patterns": [
+            {
+              "match": "\\*\\/",
+              "name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+            },
+            {
+              "match": "\\*",
+              "name": "comment.block.cpp"
+            }
+          ]
+        },
+        "5": {
+          "name": "keyword.control.exception.$5.cpp"
+        }
+      }
+    },
+    "extern_block": {
+      "name": "meta.block.extern.cpp",
+      "begin": "(((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))(extern)(?=\\s*\\\"))",
+      "beginCaptures": {
+        "1": {
+          "name": "meta.head.extern.cpp"
+        },
+        "2": {
+          "patterns": [
+            {
+              "include": "#inline_comment"
+            }
+          ]
+        },
+        "3": {
+          "name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+        },
+        "4": {
+          "name": "comment.block.cpp"
+        },
+        "5": {
+          "patterns": [
+            {
+              "match": "\\*\\/",
+              "name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+            },
+            {
+              "match": "\\*",
+              "name": "comment.block.cpp"
+            }
+          ]
+        },
+        "6": {
+          "name": "storage.type.extern.cpp"
+        }
+      },
+      "end": "(?:(?:(?<=\\}|%>|\\?\\?>)\\s*(;)|(;))|(?=[;>\\[\\]=]))|(?=(?<!\\\\)\n)",
+      "endCaptures": {
+        "1": {
+          "name": "punctuation.terminator.statement.cpp"
+        },
+        "2": {
+          "name": "punctuation.terminator.statement.cpp"
+        }
+      },
+      "patterns": [
+        {
+          "name": "meta.head.extern.cpp",
+          "begin": "\\G ?",
+          "end": "((?:\\{|<%|\\?\\?<|(?=;)))|(?=(?<!\\\\)\n)",
+          "endCaptures": {
+            "1": {
+              "name": "punctuation.section.block.begin.bracket.curly.extern.cpp"
+            }
+          },
+          "patterns": [
+            {
+              "include": "$self"
+            }
+          ]
+        },
+        {
+          "name": "meta.body.extern.cpp",
+          "begin": "(?<=\\{|<%|\\?\\?<)",
+          "end": "(\\}|%>|\\?\\?>)|(?=(?<!\\\\)\n)",
+          "endCaptures": {
+            "1": {
+              "name": "punctuation.section.block.end.bracket.curly.extern.cpp"
+            }
+          },
+          "patterns": [
+            {
+              "include": "$self"
+            }
+          ]
+        },
+        {
+          "name": "meta.tail.extern.cpp",
+          "begin": "(?<=\\}|%>|\\?\\?>)[\\s\\n]*",
+          "end": "[\\s\\n]*(?=;)|(?=(?<!\\\\)\n)",
+          "patterns": [
+            {
+              "include": "$self"
+            }
+          ]
+        },
+        {
+          "include": "$self"
+        }
+      ]
+    },
+    "function_body_context": {
+      "patterns": [
+        {
+          "include": "#ever_present_context"
+        },
+        {
+          "include": "#using_namespace"
+        },
+        {
+          "include": "#type_alias"
+        },
+        {
+          "include": "#using_name"
+        },
+        {
+          "include": "#namespace_alias"
+        },
+        {
+          "include": "#typedef_class"
+        },
+        {
+          "include": "#typedef_struct"
+        },
+        {
+          "include": "#typedef_union"
+        },
+        {
+          "include": "#typedef_keyword"
+        },
+        {
+          "include": "#standard_declares"
+        },
+        {
+          "include": "#class_block"
+        },
+        {
+          "include": "#struct_block"
+        },
+        {
+          "include": "#union_block"
+        },
+        {
+          "include": "#enum_block"
+        },
+        {
+          "include": "#access_control_keywords"
+        },
+        {
+          "include": "#block"
+        },
+        {
+          "include": "#static_assert"
+        },
+        {
+          "include": "#assembly"
+        },
+        {
+          "include": "#function_pointer"
+        },
+        {
+          "include": "#switch_statement"
+        },
+        {
+          "include": "#goto_statement"
+        },
+        {
+          "include": "#evaluation_context"
+        },
+        {
+          "include": "#label"
+        }
+      ]
+    },
+    "function_call": {
+      "begin": "((::)?(?:((?-mix:(?!\\b(?:__has_cpp_attribute|reinterpret_cast|atomic_noexcept|atomic_cancel|atomic_commit|__has_include|dynamic_cast|thread_local|synchronized|static_cast|const_cast|consteval|constexpr|protected|namespace|co_return|constexpr|constexpr|continue|explicit|volatile|noexcept|co_yield|noexcept|noexcept|requires|typename|decltype|operator|co_await|template|volatile|register|restrict|reflexpr|alignof|private|default|mutable|include|concept|__asm__|defined|_Pragma|alignas|typedef|warning|virtual|mutable|struct|sizeof|delete|not_eq|bitand|and_eq|xor_eq|typeid|switch|return|static|extern|inline|friend|public|ifndef|define|pragma|export|import|module|catch|throw|const|or_eq|while|compl|bitor|const|union|ifdef|class|undef|error|break|using|endif|goto|line|enum|this|case|else|elif|else|asm|try|for|new|and|xor|not|do|or|if|if)\\b)(?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*))\\s*+(((?<!<)<(?!<)(?>(?:(?>[^<>]*)\\g<12>?)+)>)\\s*)?::)*\\s*+)((?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*)\\b(?<!\\Wreinterpret_cast|^reinterpret_cast|\\Watomic_noexcept|^atomic_noexcept|\\Wuint_least16_t|^uint_least16_t|\\Wuint_least32_t|^uint_least32_t|\\Wuint_least64_t|^uint_least64_t|\\Wuint_fast16_t|^uint_fast16_t|\\Wint_least16_t|^int_least16_t|\\Watomic_commit|^atomic_commit|\\Watomic_cancel|^atomic_cancel|\\Wuint_fast64_t|^uint_fast64_t|\\Wuint_least8_t|^uint_least8_t|\\Wint_least64_t|^int_least64_t|\\Wint_least32_t|^int_least32_t|\\Wuint_fast32_t|^uint_fast32_t|\\Wdynamic_cast|^dynamic_cast|\\Wthread_local|^thread_local|\\Wuint_fast8_t|^uint_fast8_t|\\Wint_fast64_t|^int_fast64_t|\\Wint_fast32_t|^int_fast32_t|\\Wint_fast16_t|^int_fast16_t|\\Wsynchronized|^synchronized|\\Wint_least8_t|^int_least8_t|\\Wsuseconds_t|^suseconds_t|\\Wint_fast8_t|^int_fast8_t|\\Wstatic_cast|^static_cast|\\Wconst_cast|^const_cast|\\Wuseconds_t|^useconds_t|\\Wnamespace|^namespace|\\Wblksize_t|^blksize_t|\\Win_addr_t|^in_addr_t|\\Win_port_t|^in_port_t|\\Wuintptr_t|^uintptr_t|\\Wuintmax_t|^uintmax_t|\\Wuintmax_t|^uintmax_t|\\Wconstexpr|^constexpr|\\Wconstexpr|^constexpr|\\Wconstexpr|^constexpr|\\Wconsteval|^consteval|\\Wprotected|^protected|\\Wco_return|^co_return|\\Wuint16_t|^uint16_t|\\Wdecltype|^decltype|\\Wu_quad_t|^u_quad_t|\\Wreflexpr|^reflexpr|\\Wregister|^register|\\Wco_await|^co_await|\\Wintmax_t|^intmax_t|\\Wintmax_t|^intmax_t|\\Wco_yield|^co_yield|\\Wnoexcept|^noexcept|\\Wintptr_t|^intptr_t|\\Wnoexcept|^noexcept|\\Wvolatile|^volatile|\\Wnoexcept|^noexcept|\\Wrequires|^requires|\\Wuint64_t|^uint64_t|\\Wrestrict|^restrict|\\Wtypename|^typename|\\Wexplicit|^explicit|\\Wuint32_t|^uint32_t|\\Wunsigned|^unsigned|\\Woperator|^operator|\\Wvolatile|^volatile|\\Wblkcnt_t|^blkcnt_t|\\Wcontinue|^continue|\\Wtemplate|^template|\\Wmutable|^mutable|\\Walignas|^alignas|\\Walignof|^alignof|\\Wnullptr|^nullptr|\\Wconcept|^concept|\\Wqaddr_t|^qaddr_t|\\Wcaddr_t|^caddr_t|\\Wdaddr_t|^daddr_t|\\Wtypedef|^typedef|\\Wfixpt_t|^fixpt_t|\\W__asm__|^__asm__|\\Wwchar_t|^wchar_t|\\Wprivate|^private|\\Wdefault|^default|\\Wnlink_t|^nlink_t|\\Wmutable|^mutable|\\Wsegsz_t|^segsz_t|\\Wswblk_t|^swblk_t|\\Wvirtual|^virtual|\\Wclock_t|^clock_t|\\Wu_short|^u_short|\\Wssize_t|^ssize_t|\\Wint16_t|^int16_t|\\Wint32_t|^int32_t|\\Wint64_t|^int64_t|\\Wuint8_t|^uint8_t|\\Wstruct|^struct|\\Wsigned|^signed|\\Wdouble|^double|\\Wu_char|^u_char|\\Wu_long|^u_long|\\Wushort|^ushort|\\Wquad_t|^quad_t|\\Wexport|^export|\\Wnot_eq|^not_eq|\\Wdelete|^delete|\\Wmode_t|^mode_t|\\Wsize_t|^size_t|\\Wtime_t|^time_t|\\Wint8_t|^int8_t|\\Wtypeid|^typeid|\\Wxor_eq|^xor_eq|\\Wand_eq|^and_eq|\\Wbitand|^bitand|\\Wsizeof|^sizeof|\\Wstatic|^static|\\Wextern|^extern|\\Winline|^inline|\\Wfriend|^friend|\\Wimport|^import|\\Wmodule|^module|\\Wpublic|^public|\\Wswitch|^switch|\\Wreturn|^return|\\Wclass|^class|\\Wunion|^union|\\Wconst|^const|\\Wor_eq|^or_eq|\\Wwhile|^while|\\Wcatch|^catch|\\Wcompl|^compl|\\Wbreak|^break|\\Wuid_t|^uid_t|\\Wconst|^const|\\Woff_t|^off_t|\\Wpid_t|^pid_t|\\Wkey_t|^key_t|\\Wino_t|^ino_t|\\Wshort|^short|\\Wgid_t|^gid_t|\\Wusing|^using|\\Wdev_t|^dev_t|\\Wdiv_t|^div_t|\\Wu_int|^u_int|\\Wfloat|^float|\\Wbitor|^bitor|\\Wfalse|^false|\\Wthrow|^throw|\\Welse|^else|\\Wtrue|^true|\\Wauto|^auto|\\Wvoid|^void|\\Wuint|^uint|\\Wid_t|^id_t|\\Wbool|^bool|\\WNULL|^NULL|\\Wlong|^long|\\Wid_t|^id_t|\\Wcase|^case|\\Wgoto|^goto|\\Wthis|^this|\\Wchar|^char|\\Wenum|^enum|\\Wxor|^xor|\\Wint|^int|\\Wasm|^asm|\\Wnew|^new|\\Wtry|^try|\\Wand|^and|\\Wfor|^for|\\Wnot|^not|\\Wdo|^do|\\Wor|^or|\\Wif|^if)((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))(((?<!<)<(?!<)(?>(?:(?>[^<>]*)\\g<12>?)+)>)\\s*)?(\\()",
+      "beginCaptures": {
+        "1": {
+          "patterns": [
+            {
+              "include": "#scope_resolution_function_call_inner_generated"
+            }
+          ]
+        },
+        "2": {
+          "name": "punctuation.separator.namespace.access.cpp punctuation.separator.scope-resolution.function.call.cpp"
+        },
+        "4": {
+          "name": "meta.template.call.cpp",
+          "patterns": [
+            {
+              "include": "#template_call_range"
+            }
+          ]
+        },
+        "6": {
+          "name": "entity.name.function.call.cpp"
+        },
+        "7": {
+          "patterns": [
+            {
+              "include": "#inline_comment"
+            }
+          ]
+        },
+        "8": {
+          "name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+        },
+        "9": {
+          "name": "comment.block.cpp"
+        },
+        "10": {
+          "patterns": [
+            {
+              "match": "\\*\\/",
+              "name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+            },
+            {
+              "match": "\\*",
+              "name": "comment.block.cpp"
+            }
+          ]
+        },
+        "11": {
+          "name": "meta.template.call.cpp",
+          "patterns": [
+            {
+              "include": "#template_call_range"
+            }
+          ]
+        },
+        "13": {
+          "name": "punctuation.section.arguments.begin.bracket.round.function.call.cpp"
+        }
+      },
+      "end": "(\\))|(?=(?<!\\\\)\n)",
+      "endCaptures": {
+        "1": {
+          "name": "punctuation.section.arguments.end.bracket.round.function.call.cpp"
+        }
+      },
+      "patterns": [
+        {
+          "include": "#evaluation_context"
+        }
+      ]
+    },
+    "function_definition": {
+      "name": "meta.function.definition.cpp",
+      "begin": "((?:(?:^|\\G|(?<=;|\\}))|(?<=>))((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))(?:((?<!\\w)template(?!\\w))((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z)))))?((?:((?<!\\w)(?:(?:constexpr|explicit|mutable|virtual|inline|friend)|(?:volatile|register|restrict|static|extern|const))(?!\\w))((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z)))))*)(\\s*+((?:(?:(?:\\[\\[.*?\\]\\]|__attribute(?:__)?\\(\\(.*?\\)\\))|__declspec\\(.*?\\))|alignas\\(.*?\\))(?!\\)))?((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))(?:(?:(?:unsigned|signed|short|long)|(?:struct|class|union|enum))((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z)))))*(((::)?(?:((?-mix:(?!\\b(?:__has_cpp_attribute|reinterpret_cast|atomic_noexcept|atomic_cancel|atomic_commit|__has_include|dynamic_cast|thread_local|synchronized|static_cast|const_cast|consteval|constexpr|protected|namespace|co_return|constexpr|constexpr|continue|explicit|volatile|noexcept|co_yield|noexcept|noexcept|requires|typename|decltype|operator|co_await|template|volatile|register|restrict|reflexpr|alignof|private|default|mutable|include|concept|__asm__|defined|_Pragma|alignas|typedef|warning|virtual|mutable|struct|sizeof|delete|not_eq|bitand|and_eq|xor_eq|typeid|switch|return|static|extern|inline|friend|public|ifndef|define|pragma|export|import|module|catch|throw|const|or_eq|while|compl|bitor|const|union|ifdef|class|undef|error|break|using|endif|goto|line|enum|this|case|else|elif|else|asm|try|for|new|and|xor|not|do|or|if|if)\\b)(?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*))\\s*+(((?<!<)<(?!<)(?>(?:(?>[^<>]*)\\g<70>?)+)>)\\s*)?::)*\\s*+)((?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*)\\s*+(((?<!<)<(?!<)(?>(?:(?>[^<>]*)\\g<70>?)+)>)\\s*)?(::))?((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))(?!(?:transaction_safe_dynamic|__has_cpp_attribute|transaction_safe|reinterpret_cast|atomic_noexcept|atomic_commit|atomic_cancel|__has_include|dynamic_cast|thread_local|synchronized|static_cast|const_cast|constexpr|consteval|protected|constexpr|co_return|namespace|constexpr|noexcept|typename|decltype|template|operator|noexcept|co_yield|co_await|continue|volatile|register|restrict|explicit|override|volatile|reflexpr|noexcept|requires|default|typedef|nullptr|alignof|mutable|concept|virtual|defined|__asm__|include|_Pragma|mutable|warning|private|alignas|module|switch|not_eq|bitand|and_eq|ifndef|return|sizeof|xor_eq|export|static|delete|public|define|extern|inline|import|pragma|friend|typeid|const|compl|bitor|throw|or_eq|while|catch|break|false|final|const|endif|ifdef|undef|error|using|audit|axiom|line|else|elif|true|NULL|case|goto|else|this|new|asm|not|and|xor|try|for|if|do|or|if)\\b)((?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*)\\b(((?<!<)<(?!<)(?>(?:(?>[^<>]*)\\g<70>?)+)>)\\s*)?(?![\\w<:.]))(((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))?(?:(?:\\&|\\*)((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z)))))*(?:\\&|\\*))?((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))((?:__cdecl|__clrcall|__stdcall|__fastcall|__thiscall|__vectorcall)?)((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))((::)?(?:((?-mix:(?!\\b(?:__has_cpp_attribute|reinterpret_cast|atomic_noexcept|atomic_cancel|atomic_commit|__has_include|dynamic_cast|thread_local|synchronized|static_cast|const_cast|consteval|constexpr|protected|namespace|co_return|constexpr|constexpr|continue|explicit|volatile|noexcept|co_yield|noexcept|noexcept|requires|typename|decltype|operator|co_await|template|volatile|register|restrict|reflexpr|alignof|private|default|mutable|include|concept|__asm__|defined|_Pragma|alignas|typedef|warning|virtual|mutable|struct|sizeof|delete|not_eq|bitand|and_eq|xor_eq|typeid|switch|return|static|extern|inline|friend|public|ifndef|define|pragma|export|import|module|catch|throw|const|or_eq|while|compl|bitor|const|union|ifdef|class|undef|error|break|using|endif|goto|line|enum|this|case|else|elif|else|asm|try|for|new|and|xor|not|do|or|if|if)\\b)(?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*))\\s*+(((?<!<)<(?!<)(?>(?:(?>[^<>]*)\\g<70>?)+)>)\\s*)?::)*\\s*+)((?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*)\\b(?<!\\Wreinterpret_cast|^reinterpret_cast|\\Watomic_noexcept|^atomic_noexcept|\\Wuint_least16_t|^uint_least16_t|\\Wuint_least32_t|^uint_least32_t|\\Wuint_least64_t|^uint_least64_t|\\Wuint_fast16_t|^uint_fast16_t|\\Wint_least16_t|^int_least16_t|\\Watomic_commit|^atomic_commit|\\Watomic_cancel|^atomic_cancel|\\Wuint_fast64_t|^uint_fast64_t|\\Wuint_least8_t|^uint_least8_t|\\Wint_least64_t|^int_least64_t|\\Wint_least32_t|^int_least32_t|\\Wuint_fast32_t|^uint_fast32_t|\\Wdynamic_cast|^dynamic_cast|\\Wthread_local|^thread_local|\\Wuint_fast8_t|^uint_fast8_t|\\Wint_fast64_t|^int_fast64_t|\\Wint_fast32_t|^int_fast32_t|\\Wint_fast16_t|^int_fast16_t|\\Wsynchronized|^synchronized|\\Wint_least8_t|^int_least8_t|\\Wsuseconds_t|^suseconds_t|\\Wint_fast8_t|^int_fast8_t|\\Wstatic_cast|^static_cast|\\Wconst_cast|^const_cast|\\Wuseconds_t|^useconds_t|\\Wnamespace|^namespace|\\Wblksize_t|^blksize_t|\\Win_addr_t|^in_addr_t|\\Win_port_t|^in_port_t|\\Wuintptr_t|^uintptr_t|\\Wuintmax_t|^uintmax_t|\\Wuintmax_t|^uintmax_t|\\Wconstexpr|^constexpr|\\Wconstexpr|^constexpr|\\Wconstexpr|^constexpr|\\Wconsteval|^consteval|\\Wprotected|^protected|\\Wco_return|^co_return|\\Wuint16_t|^uint16_t|\\Wdecltype|^decltype|\\Wu_quad_t|^u_quad_t|\\Wreflexpr|^reflexpr|\\Wregister|^register|\\Wco_await|^co_await|\\Wintmax_t|^intmax_t|\\Wintmax_t|^intmax_t|\\Wco_yield|^co_yield|\\Wnoexcept|^noexcept|\\Wintptr_t|^intptr_t|\\Wnoexcept|^noexcept|\\Wvolatile|^volatile|\\Wnoexcept|^noexcept|\\Wrequires|^requires|\\Wuint64_t|^uint64_t|\\Wrestrict|^restrict|\\Wtypename|^typename|\\Wexplicit|^explicit|\\Wuint32_t|^uint32_t|\\Wunsigned|^unsigned|\\Woperator|^operator|\\Wvolatile|^volatile|\\Wblkcnt_t|^blkcnt_t|\\Wcontinue|^continue|\\Wtemplate|^template|\\Wmutable|^mutable|\\Walignas|^alignas|\\Walignof|^alignof|\\Wnullptr|^nullptr|\\Wconcept|^concept|\\Wqaddr_t|^qaddr_t|\\Wcaddr_t|^caddr_t|\\Wdaddr_t|^daddr_t|\\Wtypedef|^typedef|\\Wfixpt_t|^fixpt_t|\\W__asm__|^__asm__|\\Wwchar_t|^wchar_t|\\Wprivate|^private|\\Wdefault|^default|\\Wnlink_t|^nlink_t|\\Wmutable|^mutable|\\Wsegsz_t|^segsz_t|\\Wswblk_t|^swblk_t|\\Wvirtual|^virtual|\\Wclock_t|^clock_t|\\Wu_short|^u_short|\\Wssize_t|^ssize_t|\\Wint16_t|^int16_t|\\Wint32_t|^int32_t|\\Wint64_t|^int64_t|\\Wuint8_t|^uint8_t|\\Wstruct|^struct|\\Wsigned|^signed|\\Wdouble|^double|\\Wu_char|^u_char|\\Wu_long|^u_long|\\Wushort|^ushort|\\Wquad_t|^quad_t|\\Wexport|^export|\\Wnot_eq|^not_eq|\\Wdelete|^delete|\\Wmode_t|^mode_t|\\Wsize_t|^size_t|\\Wtime_t|^time_t|\\Wint8_t|^int8_t|\\Wtypeid|^typeid|\\Wxor_eq|^xor_eq|\\Wand_eq|^and_eq|\\Wbitand|^bitand|\\Wsizeof|^sizeof|\\Wstatic|^static|\\Wextern|^extern|\\Winline|^inline|\\Wfriend|^friend|\\Wimport|^import|\\Wmodule|^module|\\Wpublic|^public|\\Wswitch|^switch|\\Wreturn|^return|\\Wclass|^class|\\Wunion|^union|\\Wconst|^const|\\Wor_eq|^or_eq|\\Wwhile|^while|\\Wcatch|^catch|\\Wcompl|^compl|\\Wbreak|^break|\\Wuid_t|^uid_t|\\Wconst|^const|\\Woff_t|^off_t|\\Wpid_t|^pid_t|\\Wkey_t|^key_t|\\Wino_t|^ino_t|\\Wshort|^short|\\Wgid_t|^gid_t|\\Wusing|^using|\\Wdev_t|^dev_t|\\Wdiv_t|^div_t|\\Wu_int|^u_int|\\Wfloat|^float|\\Wbitor|^bitor|\\Wfalse|^false|\\Wthrow|^throw|\\Welse|^else|\\Wtrue|^true|\\Wauto|^auto|\\Wvoid|^void|\\Wuint|^uint|\\Wid_t|^id_t|\\Wbool|^bool|\\WNULL|^NULL|\\Wlong|^long|\\Wid_t|^id_t|\\Wcase|^case|\\Wgoto|^goto|\\Wthis|^this|\\Wchar|^char|\\Wenum|^enum|\\Wxor|^xor|\\Wint|^int|\\Wasm|^asm|\\Wnew|^new|\\Wtry|^try|\\Wand|^and|\\Wfor|^for|\\Wnot|^not|\\Wdo|^do|\\Wor|^or|\\Wif|^if)((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))(?=\\())",
+      "beginCaptures": {
+        "1": {
+          "name": "meta.head.function.definition.cpp"
+        },
+        "2": {
+          "patterns": [
+            {
+              "include": "#inline_comment"
+            }
+          ]
+        },
+        "3": {
+          "name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+        },
+        "4": {
+          "name": "comment.block.cpp"
+        },
+        "5": {
+          "patterns": [
+            {
+              "match": "\\*\\/",
+              "name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+            },
+            {
+              "match": "\\*",
+              "name": "comment.block.cpp"
+            }
+          ]
+        },
+        "6": {
+          "name": "storage.type.template.cpp"
+        },
+        "7": {
+          "patterns": [
+            {
+              "include": "#inline_comment"
+            }
+          ]
+        },
+        "8": {
+          "name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+        },
+        "9": {
+          "name": "comment.block.cpp"
+        },
+        "10": {
+          "patterns": [
+            {
+              "match": "\\*\\/",
+              "name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+            },
+            {
+              "match": "\\*",
+              "name": "comment.block.cpp"
+            }
+          ]
+        },
+        "11": {
+          "patterns": [
+            {
+              "match": "((?<!\\w)(?:(?:constexpr|explicit|mutable|virtual|inline|friend)|(?:volatile|register|restrict|static|extern|const))(?!\\w))((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))",
+              "captures": {
+                "1": {
+                  "name": "storage.modifier.$1.cpp"
+                },
+                "2": {
+                  "patterns": [
+                    {
+                      "include": "#inline_comment"
+                    }
+                  ]
+                },
+                "3": {
+                  "name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+                },
+                "4": {
+                  "name": "comment.block.cpp"
+                },
+                "5": {
+                  "patterns": [
+                    {
+                      "match": "\\*\\/",
+                      "name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+                    },
+                    {
+                      "match": "\\*",
+                      "name": "comment.block.cpp"
+                    }
+                  ]
+                }
+              }
+            }
+          ]
+        },
+        "12": {
+          "name": "storage.modifier.$1.cpp"
+        },
+        "13": {
+          "patterns": [
+            {
+              "include": "#inline_comment"
+            }
+          ]
+        },
+        "14": {
+          "name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+        },
+        "15": {
+          "name": "comment.block.cpp"
+        },
+        "16": {
+          "patterns": [
+            {
+              "match": "\\*\\/",
+              "name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+            },
+            {
+              "match": "\\*",
+              "name": "comment.block.cpp"
+            }
+          ]
+        },
+        "17": {
+          "name": "meta.qualified_type.cpp",
+          "patterns": [
+            {
+              "match": "(?<!\\w)(?:struct|class|union|enum)(?!\\w)",
+              "name": "storage.type.$0.cpp"
+            },
+            {
+              "include": "#attributes_context"
+            },
+            {
+              "include": "#function_type"
+            },
+            {
+              "include": "#storage_types"
+            },
+            {
+              "include": "#number_literal"
+            },
+            {
+              "include": "#string_context"
+            },
+            {
+              "include": "#comma"
+            },
+            {
+              "include": "#scope_resolution_inner_generated"
+            },
+            {
+              "include": "#template_call_range"
+            },
+            {
+              "match": "(?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*",
+              "name": "entity.name.type.cpp"
+            }
+          ]
+        },
+        "18": {
+          "patterns": [
+            {
+              "include": "#attributes_context"
+            },
+            {
+              "include": "#number_literal"
+            }
+          ]
+        },
+        "19": {
+          "patterns": [
+            {
+              "include": "#inline_comment"
+            }
+          ]
+        },
+        "20": {
+          "name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+        },
+        "21": {
+          "name": "comment.block.cpp"
+        },
+        "22": {
+          "patterns": [
+            {
+              "match": "\\*\\/",
+              "name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+            },
+            {
+              "match": "\\*",
+              "name": "comment.block.cpp"
+            }
+          ]
+        },
+        "23": {
+          "patterns": [
+            {
+              "include": "#inline_comment"
+            }
+          ]
+        },
+        "24": {
+          "name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+        },
+        "25": {
+          "name": "comment.block.cpp"
+        },
+        "26": {
+          "patterns": [
+            {
+              "match": "\\*\\/",
+              "name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+            },
+            {
+              "match": "\\*",
+              "name": "comment.block.cpp"
+            }
+          ]
+        },
+        "28": {
+          "patterns": [
+            {
+              "include": "#scope_resolution_inner_generated"
+            }
+          ]
+        },
+        "29": {
+          "name": "punctuation.separator.namespace.access.cpp punctuation.separator.scope-resolution.cpp"
+        },
+        "31": {
+          "name": "meta.template.call.cpp",
+          "patterns": [
+            {
+              "include": "#template_call_range"
+            }
+          ]
+        },
+        "33": {
+          "name": "entity.name.scope-resolution.cpp"
+        },
+        "34": {
+          "name": "meta.template.call.cpp",
+          "patterns": [
+            {
+              "include": "#template_call_range"
+            }
+          ]
+        },
+        "36": {
+          "name": "punctuation.separator.namespace.access.cpp punctuation.separator.scope-resolution.cpp"
+        },
+        "37": {
+          "patterns": [
+            {
+              "include": "#inline_comment"
+            }
+          ]
+        },
+        "38": {
+          "name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+        },
+        "39": {
+          "name": "comment.block.cpp"
+        },
+        "40": {
+          "patterns": [
+            {
+              "match": "\\*\\/",
+              "name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+            },
+            {
+              "match": "\\*",
+              "name": "comment.block.cpp"
+            }
+          ]
+        },
+        "41": {
+          "name": "entity.name.type.cpp"
+        },
+        "42": {
+          "name": "meta.template.call.cpp",
+          "patterns": [
+            {
+              "include": "#template_call_range"
+            }
+          ]
+        },
+        "44": {
+          "patterns": [
+            {
+              "match": "\\*",
+              "name": "storage.modifier.pointer.cpp"
+            },
+            {
+              "match": "(?:\\&((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))){2,}\\&",
+              "captures": {
+                "1": {
+                  "patterns": [
+                    {
+                      "include": "#inline_comment"
+                    }
+                  ]
+                },
+                "2": {
+                  "name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+                },
+                "3": {
+                  "name": "comment.block.cpp"
+                },
+                "4": {
+                  "patterns": [
+                    {
+                      "match": "\\*\\/",
+                      "name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+                    },
+                    {
+                      "match": "\\*",
+                      "name": "comment.block.cpp"
+                    }
+                  ]
+                }
+              },
+              "name": "invalid.illegal.reference-type.cpp"
+            },
+            {
+              "match": "\\&",
+              "name": "storage.modifier.reference.cpp"
+            }
+          ]
+        },
+        "45": {
+          "patterns": [
+            {
+              "include": "#inline_comment"
+            }
+          ]
+        },
+        "46": {
+          "name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+        },
+        "47": {
+          "name": "comment.block.cpp"
+        },
+        "48": {
+          "patterns": [
+            {
+              "match": "\\*\\/",
+              "name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+            },
+            {
+              "match": "\\*",
+              "name": "comment.block.cpp"
+            }
+          ]
+        },
+        "49": {
+          "patterns": [
+            {
+              "include": "#inline_comment"
+            }
+          ]
+        },
+        "50": {
+          "name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+        },
+        "51": {
+          "name": "comment.block.cpp"
+        },
+        "52": {
+          "patterns": [
+            {
+              "match": "\\*\\/",
+              "name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+            },
+            {
+              "match": "\\*",
+              "name": "comment.block.cpp"
+            }
+          ]
+        },
+        "53": {
+          "patterns": [
+            {
+              "include": "#inline_comment"
+            }
+          ]
+        },
+        "54": {
+          "name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+        },
+        "55": {
+          "name": "comment.block.cpp"
+        },
+        "56": {
+          "patterns": [
+            {
+              "match": "\\*\\/",
+              "name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+            },
+            {
+              "match": "\\*",
+              "name": "comment.block.cpp"
+            }
+          ]
+        },
+        "57": {
+          "patterns": [
+            {
+              "include": "#inline_comment"
+            }
+          ]
+        },
+        "58": {
+          "name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+        },
+        "59": {
+          "name": "comment.block.cpp"
+        },
+        "60": {
+          "patterns": [
+            {
+              "match": "\\*\\/",
+              "name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+            },
+            {
+              "match": "\\*",
+              "name": "comment.block.cpp"
+            }
+          ]
+        },
+        "61": {
+          "name": "storage.type.modifier.calling-convention.cpp"
+        },
+        "62": {
+          "patterns": [
+            {
+              "include": "#inline_comment"
+            }
+          ]
+        },
+        "63": {
+          "name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+        },
+        "64": {
+          "name": "comment.block.cpp"
+        },
+        "65": {
+          "patterns": [
+            {
+              "match": "\\*\\/",
+              "name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+            },
+            {
+              "match": "\\*",
+              "name": "comment.block.cpp"
+            }
+          ]
+        },
+        "66": {
+          "patterns": [
+            {
+              "include": "#scope_resolution_function_definition_inner_generated"
+            }
+          ]
+        },
+        "67": {
+          "name": "punctuation.separator.namespace.access.cpp punctuation.separator.scope-resolution.function.definition.cpp"
+        },
+        "69": {
+          "name": "meta.template.call.cpp",
+          "patterns": [
+            {
+              "include": "#template_call_range"
+            }
+          ]
+        },
+        "71": {
+          "name": "entity.name.function.definition.cpp"
+        },
+        "72": {
+          "patterns": [
+            {
+              "include": "#inline_comment"
+            }
+          ]
+        },
+        "73": {
+          "name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+        },
+        "74": {
+          "name": "comment.block.cpp"
+        },
+        "75": {
+          "patterns": [
+            {
+              "match": "\\*\\/",
+              "name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+            },
+            {
+              "match": "\\*",
+              "name": "comment.block.cpp"
+            }
+          ]
+        }
+      },
+      "end": "(?:(?<=\\}|%>|\\?\\?>)|(?=[;>\\[\\]=]))|(?=(?<!\\\\)\n)",
+      "patterns": [
+        {
+          "name": "meta.head.function.definition.cpp",
+          "begin": "\\G ?",
+          "end": "((?:\\{|<%|\\?\\?<|(?=;)))|(?=(?<!\\\\)\n)",
+          "endCaptures": {
+            "1": {
+              "name": "punctuation.section.block.begin.bracket.curly.function.definition.cpp"
+            }
+          },
+          "patterns": [
+            {
+              "include": "#ever_present_context"
+            },
+            {
+              "contentName": "meta.function.definition.parameters.cpp",
+              "begin": "(\\()",
+              "beginCaptures": {
+                "1": {
+                  "name": "punctuation.section.parameters.begin.bracket.round.cpp"
+                }
+              },
+              "end": "(\\))|(?=(?<!\\\\)\n)",
+              "endCaptures": {
+                "1": {
+                  "name": "punctuation.section.parameters.end.bracket.round.cpp"
+                }
+              },
+              "patterns": [
+                {
+                  "include": "#ever_present_context"
+                },
+                {
+                  "include": "#parameter_or_maybe_value"
+                },
+                {
+                  "include": "#comma"
+                },
+                {
+                  "include": "#evaluation_context"
+                }
+              ]
+            },
+            {
+              "include": "$self"
+            }
+          ]
+        },
+        {
+          "name": "meta.body.function.definition.cpp",
+          "begin": "(?<=\\{|<%|\\?\\?<)",
+          "end": "(\\}|%>|\\?\\?>)|(?=(?<!\\\\)\n)",
+          "endCaptures": {
+            "1": {
+              "name": "punctuation.section.block.end.bracket.curly.function.definition.cpp"
+            }
+          },
+          "patterns": [
+            {
+              "include": "#function_body_context"
+            }
+          ]
+        },
+        {
+          "name": "meta.tail.function.definition.cpp",
+          "begin": "(?<=\\}|%>|\\?\\?>)[\\s\\n]*",
+          "end": "[\\s\\n]*(?=;)|(?=(?<!\\\\)\n)",
+          "patterns": [
+            {
+              "include": "$self"
+            }
+          ]
+        }
+      ]
+    },
+    "function_parameter_context": {
+      "patterns": [
+        {
+          "include": "#ever_present_context"
+        },
+        {
+          "include": "#parameter"
+        },
+        {
+          "include": "#comma"
+        }
+      ]
+    },
+    "function_pointer": {
+      "begin": "(\\s*+((?:(?:(?:\\[\\[.*?\\]\\]|__attribute(?:__)?\\(\\(.*?\\)\\))|__declspec\\(.*?\\))|alignas\\(.*?\\))(?!\\)))?((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))(?:(?:(?:unsigned|signed|short|long)|(?:struct|class|union|enum))((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z)))))*(((::)?(?:((?-mix:(?!\\b(?:__has_cpp_attribute|reinterpret_cast|atomic_noexcept|atomic_cancel|atomic_commit|__has_include|dynamic_cast|thread_local|synchronized|static_cast|const_cast|consteval|constexpr|protected|namespace|co_return|constexpr|constexpr|continue|explicit|volatile|noexcept|co_yield|noexcept|noexcept|requires|typename|decltype|operator|co_await|template|volatile|register|restrict|reflexpr|alignof|private|default|mutable|include|concept|__asm__|defined|_Pragma|alignas|typedef|warning|virtual|mutable|struct|sizeof|delete|not_eq|bitand|and_eq|xor_eq|typeid|switch|return|static|extern|inline|friend|public|ifndef|define|pragma|export|import|module|catch|throw|const|or_eq|while|compl|bitor|const|union|ifdef|class|undef|error|break|using|endif|goto|line|enum|this|case|else|elif|else|asm|try|for|new|and|xor|not|do|or|if|if)\\b)(?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*))\\s*+(((?<!<)<(?!<)(?>(?:(?>[^<>]*)\\g<27>?)+)>)\\s*)?::)*\\s*+)((?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*)\\s*+(((?<!<)<(?!<)(?>(?:(?>[^<>]*)\\g<27>?)+)>)\\s*)?(::))?((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))(?!(?:transaction_safe_dynamic|__has_cpp_attribute|transaction_safe|reinterpret_cast|atomic_noexcept|atomic_commit|atomic_cancel|__has_include|dynamic_cast|thread_local|synchronized|static_cast|const_cast|constexpr|consteval|protected|constexpr|co_return|namespace|constexpr|noexcept|typename|decltype|template|operator|noexcept|co_yield|co_await|continue|volatile|register|restrict|explicit|override|volatile|reflexpr|noexcept|requires|default|typedef|nullptr|alignof|mutable|concept|virtual|defined|__asm__|include|_Pragma|mutable|warning|private|alignas|module|switch|not_eq|bitand|and_eq|ifndef|return|sizeof|xor_eq|export|static|delete|public|define|extern|inline|import|pragma|friend|typeid|const|compl|bitor|throw|or_eq|while|catch|break|false|final|const|endif|ifdef|undef|error|using|audit|axiom|line|else|elif|true|NULL|case|goto|else|this|new|asm|not|and|xor|try|for|if|do|or|if)\\b)((?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*)\\b(((?<!<)<(?!<)(?>(?:(?>[^<>]*)\\g<27>?)+)>)\\s*)?(?![\\w<:.]))(((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))?(?:(?:\\&|\\*)((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z)))))*(?:\\&|\\*))?((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))(\\()(\\*)\\s*((?:(?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*)?)\\s*(?:(\\[)(\\w*)(\\])\\s*)*(\\))\\s*(\\()",
+      "beginCaptures": {
+        "1": {
+          "name": "meta.qualified_type.cpp",
+          "patterns": [
+            {
+              "match": "(?<!\\w)(?:struct|class|union|enum)(?!\\w)",
+              "name": "storage.type.$0.cpp"
+            },
+            {
+              "include": "#attributes_context"
+            },
+            {
+              "include": "#function_type"
+            },
+            {
+              "include": "#storage_types"
+            },
+            {
+              "include": "#number_literal"
+            },
+            {
+              "include": "#string_context"
+            },
+            {
+              "include": "#comma"
+            },
+            {
+              "include": "#scope_resolution_inner_generated"
+            },
+            {
+              "include": "#template_call_range"
+            },
+            {
+              "match": "(?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*",
+              "name": "entity.name.type.cpp"
+            }
+          ]
+        },
+        "2": {
+          "patterns": [
+            {
+              "include": "#attributes_context"
+            },
+            {
+              "include": "#number_literal"
+            }
+          ]
+        },
+        "3": {
+          "patterns": [
+            {
+              "include": "#inline_comment"
+            }
+          ]
+        },
+        "4": {
+          "name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+        },
+        "5": {
+          "name": "comment.block.cpp"
+        },
+        "6": {
+          "patterns": [
+            {
+              "match": "\\*\\/",
+              "name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+            },
+            {
+              "match": "\\*",
+              "name": "comment.block.cpp"
+            }
+          ]
+        },
+        "7": {
+          "patterns": [
+            {
+              "include": "#inline_comment"
+            }
+          ]
+        },
+        "8": {
+          "name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+        },
+        "9": {
+          "name": "comment.block.cpp"
+        },
+        "10": {
+          "patterns": [
+            {
+              "match": "\\*\\/",
+              "name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+            },
+            {
+              "match": "\\*",
+              "name": "comment.block.cpp"
+            }
+          ]
+        },
+        "12": {
+          "patterns": [
+            {
+              "include": "#scope_resolution_inner_generated"
+            }
+          ]
+        },
+        "13": {
+          "name": "punctuation.separator.namespace.access.cpp punctuation.separator.scope-resolution.cpp"
+        },
+        "15": {
+          "name": "meta.template.call.cpp",
+          "patterns": [
+            {
+              "include": "#template_call_range"
+            }
+          ]
+        },
+        "17": {
+          "name": "entity.name.scope-resolution.cpp"
+        },
+        "18": {
+          "name": "meta.template.call.cpp",
+          "patterns": [
+            {
+              "include": "#template_call_range"
+            }
+          ]
+        },
+        "20": {
+          "name": "punctuation.separator.namespace.access.cpp punctuation.separator.scope-resolution.cpp"
+        },
+        "21": {
+          "patterns": [
+            {
+              "include": "#inline_comment"
+            }
+          ]
+        },
+        "22": {
+          "name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+        },
+        "23": {
+          "name": "comment.block.cpp"
+        },
+        "24": {
+          "patterns": [
+            {
+              "match": "\\*\\/",
+              "name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+            },
+            {
+              "match": "\\*",
+              "name": "comment.block.cpp"
+            }
+          ]
+        },
+        "25": {
+          "name": "entity.name.type.cpp"
+        },
+        "26": {
+          "name": "meta.template.call.cpp",
+          "patterns": [
+            {
+              "include": "#template_call_range"
+            }
+          ]
+        },
+        "28": {
+          "patterns": [
+            {
+              "match": "\\*",
+              "name": "storage.modifier.pointer.cpp"
+            },
+            {
+              "match": "(?:\\&((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))){2,}\\&",
+              "captures": {
+                "1": {
+                  "patterns": [
+                    {
+                      "include": "#inline_comment"
+                    }
+                  ]
+                },
+                "2": {
+                  "name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+                },
+                "3": {
+                  "name": "comment.block.cpp"
+                },
+                "4": {
+                  "patterns": [
+                    {
+                      "match": "\\*\\/",
+                      "name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+                    },
+                    {
+                      "match": "\\*",
+                      "name": "comment.block.cpp"
+                    }
+                  ]
+                }
+              },
+              "name": "invalid.illegal.reference-type.cpp"
+            },
+            {
+              "match": "\\&",
+              "name": "storage.modifier.reference.cpp"
+            }
+          ]
+        },
+        "29": {
+          "patterns": [
+            {
+              "include": "#inline_comment"
+            }
+          ]
+        },
+        "30": {
+          "name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+        },
+        "31": {
+          "name": "comment.block.cpp"
+        },
+        "32": {
+          "patterns": [
+            {
+              "match": "\\*\\/",
+              "name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+            },
+            {
+              "match": "\\*",
+              "name": "comment.block.cpp"
+            }
+          ]
+        },
+        "33": {
+          "patterns": [
+            {
+              "include": "#inline_comment"
+            }
+          ]
+        },
+        "34": {
+          "name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+        },
+        "35": {
+          "name": "comment.block.cpp"
+        },
+        "36": {
+          "patterns": [
+            {
+              "match": "\\*\\/",
+              "name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+            },
+            {
+              "match": "\\*",
+              "name": "comment.block.cpp"
+            }
+          ]
+        },
+        "37": {
+          "patterns": [
+            {
+              "include": "#inline_comment"
+            }
+          ]
+        },
+        "38": {
+          "name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+        },
+        "39": {
+          "name": "comment.block.cpp"
+        },
+        "40": {
+          "patterns": [
+            {
+              "match": "\\*\\/",
+              "name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+            },
+            {
+              "match": "\\*",
+              "name": "comment.block.cpp"
+            }
+          ]
+        },
+        "41": {
+          "name": "punctuation.section.parens.begin.bracket.round.function.pointer.cpp"
+        },
+        "42": {
+          "name": "punctuation.definition.function.pointer.dereference.cpp"
+        },
+        "43": {
+          "name": "variable.other.definition.pointer.function.cpp"
+        },
+        "44": {
+          "name": "punctuation.definition.begin.bracket.square.cpp"
+        },
+        "45": {
+          "patterns": [
+            {
+              "include": "#evaluation_context"
+            }
+          ]
+        },
+        "46": {
+          "name": "punctuation.definition.end.bracket.square.cpp"
+        },
+        "47": {
+          "name": "punctuation.section.parens.end.bracket.round.function.pointer.cpp"
+        },
+        "48": {
+          "name": "punctuation.section.parameters.begin.bracket.round.function.pointer.cpp"
+        }
+      },
+      "end": "(\\))((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))(?=[{=,);]|\\n)(?!\\()|(?=(?<!\\\\)\n)",
+      "endCaptures": {
+        "1": {
+          "name": "punctuation.section.parameters.end.bracket.round.function.pointer.cpp"
+        },
+        "2": {
+          "patterns": [
+            {
+              "include": "#inline_comment"
+            }
+          ]
+        },
+        "3": {
+          "name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+        },
+        "4": {
+          "name": "comment.block.cpp"
+        },
+        "5": {
+          "patterns": [
+            {
+              "match": "\\*\\/",
+              "name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+            },
+            {
+              "match": "\\*",
+              "name": "comment.block.cpp"
+            }
+          ]
+        }
+      },
+      "patterns": [
+        {
+          "include": "#function_parameter_context"
+        }
+      ]
+    },
+    "function_pointer_parameter": {
+      "begin": "(\\s*+((?:(?:(?:\\[\\[.*?\\]\\]|__attribute(?:__)?\\(\\(.*?\\)\\))|__declspec\\(.*?\\))|alignas\\(.*?\\))(?!\\)))?((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))(?:(?:(?:unsigned|signed|short|long)|(?:struct|class|union|enum))((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z)))))*(((::)?(?:((?-mix:(?!\\b(?:__has_cpp_attribute|reinterpret_cast|atomic_noexcept|atomic_cancel|atomic_commit|__has_include|dynamic_cast|thread_local|synchronized|static_cast|const_cast|consteval|constexpr|protected|namespace|co_return|constexpr|constexpr|continue|explicit|volatile|noexcept|co_yield|noexcept|noexcept|requires|typename|decltype|operator|co_await|template|volatile|register|restrict|reflexpr|alignof|private|default|mutable|include|concept|__asm__|defined|_Pragma|alignas|typedef|warning|virtual|mutable|struct|sizeof|delete|not_eq|bitand|and_eq|xor_eq|typeid|switch|return|static|extern|inline|friend|public|ifndef|define|pragma|export|import|module|catch|throw|const|or_eq|while|compl|bitor|const|union|ifdef|class|undef|error|break|using|endif|goto|line|enum|this|case|else|elif|else|asm|try|for|new|and|xor|not|do|or|if|if)\\b)(?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*))\\s*+(((?<!<)<(?!<)(?>(?:(?>[^<>]*)\\g<27>?)+)>)\\s*)?::)*\\s*+)((?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*)\\s*+(((?<!<)<(?!<)(?>(?:(?>[^<>]*)\\g<27>?)+)>)\\s*)?(::))?((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))(?!(?:transaction_safe_dynamic|__has_cpp_attribute|transaction_safe|reinterpret_cast|atomic_noexcept|atomic_commit|atomic_cancel|__has_include|dynamic_cast|thread_local|synchronized|static_cast|const_cast|constexpr|consteval|protected|constexpr|co_return|namespace|constexpr|noexcept|typename|decltype|template|operator|noexcept|co_yield|co_await|continue|volatile|register|restrict|explicit|override|volatile|reflexpr|noexcept|requires|default|typedef|nullptr|alignof|mutable|concept|virtual|defined|__asm__|include|_Pragma|mutable|warning|private|alignas|module|switch|not_eq|bitand|and_eq|ifndef|return|sizeof|xor_eq|export|static|delete|public|define|extern|inline|import|pragma|friend|typeid|const|compl|bitor|throw|or_eq|while|catch|break|false|final|const|endif|ifdef|undef|error|using|audit|axiom|line|else|elif|true|NULL|case|goto|else|this|new|asm|not|and|xor|try|for|if|do|or|if)\\b)((?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*)\\b(((?<!<)<(?!<)(?>(?:(?>[^<>]*)\\g<27>?)+)>)\\s*)?(?![\\w<:.]))(((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))?(?:(?:\\&|\\*)((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z)))))*(?:\\&|\\*))?((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))(\\()(\\*)\\s*((?:(?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*)?)\\s*(?:(\\[)(\\w*)(\\])\\s*)*(\\))\\s*(\\()",
+      "beginCaptures": {
+        "1": {
+          "name": "meta.qualified_type.cpp",
+          "patterns": [
+            {
+              "match": "(?<!\\w)(?:struct|class|union|enum)(?!\\w)",
+              "name": "storage.type.$0.cpp"
+            },
+            {
+              "include": "#attributes_context"
+            },
+            {
+              "include": "#function_type"
+            },
+            {
+              "include": "#storage_types"
+            },
+            {
+              "include": "#number_literal"
+            },
+            {
+              "include": "#string_context"
+            },
+            {
+              "include": "#comma"
+            },
+            {
+              "include": "#scope_resolution_inner_generated"
+            },
+            {
+              "include": "#template_call_range"
+            },
+            {
+              "match": "(?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*",
+              "name": "entity.name.type.cpp"
+            }
+          ]
+        },
+        "2": {
+          "patterns": [
+            {
+              "include": "#attributes_context"
+            },
+            {
+              "include": "#number_literal"
+            }
+          ]
+        },
+        "3": {
+          "patterns": [
+            {
+              "include": "#inline_comment"
+            }
+          ]
+        },
+        "4": {
+          "name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+        },
+        "5": {
+          "name": "comment.block.cpp"
+        },
+        "6": {
+          "patterns": [
+            {
+              "match": "\\*\\/",
+              "name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+            },
+            {
+              "match": "\\*",
+              "name": "comment.block.cpp"
+            }
+          ]
+        },
+        "7": {
+          "patterns": [
+            {
+              "include": "#inline_comment"
+            }
+          ]
+        },
+        "8": {
+          "name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+        },
+        "9": {
+          "name": "comment.block.cpp"
+        },
+        "10": {
+          "patterns": [
+            {
+              "match": "\\*\\/",
+              "name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+            },
+            {
+              "match": "\\*",
+              "name": "comment.block.cpp"
+            }
+          ]
+        },
+        "12": {
+          "patterns": [
+            {
+              "include": "#scope_resolution_inner_generated"
+            }
+          ]
+        },
+        "13": {
+          "name": "punctuation.separator.namespace.access.cpp punctuation.separator.scope-resolution.cpp"
+        },
+        "15": {
+          "name": "meta.template.call.cpp",
+          "patterns": [
+            {
+              "include": "#template_call_range"
+            }
+          ]
+        },
+        "17": {
+          "name": "entity.name.scope-resolution.cpp"
+        },
+        "18": {
+          "name": "meta.template.call.cpp",
+          "patterns": [
+            {
+              "include": "#template_call_range"
+            }
+          ]
+        },
+        "20": {
+          "name": "punctuation.separator.namespace.access.cpp punctuation.separator.scope-resolution.cpp"
+        },
+        "21": {
+          "patterns": [
+            {
+              "include": "#inline_comment"
+            }
+          ]
+        },
+        "22": {
+          "name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+        },
+        "23": {
+          "name": "comment.block.cpp"
+        },
+        "24": {
+          "patterns": [
+            {
+              "match": "\\*\\/",
+              "name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+            },
+            {
+              "match": "\\*",
+              "name": "comment.block.cpp"
+            }
+          ]
+        },
+        "25": {
+          "name": "entity.name.type.cpp"
+        },
+        "26": {
+          "name": "meta.template.call.cpp",
+          "patterns": [
+            {
+              "include": "#template_call_range"
+            }
+          ]
+        },
+        "28": {
+          "patterns": [
+            {
+              "match": "\\*",
+              "name": "storage.modifier.pointer.cpp"
+            },
+            {
+              "match": "(?:\\&((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))){2,}\\&",
+              "captures": {
+                "1": {
+                  "patterns": [
+                    {
+                      "include": "#inline_comment"
+                    }
+                  ]
+                },
+                "2": {
+                  "name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+                },
+                "3": {
+                  "name": "comment.block.cpp"
+                },
+                "4": {
+                  "patterns": [
+                    {
+                      "match": "\\*\\/",
+                      "name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+                    },
+                    {
+                      "match": "\\*",
+                      "name": "comment.block.cpp"
+                    }
+                  ]
+                }
+              },
+              "name": "invalid.illegal.reference-type.cpp"
+            },
+            {
+              "match": "\\&",
+              "name": "storage.modifier.reference.cpp"
+            }
+          ]
+        },
+        "29": {
+          "patterns": [
+            {
+              "include": "#inline_comment"
+            }
+          ]
+        },
+        "30": {
+          "name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+        },
+        "31": {
+          "name": "comment.block.cpp"
+        },
+        "32": {
+          "patterns": [
+            {
+              "match": "\\*\\/",
+              "name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+            },
+            {
+              "match": "\\*",
+              "name": "comment.block.cpp"
+            }
+          ]
+        },
+        "33": {
+          "patterns": [
+            {
+              "include": "#inline_comment"
+            }
+          ]
+        },
+        "34": {
+          "name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+        },
+        "35": {
+          "name": "comment.block.cpp"
+        },
+        "36": {
+          "patterns": [
+            {
+              "match": "\\*\\/",
+              "name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+            },
+            {
+              "match": "\\*",
+              "name": "comment.block.cpp"
+            }
+          ]
+        },
+        "37": {
+          "patterns": [
+            {
+              "include": "#inline_comment"
+            }
+          ]
+        },
+        "38": {
+          "name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+        },
+        "39": {
+          "name": "comment.block.cpp"
+        },
+        "40": {
+          "patterns": [
+            {
+              "match": "\\*\\/",
+              "name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+            },
+            {
+              "match": "\\*",
+              "name": "comment.block.cpp"
+            }
+          ]
+        },
+        "41": {
+          "name": "punctuation.section.parens.begin.bracket.round.function.pointer.cpp"
+        },
+        "42": {
+          "name": "punctuation.definition.function.pointer.dereference.cpp"
+        },
+        "43": {
+          "name": "variable.parameter.pointer.function.cpp"
+        },
+        "44": {
+          "name": "punctuation.definition.begin.bracket.square.cpp"
+        },
+        "45": {
+          "patterns": [
+            {
+              "include": "#evaluation_context"
+            }
+          ]
+        },
+        "46": {
+          "name": "punctuation.definition.end.bracket.square.cpp"
+        },
+        "47": {
+          "name": "punctuation.section.parens.end.bracket.round.function.pointer.cpp"
+        },
+        "48": {
+          "name": "punctuation.section.parameters.begin.bracket.round.function.pointer.cpp"
+        }
+      },
+      "end": "(\\))((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))(?=[{=,);]|\\n)(?!\\()|(?=(?<!\\\\)\n)",
+      "endCaptures": {
+        "1": {
+          "name": "punctuation.section.parameters.end.bracket.round.function.pointer.cpp"
+        },
+        "2": {
+          "patterns": [
+            {
+              "include": "#inline_comment"
+            }
+          ]
+        },
+        "3": {
+          "name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+        },
+        "4": {
+          "name": "comment.block.cpp"
+        },
+        "5": {
+          "patterns": [
+            {
+              "match": "\\*\\/",
+              "name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+            },
+            {
+              "match": "\\*",
+              "name": "comment.block.cpp"
+            }
+          ]
+        }
+      },
+      "patterns": [
+        {
+          "include": "#function_parameter_context"
+        }
+      ]
+    },
+    "functional_specifiers_pre_parameters": {
+      "match": "(?<!\\w)(?:constexpr|explicit|mutable|virtual|inline|friend)(?!\\w)",
+      "name": "storage.modifier.specifier.functional.pre-parameters.$0.cpp"
+    },
+    "gcc_attributes": {
+      "name": "support.other.attribute.cpp",
+      "begin": "(__attribute(?:__)?\\(\\()",
+      "beginCaptures": {
+        "1": {
+          "name": "punctuation.section.attribute.begin.cpp"
+        }
+      },
+      "end": "(\\)\\))|(?=(?<!\\\\)\n)",
+      "endCaptures": {
+        "1": {
+          "name": "punctuation.section.attribute.end.cpp"
+        }
+      },
+      "patterns": [
+        {
+          "include": "#attributes_context"
+        },
+        {
+          "begin": "\\(",
+          "end": "\\)|(?=(?<!\\\\)\n)",
+          "patterns": [
+            {
+              "include": "#attributes_context"
+            },
+            {
+              "include": "#string_context"
+            }
+          ]
+        },
+        {
+          "match": "(using)\\s+((?<!\\w)(?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*(?!\\w))",
+          "captures": {
+            "1": {
+              "name": "keyword.other.using.directive.cpp"
+            },
+            "2": {
+              "name": "entity.name.namespace.cpp"
+            }
+          }
+        },
+        {
+          "match": ",",
+          "name": "punctuation.separator.attribute.cpp"
+        },
+        {
+          "match": ":",
+          "name": "punctuation.accessor.attribute.cpp"
+        },
+        {
+          "match": "(?<!\\w)(?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*(?!\\w)(?=::)",
+          "name": "entity.name.namespace.cpp"
+        },
+        {
+          "match": "(?<!\\w)(?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*(?!\\w)",
+          "name": "entity.other.attribute.$0.cpp"
+        },
+        {
+          "include": "#number_literal"
+        }
+      ]
+    },
+    "goto_statement": {
+      "match": "((?<!\\w)goto(?!\\w))((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))((?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*)",
+      "captures": {
+        "1": {
+          "name": "keyword.control.goto.cpp"
+        },
+        "2": {
+          "patterns": [
+            {
+              "include": "#inline_comment"
+            }
+          ]
+        },
+        "3": {
+          "name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+        },
+        "4": {
+          "name": "comment.block.cpp"
+        },
+        "5": {
+          "patterns": [
+            {
+              "match": "\\*\\/",
+              "name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+            },
+            {
+              "match": "\\*",
+              "name": "comment.block.cpp"
+            }
+          ]
+        },
+        "6": {
+          "name": "entity.name.label.call.cpp"
+        }
+      }
+    },
+    "include": {
+      "match": "(?:^)((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))((#)\\s*((?:include|include_next))\\b)\\s*(?:(?:(?:((<)[^>]*(>?)((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))(?:(?:\\n|$)|(?=\\/\\/)))|((\\\")[^\\\"]*(\\\"?)((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))(?:(?:\\n|$)|(?=\\/\\/))))|(((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))(?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*(?:\\.(?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*)*((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))(?:(?:\\n|$)|(?=(?:\\/\\/|;)))))|((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))(?:(?:\\n|$)|(?=(?:\\/\\/|;))))",
+      "captures": {
+        "1": {
+          "patterns": [
+            {
+              "include": "#inline_comment"
+            }
+          ]
+        },
+        "2": {
+          "name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+        },
+        "3": {
+          "name": "comment.block.cpp"
+        },
+        "4": {
+          "patterns": [
+            {
+              "match": "\\*\\/",
+              "name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+            },
+            {
+              "match": "\\*",
+              "name": "comment.block.cpp"
+            }
+          ]
+        },
+        "5": {
+          "name": "keyword.control.directive.$7.cpp"
+        },
+        "6": {
+          "name": "punctuation.definition.directive.cpp"
+        },
+        "8": {
+          "name": "string.quoted.other.lt-gt.include.cpp"
+        },
+        "9": {
+          "name": "punctuation.definition.string.begin.cpp"
+        },
+        "10": {
+          "name": "punctuation.definition.string.end.cpp"
+        },
+        "11": {
+          "patterns": [
+            {
+              "include": "#inline_comment"
+            }
+          ]
+        },
+        "12": {
+          "name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+        },
+        "13": {
+          "name": "comment.block.cpp"
+        },
+        "14": {
+          "patterns": [
+            {
+              "match": "\\*\\/",
+              "name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+            },
+            {
+              "match": "\\*",
+              "name": "comment.block.cpp"
+            }
+          ]
+        },
+        "15": {
+          "name": "string.quoted.double.include.cpp"
+        },
+        "16": {
+          "name": "punctuation.definition.string.begin.cpp"
+        },
+        "17": {
+          "name": "punctuation.definition.string.end.cpp"
+        },
+        "18": {
+          "patterns": [
+            {
+              "include": "#inline_comment"
+            }
+          ]
+        },
+        "19": {
+          "name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+        },
+        "20": {
+          "name": "comment.block.cpp"
+        },
+        "21": {
+          "patterns": [
+            {
+              "match": "\\*\\/",
+              "name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+            },
+            {
+              "match": "\\*",
+              "name": "comment.block.cpp"
+            }
+          ]
+        },
+        "22": {
+          "name": "entity.name.other.preprocessor.macro.include.cpp"
+        },
+        "23": {
+          "patterns": [
+            {
+              "include": "#inline_comment"
+            }
+          ]
+        },
+        "24": {
+          "name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+        },
+        "25": {
+          "name": "comment.block.cpp"
+        },
+        "26": {
+          "patterns": [
+            {
+              "match": "\\*\\/",
+              "name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+            },
+            {
+              "match": "\\*",
+              "name": "comment.block.cpp"
+            }
+          ]
+        },
+        "27": {
+          "patterns": [
+            {
+              "include": "#inline_comment"
+            }
+          ]
+        },
+        "28": {
+          "name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+        },
+        "29": {
+          "name": "comment.block.cpp"
+        },
+        "30": {
+          "patterns": [
+            {
+              "match": "\\*\\/",
+              "name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+            },
+            {
+              "match": "\\*",
+              "name": "comment.block.cpp"
+            }
+          ]
+        },
+        "31": {
+          "patterns": [
+            {
+              "include": "#inline_comment"
+            }
+          ]
+        },
+        "32": {
+          "name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+        },
+        "33": {
+          "name": "comment.block.cpp"
+        },
+        "34": {
+          "patterns": [
+            {
+              "match": "\\*\\/",
+              "name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+            },
+            {
+              "match": "\\*",
+              "name": "comment.block.cpp"
+            }
+          ]
+        }
+      },
+      "name": "meta.preprocessor.include.cpp"
+    },
+    "inheritance_context": {
+      "patterns": [
+        {
+          "include": "#ever_present_context"
+        },
+        {
+          "match": ",",
+          "name": "punctuation.separator.delimiter.comma.inheritance.cpp"
+        },
+        {
+          "match": "(?<!\\w)(?:protected|private|public)(?!\\w)",
+          "name": "storage.type.modifier.access.$0.cpp"
+        },
+        {
+          "match": "(?<!\\w)virtual(?!\\w)",
+          "name": "storage.type.modifier.virtual.cpp"
+        },
+        {
+          "match": "(?<=protected|virtual|private|public|,|:)\\s*(?!(?:(?:protected|private|public)|virtual))(\\s*+((?:(?:(?:\\[\\[.*?\\]\\]|__attribute(?:__)?\\(\\(.*?\\)\\))|__declspec\\(.*?\\))|alignas\\(.*?\\))(?!\\)))?((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))(?:(?:(?:unsigned|signed|short|long)|(?:struct|class|union|enum))((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z)))))*(((::)?(?:((?-mix:(?!\\b(?:__has_cpp_attribute|reinterpret_cast|atomic_noexcept|atomic_cancel|atomic_commit|__has_include|dynamic_cast|thread_local|synchronized|static_cast|const_cast|consteval|constexpr|protected|namespace|co_return|constexpr|constexpr|continue|explicit|volatile|noexcept|co_yield|noexcept|noexcept|requires|typename|decltype|operator|co_await|template|volatile|register|restrict|reflexpr|alignof|private|default|mutable|include|concept|__asm__|defined|_Pragma|alignas|typedef|warning|virtual|mutable|struct|sizeof|delete|not_eq|bitand|and_eq|xor_eq|typeid|switch|return|static|extern|inline|friend|public|ifndef|define|pragma|export|import|module|catch|throw|const|or_eq|while|compl|bitor|const|union|ifdef|class|undef|error|break|using|endif|goto|line|enum|this|case|else|elif|else|asm|try|for|new|and|xor|not|do|or|if|if)\\b)(?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*))\\s*+(((?<!<)<(?!<)(?>(?:(?>[^<>]*)\\g<27>?)+)>)\\s*)?::)*\\s*+)((?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*)\\s*+(((?<!<)<(?!<)(?>(?:(?>[^<>]*)\\g<27>?)+)>)\\s*)?(::))?((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))(?!(?:transaction_safe_dynamic|__has_cpp_attribute|transaction_safe|reinterpret_cast|atomic_noexcept|atomic_commit|atomic_cancel|__has_include|dynamic_cast|thread_local|synchronized|static_cast|const_cast|constexpr|consteval|protected|constexpr|co_return|namespace|constexpr|noexcept|typename|decltype|template|operator|noexcept|co_yield|co_await|continue|volatile|register|restrict|explicit|override|volatile|reflexpr|noexcept|requires|default|typedef|nullptr|alignof|mutable|concept|virtual|defined|__asm__|include|_Pragma|mutable|warning|private|alignas|module|switch|not_eq|bitand|and_eq|ifndef|return|sizeof|xor_eq|export|static|delete|public|define|extern|inline|import|pragma|friend|typeid|const|compl|bitor|throw|or_eq|while|catch|break|false|final|const|endif|ifdef|undef|error|using|audit|axiom|line|else|elif|true|NULL|case|goto|else|this|new|asm|not|and|xor|try|for|if|do|or|if)\\b)((?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*)\\b(((?<!<)<(?!<)(?>(?:(?>[^<>]*)\\g<27>?)+)>)\\s*)?(?![\\w<:.]))",
+          "captures": {
+            "1": {
+              "name": "meta.qualified_type.cpp",
+              "patterns": [
+                {
+                  "match": "(?<!\\w)(?:struct|class|union|enum)(?!\\w)",
+                  "name": "storage.type.$0.cpp"
+                },
+                {
+                  "include": "#attributes_context"
+                },
+                {
+                  "include": "#function_type"
+                },
+                {
+                  "include": "#storage_types"
+                },
+                {
+                  "include": "#number_literal"
+                },
+                {
+                  "include": "#string_context"
+                },
+                {
+                  "include": "#comma"
+                },
+                {
+                  "include": "#scope_resolution_inner_generated"
+                },
+                {
+                  "include": "#template_call_range"
+                },
+                {
+                  "match": "(?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*",
+                  "name": "entity.name.type.cpp"
+                }
+              ]
+            },
+            "2": {
+              "patterns": [
+                {
+                  "include": "#attributes_context"
+                },
+                {
+                  "include": "#number_literal"
+                }
+              ]
+            },
+            "3": {
+              "patterns": [
+                {
+                  "include": "#inline_comment"
+                }
+              ]
+            },
+            "4": {
+              "name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+            },
+            "5": {
+              "name": "comment.block.cpp"
+            },
+            "6": {
+              "patterns": [
+                {
+                  "match": "\\*\\/",
+                  "name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+                },
+                {
+                  "match": "\\*",
+                  "name": "comment.block.cpp"
+                }
+              ]
+            },
+            "7": {
+              "patterns": [
+                {
+                  "include": "#inline_comment"
+                }
+              ]
+            },
+            "8": {
+              "name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+            },
+            "9": {
+              "name": "comment.block.cpp"
+            },
+            "10": {
+              "patterns": [
+                {
+                  "match": "\\*\\/",
+                  "name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+                },
+                {
+                  "match": "\\*",
+                  "name": "comment.block.cpp"
+                }
+              ]
+            },
+            "12": {
+              "patterns": [
+                {
+                  "include": "#scope_resolution_inner_generated"
+                }
+              ]
+            },
+            "13": {
+              "name": "punctuation.separator.namespace.access.cpp punctuation.separator.scope-resolution.cpp"
+            },
+            "15": {
+              "name": "meta.template.call.cpp",
+              "patterns": [
+                {
+                  "include": "#template_call_range"
+                }
+              ]
+            },
+            "17": {
+              "name": "entity.name.scope-resolution.cpp"
+            },
+            "18": {
+              "name": "meta.template.call.cpp",
+              "patterns": [
+                {
+                  "include": "#template_call_range"
+                }
+              ]
+            },
+            "20": {
+              "name": "punctuation.separator.namespace.access.cpp punctuation.separator.scope-resolution.cpp"
+            },
+            "21": {
+              "patterns": [
+                {
+                  "include": "#inline_comment"
+                }
+              ]
+            },
+            "22": {
+              "name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+            },
+            "23": {
+              "name": "comment.block.cpp"
+            },
+            "24": {
+              "patterns": [
+                {
+                  "match": "\\*\\/",
+                  "name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+                },
+                {
+                  "match": "\\*",
+                  "name": "comment.block.cpp"
+                }
+              ]
+            },
+            "25": {
+              "name": "entity.name.type.cpp"
+            },
+            "26": {
+              "name": "meta.template.call.cpp",
+              "patterns": [
+                {
+                  "include": "#template_call_range"
+                }
+              ]
+            }
+          }
+        }
+      ]
+    },
+    "inline_comment": {
+      "match": "(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/))",
+      "captures": {
+        "1": {
+          "name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+        },
+        "2": {
+          "name": "comment.block.cpp"
+        },
+        "3": {
+          "patterns": [
+            {
+              "match": "\\*\\/",
+              "name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+            },
+            {
+              "match": "\\*",
+              "name": "comment.block.cpp"
+            }
+          ]
+        }
+      }
+    },
+    "invalid_comment_end": {
+      "match": "\\*\\/",
+      "name": "invalid.illegal.unexpected.punctuation.definition.comment.end.cpp"
+    },
+    "label": {
+      "match": "((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))((?<!\\w)(?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*(?!\\w))\\b(?<!case|default)((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))(:)",
+      "captures": {
+        "1": {
+          "patterns": [
+            {
+              "include": "#inline_comment"
+            }
+          ]
+        },
+        "2": {
+          "name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+        },
+        "3": {
+          "name": "comment.block.cpp"
+        },
+        "4": {
+          "patterns": [
+            {
+              "match": "\\*\\/",
+              "name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+            },
+            {
+              "match": "\\*",
+              "name": "comment.block.cpp"
+            }
+          ]
+        },
+        "5": {
+          "name": "entity.name.label.cpp"
+        },
+        "6": {
+          "patterns": [
+            {
+              "include": "#inline_comment"
+            }
+          ]
+        },
+        "7": {
+          "name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+        },
+        "8": {
+          "name": "comment.block.cpp"
+        },
+        "9": {
+          "patterns": [
+            {
+              "match": "\\*\\/",
+              "name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+            },
+            {
+              "match": "\\*",
+              "name": "comment.block.cpp"
+            }
+          ]
+        },
+        "10": {
+          "name": "punctuation.separator.label.cpp"
+        }
+      }
+    },
+    "lambdas": {
+      "begin": "((?:(?<=[^\\s]|^)(?<![\\w\\]\\)\\[\\*&\">])|(?<=\\Wreturn|^return))\\s*(\\[(?!\\[| *+\"| *+\\d))((?>(?:[^\\[\\]]|((?<!\\[)\\[(?!\\[)(?>(?:(?>[^\\[\\]]*)\\g<4>?)+)\\]))*))(\\](?!\\[)))",
+      "beginCaptures": {
+        "2": {
+          "name": "punctuation.definition.capture.begin.lambda.cpp"
+        },
+        "3": {
+          "name": "meta.lambda.capture.cpp",
+          "patterns": [
+            {
+              "include": "#the_this_keyword"
+            },
+            {
+              "match": "((?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*)((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))(?:(?:(?=\\]|\\z|$)|(,))|(\\=))",
+              "captures": {
+                "1": {
+                  "name": "variable.parameter.capture.cpp"
+                },
+                "2": {
+                  "patterns": [
+                    {
+                      "include": "#inline_comment"
+                    }
+                  ]
+                },
+                "3": {
+                  "name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+                },
+                "4": {
+                  "name": "comment.block.cpp"
+                },
+                "5": {
+                  "patterns": [
+                    {
+                      "match": "\\*\\/",
+                      "name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+                    },
+                    {
+                      "match": "\\*",
+                      "name": "comment.block.cpp"
+                    }
+                  ]
+                },
+                "6": {
+                  "name": "punctuation.separator.delimiter.comma.cpp"
+                },
+                "7": {
+                  "name": "keyword.operator.assignment.cpp"
+                }
+              }
+            },
+            {
+              "include": "#evaluation_context"
+            }
+          ]
+        },
+        "5": {
+          "name": "punctuation.definition.capture.end.lambda.cpp"
+        }
+      },
+      "end": "(?<=})|(?=(?<!\\\\)\n)",
+      "patterns": [
+        {
+          "name": "meta.function.definition.parameters.lambda.cpp",
+          "begin": "(\\()",
+          "beginCaptures": {
+            "1": {
+              "name": "punctuation.definition.parameters.begin.lambda.cpp"
+            }
+          },
+          "end": "(\\))|(?=(?<!\\\\)\n)",
+          "endCaptures": {
+            "1": {
+              "name": "punctuation.definition.parameters.end.lambda.cpp"
+            }
+          },
+          "patterns": [
+            {
+              "include": "#function_parameter_context"
+            }
+          ]
+        },
+        {
+          "match": "(?<!\\w)(?:constexpr|consteval|mutable)(?!\\w)",
+          "name": "storage.modifier.lambda.$0.cpp"
+        },
+        {
+          "match": "(->)((?:.+?(?=\\{|$))?)",
+          "captures": {
+            "1": {
+              "name": "punctuation.definition.lambda.return-type.cpp"
+            },
+            "2": {
+              "name": "storage.type.return-type.lambda.cpp"
+            }
+          }
+        },
+        {
+          "name": "meta.function.definition.body.lambda.cpp",
+          "begin": "(\\{)",
+          "beginCaptures": {
+            "1": {
+              "name": "punctuation.section.block.begin.bracket.curly.lambda.cpp"
+            }
+          },
+          "end": "(\\})|(?=(?<!\\\\)\n)",
+          "endCaptures": {
+            "1": {
+              "name": "punctuation.section.block.end.bracket.curly.lambda.cpp"
+            }
+          },
+          "patterns": [
+            {
+              "include": "$self"
+            }
+          ]
+        }
+      ]
+    },
+    "language_constants": {
+      "match": "(?<!\\w)(?:nullptr|false|NULL|true)(?!\\w)",
+      "name": "constant.language.$0.cpp"
+    },
+    "line": {
+      "name": "meta.preprocessor.line.cpp",
+      "begin": "((?:^)((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))(#)\\s*line\\b)",
+      "beginCaptures": {
+        "1": {
+          "name": "keyword.control.directive.line.cpp"
+        },
+        "2": {
+          "patterns": [
+            {
+              "include": "#inline_comment"
+            }
+          ]
+        },
+        "3": {
+          "name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+        },
+        "4": {
+          "name": "comment.block.cpp"
+        },
+        "5": {
+          "patterns": [
+            {
+              "match": "\\*\\/",
+              "name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+            },
+            {
+              "match": "\\*",
+              "name": "comment.block.cpp"
+            }
+          ]
+        },
+        "6": {
+          "name": "punctuation.definition.directive.cpp"
+        }
+      },
+      "end": "(?<!\\\\)(?=\\n)|(?=(?<!\\\\)\n)",
+      "patterns": [
+        {
+          "include": "#string_context_c"
+        },
+        {
+          "include": "#preprocessor_number_literal"
+        },
+        {
+          "include": "#line_continuation_character"
+        }
+      ]
+    },
+    "line_comment": {
+      "name": "comment.line.double-slash.cpp",
+      "begin": "\\s*+(\\/\\/)",
+      "beginCaptures": {
+        "1": {
+          "name": "punctuation.definition.comment.cpp"
+        }
+      },
+      "end": "(?<=\\n)(?<!\\\\\\n)|(?=(?<!\\\\)\n)",
+      "patterns": [
+        {
+          "include": "#line_continuation_character"
+        }
+      ]
+    },
+    "line_continuation_character": {
+      "match": "\\\\\\n",
+      "name": "constant.character.escape.line-continuation.cpp"
+    },
+    "macro": {
+      "name": "meta.preprocessor.macro.cpp",
+      "begin": "((?:^)((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))(#)\\s*define\\b)\\s*((?<!\\w)(?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*(?!\\w))",
+      "beginCaptures": {
+        "1": {
+          "name": "keyword.control.directive.define.cpp"
+        },
+        "2": {
+          "patterns": [
+            {
+              "include": "#inline_comment"
+            }
+          ]
+        },
+        "3": {
+          "name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+        },
+        "4": {
+          "name": "comment.block.cpp"
+        },
+        "5": {
+          "patterns": [
+            {
+              "match": "\\*\\/",
+              "name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+            },
+            {
+              "match": "\\*",
+              "name": "comment.block.cpp"
+            }
+          ]
+        },
+        "6": {
+          "name": "punctuation.definition.directive.cpp"
+        },
+        "7": {
+          "name": "entity.name.function.preprocessor.cpp"
+        }
+      },
+      "end": "(?<!\\\\)(?=\\n)|(?=(?<!\\\\)\n)",
+      "patterns": [
+        {
+          "begin": "\\G\\s*(\\()",
+          "beginCaptures": {
+            "1": {
+              "name": "punctuation.definition.parameters.begin.preprocessor.cpp"
+            }
+          },
+          "end": "(\\))|(?=(?<!\\\\)\n)",
+          "endCaptures": {
+            "1": {
+              "name": "punctuation.definition.parameters.end.preprocessor.cpp"
+            }
+          },
+          "patterns": [
+            {
+              "match": "(?<=[(,])\\s*((?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*)\\s*",
+              "captures": {
+                "1": {
+                  "name": "variable.parameter.preprocessor.cpp"
+                }
+              }
+            },
+            {
+              "match": ",",
+              "name": "punctuation.separator.parameters.cpp"
+            },
+            {
+              "match": "\\.\\.\\.",
+              "name": "punctuation.vararg-ellipses.variable.parameter.preprocessor.cpp"
+            }
+          ]
+        },
+        {
+          "include": "#macro_context"
+        },
+        {
+          "include": "#macro_argument"
+        }
+      ]
+    },
+    "macro_argument": {
+      "match": "##?(?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*(?!\\w)",
+      "name": "variable.other.macro.argument.cpp"
+    },
+    "macro_context": {
+      "patterns": [
+        {
+          "include": "source.cpp.embedded.macro"
+        }
+      ]
+    },
+    "macro_name": {
+      "match": "(?<!\\w)(?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*(?!\\w)",
+      "name": "entity.name.function.preprocessor.cpp"
+    },
+    "member_access": {
+      "match": "(?:((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))((?<!\\w)this(?!\\w))|((?:(?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*|(?<=\\]|\\)))\\s*))(?:((?:\\.\\*|\\.))|((?:->\\*|->)))((?:(?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*\\s*(?:(?:(?:\\.\\*|\\.))|(?:(?:->\\*|->)))\\s*)*)\\s*(\\b(?!uint_least64_t[^(?-mix:\\w)]|uint_least16_t[^(?-mix:\\w)]|uint_least32_t[^(?-mix:\\w)]|int_least16_t[^(?-mix:\\w)]|uint_fast64_t[^(?-mix:\\w)]|uint_fast32_t[^(?-mix:\\w)]|uint_fast16_t[^(?-mix:\\w)]|uint_least8_t[^(?-mix:\\w)]|int_least64_t[^(?-mix:\\w)]|int_least32_t[^(?-mix:\\w)]|int_fast32_t[^(?-mix:\\w)]|int_fast16_t[^(?-mix:\\w)]|int_least8_t[^(?-mix:\\w)]|uint_fast8_t[^(?-mix:\\w)]|int_fast64_t[^(?-mix:\\w)]|int_fast8_t[^(?-mix:\\w)]|suseconds_t[^(?-mix:\\w)]|useconds_t[^(?-mix:\\w)]|in_addr_t[^(?-mix:\\w)]|uintmax_t[^(?-mix:\\w)]|uintmax_t[^(?-mix:\\w)]|uintptr_t[^(?-mix:\\w)]|blksize_t[^(?-mix:\\w)]|in_port_t[^(?-mix:\\w)]|intmax_t[^(?-mix:\\w)]|unsigned[^(?-mix:\\w)]|blkcnt_t[^(?-mix:\\w)]|uint32_t[^(?-mix:\\w)]|u_quad_t[^(?-mix:\\w)]|uint16_t[^(?-mix:\\w)]|intmax_t[^(?-mix:\\w)]|uint64_t[^(?-mix:\\w)]|intptr_t[^(?-mix:\\w)]|swblk_t[^(?-mix:\\w)]|wchar_t[^(?-mix:\\w)]|u_short[^(?-mix:\\w)]|qaddr_t[^(?-mix:\\w)]|caddr_t[^(?-mix:\\w)]|daddr_t[^(?-mix:\\w)]|fixpt_t[^(?-mix:\\w)]|nlink_t[^(?-mix:\\w)]|segsz_t[^(?-mix:\\w)]|clock_t[^(?-mix:\\w)]|ssize_t[^(?-mix:\\w)]|int16_t[^(?-mix:\\w)]|int32_t[^(?-mix:\\w)]|int64_t[^(?-mix:\\w)]|uint8_t[^(?-mix:\\w)]|int8_t[^(?-mix:\\w)]|mode_t[^(?-mix:\\w)]|quad_t[^(?-mix:\\w)]|ushort[^(?-mix:\\w)]|u_long[^(?-mix:\\w)]|u_char[^(?-mix:\\w)]|double[^(?-mix:\\w)]|size_t[^(?-mix:\\w)]|signed[^(?-mix:\\w)]|time_t[^(?-mix:\\w)]|key_t[^(?-mix:\\w)]|ino_t[^(?-mix:\\w)]|gid_t[^(?-mix:\\w)]|dev_t[^(?-mix:\\w)]|div_t[^(?-mix:\\w)]|float[^(?-mix:\\w)]|u_int[^(?-mix:\\w)]|uid_t[^(?-mix:\\w)]|short[^(?-mix:\\w)]|off_t[^(?-mix:\\w)]|pid_t[^(?-mix:\\w)]|id_t[^(?-mix:\\w)]|bool[^(?-mix:\\w)]|char[^(?-mix:\\w)]|id_t[^(?-mix:\\w)]|uint[^(?-mix:\\w)]|void[^(?-mix:\\w)]|long[^(?-mix:\\w)]|auto[^(?-mix:\\w)]|int[^(?-mix:\\w)])(?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*\\b(?!\\())",
+      "captures": {
+        "1": {
+          "patterns": [
+            {
+              "include": "#inline_comment"
+            }
+          ]
+        },
+        "2": {
+          "name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+        },
+        "3": {
+          "name": "comment.block.cpp"
+        },
+        "4": {
+          "patterns": [
+            {
+              "match": "\\*\\/",
+              "name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+            },
+            {
+              "match": "\\*",
+              "name": "comment.block.cpp"
+            }
+          ]
+        },
+        "5": {
+          "name": "variable.language.this.cpp"
+        },
+        "6": {
+          "name": "variable.other.object.access.cpp"
+        },
+        "7": {
+          "name": "punctuation.separator.dot-access.cpp"
+        },
+        "8": {
+          "name": "punctuation.separator.pointer-access.cpp"
+        },
+        "9": {
+          "patterns": [
+            {
+              "match": "(?<=(?:\\.\\*|\\.|->|->\\*))\\s*(?:((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))((?<!\\w)this(?!\\w))|((?:(?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*|(?<=\\]|\\)))\\s*))(?:((?:\\.\\*|\\.))|((?:->\\*|->)))",
+              "captures": {
+                "1": {
+                  "patterns": [
+                    {
+                      "include": "#inline_comment"
+                    }
+                  ]
+                },
+                "2": {
+                  "name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+                },
+                "3": {
+                  "name": "comment.block.cpp"
+                },
+                "4": {
+                  "patterns": [
+                    {
+                      "match": "\\*\\/",
+                      "name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+                    },
+                    {
+                      "match": "\\*",
+                      "name": "comment.block.cpp"
+                    }
+                  ]
+                },
+                "5": {
+                  "name": "variable.language.this.cpp"
+                },
+                "6": {
+                  "name": "variable.other.object.property.cpp"
+                },
+                "7": {
+                  "name": "punctuation.separator.dot-access.cpp"
+                },
+                "8": {
+                  "name": "punctuation.separator.pointer-access.cpp"
+                }
+              }
+            },
+            {
+              "match": "(?:((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))((?<!\\w)this(?!\\w))|((?:(?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*|(?<=\\]|\\)))\\s*))(?:((?:\\.\\*|\\.))|((?:->\\*|->)))",
+              "captures": {
+                "1": {
+                  "patterns": [
+                    {
+                      "include": "#inline_comment"
+                    }
+                  ]
+                },
+                "2": {
+                  "name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+                },
+                "3": {
+                  "name": "comment.block.cpp"
+                },
+                "4": {
+                  "patterns": [
+                    {
+                      "match": "\\*\\/",
+                      "name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+                    },
+                    {
+                      "match": "\\*",
+                      "name": "comment.block.cpp"
+                    }
+                  ]
+                },
+                "5": {
+                  "name": "variable.language.this.cpp"
+                },
+                "6": {
+                  "name": "variable.other.object.access.cpp"
+                },
+                "7": {
+                  "name": "punctuation.separator.dot-access.cpp"
+                },
+                "8": {
+                  "name": "punctuation.separator.pointer-access.cpp"
+                }
+              }
+            },
+            {
+              "include": "#member_access"
+            },
+            {
+              "include": "#method_access"
+            }
+          ]
+        },
+        "10": {
+          "name": "variable.other.property.cpp"
+        }
+      }
+    },
+    "memory_operators": {
+      "match": "((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))((?:(?:(delete)\\s*(\\[\\])|(delete))|(new))(?!\\w))",
+      "captures": {
+        "1": {
+          "patterns": [
+            {
+              "include": "#inline_comment"
+            }
+          ]
+        },
+        "2": {
+          "name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+        },
+        "3": {
+          "name": "comment.block.cpp"
+        },
+        "4": {
+          "patterns": [
+            {
+              "match": "\\*\\/",
+              "name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+            },
+            {
+              "match": "\\*",
+              "name": "comment.block.cpp"
+            }
+          ]
+        },
+        "5": {
+          "name": "keyword.operator.wordlike.cpp"
+        },
+        "6": {
+          "name": "keyword.operator.delete.array.cpp"
+        },
+        "7": {
+          "name": "keyword.operator.delete.array.bracket.cpp"
+        },
+        "8": {
+          "name": "keyword.operator.delete.cpp"
+        },
+        "9": {
+          "name": "keyword.operator.new.cpp"
+        }
+      }
+    },
+    "method_access": {
+      "begin": "(?:((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))((?<!\\w)this(?!\\w))|((?:(?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*|(?<=\\]|\\)))\\s*))(?:((?:\\.\\*|\\.))|((?:->\\*|->)))((?:(?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*\\s*(?:(?:(?:\\.\\*|\\.))|(?:(?:->\\*|->)))\\s*)*)\\s*(~?(?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*)\\s*(\\()",
+      "beginCaptures": {
+        "1": {
+          "patterns": [
+            {
+              "include": "#inline_comment"
+            }
+          ]
+        },
+        "2": {
+          "name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+        },
+        "3": {
+          "name": "comment.block.cpp"
+        },
+        "4": {
+          "patterns": [
+            {
+              "match": "\\*\\/",
+              "name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+            },
+            {
+              "match": "\\*",
+              "name": "comment.block.cpp"
+            }
+          ]
+        },
+        "5": {
+          "name": "variable.language.this.cpp"
+        },
+        "6": {
+          "name": "variable.other.object.access.cpp"
+        },
+        "7": {
+          "name": "punctuation.separator.dot-access.cpp"
+        },
+        "8": {
+          "name": "punctuation.separator.pointer-access.cpp"
+        },
+        "9": {
+          "patterns": [
+            {
+              "match": "(?<=(?:\\.\\*|\\.|->|->\\*))\\s*(?:((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))((?<!\\w)this(?!\\w))|((?:(?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*|(?<=\\]|\\)))\\s*))(?:((?:\\.\\*|\\.))|((?:->\\*|->)))",
+              "captures": {
+                "1": {
+                  "patterns": [
+                    {
+                      "include": "#inline_comment"
+                    }
+                  ]
+                },
+                "2": {
+                  "name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+                },
+                "3": {
+                  "name": "comment.block.cpp"
+                },
+                "4": {
+                  "patterns": [
+                    {
+                      "match": "\\*\\/",
+                      "name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+                    },
+                    {
+                      "match": "\\*",
+                      "name": "comment.block.cpp"
+                    }
+                  ]
+                },
+                "5": {
+                  "name": "variable.language.this.cpp"
+                },
+                "6": {
+                  "name": "variable.other.object.property.cpp"
+                },
+                "7": {
+                  "name": "punctuation.separator.dot-access.cpp"
+                },
+                "8": {
+                  "name": "punctuation.separator.pointer-access.cpp"
+                }
+              }
+            },
+            {
+              "match": "(?:((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))((?<!\\w)this(?!\\w))|((?:(?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*|(?<=\\]|\\)))\\s*))(?:((?:\\.\\*|\\.))|((?:->\\*|->)))",
+              "captures": {
+                "1": {
+                  "patterns": [
+                    {
+                      "include": "#inline_comment"
+                    }
+                  ]
+                },
+                "2": {
+                  "name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+                },
+                "3": {
+                  "name": "comment.block.cpp"
+                },
+                "4": {
+                  "patterns": [
+                    {
+                      "match": "\\*\\/",
+                      "name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+                    },
+                    {
+                      "match": "\\*",
+                      "name": "comment.block.cpp"
+                    }
+                  ]
+                },
+                "5": {
+                  "name": "variable.language.this.cpp"
+                },
+                "6": {
+                  "name": "variable.other.object.access.cpp"
+                },
+                "7": {
+                  "name": "punctuation.separator.dot-access.cpp"
+                },
+                "8": {
+                  "name": "punctuation.separator.pointer-access.cpp"
+                }
+              }
+            },
+            {
+              "include": "#member_access"
+            },
+            {
+              "include": "#method_access"
+            }
+          ]
+        },
+        "10": {
+          "name": "entity.name.function.member.cpp"
+        },
+        "11": {
+          "name": "punctuation.section.arguments.begin.bracket.round.function.member.cpp"
+        }
+      },
+      "end": "(\\))|(?=(?<!\\\\)\n)",
+      "endCaptures": {
+        "1": {
+          "name": "punctuation.section.arguments.end.bracket.round.function.member.cpp"
+        }
+      },
+      "patterns": [
+        {
+          "include": "#evaluation_context"
+        }
+      ]
+    },
+    "misc_storage_modifiers": {
+      "match": "\\b(?:export|mutable|typename|thread_local|register|restrict|static|volatile|inline)\\b",
+      "name": "storage.modifier.$0.cpp"
+    },
+    "module_import": {
+      "match": "(?:^)((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))((import))\\s*(?:(?:(?:((<)[^>]*(>?)((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))(?:(?:\\n|$)|(?=\\/\\/)))|((\\\")[^\\\"]*(\\\"?)((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))(?:(?:\\n|$)|(?=\\/\\/))))|(((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))(?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*(?:\\.(?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*)*((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))(?:(?:\\n|$)|(?=(?:\\/\\/|;)))))|((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))(?:(?:\\n|$)|(?=(?:\\/\\/|;))))\\s*(;?)",
+      "captures": {
+        "1": {
+          "patterns": [
+            {
+              "include": "#inline_comment"
+            }
+          ]
+        },
+        "2": {
+          "name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+        },
+        "3": {
+          "name": "comment.block.cpp"
+        },
+        "4": {
+          "patterns": [
+            {
+              "match": "\\*\\/",
+              "name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+            },
+            {
+              "match": "\\*",
+              "name": "comment.block.cpp"
+            }
+          ]
+        },
+        "5": {
+          "name": "keyword.control.directive.import.cpp"
+        },
+        "7": {
+          "name": "string.quoted.other.lt-gt.include.cpp"
+        },
+        "8": {
+          "name": "punctuation.definition.string.begin.cpp"
+        },
+        "9": {
+          "name": "punctuation.definition.string.end.cpp"
+        },
+        "10": {
+          "patterns": [
+            {
+              "include": "#inline_comment"
+            }
+          ]
+        },
+        "11": {
+          "name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+        },
+        "12": {
+          "name": "comment.block.cpp"
+        },
+        "13": {
+          "patterns": [
+            {
+              "match": "\\*\\/",
+              "name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+            },
+            {
+              "match": "\\*",
+              "name": "comment.block.cpp"
+            }
+          ]
+        },
+        "14": {
+          "name": "string.quoted.double.include.cpp"
+        },
+        "15": {
+          "name": "punctuation.definition.string.begin.cpp"
+        },
+        "16": {
+          "name": "punctuation.definition.string.end.cpp"
+        },
+        "17": {
+          "patterns": [
+            {
+              "include": "#inline_comment"
+            }
+          ]
+        },
+        "18": {
+          "name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+        },
+        "19": {
+          "name": "comment.block.cpp"
+        },
+        "20": {
+          "patterns": [
+            {
+              "match": "\\*\\/",
+              "name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+            },
+            {
+              "match": "\\*",
+              "name": "comment.block.cpp"
+            }
+          ]
+        },
+        "21": {
+          "name": "entity.name.other.preprocessor.macro.include.cpp"
+        },
+        "22": {
+          "patterns": [
+            {
+              "include": "#inline_comment"
+            }
+          ]
+        },
+        "23": {
+          "name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+        },
+        "24": {
+          "name": "comment.block.cpp"
+        },
+        "25": {
+          "patterns": [
+            {
+              "match": "\\*\\/",
+              "name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+            },
+            {
+              "match": "\\*",
+              "name": "comment.block.cpp"
+            }
+          ]
+        },
+        "26": {
+          "patterns": [
+            {
+              "include": "#inline_comment"
+            }
+          ]
+        },
+        "27": {
+          "name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+        },
+        "28": {
+          "name": "comment.block.cpp"
+        },
+        "29": {
+          "patterns": [
+            {
+              "match": "\\*\\/",
+              "name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+            },
+            {
+              "match": "\\*",
+              "name": "comment.block.cpp"
+            }
+          ]
+        },
+        "30": {
+          "patterns": [
+            {
+              "include": "#inline_comment"
+            }
+          ]
+        },
+        "31": {
+          "name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+        },
+        "32": {
+          "name": "comment.block.cpp"
+        },
+        "33": {
+          "patterns": [
+            {
+              "match": "\\*\\/",
+              "name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+            },
+            {
+              "match": "\\*",
+              "name": "comment.block.cpp"
+            }
+          ]
+        },
+        "34": {
+          "name": "punctuation.terminator.statement.cpp"
+        }
+      },
+      "name": "meta.preprocessor.import.cpp"
+    },
+    "ms_attributes": {
+      "name": "support.other.attribute.cpp",
+      "begin": "(__declspec\\()",
+      "beginCaptures": {
+        "1": {
+          "name": "punctuation.section.attribute.begin.cpp"
+        }
+      },
+      "end": "(\\))|(?=(?<!\\\\)\n)",
+      "endCaptures": {
+        "1": {
+          "name": "punctuation.section.attribute.end.cpp"
+        }
+      },
+      "patterns": [
+        {
+          "include": "#attributes_context"
+        },
+        {
+          "begin": "\\(",
+          "end": "\\)|(?=(?<!\\\\)\n)",
+          "patterns": [
+            {
+              "include": "#attributes_context"
+            },
+            {
+              "include": "#string_context"
+            }
+          ]
+        },
+        {
+          "match": "(using)\\s+((?<!\\w)(?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*(?!\\w))",
+          "captures": {
+            "1": {
+              "name": "keyword.other.using.directive.cpp"
+            },
+            "2": {
+              "name": "entity.name.namespace.cpp"
+            }
+          }
+        },
+        {
+          "match": ",",
+          "name": "punctuation.separator.attribute.cpp"
+        },
+        {
+          "match": ":",
+          "name": "punctuation.accessor.attribute.cpp"
+        },
+        {
+          "match": "(?<!\\w)(?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*(?!\\w)(?=::)",
+          "name": "entity.name.namespace.cpp"
+        },
+        {
+          "match": "(?<!\\w)(?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*(?!\\w)",
+          "name": "entity.other.attribute.$0.cpp"
+        },
+        {
+          "include": "#number_literal"
+        }
+      ]
+    },
+    "namespace_alias": {
+      "match": "(?<!\\w)(namespace)\\s+((?<!\\w)(?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*(?!\\w))\\s*(\\=)\\s*(((::)?(?:((?-mix:(?!\\b(?:__has_cpp_attribute|reinterpret_cast|atomic_noexcept|atomic_cancel|atomic_commit|__has_include|dynamic_cast|thread_local|synchronized|static_cast|const_cast|consteval|constexpr|protected|namespace|co_return|constexpr|constexpr|continue|explicit|volatile|noexcept|co_yield|noexcept|noexcept|requires|typename|decltype|operator|co_await|template|volatile|register|restrict|reflexpr|alignof|private|default|mutable|include|concept|__asm__|defined|_Pragma|alignas|typedef|warning|virtual|mutable|struct|sizeof|delete|not_eq|bitand|and_eq|xor_eq|typeid|switch|return|static|extern|inline|friend|public|ifndef|define|pragma|export|import|module|catch|throw|const|or_eq|while|compl|bitor|const|union|ifdef|class|undef|error|break|using|endif|goto|line|enum|this|case|else|elif|else|asm|try|for|new|and|xor|not|do|or|if|if)\\b)(?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*))\\s*+(((?<!<)<(?!<)(?>(?:(?>[^<>]*)\\g<9>?)+)>)\\s*)?::)*\\s*+)\\s*((?<!\\w)(?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*(?!\\w))\\s*(?:(;)|\\n))",
+      "captures": {
+        "1": {
+          "name": "keyword.other.namespace.alias.cpp storage.type.namespace.alias.cpp"
+        },
+        "2": {
+          "name": "entity.name.namespace.alias.cpp"
+        },
+        "3": {
+          "name": "keyword.operator.assignment.cpp"
+        },
+        "4": {
+          "name": "meta.declaration.namespace.alias.value.cpp"
+        },
+        "5": {
+          "patterns": [
+            {
+              "include": "#scope_resolution_namespace_alias_inner_generated"
+            }
+          ]
+        },
+        "6": {
+          "name": "punctuation.separator.namespace.access.cpp punctuation.separator.scope-resolution.namespace.alias.cpp"
+        },
+        "8": {
+          "name": "meta.template.call.cpp",
+          "patterns": [
+            {
+              "include": "#template_call_range"
+            }
+          ]
+        },
+        "10": {
+          "name": "entity.name.namespace.cpp"
+        },
+        "11": {
+          "name": "punctuation.terminator.statement.cpp"
+        }
+      },
+      "name": "meta.declaration.namespace.alias.cpp"
+    },
+    "namespace_block": {
+      "name": "meta.block.namespace.cpp",
+      "begin": "(((?<!\\w)namespace(?!\\w)))",
+      "beginCaptures": {
+        "1": {
+          "name": "meta.head.namespace.cpp"
+        },
+        "2": {
+          "name": "keyword.other.namespace.definition.cpp storage.type.namespace.definition.cpp"
+        }
+      },
+      "end": "(?:(?<=\\}|%>|\\?\\?>)|(?=[;>\\[\\]=]))|(?=(?<!\\\\)\n)",
+      "patterns": [
+        {
+          "name": "meta.head.namespace.cpp",
+          "begin": "\\G ?",
+          "end": "((?:\\{|<%|\\?\\?<|(?=;)))|(?=(?<!\\\\)\n)",
+          "endCaptures": {
+            "1": {
+              "name": "punctuation.section.block.begin.bracket.curly.namespace.cpp"
+            }
+          },
+          "patterns": [
+            {
+              "include": "#ever_present_context"
+            },
+            {
+              "include": "#attributes_context"
+            },
+            {
+              "match": "((::)?(?:((?-mix:(?!\\b(?:__has_cpp_attribute|reinterpret_cast|atomic_noexcept|atomic_cancel|atomic_commit|__has_include|dynamic_cast|thread_local|synchronized|static_cast|const_cast|consteval|constexpr|protected|namespace|co_return|constexpr|constexpr|continue|explicit|volatile|noexcept|co_yield|noexcept|noexcept|requires|typename|decltype|operator|co_await|template|volatile|register|restrict|reflexpr|alignof|private|default|mutable|include|concept|__asm__|defined|_Pragma|alignas|typedef|warning|virtual|mutable|struct|sizeof|delete|not_eq|bitand|and_eq|xor_eq|typeid|switch|return|static|extern|inline|friend|public|ifndef|define|pragma|export|import|module|catch|throw|const|or_eq|while|compl|bitor|const|union|ifdef|class|undef|error|break|using|endif|goto|line|enum|this|case|else|elif|else|asm|try|for|new|and|xor|not|do|or|if|if)\\b)(?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*))\\s*+(((?<!<)<(?!<)(?>(?:(?>[^<>]*)\\g<5>?)+)>)\\s*)?::)*\\s*+)\\s*((?<!\\w)(?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*(?!\\w))\\s*(?:(::)\\s*(inline))?",
+              "captures": {
+                "1": {
+                  "patterns": [
+                    {
+                      "include": "#scope_resolution_namespace_block_inner_generated"
+                    }
+                  ]
+                },
+                "2": {
+                  "name": "punctuation.separator.namespace.access.cpp punctuation.separator.scope-resolution.namespace.block.cpp"
+                },
+                "4": {
+                  "name": "meta.template.call.cpp",
+                  "patterns": [
+                    {
+                      "include": "#template_call_range"
+                    }
+                  ]
+                },
+                "6": {
+                  "name": "entity.name.namespace.cpp"
+                },
+                "7": {
+                  "name": "punctuation.separator.scope-resolution.namespace.block.cpp"
+                },
+                "8": {
+                  "name": "storage.modifier.inline.cpp"
+                }
+              }
+            }
+          ]
+        },
+        {
+          "name": "meta.body.namespace.cpp",
+          "begin": "(?<=\\{|<%|\\?\\?<)",
+          "end": "(\\}|%>|\\?\\?>)|(?=(?<!\\\\)\n)",
+          "endCaptures": {
+            "1": {
+              "name": "punctuation.section.block.end.bracket.curly.namespace.cpp"
+            }
+          },
+          "patterns": [
+            {
+              "include": "$self"
+            }
+          ]
+        },
+        {
+          "name": "meta.tail.namespace.cpp",
+          "begin": "(?<=\\}|%>|\\?\\?>)[\\s\\n]*",
+          "end": "[\\s\\n]*(?=;)|(?=(?<!\\\\)\n)",
+          "patterns": [
+            {
+              "include": "$self"
+            }
+          ]
+        }
+      ]
+    },
+    "noexcept_operator": {
+      "contentName": "meta.arguments.operator.noexcept.cpp",
+      "begin": "((?<!\\w)noexcept(?!\\w))((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))(\\()",
+      "beginCaptures": {
+        "1": {
+          "name": "keyword.operator.functionlike.cpp keyword.operator.noexcept.cpp"
+        },
+        "2": {
+          "patterns": [
+            {
+              "include": "#inline_comment"
+            }
+          ]
+        },
+        "3": {
+          "name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+        },
+        "4": {
+          "name": "comment.block.cpp"
+        },
+        "5": {
+          "patterns": [
+            {
+              "match": "\\*\\/",
+              "name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+            },
+            {
+              "match": "\\*",
+              "name": "comment.block.cpp"
+            }
+          ]
+        },
+        "6": {
+          "name": "punctuation.section.arguments.begin.bracket.round.operator.noexcept.cpp"
+        }
+      },
+      "end": "(\\))|(?=(?<!\\\\)\n)",
+      "endCaptures": {
+        "1": {
+          "name": "punctuation.section.arguments.end.bracket.round.operator.noexcept.cpp"
+        }
+      },
+      "patterns": [
+        {
+          "include": "#evaluation_context"
+        }
+      ]
+    },
+    "non_primitive_types": {
+      "match": "((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))((?<!\\w)(?:uint_least32_t|uint_least64_t|uint_least16_t|int_least16_t|int_least64_t|int_least32_t|uint_fast32_t|uint_fast16_t|uint_fast64_t|uint_least8_t|int_fast64_t|int_fast16_t|uint_fast8_t|int_fast32_t|int_least8_t|int_fast8_t|suseconds_t|useconds_t|uintmax_t|uintptr_t|in_addr_t|uintmax_t|blksize_t|in_port_t|blkcnt_t|intptr_t|intmax_t|uint64_t|u_quad_t|uint16_t|uint32_t|intmax_t|segsz_t|fixpt_t|caddr_t|daddr_t|u_short|int16_t|int32_t|int64_t|uint8_t|nlink_t|qaddr_t|swblk_t|clock_t|ssize_t|time_t|u_long|ushort|quad_t|mode_t|size_t|u_char|int8_t|u_int|uid_t|off_t|pid_t|gid_t|dev_t|div_t|key_t|ino_t|id_t|id_t|uint)(?!\\w))",
+      "captures": {
+        "1": {
+          "patterns": [
+            {
+              "include": "#inline_comment"
+            }
+          ]
+        },
+        "2": {
+          "name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+        },
+        "3": {
+          "name": "comment.block.cpp"
+        },
+        "4": {
+          "patterns": [
+            {
+              "match": "\\*\\/",
+              "name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+            },
+            {
+              "match": "\\*",
+              "name": "comment.block.cpp"
+            }
+          ]
+        },
+        "5": {
+          "name": "storage.type.cpp storage.type.built-in.cpp"
+        }
+      }
+    },
+    "number_literal": {
+      "match": "(?<!\\w)\\.?\\d(?:(?:[0-9a-zA-Z_\\.]|')|(?<=[eEpP])[+-])*",
+      "captures": {
+        "0": {
+          "patterns": [
+            {
+              "begin": "(?=.)",
+              "end": "$|(?=(?<!\\\\)\n)",
+              "patterns": [
+                {
+                  "match": "(\\G0[xX])([0-9a-fA-F](?:[0-9a-fA-F]|((?<=[0-9a-fA-F])'(?=[0-9a-fA-F])))*)?((?:(?<=[0-9a-fA-F])\\.|\\.(?=[0-9a-fA-F])))([0-9a-fA-F](?:[0-9a-fA-F]|((?<=[0-9a-fA-F])'(?=[0-9a-fA-F])))*)?((?<!')([pP])(\\+?)(\\-?)((?:[0-9](?:[0-9]|(?:(?<=[0-9a-fA-F])'(?=[0-9a-fA-F])))*)))?([lLfF](?!\\w))?((?:\\w(?<![0-9a-fA-FpP])\\w*)?$)",
+                  "captures": {
+                    "1": {
+                      "name": "keyword.other.unit.hexadecimal.cpp"
+                    },
+                    "2": {
+                      "name": "constant.numeric.hexadecimal.cpp",
+                      "patterns": [
+                        {
+                          "match": "(?<=[0-9a-fA-F])'(?=[0-9a-fA-F])",
+                          "name": "punctuation.separator.constant.numeric.cpp"
+                        }
+                      ]
+                    },
+                    "3": {
+                      "name": "punctuation.separator.constant.numeric.cpp"
+                    },
+                    "4": {
+                      "name": "constant.numeric.hexadecimal.cpp"
+                    },
+                    "5": {
+                      "name": "constant.numeric.hexadecimal.cpp",
+                      "patterns": [
+                        {
+                          "match": "(?<=[0-9a-fA-F])'(?=[0-9a-fA-F])",
+                          "name": "punctuation.separator.constant.numeric.cpp"
+                        }
+                      ]
+                    },
+                    "6": {
+                      "name": "punctuation.separator.constant.numeric.cpp"
+                    },
+                    "8": {
+                      "name": "keyword.other.unit.exponent.hexadecimal.cpp"
+                    },
+                    "9": {
+                      "name": "keyword.operator.plus.exponent.hexadecimal.cpp"
+                    },
+                    "10": {
+                      "name": "keyword.operator.minus.exponent.hexadecimal.cpp"
+                    },
+                    "11": {
+                      "name": "constant.numeric.exponent.hexadecimal.cpp",
+                      "patterns": [
+                        {
+                          "match": "(?<=[0-9a-fA-F])'(?=[0-9a-fA-F])",
+                          "name": "punctuation.separator.constant.numeric.cpp"
+                        }
+                      ]
+                    },
+                    "12": {
+                      "name": "keyword.other.unit.suffix.floating-point.cpp"
+                    },
+                    "13": {
+                      "name": "keyword.other.unit.user-defined.cpp"
+                    }
+                  }
+                },
+                {
+                  "match": "(\\G(?=[0-9.])(?!0[xXbB]))([0-9](?:[0-9]|((?<=[0-9a-fA-F])'(?=[0-9a-fA-F])))*)?((?:(?<=[0-9])\\.|\\.(?=[0-9])))([0-9](?:[0-9]|((?<=[0-9a-fA-F])'(?=[0-9a-fA-F])))*)?((?<!')([eE])(\\+?)(\\-?)((?:[0-9](?:[0-9]|(?:(?<=[0-9a-fA-F])'(?=[0-9a-fA-F])))*)))?([lLfF](?!\\w))?((?:\\w(?<![0-9eE])\\w*)?$)",
+                  "captures": {
+                    "2": {
+                      "name": "constant.numeric.decimal.cpp",
+                      "patterns": [
+                        {
+                          "match": "(?<=[0-9a-fA-F])'(?=[0-9a-fA-F])",
+                          "name": "punctuation.separator.constant.numeric.cpp"
+                        }
+                      ]
+                    },
+                    "3": {
+                      "name": "punctuation.separator.constant.numeric.cpp"
+                    },
+                    "4": {
+                      "name": "constant.numeric.decimal.point.cpp"
+                    },
+                    "5": {
+                      "name": "constant.numeric.decimal.cpp",
+                      "patterns": [
+                        {
+                          "match": "(?<=[0-9a-fA-F])'(?=[0-9a-fA-F])",
+                          "name": "punctuation.separator.constant.numeric.cpp"
+                        }
+                      ]
+                    },
+                    "6": {
+                      "name": "punctuation.separator.constant.numeric.cpp"
+                    },
+                    "8": {
+                      "name": "keyword.other.unit.exponent.decimal.cpp"
+                    },
+                    "9": {
+                      "name": "keyword.operator.plus.exponent.decimal.cpp"
+                    },
+                    "10": {
+                      "name": "keyword.operator.minus.exponent.decimal.cpp"
+                    },
+                    "11": {
+                      "name": "constant.numeric.exponent.decimal.cpp",
+                      "patterns": [
+                        {
+                          "match": "(?<=[0-9a-fA-F])'(?=[0-9a-fA-F])",
+                          "name": "punctuation.separator.constant.numeric.cpp"
+                        }
+                      ]
+                    },
+                    "12": {
+                      "name": "keyword.other.unit.suffix.floating-point.cpp"
+                    },
+                    "13": {
+                      "name": "keyword.other.unit.user-defined.cpp"
+                    }
+                  }
+                },
+                {
+                  "match": "(\\G0[bB])([01](?:[01]|((?<=[0-9a-fA-F])'(?=[0-9a-fA-F])))*)((?:(?:(?:(?:(?:[uU]|[uU]ll?)|[uU]LL?)|ll?[uU]?)|LL?[uU]?)|[fF])(?!\\w))?((?:\\w(?<![0-9])\\w*)?$)",
+                  "captures": {
+                    "1": {
+                      "name": "keyword.other.unit.binary.cpp"
+                    },
+                    "2": {
+                      "name": "constant.numeric.binary.cpp",
+                      "patterns": [
+                        {
+                          "match": "(?<=[0-9a-fA-F])'(?=[0-9a-fA-F])",
+                          "name": "punctuation.separator.constant.numeric.cpp"
+                        }
+                      ]
+                    },
+                    "3": {
+                      "name": "punctuation.separator.constant.numeric.cpp"
+                    },
+                    "4": {
+                      "name": "keyword.other.unit.suffix.integer.cpp"
+                    },
+                    "5": {
+                      "name": "keyword.other.unit.user-defined.cpp"
+                    }
+                  }
+                },
+                {
+                  "match": "(\\G0)((?:[0-7]|((?<=[0-9a-fA-F])'(?=[0-9a-fA-F])))+)((?:(?:(?:(?:(?:[uU]|[uU]ll?)|[uU]LL?)|ll?[uU]?)|LL?[uU]?)|[fF])(?!\\w))?((?:\\w(?<![0-9])\\w*)?$)",
+                  "captures": {
+                    "1": {
+                      "name": "keyword.other.unit.octal.cpp"
+                    },
+                    "2": {
+                      "name": "constant.numeric.octal.cpp",
+                      "patterns": [
+                        {
+                          "match": "(?<=[0-9a-fA-F])'(?=[0-9a-fA-F])",
+                          "name": "punctuation.separator.constant.numeric.cpp"
+                        }
+                      ]
+                    },
+                    "3": {
+                      "name": "punctuation.separator.constant.numeric.cpp"
+                    },
+                    "4": {
+                      "name": "keyword.other.unit.suffix.integer.cpp"
+                    },
+                    "5": {
+                      "name": "keyword.other.unit.user-defined.cpp"
+                    }
+                  }
+                },
+                {
+                  "match": "(\\G0[xX])([0-9a-fA-F](?:[0-9a-fA-F]|((?<=[0-9a-fA-F])'(?=[0-9a-fA-F])))*)((?<!')([pP])(\\+?)(\\-?)((?:[0-9](?:[0-9]|(?:(?<=[0-9a-fA-F])'(?=[0-9a-fA-F])))*)))?((?:(?:(?:(?:(?:[uU]|[uU]ll?)|[uU]LL?)|ll?[uU]?)|LL?[uU]?)|[fF])(?!\\w))?((?:\\w(?<![0-9a-fA-FpP])\\w*)?$)",
+                  "captures": {
+                    "1": {
+                      "name": "keyword.other.unit.hexadecimal.cpp"
+                    },
+                    "2": {
+                      "name": "constant.numeric.hexadecimal.cpp",
+                      "patterns": [
+                        {
+                          "match": "(?<=[0-9a-fA-F])'(?=[0-9a-fA-F])",
+                          "name": "punctuation.separator.constant.numeric.cpp"
+                        }
+                      ]
+                    },
+                    "3": {
+                      "name": "punctuation.separator.constant.numeric.cpp"
+                    },
+                    "5": {
+                      "name": "keyword.other.unit.exponent.hexadecimal.cpp"
+                    },
+                    "6": {
+                      "name": "keyword.operator.plus.exponent.hexadecimal.cpp"
+                    },
+                    "7": {
+                      "name": "keyword.operator.minus.exponent.hexadecimal.cpp"
+                    },
+                    "8": {
+                      "name": "constant.numeric.exponent.hexadecimal.cpp",
+                      "patterns": [
+                        {
+                          "match": "(?<=[0-9a-fA-F])'(?=[0-9a-fA-F])",
+                          "name": "punctuation.separator.constant.numeric.cpp"
+                        }
+                      ]
+                    },
+                    "9": {
+                      "name": "keyword.other.unit.suffix.integer.cpp"
+                    },
+                    "10": {
+                      "name": "keyword.other.unit.user-defined.cpp"
+                    }
+                  }
+                },
+                {
+                  "match": "(\\G(?=[0-9.])(?!0[xXbB]))([0-9](?:[0-9]|((?<=[0-9a-fA-F])'(?=[0-9a-fA-F])))*)((?<!')([eE])(\\+?)(\\-?)((?:[0-9](?:[0-9]|(?:(?<=[0-9a-fA-F])'(?=[0-9a-fA-F])))*)))?((?:(?:(?:(?:(?:[uU]|[uU]ll?)|[uU]LL?)|ll?[uU]?)|LL?[uU]?)|[fF])(?!\\w))?((?:\\w(?<![0-9eE])\\w*)?$)",
+                  "captures": {
+                    "2": {
+                      "name": "constant.numeric.decimal.cpp",
+                      "patterns": [
+                        {
+                          "match": "(?<=[0-9a-fA-F])'(?=[0-9a-fA-F])",
+                          "name": "punctuation.separator.constant.numeric.cpp"
+                        }
+                      ]
+                    },
+                    "3": {
+                      "name": "punctuation.separator.constant.numeric.cpp"
+                    },
+                    "5": {
+                      "name": "keyword.other.unit.exponent.decimal.cpp"
+                    },
+                    "6": {
+                      "name": "keyword.operator.plus.exponent.decimal.cpp"
+                    },
+                    "7": {
+                      "name": "keyword.operator.minus.exponent.decimal.cpp"
+                    },
+                    "8": {
+                      "name": "constant.numeric.exponent.decimal.cpp",
+                      "patterns": [
+                        {
+                          "match": "(?<=[0-9a-fA-F])'(?=[0-9a-fA-F])",
+                          "name": "punctuation.separator.constant.numeric.cpp"
+                        }
+                      ]
+                    },
+                    "9": {
+                      "name": "keyword.other.unit.suffix.integer.cpp"
+                    },
+                    "10": {
+                      "name": "keyword.other.unit.user-defined.cpp"
+                    }
+                  }
+                },
+                {
+                  "match": "(?:(?:[0-9a-zA-Z_\\.]|')|(?<=[eEpP])[+-])+",
+                  "name": "invalid.illegal.constant.numeric.cpp"
+                }
+              ]
+            }
+          ]
+        }
+      }
+    },
+    "operator_overload": {
+      "name": "meta.function.definition.special.operator-overload.cpp",
+      "begin": "((?:(\\s*+((?:(?:(?:\\[\\[.*?\\]\\]|__attribute(?:__)?\\(\\(.*?\\)\\))|__declspec\\(.*?\\))|alignas\\(.*?\\))(?!\\)))?((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))(?:(?:(?:unsigned|signed|short|long)|(?:struct|class|union|enum))((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z)))))*(((::)?(?:((?-mix:(?!\\b(?:__has_cpp_attribute|reinterpret_cast|atomic_noexcept|atomic_cancel|atomic_commit|__has_include|dynamic_cast|thread_local|synchronized|static_cast|const_cast|consteval|constexpr|protected|namespace|co_return|constexpr|constexpr|continue|explicit|volatile|noexcept|co_yield|noexcept|noexcept|requires|typename|decltype|operator|co_await|template|volatile|register|restrict|reflexpr|alignof|private|default|mutable|include|concept|__asm__|defined|_Pragma|alignas|typedef|warning|virtual|mutable|struct|sizeof|delete|not_eq|bitand|and_eq|xor_eq|typeid|switch|return|static|extern|inline|friend|public|ifndef|define|pragma|export|import|module|catch|throw|const|or_eq|while|compl|bitor|const|union|ifdef|class|undef|error|break|using|endif|goto|line|enum|this|case|else|elif|else|asm|try|for|new|and|xor|not|do|or|if|if)\\b)(?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*))\\s*+(((?<!<)<(?!<)(?>(?:(?>[^<>]*)\\g<67>?)+)>)\\s*)?::)*\\s*+)((?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*)\\s*+(((?<!<)<(?!<)(?>(?:(?>[^<>]*)\\g<67>?)+)>)\\s*)?(::))?((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))(?!(?:transaction_safe_dynamic|__has_cpp_attribute|transaction_safe|reinterpret_cast|atomic_noexcept|atomic_commit|atomic_cancel|__has_include|dynamic_cast|thread_local|synchronized|static_cast|const_cast|constexpr|consteval|protected|constexpr|co_return|namespace|constexpr|noexcept|typename|decltype|template|operator|noexcept|co_yield|co_await|continue|volatile|register|restrict|explicit|override|volatile|reflexpr|noexcept|requires|default|typedef|nullptr|alignof|mutable|concept|virtual|defined|__asm__|include|_Pragma|mutable|warning|private|alignas|module|switch|not_eq|bitand|and_eq|ifndef|return|sizeof|xor_eq|export|static|delete|public|define|extern|inline|import|pragma|friend|typeid|const|compl|bitor|throw|or_eq|while|catch|break|false|final|const|endif|ifdef|undef|error|using|audit|axiom|line|else|elif|true|NULL|case|goto|else|this|new|asm|not|and|xor|try|for|if|do|or|if)\\b)((?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*)\\b(((?<!<)<(?!<)(?>(?:(?>[^<>]*)\\g<67>?)+)>)\\s*)?(?![\\w<:.]))(((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))?(?:(?:\\&|\\*)((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z)))))*(?:\\&|\\*))?((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z)))))?((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))((?:__cdecl|__clrcall|__stdcall|__fastcall|__thiscall|__vectorcall)?)((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))((?:((?-mix:(?!\\b(?:__has_cpp_attribute|reinterpret_cast|atomic_noexcept|atomic_cancel|atomic_commit|__has_include|dynamic_cast|thread_local|synchronized|static_cast|const_cast|consteval|constexpr|protected|namespace|co_return|constexpr|constexpr|continue|explicit|volatile|noexcept|co_yield|noexcept|noexcept|requires|typename|decltype|operator|co_await|template|volatile|register|restrict|reflexpr|alignof|private|default|mutable|include|concept|__asm__|defined|_Pragma|alignas|typedef|warning|virtual|mutable|struct|sizeof|delete|not_eq|bitand|and_eq|xor_eq|typeid|switch|return|static|extern|inline|friend|public|ifndef|define|pragma|export|import|module|catch|throw|const|or_eq|while|compl|bitor|const|union|ifdef|class|undef|error|break|using|endif|goto|line|enum|this|case|else|elif|else|asm|try|for|new|and|xor|not|do|or|if|if)\\b)(?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*))\\s*+(((?<!<)<(?!<)(?>(?:(?>[^<>]*)\\g<67>?)+)>)\\s*)?::)*)(operator)((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))((?:((?-mix:(?!\\b(?:__has_cpp_attribute|reinterpret_cast|atomic_noexcept|atomic_cancel|atomic_commit|__has_include|dynamic_cast|thread_local|synchronized|static_cast|const_cast|consteval|constexpr|protected|namespace|co_return|constexpr|constexpr|continue|explicit|volatile|noexcept|co_yield|noexcept|noexcept|requires|typename|decltype|operator|co_await|template|volatile|register|restrict|reflexpr|alignof|private|default|mutable|include|concept|__asm__|defined|_Pragma|alignas|typedef|warning|virtual|mutable|struct|sizeof|delete|not_eq|bitand|and_eq|xor_eq|typeid|switch|return|static|extern|inline|friend|public|ifndef|define|pragma|export|import|module|catch|throw|const|or_eq|while|compl|bitor|const|union|ifdef|class|undef|error|break|using|endif|goto|line|enum|this|case|else|elif|else|asm|try|for|new|and|xor|not|do|or|if|if)\\b)(?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*))\\s*+(((?<!<)<(?!<)(?>(?:(?>[^<>]*)\\g<67>?)+)>)\\s*)?::)*)(?:(?:((?:delete\\[\\]|delete|new\\[\\]|<=>|<<=|new|>>=|\\->\\*|\\/=|%=|&=|>=|\\|=|\\+\\+|\\-\\-|\\(\\)|\\[\\]|\\->|\\+\\+|<<|>>|\\-\\-|<=|\\^=|==|!=|&&|\\|\\||\\+=|\\-=|\\*=|,|\\+|\\-|!|~|\\*|&|\\*|\\/|%|\\+|\\-|<|>|&|\\^|\\||=))|((?<!\\w)(?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*(?!\\w)(((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))?(?:(?:\\&|\\*)((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z)))))*(?:\\&|\\*))?((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))((?:\\[\\])?)))|(\"\")((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))((?<!\\w)(?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*(?!\\w)))((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))(?=\\<|\\())",
+      "beginCaptures": {
+        "1": {
+          "name": "meta.head.function.definition.special.operator-overload.cpp"
+        },
+        "2": {
+          "name": "meta.qualified_type.cpp",
+          "patterns": [
+            {
+              "match": "(?<!\\w)(?:struct|class|union|enum)(?!\\w)",
+              "name": "storage.type.$0.cpp"
+            },
+            {
+              "include": "#attributes_context"
+            },
+            {
+              "include": "#function_type"
+            },
+            {
+              "include": "#storage_types"
+            },
+            {
+              "include": "#number_literal"
+            },
+            {
+              "include": "#string_context"
+            },
+            {
+              "include": "#comma"
+            },
+            {
+              "include": "#scope_resolution_inner_generated"
+            },
+            {
+              "include": "#template_call_range"
+            },
+            {
+              "match": "(?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*",
+              "name": "entity.name.type.cpp"
+            }
+          ]
+        },
+        "3": {
+          "patterns": [
+            {
+              "include": "#attributes_context"
+            },
+            {
+              "include": "#number_literal"
+            }
+          ]
+        },
+        "4": {
+          "patterns": [
+            {
+              "include": "#inline_comment"
+            }
+          ]
+        },
+        "5": {
+          "name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+        },
+        "6": {
+          "name": "comment.block.cpp"
+        },
+        "7": {
+          "patterns": [
+            {
+              "match": "\\*\\/",
+              "name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+            },
+            {
+              "match": "\\*",
+              "name": "comment.block.cpp"
+            }
+          ]
+        },
+        "8": {
+          "patterns": [
+            {
+              "include": "#inline_comment"
+            }
+          ]
+        },
+        "9": {
+          "name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+        },
+        "10": {
+          "name": "comment.block.cpp"
+        },
+        "11": {
+          "patterns": [
+            {
+              "match": "\\*\\/",
+              "name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+            },
+            {
+              "match": "\\*",
+              "name": "comment.block.cpp"
+            }
+          ]
+        },
+        "13": {
+          "patterns": [
+            {
+              "include": "#scope_resolution_inner_generated"
+            }
+          ]
+        },
+        "14": {
+          "name": "punctuation.separator.namespace.access.cpp punctuation.separator.scope-resolution.cpp"
+        },
+        "16": {
+          "name": "meta.template.call.cpp",
+          "patterns": [
+            {
+              "include": "#template_call_range"
+            }
+          ]
+        },
+        "18": {
+          "name": "entity.name.scope-resolution.cpp"
+        },
+        "19": {
+          "name": "meta.template.call.cpp",
+          "patterns": [
+            {
+              "include": "#template_call_range"
+            }
+          ]
+        },
+        "21": {
+          "name": "punctuation.separator.namespace.access.cpp punctuation.separator.scope-resolution.cpp"
+        },
+        "22": {
+          "patterns": [
+            {
+              "include": "#inline_comment"
+            }
+          ]
+        },
+        "23": {
+          "name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+        },
+        "24": {
+          "name": "comment.block.cpp"
+        },
+        "25": {
+          "patterns": [
+            {
+              "match": "\\*\\/",
+              "name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+            },
+            {
+              "match": "\\*",
+              "name": "comment.block.cpp"
+            }
+          ]
+        },
+        "26": {
+          "name": "entity.name.type.cpp"
+        },
+        "27": {
+          "name": "meta.template.call.cpp",
+          "patterns": [
+            {
+              "include": "#template_call_range"
+            }
+          ]
+        },
+        "29": {
+          "patterns": [
+            {
+              "match": "\\*",
+              "name": "storage.modifier.pointer.cpp"
+            },
+            {
+              "match": "(?:\\&((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))){2,}\\&",
+              "captures": {
+                "1": {
+                  "patterns": [
+                    {
+                      "include": "#inline_comment"
+                    }
+                  ]
+                },
+                "2": {
+                  "name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+                },
+                "3": {
+                  "name": "comment.block.cpp"
+                },
+                "4": {
+                  "patterns": [
+                    {
+                      "match": "\\*\\/",
+                      "name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+                    },
+                    {
+                      "match": "\\*",
+                      "name": "comment.block.cpp"
+                    }
+                  ]
+                }
+              },
+              "name": "invalid.illegal.reference-type.cpp"
+            },
+            {
+              "match": "\\&",
+              "name": "storage.modifier.reference.cpp"
+            }
+          ]
+        },
+        "30": {
+          "patterns": [
+            {
+              "include": "#inline_comment"
+            }
+          ]
+        },
+        "31": {
+          "name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+        },
+        "32": {
+          "name": "comment.block.cpp"
+        },
+        "33": {
+          "patterns": [
+            {
+              "match": "\\*\\/",
+              "name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+            },
+            {
+              "match": "\\*",
+              "name": "comment.block.cpp"
+            }
+          ]
+        },
+        "34": {
+          "patterns": [
+            {
+              "include": "#inline_comment"
+            }
+          ]
+        },
+        "35": {
+          "name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+        },
+        "36": {
+          "name": "comment.block.cpp"
+        },
+        "37": {
+          "patterns": [
+            {
+              "match": "\\*\\/",
+              "name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+            },
+            {
+              "match": "\\*",
+              "name": "comment.block.cpp"
+            }
+          ]
+        },
+        "38": {
+          "patterns": [
+            {
+              "include": "#inline_comment"
+            }
+          ]
+        },
+        "39": {
+          "name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+        },
+        "40": {
+          "name": "comment.block.cpp"
+        },
+        "41": {
+          "patterns": [
+            {
+              "match": "\\*\\/",
+              "name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+            },
+            {
+              "match": "\\*",
+              "name": "comment.block.cpp"
+            }
+          ]
+        },
+        "42": {
+          "patterns": [
+            {
+              "include": "#inline_comment"
+            }
+          ]
+        },
+        "43": {
+          "name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+        },
+        "44": {
+          "name": "comment.block.cpp"
+        },
+        "45": {
+          "patterns": [
+            {
+              "match": "\\*\\/",
+              "name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+            },
+            {
+              "match": "\\*",
+              "name": "comment.block.cpp"
+            }
+          ]
+        },
+        "46": {
+          "name": "storage.type.modifier.calling-convention.cpp"
+        },
+        "47": {
+          "patterns": [
+            {
+              "include": "#inline_comment"
+            }
+          ]
+        },
+        "48": {
+          "name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+        },
+        "49": {
+          "name": "comment.block.cpp"
+        },
+        "50": {
+          "patterns": [
+            {
+              "match": "\\*\\/",
+              "name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+            },
+            {
+              "match": "\\*",
+              "name": "comment.block.cpp"
+            }
+          ]
+        },
+        "51": {
+          "patterns": [
+            {
+              "include": "#inline_comment"
+            }
+          ]
+        },
+        "52": {
+          "name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+        },
+        "53": {
+          "name": "comment.block.cpp"
+        },
+        "54": {
+          "patterns": [
+            {
+              "match": "\\*\\/",
+              "name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+            },
+            {
+              "match": "\\*",
+              "name": "comment.block.cpp"
+            }
+          ]
+        },
+        "55": {
+          "patterns": [
+            {
+              "match": "::",
+              "name": "punctuation.separator.namespace.access.cpp punctuation.separator.scope-resolution.operator.cpp"
+            },
+            {
+              "match": "(?<!\\w)(?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*(?!\\w)",
+              "name": "entity.name.scope-resolution.operator.cpp"
+            },
+            {
+              "include": "#template_call_range"
+            }
+          ]
+        },
+        "57": {
+          "name": "meta.template.call.cpp",
+          "patterns": [
+            {
+              "include": "#template_call_range"
+            }
+          ]
+        },
+        "59": {
+          "name": "keyword.other.operator.overload.cpp"
+        },
+        "60": {
+          "patterns": [
+            {
+              "include": "#inline_comment"
+            }
+          ]
+        },
+        "61": {
+          "name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+        },
+        "62": {
+          "name": "comment.block.cpp"
+        },
+        "63": {
+          "patterns": [
+            {
+              "match": "\\*\\/",
+              "name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+            },
+            {
+              "match": "\\*",
+              "name": "comment.block.cpp"
+            }
+          ]
+        },
+        "64": {
+          "patterns": [
+            {
+              "match": "::",
+              "name": "punctuation.separator.namespace.access.cpp punctuation.separator.scope-resolution.operator-overload.cpp"
+            },
+            {
+              "match": "(?<!\\w)(?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*(?!\\w)",
+              "name": "entity.name.scope-resolution.operator-overload.cpp"
+            },
+            {
+              "include": "#template_call_range"
+            }
+          ]
+        },
+        "66": {
+          "name": "meta.template.call.cpp",
+          "patterns": [
+            {
+              "include": "#template_call_range"
+            }
+          ]
+        },
+        "68": {
+          "name": "entity.name.operator.cpp"
+        },
+        "69": {
+          "name": "entity.name.operator.type.cpp"
+        },
+        "70": {
+          "patterns": [
+            {
+              "match": "\\*",
+              "name": "entity.name.operator.type.pointer.cpp"
+            },
+            {
+              "match": "(?:\\&((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))){2,}\\&",
+              "captures": {
+                "1": {
+                  "patterns": [
+                    {
+                      "include": "#inline_comment"
+                    }
+                  ]
+                },
+                "2": {
+                  "name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+                },
+                "3": {
+                  "name": "comment.block.cpp"
+                },
+                "4": {
+                  "patterns": [
+                    {
+                      "match": "\\*\\/",
+                      "name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+                    },
+                    {
+                      "match": "\\*",
+                      "name": "comment.block.cpp"
+                    }
+                  ]
+                }
+              },
+              "name": "invalid.illegal.reference-type.cpp"
+            },
+            {
+              "match": "\\&",
+              "name": "entity.name.operator.type.reference.cpp"
+            }
+          ]
+        },
+        "71": {
+          "patterns": [
+            {
+              "include": "#inline_comment"
+            }
+          ]
+        },
+        "72": {
+          "name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+        },
+        "73": {
+          "name": "comment.block.cpp"
+        },
+        "74": {
+          "patterns": [
+            {
+              "match": "\\*\\/",
+              "name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+            },
+            {
+              "match": "\\*",
+              "name": "comment.block.cpp"
+            }
+          ]
+        },
+        "75": {
+          "patterns": [
+            {
+              "include": "#inline_comment"
+            }
+          ]
+        },
+        "76": {
+          "name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+        },
+        "77": {
+          "name": "comment.block.cpp"
+        },
+        "78": {
+          "patterns": [
+            {
+              "match": "\\*\\/",
+              "name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+            },
+            {
+              "match": "\\*",
+              "name": "comment.block.cpp"
+            }
+          ]
+        },
+        "79": {
+          "patterns": [
+            {
+              "include": "#inline_comment"
+            }
+          ]
+        },
+        "80": {
+          "name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+        },
+        "81": {
+          "name": "comment.block.cpp"
+        },
+        "82": {
+          "patterns": [
+            {
+              "match": "\\*\\/",
+              "name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+            },
+            {
+              "match": "\\*",
+              "name": "comment.block.cpp"
+            }
+          ]
+        },
+        "83": {
+          "name": "entity.name.operator.type.array.cpp"
+        },
+        "84": {
+          "name": "entity.name.operator.custom-literal.cpp"
+        },
+        "85": {
+          "patterns": [
+            {
+              "include": "#inline_comment"
+            }
+          ]
+        },
+        "86": {
+          "name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+        },
+        "87": {
+          "name": "comment.block.cpp"
+        },
+        "88": {
+          "patterns": [
+            {
+              "match": "\\*\\/",
+              "name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+            },
+            {
+              "match": "\\*",
+              "name": "comment.block.cpp"
+            }
+          ]
+        },
+        "89": {
+          "name": "entity.name.operator.custom-literal.cpp"
+        },
+        "90": {
+          "patterns": [
+            {
+              "include": "#inline_comment"
+            }
+          ]
+        },
+        "91": {
+          "name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+        },
+        "92": {
+          "name": "comment.block.cpp"
+        },
+        "93": {
+          "patterns": [
+            {
+              "match": "\\*\\/",
+              "name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+            },
+            {
+              "match": "\\*",
+              "name": "comment.block.cpp"
+            }
+          ]
+        }
+      },
+      "end": "(?:(?<=\\}|%>|\\?\\?>)|(?=[;>\\[\\]=]))|(?=(?<!\\\\)\n)",
+      "patterns": [
+        {
+          "name": "meta.head.function.definition.special.operator-overload.cpp",
+          "begin": "\\G ?",
+          "end": "((?:\\{|<%|\\?\\?<|(?=;)))|(?=(?<!\\\\)\n)",
+          "endCaptures": {
+            "1": {
+              "name": "punctuation.section.block.begin.bracket.curly.function.definition.special.operator-overload.cpp"
+            }
+          },
+          "patterns": [
+            {
+              "include": "#ever_present_context"
+            },
+            {
+              "include": "#template_call_range"
+            },
+            {
+              "contentName": "meta.function.definition.parameters.special.operator-overload.cpp",
+              "begin": "(\\()",
+              "beginCaptures": {
+                "1": {
+                  "name": "punctuation.section.parameters.begin.bracket.round.special.operator-overload.cpp"
+                }
+              },
+              "end": "(\\))|(?=(?<!\\\\)\n)",
+              "endCaptures": {
+                "1": {
+                  "name": "punctuation.section.parameters.end.bracket.round.special.operator-overload.cpp"
+                }
+              },
+              "patterns": [
+                {
+                  "include": "#function_parameter_context"
+                },
+                {
+                  "include": "#evaluation_context"
+                }
+              ]
+            },
+            {
+              "include": "#qualifiers_and_specifiers_post_parameters"
+            },
+            {
+              "include": "$self"
+            }
+          ]
+        },
+        {
+          "name": "meta.body.function.definition.special.operator-overload.cpp",
+          "begin": "(?<=\\{|<%|\\?\\?<)",
+          "end": "(\\}|%>|\\?\\?>)|(?=(?<!\\\\)\n)",
+          "endCaptures": {
+            "1": {
+              "name": "punctuation.section.block.end.bracket.curly.function.definition.special.operator-overload.cpp"
+            }
+          },
+          "patterns": [
+            {
+              "include": "#function_body_context"
+            }
+          ]
+        },
+        {
+          "name": "meta.tail.function.definition.special.operator-overload.cpp",
+          "begin": "(?<=\\}|%>|\\?\\?>)[\\s\\n]*",
+          "end": "[\\s\\n]*(?=;)|(?=(?<!\\\\)\n)",
+          "patterns": [
+            {
+              "include": "$self"
+            }
+          ]
+        }
+      ]
+    },
+    "operators": {
+      "patterns": [
+        {
+          "include": "#sizeof_operator"
+        },
+        {
+          "include": "#alignof_operator"
+        },
+        {
+          "include": "#alignas_operator"
+        },
+        {
+          "include": "#typeid_operator"
+        },
+        {
+          "include": "#noexcept_operator"
+        },
+        {
+          "include": "#sizeof_variadic_operator"
+        },
+        {
+          "match": "--",
+          "name": "keyword.operator.decrement.cpp"
+        },
+        {
+          "match": "\\+\\+",
+          "name": "keyword.operator.increment.cpp"
+        },
+        {
+          "match": "%=|\\+=|-=|\\*=|(?<!\\()\\/=",
+          "name": "keyword.operator.assignment.compound.cpp"
+        },
+        {
+          "match": "&=|\\^=|<<=|>>=|\\|=",
+          "name": "keyword.operator.assignment.compound.bitwise.cpp"
+        },
+        {
+          "match": "<<|>>",
+          "name": "keyword.operator.bitwise.shift.cpp"
+        },
+        {
+          "match": "!=|<=|>=|==|<|>",
+          "name": "keyword.operator.comparison.cpp"
+        },
+        {
+          "match": "&&|!|\\|\\|",
+          "name": "keyword.operator.logical.cpp"
+        },
+        {
+          "match": "&|\\||\\^|~",
+          "name": "keyword.operator.cpp"
+        },
+        {
+          "include": "#assignment_operator"
+        },
+        {
+          "match": "%|\\*|\\/|-|\\+",
+          "name": "keyword.operator.cpp"
+        },
+        {
+          "include": "#ternary_operator"
+        }
+      ]
+    },
+    "over_qualified_types": {
+      "patterns": [
+        {
+          "include": "#parameter_struct"
+        },
+        {
+          "include": "#parameter_enum"
+        },
+        {
+          "include": "#parameter_union"
+        },
+        {
+          "include": "#parameter_class"
+        }
+      ]
+    },
+    "parameter": {
+      "name": "meta.parameter.cpp",
+      "begin": "((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))(?=\\w)",
+      "beginCaptures": {
+        "1": {
+          "patterns": [
+            {
+              "include": "#inline_comment"
+            }
+          ]
+        },
+        "2": {
+          "name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+        },
+        "3": {
+          "name": "comment.block.cpp"
+        },
+        "4": {
+          "patterns": [
+            {
+              "match": "\\*\\/",
+              "name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+            },
+            {
+              "match": "\\*",
+              "name": "comment.block.cpp"
+            }
+          ]
+        }
+      },
+      "end": "(?:(?=\\))|(,))|(?=(?<!\\\\)\n)",
+      "endCaptures": {
+        "1": {
+          "name": "punctuation.separator.delimiter.comma.cpp"
+        }
+      },
+      "patterns": [
+        {
+          "include": "#ever_present_context"
+        },
+        {
+          "include": "#function_pointer_parameter"
+        },
+        {
+          "include": "#decltype"
+        },
+        {
+          "include": "#vararg_ellipses"
+        },
+        {
+          "match": "((?:((?:volatile|register|restrict|static|extern|const))((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z)))))+)((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))(?:((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))(?:(?:(?:((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))((?<!\\w)(?:unsigned|wchar_t|double|signed|short|float|auto|void|long|char|bool|int)(?!\\w))|((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))((?<!\\w)(?:uint_least32_t|uint_least64_t|uint_least16_t|int_least16_t|int_least64_t|int_least32_t|uint_fast32_t|uint_fast16_t|uint_fast64_t|uint_least8_t|int_fast64_t|int_fast16_t|uint_fast8_t|int_fast32_t|int_least8_t|int_fast8_t|suseconds_t|useconds_t|uintmax_t|uintptr_t|in_addr_t|uintmax_t|blksize_t|in_port_t|blkcnt_t|intptr_t|intmax_t|uint64_t|u_quad_t|uint16_t|uint32_t|intmax_t|segsz_t|fixpt_t|caddr_t|daddr_t|u_short|int16_t|int32_t|int64_t|uint8_t|nlink_t|qaddr_t|swblk_t|clock_t|ssize_t|time_t|u_long|ushort|quad_t|mode_t|size_t|u_char|int8_t|u_int|uid_t|off_t|pid_t|gid_t|dev_t|div_t|key_t|ino_t|id_t|id_t|uint)(?!\\w)))|((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))((?<!\\w)pthread_attr_t|pthread_cond_t|pthread_condattr_t|pthread_mutex_t|pthread_mutexattr_t|pthread_once_t|pthread_rwlock_t|pthread_rwlockattr_t|pthread_t|pthread_key_t(?!\\w)))|((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))((?<!\\w)[a-zA-Z_]\\w*_t(?!\\w)))|((?<!\\w)(?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*(?!\\w)\\b\\b(?<!\\Wvolatile|^volatile|\\Wregister|^register|\\Wrestrict|^restrict|\\Wstatic|^static|\\Wextern|^extern|\\Wconst|^const)))((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))(?=,|\\)|=)",
+          "captures": {
+            "1": {
+              "patterns": [
+                {
+                  "include": "#storage_types"
+                }
+              ]
+            },
+            "2": {
+              "name": "storage.modifier.specifier.parameter.cpp"
+            },
+            "3": {
+              "patterns": [
+                {
+                  "include": "#inline_comment"
+                }
+              ]
+            },
+            "4": {
+              "name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+            },
+            "5": {
+              "name": "comment.block.cpp"
+            },
+            "6": {
+              "patterns": [
+                {
+                  "match": "\\*\\/",
+                  "name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+                },
+                {
+                  "match": "\\*",
+                  "name": "comment.block.cpp"
+                }
+              ]
+            },
+            "7": {
+              "patterns": [
+                {
+                  "include": "#inline_comment"
+                }
+              ]
+            },
+            "8": {
+              "name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+            },
+            "9": {
+              "name": "comment.block.cpp"
+            },
+            "10": {
+              "patterns": [
+                {
+                  "match": "\\*\\/",
+                  "name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+                },
+                {
+                  "match": "\\*",
+                  "name": "comment.block.cpp"
+                }
+              ]
+            },
+            "11": {
+              "patterns": [
+                {
+                  "include": "#inline_comment"
+                }
+              ]
+            },
+            "12": {
+              "name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+            },
+            "13": {
+              "name": "comment.block.cpp"
+            },
+            "14": {
+              "patterns": [
+                {
+                  "match": "\\*\\/",
+                  "name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+                },
+                {
+                  "match": "\\*",
+                  "name": "comment.block.cpp"
+                }
+              ]
+            },
+            "15": {
+              "patterns": [
+                {
+                  "include": "#inline_comment"
+                }
+              ]
+            },
+            "16": {
+              "name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+            },
+            "17": {
+              "name": "comment.block.cpp"
+            },
+            "18": {
+              "patterns": [
+                {
+                  "match": "\\*\\/",
+                  "name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+                },
+                {
+                  "match": "\\*",
+                  "name": "comment.block.cpp"
+                }
+              ]
+            },
+            "19": {
+              "name": "storage.type.primitive.cpp storage.type.built-in.primitive.cpp"
+            },
+            "20": {
+              "patterns": [
+                {
+                  "include": "#inline_comment"
+                }
+              ]
+            },
+            "21": {
+              "name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+            },
+            "22": {
+              "name": "comment.block.cpp"
+            },
+            "23": {
+              "patterns": [
+                {
+                  "match": "\\*\\/",
+                  "name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+                },
+                {
+                  "match": "\\*",
+                  "name": "comment.block.cpp"
+                }
+              ]
+            },
+            "24": {
+              "name": "storage.type.cpp storage.type.built-in.cpp"
+            },
+            "25": {
+              "patterns": [
+                {
+                  "include": "#inline_comment"
+                }
+              ]
+            },
+            "26": {
+              "name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+            },
+            "27": {
+              "name": "comment.block.cpp"
+            },
+            "28": {
+              "patterns": [
+                {
+                  "match": "\\*\\/",
+                  "name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+                },
+                {
+                  "match": "\\*",
+                  "name": "comment.block.cpp"
+                }
+              ]
+            },
+            "29": {
+              "name": "support.type.posix-reserved.pthread.cpp support.type.built-in.posix-reserved.pthread.cpp"
+            },
+            "30": {
+              "patterns": [
+                {
+                  "include": "#inline_comment"
+                }
+              ]
+            },
+            "31": {
+              "name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+            },
+            "32": {
+              "name": "comment.block.cpp"
+            },
+            "33": {
+              "patterns": [
+                {
+                  "match": "\\*\\/",
+                  "name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+                },
+                {
+                  "match": "\\*",
+                  "name": "comment.block.cpp"
+                }
+              ]
+            },
+            "34": {
+              "name": "support.type.posix-reserved.cpp support.type.built-in.posix-reserved.cpp"
+            },
+            "35": {
+              "name": "entity.name.type.parameter.cpp"
+            },
+            "36": {
+              "patterns": [
+                {
+                  "include": "#inline_comment"
+                }
+              ]
+            },
+            "37": {
+              "name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+            },
+            "38": {
+              "name": "comment.block.cpp"
+            },
+            "39": {
+              "patterns": [
+                {
+                  "match": "\\*\\/",
+                  "name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+                },
+                {
+                  "match": "\\*",
+                  "name": "comment.block.cpp"
+                }
+              ]
+            }
+          }
+        },
+        {
+          "include": "#storage_types"
+        },
+        {
+          "include": "#scope_resolution_parameter_inner_generated"
+        },
+        {
+          "match": "(?:struct|class|union|enum)",
+          "name": "storage.type.$0.cpp"
+        },
+        {
+          "begin": "(?<==)",
+          "end": "(?:(?=\\))|(,))|(?=(?<!\\\\)\n)",
+          "endCaptures": {
+            "1": {
+              "name": "punctuation.separator.delimiter.comma.cpp"
+            }
+          },
+          "patterns": [
+            {
+              "include": "#evaluation_context"
+            }
+          ]
+        },
+        {
+          "include": "#assignment_operator"
+        },
+        {
+          "match": "(?<!\\s|\\(|,|:)((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))((?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*)((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))(?=\\)|,|\\[|=|\\n)",
+          "captures": {
+            "1": {
+              "patterns": [
+                {
+                  "include": "#inline_comment"
+                }
+              ]
+            },
+            "2": {
+              "name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+            },
+            "3": {
+              "name": "comment.block.cpp"
+            },
+            "4": {
+              "patterns": [
+                {
+                  "match": "\\*\\/",
+                  "name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+                },
+                {
+                  "match": "\\*",
+                  "name": "comment.block.cpp"
+                }
+              ]
+            },
+            "5": {
+              "name": "variable.parameter.cpp"
+            },
+            "6": {
+              "patterns": [
+                {
+                  "include": "#inline_comment"
+                }
+              ]
+            },
+            "7": {
+              "name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+            },
+            "8": {
+              "name": "comment.block.cpp"
+            },
+            "9": {
+              "patterns": [
+                {
+                  "match": "\\*\\/",
+                  "name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+                },
+                {
+                  "match": "\\*",
+                  "name": "comment.block.cpp"
+                }
+              ]
+            }
+          }
+        },
+        {
+          "include": "#attributes_context"
+        },
+        {
+          "name": "meta.bracket.square.array.cpp",
+          "begin": "(\\[)",
+          "beginCaptures": {
+            "1": {
+              "name": "punctuation.definition.begin.bracket.square.array.type.cpp"
+            }
+          },
+          "end": "(\\])|(?=(?<!\\\\)\n)",
+          "endCaptures": {
+            "1": {
+              "name": "punctuation.definition.end.bracket.square.array.type.cpp"
+            }
+          },
+          "patterns": [
+            {
+              "include": "#evaluation_context"
+            }
+          ]
+        },
+        {
+          "match": "(?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*\\b(?<!\\Wstruct|^struct|\\Wclass|^class|\\Wunion|^union|\\Wenum|^enum)",
+          "name": "entity.name.type.parameter.cpp"
+        },
+        {
+          "include": "#template_call_range"
+        },
+        {
+          "match": "((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))?(?:(?:\\&|\\*)((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z)))))*(?:\\&|\\*)",
+          "captures": {
+            "0": {
+              "patterns": [
+                {
+                  "match": "\\*",
+                  "name": "storage.modifier.pointer.cpp"
+                },
+                {
+                  "match": "(?:\\&((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))){2,}\\&",
+                  "captures": {
+                    "1": {
+                      "patterns": [
+                        {
+                          "include": "#inline_comment"
+                        }
+                      ]
+                    },
+                    "2": {
+                      "name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+                    },
+                    "3": {
+                      "name": "comment.block.cpp"
+                    },
+                    "4": {
+                      "patterns": [
+                        {
+                          "match": "\\*\\/",
+                          "name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+                        },
+                        {
+                          "match": "\\*",
+                          "name": "comment.block.cpp"
+                        }
+                      ]
+                    }
+                  },
+                  "name": "invalid.illegal.reference-type.cpp"
+                },
+                {
+                  "match": "\\&",
+                  "name": "storage.modifier.reference.cpp"
+                }
+              ]
+            },
+            "1": {
+              "patterns": [
+                {
+                  "include": "#inline_comment"
+                }
+              ]
+            },
+            "2": {
+              "name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+            },
+            "3": {
+              "name": "comment.block.cpp"
+            },
+            "4": {
+              "patterns": [
+                {
+                  "match": "\\*\\/",
+                  "name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+                },
+                {
+                  "match": "\\*",
+                  "name": "comment.block.cpp"
+                }
+              ]
+            },
+            "5": {
+              "patterns": [
+                {
+                  "include": "#inline_comment"
+                }
+              ]
+            },
+            "6": {
+              "name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+            },
+            "7": {
+              "name": "comment.block.cpp"
+            },
+            "8": {
+              "patterns": [
+                {
+                  "match": "\\*\\/",
+                  "name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+                },
+                {
+                  "match": "\\*",
+                  "name": "comment.block.cpp"
+                }
+              ]
+            }
+          }
+        }
+      ]
+    },
+    "parameter_class": {
+      "match": "(class)((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))((?<!\\w)(?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*(?!\\w))((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))(?:(((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))?(?:(?:\\&|\\*)((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z)))))*(?:\\&|\\*))((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z)))))?((?:(?<!\\w)(?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*(?!\\w))?)((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))(?:\\[((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))\\]((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z)))))?(?=,|\\)|\\n)",
+      "captures": {
+        "1": {
+          "name": "storage.type.class.parameter.cpp"
+        },
+        "2": {
+          "patterns": [
+            {
+              "include": "#inline_comment"
+            }
+          ]
+        },
+        "3": {
+          "name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+        },
+        "4": {
+          "name": "comment.block.cpp"
+        },
+        "5": {
+          "patterns": [
+            {
+              "match": "\\*\\/",
+              "name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+            },
+            {
+              "match": "\\*",
+              "name": "comment.block.cpp"
+            }
+          ]
+        },
+        "6": {
+          "name": "entity.name.type.class.parameter.cpp"
+        },
+        "7": {
+          "patterns": [
+            {
+              "include": "#inline_comment"
+            }
+          ]
+        },
+        "8": {
+          "name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+        },
+        "9": {
+          "name": "comment.block.cpp"
+        },
+        "10": {
+          "patterns": [
+            {
+              "match": "\\*\\/",
+              "name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+            },
+            {
+              "match": "\\*",
+              "name": "comment.block.cpp"
+            }
+          ]
+        },
+        "11": {
+          "patterns": [
+            {
+              "match": "\\*",
+              "name": "storage.modifier.pointer.cpp"
+            },
+            {
+              "match": "(?:\\&((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))){2,}\\&",
+              "captures": {
+                "1": {
+                  "patterns": [
+                    {
+                      "include": "#inline_comment"
+                    }
+                  ]
+                },
+                "2": {
+                  "name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+                },
+                "3": {
+                  "name": "comment.block.cpp"
+                },
+                "4": {
+                  "patterns": [
+                    {
+                      "match": "\\*\\/",
+                      "name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+                    },
+                    {
+                      "match": "\\*",
+                      "name": "comment.block.cpp"
+                    }
+                  ]
+                }
+              },
+              "name": "invalid.illegal.reference-type.cpp"
+            },
+            {
+              "match": "\\&",
+              "name": "storage.modifier.reference.cpp"
+            }
+          ]
+        },
+        "12": {
+          "patterns": [
+            {
+              "include": "#inline_comment"
+            }
+          ]
+        },
+        "13": {
+          "name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+        },
+        "14": {
+          "name": "comment.block.cpp"
+        },
+        "15": {
+          "patterns": [
+            {
+              "match": "\\*\\/",
+              "name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+            },
+            {
+              "match": "\\*",
+              "name": "comment.block.cpp"
+            }
+          ]
+        },
+        "16": {
+          "patterns": [
+            {
+              "include": "#inline_comment"
+            }
+          ]
+        },
+        "17": {
+          "name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+        },
+        "18": {
+          "name": "comment.block.cpp"
+        },
+        "19": {
+          "patterns": [
+            {
+              "match": "\\*\\/",
+              "name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+            },
+            {
+              "match": "\\*",
+              "name": "comment.block.cpp"
+            }
+          ]
+        },
+        "20": {
+          "patterns": [
+            {
+              "include": "#inline_comment"
+            }
+          ]
+        },
+        "21": {
+          "name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+        },
+        "22": {
+          "name": "comment.block.cpp"
+        },
+        "23": {
+          "patterns": [
+            {
+              "match": "\\*\\/",
+              "name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+            },
+            {
+              "match": "\\*",
+              "name": "comment.block.cpp"
+            }
+          ]
+        },
+        "24": {
+          "name": "variable.other.object.declare.cpp"
+        },
+        "25": {
+          "patterns": [
+            {
+              "include": "#inline_comment"
+            }
+          ]
+        },
+        "26": {
+          "name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+        },
+        "27": {
+          "name": "comment.block.cpp"
+        },
+        "28": {
+          "patterns": [
+            {
+              "match": "\\*\\/",
+              "name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+            },
+            {
+              "match": "\\*",
+              "name": "comment.block.cpp"
+            }
+          ]
+        },
+        "29": {
+          "patterns": [
+            {
+              "include": "#inline_comment"
+            }
+          ]
+        },
+        "30": {
+          "name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+        },
+        "31": {
+          "name": "comment.block.cpp"
+        },
+        "32": {
+          "patterns": [
+            {
+              "match": "\\*\\/",
+              "name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+            },
+            {
+              "match": "\\*",
+              "name": "comment.block.cpp"
+            }
+          ]
+        },
+        "33": {
+          "patterns": [
+            {
+              "include": "#inline_comment"
+            }
+          ]
+        },
+        "34": {
+          "name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+        },
+        "35": {
+          "name": "comment.block.cpp"
+        },
+        "36": {
+          "patterns": [
+            {
+              "match": "\\*\\/",
+              "name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+            },
+            {
+              "match": "\\*",
+              "name": "comment.block.cpp"
+            }
+          ]
+        }
+      }
+    },
+    "parameter_enum": {
+      "match": "(enum)((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))((?<!\\w)(?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*(?!\\w))((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))(?:(((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))?(?:(?:\\&|\\*)((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z)))))*(?:\\&|\\*))((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z)))))?((?:(?<!\\w)(?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*(?!\\w))?)((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))(?:\\[((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))\\]((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z)))))?(?=,|\\)|\\n)",
+      "captures": {
+        "1": {
+          "name": "storage.type.enum.parameter.cpp"
+        },
+        "2": {
+          "patterns": [
+            {
+              "include": "#inline_comment"
+            }
+          ]
+        },
+        "3": {
+          "name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+        },
+        "4": {
+          "name": "comment.block.cpp"
+        },
+        "5": {
+          "patterns": [
+            {
+              "match": "\\*\\/",
+              "name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+            },
+            {
+              "match": "\\*",
+              "name": "comment.block.cpp"
+            }
+          ]
+        },
+        "6": {
+          "name": "entity.name.type.enum.parameter.cpp"
+        },
+        "7": {
+          "patterns": [
+            {
+              "include": "#inline_comment"
+            }
+          ]
+        },
+        "8": {
+          "name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+        },
+        "9": {
+          "name": "comment.block.cpp"
+        },
+        "10": {
+          "patterns": [
+            {
+              "match": "\\*\\/",
+              "name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+            },
+            {
+              "match": "\\*",
+              "name": "comment.block.cpp"
+            }
+          ]
+        },
+        "11": {
+          "patterns": [
+            {
+              "match": "\\*",
+              "name": "storage.modifier.pointer.cpp"
+            },
+            {
+              "match": "(?:\\&((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))){2,}\\&",
+              "captures": {
+                "1": {
+                  "patterns": [
+                    {
+                      "include": "#inline_comment"
+                    }
+                  ]
+                },
+                "2": {
+                  "name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+                },
+                "3": {
+                  "name": "comment.block.cpp"
+                },
+                "4": {
+                  "patterns": [
+                    {
+                      "match": "\\*\\/",
+                      "name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+                    },
+                    {
+                      "match": "\\*",
+                      "name": "comment.block.cpp"
+                    }
+                  ]
+                }
+              },
+              "name": "invalid.illegal.reference-type.cpp"
+            },
+            {
+              "match": "\\&",
+              "name": "storage.modifier.reference.cpp"
+            }
+          ]
+        },
+        "12": {
+          "patterns": [
+            {
+              "include": "#inline_comment"
+            }
+          ]
+        },
+        "13": {
+          "name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+        },
+        "14": {
+          "name": "comment.block.cpp"
+        },
+        "15": {
+          "patterns": [
+            {
+              "match": "\\*\\/",
+              "name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+            },
+            {
+              "match": "\\*",
+              "name": "comment.block.cpp"
+            }
+          ]
+        },
+        "16": {
+          "patterns": [
+            {
+              "include": "#inline_comment"
+            }
+          ]
+        },
+        "17": {
+          "name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+        },
+        "18": {
+          "name": "comment.block.cpp"
+        },
+        "19": {
+          "patterns": [
+            {
+              "match": "\\*\\/",
+              "name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+            },
+            {
+              "match": "\\*",
+              "name": "comment.block.cpp"
+            }
+          ]
+        },
+        "20": {
+          "patterns": [
+            {
+              "include": "#inline_comment"
+            }
+          ]
+        },
+        "21": {
+          "name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+        },
+        "22": {
+          "name": "comment.block.cpp"
+        },
+        "23": {
+          "patterns": [
+            {
+              "match": "\\*\\/",
+              "name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+            },
+            {
+              "match": "\\*",
+              "name": "comment.block.cpp"
+            }
+          ]
+        },
+        "24": {
+          "name": "variable.other.object.declare.cpp"
+        },
+        "25": {
+          "patterns": [
+            {
+              "include": "#inline_comment"
+            }
+          ]
+        },
+        "26": {
+          "name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+        },
+        "27": {
+          "name": "comment.block.cpp"
+        },
+        "28": {
+          "patterns": [
+            {
+              "match": "\\*\\/",
+              "name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+            },
+            {
+              "match": "\\*",
+              "name": "comment.block.cpp"
+            }
+          ]
+        },
+        "29": {
+          "patterns": [
+            {
+              "include": "#inline_comment"
+            }
+          ]
+        },
+        "30": {
+          "name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+        },
+        "31": {
+          "name": "comment.block.cpp"
+        },
+        "32": {
+          "patterns": [
+            {
+              "match": "\\*\\/",
+              "name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+            },
+            {
+              "match": "\\*",
+              "name": "comment.block.cpp"
+            }
+          ]
+        },
+        "33": {
+          "patterns": [
+            {
+              "include": "#inline_comment"
+            }
+          ]
+        },
+        "34": {
+          "name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+        },
+        "35": {
+          "name": "comment.block.cpp"
+        },
+        "36": {
+          "patterns": [
+            {
+              "match": "\\*\\/",
+              "name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+            },
+            {
+              "match": "\\*",
+              "name": "comment.block.cpp"
+            }
+          ]
+        }
+      }
+    },
+    "parameter_or_maybe_value": {
+      "name": "meta.parameter.cpp",
+      "begin": "((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))(?=\\w)",
+      "beginCaptures": {
+        "1": {
+          "patterns": [
+            {
+              "include": "#inline_comment"
+            }
+          ]
+        },
+        "2": {
+          "name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+        },
+        "3": {
+          "name": "comment.block.cpp"
+        },
+        "4": {
+          "patterns": [
+            {
+              "match": "\\*\\/",
+              "name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+            },
+            {
+              "match": "\\*",
+              "name": "comment.block.cpp"
+            }
+          ]
+        }
+      },
+      "end": "(?:(?=\\))|(,))|(?=(?<!\\\\)\n)",
+      "endCaptures": {
+        "1": {
+          "name": "punctuation.separator.delimiter.comma.cpp"
+        }
+      },
+      "patterns": [
+        {
+          "include": "#ever_present_context"
+        },
+        {
+          "include": "#function_pointer_parameter"
+        },
+        {
+          "include": "#memory_operators"
+        },
+        {
+          "include": "#builtin_storage_type_initilizer"
+        },
+        {
+          "include": "#curly_initializer"
+        },
+        {
+          "include": "#decltype"
+        },
+        {
+          "include": "#vararg_ellipses"
+        },
+        {
+          "match": "((?:((?:volatile|register|restrict|static|extern|const))((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z)))))+)((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))(?:((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))(?:(?:(?:((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))((?<!\\w)(?:unsigned|wchar_t|double|signed|short|float|auto|void|long|char|bool|int)(?!\\w))|((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))((?<!\\w)(?:uint_least32_t|uint_least64_t|uint_least16_t|int_least16_t|int_least64_t|int_least32_t|uint_fast32_t|uint_fast16_t|uint_fast64_t|uint_least8_t|int_fast64_t|int_fast16_t|uint_fast8_t|int_fast32_t|int_least8_t|int_fast8_t|suseconds_t|useconds_t|uintmax_t|uintptr_t|in_addr_t|uintmax_t|blksize_t|in_port_t|blkcnt_t|intptr_t|intmax_t|uint64_t|u_quad_t|uint16_t|uint32_t|intmax_t|segsz_t|fixpt_t|caddr_t|daddr_t|u_short|int16_t|int32_t|int64_t|uint8_t|nlink_t|qaddr_t|swblk_t|clock_t|ssize_t|time_t|u_long|ushort|quad_t|mode_t|size_t|u_char|int8_t|u_int|uid_t|off_t|pid_t|gid_t|dev_t|div_t|key_t|ino_t|id_t|id_t|uint)(?!\\w)))|((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))((?<!\\w)pthread_attr_t|pthread_cond_t|pthread_condattr_t|pthread_mutex_t|pthread_mutexattr_t|pthread_once_t|pthread_rwlock_t|pthread_rwlockattr_t|pthread_t|pthread_key_t(?!\\w)))|((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))((?<!\\w)[a-zA-Z_]\\w*_t(?!\\w)))|((?<!\\w)(?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*(?!\\w)\\b\\b(?<!\\Wvolatile|^volatile|\\Wregister|^register|\\Wrestrict|^restrict|\\Wstatic|^static|\\Wextern|^extern|\\Wconst|^const)))((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))(?=,|\\)|=)",
+          "captures": {
+            "1": {
+              "patterns": [
+                {
+                  "include": "#storage_types"
+                }
+              ]
+            },
+            "2": {
+              "name": "storage.modifier.specifier.parameter.cpp"
+            },
+            "3": {
+              "patterns": [
+                {
+                  "include": "#inline_comment"
+                }
+              ]
+            },
+            "4": {
+              "name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+            },
+            "5": {
+              "name": "comment.block.cpp"
+            },
+            "6": {
+              "patterns": [
+                {
+                  "match": "\\*\\/",
+                  "name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+                },
+                {
+                  "match": "\\*",
+                  "name": "comment.block.cpp"
+                }
+              ]
+            },
+            "7": {
+              "patterns": [
+                {
+                  "include": "#inline_comment"
+                }
+              ]
+            },
+            "8": {
+              "name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+            },
+            "9": {
+              "name": "comment.block.cpp"
+            },
+            "10": {
+              "patterns": [
+                {
+                  "match": "\\*\\/",
+                  "name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+                },
+                {
+                  "match": "\\*",
+                  "name": "comment.block.cpp"
+                }
+              ]
+            },
+            "11": {
+              "patterns": [
+                {
+                  "include": "#inline_comment"
+                }
+              ]
+            },
+            "12": {
+              "name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+            },
+            "13": {
+              "name": "comment.block.cpp"
+            },
+            "14": {
+              "patterns": [
+                {
+                  "match": "\\*\\/",
+                  "name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+                },
+                {
+                  "match": "\\*",
+                  "name": "comment.block.cpp"
+                }
+              ]
+            },
+            "15": {
+              "patterns": [
+                {
+                  "include": "#inline_comment"
+                }
+              ]
+            },
+            "16": {
+              "name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+            },
+            "17": {
+              "name": "comment.block.cpp"
+            },
+            "18": {
+              "patterns": [
+                {
+                  "match": "\\*\\/",
+                  "name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+                },
+                {
+                  "match": "\\*",
+                  "name": "comment.block.cpp"
+                }
+              ]
+            },
+            "19": {
+              "name": "storage.type.primitive.cpp storage.type.built-in.primitive.cpp"
+            },
+            "20": {
+              "patterns": [
+                {
+                  "include": "#inline_comment"
+                }
+              ]
+            },
+            "21": {
+              "name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+            },
+            "22": {
+              "name": "comment.block.cpp"
+            },
+            "23": {
+              "patterns": [
+                {
+                  "match": "\\*\\/",
+                  "name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+                },
+                {
+                  "match": "\\*",
+                  "name": "comment.block.cpp"
+                }
+              ]
+            },
+            "24": {
+              "name": "storage.type.cpp storage.type.built-in.cpp"
+            },
+            "25": {
+              "patterns": [
+                {
+                  "include": "#inline_comment"
+                }
+              ]
+            },
+            "26": {
+              "name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+            },
+            "27": {
+              "name": "comment.block.cpp"
+            },
+            "28": {
+              "patterns": [
+                {
+                  "match": "\\*\\/",
+                  "name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+                },
+                {
+                  "match": "\\*",
+                  "name": "comment.block.cpp"
+                }
+              ]
+            },
+            "29": {
+              "name": "support.type.posix-reserved.pthread.cpp support.type.built-in.posix-reserved.pthread.cpp"
+            },
+            "30": {
+              "patterns": [
+                {
+                  "include": "#inline_comment"
+                }
+              ]
+            },
+            "31": {
+              "name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+            },
+            "32": {
+              "name": "comment.block.cpp"
+            },
+            "33": {
+              "patterns": [
+                {
+                  "match": "\\*\\/",
+                  "name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+                },
+                {
+                  "match": "\\*",
+                  "name": "comment.block.cpp"
+                }
+              ]
+            },
+            "34": {
+              "name": "support.type.posix-reserved.cpp support.type.built-in.posix-reserved.cpp"
+            },
+            "35": {
+              "name": "entity.name.type.parameter.cpp"
+            },
+            "36": {
+              "patterns": [
+                {
+                  "include": "#inline_comment"
+                }
+              ]
+            },
+            "37": {
+              "name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+            },
+            "38": {
+              "name": "comment.block.cpp"
+            },
+            "39": {
+              "patterns": [
+                {
+                  "match": "\\*\\/",
+                  "name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+                },
+                {
+                  "match": "\\*",
+                  "name": "comment.block.cpp"
+                }
+              ]
+            }
+          }
+        },
+        {
+          "include": "#storage_types"
+        },
+        {
+          "include": "#function_call"
+        },
+        {
+          "include": "#scope_resolution_parameter_inner_generated"
+        },
+        {
+          "match": "(?:struct|class|union|enum)",
+          "name": "storage.type.$0.cpp"
+        },
+        {
+          "begin": "(?<==)",
+          "end": "(?:(?=\\))|(,))|(?=(?<!\\\\)\n)",
+          "endCaptures": {
+            "1": {
+              "name": "punctuation.separator.delimiter.comma.cpp"
+            }
+          },
+          "patterns": [
+            {
+              "include": "#evaluation_context"
+            }
+          ]
+        },
+        {
+          "match": "(?<!\\s|\\(|,|:)((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))((?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*)((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))(?=(?:\\)|,|\\[|=|\\/\\/|(?:\\n|$)))",
+          "captures": {
+            "1": {
+              "patterns": [
+                {
+                  "include": "#inline_comment"
+                }
+              ]
+            },
+            "2": {
+              "name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+            },
+            "3": {
+              "name": "comment.block.cpp"
+            },
+            "4": {
+              "patterns": [
+                {
+                  "match": "\\*\\/",
+                  "name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+                },
+                {
+                  "match": "\\*",
+                  "name": "comment.block.cpp"
+                }
+              ]
+            },
+            "5": {
+              "name": "variable.parameter.cpp"
+            },
+            "6": {
+              "patterns": [
+                {
+                  "include": "#inline_comment"
+                }
+              ]
+            },
+            "7": {
+              "name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+            },
+            "8": {
+              "name": "comment.block.cpp"
+            },
+            "9": {
+              "patterns": [
+                {
+                  "match": "\\*\\/",
+                  "name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+                },
+                {
+                  "match": "\\*",
+                  "name": "comment.block.cpp"
+                }
+              ]
+            }
+          }
+        },
+        {
+          "include": "#attributes_context"
+        },
+        {
+          "name": "meta.bracket.square.array.cpp",
+          "begin": "(\\[)",
+          "beginCaptures": {
+            "1": {
+              "name": "punctuation.definition.begin.bracket.square.array.type.cpp"
+            }
+          },
+          "end": "(\\])|(?=(?<!\\\\)\n)",
+          "endCaptures": {
+            "1": {
+              "name": "punctuation.definition.end.bracket.square.array.type.cpp"
+            }
+          },
+          "patterns": [
+            {
+              "include": "#evaluation_context"
+            }
+          ]
+        },
+        {
+          "match": "(?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*\\b(?<!\\Wstruct|^struct|\\Wclass|^class|\\Wunion|^union|\\Wenum|^enum)",
+          "name": "entity.name.type.parameter.cpp"
+        },
+        {
+          "include": "#template_call_range"
+        },
+        {
+          "match": "((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))?(?:(?:\\&|\\*)((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z)))))*(?:\\&|\\*)",
+          "captures": {
+            "0": {
+              "patterns": [
+                {
+                  "match": "\\*",
+                  "name": "storage.modifier.pointer.cpp"
+                },
+                {
+                  "match": "(?:\\&((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))){2,}\\&",
+                  "captures": {
+                    "1": {
+                      "patterns": [
+                        {
+                          "include": "#inline_comment"
+                        }
+                      ]
+                    },
+                    "2": {
+                      "name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+                    },
+                    "3": {
+                      "name": "comment.block.cpp"
+                    },
+                    "4": {
+                      "patterns": [
+                        {
+                          "match": "\\*\\/",
+                          "name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+                        },
+                        {
+                          "match": "\\*",
+                          "name": "comment.block.cpp"
+                        }
+                      ]
+                    }
+                  },
+                  "name": "invalid.illegal.reference-type.cpp"
+                },
+                {
+                  "match": "\\&",
+                  "name": "storage.modifier.reference.cpp"
+                }
+              ]
+            },
+            "1": {
+              "patterns": [
+                {
+                  "include": "#inline_comment"
+                }
+              ]
+            },
+            "2": {
+              "name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+            },
+            "3": {
+              "name": "comment.block.cpp"
+            },
+            "4": {
+              "patterns": [
+                {
+                  "match": "\\*\\/",
+                  "name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+                },
+                {
+                  "match": "\\*",
+                  "name": "comment.block.cpp"
+                }
+              ]
+            },
+            "5": {
+              "patterns": [
+                {
+                  "include": "#inline_comment"
+                }
+              ]
+            },
+            "6": {
+              "name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+            },
+            "7": {
+              "name": "comment.block.cpp"
+            },
+            "8": {
+              "patterns": [
+                {
+                  "match": "\\*\\/",
+                  "name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+                },
+                {
+                  "match": "\\*",
+                  "name": "comment.block.cpp"
+                }
+              ]
+            }
+          }
+        },
+        {
+          "include": "#evaluation_context"
+        }
+      ]
+    },
+    "parameter_struct": {
+      "match": "(struct)((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))((?<!\\w)(?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*(?!\\w))((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))(?:(((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))?(?:(?:\\&|\\*)((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z)))))*(?:\\&|\\*))((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z)))))?((?:(?<!\\w)(?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*(?!\\w))?)((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))(?:\\[((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))\\]((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z)))))?(?=,|\\)|\\n)",
+      "captures": {
+        "1": {
+          "name": "storage.type.struct.parameter.cpp"
+        },
+        "2": {
+          "patterns": [
+            {
+              "include": "#inline_comment"
+            }
+          ]
+        },
+        "3": {
+          "name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+        },
+        "4": {
+          "name": "comment.block.cpp"
+        },
+        "5": {
+          "patterns": [
+            {
+              "match": "\\*\\/",
+              "name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+            },
+            {
+              "match": "\\*",
+              "name": "comment.block.cpp"
+            }
+          ]
+        },
+        "6": {
+          "name": "entity.name.type.struct.parameter.cpp"
+        },
+        "7": {
+          "patterns": [
+            {
+              "include": "#inline_comment"
+            }
+          ]
+        },
+        "8": {
+          "name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+        },
+        "9": {
+          "name": "comment.block.cpp"
+        },
+        "10": {
+          "patterns": [
+            {
+              "match": "\\*\\/",
+              "name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+            },
+            {
+              "match": "\\*",
+              "name": "comment.block.cpp"
+            }
+          ]
+        },
+        "11": {
+          "patterns": [
+            {
+              "match": "\\*",
+              "name": "storage.modifier.pointer.cpp"
+            },
+            {
+              "match": "(?:\\&((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))){2,}\\&",
+              "captures": {
+                "1": {
+                  "patterns": [
+                    {
+                      "include": "#inline_comment"
+                    }
+                  ]
+                },
+                "2": {
+                  "name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+                },
+                "3": {
+                  "name": "comment.block.cpp"
+                },
+                "4": {
+                  "patterns": [
+                    {
+                      "match": "\\*\\/",
+                      "name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+                    },
+                    {
+                      "match": "\\*",
+                      "name": "comment.block.cpp"
+                    }
+                  ]
+                }
+              },
+              "name": "invalid.illegal.reference-type.cpp"
+            },
+            {
+              "match": "\\&",
+              "name": "storage.modifier.reference.cpp"
+            }
+          ]
+        },
+        "12": {
+          "patterns": [
+            {
+              "include": "#inline_comment"
+            }
+          ]
+        },
+        "13": {
+          "name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+        },
+        "14": {
+          "name": "comment.block.cpp"
+        },
+        "15": {
+          "patterns": [
+            {
+              "match": "\\*\\/",
+              "name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+            },
+            {
+              "match": "\\*",
+              "name": "comment.block.cpp"
+            }
+          ]
+        },
+        "16": {
+          "patterns": [
+            {
+              "include": "#inline_comment"
+            }
+          ]
+        },
+        "17": {
+          "name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+        },
+        "18": {
+          "name": "comment.block.cpp"
+        },
+        "19": {
+          "patterns": [
+            {
+              "match": "\\*\\/",
+              "name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+            },
+            {
+              "match": "\\*",
+              "name": "comment.block.cpp"
+            }
+          ]
+        },
+        "20": {
+          "patterns": [
+            {
+              "include": "#inline_comment"
+            }
+          ]
+        },
+        "21": {
+          "name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+        },
+        "22": {
+          "name": "comment.block.cpp"
+        },
+        "23": {
+          "patterns": [
+            {
+              "match": "\\*\\/",
+              "name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+            },
+            {
+              "match": "\\*",
+              "name": "comment.block.cpp"
+            }
+          ]
+        },
+        "24": {
+          "name": "variable.other.object.declare.cpp"
+        },
+        "25": {
+          "patterns": [
+            {
+              "include": "#inline_comment"
+            }
+          ]
+        },
+        "26": {
+          "name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+        },
+        "27": {
+          "name": "comment.block.cpp"
+        },
+        "28": {
+          "patterns": [
+            {
+              "match": "\\*\\/",
+              "name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+            },
+            {
+              "match": "\\*",
+              "name": "comment.block.cpp"
+            }
+          ]
+        },
+        "29": {
+          "patterns": [
+            {
+              "include": "#inline_comment"
+            }
+          ]
+        },
+        "30": {
+          "name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+        },
+        "31": {
+          "name": "comment.block.cpp"
+        },
+        "32": {
+          "patterns": [
+            {
+              "match": "\\*\\/",
+              "name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+            },
+            {
+              "match": "\\*",
+              "name": "comment.block.cpp"
+            }
+          ]
+        },
+        "33": {
+          "patterns": [
+            {
+              "include": "#inline_comment"
+            }
+          ]
+        },
+        "34": {
+          "name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+        },
+        "35": {
+          "name": "comment.block.cpp"
+        },
+        "36": {
+          "patterns": [
+            {
+              "match": "\\*\\/",
+              "name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+            },
+            {
+              "match": "\\*",
+              "name": "comment.block.cpp"
+            }
+          ]
+        }
+      }
+    },
+    "parameter_union": {
+      "match": "(union)((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))((?<!\\w)(?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*(?!\\w))((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))(?:(((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))?(?:(?:\\&|\\*)((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z)))))*(?:\\&|\\*))((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z)))))?((?:(?<!\\w)(?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*(?!\\w))?)((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))(?:\\[((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))\\]((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z)))))?(?=,|\\)|\\n)",
+      "captures": {
+        "1": {
+          "name": "storage.type.union.parameter.cpp"
+        },
+        "2": {
+          "patterns": [
+            {
+              "include": "#inline_comment"
+            }
+          ]
+        },
+        "3": {
+          "name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+        },
+        "4": {
+          "name": "comment.block.cpp"
+        },
+        "5": {
+          "patterns": [
+            {
+              "match": "\\*\\/",
+              "name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+            },
+            {
+              "match": "\\*",
+              "name": "comment.block.cpp"
+            }
+          ]
+        },
+        "6": {
+          "name": "entity.name.type.union.parameter.cpp"
+        },
+        "7": {
+          "patterns": [
+            {
+              "include": "#inline_comment"
+            }
+          ]
+        },
+        "8": {
+          "name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+        },
+        "9": {
+          "name": "comment.block.cpp"
+        },
+        "10": {
+          "patterns": [
+            {
+              "match": "\\*\\/",
+              "name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+            },
+            {
+              "match": "\\*",
+              "name": "comment.block.cpp"
+            }
+          ]
+        },
+        "11": {
+          "patterns": [
+            {
+              "match": "\\*",
+              "name": "storage.modifier.pointer.cpp"
+            },
+            {
+              "match": "(?:\\&((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))){2,}\\&",
+              "captures": {
+                "1": {
+                  "patterns": [
+                    {
+                      "include": "#inline_comment"
+                    }
+                  ]
+                },
+                "2": {
+                  "name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+                },
+                "3": {
+                  "name": "comment.block.cpp"
+                },
+                "4": {
+                  "patterns": [
+                    {
+                      "match": "\\*\\/",
+                      "name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+                    },
+                    {
+                      "match": "\\*",
+                      "name": "comment.block.cpp"
+                    }
+                  ]
+                }
+              },
+              "name": "invalid.illegal.reference-type.cpp"
+            },
+            {
+              "match": "\\&",
+              "name": "storage.modifier.reference.cpp"
+            }
+          ]
+        },
+        "12": {
+          "patterns": [
+            {
+              "include": "#inline_comment"
+            }
+          ]
+        },
+        "13": {
+          "name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+        },
+        "14": {
+          "name": "comment.block.cpp"
+        },
+        "15": {
+          "patterns": [
+            {
+              "match": "\\*\\/",
+              "name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+            },
+            {
+              "match": "\\*",
+              "name": "comment.block.cpp"
+            }
+          ]
+        },
+        "16": {
+          "patterns": [
+            {
+              "include": "#inline_comment"
+            }
+          ]
+        },
+        "17": {
+          "name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+        },
+        "18": {
+          "name": "comment.block.cpp"
+        },
+        "19": {
+          "patterns": [
+            {
+              "match": "\\*\\/",
+              "name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+            },
+            {
+              "match": "\\*",
+              "name": "comment.block.cpp"
+            }
+          ]
+        },
+        "20": {
+          "patterns": [
+            {
+              "include": "#inline_comment"
+            }
+          ]
+        },
+        "21": {
+          "name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+        },
+        "22": {
+          "name": "comment.block.cpp"
+        },
+        "23": {
+          "patterns": [
+            {
+              "match": "\\*\\/",
+              "name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+            },
+            {
+              "match": "\\*",
+              "name": "comment.block.cpp"
+            }
+          ]
+        },
+        "24": {
+          "name": "variable.other.object.declare.cpp"
+        },
+        "25": {
+          "patterns": [
+            {
+              "include": "#inline_comment"
+            }
+          ]
+        },
+        "26": {
+          "name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+        },
+        "27": {
+          "name": "comment.block.cpp"
+        },
+        "28": {
+          "patterns": [
+            {
+              "match": "\\*\\/",
+              "name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+            },
+            {
+              "match": "\\*",
+              "name": "comment.block.cpp"
+            }
+          ]
+        },
+        "29": {
+          "patterns": [
+            {
+              "include": "#inline_comment"
+            }
+          ]
+        },
+        "30": {
+          "name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+        },
+        "31": {
+          "name": "comment.block.cpp"
+        },
+        "32": {
+          "patterns": [
+            {
+              "match": "\\*\\/",
+              "name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+            },
+            {
+              "match": "\\*",
+              "name": "comment.block.cpp"
+            }
+          ]
+        },
+        "33": {
+          "patterns": [
+            {
+              "include": "#inline_comment"
+            }
+          ]
+        },
+        "34": {
+          "name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+        },
+        "35": {
+          "name": "comment.block.cpp"
+        },
+        "36": {
+          "patterns": [
+            {
+              "match": "\\*\\/",
+              "name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+            },
+            {
+              "match": "\\*",
+              "name": "comment.block.cpp"
+            }
+          ]
+        }
+      }
+    },
+    "parentheses": {
+      "name": "meta.parens.cpp",
+      "begin": "(\\()",
+      "beginCaptures": {
+        "1": {
+          "name": "punctuation.section.parens.begin.bracket.round.cpp"
+        }
+      },
+      "end": "(\\))|(?=(?<!\\\\)\n)",
+      "endCaptures": {
+        "1": {
+          "name": "punctuation.section.parens.end.bracket.round.cpp"
+        }
+      },
+      "patterns": [
+        {
+          "include": "#over_qualified_types"
+        },
+        {
+          "match": "(?<!:):(?!:)",
+          "name": "punctuation.separator.colon.range-based.cpp"
+        },
+        {
+          "include": "#evaluation_context"
+        }
+      ]
+    },
+    "posix_reserved_types": {
+      "match": "((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))((?<!\\w)[a-zA-Z_]\\w*_t(?!\\w))",
+      "captures": {
+        "1": {
+          "patterns": [
+            {
+              "include": "#inline_comment"
+            }
+          ]
+        },
+        "2": {
+          "name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+        },
+        "3": {
+          "name": "comment.block.cpp"
+        },
+        "4": {
+          "patterns": [
+            {
+              "match": "\\*\\/",
+              "name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+            },
+            {
+              "match": "\\*",
+              "name": "comment.block.cpp"
+            }
+          ]
+        },
+        "5": {
+          "name": "support.type.posix-reserved.cpp support.type.built-in.posix-reserved.cpp"
+        }
+      }
+    },
+    "pragma": {
+      "name": "meta.preprocessor.pragma.cpp",
+      "begin": "((?:^)((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))(#)\\s*pragma\\b)",
+      "beginCaptures": {
+        "1": {
+          "name": "keyword.control.directive.pragma.cpp"
+        },
+        "2": {
+          "patterns": [
+            {
+              "include": "#inline_comment"
+            }
+          ]
+        },
+        "3": {
+          "name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+        },
+        "4": {
+          "name": "comment.block.cpp"
+        },
+        "5": {
+          "patterns": [
+            {
+              "match": "\\*\\/",
+              "name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+            },
+            {
+              "match": "\\*",
+              "name": "comment.block.cpp"
+            }
+          ]
+        },
+        "6": {
+          "name": "punctuation.definition.directive.cpp"
+        }
+      },
+      "end": "(?<!\\\\)(?=\\n)|(?=(?<!\\\\)\n)",
+      "patterns": [
+        {
+          "include": "#comments"
+        },
+        {
+          "include": "#string_context_c"
+        },
+        {
+          "match": "[a-zA-Z_$][\\w\\-$]*",
+          "name": "entity.other.attribute-name.pragma.preprocessor.cpp"
+        },
+        {
+          "include": "#preprocessor_number_literal"
+        },
+        {
+          "include": "#line_continuation_character"
+        }
+      ]
+    },
+    "pragma_mark": {
+      "match": "((?:^)((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))(#)\\s*pragma\\s+mark)\\s+(.*)",
+      "captures": {
+        "1": {
+          "name": "keyword.control.directive.pragma.pragma-mark.cpp"
+        },
+        "2": {
+          "patterns": [
+            {
+              "include": "#inline_comment"
+            }
+          ]
+        },
+        "3": {
+          "name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+        },
+        "4": {
+          "name": "comment.block.cpp"
+        },
+        "5": {
+          "patterns": [
+            {
+              "match": "\\*\\/",
+              "name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+            },
+            {
+              "match": "\\*",
+              "name": "comment.block.cpp"
+            }
+          ]
+        },
+        "6": {
+          "name": "punctuation.definition.directive.cpp"
+        },
+        "7": {
+          "name": "entity.name.tag.pragma-mark.cpp"
+        }
+      },
+      "name": "meta.preprocessor.pragma.cpp"
+    },
+    "predefined_macros": {
+      "patterns": [
+        {
+          "match": "\\b(__cplusplus|__DATE__|__FILE__|__LINE__|__STDC__|__STDC_HOSTED__|__STDC_NO_COMPLEX__|__STDC_VERSION__|__STDCPP_THREADS__|__TIME__|NDEBUG|__OBJC__|__ASSEMBLER__|__ATOM__|__AVX__|__AVX2__|_CHAR_UNSIGNED|__CLR_VER|_CONTROL_FLOW_GUARD|__COUNTER__|__cplusplus_cli|__cplusplus_winrt|_CPPRTTI|_CPPUNWIND|_DEBUG|_DLL|__FUNCDNAME__|__FUNCSIG__|__FUNCTION__|_INTEGRAL_MAX_BITS|__INTELLISENSE__|_ISO_VOLATILE|_KERNEL_MODE|_M_AMD64|_M_ARM|_M_ARM_ARMV7VE|_M_ARM_FP|_M_ARM64|_M_CEE|_M_CEE_PURE|_M_CEE_SAFE|_M_FP_EXCEPT|_M_FP_FAST|_M_FP_PRECISE|_M_FP_STRICT|_M_IX86|_M_IX86_FP|_M_X64|_MANAGED|_MSC_BUILD|_MSC_EXTENSIONS|_MSC_FULL_VER|_MSC_VER|_MSVC_LANG|__MSVC_RUNTIME_CHECKS|_MT|_NATIVE_WCHAR_T_DEFINED|_OPENMP|_PREFAST|__TIMESTAMP__|_VC_NO_DEFAULTLIB|_WCHAR_T_DEFINED|_WIN32|_WIN64|_WINRT_DLL|_ATL_VER|_MFC_VER|__GFORTRAN__|__GNUC__|__GNUC_MINOR__|__GNUC_PATCHLEVEL__|__GNUG__|__STRICT_ANSI__|__BASE_FILE__|__INCLUDE_LEVEL__|__ELF__|__VERSION__|__OPTIMIZE__|__OPTIMIZE_SIZE__|__NO_INLINE__|__GNUC_STDC_INLINE__|__CHAR_UNSIGNED__|__WCHAR_UNSIGNED__|__REGISTER_PREFIX__|__REGISTER_PREFIX__|__SIZE_TYPE__|__PTRDIFF_TYPE__|__WCHAR_TYPE__|__WINT_TYPE__|__INTMAX_TYPE__|__UINTMAX_TYPE__|__SIG_ATOMIC_TYPE__|__INT8_TYPE__|__INT16_TYPE__|__INT32_TYPE__|__INT64_TYPE__|__UINT8_TYPE__|__UINT16_TYPE__|__UINT32_TYPE__|__UINT64_TYPE__|__INT_LEAST8_TYPE__|__INT_LEAST16_TYPE__|__INT_LEAST32_TYPE__|__INT_LEAST64_TYPE__|__UINT_LEAST8_TYPE__|__UINT_LEAST16_TYPE__|__UINT_LEAST32_TYPE__|__UINT_LEAST64_TYPE__|__INT_FAST8_TYPE__|__INT_FAST16_TYPE__|__INT_FAST32_TYPE__|__INT_FAST64_TYPE__|__UINT_FAST8_TYPE__|__UINT_FAST16_TYPE__|__UINT_FAST32_TYPE__|__UINT_FAST64_TYPE__|__INTPTR_TYPE__|__UINTPTR_TYPE__|__CHAR_BIT__|__SCHAR_MAX__|__WCHAR_MAX__|__SHRT_MAX__|__INT_MAX__|__LONG_MAX__|__LONG_LONG_MAX__|__WINT_MAX__|__SIZE_MAX__|__PTRDIFF_MAX__|__INTMAX_MAX__|__UINTMAX_MAX__|__SIG_ATOMIC_MAX__|__INT8_MAX__|__INT16_MAX__|__INT32_MAX__|__INT64_MAX__|__UINT8_MAX__|__UINT16_MAX__|__UINT32_MAX__|__UINT64_MAX__|__INT_LEAST8_MAX__|__INT_LEAST16_MAX__|__INT_LEAST32_MAX__|__INT_LEAST64_MAX__|__UINT_LEAST8_MAX__|__UINT_LEAST16_MAX__|__UINT_LEAST32_MAX__|__UINT_LEAST64_MAX__|__INT_FAST8_MAX__|__INT_FAST16_MAX__|__INT_FAST32_MAX__|__INT_FAST64_MAX__|__UINT_FAST8_MAX__|__UINT_FAST16_MAX__|__UINT_FAST32_MAX__|__UINT_FAST64_MAX__|__INTPTR_MAX__|__UINTPTR_MAX__|__WCHAR_MIN__|__WINT_MIN__|__SIG_ATOMIC_MIN__|__SCHAR_WIDTH__|__SHRT_WIDTH__|__INT_WIDTH__|__LONG_WIDTH__|__LONG_LONG_WIDTH__|__PTRDIFF_WIDTH__|__SIG_ATOMIC_WIDTH__|__SIZE_WIDTH__|__WCHAR_WIDTH__|__WINT_WIDTH__|__INT_LEAST8_WIDTH__|__INT_LEAST16_WIDTH__|__INT_LEAST32_WIDTH__|__INT_LEAST64_WIDTH__|__INT_FAST8_WIDTH__|__INT_FAST16_WIDTH__|__INT_FAST32_WIDTH__|__INT_FAST64_WIDTH__|__INTPTR_WIDTH__|__INTMAX_WIDTH__|__SIZEOF_INT__|__SIZEOF_LONG__|__SIZEOF_LONG_LONG__|__SIZEOF_SHORT__|__SIZEOF_POINTER__|__SIZEOF_FLOAT__|__SIZEOF_DOUBLE__|__SIZEOF_LONG_DOUBLE__|__SIZEOF_SIZE_T__|__SIZEOF_WCHAR_T__|__SIZEOF_WINT_T__|__SIZEOF_PTRDIFF_T__|__BYTE_ORDER__|__ORDER_LITTLE_ENDIAN__|__ORDER_BIG_ENDIAN__|__ORDER_PDP_ENDIAN__|__FLOAT_WORD_ORDER__|__DEPRECATED|__EXCEPTIONS|__GXX_RTTI|__USING_SJLJ_EXCEPTIONS__|__GXX_EXPERIMENTAL_CXX0X__|__GXX_WEAK__|__NEXT_RUNTIME__|__LP64__|_LP64|__SSP__|__SSP_ALL__|__SSP_STRONG__|__SSP_EXPLICIT__|__SANITIZE_ADDRESS__|__SANITIZE_THREAD__|__GCC_HAVE_SYNC_COMPARE_AND_SWAP_1|__GCC_HAVE_SYNC_COMPARE_AND_SWAP_2|__GCC_HAVE_SYNC_COMPARE_AND_SWAP_4|__GCC_HAVE_SYNC_COMPARE_AND_SWAP_8|__GCC_HAVE_SYNC_COMPARE_AND_SWAP_16|__HAVE_SPECULATION_SAFE_VALUE|__GCC_HAVE_DWARF2_CFI_ASM|__FP_FAST_FMA|__FP_FAST_FMAF|__FP_FAST_FMAL|__FP_FAST_FMAF16|__FP_FAST_FMAF32|__FP_FAST_FMAF64|__FP_FAST_FMAF128|__FP_FAST_FMAF32X|__FP_FAST_FMAF64X|__FP_FAST_FMAF128X|__GCC_IEC_559|__GCC_IEC_559_COMPLEX|__NO_MATH_ERRNO__|__has_builtin|__has_feature|__has_extension|__has_cpp_attribute|__has_c_attribute|__has_attribute|__has_declspec_attribute|__is_identifier|__has_include|__has_include_next|__has_warning|__BASE_FILE__|__FILE_NAME__|__clang__|__clang_major__|__clang_minor__|__clang_patchlevel__|__clang_version__|__fp16|_Float16)\\b",
+          "captures": {
+            "1": {
+              "name": "entity.name.other.preprocessor.macro.predefined.$1.cpp"
+            }
+          }
+        },
+        {
+          "match": "\\b__([A-Z_]+)__\\b",
+          "name": "entity.name.other.preprocessor.macro.predefined.probably.$1.cpp"
+        }
+      ]
+    },
+    "preprocessor_conditional_context": {
+      "patterns": [
+        {
+          "include": "#preprocessor_conditional_defined"
+        },
+        {
+          "include": "#comments"
+        },
+        {
+          "include": "#language_constants"
+        },
+        {
+          "include": "#string_context_c"
+        },
+        {
+          "include": "#preprocessor_number_literal"
+        },
+        {
+          "include": "#operators"
+        },
+        {
+          "include": "#predefined_macros"
+        },
+        {
+          "include": "#macro_name"
+        },
+        {
+          "include": "#line_continuation_character"
+        }
+      ]
+    },
+    "preprocessor_conditional_defined": {
+      "begin": "((?<!\\w)defined(?!\\w))(\\()",
+      "beginCaptures": {
+        "1": {
+          "name": "keyword.control.directive.conditional.defined.cpp"
+        },
+        "2": {
+          "name": "punctuation.section.parens.control.defined.cpp"
+        }
+      },
+      "end": "((?:\\)|(?<!\\\\)(?=\\n)))|(?=(?<!\\\\)\n)",
+      "endCaptures": {
+        "1": {
+          "name": "punctuation.section.parens.control.defined.cpp"
+        }
+      },
+      "patterns": [
+        {
+          "include": "#macro_name"
+        }
+      ]
+    },
+    "preprocessor_conditional_parentheses": {
+      "name": "meta.parens.preprocessor.conditional.cpp",
+      "begin": "(\\()",
+      "beginCaptures": {
+        "1": {
+          "name": "punctuation.section.parens.begin.bracket.round.cpp"
+        }
+      },
+      "end": "(\\))|(?=(?<!\\\\)\n)",
+      "endCaptures": {
+        "1": {
+          "name": "punctuation.section.parens.end.bracket.round.cpp"
+        }
+      }
+    },
+    "preprocessor_conditional_range": {
+      "begin": "((?:^)((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))(#)\\s*((?:(?:ifndef|ifdef)|if)))",
+      "beginCaptures": {
+        "1": {
+          "name": "keyword.control.directive.conditional.$7.cpp"
+        },
+        "2": {
+          "patterns": [
+            {
+              "include": "#inline_comment"
+            }
+          ]
+        },
+        "3": {
+          "name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+        },
+        "4": {
+          "name": "comment.block.cpp"
+        },
+        "5": {
+          "patterns": [
+            {
+              "match": "\\*\\/",
+              "name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+            },
+            {
+              "match": "\\*",
+              "name": "comment.block.cpp"
+            }
+          ]
+        },
+        "6": {
+          "name": "punctuation.definition.directive.cpp"
+        }
+      },
+      "end": "(?:^)(?!\\s*+#\\s*(?:else|endif))|(?=(?<!\\\\)\n)",
+      "patterns": [
+        {
+          "name": "meta.preprocessor.conditional.cpp",
+          "begin": "\\G(?<=ifndef|ifdef|if)",
+          "end": "(?<!\\\\)(?=\\n)|(?=(?<!\\\\)\n)",
+          "patterns": [
+            {
+              "include": "#preprocessor_conditional_context"
+            }
+          ]
+        },
+        {
+          "include": "$self"
+        }
+      ]
+    },
+    "preprocessor_conditional_standalone": {
+      "match": "(?:^)((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))(#)\\s*((?<!\\w)(?:endif|else|elif)(?!\\w))",
+      "captures": {
+        "1": {
+          "patterns": [
+            {
+              "include": "#inline_comment"
+            }
+          ]
+        },
+        "2": {
+          "name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+        },
+        "3": {
+          "name": "comment.block.cpp"
+        },
+        "4": {
+          "patterns": [
+            {
+              "match": "\\*\\/",
+              "name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+            },
+            {
+              "match": "\\*",
+              "name": "comment.block.cpp"
+            }
+          ]
+        },
+        "5": {
+          "name": "punctuation.definition.directive.cpp"
+        }
+      },
+      "name": "keyword.control.directive.$6.cpp"
+    },
+    "preprocessor_number_literal": {
+      "match": "(?<!\\w)\\.?\\d(?:(?:[0-9a-zA-Z_\\.]|')|(?<=[eEpP])[+-])*",
+      "captures": {
+        "0": {
+          "patterns": [
+            {
+              "begin": "(?=.)",
+              "end": "$|(?=(?<!\\\\)\n)",
+              "patterns": [
+                {
+                  "match": "(\\G0[xX])([0-9a-fA-F](?:[0-9a-fA-F]|((?<=[0-9a-fA-F])'(?=[0-9a-fA-F])))*)?((?:(?<=[0-9a-fA-F])\\.|\\.(?=[0-9a-fA-F])))([0-9a-fA-F](?:[0-9a-fA-F]|((?<=[0-9a-fA-F])'(?=[0-9a-fA-F])))*)?((?<!')([pP])(\\+?)(\\-?)((?:[0-9](?:[0-9]|(?:(?<=[0-9a-fA-F])'(?=[0-9a-fA-F])))*)))?([lLfF](?!\\w))?$",
+                  "captures": {
+                    "1": {
+                      "name": "keyword.other.unit.hexadecimal.cpp"
+                    },
+                    "2": {
+                      "name": "constant.numeric.hexadecimal.cpp",
+                      "patterns": [
+                        {
+                          "match": "(?<=[0-9a-fA-F])'(?=[0-9a-fA-F])",
+                          "name": "punctuation.separator.constant.numeric.cpp"
+                        }
+                      ]
+                    },
+                    "3": {
+                      "name": "punctuation.separator.constant.numeric.cpp"
+                    },
+                    "4": {
+                      "name": "constant.numeric.hexadecimal.cpp"
+                    },
+                    "5": {
+                      "name": "constant.numeric.hexadecimal.cpp",
+                      "patterns": [
+                        {
+                          "match": "(?<=[0-9a-fA-F])'(?=[0-9a-fA-F])",
+                          "name": "punctuation.separator.constant.numeric.cpp"
+                        }
+                      ]
+                    },
+                    "6": {
+                      "name": "punctuation.separator.constant.numeric.cpp"
+                    },
+                    "8": {
+                      "name": "keyword.other.unit.exponent.hexadecimal.cpp"
+                    },
+                    "9": {
+                      "name": "keyword.operator.plus.exponent.hexadecimal.cpp"
+                    },
+                    "10": {
+                      "name": "keyword.operator.minus.exponent.hexadecimal.cpp"
+                    },
+                    "11": {
+                      "name": "constant.numeric.exponent.hexadecimal.cpp",
+                      "patterns": [
+                        {
+                          "match": "(?<=[0-9a-fA-F])'(?=[0-9a-fA-F])",
+                          "name": "punctuation.separator.constant.numeric.cpp"
+                        }
+                      ]
+                    },
+                    "12": {
+                      "name": "keyword.other.unit.suffix.floating-point.cpp"
+                    }
+                  }
+                },
+                {
+                  "match": "(\\G(?=[0-9.])(?!0[xXbB]))([0-9](?:[0-9]|((?<=[0-9a-fA-F])'(?=[0-9a-fA-F])))*)?((?:(?<=[0-9])\\.|\\.(?=[0-9])))([0-9](?:[0-9]|((?<=[0-9a-fA-F])'(?=[0-9a-fA-F])))*)?((?<!')([eE])(\\+?)(\\-?)((?:[0-9](?:[0-9]|(?:(?<=[0-9a-fA-F])'(?=[0-9a-fA-F])))*)))?([lLfF](?!\\w))?$",
+                  "captures": {
+                    "2": {
+                      "name": "constant.numeric.decimal.cpp",
+                      "patterns": [
+                        {
+                          "match": "(?<=[0-9a-fA-F])'(?=[0-9a-fA-F])",
+                          "name": "punctuation.separator.constant.numeric.cpp"
+                        }
+                      ]
+                    },
+                    "3": {
+                      "name": "punctuation.separator.constant.numeric.cpp"
+                    },
+                    "4": {
+                      "name": "constant.numeric.decimal.point.cpp"
+                    },
+                    "5": {
+                      "name": "constant.numeric.decimal.cpp",
+                      "patterns": [
+                        {
+                          "match": "(?<=[0-9a-fA-F])'(?=[0-9a-fA-F])",
+                          "name": "punctuation.separator.constant.numeric.cpp"
+                        }
+                      ]
+                    },
+                    "6": {
+                      "name": "punctuation.separator.constant.numeric.cpp"
+                    },
+                    "8": {
+                      "name": "keyword.other.unit.exponent.decimal.cpp"
+                    },
+                    "9": {
+                      "name": "keyword.operator.plus.exponent.decimal.cpp"
+                    },
+                    "10": {
+                      "name": "keyword.operator.minus.exponent.decimal.cpp"
+                    },
+                    "11": {
+                      "name": "constant.numeric.exponent.decimal.cpp",
+                      "patterns": [
+                        {
+                          "match": "(?<=[0-9a-fA-F])'(?=[0-9a-fA-F])",
+                          "name": "punctuation.separator.constant.numeric.cpp"
+                        }
+                      ]
+                    },
+                    "12": {
+                      "name": "keyword.other.unit.suffix.floating-point.cpp"
+                    }
+                  }
+                },
+                {
+                  "match": "(\\G0[bB])([01](?:[01]|((?<=[0-9a-fA-F])'(?=[0-9a-fA-F])))*)((?:(?:(?:(?:(?:[uU]|[uU]ll?)|[uU]LL?)|ll?[uU]?)|LL?[uU]?)|[fF])(?!\\w))?$",
+                  "captures": {
+                    "1": {
+                      "name": "keyword.other.unit.binary.cpp"
+                    },
+                    "2": {
+                      "name": "constant.numeric.binary.cpp",
+                      "patterns": [
+                        {
+                          "match": "(?<=[0-9a-fA-F])'(?=[0-9a-fA-F])",
+                          "name": "punctuation.separator.constant.numeric.cpp"
+                        }
+                      ]
+                    },
+                    "3": {
+                      "name": "punctuation.separator.constant.numeric.cpp"
+                    },
+                    "4": {
+                      "name": "keyword.other.unit.suffix.integer.cpp"
+                    }
+                  }
+                },
+                {
+                  "match": "(\\G0)((?:[0-7]|((?<=[0-9a-fA-F])'(?=[0-9a-fA-F])))+)((?:(?:(?:(?:(?:[uU]|[uU]ll?)|[uU]LL?)|ll?[uU]?)|LL?[uU]?)|[fF])(?!\\w))?$",
+                  "captures": {
+                    "1": {
+                      "name": "keyword.other.unit.octal.cpp"
+                    },
+                    "2": {
+                      "name": "constant.numeric.octal.cpp",
+                      "patterns": [
+                        {
+                          "match": "(?<=[0-9a-fA-F])'(?=[0-9a-fA-F])",
+                          "name": "punctuation.separator.constant.numeric.cpp"
+                        }
+                      ]
+                    },
+                    "3": {
+                      "name": "punctuation.separator.constant.numeric.cpp"
+                    },
+                    "4": {
+                      "name": "keyword.other.unit.suffix.integer.cpp"
+                    }
+                  }
+                },
+                {
+                  "match": "(\\G0[xX])([0-9a-fA-F](?:[0-9a-fA-F]|((?<=[0-9a-fA-F])'(?=[0-9a-fA-F])))*)((?<!')([pP])(\\+?)(\\-?)((?:[0-9](?:[0-9]|(?:(?<=[0-9a-fA-F])'(?=[0-9a-fA-F])))*)))?((?:(?:(?:(?:(?:[uU]|[uU]ll?)|[uU]LL?)|ll?[uU]?)|LL?[uU]?)|[fF])(?!\\w))?$",
+                  "captures": {
+                    "1": {
+                      "name": "keyword.other.unit.hexadecimal.cpp"
+                    },
+                    "2": {
+                      "name": "constant.numeric.hexadecimal.cpp",
+                      "patterns": [
+                        {
+                          "match": "(?<=[0-9a-fA-F])'(?=[0-9a-fA-F])",
+                          "name": "punctuation.separator.constant.numeric.cpp"
+                        }
+                      ]
+                    },
+                    "3": {
+                      "name": "punctuation.separator.constant.numeric.cpp"
+                    },
+                    "5": {
+                      "name": "keyword.other.unit.exponent.hexadecimal.cpp"
+                    },
+                    "6": {
+                      "name": "keyword.operator.plus.exponent.hexadecimal.cpp"
+                    },
+                    "7": {
+                      "name": "keyword.operator.minus.exponent.hexadecimal.cpp"
+                    },
+                    "8": {
+                      "name": "constant.numeric.exponent.hexadecimal.cpp",
+                      "patterns": [
+                        {
+                          "match": "(?<=[0-9a-fA-F])'(?=[0-9a-fA-F])",
+                          "name": "punctuation.separator.constant.numeric.cpp"
+                        }
+                      ]
+                    },
+                    "9": {
+                      "name": "keyword.other.unit.suffix.integer.cpp"
+                    }
+                  }
+                },
+                {
+                  "match": "(\\G(?=[0-9.])(?!0[xXbB]))([0-9](?:[0-9]|((?<=[0-9a-fA-F])'(?=[0-9a-fA-F])))*)((?<!')([eE])(\\+?)(\\-?)((?:[0-9](?:[0-9]|(?:(?<=[0-9a-fA-F])'(?=[0-9a-fA-F])))*)))?((?:(?:(?:(?:(?:[uU]|[uU]ll?)|[uU]LL?)|ll?[uU]?)|LL?[uU]?)|[fF])(?!\\w))?$",
+                  "captures": {
+                    "2": {
+                      "name": "constant.numeric.decimal.cpp",
+                      "patterns": [
+                        {
+                          "match": "(?<=[0-9a-fA-F])'(?=[0-9a-fA-F])",
+                          "name": "punctuation.separator.constant.numeric.cpp"
+                        }
+                      ]
+                    },
+                    "3": {
+                      "name": "punctuation.separator.constant.numeric.cpp"
+                    },
+                    "5": {
+                      "name": "keyword.other.unit.exponent.decimal.cpp"
+                    },
+                    "6": {
+                      "name": "keyword.operator.plus.exponent.decimal.cpp"
+                    },
+                    "7": {
+                      "name": "keyword.operator.minus.exponent.decimal.cpp"
+                    },
+                    "8": {
+                      "name": "constant.numeric.exponent.decimal.cpp",
+                      "patterns": [
+                        {
+                          "match": "(?<=[0-9a-fA-F])'(?=[0-9a-fA-F])",
+                          "name": "punctuation.separator.constant.numeric.cpp"
+                        }
+                      ]
+                    },
+                    "9": {
+                      "name": "keyword.other.unit.suffix.integer.cpp"
+                    }
+                  }
+                },
+                {
+                  "match": "(?:(?:[0-9a-zA-Z_\\.]|')|(?<=[eEpP])[+-])+",
+                  "name": "invalid.illegal.constant.numeric.cpp"
+                }
+              ]
+            }
+          ]
+        }
+      }
+    },
+    "primitive_types": {
+      "match": "((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))((?<!\\w)(?:unsigned|wchar_t|double|signed|short|float|auto|void|long|char|bool|int)(?!\\w))",
+      "captures": {
+        "1": {
+          "patterns": [
+            {
+              "include": "#inline_comment"
+            }
+          ]
+        },
+        "2": {
+          "name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+        },
+        "3": {
+          "name": "comment.block.cpp"
+        },
+        "4": {
+          "patterns": [
+            {
+              "match": "\\*\\/",
+              "name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+            },
+            {
+              "match": "\\*",
+              "name": "comment.block.cpp"
+            }
+          ]
+        },
+        "5": {
+          "name": "storage.type.primitive.cpp storage.type.built-in.primitive.cpp"
+        }
+      }
+    },
+    "pthread_types": {
+      "match": "((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))((?<!\\w)pthread_attr_t|pthread_cond_t|pthread_condattr_t|pthread_mutex_t|pthread_mutexattr_t|pthread_once_t|pthread_rwlock_t|pthread_rwlockattr_t|pthread_t|pthread_key_t(?!\\w))",
+      "captures": {
+        "1": {
+          "patterns": [
+            {
+              "include": "#inline_comment"
+            }
+          ]
+        },
+        "2": {
+          "name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+        },
+        "3": {
+          "name": "comment.block.cpp"
+        },
+        "4": {
+          "patterns": [
+            {
+              "match": "\\*\\/",
+              "name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+            },
+            {
+              "match": "\\*",
+              "name": "comment.block.cpp"
+            }
+          ]
+        },
+        "5": {
+          "name": "support.type.posix-reserved.pthread.cpp support.type.built-in.posix-reserved.pthread.cpp"
+        }
+      }
+    },
+    "qualified_type": {
+      "match": "\\s*+((?:(?:(?:\\[\\[.*?\\]\\]|__attribute(?:__)?\\(\\(.*?\\)\\))|__declspec\\(.*?\\))|alignas\\(.*?\\))(?!\\)))?((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))(?:(?:(?:unsigned|signed|short|long)|(?:struct|class|union|enum))((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z)))))*(((::)?(?:((?-mix:(?!\\b(?:__has_cpp_attribute|reinterpret_cast|atomic_noexcept|atomic_cancel|atomic_commit|__has_include|dynamic_cast|thread_local|synchronized|static_cast|const_cast|consteval|constexpr|protected|namespace|co_return|constexpr|constexpr|continue|explicit|volatile|noexcept|co_yield|noexcept|noexcept|requires|typename|decltype|operator|co_await|template|volatile|register|restrict|reflexpr|alignof|private|default|mutable|include|concept|__asm__|defined|_Pragma|alignas|typedef|warning|virtual|mutable|struct|sizeof|delete|not_eq|bitand|and_eq|xor_eq|typeid|switch|return|static|extern|inline|friend|public|ifndef|define|pragma|export|import|module|catch|throw|const|or_eq|while|compl|bitor|const|union|ifdef|class|undef|error|break|using|endif|goto|line|enum|this|case|else|elif|else|asm|try|for|new|and|xor|not|do|or|if|if)\\b)(?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*))\\s*+(((?<!<)<(?!<)(?>(?:(?>[^<>]*)\\g<26>?)+)>)\\s*)?::)*\\s*+)((?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*)\\s*+(((?<!<)<(?!<)(?>(?:(?>[^<>]*)\\g<26>?)+)>)\\s*)?(::))?((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))(?!(?:transaction_safe_dynamic|__has_cpp_attribute|transaction_safe|reinterpret_cast|atomic_noexcept|atomic_commit|atomic_cancel|__has_include|dynamic_cast|thread_local|synchronized|static_cast|const_cast|constexpr|consteval|protected|constexpr|co_return|namespace|constexpr|noexcept|typename|decltype|template|operator|noexcept|co_yield|co_await|continue|volatile|register|restrict|explicit|override|volatile|reflexpr|noexcept|requires|default|typedef|nullptr|alignof|mutable|concept|virtual|defined|__asm__|include|_Pragma|mutable|warning|private|alignas|module|switch|not_eq|bitand|and_eq|ifndef|return|sizeof|xor_eq|export|static|delete|public|define|extern|inline|import|pragma|friend|typeid|const|compl|bitor|throw|or_eq|while|catch|break|false|final|const|endif|ifdef|undef|error|using|audit|axiom|line|else|elif|true|NULL|case|goto|else|this|new|asm|not|and|xor|try|for|if|do|or|if)\\b)((?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*)\\b(((?<!<)<(?!<)(?>(?:(?>[^<>]*)\\g<26>?)+)>)\\s*)?(?![\\w<:.])",
+      "captures": {
+        "0": {
+          "name": "meta.qualified_type.cpp",
+          "patterns": [
+            {
+              "match": "(?<!\\w)(?:struct|class|union|enum)(?!\\w)",
+              "name": "storage.type.$0.cpp"
+            },
+            {
+              "include": "#attributes_context"
+            },
+            {
+              "include": "#function_type"
+            },
+            {
+              "include": "#storage_types"
+            },
+            {
+              "include": "#number_literal"
+            },
+            {
+              "include": "#string_context"
+            },
+            {
+              "include": "#comma"
+            },
+            {
+              "include": "#scope_resolution_inner_generated"
+            },
+            {
+              "include": "#template_call_range"
+            },
+            {
+              "match": "(?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*",
+              "name": "entity.name.type.cpp"
+            }
+          ]
+        },
+        "1": {
+          "patterns": [
+            {
+              "include": "#attributes_context"
+            },
+            {
+              "include": "#number_literal"
+            }
+          ]
+        },
+        "2": {
+          "patterns": [
+            {
+              "include": "#inline_comment"
+            }
+          ]
+        },
+        "3": {
+          "name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+        },
+        "4": {
+          "name": "comment.block.cpp"
+        },
+        "5": {
+          "patterns": [
+            {
+              "match": "\\*\\/",
+              "name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+            },
+            {
+              "match": "\\*",
+              "name": "comment.block.cpp"
+            }
+          ]
+        },
+        "6": {
+          "patterns": [
+            {
+              "include": "#inline_comment"
+            }
+          ]
+        },
+        "7": {
+          "name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+        },
+        "8": {
+          "name": "comment.block.cpp"
+        },
+        "9": {
+          "patterns": [
+            {
+              "match": "\\*\\/",
+              "name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+            },
+            {
+              "match": "\\*",
+              "name": "comment.block.cpp"
+            }
+          ]
+        },
+        "11": {
+          "patterns": [
+            {
+              "include": "#scope_resolution_inner_generated"
+            }
+          ]
+        },
+        "12": {
+          "name": "punctuation.separator.namespace.access.cpp punctuation.separator.scope-resolution.cpp"
+        },
+        "14": {
+          "name": "meta.template.call.cpp",
+          "patterns": [
+            {
+              "include": "#template_call_range"
+            }
+          ]
+        },
+        "16": {
+          "name": "entity.name.scope-resolution.cpp"
+        },
+        "17": {
+          "name": "meta.template.call.cpp",
+          "patterns": [
+            {
+              "include": "#template_call_range"
+            }
+          ]
+        },
+        "19": {
+          "name": "punctuation.separator.namespace.access.cpp punctuation.separator.scope-resolution.cpp"
+        },
+        "20": {
+          "patterns": [
+            {
+              "include": "#inline_comment"
+            }
+          ]
+        },
+        "21": {
+          "name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+        },
+        "22": {
+          "name": "comment.block.cpp"
+        },
+        "23": {
+          "patterns": [
+            {
+              "match": "\\*\\/",
+              "name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+            },
+            {
+              "match": "\\*",
+              "name": "comment.block.cpp"
+            }
+          ]
+        },
+        "24": {
+          "name": "entity.name.type.cpp"
+        },
+        "25": {
+          "name": "meta.template.call.cpp",
+          "patterns": [
+            {
+              "include": "#template_call_range"
+            }
+          ]
+        }
+      }
+    },
+    "qualifiers_and_specifiers_post_parameters": {
+      "match": "((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))((?<!\\w)(?:override|volatile|noexcept|final|const)(?!\\w)(?=\\s*(?:(?:\\{|;)|[\\n\\r])))",
+      "captures": {
+        "1": {
+          "patterns": [
+            {
+              "include": "#inline_comment"
+            }
+          ]
+        },
+        "2": {
+          "name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+        },
+        "3": {
+          "name": "comment.block.cpp"
+        },
+        "4": {
+          "patterns": [
+            {
+              "match": "\\*\\/",
+              "name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+            },
+            {
+              "match": "\\*",
+              "name": "comment.block.cpp"
+            }
+          ]
+        },
+        "5": {
+          "name": "storage.modifier.specifier.functional.post-parameters.$5.cpp"
+        }
+      }
+    },
+    "scope_resolution": {
+      "match": "(::)?(?:((?-mix:(?!\\b(?:__has_cpp_attribute|reinterpret_cast|atomic_noexcept|atomic_cancel|atomic_commit|__has_include|dynamic_cast|thread_local|synchronized|static_cast|const_cast|consteval|constexpr|protected|namespace|co_return|constexpr|constexpr|continue|explicit|volatile|noexcept|co_yield|noexcept|noexcept|requires|typename|decltype|operator|co_await|template|volatile|register|restrict|reflexpr|alignof|private|default|mutable|include|concept|__asm__|defined|_Pragma|alignas|typedef|warning|virtual|mutable|struct|sizeof|delete|not_eq|bitand|and_eq|xor_eq|typeid|switch|return|static|extern|inline|friend|public|ifndef|define|pragma|export|import|module|catch|throw|const|or_eq|while|compl|bitor|const|union|ifdef|class|undef|error|break|using|endif|goto|line|enum|this|case|else|elif|else|asm|try|for|new|and|xor|not|do|or|if|if)\\b)(?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*))\\s*+(((?<!<)<(?!<)(?>(?:(?>[^<>]*)\\g<4>?)+)>)\\s*)?::)*\\s*+",
+      "captures": {
+        "0": {
+          "patterns": [
+            {
+              "include": "#scope_resolution_inner_generated"
+            }
+          ]
+        },
+        "1": {
+          "name": "punctuation.separator.namespace.access.cpp punctuation.separator.scope-resolution.cpp"
+        },
+        "3": {
+          "name": "meta.template.call.cpp",
+          "patterns": [
+            {
+              "include": "#template_call_range"
+            }
+          ]
+        }
+      }
+    },
+    "scope_resolution_function_call": {
+      "match": "(::)?(?:((?-mix:(?!\\b(?:__has_cpp_attribute|reinterpret_cast|atomic_noexcept|atomic_cancel|atomic_commit|__has_include|dynamic_cast|thread_local|synchronized|static_cast|const_cast|consteval|constexpr|protected|namespace|co_return|constexpr|constexpr|continue|explicit|volatile|noexcept|co_yield|noexcept|noexcept|requires|typename|decltype|operator|co_await|template|volatile|register|restrict|reflexpr|alignof|private|default|mutable|include|concept|__asm__|defined|_Pragma|alignas|typedef|warning|virtual|mutable|struct|sizeof|delete|not_eq|bitand|and_eq|xor_eq|typeid|switch|return|static|extern|inline|friend|public|ifndef|define|pragma|export|import|module|catch|throw|const|or_eq|while|compl|bitor|const|union|ifdef|class|undef|error|break|using|endif|goto|line|enum|this|case|else|elif|else|asm|try|for|new|and|xor|not|do|or|if|if)\\b)(?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*))\\s*+(((?<!<)<(?!<)(?>(?:(?>[^<>]*)\\g<4>?)+)>)\\s*)?::)*\\s*+",
+      "captures": {
+        "0": {
+          "patterns": [
+            {
+              "include": "#scope_resolution_function_call_inner_generated"
+            }
+          ]
+        },
+        "1": {
+          "name": "punctuation.separator.namespace.access.cpp punctuation.separator.scope-resolution.function.call.cpp"
+        },
+        "3": {
+          "name": "meta.template.call.cpp",
+          "patterns": [
+            {
+              "include": "#template_call_range"
+            }
+          ]
+        }
+      }
+    },
+    "scope_resolution_function_call_inner_generated": {
+      "match": "((::)?(?:((?-mix:(?!\\b(?:__has_cpp_attribute|reinterpret_cast|atomic_noexcept|atomic_cancel|atomic_commit|__has_include|dynamic_cast|thread_local|synchronized|static_cast|const_cast|consteval|constexpr|protected|namespace|co_return|constexpr|constexpr|continue|explicit|volatile|noexcept|co_yield|noexcept|noexcept|requires|typename|decltype|operator|co_await|template|volatile|register|restrict|reflexpr|alignof|private|default|mutable|include|concept|__asm__|defined|_Pragma|alignas|typedef|warning|virtual|mutable|struct|sizeof|delete|not_eq|bitand|and_eq|xor_eq|typeid|switch|return|static|extern|inline|friend|public|ifndef|define|pragma|export|import|module|catch|throw|const|or_eq|while|compl|bitor|const|union|ifdef|class|undef|error|break|using|endif|goto|line|enum|this|case|else|elif|else|asm|try|for|new|and|xor|not|do|or|if|if)\\b)(?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*))\\s*+(((?<!<)<(?!<)(?>(?:(?>[^<>]*)\\g<8>?)+)>)\\s*)?::)*\\s*+)((?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*)\\s*+(((?<!<)<(?!<)(?>(?:(?>[^<>]*)\\g<8>?)+)>)\\s*)?(::)",
+      "captures": {
+        "1": {
+          "patterns": [
+            {
+              "include": "#scope_resolution_function_call_inner_generated"
+            }
+          ]
+        },
+        "2": {
+          "name": "punctuation.separator.namespace.access.cpp punctuation.separator.scope-resolution.function.call.cpp"
+        },
+        "4": {
+          "name": "meta.template.call.cpp",
+          "patterns": [
+            {
+              "include": "#template_call_range"
+            }
+          ]
+        },
+        "6": {
+          "name": "entity.name.scope-resolution.function.call.cpp"
+        },
+        "7": {
+          "name": "meta.template.call.cpp",
+          "patterns": [
+            {
+              "include": "#template_call_range"
+            }
+          ]
+        },
+        "9": {
+          "name": "punctuation.separator.namespace.access.cpp punctuation.separator.scope-resolution.function.call.cpp"
+        }
+      }
+    },
+    "scope_resolution_function_definition": {
+      "match": "(::)?(?:((?-mix:(?!\\b(?:__has_cpp_attribute|reinterpret_cast|atomic_noexcept|atomic_cancel|atomic_commit|__has_include|dynamic_cast|thread_local|synchronized|static_cast|const_cast|consteval|constexpr|protected|namespace|co_return|constexpr|constexpr|continue|explicit|volatile|noexcept|co_yield|noexcept|noexcept|requires|typename|decltype|operator|co_await|template|volatile|register|restrict|reflexpr|alignof|private|default|mutable|include|concept|__asm__|defined|_Pragma|alignas|typedef|warning|virtual|mutable|struct|sizeof|delete|not_eq|bitand|and_eq|xor_eq|typeid|switch|return|static|extern|inline|friend|public|ifndef|define|pragma|export|import|module|catch|throw|const|or_eq|while|compl|bitor|const|union|ifdef|class|undef|error|break|using|endif|goto|line|enum|this|case|else|elif|else|asm|try|for|new|and|xor|not|do|or|if|if)\\b)(?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*))\\s*+(((?<!<)<(?!<)(?>(?:(?>[^<>]*)\\g<4>?)+)>)\\s*)?::)*\\s*+",
+      "captures": {
+        "0": {
+          "patterns": [
+            {
+              "include": "#scope_resolution_function_definition_inner_generated"
+            }
+          ]
+        },
+        "1": {
+          "name": "punctuation.separator.namespace.access.cpp punctuation.separator.scope-resolution.function.definition.cpp"
+        },
+        "3": {
+          "name": "meta.template.call.cpp",
+          "patterns": [
+            {
+              "include": "#template_call_range"
+            }
+          ]
+        }
+      }
+    },
+    "scope_resolution_function_definition_inner_generated": {
+      "match": "((::)?(?:((?-mix:(?!\\b(?:__has_cpp_attribute|reinterpret_cast|atomic_noexcept|atomic_cancel|atomic_commit|__has_include|dynamic_cast|thread_local|synchronized|static_cast|const_cast|consteval|constexpr|protected|namespace|co_return|constexpr|constexpr|continue|explicit|volatile|noexcept|co_yield|noexcept|noexcept|requires|typename|decltype|operator|co_await|template|volatile|register|restrict|reflexpr|alignof|private|default|mutable|include|concept|__asm__|defined|_Pragma|alignas|typedef|warning|virtual|mutable|struct|sizeof|delete|not_eq|bitand|and_eq|xor_eq|typeid|switch|return|static|extern|inline|friend|public|ifndef|define|pragma|export|import|module|catch|throw|const|or_eq|while|compl|bitor|const|union|ifdef|class|undef|error|break|using|endif|goto|line|enum|this|case|else|elif|else|asm|try|for|new|and|xor|not|do|or|if|if)\\b)(?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*))\\s*+(((?<!<)<(?!<)(?>(?:(?>[^<>]*)\\g<8>?)+)>)\\s*)?::)*\\s*+)((?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*)\\s*+(((?<!<)<(?!<)(?>(?:(?>[^<>]*)\\g<8>?)+)>)\\s*)?(::)",
+      "captures": {
+        "1": {
+          "patterns": [
+            {
+              "include": "#scope_resolution_function_definition_inner_generated"
+            }
+          ]
+        },
+        "2": {
+          "name": "punctuation.separator.namespace.access.cpp punctuation.separator.scope-resolution.function.definition.cpp"
+        },
+        "4": {
+          "name": "meta.template.call.cpp",
+          "patterns": [
+            {
+              "include": "#template_call_range"
+            }
+          ]
+        },
+        "6": {
+          "name": "entity.name.scope-resolution.function.definition.cpp"
+        },
+        "7": {
+          "name": "meta.template.call.cpp",
+          "patterns": [
+            {
+              "include": "#template_call_range"
+            }
+          ]
+        },
+        "9": {
+          "name": "punctuation.separator.namespace.access.cpp punctuation.separator.scope-resolution.function.definition.cpp"
+        }
+      }
+    },
+    "scope_resolution_function_definition_operator_overload": {
+      "match": "(::)?(?:((?-mix:(?!\\b(?:__has_cpp_attribute|reinterpret_cast|atomic_noexcept|atomic_cancel|atomic_commit|__has_include|dynamic_cast|thread_local|synchronized|static_cast|const_cast|consteval|constexpr|protected|namespace|co_return|constexpr|constexpr|continue|explicit|volatile|noexcept|co_yield|noexcept|noexcept|requires|typename|decltype|operator|co_await|template|volatile|register|restrict|reflexpr|alignof|private|default|mutable|include|concept|__asm__|defined|_Pragma|alignas|typedef|warning|virtual|mutable|struct|sizeof|delete|not_eq|bitand|and_eq|xor_eq|typeid|switch|return|static|extern|inline|friend|public|ifndef|define|pragma|export|import|module|catch|throw|const|or_eq|while|compl|bitor|const|union|ifdef|class|undef|error|break|using|endif|goto|line|enum|this|case|else|elif|else|asm|try|for|new|and|xor|not|do|or|if|if)\\b)(?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*))\\s*+(((?<!<)<(?!<)(?>(?:(?>[^<>]*)\\g<4>?)+)>)\\s*)?::)*\\s*+",
+      "captures": {
+        "0": {
+          "patterns": [
+            {
+              "include": "#scope_resolution_function_definition_operator_overload_inner_generated"
+            }
+          ]
+        },
+        "1": {
+          "name": "punctuation.separator.namespace.access.cpp punctuation.separator.scope-resolution.function.definition.operator-overload.cpp"
+        },
+        "3": {
+          "name": "meta.template.call.cpp",
+          "patterns": [
+            {
+              "include": "#template_call_range"
+            }
+          ]
+        }
+      }
+    },
+    "scope_resolution_function_definition_operator_overload_inner_generated": {
+      "match": "((::)?(?:((?-mix:(?!\\b(?:__has_cpp_attribute|reinterpret_cast|atomic_noexcept|atomic_cancel|atomic_commit|__has_include|dynamic_cast|thread_local|synchronized|static_cast|const_cast|consteval|constexpr|protected|namespace|co_return|constexpr|constexpr|continue|explicit|volatile|noexcept|co_yield|noexcept|noexcept|requires|typename|decltype|operator|co_await|template|volatile|register|restrict|reflexpr|alignof|private|default|mutable|include|concept|__asm__|defined|_Pragma|alignas|typedef|warning|virtual|mutable|struct|sizeof|delete|not_eq|bitand|and_eq|xor_eq|typeid|switch|return|static|extern|inline|friend|public|ifndef|define|pragma|export|import|module|catch|throw|const|or_eq|while|compl|bitor|const|union|ifdef|class|undef|error|break|using|endif|goto|line|enum|this|case|else|elif|else|asm|try|for|new|and|xor|not|do|or|if|if)\\b)(?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*))\\s*+(((?<!<)<(?!<)(?>(?:(?>[^<>]*)\\g<8>?)+)>)\\s*)?::)*\\s*+)((?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*)\\s*+(((?<!<)<(?!<)(?>(?:(?>[^<>]*)\\g<8>?)+)>)\\s*)?(::)",
+      "captures": {
+        "1": {
+          "patterns": [
+            {
+              "include": "#scope_resolution_function_definition_operator_overload_inner_generated"
+            }
+          ]
+        },
+        "2": {
+          "name": "punctuation.separator.namespace.access.cpp punctuation.separator.scope-resolution.function.definition.operator-overload.cpp"
+        },
+        "4": {
+          "name": "meta.template.call.cpp",
+          "patterns": [
+            {
+              "include": "#template_call_range"
+            }
+          ]
+        },
+        "6": {
+          "name": "entity.name.scope-resolution.function.definition.operator-overload.cpp"
+        },
+        "7": {
+          "name": "meta.template.call.cpp",
+          "patterns": [
+            {
+              "include": "#template_call_range"
+            }
+          ]
+        },
+        "9": {
+          "name": "punctuation.separator.namespace.access.cpp punctuation.separator.scope-resolution.function.definition.operator-overload.cpp"
+        }
+      }
+    },
+    "scope_resolution_inner_generated": {
+      "match": "((::)?(?:((?-mix:(?!\\b(?:__has_cpp_attribute|reinterpret_cast|atomic_noexcept|atomic_cancel|atomic_commit|__has_include|dynamic_cast|thread_local|synchronized|static_cast|const_cast|consteval|constexpr|protected|namespace|co_return|constexpr|constexpr|continue|explicit|volatile|noexcept|co_yield|noexcept|noexcept|requires|typename|decltype|operator|co_await|template|volatile|register|restrict|reflexpr|alignof|private|default|mutable|include|concept|__asm__|defined|_Pragma|alignas|typedef|warning|virtual|mutable|struct|sizeof|delete|not_eq|bitand|and_eq|xor_eq|typeid|switch|return|static|extern|inline|friend|public|ifndef|define|pragma|export|import|module|catch|throw|const|or_eq|while|compl|bitor|const|union|ifdef|class|undef|error|break|using|endif|goto|line|enum|this|case|else|elif|else|asm|try|for|new|and|xor|not|do|or|if|if)\\b)(?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*))\\s*+(((?<!<)<(?!<)(?>(?:(?>[^<>]*)\\g<8>?)+)>)\\s*)?::)*\\s*+)((?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*)\\s*+(((?<!<)<(?!<)(?>(?:(?>[^<>]*)\\g<8>?)+)>)\\s*)?(::)",
+      "captures": {
+        "1": {
+          "patterns": [
+            {
+              "include": "#scope_resolution_inner_generated"
+            }
+          ]
+        },
+        "2": {
+          "name": "punctuation.separator.namespace.access.cpp punctuation.separator.scope-resolution.cpp"
+        },
+        "4": {
+          "name": "meta.template.call.cpp",
+          "patterns": [
+            {
+              "include": "#template_call_range"
+            }
+          ]
+        },
+        "6": {
+          "name": "entity.name.scope-resolution.cpp"
+        },
+        "7": {
+          "name": "meta.template.call.cpp",
+          "patterns": [
+            {
+              "include": "#template_call_range"
+            }
+          ]
+        },
+        "9": {
+          "name": "punctuation.separator.namespace.access.cpp punctuation.separator.scope-resolution.cpp"
+        }
+      }
+    },
+    "scope_resolution_namespace_alias": {
+      "match": "(::)?(?:((?-mix:(?!\\b(?:__has_cpp_attribute|reinterpret_cast|atomic_noexcept|atomic_cancel|atomic_commit|__has_include|dynamic_cast|thread_local|synchronized|static_cast|const_cast|consteval|constexpr|protected|namespace|co_return|constexpr|constexpr|continue|explicit|volatile|noexcept|co_yield|noexcept|noexcept|requires|typename|decltype|operator|co_await|template|volatile|register|restrict|reflexpr|alignof|private|default|mutable|include|concept|__asm__|defined|_Pragma|alignas|typedef|warning|virtual|mutable|struct|sizeof|delete|not_eq|bitand|and_eq|xor_eq|typeid|switch|return|static|extern|inline|friend|public|ifndef|define|pragma|export|import|module|catch|throw|const|or_eq|while|compl|bitor|const|union|ifdef|class|undef|error|break|using|endif|goto|line|enum|this|case|else|elif|else|asm|try|for|new|and|xor|not|do|or|if|if)\\b)(?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*))\\s*+(((?<!<)<(?!<)(?>(?:(?>[^<>]*)\\g<4>?)+)>)\\s*)?::)*\\s*+",
+      "captures": {
+        "0": {
+          "patterns": [
+            {
+              "include": "#scope_resolution_namespace_alias_inner_generated"
+            }
+          ]
+        },
+        "1": {
+          "name": "punctuation.separator.namespace.access.cpp punctuation.separator.scope-resolution.namespace.alias.cpp"
+        },
+        "3": {
+          "name": "meta.template.call.cpp",
+          "patterns": [
+            {
+              "include": "#template_call_range"
+            }
+          ]
+        }
+      }
+    },
+    "scope_resolution_namespace_alias_inner_generated": {
+      "match": "((::)?(?:((?-mix:(?!\\b(?:__has_cpp_attribute|reinterpret_cast|atomic_noexcept|atomic_cancel|atomic_commit|__has_include|dynamic_cast|thread_local|synchronized|static_cast|const_cast|consteval|constexpr|protected|namespace|co_return|constexpr|constexpr|continue|explicit|volatile|noexcept|co_yield|noexcept|noexcept|requires|typename|decltype|operator|co_await|template|volatile|register|restrict|reflexpr|alignof|private|default|mutable|include|concept|__asm__|defined|_Pragma|alignas|typedef|warning|virtual|mutable|struct|sizeof|delete|not_eq|bitand|and_eq|xor_eq|typeid|switch|return|static|extern|inline|friend|public|ifndef|define|pragma|export|import|module|catch|throw|const|or_eq|while|compl|bitor|const|union|ifdef|class|undef|error|break|using|endif|goto|line|enum|this|case|else|elif|else|asm|try|for|new|and|xor|not|do|or|if|if)\\b)(?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*))\\s*+(((?<!<)<(?!<)(?>(?:(?>[^<>]*)\\g<8>?)+)>)\\s*)?::)*\\s*+)((?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*)\\s*+(((?<!<)<(?!<)(?>(?:(?>[^<>]*)\\g<8>?)+)>)\\s*)?(::)",
+      "captures": {
+        "1": {
+          "patterns": [
+            {
+              "include": "#scope_resolution_namespace_alias_inner_generated"
+            }
+          ]
+        },
+        "2": {
+          "name": "punctuation.separator.namespace.access.cpp punctuation.separator.scope-resolution.namespace.alias.cpp"
+        },
+        "4": {
+          "name": "meta.template.call.cpp",
+          "patterns": [
+            {
+              "include": "#template_call_range"
+            }
+          ]
+        },
+        "6": {
+          "name": "entity.name.scope-resolution.namespace.alias.cpp"
+        },
+        "7": {
+          "name": "meta.template.call.cpp",
+          "patterns": [
+            {
+              "include": "#template_call_range"
+            }
+          ]
+        },
+        "9": {
+          "name": "punctuation.separator.namespace.access.cpp punctuation.separator.scope-resolution.namespace.alias.cpp"
+        }
+      }
+    },
+    "scope_resolution_namespace_block": {
+      "match": "(::)?(?:((?-mix:(?!\\b(?:__has_cpp_attribute|reinterpret_cast|atomic_noexcept|atomic_cancel|atomic_commit|__has_include|dynamic_cast|thread_local|synchronized|static_cast|const_cast|consteval|constexpr|protected|namespace|co_return|constexpr|constexpr|continue|explicit|volatile|noexcept|co_yield|noexcept|noexcept|requires|typename|decltype|operator|co_await|template|volatile|register|restrict|reflexpr|alignof|private|default|mutable|include|concept|__asm__|defined|_Pragma|alignas|typedef|warning|virtual|mutable|struct|sizeof|delete|not_eq|bitand|and_eq|xor_eq|typeid|switch|return|static|extern|inline|friend|public|ifndef|define|pragma|export|import|module|catch|throw|const|or_eq|while|compl|bitor|const|union|ifdef|class|undef|error|break|using|endif|goto|line|enum|this|case|else|elif|else|asm|try|for|new|and|xor|not|do|or|if|if)\\b)(?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*))\\s*+(((?<!<)<(?!<)(?>(?:(?>[^<>]*)\\g<4>?)+)>)\\s*)?::)*\\s*+",
+      "captures": {
+        "0": {
+          "patterns": [
+            {
+              "include": "#scope_resolution_namespace_block_inner_generated"
+            }
+          ]
+        },
+        "1": {
+          "name": "punctuation.separator.namespace.access.cpp punctuation.separator.scope-resolution.namespace.block.cpp"
+        },
+        "3": {
+          "name": "meta.template.call.cpp",
+          "patterns": [
+            {
+              "include": "#template_call_range"
+            }
+          ]
+        }
+      }
+    },
+    "scope_resolution_namespace_block_inner_generated": {
+      "match": "((::)?(?:((?-mix:(?!\\b(?:__has_cpp_attribute|reinterpret_cast|atomic_noexcept|atomic_cancel|atomic_commit|__has_include|dynamic_cast|thread_local|synchronized|static_cast|const_cast|consteval|constexpr|protected|namespace|co_return|constexpr|constexpr|continue|explicit|volatile|noexcept|co_yield|noexcept|noexcept|requires|typename|decltype|operator|co_await|template|volatile|register|restrict|reflexpr|alignof|private|default|mutable|include|concept|__asm__|defined|_Pragma|alignas|typedef|warning|virtual|mutable|struct|sizeof|delete|not_eq|bitand|and_eq|xor_eq|typeid|switch|return|static|extern|inline|friend|public|ifndef|define|pragma|export|import|module|catch|throw|const|or_eq|while|compl|bitor|const|union|ifdef|class|undef|error|break|using|endif|goto|line|enum|this|case|else|elif|else|asm|try|for|new|and|xor|not|do|or|if|if)\\b)(?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*))\\s*+(((?<!<)<(?!<)(?>(?:(?>[^<>]*)\\g<8>?)+)>)\\s*)?::)*\\s*+)((?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*)\\s*+(((?<!<)<(?!<)(?>(?:(?>[^<>]*)\\g<8>?)+)>)\\s*)?(::)",
+      "captures": {
+        "1": {
+          "patterns": [
+            {
+              "include": "#scope_resolution_namespace_block_inner_generated"
+            }
+          ]
+        },
+        "2": {
+          "name": "punctuation.separator.namespace.access.cpp punctuation.separator.scope-resolution.namespace.block.cpp"
+        },
+        "4": {
+          "name": "meta.template.call.cpp",
+          "patterns": [
+            {
+              "include": "#template_call_range"
+            }
+          ]
+        },
+        "6": {
+          "name": "entity.name.scope-resolution.namespace.block.cpp"
+        },
+        "7": {
+          "name": "meta.template.call.cpp",
+          "patterns": [
+            {
+              "include": "#template_call_range"
+            }
+          ]
+        },
+        "9": {
+          "name": "punctuation.separator.namespace.access.cpp punctuation.separator.scope-resolution.namespace.block.cpp"
+        }
+      }
+    },
+    "scope_resolution_namespace_using": {
+      "match": "(::)?(?:((?-mix:(?!\\b(?:__has_cpp_attribute|reinterpret_cast|atomic_noexcept|atomic_cancel|atomic_commit|__has_include|dynamic_cast|thread_local|synchronized|static_cast|const_cast|consteval|constexpr|protected|namespace|co_return|constexpr|constexpr|continue|explicit|volatile|noexcept|co_yield|noexcept|noexcept|requires|typename|decltype|operator|co_await|template|volatile|register|restrict|reflexpr|alignof|private|default|mutable|include|concept|__asm__|defined|_Pragma|alignas|typedef|warning|virtual|mutable|struct|sizeof|delete|not_eq|bitand|and_eq|xor_eq|typeid|switch|return|static|extern|inline|friend|public|ifndef|define|pragma|export|import|module|catch|throw|const|or_eq|while|compl|bitor|const|union|ifdef|class|undef|error|break|using|endif|goto|line|enum|this|case|else|elif|else|asm|try|for|new|and|xor|not|do|or|if|if)\\b)(?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*))\\s*+(((?<!<)<(?!<)(?>(?:(?>[^<>]*)\\g<4>?)+)>)\\s*)?::)*\\s*+",
+      "captures": {
+        "0": {
+          "patterns": [
+            {
+              "include": "#scope_resolution_namespace_using_inner_generated"
+            }
+          ]
+        },
+        "1": {
+          "name": "punctuation.separator.namespace.access.cpp punctuation.separator.scope-resolution.namespace.using.cpp"
+        },
+        "3": {
+          "name": "meta.template.call.cpp",
+          "patterns": [
+            {
+              "include": "#template_call_range"
+            }
+          ]
+        }
+      }
+    },
+    "scope_resolution_namespace_using_inner_generated": {
+      "match": "((::)?(?:((?-mix:(?!\\b(?:__has_cpp_attribute|reinterpret_cast|atomic_noexcept|atomic_cancel|atomic_commit|__has_include|dynamic_cast|thread_local|synchronized|static_cast|const_cast|consteval|constexpr|protected|namespace|co_return|constexpr|constexpr|continue|explicit|volatile|noexcept|co_yield|noexcept|noexcept|requires|typename|decltype|operator|co_await|template|volatile|register|restrict|reflexpr|alignof|private|default|mutable|include|concept|__asm__|defined|_Pragma|alignas|typedef|warning|virtual|mutable|struct|sizeof|delete|not_eq|bitand|and_eq|xor_eq|typeid|switch|return|static|extern|inline|friend|public|ifndef|define|pragma|export|import|module|catch|throw|const|or_eq|while|compl|bitor|const|union|ifdef|class|undef|error|break|using|endif|goto|line|enum|this|case|else|elif|else|asm|try|for|new|and|xor|not|do|or|if|if)\\b)(?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*))\\s*+(((?<!<)<(?!<)(?>(?:(?>[^<>]*)\\g<8>?)+)>)\\s*)?::)*\\s*+)((?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*)\\s*+(((?<!<)<(?!<)(?>(?:(?>[^<>]*)\\g<8>?)+)>)\\s*)?(::)",
+      "captures": {
+        "1": {
+          "patterns": [
+            {
+              "include": "#scope_resolution_namespace_using_inner_generated"
+            }
+          ]
+        },
+        "2": {
+          "name": "punctuation.separator.namespace.access.cpp punctuation.separator.scope-resolution.namespace.using.cpp"
+        },
+        "4": {
+          "name": "meta.template.call.cpp",
+          "patterns": [
+            {
+              "include": "#template_call_range"
+            }
+          ]
+        },
+        "6": {
+          "name": "entity.name.scope-resolution.namespace.using.cpp"
+        },
+        "7": {
+          "name": "meta.template.call.cpp",
+          "patterns": [
+            {
+              "include": "#template_call_range"
+            }
+          ]
+        },
+        "9": {
+          "name": "punctuation.separator.namespace.access.cpp punctuation.separator.scope-resolution.namespace.using.cpp"
+        }
+      }
+    },
+    "scope_resolution_parameter": {
+      "match": "(::)?(?:((?-mix:(?!\\b(?:__has_cpp_attribute|reinterpret_cast|atomic_noexcept|atomic_cancel|atomic_commit|__has_include|dynamic_cast|thread_local|synchronized|static_cast|const_cast|consteval|constexpr|protected|namespace|co_return|constexpr|constexpr|continue|explicit|volatile|noexcept|co_yield|noexcept|noexcept|requires|typename|decltype|operator|co_await|template|volatile|register|restrict|reflexpr|alignof|private|default|mutable|include|concept|__asm__|defined|_Pragma|alignas|typedef|warning|virtual|mutable|struct|sizeof|delete|not_eq|bitand|and_eq|xor_eq|typeid|switch|return|static|extern|inline|friend|public|ifndef|define|pragma|export|import|module|catch|throw|const|or_eq|while|compl|bitor|const|union|ifdef|class|undef|error|break|using|endif|goto|line|enum|this|case|else|elif|else|asm|try|for|new|and|xor|not|do|or|if|if)\\b)(?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*))\\s*+(((?<!<)<(?!<)(?>(?:(?>[^<>]*)\\g<4>?)+)>)\\s*)?::)*\\s*+",
+      "captures": {
+        "0": {
+          "patterns": [
+            {
+              "include": "#scope_resolution_parameter_inner_generated"
+            }
+          ]
+        },
+        "1": {
+          "name": "punctuation.separator.namespace.access.cpp punctuation.separator.scope-resolution.parameter.cpp"
+        },
+        "3": {
+          "name": "meta.template.call.cpp",
+          "patterns": [
+            {
+              "include": "#template_call_range"
+            }
+          ]
+        }
+      }
+    },
+    "scope_resolution_parameter_inner_generated": {
+      "match": "((::)?(?:((?-mix:(?!\\b(?:__has_cpp_attribute|reinterpret_cast|atomic_noexcept|atomic_cancel|atomic_commit|__has_include|dynamic_cast|thread_local|synchronized|static_cast|const_cast|consteval|constexpr|protected|namespace|co_return|constexpr|constexpr|continue|explicit|volatile|noexcept|co_yield|noexcept|noexcept|requires|typename|decltype|operator|co_await|template|volatile|register|restrict|reflexpr|alignof|private|default|mutable|include|concept|__asm__|defined|_Pragma|alignas|typedef|warning|virtual|mutable|struct|sizeof|delete|not_eq|bitand|and_eq|xor_eq|typeid|switch|return|static|extern|inline|friend|public|ifndef|define|pragma|export|import|module|catch|throw|const|or_eq|while|compl|bitor|const|union|ifdef|class|undef|error|break|using|endif|goto|line|enum|this|case|else|elif|else|asm|try|for|new|and|xor|not|do|or|if|if)\\b)(?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*))\\s*+(((?<!<)<(?!<)(?>(?:(?>[^<>]*)\\g<8>?)+)>)\\s*)?::)*\\s*+)((?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*)\\s*+(((?<!<)<(?!<)(?>(?:(?>[^<>]*)\\g<8>?)+)>)\\s*)?(::)",
+      "captures": {
+        "1": {
+          "patterns": [
+            {
+              "include": "#scope_resolution_parameter_inner_generated"
+            }
+          ]
+        },
+        "2": {
+          "name": "punctuation.separator.namespace.access.cpp punctuation.separator.scope-resolution.parameter.cpp"
+        },
+        "4": {
+          "name": "meta.template.call.cpp",
+          "patterns": [
+            {
+              "include": "#template_call_range"
+            }
+          ]
+        },
+        "6": {
+          "name": "entity.name.scope-resolution.parameter.cpp"
+        },
+        "7": {
+          "name": "meta.template.call.cpp",
+          "patterns": [
+            {
+              "include": "#template_call_range"
+            }
+          ]
+        },
+        "9": {
+          "name": "punctuation.separator.namespace.access.cpp punctuation.separator.scope-resolution.parameter.cpp"
+        }
+      }
+    },
+    "scope_resolution_template_call": {
+      "match": "(::)?(?:((?-mix:(?!\\b(?:__has_cpp_attribute|reinterpret_cast|atomic_noexcept|atomic_cancel|atomic_commit|__has_include|dynamic_cast|thread_local|synchronized|static_cast|const_cast|consteval|constexpr|protected|namespace|co_return|constexpr|constexpr|continue|explicit|volatile|noexcept|co_yield|noexcept|noexcept|requires|typename|decltype|operator|co_await|template|volatile|register|restrict|reflexpr|alignof|private|default|mutable|include|concept|__asm__|defined|_Pragma|alignas|typedef|warning|virtual|mutable|struct|sizeof|delete|not_eq|bitand|and_eq|xor_eq|typeid|switch|return|static|extern|inline|friend|public|ifndef|define|pragma|export|import|module|catch|throw|const|or_eq|while|compl|bitor|const|union|ifdef|class|undef|error|break|using|endif|goto|line|enum|this|case|else|elif|else|asm|try|for|new|and|xor|not|do|or|if|if)\\b)(?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*))\\s*+(((?<!<)<(?!<)(?>(?:(?>[^<>]*)\\g<4>?)+)>)\\s*)?::)*\\s*+",
+      "captures": {
+        "0": {
+          "patterns": [
+            {
+              "include": "#scope_resolution_template_call_inner_generated"
+            }
+          ]
+        },
+        "1": {
+          "name": "punctuation.separator.namespace.access.cpp punctuation.separator.scope-resolution.template.call.cpp"
+        },
+        "3": {
+          "name": "meta.template.call.cpp",
+          "patterns": [
+            {
+              "include": "#template_call_range"
+            }
+          ]
+        }
+      }
+    },
+    "scope_resolution_template_call_inner_generated": {
+      "match": "((::)?(?:((?-mix:(?!\\b(?:__has_cpp_attribute|reinterpret_cast|atomic_noexcept|atomic_cancel|atomic_commit|__has_include|dynamic_cast|thread_local|synchronized|static_cast|const_cast|consteval|constexpr|protected|namespace|co_return|constexpr|constexpr|continue|explicit|volatile|noexcept|co_yield|noexcept|noexcept|requires|typename|decltype|operator|co_await|template|volatile|register|restrict|reflexpr|alignof|private|default|mutable|include|concept|__asm__|defined|_Pragma|alignas|typedef|warning|virtual|mutable|struct|sizeof|delete|not_eq|bitand|and_eq|xor_eq|typeid|switch|return|static|extern|inline|friend|public|ifndef|define|pragma|export|import|module|catch|throw|const|or_eq|while|compl|bitor|const|union|ifdef|class|undef|error|break|using|endif|goto|line|enum|this|case|else|elif|else|asm|try|for|new|and|xor|not|do|or|if|if)\\b)(?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*))\\s*+(((?<!<)<(?!<)(?>(?:(?>[^<>]*)\\g<8>?)+)>)\\s*)?::)*\\s*+)((?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*)\\s*+(((?<!<)<(?!<)(?>(?:(?>[^<>]*)\\g<8>?)+)>)\\s*)?(::)",
+      "captures": {
+        "1": {
+          "patterns": [
+            {
+              "include": "#scope_resolution_template_call_inner_generated"
+            }
+          ]
+        },
+        "2": {
+          "name": "punctuation.separator.namespace.access.cpp punctuation.separator.scope-resolution.template.call.cpp"
+        },
+        "4": {
+          "name": "meta.template.call.cpp",
+          "patterns": [
+            {
+              "include": "#template_call_range"
+            }
+          ]
+        },
+        "6": {
+          "name": "entity.name.scope-resolution.template.call.cpp"
+        },
+        "7": {
+          "name": "meta.template.call.cpp",
+          "patterns": [
+            {
+              "include": "#template_call_range"
+            }
+          ]
+        },
+        "9": {
+          "name": "punctuation.separator.namespace.access.cpp punctuation.separator.scope-resolution.template.call.cpp"
+        }
+      }
+    },
+    "scope_resolution_template_definition": {
+      "match": "(::)?(?:((?-mix:(?!\\b(?:__has_cpp_attribute|reinterpret_cast|atomic_noexcept|atomic_cancel|atomic_commit|__has_include|dynamic_cast|thread_local|synchronized|static_cast|const_cast|consteval|constexpr|protected|namespace|co_return|constexpr|constexpr|continue|explicit|volatile|noexcept|co_yield|noexcept|noexcept|requires|typename|decltype|operator|co_await|template|volatile|register|restrict|reflexpr|alignof|private|default|mutable|include|concept|__asm__|defined|_Pragma|alignas|typedef|warning|virtual|mutable|struct|sizeof|delete|not_eq|bitand|and_eq|xor_eq|typeid|switch|return|static|extern|inline|friend|public|ifndef|define|pragma|export|import|module|catch|throw|const|or_eq|while|compl|bitor|const|union|ifdef|class|undef|error|break|using|endif|goto|line|enum|this|case|else|elif|else|asm|try|for|new|and|xor|not|do|or|if|if)\\b)(?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*))\\s*+(((?<!<)<(?!<)(?>(?:(?>[^<>]*)\\g<4>?)+)>)\\s*)?::)*\\s*+",
+      "captures": {
+        "0": {
+          "patterns": [
+            {
+              "include": "#scope_resolution_template_definition_inner_generated"
+            }
+          ]
+        },
+        "1": {
+          "name": "punctuation.separator.namespace.access.cpp punctuation.separator.scope-resolution.template.definition.cpp"
+        },
+        "3": {
+          "name": "meta.template.call.cpp",
+          "patterns": [
+            {
+              "include": "#template_call_range"
+            }
+          ]
+        }
+      }
+    },
+    "scope_resolution_template_definition_inner_generated": {
+      "match": "((::)?(?:((?-mix:(?!\\b(?:__has_cpp_attribute|reinterpret_cast|atomic_noexcept|atomic_cancel|atomic_commit|__has_include|dynamic_cast|thread_local|synchronized|static_cast|const_cast|consteval|constexpr|protected|namespace|co_return|constexpr|constexpr|continue|explicit|volatile|noexcept|co_yield|noexcept|noexcept|requires|typename|decltype|operator|co_await|template|volatile|register|restrict|reflexpr|alignof|private|default|mutable|include|concept|__asm__|defined|_Pragma|alignas|typedef|warning|virtual|mutable|struct|sizeof|delete|not_eq|bitand|and_eq|xor_eq|typeid|switch|return|static|extern|inline|friend|public|ifndef|define|pragma|export|import|module|catch|throw|const|or_eq|while|compl|bitor|const|union|ifdef|class|undef|error|break|using|endif|goto|line|enum|this|case|else|elif|else|asm|try|for|new|and|xor|not|do|or|if|if)\\b)(?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*))\\s*+(((?<!<)<(?!<)(?>(?:(?>[^<>]*)\\g<8>?)+)>)\\s*)?::)*\\s*+)((?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*)\\s*+(((?<!<)<(?!<)(?>(?:(?>[^<>]*)\\g<8>?)+)>)\\s*)?(::)",
+      "captures": {
+        "1": {
+          "patterns": [
+            {
+              "include": "#scope_resolution_template_definition_inner_generated"
+            }
+          ]
+        },
+        "2": {
+          "name": "punctuation.separator.namespace.access.cpp punctuation.separator.scope-resolution.template.definition.cpp"
+        },
+        "4": {
+          "name": "meta.template.call.cpp",
+          "patterns": [
+            {
+              "include": "#template_call_range"
+            }
+          ]
+        },
+        "6": {
+          "name": "entity.name.scope-resolution.template.definition.cpp"
+        },
+        "7": {
+          "name": "meta.template.call.cpp",
+          "patterns": [
+            {
+              "include": "#template_call_range"
+            }
+          ]
+        },
+        "9": {
+          "name": "punctuation.separator.namespace.access.cpp punctuation.separator.scope-resolution.template.definition.cpp"
+        }
+      }
+    },
+    "semicolon": {
+      "match": ";",
+      "name": "punctuation.terminator.statement.cpp"
+    },
+    "simple_type": {
+      "match": "(\\s*+((?:(?:(?:\\[\\[.*?\\]\\]|__attribute(?:__)?\\(\\(.*?\\)\\))|__declspec\\(.*?\\))|alignas\\(.*?\\))(?!\\)))?((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))(?:(?:(?:unsigned|signed|short|long)|(?:struct|class|union|enum))((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z)))))*(((::)?(?:((?-mix:(?!\\b(?:__has_cpp_attribute|reinterpret_cast|atomic_noexcept|atomic_cancel|atomic_commit|__has_include|dynamic_cast|thread_local|synchronized|static_cast|const_cast|consteval|constexpr|protected|namespace|co_return|constexpr|constexpr|continue|explicit|volatile|noexcept|co_yield|noexcept|noexcept|requires|typename|decltype|operator|co_await|template|volatile|register|restrict|reflexpr|alignof|private|default|mutable|include|concept|__asm__|defined|_Pragma|alignas|typedef|warning|virtual|mutable|struct|sizeof|delete|not_eq|bitand|and_eq|xor_eq|typeid|switch|return|static|extern|inline|friend|public|ifndef|define|pragma|export|import|module|catch|throw|const|or_eq|while|compl|bitor|const|union|ifdef|class|undef|error|break|using|endif|goto|line|enum|this|case|else|elif|else|asm|try|for|new|and|xor|not|do|or|if|if)\\b)(?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*))\\s*+(((?<!<)<(?!<)(?>(?:(?>[^<>]*)\\g<27>?)+)>)\\s*)?::)*\\s*+)((?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*)\\s*+(((?<!<)<(?!<)(?>(?:(?>[^<>]*)\\g<27>?)+)>)\\s*)?(::))?((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))(?!(?:transaction_safe_dynamic|__has_cpp_attribute|transaction_safe|reinterpret_cast|atomic_noexcept|atomic_commit|atomic_cancel|__has_include|dynamic_cast|thread_local|synchronized|static_cast|const_cast|constexpr|consteval|protected|constexpr|co_return|namespace|constexpr|noexcept|typename|decltype|template|operator|noexcept|co_yield|co_await|continue|volatile|register|restrict|explicit|override|volatile|reflexpr|noexcept|requires|default|typedef|nullptr|alignof|mutable|concept|virtual|defined|__asm__|include|_Pragma|mutable|warning|private|alignas|module|switch|not_eq|bitand|and_eq|ifndef|return|sizeof|xor_eq|export|static|delete|public|define|extern|inline|import|pragma|friend|typeid|const|compl|bitor|throw|or_eq|while|catch|break|false|final|const|endif|ifdef|undef|error|using|audit|axiom|line|else|elif|true|NULL|case|goto|else|this|new|asm|not|and|xor|try|for|if|do|or|if)\\b)((?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*)\\b(((?<!<)<(?!<)(?>(?:(?>[^<>]*)\\g<27>?)+)>)\\s*)?(?![\\w<:.]))(((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))?(?:(?:\\&|\\*)((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z)))))*(?:\\&|\\*))?",
+      "captures": {
+        "1": {
+          "name": "meta.qualified_type.cpp",
+          "patterns": [
+            {
+              "match": "(?<!\\w)(?:struct|class|union|enum)(?!\\w)",
+              "name": "storage.type.$0.cpp"
+            },
+            {
+              "include": "#attributes_context"
+            },
+            {
+              "include": "#function_type"
+            },
+            {
+              "include": "#storage_types"
+            },
+            {
+              "include": "#number_literal"
+            },
+            {
+              "include": "#string_context"
+            },
+            {
+              "include": "#comma"
+            },
+            {
+              "include": "#scope_resolution_inner_generated"
+            },
+            {
+              "include": "#template_call_range"
+            },
+            {
+              "match": "(?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*",
+              "name": "entity.name.type.cpp"
+            }
+          ]
+        },
+        "2": {
+          "patterns": [
+            {
+              "include": "#attributes_context"
+            },
+            {
+              "include": "#number_literal"
+            }
+          ]
+        },
+        "3": {
+          "patterns": [
+            {
+              "include": "#inline_comment"
+            }
+          ]
+        },
+        "4": {
+          "name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+        },
+        "5": {
+          "name": "comment.block.cpp"
+        },
+        "6": {
+          "patterns": [
+            {
+              "match": "\\*\\/",
+              "name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+            },
+            {
+              "match": "\\*",
+              "name": "comment.block.cpp"
+            }
+          ]
+        },
+        "7": {
+          "patterns": [
+            {
+              "include": "#inline_comment"
+            }
+          ]
+        },
+        "8": {
+          "name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+        },
+        "9": {
+          "name": "comment.block.cpp"
+        },
+        "10": {
+          "patterns": [
+            {
+              "match": "\\*\\/",
+              "name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+            },
+            {
+              "match": "\\*",
+              "name": "comment.block.cpp"
+            }
+          ]
+        },
+        "12": {
+          "patterns": [
+            {
+              "include": "#scope_resolution_inner_generated"
+            }
+          ]
+        },
+        "13": {
+          "name": "punctuation.separator.namespace.access.cpp punctuation.separator.scope-resolution.cpp"
+        },
+        "15": {
+          "name": "meta.template.call.cpp",
+          "patterns": [
+            {
+              "include": "#template_call_range"
+            }
+          ]
+        },
+        "17": {
+          "name": "entity.name.scope-resolution.cpp"
+        },
+        "18": {
+          "name": "meta.template.call.cpp",
+          "patterns": [
+            {
+              "include": "#template_call_range"
+            }
+          ]
+        },
+        "20": {
+          "name": "punctuation.separator.namespace.access.cpp punctuation.separator.scope-resolution.cpp"
+        },
+        "21": {
+          "patterns": [
+            {
+              "include": "#inline_comment"
+            }
+          ]
+        },
+        "22": {
+          "name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+        },
+        "23": {
+          "name": "comment.block.cpp"
+        },
+        "24": {
+          "patterns": [
+            {
+              "match": "\\*\\/",
+              "name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+            },
+            {
+              "match": "\\*",
+              "name": "comment.block.cpp"
+            }
+          ]
+        },
+        "25": {
+          "name": "entity.name.type.cpp"
+        },
+        "26": {
+          "name": "meta.template.call.cpp",
+          "patterns": [
+            {
+              "include": "#template_call_range"
+            }
+          ]
+        },
+        "28": {
+          "patterns": [
+            {
+              "match": "\\*",
+              "name": "storage.modifier.pointer.cpp"
+            },
+            {
+              "match": "(?:\\&((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))){2,}\\&",
+              "captures": {
+                "1": {
+                  "patterns": [
+                    {
+                      "include": "#inline_comment"
+                    }
+                  ]
+                },
+                "2": {
+                  "name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+                },
+                "3": {
+                  "name": "comment.block.cpp"
+                },
+                "4": {
+                  "patterns": [
+                    {
+                      "match": "\\*\\/",
+                      "name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+                    },
+                    {
+                      "match": "\\*",
+                      "name": "comment.block.cpp"
+                    }
+                  ]
+                }
+              },
+              "name": "invalid.illegal.reference-type.cpp"
+            },
+            {
+              "match": "\\&",
+              "name": "storage.modifier.reference.cpp"
+            }
+          ]
+        },
+        "29": {
+          "patterns": [
+            {
+              "include": "#inline_comment"
+            }
+          ]
+        },
+        "30": {
+          "name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+        },
+        "31": {
+          "name": "comment.block.cpp"
+        },
+        "32": {
+          "patterns": [
+            {
+              "match": "\\*\\/",
+              "name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+            },
+            {
+              "match": "\\*",
+              "name": "comment.block.cpp"
+            }
+          ]
+        },
+        "33": {
+          "patterns": [
+            {
+              "include": "#inline_comment"
+            }
+          ]
+        },
+        "34": {
+          "name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+        },
+        "35": {
+          "name": "comment.block.cpp"
+        },
+        "36": {
+          "patterns": [
+            {
+              "match": "\\*\\/",
+              "name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+            },
+            {
+              "match": "\\*",
+              "name": "comment.block.cpp"
+            }
+          ]
+        }
+      }
+    },
+    "single_line_macro": {
+      "match": "^((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))#define.*(?<![\\\\])(?:\\n|$)",
+      "captures": {
+        "0": {
+          "patterns": [
+            {
+              "include": "#macro"
+            },
+            {
+              "include": "#comments"
+            }
+          ]
+        },
+        "1": {
+          "patterns": [
+            {
+              "include": "#inline_comment"
+            }
+          ]
+        },
+        "2": {
+          "name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+        },
+        "3": {
+          "name": "comment.block.cpp"
+        },
+        "4": {
+          "patterns": [
+            {
+              "match": "\\*\\/",
+              "name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+            },
+            {
+              "match": "\\*",
+              "name": "comment.block.cpp"
+            }
+          ]
+        }
+      }
+    },
+    "sizeof_operator": {
+      "contentName": "meta.arguments.operator.sizeof.cpp",
+      "begin": "((?<!\\w)sizeof(?!\\w))((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))(\\()",
+      "beginCaptures": {
+        "1": {
+          "name": "keyword.operator.functionlike.cpp keyword.operator.sizeof.cpp"
+        },
+        "2": {
+          "patterns": [
+            {
+              "include": "#inline_comment"
+            }
+          ]
+        },
+        "3": {
+          "name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+        },
+        "4": {
+          "name": "comment.block.cpp"
+        },
+        "5": {
+          "patterns": [
+            {
+              "match": "\\*\\/",
+              "name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+            },
+            {
+              "match": "\\*",
+              "name": "comment.block.cpp"
+            }
+          ]
+        },
+        "6": {
+          "name": "punctuation.section.arguments.begin.bracket.round.operator.sizeof.cpp"
+        }
+      },
+      "end": "(\\))|(?=(?<!\\\\)\n)",
+      "endCaptures": {
+        "1": {
+          "name": "punctuation.section.arguments.end.bracket.round.operator.sizeof.cpp"
+        }
+      },
+      "patterns": [
+        {
+          "include": "#evaluation_context"
+        }
+      ]
+    },
+    "sizeof_variadic_operator": {
+      "contentName": "meta.arguments.operator.sizeof.variadic.cpp",
+      "begin": "(\\bsizeof\\.\\.\\.)((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))(\\()",
+      "beginCaptures": {
+        "1": {
+          "name": "keyword.operator.functionlike.cpp keyword.operator.sizeof.variadic.cpp"
+        },
+        "2": {
+          "patterns": [
+            {
+              "include": "#inline_comment"
+            }
+          ]
+        },
+        "3": {
+          "name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+        },
+        "4": {
+          "name": "comment.block.cpp"
+        },
+        "5": {
+          "patterns": [
+            {
+              "match": "\\*\\/",
+              "name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+            },
+            {
+              "match": "\\*",
+              "name": "comment.block.cpp"
+            }
+          ]
+        },
+        "6": {
+          "name": "punctuation.section.arguments.begin.bracket.round.operator.sizeof.variadic.cpp"
+        }
+      },
+      "end": "(\\))|(?=(?<!\\\\)\n)",
+      "endCaptures": {
+        "1": {
+          "name": "punctuation.section.arguments.end.bracket.round.operator.sizeof.variadic.cpp"
+        }
+      },
+      "patterns": [
+        {
+          "include": "#evaluation_context"
+        }
+      ]
+    },
+    "square_brackets": {
+      "name": "meta.bracket.square.access.cpp",
+      "begin": "([a-zA-Z_][a-zA-Z_0-9]*|(?<=[\\]\\)]))?(\\[)(?!\\])",
+      "beginCaptures": {
+        "1": {
+          "name": "variable.other.object.cpp"
+        },
+        "2": {
+          "name": "punctuation.definition.begin.bracket.square.cpp"
+        }
+      },
+      "end": "\\]|(?=(?<!\\\\)\n)",
+      "endCaptures": {
+        "0": {
+          "name": "punctuation.definition.end.bracket.square.cpp"
+        }
+      },
+      "patterns": [
+        {
+          "include": "#evaluation_context"
+        }
+      ]
+    },
+    "standard_declares": {
+      "patterns": [
+        {
+          "include": "#struct_declare"
+        },
+        {
+          "include": "#union_declare"
+        },
+        {
+          "include": "#enum_declare"
+        },
+        {
+          "include": "#class_declare"
+        }
+      ]
+    },
+    "static_assert": {
+      "begin": "((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))((?<!\\w)static_assert|_Static_assert(?!\\w))((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))(\\()",
+      "beginCaptures": {
+        "1": {
+          "patterns": [
+            {
+              "include": "#inline_comment"
+            }
+          ]
+        },
+        "2": {
+          "name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+        },
+        "3": {
+          "name": "comment.block.cpp"
+        },
+        "4": {
+          "patterns": [
+            {
+              "match": "\\*\\/",
+              "name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+            },
+            {
+              "match": "\\*",
+              "name": "comment.block.cpp"
+            }
+          ]
+        },
+        "5": {
+          "name": "keyword.other.static_assert.cpp"
+        },
+        "6": {
+          "patterns": [
+            {
+              "include": "#inline_comment"
+            }
+          ]
+        },
+        "7": {
+          "name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+        },
+        "8": {
+          "name": "comment.block.cpp"
+        },
+        "9": {
+          "patterns": [
+            {
+              "match": "\\*\\/",
+              "name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+            },
+            {
+              "match": "\\*",
+              "name": "comment.block.cpp"
+            }
+          ]
+        },
+        "10": {
+          "name": "punctuation.section.arguments.begin.bracket.round.static_assert.cpp"
+        }
+      },
+      "end": "(\\))|(?=(?<!\\\\)\n)",
+      "endCaptures": {
+        "1": {
+          "name": "punctuation.section.arguments.end.bracket.round.static_assert.cpp"
+        }
+      },
+      "patterns": [
+        {
+          "name": "meta.static_assert.message.cpp",
+          "begin": "(,)\\s*(?=(?:L|u8|u|U\\s*\\\")?)",
+          "beginCaptures": {
+            "1": {
+              "name": "punctuation.separator.delimiter.comma.cpp"
+            }
+          },
+          "end": "(?=\\))|(?=(?<!\\\\)\n)",
+          "patterns": [
+            {
+              "include": "#string_context"
+            }
+          ]
+        },
+        {
+          "include": "#evaluation_context"
+        }
+      ]
+    },
+    "storage_specifiers": {
+      "match": "((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))((?<!\\w)(?:volatile|register|restrict|static|extern|const)(?!\\w))",
+      "captures": {
+        "1": {
+          "patterns": [
+            {
+              "include": "#inline_comment"
+            }
+          ]
+        },
+        "2": {
+          "name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+        },
+        "3": {
+          "name": "comment.block.cpp"
+        },
+        "4": {
+          "patterns": [
+            {
+              "match": "\\*\\/",
+              "name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+            },
+            {
+              "match": "\\*",
+              "name": "comment.block.cpp"
+            }
+          ]
+        },
+        "5": {
+          "name": "storage.modifier.specifier.$5.cpp"
+        }
+      }
+    },
+    "storage_types": {
+      "patterns": [
+        {
+          "include": "#storage_specifiers"
+        },
+        {
+          "include": "#primitive_types"
+        },
+        {
+          "include": "#non_primitive_types"
+        },
+        {
+          "include": "#pthread_types"
+        },
+        {
+          "include": "#posix_reserved_types"
+        },
+        {
+          "include": "#decltype"
+        },
+        {
+          "include": "#typename"
+        }
+      ]
+    },
+    "string_context": {
+      "patterns": [
+        {
+          "name": "string.quoted.double.cpp",
+          "begin": "(((?:u|u8|U|L)?)\")",
+          "beginCaptures": {
+            "1": {
+              "name": "punctuation.definition.string.begin.cpp"
+            },
+            "2": {
+              "name": "meta.encoding.cpp"
+            }
+          },
+          "end": "(\")|(?=(?<!\\\\)\n)",
+          "endCaptures": {
+            "1": {
+              "name": "punctuation.definition.string.end.cpp"
+            }
+          },
+          "patterns": [
+            {
+              "match": "(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8})",
+              "name": "constant.character.escape.cpp"
+            },
+            {
+              "match": "\\\\['\"?\\\\abfnrtv]",
+              "name": "constant.character.escape.cpp"
+            },
+            {
+              "match": "\\\\[0-7]{1,3}",
+              "name": "constant.character.escape.cpp"
+            },
+            {
+              "match": "\\\\x[0-9a-fA-F]{2,2}",
+              "name": "constant.character.escape.cpp"
+            },
+            {
+              "include": "#string_escapes_context_c"
+            }
+          ]
+        },
+        {
+          "name": "string.quoted.single.cpp",
+          "begin": "((?<![0-9A-Fa-f])((?:u|u8|U|L)?)')",
+          "beginCaptures": {
+            "1": {
+              "name": "punctuation.definition.string.begin.cpp"
+            },
+            "2": {
+              "name": "meta.encoding.cpp"
+            }
+          },
+          "end": "(')|(?=(?<!\\\\)\n)",
+          "endCaptures": {
+            "1": {
+              "name": "punctuation.definition.string.end.cpp"
+            }
+          },
+          "patterns": [
+            {
+              "include": "#string_escapes_context_c"
+            },
+            {
+              "include": "#line_continuation_character"
+            }
+          ]
+        },
+        {
+          "patterns": [
+            {
+              "name": "string.quoted.double.raw.regex.cpp",
+              "begin": "(((?:[uUL]8?)?R)\\\"(?:(?:_r|re)|regex)\\()",
+              "beginCaptures": {
+                "1": {
+                  "name": "punctuation.definition.string.begin.cpp"
+                },
+                "2": {
+                  "name": "meta.encoding.cpp"
+                }
+              },
+              "end": "(\\)(?:(?:_r|re)|regex)\\\")|(?=(?<!\\\\)\n)",
+              "endCaptures": {
+                "1": {
+                  "name": "punctuation.definition.string.end.cpp"
+                }
+              },
+              "patterns": [
+                {
+                  "include": "source.regexp.python"
+                }
+              ]
+            },
+            {
+              "name": "string.quoted.double.raw.sql.cpp",
+              "begin": "(((?:[uUL]8?)?R)\\\"(?:[pP]?(?:sql|SQL)|d[dm]l)\\()",
+              "beginCaptures": {
+                "1": {
+                  "name": "punctuation.definition.string.begin.cpp"
+                },
+                "2": {
+                  "name": "meta.encoding.cpp"
+                }
+              },
+              "end": "(\\)(?:[pP]?(?:sql|SQL)|d[dm]l)\\\")|(?=(?<!\\\\)\n)",
+              "endCaptures": {
+                "1": {
+                  "name": "punctuation.definition.string.end.cpp"
+                }
+              },
+              "patterns": [
+                {
+                  "include": "source.sql"
+                }
+              ]
+            },
+            {
+              "begin": "((?:u|u8|U|L)?R)\"(?:([^ ()\\\\\\t]{0,16})|([^ ()\\\\\\t]*))\\(",
+              "beginCaptures": {
+                "0": {
+                  "name": "punctuation.definition.string.begin.cpp"
+                },
+                "1": {
+                  "name": "meta.encoding.cpp"
+                },
+                "3": {
+                  "name": "invalid.illegal.delimiter-too-long.cpp"
+                }
+              },
+              "end": "\\)\\2(\\3)\"|(?=(?<!\\\\)\n)",
+              "endCaptures": {
+                "0": {
+                  "name": "punctuation.definition.string.end.cpp"
+                },
+                "1": {
+                  "name": "invalid.illegal.delimiter-too-long.cpp"
+                }
+              },
+              "name": "string.quoted.double.raw.cpp"
+            }
+          ]
+        }
+      ]
+    },
+    "string_escapes_context_c": {
+      "patterns": [
+        {
+          "include": "#backslash_escapes"
+        },
+        {
+          "match": "\\\\.",
+          "name": "invalid.illegal.unknown-escape.cpp"
+        },
+        {
+          "match": "(?x) %\n(\\d+\\$)?\t\t\t\t\t\t   # field (argument #)\n[#0\\- +']*\t\t\t\t\t\t  # flags\n[,;:_]?\t\t\t\t\t\t\t  # separator character (AltiVec)\n((-?\\d+)|\\*(-?\\d+\\$)?)?\t\t  # minimum field width\n(\\.((-?\\d+)|\\*(-?\\d+\\$)?)?)?\t# precision\n(hh|h|ll|l|j|t|z|q|L|vh|vl|v|hv|hl)? # length modifier\n[diouxXDOUeEfFgGaACcSspn%]\t\t   # conversion type",
+          "name": "constant.other.placeholder.cpp"
+        }
+      ]
+    },
+    "struct_block": {
+      "name": "meta.block.struct.cpp",
+      "begin": "((((?<!\\w)struct(?!\\w))(?:(?:((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))|((?:(?:(?:\\[\\[.*?\\]\\]|__attribute(?:__)?\\(\\(.*?\\)\\))|__declspec\\(.*?\\))|alignas\\(.*?\\))(?!\\))))|(?={))(?:((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))(DLLEXPORT)((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z)))))?((?:(?:(?:\\[\\[.*?\\]\\]|__attribute(?:__)?\\(\\(.*?\\)\\))|__declspec\\(.*?\\))|alignas\\(.*?\\))(?!\\)))?((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))((?:(?<!\\w)(?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*(?!\\w))?)(?:((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))(final)((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z)))))?(?:((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))(:)((?>[^{]*)))?))",
+      "beginCaptures": {
+        "1": {
+          "name": "meta.head.struct.cpp"
+        },
+        "3": {
+          "name": "storage.type.$3.cpp"
+        },
+        "4": {
+          "patterns": [
+            {
+              "include": "#inline_comment"
+            }
+          ]
+        },
+        "5": {
+          "name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+        },
+        "6": {
+          "name": "comment.block.cpp"
+        },
+        "7": {
+          "patterns": [
+            {
+              "match": "\\*\\/",
+              "name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+            },
+            {
+              "match": "\\*",
+              "name": "comment.block.cpp"
+            }
+          ]
+        },
+        "8": {
+          "patterns": [
+            {
+              "include": "#attributes_context"
+            },
+            {
+              "include": "#number_literal"
+            }
+          ]
+        },
+        "9": {
+          "patterns": [
+            {
+              "include": "#inline_comment"
+            }
+          ]
+        },
+        "10": {
+          "name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+        },
+        "11": {
+          "name": "comment.block.cpp"
+        },
+        "12": {
+          "patterns": [
+            {
+              "match": "\\*\\/",
+              "name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+            },
+            {
+              "match": "\\*",
+              "name": "comment.block.cpp"
+            }
+          ]
+        },
+        "13": {
+          "name": "entity.name.other.preprocessor.macro.predefined.DLLEXPORT.cpp"
+        },
+        "14": {
+          "patterns": [
+            {
+              "include": "#inline_comment"
+            }
+          ]
+        },
+        "15": {
+          "name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+        },
+        "16": {
+          "name": "comment.block.cpp"
+        },
+        "17": {
+          "patterns": [
+            {
+              "match": "\\*\\/",
+              "name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+            },
+            {
+              "match": "\\*",
+              "name": "comment.block.cpp"
+            }
+          ]
+        },
+        "18": {
+          "patterns": [
+            {
+              "include": "#attributes_context"
+            },
+            {
+              "include": "#number_literal"
+            }
+          ]
+        },
+        "19": {
+          "patterns": [
+            {
+              "include": "#inline_comment"
+            }
+          ]
+        },
+        "20": {
+          "name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+        },
+        "21": {
+          "name": "comment.block.cpp"
+        },
+        "22": {
+          "patterns": [
+            {
+              "match": "\\*\\/",
+              "name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+            },
+            {
+              "match": "\\*",
+              "name": "comment.block.cpp"
+            }
+          ]
+        },
+        "23": {
+          "name": "entity.name.type.$3.cpp"
+        },
+        "24": {
+          "patterns": [
+            {
+              "include": "#inline_comment"
+            }
+          ]
+        },
+        "25": {
+          "name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+        },
+        "26": {
+          "name": "comment.block.cpp"
+        },
+        "27": {
+          "patterns": [
+            {
+              "match": "\\*\\/",
+              "name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+            },
+            {
+              "match": "\\*",
+              "name": "comment.block.cpp"
+            }
+          ]
+        },
+        "28": {
+          "name": "storage.type.modifier.final.cpp"
+        },
+        "29": {
+          "patterns": [
+            {
+              "include": "#inline_comment"
+            }
+          ]
+        },
+        "30": {
+          "name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+        },
+        "31": {
+          "name": "comment.block.cpp"
+        },
+        "32": {
+          "patterns": [
+            {
+              "match": "\\*\\/",
+              "name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+            },
+            {
+              "match": "\\*",
+              "name": "comment.block.cpp"
+            }
+          ]
+        },
+        "33": {
+          "patterns": [
+            {
+              "include": "#inline_comment"
+            }
+          ]
+        },
+        "34": {
+          "name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+        },
+        "35": {
+          "name": "comment.block.cpp"
+        },
+        "36": {
+          "patterns": [
+            {
+              "match": "\\*\\/",
+              "name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+            },
+            {
+              "match": "\\*",
+              "name": "comment.block.cpp"
+            }
+          ]
+        },
+        "37": {
+          "name": "punctuation.separator.colon.inheritance.cpp"
+        },
+        "38": {
+          "patterns": [
+            {
+              "include": "#inheritance_context"
+            }
+          ]
+        }
+      },
+      "end": "(?:(?:(?<=\\}|%>|\\?\\?>)\\s*(;)|(;))|(?=[;>\\[\\]=]))|(?=(?<!\\\\)\n)",
+      "endCaptures": {
+        "1": {
+          "name": "punctuation.terminator.statement.cpp"
+        },
+        "2": {
+          "name": "punctuation.terminator.statement.cpp"
+        }
+      },
+      "patterns": [
+        {
+          "name": "meta.head.struct.cpp",
+          "begin": "\\G ?",
+          "end": "((?:\\{|<%|\\?\\?<|(?=;)))|(?=(?<!\\\\)\n)",
+          "endCaptures": {
+            "1": {
+              "name": "punctuation.section.block.begin.bracket.curly.struct.cpp"
+            }
+          },
+          "patterns": [
+            {
+              "include": "#ever_present_context"
+            },
+            {
+              "include": "#inheritance_context"
+            },
+            {
+              "include": "#template_call_range"
+            }
+          ]
+        },
+        {
+          "name": "meta.body.struct.cpp",
+          "begin": "(?<=\\{|<%|\\?\\?<)",
+          "end": "(\\}|%>|\\?\\?>)|(?=(?<!\\\\)\n)",
+          "endCaptures": {
+            "1": {
+              "name": "punctuation.section.block.end.bracket.curly.struct.cpp"
+            }
+          },
+          "patterns": [
+            {
+              "include": "#function_pointer"
+            },
+            {
+              "include": "#static_assert"
+            },
+            {
+              "include": "#constructor_inline"
+            },
+            {
+              "include": "#destructor_inline"
+            },
+            {
+              "include": "$self"
+            }
+          ]
+        },
+        {
+          "name": "meta.tail.struct.cpp",
+          "begin": "(?<=\\}|%>|\\?\\?>)[\\s\\n]*",
+          "end": "[\\s\\n]*(?=;)|(?=(?<!\\\\)\n)",
+          "patterns": [
+            {
+              "include": "$self"
+            }
+          ]
+        }
+      ]
+    },
+    "struct_declare": {
+      "match": "((?<!\\w)struct(?!\\w))((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))((?<!\\w)(?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*(?!\\w))(((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))?(?:(?:\\&|\\*)((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z)))))*(?:\\&|\\*))?((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))\\b(?!override\\W|override\\$|final\\W|final\\$)((?<!\\w)(?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*(?!\\w))((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))(?=\\S)(?![:{])",
+      "captures": {
+        "1": {
+          "name": "storage.type.struct.declare.cpp"
+        },
+        "2": {
+          "patterns": [
+            {
+              "include": "#inline_comment"
+            }
+          ]
+        },
+        "3": {
+          "name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+        },
+        "4": {
+          "name": "comment.block.cpp"
+        },
+        "5": {
+          "patterns": [
+            {
+              "match": "\\*\\/",
+              "name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+            },
+            {
+              "match": "\\*",
+              "name": "comment.block.cpp"
+            }
+          ]
+        },
+        "6": {
+          "name": "entity.name.type.struct.cpp"
+        },
+        "7": {
+          "patterns": [
+            {
+              "match": "\\*",
+              "name": "storage.modifier.pointer.cpp"
+            },
+            {
+              "match": "(?:\\&((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))){2,}\\&",
+              "captures": {
+                "1": {
+                  "patterns": [
+                    {
+                      "include": "#inline_comment"
+                    }
+                  ]
+                },
+                "2": {
+                  "name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+                },
+                "3": {
+                  "name": "comment.block.cpp"
+                },
+                "4": {
+                  "patterns": [
+                    {
+                      "match": "\\*\\/",
+                      "name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+                    },
+                    {
+                      "match": "\\*",
+                      "name": "comment.block.cpp"
+                    }
+                  ]
+                }
+              },
+              "name": "invalid.illegal.reference-type.cpp"
+            },
+            {
+              "match": "\\&",
+              "name": "storage.modifier.reference.cpp"
+            }
+          ]
+        },
+        "8": {
+          "patterns": [
+            {
+              "include": "#inline_comment"
+            }
+          ]
+        },
+        "9": {
+          "name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+        },
+        "10": {
+          "name": "comment.block.cpp"
+        },
+        "11": {
+          "patterns": [
+            {
+              "match": "\\*\\/",
+              "name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+            },
+            {
+              "match": "\\*",
+              "name": "comment.block.cpp"
+            }
+          ]
+        },
+        "12": {
+          "patterns": [
+            {
+              "include": "#inline_comment"
+            }
+          ]
+        },
+        "13": {
+          "name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+        },
+        "14": {
+          "name": "comment.block.cpp"
+        },
+        "15": {
+          "patterns": [
+            {
+              "match": "\\*\\/",
+              "name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+            },
+            {
+              "match": "\\*",
+              "name": "comment.block.cpp"
+            }
+          ]
+        },
+        "16": {
+          "patterns": [
+            {
+              "include": "#inline_comment"
+            }
+          ]
+        },
+        "17": {
+          "name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+        },
+        "18": {
+          "name": "comment.block.cpp"
+        },
+        "19": {
+          "patterns": [
+            {
+              "match": "\\*\\/",
+              "name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+            },
+            {
+              "match": "\\*",
+              "name": "comment.block.cpp"
+            }
+          ]
+        },
+        "20": {
+          "name": "variable.other.object.declare.cpp"
+        },
+        "21": {
+          "patterns": [
+            {
+              "include": "#inline_comment"
+            }
+          ]
+        },
+        "22": {
+          "name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+        },
+        "23": {
+          "name": "comment.block.cpp"
+        },
+        "24": {
+          "patterns": [
+            {
+              "match": "\\*\\/",
+              "name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+            },
+            {
+              "match": "\\*",
+              "name": "comment.block.cpp"
+            }
+          ]
+        }
+      }
+    },
+    "switch_conditional_parentheses": {
+      "name": "meta.conditional.switch.cpp",
+      "begin": "((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))(\\()",
+      "beginCaptures": {
+        "1": {
+          "patterns": [
+            {
+              "include": "#inline_comment"
+            }
+          ]
+        },
+        "2": {
+          "name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+        },
+        "3": {
+          "name": "comment.block.cpp"
+        },
+        "4": {
+          "patterns": [
+            {
+              "match": "\\*\\/",
+              "name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+            },
+            {
+              "match": "\\*",
+              "name": "comment.block.cpp"
+            }
+          ]
+        },
+        "5": {
+          "name": "punctuation.section.parens.begin.bracket.round.conditional.switch.cpp"
+        }
+      },
+      "end": "(\\))|(?=(?<!\\\\)\n)",
+      "endCaptures": {
+        "1": {
+          "name": "punctuation.section.parens.end.bracket.round.conditional.switch.cpp"
+        }
+      },
+      "patterns": [
+        {
+          "include": "#evaluation_context"
+        },
+        {
+          "include": "#c_conditional_context"
+        }
+      ]
+    },
+    "switch_statement": {
+      "name": "meta.block.switch.cpp",
+      "begin": "(((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))((?<!\\w)switch(?!\\w)))",
+      "beginCaptures": {
+        "1": {
+          "name": "meta.head.switch.cpp"
+        },
+        "2": {
+          "patterns": [
+            {
+              "include": "#inline_comment"
+            }
+          ]
+        },
+        "3": {
+          "name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+        },
+        "4": {
+          "name": "comment.block.cpp"
+        },
+        "5": {
+          "patterns": [
+            {
+              "match": "\\*\\/",
+              "name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+            },
+            {
+              "match": "\\*",
+              "name": "comment.block.cpp"
+            }
+          ]
+        },
+        "6": {
+          "name": "keyword.control.switch.cpp"
+        }
+      },
+      "end": "(?:(?<=\\}|%>|\\?\\?>)|(?=[;>\\[\\]=]))|(?=(?<!\\\\)\n)",
+      "patterns": [
+        {
+          "name": "meta.head.switch.cpp",
+          "begin": "\\G ?",
+          "end": "((?:\\{|<%|\\?\\?<|(?=;)))|(?=(?<!\\\\)\n)",
+          "endCaptures": {
+            "1": {
+              "name": "punctuation.section.block.begin.bracket.curly.switch.cpp"
+            }
+          },
+          "patterns": [
+            {
+              "include": "#switch_conditional_parentheses"
+            },
+            {
+              "include": "$self"
+            }
+          ]
+        },
+        {
+          "name": "meta.body.switch.cpp",
+          "begin": "(?<=\\{|<%|\\?\\?<)",
+          "end": "(\\}|%>|\\?\\?>)|(?=(?<!\\\\)\n)",
+          "endCaptures": {
+            "1": {
+              "name": "punctuation.section.block.end.bracket.curly.switch.cpp"
+            }
+          },
+          "patterns": [
+            {
+              "include": "#default_statement"
+            },
+            {
+              "include": "#case_statement"
+            },
+            {
+              "include": "$self"
+            },
+            {
+              "include": "#block_innards"
+            }
+          ]
+        },
+        {
+          "name": "meta.tail.switch.cpp",
+          "begin": "(?<=\\}|%>|\\?\\?>)[\\s\\n]*",
+          "end": "[\\s\\n]*(?=;)|(?=(?<!\\\\)\n)",
+          "patterns": [
+            {
+              "include": "$self"
+            }
+          ]
+        }
+      ]
+    },
+    "template_argument_defaulted": {
+      "match": "(?<=<|,)\\s*((?:(?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*\\s+)*)((?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*)\\s*([=])",
+      "captures": {
+        "1": {
+          "name": "storage.type.template.cpp"
+        },
+        "2": {
+          "name": "entity.name.type.template.cpp"
+        },
+        "3": {
+          "name": "keyword.operator.assignment.cpp"
+        }
+      }
+    },
+    "template_call_context": {
+      "patterns": [
+        {
+          "include": "#ever_present_context"
+        },
+        {
+          "include": "#template_call_range"
+        },
+        {
+          "include": "#storage_types"
+        },
+        {
+          "include": "#language_constants"
+        },
+        {
+          "include": "#scope_resolution_template_call_inner_generated"
+        },
+        {
+          "include": "#operators"
+        },
+        {
+          "include": "#number_literal"
+        },
+        {
+          "include": "#string_context"
+        },
+        {
+          "include": "#comma_in_template_argument"
+        },
+        {
+          "include": "#qualified_type"
+        }
+      ]
+    },
+    "template_call_innards": {
+      "match": "((?<!<)<(?!<)(?>(?:(?>[^<>]*)\\g<1>?)+)>)\\s*",
+      "captures": {
+        "0": {
+          "name": "meta.template.call.cpp",
+          "patterns": [
+            {
+              "include": "#template_call_range"
+            }
+          ]
+        }
+      }
+    },
+    "template_call_range": {
+      "name": "meta.template.call.cpp",
+      "begin": "(<)",
+      "beginCaptures": {
+        "1": {
+          "name": "punctuation.section.angle-brackets.begin.template.call.cpp"
+        }
+      },
+      "end": "(>)|(?=(?<!\\\\)\n)",
+      "endCaptures": {
+        "1": {
+          "name": "punctuation.section.angle-brackets.end.template.call.cpp"
+        }
+      },
+      "patterns": [
+        {
+          "include": "#template_call_context"
+        }
+      ]
+    },
+    "template_definition": {
+      "name": "meta.template.definition.cpp",
+      "begin": "(?<!\\w)(template)\\s*(<)",
+      "beginCaptures": {
+        "1": {
+          "name": "storage.type.template.cpp"
+        },
+        "2": {
+          "name": "punctuation.section.angle-brackets.start.template.definition.cpp"
+        }
+      },
+      "end": "(>)|(?=(?<!\\\\)\n)",
+      "endCaptures": {
+        "1": {
+          "name": "punctuation.section.angle-brackets.end.template.definition.cpp"
+        }
+      },
+      "patterns": [
+        {
+          "begin": "((?<=\\w)\\s*<)",
+          "beginCaptures": {
+            "1": {
+              "name": "punctuation.section.angle-brackets.begin.template.call.cpp"
+            }
+          },
+          "end": "(>)|(?=(?<!\\\\)\n)",
+          "endCaptures": {
+            "1": {
+              "name": "punctuation.section.angle-brackets.begin.template.call.cpp"
+            }
+          },
+          "patterns": [
+            {
+              "include": "#template_call_context"
+            }
+          ]
+        },
+        {
+          "include": "#template_definition_context"
+        }
+      ]
+    },
+    "template_definition_argument": {
+      "match": "((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))(?:(?:((?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*)|((?:(?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*\\s+)+)((?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*))|((?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*)\\s*(\\.\\.\\.)\\s*((?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*))\\s*(?:(,)|(?=>|$))",
+      "captures": {
+        "1": {
+          "patterns": [
+            {
+              "include": "#inline_comment"
+            }
+          ]
+        },
+        "2": {
+          "name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+        },
+        "3": {
+          "name": "comment.block.cpp"
+        },
+        "4": {
+          "patterns": [
+            {
+              "match": "\\*\\/",
+              "name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+            },
+            {
+              "match": "\\*",
+              "name": "comment.block.cpp"
+            }
+          ]
+        },
+        "5": {
+          "name": "storage.type.template.argument.$5.cpp"
+        },
+        "6": {
+          "patterns": [
+            {
+              "match": "(?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*",
+              "name": "storage.type.template.argument.$0.cpp"
+            }
+          ]
+        },
+        "7": {
+          "name": "entity.name.type.template.cpp"
+        },
+        "8": {
+          "name": "storage.type.template.cpp"
+        },
+        "9": {
+          "name": "punctuation.vararg-ellipses.template.definition.cpp"
+        },
+        "10": {
+          "name": "entity.name.type.template.cpp"
+        },
+        "11": {
+          "name": "punctuation.separator.delimiter.comma.template.argument.cpp"
+        }
+      }
+    },
+    "template_definition_context": {
+      "patterns": [
+        {
+          "include": "#scope_resolution_template_definition_inner_generated"
+        },
+        {
+          "include": "#template_definition_argument"
+        },
+        {
+          "include": "#template_argument_defaulted"
+        },
+        {
+          "include": "#template_call_innards"
+        },
+        {
+          "include": "#evaluation_context"
+        }
+      ]
+    },
+    "template_isolated_definition": {
+      "match": "(?<!\\w)(template)\\s*(<)(.*)(>\\s*$)",
+      "captures": {
+        "1": {
+          "name": "storage.type.template.cpp"
+        },
+        "2": {
+          "name": "punctuation.section.angle-brackets.start.template.definition.cpp"
+        },
+        "3": {
+          "name": "meta.template.definition.cpp",
+          "patterns": [
+            {
+              "include": "#template_definition_context"
+            }
+          ]
+        },
+        "4": {
+          "name": "punctuation.section.angle-brackets.end.template.definition.cpp"
+        }
+      }
+    },
+    "ternary_operator": {
+      "applyEndPatternLast": true,
+      "begin": "(\\?)",
+      "beginCaptures": {
+        "1": {
+          "name": "keyword.operator.ternary.cpp"
+        }
+      },
+      "end": "(:)|(?=(?<!\\\\)\n)",
+      "endCaptures": {
+        "1": {
+          "name": "keyword.operator.ternary.cpp"
+        }
+      },
+      "patterns": [
+        {
+          "include": "#ever_present_context"
+        },
+        {
+          "include": "#string_context"
+        },
+        {
+          "include": "#number_literal"
+        },
+        {
+          "include": "#method_access"
+        },
+        {
+          "include": "#member_access"
+        },
+        {
+          "include": "#predefined_macros"
+        },
+        {
+          "include": "#operators"
+        },
+        {
+          "include": "#memory_operators"
+        },
+        {
+          "include": "#wordlike_operators"
+        },
+        {
+          "include": "#type_casting_operators"
+        },
+        {
+          "include": "#control_flow_keywords"
+        },
+        {
+          "include": "#exception_keywords"
+        },
+        {
+          "include": "#the_this_keyword"
+        },
+        {
+          "include": "#language_constants"
+        },
+        {
+          "include": "#builtin_storage_type_initilizer"
+        },
+        {
+          "include": "#qualifiers_and_specifiers_post_parameters"
+        },
+        {
+          "include": "#functional_specifiers_pre_parameters"
+        },
+        {
+          "include": "#storage_types"
+        },
+        {
+          "include": "#misc_storage_modifiers"
+        },
+        {
+          "include": "#lambdas"
+        },
+        {
+          "include": "#attributes_context"
+        },
+        {
+          "include": "#parentheses"
+        },
+        {
+          "include": "#function_call"
+        },
+        {
+          "include": "#scope_resolution_inner_generated"
+        },
+        {
+          "include": "#square_brackets"
+        },
+        {
+          "include": "#empty_square_brackets"
+        },
+        {
+          "include": "#semicolon"
+        },
+        {
+          "include": "#comma"
+        }
+      ]
+    },
+    "the_this_keyword": {
+      "match": "((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))((?<!\\w)this(?!\\w))",
+      "captures": {
+        "1": {
+          "patterns": [
+            {
+              "include": "#inline_comment"
+            }
+          ]
+        },
+        "2": {
+          "name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+        },
+        "3": {
+          "name": "comment.block.cpp"
+        },
+        "4": {
+          "patterns": [
+            {
+              "match": "\\*\\/",
+              "name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+            },
+            {
+              "match": "\\*",
+              "name": "comment.block.cpp"
+            }
+          ]
+        },
+        "5": {
+          "name": "variable.language.this.cpp"
+        }
+      }
+    },
+    "type_alias": {
+      "match": "(using)\\s*(?!namespace)(\\s*+((?:(?:(?:\\[\\[.*?\\]\\]|__attribute(?:__)?\\(\\(.*?\\)\\))|__declspec\\(.*?\\))|alignas\\(.*?\\))(?!\\)))?((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))(?:(?:(?:unsigned|signed|short|long)|(?:struct|class|union|enum))((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z)))))*(((::)?(?:((?-mix:(?!\\b(?:__has_cpp_attribute|reinterpret_cast|atomic_noexcept|atomic_cancel|atomic_commit|__has_include|dynamic_cast|thread_local|synchronized|static_cast|const_cast|consteval|constexpr|protected|namespace|co_return|constexpr|constexpr|continue|explicit|volatile|noexcept|co_yield|noexcept|noexcept|requires|typename|decltype|operator|co_await|template|volatile|register|restrict|reflexpr|alignof|private|default|mutable|include|concept|__asm__|defined|_Pragma|alignas|typedef|warning|virtual|mutable|struct|sizeof|delete|not_eq|bitand|and_eq|xor_eq|typeid|switch|return|static|extern|inline|friend|public|ifndef|define|pragma|export|import|module|catch|throw|const|or_eq|while|compl|bitor|const|union|ifdef|class|undef|error|break|using|endif|goto|line|enum|this|case|else|elif|else|asm|try|for|new|and|xor|not|do|or|if|if)\\b)(?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*))\\s*+(((?<!<)<(?!<)(?>(?:(?>[^<>]*)\\g<58>?)+)>)\\s*)?::)*\\s*+)((?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*)\\s*+(((?<!<)<(?!<)(?>(?:(?>[^<>]*)\\g<58>?)+)>)\\s*)?(::))?((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))(?!(?:transaction_safe_dynamic|__has_cpp_attribute|transaction_safe|reinterpret_cast|atomic_noexcept|atomic_commit|atomic_cancel|__has_include|dynamic_cast|thread_local|synchronized|static_cast|const_cast|constexpr|consteval|protected|constexpr|co_return|namespace|constexpr|noexcept|typename|decltype|template|operator|noexcept|co_yield|co_await|continue|volatile|register|restrict|explicit|override|volatile|reflexpr|noexcept|requires|default|typedef|nullptr|alignof|mutable|concept|virtual|defined|__asm__|include|_Pragma|mutable|warning|private|alignas|module|switch|not_eq|bitand|and_eq|ifndef|return|sizeof|xor_eq|export|static|delete|public|define|extern|inline|import|pragma|friend|typeid|const|compl|bitor|throw|or_eq|while|catch|break|false|final|const|endif|ifdef|undef|error|using|audit|axiom|line|else|elif|true|NULL|case|goto|else|this|new|asm|not|and|xor|try|for|if|do|or|if)\\b)((?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*)\\b(((?<!<)<(?!<)(?>(?:(?>[^<>]*)\\g<58>?)+)>)\\s*)?(?![\\w<:.]))\\s*(\\=)\\s*((?:typename)?)\\s*((?:(?:(?>(?:(?:(?>(?<!\\s)\\s+)|(?:\\/\\*)(?:(?>(?:[^\\*]|(?>\\*+)[^\\/])*)(?:(?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))(?:(?<!\\w)(?:volatile|register|restrict|static|extern|const)(?!\\w))\\s+)+)?(?:(\\s*+((?:(?:(?:\\[\\[.*?\\]\\]|__attribute(?:__)?\\(\\(.*?\\)\\))|__declspec\\(.*?\\))|alignas\\(.*?\\))(?!\\)))?((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))(?:(?:(?:unsigned|signed|short|long)|(?:struct|class|union|enum))((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z)))))*(((::)?(?:((?-mix:(?!\\b(?:__has_cpp_attribute|reinterpret_cast|atomic_noexcept|atomic_cancel|atomic_commit|__has_include|dynamic_cast|thread_local|synchronized|static_cast|const_cast|consteval|constexpr|protected|namespace|co_return|constexpr|constexpr|continue|explicit|volatile|noexcept|co_yield|noexcept|noexcept|requires|typename|decltype|operator|co_await|template|volatile|register|restrict|reflexpr|alignof|private|default|mutable|include|concept|__asm__|defined|_Pragma|alignas|typedef|warning|virtual|mutable|struct|sizeof|delete|not_eq|bitand|and_eq|xor_eq|typeid|switch|return|static|extern|inline|friend|public|ifndef|define|pragma|export|import|module|catch|throw|const|or_eq|while|compl|bitor|const|union|ifdef|class|undef|error|break|using|endif|goto|line|enum|this|case|else|elif|else|asm|try|for|new|and|xor|not|do|or|if|if)\\b)(?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*))\\s*+(((?<!<)<(?!<)(?>(?:(?>[^<>]*)\\g<58>?)+)>)\\s*)?::)*\\s*+)((?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*)\\s*+(((?<!<)<(?!<)(?>(?:(?>[^<>]*)\\g<58>?)+)>)\\s*)?(::))?((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))(?!(?:transaction_safe_dynamic|__has_cpp_attribute|transaction_safe|reinterpret_cast|atomic_noexcept|atomic_commit|atomic_cancel|__has_include|dynamic_cast|thread_local|synchronized|static_cast|const_cast|constexpr|consteval|protected|constexpr|co_return|namespace|constexpr|noexcept|typename|decltype|template|operator|noexcept|co_yield|co_await|continue|volatile|register|restrict|explicit|override|volatile|reflexpr|noexcept|requires|default|typedef|nullptr|alignof|mutable|concept|virtual|defined|__asm__|include|_Pragma|mutable|warning|private|alignas|module|switch|not_eq|bitand|and_eq|ifndef|return|sizeof|xor_eq|export|static|delete|public|define|extern|inline|import|pragma|friend|typeid|const|compl|bitor|throw|or_eq|while|catch|break|false|final|const|endif|ifdef|undef|error|using|audit|axiom|line|else|elif|true|NULL|case|goto|else|this|new|asm|not|and|xor|try|for|if|do|or|if)\\b)((?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*)\\b(((?<!<)<(?!<)(?>(?:(?>[^<>]*)\\g<58>?)+)>)\\s*)?(?![\\w<:.]))|(.*(?<!;)))(?:(((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))?(?:(?:\\&|\\*)((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z)))))*(?:\\&|\\*))((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z)))))?(?:(\\[)(\\w*)(\\])\\s*)?\\s*(?:(;)|\\n)",
+      "captures": {
+        "1": {
+          "name": "keyword.other.using.directive.cpp"
+        },
+        "2": {
+          "name": "meta.qualified_type.cpp",
+          "patterns": [
+            {
+              "match": "(?<!\\w)(?:struct|class|union|enum)(?!\\w)",
+              "name": "storage.type.$0.cpp"
+            },
+            {
+              "include": "#attributes_context"
+            },
+            {
+              "include": "#function_type"
+            },
+            {
+              "include": "#storage_types"
+            },
+            {
+              "include": "#number_literal"
+            },
+            {
+              "include": "#string_context"
+            },
+            {
+              "include": "#comma"
+            },
+            {
+              "include": "#scope_resolution_inner_generated"
+            },
+            {
+              "include": "#template_call_range"
+            },
+            {
+              "match": "(?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*",
+              "name": "entity.name.type.cpp"
+            }
+          ]
+        },
+        "3": {
+          "patterns": [
+            {
+              "include": "#attributes_context"
+            },
+            {
+              "include": "#number_literal"
+            }
+          ]
+        },
+        "4": {
+          "patterns": [
+            {
+              "include": "#inline_comment"
+            }
+          ]
+        },
+        "5": {
+          "name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+        },
+        "6": {
+          "name": "comment.block.cpp"
+        },
+        "7": {
+          "patterns": [
+            {
+              "match": "\\*\\/",
+              "name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+            },
+            {
+              "match": "\\*",
+              "name": "comment.block.cpp"
+            }
+          ]
+        },
+        "8": {
+          "patterns": [
+            {
+              "include": "#inline_comment"
+            }
+          ]
+        },
+        "9": {
+          "name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+        },
+        "10": {
+          "name": "comment.block.cpp"
+        },
+        "11": {
+          "patterns": [
+            {
+              "match": "\\*\\/",
+              "name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+            },
+            {
+              "match": "\\*",
+              "name": "comment.block.cpp"
+            }
+          ]
+        },
+        "13": {
+          "patterns": [
+            {
+              "include": "#scope_resolution_inner_generated"
+            }
+          ]
+        },
+        "14": {
+          "name": "punctuation.separator.namespace.access.cpp punctuation.separator.scope-resolution.cpp"
+        },
+        "16": {
+          "name": "meta.template.call.cpp",
+          "patterns": [
+            {
+              "include": "#template_call_range"
+            }
+          ]
+        },
+        "18": {
+          "name": "entity.name.scope-resolution.cpp"
+        },
+        "19": {
+          "name": "meta.template.call.cpp",
+          "patterns": [
+            {
+              "include": "#template_call_range"
+            }
+          ]
+        },
+        "21": {
+          "name": "punctuation.separator.namespace.access.cpp punctuation.separator.scope-resolution.cpp"
+        },
+        "22": {
+          "patterns": [
+            {
+              "include": "#inline_comment"
+            }
+          ]
+        },
+        "23": {
+          "name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+        },
+        "24": {
+          "name": "comment.block.cpp"
+        },
+        "25": {
+          "patterns": [
+            {
+              "match": "\\*\\/",
+              "name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+            },
+            {
+              "match": "\\*",
+              "name": "comment.block.cpp"
+            }
+          ]
+        },
+        "26": {
+          "name": "entity.name.type.cpp"
+        },
+        "27": {
+          "name": "meta.template.call.cpp",
+          "patterns": [
+            {
+              "include": "#template_call_range"
+            }
+          ]
+        },
+        "29": {
+          "name": "keyword.operator.assignment.cpp"
+        },
+        "30": {
+          "name": "keyword.other.typename.cpp"
+        },
+        "31": {
+          "patterns": [
+            {
+              "include": "#storage_specifiers"
+            }
+          ]
+        },
+        "32": {
+          "name": "meta.qualified_type.cpp",
+          "patterns": [
+            {
+              "match": "(?<!\\w)(?:struct|class|union|enum)(?!\\w)",
+              "name": "storage.type.$0.cpp"
+            },
+            {
+              "include": "#attributes_context"
+            },
+            {
+              "include": "#function_type"
+            },
+            {
+              "include": "#storage_types"
+            },
+            {
+              "include": "#number_literal"
+            },
+            {
+              "include": "#string_context"
+            },
+            {
+              "include": "#comma"
+            },
+            {
+              "include": "#scope_resolution_inner_generated"
+            },
+            {
+              "include": "#template_call_range"
+            },
+            {
+              "match": "(?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*",
+              "name": "entity.name.type.cpp"
+            }
+          ]
+        },
+        "33": {
+          "patterns": [
+            {
+              "include": "#attributes_context"
+            },
+            {
+              "include": "#number_literal"
+            }
+          ]
+        },
+        "34": {
+          "patterns": [
+            {
+              "include": "#inline_comment"
+            }
+          ]
+        },
+        "35": {
+          "name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+        },
+        "36": {
+          "name": "comment.block.cpp"
+        },
+        "37": {
+          "patterns": [
+            {
+              "match": "\\*\\/",
+              "name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+            },
+            {
+              "match": "\\*",
+              "name": "comment.block.cpp"
+            }
+          ]
+        },
+        "38": {
+          "patterns": [
+            {
+              "include": "#inline_comment"
+            }
+          ]
+        },
+        "39": {
+          "name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+        },
+        "40": {
+          "name": "comment.block.cpp"
+        },
+        "41": {
+          "patterns": [
+            {
+              "match": "\\*\\/",
+              "name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+            },
+            {
+              "match": "\\*",
+              "name": "comment.block.cpp"
+            }
+          ]
+        },
+        "43": {
+          "patterns": [
+            {
+              "include": "#scope_resolution_inner_generated"
+            }
+          ]
+        },
+        "44": {
+          "name": "punctuation.separator.namespace.access.cpp punctuation.separator.scope-resolution.cpp"
+        },
+        "46": {
+          "name": "meta.template.call.cpp",
+          "patterns": [
+            {
+              "include": "#template_call_range"
+            }
+          ]
+        },
+        "48": {
+          "name": "entity.name.scope-resolution.cpp"
+        },
+        "49": {
+          "name": "meta.template.call.cpp",
+          "patterns": [
+            {
+              "include": "#template_call_range"
+            }
+          ]
+        },
+        "51": {
+          "name": "punctuation.separator.namespace.access.cpp punctuation.separator.scope-resolution.cpp"
+        },
+        "52": {
+          "patterns": [
+            {
+              "include": "#inline_comment"
+            }
+          ]
+        },
+        "53": {
+          "name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+        },
+        "54": {
+          "name": "comment.block.cpp"
+        },
+        "55": {
+          "patterns": [
+            {
+              "match": "\\*\\/",
+              "name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+            },
+            {
+              "match": "\\*",
+              "name": "comment.block.cpp"
+            }
+          ]
+        },
+        "56": {
+          "name": "entity.name.type.cpp"
+        },
+        "57": {
+          "name": "meta.template.call.cpp",
+          "patterns": [
+            {
+              "include": "#template_call_range"
+            }
+          ]
+        },
+        "59": {
+          "name": "meta.declaration.type.alias.value.unknown.cpp",
+          "patterns": [
+            {
+              "include": "#evaluation_context"
+            }
+          ]
+        },
+        "60": {
+          "patterns": [
+            {
+              "match": "\\*",
+              "name": "storage.modifier.pointer.cpp"
+            },
+            {
+              "match": "(?:\\&((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))){2,}\\&",
+              "captures": {
+                "1": {
+                  "patterns": [
+                    {
+                      "include": "#inline_comment"
+                    }
+                  ]
+                },
+                "2": {
+                  "name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+                },
+                "3": {
+                  "name": "comment.block.cpp"
+                },
+                "4": {
+                  "patterns": [
+                    {
+                      "match": "\\*\\/",
+                      "name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+                    },
+                    {
+                      "match": "\\*",
+                      "name": "comment.block.cpp"
+                    }
+                  ]
+                }
+              },
+              "name": "invalid.illegal.reference-type.cpp"
+            },
+            {
+              "match": "\\&",
+              "name": "storage.modifier.reference.cpp"
+            }
+          ]
+        },
+        "61": {
+          "patterns": [
+            {
+              "include": "#inline_comment"
+            }
+          ]
+        },
+        "62": {
+          "name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+        },
+        "63": {
+          "name": "comment.block.cpp"
+        },
+        "64": {
+          "patterns": [
+            {
+              "match": "\\*\\/",
+              "name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+            },
+            {
+              "match": "\\*",
+              "name": "comment.block.cpp"
+            }
+          ]
+        },
+        "65": {
+          "patterns": [
+            {
+              "include": "#inline_comment"
+            }
+          ]
+        },
+        "66": {
+          "name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+        },
+        "67": {
+          "name": "comment.block.cpp"
+        },
+        "68": {
+          "patterns": [
+            {
+              "match": "\\*\\/",
+              "name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+            },
+            {
+              "match": "\\*",
+              "name": "comment.block.cpp"
+            }
+          ]
+        },
+        "69": {
+          "patterns": [
+            {
+              "include": "#inline_comment"
+            }
+          ]
+        },
+        "70": {
+          "name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+        },
+        "71": {
+          "name": "comment.block.cpp"
+        },
+        "72": {
+          "patterns": [
+            {
+              "match": "\\*\\/",
+              "name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+            },
+            {
+              "match": "\\*",
+              "name": "comment.block.cpp"
+            }
+          ]
+        },
+        "73": {
+          "name": "punctuation.definition.begin.bracket.square.cpp"
+        },
+        "74": {
+          "patterns": [
+            {
+              "include": "#evaluation_context"
+            }
+          ]
+        },
+        "75": {
+          "name": "punctuation.definition.end.bracket.square.cpp"
+        },
+        "76": {
+          "name": "punctuation.terminator.statement.cpp"
+        }
+      },
+      "name": "meta.declaration.type.alias.cpp"
+    },
+    "type_casting_operators": {
+      "match": "((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))((?<!\\w)(?:reinterpret_cast|dynamic_cast|static_cast|const_cast)(?!\\w))",
+      "captures": {
+        "1": {
+          "patterns": [
+            {
+              "include": "#inline_comment"
+            }
+          ]
+        },
+        "2": {
+          "name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+        },
+        "3": {
+          "name": "comment.block.cpp"
+        },
+        "4": {
+          "patterns": [
+            {
+              "match": "\\*\\/",
+              "name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+            },
+            {
+              "match": "\\*",
+              "name": "comment.block.cpp"
+            }
+          ]
+        },
+        "5": {
+          "name": "keyword.operator.wordlike.cpp keyword.operator.cast.$5.cpp"
+        }
+      }
+    },
+    "typedef_class": {
+      "begin": "((?<!\\w)typedef(?!\\w))\\s*(?=(?<!\\w)class(?!\\w))",
+      "beginCaptures": {
+        "1": {
+          "name": "keyword.other.typedef.cpp"
+        }
+      },
+      "end": "(?<=;)|(?=(?<!\\\\)\n)",
+      "patterns": [
+        {
+          "name": "meta.block.class.cpp",
+          "begin": "((((?<!\\w)class(?!\\w))(?:(?:((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))|((?:(?:(?:\\[\\[.*?\\]\\]|__attribute(?:__)?\\(\\(.*?\\)\\))|__declspec\\(.*?\\))|alignas\\(.*?\\))(?!\\))))|(?={))(?:((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))(DLLEXPORT)((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z)))))?((?:(?:(?:\\[\\[.*?\\]\\]|__attribute(?:__)?\\(\\(.*?\\)\\))|__declspec\\(.*?\\))|alignas\\(.*?\\))(?!\\)))?((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))((?:(?<!\\w)(?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*(?!\\w))?)(?:((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))(final)((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z)))))?(?:((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))(:)((?>[^{]*)))?))",
+          "beginCaptures": {
+            "1": {
+              "name": "meta.head.class.cpp"
+            },
+            "3": {
+              "name": "storage.type.$3.cpp"
+            },
+            "4": {
+              "patterns": [
+                {
+                  "include": "#inline_comment"
+                }
+              ]
+            },
+            "5": {
+              "name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+            },
+            "6": {
+              "name": "comment.block.cpp"
+            },
+            "7": {
+              "patterns": [
+                {
+                  "match": "\\*\\/",
+                  "name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+                },
+                {
+                  "match": "\\*",
+                  "name": "comment.block.cpp"
+                }
+              ]
+            },
+            "8": {
+              "patterns": [
+                {
+                  "include": "#attributes_context"
+                },
+                {
+                  "include": "#number_literal"
+                }
+              ]
+            },
+            "9": {
+              "patterns": [
+                {
+                  "include": "#inline_comment"
+                }
+              ]
+            },
+            "10": {
+              "name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+            },
+            "11": {
+              "name": "comment.block.cpp"
+            },
+            "12": {
+              "patterns": [
+                {
+                  "match": "\\*\\/",
+                  "name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+                },
+                {
+                  "match": "\\*",
+                  "name": "comment.block.cpp"
+                }
+              ]
+            },
+            "13": {
+              "name": "entity.name.other.preprocessor.macro.predefined.DLLEXPORT.cpp"
+            },
+            "14": {
+              "patterns": [
+                {
+                  "include": "#inline_comment"
+                }
+              ]
+            },
+            "15": {
+              "name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+            },
+            "16": {
+              "name": "comment.block.cpp"
+            },
+            "17": {
+              "patterns": [
+                {
+                  "match": "\\*\\/",
+                  "name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+                },
+                {
+                  "match": "\\*",
+                  "name": "comment.block.cpp"
+                }
+              ]
+            },
+            "18": {
+              "patterns": [
+                {
+                  "include": "#attributes_context"
+                },
+                {
+                  "include": "#number_literal"
+                }
+              ]
+            },
+            "19": {
+              "patterns": [
+                {
+                  "include": "#inline_comment"
+                }
+              ]
+            },
+            "20": {
+              "name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+            },
+            "21": {
+              "name": "comment.block.cpp"
+            },
+            "22": {
+              "patterns": [
+                {
+                  "match": "\\*\\/",
+                  "name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+                },
+                {
+                  "match": "\\*",
+                  "name": "comment.block.cpp"
+                }
+              ]
+            },
+            "23": {
+              "name": "entity.name.type.$3.cpp"
+            },
+            "24": {
+              "patterns": [
+                {
+                  "include": "#inline_comment"
+                }
+              ]
+            },
+            "25": {
+              "name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+            },
+            "26": {
+              "name": "comment.block.cpp"
+            },
+            "27": {
+              "patterns": [
+                {
+                  "match": "\\*\\/",
+                  "name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+                },
+                {
+                  "match": "\\*",
+                  "name": "comment.block.cpp"
+                }
+              ]
+            },
+            "28": {
+              "name": "storage.type.modifier.final.cpp"
+            },
+            "29": {
+              "patterns": [
+                {
+                  "include": "#inline_comment"
+                }
+              ]
+            },
+            "30": {
+              "name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+            },
+            "31": {
+              "name": "comment.block.cpp"
+            },
+            "32": {
+              "patterns": [
+                {
+                  "match": "\\*\\/",
+                  "name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+                },
+                {
+                  "match": "\\*",
+                  "name": "comment.block.cpp"
+                }
+              ]
+            },
+            "33": {
+              "patterns": [
+                {
+                  "include": "#inline_comment"
+                }
+              ]
+            },
+            "34": {
+              "name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+            },
+            "35": {
+              "name": "comment.block.cpp"
+            },
+            "36": {
+              "patterns": [
+                {
+                  "match": "\\*\\/",
+                  "name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+                },
+                {
+                  "match": "\\*",
+                  "name": "comment.block.cpp"
+                }
+              ]
+            },
+            "37": {
+              "name": "punctuation.separator.colon.inheritance.cpp"
+            },
+            "38": {
+              "patterns": [
+                {
+                  "include": "#inheritance_context"
+                }
+              ]
+            }
+          },
+          "end": "(?:(?:(?<=\\}|%>|\\?\\?>)\\s*(;)|(;))|(?=[;>\\[\\]=]))|(?=(?<!\\\\)\n)",
+          "endCaptures": {
+            "1": {
+              "name": "punctuation.terminator.statement.cpp"
+            },
+            "2": {
+              "name": "punctuation.terminator.statement.cpp"
+            }
+          },
+          "patterns": [
+            {
+              "name": "meta.head.class.cpp",
+              "begin": "\\G ?",
+              "end": "((?:\\{|<%|\\?\\?<|(?=;)))|(?=(?<!\\\\)\n)",
+              "endCaptures": {
+                "1": {
+                  "name": "punctuation.section.block.begin.bracket.curly.class.cpp"
+                }
+              },
+              "patterns": [
+                {
+                  "include": "#ever_present_context"
+                },
+                {
+                  "include": "#inheritance_context"
+                },
+                {
+                  "include": "#template_call_range"
+                }
+              ]
+            },
+            {
+              "name": "meta.body.class.cpp",
+              "begin": "(?<=\\{|<%|\\?\\?<)",
+              "end": "(\\}|%>|\\?\\?>)|(?=(?<!\\\\)\n)",
+              "endCaptures": {
+                "1": {
+                  "name": "punctuation.section.block.end.bracket.curly.class.cpp"
+                }
+              },
+              "patterns": [
+                {
+                  "include": "#function_pointer"
+                },
+                {
+                  "include": "#static_assert"
+                },
+                {
+                  "include": "#constructor_inline"
+                },
+                {
+                  "include": "#destructor_inline"
+                },
+                {
+                  "include": "$self"
+                }
+              ]
+            },
+            {
+              "name": "meta.tail.class.cpp",
+              "begin": "(?<=\\}|%>|\\?\\?>)[\\s\\n]*",
+              "end": "[\\s\\n]*(?=;)|(?=(?<!\\\\)\n)",
+              "patterns": [
+                {
+                  "match": "(((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))?(?:(?:\\&|\\*)((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z)))))*(?:\\&|\\*))?((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))((?<!\\w)(?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*(?!\\w))",
+                  "captures": {
+                    "1": {
+                      "patterns": [
+                        {
+                          "match": "\\*",
+                          "name": "storage.modifier.pointer.cpp"
+                        },
+                        {
+                          "match": "(?:\\&((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))){2,}\\&",
+                          "captures": {
+                            "1": {
+                              "patterns": [
+                                {
+                                  "include": "#inline_comment"
+                                }
+                              ]
+                            },
+                            "2": {
+                              "name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+                            },
+                            "3": {
+                              "name": "comment.block.cpp"
+                            },
+                            "4": {
+                              "patterns": [
+                                {
+                                  "match": "\\*\\/",
+                                  "name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+                                },
+                                {
+                                  "match": "\\*",
+                                  "name": "comment.block.cpp"
+                                }
+                              ]
+                            }
+                          },
+                          "name": "invalid.illegal.reference-type.cpp"
+                        },
+                        {
+                          "match": "\\&",
+                          "name": "storage.modifier.reference.cpp"
+                        }
+                      ]
+                    },
+                    "2": {
+                      "patterns": [
+                        {
+                          "include": "#inline_comment"
+                        }
+                      ]
+                    },
+                    "3": {
+                      "name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+                    },
+                    "4": {
+                      "name": "comment.block.cpp"
+                    },
+                    "5": {
+                      "patterns": [
+                        {
+                          "match": "\\*\\/",
+                          "name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+                        },
+                        {
+                          "match": "\\*",
+                          "name": "comment.block.cpp"
+                        }
+                      ]
+                    },
+                    "6": {
+                      "patterns": [
+                        {
+                          "include": "#inline_comment"
+                        }
+                      ]
+                    },
+                    "7": {
+                      "name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+                    },
+                    "8": {
+                      "name": "comment.block.cpp"
+                    },
+                    "9": {
+                      "patterns": [
+                        {
+                          "match": "\\*\\/",
+                          "name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+                        },
+                        {
+                          "match": "\\*",
+                          "name": "comment.block.cpp"
+                        }
+                      ]
+                    },
+                    "10": {
+                      "patterns": [
+                        {
+                          "include": "#inline_comment"
+                        }
+                      ]
+                    },
+                    "11": {
+                      "name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+                    },
+                    "12": {
+                      "name": "comment.block.cpp"
+                    },
+                    "13": {
+                      "patterns": [
+                        {
+                          "match": "\\*\\/",
+                          "name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+                        },
+                        {
+                          "match": "\\*",
+                          "name": "comment.block.cpp"
+                        }
+                      ]
+                    },
+                    "14": {
+                      "name": "entity.name.type.alias.cpp"
+                    }
+                  }
+                },
+                {
+                  "match": ","
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    "typedef_function_pointer": {
+      "begin": "((?<!\\w)typedef(?!\\w))\\s*(?=.*\\(\\*\\s*(?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*\\s*\\))",
+      "beginCaptures": {
+        "1": {
+          "name": "keyword.other.typedef.cpp"
+        }
+      },
+      "end": "(?<=;)|(?=(?<!\\\\)\n)",
+      "patterns": [
+        {
+          "begin": "(\\s*+((?:(?:(?:\\[\\[.*?\\]\\]|__attribute(?:__)?\\(\\(.*?\\)\\))|__declspec\\(.*?\\))|alignas\\(.*?\\))(?!\\)))?((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))(?:(?:(?:unsigned|signed|short|long)|(?:struct|class|union|enum))((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z)))))*(((::)?(?:((?-mix:(?!\\b(?:__has_cpp_attribute|reinterpret_cast|atomic_noexcept|atomic_cancel|atomic_commit|__has_include|dynamic_cast|thread_local|synchronized|static_cast|const_cast|consteval|constexpr|protected|namespace|co_return|constexpr|constexpr|continue|explicit|volatile|noexcept|co_yield|noexcept|noexcept|requires|typename|decltype|operator|co_await|template|volatile|register|restrict|reflexpr|alignof|private|default|mutable|include|concept|__asm__|defined|_Pragma|alignas|typedef|warning|virtual|mutable|struct|sizeof|delete|not_eq|bitand|and_eq|xor_eq|typeid|switch|return|static|extern|inline|friend|public|ifndef|define|pragma|export|import|module|catch|throw|const|or_eq|while|compl|bitor|const|union|ifdef|class|undef|error|break|using|endif|goto|line|enum|this|case|else|elif|else|asm|try|for|new|and|xor|not|do|or|if|if)\\b)(?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*))\\s*+(((?<!<)<(?!<)(?>(?:(?>[^<>]*)\\g<27>?)+)>)\\s*)?::)*\\s*+)((?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*)\\s*+(((?<!<)<(?!<)(?>(?:(?>[^<>]*)\\g<27>?)+)>)\\s*)?(::))?((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))(?!(?:transaction_safe_dynamic|__has_cpp_attribute|transaction_safe|reinterpret_cast|atomic_noexcept|atomic_commit|atomic_cancel|__has_include|dynamic_cast|thread_local|synchronized|static_cast|const_cast|constexpr|consteval|protected|constexpr|co_return|namespace|constexpr|noexcept|typename|decltype|template|operator|noexcept|co_yield|co_await|continue|volatile|register|restrict|explicit|override|volatile|reflexpr|noexcept|requires|default|typedef|nullptr|alignof|mutable|concept|virtual|defined|__asm__|include|_Pragma|mutable|warning|private|alignas|module|switch|not_eq|bitand|and_eq|ifndef|return|sizeof|xor_eq|export|static|delete|public|define|extern|inline|import|pragma|friend|typeid|const|compl|bitor|throw|or_eq|while|catch|break|false|final|const|endif|ifdef|undef|error|using|audit|axiom|line|else|elif|true|NULL|case|goto|else|this|new|asm|not|and|xor|try|for|if|do|or|if)\\b)((?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*)\\b(((?<!<)<(?!<)(?>(?:(?>[^<>]*)\\g<27>?)+)>)\\s*)?(?![\\w<:.]))(((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))?(?:(?:\\&|\\*)((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z)))))*(?:\\&|\\*))?((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))(\\()(\\*)\\s*((?:(?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*)?)\\s*(?:(\\[)(\\w*)(\\])\\s*)*(\\))\\s*(\\()",
+          "beginCaptures": {
+            "1": {
+              "name": "meta.qualified_type.cpp",
+              "patterns": [
+                {
+                  "match": "(?<!\\w)(?:struct|class|union|enum)(?!\\w)",
+                  "name": "storage.type.$0.cpp"
+                },
+                {
+                  "include": "#attributes_context"
+                },
+                {
+                  "include": "#function_type"
+                },
+                {
+                  "include": "#storage_types"
+                },
+                {
+                  "include": "#number_literal"
+                },
+                {
+                  "include": "#string_context"
+                },
+                {
+                  "include": "#comma"
+                },
+                {
+                  "include": "#scope_resolution_inner_generated"
+                },
+                {
+                  "include": "#template_call_range"
+                },
+                {
+                  "match": "(?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*",
+                  "name": "entity.name.type.cpp"
+                }
+              ]
+            },
+            "2": {
+              "patterns": [
+                {
+                  "include": "#attributes_context"
+                },
+                {
+                  "include": "#number_literal"
+                }
+              ]
+            },
+            "3": {
+              "patterns": [
+                {
+                  "include": "#inline_comment"
+                }
+              ]
+            },
+            "4": {
+              "name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+            },
+            "5": {
+              "name": "comment.block.cpp"
+            },
+            "6": {
+              "patterns": [
+                {
+                  "match": "\\*\\/",
+                  "name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+                },
+                {
+                  "match": "\\*",
+                  "name": "comment.block.cpp"
+                }
+              ]
+            },
+            "7": {
+              "patterns": [
+                {
+                  "include": "#inline_comment"
+                }
+              ]
+            },
+            "8": {
+              "name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+            },
+            "9": {
+              "name": "comment.block.cpp"
+            },
+            "10": {
+              "patterns": [
+                {
+                  "match": "\\*\\/",
+                  "name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+                },
+                {
+                  "match": "\\*",
+                  "name": "comment.block.cpp"
+                }
+              ]
+            },
+            "12": {
+              "patterns": [
+                {
+                  "include": "#scope_resolution_inner_generated"
+                }
+              ]
+            },
+            "13": {
+              "name": "punctuation.separator.namespace.access.cpp punctuation.separator.scope-resolution.cpp"
+            },
+            "15": {
+              "name": "meta.template.call.cpp",
+              "patterns": [
+                {
+                  "include": "#template_call_range"
+                }
+              ]
+            },
+            "17": {
+              "name": "entity.name.scope-resolution.cpp"
+            },
+            "18": {
+              "name": "meta.template.call.cpp",
+              "patterns": [
+                {
+                  "include": "#template_call_range"
+                }
+              ]
+            },
+            "20": {
+              "name": "punctuation.separator.namespace.access.cpp punctuation.separator.scope-resolution.cpp"
+            },
+            "21": {
+              "patterns": [
+                {
+                  "include": "#inline_comment"
+                }
+              ]
+            },
+            "22": {
+              "name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+            },
+            "23": {
+              "name": "comment.block.cpp"
+            },
+            "24": {
+              "patterns": [
+                {
+                  "match": "\\*\\/",
+                  "name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+                },
+                {
+                  "match": "\\*",
+                  "name": "comment.block.cpp"
+                }
+              ]
+            },
+            "25": {
+              "name": "entity.name.type.cpp"
+            },
+            "26": {
+              "name": "meta.template.call.cpp",
+              "patterns": [
+                {
+                  "include": "#template_call_range"
+                }
+              ]
+            },
+            "28": {
+              "patterns": [
+                {
+                  "match": "\\*",
+                  "name": "storage.modifier.pointer.cpp"
+                },
+                {
+                  "match": "(?:\\&((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))){2,}\\&",
+                  "captures": {
+                    "1": {
+                      "patterns": [
+                        {
+                          "include": "#inline_comment"
+                        }
+                      ]
+                    },
+                    "2": {
+                      "name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+                    },
+                    "3": {
+                      "name": "comment.block.cpp"
+                    },
+                    "4": {
+                      "patterns": [
+                        {
+                          "match": "\\*\\/",
+                          "name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+                        },
+                        {
+                          "match": "\\*",
+                          "name": "comment.block.cpp"
+                        }
+                      ]
+                    }
+                  },
+                  "name": "invalid.illegal.reference-type.cpp"
+                },
+                {
+                  "match": "\\&",
+                  "name": "storage.modifier.reference.cpp"
+                }
+              ]
+            },
+            "29": {
+              "patterns": [
+                {
+                  "include": "#inline_comment"
+                }
+              ]
+            },
+            "30": {
+              "name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+            },
+            "31": {
+              "name": "comment.block.cpp"
+            },
+            "32": {
+              "patterns": [
+                {
+                  "match": "\\*\\/",
+                  "name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+                },
+                {
+                  "match": "\\*",
+                  "name": "comment.block.cpp"
+                }
+              ]
+            },
+            "33": {
+              "patterns": [
+                {
+                  "include": "#inline_comment"
+                }
+              ]
+            },
+            "34": {
+              "name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+            },
+            "35": {
+              "name": "comment.block.cpp"
+            },
+            "36": {
+              "patterns": [
+                {
+                  "match": "\\*\\/",
+                  "name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+                },
+                {
+                  "match": "\\*",
+                  "name": "comment.block.cpp"
+                }
+              ]
+            },
+            "37": {
+              "patterns": [
+                {
+                  "include": "#inline_comment"
+                }
+              ]
+            },
+            "38": {
+              "name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+            },
+            "39": {
+              "name": "comment.block.cpp"
+            },
+            "40": {
+              "patterns": [
+                {
+                  "match": "\\*\\/",
+                  "name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+                },
+                {
+                  "match": "\\*",
+                  "name": "comment.block.cpp"
+                }
+              ]
+            },
+            "41": {
+              "name": "punctuation.section.parens.begin.bracket.round.function.pointer.cpp"
+            },
+            "42": {
+              "name": "punctuation.definition.function.pointer.dereference.cpp"
+            },
+            "43": {
+              "name": "entity.name.type.alias.cpp entity.name.type.pointer.function.cpp"
+            },
+            "44": {
+              "name": "punctuation.definition.begin.bracket.square.cpp"
+            },
+            "45": {
+              "patterns": [
+                {
+                  "include": "#evaluation_context"
+                }
+              ]
+            },
+            "46": {
+              "name": "punctuation.definition.end.bracket.square.cpp"
+            },
+            "47": {
+              "name": "punctuation.section.parens.end.bracket.round.function.pointer.cpp"
+            },
+            "48": {
+              "name": "punctuation.section.parameters.begin.bracket.round.function.pointer.cpp"
+            }
+          },
+          "end": "(\\))((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))(?=[{=,);]|\\n)(?!\\()|(?=(?<!\\\\)\n)",
+          "endCaptures": {
+            "1": {
+              "name": "punctuation.section.parameters.end.bracket.round.function.pointer.cpp"
+            },
+            "2": {
+              "patterns": [
+                {
+                  "include": "#inline_comment"
+                }
+              ]
+            },
+            "3": {
+              "name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+            },
+            "4": {
+              "name": "comment.block.cpp"
+            },
+            "5": {
+              "patterns": [
+                {
+                  "match": "\\*\\/",
+                  "name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+                },
+                {
+                  "match": "\\*",
+                  "name": "comment.block.cpp"
+                }
+              ]
+            }
+          },
+          "patterns": [
+            {
+              "include": "#function_parameter_context"
+            }
+          ]
+        }
+      ]
+    },
+    "typedef_keyword": {
+      "match": "((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))((?<!\\w)typedef(?!\\w))",
+      "captures": {
+        "1": {
+          "patterns": [
+            {
+              "include": "#inline_comment"
+            }
+          ]
+        },
+        "2": {
+          "name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+        },
+        "3": {
+          "name": "comment.block.cpp"
+        },
+        "4": {
+          "patterns": [
+            {
+              "match": "\\*\\/",
+              "name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+            },
+            {
+              "match": "\\*",
+              "name": "comment.block.cpp"
+            }
+          ]
+        },
+        "5": {
+          "name": "keyword.other.$5.cpp"
+        }
+      }
+    },
+    "typedef_struct": {
+      "begin": "((?<!\\w)typedef(?!\\w))\\s*(?=(?<!\\w)struct(?!\\w))",
+      "beginCaptures": {
+        "1": {
+          "name": "keyword.other.typedef.cpp"
+        }
+      },
+      "end": "(?<=;)|(?=(?<!\\\\)\n)",
+      "patterns": [
+        {
+          "name": "meta.block.struct.cpp",
+          "begin": "((((?<!\\w)struct(?!\\w))(?:(?:((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))|((?:(?:(?:\\[\\[.*?\\]\\]|__attribute(?:__)?\\(\\(.*?\\)\\))|__declspec\\(.*?\\))|alignas\\(.*?\\))(?!\\))))|(?={))(?:((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))(DLLEXPORT)((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z)))))?((?:(?:(?:\\[\\[.*?\\]\\]|__attribute(?:__)?\\(\\(.*?\\)\\))|__declspec\\(.*?\\))|alignas\\(.*?\\))(?!\\)))?((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))((?:(?<!\\w)(?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*(?!\\w))?)(?:((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))(final)((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z)))))?(?:((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))(:)((?>[^{]*)))?))",
+          "beginCaptures": {
+            "1": {
+              "name": "meta.head.struct.cpp"
+            },
+            "3": {
+              "name": "storage.type.$3.cpp"
+            },
+            "4": {
+              "patterns": [
+                {
+                  "include": "#inline_comment"
+                }
+              ]
+            },
+            "5": {
+              "name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+            },
+            "6": {
+              "name": "comment.block.cpp"
+            },
+            "7": {
+              "patterns": [
+                {
+                  "match": "\\*\\/",
+                  "name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+                },
+                {
+                  "match": "\\*",
+                  "name": "comment.block.cpp"
+                }
+              ]
+            },
+            "8": {
+              "patterns": [
+                {
+                  "include": "#attributes_context"
+                },
+                {
+                  "include": "#number_literal"
+                }
+              ]
+            },
+            "9": {
+              "patterns": [
+                {
+                  "include": "#inline_comment"
+                }
+              ]
+            },
+            "10": {
+              "name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+            },
+            "11": {
+              "name": "comment.block.cpp"
+            },
+            "12": {
+              "patterns": [
+                {
+                  "match": "\\*\\/",
+                  "name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+                },
+                {
+                  "match": "\\*",
+                  "name": "comment.block.cpp"
+                }
+              ]
+            },
+            "13": {
+              "name": "entity.name.other.preprocessor.macro.predefined.DLLEXPORT.cpp"
+            },
+            "14": {
+              "patterns": [
+                {
+                  "include": "#inline_comment"
+                }
+              ]
+            },
+            "15": {
+              "name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+            },
+            "16": {
+              "name": "comment.block.cpp"
+            },
+            "17": {
+              "patterns": [
+                {
+                  "match": "\\*\\/",
+                  "name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+                },
+                {
+                  "match": "\\*",
+                  "name": "comment.block.cpp"
+                }
+              ]
+            },
+            "18": {
+              "patterns": [
+                {
+                  "include": "#attributes_context"
+                },
+                {
+                  "include": "#number_literal"
+                }
+              ]
+            },
+            "19": {
+              "patterns": [
+                {
+                  "include": "#inline_comment"
+                }
+              ]
+            },
+            "20": {
+              "name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+            },
+            "21": {
+              "name": "comment.block.cpp"
+            },
+            "22": {
+              "patterns": [
+                {
+                  "match": "\\*\\/",
+                  "name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+                },
+                {
+                  "match": "\\*",
+                  "name": "comment.block.cpp"
+                }
+              ]
+            },
+            "23": {
+              "name": "entity.name.type.$3.cpp"
+            },
+            "24": {
+              "patterns": [
+                {
+                  "include": "#inline_comment"
+                }
+              ]
+            },
+            "25": {
+              "name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+            },
+            "26": {
+              "name": "comment.block.cpp"
+            },
+            "27": {
+              "patterns": [
+                {
+                  "match": "\\*\\/",
+                  "name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+                },
+                {
+                  "match": "\\*",
+                  "name": "comment.block.cpp"
+                }
+              ]
+            },
+            "28": {
+              "name": "storage.type.modifier.final.cpp"
+            },
+            "29": {
+              "patterns": [
+                {
+                  "include": "#inline_comment"
+                }
+              ]
+            },
+            "30": {
+              "name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+            },
+            "31": {
+              "name": "comment.block.cpp"
+            },
+            "32": {
+              "patterns": [
+                {
+                  "match": "\\*\\/",
+                  "name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+                },
+                {
+                  "match": "\\*",
+                  "name": "comment.block.cpp"
+                }
+              ]
+            },
+            "33": {
+              "patterns": [
+                {
+                  "include": "#inline_comment"
+                }
+              ]
+            },
+            "34": {
+              "name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+            },
+            "35": {
+              "name": "comment.block.cpp"
+            },
+            "36": {
+              "patterns": [
+                {
+                  "match": "\\*\\/",
+                  "name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+                },
+                {
+                  "match": "\\*",
+                  "name": "comment.block.cpp"
+                }
+              ]
+            },
+            "37": {
+              "name": "punctuation.separator.colon.inheritance.cpp"
+            },
+            "38": {
+              "patterns": [
+                {
+                  "include": "#inheritance_context"
+                }
+              ]
+            }
+          },
+          "end": "(?:(?:(?<=\\}|%>|\\?\\?>)\\s*(;)|(;))|(?=[;>\\[\\]=]))|(?=(?<!\\\\)\n)",
+          "endCaptures": {
+            "1": {
+              "name": "punctuation.terminator.statement.cpp"
+            },
+            "2": {
+              "name": "punctuation.terminator.statement.cpp"
+            }
+          },
+          "patterns": [
+            {
+              "name": "meta.head.struct.cpp",
+              "begin": "\\G ?",
+              "end": "((?:\\{|<%|\\?\\?<|(?=;)))|(?=(?<!\\\\)\n)",
+              "endCaptures": {
+                "1": {
+                  "name": "punctuation.section.block.begin.bracket.curly.struct.cpp"
+                }
+              },
+              "patterns": [
+                {
+                  "include": "#ever_present_context"
+                },
+                {
+                  "include": "#inheritance_context"
+                },
+                {
+                  "include": "#template_call_range"
+                }
+              ]
+            },
+            {
+              "name": "meta.body.struct.cpp",
+              "begin": "(?<=\\{|<%|\\?\\?<)",
+              "end": "(\\}|%>|\\?\\?>)|(?=(?<!\\\\)\n)",
+              "endCaptures": {
+                "1": {
+                  "name": "punctuation.section.block.end.bracket.curly.struct.cpp"
+                }
+              },
+              "patterns": [
+                {
+                  "include": "#function_pointer"
+                },
+                {
+                  "include": "#static_assert"
+                },
+                {
+                  "include": "#constructor_inline"
+                },
+                {
+                  "include": "#destructor_inline"
+                },
+                {
+                  "include": "$self"
+                }
+              ]
+            },
+            {
+              "name": "meta.tail.struct.cpp",
+              "begin": "(?<=\\}|%>|\\?\\?>)[\\s\\n]*",
+              "end": "[\\s\\n]*(?=;)|(?=(?<!\\\\)\n)",
+              "patterns": [
+                {
+                  "match": "(((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))?(?:(?:\\&|\\*)((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z)))))*(?:\\&|\\*))?((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))((?<!\\w)(?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*(?!\\w))",
+                  "captures": {
+                    "1": {
+                      "patterns": [
+                        {
+                          "match": "\\*",
+                          "name": "storage.modifier.pointer.cpp"
+                        },
+                        {
+                          "match": "(?:\\&((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))){2,}\\&",
+                          "captures": {
+                            "1": {
+                              "patterns": [
+                                {
+                                  "include": "#inline_comment"
+                                }
+                              ]
+                            },
+                            "2": {
+                              "name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+                            },
+                            "3": {
+                              "name": "comment.block.cpp"
+                            },
+                            "4": {
+                              "patterns": [
+                                {
+                                  "match": "\\*\\/",
+                                  "name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+                                },
+                                {
+                                  "match": "\\*",
+                                  "name": "comment.block.cpp"
+                                }
+                              ]
+                            }
+                          },
+                          "name": "invalid.illegal.reference-type.cpp"
+                        },
+                        {
+                          "match": "\\&",
+                          "name": "storage.modifier.reference.cpp"
+                        }
+                      ]
+                    },
+                    "2": {
+                      "patterns": [
+                        {
+                          "include": "#inline_comment"
+                        }
+                      ]
+                    },
+                    "3": {
+                      "name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+                    },
+                    "4": {
+                      "name": "comment.block.cpp"
+                    },
+                    "5": {
+                      "patterns": [
+                        {
+                          "match": "\\*\\/",
+                          "name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+                        },
+                        {
+                          "match": "\\*",
+                          "name": "comment.block.cpp"
+                        }
+                      ]
+                    },
+                    "6": {
+                      "patterns": [
+                        {
+                          "include": "#inline_comment"
+                        }
+                      ]
+                    },
+                    "7": {
+                      "name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+                    },
+                    "8": {
+                      "name": "comment.block.cpp"
+                    },
+                    "9": {
+                      "patterns": [
+                        {
+                          "match": "\\*\\/",
+                          "name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+                        },
+                        {
+                          "match": "\\*",
+                          "name": "comment.block.cpp"
+                        }
+                      ]
+                    },
+                    "10": {
+                      "patterns": [
+                        {
+                          "include": "#inline_comment"
+                        }
+                      ]
+                    },
+                    "11": {
+                      "name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+                    },
+                    "12": {
+                      "name": "comment.block.cpp"
+                    },
+                    "13": {
+                      "patterns": [
+                        {
+                          "match": "\\*\\/",
+                          "name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+                        },
+                        {
+                          "match": "\\*",
+                          "name": "comment.block.cpp"
+                        }
+                      ]
+                    },
+                    "14": {
+                      "name": "entity.name.type.alias.cpp"
+                    }
+                  }
+                },
+                {
+                  "match": ","
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    "typedef_union": {
+      "begin": "((?<!\\w)typedef(?!\\w))\\s*(?=(?<!\\w)union(?!\\w))",
+      "beginCaptures": {
+        "1": {
+          "name": "keyword.other.typedef.cpp"
+        }
+      },
+      "end": "(?<=;)|(?=(?<!\\\\)\n)",
+      "patterns": [
+        {
+          "name": "meta.block.union.cpp",
+          "begin": "((((?<!\\w)union(?!\\w))(?:(?:((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))|((?:(?:(?:\\[\\[.*?\\]\\]|__attribute(?:__)?\\(\\(.*?\\)\\))|__declspec\\(.*?\\))|alignas\\(.*?\\))(?!\\))))|(?={))(?:((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))(DLLEXPORT)((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z)))))?((?:(?:(?:\\[\\[.*?\\]\\]|__attribute(?:__)?\\(\\(.*?\\)\\))|__declspec\\(.*?\\))|alignas\\(.*?\\))(?!\\)))?((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))((?:(?<!\\w)(?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*(?!\\w))?)(?:((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))(final)((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z)))))?(?:((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))(:)((?>[^{]*)))?))",
+          "beginCaptures": {
+            "1": {
+              "name": "meta.head.union.cpp"
+            },
+            "3": {
+              "name": "storage.type.$3.cpp"
+            },
+            "4": {
+              "patterns": [
+                {
+                  "include": "#inline_comment"
+                }
+              ]
+            },
+            "5": {
+              "name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+            },
+            "6": {
+              "name": "comment.block.cpp"
+            },
+            "7": {
+              "patterns": [
+                {
+                  "match": "\\*\\/",
+                  "name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+                },
+                {
+                  "match": "\\*",
+                  "name": "comment.block.cpp"
+                }
+              ]
+            },
+            "8": {
+              "patterns": [
+                {
+                  "include": "#attributes_context"
+                },
+                {
+                  "include": "#number_literal"
+                }
+              ]
+            },
+            "9": {
+              "patterns": [
+                {
+                  "include": "#inline_comment"
+                }
+              ]
+            },
+            "10": {
+              "name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+            },
+            "11": {
+              "name": "comment.block.cpp"
+            },
+            "12": {
+              "patterns": [
+                {
+                  "match": "\\*\\/",
+                  "name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+                },
+                {
+                  "match": "\\*",
+                  "name": "comment.block.cpp"
+                }
+              ]
+            },
+            "13": {
+              "name": "entity.name.other.preprocessor.macro.predefined.DLLEXPORT.cpp"
+            },
+            "14": {
+              "patterns": [
+                {
+                  "include": "#inline_comment"
+                }
+              ]
+            },
+            "15": {
+              "name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+            },
+            "16": {
+              "name": "comment.block.cpp"
+            },
+            "17": {
+              "patterns": [
+                {
+                  "match": "\\*\\/",
+                  "name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+                },
+                {
+                  "match": "\\*",
+                  "name": "comment.block.cpp"
+                }
+              ]
+            },
+            "18": {
+              "patterns": [
+                {
+                  "include": "#attributes_context"
+                },
+                {
+                  "include": "#number_literal"
+                }
+              ]
+            },
+            "19": {
+              "patterns": [
+                {
+                  "include": "#inline_comment"
+                }
+              ]
+            },
+            "20": {
+              "name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+            },
+            "21": {
+              "name": "comment.block.cpp"
+            },
+            "22": {
+              "patterns": [
+                {
+                  "match": "\\*\\/",
+                  "name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+                },
+                {
+                  "match": "\\*",
+                  "name": "comment.block.cpp"
+                }
+              ]
+            },
+            "23": {
+              "name": "entity.name.type.$3.cpp"
+            },
+            "24": {
+              "patterns": [
+                {
+                  "include": "#inline_comment"
+                }
+              ]
+            },
+            "25": {
+              "name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+            },
+            "26": {
+              "name": "comment.block.cpp"
+            },
+            "27": {
+              "patterns": [
+                {
+                  "match": "\\*\\/",
+                  "name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+                },
+                {
+                  "match": "\\*",
+                  "name": "comment.block.cpp"
+                }
+              ]
+            },
+            "28": {
+              "name": "storage.type.modifier.final.cpp"
+            },
+            "29": {
+              "patterns": [
+                {
+                  "include": "#inline_comment"
+                }
+              ]
+            },
+            "30": {
+              "name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+            },
+            "31": {
+              "name": "comment.block.cpp"
+            },
+            "32": {
+              "patterns": [
+                {
+                  "match": "\\*\\/",
+                  "name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+                },
+                {
+                  "match": "\\*",
+                  "name": "comment.block.cpp"
+                }
+              ]
+            },
+            "33": {
+              "patterns": [
+                {
+                  "include": "#inline_comment"
+                }
+              ]
+            },
+            "34": {
+              "name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+            },
+            "35": {
+              "name": "comment.block.cpp"
+            },
+            "36": {
+              "patterns": [
+                {
+                  "match": "\\*\\/",
+                  "name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+                },
+                {
+                  "match": "\\*",
+                  "name": "comment.block.cpp"
+                }
+              ]
+            },
+            "37": {
+              "name": "punctuation.separator.colon.inheritance.cpp"
+            },
+            "38": {
+              "patterns": [
+                {
+                  "include": "#inheritance_context"
+                }
+              ]
+            }
+          },
+          "end": "(?:(?:(?<=\\}|%>|\\?\\?>)\\s*(;)|(;))|(?=[;>\\[\\]=]))|(?=(?<!\\\\)\n)",
+          "endCaptures": {
+            "1": {
+              "name": "punctuation.terminator.statement.cpp"
+            },
+            "2": {
+              "name": "punctuation.terminator.statement.cpp"
+            }
+          },
+          "patterns": [
+            {
+              "name": "meta.head.union.cpp",
+              "begin": "\\G ?",
+              "end": "((?:\\{|<%|\\?\\?<|(?=;)))|(?=(?<!\\\\)\n)",
+              "endCaptures": {
+                "1": {
+                  "name": "punctuation.section.block.begin.bracket.curly.union.cpp"
+                }
+              },
+              "patterns": [
+                {
+                  "include": "#ever_present_context"
+                },
+                {
+                  "include": "#inheritance_context"
+                },
+                {
+                  "include": "#template_call_range"
+                }
+              ]
+            },
+            {
+              "name": "meta.body.union.cpp",
+              "begin": "(?<=\\{|<%|\\?\\?<)",
+              "end": "(\\}|%>|\\?\\?>)|(?=(?<!\\\\)\n)",
+              "endCaptures": {
+                "1": {
+                  "name": "punctuation.section.block.end.bracket.curly.union.cpp"
+                }
+              },
+              "patterns": [
+                {
+                  "include": "#function_pointer"
+                },
+                {
+                  "include": "#static_assert"
+                },
+                {
+                  "include": "#constructor_inline"
+                },
+                {
+                  "include": "#destructor_inline"
+                },
+                {
+                  "include": "$self"
+                }
+              ]
+            },
+            {
+              "name": "meta.tail.union.cpp",
+              "begin": "(?<=\\}|%>|\\?\\?>)[\\s\\n]*",
+              "end": "[\\s\\n]*(?=;)|(?=(?<!\\\\)\n)",
+              "patterns": [
+                {
+                  "match": "(((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))?(?:(?:\\&|\\*)((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z)))))*(?:\\&|\\*))?((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))((?<!\\w)(?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*(?!\\w))",
+                  "captures": {
+                    "1": {
+                      "patterns": [
+                        {
+                          "match": "\\*",
+                          "name": "storage.modifier.pointer.cpp"
+                        },
+                        {
+                          "match": "(?:\\&((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))){2,}\\&",
+                          "captures": {
+                            "1": {
+                              "patterns": [
+                                {
+                                  "include": "#inline_comment"
+                                }
+                              ]
+                            },
+                            "2": {
+                              "name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+                            },
+                            "3": {
+                              "name": "comment.block.cpp"
+                            },
+                            "4": {
+                              "patterns": [
+                                {
+                                  "match": "\\*\\/",
+                                  "name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+                                },
+                                {
+                                  "match": "\\*",
+                                  "name": "comment.block.cpp"
+                                }
+                              ]
+                            }
+                          },
+                          "name": "invalid.illegal.reference-type.cpp"
+                        },
+                        {
+                          "match": "\\&",
+                          "name": "storage.modifier.reference.cpp"
+                        }
+                      ]
+                    },
+                    "2": {
+                      "patterns": [
+                        {
+                          "include": "#inline_comment"
+                        }
+                      ]
+                    },
+                    "3": {
+                      "name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+                    },
+                    "4": {
+                      "name": "comment.block.cpp"
+                    },
+                    "5": {
+                      "patterns": [
+                        {
+                          "match": "\\*\\/",
+                          "name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+                        },
+                        {
+                          "match": "\\*",
+                          "name": "comment.block.cpp"
+                        }
+                      ]
+                    },
+                    "6": {
+                      "patterns": [
+                        {
+                          "include": "#inline_comment"
+                        }
+                      ]
+                    },
+                    "7": {
+                      "name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+                    },
+                    "8": {
+                      "name": "comment.block.cpp"
+                    },
+                    "9": {
+                      "patterns": [
+                        {
+                          "match": "\\*\\/",
+                          "name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+                        },
+                        {
+                          "match": "\\*",
+                          "name": "comment.block.cpp"
+                        }
+                      ]
+                    },
+                    "10": {
+                      "patterns": [
+                        {
+                          "include": "#inline_comment"
+                        }
+                      ]
+                    },
+                    "11": {
+                      "name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+                    },
+                    "12": {
+                      "name": "comment.block.cpp"
+                    },
+                    "13": {
+                      "patterns": [
+                        {
+                          "match": "\\*\\/",
+                          "name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+                        },
+                        {
+                          "match": "\\*",
+                          "name": "comment.block.cpp"
+                        }
+                      ]
+                    },
+                    "14": {
+                      "name": "entity.name.type.alias.cpp"
+                    }
+                  }
+                },
+                {
+                  "match": ","
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    "typeid_operator": {
+      "contentName": "meta.arguments.operator.typeid.cpp",
+      "begin": "((?<!\\w)typeid(?!\\w))((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))(\\()",
+      "beginCaptures": {
+        "1": {
+          "name": "keyword.operator.functionlike.cpp keyword.operator.typeid.cpp"
+        },
+        "2": {
+          "patterns": [
+            {
+              "include": "#inline_comment"
+            }
+          ]
+        },
+        "3": {
+          "name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+        },
+        "4": {
+          "name": "comment.block.cpp"
+        },
+        "5": {
+          "patterns": [
+            {
+              "match": "\\*\\/",
+              "name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+            },
+            {
+              "match": "\\*",
+              "name": "comment.block.cpp"
+            }
+          ]
+        },
+        "6": {
+          "name": "punctuation.section.arguments.begin.bracket.round.operator.typeid.cpp"
+        }
+      },
+      "end": "(\\))|(?=(?<!\\\\)\n)",
+      "endCaptures": {
+        "1": {
+          "name": "punctuation.section.arguments.end.bracket.round.operator.typeid.cpp"
+        }
+      },
+      "patterns": [
+        {
+          "include": "#evaluation_context"
+        }
+      ]
+    },
+    "typename": {
+      "match": "(((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))(?<!\\w)typename(?!\\w))((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))(\\s*+((?:(?:(?:\\[\\[.*?\\]\\]|__attribute(?:__)?\\(\\(.*?\\)\\))|__declspec\\(.*?\\))|alignas\\(.*?\\))(?!\\)))?((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))(?:(?:(?:unsigned|signed|short|long)|(?:struct|class|union|enum))((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z)))))*(((::)?(?:((?-mix:(?!\\b(?:__has_cpp_attribute|reinterpret_cast|atomic_noexcept|atomic_cancel|atomic_commit|__has_include|dynamic_cast|thread_local|synchronized|static_cast|const_cast|consteval|constexpr|protected|namespace|co_return|constexpr|constexpr|continue|explicit|volatile|noexcept|co_yield|noexcept|noexcept|requires|typename|decltype|operator|co_await|template|volatile|register|restrict|reflexpr|alignof|private|default|mutable|include|concept|__asm__|defined|_Pragma|alignas|typedef|warning|virtual|mutable|struct|sizeof|delete|not_eq|bitand|and_eq|xor_eq|typeid|switch|return|static|extern|inline|friend|public|ifndef|define|pragma|export|import|module|catch|throw|const|or_eq|while|compl|bitor|const|union|ifdef|class|undef|error|break|using|endif|goto|line|enum|this|case|else|elif|else|asm|try|for|new|and|xor|not|do|or|if|if)\\b)(?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*))\\s*+(((?<!<)<(?!<)(?>(?:(?>[^<>]*)\\g<36>?)+)>)\\s*)?::)*\\s*+)((?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*)\\s*+(((?<!<)<(?!<)(?>(?:(?>[^<>]*)\\g<36>?)+)>)\\s*)?(::))?((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))(?!(?:transaction_safe_dynamic|__has_cpp_attribute|transaction_safe|reinterpret_cast|atomic_noexcept|atomic_commit|atomic_cancel|__has_include|dynamic_cast|thread_local|synchronized|static_cast|const_cast|constexpr|consteval|protected|constexpr|co_return|namespace|constexpr|noexcept|typename|decltype|template|operator|noexcept|co_yield|co_await|continue|volatile|register|restrict|explicit|override|volatile|reflexpr|noexcept|requires|default|typedef|nullptr|alignof|mutable|concept|virtual|defined|__asm__|include|_Pragma|mutable|warning|private|alignas|module|switch|not_eq|bitand|and_eq|ifndef|return|sizeof|xor_eq|export|static|delete|public|define|extern|inline|import|pragma|friend|typeid|const|compl|bitor|throw|or_eq|while|catch|break|false|final|const|endif|ifdef|undef|error|using|audit|axiom|line|else|elif|true|NULL|case|goto|else|this|new|asm|not|and|xor|try|for|if|do|or|if)\\b)((?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*)\\b(((?<!<)<(?!<)(?>(?:(?>[^<>]*)\\g<36>?)+)>)\\s*)?(?![\\w<:.]))",
+      "captures": {
+        "1": {
+          "name": "storage.modifier.cpp"
+        },
+        "2": {
+          "patterns": [
+            {
+              "include": "#inline_comment"
+            }
+          ]
+        },
+        "3": {
+          "name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+        },
+        "4": {
+          "name": "comment.block.cpp"
+        },
+        "5": {
+          "patterns": [
+            {
+              "match": "\\*\\/",
+              "name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+            },
+            {
+              "match": "\\*",
+              "name": "comment.block.cpp"
+            }
+          ]
+        },
+        "6": {
+          "patterns": [
+            {
+              "include": "#inline_comment"
+            }
+          ]
+        },
+        "7": {
+          "name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+        },
+        "8": {
+          "name": "comment.block.cpp"
+        },
+        "9": {
+          "patterns": [
+            {
+              "match": "\\*\\/",
+              "name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+            },
+            {
+              "match": "\\*",
+              "name": "comment.block.cpp"
+            }
+          ]
+        },
+        "10": {
+          "name": "meta.qualified_type.cpp",
+          "patterns": [
+            {
+              "match": "(?<!\\w)(?:struct|class|union|enum)(?!\\w)",
+              "name": "storage.type.$0.cpp"
+            },
+            {
+              "include": "#attributes_context"
+            },
+            {
+              "include": "#function_type"
+            },
+            {
+              "include": "#storage_types"
+            },
+            {
+              "include": "#number_literal"
+            },
+            {
+              "include": "#string_context"
+            },
+            {
+              "include": "#comma"
+            },
+            {
+              "include": "#scope_resolution_inner_generated"
+            },
+            {
+              "include": "#template_call_range"
+            },
+            {
+              "match": "(?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*",
+              "name": "entity.name.type.cpp"
+            }
+          ]
+        },
+        "11": {
+          "patterns": [
+            {
+              "include": "#attributes_context"
+            },
+            {
+              "include": "#number_literal"
+            }
+          ]
+        },
+        "12": {
+          "patterns": [
+            {
+              "include": "#inline_comment"
+            }
+          ]
+        },
+        "13": {
+          "name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+        },
+        "14": {
+          "name": "comment.block.cpp"
+        },
+        "15": {
+          "patterns": [
+            {
+              "match": "\\*\\/",
+              "name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+            },
+            {
+              "match": "\\*",
+              "name": "comment.block.cpp"
+            }
+          ]
+        },
+        "16": {
+          "patterns": [
+            {
+              "include": "#inline_comment"
+            }
+          ]
+        },
+        "17": {
+          "name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+        },
+        "18": {
+          "name": "comment.block.cpp"
+        },
+        "19": {
+          "patterns": [
+            {
+              "match": "\\*\\/",
+              "name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+            },
+            {
+              "match": "\\*",
+              "name": "comment.block.cpp"
+            }
+          ]
+        },
+        "21": {
+          "patterns": [
+            {
+              "include": "#scope_resolution_inner_generated"
+            }
+          ]
+        },
+        "22": {
+          "name": "punctuation.separator.namespace.access.cpp punctuation.separator.scope-resolution.cpp"
+        },
+        "24": {
+          "name": "meta.template.call.cpp",
+          "patterns": [
+            {
+              "include": "#template_call_range"
+            }
+          ]
+        },
+        "26": {
+          "name": "entity.name.scope-resolution.cpp"
+        },
+        "27": {
+          "name": "meta.template.call.cpp",
+          "patterns": [
+            {
+              "include": "#template_call_range"
+            }
+          ]
+        },
+        "29": {
+          "name": "punctuation.separator.namespace.access.cpp punctuation.separator.scope-resolution.cpp"
+        },
+        "30": {
+          "patterns": [
+            {
+              "include": "#inline_comment"
+            }
+          ]
+        },
+        "31": {
+          "name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+        },
+        "32": {
+          "name": "comment.block.cpp"
+        },
+        "33": {
+          "patterns": [
+            {
+              "match": "\\*\\/",
+              "name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+            },
+            {
+              "match": "\\*",
+              "name": "comment.block.cpp"
+            }
+          ]
+        },
+        "34": {
+          "name": "entity.name.type.cpp"
+        },
+        "35": {
+          "name": "meta.template.call.cpp",
+          "patterns": [
+            {
+              "include": "#template_call_range"
+            }
+          ]
+        }
+      }
+    },
+    "undef": {
+      "match": "((?:^)((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))(#)\\s*undef\\b)((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))((?<!\\w)(?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*(?!\\w))",
+      "captures": {
+        "1": {
+          "name": "keyword.control.directive.undef.cpp"
+        },
+        "2": {
+          "patterns": [
+            {
+              "include": "#inline_comment"
+            }
+          ]
+        },
+        "3": {
+          "name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+        },
+        "4": {
+          "name": "comment.block.cpp"
+        },
+        "5": {
+          "patterns": [
+            {
+              "match": "\\*\\/",
+              "name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+            },
+            {
+              "match": "\\*",
+              "name": "comment.block.cpp"
+            }
+          ]
+        },
+        "6": {
+          "name": "punctuation.definition.directive.cpp"
+        },
+        "7": {
+          "patterns": [
+            {
+              "include": "#inline_comment"
+            }
+          ]
+        },
+        "8": {
+          "name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+        },
+        "9": {
+          "name": "comment.block.cpp"
+        },
+        "10": {
+          "patterns": [
+            {
+              "match": "\\*\\/",
+              "name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+            },
+            {
+              "match": "\\*",
+              "name": "comment.block.cpp"
+            }
+          ]
+        },
+        "11": {
+          "name": "entity.name.function.preprocessor.cpp"
+        }
+      },
+      "name": "meta.preprocessor.undef.cpp"
+    },
+    "union_block": {
+      "name": "meta.block.union.cpp",
+      "begin": "((((?<!\\w)union(?!\\w))(?:(?:((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))|((?:(?:(?:\\[\\[.*?\\]\\]|__attribute(?:__)?\\(\\(.*?\\)\\))|__declspec\\(.*?\\))|alignas\\(.*?\\))(?!\\))))|(?={))(?:((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))(DLLEXPORT)((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z)))))?((?:(?:(?:\\[\\[.*?\\]\\]|__attribute(?:__)?\\(\\(.*?\\)\\))|__declspec\\(.*?\\))|alignas\\(.*?\\))(?!\\)))?((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))((?:(?<!\\w)(?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*(?!\\w))?)(?:((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))(final)((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z)))))?(?:((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))(:)((?>[^{]*)))?))",
+      "beginCaptures": {
+        "1": {
+          "name": "meta.head.union.cpp"
+        },
+        "3": {
+          "name": "storage.type.$3.cpp"
+        },
+        "4": {
+          "patterns": [
+            {
+              "include": "#inline_comment"
+            }
+          ]
+        },
+        "5": {
+          "name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+        },
+        "6": {
+          "name": "comment.block.cpp"
+        },
+        "7": {
+          "patterns": [
+            {
+              "match": "\\*\\/",
+              "name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+            },
+            {
+              "match": "\\*",
+              "name": "comment.block.cpp"
+            }
+          ]
+        },
+        "8": {
+          "patterns": [
+            {
+              "include": "#attributes_context"
+            },
+            {
+              "include": "#number_literal"
+            }
+          ]
+        },
+        "9": {
+          "patterns": [
+            {
+              "include": "#inline_comment"
+            }
+          ]
+        },
+        "10": {
+          "name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+        },
+        "11": {
+          "name": "comment.block.cpp"
+        },
+        "12": {
+          "patterns": [
+            {
+              "match": "\\*\\/",
+              "name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+            },
+            {
+              "match": "\\*",
+              "name": "comment.block.cpp"
+            }
+          ]
+        },
+        "13": {
+          "name": "entity.name.other.preprocessor.macro.predefined.DLLEXPORT.cpp"
+        },
+        "14": {
+          "patterns": [
+            {
+              "include": "#inline_comment"
+            }
+          ]
+        },
+        "15": {
+          "name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+        },
+        "16": {
+          "name": "comment.block.cpp"
+        },
+        "17": {
+          "patterns": [
+            {
+              "match": "\\*\\/",
+              "name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+            },
+            {
+              "match": "\\*",
+              "name": "comment.block.cpp"
+            }
+          ]
+        },
+        "18": {
+          "patterns": [
+            {
+              "include": "#attributes_context"
+            },
+            {
+              "include": "#number_literal"
+            }
+          ]
+        },
+        "19": {
+          "patterns": [
+            {
+              "include": "#inline_comment"
+            }
+          ]
+        },
+        "20": {
+          "name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+        },
+        "21": {
+          "name": "comment.block.cpp"
+        },
+        "22": {
+          "patterns": [
+            {
+              "match": "\\*\\/",
+              "name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+            },
+            {
+              "match": "\\*",
+              "name": "comment.block.cpp"
+            }
+          ]
+        },
+        "23": {
+          "name": "entity.name.type.$3.cpp"
+        },
+        "24": {
+          "patterns": [
+            {
+              "include": "#inline_comment"
+            }
+          ]
+        },
+        "25": {
+          "name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+        },
+        "26": {
+          "name": "comment.block.cpp"
+        },
+        "27": {
+          "patterns": [
+            {
+              "match": "\\*\\/",
+              "name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+            },
+            {
+              "match": "\\*",
+              "name": "comment.block.cpp"
+            }
+          ]
+        },
+        "28": {
+          "name": "storage.type.modifier.final.cpp"
+        },
+        "29": {
+          "patterns": [
+            {
+              "include": "#inline_comment"
+            }
+          ]
+        },
+        "30": {
+          "name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+        },
+        "31": {
+          "name": "comment.block.cpp"
+        },
+        "32": {
+          "patterns": [
+            {
+              "match": "\\*\\/",
+              "name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+            },
+            {
+              "match": "\\*",
+              "name": "comment.block.cpp"
+            }
+          ]
+        },
+        "33": {
+          "patterns": [
+            {
+              "include": "#inline_comment"
+            }
+          ]
+        },
+        "34": {
+          "name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+        },
+        "35": {
+          "name": "comment.block.cpp"
+        },
+        "36": {
+          "patterns": [
+            {
+              "match": "\\*\\/",
+              "name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+            },
+            {
+              "match": "\\*",
+              "name": "comment.block.cpp"
+            }
+          ]
+        },
+        "37": {
+          "name": "punctuation.separator.colon.inheritance.cpp"
+        },
+        "38": {
+          "patterns": [
+            {
+              "include": "#inheritance_context"
+            }
+          ]
+        }
+      },
+      "end": "(?:(?:(?<=\\}|%>|\\?\\?>)\\s*(;)|(;))|(?=[;>\\[\\]=]))|(?=(?<!\\\\)\n)",
+      "endCaptures": {
+        "1": {
+          "name": "punctuation.terminator.statement.cpp"
+        },
+        "2": {
+          "name": "punctuation.terminator.statement.cpp"
+        }
+      },
+      "patterns": [
+        {
+          "name": "meta.head.union.cpp",
+          "begin": "\\G ?",
+          "end": "((?:\\{|<%|\\?\\?<|(?=;)))|(?=(?<!\\\\)\n)",
+          "endCaptures": {
+            "1": {
+              "name": "punctuation.section.block.begin.bracket.curly.union.cpp"
+            }
+          },
+          "patterns": [
+            {
+              "include": "#ever_present_context"
+            },
+            {
+              "include": "#inheritance_context"
+            },
+            {
+              "include": "#template_call_range"
+            }
+          ]
+        },
+        {
+          "name": "meta.body.union.cpp",
+          "begin": "(?<=\\{|<%|\\?\\?<)",
+          "end": "(\\}|%>|\\?\\?>)|(?=(?<!\\\\)\n)",
+          "endCaptures": {
+            "1": {
+              "name": "punctuation.section.block.end.bracket.curly.union.cpp"
+            }
+          },
+          "patterns": [
+            {
+              "include": "#function_pointer"
+            },
+            {
+              "include": "#static_assert"
+            },
+            {
+              "include": "#constructor_inline"
+            },
+            {
+              "include": "#destructor_inline"
+            },
+            {
+              "include": "$self"
+            }
+          ]
+        },
+        {
+          "name": "meta.tail.union.cpp",
+          "begin": "(?<=\\}|%>|\\?\\?>)[\\s\\n]*",
+          "end": "[\\s\\n]*(?=;)|(?=(?<!\\\\)\n)",
+          "patterns": [
+            {
+              "include": "$self"
+            }
+          ]
+        }
+      ]
+    },
+    "union_declare": {
+      "match": "((?<!\\w)union(?!\\w))((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))((?<!\\w)(?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*(?!\\w))(((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))?(?:(?:\\&|\\*)((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z)))))*(?:\\&|\\*))?((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))\\b(?!override\\W|override\\$|final\\W|final\\$)((?<!\\w)(?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*(?!\\w))((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))(?=\\S)(?![:{])",
+      "captures": {
+        "1": {
+          "name": "storage.type.union.declare.cpp"
+        },
+        "2": {
+          "patterns": [
+            {
+              "include": "#inline_comment"
+            }
+          ]
+        },
+        "3": {
+          "name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+        },
+        "4": {
+          "name": "comment.block.cpp"
+        },
+        "5": {
+          "patterns": [
+            {
+              "match": "\\*\\/",
+              "name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+            },
+            {
+              "match": "\\*",
+              "name": "comment.block.cpp"
+            }
+          ]
+        },
+        "6": {
+          "name": "entity.name.type.union.cpp"
+        },
+        "7": {
+          "patterns": [
+            {
+              "match": "\\*",
+              "name": "storage.modifier.pointer.cpp"
+            },
+            {
+              "match": "(?:\\&((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))){2,}\\&",
+              "captures": {
+                "1": {
+                  "patterns": [
+                    {
+                      "include": "#inline_comment"
+                    }
+                  ]
+                },
+                "2": {
+                  "name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+                },
+                "3": {
+                  "name": "comment.block.cpp"
+                },
+                "4": {
+                  "patterns": [
+                    {
+                      "match": "\\*\\/",
+                      "name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+                    },
+                    {
+                      "match": "\\*",
+                      "name": "comment.block.cpp"
+                    }
+                  ]
+                }
+              },
+              "name": "invalid.illegal.reference-type.cpp"
+            },
+            {
+              "match": "\\&",
+              "name": "storage.modifier.reference.cpp"
+            }
+          ]
+        },
+        "8": {
+          "patterns": [
+            {
+              "include": "#inline_comment"
+            }
+          ]
+        },
+        "9": {
+          "name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+        },
+        "10": {
+          "name": "comment.block.cpp"
+        },
+        "11": {
+          "patterns": [
+            {
+              "match": "\\*\\/",
+              "name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+            },
+            {
+              "match": "\\*",
+              "name": "comment.block.cpp"
+            }
+          ]
+        },
+        "12": {
+          "patterns": [
+            {
+              "include": "#inline_comment"
+            }
+          ]
+        },
+        "13": {
+          "name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+        },
+        "14": {
+          "name": "comment.block.cpp"
+        },
+        "15": {
+          "patterns": [
+            {
+              "match": "\\*\\/",
+              "name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+            },
+            {
+              "match": "\\*",
+              "name": "comment.block.cpp"
+            }
+          ]
+        },
+        "16": {
+          "patterns": [
+            {
+              "include": "#inline_comment"
+            }
+          ]
+        },
+        "17": {
+          "name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+        },
+        "18": {
+          "name": "comment.block.cpp"
+        },
+        "19": {
+          "patterns": [
+            {
+              "match": "\\*\\/",
+              "name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+            },
+            {
+              "match": "\\*",
+              "name": "comment.block.cpp"
+            }
+          ]
+        },
+        "20": {
+          "name": "variable.other.object.declare.cpp"
+        },
+        "21": {
+          "patterns": [
+            {
+              "include": "#inline_comment"
+            }
+          ]
+        },
+        "22": {
+          "name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+        },
+        "23": {
+          "name": "comment.block.cpp"
+        },
+        "24": {
+          "patterns": [
+            {
+              "match": "\\*\\/",
+              "name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+            },
+            {
+              "match": "\\*",
+              "name": "comment.block.cpp"
+            }
+          ]
+        }
+      }
+    },
+    "using_name": {
+      "match": "(using)\\s+(?!namespace\\b)",
+      "captures": {
+        "1": {
+          "name": "keyword.other.using.directive.cpp"
+        }
+      }
+    },
+    "using_namespace": {
+      "name": "meta.using-namespace.cpp",
+      "begin": "(?<!\\w)(using)\\s+(namespace)\\s+((::)?(?:((?-mix:(?!\\b(?:__has_cpp_attribute|reinterpret_cast|atomic_noexcept|atomic_cancel|atomic_commit|__has_include|dynamic_cast|thread_local|synchronized|static_cast|const_cast|consteval|constexpr|protected|namespace|co_return|constexpr|constexpr|continue|explicit|volatile|noexcept|co_yield|noexcept|noexcept|requires|typename|decltype|operator|co_await|template|volatile|register|restrict|reflexpr|alignof|private|default|mutable|include|concept|__asm__|defined|_Pragma|alignas|typedef|warning|virtual|mutable|struct|sizeof|delete|not_eq|bitand|and_eq|xor_eq|typeid|switch|return|static|extern|inline|friend|public|ifndef|define|pragma|export|import|module|catch|throw|const|or_eq|while|compl|bitor|const|union|ifdef|class|undef|error|break|using|endif|goto|line|enum|this|case|else|elif|else|asm|try|for|new|and|xor|not|do|or|if|if)\\b)(?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*))\\s*+(((?<!<)<(?!<)(?>(?:(?>[^<>]*)\\g<7>?)+)>)\\s*)?::)*\\s*+)?((?<!\\w)(?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*(?!\\w))(?=;|\\n)",
+      "beginCaptures": {
+        "1": {
+          "name": "keyword.other.using.directive.cpp"
+        },
+        "2": {
+          "name": "keyword.other.namespace.directive.cpp storage.type.namespace.directive.cpp"
+        },
+        "3": {
+          "patterns": [
+            {
+              "include": "#scope_resolution_namespace_using_inner_generated"
+            }
+          ]
+        },
+        "4": {
+          "name": "punctuation.separator.namespace.access.cpp punctuation.separator.scope-resolution.namespace.using.cpp"
+        },
+        "6": {
+          "name": "meta.template.call.cpp",
+          "patterns": [
+            {
+              "include": "#template_call_range"
+            }
+          ]
+        },
+        "8": {
+          "name": "entity.name.namespace.cpp"
+        }
+      },
+      "end": "(;)|(?=(?<!\\\\)\n)",
+      "endCaptures": {
+        "1": {
+          "name": "punctuation.terminator.statement.cpp"
+        }
+      }
+    },
+    "vararg_ellipses": {
+      "match": "(?<!\\.)\\.\\.\\.(?!\\.)",
+      "name": "punctuation.vararg-ellipses.cpp"
+    },
+    "wordlike_operators": {
+      "patterns": [
+        {
+          "match": "(?<!\\w)(?:noexcept|xor_eq|and_eq|delete|not_eq|bitand|bitor|compl|or_eq|not|xor|new|and|or)(?!\\w)",
+          "name": "keyword.operator.wordlike.cpp keyword.operator.$0.cpp"
+        }
+      ]
+    }
+  }
+}

--- a/packages/textmate-grammars/data/cpp.tmLanguage.json
+++ b/packages/textmate-grammars/data/cpp.tmLanguage.json
@@ -1,403 +1,12023 @@
 {
 	"information_for_contributors": [
-		"This file has been converted from https://github.com/atom/language-c/blob/master/grammars/c%2B%2B.cson",
+		"This file has been converted from https://github.com/jeff-hykin/cpp-textmate-grammar/blob/master//syntaxes/cpp.tmLanguage.json",
 		"If you want to provide a fix or improvement, please create a pull request against the original repository.",
 		"Once accepted there, we are happy to receive an update request."
 	],
-	"version": "https://github.com/atom/language-c/commit/3a269f88b12e512fb9495dc006a1dabf325d3d7f",
+	"version": "https://github.com/jeff-hykin/cpp-textmate-grammar/commit/666808cab3907fc91ed4d3901060ee6b045cca58",
 	"name": "C++",
 	"scopeName": "source.cpp",
 	"patterns": [
 		{
-			"include": "#special_block"
+			"include": "#ever_present_context"
 		},
 		{
-			"include": "#strings"
+			"include": "#constructor_root"
 		},
 		{
-			"match": "\\b(friend|explicit|virtual|override|final|noexcept)\\b",
-			"name": "storage.modifier.cpp"
+			"include": "#destructor_root"
 		},
 		{
-			"match": "\\b(private:|protected:|public:)",
-			"name": "storage.modifier.cpp"
+			"include": "#function_definition"
 		},
 		{
-			"match": "\\b(catch|operator|try|throw|using)\\b",
-			"name": "keyword.control.cpp"
+			"include": "#operator_overload"
 		},
 		{
-			"match": "\\bdelete\\b(\\s*\\[\\])?|\\bnew\\b(?!])",
-			"name": "keyword.control.cpp"
+			"include": "#using_namespace"
 		},
 		{
-			"match": "\\b(f|m)[A-Z]\\w*\\b",
-			"name": "variable.other.readwrite.member.cpp"
+			"include": "#type_alias"
 		},
 		{
-			"match": "\\bthis\\b",
-			"name": "variable.language.this.cpp"
+			"include": "#using_name"
 		},
 		{
-			"match": "\\bnullptr\\b",
-			"name": "constant.language.cpp"
+			"include": "#namespace_alias"
 		},
 		{
-			"match": "\\btemplate\\b\\s*",
-			"name": "storage.type.template.cpp"
+			"include": "#namespace_block"
 		},
 		{
-			"match": "\\b(const_cast|dynamic_cast|reinterpret_cast|static_cast)\\b\\s*",
-			"name": "keyword.operator.cast.cpp"
+			"include": "#extern_block"
 		},
 		{
-			"match": "::",
-			"name": "punctuation.separator.namespace.access.cpp"
+			"include": "#typedef_class"
 		},
 		{
-			"match": "\\b(and|and_eq|bitand|bitor|compl|not|not_eq|or|or_eq|typeid|xor|xor_eq|alignof|alignas)\\b",
-			"name": "keyword.operator.cpp"
+			"include": "#typedef_struct"
 		},
 		{
-			"match": "\\b(class|decltype|wchar_t|char16_t|char32_t)\\b",
-			"name": "storage.type.cpp"
+			"include": "#typedef_union"
 		},
 		{
-			"match": "\\b(constexpr|export|mutable|typename|thread_local)\\b",
-			"name": "storage.modifier.cpp"
+			"include": "#typedef_keyword"
 		},
 		{
-			"begin": "(?x)\n(?:\n  ^ |                  # beginning of line\n  (?:(?<!else|new|=))  # or word + space before name\n)\n((?:[A-Za-z_][A-Za-z0-9_]*::)*+~[A-Za-z_][A-Za-z0-9_]*) # actual name\n\\s*(\\()              # opening bracket",
-			"beginCaptures": {
-				"1": {
-					"name": "entity.name.function.cpp"
-				},
-				"2": {
-					"name": "punctuation.definition.parameters.begin.c"
-				}
-			},
-			"end": "\\)",
-			"endCaptures": {
-				"0": {
-					"name": "punctuation.definition.parameters.end.c"
-				}
-			},
-			"name": "meta.function.destructor.cpp",
-			"patterns": [
-				{
-					"include": "$base"
-				}
-			]
+			"include": "#standard_declares"
 		},
 		{
-			"begin": "(?x)\n(?:\n  ^ |                  # beginning of line\n  (?:(?<!else|new|=))  # or word + space before name\n)\n((?:[A-Za-z_][A-Za-z0-9_]*::)*+~[A-Za-z_][A-Za-z0-9_]*) # actual name\n\\s*(\\()              # opening bracket",
-			"beginCaptures": {
-				"1": {
-					"name": "entity.name.function.cpp"
-				},
-				"2": {
-					"name": "punctuation.definition.parameters.begin.c"
-				}
-			},
-			"end": "\\)",
-			"endCaptures": {
-				"0": {
-					"name": "punctuation.definition.parameters.end.c"
-				}
-			},
-			"name": "meta.function.destructor.prototype.cpp",
-			"patterns": [
-				{
-					"include": "$base"
-				}
-			]
+			"include": "#class_block"
 		},
 		{
-			"include": "source.c"
+			"include": "#struct_block"
+		},
+		{
+			"include": "#union_block"
+		},
+		{
+			"include": "#enum_block"
+		},
+		{
+			"include": "#template_isolated_definition"
+		},
+		{
+			"include": "#template_definition"
+		},
+		{
+			"include": "#access_control_keywords"
+		},
+		{
+			"include": "#block"
+		},
+		{
+			"include": "#static_assert"
+		},
+		{
+			"include": "#assembly"
+		},
+		{
+			"include": "#function_pointer"
+		},
+		{
+			"include": "#evaluation_context"
 		}
 	],
 	"repository": {
-		"angle_brackets": {
-			"begin": "<",
-			"end": ">",
-			"name": "meta.angle-brackets.cpp",
+		"access_control_keywords": {
+			"match": "((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))(((?:protected|private|public))\\s*(:))",
+			"captures": {
+				"1": {
+					"patterns": [
+						{
+							"include": "#inline_comment"
+						}
+					]
+				},
+				"2": {
+					"name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+				},
+				"3": {
+					"name": "comment.block.cpp"
+				},
+				"4": {
+					"patterns": [
+						{
+							"match": "\\*\\/",
+							"name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+						},
+						{
+							"match": "\\*",
+							"name": "comment.block.cpp"
+						}
+					]
+				},
+				"5": {
+					"name": "storage.type.modifier.access.control.$6.cpp"
+				},
+				"7": {
+					"name": "punctuation.separator.colon.access.control.cpp"
+				}
+			}
+		},
+		"alignas_attribute": {
+			"name": "support.other.attribute.cpp",
+			"begin": "(alignas\\()",
+			"beginCaptures": {
+				"1": {
+					"name": "punctuation.section.attribute.begin.cpp"
+				}
+			},
+			"end": "(\\))",
+			"endCaptures": {
+				"1": {
+					"name": "punctuation.section.attribute.end.cpp"
+				}
+			},
 			"patterns": [
 				{
-					"include": "#angle_brackets"
+					"include": "#attributes_context"
 				},
 				{
-					"include": "$base"
+					"begin": "\\(",
+					"end": "\\)",
+					"patterns": [
+						{
+							"include": "#attributes_context"
+						},
+						{
+							"include": "#string_context"
+						}
+					]
+				},
+				{
+					"match": "(using)\\s+((?<!\\w)(?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*(?!\\w))",
+					"captures": {
+						"1": {
+							"name": "keyword.other.using.directive.cpp"
+						},
+						"2": {
+							"name": "entity.name.namespace.cpp"
+						}
+					}
+				},
+				{
+					"match": ",",
+					"name": "punctuation.separator.attribute.cpp"
+				},
+				{
+					"match": ":",
+					"name": "punctuation.accessor.attribute.cpp"
+				},
+				{
+					"match": "(?<!\\w)(?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*(?!\\w)(?=::)",
+					"name": "entity.name.namespace.cpp"
+				},
+				{
+					"match": "(?<!\\w)(?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*(?!\\w)",
+					"name": "entity.other.attribute.$0.cpp"
+				},
+				{
+					"include": "#number_literal"
 				}
 			]
+		},
+		"alignas_operator": {
+			"contentName": "meta.arguments.operator.alignas.cpp",
+			"begin": "((?<!\\w)alignas(?!\\w))((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))(\\()",
+			"beginCaptures": {
+				"1": {
+					"name": "keyword.operator.functionlike.cpp keyword.operator.alignas.cpp"
+				},
+				"2": {
+					"patterns": [
+						{
+							"include": "#inline_comment"
+						}
+					]
+				},
+				"3": {
+					"name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+				},
+				"4": {
+					"name": "comment.block.cpp"
+				},
+				"5": {
+					"patterns": [
+						{
+							"match": "\\*\\/",
+							"name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+						},
+						{
+							"match": "\\*",
+							"name": "comment.block.cpp"
+						}
+					]
+				},
+				"6": {
+					"name": "punctuation.section.arguments.begin.bracket.round.operator.alignas.cpp"
+				}
+			},
+			"end": "(\\))",
+			"endCaptures": {
+				"1": {
+					"name": "punctuation.section.arguments.end.bracket.round.operator.alignas.cpp"
+				}
+			},
+			"patterns": [
+				{
+					"include": "#evaluation_context"
+				}
+			]
+		},
+		"alignof_operator": {
+			"contentName": "meta.arguments.operator.alignof.cpp",
+			"begin": "((?<!\\w)alignof(?!\\w))((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))(\\()",
+			"beginCaptures": {
+				"1": {
+					"name": "keyword.operator.functionlike.cpp keyword.operator.alignof.cpp"
+				},
+				"2": {
+					"patterns": [
+						{
+							"include": "#inline_comment"
+						}
+					]
+				},
+				"3": {
+					"name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+				},
+				"4": {
+					"name": "comment.block.cpp"
+				},
+				"5": {
+					"patterns": [
+						{
+							"match": "\\*\\/",
+							"name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+						},
+						{
+							"match": "\\*",
+							"name": "comment.block.cpp"
+						}
+					]
+				},
+				"6": {
+					"name": "punctuation.section.arguments.begin.bracket.round.operator.alignof.cpp"
+				}
+			},
+			"end": "(\\))",
+			"endCaptures": {
+				"1": {
+					"name": "punctuation.section.arguments.end.bracket.round.operator.alignof.cpp"
+				}
+			},
+			"patterns": [
+				{
+					"include": "#evaluation_context"
+				}
+			]
+		},
+		"assembly": {
+			"name": "meta.asm.cpp",
+			"begin": "(\\b(?:__asm__|asm)\\b)\\s*((?:volatile)?)\\s*(\\()",
+			"beginCaptures": {
+				"1": {
+					"name": "storage.type.asm.cpp"
+				},
+				"2": {
+					"name": "storage.modifier.cpp"
+				},
+				"3": {
+					"name": "punctuation.section.parens.begin.bracket.round.assembly.cpp"
+				}
+			},
+			"end": "(\\))",
+			"endCaptures": {
+				"1": {
+					"name": "punctuation.section.parens.end.bracket.round.assembly.cpp"
+				}
+			},
+			"patterns": [
+				{
+					"name": "string.quoted.double.cpp",
+					"contentName": "meta.embedded.assembly.cpp",
+					"begin": "(R?)(\")",
+					"beginCaptures": {
+						"1": {
+							"name": "meta.encoding.cpp"
+						},
+						"2": {
+							"name": "punctuation.definition.string.begin.assembly.cpp"
+						}
+					},
+					"end": "(\")",
+					"endCaptures": {
+						"1": {
+							"name": "punctuation.definition.string.end.assembly.cpp"
+						}
+					},
+					"patterns": [
+						{
+							"include": "source.asm"
+						},
+						{
+							"include": "source.x86"
+						},
+						{
+							"include": "source.x86_64"
+						},
+						{
+							"include": "source.arm"
+						},
+						{
+							"include": "#backslash_escapes"
+						},
+						{
+							"include": "#string_escaped_char"
+						},
+						{
+							"match": "(?=not)possible"
+						}
+					]
+				},
+				{
+					"begin": "(\\()",
+					"beginCaptures": {
+						"1": {
+							"name": "punctuation.section.parens.begin.bracket.round.assembly.inner.cpp"
+						}
+					},
+					"end": "(\\))",
+					"endCaptures": {
+						"1": {
+							"name": "punctuation.section.parens.end.bracket.round.assembly.inner.cpp"
+						}
+					},
+					"patterns": [
+						{
+							"include": "#evaluation_context"
+						}
+					]
+				},
+				{
+					"match": ":",
+					"name": "punctuation.separator.delimiter.colon.assembly.cpp"
+				},
+				{
+					"include": "#comments_context"
+				},
+				{
+					"include": "#comments"
+				}
+			]
+		},
+		"assignment_operator": {
+			"match": "\\=",
+			"name": "keyword.operator.assignment.cpp"
+		},
+		"attributes_context": {
+			"patterns": [
+				{
+					"include": "#cpp_attributes"
+				},
+				{
+					"include": "#gcc_attributes"
+				},
+				{
+					"include": "#ms_attributes"
+				},
+				{
+					"include": "#alignas_attribute"
+				}
+			]
+		},
+		"backslash_escapes": {
+			"match": "(?x)\\\\ (\n\\\\\t\t\t |\n[abefnprtv'\"?]   |\n[0-3]\\d{,2}\t |\n[4-7]\\d?\t\t|\nx[a-fA-F0-9]{,2} |\nu[a-fA-F0-9]{,4} |\nU[a-fA-F0-9]{,8} )",
+			"name": "constant.character.escape.cpp"
 		},
 		"block": {
-			"begin": "\\{",
-			"beginCaptures": {
-				"0": {
-					"name": "punctuation.section.block.begin.bracket.curly.c"
-				}
-			},
-			"end": "\\}",
-			"endCaptures": {
-				"0": {
-					"name": "punctuation.section.block.end.bracket.curly.c"
-				}
-			},
 			"name": "meta.block.cpp",
+			"begin": "({)",
+			"beginCaptures": {
+				"1": {
+					"name": "punctuation.section.block.begin.bracket.curly.cpp"
+				}
+			},
+			"end": "(}|(?=\\s*#\\s*(?:elif|else|endif)\\b))",
+			"endCaptures": {
+				"1": {
+					"name": "punctuation.section.block.end.bracket.curly.cpp"
+				}
+			},
 			"patterns": [
 				{
-					"captures": {
-						"1": {
-							"name": "support.function.any-method.c"
-						},
-						"2": {
-							"name": "punctuation.definition.parameters.c"
-						}
-					},
-					"match": "(?x)\n(\n  (?!while|for|do|if|else|switch|catch|enumerate|return|r?iterate)\n  (?:\\b[A-Za-z_][A-Za-z0-9_]*+\\b|::)*+ # actual name\n)\n\\s*(\\() # opening bracket",
-					"name": "meta.function-call.c"
-				},
-				{
-					"include": "$base"
+					"include": "#function_body_context"
 				}
 			]
 		},
-		"constructor": {
+		"block_comment": {
+			"name": "comment.block.cpp",
+			"begin": "\\s*+(\\/\\*)",
+			"beginCaptures": {
+				"1": {
+					"name": "punctuation.definition.comment.begin.cpp"
+				}
+			},
+			"end": "(\\*\\/)",
+			"endCaptures": {
+				"1": {
+					"name": "punctuation.definition.comment.end.cpp"
+				}
+			}
+		},
+		"builtin_storage_type_initilizer": {
+			"begin": "((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))(?:(?:(?:((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))((?<!\\w)(?:unsigned|wchar_t|double|signed|short|float|auto|void|long|char|bool|int)(?!\\w))|((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))((?<!\\w)(?:uint_least32_t|uint_least64_t|uint_least16_t|int_least16_t|int_least64_t|int_least32_t|uint_fast32_t|uint_fast16_t|uint_fast64_t|uint_least8_t|int_fast64_t|int_fast16_t|uint_fast8_t|int_fast32_t|int_least8_t|int_fast8_t|suseconds_t|useconds_t|uintmax_t|uintptr_t|in_addr_t|uintmax_t|blksize_t|in_port_t|blkcnt_t|intptr_t|intmax_t|uint64_t|u_quad_t|uint16_t|uint32_t|intmax_t|segsz_t|fixpt_t|caddr_t|daddr_t|u_short|int16_t|int32_t|int64_t|uint8_t|nlink_t|qaddr_t|swblk_t|clock_t|ssize_t|time_t|u_long|ushort|quad_t|mode_t|size_t|u_char|int8_t|u_int|uid_t|off_t|pid_t|gid_t|dev_t|div_t|key_t|ino_t|id_t|id_t|uint)(?!\\w)))|((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))((?<!\\w)pthread_attr_t|pthread_cond_t|pthread_condattr_t|pthread_mutex_t|pthread_mutexattr_t|pthread_once_t|pthread_rwlock_t|pthread_rwlockattr_t|pthread_t|pthread_key_t(?!\\w)))|((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))((?<!\\w)[a-zA-Z_]\\w*_t(?!\\w)))((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))(\\()",
+			"beginCaptures": {
+				"1": {
+					"patterns": [
+						{
+							"include": "#inline_comment"
+						}
+					]
+				},
+				"2": {
+					"name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+				},
+				"3": {
+					"name": "comment.block.cpp"
+				},
+				"4": {
+					"patterns": [
+						{
+							"match": "\\*\\/",
+							"name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+						},
+						{
+							"match": "\\*",
+							"name": "comment.block.cpp"
+						}
+					]
+				},
+				"5": {
+					"patterns": [
+						{
+							"include": "#inline_comment"
+						}
+					]
+				},
+				"6": {
+					"name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+				},
+				"7": {
+					"name": "comment.block.cpp"
+				},
+				"8": {
+					"patterns": [
+						{
+							"match": "\\*\\/",
+							"name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+						},
+						{
+							"match": "\\*",
+							"name": "comment.block.cpp"
+						}
+					]
+				},
+				"9": {
+					"name": "storage.type.primitive.cpp storage.type.built-in.primitive.cpp"
+				},
+				"10": {
+					"patterns": [
+						{
+							"include": "#inline_comment"
+						}
+					]
+				},
+				"11": {
+					"name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+				},
+				"12": {
+					"name": "comment.block.cpp"
+				},
+				"13": {
+					"patterns": [
+						{
+							"match": "\\*\\/",
+							"name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+						},
+						{
+							"match": "\\*",
+							"name": "comment.block.cpp"
+						}
+					]
+				},
+				"14": {
+					"name": "storage.type.cpp storage.type.built-in.cpp"
+				},
+				"15": {
+					"patterns": [
+						{
+							"include": "#inline_comment"
+						}
+					]
+				},
+				"16": {
+					"name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+				},
+				"17": {
+					"name": "comment.block.cpp"
+				},
+				"18": {
+					"patterns": [
+						{
+							"match": "\\*\\/",
+							"name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+						},
+						{
+							"match": "\\*",
+							"name": "comment.block.cpp"
+						}
+					]
+				},
+				"19": {
+					"name": "support.type.posix-reserved.pthread.cpp support.type.built-in.posix-reserved.pthread.cpp"
+				},
+				"20": {
+					"patterns": [
+						{
+							"include": "#inline_comment"
+						}
+					]
+				},
+				"21": {
+					"name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+				},
+				"22": {
+					"name": "comment.block.cpp"
+				},
+				"23": {
+					"patterns": [
+						{
+							"match": "\\*\\/",
+							"name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+						},
+						{
+							"match": "\\*",
+							"name": "comment.block.cpp"
+						}
+					]
+				},
+				"24": {
+					"name": "support.type.posix-reserved.cpp support.type.built-in.posix-reserved.cpp"
+				},
+				"25": {
+					"patterns": [
+						{
+							"include": "#inline_comment"
+						}
+					]
+				},
+				"26": {
+					"name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+				},
+				"27": {
+					"name": "comment.block.cpp"
+				},
+				"28": {
+					"patterns": [
+						{
+							"match": "\\*\\/",
+							"name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+						},
+						{
+							"match": "\\*",
+							"name": "comment.block.cpp"
+						}
+					]
+				},
+				"29": {
+					"name": "punctuation.section.arguments.begin.bracket.round.initializer.cpp"
+				}
+			},
+			"end": "(\\))",
+			"endCaptures": {
+				"1": {
+					"name": "punctuation.section.arguments.end.bracket.round.initializer.cpp"
+				}
+			},
 			"patterns": [
 				{
-					"begin": "(?x)\n(?:^\\s*)  # beginning of line\n((?!while|for|do|if|else|switch|catch|enumerate|r?iterate)[A-Za-z_][A-Za-z0-9_:]*) # actual name\n\\s*(\\()  # opening bracket",
-					"beginCaptures": {
-						"1": {
-							"name": "entity.name.function.cpp"
-						},
-						"2": {
-							"name": "punctuation.definition.parameters.begin.c"
+					"include": "#evaluation_context"
+				}
+			]
+		},
+		"case_statement": {
+			"name": "meta.conditional.case.cpp",
+			"begin": "((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))((?<!\\w)case(?!\\w))",
+			"beginCaptures": {
+				"1": {
+					"patterns": [
+						{
+							"include": "#inline_comment"
 						}
-					},
-					"end": "\\)",
+					]
+				},
+				"2": {
+					"name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+				},
+				"3": {
+					"name": "comment.block.cpp"
+				},
+				"4": {
+					"patterns": [
+						{
+							"match": "\\*\\/",
+							"name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+						},
+						{
+							"match": "\\*",
+							"name": "comment.block.cpp"
+						}
+					]
+				},
+				"5": {
+					"name": "keyword.control.case.cpp"
+				}
+			},
+			"end": "(:)",
+			"endCaptures": {
+				"1": {
+					"name": "punctuation.separator.colon.case.cpp"
+				}
+			},
+			"patterns": [
+				{
+					"include": "#evaluation_context"
+				},
+				{
+					"include": "#c_conditional_context"
+				}
+			]
+		},
+		"class_block": {
+			"name": "meta.block.class.cpp",
+			"begin": "((((?<!\\w)class(?!\\w))(?:(?:((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))|((?:(?:(?:\\[\\[.*?\\]\\]|__attribute(?:__)?\\(\\(.*?\\)\\))|__declspec\\(.*?\\))|alignas\\(.*?\\))(?!\\))))|(?={))(?:((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))(DLLEXPORT)((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z)))))?((?:(?:(?:\\[\\[.*?\\]\\]|__attribute(?:__)?\\(\\(.*?\\)\\))|__declspec\\(.*?\\))|alignas\\(.*?\\))(?!\\)))?((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))((?:(?<!\\w)(?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*(?!\\w))?)(?:((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))(final)((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z)))))?(?:((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))(:)((?>[^{]*)))?))",
+			"beginCaptures": {
+				"1": {
+					"name": "meta.head.class.cpp"
+				},
+				"3": {
+					"name": "storage.type.$3.cpp"
+				},
+				"4": {
+					"patterns": [
+						{
+							"include": "#inline_comment"
+						}
+					]
+				},
+				"5": {
+					"name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+				},
+				"6": {
+					"name": "comment.block.cpp"
+				},
+				"7": {
+					"patterns": [
+						{
+							"match": "\\*\\/",
+							"name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+						},
+						{
+							"match": "\\*",
+							"name": "comment.block.cpp"
+						}
+					]
+				},
+				"8": {
+					"patterns": [
+						{
+							"include": "#attributes_context"
+						},
+						{
+							"include": "#number_literal"
+						}
+					]
+				},
+				"9": {
+					"patterns": [
+						{
+							"include": "#inline_comment"
+						}
+					]
+				},
+				"10": {
+					"name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+				},
+				"11": {
+					"name": "comment.block.cpp"
+				},
+				"12": {
+					"patterns": [
+						{
+							"match": "\\*\\/",
+							"name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+						},
+						{
+							"match": "\\*",
+							"name": "comment.block.cpp"
+						}
+					]
+				},
+				"13": {
+					"name": "entity.name.other.preprocessor.macro.predefined.DLLEXPORT.cpp"
+				},
+				"14": {
+					"patterns": [
+						{
+							"include": "#inline_comment"
+						}
+					]
+				},
+				"15": {
+					"name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+				},
+				"16": {
+					"name": "comment.block.cpp"
+				},
+				"17": {
+					"patterns": [
+						{
+							"match": "\\*\\/",
+							"name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+						},
+						{
+							"match": "\\*",
+							"name": "comment.block.cpp"
+						}
+					]
+				},
+				"18": {
+					"patterns": [
+						{
+							"include": "#attributes_context"
+						},
+						{
+							"include": "#number_literal"
+						}
+					]
+				},
+				"19": {
+					"patterns": [
+						{
+							"include": "#inline_comment"
+						}
+					]
+				},
+				"20": {
+					"name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+				},
+				"21": {
+					"name": "comment.block.cpp"
+				},
+				"22": {
+					"patterns": [
+						{
+							"match": "\\*\\/",
+							"name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+						},
+						{
+							"match": "\\*",
+							"name": "comment.block.cpp"
+						}
+					]
+				},
+				"23": {
+					"name": "entity.name.type.$3.cpp"
+				},
+				"24": {
+					"patterns": [
+						{
+							"include": "#inline_comment"
+						}
+					]
+				},
+				"25": {
+					"name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+				},
+				"26": {
+					"name": "comment.block.cpp"
+				},
+				"27": {
+					"patterns": [
+						{
+							"match": "\\*\\/",
+							"name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+						},
+						{
+							"match": "\\*",
+							"name": "comment.block.cpp"
+						}
+					]
+				},
+				"28": {
+					"name": "storage.type.modifier.final.cpp"
+				},
+				"29": {
+					"patterns": [
+						{
+							"include": "#inline_comment"
+						}
+					]
+				},
+				"30": {
+					"name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+				},
+				"31": {
+					"name": "comment.block.cpp"
+				},
+				"32": {
+					"patterns": [
+						{
+							"match": "\\*\\/",
+							"name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+						},
+						{
+							"match": "\\*",
+							"name": "comment.block.cpp"
+						}
+					]
+				},
+				"33": {
+					"patterns": [
+						{
+							"include": "#inline_comment"
+						}
+					]
+				},
+				"34": {
+					"name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+				},
+				"35": {
+					"name": "comment.block.cpp"
+				},
+				"36": {
+					"patterns": [
+						{
+							"match": "\\*\\/",
+							"name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+						},
+						{
+							"match": "\\*",
+							"name": "comment.block.cpp"
+						}
+					]
+				},
+				"37": {
+					"name": "punctuation.separator.colon.inheritance.cpp"
+				},
+				"38": {
+					"patterns": [
+						{
+							"include": "#inheritance_context"
+						}
+					]
+				}
+			},
+			"end": "(?:(?:(?<=\\}|%>|\\?\\?>)\\s*(;)|(;))|(?=[;>\\[\\]=]))",
+			"endCaptures": {
+				"1": {
+					"name": "punctuation.terminator.statement.cpp"
+				},
+				"2": {
+					"name": "punctuation.terminator.statement.cpp"
+				}
+			},
+			"patterns": [
+				{
+					"name": "meta.head.class.cpp",
+					"begin": "\\G ?",
+					"end": "((?:\\{|<%|\\?\\?<|(?=;)))",
 					"endCaptures": {
-						"0": {
-							"name": "punctuation.definition.parameters.end.c"
+						"1": {
+							"name": "punctuation.section.block.begin.bracket.curly.class.cpp"
 						}
 					},
-					"name": "meta.function.constructor.cpp",
 					"patterns": [
 						{
-							"include": "$base"
+							"include": "#ever_present_context"
+						},
+						{
+							"include": "#inheritance_context"
+						},
+						{
+							"include": "#template_call_range"
 						}
 					]
 				},
 				{
-					"begin": "(?x)\n(:)\n(\n  (?=\n    \\s*[A-Za-z_][A-Za-z0-9_:]* # actual name\n    \\s* (\\() # opening bracket\n  )\n)",
-					"beginCaptures": {
+					"name": "meta.body.class.cpp",
+					"begin": "(?<=\\{|<%|\\?\\?<)",
+					"end": "(\\}|%>|\\?\\?>)",
+					"endCaptures": {
 						"1": {
-							"name": "punctuation.definition.parameters.c"
+							"name": "punctuation.section.block.end.bracket.curly.class.cpp"
 						}
 					},
-					"end": "(?=\\{)",
-					"name": "meta.function.constructor.initializer-list.cpp",
 					"patterns": [
 						{
-							"include": "$base"
+							"include": "#function_pointer"
+						},
+						{
+							"include": "#static_assert"
+						},
+						{
+							"include": "#constructor_inline"
+						},
+						{
+							"include": "#destructor_inline"
+						},
+						{
+							"include": "$self"
+						}
+					]
+				},
+				{
+					"name": "meta.tail.class.cpp",
+					"begin": "(?<=\\}|%>|\\?\\?>)[\\s\\n]*",
+					"end": "[\\s\\n]*(?=;)",
+					"patterns": [
+						{
+							"include": "$self"
 						}
 					]
 				}
 			]
 		},
-		"special_block": {
-			"patterns": [
-				{
-					"begin": "\\b(using)\\b\\s*(namespace)\\b\\s*((?:[_A-Za-z][_A-Za-z0-9]*\\b(::)?)*)",
-					"beginCaptures": {
-						"1": {
-							"name": "keyword.control.cpp"
-						},
-						"2": {
-							"name": "storage.type.cpp"
-						},
-						"3": {
-							"name": "entity.name.type.cpp"
-						}
-					},
-					"end": "(;)",
-					"name": "meta.using-namespace-declaration.cpp"
+		"class_declare": {
+			"match": "((?<!\\w)class(?!\\w))((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))((?<!\\w)(?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*(?!\\w))(((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))?(?:(?:\\&|\\*)((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z)))))*(?:\\&|\\*))?((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))\\b(?!override\\W|override\\$|final\\W|final\\$)((?<!\\w)(?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*(?!\\w))((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))(?=\\S)(?![:{])",
+			"captures": {
+				"1": {
+					"name": "storage.type.class.declare.cpp"
 				},
-				{
-					"begin": "\\b(namespace)\\b\\s*([_A-Za-z][_A-Za-z0-9]*\\b)?+",
-					"beginCaptures": {
-						"1": {
-							"name": "storage.type.cpp"
-						},
-						"2": {
-							"name": "entity.name.type.cpp"
-						}
-					},
-					"captures": {
-						"1": {
-							"name": "keyword.control.namespace.$2"
-						}
-					},
-					"end": "(?<=\\})|(?=(;|,|\\(|\\)|>|\\[|\\]|=))",
-					"name": "meta.namespace-block.cpp",
+				"2": {
 					"patterns": [
 						{
-							"begin": "\\{",
-							"beginCaptures": {
-								"0": {
-									"name": "punctuation.definition.scope.cpp"
+							"include": "#inline_comment"
+						}
+					]
+				},
+				"3": {
+					"name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+				},
+				"4": {
+					"name": "comment.block.cpp"
+				},
+				"5": {
+					"patterns": [
+						{
+							"match": "\\*\\/",
+							"name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+						},
+						{
+							"match": "\\*",
+							"name": "comment.block.cpp"
+						}
+					]
+				},
+				"6": {
+					"name": "entity.name.type.class.cpp"
+				},
+				"7": {
+					"patterns": [
+						{
+							"match": "\\*",
+							"name": "storage.modifier.pointer.cpp"
+						},
+						{
+							"match": "(?:\\&((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))){2,}\\&",
+							"captures": {
+								"1": {
+									"patterns": [
+										{
+											"include": "#inline_comment"
+										}
+									]
+								},
+								"2": {
+									"name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+								},
+								"3": {
+									"name": "comment.block.cpp"
+								},
+								"4": {
+									"patterns": [
+										{
+											"match": "\\*\\/",
+											"name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+										},
+										{
+											"match": "\\*",
+											"name": "comment.block.cpp"
+										}
+									]
 								}
 							},
-							"end": "\\}",
-							"endCaptures": {
-								"0": {
-									"name": "punctuation.definition.scope.cpp"
+							"name": "invalid.illegal.reference-type.cpp"
+						},
+						{
+							"match": "\\&",
+							"name": "storage.modifier.reference.cpp"
+						}
+					]
+				},
+				"8": {
+					"patterns": [
+						{
+							"include": "#inline_comment"
+						}
+					]
+				},
+				"9": {
+					"name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+				},
+				"10": {
+					"name": "comment.block.cpp"
+				},
+				"11": {
+					"patterns": [
+						{
+							"match": "\\*\\/",
+							"name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+						},
+						{
+							"match": "\\*",
+							"name": "comment.block.cpp"
+						}
+					]
+				},
+				"12": {
+					"patterns": [
+						{
+							"include": "#inline_comment"
+						}
+					]
+				},
+				"13": {
+					"name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+				},
+				"14": {
+					"name": "comment.block.cpp"
+				},
+				"15": {
+					"patterns": [
+						{
+							"match": "\\*\\/",
+							"name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+						},
+						{
+							"match": "\\*",
+							"name": "comment.block.cpp"
+						}
+					]
+				},
+				"16": {
+					"patterns": [
+						{
+							"include": "#inline_comment"
+						}
+					]
+				},
+				"17": {
+					"name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+				},
+				"18": {
+					"name": "comment.block.cpp"
+				},
+				"19": {
+					"patterns": [
+						{
+							"match": "\\*\\/",
+							"name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+						},
+						{
+							"match": "\\*",
+							"name": "comment.block.cpp"
+						}
+					]
+				},
+				"20": {
+					"name": "variable.other.object.declare.cpp"
+				},
+				"21": {
+					"patterns": [
+						{
+							"include": "#inline_comment"
+						}
+					]
+				},
+				"22": {
+					"name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+				},
+				"23": {
+					"name": "comment.block.cpp"
+				},
+				"24": {
+					"patterns": [
+						{
+							"match": "\\*\\/",
+							"name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+						},
+						{
+							"match": "\\*",
+							"name": "comment.block.cpp"
+						}
+					]
+				}
+			}
+		},
+		"comma": {
+			"match": ",",
+			"name": "punctuation.separator.delimiter.comma.cpp"
+		},
+		"comma_in_template_argument": {
+			"match": ",",
+			"name": "punctuation.separator.delimiter.comma.template.argument.cpp"
+		},
+		"comments": {
+			"patterns": [
+				{
+					"name": "comment.line.double-slash.documentation.cpp",
+					"begin": "(?:^)(?>\\s*)(\\/\\/[!\\/]+)",
+					"beginCaptures": {
+						"1": {
+							"name": "punctuation.definition.comment.documentation.cpp"
+						}
+					},
+					"end": "(?<=\\n)(?<!\\\\\\n)",
+					"patterns": [
+						{
+							"include": "#line_continuation_character"
+						},
+						{
+							"match": "(?<=[\\s*!\\/])[\\\\@](?:callergraph|callgraph|else|endif|f\\$|f\\[|f\\]|hidecallergraph|hidecallgraph|hiderefby|hiderefs|hideinitializer|htmlinclude|n|nosubgrouping|private|privatesection|protected|protectedsection|public|publicsection|pure|showinitializer|showrefby|showrefs|tableofcontents|\\$|\\#|<|>|%|\"|\\.|=|::|\\||\\-\\-|\\-\\-\\-)\\b(?:\\{[^}]*\\})?",
+							"name": "storage.type.class.doxygen.cpp"
+						},
+						{
+							"match": "((?<=[\\s*!\\/])[\\\\@](?:a|em|e))\\s+(\\S+)",
+							"captures": {
+								"1": {
+									"name": "storage.type.class.doxygen.cpp"
+								},
+								"2": {
+									"name": "markup.italic.doxygen.cpp"
 								}
-							},
+							}
+						},
+						{
+							"match": "((?<=[\\s*!\\/])[\\\\@]b)\\s+(\\S+)",
+							"captures": {
+								"1": {
+									"name": "storage.type.class.doxygen.cpp"
+								},
+								"2": {
+									"name": "markup.bold.doxygen.cpp"
+								}
+							}
+						},
+						{
+							"match": "((?<=[\\s*!\\/])[\\\\@](?:c|p))\\s+(\\S+)",
+							"captures": {
+								"1": {
+									"name": "storage.type.class.doxygen.cpp"
+								},
+								"2": {
+									"name": "markup.inline.raw.string.cpp"
+								}
+							}
+						},
+						{
+							"match": "(?<=[\\s*!\\/])[\\\\@](?:a|anchor|b|c|cite|copybrief|copydetail|copydoc|def|dir|dontinclude|e|em|emoji|enum|example|extends|file|idlexcept|implements|include|includedoc|includelineno|latexinclude|link|memberof|namespace|p|package|ref|refitem|related|relates|relatedalso|relatesalso|verbinclude)\\b(?:\\{[^}]*\\})?",
+							"name": "storage.type.class.doxygen.cpp"
+						},
+						{
+							"match": "(?<=[\\s*!\\/])[\\\\@](?:addindex|addtogroup|category|class|defgroup|diafile|dotfile|elseif|fn|headerfile|if|ifnot|image|ingroup|interface|line|mainpage|mscfile|name|overload|page|property|protocol|section|skip|skipline|snippet|snippetdoc|snippetlineno|struct|subpage|subsection|subsubsection|typedef|union|until|vhdlflow|weakgroup)\\b(?:\\{[^}]*\\})?",
+							"name": "storage.type.class.doxygen.cpp"
+						},
+						{
+							"match": "((?<=[\\s*!\\/])[\\\\@]param)\\s+(\\b\\w+\\b)",
+							"captures": {
+								"1": {
+									"name": "storage.type.class.doxygen.cpp"
+								},
+								"2": {
+									"name": "variable.parameter.cpp"
+								}
+							}
+						},
+						{
+							"match": "(?<=[\\s*!\\/])[\\\\@](?:arg|attention|author|authors|brief|bug|copyright|date|deprecated|details|exception|invariant|li|note|par|paragraph|param|post|pre|remark|remarks|result|return|returns|retval|sa|see|short|since|test|throw|todo|tparam|version|warning|xrefitem)\\b(?:\\{[^}]*\\})?",
+							"name": "storage.type.class.doxygen.cpp"
+						},
+						{
+							"match": "(?<=[\\s*!\\/])[\\\\@](?:code|cond|docbookonly|dot|htmlonly|internal|latexonly|link|manonly|msc|parblock|rtfonly|secreflist|uml|verbatim|xmlonly|endcode|endcond|enddocbookonly|enddot|endhtmlonly|endinternal|endlatexonly|endlink|endmanonly|endmsc|endparblock|endrtfonly|endsecreflist|enduml|endverbatim|endxmlonly)\\b(?:\\{[^}]*\\})?",
+							"name": "storage.type.class.doxygen.cpp"
+						},
+						{
+							"match": "(?:\\b[A-Z]+:|@[a-z_]+:)",
+							"name": "storage.type.class.gtkdoc.cpp"
+						}
+					]
+				},
+				{
+					"match": "(\\/\\*[!*]+(?=\\s))(.+)([!*]*\\*\\/)",
+					"captures": {
+						"1": {
+							"name": "punctuation.definition.comment.begin.documentation.cpp"
+						},
+						"2": {
 							"patterns": [
 								{
-									"include": "#special_block"
+									"match": "(?<=[\\s*!\\/])[\\\\@](?:callergraph|callgraph|else|endif|f\\$|f\\[|f\\]|hidecallergraph|hidecallgraph|hiderefby|hiderefs|hideinitializer|htmlinclude|n|nosubgrouping|private|privatesection|protected|protectedsection|public|publicsection|pure|showinitializer|showrefby|showrefs|tableofcontents|\\$|\\#|<|>|%|\"|\\.|=|::|\\||\\-\\-|\\-\\-\\-)\\b(?:\\{[^}]*\\})?",
+									"name": "storage.type.class.doxygen.cpp"
 								},
 								{
-									"include": "#constructor"
+									"match": "((?<=[\\s*!\\/])[\\\\@](?:a|em|e))\\s+(\\S+)",
+									"captures": {
+										"1": {
+											"name": "storage.type.class.doxygen.cpp"
+										},
+										"2": {
+											"name": "markup.italic.doxygen.cpp"
+										}
+									}
 								},
 								{
-									"include": "$base"
+									"match": "((?<=[\\s*!\\/])[\\\\@]b)\\s+(\\S+)",
+									"captures": {
+										"1": {
+											"name": "storage.type.class.doxygen.cpp"
+										},
+										"2": {
+											"name": "markup.bold.doxygen.cpp"
+										}
+									}
+								},
+								{
+									"match": "((?<=[\\s*!\\/])[\\\\@](?:c|p))\\s+(\\S+)",
+									"captures": {
+										"1": {
+											"name": "storage.type.class.doxygen.cpp"
+										},
+										"2": {
+											"name": "markup.inline.raw.string.cpp"
+										}
+									}
+								},
+								{
+									"match": "(?<=[\\s*!\\/])[\\\\@](?:a|anchor|b|c|cite|copybrief|copydetail|copydoc|def|dir|dontinclude|e|em|emoji|enum|example|extends|file|idlexcept|implements|include|includedoc|includelineno|latexinclude|link|memberof|namespace|p|package|ref|refitem|related|relates|relatedalso|relatesalso|verbinclude)\\b(?:\\{[^}]*\\})?",
+									"name": "storage.type.class.doxygen.cpp"
+								},
+								{
+									"match": "(?<=[\\s*!\\/])[\\\\@](?:addindex|addtogroup|category|class|defgroup|diafile|dotfile|elseif|fn|headerfile|if|ifnot|image|ingroup|interface|line|mainpage|mscfile|name|overload|page|property|protocol|section|skip|skipline|snippet|snippetdoc|snippetlineno|struct|subpage|subsection|subsubsection|typedef|union|until|vhdlflow|weakgroup)\\b(?:\\{[^}]*\\})?",
+									"name": "storage.type.class.doxygen.cpp"
+								},
+								{
+									"match": "((?<=[\\s*!\\/])[\\\\@]param)\\s+(\\b\\w+\\b)",
+									"captures": {
+										"1": {
+											"name": "storage.type.class.doxygen.cpp"
+										},
+										"2": {
+											"name": "variable.parameter.cpp"
+										}
+									}
+								},
+								{
+									"match": "(?<=[\\s*!\\/])[\\\\@](?:arg|attention|author|authors|brief|bug|copyright|date|deprecated|details|exception|invariant|li|note|par|paragraph|param|post|pre|remark|remarks|result|return|returns|retval|sa|see|short|since|test|throw|todo|tparam|version|warning|xrefitem)\\b(?:\\{[^}]*\\})?",
+									"name": "storage.type.class.doxygen.cpp"
+								},
+								{
+									"match": "(?<=[\\s*!\\/])[\\\\@](?:code|cond|docbookonly|dot|htmlonly|internal|latexonly|link|manonly|msc|parblock|rtfonly|secreflist|uml|verbatim|xmlonly|endcode|endcond|enddocbookonly|enddot|endhtmlonly|endinternal|endlatexonly|endlink|endmanonly|endmsc|endparblock|endrtfonly|endsecreflist|enduml|endverbatim|endxmlonly)\\b(?:\\{[^}]*\\})?",
+									"name": "storage.type.class.doxygen.cpp"
+								},
+								{
+									"match": "(?:\\b[A-Z]+:|@[a-z_]+:)",
+									"name": "storage.type.class.gtkdoc.cpp"
+								}
+							]
+						},
+						"3": {
+							"name": "punctuation.definition.comment.end.documentation.cpp"
+						}
+					},
+					"name": "comment.block.documentation.cpp"
+				},
+				{
+					"name": "comment.block.documentation.cpp",
+					"begin": "((?>\\s*)\\/\\*[!*]+(?:(?:\\n|$)|(?=\\s)))",
+					"beginCaptures": {
+						"1": {
+							"name": "punctuation.definition.comment.begin.documentation.cpp"
+						}
+					},
+					"end": "([!*]*\\*\\/)",
+					"endCaptures": {
+						"1": {
+							"name": "punctuation.definition.comment.end.documentation.cpp"
+						}
+					},
+					"patterns": [
+						{
+							"match": "(?<=[\\s*!\\/])[\\\\@](?:callergraph|callgraph|else|endif|f\\$|f\\[|f\\]|hidecallergraph|hidecallgraph|hiderefby|hiderefs|hideinitializer|htmlinclude|n|nosubgrouping|private|privatesection|protected|protectedsection|public|publicsection|pure|showinitializer|showrefby|showrefs|tableofcontents|\\$|\\#|<|>|%|\"|\\.|=|::|\\||\\-\\-|\\-\\-\\-)\\b(?:\\{[^}]*\\})?",
+							"name": "storage.type.class.doxygen.cpp"
+						},
+						{
+							"match": "((?<=[\\s*!\\/])[\\\\@](?:a|em|e))\\s+(\\S+)",
+							"captures": {
+								"1": {
+									"name": "storage.type.class.doxygen.cpp"
+								},
+								"2": {
+									"name": "markup.italic.doxygen.cpp"
+								}
+							}
+						},
+						{
+							"match": "((?<=[\\s*!\\/])[\\\\@]b)\\s+(\\S+)",
+							"captures": {
+								"1": {
+									"name": "storage.type.class.doxygen.cpp"
+								},
+								"2": {
+									"name": "markup.bold.doxygen.cpp"
+								}
+							}
+						},
+						{
+							"match": "((?<=[\\s*!\\/])[\\\\@](?:c|p))\\s+(\\S+)",
+							"captures": {
+								"1": {
+									"name": "storage.type.class.doxygen.cpp"
+								},
+								"2": {
+									"name": "markup.inline.raw.string.cpp"
+								}
+							}
+						},
+						{
+							"match": "(?<=[\\s*!\\/])[\\\\@](?:a|anchor|b|c|cite|copybrief|copydetail|copydoc|def|dir|dontinclude|e|em|emoji|enum|example|extends|file|idlexcept|implements|include|includedoc|includelineno|latexinclude|link|memberof|namespace|p|package|ref|refitem|related|relates|relatedalso|relatesalso|verbinclude)\\b(?:\\{[^}]*\\})?",
+							"name": "storage.type.class.doxygen.cpp"
+						},
+						{
+							"match": "(?<=[\\s*!\\/])[\\\\@](?:addindex|addtogroup|category|class|defgroup|diafile|dotfile|elseif|fn|headerfile|if|ifnot|image|ingroup|interface|line|mainpage|mscfile|name|overload|page|property|protocol|section|skip|skipline|snippet|snippetdoc|snippetlineno|struct|subpage|subsection|subsubsection|typedef|union|until|vhdlflow|weakgroup)\\b(?:\\{[^}]*\\})?",
+							"name": "storage.type.class.doxygen.cpp"
+						},
+						{
+							"match": "((?<=[\\s*!\\/])[\\\\@]param)\\s+(\\b\\w+\\b)",
+							"captures": {
+								"1": {
+									"name": "storage.type.class.doxygen.cpp"
+								},
+								"2": {
+									"name": "variable.parameter.cpp"
+								}
+							}
+						},
+						{
+							"match": "(?<=[\\s*!\\/])[\\\\@](?:arg|attention|author|authors|brief|bug|copyright|date|deprecated|details|exception|invariant|li|note|par|paragraph|param|post|pre|remark|remarks|result|return|returns|retval|sa|see|short|since|test|throw|todo|tparam|version|warning|xrefitem)\\b(?:\\{[^}]*\\})?",
+							"name": "storage.type.class.doxygen.cpp"
+						},
+						{
+							"match": "(?<=[\\s*!\\/])[\\\\@](?:code|cond|docbookonly|dot|htmlonly|internal|latexonly|link|manonly|msc|parblock|rtfonly|secreflist|uml|verbatim|xmlonly|endcode|endcond|enddocbookonly|enddot|endhtmlonly|endinternal|endlatexonly|endlink|endmanonly|endmsc|endparblock|endrtfonly|endsecreflist|enduml|endverbatim|endxmlonly)\\b(?:\\{[^}]*\\})?",
+							"name": "storage.type.class.doxygen.cpp"
+						},
+						{
+							"match": "(?:\\b[A-Z]+:|@[a-z_]+:)",
+							"name": "storage.type.class.gtkdoc.cpp"
+						}
+					]
+				},
+				{
+					"include": "#emacs_file_banner"
+				},
+				{
+					"include": "#block_comment"
+				},
+				{
+					"include": "#line_comment"
+				},
+				{
+					"include": "#invalid_comment_end"
+				}
+			]
+		},
+		"constructor_inline": {
+			"name": "meta.function.definition.special.constructor.cpp",
+			"begin": "(^((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))((?:(?:constexpr|explicit|mutable|virtual|inline|friend)((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z)))))*)((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))((?:__cdecl|__clrcall|__stdcall|__fastcall|__thiscall|__vectorcall)?)((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))((?<!\\w)(?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*(?!\\w)(?=\\()))",
+			"beginCaptures": {
+				"1": {
+					"name": "meta.head.function.definition.special.constructor.cpp"
+				},
+				"2": {
+					"patterns": [
+						{
+							"include": "#inline_comment"
+						}
+					]
+				},
+				"3": {
+					"name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+				},
+				"4": {
+					"name": "comment.block.cpp"
+				},
+				"5": {
+					"patterns": [
+						{
+							"match": "\\*\\/",
+							"name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+						},
+						{
+							"match": "\\*",
+							"name": "comment.block.cpp"
+						}
+					]
+				},
+				"6": {
+					"patterns": [
+						{
+							"include": "#functional_specifiers_pre_parameters"
+						}
+					]
+				},
+				"7": {
+					"patterns": [
+						{
+							"include": "#inline_comment"
+						}
+					]
+				},
+				"8": {
+					"name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+				},
+				"9": {
+					"name": "comment.block.cpp"
+				},
+				"10": {
+					"patterns": [
+						{
+							"match": "\\*\\/",
+							"name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+						},
+						{
+							"match": "\\*",
+							"name": "comment.block.cpp"
+						}
+					]
+				},
+				"11": {
+					"patterns": [
+						{
+							"include": "#inline_comment"
+						}
+					]
+				},
+				"12": {
+					"name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+				},
+				"13": {
+					"name": "comment.block.cpp"
+				},
+				"14": {
+					"patterns": [
+						{
+							"match": "\\*\\/",
+							"name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+						},
+						{
+							"match": "\\*",
+							"name": "comment.block.cpp"
+						}
+					]
+				},
+				"15": {
+					"name": "storage.type.modifier.calling-convention.cpp"
+				},
+				"16": {
+					"patterns": [
+						{
+							"include": "#inline_comment"
+						}
+					]
+				},
+				"17": {
+					"name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+				},
+				"18": {
+					"name": "comment.block.cpp"
+				},
+				"19": {
+					"patterns": [
+						{
+							"match": "\\*\\/",
+							"name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+						},
+						{
+							"match": "\\*",
+							"name": "comment.block.cpp"
+						}
+					]
+				},
+				"20": {
+					"name": "entity.name.function.constructor.cpp entity.name.function.definition.special.constructor.cpp"
+				}
+			},
+			"end": "(?:(?<=\\}|%>|\\?\\?>)|(?=[;>\\[\\]=]))",
+			"patterns": [
+				{
+					"name": "meta.head.function.definition.special.constructor.cpp",
+					"begin": "\\G ?",
+					"end": "((?:\\{|<%|\\?\\?<|(?=;)))",
+					"endCaptures": {
+						"1": {
+							"name": "punctuation.section.block.begin.bracket.curly.function.definition.special.constructor.cpp"
+						}
+					},
+					"patterns": [
+						{
+							"include": "#ever_present_context"
+						},
+						{
+							"patterns": [
+								{
+									"match": "(\\=)((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))(?:(default)|(delete))",
+									"captures": {
+										"1": {
+											"name": "keyword.operator.assignment.cpp"
+										},
+										"2": {
+											"patterns": [
+												{
+													"include": "#inline_comment"
+												}
+											]
+										},
+										"3": {
+											"name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+										},
+										"4": {
+											"name": "comment.block.cpp"
+										},
+										"5": {
+											"patterns": [
+												{
+													"match": "\\*\\/",
+													"name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+												},
+												{
+													"match": "\\*",
+													"name": "comment.block.cpp"
+												}
+											]
+										},
+										"6": {
+											"name": "keyword.other.default.constructor.cpp"
+										},
+										"7": {
+											"name": "keyword.other.delete.constructor.cpp"
+										}
+									}
 								}
 							]
 						},
 						{
-							"include": "$base"
+							"include": "#functional_specifiers_pre_parameters"
+						},
+						{
+							"begin": "(:)",
+							"beginCaptures": {
+								"1": {
+									"name": "punctuation.separator.initializers.cpp"
+								}
+							},
+							"end": "(?=\\{)",
+							"patterns": [
+								{
+									"contentName": "meta.parameter.initialization.cpp",
+									"begin": "((?<!\\w)(?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*(?!\\w))(((?<!<)<(?!<)(?>(?:(?>[^<>]*)\\g<3>?)+)>)\\s*)?(\\()",
+									"beginCaptures": {
+										"1": {
+											"name": "entity.name.function.call.initializer.cpp"
+										},
+										"2": {
+											"name": "meta.template.call.cpp",
+											"patterns": [
+												{
+													"include": "#template_call_range"
+												}
+											]
+										},
+										"4": {
+											"name": "punctuation.section.arguments.begin.bracket.round.function.call.initializer.cpp"
+										}
+									},
+									"end": "(\\))",
+									"endCaptures": {
+										"1": {
+											"name": "punctuation.section.arguments.end.bracket.round.function.call.initializer.cpp"
+										}
+									},
+									"patterns": [
+										{
+											"include": "#evaluation_context"
+										}
+									]
+								},
+								{
+									"contentName": "meta.parameter.initialization.cpp",
+									"begin": "((?<!\\w)(?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*(?!\\w))(\\{)",
+									"beginCaptures": {
+										"1": {
+											"name": "entity.name.function.call.initializer.cpp"
+										},
+										"2": {
+											"name": "punctuation.section.arguments.begin.bracket.round.function.call.initializer.cpp"
+										}
+									},
+									"end": "(\\})",
+									"endCaptures": {
+										"1": {
+											"name": "punctuation.section.arguments.end.bracket.round.function.call.initializer.cpp"
+										}
+									},
+									"patterns": [
+										{
+											"include": "#evaluation_context"
+										}
+									]
+								},
+								{
+									"include": "#comma"
+								},
+								{
+									"include": "#comments"
+								}
+							]
+						},
+						{
+							"contentName": "meta.function.definition.parameters.special.constructor.cpp",
+							"begin": "(\\()",
+							"beginCaptures": {
+								"1": {
+									"name": "punctuation.section.parameters.begin.bracket.round.special.constructor.cpp"
+								}
+							},
+							"end": "(\\))",
+							"endCaptures": {
+								"1": {
+									"name": "punctuation.section.parameters.end.bracket.round.special.constructor.cpp"
+								}
+							},
+							"patterns": [
+								{
+									"include": "#function_parameter_context"
+								},
+								{
+									"include": "#evaluation_context"
+								}
+							]
+						},
+						{
+							"include": "$self"
 						}
 					]
 				},
 				{
-					"begin": "\\b(class|struct)\\b\\s*([_A-Za-z][_A-Za-z0-9]*\\b)?+(\\s*:\\s*(public|protected|private)\\s*([_A-Za-z][_A-Za-z0-9]*\\b)((\\s*,\\s*(public|protected|private)\\s*[_A-Za-z][_A-Za-z0-9]*\\b)*))?",
-					"beginCaptures": {
+					"name": "meta.body.function.definition.special.constructor.cpp",
+					"begin": "(?<=\\{|<%|\\?\\?<)",
+					"end": "(\\}|%>|\\?\\?>)",
+					"endCaptures": {
 						"1": {
-							"name": "storage.type.cpp"
+							"name": "punctuation.section.block.end.bracket.curly.function.definition.special.constructor.cpp"
+						}
+					},
+					"patterns": [
+						{
+							"include": "#function_body_context"
+						}
+					]
+				},
+				{
+					"name": "meta.tail.function.definition.special.constructor.cpp",
+					"begin": "(?<=\\}|%>|\\?\\?>)[\\s\\n]*",
+					"end": "[\\s\\n]*(?=;)",
+					"patterns": [
+						{
+							"include": "$self"
+						}
+					]
+				}
+			]
+		},
+		"constructor_root": {
+			"name": "meta.function.definition.special.constructor.cpp",
+			"begin": "(\\s*+((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))((?:__cdecl|__clrcall|__stdcall|__fastcall|__thiscall|__vectorcall)?)((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))((?:((?-mix:(?!\\b(?:__has_cpp_attribute|reinterpret_cast|atomic_noexcept|atomic_cancel|atomic_commit|__has_include|dynamic_cast|thread_local|synchronized|static_cast|const_cast|consteval|constexpr|protected|namespace|co_return|constexpr|constexpr|continue|explicit|volatile|noexcept|co_yield|noexcept|noexcept|requires|typename|decltype|operator|co_await|template|volatile|register|restrict|reflexpr|alignof|private|default|mutable|include|concept|__asm__|defined|_Pragma|alignas|typedef|warning|virtual|mutable|struct|sizeof|delete|not_eq|bitand|and_eq|xor_eq|typeid|switch|return|static|extern|inline|friend|public|ifndef|define|pragma|export|import|module|catch|throw|const|or_eq|while|compl|bitor|const|union|ifdef|class|undef|error|break|using|endif|goto|line|enum|this|case|else|elif|else|asm|try|for|new|and|xor|not|do|or|if|if)\\b)(?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*))\\s*+(((?<!<)<(?!<)(?>(?:(?>[^<>]*)\\g<14>?)+)>)\\s*)?::)*)(((?>(?<!\\w)(?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*(?!\\w)))((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))::((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))\\16((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))(?=\\()))",
+			"beginCaptures": {
+				"1": {
+					"name": "meta.head.function.definition.special.constructor.cpp"
+				},
+				"2": {
+					"patterns": [
+						{
+							"include": "#inline_comment"
+						}
+					]
+				},
+				"3": {
+					"name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+				},
+				"4": {
+					"name": "comment.block.cpp"
+				},
+				"5": {
+					"patterns": [
+						{
+							"match": "\\*\\/",
+							"name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+						},
+						{
+							"match": "\\*",
+							"name": "comment.block.cpp"
+						}
+					]
+				},
+				"6": {
+					"name": "storage.type.modifier.calling-convention.cpp"
+				},
+				"7": {
+					"patterns": [
+						{
+							"include": "#inline_comment"
+						}
+					]
+				},
+				"8": {
+					"name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+				},
+				"9": {
+					"name": "comment.block.cpp"
+				},
+				"10": {
+					"patterns": [
+						{
+							"match": "\\*\\/",
+							"name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+						},
+						{
+							"match": "\\*",
+							"name": "comment.block.cpp"
+						}
+					]
+				},
+				"11": {
+					"patterns": [
+						{
+							"match": "::",
+							"name": "punctuation.separator.namespace.access.cpp punctuation.separator.scope-resolution.constructor.cpp"
+						},
+						{
+							"match": "(?<!\\w)(?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*(?!\\w)",
+							"name": "entity.name.scope-resolution.constructor.cpp"
+						},
+						{
+							"include": "#template_call_range"
+						}
+					]
+				},
+				"13": {
+					"name": "meta.template.call.cpp",
+					"patterns": [
+						{
+							"include": "#template_call_range"
+						}
+					]
+				},
+				"15": {
+					"patterns": [
+						{
+							"match": "(?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*(?=:)",
+							"name": "entity.name.type.constructor.cpp"
+						},
+						{
+							"match": "(?<=:)(?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*",
+							"name": "entity.name.function.definition.special.constructor.cpp"
+						},
+						{
+							"match": "::",
+							"name": "punctuation.separator.namespace.access.cpp punctuation.separator.scope-resolution.constructor.cpp"
+						}
+					]
+				},
+				"17": {
+					"patterns": [
+						{
+							"include": "#inline_comment"
+						}
+					]
+				},
+				"18": {
+					"name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+				},
+				"19": {
+					"name": "comment.block.cpp"
+				},
+				"20": {
+					"patterns": [
+						{
+							"match": "\\*\\/",
+							"name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+						},
+						{
+							"match": "\\*",
+							"name": "comment.block.cpp"
+						}
+					]
+				},
+				"21": {
+					"patterns": [
+						{
+							"include": "#inline_comment"
+						}
+					]
+				},
+				"22": {
+					"name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+				},
+				"23": {
+					"name": "comment.block.cpp"
+				},
+				"24": {
+					"patterns": [
+						{
+							"match": "\\*\\/",
+							"name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+						},
+						{
+							"match": "\\*",
+							"name": "comment.block.cpp"
+						}
+					]
+				},
+				"25": {
+					"patterns": [
+						{
+							"include": "#inline_comment"
+						}
+					]
+				},
+				"26": {
+					"name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+				},
+				"27": {
+					"name": "comment.block.cpp"
+				},
+				"28": {
+					"patterns": [
+						{
+							"match": "\\*\\/",
+							"name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+						},
+						{
+							"match": "\\*",
+							"name": "comment.block.cpp"
+						}
+					]
+				}
+			},
+			"end": "(?:(?<=\\}|%>|\\?\\?>)|(?=[;>\\[\\]=]))",
+			"patterns": [
+				{
+					"name": "meta.head.function.definition.special.constructor.cpp",
+					"begin": "\\G ?",
+					"end": "((?:\\{|<%|\\?\\?<|(?=;)))",
+					"endCaptures": {
+						"1": {
+							"name": "punctuation.section.block.begin.bracket.curly.function.definition.special.constructor.cpp"
+						}
+					},
+					"patterns": [
+						{
+							"include": "#ever_present_context"
+						},
+						{
+							"patterns": [
+								{
+									"match": "(\\=)((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))(?:(default)|(delete))",
+									"captures": {
+										"1": {
+											"name": "keyword.operator.assignment.cpp"
+										},
+										"2": {
+											"patterns": [
+												{
+													"include": "#inline_comment"
+												}
+											]
+										},
+										"3": {
+											"name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+										},
+										"4": {
+											"name": "comment.block.cpp"
+										},
+										"5": {
+											"patterns": [
+												{
+													"match": "\\*\\/",
+													"name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+												},
+												{
+													"match": "\\*",
+													"name": "comment.block.cpp"
+												}
+											]
+										},
+										"6": {
+											"name": "keyword.other.default.constructor.cpp"
+										},
+										"7": {
+											"name": "keyword.other.delete.constructor.cpp"
+										}
+									}
+								}
+							]
+						},
+						{
+							"include": "#functional_specifiers_pre_parameters"
+						},
+						{
+							"begin": "(:)",
+							"beginCaptures": {
+								"1": {
+									"name": "punctuation.separator.initializers.cpp"
+								}
+							},
+							"end": "(?=\\{)",
+							"patterns": [
+								{
+									"contentName": "meta.parameter.initialization.cpp",
+									"begin": "((?<!\\w)(?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*(?!\\w))(((?<!<)<(?!<)(?>(?:(?>[^<>]*)\\g<3>?)+)>)\\s*)?(\\()",
+									"beginCaptures": {
+										"1": {
+											"name": "entity.name.function.call.initializer.cpp"
+										},
+										"2": {
+											"name": "meta.template.call.cpp",
+											"patterns": [
+												{
+													"include": "#template_call_range"
+												}
+											]
+										},
+										"4": {
+											"name": "punctuation.section.arguments.begin.bracket.round.function.call.initializer.cpp"
+										}
+									},
+									"end": "(\\))",
+									"endCaptures": {
+										"1": {
+											"name": "punctuation.section.arguments.end.bracket.round.function.call.initializer.cpp"
+										}
+									},
+									"patterns": [
+										{
+											"include": "#evaluation_context"
+										}
+									]
+								},
+								{
+									"contentName": "meta.parameter.initialization.cpp",
+									"begin": "((?<!\\w)(?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*(?!\\w))(\\{)",
+									"beginCaptures": {
+										"1": {
+											"name": "entity.name.function.call.initializer.cpp"
+										},
+										"2": {
+											"name": "punctuation.section.arguments.begin.bracket.round.function.call.initializer.cpp"
+										}
+									},
+									"end": "(\\})",
+									"endCaptures": {
+										"1": {
+											"name": "punctuation.section.arguments.end.bracket.round.function.call.initializer.cpp"
+										}
+									},
+									"patterns": [
+										{
+											"include": "#evaluation_context"
+										}
+									]
+								},
+								{
+									"include": "#comma"
+								},
+								{
+									"include": "#comments"
+								}
+							]
+						},
+						{
+							"contentName": "meta.function.definition.parameters.special.constructor.cpp",
+							"begin": "(\\()",
+							"beginCaptures": {
+								"1": {
+									"name": "punctuation.section.parameters.begin.bracket.round.special.constructor.cpp"
+								}
+							},
+							"end": "(\\))",
+							"endCaptures": {
+								"1": {
+									"name": "punctuation.section.parameters.end.bracket.round.special.constructor.cpp"
+								}
+							},
+							"patterns": [
+								{
+									"include": "#function_parameter_context"
+								},
+								{
+									"include": "#evaluation_context"
+								}
+							]
+						},
+						{
+							"include": "$self"
+						}
+					]
+				},
+				{
+					"name": "meta.body.function.definition.special.constructor.cpp",
+					"begin": "(?<=\\{|<%|\\?\\?<)",
+					"end": "(\\}|%>|\\?\\?>)",
+					"endCaptures": {
+						"1": {
+							"name": "punctuation.section.block.end.bracket.curly.function.definition.special.constructor.cpp"
+						}
+					},
+					"patterns": [
+						{
+							"include": "#function_body_context"
+						}
+					]
+				},
+				{
+					"name": "meta.tail.function.definition.special.constructor.cpp",
+					"begin": "(?<=\\}|%>|\\?\\?>)[\\s\\n]*",
+					"end": "[\\s\\n]*(?=;)",
+					"patterns": [
+						{
+							"include": "$self"
+						}
+					]
+				}
+			]
+		},
+		"control_flow_keywords": {
+			"match": "((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))((?<!\\w)(?:continue|default|switch|return|throw|break|catch|while|case|goto|else|try|for|do|if)(?!\\w))",
+			"captures": {
+				"1": {
+					"patterns": [
+						{
+							"include": "#inline_comment"
+						}
+					]
+				},
+				"2": {
+					"name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+				},
+				"3": {
+					"name": "comment.block.cpp"
+				},
+				"4": {
+					"patterns": [
+						{
+							"match": "\\*\\/",
+							"name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+						},
+						{
+							"match": "\\*",
+							"name": "comment.block.cpp"
+						}
+					]
+				},
+				"5": {
+					"name": "keyword.control.$5.cpp"
+				}
+			}
+		},
+		"cpp_attributes": {
+			"name": "support.other.attribute.cpp",
+			"begin": "(\\[\\[)",
+			"beginCaptures": {
+				"1": {
+					"name": "punctuation.section.attribute.begin.cpp"
+				}
+			},
+			"end": "(\\]\\])",
+			"endCaptures": {
+				"1": {
+					"name": "punctuation.section.attribute.end.cpp"
+				}
+			},
+			"patterns": [
+				{
+					"include": "#attributes_context"
+				},
+				{
+					"begin": "\\(",
+					"end": "\\)",
+					"patterns": [
+						{
+							"include": "#attributes_context"
+						},
+						{
+							"include": "#string_context"
+						}
+					]
+				},
+				{
+					"match": "(using)\\s+((?<!\\w)(?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*(?!\\w))",
+					"captures": {
+						"1": {
+							"name": "keyword.other.using.directive.cpp"
 						},
 						"2": {
+							"name": "entity.name.namespace.cpp"
+						}
+					}
+				},
+				{
+					"match": ",",
+					"name": "punctuation.separator.attribute.cpp"
+				},
+				{
+					"match": ":",
+					"name": "punctuation.accessor.attribute.cpp"
+				},
+				{
+					"match": "(?<!\\w)(?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*(?!\\w)(?=::)",
+					"name": "entity.name.namespace.cpp"
+				},
+				{
+					"match": "(?<!\\w)(?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*(?!\\w)",
+					"name": "entity.other.attribute.$0.cpp"
+				},
+				{
+					"include": "#number_literal"
+				}
+			]
+		},
+		"curly_initializer": {
+			"name": "meta.initialization.cpp",
+			"begin": "(\\s*+((?:(?:(?:\\[\\[.*?\\]\\]|__attribute(?:__)?\\(\\(.*?\\)\\))|__declspec\\(.*?\\))|alignas\\(.*?\\))(?!\\)))?((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))(?:(?:(?:unsigned|signed|short|long)|(?:struct|class|union|enum))((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z)))))*(((::)?(?:((?-mix:(?!\\b(?:__has_cpp_attribute|reinterpret_cast|atomic_noexcept|atomic_cancel|atomic_commit|__has_include|dynamic_cast|thread_local|synchronized|static_cast|const_cast|consteval|constexpr|protected|namespace|co_return|constexpr|constexpr|continue|explicit|volatile|noexcept|co_yield|noexcept|noexcept|requires|typename|decltype|operator|co_await|template|volatile|register|restrict|reflexpr|alignof|private|default|mutable|include|concept|__asm__|defined|_Pragma|alignas|typedef|warning|virtual|mutable|struct|sizeof|delete|not_eq|bitand|and_eq|xor_eq|typeid|switch|return|static|extern|inline|friend|public|ifndef|define|pragma|export|import|module|catch|throw|const|or_eq|while|compl|bitor|const|union|ifdef|class|undef|error|break|using|endif|goto|line|enum|this|case|else|elif|else|asm|try|for|new|and|xor|not|do|or|if|if)\\b)(?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*))\\s*+(((?<!<)<(?!<)(?>(?:(?>[^<>]*)\\g<27>?)+)>)\\s*)?::)*\\s*+)((?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*)\\s*+(((?<!<)<(?!<)(?>(?:(?>[^<>]*)\\g<27>?)+)>)\\s*)?(::))?((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))(?!(?:transaction_safe_dynamic|__has_cpp_attribute|transaction_safe|reinterpret_cast|atomic_noexcept|atomic_commit|atomic_cancel|__has_include|dynamic_cast|thread_local|synchronized|static_cast|const_cast|constexpr|consteval|protected|constexpr|co_return|namespace|constexpr|noexcept|typename|decltype|template|operator|noexcept|co_yield|co_await|continue|volatile|register|restrict|explicit|override|volatile|reflexpr|noexcept|requires|default|typedef|nullptr|alignof|mutable|concept|virtual|defined|__asm__|include|_Pragma|mutable|warning|private|alignas|module|switch|not_eq|bitand|and_eq|ifndef|return|sizeof|xor_eq|export|static|delete|public|define|extern|inline|import|pragma|friend|typeid|const|compl|bitor|throw|or_eq|while|catch|break|false|final|const|endif|ifdef|undef|error|using|audit|axiom|line|else|elif|true|NULL|case|goto|else|this|new|asm|not|and|xor|try|for|if|do|or|if)\\b)((?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*)\\b(((?<!<)<(?!<)(?>(?:(?>[^<>]*)\\g<27>?)+)>)\\s*)?(?![\\w<:.]))((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))(\\{)",
+			"beginCaptures": {
+				"1": {
+					"name": "meta.qualified_type.cpp",
+					"patterns": [
+						{
+							"match": "(?<!\\w)(?:struct|class|union|enum)(?!\\w)",
+							"name": "storage.type.$0.cpp"
+						},
+						{
+							"include": "#attributes_context"
+						},
+						{
+							"include": "#function_type"
+						},
+						{
+							"include": "#storage_types"
+						},
+						{
+							"include": "#number_literal"
+						},
+						{
+							"include": "#string_context"
+						},
+						{
+							"include": "#comma"
+						},
+						{
+							"include": "#scope_resolution_inner_generated"
+						},
+						{
+							"include": "#template_call_range"
+						},
+						{
+							"match": "(?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*",
 							"name": "entity.name.type.cpp"
+						}
+					]
+				},
+				"2": {
+					"patterns": [
+						{
+							"include": "#attributes_context"
+						},
+						{
+							"include": "#number_literal"
+						}
+					]
+				},
+				"3": {
+					"patterns": [
+						{
+							"include": "#inline_comment"
+						}
+					]
+				},
+				"4": {
+					"name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+				},
+				"5": {
+					"name": "comment.block.cpp"
+				},
+				"6": {
+					"patterns": [
+						{
+							"match": "\\*\\/",
+							"name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+						},
+						{
+							"match": "\\*",
+							"name": "comment.block.cpp"
+						}
+					]
+				},
+				"7": {
+					"patterns": [
+						{
+							"include": "#inline_comment"
+						}
+					]
+				},
+				"8": {
+					"name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+				},
+				"9": {
+					"name": "comment.block.cpp"
+				},
+				"10": {
+					"patterns": [
+						{
+							"match": "\\*\\/",
+							"name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+						},
+						{
+							"match": "\\*",
+							"name": "comment.block.cpp"
+						}
+					]
+				},
+				"12": {
+					"patterns": [
+						{
+							"include": "#scope_resolution_inner_generated"
+						}
+					]
+				},
+				"13": {
+					"name": "punctuation.separator.namespace.access.cpp punctuation.separator.scope-resolution.cpp"
+				},
+				"15": {
+					"name": "meta.template.call.cpp",
+					"patterns": [
+						{
+							"include": "#template_call_range"
+						}
+					]
+				},
+				"17": {
+					"name": "entity.name.scope-resolution.cpp"
+				},
+				"18": {
+					"name": "meta.template.call.cpp",
+					"patterns": [
+						{
+							"include": "#template_call_range"
+						}
+					]
+				},
+				"20": {
+					"name": "punctuation.separator.namespace.access.cpp punctuation.separator.scope-resolution.cpp"
+				},
+				"21": {
+					"patterns": [
+						{
+							"include": "#inline_comment"
+						}
+					]
+				},
+				"22": {
+					"name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+				},
+				"23": {
+					"name": "comment.block.cpp"
+				},
+				"24": {
+					"patterns": [
+						{
+							"match": "\\*\\/",
+							"name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+						},
+						{
+							"match": "\\*",
+							"name": "comment.block.cpp"
+						}
+					]
+				},
+				"25": {
+					"name": "entity.name.type.cpp"
+				},
+				"26": {
+					"name": "meta.template.call.cpp",
+					"patterns": [
+						{
+							"include": "#template_call_range"
+						}
+					]
+				},
+				"28": {
+					"patterns": [
+						{
+							"include": "#inline_comment"
+						}
+					]
+				},
+				"29": {
+					"name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+				},
+				"30": {
+					"name": "comment.block.cpp"
+				},
+				"31": {
+					"patterns": [
+						{
+							"match": "\\*\\/",
+							"name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+						},
+						{
+							"match": "\\*",
+							"name": "comment.block.cpp"
+						}
+					]
+				},
+				"32": {
+					"name": "punctuation.section.arguments.begin.bracket.curly.initializer.cpp"
+				}
+			},
+			"end": "(\\})",
+			"endCaptures": {
+				"1": {
+					"name": "punctuation.section.arguments.end.bracket.curly.initializer.cpp"
+				}
+			},
+			"patterns": [
+				{
+					"include": "#evaluation_context"
+				},
+				{
+					"include": "#comma"
+				}
+			]
+		},
+		"decltype": {
+			"contentName": "meta.arguments.decltype.cpp",
+			"begin": "((?<!\\w)decltype(?!\\w))((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))(\\()",
+			"beginCaptures": {
+				"1": {
+					"name": "keyword.operator.functionlike.cpp keyword.other.decltype.cpp storage.type.decltype.cpp"
+				},
+				"2": {
+					"patterns": [
+						{
+							"include": "#inline_comment"
+						}
+					]
+				},
+				"3": {
+					"name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+				},
+				"4": {
+					"name": "comment.block.cpp"
+				},
+				"5": {
+					"patterns": [
+						{
+							"match": "\\*\\/",
+							"name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+						},
+						{
+							"match": "\\*",
+							"name": "comment.block.cpp"
+						}
+					]
+				},
+				"6": {
+					"name": "punctuation.section.arguments.begin.bracket.round.decltype.cpp"
+				}
+			},
+			"end": "(\\))",
+			"endCaptures": {
+				"1": {
+					"name": "punctuation.section.arguments.end.bracket.round.decltype.cpp"
+				}
+			},
+			"patterns": [
+				{
+					"include": "#evaluation_context"
+				}
+			]
+		},
+		"decltype_specifier": {
+			"contentName": "meta.arguments.decltype.cpp",
+			"begin": "((?<!\\w)decltype(?!\\w))((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))(\\()",
+			"beginCaptures": {
+				"1": {
+					"name": "keyword.operator.functionlike.cpp keyword.other.decltype.cpp storage.type.decltype.cpp"
+				},
+				"2": {
+					"patterns": [
+						{
+							"include": "#inline_comment"
+						}
+					]
+				},
+				"3": {
+					"name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+				},
+				"4": {
+					"name": "comment.block.cpp"
+				},
+				"5": {
+					"patterns": [
+						{
+							"match": "\\*\\/",
+							"name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+						},
+						{
+							"match": "\\*",
+							"name": "comment.block.cpp"
+						}
+					]
+				},
+				"6": {
+					"name": "punctuation.section.arguments.begin.bracket.round.decltype.cpp"
+				}
+			},
+			"end": "(\\))",
+			"endCaptures": {
+				"1": {
+					"name": "punctuation.section.arguments.end.bracket.round.decltype.cpp"
+				}
+			},
+			"patterns": [
+				{
+					"include": "#evaluation_context"
+				}
+			]
+		},
+		"default_statement": {
+			"name": "meta.conditional.case.cpp",
+			"begin": "((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))((?<!\\w)default(?!\\w))",
+			"beginCaptures": {
+				"1": {
+					"patterns": [
+						{
+							"include": "#inline_comment"
+						}
+					]
+				},
+				"2": {
+					"name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+				},
+				"3": {
+					"name": "comment.block.cpp"
+				},
+				"4": {
+					"patterns": [
+						{
+							"match": "\\*\\/",
+							"name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+						},
+						{
+							"match": "\\*",
+							"name": "comment.block.cpp"
+						}
+					]
+				},
+				"5": {
+					"name": "keyword.control.default.cpp"
+				}
+			},
+			"end": "(:)",
+			"endCaptures": {
+				"1": {
+					"name": "punctuation.separator.colon.case.default.cpp"
+				}
+			},
+			"patterns": [
+				{
+					"include": "#evaluation_context"
+				},
+				{
+					"include": "#c_conditional_context"
+				}
+			]
+		},
+		"destructor_inline": {
+			"name": "meta.function.definition.special.member.destructor.cpp",
+			"begin": "(^((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))((?:__cdecl|__clrcall|__stdcall|__fastcall|__thiscall|__vectorcall)?)((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))((?:(?:constexpr|explicit|mutable|virtual|inline|friend)((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z)))))*)(~(?<!\\w)(?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*(?!\\w)(?=\\()))",
+			"beginCaptures": {
+				"1": {
+					"name": "meta.head.function.definition.special.member.destructor.cpp"
+				},
+				"2": {
+					"patterns": [
+						{
+							"include": "#inline_comment"
+						}
+					]
+				},
+				"3": {
+					"name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+				},
+				"4": {
+					"name": "comment.block.cpp"
+				},
+				"5": {
+					"patterns": [
+						{
+							"match": "\\*\\/",
+							"name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+						},
+						{
+							"match": "\\*",
+							"name": "comment.block.cpp"
+						}
+					]
+				},
+				"6": {
+					"patterns": [
+						{
+							"include": "#inline_comment"
+						}
+					]
+				},
+				"7": {
+					"name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+				},
+				"8": {
+					"name": "comment.block.cpp"
+				},
+				"9": {
+					"patterns": [
+						{
+							"match": "\\*\\/",
+							"name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+						},
+						{
+							"match": "\\*",
+							"name": "comment.block.cpp"
+						}
+					]
+				},
+				"10": {
+					"name": "storage.type.modifier.calling-convention.cpp"
+				},
+				"11": {
+					"patterns": [
+						{
+							"include": "#inline_comment"
+						}
+					]
+				},
+				"12": {
+					"name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+				},
+				"13": {
+					"name": "comment.block.cpp"
+				},
+				"14": {
+					"patterns": [
+						{
+							"match": "\\*\\/",
+							"name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+						},
+						{
+							"match": "\\*",
+							"name": "comment.block.cpp"
+						}
+					]
+				},
+				"15": {
+					"patterns": [
+						{
+							"include": "#functional_specifiers_pre_parameters"
+						}
+					]
+				},
+				"16": {
+					"patterns": [
+						{
+							"include": "#inline_comment"
+						}
+					]
+				},
+				"17": {
+					"name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+				},
+				"18": {
+					"name": "comment.block.cpp"
+				},
+				"19": {
+					"patterns": [
+						{
+							"match": "\\*\\/",
+							"name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+						},
+						{
+							"match": "\\*",
+							"name": "comment.block.cpp"
+						}
+					]
+				},
+				"20": {
+					"name": "entity.name.function.destructor.cpp entity.name.function.definition.special.member.destructor.cpp"
+				}
+			},
+			"end": "(?:(?<=\\}|%>|\\?\\?>)|(?=[;>\\[\\]=]))",
+			"patterns": [
+				{
+					"name": "meta.head.function.definition.special.member.destructor.cpp",
+					"begin": "\\G ?",
+					"end": "((?:\\{|<%|\\?\\?<|(?=;)))",
+					"endCaptures": {
+						"1": {
+							"name": "punctuation.section.block.begin.bracket.curly.function.definition.special.member.destructor.cpp"
+						}
+					},
+					"patterns": [
+						{
+							"include": "#ever_present_context"
+						},
+						{
+							"patterns": [
+								{
+									"match": "(\\=)((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))(?:(default)|(delete))",
+									"captures": {
+										"1": {
+											"name": "keyword.operator.assignment.cpp"
+										},
+										"2": {
+											"patterns": [
+												{
+													"include": "#inline_comment"
+												}
+											]
+										},
+										"3": {
+											"name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+										},
+										"4": {
+											"name": "comment.block.cpp"
+										},
+										"5": {
+											"patterns": [
+												{
+													"match": "\\*\\/",
+													"name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+												},
+												{
+													"match": "\\*",
+													"name": "comment.block.cpp"
+												}
+											]
+										},
+										"6": {
+											"name": "keyword.other.default.constructor.cpp"
+										},
+										"7": {
+											"name": "keyword.other.delete.constructor.cpp"
+										}
+									}
+								}
+							]
+						},
+						{
+							"contentName": "meta.function.definition.parameters.special.member.destructor.cpp",
+							"begin": "(\\()",
+							"beginCaptures": {
+								"1": {
+									"name": "punctuation.section.parameters.begin.bracket.round.special.member.destructor.cpp"
+								}
+							},
+							"end": "(\\))",
+							"endCaptures": {
+								"1": {
+									"name": "punctuation.section.parameters.end.bracket.round.special.member.destructor.cpp"
+								}
+							}
+						},
+						{
+							"include": "$self"
+						}
+					]
+				},
+				{
+					"name": "meta.body.function.definition.special.member.destructor.cpp",
+					"begin": "(?<=\\{|<%|\\?\\?<)",
+					"end": "(\\}|%>|\\?\\?>)",
+					"endCaptures": {
+						"1": {
+							"name": "punctuation.section.block.end.bracket.curly.function.definition.special.member.destructor.cpp"
+						}
+					},
+					"patterns": [
+						{
+							"include": "#function_body_context"
+						}
+					]
+				},
+				{
+					"name": "meta.tail.function.definition.special.member.destructor.cpp",
+					"begin": "(?<=\\}|%>|\\?\\?>)[\\s\\n]*",
+					"end": "[\\s\\n]*(?=;)",
+					"patterns": [
+						{
+							"include": "$self"
+						}
+					]
+				}
+			]
+		},
+		"destructor_root": {
+			"name": "meta.function.definition.special.member.destructor.cpp",
+			"begin": "(((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))((?:__cdecl|__clrcall|__stdcall|__fastcall|__thiscall|__vectorcall)?)((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))((?:((?-mix:(?!\\b(?:__has_cpp_attribute|reinterpret_cast|atomic_noexcept|atomic_cancel|atomic_commit|__has_include|dynamic_cast|thread_local|synchronized|static_cast|const_cast|consteval|constexpr|protected|namespace|co_return|constexpr|constexpr|continue|explicit|volatile|noexcept|co_yield|noexcept|noexcept|requires|typename|decltype|operator|co_await|template|volatile|register|restrict|reflexpr|alignof|private|default|mutable|include|concept|__asm__|defined|_Pragma|alignas|typedef|warning|virtual|mutable|struct|sizeof|delete|not_eq|bitand|and_eq|xor_eq|typeid|switch|return|static|extern|inline|friend|public|ifndef|define|pragma|export|import|module|catch|throw|const|or_eq|while|compl|bitor|const|union|ifdef|class|undef|error|break|using|endif|goto|line|enum|this|case|else|elif|else|asm|try|for|new|and|xor|not|do|or|if|if)\\b)(?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*))\\s*+(((?<!<)<(?!<)(?>(?:(?>[^<>]*)\\g<14>?)+)>)\\s*)?::)*)(((?>(?<!\\w)(?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*(?!\\w)))((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))::((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))~\\16((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))(?=\\()))",
+			"beginCaptures": {
+				"1": {
+					"name": "meta.head.function.definition.special.member.destructor.cpp"
+				},
+				"2": {
+					"patterns": [
+						{
+							"include": "#inline_comment"
+						}
+					]
+				},
+				"3": {
+					"name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+				},
+				"4": {
+					"name": "comment.block.cpp"
+				},
+				"5": {
+					"patterns": [
+						{
+							"match": "\\*\\/",
+							"name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+						},
+						{
+							"match": "\\*",
+							"name": "comment.block.cpp"
+						}
+					]
+				},
+				"6": {
+					"name": "storage.type.modifier.calling-convention.cpp"
+				},
+				"7": {
+					"patterns": [
+						{
+							"include": "#inline_comment"
+						}
+					]
+				},
+				"8": {
+					"name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+				},
+				"9": {
+					"name": "comment.block.cpp"
+				},
+				"10": {
+					"patterns": [
+						{
+							"match": "\\*\\/",
+							"name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+						},
+						{
+							"match": "\\*",
+							"name": "comment.block.cpp"
+						}
+					]
+				},
+				"11": {
+					"patterns": [
+						{
+							"match": "::",
+							"name": "punctuation.separator.namespace.access.cpp punctuation.separator.scope-resolution.destructor.cpp"
+						},
+						{
+							"match": "(?<!\\w)(?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*(?!\\w)",
+							"name": "entity.name.scope-resolution.destructor.cpp"
+						},
+						{
+							"include": "#template_call_range"
+						}
+					]
+				},
+				"13": {
+					"name": "meta.template.call.cpp",
+					"patterns": [
+						{
+							"include": "#template_call_range"
+						}
+					]
+				},
+				"15": {
+					"patterns": [
+						{
+							"match": "(?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*(?=:)",
+							"name": "entity.name.type.destructor.cpp"
+						},
+						{
+							"match": "(?<=:)~(?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*",
+							"name": "entity.name.function.definition.special.member.destructor.cpp"
+						},
+						{
+							"match": "::",
+							"name": "punctuation.separator.namespace.access.cpp punctuation.separator.scope-resolution.destructor.cpp"
+						}
+					]
+				},
+				"17": {
+					"patterns": [
+						{
+							"include": "#inline_comment"
+						}
+					]
+				},
+				"18": {
+					"name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+				},
+				"19": {
+					"name": "comment.block.cpp"
+				},
+				"20": {
+					"patterns": [
+						{
+							"match": "\\*\\/",
+							"name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+						},
+						{
+							"match": "\\*",
+							"name": "comment.block.cpp"
+						}
+					]
+				},
+				"21": {
+					"patterns": [
+						{
+							"include": "#inline_comment"
+						}
+					]
+				},
+				"22": {
+					"name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+				},
+				"23": {
+					"name": "comment.block.cpp"
+				},
+				"24": {
+					"patterns": [
+						{
+							"match": "\\*\\/",
+							"name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+						},
+						{
+							"match": "\\*",
+							"name": "comment.block.cpp"
+						}
+					]
+				},
+				"25": {
+					"patterns": [
+						{
+							"include": "#inline_comment"
+						}
+					]
+				},
+				"26": {
+					"name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+				},
+				"27": {
+					"name": "comment.block.cpp"
+				},
+				"28": {
+					"patterns": [
+						{
+							"match": "\\*\\/",
+							"name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+						},
+						{
+							"match": "\\*",
+							"name": "comment.block.cpp"
+						}
+					]
+				}
+			},
+			"end": "(?:(?<=\\}|%>|\\?\\?>)|(?=[;>\\[\\]=]))",
+			"patterns": [
+				{
+					"name": "meta.head.function.definition.special.member.destructor.cpp",
+					"begin": "\\G ?",
+					"end": "((?:\\{|<%|\\?\\?<|(?=;)))",
+					"endCaptures": {
+						"1": {
+							"name": "punctuation.section.block.begin.bracket.curly.function.definition.special.member.destructor.cpp"
+						}
+					},
+					"patterns": [
+						{
+							"include": "#ever_present_context"
+						},
+						{
+							"patterns": [
+								{
+									"match": "(\\=)((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))(?:(default)|(delete))",
+									"captures": {
+										"1": {
+											"name": "keyword.operator.assignment.cpp"
+										},
+										"2": {
+											"patterns": [
+												{
+													"include": "#inline_comment"
+												}
+											]
+										},
+										"3": {
+											"name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+										},
+										"4": {
+											"name": "comment.block.cpp"
+										},
+										"5": {
+											"patterns": [
+												{
+													"match": "\\*\\/",
+													"name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+												},
+												{
+													"match": "\\*",
+													"name": "comment.block.cpp"
+												}
+											]
+										},
+										"6": {
+											"name": "keyword.other.default.constructor.cpp"
+										},
+										"7": {
+											"name": "keyword.other.delete.constructor.cpp"
+										}
+									}
+								}
+							]
+						},
+						{
+							"contentName": "meta.function.definition.parameters.special.member.destructor.cpp",
+							"begin": "(\\()",
+							"beginCaptures": {
+								"1": {
+									"name": "punctuation.section.parameters.begin.bracket.round.special.member.destructor.cpp"
+								}
+							},
+							"end": "(\\))",
+							"endCaptures": {
+								"1": {
+									"name": "punctuation.section.parameters.end.bracket.round.special.member.destructor.cpp"
+								}
+							}
+						},
+						{
+							"include": "$self"
+						}
+					]
+				},
+				{
+					"name": "meta.body.function.definition.special.member.destructor.cpp",
+					"begin": "(?<=\\{|<%|\\?\\?<)",
+					"end": "(\\}|%>|\\?\\?>)",
+					"endCaptures": {
+						"1": {
+							"name": "punctuation.section.block.end.bracket.curly.function.definition.special.member.destructor.cpp"
+						}
+					},
+					"patterns": [
+						{
+							"include": "#function_body_context"
+						}
+					]
+				},
+				{
+					"name": "meta.tail.function.definition.special.member.destructor.cpp",
+					"begin": "(?<=\\}|%>|\\?\\?>)[\\s\\n]*",
+					"end": "[\\s\\n]*(?=;)",
+					"patterns": [
+						{
+							"include": "$self"
+						}
+					]
+				}
+			]
+		},
+		"diagnostic": {
+			"name": "meta.preprocessor.diagnostic.$reference(directive).cpp",
+			"begin": "((?:^)((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))(#)\\s*((?:error|warning)))\\b\\s*",
+			"beginCaptures": {
+				"1": {
+					"name": "keyword.control.directive.diagnostic.$7.cpp"
+				},
+				"2": {
+					"patterns": [
+						{
+							"include": "#inline_comment"
+						}
+					]
+				},
+				"3": {
+					"name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+				},
+				"4": {
+					"name": "comment.block.cpp"
+				},
+				"5": {
+					"patterns": [
+						{
+							"match": "\\*\\/",
+							"name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+						},
+						{
+							"match": "\\*",
+							"name": "comment.block.cpp"
+						}
+					]
+				},
+				"6": {
+					"name": "punctuation.definition.directive.cpp"
+				}
+			},
+			"end": "(?<!\\\\)(?=\\n)",
+			"patterns": [
+				{
+					"name": "string.quoted.double.cpp",
+					"begin": "(\")",
+					"beginCaptures": {
+						"1": {
+							"name": "punctuation.definition.string.begin.cpp"
+						}
+					},
+					"end": "(?:(\")|(?<!\\\\)(?=\\n))",
+					"endCaptures": {
+						"1": {
+							"name": "punctuation.definition.string.end.cpp"
+						}
+					},
+					"patterns": [
+						{
+							"include": "#line_continuation_character"
+						}
+					]
+				},
+				{
+					"name": "string.quoted.single.cpp",
+					"begin": "(')",
+					"beginCaptures": {
+						"1": {
+							"name": "punctuation.definition.string.begin.cpp"
+						}
+					},
+					"end": "(?:(')|(?<!\\\\)(?=\\n))",
+					"endCaptures": {
+						"1": {
+							"name": "punctuation.definition.string.end.cpp"
+						}
+					},
+					"patterns": [
+						{
+							"include": "#line_continuation_character"
+						}
+					]
+				},
+				{
+					"name": "string.unquoted.cpp",
+					"begin": "[^'\"]",
+					"end": "(?<!\\\\)(?=\\n)",
+					"patterns": [
+						{
+							"include": "#line_continuation_character"
+						},
+						{
+							"include": "#comments"
+						}
+					]
+				}
+			]
+		},
+		"emacs_file_banner": {
+			"match": "(?:(^\\s*((\\/\\/)\\s*((?>[#;\\/=*C~]+)(?![#;\\/=*C~]))\\s*.+\\s*\\8\\s*(?:\\n|$)))|(^\\s*((\\/\\*)\\s*?((?>[#;\\/=*C~]+)(?![#;\\/=*C~]))\\s*.+\\s*\\8\\s*\\*\\/)))",
+			"captures": {
+				"1": {
+					"name": "meta.toc-list.banner.double-slash.cpp"
+				},
+				"2": {
+					"name": "comment.line.double-slash.cpp"
+				},
+				"3": {
+					"name": "punctuation.definition.comment.cpp"
+				},
+				"4": {
+					"name": "meta.banner.character.cpp"
+				},
+				"5": {
+					"name": "meta.toc-list.banner.block.cpp"
+				},
+				"6": {
+					"name": "comment.line.banner.cpp"
+				},
+				"7": {
+					"name": "punctuation.definition.comment.cpp"
+				},
+				"8": {
+					"name": "meta.banner.character.cpp"
+				}
+			}
+		},
+		"empty_square_brackets": {
+			"name": "storage.modifier.array.bracket.square.cpp",
+			"match": "(?-mix:(?-mix:(?<!delete))\\\\[\\\\s*\\\\])"
+		},
+		"enum_block": {
+			"name": "meta.block.enum.cpp",
+			"begin": "(((?<!\\w)enum(?!\\w))(?:\\s+(class|struct))?(?:(?:\\s+|((?:(?:(?:\\[\\[.*?\\]\\]|__attribute(?:__)?\\(\\(.*?\\)\\))|__declspec\\(.*?\\))|alignas\\(.*?\\))(?!\\))))|(?={))\\s*((?:(?<!\\w)(?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*(?!\\w))?)(?:\\s*(:)\\s*(((::)?(?:((?-mix:(?!\\b(?:__has_cpp_attribute|reinterpret_cast|atomic_noexcept|atomic_cancel|atomic_commit|__has_include|dynamic_cast|thread_local|synchronized|static_cast|const_cast|consteval|constexpr|protected|namespace|co_return|constexpr|constexpr|continue|explicit|volatile|noexcept|co_yield|noexcept|noexcept|requires|typename|decltype|operator|co_await|template|volatile|register|restrict|reflexpr|alignof|private|default|mutable|include|concept|__asm__|defined|_Pragma|alignas|typedef|warning|virtual|mutable|struct|sizeof|delete|not_eq|bitand|and_eq|xor_eq|typeid|switch|return|static|extern|inline|friend|public|ifndef|define|pragma|export|import|module|catch|throw|const|or_eq|while|compl|bitor|const|union|ifdef|class|undef|error|break|using|endif|goto|line|enum|this|case|else|elif|else|asm|try|for|new|and|xor|not|do|or|if|if)\\b)(?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*))\\s*+(((?<!<)<(?!<)(?>(?:(?>[^<>]*)\\g<15>?)+)>)\\s*)?::)*\\s*+)((?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*)\\s*+(((?<!<)<(?!<)(?>(?:(?>[^<>]*)\\g<15>?)+)>)\\s*)?(::))?\\s*((?<!\\w)(?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*(?!\\w)))?)",
+			"beginCaptures": {
+				"1": {
+					"name": "meta.head.enum.cpp"
+				},
+				"2": {
+					"name": "storage.type.enum.cpp"
+				},
+				"3": {
+					"name": "storage.type.enum.enum-key.$3.cpp"
+				},
+				"4": {
+					"patterns": [
+						{
+							"include": "#attributes_context"
+						},
+						{
+							"include": "#number_literal"
+						}
+					]
+				},
+				"5": {
+					"name": "entity.name.type.enum.cpp"
+				},
+				"6": {
+					"name": "punctuation.separator.colon.type-specifier.cpp"
+				},
+				"8": {
+					"patterns": [
+						{
+							"include": "#scope_resolution_inner_generated"
+						}
+					]
+				},
+				"9": {
+					"name": "punctuation.separator.namespace.access.cpp punctuation.separator.scope-resolution.cpp"
+				},
+				"11": {
+					"name": "meta.template.call.cpp",
+					"patterns": [
+						{
+							"include": "#template_call_range"
+						}
+					]
+				},
+				"13": {
+					"name": "entity.name.scope-resolution.cpp"
+				},
+				"14": {
+					"name": "meta.template.call.cpp",
+					"patterns": [
+						{
+							"include": "#template_call_range"
+						}
+					]
+				},
+				"16": {
+					"name": "punctuation.separator.namespace.access.cpp punctuation.separator.scope-resolution.cpp"
+				},
+				"17": {
+					"name": "storage.type.integral.$17.cpp"
+				}
+			},
+			"end": "(?:(?:(?<=\\}|%>|\\?\\?>)\\s*(;)|(;))|(?=[;>\\[\\]=]))",
+			"endCaptures": {
+				"1": {
+					"name": "punctuation.terminator.statement.cpp"
+				},
+				"2": {
+					"name": "punctuation.terminator.statement.cpp"
+				}
+			},
+			"patterns": [
+				{
+					"name": "meta.head.enum.cpp",
+					"begin": "\\G ?",
+					"end": "((?:\\{|<%|\\?\\?<|(?=;)))",
+					"endCaptures": {
+						"1": {
+							"name": "punctuation.section.block.begin.bracket.curly.enum.cpp"
+						}
+					},
+					"patterns": [
+						{
+							"include": "$self"
+						}
+					]
+				},
+				{
+					"name": "meta.body.enum.cpp",
+					"begin": "(?<=\\{|<%|\\?\\?<)",
+					"end": "(\\}|%>|\\?\\?>)",
+					"endCaptures": {
+						"1": {
+							"name": "punctuation.section.block.end.bracket.curly.enum.cpp"
+						}
+					},
+					"patterns": [
+						{
+							"include": "#ever_present_context"
+						},
+						{
+							"include": "#enumerator_list"
+						},
+						{
+							"include": "#comments"
+						},
+						{
+							"include": "#comma"
+						},
+						{
+							"include": "#semicolon"
+						}
+					]
+				},
+				{
+					"name": "meta.tail.enum.cpp",
+					"begin": "(?<=\\}|%>|\\?\\?>)[\\s\\n]*",
+					"end": "[\\s\\n]*(?=;)",
+					"patterns": [
+						{
+							"include": "$self"
+						}
+					]
+				}
+			]
+		},
+		"enum_declare": {
+			"match": "((?<!\\w)enum(?!\\w))((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))((?<!\\w)(?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*(?!\\w))(((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))?(?:(?:\\&|\\*)((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z)))))*(?:\\&|\\*))?((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))\\b(?!override\\W|override\\$|final\\W|final\\$)((?<!\\w)(?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*(?!\\w))((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))(?=\\S)(?![:{])",
+			"captures": {
+				"1": {
+					"name": "storage.type.enum.declare.cpp"
+				},
+				"2": {
+					"patterns": [
+						{
+							"include": "#inline_comment"
+						}
+					]
+				},
+				"3": {
+					"name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+				},
+				"4": {
+					"name": "comment.block.cpp"
+				},
+				"5": {
+					"patterns": [
+						{
+							"match": "\\*\\/",
+							"name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+						},
+						{
+							"match": "\\*",
+							"name": "comment.block.cpp"
+						}
+					]
+				},
+				"6": {
+					"name": "entity.name.type.enum.cpp"
+				},
+				"7": {
+					"patterns": [
+						{
+							"match": "\\*",
+							"name": "storage.modifier.pointer.cpp"
+						},
+						{
+							"match": "(?:\\&((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))){2,}\\&",
+							"captures": {
+								"1": {
+									"patterns": [
+										{
+											"include": "#inline_comment"
+										}
+									]
+								},
+								"2": {
+									"name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+								},
+								"3": {
+									"name": "comment.block.cpp"
+								},
+								"4": {
+									"patterns": [
+										{
+											"match": "\\*\\/",
+											"name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+										},
+										{
+											"match": "\\*",
+											"name": "comment.block.cpp"
+										}
+									]
+								}
+							},
+							"name": "invalid.illegal.reference-type.cpp"
+						},
+						{
+							"match": "\\&",
+							"name": "storage.modifier.reference.cpp"
+						}
+					]
+				},
+				"8": {
+					"patterns": [
+						{
+							"include": "#inline_comment"
+						}
+					]
+				},
+				"9": {
+					"name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+				},
+				"10": {
+					"name": "comment.block.cpp"
+				},
+				"11": {
+					"patterns": [
+						{
+							"match": "\\*\\/",
+							"name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+						},
+						{
+							"match": "\\*",
+							"name": "comment.block.cpp"
+						}
+					]
+				},
+				"12": {
+					"patterns": [
+						{
+							"include": "#inline_comment"
+						}
+					]
+				},
+				"13": {
+					"name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+				},
+				"14": {
+					"name": "comment.block.cpp"
+				},
+				"15": {
+					"patterns": [
+						{
+							"match": "\\*\\/",
+							"name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+						},
+						{
+							"match": "\\*",
+							"name": "comment.block.cpp"
+						}
+					]
+				},
+				"16": {
+					"patterns": [
+						{
+							"include": "#inline_comment"
+						}
+					]
+				},
+				"17": {
+					"name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+				},
+				"18": {
+					"name": "comment.block.cpp"
+				},
+				"19": {
+					"patterns": [
+						{
+							"match": "\\*\\/",
+							"name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+						},
+						{
+							"match": "\\*",
+							"name": "comment.block.cpp"
+						}
+					]
+				},
+				"20": {
+					"name": "variable.other.object.declare.cpp"
+				},
+				"21": {
+					"patterns": [
+						{
+							"include": "#inline_comment"
+						}
+					]
+				},
+				"22": {
+					"name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+				},
+				"23": {
+					"name": "comment.block.cpp"
+				},
+				"24": {
+					"patterns": [
+						{
+							"match": "\\*\\/",
+							"name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+						},
+						{
+							"match": "\\*",
+							"name": "comment.block.cpp"
+						}
+					]
+				}
+			}
+		},
+		"enumerator_list": {
+			"match": "((?<!\\w)(?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*(?!\\w))\\s*((?:(?:(?:\\[\\[.*?\\]\\]|__attribute(?:__)?\\(\\(.*?\\)\\))|__declspec\\(.*?\\))|alignas\\(.*?\\))(?!\\)))?\\s*(?:(\\=)\\s*(.+?)\\s*)?(?:(?:((?:[,;](?!')|\\n))|(?=\\}[^']))|(?=(?:\\/\\/|\\/\\*)))",
+			"captures": {
+				"1": {
+					"name": "variable.other.enummember.cpp"
+				},
+				"2": {
+					"patterns": [
+						{
+							"include": "#attributes_context"
+						},
+						{
+							"include": "#number_literal"
+						}
+					]
+				},
+				"3": {
+					"name": "keyword.operator.assignment.cpp"
+				},
+				"4": {
+					"patterns": [
+						{
+							"include": "#evaluation_context"
+						}
+					]
+				},
+				"5": {
+					"patterns": [
+						{
+							"include": "#comma"
+						},
+						{
+							"include": "#semicolon"
+						}
+					]
+				}
+			},
+			"name": "meta.enum.definition.cpp"
+		},
+		"evaluation_context": {
+			"patterns": [
+				{
+					"include": "#ever_present_context"
+				},
+				{
+					"include": "#string_context"
+				},
+				{
+					"include": "#number_literal"
+				},
+				{
+					"include": "#method_access"
+				},
+				{
+					"include": "#member_access"
+				},
+				{
+					"include": "#predefined_macros"
+				},
+				{
+					"include": "#operators"
+				},
+				{
+					"include": "#memory_operators"
+				},
+				{
+					"include": "#wordlike_operators"
+				},
+				{
+					"include": "#type_casting_operators"
+				},
+				{
+					"include": "#control_flow_keywords"
+				},
+				{
+					"include": "#exception_keywords"
+				},
+				{
+					"include": "#the_this_keyword"
+				},
+				{
+					"include": "#language_constants"
+				},
+				{
+					"include": "#builtin_storage_type_initilizer"
+				},
+				{
+					"include": "#qualifiers_and_specifiers_post_parameters"
+				},
+				{
+					"include": "#functional_specifiers_pre_parameters"
+				},
+				{
+					"include": "#storage_types"
+				},
+				{
+					"include": "#misc_storage_modifiers"
+				},
+				{
+					"include": "#lambdas"
+				},
+				{
+					"include": "#attributes_context"
+				},
+				{
+					"include": "#parentheses"
+				},
+				{
+					"include": "#function_call"
+				},
+				{
+					"include": "#scope_resolution_inner_generated"
+				},
+				{
+					"include": "#square_brackets"
+				},
+				{
+					"include": "#empty_square_brackets"
+				},
+				{
+					"include": "#semicolon"
+				},
+				{
+					"include": "#comma"
+				}
+			]
+		},
+		"ever_present_context": {
+			"patterns": [
+				{
+					"include": "#pragma_mark"
+				},
+				{
+					"include": "#pragma"
+				},
+				{
+					"include": "#include"
+				},
+				{
+					"include": "#module_import"
+				},
+				{
+					"include": "#line"
+				},
+				{
+					"include": "#diagnostic"
+				},
+				{
+					"include": "#undef"
+				},
+				{
+					"include": "#preprocessor_conditional_range"
+				},
+				{
+					"include": "#single_line_macro"
+				},
+				{
+					"include": "#macro"
+				},
+				{
+					"include": "#preprocessor_conditional_standalone"
+				},
+				{
+					"include": "#macro_argument"
+				},
+				{
+					"include": "#comments"
+				},
+				{
+					"include": "#line_continuation_character"
+				}
+			]
+		},
+		"exception_keywords": {
+			"match": "((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))((?<!\\w)(?:throw|catch|try)(?!\\w))",
+			"captures": {
+				"1": {
+					"patterns": [
+						{
+							"include": "#inline_comment"
+						}
+					]
+				},
+				"2": {
+					"name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+				},
+				"3": {
+					"name": "comment.block.cpp"
+				},
+				"4": {
+					"patterns": [
+						{
+							"match": "\\*\\/",
+							"name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+						},
+						{
+							"match": "\\*",
+							"name": "comment.block.cpp"
+						}
+					]
+				},
+				"5": {
+					"name": "keyword.control.exception.$5.cpp"
+				}
+			}
+		},
+		"extern_block": {
+			"name": "meta.block.extern.cpp",
+			"begin": "(((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))(extern)(?=\\s*\\\"))",
+			"beginCaptures": {
+				"1": {
+					"name": "meta.head.extern.cpp"
+				},
+				"2": {
+					"patterns": [
+						{
+							"include": "#inline_comment"
+						}
+					]
+				},
+				"3": {
+					"name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+				},
+				"4": {
+					"name": "comment.block.cpp"
+				},
+				"5": {
+					"patterns": [
+						{
+							"match": "\\*\\/",
+							"name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+						},
+						{
+							"match": "\\*",
+							"name": "comment.block.cpp"
+						}
+					]
+				},
+				"6": {
+					"name": "storage.type.extern.cpp"
+				}
+			},
+			"end": "(?:(?:(?<=\\}|%>|\\?\\?>)\\s*(;)|(;))|(?=[;>\\[\\]=]))",
+			"endCaptures": {
+				"1": {
+					"name": "punctuation.terminator.statement.cpp"
+				},
+				"2": {
+					"name": "punctuation.terminator.statement.cpp"
+				}
+			},
+			"patterns": [
+				{
+					"name": "meta.head.extern.cpp",
+					"begin": "\\G ?",
+					"end": "((?:\\{|<%|\\?\\?<|(?=;)))",
+					"endCaptures": {
+						"1": {
+							"name": "punctuation.section.block.begin.bracket.curly.extern.cpp"
+						}
+					},
+					"patterns": [
+						{
+							"include": "$self"
+						}
+					]
+				},
+				{
+					"name": "meta.body.extern.cpp",
+					"begin": "(?<=\\{|<%|\\?\\?<)",
+					"end": "(\\}|%>|\\?\\?>)",
+					"endCaptures": {
+						"1": {
+							"name": "punctuation.section.block.end.bracket.curly.extern.cpp"
+						}
+					},
+					"patterns": [
+						{
+							"include": "$self"
+						}
+					]
+				},
+				{
+					"name": "meta.tail.extern.cpp",
+					"begin": "(?<=\\}|%>|\\?\\?>)[\\s\\n]*",
+					"end": "[\\s\\n]*(?=;)",
+					"patterns": [
+						{
+							"include": "$self"
+						}
+					]
+				},
+				{
+					"include": "$self"
+				}
+			]
+		},
+		"function_body_context": {
+			"patterns": [
+				{
+					"include": "#ever_present_context"
+				},
+				{
+					"include": "#using_namespace"
+				},
+				{
+					"include": "#type_alias"
+				},
+				{
+					"include": "#using_name"
+				},
+				{
+					"include": "#namespace_alias"
+				},
+				{
+					"include": "#typedef_class"
+				},
+				{
+					"include": "#typedef_struct"
+				},
+				{
+					"include": "#typedef_union"
+				},
+				{
+					"include": "#typedef_keyword"
+				},
+				{
+					"include": "#standard_declares"
+				},
+				{
+					"include": "#class_block"
+				},
+				{
+					"include": "#struct_block"
+				},
+				{
+					"include": "#union_block"
+				},
+				{
+					"include": "#enum_block"
+				},
+				{
+					"include": "#access_control_keywords"
+				},
+				{
+					"include": "#block"
+				},
+				{
+					"include": "#static_assert"
+				},
+				{
+					"include": "#assembly"
+				},
+				{
+					"include": "#function_pointer"
+				},
+				{
+					"include": "#switch_statement"
+				},
+				{
+					"include": "#goto_statement"
+				},
+				{
+					"include": "#evaluation_context"
+				},
+				{
+					"include": "#label"
+				}
+			]
+		},
+		"function_call": {
+			"begin": "((::)?(?:((?-mix:(?!\\b(?:__has_cpp_attribute|reinterpret_cast|atomic_noexcept|atomic_cancel|atomic_commit|__has_include|dynamic_cast|thread_local|synchronized|static_cast|const_cast|consteval|constexpr|protected|namespace|co_return|constexpr|constexpr|continue|explicit|volatile|noexcept|co_yield|noexcept|noexcept|requires|typename|decltype|operator|co_await|template|volatile|register|restrict|reflexpr|alignof|private|default|mutable|include|concept|__asm__|defined|_Pragma|alignas|typedef|warning|virtual|mutable|struct|sizeof|delete|not_eq|bitand|and_eq|xor_eq|typeid|switch|return|static|extern|inline|friend|public|ifndef|define|pragma|export|import|module|catch|throw|const|or_eq|while|compl|bitor|const|union|ifdef|class|undef|error|break|using|endif|goto|line|enum|this|case|else|elif|else|asm|try|for|new|and|xor|not|do|or|if|if)\\b)(?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*))\\s*+(((?<!<)<(?!<)(?>(?:(?>[^<>]*)\\g<12>?)+)>)\\s*)?::)*\\s*+)((?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*)\\b(?<!\\Wreinterpret_cast|^reinterpret_cast|\\Watomic_noexcept|^atomic_noexcept|\\Wuint_least16_t|^uint_least16_t|\\Wuint_least32_t|^uint_least32_t|\\Wuint_least64_t|^uint_least64_t|\\Wuint_fast16_t|^uint_fast16_t|\\Wint_least16_t|^int_least16_t|\\Watomic_commit|^atomic_commit|\\Watomic_cancel|^atomic_cancel|\\Wuint_fast64_t|^uint_fast64_t|\\Wuint_least8_t|^uint_least8_t|\\Wint_least64_t|^int_least64_t|\\Wint_least32_t|^int_least32_t|\\Wuint_fast32_t|^uint_fast32_t|\\Wdynamic_cast|^dynamic_cast|\\Wthread_local|^thread_local|\\Wuint_fast8_t|^uint_fast8_t|\\Wint_fast64_t|^int_fast64_t|\\Wint_fast32_t|^int_fast32_t|\\Wint_fast16_t|^int_fast16_t|\\Wsynchronized|^synchronized|\\Wint_least8_t|^int_least8_t|\\Wsuseconds_t|^suseconds_t|\\Wint_fast8_t|^int_fast8_t|\\Wstatic_cast|^static_cast|\\Wconst_cast|^const_cast|\\Wuseconds_t|^useconds_t|\\Wnamespace|^namespace|\\Wblksize_t|^blksize_t|\\Win_addr_t|^in_addr_t|\\Win_port_t|^in_port_t|\\Wuintptr_t|^uintptr_t|\\Wuintmax_t|^uintmax_t|\\Wuintmax_t|^uintmax_t|\\Wconstexpr|^constexpr|\\Wconstexpr|^constexpr|\\Wconstexpr|^constexpr|\\Wconsteval|^consteval|\\Wprotected|^protected|\\Wco_return|^co_return|\\Wuint16_t|^uint16_t|\\Wdecltype|^decltype|\\Wu_quad_t|^u_quad_t|\\Wreflexpr|^reflexpr|\\Wregister|^register|\\Wco_await|^co_await|\\Wintmax_t|^intmax_t|\\Wintmax_t|^intmax_t|\\Wco_yield|^co_yield|\\Wnoexcept|^noexcept|\\Wintptr_t|^intptr_t|\\Wnoexcept|^noexcept|\\Wvolatile|^volatile|\\Wnoexcept|^noexcept|\\Wrequires|^requires|\\Wuint64_t|^uint64_t|\\Wrestrict|^restrict|\\Wtypename|^typename|\\Wexplicit|^explicit|\\Wuint32_t|^uint32_t|\\Wunsigned|^unsigned|\\Woperator|^operator|\\Wvolatile|^volatile|\\Wblkcnt_t|^blkcnt_t|\\Wcontinue|^continue|\\Wtemplate|^template|\\Wmutable|^mutable|\\Walignas|^alignas|\\Walignof|^alignof|\\Wnullptr|^nullptr|\\Wconcept|^concept|\\Wqaddr_t|^qaddr_t|\\Wcaddr_t|^caddr_t|\\Wdaddr_t|^daddr_t|\\Wtypedef|^typedef|\\Wfixpt_t|^fixpt_t|\\W__asm__|^__asm__|\\Wwchar_t|^wchar_t|\\Wprivate|^private|\\Wdefault|^default|\\Wnlink_t|^nlink_t|\\Wmutable|^mutable|\\Wsegsz_t|^segsz_t|\\Wswblk_t|^swblk_t|\\Wvirtual|^virtual|\\Wclock_t|^clock_t|\\Wu_short|^u_short|\\Wssize_t|^ssize_t|\\Wint16_t|^int16_t|\\Wint32_t|^int32_t|\\Wint64_t|^int64_t|\\Wuint8_t|^uint8_t|\\Wstruct|^struct|\\Wsigned|^signed|\\Wdouble|^double|\\Wu_char|^u_char|\\Wu_long|^u_long|\\Wushort|^ushort|\\Wquad_t|^quad_t|\\Wexport|^export|\\Wnot_eq|^not_eq|\\Wdelete|^delete|\\Wmode_t|^mode_t|\\Wsize_t|^size_t|\\Wtime_t|^time_t|\\Wint8_t|^int8_t|\\Wtypeid|^typeid|\\Wxor_eq|^xor_eq|\\Wand_eq|^and_eq|\\Wbitand|^bitand|\\Wsizeof|^sizeof|\\Wstatic|^static|\\Wextern|^extern|\\Winline|^inline|\\Wfriend|^friend|\\Wimport|^import|\\Wmodule|^module|\\Wpublic|^public|\\Wswitch|^switch|\\Wreturn|^return|\\Wclass|^class|\\Wunion|^union|\\Wconst|^const|\\Wor_eq|^or_eq|\\Wwhile|^while|\\Wcatch|^catch|\\Wcompl|^compl|\\Wbreak|^break|\\Wuid_t|^uid_t|\\Wconst|^const|\\Woff_t|^off_t|\\Wpid_t|^pid_t|\\Wkey_t|^key_t|\\Wino_t|^ino_t|\\Wshort|^short|\\Wgid_t|^gid_t|\\Wusing|^using|\\Wdev_t|^dev_t|\\Wdiv_t|^div_t|\\Wu_int|^u_int|\\Wfloat|^float|\\Wbitor|^bitor|\\Wfalse|^false|\\Wthrow|^throw|\\Welse|^else|\\Wtrue|^true|\\Wauto|^auto|\\Wvoid|^void|\\Wuint|^uint|\\Wid_t|^id_t|\\Wbool|^bool|\\WNULL|^NULL|\\Wlong|^long|\\Wid_t|^id_t|\\Wcase|^case|\\Wgoto|^goto|\\Wthis|^this|\\Wchar|^char|\\Wenum|^enum|\\Wxor|^xor|\\Wint|^int|\\Wasm|^asm|\\Wnew|^new|\\Wtry|^try|\\Wand|^and|\\Wfor|^for|\\Wnot|^not|\\Wdo|^do|\\Wor|^or|\\Wif|^if)((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))(((?<!<)<(?!<)(?>(?:(?>[^<>]*)\\g<12>?)+)>)\\s*)?(\\()",
+			"beginCaptures": {
+				"1": {
+					"patterns": [
+						{
+							"include": "#scope_resolution_function_call_inner_generated"
+						}
+					]
+				},
+				"2": {
+					"name": "punctuation.separator.namespace.access.cpp punctuation.separator.scope-resolution.function.call.cpp"
+				},
+				"4": {
+					"name": "meta.template.call.cpp",
+					"patterns": [
+						{
+							"include": "#template_call_range"
+						}
+					]
+				},
+				"6": {
+					"name": "entity.name.function.call.cpp"
+				},
+				"7": {
+					"patterns": [
+						{
+							"include": "#inline_comment"
+						}
+					]
+				},
+				"8": {
+					"name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+				},
+				"9": {
+					"name": "comment.block.cpp"
+				},
+				"10": {
+					"patterns": [
+						{
+							"match": "\\*\\/",
+							"name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+						},
+						{
+							"match": "\\*",
+							"name": "comment.block.cpp"
+						}
+					]
+				},
+				"11": {
+					"name": "meta.template.call.cpp",
+					"patterns": [
+						{
+							"include": "#template_call_range"
+						}
+					]
+				},
+				"13": {
+					"name": "punctuation.section.arguments.begin.bracket.round.function.call.cpp"
+				}
+			},
+			"end": "(\\))",
+			"endCaptures": {
+				"1": {
+					"name": "punctuation.section.arguments.end.bracket.round.function.call.cpp"
+				}
+			},
+			"patterns": [
+				{
+					"include": "#evaluation_context"
+				}
+			]
+		},
+		"function_definition": {
+			"name": "meta.function.definition.cpp",
+			"begin": "((?:(?:^|\\G|(?<=;|\\}))|(?<=>))((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))(?:((?<!\\w)template(?!\\w))((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z)))))?((?:((?<!\\w)(?:(?:constexpr|explicit|mutable|virtual|inline|friend)|(?:volatile|register|restrict|static|extern|const))(?!\\w))((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z)))))*)(\\s*+((?:(?:(?:\\[\\[.*?\\]\\]|__attribute(?:__)?\\(\\(.*?\\)\\))|__declspec\\(.*?\\))|alignas\\(.*?\\))(?!\\)))?((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))(?:(?:(?:unsigned|signed|short|long)|(?:struct|class|union|enum))((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z)))))*(((::)?(?:((?-mix:(?!\\b(?:__has_cpp_attribute|reinterpret_cast|atomic_noexcept|atomic_cancel|atomic_commit|__has_include|dynamic_cast|thread_local|synchronized|static_cast|const_cast|consteval|constexpr|protected|namespace|co_return|constexpr|constexpr|continue|explicit|volatile|noexcept|co_yield|noexcept|noexcept|requires|typename|decltype|operator|co_await|template|volatile|register|restrict|reflexpr|alignof|private|default|mutable|include|concept|__asm__|defined|_Pragma|alignas|typedef|warning|virtual|mutable|struct|sizeof|delete|not_eq|bitand|and_eq|xor_eq|typeid|switch|return|static|extern|inline|friend|public|ifndef|define|pragma|export|import|module|catch|throw|const|or_eq|while|compl|bitor|const|union|ifdef|class|undef|error|break|using|endif|goto|line|enum|this|case|else|elif|else|asm|try|for|new|and|xor|not|do|or|if|if)\\b)(?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*))\\s*+(((?<!<)<(?!<)(?>(?:(?>[^<>]*)\\g<70>?)+)>)\\s*)?::)*\\s*+)((?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*)\\s*+(((?<!<)<(?!<)(?>(?:(?>[^<>]*)\\g<70>?)+)>)\\s*)?(::))?((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))(?!(?:transaction_safe_dynamic|__has_cpp_attribute|transaction_safe|reinterpret_cast|atomic_noexcept|atomic_commit|atomic_cancel|__has_include|dynamic_cast|thread_local|synchronized|static_cast|const_cast|constexpr|consteval|protected|constexpr|co_return|namespace|constexpr|noexcept|typename|decltype|template|operator|noexcept|co_yield|co_await|continue|volatile|register|restrict|explicit|override|volatile|reflexpr|noexcept|requires|default|typedef|nullptr|alignof|mutable|concept|virtual|defined|__asm__|include|_Pragma|mutable|warning|private|alignas|module|switch|not_eq|bitand|and_eq|ifndef|return|sizeof|xor_eq|export|static|delete|public|define|extern|inline|import|pragma|friend|typeid|const|compl|bitor|throw|or_eq|while|catch|break|false|final|const|endif|ifdef|undef|error|using|audit|axiom|line|else|elif|true|NULL|case|goto|else|this|new|asm|not|and|xor|try|for|if|do|or|if)\\b)((?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*)\\b(((?<!<)<(?!<)(?>(?:(?>[^<>]*)\\g<70>?)+)>)\\s*)?(?![\\w<:.]))(((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))?(?:(?:\\&|\\*)((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z)))))*(?:\\&|\\*))?((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))((?:__cdecl|__clrcall|__stdcall|__fastcall|__thiscall|__vectorcall)?)((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))((::)?(?:((?-mix:(?!\\b(?:__has_cpp_attribute|reinterpret_cast|atomic_noexcept|atomic_cancel|atomic_commit|__has_include|dynamic_cast|thread_local|synchronized|static_cast|const_cast|consteval|constexpr|protected|namespace|co_return|constexpr|constexpr|continue|explicit|volatile|noexcept|co_yield|noexcept|noexcept|requires|typename|decltype|operator|co_await|template|volatile|register|restrict|reflexpr|alignof|private|default|mutable|include|concept|__asm__|defined|_Pragma|alignas|typedef|warning|virtual|mutable|struct|sizeof|delete|not_eq|bitand|and_eq|xor_eq|typeid|switch|return|static|extern|inline|friend|public|ifndef|define|pragma|export|import|module|catch|throw|const|or_eq|while|compl|bitor|const|union|ifdef|class|undef|error|break|using|endif|goto|line|enum|this|case|else|elif|else|asm|try|for|new|and|xor|not|do|or|if|if)\\b)(?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*))\\s*+(((?<!<)<(?!<)(?>(?:(?>[^<>]*)\\g<70>?)+)>)\\s*)?::)*\\s*+)((?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*)\\b(?<!\\Wreinterpret_cast|^reinterpret_cast|\\Watomic_noexcept|^atomic_noexcept|\\Wuint_least16_t|^uint_least16_t|\\Wuint_least32_t|^uint_least32_t|\\Wuint_least64_t|^uint_least64_t|\\Wuint_fast16_t|^uint_fast16_t|\\Wint_least16_t|^int_least16_t|\\Watomic_commit|^atomic_commit|\\Watomic_cancel|^atomic_cancel|\\Wuint_fast64_t|^uint_fast64_t|\\Wuint_least8_t|^uint_least8_t|\\Wint_least64_t|^int_least64_t|\\Wint_least32_t|^int_least32_t|\\Wuint_fast32_t|^uint_fast32_t|\\Wdynamic_cast|^dynamic_cast|\\Wthread_local|^thread_local|\\Wuint_fast8_t|^uint_fast8_t|\\Wint_fast64_t|^int_fast64_t|\\Wint_fast32_t|^int_fast32_t|\\Wint_fast16_t|^int_fast16_t|\\Wsynchronized|^synchronized|\\Wint_least8_t|^int_least8_t|\\Wsuseconds_t|^suseconds_t|\\Wint_fast8_t|^int_fast8_t|\\Wstatic_cast|^static_cast|\\Wconst_cast|^const_cast|\\Wuseconds_t|^useconds_t|\\Wnamespace|^namespace|\\Wblksize_t|^blksize_t|\\Win_addr_t|^in_addr_t|\\Win_port_t|^in_port_t|\\Wuintptr_t|^uintptr_t|\\Wuintmax_t|^uintmax_t|\\Wuintmax_t|^uintmax_t|\\Wconstexpr|^constexpr|\\Wconstexpr|^constexpr|\\Wconstexpr|^constexpr|\\Wconsteval|^consteval|\\Wprotected|^protected|\\Wco_return|^co_return|\\Wuint16_t|^uint16_t|\\Wdecltype|^decltype|\\Wu_quad_t|^u_quad_t|\\Wreflexpr|^reflexpr|\\Wregister|^register|\\Wco_await|^co_await|\\Wintmax_t|^intmax_t|\\Wintmax_t|^intmax_t|\\Wco_yield|^co_yield|\\Wnoexcept|^noexcept|\\Wintptr_t|^intptr_t|\\Wnoexcept|^noexcept|\\Wvolatile|^volatile|\\Wnoexcept|^noexcept|\\Wrequires|^requires|\\Wuint64_t|^uint64_t|\\Wrestrict|^restrict|\\Wtypename|^typename|\\Wexplicit|^explicit|\\Wuint32_t|^uint32_t|\\Wunsigned|^unsigned|\\Woperator|^operator|\\Wvolatile|^volatile|\\Wblkcnt_t|^blkcnt_t|\\Wcontinue|^continue|\\Wtemplate|^template|\\Wmutable|^mutable|\\Walignas|^alignas|\\Walignof|^alignof|\\Wnullptr|^nullptr|\\Wconcept|^concept|\\Wqaddr_t|^qaddr_t|\\Wcaddr_t|^caddr_t|\\Wdaddr_t|^daddr_t|\\Wtypedef|^typedef|\\Wfixpt_t|^fixpt_t|\\W__asm__|^__asm__|\\Wwchar_t|^wchar_t|\\Wprivate|^private|\\Wdefault|^default|\\Wnlink_t|^nlink_t|\\Wmutable|^mutable|\\Wsegsz_t|^segsz_t|\\Wswblk_t|^swblk_t|\\Wvirtual|^virtual|\\Wclock_t|^clock_t|\\Wu_short|^u_short|\\Wssize_t|^ssize_t|\\Wint16_t|^int16_t|\\Wint32_t|^int32_t|\\Wint64_t|^int64_t|\\Wuint8_t|^uint8_t|\\Wstruct|^struct|\\Wsigned|^signed|\\Wdouble|^double|\\Wu_char|^u_char|\\Wu_long|^u_long|\\Wushort|^ushort|\\Wquad_t|^quad_t|\\Wexport|^export|\\Wnot_eq|^not_eq|\\Wdelete|^delete|\\Wmode_t|^mode_t|\\Wsize_t|^size_t|\\Wtime_t|^time_t|\\Wint8_t|^int8_t|\\Wtypeid|^typeid|\\Wxor_eq|^xor_eq|\\Wand_eq|^and_eq|\\Wbitand|^bitand|\\Wsizeof|^sizeof|\\Wstatic|^static|\\Wextern|^extern|\\Winline|^inline|\\Wfriend|^friend|\\Wimport|^import|\\Wmodule|^module|\\Wpublic|^public|\\Wswitch|^switch|\\Wreturn|^return|\\Wclass|^class|\\Wunion|^union|\\Wconst|^const|\\Wor_eq|^or_eq|\\Wwhile|^while|\\Wcatch|^catch|\\Wcompl|^compl|\\Wbreak|^break|\\Wuid_t|^uid_t|\\Wconst|^const|\\Woff_t|^off_t|\\Wpid_t|^pid_t|\\Wkey_t|^key_t|\\Wino_t|^ino_t|\\Wshort|^short|\\Wgid_t|^gid_t|\\Wusing|^using|\\Wdev_t|^dev_t|\\Wdiv_t|^div_t|\\Wu_int|^u_int|\\Wfloat|^float|\\Wbitor|^bitor|\\Wfalse|^false|\\Wthrow|^throw|\\Welse|^else|\\Wtrue|^true|\\Wauto|^auto|\\Wvoid|^void|\\Wuint|^uint|\\Wid_t|^id_t|\\Wbool|^bool|\\WNULL|^NULL|\\Wlong|^long|\\Wid_t|^id_t|\\Wcase|^case|\\Wgoto|^goto|\\Wthis|^this|\\Wchar|^char|\\Wenum|^enum|\\Wxor|^xor|\\Wint|^int|\\Wasm|^asm|\\Wnew|^new|\\Wtry|^try|\\Wand|^and|\\Wfor|^for|\\Wnot|^not|\\Wdo|^do|\\Wor|^or|\\Wif|^if)((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))(?=\\())",
+			"beginCaptures": {
+				"1": {
+					"name": "meta.head.function.definition.cpp"
+				},
+				"2": {
+					"patterns": [
+						{
+							"include": "#inline_comment"
+						}
+					]
+				},
+				"3": {
+					"name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+				},
+				"4": {
+					"name": "comment.block.cpp"
+				},
+				"5": {
+					"patterns": [
+						{
+							"match": "\\*\\/",
+							"name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+						},
+						{
+							"match": "\\*",
+							"name": "comment.block.cpp"
+						}
+					]
+				},
+				"6": {
+					"name": "storage.type.template.cpp"
+				},
+				"7": {
+					"patterns": [
+						{
+							"include": "#inline_comment"
+						}
+					]
+				},
+				"8": {
+					"name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+				},
+				"9": {
+					"name": "comment.block.cpp"
+				},
+				"10": {
+					"patterns": [
+						{
+							"match": "\\*\\/",
+							"name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+						},
+						{
+							"match": "\\*",
+							"name": "comment.block.cpp"
+						}
+					]
+				},
+				"11": {
+					"patterns": [
+						{
+							"match": "((?<!\\w)(?:(?:constexpr|explicit|mutable|virtual|inline|friend)|(?:volatile|register|restrict|static|extern|const))(?!\\w))((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))",
+							"captures": {
+								"1": {
+									"name": "storage.modifier.$1.cpp"
+								},
+								"2": {
+									"patterns": [
+										{
+											"include": "#inline_comment"
+										}
+									]
+								},
+								"3": {
+									"name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+								},
+								"4": {
+									"name": "comment.block.cpp"
+								},
+								"5": {
+									"patterns": [
+										{
+											"match": "\\*\\/",
+											"name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+										},
+										{
+											"match": "\\*",
+											"name": "comment.block.cpp"
+										}
+									]
+								}
+							}
+						}
+					]
+				},
+				"12": {
+					"name": "storage.modifier.$1.cpp"
+				},
+				"13": {
+					"patterns": [
+						{
+							"include": "#inline_comment"
+						}
+					]
+				},
+				"14": {
+					"name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+				},
+				"15": {
+					"name": "comment.block.cpp"
+				},
+				"16": {
+					"patterns": [
+						{
+							"match": "\\*\\/",
+							"name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+						},
+						{
+							"match": "\\*",
+							"name": "comment.block.cpp"
+						}
+					]
+				},
+				"17": {
+					"name": "meta.qualified_type.cpp",
+					"patterns": [
+						{
+							"match": "(?<!\\w)(?:struct|class|union|enum)(?!\\w)",
+							"name": "storage.type.$0.cpp"
+						},
+						{
+							"include": "#attributes_context"
+						},
+						{
+							"include": "#function_type"
+						},
+						{
+							"include": "#storage_types"
+						},
+						{
+							"include": "#number_literal"
+						},
+						{
+							"include": "#string_context"
+						},
+						{
+							"include": "#comma"
+						},
+						{
+							"include": "#scope_resolution_inner_generated"
+						},
+						{
+							"include": "#template_call_range"
+						},
+						{
+							"match": "(?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*",
+							"name": "entity.name.type.cpp"
+						}
+					]
+				},
+				"18": {
+					"patterns": [
+						{
+							"include": "#attributes_context"
+						},
+						{
+							"include": "#number_literal"
+						}
+					]
+				},
+				"19": {
+					"patterns": [
+						{
+							"include": "#inline_comment"
+						}
+					]
+				},
+				"20": {
+					"name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+				},
+				"21": {
+					"name": "comment.block.cpp"
+				},
+				"22": {
+					"patterns": [
+						{
+							"match": "\\*\\/",
+							"name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+						},
+						{
+							"match": "\\*",
+							"name": "comment.block.cpp"
+						}
+					]
+				},
+				"23": {
+					"patterns": [
+						{
+							"include": "#inline_comment"
+						}
+					]
+				},
+				"24": {
+					"name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+				},
+				"25": {
+					"name": "comment.block.cpp"
+				},
+				"26": {
+					"patterns": [
+						{
+							"match": "\\*\\/",
+							"name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+						},
+						{
+							"match": "\\*",
+							"name": "comment.block.cpp"
+						}
+					]
+				},
+				"28": {
+					"patterns": [
+						{
+							"include": "#scope_resolution_inner_generated"
+						}
+					]
+				},
+				"29": {
+					"name": "punctuation.separator.namespace.access.cpp punctuation.separator.scope-resolution.cpp"
+				},
+				"31": {
+					"name": "meta.template.call.cpp",
+					"patterns": [
+						{
+							"include": "#template_call_range"
+						}
+					]
+				},
+				"33": {
+					"name": "entity.name.scope-resolution.cpp"
+				},
+				"34": {
+					"name": "meta.template.call.cpp",
+					"patterns": [
+						{
+							"include": "#template_call_range"
+						}
+					]
+				},
+				"36": {
+					"name": "punctuation.separator.namespace.access.cpp punctuation.separator.scope-resolution.cpp"
+				},
+				"37": {
+					"patterns": [
+						{
+							"include": "#inline_comment"
+						}
+					]
+				},
+				"38": {
+					"name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+				},
+				"39": {
+					"name": "comment.block.cpp"
+				},
+				"40": {
+					"patterns": [
+						{
+							"match": "\\*\\/",
+							"name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+						},
+						{
+							"match": "\\*",
+							"name": "comment.block.cpp"
+						}
+					]
+				},
+				"41": {
+					"name": "entity.name.type.cpp"
+				},
+				"42": {
+					"name": "meta.template.call.cpp",
+					"patterns": [
+						{
+							"include": "#template_call_range"
+						}
+					]
+				},
+				"44": {
+					"patterns": [
+						{
+							"match": "\\*",
+							"name": "storage.modifier.pointer.cpp"
+						},
+						{
+							"match": "(?:\\&((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))){2,}\\&",
+							"captures": {
+								"1": {
+									"patterns": [
+										{
+											"include": "#inline_comment"
+										}
+									]
+								},
+								"2": {
+									"name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+								},
+								"3": {
+									"name": "comment.block.cpp"
+								},
+								"4": {
+									"patterns": [
+										{
+											"match": "\\*\\/",
+											"name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+										},
+										{
+											"match": "\\*",
+											"name": "comment.block.cpp"
+										}
+									]
+								}
+							},
+							"name": "invalid.illegal.reference-type.cpp"
+						},
+						{
+							"match": "\\&",
+							"name": "storage.modifier.reference.cpp"
+						}
+					]
+				},
+				"45": {
+					"patterns": [
+						{
+							"include": "#inline_comment"
+						}
+					]
+				},
+				"46": {
+					"name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+				},
+				"47": {
+					"name": "comment.block.cpp"
+				},
+				"48": {
+					"patterns": [
+						{
+							"match": "\\*\\/",
+							"name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+						},
+						{
+							"match": "\\*",
+							"name": "comment.block.cpp"
+						}
+					]
+				},
+				"49": {
+					"patterns": [
+						{
+							"include": "#inline_comment"
+						}
+					]
+				},
+				"50": {
+					"name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+				},
+				"51": {
+					"name": "comment.block.cpp"
+				},
+				"52": {
+					"patterns": [
+						{
+							"match": "\\*\\/",
+							"name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+						},
+						{
+							"match": "\\*",
+							"name": "comment.block.cpp"
+						}
+					]
+				},
+				"53": {
+					"patterns": [
+						{
+							"include": "#inline_comment"
+						}
+					]
+				},
+				"54": {
+					"name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+				},
+				"55": {
+					"name": "comment.block.cpp"
+				},
+				"56": {
+					"patterns": [
+						{
+							"match": "\\*\\/",
+							"name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+						},
+						{
+							"match": "\\*",
+							"name": "comment.block.cpp"
+						}
+					]
+				},
+				"57": {
+					"patterns": [
+						{
+							"include": "#inline_comment"
+						}
+					]
+				},
+				"58": {
+					"name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+				},
+				"59": {
+					"name": "comment.block.cpp"
+				},
+				"60": {
+					"patterns": [
+						{
+							"match": "\\*\\/",
+							"name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+						},
+						{
+							"match": "\\*",
+							"name": "comment.block.cpp"
+						}
+					]
+				},
+				"61": {
+					"name": "storage.type.modifier.calling-convention.cpp"
+				},
+				"62": {
+					"patterns": [
+						{
+							"include": "#inline_comment"
+						}
+					]
+				},
+				"63": {
+					"name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+				},
+				"64": {
+					"name": "comment.block.cpp"
+				},
+				"65": {
+					"patterns": [
+						{
+							"match": "\\*\\/",
+							"name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+						},
+						{
+							"match": "\\*",
+							"name": "comment.block.cpp"
+						}
+					]
+				},
+				"66": {
+					"patterns": [
+						{
+							"include": "#scope_resolution_function_definition_inner_generated"
+						}
+					]
+				},
+				"67": {
+					"name": "punctuation.separator.namespace.access.cpp punctuation.separator.scope-resolution.function.definition.cpp"
+				},
+				"69": {
+					"name": "meta.template.call.cpp",
+					"patterns": [
+						{
+							"include": "#template_call_range"
+						}
+					]
+				},
+				"71": {
+					"name": "entity.name.function.definition.cpp"
+				},
+				"72": {
+					"patterns": [
+						{
+							"include": "#inline_comment"
+						}
+					]
+				},
+				"73": {
+					"name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+				},
+				"74": {
+					"name": "comment.block.cpp"
+				},
+				"75": {
+					"patterns": [
+						{
+							"match": "\\*\\/",
+							"name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+						},
+						{
+							"match": "\\*",
+							"name": "comment.block.cpp"
+						}
+					]
+				}
+			},
+			"end": "(?:(?<=\\}|%>|\\?\\?>)|(?=[;>\\[\\]=]))",
+			"patterns": [
+				{
+					"name": "meta.head.function.definition.cpp",
+					"begin": "\\G ?",
+					"end": "((?:\\{|<%|\\?\\?<|(?=;)))",
+					"endCaptures": {
+						"1": {
+							"name": "punctuation.section.block.begin.bracket.curly.function.definition.cpp"
+						}
+					},
+					"patterns": [
+						{
+							"include": "#ever_present_context"
+						},
+						{
+							"contentName": "meta.function.definition.parameters.cpp",
+							"begin": "(\\()",
+							"beginCaptures": {
+								"1": {
+									"name": "punctuation.section.parameters.begin.bracket.round.cpp"
+								}
+							},
+							"end": "(\\))",
+							"endCaptures": {
+								"1": {
+									"name": "punctuation.section.parameters.end.bracket.round.cpp"
+								}
+							},
+							"patterns": [
+								{
+									"include": "#ever_present_context"
+								},
+								{
+									"include": "#parameter_or_maybe_value"
+								},
+								{
+									"include": "#comma"
+								},
+								{
+									"include": "#evaluation_context"
+								}
+							]
+						},
+						{
+							"include": "$self"
+						}
+					]
+				},
+				{
+					"name": "meta.body.function.definition.cpp",
+					"begin": "(?<=\\{|<%|\\?\\?<)",
+					"end": "(\\}|%>|\\?\\?>)",
+					"endCaptures": {
+						"1": {
+							"name": "punctuation.section.block.end.bracket.curly.function.definition.cpp"
+						}
+					},
+					"patterns": [
+						{
+							"include": "#function_body_context"
+						}
+					]
+				},
+				{
+					"name": "meta.tail.function.definition.cpp",
+					"begin": "(?<=\\}|%>|\\?\\?>)[\\s\\n]*",
+					"end": "[\\s\\n]*(?=;)",
+					"patterns": [
+						{
+							"include": "$self"
+						}
+					]
+				}
+			]
+		},
+		"function_parameter_context": {
+			"patterns": [
+				{
+					"include": "#ever_present_context"
+				},
+				{
+					"include": "#parameter"
+				},
+				{
+					"include": "#comma"
+				}
+			]
+		},
+		"function_pointer": {
+			"begin": "(\\s*+((?:(?:(?:\\[\\[.*?\\]\\]|__attribute(?:__)?\\(\\(.*?\\)\\))|__declspec\\(.*?\\))|alignas\\(.*?\\))(?!\\)))?((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))(?:(?:(?:unsigned|signed|short|long)|(?:struct|class|union|enum))((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z)))))*(((::)?(?:((?-mix:(?!\\b(?:__has_cpp_attribute|reinterpret_cast|atomic_noexcept|atomic_cancel|atomic_commit|__has_include|dynamic_cast|thread_local|synchronized|static_cast|const_cast|consteval|constexpr|protected|namespace|co_return|constexpr|constexpr|continue|explicit|volatile|noexcept|co_yield|noexcept|noexcept|requires|typename|decltype|operator|co_await|template|volatile|register|restrict|reflexpr|alignof|private|default|mutable|include|concept|__asm__|defined|_Pragma|alignas|typedef|warning|virtual|mutable|struct|sizeof|delete|not_eq|bitand|and_eq|xor_eq|typeid|switch|return|static|extern|inline|friend|public|ifndef|define|pragma|export|import|module|catch|throw|const|or_eq|while|compl|bitor|const|union|ifdef|class|undef|error|break|using|endif|goto|line|enum|this|case|else|elif|else|asm|try|for|new|and|xor|not|do|or|if|if)\\b)(?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*))\\s*+(((?<!<)<(?!<)(?>(?:(?>[^<>]*)\\g<27>?)+)>)\\s*)?::)*\\s*+)((?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*)\\s*+(((?<!<)<(?!<)(?>(?:(?>[^<>]*)\\g<27>?)+)>)\\s*)?(::))?((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))(?!(?:transaction_safe_dynamic|__has_cpp_attribute|transaction_safe|reinterpret_cast|atomic_noexcept|atomic_commit|atomic_cancel|__has_include|dynamic_cast|thread_local|synchronized|static_cast|const_cast|constexpr|consteval|protected|constexpr|co_return|namespace|constexpr|noexcept|typename|decltype|template|operator|noexcept|co_yield|co_await|continue|volatile|register|restrict|explicit|override|volatile|reflexpr|noexcept|requires|default|typedef|nullptr|alignof|mutable|concept|virtual|defined|__asm__|include|_Pragma|mutable|warning|private|alignas|module|switch|not_eq|bitand|and_eq|ifndef|return|sizeof|xor_eq|export|static|delete|public|define|extern|inline|import|pragma|friend|typeid|const|compl|bitor|throw|or_eq|while|catch|break|false|final|const|endif|ifdef|undef|error|using|audit|axiom|line|else|elif|true|NULL|case|goto|else|this|new|asm|not|and|xor|try|for|if|do|or|if)\\b)((?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*)\\b(((?<!<)<(?!<)(?>(?:(?>[^<>]*)\\g<27>?)+)>)\\s*)?(?![\\w<:.]))(((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))?(?:(?:\\&|\\*)((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z)))))*(?:\\&|\\*))?((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))(\\()(\\*)\\s*((?:(?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*)?)\\s*(?:(\\[)(\\w*)(\\])\\s*)*(\\))\\s*(\\()",
+			"beginCaptures": {
+				"1": {
+					"name": "meta.qualified_type.cpp",
+					"patterns": [
+						{
+							"match": "(?<!\\w)(?:struct|class|union|enum)(?!\\w)",
+							"name": "storage.type.$0.cpp"
+						},
+						{
+							"include": "#attributes_context"
+						},
+						{
+							"include": "#function_type"
+						},
+						{
+							"include": "#storage_types"
+						},
+						{
+							"include": "#number_literal"
+						},
+						{
+							"include": "#string_context"
+						},
+						{
+							"include": "#comma"
+						},
+						{
+							"include": "#scope_resolution_inner_generated"
+						},
+						{
+							"include": "#template_call_range"
+						},
+						{
+							"match": "(?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*",
+							"name": "entity.name.type.cpp"
+						}
+					]
+				},
+				"2": {
+					"patterns": [
+						{
+							"include": "#attributes_context"
+						},
+						{
+							"include": "#number_literal"
+						}
+					]
+				},
+				"3": {
+					"patterns": [
+						{
+							"include": "#inline_comment"
+						}
+					]
+				},
+				"4": {
+					"name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+				},
+				"5": {
+					"name": "comment.block.cpp"
+				},
+				"6": {
+					"patterns": [
+						{
+							"match": "\\*\\/",
+							"name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+						},
+						{
+							"match": "\\*",
+							"name": "comment.block.cpp"
+						}
+					]
+				},
+				"7": {
+					"patterns": [
+						{
+							"include": "#inline_comment"
+						}
+					]
+				},
+				"8": {
+					"name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+				},
+				"9": {
+					"name": "comment.block.cpp"
+				},
+				"10": {
+					"patterns": [
+						{
+							"match": "\\*\\/",
+							"name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+						},
+						{
+							"match": "\\*",
+							"name": "comment.block.cpp"
+						}
+					]
+				},
+				"12": {
+					"patterns": [
+						{
+							"include": "#scope_resolution_inner_generated"
+						}
+					]
+				},
+				"13": {
+					"name": "punctuation.separator.namespace.access.cpp punctuation.separator.scope-resolution.cpp"
+				},
+				"15": {
+					"name": "meta.template.call.cpp",
+					"patterns": [
+						{
+							"include": "#template_call_range"
+						}
+					]
+				},
+				"17": {
+					"name": "entity.name.scope-resolution.cpp"
+				},
+				"18": {
+					"name": "meta.template.call.cpp",
+					"patterns": [
+						{
+							"include": "#template_call_range"
+						}
+					]
+				},
+				"20": {
+					"name": "punctuation.separator.namespace.access.cpp punctuation.separator.scope-resolution.cpp"
+				},
+				"21": {
+					"patterns": [
+						{
+							"include": "#inline_comment"
+						}
+					]
+				},
+				"22": {
+					"name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+				},
+				"23": {
+					"name": "comment.block.cpp"
+				},
+				"24": {
+					"patterns": [
+						{
+							"match": "\\*\\/",
+							"name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+						},
+						{
+							"match": "\\*",
+							"name": "comment.block.cpp"
+						}
+					]
+				},
+				"25": {
+					"name": "entity.name.type.cpp"
+				},
+				"26": {
+					"name": "meta.template.call.cpp",
+					"patterns": [
+						{
+							"include": "#template_call_range"
+						}
+					]
+				},
+				"28": {
+					"patterns": [
+						{
+							"match": "\\*",
+							"name": "storage.modifier.pointer.cpp"
+						},
+						{
+							"match": "(?:\\&((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))){2,}\\&",
+							"captures": {
+								"1": {
+									"patterns": [
+										{
+											"include": "#inline_comment"
+										}
+									]
+								},
+								"2": {
+									"name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+								},
+								"3": {
+									"name": "comment.block.cpp"
+								},
+								"4": {
+									"patterns": [
+										{
+											"match": "\\*\\/",
+											"name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+										},
+										{
+											"match": "\\*",
+											"name": "comment.block.cpp"
+										}
+									]
+								}
+							},
+							"name": "invalid.illegal.reference-type.cpp"
+						},
+						{
+							"match": "\\&",
+							"name": "storage.modifier.reference.cpp"
+						}
+					]
+				},
+				"29": {
+					"patterns": [
+						{
+							"include": "#inline_comment"
+						}
+					]
+				},
+				"30": {
+					"name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+				},
+				"31": {
+					"name": "comment.block.cpp"
+				},
+				"32": {
+					"patterns": [
+						{
+							"match": "\\*\\/",
+							"name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+						},
+						{
+							"match": "\\*",
+							"name": "comment.block.cpp"
+						}
+					]
+				},
+				"33": {
+					"patterns": [
+						{
+							"include": "#inline_comment"
+						}
+					]
+				},
+				"34": {
+					"name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+				},
+				"35": {
+					"name": "comment.block.cpp"
+				},
+				"36": {
+					"patterns": [
+						{
+							"match": "\\*\\/",
+							"name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+						},
+						{
+							"match": "\\*",
+							"name": "comment.block.cpp"
+						}
+					]
+				},
+				"37": {
+					"patterns": [
+						{
+							"include": "#inline_comment"
+						}
+					]
+				},
+				"38": {
+					"name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+				},
+				"39": {
+					"name": "comment.block.cpp"
+				},
+				"40": {
+					"patterns": [
+						{
+							"match": "\\*\\/",
+							"name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+						},
+						{
+							"match": "\\*",
+							"name": "comment.block.cpp"
+						}
+					]
+				},
+				"41": {
+					"name": "punctuation.section.parens.begin.bracket.round.function.pointer.cpp"
+				},
+				"42": {
+					"name": "punctuation.definition.function.pointer.dereference.cpp"
+				},
+				"43": {
+					"name": "variable.other.definition.pointer.function.cpp"
+				},
+				"44": {
+					"name": "punctuation.definition.begin.bracket.square.cpp"
+				},
+				"45": {
+					"patterns": [
+						{
+							"include": "#evaluation_context"
+						}
+					]
+				},
+				"46": {
+					"name": "punctuation.definition.end.bracket.square.cpp"
+				},
+				"47": {
+					"name": "punctuation.section.parens.end.bracket.round.function.pointer.cpp"
+				},
+				"48": {
+					"name": "punctuation.section.parameters.begin.bracket.round.function.pointer.cpp"
+				}
+			},
+			"end": "(\\))((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))(?=[{=,);]|\\n)(?!\\()",
+			"endCaptures": {
+				"1": {
+					"name": "punctuation.section.parameters.end.bracket.round.function.pointer.cpp"
+				},
+				"2": {
+					"patterns": [
+						{
+							"include": "#inline_comment"
+						}
+					]
+				},
+				"3": {
+					"name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+				},
+				"4": {
+					"name": "comment.block.cpp"
+				},
+				"5": {
+					"patterns": [
+						{
+							"match": "\\*\\/",
+							"name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+						},
+						{
+							"match": "\\*",
+							"name": "comment.block.cpp"
+						}
+					]
+				}
+			},
+			"patterns": [
+				{
+					"include": "#function_parameter_context"
+				}
+			]
+		},
+		"function_pointer_parameter": {
+			"begin": "(\\s*+((?:(?:(?:\\[\\[.*?\\]\\]|__attribute(?:__)?\\(\\(.*?\\)\\))|__declspec\\(.*?\\))|alignas\\(.*?\\))(?!\\)))?((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))(?:(?:(?:unsigned|signed|short|long)|(?:struct|class|union|enum))((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z)))))*(((::)?(?:((?-mix:(?!\\b(?:__has_cpp_attribute|reinterpret_cast|atomic_noexcept|atomic_cancel|atomic_commit|__has_include|dynamic_cast|thread_local|synchronized|static_cast|const_cast|consteval|constexpr|protected|namespace|co_return|constexpr|constexpr|continue|explicit|volatile|noexcept|co_yield|noexcept|noexcept|requires|typename|decltype|operator|co_await|template|volatile|register|restrict|reflexpr|alignof|private|default|mutable|include|concept|__asm__|defined|_Pragma|alignas|typedef|warning|virtual|mutable|struct|sizeof|delete|not_eq|bitand|and_eq|xor_eq|typeid|switch|return|static|extern|inline|friend|public|ifndef|define|pragma|export|import|module|catch|throw|const|or_eq|while|compl|bitor|const|union|ifdef|class|undef|error|break|using|endif|goto|line|enum|this|case|else|elif|else|asm|try|for|new|and|xor|not|do|or|if|if)\\b)(?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*))\\s*+(((?<!<)<(?!<)(?>(?:(?>[^<>]*)\\g<27>?)+)>)\\s*)?::)*\\s*+)((?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*)\\s*+(((?<!<)<(?!<)(?>(?:(?>[^<>]*)\\g<27>?)+)>)\\s*)?(::))?((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))(?!(?:transaction_safe_dynamic|__has_cpp_attribute|transaction_safe|reinterpret_cast|atomic_noexcept|atomic_commit|atomic_cancel|__has_include|dynamic_cast|thread_local|synchronized|static_cast|const_cast|constexpr|consteval|protected|constexpr|co_return|namespace|constexpr|noexcept|typename|decltype|template|operator|noexcept|co_yield|co_await|continue|volatile|register|restrict|explicit|override|volatile|reflexpr|noexcept|requires|default|typedef|nullptr|alignof|mutable|concept|virtual|defined|__asm__|include|_Pragma|mutable|warning|private|alignas|module|switch|not_eq|bitand|and_eq|ifndef|return|sizeof|xor_eq|export|static|delete|public|define|extern|inline|import|pragma|friend|typeid|const|compl|bitor|throw|or_eq|while|catch|break|false|final|const|endif|ifdef|undef|error|using|audit|axiom|line|else|elif|true|NULL|case|goto|else|this|new|asm|not|and|xor|try|for|if|do|or|if)\\b)((?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*)\\b(((?<!<)<(?!<)(?>(?:(?>[^<>]*)\\g<27>?)+)>)\\s*)?(?![\\w<:.]))(((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))?(?:(?:\\&|\\*)((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z)))))*(?:\\&|\\*))?((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))(\\()(\\*)\\s*((?:(?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*)?)\\s*(?:(\\[)(\\w*)(\\])\\s*)*(\\))\\s*(\\()",
+			"beginCaptures": {
+				"1": {
+					"name": "meta.qualified_type.cpp",
+					"patterns": [
+						{
+							"match": "(?<!\\w)(?:struct|class|union|enum)(?!\\w)",
+							"name": "storage.type.$0.cpp"
+						},
+						{
+							"include": "#attributes_context"
+						},
+						{
+							"include": "#function_type"
+						},
+						{
+							"include": "#storage_types"
+						},
+						{
+							"include": "#number_literal"
+						},
+						{
+							"include": "#string_context"
+						},
+						{
+							"include": "#comma"
+						},
+						{
+							"include": "#scope_resolution_inner_generated"
+						},
+						{
+							"include": "#template_call_range"
+						},
+						{
+							"match": "(?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*",
+							"name": "entity.name.type.cpp"
+						}
+					]
+				},
+				"2": {
+					"patterns": [
+						{
+							"include": "#attributes_context"
+						},
+						{
+							"include": "#number_literal"
+						}
+					]
+				},
+				"3": {
+					"patterns": [
+						{
+							"include": "#inline_comment"
+						}
+					]
+				},
+				"4": {
+					"name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+				},
+				"5": {
+					"name": "comment.block.cpp"
+				},
+				"6": {
+					"patterns": [
+						{
+							"match": "\\*\\/",
+							"name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+						},
+						{
+							"match": "\\*",
+							"name": "comment.block.cpp"
+						}
+					]
+				},
+				"7": {
+					"patterns": [
+						{
+							"include": "#inline_comment"
+						}
+					]
+				},
+				"8": {
+					"name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+				},
+				"9": {
+					"name": "comment.block.cpp"
+				},
+				"10": {
+					"patterns": [
+						{
+							"match": "\\*\\/",
+							"name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+						},
+						{
+							"match": "\\*",
+							"name": "comment.block.cpp"
+						}
+					]
+				},
+				"12": {
+					"patterns": [
+						{
+							"include": "#scope_resolution_inner_generated"
+						}
+					]
+				},
+				"13": {
+					"name": "punctuation.separator.namespace.access.cpp punctuation.separator.scope-resolution.cpp"
+				},
+				"15": {
+					"name": "meta.template.call.cpp",
+					"patterns": [
+						{
+							"include": "#template_call_range"
+						}
+					]
+				},
+				"17": {
+					"name": "entity.name.scope-resolution.cpp"
+				},
+				"18": {
+					"name": "meta.template.call.cpp",
+					"patterns": [
+						{
+							"include": "#template_call_range"
+						}
+					]
+				},
+				"20": {
+					"name": "punctuation.separator.namespace.access.cpp punctuation.separator.scope-resolution.cpp"
+				},
+				"21": {
+					"patterns": [
+						{
+							"include": "#inline_comment"
+						}
+					]
+				},
+				"22": {
+					"name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+				},
+				"23": {
+					"name": "comment.block.cpp"
+				},
+				"24": {
+					"patterns": [
+						{
+							"match": "\\*\\/",
+							"name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+						},
+						{
+							"match": "\\*",
+							"name": "comment.block.cpp"
+						}
+					]
+				},
+				"25": {
+					"name": "entity.name.type.cpp"
+				},
+				"26": {
+					"name": "meta.template.call.cpp",
+					"patterns": [
+						{
+							"include": "#template_call_range"
+						}
+					]
+				},
+				"28": {
+					"patterns": [
+						{
+							"match": "\\*",
+							"name": "storage.modifier.pointer.cpp"
+						},
+						{
+							"match": "(?:\\&((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))){2,}\\&",
+							"captures": {
+								"1": {
+									"patterns": [
+										{
+											"include": "#inline_comment"
+										}
+									]
+								},
+								"2": {
+									"name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+								},
+								"3": {
+									"name": "comment.block.cpp"
+								},
+								"4": {
+									"patterns": [
+										{
+											"match": "\\*\\/",
+											"name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+										},
+										{
+											"match": "\\*",
+											"name": "comment.block.cpp"
+										}
+									]
+								}
+							},
+							"name": "invalid.illegal.reference-type.cpp"
+						},
+						{
+							"match": "\\&",
+							"name": "storage.modifier.reference.cpp"
+						}
+					]
+				},
+				"29": {
+					"patterns": [
+						{
+							"include": "#inline_comment"
+						}
+					]
+				},
+				"30": {
+					"name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+				},
+				"31": {
+					"name": "comment.block.cpp"
+				},
+				"32": {
+					"patterns": [
+						{
+							"match": "\\*\\/",
+							"name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+						},
+						{
+							"match": "\\*",
+							"name": "comment.block.cpp"
+						}
+					]
+				},
+				"33": {
+					"patterns": [
+						{
+							"include": "#inline_comment"
+						}
+					]
+				},
+				"34": {
+					"name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+				},
+				"35": {
+					"name": "comment.block.cpp"
+				},
+				"36": {
+					"patterns": [
+						{
+							"match": "\\*\\/",
+							"name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+						},
+						{
+							"match": "\\*",
+							"name": "comment.block.cpp"
+						}
+					]
+				},
+				"37": {
+					"patterns": [
+						{
+							"include": "#inline_comment"
+						}
+					]
+				},
+				"38": {
+					"name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+				},
+				"39": {
+					"name": "comment.block.cpp"
+				},
+				"40": {
+					"patterns": [
+						{
+							"match": "\\*\\/",
+							"name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+						},
+						{
+							"match": "\\*",
+							"name": "comment.block.cpp"
+						}
+					]
+				},
+				"41": {
+					"name": "punctuation.section.parens.begin.bracket.round.function.pointer.cpp"
+				},
+				"42": {
+					"name": "punctuation.definition.function.pointer.dereference.cpp"
+				},
+				"43": {
+					"name": "variable.parameter.pointer.function.cpp"
+				},
+				"44": {
+					"name": "punctuation.definition.begin.bracket.square.cpp"
+				},
+				"45": {
+					"patterns": [
+						{
+							"include": "#evaluation_context"
+						}
+					]
+				},
+				"46": {
+					"name": "punctuation.definition.end.bracket.square.cpp"
+				},
+				"47": {
+					"name": "punctuation.section.parens.end.bracket.round.function.pointer.cpp"
+				},
+				"48": {
+					"name": "punctuation.section.parameters.begin.bracket.round.function.pointer.cpp"
+				}
+			},
+			"end": "(\\))((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))(?=[{=,);]|\\n)(?!\\()",
+			"endCaptures": {
+				"1": {
+					"name": "punctuation.section.parameters.end.bracket.round.function.pointer.cpp"
+				},
+				"2": {
+					"patterns": [
+						{
+							"include": "#inline_comment"
+						}
+					]
+				},
+				"3": {
+					"name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+				},
+				"4": {
+					"name": "comment.block.cpp"
+				},
+				"5": {
+					"patterns": [
+						{
+							"match": "\\*\\/",
+							"name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+						},
+						{
+							"match": "\\*",
+							"name": "comment.block.cpp"
+						}
+					]
+				}
+			},
+			"patterns": [
+				{
+					"include": "#function_parameter_context"
+				}
+			]
+		},
+		"functional_specifiers_pre_parameters": {
+			"match": "(?<!\\w)(?:constexpr|explicit|mutable|virtual|inline|friend)(?!\\w)",
+			"name": "storage.modifier.specifier.functional.pre-parameters.$0.cpp"
+		},
+		"gcc_attributes": {
+			"name": "support.other.attribute.cpp",
+			"begin": "(__attribute(?:__)?\\(\\()",
+			"beginCaptures": {
+				"1": {
+					"name": "punctuation.section.attribute.begin.cpp"
+				}
+			},
+			"end": "(\\)\\))",
+			"endCaptures": {
+				"1": {
+					"name": "punctuation.section.attribute.end.cpp"
+				}
+			},
+			"patterns": [
+				{
+					"include": "#attributes_context"
+				},
+				{
+					"begin": "\\(",
+					"end": "\\)",
+					"patterns": [
+						{
+							"include": "#attributes_context"
+						},
+						{
+							"include": "#string_context"
+						}
+					]
+				},
+				{
+					"match": "(using)\\s+((?<!\\w)(?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*(?!\\w))",
+					"captures": {
+						"1": {
+							"name": "keyword.other.using.directive.cpp"
+						},
+						"2": {
+							"name": "entity.name.namespace.cpp"
+						}
+					}
+				},
+				{
+					"match": ",",
+					"name": "punctuation.separator.attribute.cpp"
+				},
+				{
+					"match": ":",
+					"name": "punctuation.accessor.attribute.cpp"
+				},
+				{
+					"match": "(?<!\\w)(?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*(?!\\w)(?=::)",
+					"name": "entity.name.namespace.cpp"
+				},
+				{
+					"match": "(?<!\\w)(?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*(?!\\w)",
+					"name": "entity.other.attribute.$0.cpp"
+				},
+				{
+					"include": "#number_literal"
+				}
+			]
+		},
+		"goto_statement": {
+			"match": "((?<!\\w)goto(?!\\w))((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))((?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*)",
+			"captures": {
+				"1": {
+					"name": "keyword.control.goto.cpp"
+				},
+				"2": {
+					"patterns": [
+						{
+							"include": "#inline_comment"
+						}
+					]
+				},
+				"3": {
+					"name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+				},
+				"4": {
+					"name": "comment.block.cpp"
+				},
+				"5": {
+					"patterns": [
+						{
+							"match": "\\*\\/",
+							"name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+						},
+						{
+							"match": "\\*",
+							"name": "comment.block.cpp"
+						}
+					]
+				},
+				"6": {
+					"name": "entity.name.label.call.cpp"
+				}
+			}
+		},
+		"include": {
+			"match": "(?:^)((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))((#)\\s*((?:include|include_next))\\b)\\s*(?:(?:(?:((<)[^>]*(>?)((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))(?:(?:\\n|$)|(?=\\/\\/)))|((\\\")[^\\\"]*(\\\"?)((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))(?:(?:\\n|$)|(?=\\/\\/))))|(((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))(?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*(?:\\.(?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*)*((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))(?:(?:\\n|$)|(?=(?:\\/\\/|;)))))|((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))(?:(?:\\n|$)|(?=(?:\\/\\/|;))))",
+			"captures": {
+				"1": {
+					"patterns": [
+						{
+							"include": "#inline_comment"
+						}
+					]
+				},
+				"2": {
+					"name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+				},
+				"3": {
+					"name": "comment.block.cpp"
+				},
+				"4": {
+					"patterns": [
+						{
+							"match": "\\*\\/",
+							"name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+						},
+						{
+							"match": "\\*",
+							"name": "comment.block.cpp"
+						}
+					]
+				},
+				"5": {
+					"name": "keyword.control.directive.$7.cpp"
+				},
+				"6": {
+					"name": "punctuation.definition.directive.cpp"
+				},
+				"8": {
+					"name": "string.quoted.other.lt-gt.include.cpp"
+				},
+				"9": {
+					"name": "punctuation.definition.string.begin.cpp"
+				},
+				"10": {
+					"name": "punctuation.definition.string.end.cpp"
+				},
+				"11": {
+					"patterns": [
+						{
+							"include": "#inline_comment"
+						}
+					]
+				},
+				"12": {
+					"name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+				},
+				"13": {
+					"name": "comment.block.cpp"
+				},
+				"14": {
+					"patterns": [
+						{
+							"match": "\\*\\/",
+							"name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+						},
+						{
+							"match": "\\*",
+							"name": "comment.block.cpp"
+						}
+					]
+				},
+				"15": {
+					"name": "string.quoted.double.include.cpp"
+				},
+				"16": {
+					"name": "punctuation.definition.string.begin.cpp"
+				},
+				"17": {
+					"name": "punctuation.definition.string.end.cpp"
+				},
+				"18": {
+					"patterns": [
+						{
+							"include": "#inline_comment"
+						}
+					]
+				},
+				"19": {
+					"name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+				},
+				"20": {
+					"name": "comment.block.cpp"
+				},
+				"21": {
+					"patterns": [
+						{
+							"match": "\\*\\/",
+							"name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+						},
+						{
+							"match": "\\*",
+							"name": "comment.block.cpp"
+						}
+					]
+				},
+				"22": {
+					"name": "entity.name.other.preprocessor.macro.include.cpp"
+				},
+				"23": {
+					"patterns": [
+						{
+							"include": "#inline_comment"
+						}
+					]
+				},
+				"24": {
+					"name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+				},
+				"25": {
+					"name": "comment.block.cpp"
+				},
+				"26": {
+					"patterns": [
+						{
+							"match": "\\*\\/",
+							"name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+						},
+						{
+							"match": "\\*",
+							"name": "comment.block.cpp"
+						}
+					]
+				},
+				"27": {
+					"patterns": [
+						{
+							"include": "#inline_comment"
+						}
+					]
+				},
+				"28": {
+					"name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+				},
+				"29": {
+					"name": "comment.block.cpp"
+				},
+				"30": {
+					"patterns": [
+						{
+							"match": "\\*\\/",
+							"name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+						},
+						{
+							"match": "\\*",
+							"name": "comment.block.cpp"
+						}
+					]
+				},
+				"31": {
+					"patterns": [
+						{
+							"include": "#inline_comment"
+						}
+					]
+				},
+				"32": {
+					"name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+				},
+				"33": {
+					"name": "comment.block.cpp"
+				},
+				"34": {
+					"patterns": [
+						{
+							"match": "\\*\\/",
+							"name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+						},
+						{
+							"match": "\\*",
+							"name": "comment.block.cpp"
+						}
+					]
+				}
+			},
+			"name": "meta.preprocessor.include.cpp"
+		},
+		"inheritance_context": {
+			"patterns": [
+				{
+					"include": "#ever_present_context"
+				},
+				{
+					"match": ",",
+					"name": "punctuation.separator.delimiter.comma.inheritance.cpp"
+				},
+				{
+					"match": "(?<!\\w)(?:protected|private|public)(?!\\w)",
+					"name": "storage.type.modifier.access.$0.cpp"
+				},
+				{
+					"match": "(?<!\\w)virtual(?!\\w)",
+					"name": "storage.type.modifier.virtual.cpp"
+				},
+				{
+					"match": "(?<=protected|virtual|private|public|,|:)\\s*(?!(?:(?:protected|private|public)|virtual))(\\s*+((?:(?:(?:\\[\\[.*?\\]\\]|__attribute(?:__)?\\(\\(.*?\\)\\))|__declspec\\(.*?\\))|alignas\\(.*?\\))(?!\\)))?((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))(?:(?:(?:unsigned|signed|short|long)|(?:struct|class|union|enum))((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z)))))*(((::)?(?:((?-mix:(?!\\b(?:__has_cpp_attribute|reinterpret_cast|atomic_noexcept|atomic_cancel|atomic_commit|__has_include|dynamic_cast|thread_local|synchronized|static_cast|const_cast|consteval|constexpr|protected|namespace|co_return|constexpr|constexpr|continue|explicit|volatile|noexcept|co_yield|noexcept|noexcept|requires|typename|decltype|operator|co_await|template|volatile|register|restrict|reflexpr|alignof|private|default|mutable|include|concept|__asm__|defined|_Pragma|alignas|typedef|warning|virtual|mutable|struct|sizeof|delete|not_eq|bitand|and_eq|xor_eq|typeid|switch|return|static|extern|inline|friend|public|ifndef|define|pragma|export|import|module|catch|throw|const|or_eq|while|compl|bitor|const|union|ifdef|class|undef|error|break|using|endif|goto|line|enum|this|case|else|elif|else|asm|try|for|new|and|xor|not|do|or|if|if)\\b)(?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*))\\s*+(((?<!<)<(?!<)(?>(?:(?>[^<>]*)\\g<27>?)+)>)\\s*)?::)*\\s*+)((?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*)\\s*+(((?<!<)<(?!<)(?>(?:(?>[^<>]*)\\g<27>?)+)>)\\s*)?(::))?((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))(?!(?:transaction_safe_dynamic|__has_cpp_attribute|transaction_safe|reinterpret_cast|atomic_noexcept|atomic_commit|atomic_cancel|__has_include|dynamic_cast|thread_local|synchronized|static_cast|const_cast|constexpr|consteval|protected|constexpr|co_return|namespace|constexpr|noexcept|typename|decltype|template|operator|noexcept|co_yield|co_await|continue|volatile|register|restrict|explicit|override|volatile|reflexpr|noexcept|requires|default|typedef|nullptr|alignof|mutable|concept|virtual|defined|__asm__|include|_Pragma|mutable|warning|private|alignas|module|switch|not_eq|bitand|and_eq|ifndef|return|sizeof|xor_eq|export|static|delete|public|define|extern|inline|import|pragma|friend|typeid|const|compl|bitor|throw|or_eq|while|catch|break|false|final|const|endif|ifdef|undef|error|using|audit|axiom|line|else|elif|true|NULL|case|goto|else|this|new|asm|not|and|xor|try|for|if|do|or|if)\\b)((?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*)\\b(((?<!<)<(?!<)(?>(?:(?>[^<>]*)\\g<27>?)+)>)\\s*)?(?![\\w<:.]))",
+					"captures": {
+						"1": {
+							"name": "meta.qualified_type.cpp",
+							"patterns": [
+								{
+									"match": "(?<!\\w)(?:struct|class|union|enum)(?!\\w)",
+									"name": "storage.type.$0.cpp"
+								},
+								{
+									"include": "#attributes_context"
+								},
+								{
+									"include": "#function_type"
+								},
+								{
+									"include": "#storage_types"
+								},
+								{
+									"include": "#number_literal"
+								},
+								{
+									"include": "#string_context"
+								},
+								{
+									"include": "#comma"
+								},
+								{
+									"include": "#scope_resolution_inner_generated"
+								},
+								{
+									"include": "#template_call_range"
+								},
+								{
+									"match": "(?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*",
+									"name": "entity.name.type.cpp"
+								}
+							]
+						},
+						"2": {
+							"patterns": [
+								{
+									"include": "#attributes_context"
+								},
+								{
+									"include": "#number_literal"
+								}
+							]
+						},
+						"3": {
+							"patterns": [
+								{
+									"include": "#inline_comment"
+								}
+							]
 						},
 						"4": {
-							"name": "storage.type.modifier.cpp"
+							"name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
 						},
 						"5": {
-							"name": "entity.name.type.inherited.cpp"
+							"name": "comment.block.cpp"
 						},
 						"6": {
 							"patterns": [
 								{
-									"match": "(public|protected|private)",
-									"name": "storage.type.modifier.cpp"
+									"match": "\\*\\/",
+									"name": "comment.block.cpp punctuation.definition.comment.end.cpp"
 								},
 								{
-									"match": "[_A-Za-z][_A-Za-z0-9]*",
-									"name": "entity.name.type.inherited.cpp"
+									"match": "\\*",
+									"name": "comment.block.cpp"
+								}
+							]
+						},
+						"7": {
+							"patterns": [
+								{
+									"include": "#inline_comment"
+								}
+							]
+						},
+						"8": {
+							"name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+						},
+						"9": {
+							"name": "comment.block.cpp"
+						},
+						"10": {
+							"patterns": [
+								{
+									"match": "\\*\\/",
+									"name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+								},
+								{
+									"match": "\\*",
+									"name": "comment.block.cpp"
+								}
+							]
+						},
+						"12": {
+							"patterns": [
+								{
+									"include": "#scope_resolution_inner_generated"
+								}
+							]
+						},
+						"13": {
+							"name": "punctuation.separator.namespace.access.cpp punctuation.separator.scope-resolution.cpp"
+						},
+						"15": {
+							"name": "meta.template.call.cpp",
+							"patterns": [
+								{
+									"include": "#template_call_range"
+								}
+							]
+						},
+						"17": {
+							"name": "entity.name.scope-resolution.cpp"
+						},
+						"18": {
+							"name": "meta.template.call.cpp",
+							"patterns": [
+								{
+									"include": "#template_call_range"
+								}
+							]
+						},
+						"20": {
+							"name": "punctuation.separator.namespace.access.cpp punctuation.separator.scope-resolution.cpp"
+						},
+						"21": {
+							"patterns": [
+								{
+									"include": "#inline_comment"
+								}
+							]
+						},
+						"22": {
+							"name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+						},
+						"23": {
+							"name": "comment.block.cpp"
+						},
+						"24": {
+							"patterns": [
+								{
+									"match": "\\*\\/",
+									"name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+								},
+								{
+									"match": "\\*",
+									"name": "comment.block.cpp"
+								}
+							]
+						},
+						"25": {
+							"name": "entity.name.type.cpp"
+						},
+						"26": {
+							"name": "meta.template.call.cpp",
+							"patterns": [
+								{
+									"include": "#template_call_range"
 								}
 							]
 						}
-					},
-					"end": "(?<=\\})|(?=(;|\\(|\\)|>|\\[|\\]|=))",
-					"name": "meta.class-struct-block.cpp",
+					}
+				}
+			]
+		},
+		"inline_comment": {
+			"match": "(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/))",
+			"captures": {
+				"1": {
+					"name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+				},
+				"2": {
+					"name": "comment.block.cpp"
+				},
+				"3": {
 					"patterns": [
 						{
-							"include": "#angle_brackets"
+							"match": "\\*\\/",
+							"name": "comment.block.cpp punctuation.definition.comment.end.cpp"
 						},
 						{
-							"begin": "\\{",
-							"beginCaptures": {
-								"0": {
-									"name": "punctuation.section.block.begin.bracket.curly.cpp"
-								}
-							},
-							"end": "(\\})(\\s*\\n)?",
-							"endCaptures": {
+							"match": "\\*",
+							"name": "comment.block.cpp"
+						}
+					]
+				}
+			}
+		},
+		"invalid_comment_end": {
+			"match": "\\*\\/",
+			"name": "invalid.illegal.unexpected.punctuation.definition.comment.end.cpp"
+		},
+		"label": {
+			"match": "((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))((?<!\\w)(?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*(?!\\w))\\b(?<!case|default)((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))(:)",
+			"captures": {
+				"1": {
+					"patterns": [
+						{
+							"include": "#inline_comment"
+						}
+					]
+				},
+				"2": {
+					"name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+				},
+				"3": {
+					"name": "comment.block.cpp"
+				},
+				"4": {
+					"patterns": [
+						{
+							"match": "\\*\\/",
+							"name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+						},
+						{
+							"match": "\\*",
+							"name": "comment.block.cpp"
+						}
+					]
+				},
+				"5": {
+					"name": "entity.name.label.cpp"
+				},
+				"6": {
+					"patterns": [
+						{
+							"include": "#inline_comment"
+						}
+					]
+				},
+				"7": {
+					"name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+				},
+				"8": {
+					"name": "comment.block.cpp"
+				},
+				"9": {
+					"patterns": [
+						{
+							"match": "\\*\\/",
+							"name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+						},
+						{
+							"match": "\\*",
+							"name": "comment.block.cpp"
+						}
+					]
+				},
+				"10": {
+					"name": "punctuation.separator.label.cpp"
+				}
+			}
+		},
+		"lambdas": {
+			"begin": "((?:(?<=[^\\s]|^)(?<![\\w\\]\\)\\[\\*&\">])|(?<=\\Wreturn|^return))\\s*(\\[(?!\\[| *+\"| *+\\d))((?>(?:[^\\[\\]]|((?<!\\[)\\[(?!\\[)(?>(?:(?>[^\\[\\]]*)\\g<4>?)+)\\]))*))(\\](?!\\[)))",
+			"beginCaptures": {
+				"2": {
+					"name": "punctuation.definition.capture.begin.lambda.cpp"
+				},
+				"3": {
+					"name": "meta.lambda.capture.cpp",
+					"patterns": [
+						{
+							"include": "#the_this_keyword"
+						},
+						{
+							"match": "((?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*)((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))(?:(?:(?=\\]|\\z|$)|(,))|(\\=))",
+							"captures": {
 								"1": {
-									"name": "punctuation.section.block.end.bracket.curly.cpp"
+									"name": "variable.parameter.capture.cpp"
 								},
 								"2": {
-									"name": "invalid.illegal.you-forgot-semicolon.cpp"
-								}
-							},
-							"patterns": [
-								{
-									"include": "#special_block"
+									"patterns": [
+										{
+											"include": "#inline_comment"
+										}
+									]
 								},
-								{
-									"include": "#constructor"
+								"3": {
+									"name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
 								},
-								{
-									"include": "$base"
+								"4": {
+									"name": "comment.block.cpp"
+								},
+								"5": {
+									"patterns": [
+										{
+											"match": "\\*\\/",
+											"name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+										},
+										{
+											"match": "\\*",
+											"name": "comment.block.cpp"
+										}
+									]
+								},
+								"6": {
+									"name": "punctuation.separator.delimiter.comma.cpp"
+								},
+								"7": {
+									"name": "keyword.operator.assignment.cpp"
 								}
-							]
+							}
 						},
 						{
-							"include": "$base"
+							"include": "#evaluation_context"
+						}
+					]
+				},
+				"5": {
+					"name": "punctuation.definition.capture.end.lambda.cpp"
+				}
+			},
+			"end": "(?<=})",
+			"patterns": [
+				{
+					"name": "meta.function.definition.parameters.lambda.cpp",
+					"begin": "(\\()",
+					"beginCaptures": {
+						"1": {
+							"name": "punctuation.definition.parameters.begin.lambda.cpp"
+						}
+					},
+					"end": "(\\))",
+					"endCaptures": {
+						"1": {
+							"name": "punctuation.definition.parameters.end.lambda.cpp"
+						}
+					},
+					"patterns": [
+						{
+							"include": "#function_parameter_context"
 						}
 					]
 				},
 				{
-					"begin": "\\b(extern)(?=\\s*\")",
+					"match": "(?<!\\w)(?:constexpr|consteval|mutable)(?!\\w)",
+					"name": "storage.modifier.lambda.$0.cpp"
+				},
+				{
+					"match": "(->)((?:.+?(?=\\{|$))?)",
+					"captures": {
+						"1": {
+							"name": "punctuation.definition.lambda.return-type.cpp"
+						},
+						"2": {
+							"name": "storage.type.return-type.lambda.cpp"
+						}
+					}
+				},
+				{
+					"name": "meta.function.definition.body.lambda.cpp",
+					"begin": "(\\{)",
 					"beginCaptures": {
 						"1": {
-							"name": "storage.modifier.cpp"
+							"name": "punctuation.section.block.begin.bracket.curly.lambda.cpp"
 						}
 					},
-					"end": "(?<=\\})|(?=\\w)|(?=\\s*#\\s*endif\\b)",
-					"name": "meta.extern-block.cpp",
+					"end": "(\\})",
+					"endCaptures": {
+						"1": {
+							"name": "punctuation.section.block.end.bracket.curly.lambda.cpp"
+						}
+					},
 					"patterns": [
 						{
-							"begin": "\\{",
-							"beginCaptures": {
-								"0": {
-									"name": "punctuation.section.block.begin.bracket.curly.c"
-								}
-							},
-							"end": "\\}|(?=\\s*#\\s*endif\\b)",
-							"endCaptures": {
-								"0": {
-									"name": "punctuation.section.block.end.bracket.curly.c"
-								}
-							},
-							"patterns": [
-								{
-									"include": "#special_block"
-								},
-								{
-									"include": "$base"
-								}
-							]
-						},
-						{
-							"include": "$base"
+							"include": "$self"
 						}
 					]
 				}
 			]
 		},
-		"strings": {
+		"language_constants": {
+			"match": "(?<!\\w)(?:nullptr|false|NULL|true)(?!\\w)",
+			"name": "constant.language.$0.cpp"
+		},
+		"line": {
+			"name": "meta.preprocessor.line.cpp",
+			"begin": "((?:^)((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))(#)\\s*line\\b)",
+			"beginCaptures": {
+				"1": {
+					"name": "keyword.control.directive.line.cpp"
+				},
+				"2": {
+					"patterns": [
+						{
+							"include": "#inline_comment"
+						}
+					]
+				},
+				"3": {
+					"name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+				},
+				"4": {
+					"name": "comment.block.cpp"
+				},
+				"5": {
+					"patterns": [
+						{
+							"match": "\\*\\/",
+							"name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+						},
+						{
+							"match": "\\*",
+							"name": "comment.block.cpp"
+						}
+					]
+				},
+				"6": {
+					"name": "punctuation.definition.directive.cpp"
+				}
+			},
+			"end": "(?<!\\\\)(?=\\n)",
 			"patterns": [
 				{
-					"begin": "(u|u8|U|L)?\"",
+					"include": "#string_context_c"
+				},
+				{
+					"include": "#preprocessor_number_literal"
+				},
+				{
+					"include": "#line_continuation_character"
+				}
+			]
+		},
+		"line_comment": {
+			"name": "comment.line.double-slash.cpp",
+			"begin": "\\s*+(\\/\\/)",
+			"beginCaptures": {
+				"1": {
+					"name": "punctuation.definition.comment.cpp"
+				}
+			},
+			"end": "(?<=\\n)(?<!\\\\\\n)",
+			"patterns": [
+				{
+					"include": "#line_continuation_character"
+				}
+			]
+		},
+		"line_continuation_character": {
+			"match": "\\\\\\n",
+			"name": "constant.character.escape.line-continuation.cpp"
+		},
+		"macro": {
+			"name": "meta.preprocessor.macro.cpp",
+			"begin": "((?:^)((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))(#)\\s*define\\b)\\s*((?<!\\w)(?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*(?!\\w))",
+			"beginCaptures": {
+				"1": {
+					"name": "keyword.control.directive.define.cpp"
+				},
+				"2": {
+					"patterns": [
+						{
+							"include": "#inline_comment"
+						}
+					]
+				},
+				"3": {
+					"name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+				},
+				"4": {
+					"name": "comment.block.cpp"
+				},
+				"5": {
+					"patterns": [
+						{
+							"match": "\\*\\/",
+							"name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+						},
+						{
+							"match": "\\*",
+							"name": "comment.block.cpp"
+						}
+					]
+				},
+				"6": {
+					"name": "punctuation.definition.directive.cpp"
+				},
+				"7": {
+					"name": "entity.name.function.preprocessor.cpp"
+				}
+			},
+			"end": "(?<!\\\\)(?=\\n)",
+			"patterns": [
+				{
+					"begin": "\\G\\s*(\\()",
 					"beginCaptures": {
+						"1": {
+							"name": "punctuation.definition.parameters.begin.preprocessor.cpp"
+						}
+					},
+					"end": "(\\))",
+					"endCaptures": {
+						"1": {
+							"name": "punctuation.definition.parameters.end.preprocessor.cpp"
+						}
+					},
+					"patterns": [
+						{
+							"match": "(?<=[(,])\\s*((?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*)\\s*",
+							"captures": {
+								"1": {
+									"name": "variable.parameter.preprocessor.cpp"
+								}
+							}
+						},
+						{
+							"match": ",",
+							"name": "punctuation.separator.parameters.cpp"
+						},
+						{
+							"match": "\\.\\.\\.",
+							"name": "punctuation.vararg-ellipses.variable.parameter.preprocessor.cpp"
+						}
+					]
+				},
+				{
+					"include": "#macro_context"
+				},
+				{
+					"include": "#macro_argument"
+				}
+			]
+		},
+		"macro_argument": {
+			"match": "##?(?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*(?!\\w)",
+			"name": "variable.other.macro.argument.cpp"
+		},
+		"macro_context": {
+			"patterns": [
+				{
+					"include": "source.cpp.embedded.macro"
+				}
+			]
+		},
+		"macro_name": {
+			"match": "(?<!\\w)(?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*(?!\\w)",
+			"name": "entity.name.function.preprocessor.cpp"
+		},
+		"member_access": {
+			"match": "(?:((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))((?<!\\w)this(?!\\w))|((?:(?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*|(?<=\\]|\\)))\\s*))(?:((?:\\.\\*|\\.))|((?:->\\*|->)))((?:(?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*\\s*(?:(?:(?:\\.\\*|\\.))|(?:(?:->\\*|->)))\\s*)*)\\s*(\\b(?!uint_least64_t[^(?-mix:\\w)]|uint_least16_t[^(?-mix:\\w)]|uint_least32_t[^(?-mix:\\w)]|int_least16_t[^(?-mix:\\w)]|uint_fast64_t[^(?-mix:\\w)]|uint_fast32_t[^(?-mix:\\w)]|uint_fast16_t[^(?-mix:\\w)]|uint_least8_t[^(?-mix:\\w)]|int_least64_t[^(?-mix:\\w)]|int_least32_t[^(?-mix:\\w)]|int_fast32_t[^(?-mix:\\w)]|int_fast16_t[^(?-mix:\\w)]|int_least8_t[^(?-mix:\\w)]|uint_fast8_t[^(?-mix:\\w)]|int_fast64_t[^(?-mix:\\w)]|int_fast8_t[^(?-mix:\\w)]|suseconds_t[^(?-mix:\\w)]|useconds_t[^(?-mix:\\w)]|in_addr_t[^(?-mix:\\w)]|uintmax_t[^(?-mix:\\w)]|uintmax_t[^(?-mix:\\w)]|uintptr_t[^(?-mix:\\w)]|blksize_t[^(?-mix:\\w)]|in_port_t[^(?-mix:\\w)]|intmax_t[^(?-mix:\\w)]|unsigned[^(?-mix:\\w)]|blkcnt_t[^(?-mix:\\w)]|uint32_t[^(?-mix:\\w)]|u_quad_t[^(?-mix:\\w)]|uint16_t[^(?-mix:\\w)]|intmax_t[^(?-mix:\\w)]|uint64_t[^(?-mix:\\w)]|intptr_t[^(?-mix:\\w)]|swblk_t[^(?-mix:\\w)]|wchar_t[^(?-mix:\\w)]|u_short[^(?-mix:\\w)]|qaddr_t[^(?-mix:\\w)]|caddr_t[^(?-mix:\\w)]|daddr_t[^(?-mix:\\w)]|fixpt_t[^(?-mix:\\w)]|nlink_t[^(?-mix:\\w)]|segsz_t[^(?-mix:\\w)]|clock_t[^(?-mix:\\w)]|ssize_t[^(?-mix:\\w)]|int16_t[^(?-mix:\\w)]|int32_t[^(?-mix:\\w)]|int64_t[^(?-mix:\\w)]|uint8_t[^(?-mix:\\w)]|int8_t[^(?-mix:\\w)]|mode_t[^(?-mix:\\w)]|quad_t[^(?-mix:\\w)]|ushort[^(?-mix:\\w)]|u_long[^(?-mix:\\w)]|u_char[^(?-mix:\\w)]|double[^(?-mix:\\w)]|size_t[^(?-mix:\\w)]|signed[^(?-mix:\\w)]|time_t[^(?-mix:\\w)]|key_t[^(?-mix:\\w)]|ino_t[^(?-mix:\\w)]|gid_t[^(?-mix:\\w)]|dev_t[^(?-mix:\\w)]|div_t[^(?-mix:\\w)]|float[^(?-mix:\\w)]|u_int[^(?-mix:\\w)]|uid_t[^(?-mix:\\w)]|short[^(?-mix:\\w)]|off_t[^(?-mix:\\w)]|pid_t[^(?-mix:\\w)]|id_t[^(?-mix:\\w)]|bool[^(?-mix:\\w)]|char[^(?-mix:\\w)]|id_t[^(?-mix:\\w)]|uint[^(?-mix:\\w)]|void[^(?-mix:\\w)]|long[^(?-mix:\\w)]|auto[^(?-mix:\\w)]|int[^(?-mix:\\w)])(?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*\\b(?!\\())",
+			"captures": {
+				"1": {
+					"patterns": [
+						{
+							"include": "#inline_comment"
+						}
+					]
+				},
+				"2": {
+					"name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+				},
+				"3": {
+					"name": "comment.block.cpp"
+				},
+				"4": {
+					"patterns": [
+						{
+							"match": "\\*\\/",
+							"name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+						},
+						{
+							"match": "\\*",
+							"name": "comment.block.cpp"
+						}
+					]
+				},
+				"5": {
+					"name": "variable.language.this.cpp"
+				},
+				"6": {
+					"name": "variable.other.object.access.cpp"
+				},
+				"7": {
+					"name": "punctuation.separator.dot-access.cpp"
+				},
+				"8": {
+					"name": "punctuation.separator.pointer-access.cpp"
+				},
+				"9": {
+					"patterns": [
+						{
+							"match": "(?<=(?:\\.\\*|\\.|->|->\\*))\\s*(?:((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))((?<!\\w)this(?!\\w))|((?:(?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*|(?<=\\]|\\)))\\s*))(?:((?:\\.\\*|\\.))|((?:->\\*|->)))",
+							"captures": {
+								"1": {
+									"patterns": [
+										{
+											"include": "#inline_comment"
+										}
+									]
+								},
+								"2": {
+									"name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+								},
+								"3": {
+									"name": "comment.block.cpp"
+								},
+								"4": {
+									"patterns": [
+										{
+											"match": "\\*\\/",
+											"name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+										},
+										{
+											"match": "\\*",
+											"name": "comment.block.cpp"
+										}
+									]
+								},
+								"5": {
+									"name": "variable.language.this.cpp"
+								},
+								"6": {
+									"name": "variable.other.object.property.cpp"
+								},
+								"7": {
+									"name": "punctuation.separator.dot-access.cpp"
+								},
+								"8": {
+									"name": "punctuation.separator.pointer-access.cpp"
+								}
+							}
+						},
+						{
+							"match": "(?:((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))((?<!\\w)this(?!\\w))|((?:(?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*|(?<=\\]|\\)))\\s*))(?:((?:\\.\\*|\\.))|((?:->\\*|->)))",
+							"captures": {
+								"1": {
+									"patterns": [
+										{
+											"include": "#inline_comment"
+										}
+									]
+								},
+								"2": {
+									"name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+								},
+								"3": {
+									"name": "comment.block.cpp"
+								},
+								"4": {
+									"patterns": [
+										{
+											"match": "\\*\\/",
+											"name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+										},
+										{
+											"match": "\\*",
+											"name": "comment.block.cpp"
+										}
+									]
+								},
+								"5": {
+									"name": "variable.language.this.cpp"
+								},
+								"6": {
+									"name": "variable.other.object.access.cpp"
+								},
+								"7": {
+									"name": "punctuation.separator.dot-access.cpp"
+								},
+								"8": {
+									"name": "punctuation.separator.pointer-access.cpp"
+								}
+							}
+						},
+						{
+							"include": "#member_access"
+						},
+						{
+							"include": "#method_access"
+						}
+					]
+				},
+				"10": {
+					"name": "variable.other.property.cpp"
+				}
+			}
+		},
+		"memory_operators": {
+			"match": "((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))((?:(?:(delete)\\s*(\\[\\])|(delete))|(new))(?!\\w))",
+			"captures": {
+				"1": {
+					"patterns": [
+						{
+							"include": "#inline_comment"
+						}
+					]
+				},
+				"2": {
+					"name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+				},
+				"3": {
+					"name": "comment.block.cpp"
+				},
+				"4": {
+					"patterns": [
+						{
+							"match": "\\*\\/",
+							"name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+						},
+						{
+							"match": "\\*",
+							"name": "comment.block.cpp"
+						}
+					]
+				},
+				"5": {
+					"name": "keyword.operator.wordlike.cpp"
+				},
+				"6": {
+					"name": "keyword.operator.delete.array.cpp"
+				},
+				"7": {
+					"name": "keyword.operator.delete.array.bracket.cpp"
+				},
+				"8": {
+					"name": "keyword.operator.delete.cpp"
+				},
+				"9": {
+					"name": "keyword.operator.new.cpp"
+				}
+			}
+		},
+		"method_access": {
+			"begin": "(?:((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))((?<!\\w)this(?!\\w))|((?:(?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*|(?<=\\]|\\)))\\s*))(?:((?:\\.\\*|\\.))|((?:->\\*|->)))((?:(?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*\\s*(?:(?:(?:\\.\\*|\\.))|(?:(?:->\\*|->)))\\s*)*)\\s*(~?(?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*)\\s*(\\()",
+			"beginCaptures": {
+				"1": {
+					"patterns": [
+						{
+							"include": "#inline_comment"
+						}
+					]
+				},
+				"2": {
+					"name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+				},
+				"3": {
+					"name": "comment.block.cpp"
+				},
+				"4": {
+					"patterns": [
+						{
+							"match": "\\*\\/",
+							"name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+						},
+						{
+							"match": "\\*",
+							"name": "comment.block.cpp"
+						}
+					]
+				},
+				"5": {
+					"name": "variable.language.this.cpp"
+				},
+				"6": {
+					"name": "variable.other.object.access.cpp"
+				},
+				"7": {
+					"name": "punctuation.separator.dot-access.cpp"
+				},
+				"8": {
+					"name": "punctuation.separator.pointer-access.cpp"
+				},
+				"9": {
+					"patterns": [
+						{
+							"match": "(?<=(?:\\.\\*|\\.|->|->\\*))\\s*(?:((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))((?<!\\w)this(?!\\w))|((?:(?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*|(?<=\\]|\\)))\\s*))(?:((?:\\.\\*|\\.))|((?:->\\*|->)))",
+							"captures": {
+								"1": {
+									"patterns": [
+										{
+											"include": "#inline_comment"
+										}
+									]
+								},
+								"2": {
+									"name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+								},
+								"3": {
+									"name": "comment.block.cpp"
+								},
+								"4": {
+									"patterns": [
+										{
+											"match": "\\*\\/",
+											"name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+										},
+										{
+											"match": "\\*",
+											"name": "comment.block.cpp"
+										}
+									]
+								},
+								"5": {
+									"name": "variable.language.this.cpp"
+								},
+								"6": {
+									"name": "variable.other.object.property.cpp"
+								},
+								"7": {
+									"name": "punctuation.separator.dot-access.cpp"
+								},
+								"8": {
+									"name": "punctuation.separator.pointer-access.cpp"
+								}
+							}
+						},
+						{
+							"match": "(?:((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))((?<!\\w)this(?!\\w))|((?:(?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*|(?<=\\]|\\)))\\s*))(?:((?:\\.\\*|\\.))|((?:->\\*|->)))",
+							"captures": {
+								"1": {
+									"patterns": [
+										{
+											"include": "#inline_comment"
+										}
+									]
+								},
+								"2": {
+									"name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+								},
+								"3": {
+									"name": "comment.block.cpp"
+								},
+								"4": {
+									"patterns": [
+										{
+											"match": "\\*\\/",
+											"name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+										},
+										{
+											"match": "\\*",
+											"name": "comment.block.cpp"
+										}
+									]
+								},
+								"5": {
+									"name": "variable.language.this.cpp"
+								},
+								"6": {
+									"name": "variable.other.object.access.cpp"
+								},
+								"7": {
+									"name": "punctuation.separator.dot-access.cpp"
+								},
+								"8": {
+									"name": "punctuation.separator.pointer-access.cpp"
+								}
+							}
+						},
+						{
+							"include": "#member_access"
+						},
+						{
+							"include": "#method_access"
+						}
+					]
+				},
+				"10": {
+					"name": "entity.name.function.member.cpp"
+				},
+				"11": {
+					"name": "punctuation.section.arguments.begin.bracket.round.function.member.cpp"
+				}
+			},
+			"end": "(\\))",
+			"endCaptures": {
+				"1": {
+					"name": "punctuation.section.arguments.end.bracket.round.function.member.cpp"
+				}
+			},
+			"patterns": [
+				{
+					"include": "#evaluation_context"
+				}
+			]
+		},
+		"misc_storage_modifiers": {
+			"match": "\\b(?:export|mutable|typename|thread_local|register|restrict|static|volatile|inline)\\b",
+			"name": "storage.modifier.$0.cpp"
+		},
+		"module_import": {
+			"match": "(?:^)((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))((import))\\s*(?:(?:(?:((<)[^>]*(>?)((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))(?:(?:\\n|$)|(?=\\/\\/)))|((\\\")[^\\\"]*(\\\"?)((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))(?:(?:\\n|$)|(?=\\/\\/))))|(((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))(?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*(?:\\.(?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*)*((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))(?:(?:\\n|$)|(?=(?:\\/\\/|;)))))|((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))(?:(?:\\n|$)|(?=(?:\\/\\/|;))))\\s*(;?)",
+			"captures": {
+				"1": {
+					"patterns": [
+						{
+							"include": "#inline_comment"
+						}
+					]
+				},
+				"2": {
+					"name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+				},
+				"3": {
+					"name": "comment.block.cpp"
+				},
+				"4": {
+					"patterns": [
+						{
+							"match": "\\*\\/",
+							"name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+						},
+						{
+							"match": "\\*",
+							"name": "comment.block.cpp"
+						}
+					]
+				},
+				"5": {
+					"name": "keyword.control.directive.import.cpp"
+				},
+				"7": {
+					"name": "string.quoted.other.lt-gt.include.cpp"
+				},
+				"8": {
+					"name": "punctuation.definition.string.begin.cpp"
+				},
+				"9": {
+					"name": "punctuation.definition.string.end.cpp"
+				},
+				"10": {
+					"patterns": [
+						{
+							"include": "#inline_comment"
+						}
+					]
+				},
+				"11": {
+					"name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+				},
+				"12": {
+					"name": "comment.block.cpp"
+				},
+				"13": {
+					"patterns": [
+						{
+							"match": "\\*\\/",
+							"name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+						},
+						{
+							"match": "\\*",
+							"name": "comment.block.cpp"
+						}
+					]
+				},
+				"14": {
+					"name": "string.quoted.double.include.cpp"
+				},
+				"15": {
+					"name": "punctuation.definition.string.begin.cpp"
+				},
+				"16": {
+					"name": "punctuation.definition.string.end.cpp"
+				},
+				"17": {
+					"patterns": [
+						{
+							"include": "#inline_comment"
+						}
+					]
+				},
+				"18": {
+					"name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+				},
+				"19": {
+					"name": "comment.block.cpp"
+				},
+				"20": {
+					"patterns": [
+						{
+							"match": "\\*\\/",
+							"name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+						},
+						{
+							"match": "\\*",
+							"name": "comment.block.cpp"
+						}
+					]
+				},
+				"21": {
+					"name": "entity.name.other.preprocessor.macro.include.cpp"
+				},
+				"22": {
+					"patterns": [
+						{
+							"include": "#inline_comment"
+						}
+					]
+				},
+				"23": {
+					"name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+				},
+				"24": {
+					"name": "comment.block.cpp"
+				},
+				"25": {
+					"patterns": [
+						{
+							"match": "\\*\\/",
+							"name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+						},
+						{
+							"match": "\\*",
+							"name": "comment.block.cpp"
+						}
+					]
+				},
+				"26": {
+					"patterns": [
+						{
+							"include": "#inline_comment"
+						}
+					]
+				},
+				"27": {
+					"name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+				},
+				"28": {
+					"name": "comment.block.cpp"
+				},
+				"29": {
+					"patterns": [
+						{
+							"match": "\\*\\/",
+							"name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+						},
+						{
+							"match": "\\*",
+							"name": "comment.block.cpp"
+						}
+					]
+				},
+				"30": {
+					"patterns": [
+						{
+							"include": "#inline_comment"
+						}
+					]
+				},
+				"31": {
+					"name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+				},
+				"32": {
+					"name": "comment.block.cpp"
+				},
+				"33": {
+					"patterns": [
+						{
+							"match": "\\*\\/",
+							"name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+						},
+						{
+							"match": "\\*",
+							"name": "comment.block.cpp"
+						}
+					]
+				},
+				"34": {
+					"name": "punctuation.terminator.statement.cpp"
+				}
+			},
+			"name": "meta.preprocessor.import.cpp"
+		},
+		"ms_attributes": {
+			"name": "support.other.attribute.cpp",
+			"begin": "(__declspec\\()",
+			"beginCaptures": {
+				"1": {
+					"name": "punctuation.section.attribute.begin.cpp"
+				}
+			},
+			"end": "(\\))",
+			"endCaptures": {
+				"1": {
+					"name": "punctuation.section.attribute.end.cpp"
+				}
+			},
+			"patterns": [
+				{
+					"include": "#attributes_context"
+				},
+				{
+					"begin": "\\(",
+					"end": "\\)",
+					"patterns": [
+						{
+							"include": "#attributes_context"
+						},
+						{
+							"include": "#string_context"
+						}
+					]
+				},
+				{
+					"match": "(using)\\s+((?<!\\w)(?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*(?!\\w))",
+					"captures": {
+						"1": {
+							"name": "keyword.other.using.directive.cpp"
+						},
+						"2": {
+							"name": "entity.name.namespace.cpp"
+						}
+					}
+				},
+				{
+					"match": ",",
+					"name": "punctuation.separator.attribute.cpp"
+				},
+				{
+					"match": ":",
+					"name": "punctuation.accessor.attribute.cpp"
+				},
+				{
+					"match": "(?<!\\w)(?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*(?!\\w)(?=::)",
+					"name": "entity.name.namespace.cpp"
+				},
+				{
+					"match": "(?<!\\w)(?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*(?!\\w)",
+					"name": "entity.other.attribute.$0.cpp"
+				},
+				{
+					"include": "#number_literal"
+				}
+			]
+		},
+		"namespace_alias": {
+			"match": "(?<!\\w)(namespace)\\s+((?<!\\w)(?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*(?!\\w))\\s*(\\=)\\s*(((::)?(?:((?-mix:(?!\\b(?:__has_cpp_attribute|reinterpret_cast|atomic_noexcept|atomic_cancel|atomic_commit|__has_include|dynamic_cast|thread_local|synchronized|static_cast|const_cast|consteval|constexpr|protected|namespace|co_return|constexpr|constexpr|continue|explicit|volatile|noexcept|co_yield|noexcept|noexcept|requires|typename|decltype|operator|co_await|template|volatile|register|restrict|reflexpr|alignof|private|default|mutable|include|concept|__asm__|defined|_Pragma|alignas|typedef|warning|virtual|mutable|struct|sizeof|delete|not_eq|bitand|and_eq|xor_eq|typeid|switch|return|static|extern|inline|friend|public|ifndef|define|pragma|export|import|module|catch|throw|const|or_eq|while|compl|bitor|const|union|ifdef|class|undef|error|break|using|endif|goto|line|enum|this|case|else|elif|else|asm|try|for|new|and|xor|not|do|or|if|if)\\b)(?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*))\\s*+(((?<!<)<(?!<)(?>(?:(?>[^<>]*)\\g<9>?)+)>)\\s*)?::)*\\s*+)\\s*((?<!\\w)(?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*(?!\\w))\\s*(?:(;)|\\n))",
+			"captures": {
+				"1": {
+					"name": "keyword.other.namespace.alias.cpp storage.type.namespace.alias.cpp"
+				},
+				"2": {
+					"name": "entity.name.namespace.alias.cpp"
+				},
+				"3": {
+					"name": "keyword.operator.assignment.cpp"
+				},
+				"4": {
+					"name": "meta.declaration.namespace.alias.value.cpp"
+				},
+				"5": {
+					"patterns": [
+						{
+							"include": "#scope_resolution_namespace_alias_inner_generated"
+						}
+					]
+				},
+				"6": {
+					"name": "punctuation.separator.namespace.access.cpp punctuation.separator.scope-resolution.namespace.alias.cpp"
+				},
+				"8": {
+					"name": "meta.template.call.cpp",
+					"patterns": [
+						{
+							"include": "#template_call_range"
+						}
+					]
+				},
+				"10": {
+					"name": "entity.name.namespace.cpp"
+				},
+				"11": {
+					"name": "punctuation.terminator.statement.cpp"
+				}
+			},
+			"name": "meta.declaration.namespace.alias.cpp"
+		},
+		"namespace_block": {
+			"name": "meta.block.namespace.cpp",
+			"begin": "(((?<!\\w)namespace(?!\\w)))",
+			"beginCaptures": {
+				"1": {
+					"name": "meta.head.namespace.cpp"
+				},
+				"2": {
+					"name": "keyword.other.namespace.definition.cpp storage.type.namespace.definition.cpp"
+				}
+			},
+			"end": "(?:(?<=\\}|%>|\\?\\?>)|(?=[;>\\[\\]=]))",
+			"patterns": [
+				{
+					"name": "meta.head.namespace.cpp",
+					"begin": "\\G ?",
+					"end": "((?:\\{|<%|\\?\\?<|(?=;)))",
+					"endCaptures": {
+						"1": {
+							"name": "punctuation.section.block.begin.bracket.curly.namespace.cpp"
+						}
+					},
+					"patterns": [
+						{
+							"include": "#ever_present_context"
+						},
+						{
+							"include": "#attributes_context"
+						},
+						{
+							"match": "((::)?(?:((?-mix:(?!\\b(?:__has_cpp_attribute|reinterpret_cast|atomic_noexcept|atomic_cancel|atomic_commit|__has_include|dynamic_cast|thread_local|synchronized|static_cast|const_cast|consteval|constexpr|protected|namespace|co_return|constexpr|constexpr|continue|explicit|volatile|noexcept|co_yield|noexcept|noexcept|requires|typename|decltype|operator|co_await|template|volatile|register|restrict|reflexpr|alignof|private|default|mutable|include|concept|__asm__|defined|_Pragma|alignas|typedef|warning|virtual|mutable|struct|sizeof|delete|not_eq|bitand|and_eq|xor_eq|typeid|switch|return|static|extern|inline|friend|public|ifndef|define|pragma|export|import|module|catch|throw|const|or_eq|while|compl|bitor|const|union|ifdef|class|undef|error|break|using|endif|goto|line|enum|this|case|else|elif|else|asm|try|for|new|and|xor|not|do|or|if|if)\\b)(?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*))\\s*+(((?<!<)<(?!<)(?>(?:(?>[^<>]*)\\g<5>?)+)>)\\s*)?::)*\\s*+)\\s*((?<!\\w)(?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*(?!\\w))\\s*(?:(::)\\s*(inline))?",
+							"captures": {
+								"1": {
+									"patterns": [
+										{
+											"include": "#scope_resolution_namespace_block_inner_generated"
+										}
+									]
+								},
+								"2": {
+									"name": "punctuation.separator.namespace.access.cpp punctuation.separator.scope-resolution.namespace.block.cpp"
+								},
+								"4": {
+									"name": "meta.template.call.cpp",
+									"patterns": [
+										{
+											"include": "#template_call_range"
+										}
+									]
+								},
+								"6": {
+									"name": "entity.name.namespace.cpp"
+								},
+								"7": {
+									"name": "punctuation.separator.scope-resolution.namespace.block.cpp"
+								},
+								"8": {
+									"name": "storage.modifier.inline.cpp"
+								}
+							}
+						}
+					]
+				},
+				{
+					"name": "meta.body.namespace.cpp",
+					"begin": "(?<=\\{|<%|\\?\\?<)",
+					"end": "(\\}|%>|\\?\\?>)",
+					"endCaptures": {
+						"1": {
+							"name": "punctuation.section.block.end.bracket.curly.namespace.cpp"
+						}
+					},
+					"patterns": [
+						{
+							"include": "$self"
+						}
+					]
+				},
+				{
+					"name": "meta.tail.namespace.cpp",
+					"begin": "(?<=\\}|%>|\\?\\?>)[\\s\\n]*",
+					"end": "[\\s\\n]*(?=;)",
+					"patterns": [
+						{
+							"include": "$self"
+						}
+					]
+				}
+			]
+		},
+		"noexcept_operator": {
+			"contentName": "meta.arguments.operator.noexcept.cpp",
+			"begin": "((?<!\\w)noexcept(?!\\w))((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))(\\()",
+			"beginCaptures": {
+				"1": {
+					"name": "keyword.operator.functionlike.cpp keyword.operator.noexcept.cpp"
+				},
+				"2": {
+					"patterns": [
+						{
+							"include": "#inline_comment"
+						}
+					]
+				},
+				"3": {
+					"name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+				},
+				"4": {
+					"name": "comment.block.cpp"
+				},
+				"5": {
+					"patterns": [
+						{
+							"match": "\\*\\/",
+							"name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+						},
+						{
+							"match": "\\*",
+							"name": "comment.block.cpp"
+						}
+					]
+				},
+				"6": {
+					"name": "punctuation.section.arguments.begin.bracket.round.operator.noexcept.cpp"
+				}
+			},
+			"end": "(\\))",
+			"endCaptures": {
+				"1": {
+					"name": "punctuation.section.arguments.end.bracket.round.operator.noexcept.cpp"
+				}
+			},
+			"patterns": [
+				{
+					"include": "#evaluation_context"
+				}
+			]
+		},
+		"non_primitive_types": {
+			"match": "((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))((?<!\\w)(?:uint_least32_t|uint_least64_t|uint_least16_t|int_least16_t|int_least64_t|int_least32_t|uint_fast32_t|uint_fast16_t|uint_fast64_t|uint_least8_t|int_fast64_t|int_fast16_t|uint_fast8_t|int_fast32_t|int_least8_t|int_fast8_t|suseconds_t|useconds_t|uintmax_t|uintptr_t|in_addr_t|uintmax_t|blksize_t|in_port_t|blkcnt_t|intptr_t|intmax_t|uint64_t|u_quad_t|uint16_t|uint32_t|intmax_t|segsz_t|fixpt_t|caddr_t|daddr_t|u_short|int16_t|int32_t|int64_t|uint8_t|nlink_t|qaddr_t|swblk_t|clock_t|ssize_t|time_t|u_long|ushort|quad_t|mode_t|size_t|u_char|int8_t|u_int|uid_t|off_t|pid_t|gid_t|dev_t|div_t|key_t|ino_t|id_t|id_t|uint)(?!\\w))",
+			"captures": {
+				"1": {
+					"patterns": [
+						{
+							"include": "#inline_comment"
+						}
+					]
+				},
+				"2": {
+					"name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+				},
+				"3": {
+					"name": "comment.block.cpp"
+				},
+				"4": {
+					"patterns": [
+						{
+							"match": "\\*\\/",
+							"name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+						},
+						{
+							"match": "\\*",
+							"name": "comment.block.cpp"
+						}
+					]
+				},
+				"5": {
+					"name": "storage.type.cpp storage.type.built-in.cpp"
+				}
+			}
+		},
+		"number_literal": {
+			"match": "(?<!\\w)\\.?\\d(?:(?:[0-9a-zA-Z_\\.]|')|(?<=[eEpP])[+-])*",
+			"captures": {
+				"0": {
+					"patterns": [
+						{
+							"begin": "(?=.)",
+							"end": "$",
+							"patterns": [
+								{
+									"match": "(\\G0[xX])([0-9a-fA-F](?:[0-9a-fA-F]|((?<=[0-9a-fA-F])'(?=[0-9a-fA-F])))*)?((?:(?<=[0-9a-fA-F])\\.|\\.(?=[0-9a-fA-F])))([0-9a-fA-F](?:[0-9a-fA-F]|((?<=[0-9a-fA-F])'(?=[0-9a-fA-F])))*)?((?<!')([pP])(\\+?)(\\-?)((?:[0-9](?:[0-9]|(?:(?<=[0-9a-fA-F])'(?=[0-9a-fA-F])))*)))?([lLfF](?!\\w))?((?:\\w(?<![0-9a-fA-FpP])\\w*)?$)",
+									"captures": {
+										"1": {
+											"name": "keyword.other.unit.hexadecimal.cpp"
+										},
+										"2": {
+											"name": "constant.numeric.hexadecimal.cpp",
+											"patterns": [
+												{
+													"match": "(?<=[0-9a-fA-F])'(?=[0-9a-fA-F])",
+													"name": "punctuation.separator.constant.numeric.cpp"
+												}
+											]
+										},
+										"3": {
+											"name": "punctuation.separator.constant.numeric.cpp"
+										},
+										"4": {
+											"name": "constant.numeric.hexadecimal.cpp"
+										},
+										"5": {
+											"name": "constant.numeric.hexadecimal.cpp",
+											"patterns": [
+												{
+													"match": "(?<=[0-9a-fA-F])'(?=[0-9a-fA-F])",
+													"name": "punctuation.separator.constant.numeric.cpp"
+												}
+											]
+										},
+										"6": {
+											"name": "punctuation.separator.constant.numeric.cpp"
+										},
+										"8": {
+											"name": "keyword.other.unit.exponent.hexadecimal.cpp"
+										},
+										"9": {
+											"name": "keyword.operator.plus.exponent.hexadecimal.cpp"
+										},
+										"10": {
+											"name": "keyword.operator.minus.exponent.hexadecimal.cpp"
+										},
+										"11": {
+											"name": "constant.numeric.exponent.hexadecimal.cpp",
+											"patterns": [
+												{
+													"match": "(?<=[0-9a-fA-F])'(?=[0-9a-fA-F])",
+													"name": "punctuation.separator.constant.numeric.cpp"
+												}
+											]
+										},
+										"12": {
+											"name": "keyword.other.unit.suffix.floating-point.cpp"
+										},
+										"13": {
+											"name": "keyword.other.unit.user-defined.cpp"
+										}
+									}
+								},
+								{
+									"match": "(\\G(?=[0-9.])(?!0[xXbB]))([0-9](?:[0-9]|((?<=[0-9a-fA-F])'(?=[0-9a-fA-F])))*)?((?:(?<=[0-9])\\.|\\.(?=[0-9])))([0-9](?:[0-9]|((?<=[0-9a-fA-F])'(?=[0-9a-fA-F])))*)?((?<!')([eE])(\\+?)(\\-?)((?:[0-9](?:[0-9]|(?:(?<=[0-9a-fA-F])'(?=[0-9a-fA-F])))*)))?([lLfF](?!\\w))?((?:\\w(?<![0-9eE])\\w*)?$)",
+									"captures": {
+										"2": {
+											"name": "constant.numeric.decimal.cpp",
+											"patterns": [
+												{
+													"match": "(?<=[0-9a-fA-F])'(?=[0-9a-fA-F])",
+													"name": "punctuation.separator.constant.numeric.cpp"
+												}
+											]
+										},
+										"3": {
+											"name": "punctuation.separator.constant.numeric.cpp"
+										},
+										"4": {
+											"name": "constant.numeric.decimal.point.cpp"
+										},
+										"5": {
+											"name": "constant.numeric.decimal.cpp",
+											"patterns": [
+												{
+													"match": "(?<=[0-9a-fA-F])'(?=[0-9a-fA-F])",
+													"name": "punctuation.separator.constant.numeric.cpp"
+												}
+											]
+										},
+										"6": {
+											"name": "punctuation.separator.constant.numeric.cpp"
+										},
+										"8": {
+											"name": "keyword.other.unit.exponent.decimal.cpp"
+										},
+										"9": {
+											"name": "keyword.operator.plus.exponent.decimal.cpp"
+										},
+										"10": {
+											"name": "keyword.operator.minus.exponent.decimal.cpp"
+										},
+										"11": {
+											"name": "constant.numeric.exponent.decimal.cpp",
+											"patterns": [
+												{
+													"match": "(?<=[0-9a-fA-F])'(?=[0-9a-fA-F])",
+													"name": "punctuation.separator.constant.numeric.cpp"
+												}
+											]
+										},
+										"12": {
+											"name": "keyword.other.unit.suffix.floating-point.cpp"
+										},
+										"13": {
+											"name": "keyword.other.unit.user-defined.cpp"
+										}
+									}
+								},
+								{
+									"match": "(\\G0[bB])([01](?:[01]|((?<=[0-9a-fA-F])'(?=[0-9a-fA-F])))*)((?:(?:(?:(?:(?:[uU]|[uU]ll?)|[uU]LL?)|ll?[uU]?)|LL?[uU]?)|[fF])(?!\\w))?((?:\\w(?<![0-9])\\w*)?$)",
+									"captures": {
+										"1": {
+											"name": "keyword.other.unit.binary.cpp"
+										},
+										"2": {
+											"name": "constant.numeric.binary.cpp",
+											"patterns": [
+												{
+													"match": "(?<=[0-9a-fA-F])'(?=[0-9a-fA-F])",
+													"name": "punctuation.separator.constant.numeric.cpp"
+												}
+											]
+										},
+										"3": {
+											"name": "punctuation.separator.constant.numeric.cpp"
+										},
+										"4": {
+											"name": "keyword.other.unit.suffix.integer.cpp"
+										},
+										"5": {
+											"name": "keyword.other.unit.user-defined.cpp"
+										}
+									}
+								},
+								{
+									"match": "(\\G0)((?:[0-7]|((?<=[0-9a-fA-F])'(?=[0-9a-fA-F])))+)((?:(?:(?:(?:(?:[uU]|[uU]ll?)|[uU]LL?)|ll?[uU]?)|LL?[uU]?)|[fF])(?!\\w))?((?:\\w(?<![0-9])\\w*)?$)",
+									"captures": {
+										"1": {
+											"name": "keyword.other.unit.octal.cpp"
+										},
+										"2": {
+											"name": "constant.numeric.octal.cpp",
+											"patterns": [
+												{
+													"match": "(?<=[0-9a-fA-F])'(?=[0-9a-fA-F])",
+													"name": "punctuation.separator.constant.numeric.cpp"
+												}
+											]
+										},
+										"3": {
+											"name": "punctuation.separator.constant.numeric.cpp"
+										},
+										"4": {
+											"name": "keyword.other.unit.suffix.integer.cpp"
+										},
+										"5": {
+											"name": "keyword.other.unit.user-defined.cpp"
+										}
+									}
+								},
+								{
+									"match": "(\\G0[xX])([0-9a-fA-F](?:[0-9a-fA-F]|((?<=[0-9a-fA-F])'(?=[0-9a-fA-F])))*)((?<!')([pP])(\\+?)(\\-?)((?:[0-9](?:[0-9]|(?:(?<=[0-9a-fA-F])'(?=[0-9a-fA-F])))*)))?((?:(?:(?:(?:(?:[uU]|[uU]ll?)|[uU]LL?)|ll?[uU]?)|LL?[uU]?)|[fF])(?!\\w))?((?:\\w(?<![0-9a-fA-FpP])\\w*)?$)",
+									"captures": {
+										"1": {
+											"name": "keyword.other.unit.hexadecimal.cpp"
+										},
+										"2": {
+											"name": "constant.numeric.hexadecimal.cpp",
+											"patterns": [
+												{
+													"match": "(?<=[0-9a-fA-F])'(?=[0-9a-fA-F])",
+													"name": "punctuation.separator.constant.numeric.cpp"
+												}
+											]
+										},
+										"3": {
+											"name": "punctuation.separator.constant.numeric.cpp"
+										},
+										"5": {
+											"name": "keyword.other.unit.exponent.hexadecimal.cpp"
+										},
+										"6": {
+											"name": "keyword.operator.plus.exponent.hexadecimal.cpp"
+										},
+										"7": {
+											"name": "keyword.operator.minus.exponent.hexadecimal.cpp"
+										},
+										"8": {
+											"name": "constant.numeric.exponent.hexadecimal.cpp",
+											"patterns": [
+												{
+													"match": "(?<=[0-9a-fA-F])'(?=[0-9a-fA-F])",
+													"name": "punctuation.separator.constant.numeric.cpp"
+												}
+											]
+										},
+										"9": {
+											"name": "keyword.other.unit.suffix.integer.cpp"
+										},
+										"10": {
+											"name": "keyword.other.unit.user-defined.cpp"
+										}
+									}
+								},
+								{
+									"match": "(\\G(?=[0-9.])(?!0[xXbB]))([0-9](?:[0-9]|((?<=[0-9a-fA-F])'(?=[0-9a-fA-F])))*)((?<!')([eE])(\\+?)(\\-?)((?:[0-9](?:[0-9]|(?:(?<=[0-9a-fA-F])'(?=[0-9a-fA-F])))*)))?((?:(?:(?:(?:(?:[uU]|[uU]ll?)|[uU]LL?)|ll?[uU]?)|LL?[uU]?)|[fF])(?!\\w))?((?:\\w(?<![0-9eE])\\w*)?$)",
+									"captures": {
+										"2": {
+											"name": "constant.numeric.decimal.cpp",
+											"patterns": [
+												{
+													"match": "(?<=[0-9a-fA-F])'(?=[0-9a-fA-F])",
+													"name": "punctuation.separator.constant.numeric.cpp"
+												}
+											]
+										},
+										"3": {
+											"name": "punctuation.separator.constant.numeric.cpp"
+										},
+										"5": {
+											"name": "keyword.other.unit.exponent.decimal.cpp"
+										},
+										"6": {
+											"name": "keyword.operator.plus.exponent.decimal.cpp"
+										},
+										"7": {
+											"name": "keyword.operator.minus.exponent.decimal.cpp"
+										},
+										"8": {
+											"name": "constant.numeric.exponent.decimal.cpp",
+											"patterns": [
+												{
+													"match": "(?<=[0-9a-fA-F])'(?=[0-9a-fA-F])",
+													"name": "punctuation.separator.constant.numeric.cpp"
+												}
+											]
+										},
+										"9": {
+											"name": "keyword.other.unit.suffix.integer.cpp"
+										},
+										"10": {
+											"name": "keyword.other.unit.user-defined.cpp"
+										}
+									}
+								},
+								{
+									"match": "(?:(?:[0-9a-zA-Z_\\.]|')|(?<=[eEpP])[+-])+",
+									"name": "invalid.illegal.constant.numeric.cpp"
+								}
+							]
+						}
+					]
+				}
+			}
+		},
+		"operator_overload": {
+			"name": "meta.function.definition.special.operator-overload.cpp",
+			"begin": "((?:(\\s*+((?:(?:(?:\\[\\[.*?\\]\\]|__attribute(?:__)?\\(\\(.*?\\)\\))|__declspec\\(.*?\\))|alignas\\(.*?\\))(?!\\)))?((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))(?:(?:(?:unsigned|signed|short|long)|(?:struct|class|union|enum))((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z)))))*(((::)?(?:((?-mix:(?!\\b(?:__has_cpp_attribute|reinterpret_cast|atomic_noexcept|atomic_cancel|atomic_commit|__has_include|dynamic_cast|thread_local|synchronized|static_cast|const_cast|consteval|constexpr|protected|namespace|co_return|constexpr|constexpr|continue|explicit|volatile|noexcept|co_yield|noexcept|noexcept|requires|typename|decltype|operator|co_await|template|volatile|register|restrict|reflexpr|alignof|private|default|mutable|include|concept|__asm__|defined|_Pragma|alignas|typedef|warning|virtual|mutable|struct|sizeof|delete|not_eq|bitand|and_eq|xor_eq|typeid|switch|return|static|extern|inline|friend|public|ifndef|define|pragma|export|import|module|catch|throw|const|or_eq|while|compl|bitor|const|union|ifdef|class|undef|error|break|using|endif|goto|line|enum|this|case|else|elif|else|asm|try|for|new|and|xor|not|do|or|if|if)\\b)(?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*))\\s*+(((?<!<)<(?!<)(?>(?:(?>[^<>]*)\\g<67>?)+)>)\\s*)?::)*\\s*+)((?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*)\\s*+(((?<!<)<(?!<)(?>(?:(?>[^<>]*)\\g<67>?)+)>)\\s*)?(::))?((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))(?!(?:transaction_safe_dynamic|__has_cpp_attribute|transaction_safe|reinterpret_cast|atomic_noexcept|atomic_commit|atomic_cancel|__has_include|dynamic_cast|thread_local|synchronized|static_cast|const_cast|constexpr|consteval|protected|constexpr|co_return|namespace|constexpr|noexcept|typename|decltype|template|operator|noexcept|co_yield|co_await|continue|volatile|register|restrict|explicit|override|volatile|reflexpr|noexcept|requires|default|typedef|nullptr|alignof|mutable|concept|virtual|defined|__asm__|include|_Pragma|mutable|warning|private|alignas|module|switch|not_eq|bitand|and_eq|ifndef|return|sizeof|xor_eq|export|static|delete|public|define|extern|inline|import|pragma|friend|typeid|const|compl|bitor|throw|or_eq|while|catch|break|false|final|const|endif|ifdef|undef|error|using|audit|axiom|line|else|elif|true|NULL|case|goto|else|this|new|asm|not|and|xor|try|for|if|do|or|if)\\b)((?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*)\\b(((?<!<)<(?!<)(?>(?:(?>[^<>]*)\\g<67>?)+)>)\\s*)?(?![\\w<:.]))(((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))?(?:(?:\\&|\\*)((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z)))))*(?:\\&|\\*))?((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z)))))?((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))((?:__cdecl|__clrcall|__stdcall|__fastcall|__thiscall|__vectorcall)?)((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))((?:((?-mix:(?!\\b(?:__has_cpp_attribute|reinterpret_cast|atomic_noexcept|atomic_cancel|atomic_commit|__has_include|dynamic_cast|thread_local|synchronized|static_cast|const_cast|consteval|constexpr|protected|namespace|co_return|constexpr|constexpr|continue|explicit|volatile|noexcept|co_yield|noexcept|noexcept|requires|typename|decltype|operator|co_await|template|volatile|register|restrict|reflexpr|alignof|private|default|mutable|include|concept|__asm__|defined|_Pragma|alignas|typedef|warning|virtual|mutable|struct|sizeof|delete|not_eq|bitand|and_eq|xor_eq|typeid|switch|return|static|extern|inline|friend|public|ifndef|define|pragma|export|import|module|catch|throw|const|or_eq|while|compl|bitor|const|union|ifdef|class|undef|error|break|using|endif|goto|line|enum|this|case|else|elif|else|asm|try|for|new|and|xor|not|do|or|if|if)\\b)(?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*))\\s*+(((?<!<)<(?!<)(?>(?:(?>[^<>]*)\\g<67>?)+)>)\\s*)?::)*)(operator)((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))((?:((?-mix:(?!\\b(?:__has_cpp_attribute|reinterpret_cast|atomic_noexcept|atomic_cancel|atomic_commit|__has_include|dynamic_cast|thread_local|synchronized|static_cast|const_cast|consteval|constexpr|protected|namespace|co_return|constexpr|constexpr|continue|explicit|volatile|noexcept|co_yield|noexcept|noexcept|requires|typename|decltype|operator|co_await|template|volatile|register|restrict|reflexpr|alignof|private|default|mutable|include|concept|__asm__|defined|_Pragma|alignas|typedef|warning|virtual|mutable|struct|sizeof|delete|not_eq|bitand|and_eq|xor_eq|typeid|switch|return|static|extern|inline|friend|public|ifndef|define|pragma|export|import|module|catch|throw|const|or_eq|while|compl|bitor|const|union|ifdef|class|undef|error|break|using|endif|goto|line|enum|this|case|else|elif|else|asm|try|for|new|and|xor|not|do|or|if|if)\\b)(?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*))\\s*+(((?<!<)<(?!<)(?>(?:(?>[^<>]*)\\g<67>?)+)>)\\s*)?::)*)(?:(?:((?:delete\\[\\]|delete|new\\[\\]|<=>|<<=|new|>>=|\\->\\*|\\/=|%=|&=|>=|\\|=|\\+\\+|\\-\\-|\\(\\)|\\[\\]|\\->|\\+\\+|<<|>>|\\-\\-|<=|\\^=|==|!=|&&|\\|\\||\\+=|\\-=|\\*=|,|\\+|\\-|!|~|\\*|&|\\*|\\/|%|\\+|\\-|<|>|&|\\^|\\||=))|((?<!\\w)(?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*(?!\\w)(((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))?(?:(?:\\&|\\*)((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z)))))*(?:\\&|\\*))?((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))((?:\\[\\])?)))|(\"\")((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))((?<!\\w)(?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*(?!\\w)))((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))(?=\\<|\\())",
+			"beginCaptures": {
+				"1": {
+					"name": "meta.head.function.definition.special.operator-overload.cpp"
+				},
+				"2": {
+					"name": "meta.qualified_type.cpp",
+					"patterns": [
+						{
+							"match": "(?<!\\w)(?:struct|class|union|enum)(?!\\w)",
+							"name": "storage.type.$0.cpp"
+						},
+						{
+							"include": "#attributes_context"
+						},
+						{
+							"include": "#function_type"
+						},
+						{
+							"include": "#storage_types"
+						},
+						{
+							"include": "#number_literal"
+						},
+						{
+							"include": "#string_context"
+						},
+						{
+							"include": "#comma"
+						},
+						{
+							"include": "#scope_resolution_inner_generated"
+						},
+						{
+							"include": "#template_call_range"
+						},
+						{
+							"match": "(?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*",
+							"name": "entity.name.type.cpp"
+						}
+					]
+				},
+				"3": {
+					"patterns": [
+						{
+							"include": "#attributes_context"
+						},
+						{
+							"include": "#number_literal"
+						}
+					]
+				},
+				"4": {
+					"patterns": [
+						{
+							"include": "#inline_comment"
+						}
+					]
+				},
+				"5": {
+					"name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+				},
+				"6": {
+					"name": "comment.block.cpp"
+				},
+				"7": {
+					"patterns": [
+						{
+							"match": "\\*\\/",
+							"name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+						},
+						{
+							"match": "\\*",
+							"name": "comment.block.cpp"
+						}
+					]
+				},
+				"8": {
+					"patterns": [
+						{
+							"include": "#inline_comment"
+						}
+					]
+				},
+				"9": {
+					"name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+				},
+				"10": {
+					"name": "comment.block.cpp"
+				},
+				"11": {
+					"patterns": [
+						{
+							"match": "\\*\\/",
+							"name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+						},
+						{
+							"match": "\\*",
+							"name": "comment.block.cpp"
+						}
+					]
+				},
+				"13": {
+					"patterns": [
+						{
+							"include": "#scope_resolution_inner_generated"
+						}
+					]
+				},
+				"14": {
+					"name": "punctuation.separator.namespace.access.cpp punctuation.separator.scope-resolution.cpp"
+				},
+				"16": {
+					"name": "meta.template.call.cpp",
+					"patterns": [
+						{
+							"include": "#template_call_range"
+						}
+					]
+				},
+				"18": {
+					"name": "entity.name.scope-resolution.cpp"
+				},
+				"19": {
+					"name": "meta.template.call.cpp",
+					"patterns": [
+						{
+							"include": "#template_call_range"
+						}
+					]
+				},
+				"21": {
+					"name": "punctuation.separator.namespace.access.cpp punctuation.separator.scope-resolution.cpp"
+				},
+				"22": {
+					"patterns": [
+						{
+							"include": "#inline_comment"
+						}
+					]
+				},
+				"23": {
+					"name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+				},
+				"24": {
+					"name": "comment.block.cpp"
+				},
+				"25": {
+					"patterns": [
+						{
+							"match": "\\*\\/",
+							"name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+						},
+						{
+							"match": "\\*",
+							"name": "comment.block.cpp"
+						}
+					]
+				},
+				"26": {
+					"name": "entity.name.type.cpp"
+				},
+				"27": {
+					"name": "meta.template.call.cpp",
+					"patterns": [
+						{
+							"include": "#template_call_range"
+						}
+					]
+				},
+				"29": {
+					"patterns": [
+						{
+							"match": "\\*",
+							"name": "storage.modifier.pointer.cpp"
+						},
+						{
+							"match": "(?:\\&((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))){2,}\\&",
+							"captures": {
+								"1": {
+									"patterns": [
+										{
+											"include": "#inline_comment"
+										}
+									]
+								},
+								"2": {
+									"name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+								},
+								"3": {
+									"name": "comment.block.cpp"
+								},
+								"4": {
+									"patterns": [
+										{
+											"match": "\\*\\/",
+											"name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+										},
+										{
+											"match": "\\*",
+											"name": "comment.block.cpp"
+										}
+									]
+								}
+							},
+							"name": "invalid.illegal.reference-type.cpp"
+						},
+						{
+							"match": "\\&",
+							"name": "storage.modifier.reference.cpp"
+						}
+					]
+				},
+				"30": {
+					"patterns": [
+						{
+							"include": "#inline_comment"
+						}
+					]
+				},
+				"31": {
+					"name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+				},
+				"32": {
+					"name": "comment.block.cpp"
+				},
+				"33": {
+					"patterns": [
+						{
+							"match": "\\*\\/",
+							"name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+						},
+						{
+							"match": "\\*",
+							"name": "comment.block.cpp"
+						}
+					]
+				},
+				"34": {
+					"patterns": [
+						{
+							"include": "#inline_comment"
+						}
+					]
+				},
+				"35": {
+					"name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+				},
+				"36": {
+					"name": "comment.block.cpp"
+				},
+				"37": {
+					"patterns": [
+						{
+							"match": "\\*\\/",
+							"name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+						},
+						{
+							"match": "\\*",
+							"name": "comment.block.cpp"
+						}
+					]
+				},
+				"38": {
+					"patterns": [
+						{
+							"include": "#inline_comment"
+						}
+					]
+				},
+				"39": {
+					"name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+				},
+				"40": {
+					"name": "comment.block.cpp"
+				},
+				"41": {
+					"patterns": [
+						{
+							"match": "\\*\\/",
+							"name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+						},
+						{
+							"match": "\\*",
+							"name": "comment.block.cpp"
+						}
+					]
+				},
+				"42": {
+					"patterns": [
+						{
+							"include": "#inline_comment"
+						}
+					]
+				},
+				"43": {
+					"name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+				},
+				"44": {
+					"name": "comment.block.cpp"
+				},
+				"45": {
+					"patterns": [
+						{
+							"match": "\\*\\/",
+							"name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+						},
+						{
+							"match": "\\*",
+							"name": "comment.block.cpp"
+						}
+					]
+				},
+				"46": {
+					"name": "storage.type.modifier.calling-convention.cpp"
+				},
+				"47": {
+					"patterns": [
+						{
+							"include": "#inline_comment"
+						}
+					]
+				},
+				"48": {
+					"name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+				},
+				"49": {
+					"name": "comment.block.cpp"
+				},
+				"50": {
+					"patterns": [
+						{
+							"match": "\\*\\/",
+							"name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+						},
+						{
+							"match": "\\*",
+							"name": "comment.block.cpp"
+						}
+					]
+				},
+				"51": {
+					"patterns": [
+						{
+							"include": "#inline_comment"
+						}
+					]
+				},
+				"52": {
+					"name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+				},
+				"53": {
+					"name": "comment.block.cpp"
+				},
+				"54": {
+					"patterns": [
+						{
+							"match": "\\*\\/",
+							"name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+						},
+						{
+							"match": "\\*",
+							"name": "comment.block.cpp"
+						}
+					]
+				},
+				"55": {
+					"patterns": [
+						{
+							"match": "::",
+							"name": "punctuation.separator.namespace.access.cpp punctuation.separator.scope-resolution.operator.cpp"
+						},
+						{
+							"match": "(?<!\\w)(?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*(?!\\w)",
+							"name": "entity.name.scope-resolution.operator.cpp"
+						},
+						{
+							"include": "#template_call_range"
+						}
+					]
+				},
+				"57": {
+					"name": "meta.template.call.cpp",
+					"patterns": [
+						{
+							"include": "#template_call_range"
+						}
+					]
+				},
+				"59": {
+					"name": "keyword.other.operator.overload.cpp"
+				},
+				"60": {
+					"patterns": [
+						{
+							"include": "#inline_comment"
+						}
+					]
+				},
+				"61": {
+					"name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+				},
+				"62": {
+					"name": "comment.block.cpp"
+				},
+				"63": {
+					"patterns": [
+						{
+							"match": "\\*\\/",
+							"name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+						},
+						{
+							"match": "\\*",
+							"name": "comment.block.cpp"
+						}
+					]
+				},
+				"64": {
+					"patterns": [
+						{
+							"match": "::",
+							"name": "punctuation.separator.namespace.access.cpp punctuation.separator.scope-resolution.operator-overload.cpp"
+						},
+						{
+							"match": "(?<!\\w)(?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*(?!\\w)",
+							"name": "entity.name.scope-resolution.operator-overload.cpp"
+						},
+						{
+							"include": "#template_call_range"
+						}
+					]
+				},
+				"66": {
+					"name": "meta.template.call.cpp",
+					"patterns": [
+						{
+							"include": "#template_call_range"
+						}
+					]
+				},
+				"68": {
+					"name": "entity.name.operator.cpp"
+				},
+				"69": {
+					"name": "entity.name.operator.type.cpp"
+				},
+				"70": {
+					"patterns": [
+						{
+							"match": "\\*",
+							"name": "entity.name.operator.type.pointer.cpp"
+						},
+						{
+							"match": "(?:\\&((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))){2,}\\&",
+							"captures": {
+								"1": {
+									"patterns": [
+										{
+											"include": "#inline_comment"
+										}
+									]
+								},
+								"2": {
+									"name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+								},
+								"3": {
+									"name": "comment.block.cpp"
+								},
+								"4": {
+									"patterns": [
+										{
+											"match": "\\*\\/",
+											"name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+										},
+										{
+											"match": "\\*",
+											"name": "comment.block.cpp"
+										}
+									]
+								}
+							},
+							"name": "invalid.illegal.reference-type.cpp"
+						},
+						{
+							"match": "\\&",
+							"name": "entity.name.operator.type.reference.cpp"
+						}
+					]
+				},
+				"71": {
+					"patterns": [
+						{
+							"include": "#inline_comment"
+						}
+					]
+				},
+				"72": {
+					"name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+				},
+				"73": {
+					"name": "comment.block.cpp"
+				},
+				"74": {
+					"patterns": [
+						{
+							"match": "\\*\\/",
+							"name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+						},
+						{
+							"match": "\\*",
+							"name": "comment.block.cpp"
+						}
+					]
+				},
+				"75": {
+					"patterns": [
+						{
+							"include": "#inline_comment"
+						}
+					]
+				},
+				"76": {
+					"name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+				},
+				"77": {
+					"name": "comment.block.cpp"
+				},
+				"78": {
+					"patterns": [
+						{
+							"match": "\\*\\/",
+							"name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+						},
+						{
+							"match": "\\*",
+							"name": "comment.block.cpp"
+						}
+					]
+				},
+				"79": {
+					"patterns": [
+						{
+							"include": "#inline_comment"
+						}
+					]
+				},
+				"80": {
+					"name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+				},
+				"81": {
+					"name": "comment.block.cpp"
+				},
+				"82": {
+					"patterns": [
+						{
+							"match": "\\*\\/",
+							"name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+						},
+						{
+							"match": "\\*",
+							"name": "comment.block.cpp"
+						}
+					]
+				},
+				"83": {
+					"name": "entity.name.operator.type.array.cpp"
+				},
+				"84": {
+					"name": "entity.name.operator.custom-literal.cpp"
+				},
+				"85": {
+					"patterns": [
+						{
+							"include": "#inline_comment"
+						}
+					]
+				},
+				"86": {
+					"name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+				},
+				"87": {
+					"name": "comment.block.cpp"
+				},
+				"88": {
+					"patterns": [
+						{
+							"match": "\\*\\/",
+							"name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+						},
+						{
+							"match": "\\*",
+							"name": "comment.block.cpp"
+						}
+					]
+				},
+				"89": {
+					"name": "entity.name.operator.custom-literal.cpp"
+				},
+				"90": {
+					"patterns": [
+						{
+							"include": "#inline_comment"
+						}
+					]
+				},
+				"91": {
+					"name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+				},
+				"92": {
+					"name": "comment.block.cpp"
+				},
+				"93": {
+					"patterns": [
+						{
+							"match": "\\*\\/",
+							"name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+						},
+						{
+							"match": "\\*",
+							"name": "comment.block.cpp"
+						}
+					]
+				}
+			},
+			"end": "(?:(?<=\\}|%>|\\?\\?>)|(?=[;>\\[\\]=]))",
+			"patterns": [
+				{
+					"name": "meta.head.function.definition.special.operator-overload.cpp",
+					"begin": "\\G ?",
+					"end": "((?:\\{|<%|\\?\\?<|(?=;)))",
+					"endCaptures": {
+						"1": {
+							"name": "punctuation.section.block.begin.bracket.curly.function.definition.special.operator-overload.cpp"
+						}
+					},
+					"patterns": [
+						{
+							"include": "#ever_present_context"
+						},
+						{
+							"include": "#template_call_range"
+						},
+						{
+							"contentName": "meta.function.definition.parameters.special.operator-overload.cpp",
+							"begin": "(\\()",
+							"beginCaptures": {
+								"1": {
+									"name": "punctuation.section.parameters.begin.bracket.round.special.operator-overload.cpp"
+								}
+							},
+							"end": "(\\))",
+							"endCaptures": {
+								"1": {
+									"name": "punctuation.section.parameters.end.bracket.round.special.operator-overload.cpp"
+								}
+							},
+							"patterns": [
+								{
+									"include": "#function_parameter_context"
+								},
+								{
+									"include": "#evaluation_context"
+								}
+							]
+						},
+						{
+							"include": "#qualifiers_and_specifiers_post_parameters"
+						},
+						{
+							"include": "$self"
+						}
+					]
+				},
+				{
+					"name": "meta.body.function.definition.special.operator-overload.cpp",
+					"begin": "(?<=\\{|<%|\\?\\?<)",
+					"end": "(\\}|%>|\\?\\?>)",
+					"endCaptures": {
+						"1": {
+							"name": "punctuation.section.block.end.bracket.curly.function.definition.special.operator-overload.cpp"
+						}
+					},
+					"patterns": [
+						{
+							"include": "#function_body_context"
+						}
+					]
+				},
+				{
+					"name": "meta.tail.function.definition.special.operator-overload.cpp",
+					"begin": "(?<=\\}|%>|\\?\\?>)[\\s\\n]*",
+					"end": "[\\s\\n]*(?=;)",
+					"patterns": [
+						{
+							"include": "$self"
+						}
+					]
+				}
+			]
+		},
+		"operators": {
+			"patterns": [
+				{
+					"include": "#sizeof_operator"
+				},
+				{
+					"include": "#alignof_operator"
+				},
+				{
+					"include": "#alignas_operator"
+				},
+				{
+					"include": "#typeid_operator"
+				},
+				{
+					"include": "#noexcept_operator"
+				},
+				{
+					"include": "#sizeof_variadic_operator"
+				},
+				{
+					"match": "--",
+					"name": "keyword.operator.decrement.cpp"
+				},
+				{
+					"match": "\\+\\+",
+					"name": "keyword.operator.increment.cpp"
+				},
+				{
+					"match": "%=|\\+=|-=|\\*=|(?<!\\()\\/=",
+					"name": "keyword.operator.assignment.compound.cpp"
+				},
+				{
+					"match": "&=|\\^=|<<=|>>=|\\|=",
+					"name": "keyword.operator.assignment.compound.bitwise.cpp"
+				},
+				{
+					"match": "<<|>>",
+					"name": "keyword.operator.bitwise.shift.cpp"
+				},
+				{
+					"match": "!=|<=|>=|==|<|>",
+					"name": "keyword.operator.comparison.cpp"
+				},
+				{
+					"match": "&&|!|\\|\\|",
+					"name": "keyword.operator.logical.cpp"
+				},
+				{
+					"match": "&|\\||\\^|~",
+					"name": "keyword.operator.cpp"
+				},
+				{
+					"include": "#assignment_operator"
+				},
+				{
+					"match": "%|\\*|\\/|-|\\+",
+					"name": "keyword.operator.cpp"
+				},
+				{
+					"include": "#ternary_operator"
+				}
+			]
+		},
+		"over_qualified_types": {
+			"patterns": [
+				{
+					"include": "#parameter_struct"
+				},
+				{
+					"include": "#parameter_enum"
+				},
+				{
+					"include": "#parameter_union"
+				},
+				{
+					"include": "#parameter_class"
+				}
+			]
+		},
+		"parameter": {
+			"name": "meta.parameter.cpp",
+			"begin": "((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))(?=\\w)",
+			"beginCaptures": {
+				"1": {
+					"patterns": [
+						{
+							"include": "#inline_comment"
+						}
+					]
+				},
+				"2": {
+					"name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+				},
+				"3": {
+					"name": "comment.block.cpp"
+				},
+				"4": {
+					"patterns": [
+						{
+							"match": "\\*\\/",
+							"name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+						},
+						{
+							"match": "\\*",
+							"name": "comment.block.cpp"
+						}
+					]
+				}
+			},
+			"end": "(?:(?=\\))|(,))",
+			"endCaptures": {
+				"1": {
+					"name": "punctuation.separator.delimiter.comma.cpp"
+				}
+			},
+			"patterns": [
+				{
+					"include": "#ever_present_context"
+				},
+				{
+					"include": "#function_pointer_parameter"
+				},
+				{
+					"include": "#decltype"
+				},
+				{
+					"include": "#vararg_ellipses"
+				},
+				{
+					"match": "((?:((?:volatile|register|restrict|static|extern|const))((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z)))))+)((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))(?:((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))(?:(?:(?:((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))((?<!\\w)(?:unsigned|wchar_t|double|signed|short|float|auto|void|long|char|bool|int)(?!\\w))|((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))((?<!\\w)(?:uint_least32_t|uint_least64_t|uint_least16_t|int_least16_t|int_least64_t|int_least32_t|uint_fast32_t|uint_fast16_t|uint_fast64_t|uint_least8_t|int_fast64_t|int_fast16_t|uint_fast8_t|int_fast32_t|int_least8_t|int_fast8_t|suseconds_t|useconds_t|uintmax_t|uintptr_t|in_addr_t|uintmax_t|blksize_t|in_port_t|blkcnt_t|intptr_t|intmax_t|uint64_t|u_quad_t|uint16_t|uint32_t|intmax_t|segsz_t|fixpt_t|caddr_t|daddr_t|u_short|int16_t|int32_t|int64_t|uint8_t|nlink_t|qaddr_t|swblk_t|clock_t|ssize_t|time_t|u_long|ushort|quad_t|mode_t|size_t|u_char|int8_t|u_int|uid_t|off_t|pid_t|gid_t|dev_t|div_t|key_t|ino_t|id_t|id_t|uint)(?!\\w)))|((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))((?<!\\w)pthread_attr_t|pthread_cond_t|pthread_condattr_t|pthread_mutex_t|pthread_mutexattr_t|pthread_once_t|pthread_rwlock_t|pthread_rwlockattr_t|pthread_t|pthread_key_t(?!\\w)))|((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))((?<!\\w)[a-zA-Z_]\\w*_t(?!\\w)))|((?<!\\w)(?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*(?!\\w)\\b\\b(?<!\\Wvolatile|^volatile|\\Wregister|^register|\\Wrestrict|^restrict|\\Wstatic|^static|\\Wextern|^extern|\\Wconst|^const)))((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))(?=,|\\)|=)",
+					"captures": {
+						"1": {
+							"patterns": [
+								{
+									"include": "#storage_types"
+								}
+							]
+						},
+						"2": {
+							"name": "storage.modifier.specifier.parameter.cpp"
+						},
+						"3": {
+							"patterns": [
+								{
+									"include": "#inline_comment"
+								}
+							]
+						},
+						"4": {
+							"name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+						},
+						"5": {
+							"name": "comment.block.cpp"
+						},
+						"6": {
+							"patterns": [
+								{
+									"match": "\\*\\/",
+									"name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+								},
+								{
+									"match": "\\*",
+									"name": "comment.block.cpp"
+								}
+							]
+						},
+						"7": {
+							"patterns": [
+								{
+									"include": "#inline_comment"
+								}
+							]
+						},
+						"8": {
+							"name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+						},
+						"9": {
+							"name": "comment.block.cpp"
+						},
+						"10": {
+							"patterns": [
+								{
+									"match": "\\*\\/",
+									"name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+								},
+								{
+									"match": "\\*",
+									"name": "comment.block.cpp"
+								}
+							]
+						},
+						"11": {
+							"patterns": [
+								{
+									"include": "#inline_comment"
+								}
+							]
+						},
+						"12": {
+							"name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+						},
+						"13": {
+							"name": "comment.block.cpp"
+						},
+						"14": {
+							"patterns": [
+								{
+									"match": "\\*\\/",
+									"name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+								},
+								{
+									"match": "\\*",
+									"name": "comment.block.cpp"
+								}
+							]
+						},
+						"15": {
+							"patterns": [
+								{
+									"include": "#inline_comment"
+								}
+							]
+						},
+						"16": {
+							"name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+						},
+						"17": {
+							"name": "comment.block.cpp"
+						},
+						"18": {
+							"patterns": [
+								{
+									"match": "\\*\\/",
+									"name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+								},
+								{
+									"match": "\\*",
+									"name": "comment.block.cpp"
+								}
+							]
+						},
+						"19": {
+							"name": "storage.type.primitive.cpp storage.type.built-in.primitive.cpp"
+						},
+						"20": {
+							"patterns": [
+								{
+									"include": "#inline_comment"
+								}
+							]
+						},
+						"21": {
+							"name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+						},
+						"22": {
+							"name": "comment.block.cpp"
+						},
+						"23": {
+							"patterns": [
+								{
+									"match": "\\*\\/",
+									"name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+								},
+								{
+									"match": "\\*",
+									"name": "comment.block.cpp"
+								}
+							]
+						},
+						"24": {
+							"name": "storage.type.cpp storage.type.built-in.cpp"
+						},
+						"25": {
+							"patterns": [
+								{
+									"include": "#inline_comment"
+								}
+							]
+						},
+						"26": {
+							"name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+						},
+						"27": {
+							"name": "comment.block.cpp"
+						},
+						"28": {
+							"patterns": [
+								{
+									"match": "\\*\\/",
+									"name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+								},
+								{
+									"match": "\\*",
+									"name": "comment.block.cpp"
+								}
+							]
+						},
+						"29": {
+							"name": "support.type.posix-reserved.pthread.cpp support.type.built-in.posix-reserved.pthread.cpp"
+						},
+						"30": {
+							"patterns": [
+								{
+									"include": "#inline_comment"
+								}
+							]
+						},
+						"31": {
+							"name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+						},
+						"32": {
+							"name": "comment.block.cpp"
+						},
+						"33": {
+							"patterns": [
+								{
+									"match": "\\*\\/",
+									"name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+								},
+								{
+									"match": "\\*",
+									"name": "comment.block.cpp"
+								}
+							]
+						},
+						"34": {
+							"name": "support.type.posix-reserved.cpp support.type.built-in.posix-reserved.cpp"
+						},
+						"35": {
+							"name": "entity.name.type.parameter.cpp"
+						},
+						"36": {
+							"patterns": [
+								{
+									"include": "#inline_comment"
+								}
+							]
+						},
+						"37": {
+							"name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+						},
+						"38": {
+							"name": "comment.block.cpp"
+						},
+						"39": {
+							"patterns": [
+								{
+									"match": "\\*\\/",
+									"name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+								},
+								{
+									"match": "\\*",
+									"name": "comment.block.cpp"
+								}
+							]
+						}
+					}
+				},
+				{
+					"include": "#storage_types"
+				},
+				{
+					"include": "#scope_resolution_parameter_inner_generated"
+				},
+				{
+					"match": "(?:struct|class|union|enum)",
+					"name": "storage.type.$0.cpp"
+				},
+				{
+					"begin": "(?<==)",
+					"end": "(?:(?=\\))|(,))",
+					"endCaptures": {
+						"1": {
+							"name": "punctuation.separator.delimiter.comma.cpp"
+						}
+					},
+					"patterns": [
+						{
+							"include": "#evaluation_context"
+						}
+					]
+				},
+				{
+					"include": "#assignment_operator"
+				},
+				{
+					"match": "(?<!\\s|\\(|,|:)((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))((?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*)((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))(?=\\)|,|\\[|=|\\n)",
+					"captures": {
+						"1": {
+							"patterns": [
+								{
+									"include": "#inline_comment"
+								}
+							]
+						},
+						"2": {
+							"name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+						},
+						"3": {
+							"name": "comment.block.cpp"
+						},
+						"4": {
+							"patterns": [
+								{
+									"match": "\\*\\/",
+									"name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+								},
+								{
+									"match": "\\*",
+									"name": "comment.block.cpp"
+								}
+							]
+						},
+						"5": {
+							"name": "variable.parameter.cpp"
+						},
+						"6": {
+							"patterns": [
+								{
+									"include": "#inline_comment"
+								}
+							]
+						},
+						"7": {
+							"name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+						},
+						"8": {
+							"name": "comment.block.cpp"
+						},
+						"9": {
+							"patterns": [
+								{
+									"match": "\\*\\/",
+									"name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+								},
+								{
+									"match": "\\*",
+									"name": "comment.block.cpp"
+								}
+							]
+						}
+					}
+				},
+				{
+					"include": "#attributes_context"
+				},
+				{
+					"name": "meta.bracket.square.array.cpp",
+					"begin": "(\\[)",
+					"beginCaptures": {
+						"1": {
+							"name": "punctuation.definition.begin.bracket.square.array.type.cpp"
+						}
+					},
+					"end": "(\\])",
+					"endCaptures": {
+						"1": {
+							"name": "punctuation.definition.end.bracket.square.array.type.cpp"
+						}
+					},
+					"patterns": [
+						{
+							"include": "#evaluation_context"
+						}
+					]
+				},
+				{
+					"match": "(?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*\\b(?<!\\Wstruct|^struct|\\Wclass|^class|\\Wunion|^union|\\Wenum|^enum)",
+					"name": "entity.name.type.parameter.cpp"
+				},
+				{
+					"include": "#template_call_range"
+				},
+				{
+					"match": "((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))?(?:(?:\\&|\\*)((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z)))))*(?:\\&|\\*)",
+					"captures": {
 						"0": {
-							"name": "punctuation.definition.string.begin.cpp"
+							"patterns": [
+								{
+									"match": "\\*",
+									"name": "storage.modifier.pointer.cpp"
+								},
+								{
+									"match": "(?:\\&((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))){2,}\\&",
+									"captures": {
+										"1": {
+											"patterns": [
+												{
+													"include": "#inline_comment"
+												}
+											]
+										},
+										"2": {
+											"name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+										},
+										"3": {
+											"name": "comment.block.cpp"
+										},
+										"4": {
+											"patterns": [
+												{
+													"match": "\\*\\/",
+													"name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+												},
+												{
+													"match": "\\*",
+													"name": "comment.block.cpp"
+												}
+											]
+										}
+									},
+									"name": "invalid.illegal.reference-type.cpp"
+								},
+								{
+									"match": "\\&",
+									"name": "storage.modifier.reference.cpp"
+								}
+							]
 						},
 						"1": {
+							"patterns": [
+								{
+									"include": "#inline_comment"
+								}
+							]
+						},
+						"2": {
+							"name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+						},
+						"3": {
+							"name": "comment.block.cpp"
+						},
+						"4": {
+							"patterns": [
+								{
+									"match": "\\*\\/",
+									"name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+								},
+								{
+									"match": "\\*",
+									"name": "comment.block.cpp"
+								}
+							]
+						},
+						"5": {
+							"patterns": [
+								{
+									"include": "#inline_comment"
+								}
+							]
+						},
+						"6": {
+							"name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+						},
+						"7": {
+							"name": "comment.block.cpp"
+						},
+						"8": {
+							"patterns": [
+								{
+									"match": "\\*\\/",
+									"name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+								},
+								{
+									"match": "\\*",
+									"name": "comment.block.cpp"
+								}
+							]
+						}
+					}
+				}
+			]
+		},
+		"parameter_class": {
+			"match": "(class)((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))((?<!\\w)(?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*(?!\\w))((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))(?:(((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))?(?:(?:\\&|\\*)((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z)))))*(?:\\&|\\*))((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z)))))?((?:(?<!\\w)(?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*(?!\\w))?)((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))(?:\\[((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))\\]((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z)))))?(?=,|\\)|\\n)",
+			"captures": {
+				"1": {
+					"name": "storage.type.class.parameter.cpp"
+				},
+				"2": {
+					"patterns": [
+						{
+							"include": "#inline_comment"
+						}
+					]
+				},
+				"3": {
+					"name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+				},
+				"4": {
+					"name": "comment.block.cpp"
+				},
+				"5": {
+					"patterns": [
+						{
+							"match": "\\*\\/",
+							"name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+						},
+						{
+							"match": "\\*",
+							"name": "comment.block.cpp"
+						}
+					]
+				},
+				"6": {
+					"name": "entity.name.type.class.parameter.cpp"
+				},
+				"7": {
+					"patterns": [
+						{
+							"include": "#inline_comment"
+						}
+					]
+				},
+				"8": {
+					"name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+				},
+				"9": {
+					"name": "comment.block.cpp"
+				},
+				"10": {
+					"patterns": [
+						{
+							"match": "\\*\\/",
+							"name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+						},
+						{
+							"match": "\\*",
+							"name": "comment.block.cpp"
+						}
+					]
+				},
+				"11": {
+					"patterns": [
+						{
+							"match": "\\*",
+							"name": "storage.modifier.pointer.cpp"
+						},
+						{
+							"match": "(?:\\&((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))){2,}\\&",
+							"captures": {
+								"1": {
+									"patterns": [
+										{
+											"include": "#inline_comment"
+										}
+									]
+								},
+								"2": {
+									"name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+								},
+								"3": {
+									"name": "comment.block.cpp"
+								},
+								"4": {
+									"patterns": [
+										{
+											"match": "\\*\\/",
+											"name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+										},
+										{
+											"match": "\\*",
+											"name": "comment.block.cpp"
+										}
+									]
+								}
+							},
+							"name": "invalid.illegal.reference-type.cpp"
+						},
+						{
+							"match": "\\&",
+							"name": "storage.modifier.reference.cpp"
+						}
+					]
+				},
+				"12": {
+					"patterns": [
+						{
+							"include": "#inline_comment"
+						}
+					]
+				},
+				"13": {
+					"name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+				},
+				"14": {
+					"name": "comment.block.cpp"
+				},
+				"15": {
+					"patterns": [
+						{
+							"match": "\\*\\/",
+							"name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+						},
+						{
+							"match": "\\*",
+							"name": "comment.block.cpp"
+						}
+					]
+				},
+				"16": {
+					"patterns": [
+						{
+							"include": "#inline_comment"
+						}
+					]
+				},
+				"17": {
+					"name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+				},
+				"18": {
+					"name": "comment.block.cpp"
+				},
+				"19": {
+					"patterns": [
+						{
+							"match": "\\*\\/",
+							"name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+						},
+						{
+							"match": "\\*",
+							"name": "comment.block.cpp"
+						}
+					]
+				},
+				"20": {
+					"patterns": [
+						{
+							"include": "#inline_comment"
+						}
+					]
+				},
+				"21": {
+					"name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+				},
+				"22": {
+					"name": "comment.block.cpp"
+				},
+				"23": {
+					"patterns": [
+						{
+							"match": "\\*\\/",
+							"name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+						},
+						{
+							"match": "\\*",
+							"name": "comment.block.cpp"
+						}
+					]
+				},
+				"24": {
+					"name": "variable.other.object.declare.cpp"
+				},
+				"25": {
+					"patterns": [
+						{
+							"include": "#inline_comment"
+						}
+					]
+				},
+				"26": {
+					"name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+				},
+				"27": {
+					"name": "comment.block.cpp"
+				},
+				"28": {
+					"patterns": [
+						{
+							"match": "\\*\\/",
+							"name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+						},
+						{
+							"match": "\\*",
+							"name": "comment.block.cpp"
+						}
+					]
+				},
+				"29": {
+					"patterns": [
+						{
+							"include": "#inline_comment"
+						}
+					]
+				},
+				"30": {
+					"name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+				},
+				"31": {
+					"name": "comment.block.cpp"
+				},
+				"32": {
+					"patterns": [
+						{
+							"match": "\\*\\/",
+							"name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+						},
+						{
+							"match": "\\*",
+							"name": "comment.block.cpp"
+						}
+					]
+				},
+				"33": {
+					"patterns": [
+						{
+							"include": "#inline_comment"
+						}
+					]
+				},
+				"34": {
+					"name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+				},
+				"35": {
+					"name": "comment.block.cpp"
+				},
+				"36": {
+					"patterns": [
+						{
+							"match": "\\*\\/",
+							"name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+						},
+						{
+							"match": "\\*",
+							"name": "comment.block.cpp"
+						}
+					]
+				}
+			}
+		},
+		"parameter_enum": {
+			"match": "(enum)((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))((?<!\\w)(?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*(?!\\w))((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))(?:(((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))?(?:(?:\\&|\\*)((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z)))))*(?:\\&|\\*))((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z)))))?((?:(?<!\\w)(?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*(?!\\w))?)((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))(?:\\[((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))\\]((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z)))))?(?=,|\\)|\\n)",
+			"captures": {
+				"1": {
+					"name": "storage.type.enum.parameter.cpp"
+				},
+				"2": {
+					"patterns": [
+						{
+							"include": "#inline_comment"
+						}
+					]
+				},
+				"3": {
+					"name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+				},
+				"4": {
+					"name": "comment.block.cpp"
+				},
+				"5": {
+					"patterns": [
+						{
+							"match": "\\*\\/",
+							"name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+						},
+						{
+							"match": "\\*",
+							"name": "comment.block.cpp"
+						}
+					]
+				},
+				"6": {
+					"name": "entity.name.type.enum.parameter.cpp"
+				},
+				"7": {
+					"patterns": [
+						{
+							"include": "#inline_comment"
+						}
+					]
+				},
+				"8": {
+					"name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+				},
+				"9": {
+					"name": "comment.block.cpp"
+				},
+				"10": {
+					"patterns": [
+						{
+							"match": "\\*\\/",
+							"name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+						},
+						{
+							"match": "\\*",
+							"name": "comment.block.cpp"
+						}
+					]
+				},
+				"11": {
+					"patterns": [
+						{
+							"match": "\\*",
+							"name": "storage.modifier.pointer.cpp"
+						},
+						{
+							"match": "(?:\\&((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))){2,}\\&",
+							"captures": {
+								"1": {
+									"patterns": [
+										{
+											"include": "#inline_comment"
+										}
+									]
+								},
+								"2": {
+									"name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+								},
+								"3": {
+									"name": "comment.block.cpp"
+								},
+								"4": {
+									"patterns": [
+										{
+											"match": "\\*\\/",
+											"name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+										},
+										{
+											"match": "\\*",
+											"name": "comment.block.cpp"
+										}
+									]
+								}
+							},
+							"name": "invalid.illegal.reference-type.cpp"
+						},
+						{
+							"match": "\\&",
+							"name": "storage.modifier.reference.cpp"
+						}
+					]
+				},
+				"12": {
+					"patterns": [
+						{
+							"include": "#inline_comment"
+						}
+					]
+				},
+				"13": {
+					"name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+				},
+				"14": {
+					"name": "comment.block.cpp"
+				},
+				"15": {
+					"patterns": [
+						{
+							"match": "\\*\\/",
+							"name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+						},
+						{
+							"match": "\\*",
+							"name": "comment.block.cpp"
+						}
+					]
+				},
+				"16": {
+					"patterns": [
+						{
+							"include": "#inline_comment"
+						}
+					]
+				},
+				"17": {
+					"name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+				},
+				"18": {
+					"name": "comment.block.cpp"
+				},
+				"19": {
+					"patterns": [
+						{
+							"match": "\\*\\/",
+							"name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+						},
+						{
+							"match": "\\*",
+							"name": "comment.block.cpp"
+						}
+					]
+				},
+				"20": {
+					"patterns": [
+						{
+							"include": "#inline_comment"
+						}
+					]
+				},
+				"21": {
+					"name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+				},
+				"22": {
+					"name": "comment.block.cpp"
+				},
+				"23": {
+					"patterns": [
+						{
+							"match": "\\*\\/",
+							"name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+						},
+						{
+							"match": "\\*",
+							"name": "comment.block.cpp"
+						}
+					]
+				},
+				"24": {
+					"name": "variable.other.object.declare.cpp"
+				},
+				"25": {
+					"patterns": [
+						{
+							"include": "#inline_comment"
+						}
+					]
+				},
+				"26": {
+					"name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+				},
+				"27": {
+					"name": "comment.block.cpp"
+				},
+				"28": {
+					"patterns": [
+						{
+							"match": "\\*\\/",
+							"name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+						},
+						{
+							"match": "\\*",
+							"name": "comment.block.cpp"
+						}
+					]
+				},
+				"29": {
+					"patterns": [
+						{
+							"include": "#inline_comment"
+						}
+					]
+				},
+				"30": {
+					"name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+				},
+				"31": {
+					"name": "comment.block.cpp"
+				},
+				"32": {
+					"patterns": [
+						{
+							"match": "\\*\\/",
+							"name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+						},
+						{
+							"match": "\\*",
+							"name": "comment.block.cpp"
+						}
+					]
+				},
+				"33": {
+					"patterns": [
+						{
+							"include": "#inline_comment"
+						}
+					]
+				},
+				"34": {
+					"name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+				},
+				"35": {
+					"name": "comment.block.cpp"
+				},
+				"36": {
+					"patterns": [
+						{
+							"match": "\\*\\/",
+							"name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+						},
+						{
+							"match": "\\*",
+							"name": "comment.block.cpp"
+						}
+					]
+				}
+			}
+		},
+		"parameter_or_maybe_value": {
+			"name": "meta.parameter.cpp",
+			"begin": "((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))(?=\\w)",
+			"beginCaptures": {
+				"1": {
+					"patterns": [
+						{
+							"include": "#inline_comment"
+						}
+					]
+				},
+				"2": {
+					"name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+				},
+				"3": {
+					"name": "comment.block.cpp"
+				},
+				"4": {
+					"patterns": [
+						{
+							"match": "\\*\\/",
+							"name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+						},
+						{
+							"match": "\\*",
+							"name": "comment.block.cpp"
+						}
+					]
+				}
+			},
+			"end": "(?:(?=\\))|(,))",
+			"endCaptures": {
+				"1": {
+					"name": "punctuation.separator.delimiter.comma.cpp"
+				}
+			},
+			"patterns": [
+				{
+					"include": "#ever_present_context"
+				},
+				{
+					"include": "#function_pointer_parameter"
+				},
+				{
+					"include": "#memory_operators"
+				},
+				{
+					"include": "#builtin_storage_type_initilizer"
+				},
+				{
+					"include": "#curly_initializer"
+				},
+				{
+					"include": "#decltype"
+				},
+				{
+					"include": "#vararg_ellipses"
+				},
+				{
+					"match": "((?:((?:volatile|register|restrict|static|extern|const))((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z)))))+)((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))(?:((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))(?:(?:(?:((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))((?<!\\w)(?:unsigned|wchar_t|double|signed|short|float|auto|void|long|char|bool|int)(?!\\w))|((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))((?<!\\w)(?:uint_least32_t|uint_least64_t|uint_least16_t|int_least16_t|int_least64_t|int_least32_t|uint_fast32_t|uint_fast16_t|uint_fast64_t|uint_least8_t|int_fast64_t|int_fast16_t|uint_fast8_t|int_fast32_t|int_least8_t|int_fast8_t|suseconds_t|useconds_t|uintmax_t|uintptr_t|in_addr_t|uintmax_t|blksize_t|in_port_t|blkcnt_t|intptr_t|intmax_t|uint64_t|u_quad_t|uint16_t|uint32_t|intmax_t|segsz_t|fixpt_t|caddr_t|daddr_t|u_short|int16_t|int32_t|int64_t|uint8_t|nlink_t|qaddr_t|swblk_t|clock_t|ssize_t|time_t|u_long|ushort|quad_t|mode_t|size_t|u_char|int8_t|u_int|uid_t|off_t|pid_t|gid_t|dev_t|div_t|key_t|ino_t|id_t|id_t|uint)(?!\\w)))|((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))((?<!\\w)pthread_attr_t|pthread_cond_t|pthread_condattr_t|pthread_mutex_t|pthread_mutexattr_t|pthread_once_t|pthread_rwlock_t|pthread_rwlockattr_t|pthread_t|pthread_key_t(?!\\w)))|((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))((?<!\\w)[a-zA-Z_]\\w*_t(?!\\w)))|((?<!\\w)(?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*(?!\\w)\\b\\b(?<!\\Wvolatile|^volatile|\\Wregister|^register|\\Wrestrict|^restrict|\\Wstatic|^static|\\Wextern|^extern|\\Wconst|^const)))((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))(?=,|\\)|=)",
+					"captures": {
+						"1": {
+							"patterns": [
+								{
+									"include": "#storage_types"
+								}
+							]
+						},
+						"2": {
+							"name": "storage.modifier.specifier.parameter.cpp"
+						},
+						"3": {
+							"patterns": [
+								{
+									"include": "#inline_comment"
+								}
+							]
+						},
+						"4": {
+							"name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+						},
+						"5": {
+							"name": "comment.block.cpp"
+						},
+						"6": {
+							"patterns": [
+								{
+									"match": "\\*\\/",
+									"name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+								},
+								{
+									"match": "\\*",
+									"name": "comment.block.cpp"
+								}
+							]
+						},
+						"7": {
+							"patterns": [
+								{
+									"include": "#inline_comment"
+								}
+							]
+						},
+						"8": {
+							"name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+						},
+						"9": {
+							"name": "comment.block.cpp"
+						},
+						"10": {
+							"patterns": [
+								{
+									"match": "\\*\\/",
+									"name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+								},
+								{
+									"match": "\\*",
+									"name": "comment.block.cpp"
+								}
+							]
+						},
+						"11": {
+							"patterns": [
+								{
+									"include": "#inline_comment"
+								}
+							]
+						},
+						"12": {
+							"name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+						},
+						"13": {
+							"name": "comment.block.cpp"
+						},
+						"14": {
+							"patterns": [
+								{
+									"match": "\\*\\/",
+									"name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+								},
+								{
+									"match": "\\*",
+									"name": "comment.block.cpp"
+								}
+							]
+						},
+						"15": {
+							"patterns": [
+								{
+									"include": "#inline_comment"
+								}
+							]
+						},
+						"16": {
+							"name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+						},
+						"17": {
+							"name": "comment.block.cpp"
+						},
+						"18": {
+							"patterns": [
+								{
+									"match": "\\*\\/",
+									"name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+								},
+								{
+									"match": "\\*",
+									"name": "comment.block.cpp"
+								}
+							]
+						},
+						"19": {
+							"name": "storage.type.primitive.cpp storage.type.built-in.primitive.cpp"
+						},
+						"20": {
+							"patterns": [
+								{
+									"include": "#inline_comment"
+								}
+							]
+						},
+						"21": {
+							"name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+						},
+						"22": {
+							"name": "comment.block.cpp"
+						},
+						"23": {
+							"patterns": [
+								{
+									"match": "\\*\\/",
+									"name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+								},
+								{
+									"match": "\\*",
+									"name": "comment.block.cpp"
+								}
+							]
+						},
+						"24": {
+							"name": "storage.type.cpp storage.type.built-in.cpp"
+						},
+						"25": {
+							"patterns": [
+								{
+									"include": "#inline_comment"
+								}
+							]
+						},
+						"26": {
+							"name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+						},
+						"27": {
+							"name": "comment.block.cpp"
+						},
+						"28": {
+							"patterns": [
+								{
+									"match": "\\*\\/",
+									"name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+								},
+								{
+									"match": "\\*",
+									"name": "comment.block.cpp"
+								}
+							]
+						},
+						"29": {
+							"name": "support.type.posix-reserved.pthread.cpp support.type.built-in.posix-reserved.pthread.cpp"
+						},
+						"30": {
+							"patterns": [
+								{
+									"include": "#inline_comment"
+								}
+							]
+						},
+						"31": {
+							"name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+						},
+						"32": {
+							"name": "comment.block.cpp"
+						},
+						"33": {
+							"patterns": [
+								{
+									"match": "\\*\\/",
+									"name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+								},
+								{
+									"match": "\\*",
+									"name": "comment.block.cpp"
+								}
+							]
+						},
+						"34": {
+							"name": "support.type.posix-reserved.cpp support.type.built-in.posix-reserved.cpp"
+						},
+						"35": {
+							"name": "entity.name.type.parameter.cpp"
+						},
+						"36": {
+							"patterns": [
+								{
+									"include": "#inline_comment"
+								}
+							]
+						},
+						"37": {
+							"name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+						},
+						"38": {
+							"name": "comment.block.cpp"
+						},
+						"39": {
+							"patterns": [
+								{
+									"match": "\\*\\/",
+									"name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+								},
+								{
+									"match": "\\*",
+									"name": "comment.block.cpp"
+								}
+							]
+						}
+					}
+				},
+				{
+					"include": "#storage_types"
+				},
+				{
+					"include": "#function_call"
+				},
+				{
+					"include": "#scope_resolution_parameter_inner_generated"
+				},
+				{
+					"match": "(?:struct|class|union|enum)",
+					"name": "storage.type.$0.cpp"
+				},
+				{
+					"begin": "(?<==)",
+					"end": "(?:(?=\\))|(,))",
+					"endCaptures": {
+						"1": {
+							"name": "punctuation.separator.delimiter.comma.cpp"
+						}
+					},
+					"patterns": [
+						{
+							"include": "#evaluation_context"
+						}
+					]
+				},
+				{
+					"match": "(?<!\\s|\\(|,|:)((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))((?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*)((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))(?=(?:\\)|,|\\[|=|\\/\\/|(?:\\n|$)))",
+					"captures": {
+						"1": {
+							"patterns": [
+								{
+									"include": "#inline_comment"
+								}
+							]
+						},
+						"2": {
+							"name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+						},
+						"3": {
+							"name": "comment.block.cpp"
+						},
+						"4": {
+							"patterns": [
+								{
+									"match": "\\*\\/",
+									"name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+								},
+								{
+									"match": "\\*",
+									"name": "comment.block.cpp"
+								}
+							]
+						},
+						"5": {
+							"name": "variable.parameter.cpp"
+						},
+						"6": {
+							"patterns": [
+								{
+									"include": "#inline_comment"
+								}
+							]
+						},
+						"7": {
+							"name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+						},
+						"8": {
+							"name": "comment.block.cpp"
+						},
+						"9": {
+							"patterns": [
+								{
+									"match": "\\*\\/",
+									"name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+								},
+								{
+									"match": "\\*",
+									"name": "comment.block.cpp"
+								}
+							]
+						}
+					}
+				},
+				{
+					"include": "#attributes_context"
+				},
+				{
+					"name": "meta.bracket.square.array.cpp",
+					"begin": "(\\[)",
+					"beginCaptures": {
+						"1": {
+							"name": "punctuation.definition.begin.bracket.square.array.type.cpp"
+						}
+					},
+					"end": "(\\])",
+					"endCaptures": {
+						"1": {
+							"name": "punctuation.definition.end.bracket.square.array.type.cpp"
+						}
+					},
+					"patterns": [
+						{
+							"include": "#evaluation_context"
+						}
+					]
+				},
+				{
+					"match": "(?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*\\b(?<!\\Wstruct|^struct|\\Wclass|^class|\\Wunion|^union|\\Wenum|^enum)",
+					"name": "entity.name.type.parameter.cpp"
+				},
+				{
+					"include": "#template_call_range"
+				},
+				{
+					"match": "((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))?(?:(?:\\&|\\*)((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z)))))*(?:\\&|\\*)",
+					"captures": {
+						"0": {
+							"patterns": [
+								{
+									"match": "\\*",
+									"name": "storage.modifier.pointer.cpp"
+								},
+								{
+									"match": "(?:\\&((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))){2,}\\&",
+									"captures": {
+										"1": {
+											"patterns": [
+												{
+													"include": "#inline_comment"
+												}
+											]
+										},
+										"2": {
+											"name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+										},
+										"3": {
+											"name": "comment.block.cpp"
+										},
+										"4": {
+											"patterns": [
+												{
+													"match": "\\*\\/",
+													"name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+												},
+												{
+													"match": "\\*",
+													"name": "comment.block.cpp"
+												}
+											]
+										}
+									},
+									"name": "invalid.illegal.reference-type.cpp"
+								},
+								{
+									"match": "\\&",
+									"name": "storage.modifier.reference.cpp"
+								}
+							]
+						},
+						"1": {
+							"patterns": [
+								{
+									"include": "#inline_comment"
+								}
+							]
+						},
+						"2": {
+							"name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+						},
+						"3": {
+							"name": "comment.block.cpp"
+						},
+						"4": {
+							"patterns": [
+								{
+									"match": "\\*\\/",
+									"name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+								},
+								{
+									"match": "\\*",
+									"name": "comment.block.cpp"
+								}
+							]
+						},
+						"5": {
+							"patterns": [
+								{
+									"include": "#inline_comment"
+								}
+							]
+						},
+						"6": {
+							"name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+						},
+						"7": {
+							"name": "comment.block.cpp"
+						},
+						"8": {
+							"patterns": [
+								{
+									"match": "\\*\\/",
+									"name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+								},
+								{
+									"match": "\\*",
+									"name": "comment.block.cpp"
+								}
+							]
+						}
+					}
+				},
+				{
+					"include": "#evaluation_context"
+				}
+			]
+		},
+		"parameter_struct": {
+			"match": "(struct)((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))((?<!\\w)(?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*(?!\\w))((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))(?:(((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))?(?:(?:\\&|\\*)((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z)))))*(?:\\&|\\*))((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z)))))?((?:(?<!\\w)(?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*(?!\\w))?)((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))(?:\\[((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))\\]((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z)))))?(?=,|\\)|\\n)",
+			"captures": {
+				"1": {
+					"name": "storage.type.struct.parameter.cpp"
+				},
+				"2": {
+					"patterns": [
+						{
+							"include": "#inline_comment"
+						}
+					]
+				},
+				"3": {
+					"name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+				},
+				"4": {
+					"name": "comment.block.cpp"
+				},
+				"5": {
+					"patterns": [
+						{
+							"match": "\\*\\/",
+							"name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+						},
+						{
+							"match": "\\*",
+							"name": "comment.block.cpp"
+						}
+					]
+				},
+				"6": {
+					"name": "entity.name.type.struct.parameter.cpp"
+				},
+				"7": {
+					"patterns": [
+						{
+							"include": "#inline_comment"
+						}
+					]
+				},
+				"8": {
+					"name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+				},
+				"9": {
+					"name": "comment.block.cpp"
+				},
+				"10": {
+					"patterns": [
+						{
+							"match": "\\*\\/",
+							"name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+						},
+						{
+							"match": "\\*",
+							"name": "comment.block.cpp"
+						}
+					]
+				},
+				"11": {
+					"patterns": [
+						{
+							"match": "\\*",
+							"name": "storage.modifier.pointer.cpp"
+						},
+						{
+							"match": "(?:\\&((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))){2,}\\&",
+							"captures": {
+								"1": {
+									"patterns": [
+										{
+											"include": "#inline_comment"
+										}
+									]
+								},
+								"2": {
+									"name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+								},
+								"3": {
+									"name": "comment.block.cpp"
+								},
+								"4": {
+									"patterns": [
+										{
+											"match": "\\*\\/",
+											"name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+										},
+										{
+											"match": "\\*",
+											"name": "comment.block.cpp"
+										}
+									]
+								}
+							},
+							"name": "invalid.illegal.reference-type.cpp"
+						},
+						{
+							"match": "\\&",
+							"name": "storage.modifier.reference.cpp"
+						}
+					]
+				},
+				"12": {
+					"patterns": [
+						{
+							"include": "#inline_comment"
+						}
+					]
+				},
+				"13": {
+					"name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+				},
+				"14": {
+					"name": "comment.block.cpp"
+				},
+				"15": {
+					"patterns": [
+						{
+							"match": "\\*\\/",
+							"name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+						},
+						{
+							"match": "\\*",
+							"name": "comment.block.cpp"
+						}
+					]
+				},
+				"16": {
+					"patterns": [
+						{
+							"include": "#inline_comment"
+						}
+					]
+				},
+				"17": {
+					"name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+				},
+				"18": {
+					"name": "comment.block.cpp"
+				},
+				"19": {
+					"patterns": [
+						{
+							"match": "\\*\\/",
+							"name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+						},
+						{
+							"match": "\\*",
+							"name": "comment.block.cpp"
+						}
+					]
+				},
+				"20": {
+					"patterns": [
+						{
+							"include": "#inline_comment"
+						}
+					]
+				},
+				"21": {
+					"name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+				},
+				"22": {
+					"name": "comment.block.cpp"
+				},
+				"23": {
+					"patterns": [
+						{
+							"match": "\\*\\/",
+							"name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+						},
+						{
+							"match": "\\*",
+							"name": "comment.block.cpp"
+						}
+					]
+				},
+				"24": {
+					"name": "variable.other.object.declare.cpp"
+				},
+				"25": {
+					"patterns": [
+						{
+							"include": "#inline_comment"
+						}
+					]
+				},
+				"26": {
+					"name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+				},
+				"27": {
+					"name": "comment.block.cpp"
+				},
+				"28": {
+					"patterns": [
+						{
+							"match": "\\*\\/",
+							"name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+						},
+						{
+							"match": "\\*",
+							"name": "comment.block.cpp"
+						}
+					]
+				},
+				"29": {
+					"patterns": [
+						{
+							"include": "#inline_comment"
+						}
+					]
+				},
+				"30": {
+					"name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+				},
+				"31": {
+					"name": "comment.block.cpp"
+				},
+				"32": {
+					"patterns": [
+						{
+							"match": "\\*\\/",
+							"name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+						},
+						{
+							"match": "\\*",
+							"name": "comment.block.cpp"
+						}
+					]
+				},
+				"33": {
+					"patterns": [
+						{
+							"include": "#inline_comment"
+						}
+					]
+				},
+				"34": {
+					"name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+				},
+				"35": {
+					"name": "comment.block.cpp"
+				},
+				"36": {
+					"patterns": [
+						{
+							"match": "\\*\\/",
+							"name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+						},
+						{
+							"match": "\\*",
+							"name": "comment.block.cpp"
+						}
+					]
+				}
+			}
+		},
+		"parameter_union": {
+			"match": "(union)((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))((?<!\\w)(?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*(?!\\w))((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))(?:(((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))?(?:(?:\\&|\\*)((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z)))))*(?:\\&|\\*))((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z)))))?((?:(?<!\\w)(?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*(?!\\w))?)((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))(?:\\[((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))\\]((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z)))))?(?=,|\\)|\\n)",
+			"captures": {
+				"1": {
+					"name": "storage.type.union.parameter.cpp"
+				},
+				"2": {
+					"patterns": [
+						{
+							"include": "#inline_comment"
+						}
+					]
+				},
+				"3": {
+					"name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+				},
+				"4": {
+					"name": "comment.block.cpp"
+				},
+				"5": {
+					"patterns": [
+						{
+							"match": "\\*\\/",
+							"name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+						},
+						{
+							"match": "\\*",
+							"name": "comment.block.cpp"
+						}
+					]
+				},
+				"6": {
+					"name": "entity.name.type.union.parameter.cpp"
+				},
+				"7": {
+					"patterns": [
+						{
+							"include": "#inline_comment"
+						}
+					]
+				},
+				"8": {
+					"name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+				},
+				"9": {
+					"name": "comment.block.cpp"
+				},
+				"10": {
+					"patterns": [
+						{
+							"match": "\\*\\/",
+							"name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+						},
+						{
+							"match": "\\*",
+							"name": "comment.block.cpp"
+						}
+					]
+				},
+				"11": {
+					"patterns": [
+						{
+							"match": "\\*",
+							"name": "storage.modifier.pointer.cpp"
+						},
+						{
+							"match": "(?:\\&((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))){2,}\\&",
+							"captures": {
+								"1": {
+									"patterns": [
+										{
+											"include": "#inline_comment"
+										}
+									]
+								},
+								"2": {
+									"name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+								},
+								"3": {
+									"name": "comment.block.cpp"
+								},
+								"4": {
+									"patterns": [
+										{
+											"match": "\\*\\/",
+											"name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+										},
+										{
+											"match": "\\*",
+											"name": "comment.block.cpp"
+										}
+									]
+								}
+							},
+							"name": "invalid.illegal.reference-type.cpp"
+						},
+						{
+							"match": "\\&",
+							"name": "storage.modifier.reference.cpp"
+						}
+					]
+				},
+				"12": {
+					"patterns": [
+						{
+							"include": "#inline_comment"
+						}
+					]
+				},
+				"13": {
+					"name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+				},
+				"14": {
+					"name": "comment.block.cpp"
+				},
+				"15": {
+					"patterns": [
+						{
+							"match": "\\*\\/",
+							"name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+						},
+						{
+							"match": "\\*",
+							"name": "comment.block.cpp"
+						}
+					]
+				},
+				"16": {
+					"patterns": [
+						{
+							"include": "#inline_comment"
+						}
+					]
+				},
+				"17": {
+					"name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+				},
+				"18": {
+					"name": "comment.block.cpp"
+				},
+				"19": {
+					"patterns": [
+						{
+							"match": "\\*\\/",
+							"name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+						},
+						{
+							"match": "\\*",
+							"name": "comment.block.cpp"
+						}
+					]
+				},
+				"20": {
+					"patterns": [
+						{
+							"include": "#inline_comment"
+						}
+					]
+				},
+				"21": {
+					"name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+				},
+				"22": {
+					"name": "comment.block.cpp"
+				},
+				"23": {
+					"patterns": [
+						{
+							"match": "\\*\\/",
+							"name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+						},
+						{
+							"match": "\\*",
+							"name": "comment.block.cpp"
+						}
+					]
+				},
+				"24": {
+					"name": "variable.other.object.declare.cpp"
+				},
+				"25": {
+					"patterns": [
+						{
+							"include": "#inline_comment"
+						}
+					]
+				},
+				"26": {
+					"name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+				},
+				"27": {
+					"name": "comment.block.cpp"
+				},
+				"28": {
+					"patterns": [
+						{
+							"match": "\\*\\/",
+							"name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+						},
+						{
+							"match": "\\*",
+							"name": "comment.block.cpp"
+						}
+					]
+				},
+				"29": {
+					"patterns": [
+						{
+							"include": "#inline_comment"
+						}
+					]
+				},
+				"30": {
+					"name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+				},
+				"31": {
+					"name": "comment.block.cpp"
+				},
+				"32": {
+					"patterns": [
+						{
+							"match": "\\*\\/",
+							"name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+						},
+						{
+							"match": "\\*",
+							"name": "comment.block.cpp"
+						}
+					]
+				},
+				"33": {
+					"patterns": [
+						{
+							"include": "#inline_comment"
+						}
+					]
+				},
+				"34": {
+					"name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+				},
+				"35": {
+					"name": "comment.block.cpp"
+				},
+				"36": {
+					"patterns": [
+						{
+							"match": "\\*\\/",
+							"name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+						},
+						{
+							"match": "\\*",
+							"name": "comment.block.cpp"
+						}
+					]
+				}
+			}
+		},
+		"parentheses": {
+			"name": "meta.parens.cpp",
+			"begin": "(\\()",
+			"beginCaptures": {
+				"1": {
+					"name": "punctuation.section.parens.begin.bracket.round.cpp"
+				}
+			},
+			"end": "(\\))",
+			"endCaptures": {
+				"1": {
+					"name": "punctuation.section.parens.end.bracket.round.cpp"
+				}
+			},
+			"patterns": [
+				{
+					"include": "#over_qualified_types"
+				},
+				{
+					"match": "(?<!:):(?!:)",
+					"name": "punctuation.separator.colon.range-based.cpp"
+				},
+				{
+					"include": "#evaluation_context"
+				}
+			]
+		},
+		"posix_reserved_types": {
+			"match": "((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))((?<!\\w)[a-zA-Z_]\\w*_t(?!\\w))",
+			"captures": {
+				"1": {
+					"patterns": [
+						{
+							"include": "#inline_comment"
+						}
+					]
+				},
+				"2": {
+					"name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+				},
+				"3": {
+					"name": "comment.block.cpp"
+				},
+				"4": {
+					"patterns": [
+						{
+							"match": "\\*\\/",
+							"name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+						},
+						{
+							"match": "\\*",
+							"name": "comment.block.cpp"
+						}
+					]
+				},
+				"5": {
+					"name": "support.type.posix-reserved.cpp support.type.built-in.posix-reserved.cpp"
+				}
+			}
+		},
+		"pragma": {
+			"name": "meta.preprocessor.pragma.cpp",
+			"begin": "((?:^)((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))(#)\\s*pragma\\b)",
+			"beginCaptures": {
+				"1": {
+					"name": "keyword.control.directive.pragma.cpp"
+				},
+				"2": {
+					"patterns": [
+						{
+							"include": "#inline_comment"
+						}
+					]
+				},
+				"3": {
+					"name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+				},
+				"4": {
+					"name": "comment.block.cpp"
+				},
+				"5": {
+					"patterns": [
+						{
+							"match": "\\*\\/",
+							"name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+						},
+						{
+							"match": "\\*",
+							"name": "comment.block.cpp"
+						}
+					]
+				},
+				"6": {
+					"name": "punctuation.definition.directive.cpp"
+				}
+			},
+			"end": "(?<!\\\\)(?=\\n)",
+			"patterns": [
+				{
+					"include": "#comments"
+				},
+				{
+					"include": "#string_context_c"
+				},
+				{
+					"match": "[a-zA-Z_$][\\w\\-$]*",
+					"name": "entity.other.attribute-name.pragma.preprocessor.cpp"
+				},
+				{
+					"include": "#preprocessor_number_literal"
+				},
+				{
+					"include": "#line_continuation_character"
+				}
+			]
+		},
+		"pragma_mark": {
+			"match": "((?:^)((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))(#)\\s*pragma\\s+mark)\\s+(.*)",
+			"captures": {
+				"1": {
+					"name": "keyword.control.directive.pragma.pragma-mark.cpp"
+				},
+				"2": {
+					"patterns": [
+						{
+							"include": "#inline_comment"
+						}
+					]
+				},
+				"3": {
+					"name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+				},
+				"4": {
+					"name": "comment.block.cpp"
+				},
+				"5": {
+					"patterns": [
+						{
+							"match": "\\*\\/",
+							"name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+						},
+						{
+							"match": "\\*",
+							"name": "comment.block.cpp"
+						}
+					]
+				},
+				"6": {
+					"name": "punctuation.definition.directive.cpp"
+				},
+				"7": {
+					"name": "entity.name.tag.pragma-mark.cpp"
+				}
+			},
+			"name": "meta.preprocessor.pragma.cpp"
+		},
+		"predefined_macros": {
+			"patterns": [
+				{
+					"match": "\\b(__cplusplus|__DATE__|__FILE__|__LINE__|__STDC__|__STDC_HOSTED__|__STDC_NO_COMPLEX__|__STDC_VERSION__|__STDCPP_THREADS__|__TIME__|NDEBUG|__OBJC__|__ASSEMBLER__|__ATOM__|__AVX__|__AVX2__|_CHAR_UNSIGNED|__CLR_VER|_CONTROL_FLOW_GUARD|__COUNTER__|__cplusplus_cli|__cplusplus_winrt|_CPPRTTI|_CPPUNWIND|_DEBUG|_DLL|__FUNCDNAME__|__FUNCSIG__|__FUNCTION__|_INTEGRAL_MAX_BITS|__INTELLISENSE__|_ISO_VOLATILE|_KERNEL_MODE|_M_AMD64|_M_ARM|_M_ARM_ARMV7VE|_M_ARM_FP|_M_ARM64|_M_CEE|_M_CEE_PURE|_M_CEE_SAFE|_M_FP_EXCEPT|_M_FP_FAST|_M_FP_PRECISE|_M_FP_STRICT|_M_IX86|_M_IX86_FP|_M_X64|_MANAGED|_MSC_BUILD|_MSC_EXTENSIONS|_MSC_FULL_VER|_MSC_VER|_MSVC_LANG|__MSVC_RUNTIME_CHECKS|_MT|_NATIVE_WCHAR_T_DEFINED|_OPENMP|_PREFAST|__TIMESTAMP__|_VC_NO_DEFAULTLIB|_WCHAR_T_DEFINED|_WIN32|_WIN64|_WINRT_DLL|_ATL_VER|_MFC_VER|__GFORTRAN__|__GNUC__|__GNUC_MINOR__|__GNUC_PATCHLEVEL__|__GNUG__|__STRICT_ANSI__|__BASE_FILE__|__INCLUDE_LEVEL__|__ELF__|__VERSION__|__OPTIMIZE__|__OPTIMIZE_SIZE__|__NO_INLINE__|__GNUC_STDC_INLINE__|__CHAR_UNSIGNED__|__WCHAR_UNSIGNED__|__REGISTER_PREFIX__|__REGISTER_PREFIX__|__SIZE_TYPE__|__PTRDIFF_TYPE__|__WCHAR_TYPE__|__WINT_TYPE__|__INTMAX_TYPE__|__UINTMAX_TYPE__|__SIG_ATOMIC_TYPE__|__INT8_TYPE__|__INT16_TYPE__|__INT32_TYPE__|__INT64_TYPE__|__UINT8_TYPE__|__UINT16_TYPE__|__UINT32_TYPE__|__UINT64_TYPE__|__INT_LEAST8_TYPE__|__INT_LEAST16_TYPE__|__INT_LEAST32_TYPE__|__INT_LEAST64_TYPE__|__UINT_LEAST8_TYPE__|__UINT_LEAST16_TYPE__|__UINT_LEAST32_TYPE__|__UINT_LEAST64_TYPE__|__INT_FAST8_TYPE__|__INT_FAST16_TYPE__|__INT_FAST32_TYPE__|__INT_FAST64_TYPE__|__UINT_FAST8_TYPE__|__UINT_FAST16_TYPE__|__UINT_FAST32_TYPE__|__UINT_FAST64_TYPE__|__INTPTR_TYPE__|__UINTPTR_TYPE__|__CHAR_BIT__|__SCHAR_MAX__|__WCHAR_MAX__|__SHRT_MAX__|__INT_MAX__|__LONG_MAX__|__LONG_LONG_MAX__|__WINT_MAX__|__SIZE_MAX__|__PTRDIFF_MAX__|__INTMAX_MAX__|__UINTMAX_MAX__|__SIG_ATOMIC_MAX__|__INT8_MAX__|__INT16_MAX__|__INT32_MAX__|__INT64_MAX__|__UINT8_MAX__|__UINT16_MAX__|__UINT32_MAX__|__UINT64_MAX__|__INT_LEAST8_MAX__|__INT_LEAST16_MAX__|__INT_LEAST32_MAX__|__INT_LEAST64_MAX__|__UINT_LEAST8_MAX__|__UINT_LEAST16_MAX__|__UINT_LEAST32_MAX__|__UINT_LEAST64_MAX__|__INT_FAST8_MAX__|__INT_FAST16_MAX__|__INT_FAST32_MAX__|__INT_FAST64_MAX__|__UINT_FAST8_MAX__|__UINT_FAST16_MAX__|__UINT_FAST32_MAX__|__UINT_FAST64_MAX__|__INTPTR_MAX__|__UINTPTR_MAX__|__WCHAR_MIN__|__WINT_MIN__|__SIG_ATOMIC_MIN__|__SCHAR_WIDTH__|__SHRT_WIDTH__|__INT_WIDTH__|__LONG_WIDTH__|__LONG_LONG_WIDTH__|__PTRDIFF_WIDTH__|__SIG_ATOMIC_WIDTH__|__SIZE_WIDTH__|__WCHAR_WIDTH__|__WINT_WIDTH__|__INT_LEAST8_WIDTH__|__INT_LEAST16_WIDTH__|__INT_LEAST32_WIDTH__|__INT_LEAST64_WIDTH__|__INT_FAST8_WIDTH__|__INT_FAST16_WIDTH__|__INT_FAST32_WIDTH__|__INT_FAST64_WIDTH__|__INTPTR_WIDTH__|__INTMAX_WIDTH__|__SIZEOF_INT__|__SIZEOF_LONG__|__SIZEOF_LONG_LONG__|__SIZEOF_SHORT__|__SIZEOF_POINTER__|__SIZEOF_FLOAT__|__SIZEOF_DOUBLE__|__SIZEOF_LONG_DOUBLE__|__SIZEOF_SIZE_T__|__SIZEOF_WCHAR_T__|__SIZEOF_WINT_T__|__SIZEOF_PTRDIFF_T__|__BYTE_ORDER__|__ORDER_LITTLE_ENDIAN__|__ORDER_BIG_ENDIAN__|__ORDER_PDP_ENDIAN__|__FLOAT_WORD_ORDER__|__DEPRECATED|__EXCEPTIONS|__GXX_RTTI|__USING_SJLJ_EXCEPTIONS__|__GXX_EXPERIMENTAL_CXX0X__|__GXX_WEAK__|__NEXT_RUNTIME__|__LP64__|_LP64|__SSP__|__SSP_ALL__|__SSP_STRONG__|__SSP_EXPLICIT__|__SANITIZE_ADDRESS__|__SANITIZE_THREAD__|__GCC_HAVE_SYNC_COMPARE_AND_SWAP_1|__GCC_HAVE_SYNC_COMPARE_AND_SWAP_2|__GCC_HAVE_SYNC_COMPARE_AND_SWAP_4|__GCC_HAVE_SYNC_COMPARE_AND_SWAP_8|__GCC_HAVE_SYNC_COMPARE_AND_SWAP_16|__HAVE_SPECULATION_SAFE_VALUE|__GCC_HAVE_DWARF2_CFI_ASM|__FP_FAST_FMA|__FP_FAST_FMAF|__FP_FAST_FMAL|__FP_FAST_FMAF16|__FP_FAST_FMAF32|__FP_FAST_FMAF64|__FP_FAST_FMAF128|__FP_FAST_FMAF32X|__FP_FAST_FMAF64X|__FP_FAST_FMAF128X|__GCC_IEC_559|__GCC_IEC_559_COMPLEX|__NO_MATH_ERRNO__|__has_builtin|__has_feature|__has_extension|__has_cpp_attribute|__has_c_attribute|__has_attribute|__has_declspec_attribute|__is_identifier|__has_include|__has_include_next|__has_warning|__BASE_FILE__|__FILE_NAME__|__clang__|__clang_major__|__clang_minor__|__clang_patchlevel__|__clang_version__|__fp16|_Float16)\\b",
+					"captures": {
+						"1": {
+							"name": "entity.name.other.preprocessor.macro.predefined.$1.cpp"
+						}
+					}
+				},
+				{
+					"match": "\\b__([A-Z_]+)__\\b",
+					"name": "entity.name.other.preprocessor.macro.predefined.probably.$1.cpp"
+				}
+			]
+		},
+		"preprocessor_conditional_context": {
+			"patterns": [
+				{
+					"include": "#preprocessor_conditional_defined"
+				},
+				{
+					"include": "#comments"
+				},
+				{
+					"include": "#language_constants"
+				},
+				{
+					"include": "#string_context_c"
+				},
+				{
+					"include": "#preprocessor_number_literal"
+				},
+				{
+					"include": "#operators"
+				},
+				{
+					"include": "#predefined_macros"
+				},
+				{
+					"include": "#macro_name"
+				},
+				{
+					"include": "#line_continuation_character"
+				}
+			]
+		},
+		"preprocessor_conditional_defined": {
+			"begin": "((?<!\\w)defined(?!\\w))(\\()",
+			"beginCaptures": {
+				"1": {
+					"name": "keyword.control.directive.conditional.defined.cpp"
+				},
+				"2": {
+					"name": "punctuation.section.parens.control.defined.cpp"
+				}
+			},
+			"end": "((?:\\)|(?<!\\\\)(?=\\n)))",
+			"endCaptures": {
+				"1": {
+					"name": "punctuation.section.parens.control.defined.cpp"
+				}
+			},
+			"patterns": [
+				{
+					"include": "#macro_name"
+				}
+			]
+		},
+		"preprocessor_conditional_parentheses": {
+			"name": "meta.parens.preprocessor.conditional.cpp",
+			"begin": "(\\()",
+			"beginCaptures": {
+				"1": {
+					"name": "punctuation.section.parens.begin.bracket.round.cpp"
+				}
+			},
+			"end": "(\\))",
+			"endCaptures": {
+				"1": {
+					"name": "punctuation.section.parens.end.bracket.round.cpp"
+				}
+			}
+		},
+		"preprocessor_conditional_range": {
+			"begin": "((?:^)((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))(#)\\s*((?:(?:ifndef|ifdef)|if)))",
+			"beginCaptures": {
+				"1": {
+					"name": "keyword.control.directive.conditional.$7.cpp"
+				},
+				"2": {
+					"patterns": [
+						{
+							"include": "#inline_comment"
+						}
+					]
+				},
+				"3": {
+					"name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+				},
+				"4": {
+					"name": "comment.block.cpp"
+				},
+				"5": {
+					"patterns": [
+						{
+							"match": "\\*\\/",
+							"name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+						},
+						{
+							"match": "\\*",
+							"name": "comment.block.cpp"
+						}
+					]
+				},
+				"6": {
+					"name": "punctuation.definition.directive.cpp"
+				}
+			},
+			"end": "(?:^)(?!\\s*+#\\s*(?:else|endif))",
+			"patterns": [
+				{
+					"name": "meta.preprocessor.conditional.cpp",
+					"begin": "\\G(?<=ifndef|ifdef|if)",
+					"end": "(?<!\\\\)(?=\\n)",
+					"patterns": [
+						{
+							"include": "#preprocessor_conditional_context"
+						}
+					]
+				},
+				{
+					"include": "$self"
+				}
+			]
+		},
+		"preprocessor_conditional_standalone": {
+			"match": "(?:^)((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))(#)\\s*((?<!\\w)(?:endif|else|elif)(?!\\w))",
+			"captures": {
+				"1": {
+					"patterns": [
+						{
+							"include": "#inline_comment"
+						}
+					]
+				},
+				"2": {
+					"name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+				},
+				"3": {
+					"name": "comment.block.cpp"
+				},
+				"4": {
+					"patterns": [
+						{
+							"match": "\\*\\/",
+							"name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+						},
+						{
+							"match": "\\*",
+							"name": "comment.block.cpp"
+						}
+					]
+				},
+				"5": {
+					"name": "punctuation.definition.directive.cpp"
+				}
+			},
+			"name": "keyword.control.directive.$6.cpp"
+		},
+		"preprocessor_number_literal": {
+			"match": "(?<!\\w)\\.?\\d(?:(?:[0-9a-zA-Z_\\.]|')|(?<=[eEpP])[+-])*",
+			"captures": {
+				"0": {
+					"patterns": [
+						{
+							"begin": "(?=.)",
+							"end": "$",
+							"patterns": [
+								{
+									"match": "(\\G0[xX])([0-9a-fA-F](?:[0-9a-fA-F]|((?<=[0-9a-fA-F])'(?=[0-9a-fA-F])))*)?((?:(?<=[0-9a-fA-F])\\.|\\.(?=[0-9a-fA-F])))([0-9a-fA-F](?:[0-9a-fA-F]|((?<=[0-9a-fA-F])'(?=[0-9a-fA-F])))*)?((?<!')([pP])(\\+?)(\\-?)((?:[0-9](?:[0-9]|(?:(?<=[0-9a-fA-F])'(?=[0-9a-fA-F])))*)))?([lLfF](?!\\w))?$",
+									"captures": {
+										"1": {
+											"name": "keyword.other.unit.hexadecimal.cpp"
+										},
+										"2": {
+											"name": "constant.numeric.hexadecimal.cpp",
+											"patterns": [
+												{
+													"match": "(?<=[0-9a-fA-F])'(?=[0-9a-fA-F])",
+													"name": "punctuation.separator.constant.numeric.cpp"
+												}
+											]
+										},
+										"3": {
+											"name": "punctuation.separator.constant.numeric.cpp"
+										},
+										"4": {
+											"name": "constant.numeric.hexadecimal.cpp"
+										},
+										"5": {
+											"name": "constant.numeric.hexadecimal.cpp",
+											"patterns": [
+												{
+													"match": "(?<=[0-9a-fA-F])'(?=[0-9a-fA-F])",
+													"name": "punctuation.separator.constant.numeric.cpp"
+												}
+											]
+										},
+										"6": {
+											"name": "punctuation.separator.constant.numeric.cpp"
+										},
+										"8": {
+											"name": "keyword.other.unit.exponent.hexadecimal.cpp"
+										},
+										"9": {
+											"name": "keyword.operator.plus.exponent.hexadecimal.cpp"
+										},
+										"10": {
+											"name": "keyword.operator.minus.exponent.hexadecimal.cpp"
+										},
+										"11": {
+											"name": "constant.numeric.exponent.hexadecimal.cpp",
+											"patterns": [
+												{
+													"match": "(?<=[0-9a-fA-F])'(?=[0-9a-fA-F])",
+													"name": "punctuation.separator.constant.numeric.cpp"
+												}
+											]
+										},
+										"12": {
+											"name": "keyword.other.unit.suffix.floating-point.cpp"
+										}
+									}
+								},
+								{
+									"match": "(\\G(?=[0-9.])(?!0[xXbB]))([0-9](?:[0-9]|((?<=[0-9a-fA-F])'(?=[0-9a-fA-F])))*)?((?:(?<=[0-9])\\.|\\.(?=[0-9])))([0-9](?:[0-9]|((?<=[0-9a-fA-F])'(?=[0-9a-fA-F])))*)?((?<!')([eE])(\\+?)(\\-?)((?:[0-9](?:[0-9]|(?:(?<=[0-9a-fA-F])'(?=[0-9a-fA-F])))*)))?([lLfF](?!\\w))?$",
+									"captures": {
+										"2": {
+											"name": "constant.numeric.decimal.cpp",
+											"patterns": [
+												{
+													"match": "(?<=[0-9a-fA-F])'(?=[0-9a-fA-F])",
+													"name": "punctuation.separator.constant.numeric.cpp"
+												}
+											]
+										},
+										"3": {
+											"name": "punctuation.separator.constant.numeric.cpp"
+										},
+										"4": {
+											"name": "constant.numeric.decimal.point.cpp"
+										},
+										"5": {
+											"name": "constant.numeric.decimal.cpp",
+											"patterns": [
+												{
+													"match": "(?<=[0-9a-fA-F])'(?=[0-9a-fA-F])",
+													"name": "punctuation.separator.constant.numeric.cpp"
+												}
+											]
+										},
+										"6": {
+											"name": "punctuation.separator.constant.numeric.cpp"
+										},
+										"8": {
+											"name": "keyword.other.unit.exponent.decimal.cpp"
+										},
+										"9": {
+											"name": "keyword.operator.plus.exponent.decimal.cpp"
+										},
+										"10": {
+											"name": "keyword.operator.minus.exponent.decimal.cpp"
+										},
+										"11": {
+											"name": "constant.numeric.exponent.decimal.cpp",
+											"patterns": [
+												{
+													"match": "(?<=[0-9a-fA-F])'(?=[0-9a-fA-F])",
+													"name": "punctuation.separator.constant.numeric.cpp"
+												}
+											]
+										},
+										"12": {
+											"name": "keyword.other.unit.suffix.floating-point.cpp"
+										}
+									}
+								},
+								{
+									"match": "(\\G0[bB])([01](?:[01]|((?<=[0-9a-fA-F])'(?=[0-9a-fA-F])))*)((?:(?:(?:(?:(?:[uU]|[uU]ll?)|[uU]LL?)|ll?[uU]?)|LL?[uU]?)|[fF])(?!\\w))?$",
+									"captures": {
+										"1": {
+											"name": "keyword.other.unit.binary.cpp"
+										},
+										"2": {
+											"name": "constant.numeric.binary.cpp",
+											"patterns": [
+												{
+													"match": "(?<=[0-9a-fA-F])'(?=[0-9a-fA-F])",
+													"name": "punctuation.separator.constant.numeric.cpp"
+												}
+											]
+										},
+										"3": {
+											"name": "punctuation.separator.constant.numeric.cpp"
+										},
+										"4": {
+											"name": "keyword.other.unit.suffix.integer.cpp"
+										}
+									}
+								},
+								{
+									"match": "(\\G0)((?:[0-7]|((?<=[0-9a-fA-F])'(?=[0-9a-fA-F])))+)((?:(?:(?:(?:(?:[uU]|[uU]ll?)|[uU]LL?)|ll?[uU]?)|LL?[uU]?)|[fF])(?!\\w))?$",
+									"captures": {
+										"1": {
+											"name": "keyword.other.unit.octal.cpp"
+										},
+										"2": {
+											"name": "constant.numeric.octal.cpp",
+											"patterns": [
+												{
+													"match": "(?<=[0-9a-fA-F])'(?=[0-9a-fA-F])",
+													"name": "punctuation.separator.constant.numeric.cpp"
+												}
+											]
+										},
+										"3": {
+											"name": "punctuation.separator.constant.numeric.cpp"
+										},
+										"4": {
+											"name": "keyword.other.unit.suffix.integer.cpp"
+										}
+									}
+								},
+								{
+									"match": "(\\G0[xX])([0-9a-fA-F](?:[0-9a-fA-F]|((?<=[0-9a-fA-F])'(?=[0-9a-fA-F])))*)((?<!')([pP])(\\+?)(\\-?)((?:[0-9](?:[0-9]|(?:(?<=[0-9a-fA-F])'(?=[0-9a-fA-F])))*)))?((?:(?:(?:(?:(?:[uU]|[uU]ll?)|[uU]LL?)|ll?[uU]?)|LL?[uU]?)|[fF])(?!\\w))?$",
+									"captures": {
+										"1": {
+											"name": "keyword.other.unit.hexadecimal.cpp"
+										},
+										"2": {
+											"name": "constant.numeric.hexadecimal.cpp",
+											"patterns": [
+												{
+													"match": "(?<=[0-9a-fA-F])'(?=[0-9a-fA-F])",
+													"name": "punctuation.separator.constant.numeric.cpp"
+												}
+											]
+										},
+										"3": {
+											"name": "punctuation.separator.constant.numeric.cpp"
+										},
+										"5": {
+											"name": "keyword.other.unit.exponent.hexadecimal.cpp"
+										},
+										"6": {
+											"name": "keyword.operator.plus.exponent.hexadecimal.cpp"
+										},
+										"7": {
+											"name": "keyword.operator.minus.exponent.hexadecimal.cpp"
+										},
+										"8": {
+											"name": "constant.numeric.exponent.hexadecimal.cpp",
+											"patterns": [
+												{
+													"match": "(?<=[0-9a-fA-F])'(?=[0-9a-fA-F])",
+													"name": "punctuation.separator.constant.numeric.cpp"
+												}
+											]
+										},
+										"9": {
+											"name": "keyword.other.unit.suffix.integer.cpp"
+										}
+									}
+								},
+								{
+									"match": "(\\G(?=[0-9.])(?!0[xXbB]))([0-9](?:[0-9]|((?<=[0-9a-fA-F])'(?=[0-9a-fA-F])))*)((?<!')([eE])(\\+?)(\\-?)((?:[0-9](?:[0-9]|(?:(?<=[0-9a-fA-F])'(?=[0-9a-fA-F])))*)))?((?:(?:(?:(?:(?:[uU]|[uU]ll?)|[uU]LL?)|ll?[uU]?)|LL?[uU]?)|[fF])(?!\\w))?$",
+									"captures": {
+										"2": {
+											"name": "constant.numeric.decimal.cpp",
+											"patterns": [
+												{
+													"match": "(?<=[0-9a-fA-F])'(?=[0-9a-fA-F])",
+													"name": "punctuation.separator.constant.numeric.cpp"
+												}
+											]
+										},
+										"3": {
+											"name": "punctuation.separator.constant.numeric.cpp"
+										},
+										"5": {
+											"name": "keyword.other.unit.exponent.decimal.cpp"
+										},
+										"6": {
+											"name": "keyword.operator.plus.exponent.decimal.cpp"
+										},
+										"7": {
+											"name": "keyword.operator.minus.exponent.decimal.cpp"
+										},
+										"8": {
+											"name": "constant.numeric.exponent.decimal.cpp",
+											"patterns": [
+												{
+													"match": "(?<=[0-9a-fA-F])'(?=[0-9a-fA-F])",
+													"name": "punctuation.separator.constant.numeric.cpp"
+												}
+											]
+										},
+										"9": {
+											"name": "keyword.other.unit.suffix.integer.cpp"
+										}
+									}
+								},
+								{
+									"match": "(?:(?:[0-9a-zA-Z_\\.]|')|(?<=[eEpP])[+-])+",
+									"name": "invalid.illegal.constant.numeric.cpp"
+								}
+							]
+						}
+					]
+				}
+			}
+		},
+		"primitive_types": {
+			"match": "((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))((?<!\\w)(?:unsigned|wchar_t|double|signed|short|float|auto|void|long|char|bool|int)(?!\\w))",
+			"captures": {
+				"1": {
+					"patterns": [
+						{
+							"include": "#inline_comment"
+						}
+					]
+				},
+				"2": {
+					"name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+				},
+				"3": {
+					"name": "comment.block.cpp"
+				},
+				"4": {
+					"patterns": [
+						{
+							"match": "\\*\\/",
+							"name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+						},
+						{
+							"match": "\\*",
+							"name": "comment.block.cpp"
+						}
+					]
+				},
+				"5": {
+					"name": "storage.type.primitive.cpp storage.type.built-in.primitive.cpp"
+				}
+			}
+		},
+		"pthread_types": {
+			"match": "((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))((?<!\\w)pthread_attr_t|pthread_cond_t|pthread_condattr_t|pthread_mutex_t|pthread_mutexattr_t|pthread_once_t|pthread_rwlock_t|pthread_rwlockattr_t|pthread_t|pthread_key_t(?!\\w))",
+			"captures": {
+				"1": {
+					"patterns": [
+						{
+							"include": "#inline_comment"
+						}
+					]
+				},
+				"2": {
+					"name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+				},
+				"3": {
+					"name": "comment.block.cpp"
+				},
+				"4": {
+					"patterns": [
+						{
+							"match": "\\*\\/",
+							"name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+						},
+						{
+							"match": "\\*",
+							"name": "comment.block.cpp"
+						}
+					]
+				},
+				"5": {
+					"name": "support.type.posix-reserved.pthread.cpp support.type.built-in.posix-reserved.pthread.cpp"
+				}
+			}
+		},
+		"qualified_type": {
+			"match": "\\s*+((?:(?:(?:\\[\\[.*?\\]\\]|__attribute(?:__)?\\(\\(.*?\\)\\))|__declspec\\(.*?\\))|alignas\\(.*?\\))(?!\\)))?((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))(?:(?:(?:unsigned|signed|short|long)|(?:struct|class|union|enum))((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z)))))*(((::)?(?:((?-mix:(?!\\b(?:__has_cpp_attribute|reinterpret_cast|atomic_noexcept|atomic_cancel|atomic_commit|__has_include|dynamic_cast|thread_local|synchronized|static_cast|const_cast|consteval|constexpr|protected|namespace|co_return|constexpr|constexpr|continue|explicit|volatile|noexcept|co_yield|noexcept|noexcept|requires|typename|decltype|operator|co_await|template|volatile|register|restrict|reflexpr|alignof|private|default|mutable|include|concept|__asm__|defined|_Pragma|alignas|typedef|warning|virtual|mutable|struct|sizeof|delete|not_eq|bitand|and_eq|xor_eq|typeid|switch|return|static|extern|inline|friend|public|ifndef|define|pragma|export|import|module|catch|throw|const|or_eq|while|compl|bitor|const|union|ifdef|class|undef|error|break|using|endif|goto|line|enum|this|case|else|elif|else|asm|try|for|new|and|xor|not|do|or|if|if)\\b)(?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*))\\s*+(((?<!<)<(?!<)(?>(?:(?>[^<>]*)\\g<26>?)+)>)\\s*)?::)*\\s*+)((?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*)\\s*+(((?<!<)<(?!<)(?>(?:(?>[^<>]*)\\g<26>?)+)>)\\s*)?(::))?((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))(?!(?:transaction_safe_dynamic|__has_cpp_attribute|transaction_safe|reinterpret_cast|atomic_noexcept|atomic_commit|atomic_cancel|__has_include|dynamic_cast|thread_local|synchronized|static_cast|const_cast|constexpr|consteval|protected|constexpr|co_return|namespace|constexpr|noexcept|typename|decltype|template|operator|noexcept|co_yield|co_await|continue|volatile|register|restrict|explicit|override|volatile|reflexpr|noexcept|requires|default|typedef|nullptr|alignof|mutable|concept|virtual|defined|__asm__|include|_Pragma|mutable|warning|private|alignas|module|switch|not_eq|bitand|and_eq|ifndef|return|sizeof|xor_eq|export|static|delete|public|define|extern|inline|import|pragma|friend|typeid|const|compl|bitor|throw|or_eq|while|catch|break|false|final|const|endif|ifdef|undef|error|using|audit|axiom|line|else|elif|true|NULL|case|goto|else|this|new|asm|not|and|xor|try|for|if|do|or|if)\\b)((?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*)\\b(((?<!<)<(?!<)(?>(?:(?>[^<>]*)\\g<26>?)+)>)\\s*)?(?![\\w<:.])",
+			"captures": {
+				"0": {
+					"name": "meta.qualified_type.cpp",
+					"patterns": [
+						{
+							"match": "(?<!\\w)(?:struct|class|union|enum)(?!\\w)",
+							"name": "storage.type.$0.cpp"
+						},
+						{
+							"include": "#attributes_context"
+						},
+						{
+							"include": "#function_type"
+						},
+						{
+							"include": "#storage_types"
+						},
+						{
+							"include": "#number_literal"
+						},
+						{
+							"include": "#string_context"
+						},
+						{
+							"include": "#comma"
+						},
+						{
+							"include": "#scope_resolution_inner_generated"
+						},
+						{
+							"include": "#template_call_range"
+						},
+						{
+							"match": "(?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*",
+							"name": "entity.name.type.cpp"
+						}
+					]
+				},
+				"1": {
+					"patterns": [
+						{
+							"include": "#attributes_context"
+						},
+						{
+							"include": "#number_literal"
+						}
+					]
+				},
+				"2": {
+					"patterns": [
+						{
+							"include": "#inline_comment"
+						}
+					]
+				},
+				"3": {
+					"name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+				},
+				"4": {
+					"name": "comment.block.cpp"
+				},
+				"5": {
+					"patterns": [
+						{
+							"match": "\\*\\/",
+							"name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+						},
+						{
+							"match": "\\*",
+							"name": "comment.block.cpp"
+						}
+					]
+				},
+				"6": {
+					"patterns": [
+						{
+							"include": "#inline_comment"
+						}
+					]
+				},
+				"7": {
+					"name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+				},
+				"8": {
+					"name": "comment.block.cpp"
+				},
+				"9": {
+					"patterns": [
+						{
+							"match": "\\*\\/",
+							"name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+						},
+						{
+							"match": "\\*",
+							"name": "comment.block.cpp"
+						}
+					]
+				},
+				"11": {
+					"patterns": [
+						{
+							"include": "#scope_resolution_inner_generated"
+						}
+					]
+				},
+				"12": {
+					"name": "punctuation.separator.namespace.access.cpp punctuation.separator.scope-resolution.cpp"
+				},
+				"14": {
+					"name": "meta.template.call.cpp",
+					"patterns": [
+						{
+							"include": "#template_call_range"
+						}
+					]
+				},
+				"16": {
+					"name": "entity.name.scope-resolution.cpp"
+				},
+				"17": {
+					"name": "meta.template.call.cpp",
+					"patterns": [
+						{
+							"include": "#template_call_range"
+						}
+					]
+				},
+				"19": {
+					"name": "punctuation.separator.namespace.access.cpp punctuation.separator.scope-resolution.cpp"
+				},
+				"20": {
+					"patterns": [
+						{
+							"include": "#inline_comment"
+						}
+					]
+				},
+				"21": {
+					"name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+				},
+				"22": {
+					"name": "comment.block.cpp"
+				},
+				"23": {
+					"patterns": [
+						{
+							"match": "\\*\\/",
+							"name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+						},
+						{
+							"match": "\\*",
+							"name": "comment.block.cpp"
+						}
+					]
+				},
+				"24": {
+					"name": "entity.name.type.cpp"
+				},
+				"25": {
+					"name": "meta.template.call.cpp",
+					"patterns": [
+						{
+							"include": "#template_call_range"
+						}
+					]
+				}
+			}
+		},
+		"qualifiers_and_specifiers_post_parameters": {
+			"match": "((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))((?<!\\w)(?:override|volatile|noexcept|final|const)(?!\\w)(?=\\s*(?:(?:\\{|;)|[\\n\\r])))",
+			"captures": {
+				"1": {
+					"patterns": [
+						{
+							"include": "#inline_comment"
+						}
+					]
+				},
+				"2": {
+					"name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+				},
+				"3": {
+					"name": "comment.block.cpp"
+				},
+				"4": {
+					"patterns": [
+						{
+							"match": "\\*\\/",
+							"name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+						},
+						{
+							"match": "\\*",
+							"name": "comment.block.cpp"
+						}
+					]
+				},
+				"5": {
+					"name": "storage.modifier.specifier.functional.post-parameters.$5.cpp"
+				}
+			}
+		},
+		"scope_resolution": {
+			"match": "(::)?(?:((?-mix:(?!\\b(?:__has_cpp_attribute|reinterpret_cast|atomic_noexcept|atomic_cancel|atomic_commit|__has_include|dynamic_cast|thread_local|synchronized|static_cast|const_cast|consteval|constexpr|protected|namespace|co_return|constexpr|constexpr|continue|explicit|volatile|noexcept|co_yield|noexcept|noexcept|requires|typename|decltype|operator|co_await|template|volatile|register|restrict|reflexpr|alignof|private|default|mutable|include|concept|__asm__|defined|_Pragma|alignas|typedef|warning|virtual|mutable|struct|sizeof|delete|not_eq|bitand|and_eq|xor_eq|typeid|switch|return|static|extern|inline|friend|public|ifndef|define|pragma|export|import|module|catch|throw|const|or_eq|while|compl|bitor|const|union|ifdef|class|undef|error|break|using|endif|goto|line|enum|this|case|else|elif|else|asm|try|for|new|and|xor|not|do|or|if|if)\\b)(?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*))\\s*+(((?<!<)<(?!<)(?>(?:(?>[^<>]*)\\g<4>?)+)>)\\s*)?::)*\\s*+",
+			"captures": {
+				"0": {
+					"patterns": [
+						{
+							"include": "#scope_resolution_inner_generated"
+						}
+					]
+				},
+				"1": {
+					"name": "punctuation.separator.namespace.access.cpp punctuation.separator.scope-resolution.cpp"
+				},
+				"3": {
+					"name": "meta.template.call.cpp",
+					"patterns": [
+						{
+							"include": "#template_call_range"
+						}
+					]
+				}
+			}
+		},
+		"scope_resolution_function_call": {
+			"match": "(::)?(?:((?-mix:(?!\\b(?:__has_cpp_attribute|reinterpret_cast|atomic_noexcept|atomic_cancel|atomic_commit|__has_include|dynamic_cast|thread_local|synchronized|static_cast|const_cast|consteval|constexpr|protected|namespace|co_return|constexpr|constexpr|continue|explicit|volatile|noexcept|co_yield|noexcept|noexcept|requires|typename|decltype|operator|co_await|template|volatile|register|restrict|reflexpr|alignof|private|default|mutable|include|concept|__asm__|defined|_Pragma|alignas|typedef|warning|virtual|mutable|struct|sizeof|delete|not_eq|bitand|and_eq|xor_eq|typeid|switch|return|static|extern|inline|friend|public|ifndef|define|pragma|export|import|module|catch|throw|const|or_eq|while|compl|bitor|const|union|ifdef|class|undef|error|break|using|endif|goto|line|enum|this|case|else|elif|else|asm|try|for|new|and|xor|not|do|or|if|if)\\b)(?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*))\\s*+(((?<!<)<(?!<)(?>(?:(?>[^<>]*)\\g<4>?)+)>)\\s*)?::)*\\s*+",
+			"captures": {
+				"0": {
+					"patterns": [
+						{
+							"include": "#scope_resolution_function_call_inner_generated"
+						}
+					]
+				},
+				"1": {
+					"name": "punctuation.separator.namespace.access.cpp punctuation.separator.scope-resolution.function.call.cpp"
+				},
+				"3": {
+					"name": "meta.template.call.cpp",
+					"patterns": [
+						{
+							"include": "#template_call_range"
+						}
+					]
+				}
+			}
+		},
+		"scope_resolution_function_call_inner_generated": {
+			"match": "((::)?(?:((?-mix:(?!\\b(?:__has_cpp_attribute|reinterpret_cast|atomic_noexcept|atomic_cancel|atomic_commit|__has_include|dynamic_cast|thread_local|synchronized|static_cast|const_cast|consteval|constexpr|protected|namespace|co_return|constexpr|constexpr|continue|explicit|volatile|noexcept|co_yield|noexcept|noexcept|requires|typename|decltype|operator|co_await|template|volatile|register|restrict|reflexpr|alignof|private|default|mutable|include|concept|__asm__|defined|_Pragma|alignas|typedef|warning|virtual|mutable|struct|sizeof|delete|not_eq|bitand|and_eq|xor_eq|typeid|switch|return|static|extern|inline|friend|public|ifndef|define|pragma|export|import|module|catch|throw|const|or_eq|while|compl|bitor|const|union|ifdef|class|undef|error|break|using|endif|goto|line|enum|this|case|else|elif|else|asm|try|for|new|and|xor|not|do|or|if|if)\\b)(?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*))\\s*+(((?<!<)<(?!<)(?>(?:(?>[^<>]*)\\g<8>?)+)>)\\s*)?::)*\\s*+)((?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*)\\s*+(((?<!<)<(?!<)(?>(?:(?>[^<>]*)\\g<8>?)+)>)\\s*)?(::)",
+			"captures": {
+				"1": {
+					"patterns": [
+						{
+							"include": "#scope_resolution_function_call_inner_generated"
+						}
+					]
+				},
+				"2": {
+					"name": "punctuation.separator.namespace.access.cpp punctuation.separator.scope-resolution.function.call.cpp"
+				},
+				"4": {
+					"name": "meta.template.call.cpp",
+					"patterns": [
+						{
+							"include": "#template_call_range"
+						}
+					]
+				},
+				"6": {
+					"name": "entity.name.scope-resolution.function.call.cpp"
+				},
+				"7": {
+					"name": "meta.template.call.cpp",
+					"patterns": [
+						{
+							"include": "#template_call_range"
+						}
+					]
+				},
+				"9": {
+					"name": "punctuation.separator.namespace.access.cpp punctuation.separator.scope-resolution.function.call.cpp"
+				}
+			}
+		},
+		"scope_resolution_function_definition": {
+			"match": "(::)?(?:((?-mix:(?!\\b(?:__has_cpp_attribute|reinterpret_cast|atomic_noexcept|atomic_cancel|atomic_commit|__has_include|dynamic_cast|thread_local|synchronized|static_cast|const_cast|consteval|constexpr|protected|namespace|co_return|constexpr|constexpr|continue|explicit|volatile|noexcept|co_yield|noexcept|noexcept|requires|typename|decltype|operator|co_await|template|volatile|register|restrict|reflexpr|alignof|private|default|mutable|include|concept|__asm__|defined|_Pragma|alignas|typedef|warning|virtual|mutable|struct|sizeof|delete|not_eq|bitand|and_eq|xor_eq|typeid|switch|return|static|extern|inline|friend|public|ifndef|define|pragma|export|import|module|catch|throw|const|or_eq|while|compl|bitor|const|union|ifdef|class|undef|error|break|using|endif|goto|line|enum|this|case|else|elif|else|asm|try|for|new|and|xor|not|do|or|if|if)\\b)(?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*))\\s*+(((?<!<)<(?!<)(?>(?:(?>[^<>]*)\\g<4>?)+)>)\\s*)?::)*\\s*+",
+			"captures": {
+				"0": {
+					"patterns": [
+						{
+							"include": "#scope_resolution_function_definition_inner_generated"
+						}
+					]
+				},
+				"1": {
+					"name": "punctuation.separator.namespace.access.cpp punctuation.separator.scope-resolution.function.definition.cpp"
+				},
+				"3": {
+					"name": "meta.template.call.cpp",
+					"patterns": [
+						{
+							"include": "#template_call_range"
+						}
+					]
+				}
+			}
+		},
+		"scope_resolution_function_definition_inner_generated": {
+			"match": "((::)?(?:((?-mix:(?!\\b(?:__has_cpp_attribute|reinterpret_cast|atomic_noexcept|atomic_cancel|atomic_commit|__has_include|dynamic_cast|thread_local|synchronized|static_cast|const_cast|consteval|constexpr|protected|namespace|co_return|constexpr|constexpr|continue|explicit|volatile|noexcept|co_yield|noexcept|noexcept|requires|typename|decltype|operator|co_await|template|volatile|register|restrict|reflexpr|alignof|private|default|mutable|include|concept|__asm__|defined|_Pragma|alignas|typedef|warning|virtual|mutable|struct|sizeof|delete|not_eq|bitand|and_eq|xor_eq|typeid|switch|return|static|extern|inline|friend|public|ifndef|define|pragma|export|import|module|catch|throw|const|or_eq|while|compl|bitor|const|union|ifdef|class|undef|error|break|using|endif|goto|line|enum|this|case|else|elif|else|asm|try|for|new|and|xor|not|do|or|if|if)\\b)(?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*))\\s*+(((?<!<)<(?!<)(?>(?:(?>[^<>]*)\\g<8>?)+)>)\\s*)?::)*\\s*+)((?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*)\\s*+(((?<!<)<(?!<)(?>(?:(?>[^<>]*)\\g<8>?)+)>)\\s*)?(::)",
+			"captures": {
+				"1": {
+					"patterns": [
+						{
+							"include": "#scope_resolution_function_definition_inner_generated"
+						}
+					]
+				},
+				"2": {
+					"name": "punctuation.separator.namespace.access.cpp punctuation.separator.scope-resolution.function.definition.cpp"
+				},
+				"4": {
+					"name": "meta.template.call.cpp",
+					"patterns": [
+						{
+							"include": "#template_call_range"
+						}
+					]
+				},
+				"6": {
+					"name": "entity.name.scope-resolution.function.definition.cpp"
+				},
+				"7": {
+					"name": "meta.template.call.cpp",
+					"patterns": [
+						{
+							"include": "#template_call_range"
+						}
+					]
+				},
+				"9": {
+					"name": "punctuation.separator.namespace.access.cpp punctuation.separator.scope-resolution.function.definition.cpp"
+				}
+			}
+		},
+		"scope_resolution_function_definition_operator_overload": {
+			"match": "(::)?(?:((?-mix:(?!\\b(?:__has_cpp_attribute|reinterpret_cast|atomic_noexcept|atomic_cancel|atomic_commit|__has_include|dynamic_cast|thread_local|synchronized|static_cast|const_cast|consteval|constexpr|protected|namespace|co_return|constexpr|constexpr|continue|explicit|volatile|noexcept|co_yield|noexcept|noexcept|requires|typename|decltype|operator|co_await|template|volatile|register|restrict|reflexpr|alignof|private|default|mutable|include|concept|__asm__|defined|_Pragma|alignas|typedef|warning|virtual|mutable|struct|sizeof|delete|not_eq|bitand|and_eq|xor_eq|typeid|switch|return|static|extern|inline|friend|public|ifndef|define|pragma|export|import|module|catch|throw|const|or_eq|while|compl|bitor|const|union|ifdef|class|undef|error|break|using|endif|goto|line|enum|this|case|else|elif|else|asm|try|for|new|and|xor|not|do|or|if|if)\\b)(?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*))\\s*+(((?<!<)<(?!<)(?>(?:(?>[^<>]*)\\g<4>?)+)>)\\s*)?::)*\\s*+",
+			"captures": {
+				"0": {
+					"patterns": [
+						{
+							"include": "#scope_resolution_function_definition_operator_overload_inner_generated"
+						}
+					]
+				},
+				"1": {
+					"name": "punctuation.separator.namespace.access.cpp punctuation.separator.scope-resolution.function.definition.operator-overload.cpp"
+				},
+				"3": {
+					"name": "meta.template.call.cpp",
+					"patterns": [
+						{
+							"include": "#template_call_range"
+						}
+					]
+				}
+			}
+		},
+		"scope_resolution_function_definition_operator_overload_inner_generated": {
+			"match": "((::)?(?:((?-mix:(?!\\b(?:__has_cpp_attribute|reinterpret_cast|atomic_noexcept|atomic_cancel|atomic_commit|__has_include|dynamic_cast|thread_local|synchronized|static_cast|const_cast|consteval|constexpr|protected|namespace|co_return|constexpr|constexpr|continue|explicit|volatile|noexcept|co_yield|noexcept|noexcept|requires|typename|decltype|operator|co_await|template|volatile|register|restrict|reflexpr|alignof|private|default|mutable|include|concept|__asm__|defined|_Pragma|alignas|typedef|warning|virtual|mutable|struct|sizeof|delete|not_eq|bitand|and_eq|xor_eq|typeid|switch|return|static|extern|inline|friend|public|ifndef|define|pragma|export|import|module|catch|throw|const|or_eq|while|compl|bitor|const|union|ifdef|class|undef|error|break|using|endif|goto|line|enum|this|case|else|elif|else|asm|try|for|new|and|xor|not|do|or|if|if)\\b)(?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*))\\s*+(((?<!<)<(?!<)(?>(?:(?>[^<>]*)\\g<8>?)+)>)\\s*)?::)*\\s*+)((?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*)\\s*+(((?<!<)<(?!<)(?>(?:(?>[^<>]*)\\g<8>?)+)>)\\s*)?(::)",
+			"captures": {
+				"1": {
+					"patterns": [
+						{
+							"include": "#scope_resolution_function_definition_operator_overload_inner_generated"
+						}
+					]
+				},
+				"2": {
+					"name": "punctuation.separator.namespace.access.cpp punctuation.separator.scope-resolution.function.definition.operator-overload.cpp"
+				},
+				"4": {
+					"name": "meta.template.call.cpp",
+					"patterns": [
+						{
+							"include": "#template_call_range"
+						}
+					]
+				},
+				"6": {
+					"name": "entity.name.scope-resolution.function.definition.operator-overload.cpp"
+				},
+				"7": {
+					"name": "meta.template.call.cpp",
+					"patterns": [
+						{
+							"include": "#template_call_range"
+						}
+					]
+				},
+				"9": {
+					"name": "punctuation.separator.namespace.access.cpp punctuation.separator.scope-resolution.function.definition.operator-overload.cpp"
+				}
+			}
+		},
+		"scope_resolution_inner_generated": {
+			"match": "((::)?(?:((?-mix:(?!\\b(?:__has_cpp_attribute|reinterpret_cast|atomic_noexcept|atomic_cancel|atomic_commit|__has_include|dynamic_cast|thread_local|synchronized|static_cast|const_cast|consteval|constexpr|protected|namespace|co_return|constexpr|constexpr|continue|explicit|volatile|noexcept|co_yield|noexcept|noexcept|requires|typename|decltype|operator|co_await|template|volatile|register|restrict|reflexpr|alignof|private|default|mutable|include|concept|__asm__|defined|_Pragma|alignas|typedef|warning|virtual|mutable|struct|sizeof|delete|not_eq|bitand|and_eq|xor_eq|typeid|switch|return|static|extern|inline|friend|public|ifndef|define|pragma|export|import|module|catch|throw|const|or_eq|while|compl|bitor|const|union|ifdef|class|undef|error|break|using|endif|goto|line|enum|this|case|else|elif|else|asm|try|for|new|and|xor|not|do|or|if|if)\\b)(?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*))\\s*+(((?<!<)<(?!<)(?>(?:(?>[^<>]*)\\g<8>?)+)>)\\s*)?::)*\\s*+)((?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*)\\s*+(((?<!<)<(?!<)(?>(?:(?>[^<>]*)\\g<8>?)+)>)\\s*)?(::)",
+			"captures": {
+				"1": {
+					"patterns": [
+						{
+							"include": "#scope_resolution_inner_generated"
+						}
+					]
+				},
+				"2": {
+					"name": "punctuation.separator.namespace.access.cpp punctuation.separator.scope-resolution.cpp"
+				},
+				"4": {
+					"name": "meta.template.call.cpp",
+					"patterns": [
+						{
+							"include": "#template_call_range"
+						}
+					]
+				},
+				"6": {
+					"name": "entity.name.scope-resolution.cpp"
+				},
+				"7": {
+					"name": "meta.template.call.cpp",
+					"patterns": [
+						{
+							"include": "#template_call_range"
+						}
+					]
+				},
+				"9": {
+					"name": "punctuation.separator.namespace.access.cpp punctuation.separator.scope-resolution.cpp"
+				}
+			}
+		},
+		"scope_resolution_namespace_alias": {
+			"match": "(::)?(?:((?-mix:(?!\\b(?:__has_cpp_attribute|reinterpret_cast|atomic_noexcept|atomic_cancel|atomic_commit|__has_include|dynamic_cast|thread_local|synchronized|static_cast|const_cast|consteval|constexpr|protected|namespace|co_return|constexpr|constexpr|continue|explicit|volatile|noexcept|co_yield|noexcept|noexcept|requires|typename|decltype|operator|co_await|template|volatile|register|restrict|reflexpr|alignof|private|default|mutable|include|concept|__asm__|defined|_Pragma|alignas|typedef|warning|virtual|mutable|struct|sizeof|delete|not_eq|bitand|and_eq|xor_eq|typeid|switch|return|static|extern|inline|friend|public|ifndef|define|pragma|export|import|module|catch|throw|const|or_eq|while|compl|bitor|const|union|ifdef|class|undef|error|break|using|endif|goto|line|enum|this|case|else|elif|else|asm|try|for|new|and|xor|not|do|or|if|if)\\b)(?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*))\\s*+(((?<!<)<(?!<)(?>(?:(?>[^<>]*)\\g<4>?)+)>)\\s*)?::)*\\s*+",
+			"captures": {
+				"0": {
+					"patterns": [
+						{
+							"include": "#scope_resolution_namespace_alias_inner_generated"
+						}
+					]
+				},
+				"1": {
+					"name": "punctuation.separator.namespace.access.cpp punctuation.separator.scope-resolution.namespace.alias.cpp"
+				},
+				"3": {
+					"name": "meta.template.call.cpp",
+					"patterns": [
+						{
+							"include": "#template_call_range"
+						}
+					]
+				}
+			}
+		},
+		"scope_resolution_namespace_alias_inner_generated": {
+			"match": "((::)?(?:((?-mix:(?!\\b(?:__has_cpp_attribute|reinterpret_cast|atomic_noexcept|atomic_cancel|atomic_commit|__has_include|dynamic_cast|thread_local|synchronized|static_cast|const_cast|consteval|constexpr|protected|namespace|co_return|constexpr|constexpr|continue|explicit|volatile|noexcept|co_yield|noexcept|noexcept|requires|typename|decltype|operator|co_await|template|volatile|register|restrict|reflexpr|alignof|private|default|mutable|include|concept|__asm__|defined|_Pragma|alignas|typedef|warning|virtual|mutable|struct|sizeof|delete|not_eq|bitand|and_eq|xor_eq|typeid|switch|return|static|extern|inline|friend|public|ifndef|define|pragma|export|import|module|catch|throw|const|or_eq|while|compl|bitor|const|union|ifdef|class|undef|error|break|using|endif|goto|line|enum|this|case|else|elif|else|asm|try|for|new|and|xor|not|do|or|if|if)\\b)(?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*))\\s*+(((?<!<)<(?!<)(?>(?:(?>[^<>]*)\\g<8>?)+)>)\\s*)?::)*\\s*+)((?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*)\\s*+(((?<!<)<(?!<)(?>(?:(?>[^<>]*)\\g<8>?)+)>)\\s*)?(::)",
+			"captures": {
+				"1": {
+					"patterns": [
+						{
+							"include": "#scope_resolution_namespace_alias_inner_generated"
+						}
+					]
+				},
+				"2": {
+					"name": "punctuation.separator.namespace.access.cpp punctuation.separator.scope-resolution.namespace.alias.cpp"
+				},
+				"4": {
+					"name": "meta.template.call.cpp",
+					"patterns": [
+						{
+							"include": "#template_call_range"
+						}
+					]
+				},
+				"6": {
+					"name": "entity.name.scope-resolution.namespace.alias.cpp"
+				},
+				"7": {
+					"name": "meta.template.call.cpp",
+					"patterns": [
+						{
+							"include": "#template_call_range"
+						}
+					]
+				},
+				"9": {
+					"name": "punctuation.separator.namespace.access.cpp punctuation.separator.scope-resolution.namespace.alias.cpp"
+				}
+			}
+		},
+		"scope_resolution_namespace_block": {
+			"match": "(::)?(?:((?-mix:(?!\\b(?:__has_cpp_attribute|reinterpret_cast|atomic_noexcept|atomic_cancel|atomic_commit|__has_include|dynamic_cast|thread_local|synchronized|static_cast|const_cast|consteval|constexpr|protected|namespace|co_return|constexpr|constexpr|continue|explicit|volatile|noexcept|co_yield|noexcept|noexcept|requires|typename|decltype|operator|co_await|template|volatile|register|restrict|reflexpr|alignof|private|default|mutable|include|concept|__asm__|defined|_Pragma|alignas|typedef|warning|virtual|mutable|struct|sizeof|delete|not_eq|bitand|and_eq|xor_eq|typeid|switch|return|static|extern|inline|friend|public|ifndef|define|pragma|export|import|module|catch|throw|const|or_eq|while|compl|bitor|const|union|ifdef|class|undef|error|break|using|endif|goto|line|enum|this|case|else|elif|else|asm|try|for|new|and|xor|not|do|or|if|if)\\b)(?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*))\\s*+(((?<!<)<(?!<)(?>(?:(?>[^<>]*)\\g<4>?)+)>)\\s*)?::)*\\s*+",
+			"captures": {
+				"0": {
+					"patterns": [
+						{
+							"include": "#scope_resolution_namespace_block_inner_generated"
+						}
+					]
+				},
+				"1": {
+					"name": "punctuation.separator.namespace.access.cpp punctuation.separator.scope-resolution.namespace.block.cpp"
+				},
+				"3": {
+					"name": "meta.template.call.cpp",
+					"patterns": [
+						{
+							"include": "#template_call_range"
+						}
+					]
+				}
+			}
+		},
+		"scope_resolution_namespace_block_inner_generated": {
+			"match": "((::)?(?:((?-mix:(?!\\b(?:__has_cpp_attribute|reinterpret_cast|atomic_noexcept|atomic_cancel|atomic_commit|__has_include|dynamic_cast|thread_local|synchronized|static_cast|const_cast|consteval|constexpr|protected|namespace|co_return|constexpr|constexpr|continue|explicit|volatile|noexcept|co_yield|noexcept|noexcept|requires|typename|decltype|operator|co_await|template|volatile|register|restrict|reflexpr|alignof|private|default|mutable|include|concept|__asm__|defined|_Pragma|alignas|typedef|warning|virtual|mutable|struct|sizeof|delete|not_eq|bitand|and_eq|xor_eq|typeid|switch|return|static|extern|inline|friend|public|ifndef|define|pragma|export|import|module|catch|throw|const|or_eq|while|compl|bitor|const|union|ifdef|class|undef|error|break|using|endif|goto|line|enum|this|case|else|elif|else|asm|try|for|new|and|xor|not|do|or|if|if)\\b)(?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*))\\s*+(((?<!<)<(?!<)(?>(?:(?>[^<>]*)\\g<8>?)+)>)\\s*)?::)*\\s*+)((?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*)\\s*+(((?<!<)<(?!<)(?>(?:(?>[^<>]*)\\g<8>?)+)>)\\s*)?(::)",
+			"captures": {
+				"1": {
+					"patterns": [
+						{
+							"include": "#scope_resolution_namespace_block_inner_generated"
+						}
+					]
+				},
+				"2": {
+					"name": "punctuation.separator.namespace.access.cpp punctuation.separator.scope-resolution.namespace.block.cpp"
+				},
+				"4": {
+					"name": "meta.template.call.cpp",
+					"patterns": [
+						{
+							"include": "#template_call_range"
+						}
+					]
+				},
+				"6": {
+					"name": "entity.name.scope-resolution.namespace.block.cpp"
+				},
+				"7": {
+					"name": "meta.template.call.cpp",
+					"patterns": [
+						{
+							"include": "#template_call_range"
+						}
+					]
+				},
+				"9": {
+					"name": "punctuation.separator.namespace.access.cpp punctuation.separator.scope-resolution.namespace.block.cpp"
+				}
+			}
+		},
+		"scope_resolution_namespace_using": {
+			"match": "(::)?(?:((?-mix:(?!\\b(?:__has_cpp_attribute|reinterpret_cast|atomic_noexcept|atomic_cancel|atomic_commit|__has_include|dynamic_cast|thread_local|synchronized|static_cast|const_cast|consteval|constexpr|protected|namespace|co_return|constexpr|constexpr|continue|explicit|volatile|noexcept|co_yield|noexcept|noexcept|requires|typename|decltype|operator|co_await|template|volatile|register|restrict|reflexpr|alignof|private|default|mutable|include|concept|__asm__|defined|_Pragma|alignas|typedef|warning|virtual|mutable|struct|sizeof|delete|not_eq|bitand|and_eq|xor_eq|typeid|switch|return|static|extern|inline|friend|public|ifndef|define|pragma|export|import|module|catch|throw|const|or_eq|while|compl|bitor|const|union|ifdef|class|undef|error|break|using|endif|goto|line|enum|this|case|else|elif|else|asm|try|for|new|and|xor|not|do|or|if|if)\\b)(?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*))\\s*+(((?<!<)<(?!<)(?>(?:(?>[^<>]*)\\g<4>?)+)>)\\s*)?::)*\\s*+",
+			"captures": {
+				"0": {
+					"patterns": [
+						{
+							"include": "#scope_resolution_namespace_using_inner_generated"
+						}
+					]
+				},
+				"1": {
+					"name": "punctuation.separator.namespace.access.cpp punctuation.separator.scope-resolution.namespace.using.cpp"
+				},
+				"3": {
+					"name": "meta.template.call.cpp",
+					"patterns": [
+						{
+							"include": "#template_call_range"
+						}
+					]
+				}
+			}
+		},
+		"scope_resolution_namespace_using_inner_generated": {
+			"match": "((::)?(?:((?-mix:(?!\\b(?:__has_cpp_attribute|reinterpret_cast|atomic_noexcept|atomic_cancel|atomic_commit|__has_include|dynamic_cast|thread_local|synchronized|static_cast|const_cast|consteval|constexpr|protected|namespace|co_return|constexpr|constexpr|continue|explicit|volatile|noexcept|co_yield|noexcept|noexcept|requires|typename|decltype|operator|co_await|template|volatile|register|restrict|reflexpr|alignof|private|default|mutable|include|concept|__asm__|defined|_Pragma|alignas|typedef|warning|virtual|mutable|struct|sizeof|delete|not_eq|bitand|and_eq|xor_eq|typeid|switch|return|static|extern|inline|friend|public|ifndef|define|pragma|export|import|module|catch|throw|const|or_eq|while|compl|bitor|const|union|ifdef|class|undef|error|break|using|endif|goto|line|enum|this|case|else|elif|else|asm|try|for|new|and|xor|not|do|or|if|if)\\b)(?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*))\\s*+(((?<!<)<(?!<)(?>(?:(?>[^<>]*)\\g<8>?)+)>)\\s*)?::)*\\s*+)((?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*)\\s*+(((?<!<)<(?!<)(?>(?:(?>[^<>]*)\\g<8>?)+)>)\\s*)?(::)",
+			"captures": {
+				"1": {
+					"patterns": [
+						{
+							"include": "#scope_resolution_namespace_using_inner_generated"
+						}
+					]
+				},
+				"2": {
+					"name": "punctuation.separator.namespace.access.cpp punctuation.separator.scope-resolution.namespace.using.cpp"
+				},
+				"4": {
+					"name": "meta.template.call.cpp",
+					"patterns": [
+						{
+							"include": "#template_call_range"
+						}
+					]
+				},
+				"6": {
+					"name": "entity.name.scope-resolution.namespace.using.cpp"
+				},
+				"7": {
+					"name": "meta.template.call.cpp",
+					"patterns": [
+						{
+							"include": "#template_call_range"
+						}
+					]
+				},
+				"9": {
+					"name": "punctuation.separator.namespace.access.cpp punctuation.separator.scope-resolution.namespace.using.cpp"
+				}
+			}
+		},
+		"scope_resolution_parameter": {
+			"match": "(::)?(?:((?-mix:(?!\\b(?:__has_cpp_attribute|reinterpret_cast|atomic_noexcept|atomic_cancel|atomic_commit|__has_include|dynamic_cast|thread_local|synchronized|static_cast|const_cast|consteval|constexpr|protected|namespace|co_return|constexpr|constexpr|continue|explicit|volatile|noexcept|co_yield|noexcept|noexcept|requires|typename|decltype|operator|co_await|template|volatile|register|restrict|reflexpr|alignof|private|default|mutable|include|concept|__asm__|defined|_Pragma|alignas|typedef|warning|virtual|mutable|struct|sizeof|delete|not_eq|bitand|and_eq|xor_eq|typeid|switch|return|static|extern|inline|friend|public|ifndef|define|pragma|export|import|module|catch|throw|const|or_eq|while|compl|bitor|const|union|ifdef|class|undef|error|break|using|endif|goto|line|enum|this|case|else|elif|else|asm|try|for|new|and|xor|not|do|or|if|if)\\b)(?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*))\\s*+(((?<!<)<(?!<)(?>(?:(?>[^<>]*)\\g<4>?)+)>)\\s*)?::)*\\s*+",
+			"captures": {
+				"0": {
+					"patterns": [
+						{
+							"include": "#scope_resolution_parameter_inner_generated"
+						}
+					]
+				},
+				"1": {
+					"name": "punctuation.separator.namespace.access.cpp punctuation.separator.scope-resolution.parameter.cpp"
+				},
+				"3": {
+					"name": "meta.template.call.cpp",
+					"patterns": [
+						{
+							"include": "#template_call_range"
+						}
+					]
+				}
+			}
+		},
+		"scope_resolution_parameter_inner_generated": {
+			"match": "((::)?(?:((?-mix:(?!\\b(?:__has_cpp_attribute|reinterpret_cast|atomic_noexcept|atomic_cancel|atomic_commit|__has_include|dynamic_cast|thread_local|synchronized|static_cast|const_cast|consteval|constexpr|protected|namespace|co_return|constexpr|constexpr|continue|explicit|volatile|noexcept|co_yield|noexcept|noexcept|requires|typename|decltype|operator|co_await|template|volatile|register|restrict|reflexpr|alignof|private|default|mutable|include|concept|__asm__|defined|_Pragma|alignas|typedef|warning|virtual|mutable|struct|sizeof|delete|not_eq|bitand|and_eq|xor_eq|typeid|switch|return|static|extern|inline|friend|public|ifndef|define|pragma|export|import|module|catch|throw|const|or_eq|while|compl|bitor|const|union|ifdef|class|undef|error|break|using|endif|goto|line|enum|this|case|else|elif|else|asm|try|for|new|and|xor|not|do|or|if|if)\\b)(?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*))\\s*+(((?<!<)<(?!<)(?>(?:(?>[^<>]*)\\g<8>?)+)>)\\s*)?::)*\\s*+)((?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*)\\s*+(((?<!<)<(?!<)(?>(?:(?>[^<>]*)\\g<8>?)+)>)\\s*)?(::)",
+			"captures": {
+				"1": {
+					"patterns": [
+						{
+							"include": "#scope_resolution_parameter_inner_generated"
+						}
+					]
+				},
+				"2": {
+					"name": "punctuation.separator.namespace.access.cpp punctuation.separator.scope-resolution.parameter.cpp"
+				},
+				"4": {
+					"name": "meta.template.call.cpp",
+					"patterns": [
+						{
+							"include": "#template_call_range"
+						}
+					]
+				},
+				"6": {
+					"name": "entity.name.scope-resolution.parameter.cpp"
+				},
+				"7": {
+					"name": "meta.template.call.cpp",
+					"patterns": [
+						{
+							"include": "#template_call_range"
+						}
+					]
+				},
+				"9": {
+					"name": "punctuation.separator.namespace.access.cpp punctuation.separator.scope-resolution.parameter.cpp"
+				}
+			}
+		},
+		"scope_resolution_template_call": {
+			"match": "(::)?(?:((?-mix:(?!\\b(?:__has_cpp_attribute|reinterpret_cast|atomic_noexcept|atomic_cancel|atomic_commit|__has_include|dynamic_cast|thread_local|synchronized|static_cast|const_cast|consteval|constexpr|protected|namespace|co_return|constexpr|constexpr|continue|explicit|volatile|noexcept|co_yield|noexcept|noexcept|requires|typename|decltype|operator|co_await|template|volatile|register|restrict|reflexpr|alignof|private|default|mutable|include|concept|__asm__|defined|_Pragma|alignas|typedef|warning|virtual|mutable|struct|sizeof|delete|not_eq|bitand|and_eq|xor_eq|typeid|switch|return|static|extern|inline|friend|public|ifndef|define|pragma|export|import|module|catch|throw|const|or_eq|while|compl|bitor|const|union|ifdef|class|undef|error|break|using|endif|goto|line|enum|this|case|else|elif|else|asm|try|for|new|and|xor|not|do|or|if|if)\\b)(?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*))\\s*+(((?<!<)<(?!<)(?>(?:(?>[^<>]*)\\g<4>?)+)>)\\s*)?::)*\\s*+",
+			"captures": {
+				"0": {
+					"patterns": [
+						{
+							"include": "#scope_resolution_template_call_inner_generated"
+						}
+					]
+				},
+				"1": {
+					"name": "punctuation.separator.namespace.access.cpp punctuation.separator.scope-resolution.template.call.cpp"
+				},
+				"3": {
+					"name": "meta.template.call.cpp",
+					"patterns": [
+						{
+							"include": "#template_call_range"
+						}
+					]
+				}
+			}
+		},
+		"scope_resolution_template_call_inner_generated": {
+			"match": "((::)?(?:((?-mix:(?!\\b(?:__has_cpp_attribute|reinterpret_cast|atomic_noexcept|atomic_cancel|atomic_commit|__has_include|dynamic_cast|thread_local|synchronized|static_cast|const_cast|consteval|constexpr|protected|namespace|co_return|constexpr|constexpr|continue|explicit|volatile|noexcept|co_yield|noexcept|noexcept|requires|typename|decltype|operator|co_await|template|volatile|register|restrict|reflexpr|alignof|private|default|mutable|include|concept|__asm__|defined|_Pragma|alignas|typedef|warning|virtual|mutable|struct|sizeof|delete|not_eq|bitand|and_eq|xor_eq|typeid|switch|return|static|extern|inline|friend|public|ifndef|define|pragma|export|import|module|catch|throw|const|or_eq|while|compl|bitor|const|union|ifdef|class|undef|error|break|using|endif|goto|line|enum|this|case|else|elif|else|asm|try|for|new|and|xor|not|do|or|if|if)\\b)(?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*))\\s*+(((?<!<)<(?!<)(?>(?:(?>[^<>]*)\\g<8>?)+)>)\\s*)?::)*\\s*+)((?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*)\\s*+(((?<!<)<(?!<)(?>(?:(?>[^<>]*)\\g<8>?)+)>)\\s*)?(::)",
+			"captures": {
+				"1": {
+					"patterns": [
+						{
+							"include": "#scope_resolution_template_call_inner_generated"
+						}
+					]
+				},
+				"2": {
+					"name": "punctuation.separator.namespace.access.cpp punctuation.separator.scope-resolution.template.call.cpp"
+				},
+				"4": {
+					"name": "meta.template.call.cpp",
+					"patterns": [
+						{
+							"include": "#template_call_range"
+						}
+					]
+				},
+				"6": {
+					"name": "entity.name.scope-resolution.template.call.cpp"
+				},
+				"7": {
+					"name": "meta.template.call.cpp",
+					"patterns": [
+						{
+							"include": "#template_call_range"
+						}
+					]
+				},
+				"9": {
+					"name": "punctuation.separator.namespace.access.cpp punctuation.separator.scope-resolution.template.call.cpp"
+				}
+			}
+		},
+		"scope_resolution_template_definition": {
+			"match": "(::)?(?:((?-mix:(?!\\b(?:__has_cpp_attribute|reinterpret_cast|atomic_noexcept|atomic_cancel|atomic_commit|__has_include|dynamic_cast|thread_local|synchronized|static_cast|const_cast|consteval|constexpr|protected|namespace|co_return|constexpr|constexpr|continue|explicit|volatile|noexcept|co_yield|noexcept|noexcept|requires|typename|decltype|operator|co_await|template|volatile|register|restrict|reflexpr|alignof|private|default|mutable|include|concept|__asm__|defined|_Pragma|alignas|typedef|warning|virtual|mutable|struct|sizeof|delete|not_eq|bitand|and_eq|xor_eq|typeid|switch|return|static|extern|inline|friend|public|ifndef|define|pragma|export|import|module|catch|throw|const|or_eq|while|compl|bitor|const|union|ifdef|class|undef|error|break|using|endif|goto|line|enum|this|case|else|elif|else|asm|try|for|new|and|xor|not|do|or|if|if)\\b)(?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*))\\s*+(((?<!<)<(?!<)(?>(?:(?>[^<>]*)\\g<4>?)+)>)\\s*)?::)*\\s*+",
+			"captures": {
+				"0": {
+					"patterns": [
+						{
+							"include": "#scope_resolution_template_definition_inner_generated"
+						}
+					]
+				},
+				"1": {
+					"name": "punctuation.separator.namespace.access.cpp punctuation.separator.scope-resolution.template.definition.cpp"
+				},
+				"3": {
+					"name": "meta.template.call.cpp",
+					"patterns": [
+						{
+							"include": "#template_call_range"
+						}
+					]
+				}
+			}
+		},
+		"scope_resolution_template_definition_inner_generated": {
+			"match": "((::)?(?:((?-mix:(?!\\b(?:__has_cpp_attribute|reinterpret_cast|atomic_noexcept|atomic_cancel|atomic_commit|__has_include|dynamic_cast|thread_local|synchronized|static_cast|const_cast|consteval|constexpr|protected|namespace|co_return|constexpr|constexpr|continue|explicit|volatile|noexcept|co_yield|noexcept|noexcept|requires|typename|decltype|operator|co_await|template|volatile|register|restrict|reflexpr|alignof|private|default|mutable|include|concept|__asm__|defined|_Pragma|alignas|typedef|warning|virtual|mutable|struct|sizeof|delete|not_eq|bitand|and_eq|xor_eq|typeid|switch|return|static|extern|inline|friend|public|ifndef|define|pragma|export|import|module|catch|throw|const|or_eq|while|compl|bitor|const|union|ifdef|class|undef|error|break|using|endif|goto|line|enum|this|case|else|elif|else|asm|try|for|new|and|xor|not|do|or|if|if)\\b)(?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*))\\s*+(((?<!<)<(?!<)(?>(?:(?>[^<>]*)\\g<8>?)+)>)\\s*)?::)*\\s*+)((?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*)\\s*+(((?<!<)<(?!<)(?>(?:(?>[^<>]*)\\g<8>?)+)>)\\s*)?(::)",
+			"captures": {
+				"1": {
+					"patterns": [
+						{
+							"include": "#scope_resolution_template_definition_inner_generated"
+						}
+					]
+				},
+				"2": {
+					"name": "punctuation.separator.namespace.access.cpp punctuation.separator.scope-resolution.template.definition.cpp"
+				},
+				"4": {
+					"name": "meta.template.call.cpp",
+					"patterns": [
+						{
+							"include": "#template_call_range"
+						}
+					]
+				},
+				"6": {
+					"name": "entity.name.scope-resolution.template.definition.cpp"
+				},
+				"7": {
+					"name": "meta.template.call.cpp",
+					"patterns": [
+						{
+							"include": "#template_call_range"
+						}
+					]
+				},
+				"9": {
+					"name": "punctuation.separator.namespace.access.cpp punctuation.separator.scope-resolution.template.definition.cpp"
+				}
+			}
+		},
+		"semicolon": {
+			"match": ";",
+			"name": "punctuation.terminator.statement.cpp"
+		},
+		"simple_type": {
+			"match": "(\\s*+((?:(?:(?:\\[\\[.*?\\]\\]|__attribute(?:__)?\\(\\(.*?\\)\\))|__declspec\\(.*?\\))|alignas\\(.*?\\))(?!\\)))?((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))(?:(?:(?:unsigned|signed|short|long)|(?:struct|class|union|enum))((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z)))))*(((::)?(?:((?-mix:(?!\\b(?:__has_cpp_attribute|reinterpret_cast|atomic_noexcept|atomic_cancel|atomic_commit|__has_include|dynamic_cast|thread_local|synchronized|static_cast|const_cast|consteval|constexpr|protected|namespace|co_return|constexpr|constexpr|continue|explicit|volatile|noexcept|co_yield|noexcept|noexcept|requires|typename|decltype|operator|co_await|template|volatile|register|restrict|reflexpr|alignof|private|default|mutable|include|concept|__asm__|defined|_Pragma|alignas|typedef|warning|virtual|mutable|struct|sizeof|delete|not_eq|bitand|and_eq|xor_eq|typeid|switch|return|static|extern|inline|friend|public|ifndef|define|pragma|export|import|module|catch|throw|const|or_eq|while|compl|bitor|const|union|ifdef|class|undef|error|break|using|endif|goto|line|enum|this|case|else|elif|else|asm|try|for|new|and|xor|not|do|or|if|if)\\b)(?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*))\\s*+(((?<!<)<(?!<)(?>(?:(?>[^<>]*)\\g<27>?)+)>)\\s*)?::)*\\s*+)((?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*)\\s*+(((?<!<)<(?!<)(?>(?:(?>[^<>]*)\\g<27>?)+)>)\\s*)?(::))?((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))(?!(?:transaction_safe_dynamic|__has_cpp_attribute|transaction_safe|reinterpret_cast|atomic_noexcept|atomic_commit|atomic_cancel|__has_include|dynamic_cast|thread_local|synchronized|static_cast|const_cast|constexpr|consteval|protected|constexpr|co_return|namespace|constexpr|noexcept|typename|decltype|template|operator|noexcept|co_yield|co_await|continue|volatile|register|restrict|explicit|override|volatile|reflexpr|noexcept|requires|default|typedef|nullptr|alignof|mutable|concept|virtual|defined|__asm__|include|_Pragma|mutable|warning|private|alignas|module|switch|not_eq|bitand|and_eq|ifndef|return|sizeof|xor_eq|export|static|delete|public|define|extern|inline|import|pragma|friend|typeid|const|compl|bitor|throw|or_eq|while|catch|break|false|final|const|endif|ifdef|undef|error|using|audit|axiom|line|else|elif|true|NULL|case|goto|else|this|new|asm|not|and|xor|try|for|if|do|or|if)\\b)((?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*)\\b(((?<!<)<(?!<)(?>(?:(?>[^<>]*)\\g<27>?)+)>)\\s*)?(?![\\w<:.]))(((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))?(?:(?:\\&|\\*)((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z)))))*(?:\\&|\\*))?",
+			"captures": {
+				"1": {
+					"name": "meta.qualified_type.cpp",
+					"patterns": [
+						{
+							"match": "(?<!\\w)(?:struct|class|union|enum)(?!\\w)",
+							"name": "storage.type.$0.cpp"
+						},
+						{
+							"include": "#attributes_context"
+						},
+						{
+							"include": "#function_type"
+						},
+						{
+							"include": "#storage_types"
+						},
+						{
+							"include": "#number_literal"
+						},
+						{
+							"include": "#string_context"
+						},
+						{
+							"include": "#comma"
+						},
+						{
+							"include": "#scope_resolution_inner_generated"
+						},
+						{
+							"include": "#template_call_range"
+						},
+						{
+							"match": "(?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*",
+							"name": "entity.name.type.cpp"
+						}
+					]
+				},
+				"2": {
+					"patterns": [
+						{
+							"include": "#attributes_context"
+						},
+						{
+							"include": "#number_literal"
+						}
+					]
+				},
+				"3": {
+					"patterns": [
+						{
+							"include": "#inline_comment"
+						}
+					]
+				},
+				"4": {
+					"name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+				},
+				"5": {
+					"name": "comment.block.cpp"
+				},
+				"6": {
+					"patterns": [
+						{
+							"match": "\\*\\/",
+							"name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+						},
+						{
+							"match": "\\*",
+							"name": "comment.block.cpp"
+						}
+					]
+				},
+				"7": {
+					"patterns": [
+						{
+							"include": "#inline_comment"
+						}
+					]
+				},
+				"8": {
+					"name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+				},
+				"9": {
+					"name": "comment.block.cpp"
+				},
+				"10": {
+					"patterns": [
+						{
+							"match": "\\*\\/",
+							"name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+						},
+						{
+							"match": "\\*",
+							"name": "comment.block.cpp"
+						}
+					]
+				},
+				"12": {
+					"patterns": [
+						{
+							"include": "#scope_resolution_inner_generated"
+						}
+					]
+				},
+				"13": {
+					"name": "punctuation.separator.namespace.access.cpp punctuation.separator.scope-resolution.cpp"
+				},
+				"15": {
+					"name": "meta.template.call.cpp",
+					"patterns": [
+						{
+							"include": "#template_call_range"
+						}
+					]
+				},
+				"17": {
+					"name": "entity.name.scope-resolution.cpp"
+				},
+				"18": {
+					"name": "meta.template.call.cpp",
+					"patterns": [
+						{
+							"include": "#template_call_range"
+						}
+					]
+				},
+				"20": {
+					"name": "punctuation.separator.namespace.access.cpp punctuation.separator.scope-resolution.cpp"
+				},
+				"21": {
+					"patterns": [
+						{
+							"include": "#inline_comment"
+						}
+					]
+				},
+				"22": {
+					"name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+				},
+				"23": {
+					"name": "comment.block.cpp"
+				},
+				"24": {
+					"patterns": [
+						{
+							"match": "\\*\\/",
+							"name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+						},
+						{
+							"match": "\\*",
+							"name": "comment.block.cpp"
+						}
+					]
+				},
+				"25": {
+					"name": "entity.name.type.cpp"
+				},
+				"26": {
+					"name": "meta.template.call.cpp",
+					"patterns": [
+						{
+							"include": "#template_call_range"
+						}
+					]
+				},
+				"28": {
+					"patterns": [
+						{
+							"match": "\\*",
+							"name": "storage.modifier.pointer.cpp"
+						},
+						{
+							"match": "(?:\\&((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))){2,}\\&",
+							"captures": {
+								"1": {
+									"patterns": [
+										{
+											"include": "#inline_comment"
+										}
+									]
+								},
+								"2": {
+									"name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+								},
+								"3": {
+									"name": "comment.block.cpp"
+								},
+								"4": {
+									"patterns": [
+										{
+											"match": "\\*\\/",
+											"name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+										},
+										{
+											"match": "\\*",
+											"name": "comment.block.cpp"
+										}
+									]
+								}
+							},
+							"name": "invalid.illegal.reference-type.cpp"
+						},
+						{
+							"match": "\\&",
+							"name": "storage.modifier.reference.cpp"
+						}
+					]
+				},
+				"29": {
+					"patterns": [
+						{
+							"include": "#inline_comment"
+						}
+					]
+				},
+				"30": {
+					"name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+				},
+				"31": {
+					"name": "comment.block.cpp"
+				},
+				"32": {
+					"patterns": [
+						{
+							"match": "\\*\\/",
+							"name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+						},
+						{
+							"match": "\\*",
+							"name": "comment.block.cpp"
+						}
+					]
+				},
+				"33": {
+					"patterns": [
+						{
+							"include": "#inline_comment"
+						}
+					]
+				},
+				"34": {
+					"name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+				},
+				"35": {
+					"name": "comment.block.cpp"
+				},
+				"36": {
+					"patterns": [
+						{
+							"match": "\\*\\/",
+							"name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+						},
+						{
+							"match": "\\*",
+							"name": "comment.block.cpp"
+						}
+					]
+				}
+			}
+		},
+		"single_line_macro": {
+			"match": "^((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))#define.*(?<![\\\\])(?:\\n|$)",
+			"captures": {
+				"0": {
+					"patterns": [
+						{
+							"include": "#macro"
+						},
+						{
+							"include": "#comments"
+						}
+					]
+				},
+				"1": {
+					"patterns": [
+						{
+							"include": "#inline_comment"
+						}
+					]
+				},
+				"2": {
+					"name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+				},
+				"3": {
+					"name": "comment.block.cpp"
+				},
+				"4": {
+					"patterns": [
+						{
+							"match": "\\*\\/",
+							"name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+						},
+						{
+							"match": "\\*",
+							"name": "comment.block.cpp"
+						}
+					]
+				}
+			}
+		},
+		"sizeof_operator": {
+			"contentName": "meta.arguments.operator.sizeof.cpp",
+			"begin": "((?<!\\w)sizeof(?!\\w))((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))(\\()",
+			"beginCaptures": {
+				"1": {
+					"name": "keyword.operator.functionlike.cpp keyword.operator.sizeof.cpp"
+				},
+				"2": {
+					"patterns": [
+						{
+							"include": "#inline_comment"
+						}
+					]
+				},
+				"3": {
+					"name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+				},
+				"4": {
+					"name": "comment.block.cpp"
+				},
+				"5": {
+					"patterns": [
+						{
+							"match": "\\*\\/",
+							"name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+						},
+						{
+							"match": "\\*",
+							"name": "comment.block.cpp"
+						}
+					]
+				},
+				"6": {
+					"name": "punctuation.section.arguments.begin.bracket.round.operator.sizeof.cpp"
+				}
+			},
+			"end": "(\\))",
+			"endCaptures": {
+				"1": {
+					"name": "punctuation.section.arguments.end.bracket.round.operator.sizeof.cpp"
+				}
+			},
+			"patterns": [
+				{
+					"include": "#evaluation_context"
+				}
+			]
+		},
+		"sizeof_variadic_operator": {
+			"contentName": "meta.arguments.operator.sizeof.variadic.cpp",
+			"begin": "(\\bsizeof\\.\\.\\.)((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))(\\()",
+			"beginCaptures": {
+				"1": {
+					"name": "keyword.operator.functionlike.cpp keyword.operator.sizeof.variadic.cpp"
+				},
+				"2": {
+					"patterns": [
+						{
+							"include": "#inline_comment"
+						}
+					]
+				},
+				"3": {
+					"name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+				},
+				"4": {
+					"name": "comment.block.cpp"
+				},
+				"5": {
+					"patterns": [
+						{
+							"match": "\\*\\/",
+							"name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+						},
+						{
+							"match": "\\*",
+							"name": "comment.block.cpp"
+						}
+					]
+				},
+				"6": {
+					"name": "punctuation.section.arguments.begin.bracket.round.operator.sizeof.variadic.cpp"
+				}
+			},
+			"end": "(\\))",
+			"endCaptures": {
+				"1": {
+					"name": "punctuation.section.arguments.end.bracket.round.operator.sizeof.variadic.cpp"
+				}
+			},
+			"patterns": [
+				{
+					"include": "#evaluation_context"
+				}
+			]
+		},
+		"square_brackets": {
+			"name": "meta.bracket.square.access.cpp",
+			"begin": "([a-zA-Z_][a-zA-Z_0-9]*|(?<=[\\]\\)]))?(\\[)(?!\\])",
+			"beginCaptures": {
+				"1": {
+					"name": "variable.other.object.cpp"
+				},
+				"2": {
+					"name": "punctuation.definition.begin.bracket.square.cpp"
+				}
+			},
+			"end": "\\]",
+			"endCaptures": {
+				"0": {
+					"name": "punctuation.definition.end.bracket.square.cpp"
+				}
+			},
+			"patterns": [
+				{
+					"include": "#evaluation_context"
+				}
+			]
+		},
+		"standard_declares": {
+			"patterns": [
+				{
+					"include": "#struct_declare"
+				},
+				{
+					"include": "#union_declare"
+				},
+				{
+					"include": "#enum_declare"
+				},
+				{
+					"include": "#class_declare"
+				}
+			]
+		},
+		"static_assert": {
+			"begin": "((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))((?<!\\w)static_assert|_Static_assert(?!\\w))((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))(\\()",
+			"beginCaptures": {
+				"1": {
+					"patterns": [
+						{
+							"include": "#inline_comment"
+						}
+					]
+				},
+				"2": {
+					"name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+				},
+				"3": {
+					"name": "comment.block.cpp"
+				},
+				"4": {
+					"patterns": [
+						{
+							"match": "\\*\\/",
+							"name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+						},
+						{
+							"match": "\\*",
+							"name": "comment.block.cpp"
+						}
+					]
+				},
+				"5": {
+					"name": "keyword.other.static_assert.cpp"
+				},
+				"6": {
+					"patterns": [
+						{
+							"include": "#inline_comment"
+						}
+					]
+				},
+				"7": {
+					"name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+				},
+				"8": {
+					"name": "comment.block.cpp"
+				},
+				"9": {
+					"patterns": [
+						{
+							"match": "\\*\\/",
+							"name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+						},
+						{
+							"match": "\\*",
+							"name": "comment.block.cpp"
+						}
+					]
+				},
+				"10": {
+					"name": "punctuation.section.arguments.begin.bracket.round.static_assert.cpp"
+				}
+			},
+			"end": "(\\))",
+			"endCaptures": {
+				"1": {
+					"name": "punctuation.section.arguments.end.bracket.round.static_assert.cpp"
+				}
+			},
+			"patterns": [
+				{
+					"name": "meta.static_assert.message.cpp",
+					"begin": "(,)\\s*(?=(?:L|u8|u|U\\s*\\\")?)",
+					"beginCaptures": {
+						"1": {
+							"name": "punctuation.separator.delimiter.comma.cpp"
+						}
+					},
+					"end": "(?=\\))",
+					"patterns": [
+						{
+							"include": "#string_context"
+						}
+					]
+				},
+				{
+					"include": "#evaluation_context"
+				}
+			]
+		},
+		"storage_specifiers": {
+			"match": "((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))((?<!\\w)(?:volatile|register|restrict|static|extern|const)(?!\\w))",
+			"captures": {
+				"1": {
+					"patterns": [
+						{
+							"include": "#inline_comment"
+						}
+					]
+				},
+				"2": {
+					"name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+				},
+				"3": {
+					"name": "comment.block.cpp"
+				},
+				"4": {
+					"patterns": [
+						{
+							"match": "\\*\\/",
+							"name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+						},
+						{
+							"match": "\\*",
+							"name": "comment.block.cpp"
+						}
+					]
+				},
+				"5": {
+					"name": "storage.modifier.specifier.$5.cpp"
+				}
+			}
+		},
+		"storage_types": {
+			"patterns": [
+				{
+					"include": "#storage_specifiers"
+				},
+				{
+					"include": "#primitive_types"
+				},
+				{
+					"include": "#non_primitive_types"
+				},
+				{
+					"include": "#pthread_types"
+				},
+				{
+					"include": "#posix_reserved_types"
+				},
+				{
+					"include": "#decltype"
+				},
+				{
+					"include": "#typename"
+				}
+			]
+		},
+		"string_context": {
+			"patterns": [
+				{
+					"name": "string.quoted.double.cpp",
+					"begin": "(((?:u|u8|U|L)?)\")",
+					"beginCaptures": {
+						"1": {
+							"name": "punctuation.definition.string.begin.cpp"
+						},
+						"2": {
 							"name": "meta.encoding.cpp"
 						}
 					},
-					"end": "\"",
+					"end": "(\")",
 					"endCaptures": {
-						"0": {
+						"1": {
 							"name": "punctuation.definition.string.end.cpp"
 						}
 					},
-					"name": "string.quoted.double.cpp",
 					"patterns": [
 						{
-							"match": "\\\\u\\h{4}|\\\\U\\h{8}",
+							"match": "(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8})",
 							"name": "constant.character.escape.cpp"
 						},
 						{
@@ -409,37 +12029,4190 @@
 							"name": "constant.character.escape.cpp"
 						},
 						{
-							"match": "\\\\x\\h+",
+							"match": "\\\\x[0-9a-fA-F]{2,2}",
 							"name": "constant.character.escape.cpp"
 						},
 						{
-							"include": "source.c#string_placeholder"
+							"include": "#string_escapes_context_c"
 						}
 					]
 				},
 				{
-					"begin": "(u|u8|U|L)?R\"(?:([^ ()\\\\\\t]{0,16})|([^ ()\\\\\\t]*))\\(",
+					"name": "string.quoted.single.cpp",
+					"begin": "((?<![0-9A-Fa-f])((?:u|u8|U|L)?)')",
 					"beginCaptures": {
-						"0": {
+						"1": {
 							"name": "punctuation.definition.string.begin.cpp"
 						},
-						"1": {
+						"2": {
 							"name": "meta.encoding.cpp"
+						}
+					},
+					"end": "(')",
+					"endCaptures": {
+						"1": {
+							"name": "punctuation.definition.string.end.cpp"
+						}
+					},
+					"patterns": [
+						{
+							"include": "#string_escapes_context_c"
+						},
+						{
+							"include": "#line_continuation_character"
+						}
+					]
+				},
+				{
+					"patterns": [
+						{
+							"name": "string.quoted.double.raw.regex.cpp",
+							"begin": "(((?:[uUL]8?)?R)\\\"(?:(?:_r|re)|regex)\\()",
+							"beginCaptures": {
+								"1": {
+									"name": "punctuation.definition.string.begin.cpp"
+								},
+								"2": {
+									"name": "meta.encoding.cpp"
+								}
+							},
+							"end": "(\\)(?:(?:_r|re)|regex)\\\")",
+							"endCaptures": {
+								"1": {
+									"name": "punctuation.definition.string.end.cpp"
+								}
+							},
+							"patterns": [
+								{
+									"include": "source.regexp.python"
+								}
+							]
+						},
+						{
+							"name": "string.quoted.double.raw.sql.cpp",
+							"begin": "(((?:[uUL]8?)?R)\\\"(?:[pP]?(?:sql|SQL)|d[dm]l)\\()",
+							"beginCaptures": {
+								"1": {
+									"name": "punctuation.definition.string.begin.cpp"
+								},
+								"2": {
+									"name": "meta.encoding.cpp"
+								}
+							},
+							"end": "(\\)(?:[pP]?(?:sql|SQL)|d[dm]l)\\\")",
+							"endCaptures": {
+								"1": {
+									"name": "punctuation.definition.string.end.cpp"
+								}
+							},
+							"patterns": [
+								{
+									"include": "source.sql"
+								}
+							]
+						},
+						{
+							"begin": "((?:u|u8|U|L)?R)\"(?:([^ ()\\\\\\t]{0,16})|([^ ()\\\\\\t]*))\\(",
+							"beginCaptures": {
+								"0": {
+									"name": "punctuation.definition.string.begin.cpp"
+								},
+								"1": {
+									"name": "meta.encoding.cpp"
+								},
+								"3": {
+									"name": "invalid.illegal.delimiter-too-long.cpp"
+								}
+							},
+							"end": "\\)\\2(\\3)\"",
+							"endCaptures": {
+								"0": {
+									"name": "punctuation.definition.string.end.cpp"
+								},
+								"1": {
+									"name": "invalid.illegal.delimiter-too-long.cpp"
+								}
+							},
+							"name": "string.quoted.double.raw.cpp"
+						}
+					]
+				}
+			]
+		},
+		"string_escapes_context_c": {
+			"patterns": [
+				{
+					"include": "#backslash_escapes"
+				},
+				{
+					"match": "\\\\.",
+					"name": "invalid.illegal.unknown-escape.cpp"
+				},
+				{
+					"match": "(?x) %\n(\\d+\\$)?\t\t\t\t\t\t   # field (argument #)\n[#0\\- +']*\t\t\t\t\t\t  # flags\n[,;:_]?\t\t\t\t\t\t\t  # separator character (AltiVec)\n((-?\\d+)|\\*(-?\\d+\\$)?)?\t\t  # minimum field width\n(\\.((-?\\d+)|\\*(-?\\d+\\$)?)?)?\t# precision\n(hh|h|ll|l|j|t|z|q|L|vh|vl|v|hv|hl)? # length modifier\n[diouxXDOUeEfFgGaACcSspn%]\t\t   # conversion type",
+					"name": "constant.other.placeholder.cpp"
+				}
+			]
+		},
+		"struct_block": {
+			"name": "meta.block.struct.cpp",
+			"begin": "((((?<!\\w)struct(?!\\w))(?:(?:((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))|((?:(?:(?:\\[\\[.*?\\]\\]|__attribute(?:__)?\\(\\(.*?\\)\\))|__declspec\\(.*?\\))|alignas\\(.*?\\))(?!\\))))|(?={))(?:((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))(DLLEXPORT)((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z)))))?((?:(?:(?:\\[\\[.*?\\]\\]|__attribute(?:__)?\\(\\(.*?\\)\\))|__declspec\\(.*?\\))|alignas\\(.*?\\))(?!\\)))?((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))((?:(?<!\\w)(?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*(?!\\w))?)(?:((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))(final)((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z)))))?(?:((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))(:)((?>[^{]*)))?))",
+			"beginCaptures": {
+				"1": {
+					"name": "meta.head.struct.cpp"
+				},
+				"3": {
+					"name": "storage.type.$3.cpp"
+				},
+				"4": {
+					"patterns": [
+						{
+							"include": "#inline_comment"
+						}
+					]
+				},
+				"5": {
+					"name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+				},
+				"6": {
+					"name": "comment.block.cpp"
+				},
+				"7": {
+					"patterns": [
+						{
+							"match": "\\*\\/",
+							"name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+						},
+						{
+							"match": "\\*",
+							"name": "comment.block.cpp"
+						}
+					]
+				},
+				"8": {
+					"patterns": [
+						{
+							"include": "#attributes_context"
+						},
+						{
+							"include": "#number_literal"
+						}
+					]
+				},
+				"9": {
+					"patterns": [
+						{
+							"include": "#inline_comment"
+						}
+					]
+				},
+				"10": {
+					"name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+				},
+				"11": {
+					"name": "comment.block.cpp"
+				},
+				"12": {
+					"patterns": [
+						{
+							"match": "\\*\\/",
+							"name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+						},
+						{
+							"match": "\\*",
+							"name": "comment.block.cpp"
+						}
+					]
+				},
+				"13": {
+					"name": "entity.name.other.preprocessor.macro.predefined.DLLEXPORT.cpp"
+				},
+				"14": {
+					"patterns": [
+						{
+							"include": "#inline_comment"
+						}
+					]
+				},
+				"15": {
+					"name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+				},
+				"16": {
+					"name": "comment.block.cpp"
+				},
+				"17": {
+					"patterns": [
+						{
+							"match": "\\*\\/",
+							"name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+						},
+						{
+							"match": "\\*",
+							"name": "comment.block.cpp"
+						}
+					]
+				},
+				"18": {
+					"patterns": [
+						{
+							"include": "#attributes_context"
+						},
+						{
+							"include": "#number_literal"
+						}
+					]
+				},
+				"19": {
+					"patterns": [
+						{
+							"include": "#inline_comment"
+						}
+					]
+				},
+				"20": {
+					"name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+				},
+				"21": {
+					"name": "comment.block.cpp"
+				},
+				"22": {
+					"patterns": [
+						{
+							"match": "\\*\\/",
+							"name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+						},
+						{
+							"match": "\\*",
+							"name": "comment.block.cpp"
+						}
+					]
+				},
+				"23": {
+					"name": "entity.name.type.$3.cpp"
+				},
+				"24": {
+					"patterns": [
+						{
+							"include": "#inline_comment"
+						}
+					]
+				},
+				"25": {
+					"name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+				},
+				"26": {
+					"name": "comment.block.cpp"
+				},
+				"27": {
+					"patterns": [
+						{
+							"match": "\\*\\/",
+							"name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+						},
+						{
+							"match": "\\*",
+							"name": "comment.block.cpp"
+						}
+					]
+				},
+				"28": {
+					"name": "storage.type.modifier.final.cpp"
+				},
+				"29": {
+					"patterns": [
+						{
+							"include": "#inline_comment"
+						}
+					]
+				},
+				"30": {
+					"name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+				},
+				"31": {
+					"name": "comment.block.cpp"
+				},
+				"32": {
+					"patterns": [
+						{
+							"match": "\\*\\/",
+							"name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+						},
+						{
+							"match": "\\*",
+							"name": "comment.block.cpp"
+						}
+					]
+				},
+				"33": {
+					"patterns": [
+						{
+							"include": "#inline_comment"
+						}
+					]
+				},
+				"34": {
+					"name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+				},
+				"35": {
+					"name": "comment.block.cpp"
+				},
+				"36": {
+					"patterns": [
+						{
+							"match": "\\*\\/",
+							"name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+						},
+						{
+							"match": "\\*",
+							"name": "comment.block.cpp"
+						}
+					]
+				},
+				"37": {
+					"name": "punctuation.separator.colon.inheritance.cpp"
+				},
+				"38": {
+					"patterns": [
+						{
+							"include": "#inheritance_context"
+						}
+					]
+				}
+			},
+			"end": "(?:(?:(?<=\\}|%>|\\?\\?>)\\s*(;)|(;))|(?=[;>\\[\\]=]))",
+			"endCaptures": {
+				"1": {
+					"name": "punctuation.terminator.statement.cpp"
+				},
+				"2": {
+					"name": "punctuation.terminator.statement.cpp"
+				}
+			},
+			"patterns": [
+				{
+					"name": "meta.head.struct.cpp",
+					"begin": "\\G ?",
+					"end": "((?:\\{|<%|\\?\\?<|(?=;)))",
+					"endCaptures": {
+						"1": {
+							"name": "punctuation.section.block.begin.bracket.curly.struct.cpp"
+						}
+					},
+					"patterns": [
+						{
+							"include": "#ever_present_context"
+						},
+						{
+							"include": "#inheritance_context"
+						},
+						{
+							"include": "#template_call_range"
+						}
+					]
+				},
+				{
+					"name": "meta.body.struct.cpp",
+					"begin": "(?<=\\{|<%|\\?\\?<)",
+					"end": "(\\}|%>|\\?\\?>)",
+					"endCaptures": {
+						"1": {
+							"name": "punctuation.section.block.end.bracket.curly.struct.cpp"
+						}
+					},
+					"patterns": [
+						{
+							"include": "#function_pointer"
+						},
+						{
+							"include": "#static_assert"
+						},
+						{
+							"include": "#constructor_inline"
+						},
+						{
+							"include": "#destructor_inline"
+						},
+						{
+							"include": "$self"
+						}
+					]
+				},
+				{
+					"name": "meta.tail.struct.cpp",
+					"begin": "(?<=\\}|%>|\\?\\?>)[\\s\\n]*",
+					"end": "[\\s\\n]*(?=;)",
+					"patterns": [
+						{
+							"include": "$self"
+						}
+					]
+				}
+			]
+		},
+		"struct_declare": {
+			"match": "((?<!\\w)struct(?!\\w))((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))((?<!\\w)(?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*(?!\\w))(((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))?(?:(?:\\&|\\*)((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z)))))*(?:\\&|\\*))?((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))\\b(?!override\\W|override\\$|final\\W|final\\$)((?<!\\w)(?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*(?!\\w))((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))(?=\\S)(?![:{])",
+			"captures": {
+				"1": {
+					"name": "storage.type.struct.declare.cpp"
+				},
+				"2": {
+					"patterns": [
+						{
+							"include": "#inline_comment"
+						}
+					]
+				},
+				"3": {
+					"name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+				},
+				"4": {
+					"name": "comment.block.cpp"
+				},
+				"5": {
+					"patterns": [
+						{
+							"match": "\\*\\/",
+							"name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+						},
+						{
+							"match": "\\*",
+							"name": "comment.block.cpp"
+						}
+					]
+				},
+				"6": {
+					"name": "entity.name.type.struct.cpp"
+				},
+				"7": {
+					"patterns": [
+						{
+							"match": "\\*",
+							"name": "storage.modifier.pointer.cpp"
+						},
+						{
+							"match": "(?:\\&((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))){2,}\\&",
+							"captures": {
+								"1": {
+									"patterns": [
+										{
+											"include": "#inline_comment"
+										}
+									]
+								},
+								"2": {
+									"name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+								},
+								"3": {
+									"name": "comment.block.cpp"
+								},
+								"4": {
+									"patterns": [
+										{
+											"match": "\\*\\/",
+											"name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+										},
+										{
+											"match": "\\*",
+											"name": "comment.block.cpp"
+										}
+									]
+								}
+							},
+							"name": "invalid.illegal.reference-type.cpp"
+						},
+						{
+							"match": "\\&",
+							"name": "storage.modifier.reference.cpp"
+						}
+					]
+				},
+				"8": {
+					"patterns": [
+						{
+							"include": "#inline_comment"
+						}
+					]
+				},
+				"9": {
+					"name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+				},
+				"10": {
+					"name": "comment.block.cpp"
+				},
+				"11": {
+					"patterns": [
+						{
+							"match": "\\*\\/",
+							"name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+						},
+						{
+							"match": "\\*",
+							"name": "comment.block.cpp"
+						}
+					]
+				},
+				"12": {
+					"patterns": [
+						{
+							"include": "#inline_comment"
+						}
+					]
+				},
+				"13": {
+					"name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+				},
+				"14": {
+					"name": "comment.block.cpp"
+				},
+				"15": {
+					"patterns": [
+						{
+							"match": "\\*\\/",
+							"name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+						},
+						{
+							"match": "\\*",
+							"name": "comment.block.cpp"
+						}
+					]
+				},
+				"16": {
+					"patterns": [
+						{
+							"include": "#inline_comment"
+						}
+					]
+				},
+				"17": {
+					"name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+				},
+				"18": {
+					"name": "comment.block.cpp"
+				},
+				"19": {
+					"patterns": [
+						{
+							"match": "\\*\\/",
+							"name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+						},
+						{
+							"match": "\\*",
+							"name": "comment.block.cpp"
+						}
+					]
+				},
+				"20": {
+					"name": "variable.other.object.declare.cpp"
+				},
+				"21": {
+					"patterns": [
+						{
+							"include": "#inline_comment"
+						}
+					]
+				},
+				"22": {
+					"name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+				},
+				"23": {
+					"name": "comment.block.cpp"
+				},
+				"24": {
+					"patterns": [
+						{
+							"match": "\\*\\/",
+							"name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+						},
+						{
+							"match": "\\*",
+							"name": "comment.block.cpp"
+						}
+					]
+				}
+			}
+		},
+		"switch_conditional_parentheses": {
+			"name": "meta.conditional.switch.cpp",
+			"begin": "((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))(\\()",
+			"beginCaptures": {
+				"1": {
+					"patterns": [
+						{
+							"include": "#inline_comment"
+						}
+					]
+				},
+				"2": {
+					"name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+				},
+				"3": {
+					"name": "comment.block.cpp"
+				},
+				"4": {
+					"patterns": [
+						{
+							"match": "\\*\\/",
+							"name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+						},
+						{
+							"match": "\\*",
+							"name": "comment.block.cpp"
+						}
+					]
+				},
+				"5": {
+					"name": "punctuation.section.parens.begin.bracket.round.conditional.switch.cpp"
+				}
+			},
+			"end": "(\\))",
+			"endCaptures": {
+				"1": {
+					"name": "punctuation.section.parens.end.bracket.round.conditional.switch.cpp"
+				}
+			},
+			"patterns": [
+				{
+					"include": "#evaluation_context"
+				},
+				{
+					"include": "#c_conditional_context"
+				}
+			]
+		},
+		"switch_statement": {
+			"name": "meta.block.switch.cpp",
+			"begin": "(((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))((?<!\\w)switch(?!\\w)))",
+			"beginCaptures": {
+				"1": {
+					"name": "meta.head.switch.cpp"
+				},
+				"2": {
+					"patterns": [
+						{
+							"include": "#inline_comment"
+						}
+					]
+				},
+				"3": {
+					"name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+				},
+				"4": {
+					"name": "comment.block.cpp"
+				},
+				"5": {
+					"patterns": [
+						{
+							"match": "\\*\\/",
+							"name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+						},
+						{
+							"match": "\\*",
+							"name": "comment.block.cpp"
+						}
+					]
+				},
+				"6": {
+					"name": "keyword.control.switch.cpp"
+				}
+			},
+			"end": "(?:(?<=\\}|%>|\\?\\?>)|(?=[;>\\[\\]=]))",
+			"patterns": [
+				{
+					"name": "meta.head.switch.cpp",
+					"begin": "\\G ?",
+					"end": "((?:\\{|<%|\\?\\?<|(?=;)))",
+					"endCaptures": {
+						"1": {
+							"name": "punctuation.section.block.begin.bracket.curly.switch.cpp"
+						}
+					},
+					"patterns": [
+						{
+							"include": "#switch_conditional_parentheses"
+						},
+						{
+							"include": "$self"
+						}
+					]
+				},
+				{
+					"name": "meta.body.switch.cpp",
+					"begin": "(?<=\\{|<%|\\?\\?<)",
+					"end": "(\\}|%>|\\?\\?>)",
+					"endCaptures": {
+						"1": {
+							"name": "punctuation.section.block.end.bracket.curly.switch.cpp"
+						}
+					},
+					"patterns": [
+						{
+							"include": "#default_statement"
+						},
+						{
+							"include": "#case_statement"
+						},
+						{
+							"include": "$self"
+						},
+						{
+							"include": "#block_innards"
+						}
+					]
+				},
+				{
+					"name": "meta.tail.switch.cpp",
+					"begin": "(?<=\\}|%>|\\?\\?>)[\\s\\n]*",
+					"end": "[\\s\\n]*(?=;)",
+					"patterns": [
+						{
+							"include": "$self"
+						}
+					]
+				}
+			]
+		},
+		"template_argument_defaulted": {
+			"match": "(?<=<|,)\\s*((?:(?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*\\s+)*)((?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*)\\s*([=])",
+			"captures": {
+				"1": {
+					"name": "storage.type.template.cpp"
+				},
+				"2": {
+					"name": "entity.name.type.template.cpp"
+				},
+				"3": {
+					"name": "keyword.operator.assignment.cpp"
+				}
+			}
+		},
+		"template_call_context": {
+			"patterns": [
+				{
+					"include": "#ever_present_context"
+				},
+				{
+					"include": "#template_call_range"
+				},
+				{
+					"include": "#storage_types"
+				},
+				{
+					"include": "#language_constants"
+				},
+				{
+					"include": "#scope_resolution_template_call_inner_generated"
+				},
+				{
+					"include": "#operators"
+				},
+				{
+					"include": "#number_literal"
+				},
+				{
+					"include": "#string_context"
+				},
+				{
+					"include": "#comma_in_template_argument"
+				},
+				{
+					"include": "#qualified_type"
+				}
+			]
+		},
+		"template_call_innards": {
+			"match": "((?<!<)<(?!<)(?>(?:(?>[^<>]*)\\g<1>?)+)>)\\s*",
+			"captures": {
+				"0": {
+					"name": "meta.template.call.cpp",
+					"patterns": [
+						{
+							"include": "#template_call_range"
+						}
+					]
+				}
+			}
+		},
+		"template_call_range": {
+			"name": "meta.template.call.cpp",
+			"begin": "(<)",
+			"beginCaptures": {
+				"1": {
+					"name": "punctuation.section.angle-brackets.begin.template.call.cpp"
+				}
+			},
+			"end": "(>)",
+			"endCaptures": {
+				"1": {
+					"name": "punctuation.section.angle-brackets.end.template.call.cpp"
+				}
+			},
+			"patterns": [
+				{
+					"include": "#template_call_context"
+				}
+			]
+		},
+		"template_definition": {
+			"name": "meta.template.definition.cpp",
+			"begin": "(?<!\\w)(template)\\s*(<)",
+			"beginCaptures": {
+				"1": {
+					"name": "storage.type.template.cpp"
+				},
+				"2": {
+					"name": "punctuation.section.angle-brackets.start.template.definition.cpp"
+				}
+			},
+			"end": "(>)",
+			"endCaptures": {
+				"1": {
+					"name": "punctuation.section.angle-brackets.end.template.definition.cpp"
+				}
+			},
+			"patterns": [
+				{
+					"begin": "((?<=\\w)\\s*<)",
+					"beginCaptures": {
+						"1": {
+							"name": "punctuation.section.angle-brackets.begin.template.call.cpp"
+						}
+					},
+					"end": "(>)",
+					"endCaptures": {
+						"1": {
+							"name": "punctuation.section.angle-brackets.begin.template.call.cpp"
+						}
+					},
+					"patterns": [
+						{
+							"include": "#template_call_context"
+						}
+					]
+				},
+				{
+					"include": "#template_definition_context"
+				}
+			]
+		},
+		"template_definition_argument": {
+			"match": "((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))(?:(?:((?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*)|((?:(?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*\\s+)+)((?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*))|((?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*)\\s*(\\.\\.\\.)\\s*((?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*))\\s*(?:(,)|(?=>|$))",
+			"captures": {
+				"1": {
+					"patterns": [
+						{
+							"include": "#inline_comment"
+						}
+					]
+				},
+				"2": {
+					"name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+				},
+				"3": {
+					"name": "comment.block.cpp"
+				},
+				"4": {
+					"patterns": [
+						{
+							"match": "\\*\\/",
+							"name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+						},
+						{
+							"match": "\\*",
+							"name": "comment.block.cpp"
+						}
+					]
+				},
+				"5": {
+					"name": "storage.type.template.argument.$5.cpp"
+				},
+				"6": {
+					"patterns": [
+						{
+							"match": "(?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*",
+							"name": "storage.type.template.argument.$0.cpp"
+						}
+					]
+				},
+				"7": {
+					"name": "entity.name.type.template.cpp"
+				},
+				"8": {
+					"name": "storage.type.template.cpp"
+				},
+				"9": {
+					"name": "punctuation.vararg-ellipses.template.definition.cpp"
+				},
+				"10": {
+					"name": "entity.name.type.template.cpp"
+				},
+				"11": {
+					"name": "punctuation.separator.delimiter.comma.template.argument.cpp"
+				}
+			}
+		},
+		"template_definition_context": {
+			"patterns": [
+				{
+					"include": "#scope_resolution_template_definition_inner_generated"
+				},
+				{
+					"include": "#template_definition_argument"
+				},
+				{
+					"include": "#template_argument_defaulted"
+				},
+				{
+					"include": "#template_call_innards"
+				},
+				{
+					"include": "#evaluation_context"
+				}
+			]
+		},
+		"template_isolated_definition": {
+			"match": "(?<!\\w)(template)\\s*(<)(.*)(>\\s*$)",
+			"captures": {
+				"1": {
+					"name": "storage.type.template.cpp"
+				},
+				"2": {
+					"name": "punctuation.section.angle-brackets.start.template.definition.cpp"
+				},
+				"3": {
+					"name": "meta.template.definition.cpp",
+					"patterns": [
+						{
+							"include": "#template_definition_context"
+						}
+					]
+				},
+				"4": {
+					"name": "punctuation.section.angle-brackets.end.template.definition.cpp"
+				}
+			}
+		},
+		"ternary_operator": {
+			"applyEndPatternLast": true,
+			"begin": "(\\?)",
+			"beginCaptures": {
+				"1": {
+					"name": "keyword.operator.ternary.cpp"
+				}
+			},
+			"end": "(:)",
+			"endCaptures": {
+				"1": {
+					"name": "keyword.operator.ternary.cpp"
+				}
+			},
+			"patterns": [
+				{
+					"include": "#ever_present_context"
+				},
+				{
+					"include": "#string_context"
+				},
+				{
+					"include": "#number_literal"
+				},
+				{
+					"include": "#method_access"
+				},
+				{
+					"include": "#member_access"
+				},
+				{
+					"include": "#predefined_macros"
+				},
+				{
+					"include": "#operators"
+				},
+				{
+					"include": "#memory_operators"
+				},
+				{
+					"include": "#wordlike_operators"
+				},
+				{
+					"include": "#type_casting_operators"
+				},
+				{
+					"include": "#control_flow_keywords"
+				},
+				{
+					"include": "#exception_keywords"
+				},
+				{
+					"include": "#the_this_keyword"
+				},
+				{
+					"include": "#language_constants"
+				},
+				{
+					"include": "#builtin_storage_type_initilizer"
+				},
+				{
+					"include": "#qualifiers_and_specifiers_post_parameters"
+				},
+				{
+					"include": "#functional_specifiers_pre_parameters"
+				},
+				{
+					"include": "#storage_types"
+				},
+				{
+					"include": "#misc_storage_modifiers"
+				},
+				{
+					"include": "#lambdas"
+				},
+				{
+					"include": "#attributes_context"
+				},
+				{
+					"include": "#parentheses"
+				},
+				{
+					"include": "#function_call"
+				},
+				{
+					"include": "#scope_resolution_inner_generated"
+				},
+				{
+					"include": "#square_brackets"
+				},
+				{
+					"include": "#empty_square_brackets"
+				},
+				{
+					"include": "#semicolon"
+				},
+				{
+					"include": "#comma"
+				}
+			]
+		},
+		"the_this_keyword": {
+			"match": "((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))((?<!\\w)this(?!\\w))",
+			"captures": {
+				"1": {
+					"patterns": [
+						{
+							"include": "#inline_comment"
+						}
+					]
+				},
+				"2": {
+					"name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+				},
+				"3": {
+					"name": "comment.block.cpp"
+				},
+				"4": {
+					"patterns": [
+						{
+							"match": "\\*\\/",
+							"name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+						},
+						{
+							"match": "\\*",
+							"name": "comment.block.cpp"
+						}
+					]
+				},
+				"5": {
+					"name": "variable.language.this.cpp"
+				}
+			}
+		},
+		"type_alias": {
+			"match": "(using)\\s*(?!namespace)(\\s*+((?:(?:(?:\\[\\[.*?\\]\\]|__attribute(?:__)?\\(\\(.*?\\)\\))|__declspec\\(.*?\\))|alignas\\(.*?\\))(?!\\)))?((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))(?:(?:(?:unsigned|signed|short|long)|(?:struct|class|union|enum))((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z)))))*(((::)?(?:((?-mix:(?!\\b(?:__has_cpp_attribute|reinterpret_cast|atomic_noexcept|atomic_cancel|atomic_commit|__has_include|dynamic_cast|thread_local|synchronized|static_cast|const_cast|consteval|constexpr|protected|namespace|co_return|constexpr|constexpr|continue|explicit|volatile|noexcept|co_yield|noexcept|noexcept|requires|typename|decltype|operator|co_await|template|volatile|register|restrict|reflexpr|alignof|private|default|mutable|include|concept|__asm__|defined|_Pragma|alignas|typedef|warning|virtual|mutable|struct|sizeof|delete|not_eq|bitand|and_eq|xor_eq|typeid|switch|return|static|extern|inline|friend|public|ifndef|define|pragma|export|import|module|catch|throw|const|or_eq|while|compl|bitor|const|union|ifdef|class|undef|error|break|using|endif|goto|line|enum|this|case|else|elif|else|asm|try|for|new|and|xor|not|do|or|if|if)\\b)(?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*))\\s*+(((?<!<)<(?!<)(?>(?:(?>[^<>]*)\\g<58>?)+)>)\\s*)?::)*\\s*+)((?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*)\\s*+(((?<!<)<(?!<)(?>(?:(?>[^<>]*)\\g<58>?)+)>)\\s*)?(::))?((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))(?!(?:transaction_safe_dynamic|__has_cpp_attribute|transaction_safe|reinterpret_cast|atomic_noexcept|atomic_commit|atomic_cancel|__has_include|dynamic_cast|thread_local|synchronized|static_cast|const_cast|constexpr|consteval|protected|constexpr|co_return|namespace|constexpr|noexcept|typename|decltype|template|operator|noexcept|co_yield|co_await|continue|volatile|register|restrict|explicit|override|volatile|reflexpr|noexcept|requires|default|typedef|nullptr|alignof|mutable|concept|virtual|defined|__asm__|include|_Pragma|mutable|warning|private|alignas|module|switch|not_eq|bitand|and_eq|ifndef|return|sizeof|xor_eq|export|static|delete|public|define|extern|inline|import|pragma|friend|typeid|const|compl|bitor|throw|or_eq|while|catch|break|false|final|const|endif|ifdef|undef|error|using|audit|axiom|line|else|elif|true|NULL|case|goto|else|this|new|asm|not|and|xor|try|for|if|do|or|if)\\b)((?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*)\\b(((?<!<)<(?!<)(?>(?:(?>[^<>]*)\\g<58>?)+)>)\\s*)?(?![\\w<:.]))\\s*(\\=)\\s*((?:typename)?)\\s*((?:(?:(?>(?:(?:(?>(?<!\\s)\\s+)|(?:\\/\\*)(?:(?>(?:[^\\*]|(?>\\*+)[^\\/])*)(?:(?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))(?:(?<!\\w)(?:volatile|register|restrict|static|extern|const)(?!\\w))\\s+)+)?(?:(\\s*+((?:(?:(?:\\[\\[.*?\\]\\]|__attribute(?:__)?\\(\\(.*?\\)\\))|__declspec\\(.*?\\))|alignas\\(.*?\\))(?!\\)))?((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))(?:(?:(?:unsigned|signed|short|long)|(?:struct|class|union|enum))((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z)))))*(((::)?(?:((?-mix:(?!\\b(?:__has_cpp_attribute|reinterpret_cast|atomic_noexcept|atomic_cancel|atomic_commit|__has_include|dynamic_cast|thread_local|synchronized|static_cast|const_cast|consteval|constexpr|protected|namespace|co_return|constexpr|constexpr|continue|explicit|volatile|noexcept|co_yield|noexcept|noexcept|requires|typename|decltype|operator|co_await|template|volatile|register|restrict|reflexpr|alignof|private|default|mutable|include|concept|__asm__|defined|_Pragma|alignas|typedef|warning|virtual|mutable|struct|sizeof|delete|not_eq|bitand|and_eq|xor_eq|typeid|switch|return|static|extern|inline|friend|public|ifndef|define|pragma|export|import|module|catch|throw|const|or_eq|while|compl|bitor|const|union|ifdef|class|undef|error|break|using|endif|goto|line|enum|this|case|else|elif|else|asm|try|for|new|and|xor|not|do|or|if|if)\\b)(?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*))\\s*+(((?<!<)<(?!<)(?>(?:(?>[^<>]*)\\g<58>?)+)>)\\s*)?::)*\\s*+)((?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*)\\s*+(((?<!<)<(?!<)(?>(?:(?>[^<>]*)\\g<58>?)+)>)\\s*)?(::))?((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))(?!(?:transaction_safe_dynamic|__has_cpp_attribute|transaction_safe|reinterpret_cast|atomic_noexcept|atomic_commit|atomic_cancel|__has_include|dynamic_cast|thread_local|synchronized|static_cast|const_cast|constexpr|consteval|protected|constexpr|co_return|namespace|constexpr|noexcept|typename|decltype|template|operator|noexcept|co_yield|co_await|continue|volatile|register|restrict|explicit|override|volatile|reflexpr|noexcept|requires|default|typedef|nullptr|alignof|mutable|concept|virtual|defined|__asm__|include|_Pragma|mutable|warning|private|alignas|module|switch|not_eq|bitand|and_eq|ifndef|return|sizeof|xor_eq|export|static|delete|public|define|extern|inline|import|pragma|friend|typeid|const|compl|bitor|throw|or_eq|while|catch|break|false|final|const|endif|ifdef|undef|error|using|audit|axiom|line|else|elif|true|NULL|case|goto|else|this|new|asm|not|and|xor|try|for|if|do|or|if)\\b)((?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*)\\b(((?<!<)<(?!<)(?>(?:(?>[^<>]*)\\g<58>?)+)>)\\s*)?(?![\\w<:.]))|(.*(?<!;)))(?:(((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))?(?:(?:\\&|\\*)((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z)))))*(?:\\&|\\*))((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z)))))?(?:(\\[)(\\w*)(\\])\\s*)?\\s*(?:(;)|\\n)",
+			"captures": {
+				"1": {
+					"name": "keyword.other.using.directive.cpp"
+				},
+				"2": {
+					"name": "meta.qualified_type.cpp",
+					"patterns": [
+						{
+							"match": "(?<!\\w)(?:struct|class|union|enum)(?!\\w)",
+							"name": "storage.type.$0.cpp"
+						},
+						{
+							"include": "#attributes_context"
+						},
+						{
+							"include": "#function_type"
+						},
+						{
+							"include": "#storage_types"
+						},
+						{
+							"include": "#number_literal"
+						},
+						{
+							"include": "#string_context"
+						},
+						{
+							"include": "#comma"
+						},
+						{
+							"include": "#scope_resolution_inner_generated"
+						},
+						{
+							"include": "#template_call_range"
+						},
+						{
+							"match": "(?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*",
+							"name": "entity.name.type.cpp"
+						}
+					]
+				},
+				"3": {
+					"patterns": [
+						{
+							"include": "#attributes_context"
+						},
+						{
+							"include": "#number_literal"
+						}
+					]
+				},
+				"4": {
+					"patterns": [
+						{
+							"include": "#inline_comment"
+						}
+					]
+				},
+				"5": {
+					"name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+				},
+				"6": {
+					"name": "comment.block.cpp"
+				},
+				"7": {
+					"patterns": [
+						{
+							"match": "\\*\\/",
+							"name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+						},
+						{
+							"match": "\\*",
+							"name": "comment.block.cpp"
+						}
+					]
+				},
+				"8": {
+					"patterns": [
+						{
+							"include": "#inline_comment"
+						}
+					]
+				},
+				"9": {
+					"name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+				},
+				"10": {
+					"name": "comment.block.cpp"
+				},
+				"11": {
+					"patterns": [
+						{
+							"match": "\\*\\/",
+							"name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+						},
+						{
+							"match": "\\*",
+							"name": "comment.block.cpp"
+						}
+					]
+				},
+				"13": {
+					"patterns": [
+						{
+							"include": "#scope_resolution_inner_generated"
+						}
+					]
+				},
+				"14": {
+					"name": "punctuation.separator.namespace.access.cpp punctuation.separator.scope-resolution.cpp"
+				},
+				"16": {
+					"name": "meta.template.call.cpp",
+					"patterns": [
+						{
+							"include": "#template_call_range"
+						}
+					]
+				},
+				"18": {
+					"name": "entity.name.scope-resolution.cpp"
+				},
+				"19": {
+					"name": "meta.template.call.cpp",
+					"patterns": [
+						{
+							"include": "#template_call_range"
+						}
+					]
+				},
+				"21": {
+					"name": "punctuation.separator.namespace.access.cpp punctuation.separator.scope-resolution.cpp"
+				},
+				"22": {
+					"patterns": [
+						{
+							"include": "#inline_comment"
+						}
+					]
+				},
+				"23": {
+					"name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+				},
+				"24": {
+					"name": "comment.block.cpp"
+				},
+				"25": {
+					"patterns": [
+						{
+							"match": "\\*\\/",
+							"name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+						},
+						{
+							"match": "\\*",
+							"name": "comment.block.cpp"
+						}
+					]
+				},
+				"26": {
+					"name": "entity.name.type.cpp"
+				},
+				"27": {
+					"name": "meta.template.call.cpp",
+					"patterns": [
+						{
+							"include": "#template_call_range"
+						}
+					]
+				},
+				"29": {
+					"name": "keyword.operator.assignment.cpp"
+				},
+				"30": {
+					"name": "keyword.other.typename.cpp"
+				},
+				"31": {
+					"patterns": [
+						{
+							"include": "#storage_specifiers"
+						}
+					]
+				},
+				"32": {
+					"name": "meta.qualified_type.cpp",
+					"patterns": [
+						{
+							"match": "(?<!\\w)(?:struct|class|union|enum)(?!\\w)",
+							"name": "storage.type.$0.cpp"
+						},
+						{
+							"include": "#attributes_context"
+						},
+						{
+							"include": "#function_type"
+						},
+						{
+							"include": "#storage_types"
+						},
+						{
+							"include": "#number_literal"
+						},
+						{
+							"include": "#string_context"
+						},
+						{
+							"include": "#comma"
+						},
+						{
+							"include": "#scope_resolution_inner_generated"
+						},
+						{
+							"include": "#template_call_range"
+						},
+						{
+							"match": "(?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*",
+							"name": "entity.name.type.cpp"
+						}
+					]
+				},
+				"33": {
+					"patterns": [
+						{
+							"include": "#attributes_context"
+						},
+						{
+							"include": "#number_literal"
+						}
+					]
+				},
+				"34": {
+					"patterns": [
+						{
+							"include": "#inline_comment"
+						}
+					]
+				},
+				"35": {
+					"name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+				},
+				"36": {
+					"name": "comment.block.cpp"
+				},
+				"37": {
+					"patterns": [
+						{
+							"match": "\\*\\/",
+							"name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+						},
+						{
+							"match": "\\*",
+							"name": "comment.block.cpp"
+						}
+					]
+				},
+				"38": {
+					"patterns": [
+						{
+							"include": "#inline_comment"
+						}
+					]
+				},
+				"39": {
+					"name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+				},
+				"40": {
+					"name": "comment.block.cpp"
+				},
+				"41": {
+					"patterns": [
+						{
+							"match": "\\*\\/",
+							"name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+						},
+						{
+							"match": "\\*",
+							"name": "comment.block.cpp"
+						}
+					]
+				},
+				"43": {
+					"patterns": [
+						{
+							"include": "#scope_resolution_inner_generated"
+						}
+					]
+				},
+				"44": {
+					"name": "punctuation.separator.namespace.access.cpp punctuation.separator.scope-resolution.cpp"
+				},
+				"46": {
+					"name": "meta.template.call.cpp",
+					"patterns": [
+						{
+							"include": "#template_call_range"
+						}
+					]
+				},
+				"48": {
+					"name": "entity.name.scope-resolution.cpp"
+				},
+				"49": {
+					"name": "meta.template.call.cpp",
+					"patterns": [
+						{
+							"include": "#template_call_range"
+						}
+					]
+				},
+				"51": {
+					"name": "punctuation.separator.namespace.access.cpp punctuation.separator.scope-resolution.cpp"
+				},
+				"52": {
+					"patterns": [
+						{
+							"include": "#inline_comment"
+						}
+					]
+				},
+				"53": {
+					"name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+				},
+				"54": {
+					"name": "comment.block.cpp"
+				},
+				"55": {
+					"patterns": [
+						{
+							"match": "\\*\\/",
+							"name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+						},
+						{
+							"match": "\\*",
+							"name": "comment.block.cpp"
+						}
+					]
+				},
+				"56": {
+					"name": "entity.name.type.cpp"
+				},
+				"57": {
+					"name": "meta.template.call.cpp",
+					"patterns": [
+						{
+							"include": "#template_call_range"
+						}
+					]
+				},
+				"59": {
+					"name": "meta.declaration.type.alias.value.unknown.cpp",
+					"patterns": [
+						{
+							"include": "#evaluation_context"
+						}
+					]
+				},
+				"60": {
+					"patterns": [
+						{
+							"match": "\\*",
+							"name": "storage.modifier.pointer.cpp"
+						},
+						{
+							"match": "(?:\\&((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))){2,}\\&",
+							"captures": {
+								"1": {
+									"patterns": [
+										{
+											"include": "#inline_comment"
+										}
+									]
+								},
+								"2": {
+									"name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+								},
+								"3": {
+									"name": "comment.block.cpp"
+								},
+								"4": {
+									"patterns": [
+										{
+											"match": "\\*\\/",
+											"name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+										},
+										{
+											"match": "\\*",
+											"name": "comment.block.cpp"
+										}
+									]
+								}
+							},
+							"name": "invalid.illegal.reference-type.cpp"
+						},
+						{
+							"match": "\\&",
+							"name": "storage.modifier.reference.cpp"
+						}
+					]
+				},
+				"61": {
+					"patterns": [
+						{
+							"include": "#inline_comment"
+						}
+					]
+				},
+				"62": {
+					"name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+				},
+				"63": {
+					"name": "comment.block.cpp"
+				},
+				"64": {
+					"patterns": [
+						{
+							"match": "\\*\\/",
+							"name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+						},
+						{
+							"match": "\\*",
+							"name": "comment.block.cpp"
+						}
+					]
+				},
+				"65": {
+					"patterns": [
+						{
+							"include": "#inline_comment"
+						}
+					]
+				},
+				"66": {
+					"name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+				},
+				"67": {
+					"name": "comment.block.cpp"
+				},
+				"68": {
+					"patterns": [
+						{
+							"match": "\\*\\/",
+							"name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+						},
+						{
+							"match": "\\*",
+							"name": "comment.block.cpp"
+						}
+					]
+				},
+				"69": {
+					"patterns": [
+						{
+							"include": "#inline_comment"
+						}
+					]
+				},
+				"70": {
+					"name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+				},
+				"71": {
+					"name": "comment.block.cpp"
+				},
+				"72": {
+					"patterns": [
+						{
+							"match": "\\*\\/",
+							"name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+						},
+						{
+							"match": "\\*",
+							"name": "comment.block.cpp"
+						}
+					]
+				},
+				"73": {
+					"name": "punctuation.definition.begin.bracket.square.cpp"
+				},
+				"74": {
+					"patterns": [
+						{
+							"include": "#evaluation_context"
+						}
+					]
+				},
+				"75": {
+					"name": "punctuation.definition.end.bracket.square.cpp"
+				},
+				"76": {
+					"name": "punctuation.terminator.statement.cpp"
+				}
+			},
+			"name": "meta.declaration.type.alias.cpp"
+		},
+		"type_casting_operators": {
+			"match": "((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))((?<!\\w)(?:reinterpret_cast|dynamic_cast|static_cast|const_cast)(?!\\w))",
+			"captures": {
+				"1": {
+					"patterns": [
+						{
+							"include": "#inline_comment"
+						}
+					]
+				},
+				"2": {
+					"name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+				},
+				"3": {
+					"name": "comment.block.cpp"
+				},
+				"4": {
+					"patterns": [
+						{
+							"match": "\\*\\/",
+							"name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+						},
+						{
+							"match": "\\*",
+							"name": "comment.block.cpp"
+						}
+					]
+				},
+				"5": {
+					"name": "keyword.operator.wordlike.cpp keyword.operator.cast.$5.cpp"
+				}
+			}
+		},
+		"typedef_class": {
+			"begin": "((?<!\\w)typedef(?!\\w))\\s*(?=(?<!\\w)class(?!\\w))",
+			"beginCaptures": {
+				"1": {
+					"name": "keyword.other.typedef.cpp"
+				}
+			},
+			"end": "(?<=;)",
+			"patterns": [
+				{
+					"name": "meta.block.class.cpp",
+					"begin": "((((?<!\\w)class(?!\\w))(?:(?:((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))|((?:(?:(?:\\[\\[.*?\\]\\]|__attribute(?:__)?\\(\\(.*?\\)\\))|__declspec\\(.*?\\))|alignas\\(.*?\\))(?!\\))))|(?={))(?:((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))(DLLEXPORT)((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z)))))?((?:(?:(?:\\[\\[.*?\\]\\]|__attribute(?:__)?\\(\\(.*?\\)\\))|__declspec\\(.*?\\))|alignas\\(.*?\\))(?!\\)))?((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))((?:(?<!\\w)(?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*(?!\\w))?)(?:((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))(final)((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z)))))?(?:((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))(:)((?>[^{]*)))?))",
+					"beginCaptures": {
+						"1": {
+							"name": "meta.head.class.cpp"
 						},
 						"3": {
-							"name": "invalid.illegal.delimiter-too-long.cpp"
-						}
-					},
-					"end": "\\)\\2(\\3)\"",
-					"endCaptures": {
-						"0": {
-							"name": "punctuation.definition.string.end.cpp"
+							"name": "storage.type.$3.cpp"
 						},
-						"1": {
-							"name": "invalid.illegal.delimiter-too-long.cpp"
+						"4": {
+							"patterns": [
+								{
+									"include": "#inline_comment"
+								}
+							]
+						},
+						"5": {
+							"name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+						},
+						"6": {
+							"name": "comment.block.cpp"
+						},
+						"7": {
+							"patterns": [
+								{
+									"match": "\\*\\/",
+									"name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+								},
+								{
+									"match": "\\*",
+									"name": "comment.block.cpp"
+								}
+							]
+						},
+						"8": {
+							"patterns": [
+								{
+									"include": "#attributes_context"
+								},
+								{
+									"include": "#number_literal"
+								}
+							]
+						},
+						"9": {
+							"patterns": [
+								{
+									"include": "#inline_comment"
+								}
+							]
+						},
+						"10": {
+							"name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+						},
+						"11": {
+							"name": "comment.block.cpp"
+						},
+						"12": {
+							"patterns": [
+								{
+									"match": "\\*\\/",
+									"name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+								},
+								{
+									"match": "\\*",
+									"name": "comment.block.cpp"
+								}
+							]
+						},
+						"13": {
+							"name": "entity.name.other.preprocessor.macro.predefined.DLLEXPORT.cpp"
+						},
+						"14": {
+							"patterns": [
+								{
+									"include": "#inline_comment"
+								}
+							]
+						},
+						"15": {
+							"name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+						},
+						"16": {
+							"name": "comment.block.cpp"
+						},
+						"17": {
+							"patterns": [
+								{
+									"match": "\\*\\/",
+									"name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+								},
+								{
+									"match": "\\*",
+									"name": "comment.block.cpp"
+								}
+							]
+						},
+						"18": {
+							"patterns": [
+								{
+									"include": "#attributes_context"
+								},
+								{
+									"include": "#number_literal"
+								}
+							]
+						},
+						"19": {
+							"patterns": [
+								{
+									"include": "#inline_comment"
+								}
+							]
+						},
+						"20": {
+							"name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+						},
+						"21": {
+							"name": "comment.block.cpp"
+						},
+						"22": {
+							"patterns": [
+								{
+									"match": "\\*\\/",
+									"name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+								},
+								{
+									"match": "\\*",
+									"name": "comment.block.cpp"
+								}
+							]
+						},
+						"23": {
+							"name": "entity.name.type.$3.cpp"
+						},
+						"24": {
+							"patterns": [
+								{
+									"include": "#inline_comment"
+								}
+							]
+						},
+						"25": {
+							"name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+						},
+						"26": {
+							"name": "comment.block.cpp"
+						},
+						"27": {
+							"patterns": [
+								{
+									"match": "\\*\\/",
+									"name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+								},
+								{
+									"match": "\\*",
+									"name": "comment.block.cpp"
+								}
+							]
+						},
+						"28": {
+							"name": "storage.type.modifier.final.cpp"
+						},
+						"29": {
+							"patterns": [
+								{
+									"include": "#inline_comment"
+								}
+							]
+						},
+						"30": {
+							"name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+						},
+						"31": {
+							"name": "comment.block.cpp"
+						},
+						"32": {
+							"patterns": [
+								{
+									"match": "\\*\\/",
+									"name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+								},
+								{
+									"match": "\\*",
+									"name": "comment.block.cpp"
+								}
+							]
+						},
+						"33": {
+							"patterns": [
+								{
+									"include": "#inline_comment"
+								}
+							]
+						},
+						"34": {
+							"name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+						},
+						"35": {
+							"name": "comment.block.cpp"
+						},
+						"36": {
+							"patterns": [
+								{
+									"match": "\\*\\/",
+									"name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+								},
+								{
+									"match": "\\*",
+									"name": "comment.block.cpp"
+								}
+							]
+						},
+						"37": {
+							"name": "punctuation.separator.colon.inheritance.cpp"
+						},
+						"38": {
+							"patterns": [
+								{
+									"include": "#inheritance_context"
+								}
+							]
 						}
 					},
-					"name": "string.quoted.double.raw.cpp"
+					"end": "(?:(?:(?<=\\}|%>|\\?\\?>)\\s*(;)|(;))|(?=[;>\\[\\]=]))",
+					"endCaptures": {
+						"1": {
+							"name": "punctuation.terminator.statement.cpp"
+						},
+						"2": {
+							"name": "punctuation.terminator.statement.cpp"
+						}
+					},
+					"patterns": [
+						{
+							"name": "meta.head.class.cpp",
+							"begin": "\\G ?",
+							"end": "((?:\\{|<%|\\?\\?<|(?=;)))",
+							"endCaptures": {
+								"1": {
+									"name": "punctuation.section.block.begin.bracket.curly.class.cpp"
+								}
+							},
+							"patterns": [
+								{
+									"include": "#ever_present_context"
+								},
+								{
+									"include": "#inheritance_context"
+								},
+								{
+									"include": "#template_call_range"
+								}
+							]
+						},
+						{
+							"name": "meta.body.class.cpp",
+							"begin": "(?<=\\{|<%|\\?\\?<)",
+							"end": "(\\}|%>|\\?\\?>)",
+							"endCaptures": {
+								"1": {
+									"name": "punctuation.section.block.end.bracket.curly.class.cpp"
+								}
+							},
+							"patterns": [
+								{
+									"include": "#function_pointer"
+								},
+								{
+									"include": "#static_assert"
+								},
+								{
+									"include": "#constructor_inline"
+								},
+								{
+									"include": "#destructor_inline"
+								},
+								{
+									"include": "$self"
+								}
+							]
+						},
+						{
+							"name": "meta.tail.class.cpp",
+							"begin": "(?<=\\}|%>|\\?\\?>)[\\s\\n]*",
+							"end": "[\\s\\n]*(?=;)",
+							"patterns": [
+								{
+									"match": "(((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))?(?:(?:\\&|\\*)((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z)))))*(?:\\&|\\*))?((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))((?<!\\w)(?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*(?!\\w))",
+									"captures": {
+										"1": {
+											"patterns": [
+												{
+													"match": "\\*",
+													"name": "storage.modifier.pointer.cpp"
+												},
+												{
+													"match": "(?:\\&((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))){2,}\\&",
+													"captures": {
+														"1": {
+															"patterns": [
+																{
+																	"include": "#inline_comment"
+																}
+															]
+														},
+														"2": {
+															"name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+														},
+														"3": {
+															"name": "comment.block.cpp"
+														},
+														"4": {
+															"patterns": [
+																{
+																	"match": "\\*\\/",
+																	"name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+																},
+																{
+																	"match": "\\*",
+																	"name": "comment.block.cpp"
+																}
+															]
+														}
+													},
+													"name": "invalid.illegal.reference-type.cpp"
+												},
+												{
+													"match": "\\&",
+													"name": "storage.modifier.reference.cpp"
+												}
+											]
+										},
+										"2": {
+											"patterns": [
+												{
+													"include": "#inline_comment"
+												}
+											]
+										},
+										"3": {
+											"name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+										},
+										"4": {
+											"name": "comment.block.cpp"
+										},
+										"5": {
+											"patterns": [
+												{
+													"match": "\\*\\/",
+													"name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+												},
+												{
+													"match": "\\*",
+													"name": "comment.block.cpp"
+												}
+											]
+										},
+										"6": {
+											"patterns": [
+												{
+													"include": "#inline_comment"
+												}
+											]
+										},
+										"7": {
+											"name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+										},
+										"8": {
+											"name": "comment.block.cpp"
+										},
+										"9": {
+											"patterns": [
+												{
+													"match": "\\*\\/",
+													"name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+												},
+												{
+													"match": "\\*",
+													"name": "comment.block.cpp"
+												}
+											]
+										},
+										"10": {
+											"patterns": [
+												{
+													"include": "#inline_comment"
+												}
+											]
+										},
+										"11": {
+											"name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+										},
+										"12": {
+											"name": "comment.block.cpp"
+										},
+										"13": {
+											"patterns": [
+												{
+													"match": "\\*\\/",
+													"name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+												},
+												{
+													"match": "\\*",
+													"name": "comment.block.cpp"
+												}
+											]
+										},
+										"14": {
+											"name": "entity.name.type.alias.cpp"
+										}
+									}
+								},
+								{
+									"match": ","
+								}
+							]
+						}
+					]
+				}
+			]
+		},
+		"typedef_function_pointer": {
+			"begin": "((?<!\\w)typedef(?!\\w))\\s*(?=.*\\(\\*\\s*(?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*\\s*\\))",
+			"beginCaptures": {
+				"1": {
+					"name": "keyword.other.typedef.cpp"
+				}
+			},
+			"end": "(?<=;)",
+			"patterns": [
+				{
+					"begin": "(\\s*+((?:(?:(?:\\[\\[.*?\\]\\]|__attribute(?:__)?\\(\\(.*?\\)\\))|__declspec\\(.*?\\))|alignas\\(.*?\\))(?!\\)))?((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))(?:(?:(?:unsigned|signed|short|long)|(?:struct|class|union|enum))((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z)))))*(((::)?(?:((?-mix:(?!\\b(?:__has_cpp_attribute|reinterpret_cast|atomic_noexcept|atomic_cancel|atomic_commit|__has_include|dynamic_cast|thread_local|synchronized|static_cast|const_cast|consteval|constexpr|protected|namespace|co_return|constexpr|constexpr|continue|explicit|volatile|noexcept|co_yield|noexcept|noexcept|requires|typename|decltype|operator|co_await|template|volatile|register|restrict|reflexpr|alignof|private|default|mutable|include|concept|__asm__|defined|_Pragma|alignas|typedef|warning|virtual|mutable|struct|sizeof|delete|not_eq|bitand|and_eq|xor_eq|typeid|switch|return|static|extern|inline|friend|public|ifndef|define|pragma|export|import|module|catch|throw|const|or_eq|while|compl|bitor|const|union|ifdef|class|undef|error|break|using|endif|goto|line|enum|this|case|else|elif|else|asm|try|for|new|and|xor|not|do|or|if|if)\\b)(?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*))\\s*+(((?<!<)<(?!<)(?>(?:(?>[^<>]*)\\g<27>?)+)>)\\s*)?::)*\\s*+)((?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*)\\s*+(((?<!<)<(?!<)(?>(?:(?>[^<>]*)\\g<27>?)+)>)\\s*)?(::))?((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))(?!(?:transaction_safe_dynamic|__has_cpp_attribute|transaction_safe|reinterpret_cast|atomic_noexcept|atomic_commit|atomic_cancel|__has_include|dynamic_cast|thread_local|synchronized|static_cast|const_cast|constexpr|consteval|protected|constexpr|co_return|namespace|constexpr|noexcept|typename|decltype|template|operator|noexcept|co_yield|co_await|continue|volatile|register|restrict|explicit|override|volatile|reflexpr|noexcept|requires|default|typedef|nullptr|alignof|mutable|concept|virtual|defined|__asm__|include|_Pragma|mutable|warning|private|alignas|module|switch|not_eq|bitand|and_eq|ifndef|return|sizeof|xor_eq|export|static|delete|public|define|extern|inline|import|pragma|friend|typeid|const|compl|bitor|throw|or_eq|while|catch|break|false|final|const|endif|ifdef|undef|error|using|audit|axiom|line|else|elif|true|NULL|case|goto|else|this|new|asm|not|and|xor|try|for|if|do|or|if)\\b)((?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*)\\b(((?<!<)<(?!<)(?>(?:(?>[^<>]*)\\g<27>?)+)>)\\s*)?(?![\\w<:.]))(((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))?(?:(?:\\&|\\*)((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z)))))*(?:\\&|\\*))?((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))(\\()(\\*)\\s*((?:(?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*)?)\\s*(?:(\\[)(\\w*)(\\])\\s*)*(\\))\\s*(\\()",
+					"beginCaptures": {
+						"1": {
+							"name": "meta.qualified_type.cpp",
+							"patterns": [
+								{
+									"match": "(?<!\\w)(?:struct|class|union|enum)(?!\\w)",
+									"name": "storage.type.$0.cpp"
+								},
+								{
+									"include": "#attributes_context"
+								},
+								{
+									"include": "#function_type"
+								},
+								{
+									"include": "#storage_types"
+								},
+								{
+									"include": "#number_literal"
+								},
+								{
+									"include": "#string_context"
+								},
+								{
+									"include": "#comma"
+								},
+								{
+									"include": "#scope_resolution_inner_generated"
+								},
+								{
+									"include": "#template_call_range"
+								},
+								{
+									"match": "(?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*",
+									"name": "entity.name.type.cpp"
+								}
+							]
+						},
+						"2": {
+							"patterns": [
+								{
+									"include": "#attributes_context"
+								},
+								{
+									"include": "#number_literal"
+								}
+							]
+						},
+						"3": {
+							"patterns": [
+								{
+									"include": "#inline_comment"
+								}
+							]
+						},
+						"4": {
+							"name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+						},
+						"5": {
+							"name": "comment.block.cpp"
+						},
+						"6": {
+							"patterns": [
+								{
+									"match": "\\*\\/",
+									"name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+								},
+								{
+									"match": "\\*",
+									"name": "comment.block.cpp"
+								}
+							]
+						},
+						"7": {
+							"patterns": [
+								{
+									"include": "#inline_comment"
+								}
+							]
+						},
+						"8": {
+							"name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+						},
+						"9": {
+							"name": "comment.block.cpp"
+						},
+						"10": {
+							"patterns": [
+								{
+									"match": "\\*\\/",
+									"name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+								},
+								{
+									"match": "\\*",
+									"name": "comment.block.cpp"
+								}
+							]
+						},
+						"12": {
+							"patterns": [
+								{
+									"include": "#scope_resolution_inner_generated"
+								}
+							]
+						},
+						"13": {
+							"name": "punctuation.separator.namespace.access.cpp punctuation.separator.scope-resolution.cpp"
+						},
+						"15": {
+							"name": "meta.template.call.cpp",
+							"patterns": [
+								{
+									"include": "#template_call_range"
+								}
+							]
+						},
+						"17": {
+							"name": "entity.name.scope-resolution.cpp"
+						},
+						"18": {
+							"name": "meta.template.call.cpp",
+							"patterns": [
+								{
+									"include": "#template_call_range"
+								}
+							]
+						},
+						"20": {
+							"name": "punctuation.separator.namespace.access.cpp punctuation.separator.scope-resolution.cpp"
+						},
+						"21": {
+							"patterns": [
+								{
+									"include": "#inline_comment"
+								}
+							]
+						},
+						"22": {
+							"name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+						},
+						"23": {
+							"name": "comment.block.cpp"
+						},
+						"24": {
+							"patterns": [
+								{
+									"match": "\\*\\/",
+									"name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+								},
+								{
+									"match": "\\*",
+									"name": "comment.block.cpp"
+								}
+							]
+						},
+						"25": {
+							"name": "entity.name.type.cpp"
+						},
+						"26": {
+							"name": "meta.template.call.cpp",
+							"patterns": [
+								{
+									"include": "#template_call_range"
+								}
+							]
+						},
+						"28": {
+							"patterns": [
+								{
+									"match": "\\*",
+									"name": "storage.modifier.pointer.cpp"
+								},
+								{
+									"match": "(?:\\&((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))){2,}\\&",
+									"captures": {
+										"1": {
+											"patterns": [
+												{
+													"include": "#inline_comment"
+												}
+											]
+										},
+										"2": {
+											"name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+										},
+										"3": {
+											"name": "comment.block.cpp"
+										},
+										"4": {
+											"patterns": [
+												{
+													"match": "\\*\\/",
+													"name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+												},
+												{
+													"match": "\\*",
+													"name": "comment.block.cpp"
+												}
+											]
+										}
+									},
+									"name": "invalid.illegal.reference-type.cpp"
+								},
+								{
+									"match": "\\&",
+									"name": "storage.modifier.reference.cpp"
+								}
+							]
+						},
+						"29": {
+							"patterns": [
+								{
+									"include": "#inline_comment"
+								}
+							]
+						},
+						"30": {
+							"name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+						},
+						"31": {
+							"name": "comment.block.cpp"
+						},
+						"32": {
+							"patterns": [
+								{
+									"match": "\\*\\/",
+									"name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+								},
+								{
+									"match": "\\*",
+									"name": "comment.block.cpp"
+								}
+							]
+						},
+						"33": {
+							"patterns": [
+								{
+									"include": "#inline_comment"
+								}
+							]
+						},
+						"34": {
+							"name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+						},
+						"35": {
+							"name": "comment.block.cpp"
+						},
+						"36": {
+							"patterns": [
+								{
+									"match": "\\*\\/",
+									"name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+								},
+								{
+									"match": "\\*",
+									"name": "comment.block.cpp"
+								}
+							]
+						},
+						"37": {
+							"patterns": [
+								{
+									"include": "#inline_comment"
+								}
+							]
+						},
+						"38": {
+							"name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+						},
+						"39": {
+							"name": "comment.block.cpp"
+						},
+						"40": {
+							"patterns": [
+								{
+									"match": "\\*\\/",
+									"name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+								},
+								{
+									"match": "\\*",
+									"name": "comment.block.cpp"
+								}
+							]
+						},
+						"41": {
+							"name": "punctuation.section.parens.begin.bracket.round.function.pointer.cpp"
+						},
+						"42": {
+							"name": "punctuation.definition.function.pointer.dereference.cpp"
+						},
+						"43": {
+							"name": "entity.name.type.alias.cpp entity.name.type.pointer.function.cpp"
+						},
+						"44": {
+							"name": "punctuation.definition.begin.bracket.square.cpp"
+						},
+						"45": {
+							"patterns": [
+								{
+									"include": "#evaluation_context"
+								}
+							]
+						},
+						"46": {
+							"name": "punctuation.definition.end.bracket.square.cpp"
+						},
+						"47": {
+							"name": "punctuation.section.parens.end.bracket.round.function.pointer.cpp"
+						},
+						"48": {
+							"name": "punctuation.section.parameters.begin.bracket.round.function.pointer.cpp"
+						}
+					},
+					"end": "(\\))((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))(?=[{=,);]|\\n)(?!\\()",
+					"endCaptures": {
+						"1": {
+							"name": "punctuation.section.parameters.end.bracket.round.function.pointer.cpp"
+						},
+						"2": {
+							"patterns": [
+								{
+									"include": "#inline_comment"
+								}
+							]
+						},
+						"3": {
+							"name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+						},
+						"4": {
+							"name": "comment.block.cpp"
+						},
+						"5": {
+							"patterns": [
+								{
+									"match": "\\*\\/",
+									"name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+								},
+								{
+									"match": "\\*",
+									"name": "comment.block.cpp"
+								}
+							]
+						}
+					},
+					"patterns": [
+						{
+							"include": "#function_parameter_context"
+						}
+					]
+				}
+			]
+		},
+		"typedef_keyword": {
+			"match": "((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))((?<!\\w)typedef(?!\\w))",
+			"captures": {
+				"1": {
+					"patterns": [
+						{
+							"include": "#inline_comment"
+						}
+					]
+				},
+				"2": {
+					"name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+				},
+				"3": {
+					"name": "comment.block.cpp"
+				},
+				"4": {
+					"patterns": [
+						{
+							"match": "\\*\\/",
+							"name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+						},
+						{
+							"match": "\\*",
+							"name": "comment.block.cpp"
+						}
+					]
+				},
+				"5": {
+					"name": "keyword.other.$5.cpp"
+				}
+			}
+		},
+		"typedef_struct": {
+			"begin": "((?<!\\w)typedef(?!\\w))\\s*(?=(?<!\\w)struct(?!\\w))",
+			"beginCaptures": {
+				"1": {
+					"name": "keyword.other.typedef.cpp"
+				}
+			},
+			"end": "(?<=;)",
+			"patterns": [
+				{
+					"name": "meta.block.struct.cpp",
+					"begin": "((((?<!\\w)struct(?!\\w))(?:(?:((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))|((?:(?:(?:\\[\\[.*?\\]\\]|__attribute(?:__)?\\(\\(.*?\\)\\))|__declspec\\(.*?\\))|alignas\\(.*?\\))(?!\\))))|(?={))(?:((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))(DLLEXPORT)((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z)))))?((?:(?:(?:\\[\\[.*?\\]\\]|__attribute(?:__)?\\(\\(.*?\\)\\))|__declspec\\(.*?\\))|alignas\\(.*?\\))(?!\\)))?((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))((?:(?<!\\w)(?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*(?!\\w))?)(?:((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))(final)((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z)))))?(?:((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))(:)((?>[^{]*)))?))",
+					"beginCaptures": {
+						"1": {
+							"name": "meta.head.struct.cpp"
+						},
+						"3": {
+							"name": "storage.type.$3.cpp"
+						},
+						"4": {
+							"patterns": [
+								{
+									"include": "#inline_comment"
+								}
+							]
+						},
+						"5": {
+							"name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+						},
+						"6": {
+							"name": "comment.block.cpp"
+						},
+						"7": {
+							"patterns": [
+								{
+									"match": "\\*\\/",
+									"name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+								},
+								{
+									"match": "\\*",
+									"name": "comment.block.cpp"
+								}
+							]
+						},
+						"8": {
+							"patterns": [
+								{
+									"include": "#attributes_context"
+								},
+								{
+									"include": "#number_literal"
+								}
+							]
+						},
+						"9": {
+							"patterns": [
+								{
+									"include": "#inline_comment"
+								}
+							]
+						},
+						"10": {
+							"name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+						},
+						"11": {
+							"name": "comment.block.cpp"
+						},
+						"12": {
+							"patterns": [
+								{
+									"match": "\\*\\/",
+									"name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+								},
+								{
+									"match": "\\*",
+									"name": "comment.block.cpp"
+								}
+							]
+						},
+						"13": {
+							"name": "entity.name.other.preprocessor.macro.predefined.DLLEXPORT.cpp"
+						},
+						"14": {
+							"patterns": [
+								{
+									"include": "#inline_comment"
+								}
+							]
+						},
+						"15": {
+							"name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+						},
+						"16": {
+							"name": "comment.block.cpp"
+						},
+						"17": {
+							"patterns": [
+								{
+									"match": "\\*\\/",
+									"name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+								},
+								{
+									"match": "\\*",
+									"name": "comment.block.cpp"
+								}
+							]
+						},
+						"18": {
+							"patterns": [
+								{
+									"include": "#attributes_context"
+								},
+								{
+									"include": "#number_literal"
+								}
+							]
+						},
+						"19": {
+							"patterns": [
+								{
+									"include": "#inline_comment"
+								}
+							]
+						},
+						"20": {
+							"name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+						},
+						"21": {
+							"name": "comment.block.cpp"
+						},
+						"22": {
+							"patterns": [
+								{
+									"match": "\\*\\/",
+									"name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+								},
+								{
+									"match": "\\*",
+									"name": "comment.block.cpp"
+								}
+							]
+						},
+						"23": {
+							"name": "entity.name.type.$3.cpp"
+						},
+						"24": {
+							"patterns": [
+								{
+									"include": "#inline_comment"
+								}
+							]
+						},
+						"25": {
+							"name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+						},
+						"26": {
+							"name": "comment.block.cpp"
+						},
+						"27": {
+							"patterns": [
+								{
+									"match": "\\*\\/",
+									"name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+								},
+								{
+									"match": "\\*",
+									"name": "comment.block.cpp"
+								}
+							]
+						},
+						"28": {
+							"name": "storage.type.modifier.final.cpp"
+						},
+						"29": {
+							"patterns": [
+								{
+									"include": "#inline_comment"
+								}
+							]
+						},
+						"30": {
+							"name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+						},
+						"31": {
+							"name": "comment.block.cpp"
+						},
+						"32": {
+							"patterns": [
+								{
+									"match": "\\*\\/",
+									"name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+								},
+								{
+									"match": "\\*",
+									"name": "comment.block.cpp"
+								}
+							]
+						},
+						"33": {
+							"patterns": [
+								{
+									"include": "#inline_comment"
+								}
+							]
+						},
+						"34": {
+							"name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+						},
+						"35": {
+							"name": "comment.block.cpp"
+						},
+						"36": {
+							"patterns": [
+								{
+									"match": "\\*\\/",
+									"name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+								},
+								{
+									"match": "\\*",
+									"name": "comment.block.cpp"
+								}
+							]
+						},
+						"37": {
+							"name": "punctuation.separator.colon.inheritance.cpp"
+						},
+						"38": {
+							"patterns": [
+								{
+									"include": "#inheritance_context"
+								}
+							]
+						}
+					},
+					"end": "(?:(?:(?<=\\}|%>|\\?\\?>)\\s*(;)|(;))|(?=[;>\\[\\]=]))",
+					"endCaptures": {
+						"1": {
+							"name": "punctuation.terminator.statement.cpp"
+						},
+						"2": {
+							"name": "punctuation.terminator.statement.cpp"
+						}
+					},
+					"patterns": [
+						{
+							"name": "meta.head.struct.cpp",
+							"begin": "\\G ?",
+							"end": "((?:\\{|<%|\\?\\?<|(?=;)))",
+							"endCaptures": {
+								"1": {
+									"name": "punctuation.section.block.begin.bracket.curly.struct.cpp"
+								}
+							},
+							"patterns": [
+								{
+									"include": "#ever_present_context"
+								},
+								{
+									"include": "#inheritance_context"
+								},
+								{
+									"include": "#template_call_range"
+								}
+							]
+						},
+						{
+							"name": "meta.body.struct.cpp",
+							"begin": "(?<=\\{|<%|\\?\\?<)",
+							"end": "(\\}|%>|\\?\\?>)",
+							"endCaptures": {
+								"1": {
+									"name": "punctuation.section.block.end.bracket.curly.struct.cpp"
+								}
+							},
+							"patterns": [
+								{
+									"include": "#function_pointer"
+								},
+								{
+									"include": "#static_assert"
+								},
+								{
+									"include": "#constructor_inline"
+								},
+								{
+									"include": "#destructor_inline"
+								},
+								{
+									"include": "$self"
+								}
+							]
+						},
+						{
+							"name": "meta.tail.struct.cpp",
+							"begin": "(?<=\\}|%>|\\?\\?>)[\\s\\n]*",
+							"end": "[\\s\\n]*(?=;)",
+							"patterns": [
+								{
+									"match": "(((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))?(?:(?:\\&|\\*)((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z)))))*(?:\\&|\\*))?((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))((?<!\\w)(?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*(?!\\w))",
+									"captures": {
+										"1": {
+											"patterns": [
+												{
+													"match": "\\*",
+													"name": "storage.modifier.pointer.cpp"
+												},
+												{
+													"match": "(?:\\&((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))){2,}\\&",
+													"captures": {
+														"1": {
+															"patterns": [
+																{
+																	"include": "#inline_comment"
+																}
+															]
+														},
+														"2": {
+															"name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+														},
+														"3": {
+															"name": "comment.block.cpp"
+														},
+														"4": {
+															"patterns": [
+																{
+																	"match": "\\*\\/",
+																	"name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+																},
+																{
+																	"match": "\\*",
+																	"name": "comment.block.cpp"
+																}
+															]
+														}
+													},
+													"name": "invalid.illegal.reference-type.cpp"
+												},
+												{
+													"match": "\\&",
+													"name": "storage.modifier.reference.cpp"
+												}
+											]
+										},
+										"2": {
+											"patterns": [
+												{
+													"include": "#inline_comment"
+												}
+											]
+										},
+										"3": {
+											"name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+										},
+										"4": {
+											"name": "comment.block.cpp"
+										},
+										"5": {
+											"patterns": [
+												{
+													"match": "\\*\\/",
+													"name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+												},
+												{
+													"match": "\\*",
+													"name": "comment.block.cpp"
+												}
+											]
+										},
+										"6": {
+											"patterns": [
+												{
+													"include": "#inline_comment"
+												}
+											]
+										},
+										"7": {
+											"name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+										},
+										"8": {
+											"name": "comment.block.cpp"
+										},
+										"9": {
+											"patterns": [
+												{
+													"match": "\\*\\/",
+													"name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+												},
+												{
+													"match": "\\*",
+													"name": "comment.block.cpp"
+												}
+											]
+										},
+										"10": {
+											"patterns": [
+												{
+													"include": "#inline_comment"
+												}
+											]
+										},
+										"11": {
+											"name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+										},
+										"12": {
+											"name": "comment.block.cpp"
+										},
+										"13": {
+											"patterns": [
+												{
+													"match": "\\*\\/",
+													"name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+												},
+												{
+													"match": "\\*",
+													"name": "comment.block.cpp"
+												}
+											]
+										},
+										"14": {
+											"name": "entity.name.type.alias.cpp"
+										}
+									}
+								},
+								{
+									"match": ","
+								}
+							]
+						}
+					]
+				}
+			]
+		},
+		"typedef_union": {
+			"begin": "((?<!\\w)typedef(?!\\w))\\s*(?=(?<!\\w)union(?!\\w))",
+			"beginCaptures": {
+				"1": {
+					"name": "keyword.other.typedef.cpp"
+				}
+			},
+			"end": "(?<=;)",
+			"patterns": [
+				{
+					"name": "meta.block.union.cpp",
+					"begin": "((((?<!\\w)union(?!\\w))(?:(?:((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))|((?:(?:(?:\\[\\[.*?\\]\\]|__attribute(?:__)?\\(\\(.*?\\)\\))|__declspec\\(.*?\\))|alignas\\(.*?\\))(?!\\))))|(?={))(?:((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))(DLLEXPORT)((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z)))))?((?:(?:(?:\\[\\[.*?\\]\\]|__attribute(?:__)?\\(\\(.*?\\)\\))|__declspec\\(.*?\\))|alignas\\(.*?\\))(?!\\)))?((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))((?:(?<!\\w)(?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*(?!\\w))?)(?:((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))(final)((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z)))))?(?:((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))(:)((?>[^{]*)))?))",
+					"beginCaptures": {
+						"1": {
+							"name": "meta.head.union.cpp"
+						},
+						"3": {
+							"name": "storage.type.$3.cpp"
+						},
+						"4": {
+							"patterns": [
+								{
+									"include": "#inline_comment"
+								}
+							]
+						},
+						"5": {
+							"name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+						},
+						"6": {
+							"name": "comment.block.cpp"
+						},
+						"7": {
+							"patterns": [
+								{
+									"match": "\\*\\/",
+									"name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+								},
+								{
+									"match": "\\*",
+									"name": "comment.block.cpp"
+								}
+							]
+						},
+						"8": {
+							"patterns": [
+								{
+									"include": "#attributes_context"
+								},
+								{
+									"include": "#number_literal"
+								}
+							]
+						},
+						"9": {
+							"patterns": [
+								{
+									"include": "#inline_comment"
+								}
+							]
+						},
+						"10": {
+							"name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+						},
+						"11": {
+							"name": "comment.block.cpp"
+						},
+						"12": {
+							"patterns": [
+								{
+									"match": "\\*\\/",
+									"name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+								},
+								{
+									"match": "\\*",
+									"name": "comment.block.cpp"
+								}
+							]
+						},
+						"13": {
+							"name": "entity.name.other.preprocessor.macro.predefined.DLLEXPORT.cpp"
+						},
+						"14": {
+							"patterns": [
+								{
+									"include": "#inline_comment"
+								}
+							]
+						},
+						"15": {
+							"name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+						},
+						"16": {
+							"name": "comment.block.cpp"
+						},
+						"17": {
+							"patterns": [
+								{
+									"match": "\\*\\/",
+									"name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+								},
+								{
+									"match": "\\*",
+									"name": "comment.block.cpp"
+								}
+							]
+						},
+						"18": {
+							"patterns": [
+								{
+									"include": "#attributes_context"
+								},
+								{
+									"include": "#number_literal"
+								}
+							]
+						},
+						"19": {
+							"patterns": [
+								{
+									"include": "#inline_comment"
+								}
+							]
+						},
+						"20": {
+							"name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+						},
+						"21": {
+							"name": "comment.block.cpp"
+						},
+						"22": {
+							"patterns": [
+								{
+									"match": "\\*\\/",
+									"name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+								},
+								{
+									"match": "\\*",
+									"name": "comment.block.cpp"
+								}
+							]
+						},
+						"23": {
+							"name": "entity.name.type.$3.cpp"
+						},
+						"24": {
+							"patterns": [
+								{
+									"include": "#inline_comment"
+								}
+							]
+						},
+						"25": {
+							"name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+						},
+						"26": {
+							"name": "comment.block.cpp"
+						},
+						"27": {
+							"patterns": [
+								{
+									"match": "\\*\\/",
+									"name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+								},
+								{
+									"match": "\\*",
+									"name": "comment.block.cpp"
+								}
+							]
+						},
+						"28": {
+							"name": "storage.type.modifier.final.cpp"
+						},
+						"29": {
+							"patterns": [
+								{
+									"include": "#inline_comment"
+								}
+							]
+						},
+						"30": {
+							"name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+						},
+						"31": {
+							"name": "comment.block.cpp"
+						},
+						"32": {
+							"patterns": [
+								{
+									"match": "\\*\\/",
+									"name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+								},
+								{
+									"match": "\\*",
+									"name": "comment.block.cpp"
+								}
+							]
+						},
+						"33": {
+							"patterns": [
+								{
+									"include": "#inline_comment"
+								}
+							]
+						},
+						"34": {
+							"name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+						},
+						"35": {
+							"name": "comment.block.cpp"
+						},
+						"36": {
+							"patterns": [
+								{
+									"match": "\\*\\/",
+									"name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+								},
+								{
+									"match": "\\*",
+									"name": "comment.block.cpp"
+								}
+							]
+						},
+						"37": {
+							"name": "punctuation.separator.colon.inheritance.cpp"
+						},
+						"38": {
+							"patterns": [
+								{
+									"include": "#inheritance_context"
+								}
+							]
+						}
+					},
+					"end": "(?:(?:(?<=\\}|%>|\\?\\?>)\\s*(;)|(;))|(?=[;>\\[\\]=]))",
+					"endCaptures": {
+						"1": {
+							"name": "punctuation.terminator.statement.cpp"
+						},
+						"2": {
+							"name": "punctuation.terminator.statement.cpp"
+						}
+					},
+					"patterns": [
+						{
+							"name": "meta.head.union.cpp",
+							"begin": "\\G ?",
+							"end": "((?:\\{|<%|\\?\\?<|(?=;)))",
+							"endCaptures": {
+								"1": {
+									"name": "punctuation.section.block.begin.bracket.curly.union.cpp"
+								}
+							},
+							"patterns": [
+								{
+									"include": "#ever_present_context"
+								},
+								{
+									"include": "#inheritance_context"
+								},
+								{
+									"include": "#template_call_range"
+								}
+							]
+						},
+						{
+							"name": "meta.body.union.cpp",
+							"begin": "(?<=\\{|<%|\\?\\?<)",
+							"end": "(\\}|%>|\\?\\?>)",
+							"endCaptures": {
+								"1": {
+									"name": "punctuation.section.block.end.bracket.curly.union.cpp"
+								}
+							},
+							"patterns": [
+								{
+									"include": "#function_pointer"
+								},
+								{
+									"include": "#static_assert"
+								},
+								{
+									"include": "#constructor_inline"
+								},
+								{
+									"include": "#destructor_inline"
+								},
+								{
+									"include": "$self"
+								}
+							]
+						},
+						{
+							"name": "meta.tail.union.cpp",
+							"begin": "(?<=\\}|%>|\\?\\?>)[\\s\\n]*",
+							"end": "[\\s\\n]*(?=;)",
+							"patterns": [
+								{
+									"match": "(((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))?(?:(?:\\&|\\*)((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z)))))*(?:\\&|\\*))?((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))((?<!\\w)(?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*(?!\\w))",
+									"captures": {
+										"1": {
+											"patterns": [
+												{
+													"match": "\\*",
+													"name": "storage.modifier.pointer.cpp"
+												},
+												{
+													"match": "(?:\\&((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))){2,}\\&",
+													"captures": {
+														"1": {
+															"patterns": [
+																{
+																	"include": "#inline_comment"
+																}
+															]
+														},
+														"2": {
+															"name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+														},
+														"3": {
+															"name": "comment.block.cpp"
+														},
+														"4": {
+															"patterns": [
+																{
+																	"match": "\\*\\/",
+																	"name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+																},
+																{
+																	"match": "\\*",
+																	"name": "comment.block.cpp"
+																}
+															]
+														}
+													},
+													"name": "invalid.illegal.reference-type.cpp"
+												},
+												{
+													"match": "\\&",
+													"name": "storage.modifier.reference.cpp"
+												}
+											]
+										},
+										"2": {
+											"patterns": [
+												{
+													"include": "#inline_comment"
+												}
+											]
+										},
+										"3": {
+											"name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+										},
+										"4": {
+											"name": "comment.block.cpp"
+										},
+										"5": {
+											"patterns": [
+												{
+													"match": "\\*\\/",
+													"name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+												},
+												{
+													"match": "\\*",
+													"name": "comment.block.cpp"
+												}
+											]
+										},
+										"6": {
+											"patterns": [
+												{
+													"include": "#inline_comment"
+												}
+											]
+										},
+										"7": {
+											"name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+										},
+										"8": {
+											"name": "comment.block.cpp"
+										},
+										"9": {
+											"patterns": [
+												{
+													"match": "\\*\\/",
+													"name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+												},
+												{
+													"match": "\\*",
+													"name": "comment.block.cpp"
+												}
+											]
+										},
+										"10": {
+											"patterns": [
+												{
+													"include": "#inline_comment"
+												}
+											]
+										},
+										"11": {
+											"name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+										},
+										"12": {
+											"name": "comment.block.cpp"
+										},
+										"13": {
+											"patterns": [
+												{
+													"match": "\\*\\/",
+													"name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+												},
+												{
+													"match": "\\*",
+													"name": "comment.block.cpp"
+												}
+											]
+										},
+										"14": {
+											"name": "entity.name.type.alias.cpp"
+										}
+									}
+								},
+								{
+									"match": ","
+								}
+							]
+						}
+					]
+				}
+			]
+		},
+		"typeid_operator": {
+			"contentName": "meta.arguments.operator.typeid.cpp",
+			"begin": "((?<!\\w)typeid(?!\\w))((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))(\\()",
+			"beginCaptures": {
+				"1": {
+					"name": "keyword.operator.functionlike.cpp keyword.operator.typeid.cpp"
+				},
+				"2": {
+					"patterns": [
+						{
+							"include": "#inline_comment"
+						}
+					]
+				},
+				"3": {
+					"name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+				},
+				"4": {
+					"name": "comment.block.cpp"
+				},
+				"5": {
+					"patterns": [
+						{
+							"match": "\\*\\/",
+							"name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+						},
+						{
+							"match": "\\*",
+							"name": "comment.block.cpp"
+						}
+					]
+				},
+				"6": {
+					"name": "punctuation.section.arguments.begin.bracket.round.operator.typeid.cpp"
+				}
+			},
+			"end": "(\\))",
+			"endCaptures": {
+				"1": {
+					"name": "punctuation.section.arguments.end.bracket.round.operator.typeid.cpp"
+				}
+			},
+			"patterns": [
+				{
+					"include": "#evaluation_context"
+				}
+			]
+		},
+		"typename": {
+			"match": "(((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))(?<!\\w)typename(?!\\w))((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))(\\s*+((?:(?:(?:\\[\\[.*?\\]\\]|__attribute(?:__)?\\(\\(.*?\\)\\))|__declspec\\(.*?\\))|alignas\\(.*?\\))(?!\\)))?((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))(?:(?:(?:unsigned|signed|short|long)|(?:struct|class|union|enum))((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z)))))*(((::)?(?:((?-mix:(?!\\b(?:__has_cpp_attribute|reinterpret_cast|atomic_noexcept|atomic_cancel|atomic_commit|__has_include|dynamic_cast|thread_local|synchronized|static_cast|const_cast|consteval|constexpr|protected|namespace|co_return|constexpr|constexpr|continue|explicit|volatile|noexcept|co_yield|noexcept|noexcept|requires|typename|decltype|operator|co_await|template|volatile|register|restrict|reflexpr|alignof|private|default|mutable|include|concept|__asm__|defined|_Pragma|alignas|typedef|warning|virtual|mutable|struct|sizeof|delete|not_eq|bitand|and_eq|xor_eq|typeid|switch|return|static|extern|inline|friend|public|ifndef|define|pragma|export|import|module|catch|throw|const|or_eq|while|compl|bitor|const|union|ifdef|class|undef|error|break|using|endif|goto|line|enum|this|case|else|elif|else|asm|try|for|new|and|xor|not|do|or|if|if)\\b)(?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*))\\s*+(((?<!<)<(?!<)(?>(?:(?>[^<>]*)\\g<36>?)+)>)\\s*)?::)*\\s*+)((?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*)\\s*+(((?<!<)<(?!<)(?>(?:(?>[^<>]*)\\g<36>?)+)>)\\s*)?(::))?((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))(?!(?:transaction_safe_dynamic|__has_cpp_attribute|transaction_safe|reinterpret_cast|atomic_noexcept|atomic_commit|atomic_cancel|__has_include|dynamic_cast|thread_local|synchronized|static_cast|const_cast|constexpr|consteval|protected|constexpr|co_return|namespace|constexpr|noexcept|typename|decltype|template|operator|noexcept|co_yield|co_await|continue|volatile|register|restrict|explicit|override|volatile|reflexpr|noexcept|requires|default|typedef|nullptr|alignof|mutable|concept|virtual|defined|__asm__|include|_Pragma|mutable|warning|private|alignas|module|switch|not_eq|bitand|and_eq|ifndef|return|sizeof|xor_eq|export|static|delete|public|define|extern|inline|import|pragma|friend|typeid|const|compl|bitor|throw|or_eq|while|catch|break|false|final|const|endif|ifdef|undef|error|using|audit|axiom|line|else|elif|true|NULL|case|goto|else|this|new|asm|not|and|xor|try|for|if|do|or|if)\\b)((?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*)\\b(((?<!<)<(?!<)(?>(?:(?>[^<>]*)\\g<36>?)+)>)\\s*)?(?![\\w<:.]))",
+			"captures": {
+				"1": {
+					"name": "storage.modifier.cpp"
+				},
+				"2": {
+					"patterns": [
+						{
+							"include": "#inline_comment"
+						}
+					]
+				},
+				"3": {
+					"name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+				},
+				"4": {
+					"name": "comment.block.cpp"
+				},
+				"5": {
+					"patterns": [
+						{
+							"match": "\\*\\/",
+							"name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+						},
+						{
+							"match": "\\*",
+							"name": "comment.block.cpp"
+						}
+					]
+				},
+				"6": {
+					"patterns": [
+						{
+							"include": "#inline_comment"
+						}
+					]
+				},
+				"7": {
+					"name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+				},
+				"8": {
+					"name": "comment.block.cpp"
+				},
+				"9": {
+					"patterns": [
+						{
+							"match": "\\*\\/",
+							"name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+						},
+						{
+							"match": "\\*",
+							"name": "comment.block.cpp"
+						}
+					]
+				},
+				"10": {
+					"name": "meta.qualified_type.cpp",
+					"patterns": [
+						{
+							"match": "(?<!\\w)(?:struct|class|union|enum)(?!\\w)",
+							"name": "storage.type.$0.cpp"
+						},
+						{
+							"include": "#attributes_context"
+						},
+						{
+							"include": "#function_type"
+						},
+						{
+							"include": "#storage_types"
+						},
+						{
+							"include": "#number_literal"
+						},
+						{
+							"include": "#string_context"
+						},
+						{
+							"include": "#comma"
+						},
+						{
+							"include": "#scope_resolution_inner_generated"
+						},
+						{
+							"include": "#template_call_range"
+						},
+						{
+							"match": "(?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*",
+							"name": "entity.name.type.cpp"
+						}
+					]
+				},
+				"11": {
+					"patterns": [
+						{
+							"include": "#attributes_context"
+						},
+						{
+							"include": "#number_literal"
+						}
+					]
+				},
+				"12": {
+					"patterns": [
+						{
+							"include": "#inline_comment"
+						}
+					]
+				},
+				"13": {
+					"name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+				},
+				"14": {
+					"name": "comment.block.cpp"
+				},
+				"15": {
+					"patterns": [
+						{
+							"match": "\\*\\/",
+							"name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+						},
+						{
+							"match": "\\*",
+							"name": "comment.block.cpp"
+						}
+					]
+				},
+				"16": {
+					"patterns": [
+						{
+							"include": "#inline_comment"
+						}
+					]
+				},
+				"17": {
+					"name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+				},
+				"18": {
+					"name": "comment.block.cpp"
+				},
+				"19": {
+					"patterns": [
+						{
+							"match": "\\*\\/",
+							"name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+						},
+						{
+							"match": "\\*",
+							"name": "comment.block.cpp"
+						}
+					]
+				},
+				"21": {
+					"patterns": [
+						{
+							"include": "#scope_resolution_inner_generated"
+						}
+					]
+				},
+				"22": {
+					"name": "punctuation.separator.namespace.access.cpp punctuation.separator.scope-resolution.cpp"
+				},
+				"24": {
+					"name": "meta.template.call.cpp",
+					"patterns": [
+						{
+							"include": "#template_call_range"
+						}
+					]
+				},
+				"26": {
+					"name": "entity.name.scope-resolution.cpp"
+				},
+				"27": {
+					"name": "meta.template.call.cpp",
+					"patterns": [
+						{
+							"include": "#template_call_range"
+						}
+					]
+				},
+				"29": {
+					"name": "punctuation.separator.namespace.access.cpp punctuation.separator.scope-resolution.cpp"
+				},
+				"30": {
+					"patterns": [
+						{
+							"include": "#inline_comment"
+						}
+					]
+				},
+				"31": {
+					"name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+				},
+				"32": {
+					"name": "comment.block.cpp"
+				},
+				"33": {
+					"patterns": [
+						{
+							"match": "\\*\\/",
+							"name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+						},
+						{
+							"match": "\\*",
+							"name": "comment.block.cpp"
+						}
+					]
+				},
+				"34": {
+					"name": "entity.name.type.cpp"
+				},
+				"35": {
+					"name": "meta.template.call.cpp",
+					"patterns": [
+						{
+							"include": "#template_call_range"
+						}
+					]
+				}
+			}
+		},
+		"undef": {
+			"match": "((?:^)((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))(#)\\s*undef\\b)((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))((?<!\\w)(?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*(?!\\w))",
+			"captures": {
+				"1": {
+					"name": "keyword.control.directive.undef.cpp"
+				},
+				"2": {
+					"patterns": [
+						{
+							"include": "#inline_comment"
+						}
+					]
+				},
+				"3": {
+					"name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+				},
+				"4": {
+					"name": "comment.block.cpp"
+				},
+				"5": {
+					"patterns": [
+						{
+							"match": "\\*\\/",
+							"name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+						},
+						{
+							"match": "\\*",
+							"name": "comment.block.cpp"
+						}
+					]
+				},
+				"6": {
+					"name": "punctuation.definition.directive.cpp"
+				},
+				"7": {
+					"patterns": [
+						{
+							"include": "#inline_comment"
+						}
+					]
+				},
+				"8": {
+					"name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+				},
+				"9": {
+					"name": "comment.block.cpp"
+				},
+				"10": {
+					"patterns": [
+						{
+							"match": "\\*\\/",
+							"name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+						},
+						{
+							"match": "\\*",
+							"name": "comment.block.cpp"
+						}
+					]
+				},
+				"11": {
+					"name": "entity.name.function.preprocessor.cpp"
+				}
+			},
+			"name": "meta.preprocessor.undef.cpp"
+		},
+		"union_block": {
+			"name": "meta.block.union.cpp",
+			"begin": "((((?<!\\w)union(?!\\w))(?:(?:((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))|((?:(?:(?:\\[\\[.*?\\]\\]|__attribute(?:__)?\\(\\(.*?\\)\\))|__declspec\\(.*?\\))|alignas\\(.*?\\))(?!\\))))|(?={))(?:((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))(DLLEXPORT)((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z)))))?((?:(?:(?:\\[\\[.*?\\]\\]|__attribute(?:__)?\\(\\(.*?\\)\\))|__declspec\\(.*?\\))|alignas\\(.*?\\))(?!\\)))?((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))((?:(?<!\\w)(?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*(?!\\w))?)(?:((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))(final)((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z)))))?(?:((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))(:)((?>[^{]*)))?))",
+			"beginCaptures": {
+				"1": {
+					"name": "meta.head.union.cpp"
+				},
+				"3": {
+					"name": "storage.type.$3.cpp"
+				},
+				"4": {
+					"patterns": [
+						{
+							"include": "#inline_comment"
+						}
+					]
+				},
+				"5": {
+					"name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+				},
+				"6": {
+					"name": "comment.block.cpp"
+				},
+				"7": {
+					"patterns": [
+						{
+							"match": "\\*\\/",
+							"name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+						},
+						{
+							"match": "\\*",
+							"name": "comment.block.cpp"
+						}
+					]
+				},
+				"8": {
+					"patterns": [
+						{
+							"include": "#attributes_context"
+						},
+						{
+							"include": "#number_literal"
+						}
+					]
+				},
+				"9": {
+					"patterns": [
+						{
+							"include": "#inline_comment"
+						}
+					]
+				},
+				"10": {
+					"name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+				},
+				"11": {
+					"name": "comment.block.cpp"
+				},
+				"12": {
+					"patterns": [
+						{
+							"match": "\\*\\/",
+							"name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+						},
+						{
+							"match": "\\*",
+							"name": "comment.block.cpp"
+						}
+					]
+				},
+				"13": {
+					"name": "entity.name.other.preprocessor.macro.predefined.DLLEXPORT.cpp"
+				},
+				"14": {
+					"patterns": [
+						{
+							"include": "#inline_comment"
+						}
+					]
+				},
+				"15": {
+					"name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+				},
+				"16": {
+					"name": "comment.block.cpp"
+				},
+				"17": {
+					"patterns": [
+						{
+							"match": "\\*\\/",
+							"name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+						},
+						{
+							"match": "\\*",
+							"name": "comment.block.cpp"
+						}
+					]
+				},
+				"18": {
+					"patterns": [
+						{
+							"include": "#attributes_context"
+						},
+						{
+							"include": "#number_literal"
+						}
+					]
+				},
+				"19": {
+					"patterns": [
+						{
+							"include": "#inline_comment"
+						}
+					]
+				},
+				"20": {
+					"name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+				},
+				"21": {
+					"name": "comment.block.cpp"
+				},
+				"22": {
+					"patterns": [
+						{
+							"match": "\\*\\/",
+							"name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+						},
+						{
+							"match": "\\*",
+							"name": "comment.block.cpp"
+						}
+					]
+				},
+				"23": {
+					"name": "entity.name.type.$3.cpp"
+				},
+				"24": {
+					"patterns": [
+						{
+							"include": "#inline_comment"
+						}
+					]
+				},
+				"25": {
+					"name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+				},
+				"26": {
+					"name": "comment.block.cpp"
+				},
+				"27": {
+					"patterns": [
+						{
+							"match": "\\*\\/",
+							"name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+						},
+						{
+							"match": "\\*",
+							"name": "comment.block.cpp"
+						}
+					]
+				},
+				"28": {
+					"name": "storage.type.modifier.final.cpp"
+				},
+				"29": {
+					"patterns": [
+						{
+							"include": "#inline_comment"
+						}
+					]
+				},
+				"30": {
+					"name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+				},
+				"31": {
+					"name": "comment.block.cpp"
+				},
+				"32": {
+					"patterns": [
+						{
+							"match": "\\*\\/",
+							"name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+						},
+						{
+							"match": "\\*",
+							"name": "comment.block.cpp"
+						}
+					]
+				},
+				"33": {
+					"patterns": [
+						{
+							"include": "#inline_comment"
+						}
+					]
+				},
+				"34": {
+					"name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+				},
+				"35": {
+					"name": "comment.block.cpp"
+				},
+				"36": {
+					"patterns": [
+						{
+							"match": "\\*\\/",
+							"name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+						},
+						{
+							"match": "\\*",
+							"name": "comment.block.cpp"
+						}
+					]
+				},
+				"37": {
+					"name": "punctuation.separator.colon.inheritance.cpp"
+				},
+				"38": {
+					"patterns": [
+						{
+							"include": "#inheritance_context"
+						}
+					]
+				}
+			},
+			"end": "(?:(?:(?<=\\}|%>|\\?\\?>)\\s*(;)|(;))|(?=[;>\\[\\]=]))",
+			"endCaptures": {
+				"1": {
+					"name": "punctuation.terminator.statement.cpp"
+				},
+				"2": {
+					"name": "punctuation.terminator.statement.cpp"
+				}
+			},
+			"patterns": [
+				{
+					"name": "meta.head.union.cpp",
+					"begin": "\\G ?",
+					"end": "((?:\\{|<%|\\?\\?<|(?=;)))",
+					"endCaptures": {
+						"1": {
+							"name": "punctuation.section.block.begin.bracket.curly.union.cpp"
+						}
+					},
+					"patterns": [
+						{
+							"include": "#ever_present_context"
+						},
+						{
+							"include": "#inheritance_context"
+						},
+						{
+							"include": "#template_call_range"
+						}
+					]
+				},
+				{
+					"name": "meta.body.union.cpp",
+					"begin": "(?<=\\{|<%|\\?\\?<)",
+					"end": "(\\}|%>|\\?\\?>)",
+					"endCaptures": {
+						"1": {
+							"name": "punctuation.section.block.end.bracket.curly.union.cpp"
+						}
+					},
+					"patterns": [
+						{
+							"include": "#function_pointer"
+						},
+						{
+							"include": "#static_assert"
+						},
+						{
+							"include": "#constructor_inline"
+						},
+						{
+							"include": "#destructor_inline"
+						},
+						{
+							"include": "$self"
+						}
+					]
+				},
+				{
+					"name": "meta.tail.union.cpp",
+					"begin": "(?<=\\}|%>|\\?\\?>)[\\s\\n]*",
+					"end": "[\\s\\n]*(?=;)",
+					"patterns": [
+						{
+							"include": "$self"
+						}
+					]
+				}
+			]
+		},
+		"union_declare": {
+			"match": "((?<!\\w)union(?!\\w))((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))((?<!\\w)(?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*(?!\\w))(((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))?(?:(?:\\&|\\*)((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z)))))*(?:\\&|\\*))?((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))\\b(?!override\\W|override\\$|final\\W|final\\$)((?<!\\w)(?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*(?!\\w))((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))(?=\\S)(?![:{])",
+			"captures": {
+				"1": {
+					"name": "storage.type.union.declare.cpp"
+				},
+				"2": {
+					"patterns": [
+						{
+							"include": "#inline_comment"
+						}
+					]
+				},
+				"3": {
+					"name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+				},
+				"4": {
+					"name": "comment.block.cpp"
+				},
+				"5": {
+					"patterns": [
+						{
+							"match": "\\*\\/",
+							"name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+						},
+						{
+							"match": "\\*",
+							"name": "comment.block.cpp"
+						}
+					]
+				},
+				"6": {
+					"name": "entity.name.type.union.cpp"
+				},
+				"7": {
+					"patterns": [
+						{
+							"match": "\\*",
+							"name": "storage.modifier.pointer.cpp"
+						},
+						{
+							"match": "(?:\\&((?>(?:(?:(?>(?<!\\s)\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z))))){2,}\\&",
+							"captures": {
+								"1": {
+									"patterns": [
+										{
+											"include": "#inline_comment"
+										}
+									]
+								},
+								"2": {
+									"name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+								},
+								"3": {
+									"name": "comment.block.cpp"
+								},
+								"4": {
+									"patterns": [
+										{
+											"match": "\\*\\/",
+											"name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+										},
+										{
+											"match": "\\*",
+											"name": "comment.block.cpp"
+										}
+									]
+								}
+							},
+							"name": "invalid.illegal.reference-type.cpp"
+						},
+						{
+							"match": "\\&",
+							"name": "storage.modifier.reference.cpp"
+						}
+					]
+				},
+				"8": {
+					"patterns": [
+						{
+							"include": "#inline_comment"
+						}
+					]
+				},
+				"9": {
+					"name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+				},
+				"10": {
+					"name": "comment.block.cpp"
+				},
+				"11": {
+					"patterns": [
+						{
+							"match": "\\*\\/",
+							"name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+						},
+						{
+							"match": "\\*",
+							"name": "comment.block.cpp"
+						}
+					]
+				},
+				"12": {
+					"patterns": [
+						{
+							"include": "#inline_comment"
+						}
+					]
+				},
+				"13": {
+					"name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+				},
+				"14": {
+					"name": "comment.block.cpp"
+				},
+				"15": {
+					"patterns": [
+						{
+							"match": "\\*\\/",
+							"name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+						},
+						{
+							"match": "\\*",
+							"name": "comment.block.cpp"
+						}
+					]
+				},
+				"16": {
+					"patterns": [
+						{
+							"include": "#inline_comment"
+						}
+					]
+				},
+				"17": {
+					"name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+				},
+				"18": {
+					"name": "comment.block.cpp"
+				},
+				"19": {
+					"patterns": [
+						{
+							"match": "\\*\\/",
+							"name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+						},
+						{
+							"match": "\\*",
+							"name": "comment.block.cpp"
+						}
+					]
+				},
+				"20": {
+					"name": "variable.other.object.declare.cpp"
+				},
+				"21": {
+					"patterns": [
+						{
+							"include": "#inline_comment"
+						}
+					]
+				},
+				"22": {
+					"name": "comment.block.cpp punctuation.definition.comment.begin.cpp"
+				},
+				"23": {
+					"name": "comment.block.cpp"
+				},
+				"24": {
+					"patterns": [
+						{
+							"match": "\\*\\/",
+							"name": "comment.block.cpp punctuation.definition.comment.end.cpp"
+						},
+						{
+							"match": "\\*",
+							"name": "comment.block.cpp"
+						}
+					]
+				}
+			}
+		},
+		"using_name": {
+			"match": "(using)\\s+(?!namespace\\b)",
+			"captures": {
+				"1": {
+					"name": "keyword.other.using.directive.cpp"
+				}
+			}
+		},
+		"using_namespace": {
+			"name": "meta.using-namespace.cpp",
+			"begin": "(?<!\\w)(using)\\s+(namespace)\\s+((::)?(?:((?-mix:(?!\\b(?:__has_cpp_attribute|reinterpret_cast|atomic_noexcept|atomic_cancel|atomic_commit|__has_include|dynamic_cast|thread_local|synchronized|static_cast|const_cast|consteval|constexpr|protected|namespace|co_return|constexpr|constexpr|continue|explicit|volatile|noexcept|co_yield|noexcept|noexcept|requires|typename|decltype|operator|co_await|template|volatile|register|restrict|reflexpr|alignof|private|default|mutable|include|concept|__asm__|defined|_Pragma|alignas|typedef|warning|virtual|mutable|struct|sizeof|delete|not_eq|bitand|and_eq|xor_eq|typeid|switch|return|static|extern|inline|friend|public|ifndef|define|pragma|export|import|module|catch|throw|const|or_eq|while|compl|bitor|const|union|ifdef|class|undef|error|break|using|endif|goto|line|enum|this|case|else|elif|else|asm|try|for|new|and|xor|not|do|or|if|if)\\b)(?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*))\\s*+(((?<!<)<(?!<)(?>(?:(?>[^<>]*)\\g<7>?)+)>)\\s*)?::)*\\s*+)?((?<!\\w)(?:[a-zA-Z_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))(?:[a-zA-Z0-9_]|(?:\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}))*(?!\\w))(?=;|\\n)",
+			"beginCaptures": {
+				"1": {
+					"name": "keyword.other.using.directive.cpp"
+				},
+				"2": {
+					"name": "keyword.other.namespace.directive.cpp storage.type.namespace.directive.cpp"
+				},
+				"3": {
+					"patterns": [
+						{
+							"include": "#scope_resolution_namespace_using_inner_generated"
+						}
+					]
+				},
+				"4": {
+					"name": "punctuation.separator.namespace.access.cpp punctuation.separator.scope-resolution.namespace.using.cpp"
+				},
+				"6": {
+					"name": "meta.template.call.cpp",
+					"patterns": [
+						{
+							"include": "#template_call_range"
+						}
+					]
+				},
+				"8": {
+					"name": "entity.name.namespace.cpp"
+				}
+			},
+			"end": "(;)",
+			"endCaptures": {
+				"1": {
+					"name": "punctuation.terminator.statement.cpp"
+				}
+			}
+		},
+		"vararg_ellipses": {
+			"match": "(?<!\\.)\\.\\.\\.(?!\\.)",
+			"name": "punctuation.vararg-ellipses.cpp"
+		},
+		"wordlike_operators": {
+			"patterns": [
+				{
+					"match": "(?<!\\w)(?:noexcept|xor_eq|and_eq|delete|not_eq|bitand|bitor|compl|or_eq|not|xor|new|and|or)(?!\\w)",
+					"name": "keyword.operator.wordlike.cpp keyword.operator.$0.cpp"
 				}
 			]
 		}


### PR DESCRIPTION
#### What it does
Update textmate-grammars package to use vscode grammar files as defined here:
https://github.com/jeff-hykin/cpp-textmate-grammar
https://github.com/microsoft/vscode/tree/master/extensions/cpp/syntaxes

#### How to test
Open a C/C++ file and enjoy a richer syntax colourisation.

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

Signed-off-by: Alex Logan <Alex.Logan@arm.com>