### PR TITLE
Adjust behavior of all close tab commands

### DIFF
--- a/examples/api-samples/src/browser/api-samples-frontend-module.ts
+++ b/examples/api-samples/src/browser/api-samples-frontend-module.ts
@@ -15,14 +15,10 @@
  ********************************************************************************/
 
 import { ContainerModule } from 'inversify';
-import { CommandContribution } from '@theia/core';
-import { LabelProviderContribution } from '@theia/core/lib/browser/label-provider';
-import { ApiSamplesContribution } from './api-samples-contribution';
-import { SampleDynamicLabelProviderContribution } from './sample-dynamic-label-provider-contribution';
+import { bindDynamicLabelProvider } from './label/sample-dymanic-label-provider-command-contribution';
+import { bindSampleUnclosableView } from './view/sample-unclosable-view-contribution';
 
 export default new ContainerModule(bind => {
-    bind(CommandContribution).to(ApiSamplesContribution).inSingletonScope();
-
-    bind(SampleDynamicLabelProviderContribution).toSelf().inSingletonScope();
-    bind(LabelProviderContribution).toService(SampleDynamicLabelProviderContribution);
+    bindDynamicLabelProvider(bind);
+    bindSampleUnclosableView(bind);
 });

--- a/examples/api-samples/src/browser/label/sample-dymanic-label-provider-command-contribution.ts
+++ b/examples/api-samples/src/browser/label/sample-dymanic-label-provider-command-contribution.ts
@@ -14,9 +14,9 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
-import { injectable, inject } from 'inversify';
+import { injectable, inject, interfaces } from 'inversify';
 import { Command, CommandContribution, CommandRegistry, CommandHandler } from '@theia/core';
-import { FrontendApplicationContribution } from '@theia/core/lib/browser';
+import { FrontendApplicationContribution, LabelProviderContribution } from '@theia/core/lib/browser';
 import { SampleDynamicLabelProviderContribution } from './sample-dynamic-label-provider-contribution';
 
 export namespace ExampleLabelProviderCommands {
@@ -29,7 +29,7 @@ export namespace ExampleLabelProviderCommands {
 }
 
 @injectable()
-export class ApiSamplesContribution implements FrontendApplicationContribution, CommandContribution {
+export class SampleDynamicLabelProviderCommandContribution implements FrontendApplicationContribution, CommandContribution {
 
     @inject(SampleDynamicLabelProviderContribution)
     protected readonly labelProviderContribution: SampleDynamicLabelProviderContribution;
@@ -53,3 +53,10 @@ export class ExampleLabelProviderCommandHandler implements CommandHandler {
     }
 
 }
+
+export const bindDynamicLabelProvider = (bind: interfaces.Bind) => {
+    bind(SampleDynamicLabelProviderContribution).toSelf().inSingletonScope();
+    bind(LabelProviderContribution).toService(SampleDynamicLabelProviderContribution);
+    bind(CommandContribution).to(SampleDynamicLabelProviderCommandContribution).inSingletonScope();
+};
+

--- a/examples/api-samples/src/browser/label/sample-dynamic-label-provider-contribution.ts
+++ b/examples/api-samples/src/browser/label/sample-dynamic-label-provider-contribution.ts
@@ -14,9 +14,9 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
+import { injectable } from 'inversify';
 import { DefaultUriLabelProviderContribution, DidChangeLabelEvent } from '@theia/core/lib/browser/label-provider';
 import URI from '@theia/core/lib/common/uri';
-import { injectable } from 'inversify';
 import { Emitter, Event } from '@theia/core';
 
 @injectable()

--- a/examples/api-samples/src/browser/view/sample-unclosable-view-contribution.ts
+++ b/examples/api-samples/src/browser/view/sample-unclosable-view-contribution.ts
@@ -1,0 +1,45 @@
+/********************************************************************************
+ * Copyright (C) 2020 TORO Limited and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import { AbstractViewContribution, bindViewContribution, WidgetFactory } from '@theia/core/lib/browser';
+import { SampleViewUnclosableView } from './sample-unclosable-view';
+import { injectable, interfaces } from 'inversify';
+
+@injectable()
+export class SampleUnclosableViewContribution extends AbstractViewContribution<SampleViewUnclosableView> {
+
+    static readonly SAMPLE_UNCLOSABLE_VIEW_TOGGLE_COMMAND_ID = 'sampleUnclosableView:toggle';
+
+    constructor() {
+        super({
+            widgetId: SampleViewUnclosableView.ID,
+            widgetName: 'Sample Unclosable View',
+            toggleCommandId: SampleUnclosableViewContribution.SAMPLE_UNCLOSABLE_VIEW_TOGGLE_COMMAND_ID,
+            defaultWidgetOptions: {
+                area: 'main'
+            }
+        });
+    }
+}
+
+export const bindSampleUnclosableView = (bind: interfaces.Bind) => {
+    bindViewContribution(bind, SampleUnclosableViewContribution);
+    bind(SampleViewUnclosableView).toSelf();
+    bind(WidgetFactory).toDynamicValue(ctx => ({
+        id: SampleViewUnclosableView.ID,
+        createWidget: () => ctx.container.get<SampleViewUnclosableView>(SampleViewUnclosableView)
+    }));
+};

--- a/examples/api-samples/src/browser/view/sample-unclosable-view.tsx
+++ b/examples/api-samples/src/browser/view/sample-unclosable-view.tsx
@@ -1,0 +1,46 @@
+/********************************************************************************
+ * Copyright (C) 2020 TORO Limited and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import { ReactWidget } from '@theia/core/lib/browser';
+import { injectable, postConstruct } from 'inversify';
+import * as React from 'react';
+
+/**
+ * This sample view is used to demo the behavior of "Widget.title.closable".
+ */
+@injectable()
+export class SampleViewUnclosableView extends ReactWidget {
+  static readonly ID = 'sampleUnclosableView';
+
+  @postConstruct()
+  init(): void {
+    this.id = SampleViewUnclosableView.ID;
+    this.title.caption = 'Sample Unclosable View';
+    this.title.label = 'Sample Unclosable View';
+    this.title.iconClass = 'fa fa-window-maximize';
+    this.title.closable = false;
+    this.update();
+  }
+
+  protected render(): React.ReactNode {
+    return (
+      <div>
+        Closable
+        <input type="checkbox" defaultChecked={this.title.closable} onChange={e => this.title.closable = e.target.checked} />
+      </div>
+    );
+  }
+}


### PR DESCRIPTION
Fixes #7268, adjust behavior of all close tab commands so that they respect the `widget.title.closable` property.

#### What it does
This PR improves the close tab commands so that they take into account the `widget.title.closable` property. It means that a widget cannot be closed using any of the commands if `widget.title.closable === false`.

The behavior is as follow:
- `Close` and `Close Tab in Main Area` are enabled when the current widget is closable
- `Close Others` and `Close Other Tabs in Main Area` are enabled if at least one other widget is closable
- `Close All` and `Close All Tabs in Main Area` enabled if at least one widget is closable
- `Close to the Right` is enabled if at least one widget to the right is closable


#### How to test
I added a sample view to the examples so you can open the `Sample Unclosable View` and toggle the checkbox in it to set `title.closable` and try the logic described above.

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

