### PR TITLE
markers: improve 'description'

### DIFF
--- a/packages/markers/src/browser/marker-tree-label-provider.ts
+++ b/packages/markers/src/browser/marker-tree-label-provider.ts
@@ -48,13 +48,19 @@ export class MarkerTreeLabelProvider implements LabelProviderContribution {
 
     getLongName(node: MarkerInfoNode): string {
         const description: string[] = [];
-        if (this.workspaceService.isMultiRootWorkspaceOpened) {
-            const rootUri = this.workspaceService.getWorkspaceRootUri(node.uri);
-            if (rootUri) {
-                description.push(this.labelProvider.getName(rootUri));
-            }
+        const rootUri = this.workspaceService.getWorkspaceRootUri(node.uri);
+        // In a multiple-root workspace include the root name to the label before the parent directory.
+        if (this.workspaceService.isMultiRootWorkspaceOpened && rootUri) {
+            description.push(this.labelProvider.getName(rootUri));
         }
-        description.push(this.labelProvider.getLongName(node.uri.parent));
+        // If the given resource is not at the workspace root, include the parent directory to the label.
+        if (rootUri && rootUri.toString() !== node.uri.parent.toString()) {
+            description.push(this.labelProvider.getLongName(node.uri.parent));
+        }
+        // Get the full path of a resource which does not exist in the given workspace.
+        if (!rootUri) {
+            description.push(this.labelProvider.getLongName(node.uri.parent.withScheme('markers')));
+        }
         return description.join(' ● ');
     }
 


### PR DESCRIPTION

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

The following pull-request improves the `description` for the `MarkerInfoNodes`:

`marker-tree-label-provider.ts`:

The `marker-tree-label-provider.ts` has been updated to handle
extra cases where we want custom behavior when displaying the description.
These cases include omitting the description for when a file resource
located at the workspace root is opened with markers in both single
and multiple root workspaces. This behavior aligns the `problems-view`
further with what VS Code provides.

`marker-tree-label-provider.spec.ts`:

The `marker-tree-label-provider.spec.ts` has been updated to include a new
label contribution provider (`WorkspaceUriLabelProviderContribution`), in
order to get a better label representation of a real-world application. The test
cases have also been updated and split into a more readable and verbose format.
The test cases for `getLongName()` have been updated to include both single and
multiple root test cases.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

1. start the application using both a single and multiple root workspace
2. in general, the following should hold true:

| Root | Test Case | Result (`description`) |
|:---|:---|:---|
| single | open a file not at the workspace root | the parent directory should be displayed |
| single | open a file at the workspace root | no description should be displayed |
| single | open a file outside of the workspace | the full path should be displayed |
| multi | open a file at not at one of the workspace roots | the root name and parent folder should be displayed |
| multi | open a file at one of the workspace roots | only the root name should be displayed |
| multi | open a file outside of any workspace root | only the full path of the resource should be displayed |

<div align='center'>

![image](https://user-images.githubusercontent.com/40359487/75252273-5c21d780-57aa-11ea-9ee9-1403539478e7.png)


</div>

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

Signed-off-by: Vincent Fugnitto <vincent.fugnitto@ericsson.com>
