### PR TITLE
FIx missing progress events

### DIFF
--- a/packages/core/src/browser/frontend-application-module.ts
+++ b/packages/core/src/browser/frontend-application-module.ts
@@ -89,6 +89,8 @@ import { ExternalUriService } from './external-uri-service';
 import { IconThemeService, NoneIconTheme } from './icon-theme-service';
 import { IconThemeApplicationContribution, IconThemeContribution, DefaultFileIconThemeContribution } from './icon-theme-contribution';
 import { TreeLabelProvider } from './tree/tree-label-provider';
+import { ProgressBar } from './progress-bar';
+import { ProgressBarFactory, ProgressBarOptions } from './progress-bar-factory';
 
 export { bindResourceProvider, bindMessageService, bindPreferenceService };
 
@@ -308,6 +310,12 @@ export const frontendApplicationModule = new ContainerModule((bind, unbind, isBo
     bind(ProgressStatusBarItem).toSelf().inSingletonScope();
     bind(ProgressClient).toService(DispatchingProgressClient);
     bind(ProgressService).toSelf().inSingletonScope();
+    bind(ProgressBarFactory).toFactory(context => (options: ProgressBarOptions) => {
+        const childContainer = context.container.createChild();
+        childContainer.bind(ProgressBarOptions).toConstantValue(options);
+        childContainer.bind(ProgressBar).toSelf().inSingletonScope();
+        return childContainer.get(ProgressBar);
+    });
 
     bind(ContextMenuContext).toSelf().inSingletonScope();
 });

--- a/packages/core/src/browser/progress-bar-factory.ts
+++ b/packages/core/src/browser/progress-bar-factory.ts
@@ -1,0 +1,29 @@
+/********************************************************************************
+ * Copyright (C) 2019 TypeFox and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+ import { ProgressBar } from './progress-bar';
+
+export const ProgressBarFactory = Symbol('ProgressBarFactory');
+export interface ProgressBarFactory {
+    (options: ProgressBarOptions): ProgressBar;
+}
+
+export const ProgressBarOptions = Symbol('ProgressBarOptions');
+export interface ProgressBarOptions {
+    locationId: string;
+    container: HTMLElement;
+    insertMode: 'append' | 'prepend';
+}

--- a/packages/core/src/browser/progress-location-service.spec.ts
+++ b/packages/core/src/browser/progress-location-service.spec.ts
@@ -1,0 +1,50 @@
+/********************************************************************************
+ * Copyright (C) 2020 TypeFox and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import { expect } from 'chai';
+import { ProgressLocationService } from './progress-location-service';
+import { CancellationTokenSource } from '../common';
+
+describe('progress-location-service', () => {
+
+    const EXP = 'exp';
+    const SCM = 'scm';
+    const FOO = 'foo';
+
+    it('done event should be fired for multiple progress locations – bug #7311', async () => {
+        const eventLog = new Array<string>();
+        const logEvent = (location: string, show: boolean) => eventLog.push(`${location} show: ${show}`);
+
+        const service = new ProgressLocationService();
+
+        [EXP, SCM, FOO].map(location => {
+            service.onProgress(location)(e => logEvent(location, e.show));
+            const progressToken = new CancellationTokenSource();
+            service.showProgress(`progress-${location}-${Date.now()}`, { text: '', options: { location } }, progressToken.token);
+            return progressToken;
+        }).forEach(t => t.cancel());
+
+        expect(eventLog.join('\n')).eq(`
+exp show: true
+scm show: true
+foo show: true
+exp show: false
+scm show: false
+foo show: false
+        `.trim());
+    });
+
+});

--- a/packages/core/src/browser/view-container.ts
+++ b/packages/core/src/browser/view-container.ts
@@ -33,8 +33,7 @@ import { parseCssMagnitude } from './browser';
 import { WidgetManager } from './widget-manager';
 import { TabBarToolbarRegistry, TabBarToolbarFactory, TabBarToolbar } from './shell/tab-bar-toolbar';
 import { Key } from './keys';
-import { ProgressLocationService } from './progress-location-service';
-import { ProgressBar } from './progress-bar';
+import { ProgressBarFactory } from './progress-bar-factory';
 
 export interface ViewContainerTitleOptions {
     label: string;
@@ -92,8 +91,8 @@ export class ViewContainer extends BaseWidget implements StatefulWidget, Applica
     protected readonly onDidChangeTrackableWidgetsEmitter = new Emitter<Widget[]>();
     readonly onDidChangeTrackableWidgets = this.onDidChangeTrackableWidgetsEmitter.event;
 
-    @inject(ProgressLocationService)
-    protected readonly progressLocationService: ProgressLocationService;
+    @inject(ProgressBarFactory)
+    protected readonly progressBarFactory: ProgressBarFactory;
 
     @postConstruct()
     protected init(): void {
@@ -145,8 +144,7 @@ export class ViewContainer extends BaseWidget implements StatefulWidget, Applica
             this.onDidChangeTrackableWidgetsEmitter
         ]);
         if (this.options.progressLocationId) {
-            const onProgress = this.progressLocationService.onProgress(this.options.progressLocationId);
-            this.toDispose.push(new ProgressBar({ container: this.node, insertMode: 'prepend' }, onProgress));
+            this.toDispose.push(this.progressBarFactory({ container: this.node, insertMode: 'prepend', locationId: this.options.progressLocationId }));
         }
     }
 

--- a/packages/debug/src/browser/view/debug-widget.ts
+++ b/packages/debug/src/browser/view/debug-widget.ts
@@ -22,8 +22,7 @@ import { DebugSessionWidget } from './debug-session-widget';
 import { DebugConfigurationWidget } from './debug-configuration-widget';
 import { DebugViewModel } from './debug-view-model';
 import { DebugSessionManager } from '../debug-session-manager';
-import { ProgressLocationService } from '@theia/core/lib/browser/progress-location-service';
-import { ProgressBar } from '@theia/core/lib/browser/progress-bar';
+import { ProgressBarFactory } from '@theia/core/lib/browser/progress-bar-factory';
 
 @injectable()
 export class DebugWidget extends BaseWidget implements StatefulWidget, ApplicationShell.TrackableWidgetProvider {
@@ -53,8 +52,8 @@ export class DebugWidget extends BaseWidget implements StatefulWidget, Applicati
     @inject(DebugSessionWidget)
     protected readonly sessionWidget: DebugSessionWidget;
 
-    @inject(ProgressLocationService)
-    protected readonly progressLocationService: ProgressLocationService;
+    @inject(ProgressBarFactory)
+    protected readonly progressBarFactory: ProgressBarFactory;
 
     @postConstruct()
     protected init(): void {
@@ -78,8 +77,7 @@ export class DebugWidget extends BaseWidget implements StatefulWidget, Applicati
         layout.addWidget(this.toolbar);
         layout.addWidget(this.sessionWidget);
 
-        const onProgress = this.progressLocationService.onProgress('debug');
-        this.toDispose.push(new ProgressBar({ container: this.node, insertMode: 'prepend' }, onProgress));
+        this.toDispose.push(this.progressBarFactory({ container: this.node, insertMode: 'prepend', locationId: 'debug' }));
     }
 
     protected onActivateRequest(msg: Message): void {

--- a/packages/plugin-ext/src/main/browser/plugin-ext-widget.tsx
+++ b/packages/plugin-ext/src/main/browser/plugin-ext-widget.tsx
@@ -21,8 +21,7 @@ import { PluginMetadata } from '../../common/plugin-protocol';
 import { ReactWidget } from '@theia/core/lib/browser/widgets/react-widget';
 import { AlertMessage } from '@theia/core/lib/browser/widgets/alert-message';
 import { HostedPluginSupport, PluginProgressLocation } from '../../hosted/browser/hosted-plugin';
-import { ProgressLocationService } from '@theia/core/lib/browser/progress-location-service';
-import { ProgressBar } from '@theia/core/lib/browser/progress-bar';
+import { ProgressBarFactory } from '@theia/core/lib/browser/progress-bar-factory';
 import { DisposableCollection } from '@theia/core/lib/common/disposable';
 
 @injectable()
@@ -31,8 +30,8 @@ export class PluginWidget extends ReactWidget {
     @inject(HostedPluginSupport)
     protected readonly pluginService: HostedPluginSupport;
 
-    @inject(ProgressLocationService)
-    protected readonly progressLocationService: ProgressLocationService;
+    @inject(ProgressBarFactory)
+    protected readonly progressBarFactory: ProgressBarFactory;
 
     constructor() {
         super();
@@ -64,8 +63,7 @@ export class PluginWidget extends ReactWidget {
             this.toDisposeProgress.dispose();
             this.toDispose.push(this.toDisposeProgress);
             if (ref) {
-                const onProgress = this.progressLocationService.onProgress(PluginProgressLocation);
-                this.toDisposeProgress.push(new ProgressBar({ container: ref, insertMode: 'prepend' }, onProgress));
+                this.toDispose.push(this.progressBarFactory({ container: this.node, insertMode: 'prepend', locationId: PluginProgressLocation }));
             }
         }}>{this.doRender()}</div>;
     }

--- a/packages/search-in-workspace/src/browser/search-in-workspace-widget.tsx
+++ b/packages/search-in-workspace/src/browser/search-in-workspace-widget.tsx
@@ -23,9 +23,8 @@ import * as ReactDOM from 'react-dom';
 import { Event, Emitter, Disposable } from '@theia/core/lib/common';
 import { WorkspaceService } from '@theia/workspace/lib/browser';
 import { SearchInWorkspaceContextKeyService } from './search-in-workspace-context-key-service';
-import { ProgressLocationService } from '@theia/core/lib/browser/progress-location-service';
-import { ProgressBar } from '@theia/core/lib/browser/progress-bar';
 import { CancellationTokenSource } from '@theia/core';
+import { ProgressBarFactory } from '@theia/core/lib/browser/progress-bar-factory';
 
 export interface SearchFieldState {
     className: string;
@@ -84,8 +83,8 @@ export class SearchInWorkspaceWidget extends BaseWidget implements StatefulWidge
     @inject(SearchInWorkspaceContextKeyService)
     protected readonly contextKeyService: SearchInWorkspaceContextKeyService;
 
-    @inject(ProgressLocationService)
-    protected readonly progressLocationService: ProgressLocationService;
+    @inject(ProgressBarFactory)
+    protected readonly progressBarFactory: ProgressBarFactory;
 
     @postConstruct()
     protected init(): void {
@@ -146,8 +145,7 @@ export class SearchInWorkspaceWidget extends BaseWidget implements StatefulWidge
 
         this.toDispose.push(this.resultTreeWidget);
 
-        const onProgress = this.progressLocationService.onProgress('search');
-        this.toDispose.push(new ProgressBar({ container: this.node, insertMode: 'prepend' }, onProgress));
+        this.toDispose.push(this.progressBarFactory({ container: this.node, insertMode: 'prepend', locationId: 'search' }));
     }
 
     storeState(): object {


### PR DESCRIPTION
Fixes eclipse-theia/theia#7311


#### What it does
Fixes missing progress events which led to stale location progress'

#### How to test
Not sure how to reproduce, but if you switch between Explorer, Search, Debug views frequently and do some work there, i.e. generate some progress, you should always see the progress bar disappear, when the tasks are done.

I've added a test cases for this, and without this change the events for "scm" aren't logged at all.

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

