### PR TITLE
Fix 'Find Next' action at using Enter

### DIFF
--- a/packages/monaco/src/browser/monaco-command-registry.ts
+++ b/packages/monaco/src/browser/monaco-command-registry.ts
@@ -63,7 +63,6 @@ export class MonacoCommandRegistry {
     protected execute(monacoHandler: MonacoEditorCommandHandler, ...args: any[]): any {
         const editor = this.monacoEditors.current;
         if (editor) {
-            editor.focus();
             return Promise.resolve(monacoHandler.execute(editor, ...args));
         }
         return Promise.resolve();


### PR DESCRIPTION
#### What it does
Fixes https://github.com/eclipse-theia/theia/issues/7460

I investigated the issue and found that an editor gets focus before execution a command.
It leads to the bug described in the issue.

#### How to test
Please use steps to reproduce from https://github.com/eclipse-theia/theia/issues/7460

#### Review checklist

- [ ] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

Signed-off-by: Roman Nikitenko <rnikiten@redhat.com>