### PR TITLE
Add indent guidelines to all trees

### DIFF
--- a/packages/core/src/browser/common-frontend-contribution.ts
+++ b/packages/core/src/browser/common-frontend-contribution.ts
@@ -1005,7 +1005,7 @@ export class CommonFrontendContribution implements FrontendApplicationContributi
             // if not yet contributed by Monaco, check runtime css variables to learn.
             // TODO: Following are not yet supported/no respective elements in theia:
             // list.focusBackground, list.focusForeground, list.inactiveFocusBackground, list.filterMatchBorder,
-            // list.dropBackground, listFilterWidget.outline, listFilterWidget.noMatchesOutline, tree.indentGuidesStroke
+            // list.dropBackground, listFilterWidget.outline, listFilterWidget.noMatchesOutline
             // list.invalidItemForeground,
             // list.warningForeground, list.errorForeground => tree node needs an respective class
             { id: 'list.activeSelectionBackground', defaults: { dark: '#094771', light: '#0074E8' }, description: 'List/Tree background color for the selected item when the list/tree is active. An active list/tree has keyboard focus, an inactive does not.' },
@@ -1015,6 +1015,8 @@ export class CommonFrontendContribution implements FrontendApplicationContributi
             { id: 'list.hoverBackground', defaults: { dark: '#2A2D2E', light: '#F0F0F0' }, description: 'List/Tree background when hovering over items using the mouse.' },
             { id: 'list.hoverForeground', description: 'List/Tree foreground when hovering over items using the mouse.' },
             { id: 'list.filterMatchBackground', defaults: { dark: 'editor.findMatchHighlightBackground', light: 'editor.findMatchHighlightBackground' }, description: 'Background color of the filtered match.' },
+            { id: 'tree.indentGuidesStrokeActive', defaults: { dark: '#585858', light: '#a9a9a9', hc: '#a9a9a9' }, description: "Tree Widget's stroke color for active indent guides." },
+            { id: 'tree.indentGuidesStrokeHover', defaults: { dark: Color.rgba(88, 88, 88, 0.4), light: Color.rgba(169, 169, 169, 0.4), hc: Color.rgba(169, 169, 169, 0.4) }, description: 'Tree Widget\'s stroke color for hovered indent guides.' },
 
             // Editor Group & Tabs colors should be aligned with https://code.visualstudio.com/api/references/theme-color#editor-groups-tabs
             {

--- a/packages/core/src/browser/core-preferences.ts
+++ b/packages/core/src/browser/core-preferences.ts
@@ -62,6 +62,12 @@ export const corePreferenceSchema: PreferenceSchema = {
             type: 'boolean',
             default: false,
             description: 'Controls whether to suppress notification popups.'
+        },
+        'workbench.tree.renderIndentGuides': {
+            type: 'string',
+            enum: ['onHover', 'none', 'always'],
+            default: 'onHover',
+            description: 'Controls whether the three should render indent guides.'
         }
     }
 };
@@ -74,6 +80,7 @@ export interface CoreConfiguration {
     'workbench.colorTheme'?: string;
     'workbench.iconTheme'?: string | null;
     'workbench.silentNotifications': boolean;
+    'workbench.tree.renderIndentGuides'?: 'onHover' | 'none' | 'always';
 }
 
 export const CorePreferences = Symbol('CorePreferences');

--- a/packages/core/src/browser/style/tree.css
+++ b/packages/core/src/browser/style/tree.css
@@ -139,3 +139,33 @@
 .theia-tree-element-node {
     width: 100%
 }
+
+.theia-TreeNodeIndent {
+    display: flex;
+}
+
+.theia-treeNodeIndentBlock {
+    width: 8px;
+    border-right: 1px solid transparent;
+    height: 22px;
+}
+
+.theia-treeNodeChildPadding {
+    margin-right: 3px;
+}
+
+.theia-TreeContainer:hover .theia-treeNodeIndentBlock.theia-indentGuideOnHover {
+    border-right: 1px solid var(--theia-tree-indentGuidesStrokeHover);
+}
+
+.theia-TreeContainer .theia-treeNodeIndentBlock.theia-treeNodeActive.theia-indentGuideOnHover {
+    border-right: 1px solid var(--theia-tree-indentGuidesStrokeActive);
+}
+
+.theia-TreeContainer .theia-treeNodeIndentBlock.theia-indentGuideAlways {
+    border-right: 1px solid var(--theia-tree-indentGuidesStrokeHover);
+}
+
+.theia-TreeContainer .theia-treeNodeIndentBlock.theia-treeNodeActive.theia-indentGuideAlways {
+    border-right: 1px solid var(--theia-tree-indentGuidesStrokeActive);
+}

--- a/packages/filesystem/src/browser/file-tree/file-tree-widget.tsx
+++ b/packages/filesystem/src/browser/file-tree/file-tree-widget.tsx
@@ -235,6 +235,15 @@ export class FileTreeWidget extends TreeWidget {
         return super.getPaddingLeft(node, props);
     }
 
+    protected needsRootLevelIconPadding(node: TreeNode, props: NodeProps): boolean {
+        const theme = this.iconThemeService.getDefinition(this.iconThemeService.current);
+        if (theme && (theme.hidesExplorerArrows || (theme.hasFileIcons && !theme.hasFolderIcons))) {
+            return false;
+        }
+        return super.needsRootLevelIconPadding(node, props);
+    }
+
+    // Code is kept here to prevent broken api
     protected needsExpansionTogglePadding(node: TreeNode): boolean {
         const theme = this.iconThemeService.getDefinition(this.iconThemeService.current);
         if (theme && (theme.hidesExplorerArrows || (theme.hasFileIcons && !theme.hasFolderIcons))) {


### PR DESCRIPTION
#### What it does

Fixes #6586
- Add preference to set 'workbench.tree.renderIndentGuides' to 'onHover' (default), 'none' or 'always'
- When nodes are selected, indent guidelines are rendered for all the sibling nodes
- When parent node is selected, indent guidelines are rendered for all the child nodes
- When hovering over a tree, indent guidelines are displayed for all expanded nodes
- Selecting multiple nodes works in a similar fashion

#### How to test
- Set the workspace preference to 'onHover', 'none', 'always' and the rendering of the indent guidelines should change accordingly.
- In different locations in Theia where the tree is being used (for example, in navigator, search in workspace, outline, type hierarchy), select one/more nodes to test if the indent guidelines are rendered correctly.

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

