### PR TITLE
Search: cancel operation if the query is empty

### DIFF
--- a/packages/file-search/src/node/file-search-service-impl.ts
+++ b/packages/file-search/src/node/file-search-service-impl.ts
@@ -33,6 +33,10 @@ export class FileSearchServiceImpl implements FileSearchService {
         @inject(RawProcessFactory) protected readonly rawProcessFactory: RawProcessFactory) { }
 
     async find(searchPattern: string, options: FileSearchService.Options, clientToken?: CancellationToken): Promise<string[]> {
+        if (searchPattern === '') {
+            return [];
+        }
+
         const cancellationSource = new CancellationTokenSource();
         if (clientToken) {
             clientToken.onCancellationRequested(() => cancellationSource.cancel());


### PR DESCRIPTION
Signed-Off-By: Reece Dunham <me@rdil.rocks>

Don't continue the search if there is no query (just for performance reasons so this logic doesn't actually need to be run)
