### PR TITLE
markers: update tooltip to display full path

### DIFF
--- a/packages/markers/src/browser/problem/problem-widget.tsx
+++ b/packages/markers/src/browser/problem/problem-widget.tsx
@@ -160,10 +160,12 @@ export class ProblemWidget extends TreeWidget {
         const icon = this.toNodeIcon(node);
         const name = this.toNodeName(node);
         const description = this.toNodeDescription(node);
-        return <div className='markerFileNode'>
+        // Use a custom scheme so that we fallback to the `DefaultUriLabelProviderContribution`.
+        const path = this.labelProvider.getLongName(node.uri.withScheme('marker'));
+        return <div title={path} className='markerFileNode'>
             {icon && <div className={icon + ' file-icon'}></div>}
-            <div title={name} className='name'>{name}</div>
-            <div title={description} className='path'>{description}</div>
+            <div className='name'>{name}</div>
+            <div className='path'>{description}</div>
             <div className='notification-count-container'>
                 <span className='notification-count'>{node.numberOfMarkers.toString()}</span>
             </div>


### PR DESCRIPTION



<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

Fixes #7204

- updates the `MarkerInfoNode` (file) tooltip to display the full path of a resource.
- updates the existing tooltips to instead use the full path.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
1. start the application with a single-root workspace
2. create markers and hover over the files in the `problems-view`
3. the markers should display the full path when hovering (tooltip)
4. repeat steps 2 to 3 with a multi-root workspace

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

Signed-off-by: Vincent Fugnitto <vincent.fugnitto@ericsson.com>
