### PR TITLE
Consistently show ellipsis in place of overflowing tree content

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## v0.16.0
 
+- [tree] consistently show ellipsis in place of overflowing tree content [#7162](https://github.com/eclipse-theia/theia/pull/7162)
 - [documentation] updated code of conduct [#7161](https://github.com/eclipse-theia/theia/pull/7161)
 - [monaco] code snippets: add support for an array of prefixes [#7177](https://github.com/eclipse-theia/theia/pull/7177)
 - [monaco] close an active menubar dropdown when the quick palette is launched [#7136](https://github.com/eclipse-theia/theia/pull/7136)

--- a/packages/plugin-ext/src/main/browser/style/tree.css
+++ b/packages/plugin-ext/src/main/browser/style/tree.css
@@ -38,3 +38,9 @@
     align-items: center;
     height: 100%;
 }
+
+.theia-tree-view .theia-TreeNodeSegmentEllipsis {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}

--- a/packages/plugin-ext/src/main/browser/view/tree-view-widget.tsx
+++ b/packages/plugin-ext/src/main/browser/view/tree-view-widget.tsx
@@ -281,8 +281,7 @@ export class TreeViewWidget extends TreeWidget {
             });
         }
 
-        const className = [TREE_NODE_SEGMENT_CLASS, TREE_NODE_SEGMENT_GROW_CLASS].join(' ');
-        nodes.push(<div className={className}>{work}</div >);
+        nodes.push(<div className='theia-TreeNodeSegmentEllipsis'>{work}</div >);
         if (description) {
             nodes.push(<div className='theia-tree-view-description'>
                 {description}


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->
Fixes: #7145

The styling of overflowing tree content is currently inconsistent. An example of this is shown in the screenshot below.

<img src="https://user-images.githubusercontent.com/2885325/74595808-07f65500-503e-11ea-9cf1-971640f455e9.png" width="250">

An ellipsis should now be shown in place of overflowing content in all tree views.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
Open a project and reduce the width of the tree view until content would extend beyond the available space. In all tree views an ellipsis should replace the overflowing content.

Include the Git Lens extension in this testing (https://github.com/eclipse-theia/theia/pull/6921)

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

