### PR TITLE
Core: Do no expand the widgets on the side-bars for the context menu

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Change Log
 
+## v1.6.0
+
+- [core] added functionality for handling context menu for `tab-bars` without activating the shell tab-bar [#6965](https://github.com/eclipse-theia/theia/pull/6965)
+
+<a name="breaking_changes_1.6.0">[Breaking Changes:](#breaking_changes_1.6.0)</a>
+
+- [core] Context-menu for `tab-bars` requires an `Event` to be passed onto it to perform actions without activating the shell tab-bar [#6965](https://github.com/eclipse-theia/theia/pull/6965)
+  - Removed the logic from `handleContextMenuEvent()` that gives focus to the widget upon opening the context menu, instead functionality added to handle it without activating the widget
+  - This change triggers the context menu for a given shell tab-bar without the need to activate it
+  - While registering a command, `Event` should be passed down, if not passed, then the commands will not work correctly as they no longer rely on the activation of tab-bar
+- [core] Moved `findTitle()` and `findTabBar()` from `common-frontend-contribution.ts` to `application-shell.ts`  [#6965](https://github.com/eclipse-theia/theia/pull/6965)
+
+
 ## v1.5.0 - 27/08/2020
 
 - [application-manager] fixed issue regarding reloading electron windows [#8345](https://github.com/eclipse-theia/theia/pull/8345)

--- a/packages/core/src/browser/shell/application-shell.ts
+++ b/packages/core/src/browser/shell/application-shell.ts
@@ -812,6 +812,45 @@ export class ApplicationShell extends Widget {
     }
 
     /**
+     * Finds the title widget from the tab-bar.
+     * @param tabBar used for providing an array of titles.
+     * @returns the selected title widget, else returns the currentTitle or undefined.
+     */
+    findTitle(tabBar: TabBar<Widget>, event?: Event): Title<Widget> | undefined {
+        if (event?.target instanceof HTMLElement) {
+            let tabNode: HTMLElement | null = event.target;
+            while (tabNode && !tabNode.classList.contains('p-TabBar-tab')) {
+                tabNode = tabNode.parentElement;
+            }
+            if (tabNode && tabNode.title) {
+                let title = tabBar.titles.find(t => t.caption === tabNode!.title);
+                if (title) {
+                    return title;
+                }
+                title = tabBar.titles.find(t => t.label === tabNode!.title);
+                if (title) {
+                    return title;
+                }
+            }
+        }
+        return tabBar.currentTitle || undefined;
+    }
+
+    /**
+     * Finds the tab-bar widget.
+     * @returns the selected tab-bar, else returns the currentTabBar.
+     */
+    findTabBar(event?: Event): TabBar<Widget> | undefined {
+        if (event?.target instanceof HTMLElement) {
+            const tabBar = this.findWidgetForElement(event.target);
+            if (tabBar instanceof TabBar) {
+                return tabBar;
+            }
+        }
+        return this.currentTabBar;
+    }
+
+    /**
      * The current widget in the application shell. The current widget is the last widget that
      * was active and not yet closed. See the remarks to `activeWidget` on what _active_ means.
      */

--- a/packages/core/src/browser/shell/tab-bars.ts
+++ b/packages/core/src/browser/shell/tab-bars.ts
@@ -435,18 +435,6 @@ export class TabBarRenderer extends TabBar.Renderer {
         if (this.contextMenuRenderer && this.contextMenuPath && event.currentTarget instanceof HTMLElement) {
             event.stopPropagation();
             event.preventDefault();
-
-            if (this.tabBar) {
-                const id = event.currentTarget.id;
-                // eslint-disable-next-line no-null/no-null
-                const title = this.tabBar.titles.find(t => this.createTabId(t) === id) || null;
-                this.tabBar.currentTitle = title;
-                this.tabBar.activate();
-                if (title) {
-                    title.owner.activate();
-                }
-            }
-
             this.contextMenuRenderer.render(this.contextMenuPath, event);
         }
     };


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
Fixes: https://github.com/eclipse-theia/theia/issues/4367

With this PR, upon triggering the context menu, the widget is not activated. This helps perform commands on the context menu without actually giving focus to the widget.

**Context menu commands analysed and affected with this change**

- Close

- Close Others

- Close to the right

- Close All

- Toggle Maximized

- Reveal in Explorer

- Collapse

Signed-off-by: Muhammad Anas Shahid <muhammad.shahid@ericsson.com>


#### How to test

|  Use Case 	|  Current Master 	|   Updated Changes	|
|---	|---	|---	|
|   Open two files, right click on the unfocused one and click close		| Right clicking the tab, also reveals the tab and makes it the currentWidget  	|  The right clicked tab will `not` be take focus  	 and still will be able to `close the tab`|   
|   Open two files, right click on the unfocused one and click close others		| Right clicking the tab, also reveals the tab and makes it the currentWidget and then closes the other tabs 	|  The right clicked tab will `not`  take focus and still will be able to `close all other tabs`|   
|   Open two files, right click on the unfocused one and click close to the right (make sure there are tabs open to the right, else the option wont be enabled)		| Right clicking the tab, also reveals the tab and makes it the currentWidget and then closes the other tabs 	|  The right clicked tab will `not`  take focus   and still will be able to `close the tab available on the right`|   
|   Open two files, right click on the unfocused one and `Toggle Maximized`| Right clicking the tab, also reveals the tab and makes it the currentWidget and then `Maximizes the currentWidget` |  The right clicked tab will `not` take focus and still will be able to `maximize the right clicked widget`|   
|   Open two files, right click on the unfocused one and `Reveal In Explorer`		| Right clicking the tab, also reveals the tab and makes it the currentWidget and then `reveals in the file-explorer` |  The right clicked tab will `not` take focus and still will be able to `reveal the right clicked tab on the file-explorer`|   

```
Note: 

- The above mentioned test cases must also work for the terminal view and the sidebar view

- The keybindings for `Toggle Maximized`, `Collapse` and `Reveal In Explorer` must also work 
```

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

