### PR TITLE
[plugin-host] change THEIA_ env exclusion filter

### DIFF
--- a/packages/core/src/node/messaging/ipc-protocol.ts
+++ b/packages/core/src/node/messaging/ipc-protocol.ts
@@ -45,7 +45,7 @@ export function checkParentAlive(): void {
 
 export const ipcEntryPoint = process.env[THEIA_ENTRY_POINT];
 
-const THEIA_ENV_REGEXP_EXCLUSION = new RegExp('THEIA_*');
+const THEIA_ENV_REGEXP_EXCLUSION = new RegExp('^THEIA_*');
 export function createIpcEnv(options?: {
     entryPoint?: string
     env?: NodeJS.ProcessEnv


### PR DESCRIPTION
to match `^THEIA_` instead of `THEIA_`. this allows to access `PREFIX_THEIA_SUFFIX` env vars in plug-ins.

Fixes eclipse-theia/theia#7084


#### How to test
* export `PREFIX_THEIA_FOO` env var before launching theia backend process
* use e.g. python vscode extension to debug some code and execute `import os; print(os.environ['PREFIX_THEIA_FOO'])` to validate

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

