### PR TITLE
Centered file icons in the sidebars

### DIFF
--- a/packages/filesystem/src/browser/style/file-icons.css
+++ b/packages/filesystem/src/browser/style/file-icons.css
@@ -41,5 +41,10 @@
 
 .theia-app-sides .theia-file-icons-js:before {
     font-size: var(--theia-private-sidebar-icon-size);
-    margin-right: 0px;
+    position: absolute;
+}
+
+.p-TabBar-content .p-TabBar-tab .theia-tab-icon-label .theia-file-icons-js.file-icon {
+    position: relative;
+    top: -2px !important;
 }


### PR DESCRIPTION
Fixes: #4712 

#### What it does
- Fix alignment for the file icons in the sidebars to make sure they are all centered

#### How to test
- Move editors (ex: settings.json) and dock them in the sidepanels.

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
