### PR TITLE
vsx: sort exts based on displayname, publisher

### DIFF
--- a/packages/vsx-registry/src/browser/vsx-extensions-model.ts
+++ b/packages/vsx-registry/src/browser/vsx-extensions-model.ts
@@ -170,7 +170,8 @@ export class VSXExtensionsModel {
                 refreshing.push(this.refresh(id));
             }
             Promise.all(refreshing);
-            this._installed = installed;
+            const installedSorted = Array.from(installed).sort((a, b) => this.compareExtensions(a, b));
+            this._installed = new Set(installedSorted.values());
         });
     }
 
@@ -237,6 +238,26 @@ export class VSXExtensionsModel {
         }
         console.error(`[${id}]: failed to refresh, reason:`, error);
         return undefined;
+    }
+
+    /**
+     * Compare two extensions based on their display name, and publisher if applicable.
+     * @param a the first extension id for comparison.
+     * @param b the second extension id for comparison.
+     */
+    protected compareExtensions(a: string, b: string): number {
+        const extensionA = this.getExtension(a);
+        const extensionB = this.getExtension(b);
+        if (!extensionA || !extensionB) {
+            return 0;
+        }
+        if (extensionA.displayName && extensionB.displayName) {
+            return extensionA.displayName.localeCompare(extensionB.displayName);
+        }
+        if (extensionA.publisher && extensionB.publisher) {
+            return extensionA.publisher.localeCompare(extensionB.publisher);
+        }
+        return 0;
     }
 
 }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

Fixes #7397

This commit adds a comparator method to the `vsx` extension to ensure that extensions present in the `extensions-view` are properly sorted by `displayName`. If the `displayName` is `undefined`, attempt to use the `publisher`.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
1. start the application, and open the `extensions-view`
2. verify that the list of `builtin` extensions are properly sorted by name
3. install any extensions using the search, such extensions should be properly sorted as well

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

Signed-off-by: vince-fugnitto <vincent.fugnitto@ericsson.com>
