### PR TITLE
[firefox] incorrect display of workspace settings file icon

### DIFF
--- a/packages/preferences/src/browser/preferences-tree-widget.ts
+++ b/packages/preferences/src/browser/preferences-tree-widget.ts
@@ -344,7 +344,7 @@ export class PreferencesEditorsContainer extends DockPanel {
         if (workspacePreferences) {
             workspacePreferences.title.label = 'Workspace';
             workspacePreferences.title.caption = `Workspace Preferences: ${await this.getPreferenceEditorCaption(workspacePreferenceUri!)}`;
-            workspacePreferences.title.iconClass = 'database-icon medium-yellow file-icon';
+            workspacePreferences.title.iconClass = 'database-icon medium-yellow theia-file-icons-js file-icon';
             workspacePreferences.editor.setLanguage('jsonc');
             workspacePreferences.scope = PreferenceScope.Workspace;
         }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
Fixes: [#6990](https://github.com/eclipse-theia/theia/issues/6990)

When opening the prefence widget, the file icon size for workspace was not consistent with that of "User" so added a css class to the workspace preference and now it works for browsers I could test on such as Chrome and Firefox.

Signed-off-by: Muhammad Anas Shahid <muhammad.shahid@ericsson.com>


#### How to test

- start the application on Firefox with a workspace (ex: theia)
- open the `preferences widget`
- notice the workspace tab's icon is displayed too large
- After the patch, the size looks consistent. 


#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

