### PR TITLE
[eslint] fix bogus enable no-any rules

### DIFF
--- a/packages/core/src/common/event.ts
+++ b/packages/core/src/common/event.ts
@@ -251,7 +251,7 @@ export interface WaitUntilEvent {
      * @param thenable A thenable that delays execution.
      */
     waitUntil(thenable: Promise<any>): void;
-    // tslint:enable:no-any
+    /* eslint-enable @typescript-eslint/no-explicit-any */
 }
 export namespace WaitUntilEvent {
     export async function fire<T extends WaitUntilEvent>(

--- a/packages/monaco/src/browser/monaco-theming-service.ts
+++ b/packages/monaco/src/browser/monaco-theming-service.ts
@@ -92,7 +92,7 @@ export class MonacoThemingService {
         pending: { [uri: string]: Promise<any> },
         toDispose: DisposableCollection
     ): Promise<any> {
-        // tslint:enabled:no-any
+        /* eslint-enable @typescript-eslint/no-explicit-any */
         const { content } = await this.fileSystem.resolveContent(uri);
         if (toDispose.disposed) {
             return;
@@ -122,6 +122,7 @@ export class MonacoThemingService {
         return json;
     }
 
+    /* eslint-disable @typescript-eslint/no-explicit-any */
     protected doLoadTheme(
         themeUri: URI,
         referencedPath: string,
@@ -135,6 +136,7 @@ export class MonacoThemingService {
         }
         return pending[referencedUri];
     }
+    /* eslint-enable @typescript-eslint/no-explicit-any */
 
     static init(): void {
         this.updateBodyUiTheme();

--- a/packages/plugin-ext/src/common/types.ts
+++ b/packages/plugin-ext/src/common/types.ts
@@ -79,7 +79,7 @@ export function es5ClassCompat<T extends Function>(target: T): T {
     Object.setPrototypeOf(_.prototype, target.prototype);
     return _ as unknown as T;
 }
-// tslint:enable:no-any
+/* eslint-enable @typescript-eslint/no-explicit-any */
 const _typeof = {
     number: 'number',
     string: 'string',

--- a/packages/plugin-ext/src/plugin/command-registry.ts
+++ b/packages/plugin-ext/src/plugin/command-registry.ts
@@ -110,7 +110,7 @@ export class CommandRegistryImpl implements CommandRegistryExt {
             return this.proxy.$executeCommand(id, ...args);
         }
     }
-    // tslint:enable:no-any
+    /* eslint-enable @typescript-eslint/no-explicit-any */
 
     getKeyBinding(commandId: string): PromiseLike<theia.CommandKeyBinding[] | undefined> {
         return this.proxy.$getKeyBinding(commandId);

--- a/packages/plugin-ext/src/plugin/documents.ts
+++ b/packages/plugin-ext/src/plugin/documents.ts
@@ -152,7 +152,7 @@ export class DocumentsExtImpl implements DocumentsExt {
             }
         }));
     }
-    // tslint:enable:no-any
+    /* eslint-enable  @typescript-eslint/no-explicit-any */
 
     $acceptDirtyStateChanged(strUrl: UriComponents, isDirty: boolean): void {
         const uri = URI.revive(strUrl);


### PR DESCRIPTION

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

 Fixes #7005

Fixed bogus `enable` check for the `no-any` rule.
Before, one can use `any` after it was disabled since the re-enabling of the rule was incorrect.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

Fixes block `enable`/`disable` rules for `no-any`:
Try to use `any` after one of the blocks, it should result in an error.

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)


Signed-off-by: vince-fugnitto <vincent.fugnitto@ericsson.com>
