### PR TITLE
Prevent default handling for the browser reserved hotkeys inside webviews

### DIFF
--- a/packages/plugin-ext/src/main/browser/webview/pre/main.js
+++ b/packages/plugin-ext/src/main/browser/webview/pre/main.js
@@ -271,6 +271,7 @@
 		 * @param {KeyboardEvent} e
 		 */
         const handleInnerKeydown = (e) => {
+            e.preventDefault();
             host.postMessage('did-keydown', {
                 key: e.key,
                 keyCode: e.keyCode,


### PR DESCRIPTION
#### What it does
This changes proposal prevents calling default browser hotkeys, such as `CtrlCmd+P`, `CtrlCmd+O` inside Web Views, when the last one is under focus.

Related issue: https://github.com/eclipse/che/issues/15763

State in master:
![wrong_handling](https://user-images.githubusercontent.com/1968177/75265319-64553380-57f9-11ea-9d8f-bf80d347100b.gif)

State with current changes:
![handling](https://user-images.githubusercontent.com/1968177/75265358-77680380-57f9-11ea-84bb-a4c2b0687195.gif)

Signed-off-by: Vladyslav Zhukovskyi <vzhukovs@redhat.com>

#### How to test
Use sample extension https://github.com/microsoft/vscode-extension-samples/tree/master/webview-sample and try to call default browser hotkey.

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

