### PR TITLE
docs: fix incorrectly generated api docs

### DIFF
--- a/configs/typedoc.json
+++ b/configs/typedoc.json
@@ -11,7 +11,7 @@
   "external-modulemap": ".*\/packages\/([\\w\\-_]+)\/",
   "name": "Theia TypeDoc",
   "exclude": [
-    "**/+(dev-packages|examples|typings)/**/*.ts",
+    "**/+(dev-packages|examples|typings)/**/*",
     "**/*spec.ts"
   ]
 }


### PR DESCRIPTION



<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

Fixes #7287

The `api-samples` was incorrectly included in the generated docs since it had a `.tsx` file included. Due to the `typedoc.json` exclude rule not handling the case it was displayed. The `exclude` rule was updated to be more generic and not publish any documentation for the directories:
- `dev-packages`
- `examples`
- `typings`

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

1. from the root of the repo, run the command:
   ```console
   yarn run docs
   ```
2. once completed, observe the result by opening`gh-pages/docs/next/index.html` and verify if the bug has been successfully fixed

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

