### PR TITLE
core: fix import in `lsp-types.ts`

### DIFF
--- a/packages/core/src/common/lsp-types.ts
+++ b/packages/core/src/common/lsp-types.ts
@@ -14,7 +14,7 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
-import { Range } from 'vscode-languageserver-protocol';
+import { Range } from 'vscode-languageserver-types';
 
 export interface TextDocumentContentChangeDelta {
     readonly range: Range;


### PR DESCRIPTION
Signed-off-by: Paul Maréchal <paul.marechal@ericsson.com>

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does

Fixes an import statement in core to refer to a package that is part of its dependencies.

See https://github.com/eclipse-theia/theia/issues/7056#issuecomment-581516630

#### How to test

This should allow applications relying on core only to correctly build. In the meantime, we can check that `vscode-languageserver-types` is an actual dep of `@theia/core`.

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)