### PR TITLE
fix #6976: XSS in New File dialog.

### DIFF
--- a/packages/core/src/browser/dialogs.ts
+++ b/packages/core/src/browser/dialogs.ts
@@ -305,7 +305,7 @@ export abstract class AbstractDialog<T> extends BaseWidget {
         if (this.acceptButton) {
             this.acceptButton.disabled = !DialogError.getResult(error);
         }
-        this.errorMessageNode.innerHTML = DialogError.getMessage(error);
+        this.errorMessageNode.innerText = DialogError.getMessage(error);
     }
 
     protected addCloseAction<K extends keyof HTMLElementEventMap>(element: HTMLElement, ...additionalEventTypes: K[]): void {

--- a/packages/workspace/src/browser/workspace-commands.ts
+++ b/packages/workspace/src/browser/workspace-commands.ts
@@ -349,12 +349,12 @@ export class WorkspaceCommandContribution implements CommandContribution {
         }
         // check and validate each sub-paths
         if (name.split(/[\\/]/).some(file => !file || !validFilename(file) || /^\s+$/.test(file))) {
-            return `The name <strong>${this.trimFileName(name)}</strong> is not a valid file or folder name.`;
+            return `The name "${this.trimFileName(name)}" is not a valid file or folder name.`;
         }
         const childUri = new URI(parent.uri).resolve(name).toString();
         const exists = await this.fileSystem.exists(childUri);
         if (exists) {
-            return `A file or folder <strong>${this.trimFileName(name)}</strong> already exists at this location.`;
+            return `A file or folder "${this.trimFileName(name)}" already exists at this location.`;
         }
         return '';
     }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
Fixes XSS sink in the New File dialog. 

A side effect of this change is the error message displayed no longer displays the erroneous file name in bold.

#### How to test

Click File-> New File
Enter <style onload=alert(0)> in the text box

An alert should not be displayed on the page.

#### Review checklist

- [X] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

Signed-off-by: Casey Flynn <caseyflynn@google.com>
