### PR TITLE
Parallel resolve plugin entries

### DIFF
--- a/packages/plugin-ext/src/main/node/plugin-deployer-impl.ts
+++ b/packages/plugin-ext/src/main/node/plugin-deployer-impl.ts
@@ -20,15 +20,19 @@ import { injectable, optional, multiInject, inject } from 'inversify';
 import {
     PluginDeployerResolver, PluginDeployerFileHandler, PluginDeployerDirectoryHandler,
     PluginDeployerEntry, PluginDeployer, PluginDeployerResolverInit, PluginDeployerFileHandlerContext,
-    PluginDeployerDirectoryHandlerContext, PluginDeployerEntryType, PluginDeployerHandler,
+    PluginDeployerDirectoryHandlerContext, PluginDeployerEntryType, PluginDeployerHandler
 } from '../../common/plugin-protocol';
 import { PluginDeployerEntryImpl } from './plugin-deployer-entry-impl';
-import { PluginDeployerResolverContextImpl, PluginDeployerResolverInitImpl } from './plugin-deployer-resolver-context-impl';
+import {
+    PluginDeployerResolverContextImpl,
+    PluginDeployerResolverInitImpl
+} from './plugin-deployer-resolver-context-impl';
 import { ProxyPluginDeployerEntry } from './plugin-deployer-proxy-entry-impl';
 import { PluginDeployerFileHandlerContextImpl } from './plugin-deployer-file-handler-context-impl';
 import { PluginDeployerDirectoryHandlerContextImpl } from './plugin-deployer-directory-handler-context-impl';
 import { ILogger, Emitter } from '@theia/core';
 import { PluginCliContribution } from './plugin-cli-contribution';
+import { performance } from 'perf_hooks';
 
 @injectable()
 export class PluginDeployerImpl implements PluginDeployer {
@@ -100,27 +104,36 @@ export class PluginDeployerImpl implements PluginDeployer {
         const pluginIdList = pluginsValue ? pluginsValue.split(',') : [];
         const pluginsList = defaultPluginIdList.concat(pluginIdList).concat(defaultPluginsValueViaCli ? defaultPluginsValueViaCli.split(',') : []);
 
+        const startDeployTime = performance.now();
         await this.deployMultipleEntries(pluginsList);
-
+        this.logMeasurement('Deploy plugins list', startDeployTime);
     }
 
     public async deploy(pluginEntry: string): Promise<void> {
+        const startDeployTime = performance.now();
         await this.deployMultipleEntries([pluginEntry]);
+        this.logMeasurement('Deploy plugin entry', startDeployTime);
     }
 
     protected async deployMultipleEntries(pluginEntries: ReadonlyArray<string>): Promise<void> {
         const visited = new Set<string>();
         const pluginsToDeploy = new Map<string, PluginDeployerEntry>();
 
-        const queue = [...pluginEntries];
+        let queue = [...pluginEntries];
         while (queue.length) {
-            const chunk = [];
+            const dependenciesChunk: Array< Map<string, string>> = [];
+            const workload: string[] = [];
             while (queue.length) {
                 const current = queue.shift()!;
                 if (visited.has(current)) {
                     continue;
+                } else {
+                    workload.push(current);
                 }
                 visited.add(current);
+            }
+            queue = [];
+            await Promise.all(workload.map(async current => {
                 try {
                     const pluginDeployerEntries = await this.resolvePlugin(current);
                     await this.applyFileHandlers(pluginDeployerEntries);
@@ -130,15 +143,15 @@ export class PluginDeployerImpl implements PluginDeployer {
                         if (dependencies && !pluginsToDeploy.has(dependencies.metadata.model.id)) {
                             pluginsToDeploy.set(dependencies.metadata.model.id, deployerEntry);
                             if (dependencies.mapping) {
-                                chunk.push(dependencies.mapping);
+                                dependenciesChunk.push(dependencies.mapping);
                             }
                         }
                     }
                 } catch (e) {
                     console.error(`Failed to resolve plugins from '${current}'`, e);
                 }
-            }
-            for (const dependencies of chunk) {
+            }));
+            for (const dependencies of dependenciesChunk) {
                 for (const [dependency, deployableDependency] of dependencies) {
                     if (!pluginsToDeploy.has(dependency)) {
                         queue.push(deployableDependency);
@@ -240,5 +253,9 @@ export class PluginDeployerImpl implements PluginDeployer {
         }
 
         return pluginDeployerEntries;
+    }
+
+    protected logMeasurement(prefix: string, startTime: number): void {
+        console.log(`${prefix} took: ${(performance.now() - startTime).toFixed(1)} ms`);
     }
 }


### PR DESCRIPTION
Signed-off-by: Doron Nahari <doron.nahari@sap.com>

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->
Our theia extension is loaded with high number of plugins causes the ide to be started but the plugins are not resolved/ready yet for a few minutes.

This pr resolve the plugins in parallel with regards to their dependencies. i.e. resolve all plugins and collect their dependencies and then resolve all the collected dependencies and so on.
 
Perfomance improvement:
By deploying java-pack vscode extension
Before:
![perf-before](https://user-images.githubusercontent.com/24614792/73262914-06bccf80-41d8-11ea-9cd7-e6e0075e0180.png)
After:
![perf-after](https://user-images.githubusercontent.com/24614792/73262924-0b818380-41d8-11ea-9c99-6de27644abd7.png)

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
Add many plugins to Theia at once (preferred with dependencies) and see how they (and their dependencies) resolve in parallel.

For example: deploy vscode java pack: https://marketplace.visualstudio.com/items?itemName=vscjava.vscode-java-pack and check out the console logs for deployment time.

I created a pr with old code and added same logs for comparing the performance: https://github.com/eclipse-theia/theia/pull/6982
#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

