### PR TITLE
Fix inline breakpoints

### DIFF
--- a/packages/debug/src/browser/editor/debug-editor-model.ts
+++ b/packages/debug/src/browser/editor/debug-editor-model.ts
@@ -216,13 +216,14 @@ export class DebugEditorModel implements Disposable {
         const column = breakpoint.column;
         const range = typeof column === 'number' ? new monaco.Range(lineNumber, column, lineNumber, column + 1) : new monaco.Range(lineNumber, 1, lineNumber, 1);
         const { className, message } = breakpoint.getDecoration();
+        const renderInline = typeof column === 'number' && (column > this.editor.getControl().getModel()!.getLineFirstNonWhitespaceColumn(lineNumber));
         return {
             range,
             options: {
                 glyphMarginClassName: className,
                 glyphMarginHoverMessage: message.map(value => ({ value })),
                 stickiness: DebugEditorModel.STICKINESS,
-                beforeContentClassName: typeof column === 'number' ? `theia-debug-breakpoint-column ${className}-column` : undefined
+                beforeContentClassName: renderInline ? `theia-debug-breakpoint-column ${className}-column` : undefined
             }
         };
     }


### PR DESCRIPTION
Issue: #7114 

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->
- Fixes breakpoints that are rendered on the first column, as they become inline. 
- May also resolve #6910.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
- Open sample file and create a breakpoint without any indentation (on the first column). Run command "Copy Line Down" from Selection Tab or through Find Command. 
- New line should retain breakpoint marker but it will no longer be inline. 
- Breakpoints created with indentation will still have indented breakpoint marker when copied. 

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)