### PR TITLE
mini-browser: do not start http server

### DIFF
--- a/dev-packages/application-manager/src/generator/frontend-generator.ts
+++ b/dev-packages/application-manager/src/generator/frontend-generator.ts
@@ -132,7 +132,8 @@ process.env.LC_NUMERIC = 'C';
 const electron = require('electron');
 const { join, resolve } = require('path');
 const { fork } = require('child_process');
-const { app, dialog, shell, BrowserWindow, ipcMain, Menu, globalShortcut } = electron;
+const { app, dialog, shell, BrowserWindow, ipcMain, Menu, globalShortcut } = electron;${this.ifElectron(`
+const { ElectronSecurityToken } = require('@theia/core/lib/electron-common/electron-token');`)}
 
 const applicationName = \`${this.pck.props.frontend.config.applicationName}\`;
 const isSingleInstance = ${this.pck.props.backend.config.singleInstance === true ? 'true' : 'false'};

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -10,6 +10,7 @@
     "@primer/octicons-react": "^9.0.0",
     "@theia/application-package": "^0.15.0",
     "@types/body-parser": "^1.16.4",
+    "@types/cookie": "^0.3.3",
     "@types/express": "^4.16.0",
     "@types/fs-extra": "^4.0.2",
     "@types/lodash.debounce": "4.0.3",
@@ -22,6 +23,7 @@
     "@types/yargs": "^11.1.0",
     "ajv": "^6.5.3",
     "body-parser": "^1.17.2",
+    "cookie": "^0.4.0",
     "es6-promise": "^4.2.4",
     "express": "^4.16.3",
     "file-icons-js": "^1.0.3",
@@ -61,6 +63,10 @@
       "frontend": "lib/browser/keyboard/browser-keyboard-module",
       "frontendElectron": "lib/electron-browser/keyboard/electron-keyboard-module",
       "backendElectron": "lib/electron-node/keyboard/electron-backend-keyboard-module"
+    },
+    {
+      "frontendElectron": "lib/electron-browser/token/electron-token-frontend-module",
+      "backendElectron": "lib/electron-node/token/electron-token-backend-module"
     }
   ],
   "keywords": [

--- a/packages/core/src/common/promise-util.ts
+++ b/packages/core/src/common/promise-util.ts
@@ -27,3 +27,31 @@ export class Deferred<T> {
         this.reject = reject;
     });
 }
+
+/**
+ * DeferredSync exposes an async value in a synchronous way.
+ */
+export class DeferredSync<T> {
+
+    resolved: boolean;
+    value?: T;
+    error?: any; // eslint-disable-line @typescript-eslint/no-explicit-any
+
+    resolve: (value?: T) => void;
+    reject: (error?: any) => void; // eslint-disable-line @typescript-eslint/no-explicit-any
+
+    promise = new Promise<T>((resolve, reject) => {
+        this.resolve = (value: T) => {
+            if (!this.resolved) {
+                this.resolved = true;
+                resolve(this.value = value);
+            }
+        };
+        this.reject = (error: any) => { // eslint-disable-line @typescript-eslint/no-explicit-any
+            if (!this.resolved) {
+                this.resolved = true;
+                reject(this.error = error);
+            }
+        };
+    });
+}

--- a/packages/core/src/electron-browser/messaging/electron-messaging-frontend-module.ts
+++ b/packages/core/src/electron-browser/messaging/electron-messaging-frontend-module.ts
@@ -14,13 +14,42 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
-import { ContainerModule } from 'inversify';
+import * as electron from 'electron';
+import { interfaces, ContainerModule } from 'inversify';
+import { DeferredSync } from '../../common/promise-util';
+import { ElectronSecurityToken, ElectronSecurityTokenChannels } from '../../electron-common/electron-token';
 import { FrontendApplicationContribution } from '../../browser/frontend-application';
 import { WebSocketConnectionProvider } from '../../browser/messaging/ws-connection-provider';
 import { ElectronWebSocketConnectionProvider } from './electron-ws-connection-provider';
 
 export const messagingFrontendModule = new ContainerModule(bind => {
+    bind<ElectronSecurityToken>(ElectronSecurityToken).toConstantValue().inSingletonScope();
     bind(ElectronWebSocketConnectionProvider).toSelf().inSingletonScope();
     bind(FrontendApplicationContribution).toService(ElectronWebSocketConnectionProvider);
     bind(WebSocketConnectionProvider).toService(ElectronWebSocketConnectionProvider);
 });
+
+/**
+ * Factory for the deferred value of the ElectronSecurityToken.
+ */
+export function ElectronSecurityTokenRequestFactory(ctx: interfaces.Context): DeferredSync<ElectronSecurityToken> {
+
+    // Attach a one-time listener to get the response for our token request:
+    const tokenRequest = new DeferredSync<ElectronSecurityToken>();
+
+    // Fool-guard:
+    const timeout = setTimeout(() => {
+        tokenRequest.reject(new Error('electron token timeout'));
+    }, 5000);
+
+    // Backend should answer our token request:
+    electron.ipcRenderer.once(ElectronSecurityTokenChannels.Response, (event: electron.Event, response: ElectronSecurityToken) => {
+        clearTimeout(timeout);
+        tokenRequest.resolve(response);
+    });
+
+    // Send token request:
+    electron.ipcRenderer.send(ElectronSecurityTokenChannels.Request);
+
+    return tokenRequest;
+}

--- a/packages/core/src/electron-browser/token/electron-token-frontend-contribution.ts
+++ b/packages/core/src/electron-browser/token/electron-token-frontend-contribution.ts
@@ -1,0 +1,21 @@
+/********************************************************************************
+ * Copyright (C) 2020 Ericsson and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import { FrontendApplicationContribution } from '../../browser';
+
+export class ElectronTokenFrontendContribution implements FrontendApplicationContribution {
+
+}

--- a/packages/core/src/electron-browser/token/electron-token-frontend-module.ts
+++ b/packages/core/src/electron-browser/token/electron-token-frontend-module.ts
@@ -1,0 +1,21 @@
+/********************************************************************************
+ * Copyright (C) 2020 Ericsson and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import { ContainerModule } from 'inversify';
+
+export default new ContainerModule((bind, unbind, isBound, rebind) => {
+
+});

--- a/packages/core/src/electron-common/electron-token.ts
+++ b/packages/core/src/electron-common/electron-token.ts
@@ -1,0 +1,40 @@
+/********************************************************************************
+ * Copyright (C) 2020 Ericsson and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+/**
+ * This token is unique the the current running instance. It is used by the backend
+ * to make sure it is an electron browser window that is connecting to its services.
+ *
+ * The identifier is a string, which makes it usable as a key for cookies or similar.
+ */
+export const ElectronSecurityToken = 'x-theia-electron-token';
+export interface ElectronSecurityToken {
+    value: string;
+};
+
+export namespace ElectronSecurityTokenChannels {
+
+    /**
+     * Channel name used when requesting the electron security token.
+     */
+    export const Request = 'theia-electron-token-request';
+
+    /**
+     * Channel name used when responding to the electron security token request.
+     */
+    export const Response = 'theia-electron-token-response';
+
+}

--- a/packages/core/src/electron-node/token/electron-token-backend-contribution.ts
+++ b/packages/core/src/electron-node/token/electron-token-backend-contribution.ts
@@ -1,0 +1,91 @@
+/********************************************************************************
+ * Copyright (C) 2020 Ericsson and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import * as ws from 'ws';
+import * as url from 'url';
+import * as http from 'http';
+import * as electron from 'electron';
+import * as querystring from 'querystring';
+import express = require('express');
+import { injectable, inject } from 'inversify';
+import { BackendApplicationContribution } from '../../node';
+import { MessagingContribution } from '../../node/messaging/messaging-contribution';
+import { ElectronTokenValidator } from './electron-token-validator';
+import { ElectronSecurityTokenChannels, ElectronSecurityToken } from '../../electron-common/electron-token';
+
+/**
+ * This component contributes a middleware that will refuse all requests that do not include a specific token.
+ */
+@injectable()
+export class ElectronTokenBackendContribution implements BackendApplicationContribution {
+
+    @inject(ElectronSecurityToken)
+    protected readonly token: ElectronSecurityToken;
+
+    @inject(ElectronTokenValidator)
+    protected readonly tokenValidator: ElectronTokenValidator;
+
+    configure(app: express.Application): void {
+        this.ipcServer();
+        app.use(this.expressMiddleware.bind(this));
+    }
+
+    /**
+     * Hooks listeners to respond to IPC requests for the security token.
+     */
+    protected ipcServer(): void {
+        electron.ipcMain.on(ElectronSecurityTokenChannels.Request, (event: electron.Event) => {
+            event.sender.send(ElectronSecurityTokenChannels.Response, this.token);
+        });
+    }
+
+    /**
+     * Only allow token-bearers.
+     */
+    protected expressMiddleware(req: express.Request, res: express.Response, next: express.NextFunction): void {
+        if (this.tokenValidator.allowRequest(req)) {
+            console.error(`refused an http request: ${req.connection.remoteAddress}`);
+            res.sendStatus(403);
+        } else {
+            next();
+        }
+    }
+
+}
+
+/**
+ * Override the browser MessagingContribution class to refuse connections that do not include a specific token.
+ */
+@injectable()
+export class ElectronMessagingContribution extends MessagingContribution {
+
+    @inject(ElectronTokenValidator)
+    protected readonly tokenValidator: ElectronTokenValidator;
+
+    /**
+     * The Browser API doesn't allow us to define custom headers.
+     * Then, in order to authorize a connect, we will expect the first message to contain a token.
+     */
+    protected handleConnection(socket: ws, request: http.IncomingMessage): void {
+        if (this.tokenValidator.allowRequest(request)) {
+            super.handleConnection(socket, request);
+        } else {
+            console.error(`refused a websocket connection: ${request.connection.remoteAddress}`);
+            socket.close();
+        }
+    }
+
+}

--- a/packages/core/src/electron-node/token/electron-token-backend-module.ts
+++ b/packages/core/src/electron-node/token/electron-token-backend-module.ts
@@ -1,0 +1,32 @@
+/********************************************************************************
+ * Copyright (C) 2020 Ericsson and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import uuid = require('uuid');
+import { ContainerModule } from 'inversify';
+import { MessagingContribution } from '../../node/messaging/messaging-contribution';
+import { ElectronSecurityToken } from '../../electron-common/electron-token';
+import { ElectronMessagingContribution, ElectronTokenBackendContribution } from './electron-token-backend-contribution';
+import { BackendApplicationContribution, MessagingService } from '../../node';
+import { ElectronTokenValidator } from './electron-token-validator';
+
+export default new ContainerModule((bind, unbind, isBound, rebind) => {
+    bind<BackendApplicationContribution>(BackendApplicationContribution).to(ElectronTokenBackendContribution).inSingletonScope();
+    bind<ElectronTokenValidator>(ElectronTokenValidator).toSelf().inSingletonScope();
+    bind<ElectronSecurityToken>(ElectronSecurityToken).toConstantValue({
+        value: uuid.v4(), // should change on each run.
+    });
+    rebind<MessagingContribution>(MessagingService.Identifier).to(ElectronMessagingContribution).inSingletonScope();
+});

--- a/packages/core/src/electron-node/token/electron-token-validator.ts
+++ b/packages/core/src/electron-node/token/electron-token-validator.ts
@@ -1,0 +1,60 @@
+/********************************************************************************
+ * Copyright (C) 2020 Ericsson and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import * as url from 'url';
+import * as http from 'http';
+import * as querystring from 'querystring';
+import { injectable, inject } from 'inversify';
+import { ElectronSecurityToken } from '../../electron-common/electron-token';
+
+/**
+ * On Electron, we want to make sure that only electron windows access the backend services.
+ */
+@injectable()
+export class ElectronTokenValidator {
+
+    @inject(ElectronSecurityToken)
+    protected readonly electronSecurityToken: ElectronSecurityToken;
+
+    allowRequest(request: http.IncomingMessage): boolean {
+        const token = this.extractTokenFromRequest(request);
+        return typeof token !== 'undefined' && this.isTokenValid(token);
+    }
+
+    isTokenValid(token: ElectronSecurityToken): boolean {
+        return token.value === this.electronSecurityToken.value;
+    }
+
+    /**
+     * Expects the token to be passed via url query.
+     */
+    protected extractTokenFromRequest(request: http.IncomingMessage): ElectronSecurityToken | undefined {
+        const query = request.url ? url.parse(request.url).query : undefined;
+        const token = query && querystring.parse(query)[ElectronSecurityToken];
+        return this.parseToken(token);
+    }
+
+    /**
+     * Expects raw token data to be the actual token.
+     */
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    protected parseToken(data: any): ElectronSecurityToken | undefined {
+        return typeof data === 'string' ? {
+            value: data,
+        } : undefined;
+    }
+
+}

--- a/packages/core/src/node/messaging/messaging-backend-module.ts
+++ b/packages/core/src/node/messaging/messaging-backend-module.ts
@@ -24,11 +24,11 @@ import { MessagingService } from './messaging-service';
 export const messagingBackendModule = new ContainerModule(bind => {
     bindContributionProvider(bind, ConnectionContainerModule);
     bindContributionProvider(bind, MessagingService.Contribution);
+    bind(MessagingService.Identifier).to(MessagingContribution).inSingletonScope();
     bind(MessagingContribution).toDynamicValue(({ container }) => {
         const child = container.createChild();
         child.bind(MessagingContainer).toConstantValue(container);
-        child.bind(MessagingContribution).toSelf();
-        return child.get(MessagingContribution);
+        return child.get(MessagingService.Identifier);
     }).inSingletonScope();
     bind(BackendApplicationContribution).toService(MessagingContribution);
 });

--- a/packages/core/src/node/messaging/messaging-service.ts
+++ b/packages/core/src/node/messaging/messaging-service.ts
@@ -46,6 +46,8 @@ export interface MessagingService {
     ws(path: string, callback: (params: MessagingService.PathParams, socket: ws) => void): void;
 }
 export namespace MessagingService {
+    /** Inversify container identifier for the `MessagingService` component. */
+    export const Identifier = Symbol('MessagingService');
     export interface PathParams {
         [name: string]: string
     }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1098,6 +1098,11 @@
   dependencies:
     "@types/node" "*"
 
+"@types/cookie@^0.3.3":
+  version "0.3.3"
+  resolved "https://registry.yarnpkg.com/@types/cookie/-/cookie-0.3.3.tgz#85bc74ba782fb7aa3a514d11767832b0e3bc6803"
+  integrity sha512-LKVP3cgXBT9RYj+t+9FDKwS5tdI+rPBXaNSkma7hvqy35lc7mAokC2zsqWJH0LaqIt3B962nuYI77hsJoT1gow==
+
 "@types/decompress@^4.2.2":
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/@types/decompress/-/decompress-4.2.3.tgz#98eed48af80001038aa05690b2094915f296fe65"
@@ -4152,7 +4157,7 @@ cookie-signature@1.0.6:
   resolved "https://registry.yarnpkg.com/cookie-signature/-/cookie-signature-1.0.6.tgz#e303a882b342cc3ee8ca513a79999734dab3ae2c"
   integrity sha1-4wOogrNCzD7oylE6eZmXNNqzriw=
 
-cookie@0.4.0:
+cookie@0.4.0, cookie@^0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/cookie/-/cookie-0.4.0.tgz#beb437e7022b3b6d49019d088665303ebe9c14ba"
   integrity sha512-+Hp8fLp57wnUSt0tY0tHEXh4voZRDnoIrZPqlo3DPiI4y9lwg/jqx+1Om94/W6ZaPDOUbnjOt/99w66zk+l1Xg==


### PR DESCRIPTION
Signed-off-by: Paul Maréchal <paul.marechal@ericsson.com>

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does

HTTP endpoint is opened for browser apps but not for electron since we don't need it.

See [bugzilla](https://bugs.eclipse.org/bugs/show_bug.cgi?id=551747).

#### How to test

Preview html files and inspect the iframe's url using chrome/ff dev-tools: The `file:` scheme should be used on electron, and `http:` should be used in the browser (remote scenario).

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)