### PR TITLE
fix(prepare-travis): Always use JSON output of the yarn workspaces command

### DIFF
--- a/scripts/prepare-travis.js
+++ b/scripts/prepare-travis.js
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 /********************************************************************************
- * Copyright (c) 2018 TypeFox and others
+ * Copyright (c) 2018-2020 TypeFox and others
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -27,7 +27,7 @@ const os = require('os');
 
 const directories = ['node_modules'];
 
-const workspaces = JSON.parse(JSON.parse(child_process.execSync('yarn workspaces info --json').toString()).data);
+const workspaces = JSON.parse(JSON.parse(child_process.execSync('yarn workspaces --json info').toString()).data);
 for (const name in workspaces) {
     const workspace = workspaces[name];
     const nodeModulesPath = [workspace.location, 'node_modules'].join('/');


### PR DESCRIPTION
#### What it does

With yarn v1.22.0 the output is not rendered in JSON when it's the last parameter
Fixes https://github.com/eclipse-theia/theia/issues/7118

#### How to test
bump to yarn v1.22.0

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)


Change-Id: I98a0d59a98e3e3226cbc242c1a5e264aaa6fd607
Signed-off-by: Florent Benoit <fbenoit@redhat.com>

