### PR TITLE
[#7173] Prevent error on disabled performance API

### DIFF
--- a/packages/plugin-ext/src/hosted/browser/hosted-plugin.ts
+++ b/packages/plugin-ext/src/hosted/browser/hosted-plugin.ts
@@ -585,7 +585,10 @@ export class HostedPluginSupport {
         return () => {
             performance.mark(endMarker);
             performance.measure(name, startMarker, endMarker);
-            const duration = performance.getEntriesByName(name)[0].duration;
+
+            const entries = performance.getEntriesByName(name);
+            const duration = entries.length > 0 ? entries[0].duration : Number.NaN;
+
             performance.clearMeasures(name);
             performance.clearMarks(startMarker);
             performance.clearMarks(endMarker);
@@ -594,8 +597,14 @@ export class HostedPluginSupport {
     }
 
     protected logMeasurement(prefix: string, count: number, measurement: () => number): void {
+        const duration = measurement();
+        if (duration === Number.NaN) {
+          // Measurement was prevented by native API, do not log NaN duration
+          return;
+        }
+
         const pluginCount = `${count} plugin${count === 1 ? '' : 's'}`;
-        console.log(`[${this.clientId}] ${prefix} of ${pluginCount} took: ${measurement().toFixed(1)} ms`);
+        console.log(`[${this.clientId}] ${prefix} of ${pluginCount} took: ${duration.toFixed(1)} ms`);
     }
 
     protected readonly webviewsToRestore = new Set<WebviewWidget>();


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

When performance API is disabled through `privacy.resistFingerprinting` setting in recent Firefox all API calls are possible though `getEntriesByName` will return an empty Array.

This change checks the length of the returned array before using the first element in order not to cause a call to `undefined.duration` which breaks plugin architecture.

closes #7173 

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

In short: Enable `resistFingerprinting` in Firefox, ensure plugins are still loaded.

Please see description of #7173 for further information.

#### Review checklist

- [ ] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

