### PR TITLE
Update MiniBrowserEndpoint.defaultHandler() response to return content even when file type is not exists at mime-db

### DIFF
--- a/packages/mini-browser/src/node/mini-browser-endpoint.ts
+++ b/packages/mini-browser/src/node/mini-browser-endpoint.ts
@@ -180,9 +180,10 @@ export class MiniBrowserEndpoint implements BackendApplicationContribution, Mini
             const mimeType = lookup(FileUri.fsPath(stat.uri));
             if (!mimeType) {
                 this.logger.warn(`Cannot handle unexpected resource. URI: ${statWithContent.stat.uri}.`);
-                return response.send();
+                response.contentType('application/octet-stream');
+            } else {
+                response.contentType(mimeType);
             }
-            response.contentType(mimeType);
             return response.send(content);
         };
     }


### PR DESCRIPTION
#### What it does
Support other mime type files to be fetched on mini browser preview.

#### How to test
[test.zip](https://github.com/eclipse-theia/theia/files/4311901/test.zip)
Upload the file and unzip it into the root of workspace.
Right click on test.html file and select "Open With" -> "Preview"
The "TITLE" and "SUBTITLE" are replaced by the related translation texts from i18n.properties file.

Fixes #7231 

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
