### PR TITLE
support modifying existing problem matchers

### DIFF
--- a/packages/task/src/browser/task-schema-updater.ts
+++ b/packages/task/src/browser/task-schema-updater.ts
@@ -413,6 +413,7 @@ const problemMatcherObject: IJSONSchema = {
     properties: {
         base: {
             type: 'string',
+            enum: problemMatcherNames,
             description: 'The name of a base problem matcher to use.'
         },
         owner: {

--- a/packages/task/src/browser/task-service.ts
+++ b/packages/task/src/browser/task-service.ts
@@ -754,7 +754,7 @@ export class TaskService implements TaskConfigurationClient {
         const resolvedTask = await this.getResolvedTask(task);
         if (resolvedTask) {
             // remove problem markers from the same source before running the task
-            await this.removeProblemMarks(option);
+            await this.removeProblemMarkers(option);
             return this.runResolvedTask(resolvedTask, option);
         }
     }
@@ -869,7 +869,7 @@ export class TaskService implements TaskConfigurationClient {
         return customizationObject;
     }
 
-    private async removeProblemMarks(option?: RunTaskOption): Promise<void> {
+    private async removeProblemMarkers(option?: RunTaskOption): Promise<void> {
         if (option && option.customization) {
             const matchersFromOption = option.customization.problemMatcher || [];
             for (const matcher of matchersFromOption) {

--- a/packages/task/src/common/task-protocol.ts
+++ b/packages/task/src/common/task-protocol.ts
@@ -248,6 +248,7 @@ export interface WatchingMatcherContribution {
 }
 
 export interface ProblemMatcherContribution {
+    base?: string;
     name?: string;
     label: string;
     deprecated?: boolean;


### PR DESCRIPTION
- VS Code supports the possibility of modifying existing problem matchers. With this change, Theia users can define a base problem matcher in which they can further customize the properties `fileLocation`, `applyTo`, `owner`, `severity`, `pattern`, and `source`.

- resolves #6427

Signed-off-by: Liang Huang <lhuang4@ualberta.ca>

#### How to test

With this change, a user can define a base problem matcher in which they can further customize:
```
{
  "type": "npm",
  "script": "lint",
  "problemMatcher": {
    "base": "$eslint-stylish",
    "applyTo": "closedDocuments"
  },
  "isBackground": true
}
```
Instead of linting all files, the task above only lints the closed documents due to the existence of `"applyTo": "closedDocuments"`

**Steps to test**

1. Open a workspace, define a task that produces **warnings** ONLY.
Mine is  
```
    {
        "type": "npm",
        "script": "lintAAB",
        "problemMatcher": [
            "$eslint-stylish"
            ]
          }
        ]
    }
```
and the npm lintAAB is defined in package.json as follows
```
  "scripts": {
    "lintAAB": "eslint ."
  }
```

2. Run the task. After the task finishes, all warnings should have been displayed as warning markers in the problems view.

3. Use `"$eslint-stylish"` as the base, and override the `patterns` property. The task config looks like this:
```
        {
            "type": "npm",
            "script": "lintAAB",
            "problemMatcher": [{
                "base": "$eslint-stylish",
                "pattern": [
                        {
                            "regexp": "^([^\\s].*)$",
                            "kind": "location",
                            "file": 1
                        },
                        {
                            "regexp": "^\\s+(\\d+):(\\d+)\\s+(error|warning|info)\\s+(.+?)(?:\\s\\s+(.*))?$",
                            "line": 1,
                            "column": 2,
                            "severity": 1, // error
                            "message": 4,
                            "code": 5,
                            "loop": true
                        }
                    ]
            }   
            ]
        }
```

4. Run this task one more time, check the problems view after it finishes
Expected: all warning markers are created as error markers this time

![Peek 2020-03-30 16-04](https://user-images.githubusercontent.com/37082801/77957001-ceea0b00-72a0-11ea-87e5-3bf7ffe19e76.gif)

5. Repeat Step 1 - 4 for other properties, such as `fileLocation`, `applyTo`, `owner`, `severity`, `pattern`, and `source`.


#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

