### PR TITLE
Fix icons & file names alignment issue in tree

### DIFF
--- a/packages/filesystem/src/browser/style/file-icons.css
+++ b/packages/filesystem/src/browser/style/file-icons.css
@@ -27,6 +27,14 @@
     font-size: calc(var(--theia-content-font-size) * 0.8);
 }
 
+.theia-file-icons-js.file-icon {
+    width: var(--theia-icon-size);
+    height: var(--theia-icon-size);
+    display: flex;
+    justify-content: center;
+    align-items: center;
+}
+
 .fa-file:before,
 .fa-folder:before,
 .theia-file-icons-js:before {


### PR DESCRIPTION
Fixes #5580

#### What it does
- Adjust the spacing between file icons and file names in navigation tree so that they are aligned vertically and horizontally

#### How to test
- Open theia in the browser and examine the file tree in the navigator. Please refer to the screenshot in #5580 for more info.

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

