### PR TITLE
plugins: add workbench.action.openSettings

### DIFF
--- a/packages/plugin-ext-vscode/src/browser/plugin-vscode-commands-contribution.ts
+++ b/packages/plugin-ext-vscode/src/browser/plugin-vscode-commands-contribution.ts
@@ -202,6 +202,9 @@ export class PluginVscodeCommandsContribution implements CommandContribution {
         commands.registerCommand({ id: 'workbench.action.quickOpen' }, {
             execute: () => this.quickOpen.open('')
         });
+        commands.registerCommand({ id: 'workbench.action.openSettings' }, {
+            execute: () => commands.executeCommand(CommonCommands.OPEN_PREFERENCES.id)
+        });
         commands.registerCommand({ id: 'default:type' }, {
             execute: args => {
                 const editor = MonacoEditor.getCurrent(this.editorManager);


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

Fixes #7317

The following commit adds the `workbench.action.openSettings` command so that it can be executed successfully by VS Code extensions.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

1. include the following test [vscode extension](https://github.com/vince-fugnitto/settings-open/releases/download/1.0.0/settings-open-0.0.1.vsix)
2. execute the command `Ext: Open Settings`
3. the preferences widget should be correctly opened (this was not the case on `master`)

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

Signed-off-by: vince-fugnitto <vincent.fugnitto@ericsson.com>

