### PR TITLE
plugins: add flag to 'download:plugins' script

### DIFF
--- a/dev-packages/cli/src/theia.ts
+++ b/dev-packages/cli/src/theia.ts
@@ -144,7 +144,16 @@ function rebuildCommand(command: string, target: ApplicationProps.Target): yargs
         })
         .command({
             command: 'download:plugins',
-            handler: () => downloadPlugins()
+            describe: 'Download defined external plugins.',
+            builder: {
+                'packed': {
+                    alias: 'p',
+                    describe: 'Controls whether to pack or unpack plugins',
+                    boolean: true,
+                    default: false,
+                }
+            },
+            handler: args => downloadPlugins(args),
         }).command({
             command: 'test',
             builder: {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

Fixes #7122

The following pull-request adds a flag to the `download:plugins` script in order to control whether or not downloaded plugins should be **packed** or **unpacked**.

The **default** behavior is to **unpack** plugins (if no flag is provided), else an application may choose to specify whether or not to pack or unpack plugins using the `-packed (-p)` flag.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

Call the `download:plugins` the following way:

| Command | Outcome |
|:---|:---|
| `yarn theia download:plugins` | should download plugins and unpack (not `.vsix`) |
| `yarn theia download:plugins -p=false` | should download plugins and unpack (not `.vsix`) |
| `yarn theia download:plugins -p=true` | should download plugins and <br/> **not** unpack (not `.vsix`) |

One can also specify the full name as such:

```bash
yarn theia download:plugins -packed=true
```



#### Review checklist

- [X] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

Signed-off-by: Vincent Fugnitto <vincent.fugnitto@ericsson.com>
