### PR TITLE
Paul review

### DIFF
--- a/packages/core/src/browser/common-frontend-contribution.ts
+++ b/packages/core/src/browser/common-frontend-contribution.ts
@@ -535,6 +535,7 @@ export class CommonFrontendContribution implements FrontendApplicationContributi
             execute: (event?: Event) => {
                 const tabBar = this.findTabBar(event)!;
                 const currentTitle = this.findTitle(tabBar, event);
+
                 const area = this.shell.getAreaFor(tabBar)!;
                 this.shell.closeTabs(area, title => title !== currentTitle);
             }
@@ -542,7 +543,7 @@ export class CommonFrontendContribution implements FrontendApplicationContributi
         commandRegistry.registerCommand(CommonCommands.CLOSE_RIGHT_TABS, {
             isEnabled: (event?: Event) => {
                 const tabBar = this.findTabBar(event);
-                return tabBar !== undefined && tabBar.currentIndex < tabBar.titles.length - 1;
+                return tabBar !== undefined && tabBar.titles.length > 1;
             },
             isVisible: (event?: Event) => {
                 const area = this.findTabArea(event);
@@ -550,7 +551,13 @@ export class CommonFrontendContribution implements FrontendApplicationContributi
             },
             execute: (event?: Event) => {
                 const tabBar = this.findTabBar(event)!;
-                const currentIndex = tabBar.currentIndex;
+                const title = this.findTitle(tabBar, event);
+                let currentIndex: number;
+                if (title) {
+                    currentIndex = tabBar.titles.indexOf(title);
+                } else {
+                    currentIndex = tabBar.currentIndex;
+                }
                 this.shell.closeTabs(tabBar, (_, index) => index > currentIndex);
             }
         });

--- a/packages/core/src/browser/common-frontend-contribution.ts
+++ b/packages/core/src/browser/common-frontend-contribution.ts
@@ -601,9 +601,9 @@ export class CommonFrontendContribution implements FrontendApplicationContributi
             }
         });
         commandRegistry.registerCommand(CommonCommands.TOGGLE_MAXIMIZED, {
-            isEnabled: () => this.shell.canToggleMaximized(),
-            isVisible: () => this.shell.canToggleMaximized(),
-            execute: () => this.shell.toggleMaximized()
+            isEnabled: (event?: Event) => this.canToggleMaximized(event),
+            isVisible: (event?: Event) => this.canToggleMaximized(event),
+            execute: (event?: Event) => this.toggleMaximized(event)
         });
 
         commandRegistry.registerCommand(CommonCommands.SAVE, {
@@ -626,6 +626,19 @@ export class CommonFrontendContribution implements FrontendApplicationContributi
         commandRegistry.registerCommand(CommonCommands.SELECT_ICON_THEME, {
             execute: () => this.selectIconTheme()
         });
+    }
+
+    private canToggleMaximized(event?: Event): boolean {
+        const targetTabBar = this.findTabBar(event);
+        if (targetTabBar) {
+            return this.shell.canToggleMaximized({ targetTabBar });
+        }
+        return false;
+    }
+
+    private toggleMaximized(event?: Event): void {
+        const targetTabBar = this.findTabBar(event)!;
+        this.shell.toggleMaximized({ targetTabBar });
     }
 
     private findTabBar(event?: Event): TabBar<Widget> | undefined {
@@ -653,7 +666,11 @@ export class CommonFrontendContribution implements FrontendApplicationContributi
                 tabNode = tabNode.parentElement;
             }
             if (tabNode && tabNode.title) {
-                const title = tabBar.titles.find(t => t.label === tabNode!.title);
+                let title = tabBar.titles.find(t => t.caption === tabNode!.title);
+                if (title) {
+                    return title;
+                }
+                title = tabBar.titles.find(t => t.label === tabNode!.title);
                 if (title) {
                     return title;
                 }

--- a/packages/core/src/browser/shell/application-shell.ts
+++ b/packages/core/src/browser/shell/application-shell.ts
@@ -1618,15 +1618,47 @@ export class ApplicationShell extends Widget {
         return [...this.tracker.widgets];
     }
 
-    canToggleMaximized(): boolean {
-        const area = this.currentWidget && this.getAreaFor(this.currentWidget);
+    /**
+     * Determines if the target widget is located in an area which can be successfully maximized.
+     * - If `options` is provided, determine the area/location of the passed widget, else use the `currentWidget`.
+     * @param options: optional `targetTabBar` to be used when searching.
+     *
+     * @returns `true` if the widget is located in the `main` or `bottom` area, and `false` otherwise.
+     */
+    canToggleMaximized(options?: { targetTabBar: TabBar<Widget> }): boolean {
+        let area: ApplicationShell.Area | undefined;
+        if (options) {
+            const { targetTabBar } = options;
+            area = this.getAreaFor(targetTabBar);
+        } else {
+            area = this.currentWidget && this.getAreaFor(this.currentWidget);
+        }
         return area === 'main' || area === 'bottom';
     }
 
-    toggleMaximized(): void {
-        const area = this.currentWidget && this.getAreaPanelFor(this.currentWidget);
-        if (area instanceof TheiaDockPanel && (area === this.mainPanel || area === this.bottomPanel)) {
-            area.toggleMaximized();
+    /**
+     * Maximizes the target widget in the target area/location. Otherwise, throw a warning.
+     * - If `options` is provided, determine the area/location of the passed widget, else use the `currentWidget`.
+     * @param options: optional `targetTabBar` to be used when searching.
+     */
+    toggleMaximized(options?: { targetTabBar: TabBar<Widget> }): void {
+        let area: String | undefined;
+        if (options) {
+            const { targetTabBar } = options;
+            if (targetTabBar instanceof Widget && this.currentWidget) {
+                area = this.getAreaFor(targetTabBar ? targetTabBar : this.currentWidget);
+            }
+        }
+        if (!area && this.currentWidget) {
+            area = this.getAreaFor(this.currentWidget);
+        }
+
+        if (area === 'bottom') {
+            this.bottomPanel.toggleMaximized();
+        } else if (area === 'main') {
+            this.mainPanel.toggleMaximized();
+        } else {
+            console.warn('Could not find area for widget');
         }
     }
 

--- a/packages/core/src/browser/shell/tab-bars.ts
+++ b/packages/core/src/browser/shell/tab-bars.ts
@@ -413,18 +413,6 @@ export class TabBarRenderer extends TabBar.Renderer {
         if (this.contextMenuRenderer && this.contextMenuPath && event.currentTarget instanceof HTMLElement) {
             event.stopPropagation();
             event.preventDefault();
-
-            if (this.tabBar) {
-                const id = event.currentTarget.id;
-                // eslint-disable-next-line no-null/no-null
-                const title = this.tabBar.titles.find(t => this.createTabId(t) === id) || null;
-                this.tabBar.currentTitle = title;
-                this.tabBar.activate();
-                if (title) {
-                    title.owner.activate();
-                }
-            }
-
             this.contextMenuRenderer.render(this.contextMenuPath, event);
         }
     };

--- a/packages/navigator/src/browser/navigator-contribution.ts
+++ b/packages/navigator/src/browser/navigator-contribution.ts
@@ -18,7 +18,11 @@ import { injectable, inject, postConstruct } from 'inversify';
 import { AbstractViewContribution } from '@theia/core/lib/browser/shell/view-contribution';
 import {
     Navigatable, SelectableTreeNode, Widget, KeybindingRegistry, CommonCommands,
+<<<<<<< Updated upstream
     OpenerService, FrontendApplicationContribution, FrontendApplication, CompositeTreeNode, PreferenceScope, TabBar, Title
+=======
+    OpenerService, FrontendApplicationContribution, FrontendApplication, CompositeTreeNode, PreferenceScope, Title, TabBar
+>>>>>>> Stashed changes
 } from '@theia/core/lib/browser';
 import { FileDownloadCommands } from '@theia/filesystem/lib/browser/download/file-download-command-contribution';
 import { CommandRegistry, MenuModelRegistry, MenuPath, isOSX, Command, DisposableCollection, Mutable } from '@theia/core/lib/common';
@@ -215,24 +219,22 @@ export class FileNavigatorContribution extends AbstractViewContribution<FileNavi
         const widget = title && title.owner;
         return widget;
     }
-    private visibilityTest(event?: Event): boolean {
-        let title: Title<Widget> | undefined;
-        if (event && event.target) {
-            const tab = this.findTabBar(event);
-            title = this.findTitle(tab, event);
-        }
-        const widget = title && title.owner;
-        return widget ? Navigatable.is(widget) : Navigatable.is(this.shell.currentWidget);
-    }
+
     registerCommands(registry: CommandRegistry): void {
         super.registerCommands(registry);
         registry.registerCommand(FileNavigatorCommands.REVEAL_IN_NAVIGATOR, {
             execute: (event?: Event) => {
                 const widget = this.getRequiredWidget(event);
-                return widget ? this.shell.activateWidget(widget.id) : this.shell.currentWidget && this.shell.activateWidget(this.shell.currentWidget.id);
+                return widget ? this.selectWidgetFileNode(widget) : this.selectWidgetFileNode(this.shell.currentWidget);
             },
-            isEnabled: (event?: Event) => this.visibilityTest(event),
-            isVisible: (event?: Event) => this.visibilityTest(event)
+            isEnabled: (event?: Event) => {
+                const widget = this.getRequiredWidget(event);
+                return widget ? Navigatable.is(widget) : Navigatable.is(this.shell.currentWidget);
+            },
+            isVisible: (event?: Event) => {
+                const widget = this.getRequiredWidget(event);
+                return widget ? Navigatable.is(widget) : Navigatable.is(this.shell.currentWidget);
+            }
         });
         registry.registerCommand(FileNavigatorCommands.TOGGLE_HIDDEN_FILES, {
             execute: () => {

--- a/packages/navigator/src/browser/navigator-contribution.ts
+++ b/packages/navigator/src/browser/navigator-contribution.ts
@@ -18,11 +18,7 @@ import { injectable, inject, postConstruct } from 'inversify';
 import { AbstractViewContribution } from '@theia/core/lib/browser/shell/view-contribution';
 import {
     Navigatable, SelectableTreeNode, Widget, KeybindingRegistry, CommonCommands,
-<<<<<<< Updated upstream
-    OpenerService, FrontendApplicationContribution, FrontendApplication, CompositeTreeNode, PreferenceScope, TabBar, Title
-=======
     OpenerService, FrontendApplicationContribution, FrontendApplication, CompositeTreeNode, PreferenceScope, Title, TabBar
->>>>>>> Stashed changes
 } from '@theia/core/lib/browser';
 import { FileDownloadCommands } from '@theia/filesystem/lib/browser/download/file-download-command-contribution';
 import { CommandRegistry, MenuModelRegistry, MenuPath, isOSX, Command, DisposableCollection, Mutable } from '@theia/core/lib/common';


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
Fixes: #4367

Before, right clicking on different menus would focus the menu item and open it, however this should not be the case. There was a dangling code in the handleContextMenu which causes this effect, as it was checking for the id when right clicked and looked up the ID for the menu-item and set the current title to the menu-item.

Signed-off-by: Muhammad Anas Shahid muhammad.shahid@ericsson.com

#### How to test
Open multiple tabs

Right click on unfocused tab and it will be focused.
#### Review checklist

- [ x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

