### PR TITLE
vsx: update extension information in the extension-editor

### DIFF
--- a/packages/vsx-registry/src/browser/style/index.css
+++ b/packages/vsx-registry/src/browser/style/index.css
@@ -234,14 +234,15 @@
     display: flex;
     align-items: center;
     cursor: pointer;
-    padding-right: var(--theia-ui-padding);
     line-height: var(--theia-content-line-height);
     height: var(--theia-content-line-height);
 }
 
 .theia-vsx-extension-editor .header .details .subtitle > span:not(:first-child):not(:empty) {
     border-left: 1px solid hsla(0,0%,50%,.7);
-    padding-left: var(--theia-ui-padding);
+    padding-left: calc(var(--theia-ui-padding)*2);
+    margin-left: calc(var(--theia-ui-padding)*2);
+    font-weight: 500;
 }
 
 .theia-vsx-extension-editor .header .details .subtitle .publisher {


### PR DESCRIPTION
Fixes: #7434

#### What it does
- update styling for the action items in the extension header

#### How to test
- Click View in the top menu and select Extensions
- Search for an extension (ex. Bracket Pair Colorizer)
- The styling for the action items should look similar to how they look in vscode:
![image](https://user-images.githubusercontent.com/23107734/77787058-46b3fd80-7035-11ea-9d50-63fcb775ea01.png)


#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

