### PR TITLE
Update display of an extension's readme

### DIFF
--- a/packages/vsx-registry/src/browser/style/index.css
+++ b/packages/vsx-registry/src/browser/style/index.css
@@ -147,6 +147,8 @@
 
 .theia-vsx-extension-editor .body {
     flex: 1;
+    margin: auto;
+    padding: 0 calc(var(--theia-ui-padding)*3);
 }
 
 .theia-vsx-extension-editor .header .icon-container {


### PR DESCRIPTION
#### What it does
Fixes: #7369
- center the extension's readme

#### How to test
- Click View on the top menu and select Extensions
- Select any builtin extension to display info on the extension (including the readme)

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

