### PR TITLE
Added a config for disabling the window reload

### DIFF
--- a/dev-packages/application-manager/src/generator/frontend-generator.ts
+++ b/dev-packages/application-manager/src/generator/frontend-generator.ts
@@ -127,10 +127,11 @@ process.env.LC_NUMERIC = 'C';
 const electron = require('electron');
 const { join, resolve } = require('path');
 const { fork } = require('child_process');
-const { app, dialog, shell, BrowserWindow, ipcMain, Menu } = electron;
+const { app, dialog, shell, BrowserWindow, ipcMain, Menu, globalShortcut } = electron;
 
 const applicationName = \`${this.pck.props.frontend.config.applicationName}\`;
 const isSingleInstance = ${this.pck.props.backend.config.singleInstance === true ? 'true' : 'false'};
+const disallowReloadKeybinding = ${this.pck.props.frontend.config.disallowReloadKeybinding === true ? 'true' : 'false'};
 
 if (isSingleInstance && !app.requestSingleInstanceLock()) {
     // There is another instance running, exit now. The other instance will request focus.
@@ -143,6 +144,11 @@ const Storage = require('electron-store');
 const electronStore = new Storage();
 
 app.on('ready', () => {
+
+    if (disallowReloadKeybinding) {
+        globalShortcut.register('CmdOrCtrl+R', () => {});
+    }
+
     // Explicitly set the app name to have better menu items on macOS. ("About", "Hide", and "Quit")
     // See: https://github.com/electron-userland/electron-builder/issues/2468
     app.setName(applicationName);

--- a/dev-packages/application-package/src/application-props.ts
+++ b/dev-packages/application-package/src/application-props.ts
@@ -109,6 +109,12 @@ export interface FrontendApplicationConfig extends ApplicationConfig {
      */
     readonly applicationName: string;
 
+    /**
+     * If set to `true`, reloading the current browser window won't be possible with the `Ctrl/Cmd + R` keybinding.
+     * It is `false` by default. Has no effect if not in an electron environment.
+     */
+    readonly disallowReloadKeybinding?: boolean;
+
 }
 
 /**


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

Set the `disallowReloadKeybinding` application config to `true` if you
want to disable the browser window reload with `Ctrl/Cmd+R`.

The config does not affect the behavior of the app if it is running
in a browser environment.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

Modify your `package.json` for the electron example, and try to reload with `Ctrl/Cmd+R`:
```diff
git diff ./examples/electron/package.json 
diff --git a/examples/electron/package.json b/examples/electron/package.json
index ffb2ba700..b5271db01 100644
--- a/examples/electron/package.json
+++ b/examples/electron/package.json
@@ -7,7 +7,8 @@
     "target": "electron",
     "frontend": {
       "config": {
-        "applicationName": "Theia Electron Example"
+        "applicationName": "Theia Electron Example",
+        "disallowReloadKeybinding": true
       }
     }
   },
```

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

