### PR TITLE
theming: apply proper inputValidation theming

### DIFF
--- a/packages/core/src/browser/common-frontend-contribution.ts
+++ b/packages/core/src/browser/common-frontend-contribution.ts
@@ -986,13 +986,6 @@ export class CommonFrontendContribution implements FrontendApplicationContributi
                 }, description: 'Activity notification badge foreground color. The activity bar is showing on the far left or right and allows to switch between views of the side bar.'
             },
 
-            // Input control colors should be aligned with https://code.visualstudio.com/api/references/theme-color#input-control
-            // if not yet contributed by Monaco, check runtime css variables to learn
-            { id: 'input.border', defaults: { hc: 'contrastBorder' }, description: 'Input box border.' },
-            { id: 'inputValidation.errorForeground', defaults: { dark: 'errorForeground', light: 'errorForeground', hc: 'errorForeground' }, description: 'Input validation foreground color for error severity.' },
-            { id: 'inputValidation.infoForeground', description: 'Input validation foreground color for information severity.' },
-            { id: 'inputValidation.warningForeground', description: 'Input validation foreground color for warning severity.' },
-
             // Side Bar should be aligned with https://code.visualstudio.com/api/references/theme-color#side-bar
             // if not yet contributed by Monaco, check runtime css variables to learn
             { id: 'sideBar.background', defaults: { dark: '#252526', light: '#F3F3F3', hc: '#000000' }, description: 'Side bar background color. The side bar is the container for views like explorer and search.' },

--- a/packages/core/src/browser/style/alert-messages.css
+++ b/packages/core/src/browser/style/alert-messages.css
@@ -23,24 +23,27 @@
 .theia-alert-message-container i {
     padding-right: 3px;
 }
- 
+
 /* information message */
 .theia-info-alert {
     background-color: var(--theia-inputValidation-infoBackground);
-    color: var(--theia-editor-foreground);
+    border: var(--theia-border-width) solid var(--theia-inputValidation-infoBorder);
+    color: var(--theia-inputValidation-infoForeground);
     padding: 10px;
 }
 
 /* warning message */
 .theia-warning-alert {
-    background-color: var(--theia-warningBackground);
-    color: var(--theia-warningForeground);
+    background-color: var(--theia-inputValidation-warningBackground);
+    border: var(--theia-border-width) solid var(--theia-inputValidation-warningBorder);
+    color: var(--theia-inputValidation-warningForeground);
     padding: 10px;
 }
 
 /* error message */
 .theia-error-alert {
-    background-color: var(--theia-inputValidation-errorBorder);
-    color: var(--theia-editor-foreground);
+    background-color: var(--theia-inputValidation-errorBackground);
+    border: var(--theia-border-width) solid var(--theia-inputValidation-errorBorder);
+    color: var(--theia-inputValidation-errorForeground);
     padding: 10px;
 }

--- a/packages/core/src/browser/widgets/alert-message.tsx
+++ b/packages/core/src/browser/widgets/alert-message.tsx
@@ -29,7 +29,7 @@ const AlertMessageIcon = {
     INFO: 'fa fa-info-circle',
     SUCCESS: 'fa fa-check-circle',
     WARNING: 'fa fa-exclamation-circle',
-    ERROR: 'fa fa-error-icon'
+    ERROR: 'fa fa-times-circle'
 };
 
 export interface AlertMessageProps {

--- a/packages/scm/src/browser/style/index.css
+++ b/packages/scm/src/browser/style/index.css
@@ -140,7 +140,9 @@
 
 .theia-scm-validation-message-info {
     background-color: var(--theia-inputValidation-infoBackground) !important;
-    color: var(--theia-inputValidation-warningBackground);
+    color: var(--theia-inputValidation-infoForeground);
+    border: var(--theia-border-width) solid var(--theia-inputValidation-infoBorder);
+    border-top: none; /* remove top border since the input declares it already */
 }
 
 .theia-scm-validation-message-success {
@@ -150,13 +152,17 @@
 
 .theia-scm-message-warning,
 .theia-scm-validation-message-warning {
-    background-color: var(--theia-editorWarning-foreground) !important;
-    color: var(--theia-inputValidation-warningBackground);
+    background-color: var(--theia-inputValidation-warningBackground) !important;
+    color: var(--theia-inputValidation-warningForeground);
+    border: var(--theia-border-width) solid var(--theia-inputValidation-warningBorder);
+    border-top: none; /* remove top border since the input declares it already */
 }
 
 .theia-scm-validation-message-error {
-    background-color: var(--theia-errorBackground) !important;
-    color: var(--theia-errorForeground);
+    background-color: var(--theia-inputValidation-errorBackground) !important;
+    color: var(--theia-inputValidation-errorForeground);
+    border: var(--theia-border-width) solid var(--theia-inputValidation-errorBorder);
+    border-top: none; /* remove top border since the input declares it already */
 }
 
 .no-select {

--- a/packages/search-in-workspace/src/browser/styles/index.css
+++ b/packages/search-in-workspace/src/browser/styles/index.css
@@ -112,7 +112,7 @@
     border-style: solid;
     border-width: var(--theia-border-width);
     margin: -1px;
-    border-color: var(--theia-editorWarning-foreground);
+    border-color: var(--theia-inputValidation-warningBorder);
 }
 
 .t-siw-search-container .searchHeader .search-field-container .search-notification {
@@ -127,10 +127,10 @@
 }
 
 .t-siw-search-container .searchHeader .search-notification div{
-    background-color: var(--theia-editorWarning-foreground);
+    background-color: var(--theia-inputValidation-warningBackground);
     width: calc(100% + 2px);
     margin-left: -1px;
-    color: var(--theia-inputValidation-warningBackground);
+    color: var(--theia-inputValidation-warningForeground);
     z-index: 1000;
     position: absolute;
     border: 1px solid var(--theia-inputValidation-warningBorder);


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

This commit applies the proper `inputValidation` theming across the application. The theming is used to have consistent states of validation for all input (ex: `scm`, `siw`).

- [x] add `inputValidation` theming (id, default, description)
- [x] investigate uses of `inputValidation` across the application
- [x] look for any potential refactorings

| Ext | Case | Light | Dark |
|:---|:---|:---:|:---:|
|`scm` | warning | <img width="484" alt="Screen Shot 2020-03-16 at 1 10 38 PM" src="https://user-images.githubusercontent.com/40359487/76784471-14c7af00-678a-11ea-96e3-f74ea4b6cf29.png"> |<img width="484" alt="Screen Shot 2020-03-16 at 1 10 27 PM" src="https://user-images.githubusercontent.com/40359487/76784481-1a24f980-678a-11ea-8ef2-8ad1f551f56e.png">|
|`scm` | error | <img width="484" alt="Screen Shot 2020-03-16 at 1 10 07 PM" src="https://user-images.githubusercontent.com/40359487/76784520-2c9f3300-678a-11ea-98f9-8561492462f1.png"> | <img width="484" alt="Screen Shot 2020-03-16 at 1 10 19 PM" src="https://user-images.githubusercontent.com/40359487/76784527-31fc7d80-678a-11ea-8c3f-5fb91edba137.png"> |
|`siw` | too many results | <img width="484" alt="Screen Shot 2020-03-16 at 1 24 47 PM" src="https://user-images.githubusercontent.com/40359487/76784673-6e2fde00-678a-11ea-8b59-801fef8b2c5e.png"> | <img width="484" alt="Screen Shot 2020-03-16 at 1 32 20 PM" src="https://user-images.githubusercontent.com/40359487/76784781-9e777c80-678a-11ea-82d6-6343a0ce671c.png"> |


#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

1. verify that the `scm` message input works correctly for warnings and errors
2. verify that the `siw` input works correctly (when searching for too many results)
3. verify that alerts are properly themed
4. verify using different color themes

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

Signed-off-by: vince-fugnitto <vincent.fugnitto@ericsson.com>
