### PR TITLE
gracefully terminate plugin host process without rpc connection

### DIFF
--- a/packages/plugin-ext/src/hosted/node/hosted-plugin-cli-contribution.ts
+++ b/packages/plugin-ext/src/hosted/node/hosted-plugin-cli-contribution.ts
@@ -18,24 +18,58 @@ import { injectable } from 'inversify';
 import { Argv, Arguments } from 'yargs';
 import { CliContribution } from '@theia/core/lib/node';
 
+let pluginHostTerminateTimeout = 10 * 1000;
+if (process.env.PLUGIN_HOST_TERMINATE_TIMEOUT) {
+    pluginHostTerminateTimeout = Number.parseInt(process.env.PLUGIN_HOST_TERMINATE_TIMEOUT);
+}
+
+let pluginHostStopTimeout = 4 * 1000;
+if (process.env.PLUGIN_HOST_STOP_TIMEOUT) {
+    pluginHostStopTimeout = Number.parseInt(process.env.PLUGIN_HOST_STOP_TIMEOUT);
+}
+
 @injectable()
 export class HostedPluginCliContribution implements CliContribution {
 
     static EXTENSION_TESTS_PATH = 'extensionTestsPath';
+    static PLUGIN_HOST_TERMINATE_TIMEOUT = 'pluginHostTerminateTimeout';
+    static PLUGIN_HOST_STOP_TIMEOUT = 'pluginHostStopTimeout';
 
     protected _extensionTestsPath: string | undefined;
     get extensionTestsPath(): string | undefined {
         return this._extensionTestsPath;
     }
 
+    protected _pluginHostTerminateTimeout = pluginHostTerminateTimeout;
+    get pluginHostTerminateTimeout(): number {
+        return this._pluginHostTerminateTimeout;
+    }
+
+    protected _pluginHostStopTimeout = pluginHostStopTimeout;
+    get pluginHostStopTimeout(): number {
+        return this._pluginHostStopTimeout;
+    }
+
     configure(conf: Argv): void {
         conf.option(HostedPluginCliContribution.EXTENSION_TESTS_PATH, {
             type: 'string'
+        });
+        conf.option(HostedPluginCliContribution.PLUGIN_HOST_TERMINATE_TIMEOUT, {
+            type: 'number',
+            default: pluginHostTerminateTimeout,
+            description: 'Timeout in milliseconds to wait for the plugin host process to terminate before killing it. Use 0 for no timeout.'
+        });
+        conf.option(HostedPluginCliContribution.PLUGIN_HOST_STOP_TIMEOUT, {
+            type: 'number',
+            default: pluginHostStopTimeout,
+            description: 'Timeout in milliseconds to wait for the plugin host process to stop internal services. Use 0 for no timeout.'
         });
     }
 
     setArguments(args: Arguments): void {
         this._extensionTestsPath = args[HostedPluginCliContribution.EXTENSION_TESTS_PATH];
+        this._pluginHostTerminateTimeout = args[HostedPluginCliContribution.PLUGIN_HOST_TERMINATE_TIMEOUT];
+        this._pluginHostStopTimeout = args[HostedPluginCliContribution.PLUGIN_HOST_STOP_TIMEOUT];
     }
 
 }

--- a/packages/plugin-ext/src/hosted/node/plugin-host-rpc.ts
+++ b/packages/plugin-ext/src/hosted/node/plugin-host-rpc.ts
@@ -76,6 +76,10 @@ export class PluginHostRPC {
         );
     }
 
+    async terminate(): Promise<void> {
+        await this.pluginManager.terminate();
+    }
+
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     initContext(contextPath: string, plugin: Plugin): any {
         const { name, version } = plugin.rawModel;

--- a/packages/plugin-ext/src/hosted/node/plugin-host.ts
+++ b/packages/plugin-ext/src/hosted/node/plugin-host.ts
@@ -15,7 +15,7 @@
  ********************************************************************************/
 
 import { Emitter } from '@theia/core/lib/common/event';
-import { RPCProtocolImpl } from '../../common/rpc-protocol';
+import { RPCProtocolImpl, MessageType, ConnectionClosedError } from '../../common/rpc-protocol';
 import { PluginHostRPC } from './plugin-host-rpc';
 console.log('PLUGIN_HOST(' + process.pid + ') starting instance');
 
@@ -50,6 +50,10 @@ process.on('unhandledRejection', (reason: any, promise: Promise<any>) => {
         if (index >= 0) {
             promise.catch(err => {
                 unhandledPromises.splice(index, 1);
+                if (terminating && (ConnectionClosedError.is(err) || ConnectionClosedError.is(reason))) {
+                    // during termination it is expected that pending rpc requerst are rejected
+                    return;
+                }
                 console.error(`Promise rejection not handled in one second: ${err} , reason: ${reason}`);
                 if (err && err.stack) {
                     console.error(`With stack trace: ${err.stack}`);
@@ -67,19 +71,41 @@ process.on('rejectionHandled', (promise: Promise<any>) => {
     }
 });
 
+let terminating = false;
 const emitter = new Emitter();
 const rpc = new RPCProtocolImpl({
     onMessage: emitter.event,
     send: (m: {}) => {
-        if (process.send) {
+        if (process.send && !terminating) {
             process.send(JSON.stringify(m));
         }
     }
 });
 
-process.on('message', (message: string) => {
+process.on('message', async (message: string) => {
+    if (terminating) {
+        return;
+    }
     try {
-        emitter.fire(JSON.parse(message));
+        const msg = JSON.parse(message);
+        if ('type' in msg && msg.type === MessageType.Terminate) {
+            terminating = true;
+            emitter.dispose();
+            if ('stopTimeout' in msg && typeof msg.stopTimeout === 'number' && msg.stopTimeout) {
+                await Promise.race([
+                    pluginHostRPC.terminate(),
+                    new Promise(resolve => setTimeout(resolve, msg.stopTimeout))
+                ]);
+            } else {
+                await pluginHostRPC.terminate();
+            }
+            rpc.dispose();
+            if (process.send) {
+                process.send(JSON.stringify({ type: MessageType.Terminated }));
+            }
+        } else {
+            emitter.fire(msg);
+        }
     } catch (e) {
         console.error(e);
     }

--- a/packages/plugin-ext/src/plugin/command-registry.ts
+++ b/packages/plugin-ext/src/plugin/command-registry.ts
@@ -85,10 +85,6 @@ export class CommandRegistryImpl implements CommandRegistryExt {
         });
     }
 
-    dispose(): void {
-        throw new Error('Method not implemented.');
-    }
-
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     $executeCommand<T>(id: string, ...args: any[]): PromiseLike<T | undefined> {
         if (this.handlers.has(id)) {

--- a/packages/plugin-ext/src/plugin/tasks/tasks.ts
+++ b/packages/plugin-ext/src/plugin/tasks/tasks.ts
@@ -24,7 +24,7 @@ import {
 import * as theia from '@theia/plugin';
 import * as converter from '../type-converters';
 import { Disposable } from '../types-impl';
-import { RPCProtocol } from '../../common/rpc-protocol';
+import { RPCProtocol, ConnectionClosedError } from '../../common/rpc-protocol';
 import { TaskProviderAdapter } from './task-provider';
 import { Emitter, Event } from '@theia/core/lib/common/event';
 
@@ -40,9 +40,15 @@ export class TasksExtImpl implements TasksExt {
     private readonly onDidExecuteTaskProcess: Emitter<theia.TaskProcessStartEvent> = new Emitter<theia.TaskProcessStartEvent>();
     private readonly onDidTerminateTaskProcess: Emitter<theia.TaskProcessEndEvent> = new Emitter<theia.TaskProcessEndEvent>();
 
+    private disposed = false;
+
     constructor(rpc: RPCProtocol) {
         this.proxy = rpc.getProxy(PLUGIN_RPC_CONTEXT.TASKS_MAIN);
         this.fetchTaskExecutions();
+    }
+
+    dispose(): void {
+        this.disposed = true;
     }
 
     get taskExecutions(): ReadonlyArray<theia.TaskExecution> {
@@ -169,6 +175,9 @@ export class TasksExtImpl implements TasksExt {
             const taskExecutions = await this.proxy.$taskExecutions();
             taskExecutions.forEach(execution => this.getTaskExecution(execution));
         } catch (error) {
+            if (this.disposed && ConnectionClosedError.is(error)) {
+                return;
+            }
             console.error(`Can not fetch running tasks: ${error}`);
         }
     }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

fix #7176, fix #5019, fix #5839, fix #6677, fix #7113

The issue arises when there are pending requests in the plugin host process and the main side is already gone (which is basically always on reload). For some reasons we create a new RPC protocol which is not capable of handling such pending requests to stop plugins.

Instead of creating new protocol this PR adds new control messages:
- terminate to ask the plugin host process to shutdown rpc connection and deactivate all plugins as much as possible
- terminated to get notified when the host process is done to kill it and its children
- all other communications are prohibited during termination, since there is nobody to talk to and it will for sure fail

It fixes the issue with massive amount of error logging produced on each reload, around 2K lines.
For instance, I checked Gitpod logs for last 7 days and first 3 of 5 most frequent errors are incarnation of this issue.

It as well improves stopping of plugins, since deactivation of VS Code extension can happen asynchronous, but we were not handling it.
In addition, now the plugin host process has a chance to kill child processes on its own (by disposing RPCProtocol) without relying on Theia backend.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

- Reload the page while causing extensive communication with the plugin host process, i.e. debug something, use language features causing many diagnostics and so on.
- Check that backend logs don't have any errors about unknown actors or closed connections from the plugin host process. There can be some errors from concrete plugins though, but they should be rare.
- Check that the plugin host process is shutdown and all its children, i.e. if you debug something, you should debug it again on reload, ports should not be occupied. Use system tools to explore process trees, i.e. `ps -auxf` on linux.

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

