### PR TITLE
only run selected texts in a user terminal

### DIFF
--- a/packages/task/src/browser/task-service.ts
+++ b/packages/task/src/browser/task-service.ts
@@ -970,8 +970,8 @@ export class TaskService implements TaskConfigurationClient {
             selectedRange = Range.create(startLine, 0, endLine + 1, 0);
         }
         const selectedText: string = this.editorManager.currentEditor.editor.document.getText(selectedRange).trimRight() + '\n';
-        let terminal = this.terminalService.currentTerminal;
-        if (!terminal) {
+        let terminal = this.terminalService.lastUsedTerminal;
+        if (!terminal || terminal.kind !== 'user' || (await terminal.hasChildProcesses())) {
             terminal = <TerminalWidget>await this.terminalService.newTerminal(<TerminalWidgetFactoryOptions>{ created: new Date().toString() });
             await terminal.start();
             this.terminalService.activateTerminal(terminal);


### PR DESCRIPTION
- The selected texts are only run in a user terminal.
  If the terminal widget that has the focus
  1) is not a user terminal, or
  2) is a user terminal that has an actively running command,
  Theia should create a new user terminal and run the selected texts in that new terminal.

- fixes #7323

Signed-off-by: Liang Huang <lhuang4@ualberta.ca>


#### How to test

1. Start a task.
2. Highlight texts
3. Run highlighted texts by going to the top menu bar `Terminal -> Run selected text`
Expected: 
- The selected text should not simply be dumped into the terminal (where the task is running / ran) as a string
- The selected text should be run as a shell command in a user terminal
- If the visible terminal is not a user terminal, a new user terminal should be created to run the selected text as a shell command

![Peek 2020-03-30 15-35](https://user-images.githubusercontent.com/37082801/77954097-220d8f00-729c-11ea-93e8-25834b6fff15.gif)

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)


