### PR TITLE
[vscode] register grammars only when all languages are registered

### DIFF
--- a/packages/monaco/src/browser/monaco-loader.ts
+++ b/packages/monaco/src/browser/monaco-loader.ts
@@ -57,6 +57,7 @@ export function loadMonaco(vsRequire: any): Promise<void> {
                 'vs/editor/browser/editorExtensions',
                 'vs/editor/standalone/browser/simpleServices',
                 'vs/editor/standalone/browser/standaloneServices',
+                'vs/editor/standalone/browser/standaloneLanguages',
                 'vs/base/parts/quickopen/browser/quickOpenWidget',
                 'vs/base/parts/quickopen/browser/quickOpenModel',
                 'vs/base/common/filters',
@@ -77,7 +78,8 @@ export function loadMonaco(vsRequire: any): Promise<void> {
                 'vs/base/common/errors'
             ], (css: any, html: any, commands: any, actions: any,
                 keybindingsRegistry: any, keybindingResolver: any, resolvedKeybinding: any, keybindingLabels: any,
-                keyCodes: any, mime: any, editorExtensions: any, simpleServices: any, standaloneServices: any, quickOpenWidget: any, quickOpenModel: any,
+                keyCodes: any, mime: any, editorExtensions: any, simpleServices: any,
+                standaloneServices: any, standaloneLanguages: any, quickOpenWidget: any, quickOpenModel: any,
                 filters: any, styler: any, colorRegistry: any, color: any,
                 platform: any, modes: any, suggest: any, snippetParser: any,
                 configuration: any, configurationModels: any,
@@ -89,7 +91,7 @@ export function loadMonaco(vsRequire: any): Promise<void> {
                     global.monaco.commands = commands;
                     global.monaco.actions = actions;
                     global.monaco.keybindings = Object.assign({}, keybindingsRegistry, keybindingResolver, resolvedKeybinding, keybindingLabels, keyCodes);
-                    global.monaco.services = Object.assign({}, simpleServices, standaloneServices, configuration, configurationModels,
+                    global.monaco.services = Object.assign({}, simpleServices, standaloneServices, standaloneLanguages, configuration, configurationModels,
                         codeEditorService, codeEditorServiceImpl, markerService);
                     global.monaco.quickOpen = Object.assign({}, quickOpenWidget, quickOpenModel);
                     global.monaco.filters = filters;

--- a/packages/monaco/src/browser/textmate/monaco-textmate-service.ts
+++ b/packages/monaco/src/browser/textmate/monaco-textmate-service.ts
@@ -154,7 +154,13 @@ export class MonacoTextmateService implements FrontendApplicationContribution {
                     throw new Error(`no grammar for ${scopeName}, ${initialLanguage}, ${JSON.stringify(configuration)}`);
                 }
                 const options = configuration.tokenizerOption ? configuration.tokenizerOption : TokenizerOption.DEFAULT;
-                monaco.languages.setTokensProvider(languageId, createTextmateTokenizer(grammar, options));
+                const tokenizer = createTextmateTokenizer(grammar, options);
+                monaco.languages.setTokensProvider(languageId, tokenizer);
+                const support = monaco.modes.TokenizationRegistry.get(languageId);
+                const themeService = monaco.services.StaticServices.standaloneThemeService.get();
+                const languageIdentifier = monaco.services.StaticServices.modeService.get().getLanguageIdentifier(languageId);
+                const adapter = new monaco.services.TokenizationSupport2Adapter(themeService, languageIdentifier!, tokenizer);
+                support!.tokenize = adapter.tokenize.bind(adapter);
             } catch (error) {
                 this.logger.warn('No grammar for this language id', languageId, error);
             }

--- a/packages/monaco/src/typings/monaco/index.d.ts
+++ b/packages/monaco/src/typings/monaco/index.d.ts
@@ -438,6 +438,11 @@ declare module monaco.keybindings {
 
 declare module monaco.services {
 
+    export class TokenizationSupport2Adapter implements monaco.modes.ITokenizationSupport {
+        constructor(standaloneThemeService: IStandaloneThemeService, languageIdentifier: LanguageIdentifier, actual: monaco.languages.TokensProvider)
+        tokenize(line: string, state: monaco.languages.IState, offsetDelta: number): any;
+    }
+
     export const ICodeEditorService: any;
     export const IConfigurationService: any;
 
@@ -511,7 +516,8 @@ declare module monaco.services {
 
     // https://github.com/TypeFox/vscode/blob/70b8db24a37fafc77247de7f7cb5bb0195120ed0/src/vs/editor/common/services/modeService.ts#L30
     export interface IModeService {
-        createByFilepathOrFirstLine(rsource: monaco.Uri | null, firstLine?: string): ILanguageSelection
+        createByFilepathOrFirstLine(rsource: monaco.Uri | null, firstLine?: string): ILanguageSelection;
+        getLanguageIdentifier(modeId: string): LanguageIdentifier | null;
     }
 
     export interface ILanguageSelection {
@@ -846,6 +852,14 @@ declare module monaco.editorExtensions {
     }
 }
 declare module monaco.modes {
+
+    export interface ITokenizationSupport {
+        tokenize(line: string, state: monaco.languages.IState, offsetDelta: number): any;
+    }
+    export interface TokenizationRegistry {
+        get(language: string): ITokenizationSupport | null;
+    }
+    export const TokenizationRegistry: TokenizationRegistry;
 
     export class TokenMetadata {
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

- fix #6327: `Developer: Inspect tokens` command can be used to find out current TM scopes for a token at the cursor position
- fix #6907: register grammars contributions only when all languages are registered, otherwise not yet registered languages are not considered as embedded languages for grammars

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

- Use `Developer: Inspect Tokens` command to see TM token metadata.
  - I know that hover cannot be closed please open another issue. I don't think it is critical.
- Check that in light theme for embedded languages highlighting is correct, for instance for `shell` language.
  - Also log at the devtools, there should not be errors from markdown VS Code extension about missing embedded languages.

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

