### PR TITLE
[electron] Add ability to create folder in OpenDialog on MacOS

### DIFF
--- a/packages/filesystem/src/electron-browser/file-dialog/electron-file-dialog-service.ts
+++ b/packages/filesystem/src/electron-browser/file-dialog/electron-file-dialog-service.ts
@@ -24,6 +24,11 @@ import { FileStat } from '../../common';
 import { FileAccess } from '../../common/filesystem';
 import { DefaultFileDialogService, OpenFileDialogProps, SaveFileDialogProps } from '../../browser/file-dialog';
 
+// See https://github.com/electron/electron/blob/v4.2.12/docs/api/dialog.md
+// These properties get extended with newer versions of Electron
+type DialogProperties = 'openFile' | 'openDirectory' | 'multiSelections' | 'showHiddenFiles' |
+    'createDirectory' | 'promptToCreate' | 'noResolveAliases' | 'treatPackageAsDirectory';
+
 //
 // We are OK to use this here because the electron backend and frontend are on the same host.
 // If required, we can move this single service (and its module) to a dedicated Theia extension,
@@ -102,7 +107,7 @@ export class ElectronFileDialogService extends DefaultFileDialogService {
     }
 
     protected toOpenDialogOptions(uri: URI, props: OpenFileDialogProps): OpenDialogOptions {
-        const properties: Array<'openFile' | 'openDirectory' | 'multiSelections'> = electron.dialog.toDialogProperties(props);
+        const properties = electron.dialog.toDialogProperties(props);
         const buttonLabel = props.openLabel;
         return { ...this.toDialogOptions(uri, props, 'Open'), properties, buttonLabel };
     }
@@ -149,11 +154,11 @@ export namespace electron {
          *
          * See: https://github.com/electron/electron/issues/10252#issuecomment-322012159
          */
-        export function toDialogProperties(props: OpenFileDialogProps): Array<'openFile' | 'openDirectory' | 'multiSelections'> {
+        export function toDialogProperties(props: OpenFileDialogProps): Array<DialogProperties> {
             if (!isOSX && props.canSelectFiles !== false && props.canSelectFolders === true) {
                 throw new Error(`Illegal props. Cannot have 'canSelectFiles' and 'canSelectFolders' at the same times. Props was: ${JSON.stringify(props)}.`);
             }
-            const properties: Array<'openFile' | 'openDirectory' | 'multiSelections'> = [];
+            const properties: Array<DialogProperties> = [];
             if (!isOSX) {
                 if (props.canSelectFiles !== false && props.canSelectFolders !== true) {
                     properties.push('openFile');
@@ -167,6 +172,7 @@ export namespace electron {
                 }
                 if (props.canSelectFolders === true) {
                     properties.push('openDirectory');
+                    properties.push('createDirectory');
                 }
             }
             if (props.canSelectMany === true) {


### PR DESCRIPTION
Signed-off-by: Rob Moran <rob.moran@arm.com>

#### What it does
With reference to the [electron docs for the version we use (4.2.12)](https://github.com/electron/electron/blob/v4.2.12/docs/api/dialog.md), the file dialog on MacOS doesn't show the 'New Folder' button unless `properties.createDirectory` has been set.

This is restrictive behaviour when a user needs to use the file dialog to select a folder (`properties.openDirectory` set to true).

Short of implementing this feature for all other platforms (Windows, Linux, Browser), an easier approach is to set the `createDirectory` property whenever `openDirectory` is set on MacOS only.

#### How to test

Ensure the `New Folder` button appears when using the openDialog for folders in Electron for MacOS (e.g. open a new workspace).

<img width="716" alt="Screen Shot 2020-02-24 at 22 39 25" src="https://user-images.githubusercontent.com/61341/75197607-96618980-5756-11ea-8fd1-b712835e9aeb.png">

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

