### PR TITLE
theming: fix decoration color theming

### DIFF
--- a/packages/editor/src/browser/decorations/editor-decoration.ts
+++ b/packages/editor/src/browser/decorations/editor-decoration.ts
@@ -88,7 +88,7 @@ export interface DecorationOptions {
      * color of the decoration in the overview ruler.
      * use `rgba` values to play well with other decorations.
      */
-    color: string;
+    color: string | { id: string };
 }
 
 export enum MinimapPosition {

--- a/packages/scm/src/browser/dirty-diff/dirty-diff-decorator.ts
+++ b/packages/scm/src/browser/dirty-diff/dirty-diff-decorator.ts
@@ -36,11 +36,15 @@ export enum DirtyDiffDecorationType {
 const AddedLineDecoration = <EditorDecorationOptions>{
     linesDecorationsClassName: 'dirty-diff-glyph dirty-diff-added-line',
     overviewRuler: {
-        color: 'editorOverviewRuler.addedForeground',
+        color: {
+            id: 'editorOverviewRuler.addedForeground'
+        },
         position: OverviewRulerLane.Left,
     },
     minimap: {
-        color: 'minimapGutter.addedBackground',
+        color: {
+            id: 'minimapGutter.addedBackground'
+        },
         position: MinimapPosition.Gutter
     },
     isWholeLine: true
@@ -49,11 +53,15 @@ const AddedLineDecoration = <EditorDecorationOptions>{
 const RemovedLineDecoration = <EditorDecorationOptions>{
     linesDecorationsClassName: 'dirty-diff-glyph dirty-diff-removed-line',
     overviewRuler: {
-        color: 'editorOverviewRuler.deletedForeground',
+        color: {
+            id: 'editorOverviewRuler.deletedForeground'
+        },
         position: OverviewRulerLane.Left,
     },
     minimap: {
-        color: 'minimapGutter.deletedBackground',
+        color: {
+            id: 'minimapGutter.deletedBackground'
+        },
         position: MinimapPosition.Gutter
     },
     isWholeLine: false
@@ -62,11 +70,15 @@ const RemovedLineDecoration = <EditorDecorationOptions>{
 const ModifiedLineDecoration = <EditorDecorationOptions>{
     linesDecorationsClassName: 'dirty-diff-glyph dirty-diff-modified-line',
     overviewRuler: {
-        color: 'editorOverviewRuler.modifiedForeground',
+        color: {
+            id: 'editorOverviewRuler.modifiedForeground'
+        },
         position: OverviewRulerLane.Left,
     },
     minimap: {
-        color: 'minimapGutter.modifiedBackground',
+        color: {
+            id: 'minimapGutter.modifiedBackground'
+        },
         position: MinimapPosition.Gutter
     },
     isWholeLine: true

--- a/packages/scm/src/browser/scm-contribution.ts
+++ b/packages/scm/src/browser/scm-contribution.ts
@@ -53,6 +53,12 @@ export namespace SCM_COMMANDS {
     };
 }
 
+export namespace ScmColors {
+    export const editorGutterModifiedBackground = 'editorGutter.modifiedBackground';
+    export const editorGutterAddedBackground = 'editorGutter.addedBackground';
+    export const editorGutterDeletedBackground = 'editorGutter.deletedBackground';
+}
+
 @injectable()
 export class ScmContribution extends AbstractViewContribution<ScmWidget> implements FrontendApplicationContribution, ColorContribution {
 
@@ -186,24 +192,23 @@ export class ScmContribution extends AbstractViewContribution<ScmWidget> impleme
      * It should be aligned with https://github.com/microsoft/vscode/blob/0dfa355b3ad185a6289ba28a99c141ab9e72d2be/src/vs/workbench/contrib/scm/browser/dirtydiffDecorator.ts#L808
      */
     registerColors(colors: ColorRegistry): void {
-        const overviewRulerDefault = Color.rgba(0, 122, 204, 0.6);
         colors.register(
             {
-                id: 'editorGutter.modifiedBackground', defaults: {
+                id: ScmColors.editorGutterModifiedBackground, defaults: {
                     dark: Color.rgba(12, 125, 157),
                     light: Color.rgba(102, 175, 224),
                     hc: Color.rgba(0, 155, 249)
                 }, description: 'Editor gutter background color for lines that are modified.'
             },
             {
-                id: 'editorGutter.addedBackground', defaults: {
+                id: ScmColors.editorGutterAddedBackground, defaults: {
                     dark: Color.rgba(88, 124, 12),
                     light: Color.rgba(129, 184, 139),
                     hc: Color.rgba(51, 171, 78)
                 }, description: 'Editor gutter background color for lines that are added.'
             },
             {
-                id: 'editorGutter.deletedBackground', defaults: {
+                id: ScmColors.editorGutterDeletedBackground, defaults: {
                     dark: Color.rgba(148, 21, 27),
                     light: Color.rgba(202, 75, 81),
                     hc: Color.rgba(252, 93, 109)
@@ -233,17 +238,23 @@ export class ScmContribution extends AbstractViewContribution<ScmWidget> impleme
             },
             {
                 id: 'editorOverviewRuler.modifiedForeground', defaults: {
-                    dark: overviewRulerDefault, light: overviewRulerDefault, hc: overviewRulerDefault
+                    dark: Color.transparent(ScmColors.editorGutterModifiedBackground, 0.6),
+                    light: Color.transparent(ScmColors.editorGutterModifiedBackground, 0.6),
+                    hc: Color.transparent(ScmColors.editorGutterModifiedBackground, 0.6)
                 }, description: 'Overview ruler marker color for modified content.'
             },
             {
                 id: 'editorOverviewRuler.addedForeground', defaults: {
-                    dark: overviewRulerDefault, light: overviewRulerDefault, hc: overviewRulerDefault
+                    dark: Color.transparent(ScmColors.editorGutterAddedBackground, 0.6),
+                    light: Color.transparent(ScmColors.editorGutterAddedBackground, 0.6),
+                    hc: Color.transparent(ScmColors.editorGutterAddedBackground, 0.6)
                 }, description: 'Overview ruler marker color for added content.'
             },
             {
                 id: 'editorOverviewRuler.deletedForeground', defaults: {
-                    dark: overviewRulerDefault, light: overviewRulerDefault, hc: overviewRulerDefault
+                    dark: Color.transparent(ScmColors.editorGutterDeletedBackground, 0.6),
+                    light: Color.transparent(ScmColors.editorGutterDeletedBackground, 0.6),
+                    hc: Color.transparent(ScmColors.editorGutterDeletedBackground, 0.6)
                 }, description: 'Overview ruler marker color for deleted content.'
             }
         );

--- a/packages/search-in-workspace/src/browser/search-in-workspace-result-tree-widget.tsx
+++ b/packages/search-in-workspace/src/browser/search-in-workspace-result-tree-widget.tsx
@@ -761,7 +761,9 @@ export class SearchInWorkspaceResultTreeWidget extends TreeWidget {
                     },
                     options: {
                         overviewRuler: {
-                            color: this.colorRegistry.getCurrentColor('editor.findMatchHighlightBackground') || '',
+                            color: {
+                                id: 'editor.findMatchHighlightBackground'
+                            },
                             position: OverviewRulerLane.Center
                         },
                         className: res.selected ? 'current-search-in-workspace-editor-match' : 'search-in-workspace-editor-match',


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

Fixes #6839

The following commit addresses the following problems:
- [x] fixes the `DecorationOptions` [color](https://github.com/eclipse-theia/theia/pull/7330/files#diff-3847bbcc53225a0d03be91200806e7beR91) to also accept the `id` of color variables.
- [x] fixes the incorrect application of decorations for `scm`
(includes **additions**, **deletions**, and **modifications**).
- [x] fixes the color variables for `editorOverviewRuler`, aligning the values with those of vscode.
- [x] aligns the fix to other areas of the framework, notably `search-in-workspace`.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

1. start the application with a workspace under version control (git).
2. verify that **additions**, **modifications**, **deletions** are properly themed (similarly to vscode).
3. change themes, and verify that colors are properly applied (ex: custom [git-neon](https://github.com/vince-fugnitto/git-neon/releases/download/1.0.0/git-neon-0.0.1.vsix)).
4. perform a search-in-workspace search, verify that results are properly themed.

<div align='center'>

<img width="1236" alt="Screen Shot 2020-04-24 at 10 46 45 AM" src="https://user-images.githubusercontent.com/40359487/80225329-ebb3fd00-8618-11ea-87fa-3e853035c54d.png">

</div>

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

Signed-off-by: Vincent Fugnitto <vincent.fugnitto@ericsson.com>
