### PR TITLE
feat(vscode): Implements readFile/writeFile for workspace.fs

### DIFF
--- a/packages/plugin-ext/src/common/plugin-api-rpc.ts
+++ b/packages/plugin-ext/src/common/plugin-api-rpc.ts
@@ -1322,6 +1322,8 @@ export interface FileSystemExt {
 }
 
 export interface FileSystemMain {
+    $readFile(uri: UriComponents): Promise<string>;
+    $writeFile(uri: UriComponents, content: string): Promise<void>;
     $registerFileSystemProvider(handle: number, scheme: string): void;
     $unregisterProvider(handle: number): void;
 }

--- a/packages/plugin-ext/src/main/browser/file-system-main.ts
+++ b/packages/plugin-ext/src/main/browser/file-system-main.ts
@@ -17,21 +17,24 @@
 import { interfaces, injectable } from 'inversify';
 import Uri from 'vscode-uri';
 import { Disposable, ResourceResolver, DisposableCollection } from '@theia/core';
-import { Resource } from '@theia/core/lib/common/resource';
+import { Resource, ResourceProvider } from '@theia/core/lib/common/resource';
 import URI from '@theia/core/lib/common/uri';
 import { MAIN_RPC_CONTEXT, FileSystemMain, FileSystemExt } from '../../common/plugin-api-rpc';
 import { RPCProtocol } from '../../common/rpc-protocol';
+import { UriComponents } from '../../common/uri-components';
 
 export class FileSystemMainImpl implements FileSystemMain, Disposable {
 
     private readonly proxy: FileSystemExt;
     private readonly resourceResolver: FSResourceResolver;
+    private readonly resourceProvider: ResourceProvider;
     private readonly providers = new Map<number, Disposable>();
     private readonly toDispose = new DisposableCollection();
 
     constructor(rpc: RPCProtocol, container: interfaces.Container) {
         this.proxy = rpc.getProxy(MAIN_RPC_CONTEXT.FILE_SYSTEM_EXT);
         this.resourceResolver = container.get(FSResourceResolver);
+        this.resourceProvider = container.get(ResourceProvider);
     }
 
     dispose(): void {
@@ -52,6 +55,21 @@ export class FileSystemMainImpl implements FileSystemMain, Disposable {
         if (disposable) {
             disposable.dispose();
         }
+    }
+
+    async $readFile(uriComponents: UriComponents): Promise<string> {
+        const uri = Uri.revive(uriComponents);
+        const resource = await this.resourceProvider(new URI(uri));
+        return resource.readContents();
+    }
+
+    async $writeFile(uriComponents: UriComponents, content: string): Promise<void> {
+        const uri = Uri.revive(uriComponents);
+        const resource = await this.resourceProvider(new URI(uri));
+        if (!resource.saveContents) {
+            throw new Error(`'No write operation available on the resource for URI ${uriComponents}`);
+        }
+        return resource.saveContents(content);
     }
 
 }

--- a/packages/plugin-ext/src/plugin/file-system.ts
+++ b/packages/plugin-ext/src/plugin/file-system.ts
@@ -20,12 +20,14 @@ import { PLUGIN_RPC_CONTEXT, FileSystemExt, FileSystemMain } from '../common/plu
 import { RPCProtocol } from '../common/rpc-protocol';
 import { UriComponents, Schemes } from '../common/uri-components';
 import { Disposable } from './types-impl';
+import { InPluginFileSystemProxy } from './in-plugin-filesystem-proxy';
 
 export class FileSystemExtImpl implements FileSystemExt {
 
     private readonly proxy: FileSystemMain;
     private readonly usedSchemes = new Set<string>();
     private readonly fsProviders = new Map<number, theia.FileSystemProvider>();
+    private fileSystem: InPluginFileSystemProxy;
 
     private handlePool: number = 0;
 
@@ -41,6 +43,12 @@ export class FileSystemExtImpl implements FileSystemExt {
         this.usedSchemes.add(Schemes.MAILTO);
         this.usedSchemes.add(Schemes.DATA);
         this.usedSchemes.add(Schemes.COMMAND);
+        this.fileSystem = new InPluginFileSystemProxy(this.proxy);
+
+    }
+
+    get fs(): theia.FileSystem {
+        return this.fileSystem;
     }
 
     registerFileSystemProvider(scheme: string, provider: theia.FileSystemProvider): theia.Disposable {

--- a/packages/plugin-ext/src/plugin/in-plugin-filesystem-proxy.ts
+++ b/packages/plugin-ext/src/plugin/in-plugin-filesystem-proxy.ts
@@ -1,0 +1,62 @@
+/********************************************************************************
+ * Copyright (C) 2020 Red Hat, Inc. and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import * as theia from '@theia/plugin';
+import { TextEncoder, TextDecoder } from 'util';
+import { FileSystemMain } from '../common/plugin-api-rpc';
+import { UriComponents } from '../common/uri-components';
+import { FileSystemError } from './types-impl';
+
+/**
+ * This class is managing FileSystem proxy
+ */
+export class InPluginFileSystemProxy implements theia.FileSystem {
+
+    private proxy: FileSystemMain;
+
+    constructor(proxy: FileSystemMain) {
+        this.proxy = proxy;
+    }
+
+    async readFile(uri: UriComponents): Promise<Uint8Array> {
+        try {
+            const val = await this.proxy.$readFile(uri);
+            return new TextEncoder().encode(val);
+        } catch (error) {
+            throw this.handleError(error);
+        }
+    }
+    async writeFile(uri: UriComponents, content: Uint8Array): Promise<void> {
+        const encoded = new TextDecoder().decode(content);
+
+        try {
+            await this.proxy.$writeFile(uri, encoded);
+        } catch (error) {
+            throw this.handleError(error);
+        }
+    }
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    handleError(error: any): Error {
+        if (!(error instanceof Error)) {
+            return new FileSystemError(String(error));
+        }
+
+        // file system error
+        return new FileSystemError(error.message, error.name);
+    }
+
+}

--- a/packages/plugin-ext/src/plugin/plugin-context.ts
+++ b/packages/plugin-ext/src/plugin/plugin-context.ts
@@ -387,6 +387,11 @@ export function createAPIFactory(
         };
 
         const workspace: typeof theia.workspace = {
+
+            get fs(): theia.FileSystem {
+                return fileSystemExt.fs;
+            },
+
             get rootPath(): string | undefined {
                 return workspaceExt.rootPath;
             },

--- a/packages/plugin/src/theia.d.ts
+++ b/packages/plugin/src/theia.d.ts
@@ -4506,6 +4506,33 @@ declare module '@theia/plugin' {
     }
 
     /**
+     * The file system interface exposes the editor's built-in and contributed
+     * [file system providers](#FileSystemProvider). It allows extensions to work
+     * with files from the local disk as well as files from remote places, like the
+     * remote extension host or ftp-servers.
+     *
+     * *Note* that an instance of this interface is avaiable as [`workspace.fs`](#workspace.fs).
+     */
+    export interface FileSystem {
+
+        /**
+         * Read the entire contents of a file.
+         *
+         * @param uri The uri of the file.
+         * @return An array of bytes or a PromiseLike that resolves to such.
+         */
+        readFile(uri: Uri): PromiseLike<Uint8Array>;
+
+        /**
+         * Write data to a file, replacing its entire contents.
+         *
+         * @param uri The uri of the file.
+         * @param content The new content of the file.
+         */
+        writeFile(uri: Uri, content: Uint8Array): PromiseLike<void>;
+    }
+
+    /**
      * Namespace for dealing with the current workspace. A workspace is the representation
      * of the folder that has been opened. There is no workspace when just a file but not a
      * folder has been opened.
@@ -4515,6 +4542,14 @@ declare module '@theia/plugin' {
      * the editor-process so that they should be always used instead of nodejs-equivalents.
      */
     export namespace workspace {
+
+        /**
+         * A [file system](#FileSystem) instance that allows to interact with local and remote
+         * files, e.g. `workspace.fs.readDirectory(someUri)` allows to retrieve all entries
+         * of a directory or `workspace.fs.stat(anotherUri)` returns the meta data for a
+         * file.
+         */
+        export const fs: FileSystem;
 
         /**
          * ~~The folder that is open in the editor. `undefined` when no folder


### PR DESCRIPTION

#### What it does
Implements `workspace.fs`for readFile and writeFile

#### How to test

readFile
```typescript
        const sampleTxtAbsolutePath = context.asAbsolutePath('sample.txt');
	const fileToUse = vscode.Uri.file(sampleTxtAbsolutePath);
	let sampleTextEncoded = await vscode.workspace.fs.readFile(fileToUse);
	let sampleText = new util.TextDecoder('utf-8').decode(sampleTextEncoded);
```

writeFile
```typescript
	const sampleTxtToWriteAbsolutePath = context.asAbsolutePath('sampleToWrite.txt');
	const fileToWrite = vscode.Uri.file(sampleTxtToWriteAbsolutePath);
	const contentToWrite = new util.TextEncoder().encode('Hello World');
	await vscode.workspace.fs.writeFile(fileToWrite, contentToWrite);
```

For other methods like stat, etc, need to revise Theia core stuff as Theia is not providing enough stats info for example

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

Change-Id: I1626547e72b8230bbc0a1832f682ebc18f2b22dc
Signed-off-by: Florent Benoit <fbenoit@redhat.com>
