### PR TITLE
Omit rendering for rating/downloads of an extension if 0

### DIFF
--- a/packages/vsx-registry/src/browser/style/index.css
+++ b/packages/vsx-registry/src/browser/style/index.css
@@ -90,11 +90,11 @@
     font-size: 80%;
 }
 
-
 .theia-vsx-extension-content .title .stat .average-rating > i {
     color: #ff8e00;
 }
 
+.theia-vsx-extension-editor .download-count > i,
 .theia-vsx-extension-content .title .stat .average-rating > i,
 .theia-vsx-extension-content .title .stat .download-count > i {
     padding-right: calc(var(--theia-ui-padding)/2);

--- a/packages/vsx-registry/src/browser/vsx-extension.tsx
+++ b/packages/vsx-registry/src/browser/vsx-extension.tsx
@@ -369,7 +369,8 @@ export class VSXExtensionEditorComponent extends AbstractVSXExtensionComponent {
                             {this.renderNamespaceAccess()}
                             {publisher}
                         </span>
-                        {downloadCount && <span className='fa fa-download download-count' onClick={this.openExtension}>{downloadFormatter.format(downloadCount)}</span>}
+                        {downloadCount && <span className='download-count' onClick={this.openExtension}>
+                            <i className="fa fa-download" />{downloadFormatter.format(downloadCount)}</span>}
                         {averageRating && <span className='average-rating' onClick={this.openAverageRating}>{this.renderStars()}</span>}
                         {repository && <span className='repository' onClick={this.openRepository}>Repository</span>}
                         {license && <span className='license' onClick={this.openLicense}>{license}</span>}

--- a/packages/vsx-registry/src/browser/vsx-extension.tsx
+++ b/packages/vsx-registry/src/browser/vsx-extension.tsx
@@ -332,8 +332,8 @@ export class VSXExtensionComponent extends AbstractVSXExtensionComponent {
                         <span className='name'>{displayName}</span> <span className='version'>{version}</span>
                     </div>
                     <div className='stat'>
-                        {downloadCount && <span className='download-count'><i className='fa fa-download' />{downloadCompactFormatter.format(downloadCount)}</span>}
-                        {averageRating && <span className='average-rating'><i className='fa fa-star' />{averageRating.toFixed(1)}</span>}
+                        {!!downloadCount && <span className='download-count'><i className='fa fa-download' />{downloadCompactFormatter.format(downloadCount)}</span>}
+                        {!!averageRating && <span className='average-rating'><i className='fa fa-star' />{averageRating.toFixed(1)}</span>}
                     </div>
                 </div>
                 <div className='noWrapInfo theia-vsx-extension-description'>{description}</div>
@@ -369,9 +369,9 @@ export class VSXExtensionEditorComponent extends AbstractVSXExtensionComponent {
                             {this.renderNamespaceAccess()}
                             {publisher}
                         </span>
-                        {downloadCount && <span className='download-count' onClick={this.openExtension}>
+                        {!!downloadCount && <span className='download-count' onClick={this.openExtension}>
                             <i className="fa fa-download" />{downloadFormatter.format(downloadCount)}</span>}
-                        {averageRating && <span className='average-rating' onClick={this.openAverageRating}>{this.renderStars()}</span>}
+                        {averageRating !== undefined && <span className='average-rating' onClick={this.openAverageRating}>{this.renderStars()}</span>}
                         {repository && <span className='repository' onClick={this.openRepository}>Repository</span>}
                         {license && <span className='license' onClick={this.openLicense}>{license}</span>}
                     </div>
@@ -404,10 +404,8 @@ export class VSXExtensionEditorComponent extends AbstractVSXExtensionComponent {
     }
 
     protected renderStars(): React.ReactNode {
-        const rating = this.props.extension.averageRating;
-        if (typeof rating !== 'number') {
-            return undefined;
-        }
+        const rating = this.props.extension.averageRating || 0;
+
         const renderStarAt = (position: number) => position <= rating ?
             <i className='fa fa-star' /> :
             position > rating && position - rating < 1 ?


### PR DESCRIPTION
#### What it does
Fixes: #7376
Fixes #7423 

The pull-request addresses the following:
- Omit the rendering for rating/downloads of an extension in the extension tree if it is equal to 0
- Omit the rendering for downloads in extension editor if it is equal to 0
- Render the star icons for published extension in extension editor even if rating equals to 0
- Updates the `font-family` for the download count when viewing an extension's information

#### How to test
- Click View in the top menu and select Extensions
- Search for Omi Snippets
- The 0 rating for should no longer be there

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

