### PR TITLE
Code snippet: Add support for an array of prefixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## v0.16.0
 
+- [monaco] code snippets: add support for an array of prefixes [#7177](https://github.com/eclipse-theia/theia/pull/7177)
 - [monaco] close an active menubar dropdown when the quick palette is launched [#7136](https://github.com/eclipse-theia/theia/pull/7136)
 - [core] added a new React-based dialog type `ReactDialog` [#6855](https://github.com/eclipse-theia/theia/pull/6855)
 - [repo] added 2 new npm scripts:

--- a/packages/monaco/src/browser/monaco-snippet-suggest-provider.ts
+++ b/packages/monaco/src/browser/monaco-snippet-suggest-provider.ts
@@ -154,11 +154,11 @@ export class MonacoSnippetSuggestProvider implements monaco.languages.Completion
     fromJSON(snippets: JsonSerializedSnippets | undefined, { language, source }: SnippetLoadOptions): Disposable {
         const toDispose = new DisposableCollection();
         this.parseSnippets(snippets, (name, snippet) => {
-            let { prefix, body, description } = snippet;
-            if (Array.isArray(body)) {
-                body = body.join('\n');
-            }
-            if (typeof prefix !== 'string' || typeof body !== 'string') {
+            const { prefix, body, description } = snippet;
+            const parsedBody = Array.isArray(body) ? body.join('\n') : body;
+            const parsedPrefixes = Array.isArray(prefix) ? prefix : [prefix];
+
+            if (typeof parsedBody !== 'string') {
                 return;
             }
             const scopes: string[] = [];
@@ -176,14 +176,14 @@ export class MonacoSnippetSuggestProvider implements monaco.languages.Completion
                     }
                 }
             }
-            toDispose.push(this.push({
+            parsedPrefixes.forEach(parsedPrefix => toDispose.push(this.push({
                 scopes,
                 name,
-                prefix,
+                prefix: parsedPrefix,
                 description,
-                body,
+                body: parsedBody,
                 source
-            }));
+            })));
         });
         return toDispose;
     }
@@ -242,7 +242,7 @@ export interface JsonSerializedSnippets {
 export interface JsonSerializedSnippet {
     body: string | string[];
     scope: string;
-    prefix: string;
+    prefix: string | string[];
     description: string;
 }
 export namespace JsonSerializedSnippet {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->
Fixes: #7167

Theia code snippets currently only support a single prefix, whilst VS Code additionally supports an [array of prefixes](https://code.visualstudio.com/docs/editor/userdefinedsnippets#_create-your-own-snippets).
This PR brings Theia's support for code snippet prefixes inline with this.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
Try using a snippet with an array of prefixes and ensure these can be utilised.
Check for a regression in snippets with a string prefix.

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

