### PR TITLE
[gitpod] Update Node.js v10 pinning code

### DIFF
--- a/.gitpod.dockerfile
+++ b/.gitpod.dockerfile
@@ -14,8 +14,10 @@ RUN sudo apt-get update \
     && sudo rm -rf /var/lib/apt/lists/*
 
 # Pin Node.js to v10.
+ENV NODE_VERSION="10.19.0"
 RUN bash -c ". .nvm/nvm.sh \
-    && nvm install 10 \
-    && nvm use 10 \
-    && nvm alias default 10 \
+    && nvm install $NODE_VERSION \
+    && nvm use $NODE_VERSION \
+    && nvm alias default $NODE_VERSION \
     && npm install -g yarn"
+ENV PATH=$HOME/.nvm/versions/node/v${NODE_VERSION}/bin:$PATH


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
As Gitpod's default workspace image will upgrade to Node.js v12 LTS, and to prevent any breakage for Theia developers, I would like to update the Node.js v10 pinning code.

Worth noting: adding the pinned Node.js version to the `PATH` is required for Theia's Node.js debugging extension to work properly (because it depends on `which node` working even without calling the NVM lazy-loading functions from `~/.bashrc`).

#### How to test
1. Open this Theia branch (with Node.js v12 LTS pre-installed, and the updated v10 pin) in Gitpod:
    - https://gitpod.io/#https://github.com/jankeromnes/theia/tree/jx/test-node-12-upgrade
2. `node --version` should indicate v10 is used
3. Theia build should pass

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

