### PR TITLE
Revert "Lazily update frames of all threads in all-stop mode"

### DIFF
--- a/packages/debug/src/browser/debug-session.tsx
+++ b/packages/debug/src/browser/debug-session.tsx
@@ -93,10 +93,7 @@ export class DebugSession implements CompositeTreeElement {
                 }
             }),
             this.on('stopped', async ({ body }) => {
-                // Update thread list
                 await this.updateThreads(body);
-
-                // Update current thread's frames immediately
                 await this.updateFrames();
             }),
             this.on('thread', ({ body: { reason, threadId } }) => {
@@ -224,9 +221,6 @@ export class DebugSession implements CompositeTreeElement {
         this.fireDidChange();
         if (thread) {
             this.toDisposeOnCurrentThread.push(thread.onDidChanged(() => this.fireDidChange()));
-
-            // If this thread is missing stack frame information, then load that.
-            this.updateFrames();
         }
     }
 
@@ -471,7 +465,7 @@ export class DebugSession implements CompositeTreeElement {
 
     protected async updateFrames(): Promise<void> {
         const thread = this._currentThread;
-        if (!thread || thread.pendingFrameCount || thread.frameCount) {
+        if (!thread || thread.frameCount) {
             return;
         }
         if (this.capabilities.supportsDelayedStackTraceLoading) {

--- a/packages/debug/src/browser/model/debug-thread.tsx
+++ b/packages/debug/src/browser/model/debug-thread.tsx
@@ -140,9 +140,7 @@ export class DebugThread extends DebugThreadData implements TreeElement {
     }
 
     protected pendingFetch = Promise.resolve<DebugStackFrame[]>([]);
-    protected _pendingFetchCount: number = 0;
     async fetchFrames(levels: number = 20): Promise<DebugStackFrame[]> {
-        this._pendingFetchCount += 1;
         return this.pendingFetch = this.pendingFetch.then(async () => {
             try {
                 const start = this.frameCount;
@@ -151,13 +149,8 @@ export class DebugThread extends DebugThreadData implements TreeElement {
             } catch (e) {
                 console.error(e);
                 return [];
-            } finally {
-                this._pendingFetchCount -= 1;
             }
         });
-    }
-    get pendingFrameCount(): number {
-        return this._pendingFetchCount;
     }
     protected async doFetchFrames(startFrame: number, levels: number): Promise<DebugProtocol.StackFrame[]> {
         try {


### PR DESCRIPTION
Reverts eclipse-theia/theia#6869 because of this regression https://github.com/eclipse-theia/theia/issues/7264

We're still looking for a fix that would avoid reverting #6969 - please do not merge this PR yet. 