### PR TITLE
Update styling for description when a tree node is focused

### DIFF
--- a/packages/debug/src/browser/style/index.css
+++ b/packages/debug/src/browser/style/index.css
@@ -54,6 +54,11 @@
 .theia-source-breakpoint .path {
     font-size: var(--theia-ui-font-size0);
     color: var(--theia-descriptionForeground);
+    opacity: 0.7;
+}
+
+.theia-debug-container .theia-Tree:focus .theia-TreeNode.theia-mod-selected .theia-source-breakpoint .path {
+    color: var(--theia-list-activeSelectionForeground) !important;
 }
 
 .theia-source-breakpoint .line-info {

--- a/packages/markers/src/browser/style/index.css
+++ b/packages/markers/src/browser/style/index.css
@@ -50,6 +50,18 @@
     color: var(--theia-descriptionForeground);
     align-self: flex-end;
     white-space: nowrap;
+    opacity: 0.7;
+}
+
+.theia-marker-container .markerNode .message .position,
+.theia-marker-container .markerNode .message .owner {
+    opacity: 0.7;
+}
+
+.theia-marker-container .ReactVirtualized__List:focus .theia-TreeNode.theia-mod-selected .markerFileNode .path,
+.theia-marker-container .ReactVirtualized__List:focus .theia-TreeNode.theia-mod-selected .markerNode .message .position,
+.theia-marker-container .ReactVirtualized__List:focus .theia-TreeNode.theia-mod-selected .markerNode .message .owner {
+    color: var(--theia-list-activeSelectionForeground) !important;
 }
 
 .theia-marker-container .error {

--- a/packages/search-in-workspace/src/browser/styles/index.css
+++ b/packages/search-in-workspace/src/browser/styles/index.css
@@ -224,6 +224,11 @@
     color: var(--theia-descriptionForeground);
     font-size: var(--theia-ui-font-size0);
     margin-left: 3px;
+    opacity: 0.7;
+}
+
+.t-siw-search-container .ReactVirtualized__List:focus .theia-TreeNode.theia-mod-selected .result .result-head .file-path {
+    color: var(--theia-list-activeSelectionForeground) !important;
 }
 
 .t-siw-search-container .resultLine .match {


### PR DESCRIPTION
#### What it does
Fixes: #7189 

Updated the styling for tree nodes in the following places so that the node description can be seen when it is focused under the Light Color Theme:
1. Search in workspace
2. Debug sidebar
3. Problems View

#### How to test
1. Search in workspace
- Change the color theme by pressing f1 or Ctrl+Shift+P and setting it to light(theia)\
- Click the Search Icon or press ctrl+shift+f
- Search for something (eg. background color)
-  The description for the tree node should be easily seen when the node is focused, loses focus or unselected

2. Debug sidebar
- Go to the 'View' on the top menu and click Debug
- Select 'Launch with Node' from the dropdown and start the debugger
- The description for the node under BREAKPOINTS should be easily seen when the node is focused, loses focus or unselected

3. Problems View
- Go to the 'View' on the top menu and click Problems
- The description for the node should be easily seen when the node is focused, loses focus or unselected

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

