### PR TITLE
Handle 'workbench.action.addRootFolder' vscode command

### DIFF
--- a/packages/plugin-ext-vscode/src/browser/plugin-vscode-commands-contribution.ts
+++ b/packages/plugin-ext-vscode/src/browser/plugin-vscode-commands-contribution.ts
@@ -187,6 +187,9 @@ export class PluginVscodeCommandsContribution implements CommandContribution {
         commands.registerCommand({ id: 'workbench.action.files.openFolder' }, {
             execute: () => commands.executeCommand(WorkspaceCommands.OPEN_FOLDER.id)
         });
+        commands.registerCommand({ id: 'workbench.action.addRootFolder' }, {
+            execute: () => commands.executeCommand(WorkspaceCommands.ADD_FOLDER.id)
+        });
         commands.registerCommand({ id: 'workbench.action.gotoLine' }, {
             execute: () => commands.executeCommand('editor.action.gotoLine')
         });


### PR DESCRIPTION
Signed-off-by: Tomer Epstein tomer.epstein@sap.com

Issue: 

What it does
This change proposal adds ability to handle workbench.action.addRootFolder command.

How to test
git clone https://github.com/tomer-epstein/vscode-add-Root-Folder
cd vscode-add-Root-Folderr
npm run compile && npm run package
copy vscode-add-Root-Folder-0.0.1.vsix to plugins folder
F1, choose 'Add Root Folder'.

#### Review checklist

- [ ] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

