### PR TITLE
[preferences] use text models to update content

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,8 @@ coverage
 errorShots
 examples/*/src-gen
 examples/*/gen-webpack.config.js
+examples/*/.theia
+examples/*/.vscode
 .browser_modules
 **/docs/api
 package-backup.json

--- a/packages/filesystem/src/node/file-change-collection.spec.ts
+++ b/packages/filesystem/src/node/file-change-collection.spec.ts
@@ -22,79 +22,84 @@ import { FileChangeType } from '../common/filesystem-watcher-protocol';
 describe('FileChangeCollection', () => {
 
     assertChanges({
-        first: FileChangeType.ADDED,
-        second: FileChangeType.ADDED,
+        changes: [FileChangeType.ADDED, FileChangeType.ADDED],
         expected: FileChangeType.ADDED
     });
 
     assertChanges({
-        first: FileChangeType.ADDED,
-        second: FileChangeType.UPDATED,
+        changes: [FileChangeType.ADDED, FileChangeType.UPDATED],
         expected: FileChangeType.ADDED
     });
 
     assertChanges({
-        first: FileChangeType.ADDED,
-        second: FileChangeType.DELETED,
-        expected: undefined
+        changes: [FileChangeType.ADDED, FileChangeType.DELETED],
+        expected: [FileChangeType.ADDED, FileChangeType.DELETED]
     });
 
     assertChanges({
-        first: FileChangeType.UPDATED,
-        second: FileChangeType.ADDED,
+        changes: [FileChangeType.UPDATED, FileChangeType.ADDED],
         expected: FileChangeType.UPDATED
     });
 
     assertChanges({
-        first: FileChangeType.UPDATED,
-        second: FileChangeType.UPDATED,
+        changes: [FileChangeType.UPDATED, FileChangeType.UPDATED],
         expected: FileChangeType.UPDATED
     });
 
     assertChanges({
-        first: FileChangeType.UPDATED,
-        second: FileChangeType.DELETED,
+        changes: [FileChangeType.UPDATED, FileChangeType.DELETED],
         expected: FileChangeType.DELETED
     });
 
     assertChanges({
-        first: FileChangeType.DELETED,
-        second: FileChangeType.ADDED,
+        changes: [FileChangeType.DELETED, FileChangeType.ADDED],
         expected: FileChangeType.UPDATED
     });
 
     assertChanges({
-        first: FileChangeType.DELETED,
-        second: FileChangeType.UPDATED,
+        changes: [FileChangeType.DELETED, FileChangeType.UPDATED],
         expected: FileChangeType.UPDATED
     });
 
     assertChanges({
-        first: FileChangeType.DELETED,
-        second: FileChangeType.DELETED,
+        changes: [FileChangeType.DELETED, FileChangeType.DELETED],
         expected: FileChangeType.DELETED
     });
 
-    function assertChanges({ first, second, expected }: {
-        first: FileChangeType,
-        second: FileChangeType,
-        expected: FileChangeType | undefined
+    assertChanges({
+        changes: [FileChangeType.ADDED, FileChangeType.UPDATED, FileChangeType.DELETED],
+        expected: [FileChangeType.ADDED, FileChangeType.DELETED]
+    });
+
+    assertChanges({
+        changes: [FileChangeType.ADDED, FileChangeType.UPDATED, FileChangeType.DELETED, FileChangeType.ADDED],
+        expected: [FileChangeType.ADDED]
+    });
+
+    assertChanges({
+        changes: [FileChangeType.ADDED, FileChangeType.UPDATED, FileChangeType.DELETED, FileChangeType.UPDATED],
+        expected: [FileChangeType.ADDED]
+    });
+
+    assertChanges({
+        changes: [FileChangeType.ADDED, FileChangeType.UPDATED, FileChangeType.DELETED, FileChangeType.DELETED],
+        expected: [FileChangeType.ADDED, FileChangeType.DELETED]
+    });
+
+    function assertChanges({ changes, expected }: {
+        changes: FileChangeType[],
+        expected: FileChangeType[] | FileChangeType
     }): void {
-        it(`${FileChangeType[first]} + ${FileChangeType[second]} => ${expected !== undefined ? FileChangeType[expected] : 'NONE'}`, () => {
+        const expectedTypes = Array.isArray(expected) ? expected : [expected];
+        const expectation = expectedTypes.map(type => FileChangeType[type]).join(' + ');
+        it(`${changes.map(type => FileChangeType[type]).join(' + ')} => ${expectation}`, () => {
             const collection = new FileChangeCollection();
             const uri = FileUri.create('/root/foo/bar.txt').toString();
-            collection.push({
-                uri,
-                type: first
-            });
-            collection.push({
-                uri,
-                type: second
-            });
-            assert.deepEqual(expected !== undefined ? [{
-                uri,
-                type: expected
-            }] : [], collection.values());
+            for (const type of changes) {
+                collection.push({ uri, type });
+            }
+            const actual = collection.values().map(({ type }) => FileChangeType[type]).join(' + ');
+            assert.equal(expectation, actual);
         });
     }
 

--- a/packages/filesystem/src/node/node-filesystem.ts
+++ b/packages/filesystem/src/node/node-filesystem.ts
@@ -327,19 +327,11 @@ export class FileSystemNode implements FileSystem {
             const filePath = FileUri.fsPath(_uri);
             const outputRootPath = paths.join(os.tmpdir(), v4());
             try {
-                await new Promise<void>((resolve, reject) => {
-                    fs.rename(filePath, outputRootPath, async error => {
-                        if (error) {
-                            reject(error);
-                            return;
-                        }
-                        resolve();
-                    });
-                });
+                await fs.rename(filePath, outputRootPath);
                 // There is no reason for the promise returned by this function not to resolve
                 // as soon as the move is complete.  Clearing up the temporary files can be
                 // done in the background.
-                fs.remove(FileUri.fsPath(outputRootPath));
+                fs.remove(outputRootPath);
             } catch (error) {
                 return fs.remove(filePath);
             }

--- a/packages/monaco/src/browser/textmate/textmate-registry.ts
+++ b/packages/monaco/src/browser/textmate/textmate-registry.ts
@@ -46,6 +46,10 @@ export class TextmateRegistry {
     protected readonly languageToConfig = new Map<string, TextmateGrammarConfiguration[]>();
     protected readonly languageIdToScope = new Map<string, string[]>();
 
+    get languages(): IterableIterator<string> {
+        return this.languageIdToScope.keys();
+    }
+
     registerTextmateGrammarScope(scope: string, provider: GrammarDefinitionProvider): Disposable {
         const providers = this.scopeToProvider.get(scope) || [];
         const existingProvider = providers[0];

--- a/packages/monaco/src/typings/monaco/index.d.ts
+++ b/packages/monaco/src/typings/monaco/index.d.ts
@@ -516,8 +516,15 @@ declare module monaco.services {
         readonly language: string;
     }
 
+    export interface IMode {
+        getId(): string;
+        getLanguageIdentifier(): LanguageIdentifier;
+    }
+
     // https://github.com/TypeFox/vscode/blob/70b8db24a37fafc77247de7f7cb5bb0195120ed0/src/vs/editor/common/services/modeService.ts#L30
     export interface IModeService {
+        private readonly _instantiatedModes: { [modeId: string]: IMode; };
+        readonly onDidCreateMode: monaco.IEvent<IMode>;
         createByFilepathOrFirstLine(rsource: monaco.Uri | null, firstLine?: string): ILanguageSelection;
         getLanguageIdentifier(modeId: string): LanguageIdentifier | null;
     }

--- a/packages/plugin-ext/src/common/plugin-api-rpc.ts
+++ b/packages/plugin-ext/src/common/plugin-api-rpc.ts
@@ -811,7 +811,7 @@ export interface TextEditorsExt {
 }
 
 export interface SingleEditOperation {
-    range: Range;
+    range?: Range;
     text?: string;
     forceMoveMarkers?: boolean;
 }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

- fix #6845, fix #6786: use text models to update content. It resolves following issues:
  - edits are applied in the thread-safe fashion;
  - dirty editors are respected -> actually it is not good, it is better to way till a model is saved, otherwise intermediate values are applied.
    - [x] apply only saved values
- fix #7125, see the explanation: https://github.com/eclipse-theia/theia/issues/7125#issuecomment-584557345
- fix #7111, base language activation on monaco created modes
- activate textmate languages only if a grammar is registered, otherwise activation can be triggered too early and lead to no coloring at all
- don't swallow added file if it was deleted during debouncing, file resource rely on it to notify clients that is not valid anymore

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

- over 800 vscode compatibility preference tests are migrated to be integration tests
- (theming) test that changing themes does not lead to the conflict dialog anymore
- (vscode) use gitlens welcome screen to change different configuration and check that it does not lead to the conflict dialog anymore
- test 2 above steps with dirty editor on and off
- modify preferences and test that only saved preferences are applied
- check that formatting is respected when preference values are changed
- check that files with jsonc language are properly colored on first load and on reload with preserved editor

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

