### PR TITLE
[mini-browser] support '.xhtml' file for preview

### DIFF
--- a/packages/mini-browser/src/browser/mini-browser-open-handler.ts
+++ b/packages/mini-browser/src/browser/mini-browser-open-handler.ts
@@ -159,7 +159,12 @@ export class MiniBrowserOpenHandler extends NavigatableWidgetOpenHandler<MiniBro
 
     protected resetBackground(uri: URI): MaybePromise<boolean> {
         const { scheme } = uri;
-        return scheme === 'http' || scheme === 'https' || (scheme === 'file' && uri.toString().endsWith('.html'));
+        const uriStr = uri.toString();
+        return scheme === 'http'
+            || scheme === 'https'
+            || (scheme === 'file'
+                && (uriStr.endsWith('html') || uriStr.endsWith('.htm'))
+            );
     }
 
     protected async defaultOptions(): Promise<MiniBrowserOpenerOptions & { widgetOptions: ApplicationShell.WidgetOptions }> {

--- a/packages/mini-browser/src/node/mini-browser-endpoint.ts
+++ b/packages/mini-browser/src/node/mini-browser-endpoint.ts
@@ -198,8 +198,8 @@ const CODE_EDITOR_PRIORITY = 100;
 @injectable()
 export class HtmlHandler implements MiniBrowserEndpointHandler {
 
-    supportedExtensions(): string {
-        return 'html';
+    supportedExtensions(): string[] {
+        return ['html', 'xhtml', 'htm'];
     }
 
     priority(): number {


### PR DESCRIPTION


<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

Fixes #6968 

The pull-request adds support to display `.xhtml` files as a preview using the `mini-browser`.
- Introduces a minor change to the `resetBackground` to also accept resetting backgrounds for `.xhtml` files.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

1. open a workspace
2. open a `.html` file (verify that preview works using the toolbar item)
   - clicking the preview should be properly displayed with a reset background
3. open a `.xhtml` file (verify that the preview works using the toolbar item)
   - clicking the preview should be properly displayed with a reset background
4. open a `.htm` file (verify that the preview works using the toolbar item)
   - clicking the preview should be properly displayed with a reset background

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

Signed-off-by: Vincent Fugnitto <vincent.fugnitto@ericsson.com>