### PR TITLE
[gitpod] Improve development environment Dockerfile

### DIFF
--- a/.gitpod.dockerfile
+++ b/.gitpod.dockerfile
@@ -1,22 +1,18 @@
 FROM gitpod/workspace-full-vnc:latest
 
-USER root
 # Install custom tools, runtime, etc.
-RUN apt-get update \
+RUN sudo apt-get update \
     # window manager
-    && apt-get install -y jwm \
+    && sudo apt-get install -y jwm \
     # electron
-    && apt-get install -y libgtk-3-0 libnss3 libasound2 \
+    && sudo apt-get install -y libgtk-3-0 libnss3 libasound2 \
     # native-keymap
-    && apt-get install -y libx11-dev libxkbfile-dev \
-    && apt-get clean && rm -rf /var/cache/apt/* && rm -rf /var/lib/apt/lists/* && rm -rf /tmp/*
+    && sudo apt-get install -y libx11-dev libxkbfile-dev \
+    && sudo rm -rf /var/lib/apt/lists/*
 
-USER gitpod
-# Apply user-specific settings
+# Pin Node.js to v10.
 RUN bash -c ". .nvm/nvm.sh \
     && nvm install 10 \
     && nvm use 10 \
+    && nvm alias default 10 \
     && npm install -g yarn"
-
-# Give back control
-USER root


### PR DESCRIPTION
I've noticed a few small issues in Theia's `.gitpod.dockerfile`.

In particular, the current code to pin Node.js to `v10` doesn't work (it installs it, but doesn't set it to be the default). This is a problem because Gitpod may soon upgrade to Node.js `v12` LTS.

#### What it does

- Replaces `USER root` with `sudo` (best practice that prevents accidentally creating `root`-owned files that shouldn't be)
- Simplify the `apt-get` clean-up code (only `rm -rf /var/lib/apt/lists/*` is required -- sources: [1](https://docs.docker.com/develop/develop-images/dockerfile_best-practices/#apt-get), [2](https://hackernoon.com/tips-to-reduce-docker-image-sizes-876095da3b34))
- Tell `nvm` to use `v10` as the default Node.js version
- Don't "give back control" (this is unnecessary and confusing)

#### How to test

1. https://gitpod.io/#https://github.com/jankeromnes/theia/tree/jx/fix-gitpod-dockerfile
2. Verify that the dev environment works; that `v10` is used; and that Theia successfully starts on port `3000`

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

