### PR TITLE
multi-root: improve display of path for 'WorkspaceInputDialog'

### DIFF
--- a/packages/workspace/src/browser/workspace-commands.ts
+++ b/packages/workspace/src/browser/workspace-commands.ts
@@ -208,7 +208,7 @@ export class WorkspaceCommandContribution implements CommandContribution {
                         parentUri: parentUri,
                         initialValue: vacantChildUri.path.base,
                         validate: name => this.validateFileName(name, parent, true)
-                    }, this.labelProvider);
+                    }, this.labelProvider, this.workspaceService);
 
                     dialog.open().then(name => {
                         if (name) {
@@ -231,7 +231,7 @@ export class WorkspaceCommandContribution implements CommandContribution {
                         parentUri: parentUri,
                         initialValue: vacantChildUri.path.base,
                         validate: name => this.validateFileName(name, parent, true)
-                    }, this.labelProvider);
+                    }, this.labelProvider, this.workspaceService);
                     dialog.open().then(name => {
                         if (name) {
                             this.fileSystem.createFolder(parentUri.resolve(name).toString());


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

Fixes: https://github.com/eclipse-theia/theia/issues/7309

Improved the display of the multi-root workspace. Now it displays the absolute path of the workspace root aswell. Previously it only used to display the parent-folder name or path.

With this update, creating a new file/folder in a multi-root wont be ambiguous. If two roots have the same name, with the absolute path it would be clear as to which root is selected for a new
file/folder.

How it looks now.
![dialog](https://user-images.githubusercontent.com/43870550/77815082-71ca3b80-708d-11ea-8665-d81df89d32ea.PNG)

![multi-root](https://user-images.githubusercontent.com/43870550/77815083-71ca3b80-708d-11ea-9801-622ee947005f.PNG)
The above image displays a multi-root file-explorer where I tend to create a new file/folder in `dijon`
Signed-off-by: Anas Shahid <muhammad.shahid@ericsson.com>

#### How to test

1. Open a workspace in theia. 
2. Add a new folder to workspace
3. Try creating a new file/folder in any of the folder in any workspace. 
4. The dialogBox will show the appropiate root on which the file/folder is being created.

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

