### PR TITLE
[@theia/electron]: Removed obsolete bin.

### DIFF
--- a/dev-packages/electron/package.json
+++ b/dev-packages/electron/package.json
@@ -16,7 +16,6 @@
   "homepage": "https://github.com/eclipse-theia/theia",
   "bin": {
     "electron": "electron-cli.js",
-    "electron-h264-test": "electron-h264-test.js",
     "electron-codecs-test": "electron-codecs-test.js",
     "electron-replace-ffmpeg": "electron-replace-ffmpeg.js"
   },


### PR DESCRIPTION
The removed module was transformed into a `postinstall` script [here],
but the `bin` entry was not removed from the `package.json`. @marechal-p, can you please check whether my assumption is correct? Thanks!

[here]: https://github.com/eclipse-theia/theia/commit/33be284daa0775bb5d4aacf7731d2d48c635a12a#diff-3e4f861a7807c5cb7e5f9988b0d4542a

Signed-off-by: Akos Kitta <kittaakos@typefox.io>

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

This PR removes the obsolete `bin` from the `package.json`. It causes me a `npm rebuild` issue with `grpc`:
```
[...]

  CC(target) Release/obj.target/oniguruma/deps/onig/enc/iso8859_5.o
  CC(target) Release/obj.target/oniguruma/deps/onig/enc/iso8859_6.o
  CC(target) Release/obj.target/oniguruma/deps/onig/enc/iso8859_7.o
  CC(target) Release/obj.target/oniguruma/deps/onig/enc/iso8859_8.o
  CC(target) Release/obj.target/oniguruma/deps/onig/enc/iso8859_9.o
  CC(target) Release/obj.target/oniguruma/deps/onig/enc/iso8859_10.o
  CC(target) Release/obj.target/oniguruma/deps/onig/enc/iso8859_11.o
  CC(target) Release/obj.target/oniguruma/deps/onig/enc/iso8859_13.o
  CC(target) Release/obj.target/oniguruma/deps/onig/enc/iso8859_14.o
  CC(target) Release/obj.target/oniguruma/deps/onig/enc/iso8859_15.o
  CC(target) Release/obj.target/oniguruma/deps/onig/enc/iso8859_16.o
  CC(target) Release/obj.target/oniguruma/deps/onig/enc/koi8.o
  CC(target) Release/obj.target/oniguruma/deps/onig/enc/koi8_r.o
  CC(target) Release/obj.target/oniguruma/deps/onig/enc/mktable.o
  CC(target) Release/obj.target/oniguruma/deps/onig/enc/sjis.o
  CC(target) Release/obj.target/oniguruma/deps/onig/enc/unicode.o
  CC(target) Release/obj.target/oniguruma/deps/onig/enc/utf16_be.o
  CC(target) Release/obj.target/oniguruma/deps/onig/enc/utf16_le.o
  CC(target) Release/obj.target/oniguruma/deps/onig/enc/utf32_be.o
  CC(target) Release/obj.target/oniguruma/deps/onig/enc/utf32_le.o
  CC(target) Release/obj.target/oniguruma/deps/onig/enc/utf8.o
  LIBTOOL-STATIC Release/oniguruma.a
  CXX(target) Release/obj.target/onig_scanner/src/onig-result.o
  CXX(target) Release/obj.target/onig_scanner/src/onig-reg-exp.o
  CXX(target) Release/obj.target/onig_scanner/src/onig-scanner.o
  CXX(target) Release/obj.target/onig_scanner/src/onig-scanner-worker.o
  CXX(target) Release/obj.target/onig_scanner/src/onig-searcher.o
  CXX(target) Release/obj.target/onig_scanner/src/onig-string.o
  SOLINK_MODULE(target) Release/onig_scanner.node
npm ERR! path /Users/akos.kitta/Desktop/foo-bar/electron/build/node_modules/@theia/electron/electron-h264-test.js
npm ERR! code ENOENT
npm ERR! errno -2
npm ERR! syscall chmod
npm ERR! enoent ENOENT: no such file or directory, chmod '/Users/akos.kitta/Desktop/foo-bar/electron/build/node_modules/@theia/electron/electron-h264-test.js'
npm ERR! enoent This is related to npm not being able to find a file.
npm ERR! enoent 

npm ERR! A complete log of this run can be found in:
npm ERR!     /Users/akos.kitta/.npm/_logs/2020-02-29T20_44_48_735Z-debug.log
error Command failed with exit code 254.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

