### PR TITLE
[editor] Show languages and focus file-tree while preview

### DIFF
--- a/packages/core/src/browser/widget-open-handler.ts
+++ b/packages/core/src/browser/widget-open-handler.ts
@@ -93,6 +93,14 @@ export abstract class WidgetOpenHandler<W extends BaseWidget> implements OpenHan
             await this.shell.activateWidget(widget.id);
         } else if (op.mode === 'reveal') {
             await this.shell.revealWidget(widget.id);
+            this.shell.currentChanged.emit({
+                // eslint-disable-next-line no-null/no-null
+                oldValue: this.shell.currentWidget || null,
+
+                // eslint-disable-next-line no-null/no-null
+                newValue: widget || null,
+
+            });
         }
     }
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
Fixes: #7170 , #5027

This issue fixes the underlying problem where when a new file was opened
in preview mode, the focus was on the previously active file and not on
the navigator + the StatusBar at the bottom was not updated. This PR
collectively fixes both the issues.

Signed-off-by: Muhammad Anas Shahid <muhammad.shahid@ericsson.com>

#### How to test

- Open Theia with any repository

- Try to open a file with single click

- Check to see if the languages on the status-bar is displayed

- Check to see if the focus is still on the file-tree. 

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

