### PR TITLE
plugin tree rows are bogusly rendered [work in progress]

### DIFF
--- a/packages/plugin-ext/src/main/browser/style/tree.css
+++ b/packages/plugin-ext/src/main/browser/style/tree.css
@@ -30,7 +30,7 @@
     margin-left: var(--theia-ui-padding);
 }
 
-.theia-tree-view.theia-TreeNodeSegment {
+.theia-tree-view .theia-TreeNodeSegment {
     display: flex;
 }
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
Fixes: #7109
I reverted the changes to make it work better for gitlens, however will be looking back on it to fix the issue with the overflow. It was initially set this way just so it could work fine with the npm scripts and theia repos, but since it was causing a major change Its best to revert it for now. 

Signed-off-by: Muhammad Anas Shahid <muhammad.shahid@ericsson.com>

#### How to test
```
Open theia, 
Open the gitlens plugin
Check to see if the alignment of the text is correct
```

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

