### PR TITLE
markers: update format of markers

### DIFF
--- a/packages/markers/src/browser/problem/problem-widget.tsx
+++ b/packages/markers/src/browser/problem/problem-widget.tsx
@@ -131,15 +131,13 @@ export class ProblemWidget extends TreeWidget {
                 <div>
                     <i className={severityClass}></i>
                 </div>
-                <div className='owner'>
-                    {'[' + (problemMarker.data.source || problemMarker.owner) + ']'}
-                </div>
                 <div className='message'>{problemMarker.data.message}
-                    {
-                        (problemMarker.data.code) ? <span className='code'>{'[' + problemMarker.data.code + ']'}</span> : ''
-                    }
+                    <span className='owner'>
+                        {(problemMarker.data.source || problemMarker.owner)}
+                        {problemMarker.data.code ? `(${problemMarker.data.code})` : ''}
+                    </span>
                     <span className='position'>
-                        {'(' + (problemMarker.data.range.start.line + 1) + ', ' + (problemMarker.data.range.start.character + 1) + ')'}
+                        {'[' + (problemMarker.data.range.start.line + 1) + ', ' + (problemMarker.data.range.start.character + 1) + ']'}
                     </span>
                 </div>
             </div>;

--- a/packages/markers/src/browser/style/index.css
+++ b/packages/markers/src/browser/style/index.css
@@ -69,14 +69,9 @@
 }
 
 .theia-marker-container .markerNode .position,
-.theia-marker-container .markerNode .owner,
-.theia-marker-container .markerNode .code {
+.theia-marker-container .markerNode .owner {
     color: var(--theia-descriptionForeground);
     white-space: nowrap;
-}
-
-.theia-marker-container .markerNode .position,
-.theia-marker-container .markerNode .code {
     margin-left: 5px;
 }
 


### PR DESCRIPTION


<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

This pull-request updates the formatting of the markers present in the `problems-view` to be consistent with the latest updates present from VS Code. Namely, the pull-request updates the markers so that:
1. the `severity` icon is displayed first.
2. the `message` is displayed secondly (the message has been bumped since it holds the most important information).
3. the `owner/source` is then displayed with an attached `code` if available.
4. the `line` and `column` number is then displayed.

| Before | After |
|:---:|:---:|
| ![image](https://user-images.githubusercontent.com/40359487/76718399-10a97c00-670d-11ea-8229-26f1c9c6a602.png) | ![image](https://user-images.githubusercontent.com/40359487/76718395-0d15f500-670d-11ea-87e2-32e2037d9d7a.png) |


#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
1. start the application and open the `problems-view`.
2. ensure that the view has markers (preferably from different sources), and verify the new formatting.

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

Signed-off-by: vince-fugnitto <vincent.fugnitto@ericsson.com>
