### PR TITLE
Add vscode-references-view plugin to Theia

### DIFF
--- a/package.json
+++ b/package.json
@@ -142,6 +142,7 @@
     "vscode-builtin-xml": "https://github.com/theia-ide/vscode-builtin-extensions/releases/download/v1.39.1-prel/xml-1.39.1-prel.vsix",
     "vscode-builtin-yaml": "https://github.com/theia-ide/vscode-builtin-extensions/releases/download/v1.39.1-prel/yaml-1.39.1-prel.vsix",
     "vscode-editorconfig": "https://github.com/theia-ide/editorconfig-vscode/releases/download/v0.14.4/EditorConfig-0.14.4.vsix",
-    "vscode-eslint": "https://github.com/theia-ide/vscode-eslint/releases/download/release%2F2.0.15/vscode-eslint-2.0.15.vsix"
+    "vscode-eslint": "https://github.com/theia-ide/vscode-eslint/releases/download/release%2F2.0.15/vscode-eslint-2.0.15.vsix",
+    "vscode-references-view": "https://download.jboss.org/jbosstools/vscode/3rdparty/vscode-references-view/references-view-0.0.47-05339d.vsix"
   }
 }


### PR DESCRIPTION
This adds vscode-references-view plugin to the list of plugins to be downloaded from `https://download.jboss.org` at Theia build, so making it available for use in run time

Depends on #7055 

Signed-off-by: Victor Rubezhny <vrubezhny@redhat.com>

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->
This adds vscode-references-view plugin to the list of plugins to be downloaded from `https://download.jboss.org` at Theia build, so making it available for use in run time

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->


#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

