### PR TITLE
Fix creating a new file or folder if the preferences widget is opened.

### DIFF
--- a/packages/workspace/src/browser/workspace-commands.ts
+++ b/packages/workspace/src/browser/workspace-commands.ts
@@ -464,8 +464,8 @@ export class WorkspaceRootUriAwareCommandHandler extends UriAwareCommandHandler<
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     protected getUri(...args: any[]): URI | undefined {
         const uri = super.getUri(...args);
-        // If the URI is available, return it immediately.
-        if (uri) {
+        // Return the `uri` immediately if the resource exists in any of the workspace roots and is of `file` scheme.
+        if (uri && uri.scheme === 'file' && this.workspaceService.getWorkspaceRootUri(uri)) {
             return uri;
         }
         // Return the first root if available.


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
Fixes: https://github.com/eclipse-theia/theia/issues/7067 , https://github.com/eclipse-theia/theia/issues/7253

Initially we were unable to create a new file or folder while the user preferences was open.

The user-preferences has the file scheme set as `user-storage` and we did not fall back to the workspace root URI and instead were getting the URI from `user_storage:settings.json`.
With this approach, we create files at certain directories and if a directory doesn't have the scheme set to `file` it will fallback to the workspace root uri.

Signed-off-by: Muhammad Anas Shahid <muhammad.shahid@ericsson.com>


#### How to test

- Launch Theia

- Open any workspace

- Go to File>Settings> Open Preferences

- Make sure you are on `user` tab 

- Try creating a new file or folder from `File>New File` or `File> New Folder`. 

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

