### PR TITLE
markers: update the problem-marker decoration

### DIFF
--- a/packages/markers/src/browser/problem/problem-decorator.ts
+++ b/packages/markers/src/browser/problem/problem-decorator.ts
@@ -127,10 +127,14 @@ export class ProblemDecorator implements TreeDecorator {
     }
 
     protected toDecorator(marker: Marker<Diagnostic>): TreeDecoration.Data {
+        // Determine if the given marker is for a resource of a container.
+        const isResource = Array.from(this.problemManager.getUris()).some(m => m === marker.uri);
         const position = TreeDecoration.IconOverlayPosition.BOTTOM_RIGHT;
         const icon = this.getOverlayIcon(marker);
         const color = this.getOverlayIconColor(marker);
         const priority = this.getPriority(marker);
+        // Determine the number of stats for marker (for display purposes we only care about errors and warnings).
+        const problemStat = this.problemManager.getProblemStat(new URI(marker.uri));
         return {
             priority,
             fontData: {
@@ -145,6 +149,17 @@ export class ProblemDecorator implements TreeDecorator {
                     color: 'transparent'
                 }
             },
+            tailDecorations: [
+                {
+                    data: isResource && (problemStat.errors + problemStat.warnings > 0)
+                        ? (problemStat.errors + problemStat.warnings).toString()
+                        : '',
+                    iconClass: isResource
+                        ? []
+                        : ['theia-marker-container-decoration', 'fa', 'fa-circle'],
+                    color,
+                }
+            ]
         };
     }
 

--- a/packages/markers/src/browser/problem/problem-manager.ts
+++ b/packages/markers/src/browser/problem/problem-manager.ts
@@ -18,6 +18,7 @@ import { injectable } from 'inversify';
 import { MarkerManager } from '../marker-manager';
 import { PROBLEM_KIND } from '../../common/problem-marker';
 import { Diagnostic } from 'vscode-languageserver-types';
+import URI from '@theia/core/lib/common/uri';
 
 export interface ProblemStat {
     errors: number;
@@ -32,11 +33,18 @@ export class ProblemManager extends MarkerManager<Diagnostic> {
         return PROBLEM_KIND;
     }
 
-    getProblemStat(): ProblemStat {
+    /**
+     * Get the problem stat (number of `errors`, `warnings`, and `infos`).
+     * - If `uri` is provided, determine the total count for this resource.
+     * @param uri the marker URI for search purposes.
+     *
+     * @returns the `ProblemStat`.
+     */
+    getProblemStat(uri?: URI): ProblemStat {
         let errors = 0;
         let warnings = 0;
         let infos = 0;
-        for (const marker of this.findMarkers()) {
+        for (const marker of this.findMarkers({ uri })) {
             if (marker.data.severity === 1) {
                 errors++;
             } else if (marker.data.severity === 2) {

--- a/packages/markers/src/browser/style/index.css
+++ b/packages/markers/src/browser/style/index.css
@@ -102,3 +102,7 @@
     width: 15px;
     height: 15px;
 }
+
+.theia-marker-container-decoration {
+    font-size: calc(var(--theia-ui-font-size0) * 0.7) !important;
+}


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

Fixes #3819

The following commit updates the `problem-marker` decoration from the `explorer` to display the total count of errors and warnings for a given resource and updates container nodes (parent directories) to display a generic symbol. The following changes are aligned with the behavior with VS Code.

<img width="368" alt="Screen Shot 2020-03-31 at 1 07 39 PM" src="https://user-images.githubusercontent.com/40359487/78057990-9e17dd80-7355-11ea-9d7e-3a6de4f7700c.png">


#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

1. register error or warning markers in a given workspace
2. the explorer should display the updated marker decorations (count or generic badge)

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

Signed-off-by: vince-fugnitto <vincent.fugnitto@ericsson.com>
