### PR TITLE
Fix off-by-one error in vscode.window.showTextDocument

### DIFF
--- a/packages/plugin-ext/src/plugin/documents.ts
+++ b/packages/plugin-ext/src/plugin/documents.ts
@@ -247,10 +247,10 @@ export class DocumentsExtImpl implements DocumentsExt {
             if (options.selection) {
                 const { start, end } = options.selection;
                 selection = {
-                    startLineNumber: start.line,
-                    startColumn: start.character,
-                    endLineNumber: end.line,
-                    endColumn: end.character
+                    startLineNumber: start.line + 1,
+                    startColumn: start.character + 1,
+                    endLineNumber: end.line + 1,
+                    endColumn: end.character + 1
                 };
             }
             documentOptions = {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

Looking at the diff of this PR, the properties on the left count from one, the properties on the right count from zero, but they were assigned without taking this difference into account.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

Call `vscode.window.showTextDocument` in a VS Code extension with the `selection` parameter set, using zero-based line and column numbers (as documented and expected by VS Code).

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

