### PR TITLE
Allow ripgrep to search files in hidden folders

### DIFF
--- a/packages/file-search/src/node/file-search-service-impl.ts
+++ b/packages/file-search/src/node/file-search-service-impl.ts
@@ -141,7 +141,7 @@ export class FileSearchServiceImpl implements FileSearchService {
     }
 
     private getSearchArgs(options: FileSearchService.BaseOptions): string[] {
-        const args = ['--files', '--case-sensitive'];
+        const args = ['--files', '--hidden', '--case-sensitive'];
         if (options.includePatterns) {
             for (const includePattern of options.includePatterns) {
                 if (includePattern) {


### PR DESCRIPTION
### Problem Description
vscode.workspace.findFiles ignores hidden folders.

#### How to test
1. create .test/file.js file in the workspace.
2. Call vscode.workspace.findFiles("**/*.js")

Old behavior:
search result empty

Now:
.test/file.js in result of search

**OS and Theia version:**
MacOs Theia from master.

**Diagnostics:** 
Arguments for search in theia: https://github.com/eclipse-theia/theia/blob/93ffbab3527a1ddee36e91e315791bffa90a0b45/packages/file-search/src/node/file-search-service-impl.ts#L144
But vscode has --hidden: https://github.com/microsoft/vscode/blob/955ff025c39bcc919e7b828bc14239215f6b20ad/src/vs/workbench/services/search/node/ripgrepFileSearch.ts#L33

#### Review checklist

- [X] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)


