### PR TITLE
Add terminal scroll commands.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 Breaking changes:
 
 - [core] fixed typo (highligh -> highlight) in caption highlight fragment [#7050](https://github.com/eclipse-theia/theia/pull/7050)
+- [terminal] added new abstract methods to the TerminalWidget[#7179]: `scrollLineUp`, `scrollLineDown`, `scrollToTop`, `scrollPageUp`, `scrollPageDown`
 
 ## v0.15.0
 

--- a/packages/terminal/src/browser/base/terminal-widget.ts
+++ b/packages/terminal/src/browser/base/terminal-widget.ts
@@ -39,6 +39,16 @@ export abstract class TerminalWidget extends BaseWidget {
 
     abstract onDidOpen: Event<void>;
 
+    abstract scrollLineUp(): void;
+
+    abstract scrollLineDown(): void;
+
+    abstract scrollToTop(): void;
+
+    abstract scrollPageUp(): void;
+
+    abstract scrollPageDown(): void;
+
     /**
      * Event which fires when terminal did closed. Event value contains closed terminal widget definition.
      */

--- a/packages/terminal/src/browser/terminal-frontend-contribution.ts
+++ b/packages/terminal/src/browser/terminal-frontend-contribution.ts
@@ -93,6 +93,33 @@ export namespace TerminalCommands {
         category: TERMINAL_CATEGORY,
         label: 'Hide find widget'
     };
+
+    export const SCROLL_LINE_UP: Command = {
+        id: 'terminal:scroll:line:up',
+        category: TERMINAL_CATEGORY,
+        label: 'Scroll line up'
+    };
+    export const SCROLL_LINE_DOWN: Command = {
+        id: 'terminal:scroll:line:down',
+        category: TERMINAL_CATEGORY,
+        label: 'Scroll line down'
+    };
+    export const SCROLL_TO_TOP: Command = {
+        id: 'terminal:scroll:top',
+        category: TERMINAL_CATEGORY,
+        label: 'Scroll to top'
+    };
+    export const SCROLL_PAGE_UP: Command = {
+        id: 'terminal:scroll:page:up',
+        category: TERMINAL_CATEGORY,
+        label: 'Scroll page up'
+    };
+    export const SCROLL_PAGE_DOWN: Command = {
+        id: 'terminal:scroll:page:down',
+        category: TERMINAL_CATEGORY,
+        label: 'Scroll page down'
+    };
+
     /**
      * Command that displays all terminals that are currently opened
      */
@@ -244,6 +271,42 @@ export class TerminalFrontendContribution implements TerminalService, CommandCon
                 terminalSearchBox.hide();
             }
         });
+
+        commands.registerCommand(TerminalCommands.SCROLL_LINE_UP, {
+                isEnabled: () => this.shell.activeWidget instanceof TerminalWidget,
+                isVisible: () => false,
+                execute: () => {
+                    (this.shell.activeWidget as TerminalWidget).scrollLineUp();
+                }
+        });
+        commands.registerCommand(TerminalCommands.SCROLL_LINE_DOWN, {
+            isEnabled: () => this.shell.activeWidget instanceof TerminalWidget,
+            isVisible: () => false,
+            execute: () => {
+                (this.shell.activeWidget as TerminalWidget).scrollLineDown();
+            }
+        });
+        commands.registerCommand(TerminalCommands.SCROLL_TO_TOP, {
+            isEnabled: () => this.shell.activeWidget instanceof TerminalWidget,
+            isVisible: () => false,
+            execute: () => {
+                (this.shell.activeWidget as TerminalWidget).scrollToTop();
+            }
+        });
+        commands.registerCommand(TerminalCommands.SCROLL_PAGE_UP, {
+            isEnabled: () => this.shell.activeWidget instanceof TerminalWidget,
+            isVisible: () => false,
+            execute: () => {
+                (this.shell.activeWidget as TerminalWidget).scrollPageUp();
+            }
+        });
+        commands.registerCommand(TerminalCommands.SCROLL_PAGE_DOWN, {
+            isEnabled: () => this.shell.activeWidget instanceof TerminalWidget,
+            isVisible: () => false,
+            execute: () => {
+                (this.shell.activeWidget as TerminalWidget).scrollPageDown();
+            }
+        });
     }
 
     registerMenus(menus: MenuModelRegistry): void {
@@ -291,11 +354,35 @@ export class TerminalFrontendContribution implements TerminalService, CommandCon
             keybinding: 'ctrlcmd+f',
             context: TerminalKeybindingContexts.terminalActive
         });
-
         keybindings.registerKeybinding({
             command: TerminalCommands.TERMINAL_FIND_TEXT_CANCEL.id,
             keybinding: 'esc',
             context: TerminalKeybindingContexts.terminalHideSearch
+        });
+        keybindings.registerKeybinding({
+            command: TerminalCommands.SCROLL_LINE_UP.id,
+            keybinding: 'ctrl+shift+up',
+            context: TerminalKeybindingContexts.terminalActive
+        });
+        keybindings.registerKeybinding({
+            command: TerminalCommands.SCROLL_LINE_DOWN.id,
+            keybinding: 'ctrl+shift+down',
+            context: TerminalKeybindingContexts.terminalActive
+        });
+        keybindings.registerKeybinding({
+            command: TerminalCommands.SCROLL_TO_TOP.id,
+            keybinding: 'home',
+            context: TerminalKeybindingContexts.terminalActive
+        });
+        keybindings.registerKeybinding({
+            command: TerminalCommands.SCROLL_PAGE_UP.id,
+            keybinding: 'pageUp',
+            context: TerminalKeybindingContexts.terminalActive
+        });
+        keybindings.registerKeybinding({
+            command: TerminalCommands.SCROLL_PAGE_DOWN.id,
+            keybinding: 'pageDown',
+            context: TerminalKeybindingContexts.terminalActive
         });
 
         /* Register passthrough keybindings for combinations recognized by

--- a/packages/terminal/src/browser/terminal-widget-impl.ts
+++ b/packages/terminal/src/browser/terminal-widget-impl.ts
@@ -453,6 +453,26 @@ export class TerminalWidgetImpl extends TerminalWidget implements StatefulWidget
         }
     }
 
+    scrollLineUp(): void {
+        this.term.scrollLines(-1);
+    }
+
+    scrollLineDown(): void {
+        this.term.scrollLines(1);
+    }
+
+    scrollToTop(): void {
+        this.term.scrollToTop();
+    }
+
+    scrollPageUp(): void {
+        this.term.scrollPages(-1);
+    }
+
+    scrollPageDown(): void {
+        this.term.scrollPages(1);
+    }
+
     get onTerminalDidClose(): Event<TerminalWidget> {
         return this.onTermDidClose.event;
     }


### PR DESCRIPTION
Add terminal scroll commands.

#### What it does
Add terminal scroll commands:
- scroll line up by shortcut: Ctrl + Shift + ArrowUp
- scroll line down by shortcut: Ctrl + Shift + ArrowDown
- scroll to top of the terminal(beginning line) by shortcut: Home
- scroll page up by shortcut PageUp
- scroll page down by shortcut PageDown

#### How to test
1. Open terminal, types some content to make scrollbar appear. 
2. Use shortcuts described above to check scroll commands.

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

Signed-off-by: Oleksandr Andriienko <oandriie@redhat.com>