### PR TITLE
[notifications] disallow arbitrary html in message content

### DIFF
--- a/packages/messages/src/browser/messages-frontend-module.ts
+++ b/packages/messages/src/browser/messages-frontend-module.ts
@@ -25,8 +25,10 @@ import { NotificationsContribution, NotificationsKeybindingContext } from './not
 import { FrontendApplicationContribution, KeybindingContribution, KeybindingContext } from '@theia/core/lib/browser';
 import { CommandContribution } from '@theia/core';
 import { ColorContribution } from '@theia/core/lib/browser/color-application-contribution';
+import { NotificationContentRenderer } from './notification-content-renderer';
 
 export default new ContainerModule((bind, unbind, isBound, rebind) => {
+    bind(NotificationContentRenderer).toSelf().inSingletonScope();
     bind(NotificationsRenderer).toSelf().inSingletonScope();
     bind(NotificationsContribution).toSelf().inSingletonScope();
     bind(FrontendApplicationContribution).toService(NotificationsContribution);

--- a/packages/messages/src/browser/notification-content-renderer.spec.ts
+++ b/packages/messages/src/browser/notification-content-renderer.spec.ts
@@ -1,0 +1,75 @@
+/********************************************************************************
+ * Copyright (C) 2020 TypeFox and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import { expect } from 'chai';
+import { NotificationContentRenderer } from './notification-content-renderer';
+
+/* eslint-disable no-unused-expressions */
+
+describe('notification-content-renderer', () => {
+
+    const contentRnderer = new NotificationContentRenderer();
+
+    it('should remove new lines', () => {
+        expectRenderedContent('foo\nbar', 'foo bar');
+        expectRenderedContent('foo\n\n\nbar', 'foo bar');
+    });
+
+    it('should render links', () => {
+        expectRenderedContent(
+            'Link to [theia](https://github.com/eclipse-theia/theia)!',
+            'Link to <a href="https://github.com/eclipse-theia/theia">theia</a>!'
+        );
+        expectRenderedContent(
+            'Link to [theia](https://github.com/eclipse-theia/theia "title on hover")!',
+            'Link to <a href="https://github.com/eclipse-theia/theia" title="title on hover">theia</a>!'
+        );
+        expectRenderedContent(
+            'Click [here](command:my-command-id) to open stuff!',
+            'Click <a href="command:my-command-id">here</a> to open stuff!'
+        );
+        expectRenderedContent(
+            'Click [here](javascript:window.alert();) to open stuff!',
+            'Click [here](javascript:window.alert();) to open stuff!'
+        );
+    });
+
+    it('should render markdown', () => {
+        expectRenderedContent(
+            '*italic*',
+            '<em>italic</em>'
+        );
+        expectRenderedContent(
+            '**bold**',
+            '<strong>bold</strong>'
+        );
+    });
+
+    it('should not render html', () => {
+        expectRenderedContent(
+            '<script>document.getElementById("demo").innerHTML = "Hello JavaScript!";</script>',
+            '&lt;script&gt;document.getElementById(&quot;demo&quot;).innerHTML = &quot;Hello JavaScript!&quot;;&lt;/script&gt;'
+        );
+        expectRenderedContent(
+            '<a href="javascript:window.alert();">foobar</a>',
+            '&lt;a href=&quot;javascript:window.alert();&quot;&gt;foobar&lt;/a&gt;'
+        );
+    });
+
+    const expectRenderedContent = (input: string, output: string) =>
+        expect(contentRnderer.renderMessage(input)).to.be.equal(output);
+
+});

--- a/packages/messages/src/browser/notification-content-renderer.ts
+++ b/packages/messages/src/browser/notification-content-renderer.ts
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (C) 2017 TypeFox and others.
+ * Copyright (C) 2020 TypeFox and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -14,16 +14,18 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
-/* note: this bogus test file is required so that
-   we are able to run mocha unit tests on this
-   package, without having any actual unit tests in it.
-   This way a coverage report will be generated,
-   showing 0% coverage, instead of no report.
-   This file can be removed once we have real unit
-   tests in place. */
+import * as markdownit from 'markdown-it';
+import { injectable } from 'inversify';
 
-describe('messages package', () => {
+@injectable()
+export class NotificationContentRenderer {
 
-    it('support code coverage statistics', () => true);
+    protected readonly mdEngine = markdownit({ html: false });
 
-});
+    renderMessage(content: string): string {
+        // in alignment with vscode, new lines aren't supported
+        const contentWithoutNewlines = content.replace(/((\r)?\n)+/gm, ' ');
+
+        return this.mdEngine.renderInline(contentWithoutNewlines);
+    }
+}


### PR DESCRIPTION
In alignment with vscode, this PR will change rendering of user notifications. HTML+JavaScript won't make into the rendered output 🎉 (Thanks to @luigigubello for reporting!)

I also checked that links with `javascript:` scheme are not translated to anchors for markdown.

Closes https://github.com/eclipse-theia/theia/issues/7283

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

### hot to verify

add a task like this an use the `>Run Task` command
```
{
  "tasks": [
    {
      "label": "<a href=\"javascript:alert('foo')\">click me</a>",
      "type": "shell",
      "command": "echo 'foo!'",
      "presentation": {
        "reveal": "always",
        "focus": false
      }
    }
  ]
}
```

See the HTML is escaped with this PR:
![Screen Shot 2020-03-09 at 09 27 00](https://user-images.githubusercontent.com/914497/76195295-44a21000-61e8-11ea-879f-ce70384e01c2.png)

While it goes into the DOM on master:
![Screen Shot 2020-03-09 at 09 25 59](https://user-images.githubusercontent.com/914497/76195292-44097980-61e8-11ea-959b-af8da8f079b0.png)



