### PR TITLE
terminal: additional preferences to control xterm options

### DIFF
--- a/packages/terminal/src/browser/terminal-preferences.ts
+++ b/packages/terminal/src/browser/terminal-preferences.ts
@@ -54,6 +54,11 @@ export const TerminalConfigSchema: PreferenceSchema = {
             description: 'The font weight to use within the terminal for bold text.',
             default: 'bold'
         },
+        'terminal.integrated.drawBoldTextInBrightColors': {
+            description: 'Controls whether to draw bold text in bright colors.',
+            type: 'boolean',
+            default: true,
+        },
         'terminal.integrated.letterSpacing': {
             description: 'Controls the letter spacing of the terminal, this is an integer value which represents the amount of additional pixels to add between characters.',
             type: 'number',
@@ -70,6 +75,11 @@ export const TerminalConfigSchema: PreferenceSchema = {
             type: 'number',
             default: 1000
         },
+        'terminal.integrated.fastScrollSensitivity': {
+            description: 'Controls the scrolling speed when pressing \'alt\'.',
+            type: 'number',
+            default: 5,
+        },
         'terminal.integrated.rendererType': {
             description: 'Controls how the terminal is rendered.',
             type: 'string',
@@ -80,7 +90,22 @@ export const TerminalConfigSchema: PreferenceSchema = {
             description: 'Controls whether text selected in the terminal will be copied to the clipboard.',
             type: 'boolean',
             default: false,
-        }
+        },
+        'terminal.integrated.cursorBlinking': {
+            description: 'Controls whether the terminal cursor blinks.',
+            type: 'boolean',
+            default: false
+        },
+        'terminal.integrated.cursorStyle': {
+            description: 'Controls the style of the terminal cursor/',
+            enum: ['block', 'underline', 'line'],
+            default: 'block'
+        },
+        'terminal.integrated.cursorWidth': {
+            description: 'Controls the width of the cursor when \'cursorStyle\' is set to \'line\'.',
+            type: 'number',
+            default: 1
+        },
     }
 };
 
@@ -90,16 +115,23 @@ export interface TerminalConfiguration {
     'terminal.integrated.fontFamily': string
     'terminal.integrated.fontSize': number
     'terminal.integrated.fontWeight': FontWeight
-    'terminal.integrated.fontWeightBold': FontWeight
+    'terminal.integrated.fontWeightBold': FontWeight,
+    'terminal.integrated.drawBoldTextInBrightColors': boolean,
     'terminal.integrated.letterSpacing': number
     'terminal.integrated.lineHeight': number,
     'terminal.integrated.scrollback': number,
+    'terminal.integrated.fastScrollSensitivity': number,
     'terminal.integrated.rendererType': TerminalRendererType,
     'terminal.integrated.copyOnSelection': boolean,
+    'terminal.integrated.cursorBlinking': boolean,
+    'terminal.integrated.cursorStyle': CursorStyleVSCode,
+    'terminal.integrated.cursorWidth': number
 }
 
 type FontWeight = 'normal' | 'bold' | '100' | '200' | '300' | '400' | '500' | '600' | '700' | '800' | '900';
-
+export type CursorStyle = 'block' | 'underline' | 'bar';
+// VS Code uses 'line' to represent 'bar'. The following conversion is necessary to support their preferences.
+export type CursorStyleVSCode = CursorStyle | 'line';
 export type TerminalRendererType = 'canvas' | 'dom';
 export const DEFAULT_TERMINAL_RENDERER_TYPE = 'canvas';
 // eslint-disable-next-line @typescript-eslint/no-explicit-any


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

This commit adds additional `preferences` to control the options passed to `xterm`.
The commit includes the following new preferences:
- `terminal.integrated.drawBoldTextInBrightColors`
- `terminal.integrated.fastScrollSensitivity`
- `terminal.integrated.cursorBlinking`
- `terminal.integrated.cursorStyle`
- `terminal.integrated.cursorWidth`

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

For each test, use a `terminal` to verify the changes:

<details>
<summary>
terminal.integrated.drawBoldTextInBrightColors
</summary>

<br />

**Description** 
Controls whether to draw bold text in bright colors (notice the configs folder).

**True**
![image](https://user-images.githubusercontent.com/40359487/76001499-2def7680-5ed3-11ea-8a39-88b2aa6ffc0f.png)

**False**
![image](https://user-images.githubusercontent.com/40359487/76001535-3ba4fc00-5ed3-11ea-81c4-293ac2f5edb4.png)

</details>

<details>
<summary>
terminal.integrated.fastScrollSensitivity
</summary>

<br />

**Description** 
Controls the fast scrolling speed.

**Test Case**

Update the value, and verify the changes by scrolling while pressing <kbd>alt</kbd>.
The higher the value the faster the scroll.

</details>

<details>

<summary>
terminal.integrated.cursorBlinking
</summary>

<br />

**Description** 
Controls whether the cursor blinks.

**Test Case**

Update the value, and verify the changes (the cursor should blink when set to `true`)

</details>

<details>
<summary>
terminal.integrated.cursorStyle
</summary>

<br />

**Description** 
Controls the style of the terminal cursor.

**Block**

![image](https://user-images.githubusercontent.com/40359487/76002222-4613c580-5ed4-11ea-8b3d-bf6a9ef6b55b.png)

**Bar**

![image](https://user-images.githubusercontent.com/40359487/76002266-562ba500-5ed4-11ea-8ba1-7ceec56e3559.png)

**Underline**

![image](https://user-images.githubusercontent.com/40359487/76002291-62176700-5ed4-11ea-8da9-2af3af5805d9.png)

</details>


<details>
<summary>
terminal.integrated.cursorWidth
</summary>

<br />

**Description** 
Controls the cursor width when set to 'line'

**1**

![image](https://user-images.githubusercontent.com/40359487/76002482-ae62a700-5ed4-11ea-8d52-108f365f1f78.png)

**10**

![image](https://user-images.githubusercontent.com/40359487/76002534-c0444a00-5ed4-11ea-8615-42ccc74c9a80.png)


</details>


#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

Signed-off-by: Vincent Fugnitto <vincent.fugnitto@ericsson.com>
