### PR TITLE
preview: allow rendering of '.markdown' files

### DIFF
--- a/packages/preview/src/browser/markdown/markdown-preview-handler.spec.ts
+++ b/packages/preview/src/browser/markdown/markdown-preview-handler.spec.ts
@@ -105,6 +105,14 @@ describe('markdown-preview-handler', () => {
             expect(line).to.be.equal(expectedLine);
         }
     });
+
+    it('can handle \'.md\' files', () => {
+        expect(previewHandler.canHandle(new URI('a.md'))).greaterThan(0);
+    });
+
+    it('can handle \'.markdown\' files', () => {
+        expect(previewHandler.canHandle(new URI('a.markdown'))).greaterThan(0);
+    });
 });
 
 async function assertRenderedContent(source: string, expectation: string): Promise<void> {

--- a/packages/preview/src/browser/markdown/markdown-preview-handler.ts
+++ b/packages/preview/src/browser/markdown/markdown-preview-handler.ts
@@ -41,7 +41,11 @@ export class MarkdownPreviewHandler implements PreviewHandler {
     protected readonly linkNormalizer: PreviewLinkNormalizer;
 
     canHandle(uri: URI): number {
-        return uri.scheme === 'file' && uri.path.ext.toLowerCase() === '.md' ? 500 : 0;
+        return uri.scheme === 'file'
+            && (
+                uri.path.ext.toLowerCase() === '.md' ||
+                uri.path.ext.toLowerCase() === '.markdown'
+            ) ? 500 : 0;
     }
 
     renderContent(params: RenderContentParams): HTMLElement {


### PR DESCRIPTION


Signed-off-by: vince-fugnitto <vincent.fugnitto@ericsson.com>

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

Fixes #7228

This commit adds extra handling to be able to render `.markdown` files similarly to `.md`. With this change, users will be able to render both `.md` and `.markdown` files using the `@theia/preview` extension.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

Test cases were added to validate the `canHandle` function of the `MarkdownPreviewHandler`.

1. open a `.md` file (previewing should be available)
2. open a `.markdown` file (previewing should be available)

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

