### PR TITLE
Close active menubar dropdown when the command palette is launched

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## v0.16.0
 
+- [monaco] close an active menubar dropdown when the quick palette is launched [#7136](https://github.com/eclipse-theia/theia/pull/7136)
 - [core] added a new React-based dialog type `ReactDialog` [#6855](https://github.com/eclipse-theia/theia/pull/6855)
 
 Breaking changes:

--- a/packages/monaco/src/browser/monaco-quick-open-service.ts
+++ b/packages/monaco/src/browser/monaco-quick-open-service.ts
@@ -14,7 +14,7 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
-import { injectable, inject, postConstruct } from 'inversify';
+import { injectable, inject, optional, postConstruct } from 'inversify';
 import { MessageType } from '@theia/core/lib/common/message-service-protocol';
 import {
     QuickOpenService, QuickOpenOptions, QuickOpenItem, QuickOpenGroupItem,
@@ -25,6 +25,7 @@ import { ContextKey } from '@theia/core/lib/browser/context-key-service';
 import { MonacoContextKeyService } from './monaco-context-key-service';
 import { QuickOpenHideReason } from '@theia/core/lib/common/quick-open-service';
 import { MonacoResolvedKeybinding } from './monaco-resolved-keybinding';
+import { BrowserMenuBarContribution } from '@theia/core/lib/browser/menu/browser-menu-plugin';
 
 export interface MonacoQuickOpenControllerOpts extends monaco.quickOpen.IQuickOpenControllerOpts {
     valueSelection?: Readonly<[number, number]>;
@@ -50,6 +51,9 @@ export class MonacoQuickOpenService extends QuickOpenService {
 
     @inject(KeybindingRegistry)
     protected readonly keybindingRegistry: KeybindingRegistry;
+
+    @inject(BrowserMenuBarContribution) @optional()
+    protected readonly browserMenuBarContribution?: BrowserMenuBarContribution;
 
     protected inQuickOpenKey: ContextKey<boolean>;
 
@@ -113,6 +117,17 @@ export class MonacoQuickOpenService extends QuickOpenService {
     }
 
     internalOpen(opts: MonacoQuickOpenControllerOpts): void {
+        const browserMenuBarContribution = this.browserMenuBarContribution;
+        if (browserMenuBarContribution) {
+            const browserMenuBar = browserMenuBarContribution.menuBar;
+            if (browserMenuBar) {
+                const activeMenu = browserMenuBar.activeMenu;
+                if (activeMenu) {
+                    activeMenu.close();
+                }
+            }
+        }
+
         // eslint-disable-next-line no-null/no-null
         if (this.widgetNode && this.widgetNode.offsetParent !== null) {
             this.hide();


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

Fixes: #6847
The command palette currently overlaps an active menubar dropdown when launched via one of its keybindings.

Apart from this potentially being a less than ideal UX, toggles triggered through the command palette such as __View: Toggle Minimap__ would not have their updated state reflected in the overlapped dropdown.
Closing the menubar dropdown on command palette launch avoids this complication.

** _Update (12/02/20)_
An active menubar dropdown should now be closed when launching any quick palette.


#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

Open a menubar dropdown and then launch a quick palette via one a keybindings.
The menubar dropdown should now be closed rather than overlapped by the quick palette.
Keyboard focus should be on the quick palette input.

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

