### PR TITLE
Exposed `onChanged` event on the menu registry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,13 @@
 
 ## v0.17.0
 
+- [core] From now on, one can dynamically create and remove menu actions and arbitrary submenu items at runtime. [#7276](https://github.com/eclipse-theia/theia/pull/7276)
 - [preferences] add a new preference to silence notifications [#7195](https://github.com/eclipse-theia/theia/pull/7195)
 
 Breaking changes:
 
+- [core] Renamed the `browser-menu-plugin.ts` module to `browser-main-menu-factory.ts`. From now on, both the `BrowserMainMenuFactory` and the `ElectronMainMenuFactory`
+have a no-args `constructor`. Renamed `BrowserMenuBarContribution` to `BrowserMenuContribution`. `BrowserMenuContribution` was moved to its own `browser-menu-contribution.ts` module. Renamed the `browserMenuBarContribution` field to `browserMenuContribution` in the `MonacoQuickOpenService`.
 - [scm][git] the History view (GitHistoryWidget) has moved from the git package to a new   package, scm-extra, and
   renamed to ScmHistoryWidget.  GitNavigableListWidget has also moved.
   CSS classes have been moved renamed accordingly.  [6381](https://github.com/eclipse-theia/theia/pull/6381)

--- a/examples/api-tests/src/menus.spec.js
+++ b/examples/api-tests/src/menus.spec.js
@@ -17,7 +17,7 @@
 // @ts-check
 describe('Menus', function () {
 
-    const { BrowserMenuBarContribution } = require('@theia/core/lib/browser/menu/browser-menu-plugin');
+    const { BrowserMenuContribution } = require('@theia/core/lib/browser/menu/browser-menu-contribution');
     const { ApplicationShell } = require('@theia/core/lib/browser/shell/application-shell');
     const { CallHierarchyContribution } = require('@theia/callhierarchy/lib/browser/callhierarchy-contribution');
     const { FileNavigatorContribution } = require('@theia/navigator/lib/browser/navigator-contribution');
@@ -32,8 +32,8 @@ describe('Menus', function () {
     /** @type {import('inversify').Container} */
     const container = window['theia'].container;
     const shell = container.get(ApplicationShell);
-    const menuBarContribution = container.get(BrowserMenuBarContribution);
-    const menuBar = menuBarContribution.menuBar;
+    const menuContribution = container.get(BrowserMenuContribution);
+    const menuBar = menuContribution.menuBar;
 
     for (const contribution of [
         container.get(CallHierarchyContribution),

--- a/packages/core/src/browser/menu/browser-context-menu-renderer.ts
+++ b/packages/core/src/browser/menu/browser-context-menu-renderer.ts
@@ -19,7 +19,7 @@
 import { inject, injectable } from 'inversify';
 import { MenuPath } from '../../common/menu';
 import { ContextMenuRenderer, Anchor, RenderContextMenuOptions } from '../context-menu-renderer';
-import { BrowserMainMenuFactory } from './browser-menu-plugin';
+import { BrowserMainMenuFactory } from './browser-main-menu-factory';
 
 @injectable()
 export class BrowserContextMenuRenderer implements ContextMenuRenderer {

--- a/packages/core/src/browser/menu/browser-menu-contribution.ts
+++ b/packages/core/src/browser/menu/browser-menu-contribution.ts
@@ -1,0 +1,64 @@
+/********************************************************************************
+ * Copyright (C) 2017 TypeFox and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import { injectable, inject } from 'inversify';
+import { Widget } from '@phosphor/widgets';
+import debounce = require('lodash.debounce');
+import { ApplicationShell } from '../shell';
+import { MenuModelRegistry } from '../../common';
+import { FrontendApplicationContribution, FrontendApplication } from '../frontend-application';
+import { BrowserMainMenuFactory, MenuBarWidget } from './browser-main-menu-factory';
+
+@injectable()
+export class BrowserMenuContribution implements FrontendApplicationContribution {
+
+    @inject(ApplicationShell)
+    protected readonly shell: ApplicationShell;
+
+    @inject(BrowserMainMenuFactory)
+    protected readonly factory: BrowserMainMenuFactory;
+
+    @inject(MenuModelRegistry)
+    protected readonly menuRegistry: MenuModelRegistry;
+
+    onStart(app: FrontendApplication): void {
+        const logo = this.createLogo();
+        app.shell.addWidget(logo, { area: 'top' });
+        const menuBar = this.factory.createMenuBar();
+        app.shell.addWidget(menuBar, { area: 'top' });
+        const update = debounce(() => this.update(), 100);
+        this.menuRegistry.onChanged(update);
+    }
+
+    get menuBar(): MenuBarWidget | undefined {
+        return this.shell.topPanel.widgets.find(w => w instanceof MenuBarWidget) as MenuBarWidget | undefined;
+    }
+
+    protected createLogo(): Widget {
+        const logo = new Widget();
+        logo.id = 'theia:icon';
+        logo.addClass('theia-icon');
+        return logo;
+    }
+
+    protected update(): void {
+        if (this.menuBar) {
+            this.menuBar.clearMenus();
+            this.factory.fillMenuBar(this.menuBar);
+        }
+    }
+
+}

--- a/packages/core/src/browser/menu/browser-menu-module.ts
+++ b/packages/core/src/browser/menu/browser-menu-module.ts
@@ -17,12 +17,13 @@
 import { ContainerModule } from 'inversify';
 import { FrontendApplicationContribution } from '../frontend-application';
 import { ContextMenuRenderer } from '../context-menu-renderer';
-import { BrowserMenuBarContribution, BrowserMainMenuFactory } from './browser-menu-plugin';
+import { BrowserMainMenuFactory } from './browser-main-menu-factory';
+import { BrowserMenuContribution } from './browser-menu-contribution';
 import { BrowserContextMenuRenderer } from './browser-context-menu-renderer';
 
 export default new ContainerModule(bind => {
     bind(BrowserMainMenuFactory).toSelf().inSingletonScope();
     bind(ContextMenuRenderer).to(BrowserContextMenuRenderer).inSingletonScope();
-    bind(BrowserMenuBarContribution).toSelf().inSingletonScope();
-    bind(FrontendApplicationContribution).toService(BrowserMenuBarContribution);
+    bind(BrowserMenuContribution).toSelf().inSingletonScope();
+    bind(FrontendApplicationContribution).toService(BrowserMenuContribution);
 });

--- a/packages/monaco/src/browser/monaco-quick-open-service.ts
+++ b/packages/monaco/src/browser/monaco-quick-open-service.ts
@@ -25,7 +25,7 @@ import { ContextKey } from '@theia/core/lib/browser/context-key-service';
 import { MonacoContextKeyService } from './monaco-context-key-service';
 import { QuickOpenHideReason } from '@theia/core/lib/common/quick-open-service';
 import { MonacoResolvedKeybinding } from './monaco-resolved-keybinding';
-import { BrowserMenuBarContribution } from '@theia/core/lib/browser/menu/browser-menu-plugin';
+import { BrowserMenuContribution } from '@theia/core/lib/browser/menu/browser-menu-contribution';
 
 export interface MonacoQuickOpenControllerOpts extends monaco.quickOpen.IQuickOpenControllerOpts {
     valueSelection?: Readonly<[number, number]>;
@@ -52,8 +52,8 @@ export class MonacoQuickOpenService extends QuickOpenService {
     @inject(KeybindingRegistry)
     protected readonly keybindingRegistry: KeybindingRegistry;
 
-    @inject(BrowserMenuBarContribution) @optional()
-    protected readonly browserMenuBarContribution?: BrowserMenuBarContribution;
+    @inject(BrowserMenuContribution) @optional()
+    protected readonly browserMenuContribution?: BrowserMenuContribution;
 
     protected inQuickOpenKey: ContextKey<boolean>;
 
@@ -117,9 +117,9 @@ export class MonacoQuickOpenService extends QuickOpenService {
     }
 
     internalOpen(opts: MonacoQuickOpenControllerOpts): void {
-        const browserMenuBarContribution = this.browserMenuBarContribution;
-        if (browserMenuBarContribution) {
-            const browserMenuBar = browserMenuBarContribution.menuBar;
+        const browserMenuContribution = this.browserMenuContribution;
+        if (browserMenuContribution) {
+            const browserMenuBar = browserMenuContribution.menuBar;
             if (browserMenuBar) {
                 const activeMenu = browserMenuBar.activeMenu;
                 if (activeMenu) {


### PR DESCRIPTION
Signed-off-by: Akos Kitta <kittaakos@typefox.io>

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

 - Renamed the `browser-menu-plugin.ts` module to `browser-main-menu-factory.ts`.
 - From now on, both the `BrowserMainMenuFactory` and the `ElectronMainMenuFactory`
have a no-args `constructor`.
 - Renamed `BrowserMenuBarContribution` to `BrowserMenuContribution`. 
 - `BrowserMenuContribution` was moved to its own `browser-menu-contribution.ts` module.
 - Renamed the `browserMenuBarContribution` field to `browserMenuContribution` in the `MonacoQuickOpenService`

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

 - Start the app, check the menu under `Help` > `Dynamic Date`.
 - Modify the menu with the `Dynamically update the main menu` command.
 - [electron] Toggle `File: Auto Save` from the _Command Palette_, verify the menu item is updated.

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

