### PR TITLE
repo: fix misc typos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## v0.17.0
 
 - [preferences] add a new preference to silence notifications [#7195](https://github.com/eclipse-theia/theia/pull/7195)
-- [core] fixed keybindings for special Numpad keys in editors [#7315] 
+- [core] fixed keybindings for special Numpad keys in editors [#7315]
 
 Breaking changes:
 
@@ -13,6 +13,11 @@ Breaking changes:
 - [task] `TaskRestartRunningQuickOpenItem` class is renamed into `RunningTaskQuickOpenItem`. [7392](https://github.com/eclipse-theia/theia/pull/7392)
 - [task] `TaskAttachQuickOpenItem` class is removed. [7392](https://github.com/eclipse-theia/theia/pull/7392)
 - [task] `TaskService.taskProviderRegistry` is removed. [7418](https://github.com/eclipse-theia/theia/pull/7418)
+- [debug] renamed `debuggingStaturBar` to `debuggingStatusBar` [#7409](https://github.com/eclipse-theia/theia/pull/7409)
+- [plugin] renamed `CancelationTokenImpl` to `CancellationTokenImpl` [#7409](https://github.com/eclipse-theia/theia/pull/7409)
+- [plugin] renamed `VIEW_ITEM_INLINE_MNUE` to `VIEW_ITEM_INLINE_MENU` [#7409](https://github.com/eclipse-theia/theia/pull/7409)
+- [terminal] renamed `handleWroleWordOptionClicked` to `handleWholeWordOptionClicked` [#7409](https://github.com/eclipse-theia/theia/pull/7409)
+- [workspace] renamed `toDiposeOnUpdateCurrentWidget` to `toDisposeOnUpdateCurrentWidget` [#7409](https://github.com/eclipse-theia/theia/pull/7409)
 
 ## v0.16.0
 

--- a/packages/callhierarchy/src/browser/callhierarchy-contribution.ts
+++ b/packages/callhierarchy/src/browser/callhierarchy-contribution.ts
@@ -24,7 +24,7 @@ import { CurrentEditorAccess } from './current-editor-access';
 import { CallHierarchyServiceProvider } from './callhierarchy-service';
 import URI from '@theia/core/lib/common/uri';
 
-export const CALL_HIERARCHY_TOGGLE_COMMAND_ID = 'callhierachy:toggle';
+export const CALL_HIERARCHY_TOGGLE_COMMAND_ID = 'callhierarchy:toggle';
 export const CALL_HIERARCHY_LABEL = 'Call Hierarchy';
 
 export namespace CallHierarchyCommands {

--- a/packages/core/src/browser/preferences/preference-service.spec.ts
+++ b/packages/core/src/browser/preferences/preference-service.spec.ts
@@ -104,7 +104,7 @@ describe('Preference Service', () => {
                 done();
                 return;
             }
-            done(new Error('onPreferenceChanged() fails to return any preference change infomation'));
+            done(new Error('onPreferenceChanged() fails to return any preference change information'));
             return;
         });
 

--- a/packages/core/src/browser/quick-open/quick-title-bar.ts
+++ b/packages/core/src/browser/quick-open/quick-title-bar.ts
@@ -110,7 +110,7 @@ export class QuickTitleBar {
         this.titleElement.innerText = innerTitle;
     }
 
-    // Left buttons are for the buttons dervied from QuickInputButtons
+    // Left buttons are for the buttons derived from QuickInputButtons
     private getLeftButtons(): ReadonlyArray<QuickTitleButton> {
         if (this._buttons === undefined || this._buttons.length === 0) {
             return [];

--- a/packages/core/src/browser/shell/application-shell.ts
+++ b/packages/core/src/browser/shell/application-shell.ts
@@ -1722,7 +1722,7 @@ export namespace ApplicationShell {
          * if optional then a user will be prompted
          * if undefined then close will be canceled
          * if true then will be saved on close
-         * if falase then won't be saved on close
+         * if false then won't be saved on close
          */
         save?: boolean | undefined
     }

--- a/packages/core/src/common/resource.ts
+++ b/packages/core/src/common/resource.ts
@@ -47,7 +47,7 @@ export interface Resource extends Disposable {
      */
     readonly version?: ResourceVersion | undefined;
     /**
-     * Reads latest content of this resouce.
+     * Reads latest content of this resource.
      *
      * If a resource supports versioning it updates version to latest.
      *
@@ -66,7 +66,7 @@ export interface Resource extends Disposable {
      */
     saveContents?(content: string, options?: ResourceSaveOptions): Promise<void>;
     /**
-     * Applies incemental content changes to this resource.
+     * Applies incremental content changes to this resource.
      *
      * If a resource supports versioning clients can pass some version
      * to check against it, if it is not provided latest version is used.
@@ -106,7 +106,7 @@ export namespace Resource {
             return true;
         } catch (e) {
             if (!ResourceError.NotFound.is(e) && !ResourceError.OutOfSync.is(e)) {
-                console.error(`Failed to apply incremenal changes to '${resource.uri.toString()}':`, e);
+                console.error(`Failed to apply incremental changes to '${resource.uri.toString()}':`, e);
             }
             return false;
         }

--- a/packages/debug/src/browser/debug-frontend-application-contribution.ts
+++ b/packages/debug/src/browser/debug-frontend-application-contribution.ts
@@ -269,7 +269,7 @@ export namespace DebugCommands {
     export const REMOVE_ALL_WATCH_EXPRESSIONS: Command = {
         id: 'debug.watch.removeAllExpressions',
         category: DEBUG_CATEGORY,
-        label: 'Remove All Watch Expresssions'
+        label: 'Remove All Watch Expressions'
     };
 }
 export namespace DebugThreadContextCommands {
@@ -1294,13 +1294,13 @@ export class DebugFrontendApplicationContribution extends AbstractViewContributi
     }
 
     protected updateStatusBar(): void {
-        if (this.debuggingStaturBar === document.body.classList.contains('theia-mod-debugging')) {
+        if (this.debuggingStatusBar === document.body.classList.contains('theia-mod-debugging')) {
             return;
         }
         document.body.classList.toggle('theia-mod-debugging');
     }
 
-    protected get debuggingStaturBar(): boolean {
+    protected get debuggingStatusBar(): boolean {
         if (this.manager.state < DebugState.Running) {
             return false;
         }

--- a/packages/debug/src/browser/editor/debug-breakpoint-widget.tsx
+++ b/packages/debug/src/browser/editor/debug-breakpoint-widget.tsx
@@ -104,7 +104,7 @@ export class DebugBreakpointWidget implements Disposable {
                     if (this.context === 'condition') {
                         overwriteBefore = position.column - 1;
                     } else {
-                        // Inside the currly brackets, need to count how many useful characters are behind the position so they would all be taken into account
+                        // Inside the curly brackets, need to count how many useful characters are behind the position so they would all be taken into account
                         const value = editor.getModel()!.getValue();
                         while ((position.column - 2 - overwriteBefore >= 0)
                             && value[position.column - 2 - overwriteBefore] !== '{' && value[position.column - 2 - overwriteBefore] !== ' ') {

--- a/packages/debug/src/browser/view/debug-watch-expression.tsx
+++ b/packages/debug/src/browser/view/debug-watch-expression.tsx
@@ -38,7 +38,7 @@ export class DebugWatchExpression extends ExpressionItem {
     }
 
     protected setResult(body?: DebugProtocol.EvaluateResponse['body']): void {
-        // overriden to ignore error
+        // overridden to ignore error
         super.setResult(body);
         this.options.onDidChange();
     }

--- a/packages/file-search/src/node/file-search-service-impl.spec.ts
+++ b/packages/file-search/src/node/file-search-service-impl.spec.ts
@@ -164,23 +164,23 @@ describe('search-service', function (): void {
             const searchPattern = rootUri.path.dir.base;
             const matches = await service.find(searchPattern, { rootUris: [rootUri.toString()], fuzzyMatch: false, useGitIgnore: true, limit: 200 });
             for (const match of matches) {
-                const relativUri = rootUri.relative(new URI(match));
-                assert.notEqual(relativUri, undefined);
-                const relativMatch = relativUri!.toString();
-                assert.notEqual(relativMatch.indexOf(searchPattern), -1, relativMatch);
+                const relativeUri = rootUri.relative(new URI(match));
+                assert.notEqual(relativeUri, undefined);
+                const relativeMatch = relativeUri!.toString();
+                assert.notEqual(relativeMatch.indexOf(searchPattern), -1, relativeMatch);
             }
         });
 
         it('fuzzy', async () => {
             const matches = await service.find('shell', { rootUris: [rootUri.toString()], fuzzyMatch: true, useGitIgnore: true, limit: 200 });
             for (const match of matches) {
-                const relativUri = rootUri.relative(new URI(match));
-                assert.notEqual(relativUri, undefined);
-                const relativMatch = relativUri!.toString();
+                const relativeUri = rootUri.relative(new URI(match));
+                assert.notEqual(relativeUri, undefined);
+                const relativeMatch = relativeUri!.toString();
                 let position = 0;
                 for (const ch of 'shell') {
-                    position = relativMatch.indexOf(ch, position);
-                    assert.notEqual(position, -1, relativMatch);
+                    position = relativeMatch.indexOf(ch, position);
+                    assert.notEqual(position, -1, relativeMatch);
                 }
             }
         });

--- a/packages/filesystem/src/browser/file-tree/file-tree-widget.tsx
+++ b/packages/filesystem/src/browser/file-tree/file-tree-widget.tsx
@@ -229,7 +229,7 @@ export class FileTreeWidget extends TreeWidget {
 
     protected getPaddingLeft(node: TreeNode, props: NodeProps): number {
         if (this.hidesExplorerArrows) {
-            // aditional left padding instead of top-level expansion toggle
+            // additional left padding instead of top-level expansion toggle
             return super.getPaddingLeft(node, props) + this.props.leftPadding;
         }
         return super.getPaddingLeft(node, props);

--- a/packages/git/src/browser/git-repository-tracker.ts
+++ b/packages/git/src/browser/git-repository-tracker.ts
@@ -90,7 +90,7 @@ export class GitRepositoryTracker {
     }
 
     /**
-     * Returns the last known status of the selected respository, or `undefined` if no repositories are available.
+     * Returns the last known status of the selected repository, or `undefined` if no repositories are available.
      */
     get selectedRepositoryStatus(): WorkingDirectoryStatus | undefined {
         return this.workingDirectoryStatus;

--- a/packages/git/src/node/git-repository-manager.ts
+++ b/packages/git/src/node/git-repository-manager.ts
@@ -41,7 +41,7 @@ export class GitRepositoryManager {
     protected async sync(repository: Repository): Promise<void> {
         const reference = await this.getWatcher(repository);
         const watcher = reference.object;
-        // dispose the reference once the next sync cycle is actaully completed
+        // dispose the reference once the next sync cycle is actually completed
         watcher.sync().then(() => reference.dispose());
     }
 

--- a/packages/keymaps/src/browser/keymaps-service.ts
+++ b/packages/keymaps/src/browser/keymaps-service.ts
@@ -139,7 +139,7 @@ export class KeymapsService {
         // TODO use preference values to get proper json settings
         // TODO handle dirty models properly
         // TODO handle race conditions properly
-        // TODO only apply mimimal edits
+        // TODO only apply minimal edits
         await this.resource.saveContents(JSON.stringify(keybindings, undefined, 4));
     }
 
@@ -157,7 +157,7 @@ export class KeymapsService {
         // TODO use preference values to get proper json settings
         // TODO handle dirty models properly
         // TODO handle race conditions properly
-        // TODO only apply mimimal edits
+        // TODO only apply minimal edits
         await this.resource.saveContents(JSON.stringify(filtered, undefined, 4));
     }
 

--- a/packages/languages/src/common/language-selector/glob.ts
+++ b/packages/languages/src/common/language-selector/glob.ts
@@ -257,7 +257,7 @@ function parseRegExp(pattern: string): string {
     return regEx;
 }
 
-// regexes to check for trival glob patterns that just check for String#endsWith
+// regexes to check for trivial glob patterns that just check for String#endsWith
 const T1 = /^\*\*\/\*\.[\w\.-]+$/;                                        // **/*.something
 const T2 = /^\*\*\/([\w\.-]+)\/?$/;                                            // **/something
 const T3 = /^{\*\*\/[\*\.]?[\w\.-]+\/?(,\*\*\/[\*\.]?[\w\.-]+\/?)*}$/;     // {**/*.something,**/*.else} or {**/package.json,**/project.json}

--- a/packages/messages/src/browser/notification-content-renderer.spec.ts
+++ b/packages/messages/src/browser/notification-content-renderer.spec.ts
@@ -21,7 +21,7 @@ import { NotificationContentRenderer } from './notification-content-renderer';
 
 describe('notification-content-renderer', () => {
 
-    const contentRnderer = new NotificationContentRenderer();
+    const contentRenderer = new NotificationContentRenderer();
 
     it('should remove new lines', () => {
         expectRenderedContent('foo\nbar', 'foo bar');
@@ -70,6 +70,6 @@ describe('notification-content-renderer', () => {
     });
 
     const expectRenderedContent = (input: string, output: string) =>
-        expect(contentRnderer.renderMessage(input)).to.be.equal(output);
+        expect(contentRenderer.renderMessage(input)).to.be.equal(output);
 
 });

--- a/packages/monaco/src/browser/monaco-editor-provider.ts
+++ b/packages/monaco/src/browser/monaco-editor-provider.ts
@@ -158,7 +158,7 @@ export class MonacoEditorProvider {
 
     /**
      * Suppresses Monaco keydown listener to avoid triggering default Monaco keybindings
-     * if they are overriden by a user. Monaco keybindings should be registered as Theia keybindings
+     * if they are overridden by a user. Monaco keybindings should be registered as Theia keybindings
      * to allow a user to customize them.
      */
     protected suppressMonacoKeybindingListener(editor: MonacoEditor): void {
@@ -359,7 +359,7 @@ export class MonacoEditorProvider {
             referencesController._ignoreModelChangeEvent = true;
             const range = monaco.Range.lift(ref.range).collapseToStart();
 
-            // prerse the model that it does not get disposed if an editor preview replaces an editor
+            // preserve the model that it does not get disposed if an editor preview replaces an editor
             const model = referencesController._model;
             referencesController._model = undefined;
 

--- a/packages/monaco/src/browser/monaco-editor.ts
+++ b/packages/monaco/src/browser/monaco-editor.ts
@@ -511,9 +511,9 @@ export class MonacoEditor extends MonacoEditorServices implements TextEditor {
         }
     }
 
-    protected fireLanguageChanged(langaugeId: string): void {
+    protected fireLanguageChanged(languageId: string): void {
         this._languageAutoDetected = false;
-        this.onLanguageChangedEmitter.fire(langaugeId);
+        this.onLanguageChangedEmitter.fire(languageId);
     }
 
     getResourceUri(): URI {

--- a/packages/monaco/src/browser/monaco-semantic-highlighting-service.ts
+++ b/packages/monaco/src/browser/monaco-semantic-highlighting-service.ts
@@ -49,7 +49,7 @@ export class MonacoSemanticHighlightingService extends SemanticHighlightingServi
     protected readonly toDisposeOnEditorClose = new Map<string, Disposable>();
     protected readonly toDisposeOnUnregister = new Map<string, Disposable>();
 
-    // laguage id -> (scope index -> decoration type)
+    // language id -> (scope index -> decoration type)
     protected readonly decorationTypes = new Map<string, Map<number, DecorationTypeInfo>>();
 
     private lastDecorationTypeId: number = 0;

--- a/packages/monaco/src/browser/monaco-snippet-suggest-provider.ts
+++ b/packages/monaco/src/browser/monaco-snippet-suggest-provider.ts
@@ -89,14 +89,14 @@ export class MonacoSnippetSuggestProvider implements monaco.languages.Completion
             });
         }
         if (endsInWhitespace || lineOffsets.length === 0) {
-            // add remaing snippets when the current prefix ends in whitespace or when no
+            // add remaining snippets when the current prefix ends in whitespace or when no
             // interesting positions have been found
             availableSnippets.forEach(snippet => {
                 suggestions.push(new MonacoSnippetSuggestion(snippet, monaco.Range.fromPositions(position)));
             });
         }
 
-        // dismbiguate suggestions with same labels
+        // disambiguate suggestions with same labels
         suggestions.sort(MonacoSnippetSuggestion.compareByLabel);
         return { suggestions };
     }
@@ -134,7 +134,7 @@ export class MonacoSnippetSuggestProvider implements monaco.languages.Completion
     }
 
     /**
-     * should NOT throw to prevent load erros on suggest
+     * should NOT throw to prevent load errors on suggest
      */
     protected async loadURI(uri: string | URI, options: SnippetLoadOptions, toDispose: DisposableCollection): Promise<void> {
         try {

--- a/packages/monaco/src/browser/textmate/monaco-theme-registry.ts
+++ b/packages/monaco/src/browser/textmate/monaco-theme-registry.ts
@@ -48,7 +48,7 @@ export class MonacoThemeRegistry {
     }
 
     setTheme(name: string, data: ThemeMix): void {
-        // monaco auto refrehes a theme with new data
+        // monaco auto refreshes a theme with new data
         monaco.editor.defineTheme(name, data);
     }
 

--- a/packages/plugin-dev/src/browser/hosted-plugin-controller.ts
+++ b/packages/plugin-dev/src/browser/hosted-plugin-controller.ts
@@ -67,7 +67,7 @@ export class HostedPluginController implements FrontendApplicationContribution {
     protected readonly messageService: MessageService;
 
     private pluginState: HostedInstanceState = HostedInstanceState.STOPPED;
-    // used only for displaying Running insted of Watching in status bar if run of watcher fails
+    // used only for displaying Running instead of Watching in status bar if run of watcher fails
     private watcherSuccess: boolean;
     private entry: StatusBarEntry | undefined;
 
@@ -251,7 +251,7 @@ export class HostedPluginController implements FrontendApplicationContribution {
     }
 
     /**
-     * Updaing status bar element when changing connection status.
+     * Updating status bar element when changing connection status.
      */
     private onConnectionStatusChanged(): void {
         if (this.connectionStatusService.currentStatus === ConnectionStatus.OFFLINE) {

--- a/packages/plugin-dev/src/node/hosted-plugins-manager.ts
+++ b/packages/plugin-dev/src/node/hosted-plugins-manager.ts
@@ -28,7 +28,7 @@ export const HostedPluginsManager = Symbol('HostedPluginsManager');
 export interface HostedPluginsManager {
 
     /**
-     * Runs watcher script to recomple plugin on any changes along given path.
+     * Runs watcher script to recompile plugin on any changes along given path.
      *
      * @param uri uri to plugin root folder.
      */
@@ -42,7 +42,7 @@ export interface HostedPluginsManager {
     stopWatchCompilation(uri: string): Promise<void>;
 
     /**
-     * Chacks if watcher script to recomple plugin is running.
+     * Checks if watcher script to recompile plugin is running.
      *
      * @param uri uri to plugin root folder.
      */

--- a/packages/plugin-ext/src/common/plugin-api-rpc.ts
+++ b/packages/plugin-ext/src/common/plugin-api-rpc.ts
@@ -265,7 +265,7 @@ export interface TerminalServiceMain {
     $hide(id: string): void;
 
     /**
-     * Distroy terminal.
+     * Destroy terminal.
      * @param id - terminal id.
      */
     $dispose(id: string): void;
@@ -1241,7 +1241,7 @@ export interface LanguagesMain {
     $registerWorkspaceSymbolProvider(handle: number, pluginInfo: PluginInfo): void;
     $registerFoldingRangeProvider(handle: number, pluginInfo: PluginInfo, selector: SerializedDocumentFilter[]): void;
     $registerDocumentColorProvider(handle: number, pluginInfo: PluginInfo, selector: SerializedDocumentFilter[]): void;
-    $registerRenameProvider(handle: number, pluginInfo: PluginInfo, selector: SerializedDocumentFilter[], supportsResoveInitialValues: boolean): void;
+    $registerRenameProvider(handle: number, pluginInfo: PluginInfo, selector: SerializedDocumentFilter[], supportsResolveInitialValues: boolean): void;
     $registerCallHierarchyProvider(handle: number, selector: SerializedDocumentFilter[]): void;
 }
 

--- a/packages/plugin-ext/src/common/rpc-protocol.ts
+++ b/packages/plugin-ext/src/common/rpc-protocol.ts
@@ -392,7 +392,7 @@ class MessageFactory {
 /**
  * These functions are responsible for correct transferring objects via rpc channel.
  *
- * To reach that some specific kind of objects is converteed to json in some custom way
+ * To reach that some specific kind of objects is converted to json in some custom way
  * and then, after receiving, revived to objects again,
  * so there is feeling that object was transferred via rpc channel.
  *

--- a/packages/plugin-ext/src/hosted/browser/hosted-plugin.ts
+++ b/packages/plugin-ext/src/hosted/browser/hosted-plugin.ts
@@ -248,8 +248,8 @@ export class HostedPluginSupport {
         // process empty plugins as well in order to properly remove stale plugin widgets
         await this.syncPlugins();
 
-        // it has to be resolved before awaiting layout is initilization
-        // otherwise clients can hang forever in the initializatin phase
+        // it has to be resolved before awaiting layout is initialized
+        // otherwise clients can hang forever in the initialization phase
         this.deferredWillStart.resolve();
 
         // make sure that the previous state, including plugin widgets, is restored

--- a/packages/plugin-ext/src/hosted/node/plugin-host.ts
+++ b/packages/plugin-ext/src/hosted/node/plugin-host.ts
@@ -51,7 +51,7 @@ process.on('unhandledRejection', (reason: any, promise: Promise<any>) => {
             promise.catch(err => {
                 unhandledPromises.splice(index, 1);
                 if (terminating && (ConnectionClosedError.is(err) || ConnectionClosedError.is(reason))) {
-                    // during termination it is expected that pending rpc requerst are rejected
+                    // during termination it is expected that pending rpc request are rejected
                     return;
                 }
                 console.error(`Promise rejection not handled in one second: ${err} , reason: ${reason}`);

--- a/packages/plugin-ext/src/hosted/node/plugin-reader.ts
+++ b/packages/plugin-ext/src/hosted/node/plugin-reader.ts
@@ -50,7 +50,7 @@ export class HostedPluginReader implements BackendApplicationContribution {
             if (localPath) {
                 res.sendFile(filePath, { root: localPath }, e => {
                     if (!e) {
-                        // the file was found and successfully transfered
+                        // the file was found and successfully transferred
                         return;
                     }
                     console.error(`Could not transfer '${filePath}' file from '${pluginId}'`, e);

--- a/packages/plugin-ext/src/main/browser/languages-contribution-main.ts
+++ b/packages/plugin-ext/src/main/browser/languages-contribution-main.ts
@@ -142,7 +142,7 @@ class PluginLanguageClientContribution extends BaseLanguageClientContribution {
             try {
                 // avoid calling stop if start failed
                 await this._languageClient!.onReady();
-                // remove all listerens
+                // remove all listeners
                 await this._languageClient!.stop();
             } catch {
                 // if start or stop failed make sure the the connection is closed

--- a/packages/plugin-ext/src/main/browser/menus/menus-contribution-handler.ts
+++ b/packages/plugin-ext/src/main/browser/menus/menus-contribution-handler.ts
@@ -25,7 +25,7 @@ import { Emitter } from '@theia/core/lib/common/event';
 import { TabBarToolbarRegistry, TabBarToolbarItem } from '@theia/core/lib/browser/shell/tab-bar-toolbar';
 import { NAVIGATOR_CONTEXT_MENU } from '@theia/navigator/lib/browser/navigator-contribution';
 import { QuickCommandService } from '@theia/core/lib/browser/quick-open/quick-command-service';
-import { VIEW_ITEM_CONTEXT_MENU, TreeViewWidget, VIEW_ITEM_INLINE_MNUE } from '../view/tree-view-widget';
+import { VIEW_ITEM_CONTEXT_MENU, TreeViewWidget, VIEW_ITEM_INLINE_MENU } from '../view/tree-view-widget';
 import { PluginContribution, Menu, ScmCommandArg, TreeViewSelection } from '../../../common';
 import { DebugStackFramesWidget } from '@theia/debug/lib/browser/view/debug-stack-frames-widget';
 import { DebugThreadsWidget } from '@theia/debug/lib/browser/view/debug-threads-widget';
@@ -121,7 +121,7 @@ export class MenusContributionPointHandler {
             } else if (location === 'view/item/context') {
                 for (const menu of allMenus[location]) {
                     const inline = menu.group && /^inline/.test(menu.group) || false;
-                    const menuPath = inline ? VIEW_ITEM_INLINE_MNUE : VIEW_ITEM_CONTEXT_MENU;
+                    const menuPath = inline ? VIEW_ITEM_INLINE_MENU : VIEW_ITEM_CONTEXT_MENU;
                     toDispose.push(this.registerTreeMenuAction(menuPath, menu));
                 }
             } else if (location === 'scm/title') {

--- a/packages/plugin-ext/src/main/browser/plugin-contribution-handler.ts
+++ b/packages/plugin-ext/src/main/browser/plugin-contribution-handler.ts
@@ -99,7 +99,7 @@ export class PluginContributionHandler {
     /**
      * Always synchronous in order to simplify handling disconnections.
      * @throws never, loading of each contribution should handle errors
-     * in order to avoid preventing loading of other contibutions or extensions
+     * in order to avoid preventing loading of other contributions or extensions
      */
     handleContributions(clientId: string, plugin: DeployedPlugin): Disposable {
         const contributions = plugin.contributes;

--- a/packages/plugin-ext/src/main/browser/preference-registry-main.ts
+++ b/packages/plugin-ext/src/main/browser/preference-registry-main.ts
@@ -106,7 +106,7 @@ export class PreferenceRegistryMainImpl implements PreferenceRegistryMain, Dispo
             case ConfigurationTarget.WorkspaceFolder:
                 return PreferenceScope.Folder;
             default:
-                // PreferenceService knows how to deal with undefiend in VS Code compatible way
+                // PreferenceService knows how to deal with undefined in VS Code compatible way
                 return undefined;
         }
     }

--- a/packages/plugin-ext/src/main/browser/view/tree-view-widget.tsx
+++ b/packages/plugin-ext/src/main/browser/view/tree-view-widget.tsx
@@ -45,7 +45,7 @@ import CoreURI from '@theia/core/lib/common/uri';
 
 export const TREE_NODE_HYPERLINK = 'theia-TreeNodeHyperlink';
 export const VIEW_ITEM_CONTEXT_MENU: MenuPath = ['view-item-context-menu'];
-export const VIEW_ITEM_INLINE_MNUE: MenuPath = ['view-item-inline-menu'];
+export const VIEW_ITEM_INLINE_MENU: MenuPath = ['view-item-inline-menu'];
 
 export interface SelectionEventHandler {
     readonly node: SelectableTreeNode;
@@ -295,7 +295,7 @@ export class TreeViewWidget extends TreeWidget {
             return false;
         }
         return this.contextKeys.with({ view: this.id, viewItem: node.contextValue }, () => {
-            const menu = this.menus.getMenu(VIEW_ITEM_INLINE_MNUE);
+            const menu = this.menus.getMenu(VIEW_ITEM_INLINE_MENU);
             const arg = this.toTreeViewSelection(node);
             return <React.Fragment>
                 {menu.children.map((item, index) => item instanceof ActionMenuNode && this.renderInlineCommand(item, index, arg))}

--- a/packages/plugin-ext/src/main/browser/view/view-context-key-service.ts
+++ b/packages/plugin-ext/src/main/browser/view/view-context-key-service.ts
@@ -35,7 +35,7 @@ export class ViewContextKeyService {
      * Viewlet is a tab in the left area in VS Code. Active means visible in this context.
      *
      * In VS Code there can be only one visible viewlet at any time.
-     * It is not true for Theia, since views can be relayouted to different areas.
+     * It is not true for Theia, since views can be layed-out again to different areas.
      * So only last visible view will be an active viewlet.
      */
     get activeViewlet(): ContextKey<string> {
@@ -47,7 +47,7 @@ export class ViewContextKeyService {
      * Panel is a tab in the bottom area in VS Code. Active means visible in this context.
      *
      * In VS Code there can be only one visible panel at any time.
-     * It is not true for Theia, since views can be relayouted to different areas.
+     * It is not true for Theia, since views can be layed-out again to different areas.
      * So only last visible view will be an active panel.
      */
     get activePanel(): ContextKey<string> {

--- a/packages/plugin-ext/src/main/browser/webview/webview.ts
+++ b/packages/plugin-ext/src/main/browser/webview/webview.ts
@@ -431,7 +431,7 @@ export class WebviewWidget extends BaseWidget implements StatefulWidget {
 
     protected async loadResource(requestPath: string): Promise<void> {
         const normalizedUri = this.normalizeRequestUri(requestPath);
-        // browser cache does not suppot file scheme, normalize to current endpoint scheme and host
+        // browser cache does not support file scheme, normalize to current endpoint scheme and host
         const cacheUrl = new Endpoint({ path: normalizedUri.path.toString() }).getRestUrl().toString();
 
         try {

--- a/packages/plugin-ext/src/plugin/decorations.ts
+++ b/packages/plugin-ext/src/plugin/decorations.ts
@@ -51,7 +51,7 @@ export class DecorationsExtImpl implements DecorationsExt {
         });
         const providerMain: DecorationProvider = {
             async provideDecoration(uri: string): Promise<DecorationData | undefined> {
-                const res = await provider.provideDecoration(URI.parse(uri), new CancelationTokenImpl());
+                const res = await provider.provideDecoration(URI.parse(uri), new CancellationTokenImpl());
                 if (res) {
                     let color;
                     if (res.color) {
@@ -85,7 +85,7 @@ export class DecorationsExtImpl implements DecorationsExt {
     }
 }
 
-class CancelationTokenImpl implements theia.CancellationToken {
+class CancellationTokenImpl implements theia.CancellationToken {
     readonly isCancellationRequested: boolean;
     readonly onCancellationRequested: Event<any>;
 }

--- a/packages/plugin-ext/src/plugin/editors-and-documents.ts
+++ b/packages/plugin-ext/src/plugin/editors-and-documents.ts
@@ -110,7 +110,7 @@ export class EditorsAndDocumentsExtImpl implements EditorsAndDocumentsExt {
 
         if (this.activeEditorId && delta.removedEditors && delta.removedEditors.indexOf(this.activeEditorId) !== -1 && this.editors.size !== 0) {
             // to be compatible with VSCode, when active editor is closed onDidChangeActiveTextEditor
-            // should be trigerred with undefined before next editor, if any, become active.
+            // should be triggered with undefined before next editor, if any, become active.
             this._onDidChangeActiveTextEditors.fire(undefined);
         }
 

--- a/packages/plugin-ext/src/plugin/in-plugin-filesystem-watcher-proxy.ts
+++ b/packages/plugin-ext/src/plugin/in-plugin-filesystem-watcher-proxy.ts
@@ -88,8 +88,8 @@ class FileSystemWatcher implements theia.FileSystemWatcher {
         this.subscriberData = subscriberData;
         subscriberData.event((event: FileSystemEvent) => {
             // Here ignore event flags are not analyzed because all the logic is
-            // moved to server side to avoid unneded data transfer via network.
-            // The flags are present just to be read only accesible for user.
+            // moved to server side to avoid unneeded data transfer via network.
+            // The flags are present just to be read only accessible for user.
             switch (event.type) {
                 case 'updated':
                     this.onDidChangeEmitter.fire(event.uri);

--- a/packages/plugin-ext/src/plugin/languages.ts
+++ b/packages/plugin-ext/src/plugin/languages.ts
@@ -540,7 +540,7 @@ export class LanguagesExtImpl implements LanguagesExt {
     ): Promise<FoldingRange[] | undefined> {
         return this.withAdapter(callId, FoldingProviderAdapter, adapter => adapter.provideFoldingRanges(URI.revive(resource), context, token));
     }
-    // ### Folging Range Provider end
+    // ### Folding Range Provider end
 
     // ### Rename Provider begin
     registerRenameProvider(selector: theia.DocumentSelector, provider: theia.RenameProvider, pluginInfo: PluginInfo): theia.Disposable {

--- a/packages/plugin-ext/src/plugin/languages/diagnostics.ts
+++ b/packages/plugin-ext/src/plugin/languages/diagnostics.ts
@@ -249,7 +249,7 @@ export class Diagnostics {
     private static GENERATED_DIAGNOSTIC_COLLECTION_NAME_PREFIX = '_generated_diagnostic_collection_name_#';
 
     private proxy: LanguagesMain;
-    private diagnosticCollections: Map<string, DiagnosticCollection>; // id -> diagnostic colection
+    private diagnosticCollections: Map<string, DiagnosticCollection>; // id -> diagnostic collection
 
     private diagnosticsChangedEmitter = new Emitter<theia.DiagnosticChangeEvent>();
     public readonly onDidChangeDiagnostics: Event<theia.DiagnosticChangeEvent> = this.diagnosticsChangedEmitter.event;
@@ -264,7 +264,7 @@ export class Diagnostics {
     getDiagnostics(): [theia.Uri, theia.Diagnostic[]][];
     getDiagnostics(resource?: URI): theia.Diagnostic[] | [URI, theia.Diagnostic[]][] {
         if (resource) {
-            return this.getAllDiagnisticsForResource(resource);
+            return this.getAllDiagnosticsForResource(resource);
         } else {
             return this.getAllDiagnostics();
         }
@@ -291,7 +291,7 @@ export class Diagnostics {
         return v4();
     }
 
-    private getAllDiagnisticsForResource(uri: URI): theia.Diagnostic[] {
+    private getAllDiagnosticsForResource(uri: URI): theia.Diagnostic[] {
         let result: theia.Diagnostic[] = [];
         this.diagnosticCollections.forEach(diagnosticCollection => {
             const diagnostics = diagnosticCollection.get(uri);

--- a/packages/plugin-ext/src/plugin/type-converters.spec.ts
+++ b/packages/plugin-ext/src/plugin/type-converters.spec.ts
@@ -101,7 +101,7 @@ describe('Type converters:', () => {
                 assert.deepEqual(result === false, true);
             });
 
-            it('should reject non markdown object if it countains isTrusted field', () => {
+            it('should reject non markdown object if it contains isTrusted field', () => {
                 // given
                 const nonMarkdownObject = { isTrusted: true, field1: 5, field2: 'test' };
 

--- a/packages/process/src/node/multi-ring-buffer.spec.ts
+++ b/packages/process/src/node/multi-ring-buffer.spec.ts
@@ -163,7 +163,7 @@ describe('MultiRingBuffer', function (): void {
         expect(ringBuffer.sizeForReader(reader)).to.be.equal(0);
     });
 
-    it('expect enq a string == ring buffer size then one < ring buffer  then one < buffer size and deque ', function (): void {
+    it('expect enq a string == ring buffer size then one < ring buffer  then one < buffer size and dequeue ', function (): void {
         const size = 5;
         const ringBuffer = new MultiRingBuffer({ size });
         const buffers = ['12345', '123', '678'];
@@ -340,7 +340,7 @@ describe('MultiRingBuffer', function (): void {
         await p;
     });
 
-    it('expect data from stream when data is already enqed', async function (): Promise<void> {
+    it('expect data from stream when data is already ended', async function (): Promise<void> {
         const size = 5;
         const ringBuffer = new MultiRingBuffer({ size });
         const buffer = 'abc';

--- a/packages/process/src/node/multi-ring-buffer.ts
+++ b/packages/process/src/node/multi-ring-buffer.ts
@@ -20,7 +20,7 @@ import { Disposable } from '@theia/core/lib/common';
 
 /**
  * The MultiRingBuffer is a ring buffer implementation that allows
- * multiple independant readers.
+ * multiple independent readers.
  *
  * These readers are created using the getReader or getStream functions
  * to create a reader that can be read using deq() or one that is a readable stream.

--- a/packages/scm/src/browser/scm-amend-component.tsx
+++ b/packages/scm/src/browser/scm-amend-component.tsx
@@ -120,8 +120,8 @@ export class ScmAmendComponent extends React.Component<ScmAmendComponentProps, S
         } else if (this.transitionHint === 'none') {
             // If the 'last' commit changes, but we are not expecting an 'amend'
             // or 'unamend' to occur, then we clear out the list of amended commits.
-            // This is because an unexpected change has happened to the repoistory,
-            // perhaps the user commited, merged, or something.  The amended commits
+            // This is because an unexpected change has happened to the repository,
+            // perhaps the user committed, merged, or something.  The amended commits
             // will no longer be valid.
 
             // Note that there may or may not have been a previous lastCommit (if the
@@ -221,7 +221,7 @@ export class ScmAmendComponent extends React.Component<ScmAmendComponentProps, S
     /**
      * Commits are equal if the ids are equal or if both are undefined.
      * (If a commit is undefined, it represents the initial empty state of a repository,
-     * before the inital commit).
+     * before the initial commit).
      */
     private commitsAreEqual(lastCommit: ScmCommit | undefined, savedLastCommitId: string | undefined): boolean {
         return lastCommit
@@ -520,7 +520,7 @@ export class ScmAmendComponent extends React.Component<ScmAmendComponentProps, S
                 }
         }
 
-        throw new Error('Invalid value for transtition state: ' + this.state.transition.state);
+        throw new Error('Invalid value for transition state: ' + this.state.transition.state);
     }
 
     protected styleLastCommitMovingUp(transitionState: 'start' | 'transitioning'): React.CSSProperties {

--- a/packages/terminal/src/browser/search/terminal-search-widget.tsx
+++ b/packages/terminal/src/browser/search/terminal-search-widget.tsx
@@ -61,7 +61,7 @@ export class TerminalSearchWidget extends ReactWidget {
                     onBlur={this.onSearchInputBlur}
                 />
                 <div title='Match case' tabIndex={0} className='search-elem match-case' onClick={this.handleCaseSensitiveOptionClicked}></div>
-                <div title='Match whole word' tabIndex={0} className='search-elem whole-word' onClick={this.handleWroleWordOptionClicked}></div>
+                <div title='Match whole word' tabIndex={0} className='search-elem whole-word' onClick={this.handleWholeWordOptionClicked}></div>
                 <div title='Use regular expression' tabIndex={0} className='search-elem use-regexp' onClick={this.handleRegexOptionClicked}></div>
             </div>
             <button title='Previous match' className='search-elem arrow-up' onClick={this.handlePreviousButtonClicked}></button>
@@ -91,7 +91,7 @@ export class TerminalSearchWidget extends ReactWidget {
         this.updateSearchInputBox(this.searchOptions.caseSensitive, event.currentTarget);
     };
 
-    private handleWroleWordOptionClicked = (event: React.MouseEvent<HTMLSpanElement>): void => {
+    private handleWholeWordOptionClicked = (event: React.MouseEvent<HTMLSpanElement>): void => {
         this.searchOptions.wholeWord = !this.searchOptions.wholeWord;
         this.updateSearchInputBox(this.searchOptions.wholeWord, event.currentTarget);
     };

--- a/packages/variable-resolver/src/browser/variable.ts
+++ b/packages/variable-resolver/src/browser/variable.ts
@@ -38,7 +38,7 @@ export interface Variable {
      * `undefined` if variable cannot be resolved.
      * Never reject.
      */
-    resolve(context?: URI, argment?: string, configurationSection?: string): MaybePromise<Object | undefined>;
+    resolve(context?: URI, argument?: string, configurationSection?: string): MaybePromise<Object | undefined>;
 }
 
 export const VariableContribution = Symbol('VariableContribution');

--- a/packages/workspace/src/browser/workspace-service.spec.ts
+++ b/packages/workspace/src/browser/workspace-service.spec.ts
@@ -594,7 +594,7 @@ describe('WorkspaceService', () => {
     });
 
     describe('saved status', () => {
-        it('should be true if there is an opened workspace, and the opened workspace is not a folder, othewise false', () => {
+        it('should be true if there is an opened workspace, and the opened workspace is not a folder, otherwise false', () => {
             const file = <FileStat>{
                 uri: 'file:///home/file',
                 lastModification: 0,

--- a/packages/workspace/src/browser/workspace-variable-contribution.ts
+++ b/packages/workspace/src/browser/workspace-variable-contribution.ts
@@ -47,14 +47,14 @@ export class WorkspaceVariableContribution implements VariableContribution {
         }
     }
 
-    protected readonly toDiposeOnUpdateCurrentWidget = new DisposableCollection();
+    protected readonly toDisposeOnUpdateCurrentWidget = new DisposableCollection();
     protected setCurrentWidget(currentWidget: NavigatableWidget | undefined): void {
-        this.toDiposeOnUpdateCurrentWidget.dispose();
+        this.toDisposeOnUpdateCurrentWidget.dispose();
         this.currentWidget = currentWidget;
         if (currentWidget) {
             const resetCurrentWidget = () => this.setCurrentWidget(undefined);
             currentWidget.disposed.connect(resetCurrentWidget);
-            this.toDiposeOnUpdateCurrentWidget.push(Disposable.create(() =>
+            this.toDisposeOnUpdateCurrentWidget.push(Disposable.create(() =>
                 currentWidget.disposed.disconnect(resetCurrentWidget)
             ));
         }


### PR DESCRIPTION



<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

This commit fixes a number of typos present in different extensions.
There are a few notable potential breaking updates:
- [debug] renamed `debuggingStaturBar` to `debuggingStatusBar`
- [plugin] renamed `CancelationTokenImpl` to `CancellationTokenImpl`
- [plugin] renamed `VIEW_ITEM_INLINE_MNUE` to `VIEW_ITEM_INLINE_MENU`
- [terminal] renamed `handleWroleWordOptionClicked` to `handleWholeWordOptionClicked`
- [workspace] renamed `toDiposeOnUpdateCurrentWidget` to `toDisposeOnUpdateCurrentWidget`

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

1. CI should pass (build & test)
2. Verify typo fixes

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

Signed-off-by: vince-fugnitto <vincent.fugnitto@ericsson.com>
