### PR TITLE
Wrong icons appear on "References: Results" view of `vscode-reference…

### DIFF
--- a/packages/core/src/browser/label-provider.ts
+++ b/packages/core/src/browser/label-provider.ts
@@ -118,8 +118,11 @@ export class DefaultUriLabelProviderContribution implements LabelProviderContrib
             return this.defaultFolderIcon;
         }
         const uri = URIIconReference.is(element) ? element.uri : element;
-        const iconClass = uri && this.getFileIcon(uri);
-        return iconClass || this.defaultFileIcon;
+        if (uri) {
+            const iconClass = uri && this.getFileIcon(uri);
+            return iconClass || this.defaultFileIcon;
+        }
+        return '';
     }
 
     get defaultFolderIcon(): string {

--- a/packages/plugin-ext/src/main/browser/plugin-icon-theme-service.ts
+++ b/packages/plugin-ext/src/main/browser/plugin-icon-theme-service.ts
@@ -514,8 +514,8 @@ export class PluginIconTheme extends PluginIconThemeDefinition implements IconTh
         if (uri) {
             const language = monaco.services.StaticServices.modeService.get().createByFilepathOrFirstLine(monaco.Uri.parse(uri));
             classNames.push(this.languageIcon(language.languageIdentifier.language));
+            classNames.unshift(this.fileIcon);
         }
-        classNames.unshift(this.fileIcon);
         return classNames;
     }
 

--- a/packages/plugin-ext/src/main/browser/view/tree-view-widget.tsx
+++ b/packages/plugin-ext/src/main/browser/view/tree-view-widget.tsx
@@ -130,7 +130,7 @@ export class PluginTree extends TreeImpl {
     protected createTreeNode(item: TreeViewItem, parent: CompositeTreeNode): TreeNode {
         const icon = this.toIconClass(item);
         const resourceUri = item.resourceUri && URI.revive(item.resourceUri).toString();
-        const themeIconId = item.themeIconId || item.collapsibleState !== TreeViewItemCollapsibleState.None ? 'folder' : 'file';
+        const themeIconId = item.themeIconId ? item.themeIconId : item.collapsibleState !== TreeViewItemCollapsibleState.None ? 'folder' : 'file';
         const update: Partial<TreeViewNode> = {
             name: item.label,
             icon,


### PR DESCRIPTION
…s-view` plugin #7290

Fixes: #7290

Signed-off-by: Victor Rubezhny <vrubezhny@redhat.com>

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

The PR fixes the wrong icons appearance in References View.

![et7290](https://user-images.githubusercontent.com/620781/76112646-dfc99880-5fe2-11ea-8240-6b2c877d7c4b.png)

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

On a typescript file, right-click on a method/function call and select Find All References or Find All Implementations. Observe the icons on the Results tree.

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

