### PR TITLE
always use `CommandService.execute` to run a command

### DIFF
--- a/packages/core/src/browser/keybinding.ts
+++ b/packages/core/src/browser/keybinding.ts
@@ -546,11 +546,8 @@ export class KeybindingRegistry {
         } else {
             const command = this.commandRegistry.getCommand(binding.command);
             if (command) {
-                const commandHandler = this.commandRegistry.getActiveHandler(command.id, binding.args);
-
-                if (commandHandler) {
-                    commandHandler.execute(binding.args);
-                }
+                this.commandRegistry.executeCommand(binding.command, binding.args)
+                    .catch(e => console.error('Failed to execute command:', e));
 
                 /* Note that if a keybinding is in context but the command is
                    not active we still stop the processing here.  */

--- a/packages/monaco/src/browser/monaco-editor-provider.ts
+++ b/packages/monaco/src/browser/monaco-editor-provider.ts
@@ -123,7 +123,7 @@ export class MonacoEditorProvider {
         const contextKeyService = this.contextKeyService.createScoped();
         const { codeEditorService, textModelService, contextMenuService } = this;
         const IWorkspaceEditService = this.bulkEditService;
-        const toDispose = new DisposableCollection();
+        const toDispose = new DisposableCollection(commandService);
         const editor = await factory({
             codeEditorService,
             textModelService,

--- a/packages/monaco/src/typings/monaco/index.d.ts
+++ b/packages/monaco/src/typings/monaco/index.d.ts
@@ -288,12 +288,14 @@ declare module monaco.commands {
 
     export interface ICommandEvent {
         commandId: string;
+        args: any[];
     }
 
+    // https://github.com/TypeFox/vscode/blob/70b8db24a37fafc77247de7f7cb5bb0195120ed0/src/vs/platform/commands/common/commands.ts#L21
     export interface ICommandService {
-        readonly _onWillExecuteCommand: monaco.Emitter<ICommandEvent>;
-        executeCommand<T>(commandId: string, ...args: any[]): Promise<T>;
-        executeCommand(commandId: string, ...args: any[]): Promise<any>;
+        onWillExecuteCommand: monaco.Event<ICommandEvent>;
+        onDidExecuteCommand: monaco.Event<ICommandEvent>;
+        executeCommand<T = any>(commandId: string, ...args: any[]): Promise<T | undefined>;
     }
 
 }
@@ -474,9 +476,12 @@ declare module monaco.services {
         resolveDecorationOptions: monaco.editor.ICodeEditorService['resolveDecorationOptions'];
     }
 
+    // https://github.com/TypeFox/vscode/blob/70b8db24a37fafc77247de7f7cb5bb0195120ed0/src/vs/editor/standalone/browser/simpleServices.ts#L233
     export class StandaloneCommandService implements monaco.commands.ICommandService {
         constructor(instantiationService: monaco.instantiation.IInstantiationService);
-        readonly _onWillExecuteCommand: monaco.Emitter<monaco.commands.ICommandEvent>;
+        private readonly _onWillExecuteCommand: monaco.Emitter<monaco.commands.ICommandEvent>;
+        private readonly _onDidExecuteCommand: monaco.Emitter<monaco.commands.ICommandEvent>;
+
         executeCommand<T>(commandId: string, ...args: any[]): Promise<T>;
         executeCommand(commandId: string, ...args: any[]): Promise<any>;
     }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

- fix #7324: keybindins and monaco were directly running command handlers before, because of it command listeners as `onWillExecute` were never triggered and the plugin system could not active plugins
- fix #7270: `onDidExecute` is added to support Monaco APIs properly

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

- Trigger `Find All References` with a keybiding from ts file
- `Reference Search` view should be opened and when ts is finished initialization references should appear
- There should not be exception in logs that a command handler was not found as before.

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

