### PR TITLE
fix #7393 can't open tomcat configuration without workspaces opened

### DIFF
--- a/packages/plugin-ext/src/plugin/plugin-manager.ts
+++ b/packages/plugin-ext/src/plugin/plugin-manager.ts
@@ -314,7 +314,7 @@ export class PluginManagerExtImpl implements PluginManagerExt, PluginManager {
         const subscriptions: theia.Disposable[] = [];
         const asAbsolutePath = (relativePath: string): string => join(plugin.pluginFolder, relativePath);
         const logPath = join(configStorage.hostLogPath, plugin.model.id); // todo check format
-        const storagePath = join(configStorage.hostStoragePath || '', plugin.model.id);
+        const storagePath = configStorage.hostStoragePath ? join(configStorage.hostStoragePath, plugin.model.id) : undefined;
         const globalStoragePath = join(configStorage.hostGlobalStoragePath, plugin.model.id);
         const pluginContext: theia.PluginContext = {
             extensionPath: plugin.pluginFolder,


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->
When no workspaces are opened, storagePath should return undefined in
accordance with the vscode implementation(https://github.com/microsoft/vscode/blob/416bb2e8d08f123df4bfb458070fcbb9fb69a3da/src/vs/workbench/api/node/extHostStoragePaths.ts#L46-L49).
Then `vscode.ExtensionContext.storagePath` will return undefined and vscode tomcat will create a temp storagePath refer to https://github.com/adashen/vscode-tomcat/blob/develop/src/extension.ts#L13-L17.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
follow the Reproduction Steps in https://github.com/eclipse-theia/theia/issues/7393,
and check whether the clicking of `Open Server Configuration` is OK.

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

