### PR TITLE
[Electron] Don't stat for electron save dialog

### DIFF
--- a/packages/filesystem/src/electron-browser/file-dialog/electron-file-dialog-service.ts
+++ b/packages/filesystem/src/electron-browser/file-dialog/electron-file-dialog-service.ts
@@ -43,17 +43,16 @@ export class ElectronFileDialogService extends DefaultFileDialogService {
         const rootNode = await this.getRootNode(folder);
         if (rootNode) {
             return new Promise<MaybeArray<URI> | undefined>(resolve => {
-                remote.dialog.showOpenDialog(this.toOpenDialogOptions(rootNode.uri, props), (filePaths: string[] | undefined) => {
+                remote.dialog.showOpenDialog(this.toOpenDialogOptions(rootNode.uri, props), async (filePaths: string[] | undefined) => {
                     if (!filePaths || filePaths.length === 0) {
                         resolve(undefined);
                         return;
                     }
+
                     const uris = filePaths.map(path => FileUri.create(path));
-                    if (this.canReadWrite(uris)) {
-                        resolve(uris.length === 1 ? uris[0] : uris);
-                    } else {
-                        resolve(undefined);
-                    }
+                    const canAccess = await this.canReadWrite(uris);
+                    const result = canAccess ? uris.length === 1 ? uris[0] : uris : undefined;
+                    resolve(result);
                 });
             });
         }
@@ -64,17 +63,21 @@ export class ElectronFileDialogService extends DefaultFileDialogService {
         const rootNode = await this.getRootNode(folder);
         if (rootNode) {
             return new Promise<URI | undefined>(resolve => {
-                remote.dialog.showSaveDialog(this.toSaveDialogOptions(rootNode.uri, props), (filename: string | undefined) => {
+                remote.dialog.showSaveDialog(this.toSaveDialogOptions(rootNode.uri, props), async (filename: string | undefined) => {
                     if (!filename) {
                         resolve(undefined);
                         return;
                     }
+
                     const uri = FileUri.create(filename);
-                    if (this.canReadWrite(uri)) {
+                    const exists = await this.fileSystem.exists(uri.toString());
+                    if (!exists) {
                         resolve(uri);
-                    } else {
-                        resolve(undefined);
+                        return;
                     }
+
+                    const canAccess = await this.canReadWrite(uri);
+                    resolve(canAccess ? uri : undefined);
                 });
             });
         }


### PR DESCRIPTION
Signed-off-by: Rob Moran <rob.moran@arm.com>

#### What it does

When using the `fileDialogService.showSaveDialog()` function in Electron, a `messageService` message is shown if the file input doesn't yet exist:

`Cannot access resource at <file>.`

This is because there is an explicit stat check for the file to see if it is readable/writable, but it's possible it doesn't yet exist.

This looks like it may be a copy-paste error from the `OpenDialog()`, but I can update this PR if the checks need to be kept for when the file already exists.

#### How to test

Using the electron version, save an existing file as a new file which doesn't exist and observe the message.

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

