### PR TITLE
Collapse panel on toggle view

### DIFF
--- a/examples/api-tests/src/browser-utils.spec.js
+++ b/examples/api-tests/src/browser-utils.spec.js
@@ -1,0 +1,53 @@
+/********************************************************************************
+ * Copyright (C) 2020 TypeFox and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+// @ts-check
+describe('animationFrame', function () {
+    const { assert } = chai;
+    const { animationFrame } = require('@theia/core/lib/browser/browser');
+
+    class FrameCounter {
+        constructor() {
+            this.count = 0;
+            this.stop = false;
+            this.run();
+        }
+        run() {
+            requestAnimationFrame(this.nextFrame.bind(this));
+        }
+        nextFrame() {
+            this.count++;
+            if (!this.stop) {
+                this.run();
+            }
+        }
+    }
+
+    it('should resolve after one frame', async () => {
+        const counter = new FrameCounter();
+        await animationFrame();
+        counter.stop = true;
+        assert.equal(counter.count, 1);
+    });
+
+    it('should resolve after the given number of frames', async () => {
+        const counter = new FrameCounter();
+        await animationFrame(10);
+        counter.stop = true;
+        assert.equal(counter.count, 10);
+    });
+
+});

--- a/examples/api-tests/src/views.spec.js
+++ b/examples/api-tests/src/views.spec.js
@@ -23,6 +23,7 @@ describe('Views', function () {
     const { FileNavigatorContribution } = require('@theia/navigator/lib/browser/navigator-contribution');
     const { ScmContribution } = require('@theia/scm/lib/browser/scm-contribution');
     const { OutlineViewContribution } = require('@theia/outline-view/lib/browser/outline-view-contribution');
+    const { ProblemContribution } = require('@theia/markers/lib/browser/problem/problem-contribution');
 
     /** @type {import('inversify').Container} */
     const container = window['theia'].container;
@@ -30,12 +31,13 @@ describe('Views', function () {
     const navigatorContribution = container.get(FileNavigatorContribution);
     const scmContribution = container.get(ScmContribution);
     const outlineContribution = container.get(OutlineViewContribution);
+    const problemContribution = container.get(ProblemContribution);
 
     before(() => {
         shell.leftPanelHandler.collapse();
     });
 
-    for (const contribution of [navigatorContribution, scmContribution, outlineContribution]) {
+    for (const contribution of [navigatorContribution, scmContribution, outlineContribution, problemContribution]) {
         it(`should toggle ${contribution.viewLabel}`, async () => {
             let view = await contribution.closeView();
             if (view) {

--- a/examples/api-tests/src/views.spec.js
+++ b/examples/api-tests/src/views.spec.js
@@ -53,8 +53,8 @@ describe('Views', function () {
 
             view = await contribution.toggleView();
             assert.notEqual(view, undefined);
-            assert.isUndefined(shell.getAreaFor(view));
-            assert.isUndefined(shell.getTabBarFor(view));
+            assert.equal(shell.getAreaFor(view), contribution.defaultViewOptions.area);
+            assert.isDefined(shell.getTabBarFor(view));
             assert.isFalse(view.isVisible);
             assert.notEqual(view, shell.activeWidget);
         });

--- a/packages/core/src/browser/browser.ts
+++ b/packages/core/src/browser/browser.ts
@@ -36,6 +36,24 @@ export const isNative = typeof (window as any).process !== 'undefined';
 export const isBasicWasmSupported = typeof (window as any).WebAssembly !== 'undefined';
 
 /**
+ * Resolves after the next animation frame if no parameter is given,
+ * or after the given number of animation frames.
+ */
+export function animationFrame(n: number = 1): Promise<void> {
+    return new Promise(resolve => {
+        function frameFunc(): void {
+            if (n <= 0) {
+                resolve();
+            } else {
+                n--;
+                requestAnimationFrame(frameFunc);
+            }
+        }
+        frameFunc();
+    });
+}
+
+/**
  * Parse a magnitude value (e.g. width, height, left, top) from a CSS attribute value.
  * Returns the given default value (or undefined) if the value cannot be determined,
  * e.g. because it is a relative value like `50%` or `auto`.

--- a/packages/core/src/browser/frontend-application.ts
+++ b/packages/core/src/browser/frontend-application.ts
@@ -22,7 +22,7 @@ import { Widget } from './widgets';
 import { ApplicationShell } from './shell/application-shell';
 import { ShellLayoutRestorer, ApplicationShellLayoutMigrationError } from './shell/shell-layout-restorer';
 import { FrontendApplicationStateService } from './frontend-application-state';
-import { preventNavigation, parseCssTime } from './browser';
+import { preventNavigation, parseCssTime, animationFrame } from './browser';
 import { CorePreferences } from './core-preferences';
 
 /**
@@ -125,7 +125,7 @@ export class FrontendApplication {
 
         const host = await this.getHost();
         this.attachShell(host);
-        await new Promise(resolve => requestAnimationFrame(() => resolve()));
+        await animationFrame();
         this.stateService.state = 'attached_shell';
 
         await this.initializeLayout();

--- a/packages/core/src/browser/shell/side-panel-handler.ts
+++ b/packages/core/src/browser/shell/side-panel-handler.ts
@@ -22,6 +22,7 @@ import { Drag } from '@phosphor/dragdrop';
 import { AttachedProperty } from '@phosphor/properties';
 import { TabBarRendererFactory, TabBarRenderer, SHELL_TABBAR_CONTEXT_MENU, SideTabBar } from './tab-bars';
 import { SplitPositionHandler, SplitPositionOptions } from './split-panels';
+import { animationFrame } from '../browser';
 import { FrontendApplicationStateService } from '../frontend-application-state';
 import { TheiaDockPanel } from './theia-dock-panel';
 import { SidePanelToolbar } from './side-panel-toolbar';
@@ -339,13 +340,14 @@ export class SidePanelHandler {
     /**
      * Collapse the sidebar so no items are expanded.
      */
-    collapse(): void {
+    collapse(): Promise<void> {
         if (this.tabBar.currentTitle) {
             // tslint:disable-next-line:no-null-keyword
             this.tabBar.currentTitle = null;
         } else {
             this.refresh();
         }
+        return animationFrame();
     }
 
     /**

--- a/packages/core/src/browser/shell/view-contribution.ts
+++ b/packages/core/src/browser/shell/view-contribution.ts
@@ -112,12 +112,12 @@ export abstract class AbstractViewContribution<T extends Widget> implements Comm
             switch (area) {
                 case 'left':
                 case 'right':
-                    shell.collapsePanel(area);
+                    await shell.collapsePanel(area);
                     break;
                 case 'bottom':
                     // Don't collapse the bottom panel if it's currently split
                     if (shell.bottomAreaTabBars.length === 1) {
-                        shell.collapsePanel('bottom');
+                        await shell.collapsePanel('bottom');
                     }
                     break;
                 default:

--- a/packages/core/src/browser/shell/view-contribution.ts
+++ b/packages/core/src/browser/shell/view-contribution.ts
@@ -108,8 +108,23 @@ export abstract class AbstractViewContribution<T extends Widget> implements Comm
             };
             await shell.addWidget(widget, widgetArgs);
         } else if (args.toggle && area && shell.isExpanded(area) && tabBar.currentTitle === widget.title) {
-            // The widget is attached and visible, so close it (toggle)
-            await this.closeView();
+            // The widget is attached and visible, so collapse the containing panel (toggle)
+            switch (area) {
+                case 'left':
+                case 'right':
+                    shell.collapsePanel(area);
+                    break;
+                case 'bottom':
+                    // Don't collapse the bottom panel if it's currently split
+                    if (shell.bottomAreaTabBars.length === 1) {
+                        shell.collapsePanel('bottom');
+                    }
+                    break;
+                default:
+                    // The main area cannot be collapsed, so close the widget
+                    await this.closeView();
+            }
+            return this.widget;
         }
         if (widget.isAttached && args.activate) {
             await shell.activateWidget(this.viewId);

--- a/packages/core/src/browser/view-container.ts
+++ b/packages/core/src/browser/view-container.ts
@@ -954,7 +954,7 @@ export class ViewContainerPart extends BaseWidget {
     }
 
     protected onBeforeHide(msg: Message): void {
-        if (this.wrapped.isAttached && this.collapsed) {
+        if (this.wrapped.isAttached && !this.collapsed) {
             MessageLoop.sendMessage(this.wrapped, msg);
         }
         super.onBeforeShow(msg);
@@ -962,7 +962,7 @@ export class ViewContainerPart extends BaseWidget {
 
     protected onAfterHide(msg: Message): void {
         super.onAfterHide(msg);
-        if (this.wrapped.isAttached && this.collapsed) {
+        if (this.wrapped.isAttached && !this.collapsed) {
             MessageLoop.sendMessage(this.wrapped, msg);
         }
     }


### PR DESCRIPTION
#### What it does
Even if I once implemented this behavior myself (#1028), I often find it confusing that the command to toggle a view _closes_ it if it's already visible. And I'm not the only one:
https://github.com/eclipse-theia/theia/issues/1727#issuecomment-382308685
https://github.com/arduino/arduino-pro-ide/issues/188
A side effect of this is that if there are views in the sidebar that have not specified a `rank`, closing and reopening a view can lead to a different order of icons.

I propose to slightly change this behavior. With this PR, the toggle command collapses the containing panel when the view is visible. The result is similar as before: the view is no longer visible. The difference is that the view icon is still there. If you really want to close the view, you can do that with right-click on its icon > _Close_.

Special rules for the main and bottom panel:
 * The main panel cannot be collapsed, so if a view is in that area the behavior is the same as before (it is closed).
 * In case the bottom panel is split, i.e. it contains multiple visible widgets, the toggle command does not collapse that panel.

#### How to test
Use the _View_ menu entries or the respective keybindings to toggle some views.

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
