### PR TITLE
scm: fixed focused border of scm textarea

### DIFF
--- a/packages/scm/src/browser/style/index.css
+++ b/packages/scm/src/browser/style/index.css
@@ -102,7 +102,11 @@
 }
 
 .theia-scm-input-message-container textarea:not(:focus) {
-    border: none;
+    border: var(--theia-border-width) solid var(--theia-input-background);
+}
+
+.theia-scm-input-message-container textarea:focus {
+    border: var(--theia-border-width) solid var(--theia-focusBorder);
 }
 
 .theia-scm-input-message {
@@ -114,15 +118,15 @@
 }
 
 .theia-scm-input-message-info {
-    border-color: var(--theia-inputValidation-infoBorder);
+    border-color: var(--theia-inputValidation-infoBorder) !important;
 }
 
 .theia-scm-input-message-success {
-    border-color: var(--theia-successBackground);
+    border-color: var(--theia-successBackground) !important;
 }
 
 .theia-scm-input-message-warning {
-    border-color: var(--theia-inputValidation-warningBorder);
+    border-color: var(--theia-inputValidation-warningBorder) !important;
 }
 
 .theia-scm-input-message-error {


### PR DESCRIPTION

Signed-off-by: vince-fugnitto <vincent.fugnitto@ericsson.com>

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

Fixes #7338

The following commit fixes the issue where the `scm` textarea does not display a focused state.
**Note**: The change also updates the default border to the issue https://github.com/eclipse-theia/theia/issues/3544 is not re-introduced.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

1. start the application and open the `scm` widget
2. verify that when selecting the textarea (message), the focused border is correctly displayed

<div align='left'>

![aaa](https://user-images.githubusercontent.com/40359487/76690651-7a942980-6618-11ea-9bd2-a0ffb8933687.gif)

</div>

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

