### PR TITLE
fix set selection on right click selected node

### DIFF
--- a/packages/core/src/browser/tree/tree-widget.tsx
+++ b/packages/core/src/browser/tree/tree-widget.tsx
@@ -1116,7 +1116,7 @@ export class TreeWidget extends ReactWidget implements StatefulWidget {
                     }))
                 ));
             }
-            this.update();
+            this.doFocus();
         }
         event.stopPropagation();
         event.preventDefault();


### PR DESCRIPTION
Fixes #7146

Signed-off-by: Amiram Wingarten <amiram.wingarten@sap.com>

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
Perform selection on right click also if the node was already selected so that the global selection service is updated and the menu content is displayed with the correct context. 

#### How to test
Scenario 1:
- Put a breakpoint on selection-service.ts on selection setter.
- Click on selected node in the tree stops in this breakpoint
- Right click on selected node in the tree and make sure the debugger stop on the same breakpoint

Scenario 2
- Select some package.json file
- Refresh theia
- Now that the file from before is selected right click on it
- There should be14 menu items and not only 8

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

