### PR TITLE
Active vertical bar not visible on the sidebar

### DIFF
--- a/packages/core/src/browser/common-frontend-contribution.ts
+++ b/packages/core/src/browser/common-frontend-contribution.ts
@@ -948,6 +948,12 @@ export class CommonFrontendContribution implements FrontendApplicationContributi
                 id: 'activityBar.activeFocusBorder',
                 description: 'Activity bar focus border color for the active item. The activity bar is showing on the far left or right and allows to switch between views of the side bar.'
             },
+            {
+                id: 'activityBar.focusBorder', defaults: {
+                    dark: 'focusBorder',
+                    light: '#33AAEE'
+                }, description: 'Activity bar focus border color for the active item on the bar. The activity bar is showing on the far left or right and allows to switch between views of the side bar.'
+            },
             { id: 'activityBar.activeBackground', description: 'Activity bar background color for the active item. The activity bar is showing on the far left or right and allows to switch between views of the side bar.' },
             {
                 id: 'activityBar.dropBackground', defaults: {

--- a/packages/core/src/browser/style/sidepanel.css
+++ b/packages/core/src/browser/style/sidepanel.css
@@ -86,7 +86,7 @@
 }
 
 .p-TabBar.theia-app-left .p-TabBar-tab.p-mod-current.theia-mod-active {
-    border-left: var(--theia-panel-border-width) solid var(--theia-focusBorder);
+    border-left: var(--theia-panel-border-width) solid var(--theia-activityBar-focusBorder);
 }
 
 .p-TabBar.theia-app-right .p-TabBar-tab.p-mod-current {
@@ -95,7 +95,7 @@
 }
 
 .p-TabBar.theia-app-right .p-TabBar-tab.p-mod-current.theia-mod-active {
-    border-right: var(--theia-panel-border-width) solid var(--theia-focusBorder);
+    border-right: var(--theia-panel-border-width) solid var(--theia-activityBar-focusBorder);
 }
 
 .p-TabBar.theia-app-sides .p-TabBar-tabLabel,
@@ -234,7 +234,7 @@
 }
 
 #theia-bottom-content-panel .p-TabBar-tab.p-mod-current.theia-mod-active {
-    border-top-color: var(--theia-focusBorder);
+    border-top-color: var(--theia-activityBar-focusBorder);
 }
 
 /*-----------------------------------------------------------------------------


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
Fixes: #7148

The sidebar has been very darkly coloured, hence it was not evident as to which element is active and which is not. hence made some minor css changes to fix the issue

Signed-off-by: Muhammad Anas Shahid <muhammad.shahid@ericsson.com>

#### How to test

Open Theia with some some view available on the side-bar
-Select any view -> there is a tiny blue bar on the side of the icon which is not visible

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

