### PR TITLE
feat(plugins): Allow to customise the plugin-host process

### DIFF
--- a/packages/plugin-ext/src/hosted/node/hosted-plugin-process.ts
+++ b/packages/plugin-ext/src/hosted/node/hosted-plugin-process.ts
@@ -14,7 +14,6 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
-import * as path from 'path';
 import * as cp from 'child_process';
 import { injectable, inject, named } from 'inversify';
 import { ILogger, ConnectionErrorHandler, ContributionProvider, MessageService } from '@theia/core/lib/common';
@@ -33,8 +32,16 @@ export interface IPCConnectionOptions {
     readonly errorHandler?: ConnectionErrorHandler;
 }
 
+export const HostedPluginProcessConfiguration = Symbol('HostedPluginProcessConfiguration');
+export interface HostedPluginProcessConfiguration {
+    readonly path: string
+}
+
 @injectable()
 export class HostedPluginProcess implements ServerPluginRunner {
+
+    @inject(HostedPluginProcessConfiguration)
+    protected configuration: HostedPluginProcessConfiguration;
 
     @inject(ILogger)
     protected readonly logger: ILogger;
@@ -166,7 +173,7 @@ export class HostedPluginProcess implements ServerPluginRunner {
             forkOptions.execArgv = ['--nolazy', `--inspect${inspectArg.substr(inspectArgPrefix.length)}`];
         }
 
-        const childProcess = cp.fork(path.resolve(__dirname, 'plugin-host.js'), options.args, forkOptions);
+        const childProcess = cp.fork(this.configuration.path, options.args, forkOptions);
         childProcess.stdout.on('data', data => this.logger.info(`[${options.serverName}: ${childProcess.pid}] ${data.toString().trim()}`));
         childProcess.stderr.on('data', data => this.logger.error(`[${options.serverName}: ${childProcess.pid}] ${data.toString().trim()}`));
 

--- a/packages/plugin-ext/src/hosted/node/plugin-ext-hosted-backend-module.ts
+++ b/packages/plugin-ext/src/hosted/node/plugin-ext-hosted-backend-module.ts
@@ -14,6 +14,7 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
+import * as path from 'path';
 import { interfaces } from 'inversify';
 import { bindContributionProvider } from '@theia/core/lib/common/contribution-provider';
 import { CliContribution } from '@theia/core/lib/node/cli';
@@ -26,7 +27,7 @@ import { HostedPluginSupport } from './hosted-plugin';
 import { TheiaPluginScanner } from './scanners/scanner-theia';
 import { HostedPluginServer, PluginScanner, HostedPluginClient, hostedServicePath, PluginDeployerHandler, PluginHostEnvironmentVariable } from '../../common/plugin-protocol';
 import { GrammarsReader } from './scanners/grammars-reader';
-import { HostedPluginProcess } from './hosted-plugin-process';
+import { HostedPluginProcess, HostedPluginProcessConfiguration } from './hosted-plugin-process';
 import { ExtPluginApiProvider } from '../../common/plugin-ext-api-contribution';
 import { HostedPluginCliContribution } from './hosted-plugin-cli-contribution';
 import { HostedPluginDeployerHandler } from './hosted-plugin-deployer-handler';
@@ -59,6 +60,7 @@ export function bindCommonHostedBackend(bind: interfaces.Bind): void {
     bind(PluginDeployerHandler).toService(HostedPluginDeployerHandler);
 
     bind(GrammarsReader).toSelf().inSingletonScope();
+    bind(HostedPluginProcessConfiguration).toConstantValue({ path: path.resolve(__dirname, 'plugin-host.js') });
 
     bind(ConnectionContainerModule).toConstantValue(commonHostedConnectionModule);
 }


### PR DESCRIPTION
#### What it does
Allow to configure through `inversify` the path of the process to be launched for plug-ins
Fixes #7180 

#### How to test
Launch Theia with plug-ins (or VS Code extensions)
They should work as usual (if process is not found BTW no plug-in can start)

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

Change-Id: I6977e799a74238637c50ed7e6845c610c208ec02
Signed-off-by: Florent Benoit <fbenoit@redhat.com>
