### PR TITLE
Keymaps: adjust keybindings-widget column spacing on firefox

### DIFF
--- a/packages/keymaps/src/browser/style/index.css
+++ b/packages/keymaps/src/browser/style/index.css
@@ -122,7 +122,7 @@
 }
 
 .kb table .th-action {
-    width: 35px;
+    width: 4%;
 }
 
 .kb table .th-label {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
Fixes: [6117](https://github.com/eclipse-theia/theia/issues/6117)

When opened in firefox, there is a large column for action buttons shown, reduced the size of the column just so it can be made consistent with other browsers.

Signed-off-by: Muhammad Anas Shahid <muhammad.shahid@ericsson.com>


#### How to test

- Try to open keyboard shortcuts on Firefox and Google Chrome(File>Settings>Open Keyboard Shortcuts )

- Identify the difference in the size of the first column

- This issue fixes the width of the column in Firefox and makes it equal with that of Chrome 

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

