### PR TITLE
[git] Fixed duplicated entries for git history on merge operations

### DIFF
--- a/packages/git/src/browser/git-scm-provider.ts
+++ b/packages/git/src/browser/git-scm-provider.ts
@@ -383,7 +383,6 @@ export class GitAmendSupport implements ScmAmendSupport {
             this.repository,
             {
                 range: { toRevision: amendingHeadCommitSha, fromRevision: latestCommitSha },
-                firstParent: true,
                 maxCount: 50
             }
         );

--- a/packages/git/src/common/git.ts
+++ b/packages/git/src/common/git.ts
@@ -546,11 +546,6 @@ export namespace Git {
              * Decides whether the commit hash should be the abbreviated version.
              */
             readonly shortSha?: boolean;
-
-            /**
-             * Return only commits reached by following the first parent, giving a linear list of commits.
-             */
-            readonly firstParent?: boolean;
         }
 
         /**

--- a/packages/git/src/node/dugite-git.ts
+++ b/packages/git/src/node/dugite-git.ts
@@ -643,11 +643,8 @@ export class DugiteGit implements Git {
         if (options && options.branch) {
             args.push(options.branch);
         }
-        if (options && options.firstParent) {
-            args.push('--first-parent');
-        }
         const range = this.mapRange((options || {}).range);
-        args.push(...[range, '-C', '-M', '-m']);
+        args.push(...[range, '-C', '-M', '-m', '--first-parent']);
         const maxCount = options && options.maxCount ? options.maxCount : 0;
         if (Number.isInteger(maxCount) && maxCount > 0) {
             args.push(...['-n', `${maxCount}`]);


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->
It fixes #7186.

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->
It merges together entries for a commit, when their sha is the same. An alternative approach would be to not get duplicated entries in the first place by changing the `git log` options used to load the git history.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

Import https://github.com/ARMmbed/mbed-os-example-blinky in Theia and check its history.

#### Review checklist

- [X] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

