### PR TITLE
fixed "applyTo" property in problem matcher for task output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,8 @@ Breaking changes:
   renamed to ScmHistoryWidget.  GitNavigableListWidget has also moved.
   CSS classes have been moved renamed accordingly.  [6381](https://github.com/eclipse-theia/theia/pull/6381)
 - [task] `TaskRestartRunningQuickOpenItem` class is renamed into `RunningTaskQuickOpenItem`. [7392](https://github.com/eclipse-theia/theia/pull/7392)
-- [task] `TaskAttachQuickOpenItem` class is removed.
+- [task] `TaskAttachQuickOpenItem` class is removed. [7392](https://github.com/eclipse-theia/theia/pull/7392)
+- [task] `TaskService.taskProviderRegistry` is removed. [7418](https://github.com/eclipse-theia/theia/pull/7418)
 
 ## v0.16.0
 


### PR DESCRIPTION
- With this change, "applyTo" can be used as a property to control if a problem reported on a text document is applied only to open, closed or all documents.

- fixed #7396

Signed-off-by: Liang Huang <lhuang4@ualberta.ca>


#### How to test

1. Open a workspace, define a task that produces warnings / errors, and add a problem mactcher that parses the warnings / errors.
Mine is  
```
    {
        "type": "npm",
        "script": "lintAAB",
        "problemMatcher": [
            {
                "owner": "eslint97",
                "source": "eslint97",
                "applyTo": "closedDocuments",
                "fileLocation": "absolute",
                "pattern": [
                {
                    "regexp": "^([^\\s].*)$",
                    "kind": "location",
                    "file": 1
                },
                {
                    "regexp": "^\\s+(\\d+):(\\d+)\\s+(error|warning|info)\\s+(.+?)(?:\\s\\s+(.*))?$",
                    "line": 1,
                    "column": 2,
                    "severity": 3,
                    "message": 4,
                    "code": 5,
                    "loop": true
                }
                ]
          }
        ]
    }
```
and the npm lintAAB is defined in package.json as follows
```
  "scripts": {
    "lintAAB": "eslint ."
  }
```


2. Close all docuements, and run the task defined in Step 1. We should be able to see all warnings & errors are displayed in the problems view.

3. Open one document associated with the problem markers added in Step 2. Run the task again.  Once the task finishes, markers displayed in Step 2, **except for** those associated with the opened file, should persist. Markers associated with the opened file should not be displayed.

Please note, in this step, you could possibly still see markers associated with the opened file in the problem view, as other they could be added by other contributors.

4. Close all documents, update `applyTo` of the problem matcher to "openDocuments". Run the task again. Once the task finishes, markers displayed in Step 2 should not show up, because we only want errors & warnings from opened documents to be reported.

5. When `applyTo` is "allDocuments", all parsed warnings and errors markers should be displayed in the problems view.


![Peek 2020-03-24 19-48](https://user-images.githubusercontent.com/37082801/77488536-dd04db00-6e0b-11ea-9984-383b8c584727.gif)

 
#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)
