### PR TITLE
[preview-editor] Missing keyboard focus

### DIFF
--- a/packages/editor-preview/src/browser/editor-preview-widget.ts
+++ b/packages/editor-preview/src/browser/editor-preview-widget.ts
@@ -125,6 +125,7 @@ export class EditorPreviewWidget extends BaseWidget implements ApplicationShell.
         }
         w.parent = this;
         this.onDidChangeTrackableWidgetsEmitter.fire([w]);
+        this.activate();
     }
 
     protected onAfterAttach(msg: Message): void {


### PR DESCRIPTION

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
Fixes: #7170

When opening a file with with a single click from the File Explorer widget, the opened editor widget doesn't have keyboard focus. But now the focus is updated.

Signed-off-by: Muhammad Anas Shahid <muhammad.shahid@ericsson.com>

#### How to test

    regardless of the preview editor being included in the app or not...
    open one editor properly (double click)
    then open a file with a single click
    press ctrlcmd+f
    reveal the first editor widget and see that the search widget is shown there


#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

