### PR TITLE
 #7295 Theia API  is incompatible with VSCode

### DIFF
--- a/packages/plugin-ext-vscode/src/node/plugin-vscode-init.ts
+++ b/packages/plugin-ext-vscode/src/node/plugin-vscode-init.ts
@@ -39,21 +39,6 @@ export enum ExtensionKind {
 export const doInitialization: BackendInitializationFn = (apiFactory: PluginAPIFactory, plugin: Plugin) => {
     const vscode = Object.assign(apiFactory(plugin), { ExtensionKind });
 
-    // replace command API as it will send only the ID as a string parameter
-    const registerCommand = vscode.commands.registerCommand;
-    vscode.commands.registerCommand = function (command: theia.CommandDescription | string, handler?: <T>(...args: any[]) => T | Thenable<T>, thisArg?: any): any {
-        // use of the ID when registering commands
-        if (typeof command === 'string') {
-            const rawCommands = plugin.rawModel.contributes && plugin.rawModel.contributes.commands;
-            const commands = rawCommands ? Array.isArray(rawCommands) ? rawCommands : [rawCommands] : undefined;
-            if (handler && commands && commands.some(item => item.command === command)) {
-                return vscode.commands.registerHandler(command, handler, thisArg);
-            }
-            return registerCommand({ id: command }, handler, thisArg);
-        }
-        return registerCommand(command, handler, thisArg);
-    };
-
     // use Theia plugin api instead vscode extensions
     (<any>vscode).extensions = {
         get all(): any[] {

--- a/packages/plugin-ext/src/plugin/plugin-context.ts
+++ b/packages/plugin-ext/src/plugin/plugin-context.ts
@@ -182,7 +182,16 @@ export function createAPIFactory(
     return function (plugin: InternalPlugin): typeof theia {
         const commands: typeof theia.commands = {
             // eslint-disable-next-line @typescript-eslint/no-explicit-any
-            registerCommand(command: theia.CommandDescription, handler?: <T>(...args: any[]) => T | Thenable<T | undefined>, thisArg?: any): Disposable {
+            registerCommand(command: theia.CommandDescription | string, handler?: <T>(...args: any[]) => T | Thenable<T | undefined>, thisArg?: any): Disposable {
+                // use of the ID when registering commands
+                if (typeof command === 'string') {
+                    const rawCommands = plugin.rawModel.contributes && plugin.rawModel.contributes.commands;
+                    const contributedCommands = rawCommands ? Array.isArray(rawCommands) ? rawCommands : [rawCommands] : undefined;
+                    if (handler && contributedCommands && contributedCommands.some(item => item.command === command)) {
+                        return commandRegistry.registerHandler(command, handler, thisArg);
+                    }
+                    return commandRegistry.registerCommand({ id: command }, handler, thisArg);
+                }
                 return commandRegistry.registerCommand(command, handler, thisArg);
             },
             // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/packages/plugin/src/theia.d.ts
+++ b/packages/plugin/src/theia.d.ts
@@ -2239,7 +2239,7 @@ declare module '@theia/plugin' {
          *
          * Throw if a command is already registered for the given command identifier.
          */
-        export function registerCommand(command: CommandDescription, handler?: (...args: any[]) => any, thisArg?: any): Disposable;
+        export function registerCommand(command: CommandDescription | string, handler?: (...args: any[]) => any, thisArg?: any): Disposable;
 
         /**
          * Register the given handler for the given command identifier.
@@ -9170,3 +9170,4 @@ declare module '@theia/plugin' {
         provideCallHierarchyOutgoingCalls(item: CallHierarchyItem, token: CancellationToken): ProviderResult<CallHierarchyOutgoingCall[]>;
     }
 }
+


### PR DESCRIPTION
 fixed theia.commands.registerCommand to be compatible with VSCode

Signed-off-by: Jonas Helming <jhelming@eclipsesource.com>


#### What it does
Fixes [issue #7295](https://github.com/eclipse-theia/theia/issues/7295)
Changes the theia plugin API to accept CommandDescription OR string at commands.registerCommand.
Moves special handling of this function from initializer to plugin context.

#### How to test
Link the adapted packages locally.
instanciate a theia hello world plugin (yo @theia/plugin)

Use the following example code in the plugin implementation:
```
import * as theia from '@theia/plugin';
import * as vscode from 'vscode';

export function start(context: theia.PluginContext) {
    const informationMessageTestCommand = {
        id: 'hello-world-example-generated2',
        label: "Hello World2"
    };
    context.subscriptions.push(theia.commands.registerCommand('hello-world-example-generated1', (...args: any[]) => {
        theia.window.showInformationMessage('Hello World1!');
    }));

    context.subscriptions.push(theia.commands.registerCommand(informationMessageTestCommand, (...args: any[]) => {
        theia.window.showInformationMessage('Hello World2!');
    }));

    context.subscriptions.push(vscode.commands.registerCommand('hello-world-example-generated3', (...args: any[]) => {
        theia.window.showInformationMessage('Hello World3!');
    }));

}
```


Register the two commands without a label in the package.json like so:
```
"contributes": {
		"commands": [{
			"command": "hello-world-example-generated1",
			"title": "Hello World1"
		},
        {
			"command": "hello-world-example-generated3",
			"title": "Hello World3"
		}]
```


Test that all three hello world commands work when launching the plugin.

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

