### PR TITLE
align how tasks are displayed as quick open items

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,11 @@
 
 Breaking changes:
 
-- [scm][git] the History view (GitHistoryWidget) has moved from the git package to a new   package, scm-extra, and
+- [scm][git] the History view (GitHistoryWidget) has moved from the git package to a new package, scm-extra, and
   renamed to ScmHistoryWidget.  GitNavigableListWidget has also moved.
   CSS classes have been moved renamed accordingly.  [6381](https://github.com/eclipse-theia/theia/pull/6381)
+- [task] `TaskRestartRunningQuickOpenItem` class is renamed into `RunningTaskQuickOpenItem`. [7392](https://github.com/eclipse-theia/theia/pull/7392)
+- [task] `TaskAttachQuickOpenItem` class is removed.
 
 ## v0.16.0
 


### PR DESCRIPTION
- In a multi root workspace, detected tasks are displayed in different
ways across `Run task`, `Restart running task`, `Terminate task`,
and `Show running tasks`. This change aligns the display of the task
quick open items.

- fixed #6821

Signed-off-by: Liang Huang <lhuang4@ualberta.ca>


#### How to test

1. Open a workspace that has multiple roots.
2. Define a detected task, e.g., a npm script in your package.json
```
  "scripts": {
    "test": "echo start && sleep 1000 && echo end"
  },
```
3. Start the detected task defined in Step 2
4. Check how the task defined in Step 2 is displayed in the following quick open menus: 

`Terminal -> Run task`, `Terminal -> Restart running task`, `Terminal -> Terminate task`,
and `Terminal -> Show running tasks`.

They should all be displayed as `npm: test <- subfolder name / path> [root folder name]`

![Peek 2020-03-22 11-49](https://user-images.githubusercontent.com/37082801/77253817-55647400-6c33-11ea-88f1-3b1d0836c14b.gif)


#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

