### PR TITLE
set default value of colorTheme and iconTheme preference

### DIFF
--- a/dev-packages/application-manager/src/generator/frontend-generator.ts
+++ b/dev-packages/application-manager/src/generator/frontend-generator.ts
@@ -70,6 +70,8 @@ export class FrontendGenerator extends AbstractGenerator {
 ${this.ifBrowser("require('es6-promise/auto');")}
 require('reflect-metadata');
 const { Container } = require('inversify');
+const { FrontendApplicationConfigProvider } = require('@theia/core/lib/browser/frontend-application-config-provider');
+FrontendApplicationConfigProvider.set(${this.prettyStringify(this.pck.props.frontend.config)});
 const { FrontendApplication } = require('@theia/core/lib/browser');
 const { frontendApplicationModule } = require('@theia/core/lib/browser/frontend-application-module');
 const { messagingFrontendModule } = require('@theia/core/lib/${this.pck.isBrowser()
@@ -77,9 +79,6 @@ const { messagingFrontendModule } = require('@theia/core/lib/${this.pck.isBrowse
                 : 'electron-browser/messaging/electron-messaging-frontend-module'}');
 const { loggerFrontendModule } = require('@theia/core/lib/browser/logger-frontend-module');
 const { ThemeService } = require('@theia/core/lib/browser/theming');
-const { FrontendApplicationConfigProvider } = require('@theia/core/lib/browser/frontend-application-config-provider');
-
-FrontendApplicationConfigProvider.set(${this.prettyStringify(this.pck.props.frontend.config)});
 
 const container = new Container();
 container.load(frontendApplicationModule);

--- a/dev-packages/application-package/src/application-props.ts
+++ b/dev-packages/application-package/src/application-props.ts
@@ -105,6 +105,11 @@ export interface FrontendApplicationConfig extends ApplicationConfig {
     readonly defaultTheme?: string;
 
     /**
+     * The default icon theme for the application. If not give, defaults to `none`. If invalid theme is given, also defaults to `none`.
+     */
+    readonly defaultIconTheme?: string;
+
+    /**
      * The name of the application. `Theia` by default.
      */
     readonly applicationName: string;

--- a/examples/browser/package.json
+++ b/examples/browser/package.json
@@ -7,6 +7,8 @@
     "frontend": {
       "config": {
         "applicationName": "Theia Browser Example",
+        "defaultTheme": "dark",
+        "defaultIconTheme": "theia-file-icons",
         "preferences": {
           "files.enableTrash": false
         }

--- a/packages/core/src/browser/common-frontend-contribution.ts
+++ b/packages/core/src/browser/common-frontend-contribution.ts
@@ -47,7 +47,6 @@ import { ColorRegistry, Color } from './color-registry';
 import { CorePreferences } from './core-preferences';
 import { ThemeService } from './theming';
 import { PreferenceService, PreferenceScope } from './preferences';
-import { FrontendApplicationStateService } from './frontend-application-state';
 
 export namespace CommonMenus {
 
@@ -290,9 +289,6 @@ export class CommonFrontendContribution implements FrontendApplicationContributi
     @inject(PreferenceService)
     protected readonly preferenceService: PreferenceService;
 
-    @inject(FrontendApplicationStateService)
-    protected readonly frontendApplicationStateService: FrontendApplicationStateService;
-
     @postConstruct()
     protected init(): void {
         this.contextKeyService.createKey<boolean>('isLinux', OS.type() === OS.Type.Linux);
@@ -303,19 +299,17 @@ export class CommonFrontendContribution implements FrontendApplicationContributi
         this.registerCtrlWHandling();
 
         this.updateStyles();
-        this.frontendApplicationStateService.reachedState('ready').then(() => {
-            this.updateThemeFromPreference('workbench.colorTheme');
-            this.updateThemeFromPreference('workbench.iconTheme');
-            this.preferences.onPreferenceChanged(e => {
-                if (e.preferenceName === 'workbench.editor.highlightModifiedTabs') {
-                    this.updateStyles();
-                } else if (e.preferenceName === 'workbench.colorTheme' || e.preferenceName === 'workbench.iconTheme') {
-                    this.updateThemeFromPreference(e.preferenceName);
-                }
-            });
-            this.themeService.onThemeChange(() => this.updateThemePreference('workbench.colorTheme'));
-            this.iconThemes.onDidChangeCurrent(() => this.updateThemePreference('workbench.iconTheme'));
+        this.updateThemeFromPreference('workbench.colorTheme');
+        this.updateThemeFromPreference('workbench.iconTheme');
+        this.preferences.onPreferenceChanged(e => {
+            if (e.preferenceName === 'workbench.editor.highlightModifiedTabs') {
+                this.updateStyles();
+            } else if (e.preferenceName === 'workbench.colorTheme' || e.preferenceName === 'workbench.iconTheme') {
+                this.updateThemeFromPreference(e.preferenceName);
+            }
         });
+        this.themeService.onThemeChange(() => this.updateThemePreference('workbench.colorTheme'));
+        this.iconThemes.onDidChangeCurrent(() => this.updateThemePreference('workbench.iconTheme'));
     }
 
     protected updateStyles(): void {

--- a/packages/core/src/browser/core-preferences.ts
+++ b/packages/core/src/browser/core-preferences.ts
@@ -16,7 +16,9 @@
 
 import { interfaces } from 'inversify';
 import { createPreferenceProxy, PreferenceProxy, PreferenceService, PreferenceContribution, PreferenceSchema } from './preferences';
+import { FrontendApplicationConfigProvider } from './frontend-application-config-provider';
 
+const cfg = FrontendApplicationConfigProvider.doGet();
 export const corePreferenceSchema: PreferenceSchema = {
     'type': 'object',
     properties: {
@@ -52,10 +54,12 @@ export const corePreferenceSchema: PreferenceSchema = {
         },
         'workbench.colorTheme': {
             type: 'string',
+            default: cfg && cfg.defaultTheme || 'dark',
             description: 'Specifies the color theme used in the workbench.'
         },
         'workbench.iconTheme': {
             type: ['string', 'null'],
+            default: cfg && cfg.defaultIconTheme || 'none',
             description: "Specifies the icon theme used in the workbench or 'null' to not show any file icons."
         }
     }

--- a/packages/core/src/browser/frontend-application-config-provider.ts
+++ b/packages/core/src/browser/frontend-application-config-provider.ts
@@ -38,7 +38,7 @@ export class FrontendApplicationConfigProvider {
         globalObject[key] = config;
     }
 
-    private static doGet(): FrontendApplicationConfig | undefined {
+    static doGet(): FrontendApplicationConfig | undefined {
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         const globalObject = window as any;
         const key = FrontendApplicationConfigProvider.KEY;

--- a/packages/core/src/browser/icon-theme-contribution.ts
+++ b/packages/core/src/browser/icon-theme-contribution.ts
@@ -53,7 +53,6 @@ export class DefaultFileIconThemeContribution implements IconTheme, IconThemeCon
 
     registerIconThemes(iconThemes: IconThemeService): MaybePromise<void> {
         iconThemes.register(this);
-        iconThemes.default = this.id;
     }
 
     /* rely on behaviour before for backward-compatibility */

--- a/packages/core/src/browser/icon-theme-service.ts
+++ b/packages/core/src/browser/icon-theme-service.ts
@@ -18,6 +18,7 @@ import { injectable, inject, postConstruct } from 'inversify';
 import { Emitter } from '../common/event';
 import { Disposable, DisposableCollection } from '../common/disposable';
 import { LabelProviderContribution, DidChangeLabelEvent } from './label-provider';
+import { FrontendApplicationConfigProvider } from './frontend-application-config-provider';
 
 export interface IconThemeDefinition {
     readonly id: string
@@ -94,13 +95,13 @@ export class IconThemeService {
     protected readonly onDidChangeCurrentEmitter = new Emitter<string>();
     readonly onDidChangeCurrent = this.onDidChangeCurrentEmitter.event;
 
-    protected _default: IconTheme;
+    protected _defaultId: string;
 
     protected readonly toDeactivate = new DisposableCollection();
 
     @postConstruct()
     protected init(): void {
-        this._default = this.noneIconTheme;
+        this._defaultId = FrontendApplicationConfigProvider.get().defaultIconTheme || this.noneIconTheme.id;
         this.register(this.noneIconTheme);
     }
 
@@ -124,31 +125,35 @@ export class IconThemeService {
             return undefined;
         }
         this._iconThemes.delete(id);
-        if (this._default === iconTheme) {
-            this._default = this.noneIconTheme;
-        }
         if (window.localStorage.getItem('iconTheme') === id) {
             window.localStorage.removeItem('iconTheme');
-            this.onDidChangeCurrentEmitter.fire(this._default.id);
+            this.onDidChangeCurrentEmitter.fire(this.defaultId);
         }
         this.onDidChangeEmitter.fire(undefined);
         return iconTheme;
     }
 
     get current(): string {
-        return this.getCurrent().id;
+        if (!this.getCurrent()) {
+            this.current = this.defaultId;
+        }
+        return this.getCurrent() && this.getCurrent()!.id || this.defaultId;
     }
 
     set current(id: string) {
-        const newCurrent = this._iconThemes.get(id) || this._default;
-        if (this.getCurrent().id !== newCurrent.id) {
+        if (!id) {
+            return;
+        }
+        const newCurrent = this._iconThemes.get(id) || this.default;
+        const oldCurrent = this.getCurrent();
+        if (!oldCurrent || (oldCurrent && oldCurrent.id !== newCurrent.id)) {
             this.setCurrent(newCurrent);
         }
     }
 
-    protected getCurrent(): IconTheme {
+    protected getCurrent(): IconTheme | undefined {
         const id = window.localStorage.getItem('iconTheme');
-        return id && this._iconThemes.get(id) || this._default;
+        return id ? this._iconThemes.get(id) : undefined;
     }
 
     protected setCurrent(current: IconTheme): void {
@@ -158,19 +163,12 @@ export class IconThemeService {
         this.onDidChangeCurrentEmitter.fire(current.id);
     }
 
-    get default(): string {
-        return this._default.id;
+    get default(): IconTheme {
+        return this._iconThemes.get(this.defaultId) || this.noneIconTheme;
     }
 
-    set default(id: string) {
-        const newDefault = this._iconThemes.get(id) || this.noneIconTheme;
-        if (this._default.id === newDefault.id) {
-            return;
-        }
-        this._default = newDefault;
-        if (!window.localStorage.getItem('iconTheme')) {
-            this.onDidChangeCurrentEmitter.fire(newDefault.id);
-        }
+    get defaultId(): string {
+        return this._iconThemes.has(this._defaultId) ? this._defaultId : this.noneIconTheme.id;
     }
 
     protected load(): string | undefined {


### PR DESCRIPTION
vscode python plugin will read workbench.colorTheme,
if not find it will use the default value of Default Light+
(https://github.com/microsoft/vscode-python/blob/2008c14f4ca7305ad6aaee436174fe24a5a6c283/src/client/datascience/webViewHost.ts#L175)
which will cause the mismatch of jupyter notebook and current theia theme colors.

BTW set the default value of workbench.iconTheme

Signed-off-by: tom-shan <swt0008411@163.com>

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

