### PR TITLE
about: dialog does not display correctly when re-opened

### DIFF
--- a/packages/core/src/browser/about-dialog.tsx
+++ b/packages/core/src/browser/about-dialog.tsx
@@ -19,6 +19,7 @@ import { inject, injectable, postConstruct } from 'inversify';
 import { DialogProps } from './dialogs';
 import { ReactDialog } from './dialogs/react-dialog';
 import { ApplicationServer, ApplicationInfo, ExtensionInfo } from '../common/application-protocol';
+import { Message } from './widgets/widget';
 
 export const ABOUT_CONTENT_CLASS = 'theia-aboutDialog';
 export const ABOUT_EXTENSIONS_CLASS = 'theia-aboutExtensions';
@@ -77,6 +78,11 @@ export class AboutDialog extends ReactDialog<void> {
             {this.renderHeader()}
             {this.renderExtensions()}
         </div>;
+    }
+
+    protected onAfterAttach(msg: Message): void {
+        super.onAfterAttach(msg);
+        this.update();
     }
 
     get value(): undefined { return undefined; }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
Fixes: #7129

The help dialog was not rendering the list of extensions, hence functionality was added to display the list even after it being closed once.

Signed-off-by: Muhammad Anas Shahid <muhammad.shahid@ericsson.com>

#### How to test

1. start the application
2. in the `help` menu, select `about`
3. the dialog should be successfully displayed (with the list of extensions).
4. close the dialog using the '**x**'
5. re-perform step 2
6. the dialog should now be successfully displayed again (with the list of extensions)

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

