### PR TITLE
Add ability to display timestamp in log messages

### DIFF
--- a/packages/core/src/common/logger-protocol.ts
+++ b/packages/core/src/common/logger-protocol.ts
@@ -16,6 +16,7 @@
 
 import { injectable } from 'inversify';
 import { JsonRpcServer } from './messaging/proxy-factory';
+import * as moment from 'moment';
 
 export const ILoggerServer = Symbol('ILoggerServer');
 
@@ -109,6 +110,6 @@ export namespace ConsoleLogger {
     export function log(name: string, logLevel: number, message: string, params: any[]): void {
         const console = consoles.get(logLevel) || originalConsoleLog;
         const severity = (LogLevel.strings.get(logLevel) || 'unknown').toUpperCase();
-        console(`${name} ${severity} ${message}`, ...params);
+        console(`${moment().format('MMM Do YYYY, HH:mm:ss.SSS')} - ${name} ${severity} ${message}`, ...params);
     }
 }


### PR DESCRIPTION
#### What it does
This changes proposal adds ability to show timestamps in logs that appears in console (system and browser) in format `'MMM Do YYYY, HH:mm:ss.SSS'`

Related issue: https://github.com/redhat-developer/codeready-workspaces-theia/issues/6

System:
![timestamps](https://user-images.githubusercontent.com/1968177/75364136-e316a300-58c3-11ea-948c-794978aefdca.png)

Browser:
![timestamps_browser](https://user-images.githubusercontent.com/1968177/75364626-b020df00-58c4-11ea-8e23-7d4b171f5b10.png)

Signed-off-by: Vladyslav Zhukovskyi <vzhukovs@redhat.com>

#### How to test
Just see the system console or the browser one.

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

