### PR TITLE
Fix: Keybindings on Numpad special keys (#7315)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## v0.17.0
 
 - [preferences] add a new preference to silence notifications [#7195](https://github.com/eclipse-theia/theia/pull/7195)
+- [core] fixed keybindings for special Numpad keys in editors [#7315] 
 
 Breaking changes:
 

--- a/packages/core/src/browser/keyboard/keys.ts
+++ b/packages/core/src/browser/keyboard/keys.ts
@@ -356,6 +356,15 @@ export namespace KeyCode {
                     return Key.INTL_BACKSLASH;
                 }
             }
+
+            // https://github.com/eclipse-theia/theia/issues/7315
+            if (code.startsWith('Numpad') && event.key && event.key.length > 1) {
+                const k = Key.getKey(event.key);
+                if (k) {
+                    return k;
+                }
+            }
+
             const key = Key.getKey(code);
             if (key) {
                 return key;


### PR DESCRIPTION
Fixes #7315.

This adds an exception to `KeyCode.toKey` regarding special keys on numpads

Signed-off-by: Gero Posmyk-Leinemann <gero.posmyk-leinemann@typefox.io>

#### What it does
This adds an exception for Numpad keys during the `KeyboardEvent` -> key bindings resolution. It ensures that with Numlock disabled, special keys like `HOME` (on Numpad7), `END` (on Numpad1) etc. are detected and handled correctly.

#### How to test
 - Open a regular editor
 - ensure that Numlock is _disabled_
 - press `Numpad7` (`HOME`), `Numpad1` (`END`), `Numpad9` (`Page Up`), `Numpad3 (`Page Down`) and observe the respective cursor movement

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

