### PR TITLE
electron: only allow browser-window

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -10,6 +10,7 @@
     "@primer/octicons-react": "^9.0.0",
     "@theia/application-package": "^0.15.0",
     "@types/body-parser": "^1.16.4",
+    "@types/cookie": "^0.3.3",
     "@types/express": "^4.16.0",
     "@types/fs-extra": "^4.0.2",
     "@types/lodash.debounce": "4.0.3",
@@ -22,6 +23,7 @@
     "@types/yargs": "^11.1.0",
     "ajv": "^6.5.3",
     "body-parser": "^1.17.2",
+    "cookie": "^0.4.0",
     "es6-promise": "^4.2.4",
     "express": "^4.16.3",
     "file-icons-js": "^1.0.3",
@@ -61,6 +63,9 @@
       "frontend": "lib/browser/keyboard/browser-keyboard-module",
       "frontendElectron": "lib/electron-browser/keyboard/electron-keyboard-module",
       "backendElectron": "lib/electron-node/keyboard/electron-backend-keyboard-module"
+    },
+    {
+      "backendElectron": "lib/electron-node/token/electron-token-backend-module"
     }
   ],
   "keywords": [

--- a/packages/core/src/electron-common/electron-token.ts
+++ b/packages/core/src/electron-common/electron-token.ts
@@ -1,0 +1,26 @@
+/********************************************************************************
+ * Copyright (C) 2020 Ericsson and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+/**
+ * This token is unique the the current running instance. It is used by the backend
+ * to make sure it is an electron browser window that is connecting to its services.
+ *
+ * The identifier is a string, which makes it usable as a key for cookies or similar.
+ */
+export const ElectronSecurityToken = 'x-theia-electron-token';
+export interface ElectronSecurityToken {
+    value: string;
+};

--- a/packages/core/src/electron-node/token/electron-token-backend-contribution.ts
+++ b/packages/core/src/electron-node/token/electron-token-backend-contribution.ts
@@ -1,0 +1,48 @@
+/********************************************************************************
+ * Copyright (C) 2020 Ericsson and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import express = require('express');
+import { injectable, inject } from 'inversify';
+import { BackendApplicationContribution } from '../../node';
+import { ElectronTokenValidator } from './electron-token-validator';
+
+/**
+ * This component contributes an Express middleware that will refuse all
+ * requests that do not include a specific token.
+ */
+@injectable()
+export class ElectronTokenBackendContribution implements BackendApplicationContribution {
+
+    @inject(ElectronTokenValidator)
+    protected readonly tokenValidator: ElectronTokenValidator;
+
+    configure(app: express.Application): void {
+        app.use(this.expressMiddleware.bind(this));
+    }
+
+    /**
+     * Only allow token-bearers.
+     */
+    protected expressMiddleware(req: express.Request, res: express.Response, next: express.NextFunction): void {
+        if (this.tokenValidator.allowRequest(req)) {
+            next();
+        } else {
+            console.error(`refused an http request: ${req.connection.remoteAddress}`);
+            res.sendStatus(403);
+        }
+    }
+
+}

--- a/packages/core/src/electron-node/token/electron-token-backend-module.ts
+++ b/packages/core/src/electron-node/token/electron-token-backend-module.ts
@@ -1,0 +1,31 @@
+/********************************************************************************
+ * Copyright (C) 2020 Ericsson and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import { ContainerModule } from 'inversify';
+import { BackendApplicationContribution, MessagingService } from '../../node';
+import { MessagingContribution } from '../../node/messaging/messaging-contribution';
+import { ElectronTokenBackendContribution } from './electron-token-backend-contribution';
+import { ElectronMessagingContribution } from './electron-token-messaging-contribution';
+import { ElectronTokenValidator } from './electron-token-validator';
+
+export default new ContainerModule((bind, unbind, isBound, rebind) => {
+    bind<ElectronTokenValidator>(ElectronTokenValidator).toSelf().inSingletonScope();
+
+    bind<ElectronTokenBackendContribution>(ElectronTokenBackendContribution).toSelf().inSingletonScope();
+    bind<BackendApplicationContribution>(BackendApplicationContribution).toService(ElectronTokenBackendContribution);
+
+    rebind<MessagingContribution>(MessagingService.Identifier).to(ElectronMessagingContribution).inSingletonScope();
+});

--- a/packages/core/src/electron-node/token/electron-token-messaging-contribution.ts
+++ b/packages/core/src/electron-node/token/electron-token-messaging-contribution.ts
@@ -1,0 +1,44 @@
+/********************************************************************************
+ * Copyright (C) 2020 Ericsson and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import * as net from 'net';
+import * as http from 'http';
+import { injectable, inject } from 'inversify';
+import { MessagingContribution } from '../../node/messaging/messaging-contribution';
+import { ElectronTokenValidator } from './electron-token-validator';
+
+/**
+ * Override the browser MessagingContribution class to refuse connections that do not include a specific token.
+ */
+@injectable()
+export class ElectronMessagingContribution extends MessagingContribution {
+
+    @inject(ElectronTokenValidator)
+    protected readonly tokenValidator: ElectronTokenValidator;
+
+    /**
+     * Only allow token-bearers.
+     */
+    protected handleHttpUpgrade(request: http.IncomingMessage, socket: net.Socket, head: Buffer): void {
+        if (this.tokenValidator.allowRequest(request)) {
+            super.handleHttpUpgrade(request, socket, head);
+        } else {
+            console.error(`refused a websocket connection: ${request.connection.remoteAddress}`);
+            socket.destroy(); // kill connection, client will take that as a "no".
+        }
+    }
+
+}

--- a/packages/core/src/electron-node/token/electron-token-validator.ts
+++ b/packages/core/src/electron-node/token/electron-token-validator.ts
@@ -1,0 +1,55 @@
+/********************************************************************************
+ * Copyright (C) 2020 Ericsson and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import * as http from 'http';
+import * as cookie from 'cookie';
+import { injectable } from 'inversify';
+import { ElectronSecurityToken } from '../../electron-common/electron-token';
+
+/**
+ * On Electron, we want to make sure that only Electron's browser-windows access the backend services.
+ */
+@injectable()
+export class ElectronTokenValidator {
+
+    protected electronSecurityToken: ElectronSecurityToken = this.getToken();
+
+    /**
+     * Expects the token to be passed via cookies by default.
+     */
+    allowRequest(request: http.IncomingMessage): boolean {
+        const cookieHeader = request.headers.cookie;
+        if (typeof cookieHeader === 'string') {
+            const token = cookie.parse(cookieHeader)[ElectronSecurityToken];
+            if (typeof token === 'string') {
+                return this.isTokenValid(JSON.parse(token));
+            }
+        }
+        return false;
+    }
+
+    isTokenValid(token: ElectronSecurityToken): boolean {
+        return typeof token === 'object' && token.value === this.electronSecurityToken!.value;
+    }
+
+    /**
+     * Returns the token to compare to when authorizing requests.
+     */
+    protected getToken(): ElectronSecurityToken {
+        return JSON.parse(process.env[ElectronSecurityToken]!);
+    }
+
+}

--- a/packages/core/src/node/messaging/messaging-backend-module.ts
+++ b/packages/core/src/node/messaging/messaging-backend-module.ts
@@ -24,11 +24,11 @@ import { MessagingService } from './messaging-service';
 export const messagingBackendModule = new ContainerModule(bind => {
     bindContributionProvider(bind, ConnectionContainerModule);
     bindContributionProvider(bind, MessagingService.Contribution);
+    bind(MessagingService.Identifier).to(MessagingContribution).inSingletonScope();
     bind(MessagingContribution).toDynamicValue(({ container }) => {
         const child = container.createChild();
         child.bind(MessagingContainer).toConstantValue(container);
-        child.bind(MessagingContribution).toSelf();
-        return child.get(MessagingContribution);
+        return child.get(MessagingService.Identifier);
     }).inSingletonScope();
     bind(BackendApplicationContribution).toService(MessagingContribution);
 });

--- a/packages/core/src/node/messaging/messaging-contribution.ts
+++ b/packages/core/src/node/messaging/messaging-contribution.ts
@@ -16,6 +16,7 @@
 
 import * as ws from 'ws';
 import * as url from 'url';
+import * as net from 'net';
 import * as http from 'http';
 import * as https from 'https';
 import { injectable, inject, named, postConstruct, interfaces } from 'inversify';
@@ -46,6 +47,7 @@ export class MessagingContribution implements BackendApplicationContribution, Me
     @inject(ContributionProvider) @named(MessagingService.Contribution)
     protected readonly contributions: ContributionProvider<MessagingService.Contribution>;
 
+    protected webSocketServer: ws.Server | undefined;
     protected readonly wsHandlers = new MessagingContribution.ConnectionHandlers<ws>();
     protected readonly channelHandlers = new MessagingContribution.ConnectionHandlers<WebSocketChannel>();
 
@@ -81,23 +83,24 @@ export class MessagingContribution implements BackendApplicationContribution, Me
 
     protected checkAliveTimeout = 30000;
     onStart(server: http.Server | https.Server): void {
-        const wss = new ws.Server({
-            server,
+        this.webSocketServer = new ws.Server({
+            noServer: true,
             perMessageDeflate: {
                 // don't compress if a message is less than 256kb
                 threshold: 256 * 1024
             }
         });
+        server.on('upgrade', this.handleHttpUpgrade.bind(this));
         interface CheckAliveWS extends ws {
             alive: boolean;
         }
-        wss.on('connection', (socket: CheckAliveWS, request) => {
+        this.webSocketServer.on('connection', (socket: CheckAliveWS, request) => {
             socket.alive = true;
             socket.on('pong', () => socket.alive = true);
             this.handleConnection(socket, request);
         });
         setInterval(() => {
-            wss.clients.forEach((socket: CheckAliveWS) => {
+            this.webSocketServer!.clients.forEach((socket: CheckAliveWS) => {
                 if (socket.alive === false) {
                     socket.terminate();
                     return;
@@ -106,6 +109,15 @@ export class MessagingContribution implements BackendApplicationContribution, Me
                 socket.ping();
             });
         }, this.checkAliveTimeout);
+    }
+
+    /**
+     * Route HTTP upgrade requests to the WebSocket server.
+     */
+    protected handleHttpUpgrade(request: http.IncomingMessage, socket: net.Socket, head: Buffer): void {
+        this.webSocketServer!.handleUpgrade(request, socket, head, client => {
+            this.webSocketServer!.emit('connection', client, request);
+        });
     }
 
     protected handleConnection(socket: ws, request: http.IncomingMessage): void {

--- a/packages/core/src/node/messaging/messaging-service.ts
+++ b/packages/core/src/node/messaging/messaging-service.ts
@@ -46,6 +46,8 @@ export interface MessagingService {
     ws(path: string, callback: (params: MessagingService.PathParams, socket: ws) => void): void;
 }
 export namespace MessagingService {
+    /** Inversify container identifier for the `MessagingService` component. */
+    export const Identifier = Symbol('MessagingService');
     export interface PathParams {
         [name: string]: string
     }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1098,6 +1098,11 @@
   dependencies:
     "@types/node" "*"
 
+"@types/cookie@^0.3.3":
+  version "0.3.3"
+  resolved "https://registry.yarnpkg.com/@types/cookie/-/cookie-0.3.3.tgz#85bc74ba782fb7aa3a514d11767832b0e3bc6803"
+  integrity sha512-LKVP3cgXBT9RYj+t+9FDKwS5tdI+rPBXaNSkma7hvqy35lc7mAokC2zsqWJH0LaqIt3B962nuYI77hsJoT1gow==
+
 "@types/decompress@^4.2.2":
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/@types/decompress/-/decompress-4.2.3.tgz#98eed48af80001038aa05690b2094915f296fe65"
@@ -4152,7 +4157,7 @@ cookie-signature@1.0.6:
   resolved "https://registry.yarnpkg.com/cookie-signature/-/cookie-signature-1.0.6.tgz#e303a882b342cc3ee8ca513a79999734dab3ae2c"
   integrity sha1-4wOogrNCzD7oylE6eZmXNNqzriw=
 
-cookie@0.4.0:
+cookie@0.4.0, cookie@^0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/cookie/-/cookie-0.4.0.tgz#beb437e7022b3b6d49019d088665303ebe9c14ba"
   integrity sha512-+Hp8fLp57wnUSt0tY0tHEXh4voZRDnoIrZPqlo3DPiI4y9lwg/jqx+1Om94/W6ZaPDOUbnjOt/99w66zk+l1Xg==


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does

Only allow http request from Electron's own browser-window. Token is
generated within electron-main, which also sets it as a cookie within
browser-windows. Token is passed to the backend via environment
variables. The backend is looking for this specific token to authorize
requests.

#### How to test

Everything should keep working when running Electron. Make sure we can also display html previews. You should not be able to load `http://localhost:<dynamic-port>` in your browser anymore.

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)