### PR TITLE
FIX Issue 6997 - workbench.action.closeEditorsInGroup command

### DIFF
--- a/packages/plugin-ext-vscode/src/browser/plugin-vscode-commands-contribution.ts
+++ b/packages/plugin-ext-vscode/src/browser/plugin-vscode-commands-contribution.ts
@@ -268,7 +268,7 @@ export class PluginVscodeCommandsContribution implements CommandContribution {
                     const tabBar = this.shell.getTabBarFor(editor);
                     if (tabBar) {
                         this.shell.closeTabs(tabBar,
-                            ({ owner }) => CodeEditorWidget.is(owner) && owner !== editor
+                            ({ owner }) => CodeEditorWidget.is(owner)
                         );
                     }
                 }


### PR DESCRIPTION
FIX Issue 6997 - workbench.action.closeEditorsInGroup command

Signed-off-by: Tomer Epstein <tomer.epstein@sap.com>

Fixes: https://github.com/eclipse-theia/theia/issues/6997

#### What it does
This change proposal adds a fix to closeEditorsInGroup command doesn't close it self (the current Widget)


#### How to test

1.  git clone https://github.com/tomer-epstein/vscode-close-editor.git
2. cd vscode-close-editor && npm run compile && npm run package
3. copy vscode-close-editor-0.0.1.vsix to plugins folder
4. Click on a editor title (right) , choose 'VSCode Close Editors In Group'.

![image](https://user-images.githubusercontent.com/57438361/73452693-13c1f600-4373-11ea-8e8e-510fc1060aac.png)


#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

