### PR TITLE
support presentation.showReuseMessage & clear in task config

### DIFF
--- a/packages/task/src/browser/task-schema-updater.ts
+++ b/packages/task/src/browser/task-schema-updater.ts
@@ -540,7 +540,9 @@ const presentation: IJSONSchema = {
     default: {
         reveal: 'always',
         focus: false,
-        panel: 'shared'
+        panel: 'shared',
+        showReuseMessage: true,
+        clear: false
     },
     description: 'Configures the panel that is used to present the task\'s output and reads its input.',
     additionalProperties: true,
@@ -572,6 +574,16 @@ const presentation: IJSONSchema = {
             ],
             default: 'shared',
             description: 'Controls if the panel is shared between tasks, dedicated to this task or a new one is created on every run.'
+        },
+        showReuseMessage: {
+            type: 'boolean',
+            default: true,
+            description: 'Controls whether to show the "Terminal will be reused by tasks" message.'
+        },
+        clear: {
+            type: 'boolean',
+            default: false,
+            description: 'Controls whether the terminal is cleared before this task is run.'
         }
     }
 };

--- a/packages/task/src/common/task-protocol.ts
+++ b/packages/task/src/common/task-protocol.ts
@@ -43,6 +43,8 @@ export interface TaskOutputPresentation {
     focus?: boolean;
     reveal?: RevealKind;
     panel?: PanelKind;
+    showReuseMessage?: boolean;
+    clear?: boolean;
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     [name: string]: any;
 }
@@ -52,7 +54,9 @@ export namespace TaskOutputPresentation {
         let outputPresentation = {
             reveal: RevealKind.Always,
             focus: false,
-            panel: PanelKind.Shared
+            panel: PanelKind.Shared,
+            showReuseMessage: true,
+            clear: false
         };
         if (task && task.presentation) {
             if (task.presentation.reveal) {
@@ -73,9 +77,26 @@ export namespace TaskOutputPresentation {
                 }
                 outputPresentation = { ...outputPresentation, panel };
             }
-            outputPresentation = { ...outputPresentation, focus: !!task.presentation.focus };
+            outputPresentation = {
+                ...outputPresentation,
+                focus: shouldSetFocusToTerminal(task),
+                showReuseMessage: shouldShowReuseMessage(task),
+                clear: shouldClearTerminalBeforeRun(task)
+            };
         }
         return outputPresentation;
+    }
+
+    export function shouldSetFocusToTerminal(task: TaskCustomization): boolean {
+        return !!task.presentation && !!task.presentation.focus;
+    }
+
+    export function shouldClearTerminalBeforeRun(task: TaskCustomization): boolean {
+        return !!task.presentation && !!task.presentation.clear;
+    }
+
+    export function shouldShowReuseMessage(task: TaskCustomization): boolean {
+        return !task.presentation || task.presentation.showReuseMessage === undefined || !!task.presentation.showReuseMessage;
     }
 }
 


### PR DESCRIPTION
- support presentation.showReuseMessage, which controls whether to show the "Terminal will be reused by tasks" message.
- support presentation.clear, which controls whether the terminal is cleared before this task is run.

Signed-off-by: Liang Huang <lhuang4@ualberta.ca>


#### How to test

1. Make sure neither `showReuseMessage` or `clear` is defined in the task config
2. Start the task at least 2 times.
Expected: 
- The `Terminal will be reused by tasks` shows up after task finishes
- Every time the task is started, the terminal retains whatever it already has. 
3. Add `showReuseMessage: false` into the task config. Run task.
Expected: 
- The `Terminal will be reused by tasks` does not show up after task finishes
4. Add `clear: true` into the task config. Run task.
Expected: 
- The terminal clears all its content before the task starts. 

![Peek 2020-03-30 15-41](https://user-images.githubusercontent.com/37082801/77955158-baf0da00-729d-11ea-943f-c1214914e11e.gif)


#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

