### PR TITLE
GH-7414: Moved `fuzzy-search` to common.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,9 @@
 
 ## v0.17.0
 
+- [core] Deprecated `@theia/core/lib/browser/tree/fuzzy-search`. Use `@theia/core/lib/common/fuzzy-search` instead. [#7414](https://github.com/eclipse-theia/theia/issues/7414)
 - [preferences] add a new preference to silence notifications [#7195](https://github.com/eclipse-theia/theia/pull/7195)
-- [core] fixed keybindings for special Numpad keys in editors [#7315] 
+- [core] fixed keybindings for special Numpad keys in editors [#7315](https://github.com/eclipse-theia/theia/pull/7315)
 
 Breaking changes:
 

--- a/packages/core/src/browser/tree/fuzzy-search.spec.ts
+++ b/packages/core/src/browser/tree/fuzzy-search.spec.ts
@@ -15,7 +15,7 @@
  ********************************************************************************/
 
 import { expect } from 'chai';
-import { FuzzySearch } from './fuzzy-search';
+import { FuzzySearch } from '../../common/fuzzy-search';
 
 describe('fuzzy-search', () => {
 

--- a/packages/core/src/browser/tree/fuzzy-search.ts
+++ b/packages/core/src/browser/tree/fuzzy-search.ts
@@ -14,123 +14,25 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
-import * as fuzzy from 'fuzzy';
 import { injectable } from 'inversify';
-
-@injectable()
-export class FuzzySearch {
-
-    private static readonly PRE = '\x01';
-    private static readonly POST = '\x02';
-
-    /**
-     * Filters the input and returns with an array that contains all items that match the pattern.
-     */
-    async filter<T>(input: FuzzySearch.Input<T>): Promise<FuzzySearch.Match<T>[]> {
-        return fuzzy.filter(input.pattern, input.items.slice(), {
-            pre: FuzzySearch.PRE,
-            post: FuzzySearch.POST,
-            extract: input.transform
-        }).sort(this.sortResults.bind(this)).map(this.mapResult.bind(this));
-    }
-
-    protected sortResults<T>(left: fuzzy.FilterResult<T>, right: fuzzy.FilterResult<T>): number {
-        return left.index - right.index;
-    }
-
-    protected mapResult<T>(result: fuzzy.FilterResult<T>): FuzzySearch.Match<T> {
-        return {
-            item: result.original,
-            ranges: this.mapRanges(result.string)
-        };
-    }
-
-    protected mapRanges(input: string): ReadonlyArray<FuzzySearch.Range> {
-        const copy = input.split('').filter(s => s !== '');
-        const ranges: FuzzySearch.Range[] = [];
-        const validate = (pre: number, post: number) => {
-            if (preIndex > postIndex || (preIndex === -1) !== (postIndex === -1)) {
-                throw new Error(`Error when trying to map ranges. Escaped string was: '${input}. [${[...input].join('|')}]'`);
-            }
-        };
-        let preIndex = copy.indexOf(FuzzySearch.PRE);
-        let postIndex = copy.indexOf(FuzzySearch.POST);
-        validate(preIndex, postIndex);
-        while (preIndex !== -1 && postIndex !== -1) {
-            ranges.push({
-                offset: preIndex,
-                length: postIndex - preIndex - 1
-            });
-            copy.splice(postIndex, 1);
-            copy.splice(preIndex, 1);
-            preIndex = copy.indexOf(FuzzySearch.PRE);
-            postIndex = copy.indexOf(FuzzySearch.POST);
-        }
-        if (ranges.length === 0) {
-            throw new Error(`Unexpected zero ranges for match-string: ${input}.`);
-        }
-        return ranges;
-    }
-
-}
+import { FuzzySearch as CommonFuzzySearch } from '../../common/fuzzy-search';
 
 /**
- * Fuzzy searcher.
+ * @deprecated import from `packages/core/src/common/fuzzy-search` instead.
  */
+@injectable()
+export class FuzzySearch extends CommonFuzzySearch { }
 export namespace FuzzySearch {
-
     /**
-     * A range representing the match region.
+     * @deprecated import from `packages/core/src/common/fuzzy-search` instead.
      */
-    export interface Range {
-
-        /**
-         * The zero based offset of the match region.
-         */
-        readonly offset: number;
-
-        /**
-         * The length of the match region.
-         */
-        readonly length: number;
-    }
-
+    export type Range = CommonFuzzySearch.Range;
     /**
-     * A fuzzy search match.
+     * @deprecated import from `packages/core/src/common/fuzzy-search` instead.
      */
-    export interface Match<T> {
-
-        /**
-         * The original item.
-         */
-        readonly item: T;
-
-        /**
-         * An array of ranges representing the match regions.
-         */
-        readonly ranges: ReadonlyArray<Range>;
-    }
-
+    export type Match<T> = CommonFuzzySearch.Match<T>;
     /**
-     * The fuzzy search input.
+     * @deprecated import from `packages/core/src/common/fuzzy-search` instead.
      */
-    export interface Input<T> {
-
-        /**
-         * The pattern to match.
-         */
-        readonly pattern: string;
-
-        /**
-         * The items to filter based on the `pattern`.
-         */
-        readonly items: ReadonlyArray<T>;
-
-        /**
-         * Function that extracts the string from the inputs which will be used to evaluate the fuzzy matching filter.
-         */
-        readonly transform: (item: T) => string;
-
-    }
-
+    export type Input<T> = CommonFuzzySearch.Input<T>;
 }

--- a/packages/core/src/browser/tree/test/tree-test-container.ts
+++ b/packages/core/src/browser/tree/test/tree-test-container.ts
@@ -22,7 +22,7 @@ import { TreeSelectionService } from '../tree-selection';
 import { TreeExpansionServiceImpl, TreeExpansionService } from '../tree-expansion';
 import { TreeNavigationService } from '../tree-navigation';
 import { TreeSearch } from '../tree-search';
-import { FuzzySearch } from '../fuzzy-search';
+import { FuzzySearch } from '../../../common/fuzzy-search';
 import { MockLogger } from '../../../common/test/mock-logger';
 import { ILogger, bindContributionProvider } from '../../../common';
 import { LabelProviderContribution, LabelProvider } from '../../label-provider';

--- a/packages/core/src/browser/tree/tree-container.ts
+++ b/packages/core/src/browser/tree/tree-container.ts
@@ -24,7 +24,7 @@ import { TreeExpansionService, TreeExpansionServiceImpl } from './tree-expansion
 import { TreeNavigationService } from './tree-navigation';
 import { TreeDecoratorService, NoopTreeDecoratorService } from './tree-decorator';
 import { TreeSearch } from './tree-search';
-import { FuzzySearch } from './fuzzy-search';
+import { FuzzySearch } from '../../common/fuzzy-search';
 import { SearchBox, SearchBoxFactory, SearchBoxProps } from './search-box';
 import { SearchBoxDebounce } from './search-box-debounce';
 

--- a/packages/core/src/browser/tree/tree-search.ts
+++ b/packages/core/src/browser/tree/tree-search.ts
@@ -19,7 +19,7 @@ import { Disposable, DisposableCollection } from '../../common/disposable';
 import { Event, Emitter } from '../../common/event';
 import { Tree, TreeNode } from './tree';
 import { TreeDecoration } from './tree-decorator';
-import { FuzzySearch } from './fuzzy-search';
+import { FuzzySearch } from '../../common/fuzzy-search';
 import { TopDownTreeIterator } from './tree-iterator';
 import { LabelProvider } from '../label-provider';
 

--- a/packages/core/src/common/fuzzy-search.ts
+++ b/packages/core/src/common/fuzzy-search.ts
@@ -1,0 +1,136 @@
+/********************************************************************************
+ * Copyright (C) 2018 TypeFox and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import * as fuzzy from 'fuzzy';
+import { injectable } from 'inversify';
+
+@injectable()
+export class FuzzySearch {
+
+    private static readonly PRE = '\x01';
+    private static readonly POST = '\x02';
+
+    /**
+     * Filters the input and returns with an array that contains all items that match the pattern.
+     */
+    filter<T>(input: FuzzySearch.Input<T>): FuzzySearch.Match<T>[] {
+        return fuzzy.filter(input.pattern, input.items.slice(), {
+            pre: FuzzySearch.PRE,
+            post: FuzzySearch.POST,
+            extract: input.transform
+        }).sort(this.sortResults.bind(this)).map(this.mapResult.bind(this));
+    }
+
+    protected sortResults<T>(left: fuzzy.FilterResult<T>, right: fuzzy.FilterResult<T>): number {
+        return left.index - right.index;
+    }
+
+    protected mapResult<T>(result: fuzzy.FilterResult<T>): FuzzySearch.Match<T> {
+        return {
+            item: result.original,
+            ranges: this.mapRanges(result.string)
+        };
+    }
+
+    protected mapRanges(input: string): ReadonlyArray<FuzzySearch.Range> {
+        const copy = input.split('').filter(s => s !== '');
+        const ranges: FuzzySearch.Range[] = [];
+        const validate = (pre: number, post: number) => {
+            if (pre > post || (pre === -1) !== (post === -1)) {
+                throw new Error(`Error when trying to map ranges. Escaped string was: '${input}. [${[...input].join('|')}]'`);
+            }
+        };
+        let preIndex = copy.indexOf(FuzzySearch.PRE);
+        let postIndex = copy.indexOf(FuzzySearch.POST);
+        validate(preIndex, postIndex);
+        while (preIndex !== -1 && postIndex !== -1) {
+            ranges.push({
+                offset: preIndex,
+                length: postIndex - preIndex - 1
+            });
+            copy.splice(postIndex, 1);
+            copy.splice(preIndex, 1);
+            preIndex = copy.indexOf(FuzzySearch.PRE);
+            postIndex = copy.indexOf(FuzzySearch.POST);
+        }
+        if (ranges.length === 0) {
+            throw new Error(`Unexpected zero ranges for match-string: ${input}.`);
+        }
+        return ranges;
+    }
+
+}
+
+/**
+ * Fuzzy searcher.
+ */
+export namespace FuzzySearch {
+
+    /**
+     * A range representing the match region.
+     */
+    export interface Range {
+
+        /**
+         * The zero based offset of the match region.
+         */
+        readonly offset: number;
+
+        /**
+         * The length of the match region.
+         */
+        readonly length: number;
+    }
+
+    /**
+     * A fuzzy search match.
+     */
+    export interface Match<T> {
+
+        /**
+         * The original item.
+         */
+        readonly item: T;
+
+        /**
+         * An array of ranges representing the match regions.
+         */
+        readonly ranges: ReadonlyArray<Range>;
+    }
+
+    /**
+     * The fuzzy search input.
+     */
+    export interface Input<T> {
+
+        /**
+         * The pattern to match.
+         */
+        readonly pattern: string;
+
+        /**
+         * The items to filter based on the `pattern`.
+         */
+        readonly items: ReadonlyArray<T>;
+
+        /**
+         * Function that extracts the string from the inputs which will be used to evaluate the fuzzy matching filter.
+         */
+        readonly transform: (item: T) => string;
+
+    }
+
+}


### PR DESCRIPTION
Closes #7414.

Signed-off-by: Akos Kitta <kittaakos@typefox.io>

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

 - Moves the `fuzzy-search` module from `@theia/core/lib/browser/tree` to `@theia/core/lib/common`.
 - Makes `filter` sync.
 - Fixes a flaw in the range validation. Args were not used.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

