### PR TITLE
[tree-view]: update the styling of file-path when tree-row is selected

### DIFF
--- a/packages/core/src/browser/style/tree.css
+++ b/packages/core/src/browser/style/tree.css
@@ -140,3 +140,7 @@
 .theia-tree-element-node {
     width: 100%
 }
+
+.theia-TreeNodeSubLabel:active{
+    color: var(--theia-list-activeSelectionForeground) !important;
+}

--- a/packages/core/src/browser/tree/tree-widget.tsx
+++ b/packages/core/src/browser/tree/tree-widget.tsx
@@ -52,7 +52,7 @@ export const TREE_NODE_SEGMENT_GROW_CLASS = 'theia-TreeNodeSegmentGrow';
 export const EXPANDABLE_TREE_NODE_CLASS = 'theia-ExpandableTreeNode';
 export const COMPOSITE_TREE_NODE_CLASS = 'theia-CompositeTreeNode';
 export const TREE_NODE_CAPTION_CLASS = 'theia-TreeNodeCaption';
-
+export const TREE_NODE_SUBLABEL_CLASS = 'theia-TreeNodeSubLabel';
 export const TreeProps = Symbol('TreeProps');
 
 /**
@@ -782,7 +782,7 @@ export class TreeWidget extends ReactWidget implements StatefulWidget {
             return undefined;
         }
         const attributes = this.createNodeAttributes(node, props);
-        const content = <div className={TREE_NODE_CONTENT_CLASS}>
+        const content = <div className={`${TREE_NODE_CONTENT_CLASS} ${TREE_NODE_SUBLABEL_CLASS}`}>
             {this.renderExpansionToggle(node, props)}
             {this.decorateIcon(node, this.renderIcon(node, props))}
             {this.renderCaptionAffixes(node, props, 'captionPrefixes')}

--- a/packages/markers/src/browser/style/index.css
+++ b/packages/markers/src/browser/style/index.css
@@ -71,7 +71,6 @@
 .theia-marker-container .markerNode .position,
 .theia-marker-container .markerNode .owner,
 .theia-marker-container .markerNode .code {
-    color: var(--theia-descriptionForeground);
     white-space: nowrap;
 }
 

--- a/packages/plugin-ext/src/main/browser/style/tree.css
+++ b/packages/plugin-ext/src/main/browser/style/tree.css
@@ -25,7 +25,6 @@
 }
 
 .theia-tree-view-description {
-    color: var(--theia-descriptionForeground);
     font-size: var(--theia-ui-font-size0);
     margin-left: var(--theia-ui-padding);
 }

--- a/packages/search-in-workspace/src/browser/styles/index.css
+++ b/packages/search-in-workspace/src/browser/styles/index.css
@@ -221,7 +221,6 @@
 }
 
 .t-siw-search-container .result .result-head .file-path {
-    color: var(--theia-descriptionForeground);
     font-size: var(--theia-ui-font-size0);
     margin-left: 3px;
 }


### PR DESCRIPTION

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
Fixes: #7189

Updated the styling for all the trees in such a way that the description/label color will be set from the base tree and not individually, it will add uniformity and also fix the issue simultaneously.

Tested with:
1. Outline
2. Search-in-Workspace
3. Gitlens
4. File Explorer
5. Problems Console.
6. Source Control: Git

Signed-off-by: Muhammad Anas Shahid <muhammad.shahid@ericsson.com>

#### How to test


    Launch Theia

    Change the color theme by pressing f1 or Ctrl+Shift+P to light(theia)

    Open any repository(for e.g. Theia repo)

    Go to the Search Icon or press ctrl+shift+f

    Search for a file and select the one which has a file-path displayed

    There must be a dark highlight on the file-path, making it less visible

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

