### PR TITLE
support presentation.panel in task config

### DIFF
--- a/packages/core/src/browser/widgets/widget.ts
+++ b/packages/core/src/browser/widgets/widget.ts
@@ -46,8 +46,12 @@ export class BaseWidget extends Widget {
     readonly onScrollUp: Event<void> = this.onScrollUpEmitter.event;
     protected readonly onDidChangeVisibilityEmitter = new Emitter<boolean>();
     readonly onDidChangeVisibility = this.onDidChangeVisibilityEmitter.event;
+    protected readonly onDidDisposeEmitter = new Emitter<void>();
+    readonly onDidDispose = this.onDidDisposeEmitter.event;
 
     protected readonly toDispose = new DisposableCollection(
+        this.onDidDisposeEmitter,
+        Disposable.create(() => this.onDidDisposeEmitter.fire()),
         this.onScrollYReachEndEmitter,
         this.onScrollUpEmitter,
         this.onDidChangeVisibilityEmitter

--- a/packages/task/src/browser/task-frontend-module.ts
+++ b/packages/task/src/browser/task-frontend-module.ts
@@ -39,6 +39,7 @@ import './tasks-monaco-contribution';
 import { TaskNameResolver } from './task-name-resolver';
 import { TaskSourceResolver } from './task-source-resolver';
 import { TaskTemplateSelector } from './task-templates';
+import { TaskTerminalWidgetManager } from './task-terminal-widget-manager';
 
 export default new ContainerModule(bind => {
     bind(TaskFrontendContribution).toSelf().inSingletonScope();
@@ -77,6 +78,7 @@ export default new ContainerModule(bind => {
     bind(TaskNameResolver).toSelf().inSingletonScope();
     bind(TaskSourceResolver).toSelf().inSingletonScope();
     bind(TaskTemplateSelector).toSelf().inSingletonScope();
+    bind(TaskTerminalWidgetManager).toSelf().inSingletonScope();
 
     bindProcessTaskModule(bind);
     bindTaskPreferences(bind);

--- a/packages/task/src/browser/task-schema-updater.ts
+++ b/packages/task/src/browser/task-schema-updater.ts
@@ -162,6 +162,7 @@ export class TaskSchemaUpdater {
                 customizedDetectedTask.properties![taskProp] = { ...def.properties.schema.properties![taskProp] };
             });
             customizedDetectedTask.properties!.problemMatcher = problemMatcher;
+            customizedDetectedTask.properties!.presentation = presentation;
             customizedDetectedTask.properties!.options = commandOptionsSchema;
             customizedDetectedTask.properties!.group = group;
             customizedDetectedTask.additionalProperties = true;
@@ -538,7 +539,8 @@ const presentation: IJSONSchema = {
     type: 'object',
     default: {
         reveal: 'always',
-        focus: false
+        focus: false,
+        panel: 'shared'
     },
     description: 'Configures the panel that is used to present the task\'s output and reads its input.',
     additionalProperties: true,
@@ -558,6 +560,18 @@ const presentation: IJSONSchema = {
             ],
             default: 'always',
             description: 'Controls whether the terminal running the task is revealed or not. May be overridden by option \"revealProblems\". Default is \"always\".'
+        },
+        panel: {
+            type: 'string',
+            enum: ['shared', 'dedicated', 'new'],
+            enumDescriptions: [
+                'The terminal is shared and the output of other task runs are added to the same terminal.',
+                // eslint-disable-next-line max-len
+                'The terminal is dedicated to a specific task. If that task is executed again, the terminal is reused. However, the output of a different task is presented in a different terminal.',
+                'Every execution of that task is using a new clean terminal.'
+            ],
+            default: 'shared',
+            description: 'Controls if the panel is shared between tasks, dedicated to this task or a new one is created on every run.'
         }
     }
 };

--- a/packages/task/src/browser/task-service.ts
+++ b/packages/task/src/browser/task-service.ts
@@ -14,7 +14,7 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
-import { ApplicationShell, FrontendApplication, WidgetManager } from '@theia/core/lib/browser';
+import { ApplicationShell, FrontendApplication, WidgetManager, WidgetOpenMode } from '@theia/core/lib/browser';
 import { open, OpenerService } from '@theia/core/lib/browser/opener-service';
 import { ILogger, CommandService } from '@theia/core/lib/common';
 import { MessageService } from '@theia/core/lib/common/message-service';
@@ -62,6 +62,7 @@ import { TaskConfigurationManager } from './task-configuration-manager';
 import { PROBLEMS_WIDGET_ID, ProblemWidget } from '@theia/markers/lib/browser/problem/problem-widget';
 import { TaskNode } from './task-node';
 import { MonacoWorkspace } from '@theia/monaco/lib/browser/monaco-workspace';
+import { TaskTerminalWidgetManager, TaskTerminalWidgetOpenerOptions } from './task-terminal-widget-manager';
 
 export interface QuickPickProblemMatcherItem {
     problemMatchers: NamedProblemMatcher[] | undefined;
@@ -175,6 +176,9 @@ export class TaskService implements TaskConfigurationClient {
     @inject(MonacoWorkspace)
     protected monacoWorkspace: MonacoWorkspace;
 
+    @inject(TaskTerminalWidgetManager)
+    protected readonly taskTerminalWidgetManager: TaskTerminalWidgetManager;
+
     @postConstruct()
     protected init(): void {
         this.getRunningTasks().then(tasks =>
@@ -228,9 +232,9 @@ export class TaskService implements TaskConfigurationClient {
                                 if (terminal) {
                                     const focus = !!matchedRunningTaskInfo!.config.presentation!.focus;
                                     if (focus) { // assign focus to the terminal if presentation.focus is true
-                                        this.shell.activateWidget(terminal.id);
+                                        this.terminalService.open(terminal, { mode: 'activate' });
                                     } else { // show the terminal but not assign focus
-                                        this.shell.revealWidget(terminal.id);
+                                        this.terminalService.open(terminal, { mode: 'reveal' });
                                     }
                                 }
                             }
@@ -304,9 +308,9 @@ export class TaskService implements TaskConfigurationClient {
                         const focus = !!eventTaskConfig.presentation.focus;
                         if (terminal) {
                             if (focus) { // assign focus to the terminal if presentation.focus is true
-                                this.shell.activateWidget(terminal.id);
+                                this.terminalService.open(terminal, { mode: 'activate' });
                             } else { // show the terminal but not assign focus
-                                this.shell.revealWidget(terminal.id);
+                                this.terminalService.open(terminal, { mode: 'reveal' });
                             }
                         }
                     }
@@ -699,9 +703,9 @@ export class TaskService implements TaskConfigurationClient {
                 const terminal = this.terminalService.getById(this.getTerminalWidgetId(terminalId));
                 if (terminal && task.presentation) {
                     if (task.presentation.focus) { // assign focus to the terminal if presentation.focus is true
-                        this.shell.activateWidget(terminal.id);
+                        this.terminalService.open(terminal, { mode: 'activate' });
                     } else if (task.presentation.reveal === RevealKind.Always) { // show the terminal but not assign focus
-                        this.shell.revealWidget(terminal.id);
+                        this.terminalService.open(terminal, { mode: 'reveal' });
                     }
                 }
             }
@@ -980,26 +984,30 @@ export class TaskService implements TaskConfigurationClient {
         const runningTasks: TaskInfo[] = await this.getRunningTasks();
         // Get the corresponding task information based on task id if available.
         const taskInfo: TaskInfo | undefined = runningTasks.find((t: TaskInfo) => t.taskId === taskId);
-        // Create terminal widget to display an execution output of a task that was launched as a command inside a shell.
-        const widget = <TerminalWidget>await this.widgetManager.getOrCreateWidget(
-            TERMINAL_WIDGET_FACTORY_ID,
-            <TerminalWidgetFactoryOptions>{
+        let widgetOpenMode: WidgetOpenMode = 'open';
+        if (taskInfo && taskInfo.config.presentation && taskInfo.config.presentation.reveal === RevealKind.Always) {
+            if (taskInfo.config.presentation.focus) { // assign focus to the terminal if presentation.focus is true
+                widgetOpenMode = 'activate';
+            } else { // show the terminal but not assign focus
+                widgetOpenMode = 'reveal';
+            }
+        }
+
+        // Create / find a terminal widget to display an execution output of a task that was launched as a command inside a shell.
+        const widget = await this.taskTerminalWidgetManager.open(
+            <TaskTerminalWidgetOpenerOptions>{
                 created: new Date().toString(),
+                taskId,
                 id: this.getTerminalWidgetId(processId),
                 title: taskInfo
                     ? `Task: ${taskInfo.config.label}`
                     : `Task: #${taskId}`,
-                destroyTermOnClose: true
+                destroyTermOnClose: true,
+                widgetOptions: { area: 'bottom' },
+                mode: widgetOpenMode,
+                taskConfig: taskInfo ? taskInfo.config : undefined
             }
         );
-        this.shell.addWidget(widget, { area: 'bottom' });
-        if (taskInfo && taskInfo.config.presentation && taskInfo.config.presentation.reveal === RevealKind.Always) {
-            if (taskInfo.config.presentation.focus) { // assign focus to the terminal if presentation.focus is true
-                this.shell.activateWidget(widget.id);
-            } else { // show the terminal but not assign focus
-                this.shell.revealWidget(widget.id);
-            }
-        }
         widget.start(processId);
     }
 

--- a/packages/task/src/browser/task-terminal-widget-manager.ts
+++ b/packages/task/src/browser/task-terminal-widget-manager.ts
@@ -1,0 +1,186 @@
+/********************************************************************************
+ * Copyright (C) 2020 Ericsson and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import { inject, injectable, postConstruct } from 'inversify';
+import { ApplicationShell, WidgetOpenerOptions } from '@theia/core/lib/browser';
+import { TerminalWidget } from '@theia/terminal/lib/browser/base/terminal-widget';
+import { TerminalWidgetFactoryOptions } from '@theia/terminal/lib/browser/terminal-widget-impl';
+import { TerminalService } from '@theia/terminal/lib/browser/base/terminal-service';
+import { PanelKind, TaskConfiguration, TaskWatcher, TaskExitedEvent, TaskServer } from '../common';
+import { TaskDefinitionRegistry } from './task-definition-registry';
+import { WorkspaceService } from '@theia/workspace/lib/browser/workspace-service';
+
+export interface TaskTerminalWidget extends TerminalWidget {
+    readonly kind: 'task';
+    dedicated?: boolean;
+    taskId?: number;
+    taskConfig?: TaskConfiguration;
+    busy?: boolean;
+}
+export namespace TaskTerminalWidget {
+    export function is(widget: TerminalWidget): widget is TaskTerminalWidget {
+        return widget.kind === 'task';
+    }
+}
+
+export interface TaskTerminalWidgetOpenerOptions extends WidgetOpenerOptions, TerminalWidgetFactoryOptions {
+    taskId: number;
+    taskConfig?: TaskConfiguration;
+}
+export namespace TaskTerminalWidgetOpenerOptions {
+    export function isDedicatedTerminal(options: TaskTerminalWidgetOpenerOptions): boolean {
+        return !!options.taskConfig && !!options.taskConfig.presentation && options.taskConfig.presentation.panel === PanelKind.Dedicated;
+    }
+
+    export function isNewTerminal(options: TaskTerminalWidgetOpenerOptions): boolean {
+        return !!options.taskConfig && !!options.taskConfig.presentation && options.taskConfig.presentation.panel === PanelKind.New;
+    }
+
+    export function isSharedTerminal(options: TaskTerminalWidgetOpenerOptions): boolean {
+        return !!options.taskConfig &&
+            (options.taskConfig.presentation === undefined || options.taskConfig.presentation.panel === undefined || options.taskConfig.presentation.panel === PanelKind.Shared);
+    }
+}
+
+@injectable()
+export class TaskTerminalWidgetManager {
+
+    @inject(ApplicationShell)
+    protected readonly shell: ApplicationShell;
+
+    @inject(TaskDefinitionRegistry)
+    protected readonly taskDefinitionRegistry: TaskDefinitionRegistry;
+
+    @inject(TerminalService)
+    protected readonly terminalService: TerminalService;
+
+    @inject(TaskWatcher)
+    protected readonly taskWatcher: TaskWatcher;
+
+    @inject(TaskServer)
+    protected readonly taskServer: TaskServer;
+
+    @inject(WorkspaceService)
+    protected readonly workspaceService: WorkspaceService;
+
+    @postConstruct()
+    protected init(): void {
+        this.taskWatcher.onTaskExit((event: TaskExitedEvent) => {
+            const finishedTaskId = event.taskId;
+            // find the terminal where the task ran, and mark it as "idle"
+            for (const terminal of this.getTaskTerminalWidgets()) {
+                if (terminal.taskId === finishedTaskId) {
+                    this.notifyTaskFinished(terminal);
+                    break;
+                }
+            }
+        });
+
+        this.terminalService.onDidCreateTerminal(async (widget: TerminalWidget) => {
+            const terminal = TaskTerminalWidget.is(widget) && widget;
+            if (terminal) {
+                const didConnectListener = terminal.onDidOpen(async () => {
+                    const context = this.workspaceService.workspace && this.workspaceService.workspace.uri;
+                    const tasksInfo = await this.taskServer.getTasks(context);
+                    const taskInfo = tasksInfo.find(info => info.terminalId === widget.terminalId);
+                    if (taskInfo) {
+                        const taskConfig = taskInfo.config;
+                        terminal.dedicated = !!taskConfig.presentation && !!taskConfig.presentation.panel && taskConfig.presentation.panel === PanelKind.Dedicated;
+                        terminal.taskId = taskInfo.taskId;
+                        terminal.taskConfig = taskConfig;
+                        terminal.busy = true;
+                    } else {
+                        this.notifyTaskFinished(terminal);
+                    }
+                });
+                const didConnectFailureListener = terminal.onDidOpenFailure(async () => {
+                    this.notifyTaskFinished(terminal);
+                });
+                terminal.onDidDispose(() => {
+                    didConnectListener.dispose();
+                    didConnectFailureListener.dispose();
+                });
+            }
+        });
+    }
+
+    async open(options: TaskTerminalWidgetOpenerOptions): Promise<TerminalWidget> {
+        const dedicated = TaskTerminalWidgetOpenerOptions.isDedicatedTerminal(options);
+        if (dedicated && !options.taskConfig) {
+            throw new Error('"taskConfig" must be included as part of the "option" if "isDedicated" is true');
+        }
+
+        const { isNew, widget } = await this.getWidgetToRunTask(options);
+        if (isNew) {
+            this.shell.addWidget(widget, { area: options.widgetOptions ? options.widgetOptions.area : 'bottom' });
+            widget.resetTerminal();
+        } else if (options.title) {
+            widget.setTitle(options.title);
+        }
+        this.terminalService.open(widget, options);
+
+        return widget;
+    }
+
+    protected async getWidgetToRunTask(options: TaskTerminalWidgetOpenerOptions): Promise<{ isNew: boolean, widget: TerminalWidget }> {
+        let reusableTerminalWidget: TerminalWidget | undefined;
+        if (TaskTerminalWidgetOpenerOptions.isDedicatedTerminal(options)) {
+            for (const widget of this.getTaskTerminalWidgets()) {
+                // to run a task whose `taskPresentation === 'dedicated'`, the terminal to be reused must be
+                // 1) dedicated, 2) idle, 3) the one that ran the same task
+                if (widget.dedicated &&
+                    !widget.busy &&
+                    widget.taskConfig && options.taskConfig &&
+                    this.taskDefinitionRegistry.compareTasks(options.taskConfig, widget.taskConfig)) {
+
+                    reusableTerminalWidget = widget;
+                    break;
+                }
+            }
+        } else if (TaskTerminalWidgetOpenerOptions.isSharedTerminal(options)) {
+            const availableWidgets: TerminalWidget[] = [];
+            for (const widget of this.getTaskTerminalWidgets()) {
+                // to run a task whose `taskPresentation === 'shared'`, the terminal to be used must be
+                // 1) not dedicated, and 2) idle
+                if (!widget.dedicated && !widget.busy) {
+                    availableWidgets.push(widget);
+                }
+            }
+            const lastUsedWidget = availableWidgets.find(w => {
+                const lastUsedTerminal = this.terminalService.lastUsedTerminal;
+                return lastUsedTerminal && lastUsedTerminal.id === w.id;
+            });
+            reusableTerminalWidget = lastUsedWidget || availableWidgets[0];
+        }
+
+        // we are unable to find a terminal widget to run the task, or `taskPresentation === 'new'`
+        if (!reusableTerminalWidget) {
+            const widget = await this.terminalService.newTerminal({ ...options, kind: 'task' });
+            return { isNew: true, widget };
+        }
+        return { isNew: false, widget: reusableTerminalWidget };
+    }
+
+    private getTaskTerminalWidgets(): TaskTerminalWidget[] {
+        return this.terminalService.all.filter(TaskTerminalWidget.is);
+    }
+
+    private notifyTaskFinished(terminal: TaskTerminalWidget): void {
+        terminal.busy = false;
+        terminal.scrollToBottom();
+        terminal.writeLine('\x1b[1m\n\rTerminal will be reused by tasks. \x1b[0m\n');
+    }
+}

--- a/packages/task/src/common/task-protocol.ts
+++ b/packages/task/src/common/task-protocol.ts
@@ -33,31 +33,49 @@ export enum RevealKind {
     Never
 }
 
+export enum PanelKind {
+    Shared,
+    Dedicated,
+    New
+}
+
 export interface TaskOutputPresentation {
     focus?: boolean;
     reveal?: RevealKind;
+    panel?: PanelKind;
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     [name: string]: any;
 }
 export namespace TaskOutputPresentation {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     export function fromJson(task: any): TaskOutputPresentation {
-        if (task && task.presentation) {
-            let reveal = RevealKind.Always;
-            if (task.presentation.reveal === 'silent') {
-                reveal = RevealKind.Silent;
-            } else if (task.presentation.reveal === 'never') {
-                reveal = RevealKind.Never;
-            }
-            return {
-                reveal,
-                focus: !!task.presentation.focus
-            };
-        }
-        return {
+        let outputPresentation = {
             reveal: RevealKind.Always,
-            focus: false
+            focus: false,
+            panel: PanelKind.Shared
         };
+        if (task && task.presentation) {
+            if (task.presentation.reveal) {
+                let reveal = RevealKind.Always;
+                if (task.presentation.reveal === 'silent') {
+                    reveal = RevealKind.Silent;
+                } else if (task.presentation.reveal === 'never') {
+                    reveal = RevealKind.Never;
+                }
+                outputPresentation = { ...outputPresentation, reveal };
+            }
+            if (task.presentation.panel) {
+                let panel = PanelKind.Shared;
+                if (task.presentation.panel === 'dedicated') {
+                    panel = PanelKind.Dedicated;
+                } else if (task.presentation.panel === 'new') {
+                    panel = PanelKind.New;
+                }
+                outputPresentation = { ...outputPresentation, panel };
+            }
+            outputPresentation = { ...outputPresentation, focus: !!task.presentation.focus };
+        }
+        return outputPresentation;
     }
 }
 

--- a/packages/terminal/src/browser/base/terminal-service.ts
+++ b/packages/terminal/src/browser/base/terminal-service.ts
@@ -56,4 +56,6 @@ export interface TerminalService {
     readonly currentTerminal: TerminalWidget | undefined;
 
     readonly onDidChangeCurrentTerminal: Event<TerminalWidget | undefined>;
+
+    readonly lastUsedTerminal: TerminalWidget | undefined;
 }

--- a/packages/terminal/src/browser/base/terminal-widget.ts
+++ b/packages/terminal/src/browser/base/terminal-widget.ts
@@ -25,6 +25,11 @@ export abstract class TerminalWidget extends BaseWidget {
 
     abstract processId: Promise<number>;
 
+    /** Terminal kind that indicates whether a terminal is created by a user or by some extension for a user */
+    abstract readonly kind: 'user' | string;
+
+    abstract readonly terminalId: number;
+
     /**
      * Start terminal and return terminal id.
      * @param id - terminal id.
@@ -37,7 +42,11 @@ export abstract class TerminalWidget extends BaseWidget {
      */
     abstract sendText(text: string): void;
 
+    /** Event that fires when the terminal is connected or reconnected */
     abstract onDidOpen: Event<void>;
+
+    /** Event that fires when the terminal fails to connect or reconnect */
+    abstract onDidOpenFailure: Event<void>;
 
     abstract scrollLineUp(): void;
 
@@ -45,10 +54,13 @@ export abstract class TerminalWidget extends BaseWidget {
 
     abstract scrollToTop(): void;
 
+    abstract scrollToBottom(): void;
+
     abstract scrollPageUp(): void;
 
     abstract scrollPageDown(): void;
 
+    abstract resetTerminal(): void;
     /**
      * Event which fires when terminal did closed. Event value contains closed terminal widget definition.
      */
@@ -59,6 +71,8 @@ export abstract class TerminalWidget extends BaseWidget {
      */
     abstract clearOutput(): void;
 
+    abstract writeLine(line: string): void;
+
     /**
      * Return Terminal search box widget.
      */
@@ -67,6 +81,8 @@ export abstract class TerminalWidget extends BaseWidget {
      * Whether the terminal process has child processes.
      */
     abstract hasChildProcesses(): Promise<boolean>;
+
+    abstract setTitle(title: string): void;
 }
 
 /**
@@ -121,4 +137,9 @@ export interface TerminalWidgetOptions {
      * Terminal attributes. Can be useful to apply some implementation specific information.
      */
     readonly attributes?: { [key: string]: string | null };
+
+    /**
+     * Terminal kind that indicates whether a terminal is created by a user or by some extension for a user
+     */
+    readonly kind?: 'user' | string;
 }


### PR DESCRIPTION
- updated the task config schema to support controlling whether the terminal instance is shared between task runs.

Signed-off-by: Liang Huang <lhuang4@ualberta.ca>


#### How to test

1) Open a `tasks.json`, when adding properties to a `task.presentation`, users should get intellisense for the new property `task.presentation.panel`.

2) Without `presentation.panel` being added to any task configs, Theia should reuse task terminals as much as possible. 
  - If a terminal is idle (i.e., with no tasks running), it should be considered as a candidate to run the next task
  - if a terminal is busy (i.e., has a running task), it should not be considered as a candidate to run the next task, until the running task finishes.

![Peek 2020-03-02 22-41](https://user-images.githubusercontent.com/37082801/75741676-50b63b00-5cd9-11ea-98cc-d3cc5adb808e.gif)



3) With `presentation.panel === 'dedicated'` added to a task config, a terminal should be reserved for this particular task. Other tasks will not be started in this "reserved terminal".

4) With `presentation.panel === 'new'` added to a task config, a new terminal should be opened for this task, every single time. However, the new terminals are not reserved for this particular task. In other words, they will be considered as candidates to run other tasks (whose `presentation.panel === 'shared' or not defined`).

![Peek 2020-03-02 22-43](https://user-images.githubusercontent.com/37082801/75741988-45afda80-5cda-11ea-82ed-84e4e643d8da.gif)

5) Once a task finishes or is terminated, a line of bold text `Terminal will be reused by tasks` should show up in the terminal. Unlike what vs code does, we don't close the terminal on receiving a keyboard event.

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

