### PR TITLE
Added separate commands to close main area widgets (editors)

### DIFF
--- a/packages/core/src/browser/shell/application-shell.ts
+++ b/packages/core/src/browser/shell/application-shell.ts
@@ -829,6 +829,30 @@ export class ApplicationShell extends Widget {
     }
 
     /**
+     * Returns the last active widget in the given shell area.
+     */
+    getCurrentWidget(area: ApplicationShell.Area): Widget | undefined {
+        let title: Title<Widget> | null | undefined;
+        switch (area) {
+            case 'main':
+                title = this.mainPanel.currentTitle;
+                break;
+            case 'bottom':
+                title = this.bottomPanel.currentTitle;
+                break;
+            case 'left':
+                title = this.leftPanelHandler.tabBar.currentTitle;
+                break;
+            case 'right':
+                title = this.rightPanelHandler.tabBar.currentTitle;
+                break;
+            default:
+                throw new Error('Illegal argument: ' + area);
+        }
+        return title ? title.owner : undefined;
+    }
+
+    /**
      * A signal emitted whenever the `currentWidget` property is changed.
      *
      * @deprecated since 0.11.0, use `onDidChangeActiveWidget` instead


### PR DESCRIPTION
#### What it does
Users have been confused by the behavior of the "Close Tab" command invoked with `alt+w`: gitpod-io/gitpod#1180. Changes in this PR to improve this:

 * New Command "Close Editor" closes the current tab in the main area.
 * The keybinding `alt+w` (`ctrl/cmd+w` in Electron) maps to "Close Editor" instead of "Close Tab".
 * Added "Close Editor" to the File menu to align with VS Code.
 * New Command "Close Other Editors" closes all tabs in the main area except the current one.
 * The keybinding `ctrl/cmd+alt+t` maps to "Close Other Editors" instead of "Close Other Tabs".
 * New Command "Close All Editors" closes all tabs in the main area.
 * The keybinding `alt+shift+w` (`ctrl/cmd+k ctrl/cmd+w` in Electron) maps to "Close All Editors" instead of "Close All Tabs".
 * Reverted #4559: "Close All Tabs" always closes the tab bar of the current widget, regardless of the area.

Note that the new commands do not make any difference between editors and non-editor-widgets. While this may seem strange given the names of these commands, I believe it is the best way to achieve a behavior that is as close as possible to VS Code.

What we call the _main_ area corresponds to the _editor_ area in VS Code. The "Close Editor", "Close Other Editors" and "Close All Editors" commands in VS Code actually close tabs in the editor area, regardless of whether it is an editor or other kind of widget (e.g. Markdown preview, Extension details, etc.)

The main differences that remain:

 * In Theia we can drag views such as "Explorer" or "Problems" into the main area. If you do that, they will be affected by the new commands in the same way as editors.
 * In Theia we can drag editors into the left, right or bottom panel. If you do that, they will no longer be affected by the new commands. That means you can close them only by invoking "Close Tab" (via context menu or command palette), or by dragging them back to the main area and then invoking "Close Editor".

#### How to test
Invoke the commands "Close Tab", "Close Editor", "Close Other Tabs", "Close Other Editors", "Close All Tabs" and "Close All Editors" via command palette, keybinding or menu / context menu.

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

