### PR TITLE
fix plugin header container alignment

### DIFF
--- a/packages/plugin-ext/src/main/browser/style/index.css
+++ b/packages/plugin-ext/src/main/browser/style/index.css
@@ -34,10 +34,6 @@
     flex-direction: column;
 }
 
-.pluginHeaderContainer {
-    margin-bottom: 5px;
-}
-
 .theia-plugin-test-tab-icon {
     -webkit-mask: url('test.svg');
     mask: url('test.svg');

--- a/packages/plugin-ext/src/main/browser/style/plugin-sidebar.css
+++ b/packages/plugin-ext/src/main/browser/style/plugin-sidebar.css
@@ -28,7 +28,7 @@
 }
 
 .theia-plugins .pluginHeaderContainer {
-    padding: 3px 15px;
+    padding: 5px 15px;
     font-size: var(--theia-ui-font-size0);
     border-bottom: 1px solid;
 }


### PR DESCRIPTION
Signed-off-by: Doron Nahari <doron.nahari@sap.com>

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
In the plugins view (view -> plugins), when hovering on one of the plugins you can see that the hover color is not applied on all of the plugin container.

This pr fixes the alignment of each plugin container. the hover color fixed accordingly.
You can see the gap changes between the container and the border in the before and after images.

Before:
<img width="306" alt="Screen Shot 2020-01-28 at 0 28 41" src="https://user-images.githubusercontent.com/24614792/73265275-4c2fcb80-41dd-11ea-9357-0b682df1a1be.png">
![Screen Shot 2020-01-28 at 14 55 22](https://user-images.githubusercontent.com/24614792/73265898-8352ac80-41de-11ea-9786-acc545c35a2e.png)


After:
<img width="302" alt="Screen Shot 2020-01-28 at 0 44 13" src="https://user-images.githubusercontent.com/24614792/73265283-54880680-41dd-11ea-891d-b3c9b4c6e344.png">
![Screen Shot 2020-01-28 at 14 56 47](https://user-images.githubusercontent.com/24614792/73265908-88176080-41de-11ea-899d-9302fa8eefea.png)

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
Deploy some plugins to Theia. go to the plugins view (view -> plugins) hover on one of the plugins.
#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

