### PR TITLE
FIX Issue 6955 - workbench.action.closeActiveEditor command

### DIFF
--- a/packages/plugin-ext-vscode/src/browser/plugin-vscode-commands-contribution.ts
+++ b/packages/plugin-ext-vscode/src/browser/plugin-vscode-commands-contribution.ts
@@ -29,6 +29,7 @@ import { ApplicationShellMouseTracker } from '@theia/core/lib/browser/shell/appl
 import { CommandService } from '@theia/core/lib/common/command';
 import TheiaURI from '@theia/core/lib/common/uri';
 import { EditorManager } from '@theia/editor/lib/browser';
+import { CodeEditorWidget } from '@theia/plugin-ext/lib/main/browser/menus/menus-contribution-handler';
 import { TextDocumentShowOptions } from '@theia/plugin-ext/lib/common/plugin-api-rpc-model';
 import { DocumentsMainImpl } from '@theia/plugin-ext/lib/main/browser/documents-main';
 import { createUntitledResource } from '@theia/plugin-ext/lib/main/browser/editor/untitled-resource';
@@ -231,7 +232,7 @@ export class PluginVscodeCommandsContribution implements CommandContribution {
                         return (resourceUri && resourceUri.toString()) === uriString;
                     });
                 }
-                if (NavigatableWidget.is(widget)) {
+                if (CodeEditorWidget.is(widget)) {
                     widget.close();
                 }
             }
@@ -247,7 +248,7 @@ export class PluginVscodeCommandsContribution implements CommandContribution {
                     });
                 }
                 for (const widget of this.shell.widgets) {
-                    if (NavigatableWidget.is(widget) && widget !== editor) {
+                    if (CodeEditorWidget.is(widget) && widget !== editor) {
                         widget.close();
                     }
                 }
@@ -267,7 +268,7 @@ export class PluginVscodeCommandsContribution implements CommandContribution {
                     const tabBar = this.shell.getTabBarFor(editor);
                     if (tabBar) {
                         this.shell.closeTabs(tabBar,
-                            ({ owner }) => NavigatableWidget.is(owner) && owner !== editor
+                            ({ owner }) => CodeEditorWidget.is(owner) && owner !== editor
                         );
                     }
                 }
@@ -281,7 +282,7 @@ export class PluginVscodeCommandsContribution implements CommandContribution {
                     for (const tabBar of this.shell.allTabBars) {
                         if (tabBar !== editorTabBar) {
                             this.shell.closeTabs(tabBar,
-                                ({ owner }) => NavigatableWidget.is(owner)
+                                ({ owner }) => CodeEditorWidget.is(owner)
                             );
                         }
                     }
@@ -301,7 +302,7 @@ export class PluginVscodeCommandsContribution implements CommandContribution {
                                     left = false;
                                     return false;
                                 }
-                                return left && NavigatableWidget.is(owner);
+                                return left && CodeEditorWidget.is(owner);
                             }
                         );
                     }
@@ -321,7 +322,7 @@ export class PluginVscodeCommandsContribution implements CommandContribution {
                                     left = false;
                                     return false;
                                 }
-                                return !left && NavigatableWidget.is(owner);
+                                return !left && CodeEditorWidget.is(owner);
                             }
                         );
                     }
@@ -331,7 +332,7 @@ export class PluginVscodeCommandsContribution implements CommandContribution {
         commands.registerCommand({ id: 'workbench.action.closeAllEditors' }, {
             execute: () => {
                 for (const widget of this.shell.widgets) {
-                    if (NavigatableWidget.is(widget)) {
+                    if (CodeEditorWidget.is(widget)) {
                         widget.close();
                     }
                 }


### PR DESCRIPTION
FIX Issue 6955 - workbench.action.closeActiveEditor command doesn't close a WebviewWidget

Signed-off-by: Tomer Epstein <tomer.epstein@sap.com>

Issue: https://github.com/eclipse-theia/theia/issues/6955

#### What it does
This change proposal adds a check whether a given widget is an editor in VS Code sense and can be closed.


#### How to test

1.  git clone https://github.com/tomer-epstein/vscode-close-editor.git
2. cd vscode-close-editor && npm run compile && npm run package
3. copy vscode-close-editor-0.0.1.vsix to plugins folder
4. Click on a editor title (right) , choose 'VSCode Close Active Editor' /  'VSCode Close Other Editors' or 'VSCode Close All Editors'.

![image](https://user-images.githubusercontent.com/57438361/73243167-98641700-41af-11ea-8d96-948aa97d5e60.png)

![image](https://user-images.githubusercontent.com/57438361/73243174-9f8b2500-41af-11ea-8aef-077820644441.png)


#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

