### PR TITLE
[WIP]: GH-6428: Fixed `Undo`, `Redo`, and `Select All`

### DIFF
--- a/packages/monaco/src/browser/monaco-command-registry.ts
+++ b/packages/monaco/src/browser/monaco-command-registry.ts
@@ -26,15 +26,61 @@ export interface MonacoEditorCommandHandler {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     isEnabled?(editor: MonacoEditor, ...args: any[]): boolean;
 }
+/**
+ * A command handler that will:
+ *  1. execute on the focused `current` editor.
+ *  2. otherwise, if the `document.activeElement` is either an `input` or a `textArea`, executes the browser built-in command on it.
+ *  3. otherwise, invoke a command on the current editor after setting the focus on it.
+ */
+export interface MonacoEditorOrNativeTextInputCommandHandler extends MonacoEditorCommandHandler {
+    domCommandId: string;
+}
+export namespace MonacoEditorOrNativeTextInputCommand {
+
+    export function is(command: Partial<MonacoEditorOrNativeTextInputCommandHandler>): command is MonacoEditorOrNativeTextInputCommandHandler {
+        return !!command.domCommandId;
+    }
+
+    export function isEnabled(command: Partial<MonacoEditorOrNativeTextInputCommandHandler>): command is MonacoEditorOrNativeTextInputCommandHandler {
+        return !!command.domCommandId && !!isNativeTextInput();
+    }
+
+    /**
+     * same as `isEnabled`.
+     */
+    export function isVisible(command: Partial<MonacoEditorOrNativeTextInputCommandHandler>): command is MonacoEditorOrNativeTextInputCommandHandler {
+        return isEnabled(command);
+    }
+
+    export function execute({ domCommandId: id }: MonacoEditorOrNativeTextInputCommandHandler): void {
+        const { activeElement } = document;
+        if (isNativeTextInput(activeElement)) {
+            console.trace(`Executing DOM command '${id}' on 'activeElement': ${activeElement}`);
+            document.execCommand(id);
+        } else {
+            console.warn(`Failed to execute the DOM command '${id}'. Expected 'activeElement' to be an 'input' or a 'textArea'. Was: ${activeElement}`);
+        }
+    }
+
+    /**
+     * `element` defaults to `document.activeElement`.
+     */
+    function isNativeTextInput(element: Element | null = document.activeElement): element is HTMLInputElement | HTMLTextAreaElement {
+        return !!element && ['input', 'textarea'].indexOf(element.tagName.toLowerCase()) >= 0;
+    }
+
+}
 @injectable()
 export class MonacoCommandRegistry {
 
     @inject(MonacoEditorProvider)
     protected readonly monacoEditors: MonacoEditorProvider;
 
-    @inject(CommandRegistry) protected readonly commands: CommandRegistry;
+    @inject(CommandRegistry)
+    protected readonly commands: CommandRegistry;
 
-    @inject(SelectionService) protected readonly selectionService: SelectionService;
+    @inject(SelectionService)
+    protected readonly selectionService: SelectionService;
 
     validate(command: string): string | undefined {
         return this.commands.commandIds.indexOf(command) !== -1 ? command : undefined;
@@ -48,20 +94,36 @@ export class MonacoCommandRegistry {
     }
 
     registerHandler(command: string, handler: MonacoEditorCommandHandler): void {
-        this.commands.registerHandler(command, this.newHandler(handler));
+        const delegate = this.newHandler(handler) as MonacoEditorCommandHandler;
+        this.commands.registerHandler(command, delegate);
     }
 
     protected newHandler(monacoHandler: MonacoEditorCommandHandler): CommandHandler {
-        return {
-            execute: (...args) => this.execute(monacoHandler, ...args),
-            isEnabled: (...args) => this.isEnabled(monacoHandler, ...args),
-            isVisible: (...args) => this.isVisible(monacoHandler, ...args)
+        const handler: CommandHandler = {
+            execute: (...args: any) => this.execute(monacoHandler, ...args), // eslint-disable-line @typescript-eslint/no-explicit-any
+            isEnabled: (...args: any) => this.isEnabled(monacoHandler, ...args), // eslint-disable-line @typescript-eslint/no-explicit-any
+            isVisible: (...args: any) => this.isVisible(monacoHandler, ...args) // eslint-disable-line @typescript-eslint/no-explicit-any
         };
+        if (MonacoEditorOrNativeTextInputCommand.is(monacoHandler)) {
+            const { domCommandId } = monacoHandler;
+            return <MonacoEditorOrNativeTextInputCommandHandler>{
+                ...handler,
+                domCommandId
+            };
+        }
+        return handler;
     }
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     protected execute(monacoHandler: MonacoEditorCommandHandler, ...args: any[]): any {
         const editor = this.monacoEditors.current;
+        // Only if the monaco editor has the text focus; the cursor blinks inside the editor widget.
+        if (editor && editor.isFocused()) {
+            return Promise.resolve(monacoHandler.execute(editor, ...args));
+        }
+        if (MonacoEditorOrNativeTextInputCommand.is(monacoHandler)) {
+            return Promise.resolve(MonacoEditorOrNativeTextInputCommand.execute(monacoHandler));
+        }
         if (editor) {
             editor.focus();
             return Promise.resolve(monacoHandler.execute(editor, ...args));
@@ -71,13 +133,17 @@ export class MonacoCommandRegistry {
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     protected isEnabled(monacoHandler: MonacoEditorCommandHandler, ...args: any[]): boolean {
+        if (MonacoEditorOrNativeTextInputCommand.isEnabled(monacoHandler)) {
+            return true;
+        }
         const editor = this.monacoEditors.current;
         return !!editor && (!monacoHandler.isEnabled || monacoHandler.isEnabled(editor, ...args));
     }
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     protected isVisible(monacoHandler: MonacoEditorCommandHandler, ...args: any[]): boolean {
-        return TextEditorSelection.is(this.selectionService.selection);
+        return MonacoEditorOrNativeTextInputCommand.isVisible(monacoHandler)
+            || TextEditorSelection.is(this.selectionService.selection);
     }
 
 }


### PR DESCRIPTION
From now on, when executing the `Undo`, `Redo`, and `Select All` command
handlers, we do not focus the `current` editor but follow the following
execution order:

 - Executes on the `current` editor if it has text focus.
 - Otherwise, if the `document.activeElement` is either an `input` or a
 `textArea`, executes the browser's built-in command on it.
 - Otherwise, executes on the `current` editor after setting the focus
on it.

Closes: #6428
Closes: #2756

Signed-off-by: Akos Kitta <kittaakos@typefox.io>

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

Fixes the `Undo`, `Redo`, and `Select All` commands in electron, when the current `activeElement` is either an `input` or `textArea`. 

The [idea](https://github.com/eclipse-theia/theia/issues/6428#issuecomment-598763104) is from VS Code.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

TBA. I am experiencing glitches. Maybe related: https://github.com/eclipse-theia/theia/issues/5382

#### Review checklist

- [ ] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

