### PR TITLE
Removed duplicate Open preview to the side

### DIFF
--- a/packages/preview/src/browser/preview-contribution.ts
+++ b/packages/preview/src/browser/preview-contribution.ts
@@ -225,11 +225,6 @@ export class PreviewContribution extends NavigatableWidgetOpenHandler<PreviewWid
 
     registerToolbarItems(registry: TabBarToolbarRegistry): void {
         registry.registerItem({
-            id: PreviewCommands.OPEN.id,
-            command: PreviewCommands.OPEN.id,
-            tooltip: 'Open Preview to the Side'
-        });
-        registry.registerItem({
             id: PreviewCommands.OPEN_SOURCE.id,
             command: PreviewCommands.OPEN_SOURCE.id,
             tooltip: 'Open Source'


### PR DESCRIPTION
Signed-off-by: Josh Pinkney <joshpinkney@gmail.com>

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->
Currently on master there seems to be duplicate "Open preview to the side" buttons when editing a markdown file. It looks like one comes from the preview extension and the other comes from the builtin vscode markdown extension. This PR opts to remove the one from the preview extension because it causes errors such as: https://github.com/eclipse-theia/theia/issues/7097


#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
If you have a markdown file such as:

```markdown
[test2](test.java)
```
with test.java inside of your workspace and vscode-java as your plugin, when you open the markdown preview and click on the link, the file should have language features working (hover, autocompletion, etc)


#### Review checklist

- [X] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

