### PR TITLE
GH-7358: Corrected how we spawn the BE in electron

### DIFF
--- a/dev-packages/application-manager/src/generator/frontend-generator.ts
+++ b/dev-packages/application-manager/src/generator/frontend-generator.ts
@@ -326,46 +326,13 @@ app.on('ready', () => {
     process.env.THEIA_APP_PROJECT_PATH = resolve(__dirname, '..', '..');
 
     const mainPath = join(__dirname, '..', 'backend', 'main');
-    // We need to distinguish between bundled application and development mode when starting the clusters.
-    // See: https://github.com/electron/electron/issues/6337#issuecomment-230183287
-    if (devMode) {
-        process.env[ElectronSecurityToken] = JSON.stringify(electronSecurityToken);
-        require(mainPath).then(address => {
-            loadMainWindow(address.port);
-        }).catch((error) => {
-            console.error(error);
-            app.exit(1);
-        });
-    } else {
-        // In \`electron\`, \`child_process.fork\` will strip the \`process.versions.electron\` property so native module loading can break in a bundled app.
-        // See: https://github.com/electron/electron/issues/6001#issuecomment-225475856
-        // Theia issue: https://github.com/eclipse-theia/theia/issues/7358
-        // Further related \`electron\` issues:
-        //  - https://github.com/electron/electron/issues/8727
-        //  - https://github.com/electron/electron/issues/6656
-        const env = Object.assign({
-            [ElectronSecurityToken]: JSON.stringify(electronSecurityToken),
-        }, process.env);
-        const electronPath = require('electron/index');
-        const cp = spawn(electronPath, [mainPath], { env, stdio: ['inherit', 'inherit', 'inherit', 'ipc'] });
-        cp.on('message', address => {
-            loadMainWindow(address.port);
-        });
-        cp.on('error', error => {
-            console.error(error);
-            app.exit(1);
-        });
-        cp.on('close', () => {
-            // User closed the app. Exit the host process.
-            process.exit();
-        });
-        app.on('quit', () => {
-            // If we forked the process for the clusters, we need to manually terminate it.
-            // See: https://github.com/eclipse-theia/theia/issues/835
-            process.kill(cp.pid);
-            process.exit();
-        });
-    }
+    process.env[ElectronSecurityToken] = JSON.stringify(electronSecurityToken);
+    require(mainPath).then(address => {
+        loadMainWindow(address.port);
+    }).catch((error) => {
+        console.error(error);
+        app.exit(1);
+    });
 });
 `;
     }

--- a/dev-packages/application-package/src/environment.ts
+++ b/dev-packages/application-package/src/environment.ts
@@ -22,19 +22,14 @@ const isElectron: () => boolean = require('is-electron');
 class ElectronEnv {
 
     /**
-     * Environment variable that can be accessed on the `process` to check if running in electron or not.
-     */
-    readonly THEIA_ELECTRON_VERSION = 'THEIA_ELECTRON_VERSION';
-
-    /**
      * `true` if running in electron. Otherwise, `false`.
      *
-     * Can be called from both the `main` and the render process. Also works for forked cluster workers.
+     * Can be called from both the `main` and the render process.
      */
     is(): boolean {
         // When forking a new process from the cluster, we can rely neither on `process.versions` nor `process.argv`.
         // Se we look into the `process.env` as well. `is-electron` does not do it for us.
-        return isElectron() || typeof process !== 'undefined' && typeof process.env === 'object' && !!process.env.THEIA_ELECTRON_VERSION;
+        return isElectron();
     }
 
     /**


### PR DESCRIPTION
This PR aligns the behavior of the bundled electron app with the one we start in `devMode`. Instead of starting a new process for the backend (either with `fork` or `spawn`) we `require` the BE main module:
 - so we do not end up spawning multiple `electron` processes,
 - we have `process.versions.electron` available on the BE,
 - and we avoid "it worked for me in dev mode" scenarios.

Closes #7358
Closes #4288
Closes #4875

Signed-off-by: Akos Kitta <kittaakos@typefox.io>

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

@marechal-p and @thegecko; although the PR is in WIP, I wanted to let you know we are going to change this soon. The problem is described here: https://github.com/eclipse-theia/theia/issues/7358
