### PR TITLE
Support relative paths for JSON schema associations (Fix #7140)

### DIFF
--- a/packages/json/src/browser/json-preferences.ts
+++ b/packages/json/src/browser/json-preferences.ts
@@ -21,7 +21,8 @@ import {
     PreferenceService,
     PreferenceContribution,
     PreferenceSchema,
-    PreferenceChangeEvent
+    PreferenceChangeEvent,
+    PreferenceScope
 } from '@theia/core/lib/browser/preferences';
 import { JsonSchemaConfiguration } from '@theia/core/lib/browser/json-schema-store';
 
@@ -63,7 +64,8 @@ export const jsonPreferenceSchema: PreferenceSchema = {
             'default': true,
             'description': 'Enable/disable default JSON formatter'
         },
-    }
+    },
+    scope: PreferenceScope.Folder
 };
 
 export interface JsonConfiguration {


### PR DESCRIPTION
#### What it does

JSON preferences now also accept relative paths inside a theia workspace to associate JSON schemas to JSON files.
Absolute paths and URLs still work as expected.

#### Remark

As mentioned in #7140, I came across a minor problem, namely the jsonSchemaService (vscode-json-languageservice) returns the following warning:
`Problems loading reference 'file:///test/my-schema-definition.json': Unable to load schema from '/test/my-schema-definition.json': ENOENT: no such file or directory, open '/test/my-schema-definition.json'.`

The JSON schema support works as expected now also for relative paths, but this warning occurs in files that are associated with JSON schemas via relative paths.

#### How to test

1. Set up a theia-workspace and include a plain JSON file and a JSON schema file,
e.g. `/testing.json` and `/.schemas/json-schema.json`
2. Define a schema association for those JSON files in your settings,
e.g. 

```json
"json.schemas": [
  {
    "fileMatch": [
      "/testing.json"
    ],
    "url": "/.schemas/json-schema.json"
  }
]
```
3. JSON schema support for the matched file is supported for associations via relative workspace paths.

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

 Signed-off-by: Nina Doschek <ndoschek@eclipsesource.com>