### PR TITLE
Adjust z-index for the search box in the file tree

### DIFF
--- a/packages/core/src/browser/style/search-box.css
+++ b/packages/core/src/browser/style/search-box.css
@@ -14,7 +14,6 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
-
 .theia-search-box {
     position: absolute;
     top: 0px;
@@ -24,8 +23,8 @@
     box-shadow: var(--theia-border-width) var(--theia-border-width) var(--theia-widget-shadow);
     line-height: var(--theia-private-horizontal-tab-height);
     background-color: var(--theia-editor-background);
-    z-index: 1;
-    border: var(--theia-border-width) solid var(--theia-editor-background)
+    z-index: calc(var(--theia-tabbar-toolbar-z-index) + 1);
+    border: var(--theia-border-width) solid var(--theia-editor-background);
 }
   
 .theia-search-input {

--- a/packages/core/src/browser/style/tabs.css
+++ b/packages/core/src/browser/style/tabs.css
@@ -7,6 +7,7 @@
   --theia-private-horizontal-tab-height: 28.5px;
   --theia-private-horizontal-tab-scrollbar-rail-height: 7px;
   --theia-private-horizontal-tab-scrollbar-height: 5px;
+  --theia-tabbar-toolbar-z-index: 1001;
 }
 
 /*-----------------------------------------------------------------------------
@@ -291,7 +292,7 @@ body.theia-editor-highlightModifiedTabs
 |----------------------------------------------------------------------------*/
 
 .p-TabBar-toolbar {
-  z-index: 1001; /* Due to the scrollbar (`z-index: 1000;`) it has a greater `z-index`. */
+  z-index: var(--theia-tabbar-toolbar-z-index); /* Due to the scrollbar (`z-index: 1000;`) it has a greater `z-index`. */
   display: flex;
   flex-direction: row-reverse;
   padding: 4px;


### PR DESCRIPTION
Fixes #6350

#### What it does
- Modify the z-index for the search box in the explorer tree so that it is displayed at the highest level (above the underlying toolbar items)

#### How to test
- Focus a node on the explorer tree and start typing to open a search within the tree

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

