### PR TITLE
[#6891] Add support for setting the icon of a submenu

### DIFF
--- a/packages/core/src/browser/menu/browser-menu-plugin.ts
+++ b/packages/core/src/browser/menu/browser-menu-plugin.ts
@@ -208,6 +208,9 @@ class DynamicMenuWidget extends MenuWidget {
         if (menu.label) {
             this.title.label = menu.label;
         }
+        if (menu.iconClass) {
+            this.title.iconClass = menu.iconClass;
+        }
         this.updateSubMenus(this, this.menu, this.options.commands);
     }
 

--- a/packages/core/src/common/menu.ts
+++ b/packages/core/src/common/menu.ts
@@ -40,6 +40,10 @@ export namespace MenuAction {
     }
 }
 
+export interface SubMenuOptions {
+    iconClass: string
+}
+
 export type MenuPath = string[];
 
 export const MAIN_MENU_BAR: MenuPath = ['menubar'];
@@ -79,7 +83,7 @@ export class MenuModelRegistry {
         return parent.addNode(actionNode);
     }
 
-    registerSubmenu(menuPath: MenuPath, label: string): Disposable {
+    registerSubmenu(menuPath: MenuPath, label: string, options?: SubMenuOptions): Disposable {
         if (menuPath.length === 0) {
             throw new Error('The sub menu path cannot be empty.');
         }
@@ -89,13 +93,16 @@ export class MenuModelRegistry {
         const parent = this.findGroup(groupPath);
         let groupNode = this.findSubMenu(parent, menuId);
         if (!groupNode) {
-            groupNode = new CompositeMenuNode(menuId, label);
+            groupNode = new CompositeMenuNode(menuId, label, options ? options.iconClass : undefined);
             return parent.addNode(groupNode);
         } else {
             if (!groupNode.label) {
                 groupNode.label = label;
             } else if (groupNode.label !== label) {
                 throw new Error("The group '" + menuPath.join('/') + "' already has a different label.");
+            }
+            if (!groupNode.iconClass && options) {
+                groupNode.iconClass = options.iconClass;
             }
             return { dispose: () => { } };
         }
@@ -182,7 +189,8 @@ export class CompositeMenuNode implements MenuNode {
     protected readonly _children: MenuNode[] = [];
     constructor(
         public readonly id: string,
-        public label?: string
+        public label?: string,
+        public iconClass?: string
     ) { }
 
     get children(): ReadonlyArray<MenuNode> {


### PR DESCRIPTION
**What it does**
This PR adds support for setting the icon class of a submenu when registering it via `MenuModelRegistry`.

**How to test**
Examples:
`registry.registerSubmenu(CommonMenus.FILE_SETTINGS_SUBMENU, 'Settings', { iconClass: "theia-collapse-all-icon" });`
![Screen Shot 2020-02-06 at 10 32 57 AM](https://user-images.githubusercontent.com/6960133/73901314-63ea0c80-48cd-11ea-9da7-78e9cca15fb0.png)
`registry.registerSubmenu(NavigatorContextMenu.OPEN_WITH, 'Open With', { iconClass: "theia-collapse-all-icon" });`
![Screen Shot 2020-02-06 at 10 24 58 AM](https://user-images.githubusercontent.com/6960133/73901355-7f551780-48cd-11ea-8fa3-5f9c6883e08c.png)


Signed-off-by: Vivien Jovet <vivien.jovet@gmail.com>

