### PR TITLE
about: enhancement to use application name in title

### DIFF
--- a/packages/core/src/browser/about-dialog.tsx
+++ b/packages/core/src/browser/about-dialog.tsx
@@ -20,6 +20,7 @@ import { DialogProps } from './dialogs';
 import { ReactDialog } from './dialogs/react-dialog';
 import { ApplicationServer, ApplicationInfo, ExtensionInfo } from '../common/application-protocol';
 import { Message } from './widgets/widget';
+import { FrontendApplicationConfigProvider } from './frontend-application-config-provider';
 
 export const ABOUT_CONTENT_CLASS = 'theia-aboutDialog';
 export const ABOUT_EXTENSIONS_CLASS = 'theia-aboutExtensions';
@@ -41,7 +42,7 @@ export class AboutDialog extends ReactDialog<void> {
         @inject(AboutDialogProps) protected readonly props: AboutDialogProps
     ) {
         super({
-            title: props.title
+            title: FrontendApplicationConfigProvider.get().applicationName,
         });
         this.appendAcceptButton('Ok');
     }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does

Fixes: #7130 

The pull-request updates the `AboutDialog` to use the full `applicationName` as a title.
If an application's `applicationName` is not provided the default name is **Theia**.

Signed-off-by: Muhammad Anas Shahid <muhammad.shahid@ericsson.com>

#### How to test

1. start the application
2. in the main-menu, select `Help` > `About`
3. the dialog should correctly display the `applicationName` as it's title

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

