### PR TITLE
Expose NSFW to inheritors of NsfwFilesystemWatcher

### DIFF
--- a/packages/filesystem/src/node/filesystem-backend-module.ts
+++ b/packages/filesystem/src/node/filesystem-backend-module.ts
@@ -23,6 +23,7 @@ import { FileSystemWatcherServerClient } from './filesystem-watcher-client';
 import { NsfwFileSystemWatcherServer } from './nsfw-watcher/nsfw-filesystem-watcher';
 import { MessagingService } from '@theia/core/lib/node/messaging/messaging-service';
 import { NodeFileUploadService } from './node-file-upload-service';
+import { NsfwOptions } from './nsfw-watcher/nsfw-options';
 
 const SINGLE_THREADED = process.argv.indexOf('--no-cluster') !== -1;
 
@@ -39,10 +40,14 @@ export function bindFileSystem(bind: interfaces.Bind, props?: {
 }
 
 export function bindFileSystemWatcherServer(bind: interfaces.Bind, { singleThreaded }: { singleThreaded: boolean } = { singleThreaded: SINGLE_THREADED }): void {
+    bind(NsfwOptions).toConstantValue({});
+
     if (singleThreaded) {
         bind(FileSystemWatcherServer).toDynamicValue(ctx => {
             const logger = ctx.container.get<ILogger>(ILogger);
+            const nsfwOptions = ctx.container.get<NsfwOptions>(NsfwOptions);
             return new NsfwFileSystemWatcherServer({
+                nsfwOptions,
                 info: (message, ...args) => logger.info(message, ...args),
                 error: (message, ...args) => logger.error(message, ...args)
             });

--- a/packages/filesystem/src/node/filesystem-watcher-client.ts
+++ b/packages/filesystem/src/node/filesystem-watcher-client.ts
@@ -19,6 +19,7 @@ import { injectable, inject } from 'inversify';
 import { JsonRpcProxyFactory, ILogger, ConnectionErrorHandler, DisposableCollection, Disposable } from '@theia/core';
 import { IPCConnectionProvider } from '@theia/core/lib/node/messaging';
 import { FileSystemWatcherServer, WatchOptions, FileSystemWatcherClient, ReconnectingFileSystemWatcherServer } from '../common/filesystem-watcher-protocol';
+import { NsfwOptions } from './nsfw-watcher/nsfw-options';
 
 export const NSFW_WATCHER = 'nsfw-watcher';
 
@@ -32,7 +33,8 @@ export class FileSystemWatcherServerClient implements FileSystemWatcherServer {
 
     constructor(
         @inject(ILogger) protected readonly logger: ILogger,
-        @inject(IPCConnectionProvider) protected readonly ipcConnectionProvider: IPCConnectionProvider
+        @inject(IPCConnectionProvider) protected readonly ipcConnectionProvider: IPCConnectionProvider,
+        @inject(NsfwOptions) protected readonly nsfwOptions: NsfwOptions
     ) {
         this.remote.setClient({
             onDidFilesChanged: e => {
@@ -70,6 +72,9 @@ export class FileSystemWatcherServerClient implements FileSystemWatcherServer {
                 serverName: NSFW_WATCHER,
                 logger: this.logger
             }),
+            args: [
+                `--nsfwOptions=${JSON.stringify(this.nsfwOptions)}`
+            ],
             env: process.env
         }, connection => this.proxyFactory.listen(connection));
     }

--- a/packages/filesystem/src/node/nsfw-watcher/index.ts
+++ b/packages/filesystem/src/node/nsfw-watcher/index.ts
@@ -24,11 +24,18 @@ import { IPCEntryPoint } from '@theia/core/lib/node/messaging/ipc-protocol';
 
 const options: {
     verbose: boolean
-} = yargs.option('verbose', {
-    default: false,
-    alias: 'v',
-    type: 'boolean'
-}).argv as any;
+} = yargs
+    .option('verbose', {
+        default: false,
+        alias: 'v',
+        type: 'boolean'
+    })
+    .option('nsfwOptions', {
+        alias: 'o',
+        type: 'string',
+        coerce: JSON.parse
+    })
+    .argv as any;
 
 export default <IPCEntryPoint>(connection => {
     const server = new NsfwFileSystemWatcherServer(options);

--- a/packages/filesystem/src/node/nsfw-watcher/nsfw-filesystem-watcher.ts
+++ b/packages/filesystem/src/node/nsfw-watcher/nsfw-filesystem-watcher.ts
@@ -54,15 +54,18 @@ export class NsfwFileSystemWatcherServer implements FileSystemWatcherServer {
     protected readonly options: {
         verbose: boolean
         info: (message: string, ...args: any[]) => void
-        error: (message: string, ...args: any[]) => void
+        error: (message: string, ...args: any[]) => void,
+        nsfwOptions: nsfw.Options
     };
 
     constructor(options?: {
         verbose?: boolean,
+        nsfwOptions?: nsfw.Options,
         info?: (message: string, ...args: any[]) => void
         error?: (message: string, ...args: any[]) => void
     }) {
         this.options = {
+            nsfwOptions: {},
             verbose: false,
             info: (message, ...args) => console.info(message, ...args),
             error: (message, ...args) => console.error(message, ...args),
@@ -129,7 +132,8 @@ export class NsfwFileSystemWatcherServer implements FileSystemWatcherServer {
                 // see https://github.com/atom/github/issues/342
                 console.warn(`Failed to watch "${basePath}":`, error);
                 this.unwatchFileChanges(watcherId);
-            }
+            },
+            ...this.options.nsfwOptions
         });
         await watcher.start();
         this.options.info('Started watching:', basePath);
@@ -237,5 +241,4 @@ export class NsfwFileSystemWatcherServer implements FileSystemWatcherServer {
             this.options.info(message, ...params);
         }
     }
-
 }

--- a/packages/filesystem/src/node/nsfw-watcher/nsfw-options.ts
+++ b/packages/filesystem/src/node/nsfw-watcher/nsfw-options.ts
@@ -1,0 +1,23 @@
+/********************************************************************************
+ * Copyright (C) 2017-2020 TypeFox and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import * as nsfw from 'nsfw';
+
+/**
+ * Inversify service identifier allowing extensions to override options passed to nsfw by the file watcher.
+ */
+export const NsfwOptions = Symbol('NsfwOptions');
+export type NsfwOptions = nsfw.Options;


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

This PR adds ~a protected method to `NsfwFileSystemWatcherServer`~ a new service identifier `NsfwOptions` that allows extensions to specify options to pass to [`nsfw`](https://github.com/Axosoft/nsfw).

For example, this enables extensions to specify the `debounceMS` setting for file watchers.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

To test that the options are sent to `nsfw`, you could:

1. Rebind `NsfwOptions` to `{ debouncMS: 10000 }` in a backend extension.
2. Build the extension package and browser example app.
3. Start the browser example app. 
4. Try to add multiple files to the workspace in quick succession. Verify that there is a visible debounce in updating the file navigator.

#### Review checklist

- [X] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)