### PR TITLE
Scope local storage per-application for electron development

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -24,9 +24,10 @@
       "windows": {
         "runtimeExecutable": "${workspaceRoot}/node_modules/.bin/electron.cmd"
       },
-      "program": "${workspaceRoot}/examples/electron/src-gen/frontend/electron-main.js",
+      "cwd": "${workspaceRoot}/examples/electron",
       "protocol": "inspector",
       "args": [
+        ".",
         "--log-level=debug",
         "--hostname=localhost",
         "--no-cluster",

--- a/dev-packages/application-manager/src/application-package-manager.ts
+++ b/dev-packages/application-manager/src/application-package-manager.ts
@@ -78,7 +78,21 @@ export class ApplicationPackageManager {
     }
 
     startElectron(args: string[]): cp.ChildProcess {
-        const { mainArgs, options } = this.adjustArgs([this.pck.frontend('electron-main.js'), ...args]);
+        // If possible, pass the project root directory to electron rather than the script file so that Electron
+        // can determine the app name. This requires that the package.json has a main field.
+        let appPath = this.pck.projectPath;
+
+        if (!this.pck.pck.main) {
+            appPath = this.pck.frontend('electron-main.js');
+
+            console.warn(
+                `WARNING: ${this.pck.packagePath} does not have a "main" entry.\n` +
+                'Please add the following line:\n' +
+                '    "main": "src-gen/frontend/electron-main.js"'
+            );
+        }
+
+        const { mainArgs, options } = this.adjustArgs([ appPath, ...args ]);
         const electronCli = require.resolve('electron/cli.js', { paths: [this.pck.projectPath] });
         return this.__process.fork(electronCli, mainArgs, options);
     }

--- a/examples/electron/package.json
+++ b/examples/electron/package.json
@@ -1,7 +1,9 @@
 {
   "private": true,
   "name": "@theia/example-electron",
+  "productName": "Theia Electron Example",
   "version": "0.16.0",
+  "main": "src-gen/frontend/electron-main.js",
   "license": "EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0",
   "theia": {
     "target": "electron",


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

In https://github.com/eclipse-theia/theia/issues/7172, it was noted that different un-packaged Theia Electron apps shared the same local storage. This is because `theia start` was calling electron with the electron-main.js script rather than the root directory of the application. Using the root directory instead means that Electron can find the application's package.json file to determine its name, so it can isolate the local storage.

This PR:
- Updates `theia start` to pass the application root directory rather than the main script.
- Follows the [Electron documentation](https://www.electronjs.org/docs/tutorial/debugging-main-process-vscode) to do the same for the vscode launch configuration.
- Added `main` and `productName` to the electron example's package.json.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

This can be tested with e.g. the [theia-electron](https://github.com/theia-ide/theia-apps/tree/master/theia-electron) application:

1. Start theia-electron with `yarn start`. Open a file in the workspace.
2. Close theia-electron.
3. Start the electron example application in this repository with `theia start` or the vscode launch configuration, opening the same workspace.

Before this PR, the example application would have been loaded with same files open and the same cursor position, since both shared the same local storage.

After this PR, the open files and editor are stored independently for the different apps.

#### Review checklist

- [X] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)