### PR TITLE
set focus to terminal that the attached task is running from

### DIFF
--- a/packages/task/src/browser/task-service.ts
+++ b/packages/task/src/browser/task-service.ts
@@ -26,7 +26,7 @@ import { EditorManager } from '@theia/editor/lib/browser';
 import { ProblemManager } from '@theia/markers/lib/browser/problem/problem-manager';
 import { TerminalService } from '@theia/terminal/lib/browser/base/terminal-service';
 import { TerminalWidget } from '@theia/terminal/lib/browser/base/terminal-widget';
-import { TerminalWidgetFactoryOptions, TERMINAL_WIDGET_FACTORY_ID } from '@theia/terminal/lib/browser/terminal-widget-impl';
+import { TerminalWidgetFactoryOptions } from '@theia/terminal/lib/browser/terminal-widget-impl';
 import { VariableResolverService } from '@theia/variable-resolver/lib/browser';
 import { WorkspaceService } from '@theia/workspace/lib/browser/workspace-service';
 import { inject, injectable, named, postConstruct } from 'inversify';
@@ -228,7 +228,7 @@ export class TaskService implements TaskConfigurationClient {
                         if (isTaskActiveAndOutputSilent && problem.marker.severity === DiagnosticSeverity.Error) {
                             const terminalId = matchedRunningTaskInfo!.terminalId;
                             if (terminalId) {
-                                const terminal = this.terminalService.getById(this.getTerminalWidgetId(terminalId));
+                                const terminal = this.terminalService.getByTerminalId(terminalId);
                                 if (terminal) {
                                     const focus = !!matchedRunningTaskInfo!.config.presentation!.focus;
                                     if (focus) { // assign focus to the terminal if presentation.focus is true
@@ -304,7 +304,7 @@ export class TaskService implements TaskConfigurationClient {
                 } else {
                     const eventTaskConfig = event.config;
                     if (eventTaskConfig && eventTaskConfig.presentation && eventTaskConfig.presentation.reveal === RevealKind.Silent && event.terminalId) {
-                        const terminal = this.terminalService.getById(this.getTerminalWidgetId(event.terminalId));
+                        const terminal = this.terminalService.getByTerminalId(event.terminalId);
                         const focus = !!eventTaskConfig.presentation.focus;
                         if (terminal) {
                             if (focus) { // assign focus to the terminal if presentation.focus is true
@@ -700,7 +700,7 @@ export class TaskService implements TaskConfigurationClient {
             const taskName = this.taskNameResolver.resolve(task);
             const terminalId = matchedRunningTaskInfo.terminalId;
             if (terminalId) {
-                const terminal = this.terminalService.getById(this.getTerminalWidgetId(terminalId));
+                const terminal = this.terminalService.getByTerminalId(terminalId);
                 if (terminal && task.presentation) {
                     if (task.presentation.focus) { // assign focus to the terminal if presentation.focus is true
                         this.terminalService.open(terminal, { mode: 'activate' });
@@ -979,17 +979,24 @@ export class TaskService implements TaskConfigurationClient {
         terminal.sendText(selectedText);
     }
 
-    async attach(processId: number, taskId: number): Promise<void> {
+    async attach(terminalId: number, taskId: number): Promise<void> {
         // Get the list of all available running tasks.
         const runningTasks: TaskInfo[] = await this.getRunningTasks();
         // Get the corresponding task information based on task id if available.
         const taskInfo: TaskInfo | undefined = runningTasks.find((t: TaskInfo) => t.taskId === taskId);
         let widgetOpenMode: WidgetOpenMode = 'open';
-        if (taskInfo && taskInfo.config.presentation && taskInfo.config.presentation.reveal === RevealKind.Always) {
-            if (taskInfo.config.presentation.focus) { // assign focus to the terminal if presentation.focus is true
-                widgetOpenMode = 'activate';
-            } else { // show the terminal but not assign focus
-                widgetOpenMode = 'reveal';
+        if (taskInfo) {
+            const terminalWidget = this.terminalService.getByTerminalId(terminalId);
+            if (terminalWidget) {
+                this.messageService.error('Task is already running in terminal');
+                return this.terminalService.open(terminalWidget, { mode: 'activate' });
+            }
+            if (taskInfo.config.presentation && taskInfo.config.presentation.reveal === RevealKind.Always) {
+                if (taskInfo.config.presentation.focus) { // assign focus to the terminal if presentation.focus is true
+                    widgetOpenMode = 'activate';
+                } else { // show the terminal but not assign focus
+                    widgetOpenMode = 'reveal';
+                }
             }
         }
 
@@ -998,7 +1005,7 @@ export class TaskService implements TaskConfigurationClient {
             <TaskTerminalWidgetOpenerOptions>{
                 created: new Date().toString(),
                 taskId,
-                id: this.getTerminalWidgetId(processId),
+                id: this.getTerminalWidgetId(terminalId),
                 title: taskInfo
                     ? `Task: ${taskInfo.config.label}`
                     : `Task: #${taskId}`,
@@ -1008,11 +1015,14 @@ export class TaskService implements TaskConfigurationClient {
                 taskConfig: taskInfo ? taskInfo.config : undefined
             }
         );
-        widget.start(processId);
+        widget.start(terminalId);
     }
 
-    private getTerminalWidgetId(terminalId: number): string {
-        return `${TERMINAL_WIDGET_FACTORY_ID}-${terminalId}`;
+    protected getTerminalWidgetId(terminalId: number): string | undefined {
+        const terminalWidget = this.terminalService.getByTerminalId(terminalId);
+        if (terminalWidget) {
+            return terminalWidget.id;
+        }
     }
 
     async configure(task: TaskConfiguration): Promise<void> {

--- a/packages/terminal/src/browser/base/terminal-service.ts
+++ b/packages/terminal/src/browser/base/terminal-service.ts
@@ -47,6 +47,12 @@ export interface TerminalService {
     getById(id: string): TerminalWidget | undefined;
 
     /**
+     * @param id - the terminal id (NOT the terminal widget id!)
+     * @return the widget
+     */
+    getByTerminalId(terminalId: number): TerminalWidget | undefined;
+
+    /**
      * Returns detected default shell.
      */
     getDefaultShell(): Promise<string>;

--- a/packages/terminal/src/browser/terminal-frontend-contribution.ts
+++ b/packages/terminal/src/browser/terminal-frontend-contribution.ts
@@ -257,6 +257,10 @@ export class TerminalFrontendContribution implements TerminalService, CommandCon
         return this.all.find(terminal => terminal.id === id);
     }
 
+    getByTerminalId(terminalId: number): TerminalWidget | undefined {
+        return this.all.find(terminal => terminal.terminalId === terminalId);
+    }
+
     getDefaultShell(): Promise<string> {
         return this.shellTerminalServer.getDefaultShell();
     }


### PR DESCRIPTION
- Same task can be attached over and over again, producing multiple terminal widgets. With this change, Theia sets focus to the teminal widget that the to-be-attached task is running from. If such terminal widget is not found, Theia creates a new terminal widget for the attached task.

- fixes #7407

Signed-off-by: Liang Huang <lhuang4@ualberta.ca>

#### How to test

1. Start a long running task in a workspace
2. Open the same workspace in a different browser (or browser tab).
3. Attach the long running task in the browser opened in Step 2
4. Repeat Step 3.
Expected: Theia does not open new terminals in Step 4.

![Peek 2020-03-30 15-14](https://user-images.githubusercontent.com/37082801/77952382-8e3ac380-7299-11ea-8b12-622279cc7d1a.gif)


#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)


