### PR TITLE
getting-started: use absolute link for logo

### DIFF
--- a/packages/getting-started/README.md
+++ b/packages/getting-started/README.md
@@ -2,7 +2,7 @@
 
 <br />
 
-<img src='../../logo/theia.svg' width='100px' />
+<img src='https://raw.githubusercontent.com/eclipse-theia/theia/master/logo/theia.svg?sanitize=true' alt='theia-ext-logo' width='100px' />
 
 <h2>THEIA - GETTING-STARTED EXTENSION</h2>
 


### PR DESCRIPTION

Signed-off-by: vince-fugnitto <vincent.fugnitto@ericsson.com>

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

This commit updates the `getting-started` readme to use the external absolute link for the theia extension logo. This change is useful when embedding the document in other pages (ex: typedoc rendering).

A similar change was done in the past (https://github.com/eclipse-theia/theia/pull/4790),
but it requires the logo to exist in the repo. Now that the logo exists, we can now update the link so it is absolute.


#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

Verify that the link is still properly [rendered](https://github.com/eclipse-theia/theia/blob/a1da7123f85f34bd1ef2381652af6461dc81e380/packages/getting-started/README.md) in the `readme`.

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

