### PR TITLE
[DialogBox] : Improve display for remove folder from workspace

### DIFF
--- a/packages/core/src/browser/style/dialog.css
+++ b/packages/core/src/browser/style/dialog.css
@@ -105,3 +105,25 @@
     font-size: var(--theia-ui-font-size1);
     display: block;
 }
+
+.theia-dialog-node {
+    line-height: var(--theia-content-line-height);
+    margin-top: calc(var(--theia-ui-padding)*1.5);
+    margin-left: calc(var(--theia-ui-padding)*2.5);
+}
+
+.theia-dialog-node-content {
+    display: flex;
+    align-items: center;
+    margin-right: calc(var(--theia-ui-padding)*1.5);}
+
+.theia-dialog-node-segment {
+    flex-grow: 0;
+    user-select: none;
+    white-space: nowrap;
+}
+
+.theia-dialog-icon {
+    align-content: center;
+    margin-right: calc(var(--theia-ui-padding)*1.5);
+}

--- a/packages/workspace/src/browser/workspace-commands.ts
+++ b/packages/workspace/src/browser/workspace-commands.ts
@@ -403,17 +403,30 @@ export class WorkspaceCommandContribution implements CommandContribution {
         };
     }
 
+    /**
+     * Removes the list of folders from the workspace upon confirmation from the user.
+     * @param uris the list of folder uris to remove.
+     */
     protected async removeFolderFromWorkspace(uris: URI[]): Promise<void> {
-        const roots = new Set(this.workspaceService.tryGetRoots().map(r => r.uri));
-        const toRemove = uris.filter(u => roots.has(u.toString()));
+        const roots = new Set(this.workspaceService.tryGetRoots().map(root => root.uri));
+        const toRemove = uris.filter(uri => roots.has(uri.toString()));
         if (toRemove.length > 0) {
             const messageContainer = document.createElement('div');
-            messageContainer.textContent = 'Remove the following folders from workspace? (note: nothing will be erased from disk)';
-            const list = document.createElement('ul');
-            list.style.listStyleType = 'none';
-            toRemove.forEach(u => {
-                const listItem = document.createElement('li');
-                listItem.textContent = u.displayName;
+            messageContainer.textContent = `Are you sure you want to remove the following folder${toRemove.length > 1 ? 's' : ''} from the workspace?`;
+            messageContainer.title = 'Note: Nothing will be erased from disk';
+            const list = document.createElement('div');
+            list.classList.add('theia-dialog-node');
+            toRemove.forEach(uri => {
+                const listItem = document.createElement('div');
+                listItem.classList.add('theia-dialog-node-content');
+                const folderIcon = document.createElement('span');
+                folderIcon.classList.add('codicon', 'codicon-root-folder', 'theia-dialog-icon');
+                listItem.appendChild(folderIcon);
+                listItem.title = this.labelProvider.getLongName(uri);
+                const listContent = document.createElement('span');
+                listContent.classList.add('theia-dialog-node-segment');
+                listContent.appendChild(document.createTextNode(uri.displayName));
+                listItem.appendChild(listContent);
                 list.appendChild(listItem);
             });
             messageContainer.appendChild(list);


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
Fixes: https://github.com/eclipse-theia/theia/issues/7443

Improves the display of remove from workspace dialog, adds codicon `root-folder` and gives some margin between different items in
the dialogBox for better visual impact.

Also updated the text, and added tooltips on both the `folders` and the `textContent` which now displays the path to the root and the note respectively. 

Signed-off-by: Anas Shahid <muhammad.shahid@ericsson.com>


#### How to test
1. Open Theia
2. Open a workspace
3. Add more folder(s) to the workspace
4. Remove the folder(s) from workspace

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

