### PR TITLE
GH-7200: Made `RecursivePartial` array aware.

### DIFF
--- a/packages/core/src/common/types.spec.ts
+++ b/packages/core/src/common/types.spec.ts
@@ -15,9 +15,26 @@
  ********************************************************************************/
 
 import * as assert from 'assert';
-import { Prioritizeable } from './types';
+import { Prioritizeable, RecursivePartial } from './types';
 
 describe('types', () => {
+
+    describe('recursive-partial', () => {
+        it('should handle nested arrays', () => {
+            interface Bar {
+                readonly arr: Array<string>;
+            }
+            interface Foo {
+                readonly bar: Bar;
+            }
+            const myArr: Array<string> = [];
+            const myFoo: RecursivePartial<Foo> = {};
+            if (myFoo.bar && myFoo.bar.arr) {
+                const x = Array.from(new Set(myFoo.bar.arr));
+                myArr.push(...x);
+            }
+        });
+    });
 
     describe('Prioritizeable', () => {
         it('prioritizeAll #01', () => {

--- a/packages/core/src/common/types.ts
+++ b/packages/core/src/common/types.ts
@@ -20,7 +20,9 @@ export type Deferred<T> = {
     [P in keyof T]: Promise<T[P]>
 };
 export type RecursivePartial<T> = {
-    [P in keyof T]?: RecursivePartial<T[P]>;
+    [P in keyof T]?: T[P] extends Array<infer I>
+    ? Array<RecursivePartial<I>>
+    : RecursivePartial<T[P]>;
 };
 export type MaybeArray<T> = T | T[];
 export type MaybePromise<T> = T | Promise<T> | PromiseLike<T>;


### PR DESCRIPTION
Closes #7200.

Signed-off-by: Akos Kitta <kittaakos@typefox.io>

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->
This PR patches the `RecursivePartial` type so that it gracefully handles nested array props.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
Check the CI, it should be green.

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

