### PR TITLE
[minor] fix minor variable spellings in vsx

### DIFF
--- a/packages/vsx-registry/src/browser/vsx-extensions-source.ts
+++ b/packages/vsx-registry/src/browser/vsx-extensions-source.ts
@@ -21,7 +21,7 @@ import { VSXExtensionsModel } from './vsx-extensions-model';
 @injectable()
 export class VSXExtensionsSourceOptions {
     static INSTALLED = 'installed';
-    static BUITLT_IN = 'builtin';
+    static BUILT_IN = 'builtin';
     static SEARCH_RESULT = 'searchResult';
     readonly id: string;
 }
@@ -47,7 +47,7 @@ export class VSXExtensionsSource extends TreeSource {
             if (!extension) {
                 continue;
             }
-            if (this.options.id === VSXExtensionsSourceOptions.BUITLT_IN) {
+            if (this.options.id === VSXExtensionsSourceOptions.BUILT_IN) {
                 if (extension.builtin) {
                     yield extension;
                 }

--- a/packages/vsx-registry/src/browser/vsx-extensions-widget.ts
+++ b/packages/vsx-registry/src/browser/vsx-extensions-widget.ts
@@ -29,7 +29,7 @@ export class VSXExtensionsWidget extends SourceTreeWidget {
     static ID = 'vsx-extensions';
     static INSTALLED_ID = VSXExtensionsWidget.ID + ':' + VSXExtensionsSourceOptions.INSTALLED;
     static SEARCH_RESULT_ID = VSXExtensionsWidget.ID + ':' + VSXExtensionsSourceOptions.SEARCH_RESULT;
-    static BUITLT_IN_ID = VSXExtensionsWidget.ID + ':' + VSXExtensionsSourceOptions.BUITLT_IN;
+    static BUILT_IN_ID = VSXExtensionsWidget.ID + ':' + VSXExtensionsSourceOptions.BUILT_IN;
 
     static createWidget(parent: interfaces.Container, options: VSXExtensionsWidgetOptions): VSXExtensionsWidget {
         const child = SourceTreeWidget.createContainer(parent, {
@@ -68,7 +68,7 @@ export class VSXExtensionsWidget extends SourceTreeWidget {
         if (this.id === VSXExtensionsWidget.INSTALLED_ID) {
             return 'Installed';
         }
-        if (this.id === VSXExtensionsWidget.BUITLT_IN_ID) {
+        if (this.id === VSXExtensionsWidget.BUILT_IN_ID) {
             return 'Built-in';
         }
         return 'Open VSX Registry';

--- a/packages/vsx-registry/src/browser/vsx-registry-frontend-module.ts
+++ b/packages/vsx-registry/src/browser/vsx-registry-frontend-module.ts
@@ -73,10 +73,10 @@ export default new ContainerModule(bind => {
             child.bind(VSXExtensionsViewContainer).toSelf();
             const viewContainer = child.get(VSXExtensionsViewContainer);
             const widgetManager = child.get(WidgetManager);
-            for (const id of [VSXExtensionsSourceOptions.SEARCH_RESULT, VSXExtensionsSourceOptions.INSTALLED, VSXExtensionsSourceOptions.BUITLT_IN]) {
+            for (const id of [VSXExtensionsSourceOptions.SEARCH_RESULT, VSXExtensionsSourceOptions.INSTALLED, VSXExtensionsSourceOptions.BUILT_IN]) {
                 const widget = await widgetManager.getOrCreateWidget(VSXExtensionsWidget.ID, { id });
                 viewContainer.addWidget(widget, {
-                    initiallyCollapsed: id === VSXExtensionsSourceOptions.BUITLT_IN
+                    initiallyCollapsed: id === VSXExtensionsSourceOptions.BUILT_IN
                 });
             }
             return viewContainer;


### PR DESCRIPTION

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
Fixes: https://github.com/eclipse-theia/theia/issues/7372

Fixed some minor variable spellings, just in case if anyone else wants
to use/search it in the future.

Signed-off-by: Anas Shahid <muhammad.shahid@ericsson.com>
#### How to test
Open Theia in any text-editor and navigate to the following files: 
`theia/packages/vsx-registry/src/browser/vsx-extensions-widget.ts`
`theia/packages/vsx-registry/src/browser/vsx-extensions-source.ts` 

The variable is named as `BUITLT_IN_ID` && `BUITLT_IN` 

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

