### PR TITLE
[scm] fix alignment of file-icons

### DIFF
--- a/packages/scm/src/browser/style/index.css
+++ b/packages/scm/src/browser/style/index.css
@@ -198,10 +198,6 @@
     color: var(--theia-list-inactiveSelectionForeground);
 }
 
-.theia-scm .scmItem .file-icon {
-    display: initial;
-}
-
 .theia-scm .scmItem .path {
     font-size: var(--theia-ui-font-size0);
     margin-left: var(--theia-ui-padding);
@@ -215,6 +211,7 @@
     padding-bottom: 2px;
     font-size: var(--theia-ui-font-size0);
 }
+
 .scm-change-count {
     float: right;
 }


### PR DESCRIPTION

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
Fixes: [#7034](https://github.com/eclipse-theia/theia/issues/7034)
When theme of "File Icon(Theia) " is selected, there is a offset in the icon and the text, removed one css property to align everything.

Signed-off-by: Muhammad Anas Shahid <muhammad.shahid@ericsson.com>

#### How to test

    open a workspace under git source control (ex: theia)
    perform arbitrary changes on any number of files
    open the scm view
    notice that the file-icons in the changes are aligned now


#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

