### PR TITLE
Fix HOME, PageUp, PageDown shortcuts for terminal.

### DIFF
--- a/packages/terminal/src/browser/terminal-frontend-contribution.ts
+++ b/packages/terminal/src/browser/terminal-frontend-contribution.ts
@@ -371,17 +371,17 @@ export class TerminalFrontendContribution implements TerminalService, CommandCon
         });
         keybindings.registerKeybinding({
             command: TerminalCommands.SCROLL_TO_TOP.id,
-            keybinding: 'home',
+            keybinding: 'shift-home',
             context: TerminalKeybindingContexts.terminalActive
         });
         keybindings.registerKeybinding({
             command: TerminalCommands.SCROLL_PAGE_UP.id,
-            keybinding: 'pageUp',
+            keybinding: 'shift-pageUp',
             context: TerminalKeybindingContexts.terminalActive
         });
         keybindings.registerKeybinding({
             command: TerminalCommands.SCROLL_PAGE_DOWN.id,
-            keybinding: 'pageDown',
+            keybinding: 'shift-pageDown',
             context: TerminalKeybindingContexts.terminalActive
         });
 


### PR DESCRIPTION

### Referenced issue:
https://github.com/eclipse-theia/theia/issues/7304

#### What it does
Fix HOME, PageUp, PageDown shortcuts for terminal.

#### How to test
Use 'Shift+Home' shortcut to scroll terminal to top
Use 'Shift+PageUp' to scroll one terminal page
Use 'Shfit+PageDown' to scroll terminal bottom

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

Signed-off-by: Oleksandr Andriienko <oandriie@redhat.com>