### PR TITLE
Update styling of extensions in the tree-view

### DIFF
--- a/packages/vsx-registry/src/browser/style/index.css
+++ b/packages/vsx-registry/src/browser/style/index.css
@@ -49,6 +49,8 @@
 .theia-vsx-extension {
     display: flex;
     flex-direction: row;
+    line-height: calc(var(--theia-content-line-height)*17/22);
+    align-items: center;
 }
 
 .theia-vsx-extension-icon {
@@ -80,8 +82,8 @@
     white-space: nowrap;
 }
 
-.theia-vsx-extension-content .title .name {
-    font-weight: 700;
+.theia-vsx-extension-content .title .name {
+    font-weight: bold;
 }
 
 .theia-vsx-extension-content .title .version,

--- a/packages/vsx-registry/src/browser/vsx-extensions-widget.ts
+++ b/packages/vsx-registry/src/browser/vsx-extensions-widget.ts
@@ -15,7 +15,6 @@
  ********************************************************************************/
 
 import { injectable, interfaces, postConstruct, inject } from 'inversify';
-import { TreeNode, NodeProps } from '@theia/core/lib/browser/tree';
 import { SourceTreeWidget } from '@theia/core/lib/browser/source-tree';
 import { VSXExtensionsSource, VSXExtensionsSourceOptions } from './vsx-extensions-source';
 
@@ -72,14 +71,6 @@ export class VSXExtensionsWidget extends SourceTreeWidget {
             return 'Built-in';
         }
         return 'Open VSX Registry';
-    }
-
-    protected getDefaultNodeStyle(node: TreeNode, props: NodeProps): React.CSSProperties | undefined {
-        const style = super.getDefaultNodeStyle(node, props);
-        if (style) {
-            style.paddingLeft = `${this.props.leftPadding}px`;
-        }
-        return style;
     }
 
 }


### PR DESCRIPTION
#### What it does
Fixes: #7371

- Update the extension name to be bold
- Add left-padding for the nodes
- Update line-height for the nodes

#### How to test
- Click View on the top menu and select Extensions
- The extensions are displayed under BUILT-IN

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

