### PR TITLE
Prioritize display of an extension's name when the view's width is limited

### DIFF
--- a/packages/vsx-registry/src/browser/style/index.css
+++ b/packages/vsx-registry/src/browser/style/index.css
@@ -72,6 +72,10 @@
     width: calc(100% - var(--theia-vsx-extension-icon-size) - var(--theia-ui-padding)*2.5);
 }
 
+.theia-vsx-extension-content.no-extension-icon {
+    width: 100%;
+}
+
 .theia-vsx-extension-content .title {
     display: flex;
     flex-direction: row;

--- a/packages/vsx-registry/src/browser/vsx-extension.tsx
+++ b/packages/vsx-registry/src/browser/vsx-extension.tsx
@@ -322,18 +322,23 @@ const downloadCompactFormatter = new Intl.NumberFormat(undefined, { notation: 'c
 export class VSXExtensionComponent extends AbstractVSXExtensionComponent {
     render(): React.ReactNode {
         const { iconUrl, publisher, displayName, description, version, downloadCount, averageRating } = this.props.extension;
-        return <div className='theia-vsx-extension'>
-            {iconUrl ?
+        const extensionsContainer = document.getElementById('vsx-extensions-view-container');
+        const minPanelWidthToShowIcon = 300;
+        const showExtensionIcon = extensionsContainer && extensionsContainer.clientWidth > minPanelWidthToShowIcon;
+        return <div className='theia-vsx-extension'>{
+            !!showExtensionIcon ? iconUrl ?
                 <img className='theia-vsx-extension-icon' src={iconUrl} /> :
-                <div className='theia-vsx-extension-icon placeholder' />}
-            <div className='theia-vsx-extension-content'>
+                <div className='theia-vsx-extension-icon placeholder' /> : undefined}
+            <div className={`theia-vsx-extension-content ${!showExtensionIcon ? 'no-extension-icon' : ''}`}>
                 <div className='title'>
                     <div className='noWrapInfo'>
                         <span className='name'>{displayName}</span> <span className='version'>{version}</span>
                     </div>
                     <div className='stat'>
-                        {downloadCount && <span className='download-count'><i className='fa fa-download' />{downloadCompactFormatter.format(downloadCount)}</span>}
-                        {averageRating && <span className='average-rating'><i className='fa fa-star' />{averageRating.toFixed(1)}</span>}
+                        {!!downloadCount && !!showExtensionIcon &&
+                            <span className='download-count'><i className='fa fa-download' />{downloadCompactFormatter.format(downloadCount)}</span>}
+                        {averageRating && !!showExtensionIcon &&
+                            <span className='average-rating'><i className='fa fa-star' />{averageRating.toFixed(1)}</span>}
                     </div>
                 </div>
                 <div className='noWrapInfo theia-vsx-extension-description'>{description}</div>


### PR DESCRIPTION
#### What it does
Fixes: #7385

Prioritizing the display of the extension's name in the extension's view when the width is constrained by
- hiding the icon
- hiding the download count
- hiding the rating


#### How to test
- Click View in the top menu and select Extensions
- Resize the Extensions Views as shown in the picture:
https://user-images.githubusercontent.com/40359487/77189858-a0a14a00-6aae-11ea-9e61-54cb69dd326f.gif


#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

