### PR TITLE
Add a new preference to silence notifications

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## v0.17.0
 
+- [preferences] add a new preference to silence notifications [#7195](https://github.com/eclipse-theia/theia/pull/7195)
+
 Breaking changes:
 
 - [scm][git] the History view (GitHistoryWidget) has moved from the git package to a new   package, scm-extra, and

--- a/packages/core/src/browser/core-preferences.ts
+++ b/packages/core/src/browser/core-preferences.ts
@@ -57,6 +57,11 @@ export const corePreferenceSchema: PreferenceSchema = {
         'workbench.iconTheme': {
             type: ['string', 'null'],
             description: "Specifies the icon theme used in the workbench or 'null' to not show any file icons."
+        },
+        'workbench.silentNotifications': {
+            type: 'boolean',
+            default: false,
+            description: 'Controls whether to suppress notification popups.'
         }
     }
 };
@@ -68,6 +73,7 @@ export interface CoreConfiguration {
     'workbench.editor.highlightModifiedTabs': boolean;
     'workbench.colorTheme'?: string;
     'workbench.iconTheme'?: string | null;
+    'workbench.silentNotifications': boolean;
 }
 
 export const CorePreferences = Symbol('CorePreferences');

--- a/packages/messages/src/browser/notification-toasts-component.tsx
+++ b/packages/messages/src/browser/notification-toasts-component.tsx
@@ -18,9 +18,11 @@ import * as React from 'react';
 import { DisposableCollection } from '@theia/core';
 import { NotificationManager, NotificationUpdateEvent } from './notifications-manager';
 import { NotificationComponent } from './notification-component';
+import { CorePreferences } from '@theia/core/lib/browser';
 
 export interface NotificationToastsComponentProps {
     readonly manager: NotificationManager;
+    readonly corePreferences: CorePreferences;
 }
 
 type NotificationToastsComponentState = Pick<NotificationUpdateEvent, Exclude<keyof NotificationUpdateEvent, 'notifications'>>;
@@ -40,6 +42,7 @@ export class NotificationToastsComponent extends React.Component<NotificationToa
     async componentDidMount(): Promise<void> {
         this.toDisposeOnUnmount.push(
             this.props.manager.onUpdated(({ toasts, visibilityState }) => {
+                visibilityState = this.props.corePreferences['workbench.silentNotifications'] ? 'hidden' : visibilityState;
                 this.setState({
                     toasts: toasts.slice(-3),
                     visibilityState

--- a/packages/messages/src/browser/notifications-renderer.tsx
+++ b/packages/messages/src/browser/notifications-renderer.tsx
@@ -17,7 +17,7 @@
 import * as ReactDOM from 'react-dom';
 import * as React from 'react';
 import { injectable, inject, postConstruct } from 'inversify';
-import { ApplicationShell } from '@theia/core/lib/browser';
+import { ApplicationShell, CorePreferences } from '@theia/core/lib/browser';
 import { NotificationManager } from './notifications-manager';
 import { NotificationCenterComponent } from './notification-center-component';
 import { NotificationToastsComponent } from './notification-toasts-component';
@@ -30,6 +30,9 @@ export class NotificationsRenderer {
 
     @inject(NotificationManager)
     protected readonly manager: NotificationManager;
+
+    @inject(CorePreferences)
+    protected readonly corePreferences: CorePreferences;
 
     @postConstruct()
     protected init(): void {
@@ -48,7 +51,7 @@ export class NotificationsRenderer {
 
     protected render(): void {
         ReactDOM.render(<div>
-            <NotificationToastsComponent manager={this.manager} />
+            <NotificationToastsComponent manager={this.manager} corePreferences={this.corePreferences} />
             <NotificationCenterComponent manager={this.manager} />
         </div>, this.container);
     }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->
Resolves #5942

Provide users with the option to silence notifications, no longer showing the toasts whilst still being viewable in the status bar counter and accessible via the notifications centre.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
- Ensure notification toasts continue to appear by default (`workbench.silentNotifications: false`).
- Set preference `workbench.silentNotifications: true`, then check that toasts no longer appear.

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

