### PR TITLE
[Electron] Use absolute path for plugins running in Electron.

### DIFF
--- a/dev-packages/application-package/src/environment.ts
+++ b/dev-packages/application-package/src/environment.ts
@@ -29,12 +29,12 @@ class ElectronEnv {
     /**
      * `true` if running in electron. Otherwise, `false`.
      *
-     * Can be called from both the `main` and the render process. Also works for forked cluster workers.
+     * Can be called from both the `main` and render processes. Also works for forked cluster workers and VS Code extension processes.
      */
     is(): boolean {
         // When forking a new process from the cluster, we can rely neither on `process.versions` nor `process.argv`.
-        // Se we look into the `process.env` as well. `is-electron` does not do it for us.
-        return isElectron() || typeof process !== 'undefined' && typeof process.env === 'object' && !!process.env.THEIA_ELECTRON_VERSION;
+        // So we look into the `process.env` as well. `is-electron` does not do it for us.
+        return isElectron() || typeof process !== 'undefined' && typeof process.env === 'object' && (!!process.env.THEIA_ELECTRON_VERSION || !!process.env.ELECTRON_RUN_AS_NODE);
     }
 
     /**

--- a/packages/plugin-ext/src/common/plugin-protocol.ts
+++ b/packages/plugin-ext/src/common/plugin-protocol.ts
@@ -13,6 +13,8 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
+
+import URI from 'vscode-uri';
 import { JsonRpcServer } from '@theia/core/lib/common/messaging/proxy-factory';
 import { RPCProtocol } from './rpc-protocol';
 import { Disposable } from '@theia/core/lib/common/disposable';
@@ -58,7 +60,7 @@ export interface PluginPackage {
 }
 export namespace PluginPackage {
     export function toPluginUrl(pck: PluginPackage, relativePath: string): string {
-        return `hostedPlugin/${getPluginId(pck)}/${encodeURIComponent(relativePath)}`;
+        return URI.file(pck.packagePath + '/' + relativePath).toString();
     }
 }
 

--- a/packages/plugin-ext/src/main/browser/plugin-shared-style.ts
+++ b/packages/plugin-ext/src/main/browser/plugin-shared-style.ts
@@ -19,6 +19,7 @@ import { Disposable, DisposableCollection } from '@theia/core/lib/common/disposa
 import { ThemeService, Theme } from '@theia/core/lib/browser/theming';
 import { IconUrl } from '../../common/plugin-protocol';
 import { Reference, SyncReferenceCollection } from '@theia/core/lib/common/reference';
+import { Endpoint } from '@theia/core/lib/browser';
 
 export interface PluginIconKey {
     url: IconUrl
@@ -105,14 +106,18 @@ export class PluginSharedStyle {
         const lightIconUrl = typeof iconUrl === 'object' ? iconUrl.light : iconUrl;
         const iconClass = 'plugin-icon-' + this.iconSequence++;
         const toDispose = new DisposableCollection();
-        toDispose.push(this.insertRule('.' + iconClass, theme => `
+        toDispose.push(this.insertRule('.' + iconClass, theme => {
+            const endpoint = new Endpoint({ path: 'file' }).getRestUrl();
+            const resolvedUrl = endpoint.withQuery(theme.type === 'light' ? lightIconUrl : darkIconUrl);
+            return `
                 display: inline-block;
                 background-position: 2px;
                 width: ${size}px;
                 height: ${size}px;
-                background: no-repeat url("${theme.type === 'light' ? lightIconUrl : darkIconUrl}");
+                background: no-repeat url("${resolvedUrl}");
                 background-size: ${size}px;
-            `));
+            `;
+        }));
         return {
             iconClass,
             dispose: () => toDispose.dispose()

--- a/packages/plugin-ext/src/main/browser/view/plugin-view-registry.ts
+++ b/packages/plugin-ext/src/main/browser/view/plugin-view-registry.ts
@@ -18,7 +18,7 @@ import { injectable, inject, postConstruct } from 'inversify';
 import {
     ApplicationShell, ViewContainer as ViewContainerWidget, WidgetManager,
     ViewContainerIdentifier, ViewContainerTitleOptions, Widget, FrontendApplicationContribution,
-    StatefulWidget, CommonMenus, BaseWidget
+    StatefulWidget, CommonMenus, BaseWidget, Endpoint
 } from '@theia/core/lib/browser';
 import { ViewContainer, View } from '../../../common';
 import { PluginSharedStyle } from '../plugin-shared-style';
@@ -189,9 +189,12 @@ export class PluginViewRegistry implements FrontendApplicationContribution {
         }
         const toDispose = new DisposableCollection();
         const iconClass = 'plugin-view-container-icon-' + viewContainer.id;
+
+        const endpoint = new Endpoint({ path: 'file' }).getRestUrl();
+        const resolvedUrl = endpoint.withQuery(viewContainer.iconUrl);
         toDispose.push(this.style.insertRule('.' + iconClass, () => `
-                mask: url('${viewContainer.iconUrl}') no-repeat 50% 50%;
-                -webkit-mask: url('${viewContainer.iconUrl}') no-repeat 50% 50%;
+                mask: url('${resolvedUrl}') no-repeat 50% 50%;
+                -webkit-mask: url('${resolvedUrl}') no-repeat 50% 50%;
             `));
         toDispose.push(this.doRegisterViewContainer(viewContainer.id, location, {
             label: viewContainer.title,


### PR DESCRIPTION
Signed-off-by: Johannes Birkenstock <johannes.birkenstock@siemens.com>

#### What it does

Fixes #7040

It fixes this [bug](https://github.com/eclipse-theia/theia/issues/7040) by using absolute paths for plugins that are running in Electron. 

#### How to test
Run any vscode extension that uses its own images in the theia electron app. 

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

