### PR TITLE
Keymaps: Keyboard shortcuts text is too small

### DIFF
--- a/packages/keymaps/src/browser/style/index.css
+++ b/packages/keymaps/src/browser/style/index.css
@@ -70,7 +70,7 @@
     padding: 2px 10px 5px 10px;
 }
 
-.th-label, .th-source, .th-context,
+.th-label, .th-source, .th-context, .th-keybinding, 
 .kb-label, .kb-source, .kb-context {
     padding: 2px 10px 5px 10px;
     min-height: 18px;
@@ -84,12 +84,8 @@
     font-size: var(--theia-ui-font-size1);
 }
 
-.kb table td {
-    font-size: calc(var(--theia-ui-font-size1) * 0.85);
-}
-
 .kb table td code {
-    font-size: calc(var(--theia-ui-font-size1) * 0.8);
+    font-size: 90%;
 }
 
 .td-source {
@@ -138,7 +134,7 @@
 }
 
 .kb table .th-context {
-    width: 15%;
+    width: 25%;
 }
 
 .message-container {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
Issue ID: #7051
Fixed the sizing of the font, as well as the spacing of each column just so we can utilize the empty spaces in filling up other column's data and still look clean.

Signed-off-by: Muhammad Anas Shahid <muhammad.shahid@ericsson.com>

#### How to test
```

- Open keyboard shortcuts by going to File>Settings>Open Keyboard Shortcuts

- The font size of the context/when has been increased by a slight amount, and the columns are resized.

```

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

