### PR TITLE
Plug-ins leaking CodeLens, etc. #4472

### DIFF
--- a/packages/plugin-ext/src/common/plugin-api-rpc.ts
+++ b/packages/plugin-ext/src/common/plugin-api-rpc.ts
@@ -1173,8 +1173,10 @@ export interface LanguagesExt {
     ): Promise<TextEdit[] | undefined>;
     $provideDocumentLinks(handle: number, resource: UriComponents, token: CancellationToken): Promise<DocumentLink[] | undefined>;
     $resolveDocumentLink(handle: number, link: DocumentLink, token: CancellationToken): Promise<DocumentLink | undefined>;
+    $releaseDocumentLinks(handle: number, ids: number[]): void;
     $provideCodeLenses(handle: number, resource: UriComponents, token: CancellationToken): Promise<CodeLensSymbol[] | undefined>;
     $resolveCodeLens(handle: number, resource: UriComponents, symbol: CodeLensSymbol, token: CancellationToken): Promise<CodeLensSymbol | undefined>;
+    $releaseCodeLenses(handle: number, ids: number[]): void;
     $provideCodeActions(
         handle: number,
         resource: UriComponents,

--- a/packages/plugin-ext/src/main/browser/languages-main.ts
+++ b/packages/plugin-ext/src/main/browser/languages-main.ts
@@ -55,6 +55,7 @@ import { LanguageSelector } from '@theia/languages/lib/common/language-selector'
 import { CallHierarchyService, CallHierarchyServiceProvider, Caller, Definition } from '@theia/callhierarchy/lib/browser';
 import { toDefinition, toUriComponents, fromDefinition, fromPosition, toCaller } from './callhierarchy/callhierarchy-type-converters';
 import { Position, DocumentUri } from 'vscode-languageserver-types';
+import { ObjectIdentifier } from '../../common/object-identifier';
 
 @injectable()
 export class LanguagesMainImpl implements LanguagesMain, Disposable {
@@ -380,7 +381,9 @@ export class LanguagesMainImpl implements LanguagesMain, Disposable {
         return {
             links: links.map(link => this.toMonacoLink(link)),
             dispose: () => {
-                // TODO this.proxy.$releaseDocumentLinks(handle, links.cacheId);
+                if (links && Array.isArray(links)) {
+                    this.proxy.$releaseDocumentLinks(handle, links.map(link => ObjectIdentifier.of(link)));
+                }
             }
         };
     }
@@ -427,7 +430,9 @@ export class LanguagesMainImpl implements LanguagesMain, Disposable {
         return {
             lenses,
             dispose: () => {
-                // TODO this.proxy.$releaseCodeLenses
+                if (lenses && Array.isArray(lenses)) {
+                    this.proxy.$releaseCodeLenses(handle, lenses.map(symbol => ObjectIdentifier.of(symbol)));
+                }
             }
         };
     }

--- a/packages/plugin-ext/src/plugin/languages.ts
+++ b/packages/plugin-ext/src/plugin/languages.ts
@@ -422,6 +422,11 @@ export class LanguagesExtImpl implements LanguagesExt {
         this.proxy.$registerDocumentLinkProvider(callId, pluginInfo, this.transformDocumentSelector(selector));
         return this.createDisposable(callId);
     }
+
+    $releaseDocumentLinks(handle: number, ids: number[]): void {
+        this.withAdapter(handle, LinkProviderAdapter, async adapter => adapter.releaseDocumentLinks(ids));
+    }
+
     // ### Document Link Provider end
 
     // ### Code Actions Provider begin
@@ -473,6 +478,10 @@ export class LanguagesExtImpl implements LanguagesExt {
 
     $resolveCodeLens(handle: number, resource: UriComponents, symbol: CodeLensSymbol, token: theia.CancellationToken): Promise<CodeLensSymbol | undefined> {
         return this.withAdapter(handle, CodeLensAdapter, adapter => adapter.resolveCodeLens(URI.revive(resource), symbol, token));
+    }
+
+    $releaseCodeLenses(handle: number, ids: number[]): void {
+        this.withAdapter(handle, CodeLensAdapter, async adapter => adapter.releaseCodeLenses(ids));
     }
     // ### Code Lens Provider end
 

--- a/packages/plugin-ext/src/plugin/languages/lens.ts
+++ b/packages/plugin-ext/src/plugin/languages/lens.ts
@@ -55,7 +55,6 @@ export class CodeLensAdapter {
                         range: Converter.fromRange(lens.range)!,
                         command: this.commands.converter.toSafeCommand(lens.command, toDispose)
                     }, cacheId);
-                    // TODO: invalidate caches and dispose command handlers
                     this.cache.set(cacheId, lens);
                     this.disposables.set(cacheId, toDispose);
                     return lensSymbol;
@@ -88,5 +87,16 @@ export class CodeLensAdapter {
         }
         symbol.command = this.commands.converter.toSafeCommand(newLens.command ? newLens.command : CodeLensAdapter.BAD_CMD, disposables);
         return symbol;
+    }
+
+    releaseCodeLenses(ids: number[]): void {
+        ids.forEach(id => {
+            this.cache.delete(id);
+            const toDispose = this.disposables.get(id);
+            if (toDispose) {
+                toDispose.dispose();
+                this.disposables.delete(id);
+            }
+        });
     }
 }

--- a/packages/plugin-ext/src/plugin/languages/link-provider.ts
+++ b/packages/plugin-ext/src/plugin/languages/link-provider.ts
@@ -70,4 +70,10 @@ export class LinkProviderAdapter {
             return undefined;
         });
     }
+
+    releaseDocumentLinks(ids: number[]): void {
+        ids.forEach(id => {
+            this.cache.delete(id);
+        });
+    }
 }

--- a/packages/plugin-ext/src/plugin/tasks/task-provider.ts
+++ b/packages/plugin-ext/src/plugin/tasks/task-provider.ts
@@ -16,12 +16,9 @@
 
 import * as theia from '@theia/plugin';
 import * as Converter from '../type-converters';
-import { ObjectIdentifier } from '../../common/object-identifier';
 import { TaskDto } from '../../common';
 
 export class TaskProviderAdapter {
-    private cacheId = 0;
-    private cache = new Map<number, theia.Task>();
 
     constructor(private readonly provider: theia.TaskProvider) { }
 
@@ -37,9 +34,6 @@ export class TaskProviderAdapter {
                     continue;
                 }
 
-                const id = this.cacheId++;
-                ObjectIdentifier.mixin(data, id);
-                this.cache.set(id, task);
                 result.push(data);
             }
             return result;
@@ -50,9 +44,8 @@ export class TaskProviderAdapter {
         if (typeof this.provider.resolveTask !== 'function') {
             return Promise.resolve(undefined);
         }
-        const id = ObjectIdentifier.of(task);
-        const cached = this.cache.get(id);
-        const item = cached ? cached : Converter.toTask(task);
+
+        const item = Converter.toTask(task);
         if (!item) {
             return Promise.resolve(undefined);
         }


### PR DESCRIPTION
Fixes: #4472

Signed-off-by: Victor Rubezhny <vrubezhny@redhat.com>

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->
For the following adapters :
    CodeLensAdapter
    LinkProviderAdapter

the `releaseXXX`-like methods are added in order to release the cached items when `dispose()` is invoked on the objects provided for the according provider, These `dispose()` methods now are set via `provideCodeLenses` and `provideLinks` methods defined in `LanguagesMainImpl`.

` TaskProviderAdapter` is cleared of any result caching because, according to https://code.visualstudio.com/api/references/vscode-api#TaskProvider, the `resolveTask` method  *will not be called for tasks returned from the above provideTasks method since those tasks are always fully resolved*

All the methods/calls are already made for the ` CompletionAdapter`, so no modification is needed here

Note that the proper releasing of the cache maintained in `LinkProviderAdapter` the fix https://github.com/microsoft/vscode/commit/e59cb58ccce6393ae01f1ee6302efb2bde5ff988 for the following issue https://github.com/microsoft/vscode/issues/91536 is to be picked up into the build. 

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

https://github.com/eclipse-theia/theia/pull/7238#issuecomment-592523266

#### Review checklist

- [ ] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

