### PR TITLE
Fix travis API test broken by the move of the history view

### DIFF
--- a/examples/api-tests/src/menus.spec.js
+++ b/examples/api-tests/src/menus.spec.js
@@ -22,7 +22,7 @@ describe('Menus', function () {
     const { CallHierarchyContribution } = require('@theia/callhierarchy/lib/browser/callhierarchy-contribution');
     const { FileNavigatorContribution } = require('@theia/navigator/lib/browser/navigator-contribution');
     const { ScmContribution } = require('@theia/scm/lib/browser/scm-contribution');
-    const { GitHistoryContribution } = require('@theia/git/lib/browser/history/git-history-contribution');
+    const { ScmHistoryContribution } = require('@theia/scm-extra/lib/browser/history/scm-history-contribution');
     const { OutlineViewContribution } = require('@theia/outline-view/lib/browser/outline-view-contribution');
     const { OutputContribution } = require('@theia/output/lib/browser/output-contribution');
     const { PluginFrontendViewContribution } = require('@theia/plugin-ext/lib/main/browser/plugin-frontend-view-contribution');
@@ -39,7 +39,7 @@ describe('Menus', function () {
         container.get(CallHierarchyContribution),
         container.get(FileNavigatorContribution),
         container.get(ScmContribution),
-        container.get(GitHistoryContribution),
+        container.get(ScmHistoryContribution),
         container.get(OutlineViewContribution),
         container.get(OutputContribution),
         container.get(PluginFrontendViewContribution),


### PR DESCRIPTION
#### What it does
This PR fixes the break to the Travis API tests.  The test needs to be updated as the history view has been moved from the git package to the scm-extra package.

#### How to test
Check that the API tests now pass on Travis.

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

