### PR TITLE
fix #6996 TOGGLE_MAXIMIZED overrides monaco tab capture

### DIFF
--- a/packages/core/src/browser/common-frontend-contribution.ts
+++ b/packages/core/src/browser/common-frontend-contribution.ts
@@ -726,7 +726,7 @@ export class CommonFrontendContribution implements FrontendApplicationContributi
             },
             {
                 command: CommonCommands.TOGGLE_MAXIMIZED.id,
-                keybinding: 'ctrl+m',
+                keybinding: 'alt+m',
             },
             // Saving
             {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does

Change modifies the default TOGGLE_MAXIMIZED keybinding from ctrl+m to
alt+m to ensure it does not overwrite a11y feature of Monaco "toggle tab
key moves focus".

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

1. Open Theia
2. Open a file for edit
3. Issue Ctrl+m

Observe pressing the tab key changes focus as opposed to sending a tab to the editor.

4. Focus the editor
5. Issue alt+m

Observe toggle maximize works as intended.

#### Review checklist

- [X] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

