### PR TITLE
fix #7240: support loading plugins from symbolic links

### DIFF
--- a/packages/plugin-ext/src/main/node/plugin-deployer-entry-impl.ts
+++ b/packages/plugin-ext/src/main/node/plugin-deployer-entry-impl.ts
@@ -72,14 +72,14 @@ export class PluginDeployerEntryImpl implements PluginDeployerEntry {
     }
     isFile(): boolean {
         try {
-            return fs.lstatSync(this.currentPath).isFile();
+            return fs.statSync(this.currentPath).isFile();
         } catch (e) {
             return false;
         }
     }
     isDirectory(): boolean {
         try {
-            return fs.lstatSync(this.currentPath).isDirectory();
+            return fs.statSync(this.currentPath).isDirectory();
         } catch (e) {
             return false;
         }


### PR DESCRIPTION

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

Fixes #7240

using statSync instead of lstatSync, so isFile or isDirectory will
check what the symbolic link refer to but not the link itself.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
1. create a symbolic link to a plugin file with .vsix or .theia suffix
2. start theia with this plugin check whether this plugin is loaded

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

