### PR TITLE
[debug] Lazily update frames of all threads in all-stop mode

### DIFF
--- a/packages/debug/src/browser/model/debug-thread.tsx
+++ b/packages/debug/src/browser/model/debug-thread.tsx
@@ -15,7 +15,7 @@
  ********************************************************************************/
 
 import * as React from 'react';
-import { Event, Emitter } from '@theia/core';
+import { CancellationTokenSource, Emitter, Event } from '@theia/core';
 import { DebugProtocol } from 'vscode-debugprotocol/lib/debugProtocol';
 import { TreeElement } from '@theia/core/lib/browser/source-tree';
 import { DebugStackFrame } from './debug-stack-frame';
@@ -140,17 +140,32 @@ export class DebugThread extends DebugThreadData implements TreeElement {
     }
 
     protected pendingFetch = Promise.resolve<DebugStackFrame[]>([]);
+    protected _pendingFetchCount: number = 0;
+    protected pendingFetchCancel = new CancellationTokenSource();
     async fetchFrames(levels: number = 20): Promise<DebugStackFrame[]> {
+        const cancel = this.pendingFetchCancel.token;
+        this._pendingFetchCount += 1;
+
         return this.pendingFetch = this.pendingFetch.then(async () => {
             try {
                 const start = this.frameCount;
                 const frames = await this.doFetchFrames(start, levels);
+                if (cancel.isCancellationRequested) {
+                    return [];
+                }
                 return this.doUpdateFrames(frames);
             } catch (e) {
                 console.error(e);
                 return [];
+            } finally {
+                if (!cancel.isCancellationRequested) {
+                    this._pendingFetchCount -= 1;
+                }
             }
         });
+    }
+    get pendingFrameCount(): number {
+        return this._pendingFetchCount;
     }
     protected async doFetchFrames(startFrame: number, levels: number): Promise<DebugProtocol.StackFrame[]> {
         try {
@@ -181,7 +196,17 @@ export class DebugThread extends DebugThreadData implements TreeElement {
         return [...result.values()];
     }
     protected clearFrames(): void {
+        // Clear all frames
         this._frames.clear();
+
+        // Cancel all request promises
+        this.pendingFetchCancel.cancel();
+        this.pendingFetchCancel = new CancellationTokenSource();
+
+        // Empty all current requests
+        this.pendingFetch = Promise.resolve([]);
+        this._pendingFetchCount = 0;
+
         this.updateCurrentFrame();
     }
     protected updateCurrentFrame(): void {


### PR DESCRIPTION
#### What it does

A re-make of d1678ad8068d9a9bf9ed8b90d2a67f01c116e850.

The changed bits:

```diff
@@ -181,7 +196,17 @@ export class DebugThread extends DebugThreadData implements TreeElement {
         return [...result.values()];
     }
     protected clearFrames(): void {
+        // Clear all frames
         this._frames.clear();
+
+        // Cancel all request promises
+        this.pendingFetchCancel.cancel();
+        this.pendingFetchCancel = new CancellationTokenSource();
+
+        // Empty all current requests
+        this.pendingFetch = Promise.resolve([]);
+        this._pendingFetchCount = 0;
+
         this.updateCurrentFrame();
     }
     protected updateCurrentFrame(): void {
```

So what's the difference? Well, if you got multiple stops fast enough,
pending frames would be blocking the refresh from happening. Since
`updateFrames` was being called from one more place (when switching
thread), it forced me to avoid pointless lookups as to not error (GDB
complains when you're trying to fetch something that has already been
fetched). This new behavior that avoids pointless refreshes didn't
take speed into account, and could potentially block an entirely new
fetch.

To fix this, I cancel all frame fetches when clearing frames (which is
done when updating a thread in all-stop mode).

#### How to test

Same as in [#6869](https://github.com/eclipse-theia/theia/pull/6869), but you should also add vscode-python and try debugging a simple python file, to make sure that isn't broken (see [7264](https://github.com/eclipse-theia/theia/issues/7264)). Debugging NodeJS could also be a good idea.

For what it's worth, I apologize for causing a regression.

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)