### PR TITLE
plugin-ext: lookup plugins in user home dir

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change Log
 
+## v0.16.0
+
+- [plugin-ext] Plugins are now looked up in `$HOME/.theia/extensions` by default.
+- [plugin-ext] You can specify lookup paths for plugins from the `BackendApplicationConfig.plugins` entry.
+
 ## v0.15.0
 
 - [application-manager] added config to disable reloading windows [#6981](https://github.com/eclipse-theia/theia/pull/6981)

--- a/packages/plugin-ext/README.md
+++ b/packages/plugin-ext/README.md
@@ -1,5 +1,13 @@
 # Theia - Theia - Plugin API
 
+You can configure paths to folders containing plugins:
+
+    - Environment variables: `DEFAULT_THEIA_PLUGINS`, `THEIA_PLUGINS`. Use comma-separated paths.
+    - CLI argument: `--plugins`. Use comma-separated paths.
+    - Backend configuration: `plugins` entry. Array or single string.
+
+Use the `local-dir:` file scheme to refer to paths on your local disk (where the backend is hosted).
+
 See [here](https://www.theia-ide.org/doc/index.html) for a detailed documentation.
 
 ## License


### PR DESCRIPTION
Signed-off-by: Paul Maréchal <paul.marechal@ericsson.com>

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does

Allow configuring plugin locations via backend configuration, and look into the user home by default.

#### How to test

- After running `yarn`, move/rename the `plugins` directory.
- Start the browser application, no plugin should be found.
- Go to `examples/browser/src-gen/main.js` and edit:

```ts
BackendApplicationConfigProvider.set({
    plugins: ['local-dir:../../<renamed-plugin-folder>']
});
```

- Start the browser application, plugins should be found.
- Move the plugin folder to:
  - Windows: `C:\Users\<username>\AppData\Roaming\.theia\extensions`
  - Linux: `/home/<username>/.theia/extensions`
- Start the browser application, plugins should be found.
- Repeat the steps for the electron application.

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)