### PR TITLE
Null-check call result rather than function itself

### DIFF
--- a/examples/api-tests/src/monaco-api.spec.js
+++ b/examples/api-tests/src/monaco-api.spec.js
@@ -66,8 +66,7 @@ describe('Monaco API', async function () {
             }, {
                 label: 'Ctrl+Shift+Alt+K',
                 ariaLabel: 'Ctrl+Shift+Alt+K',
-                // eslint-disable-next-line no-null/no-null
-                electronAccelerator: null,
+                electronAccelerator: 'Ctrl+Shift+Alt+K',
                 userSettingsLabel: 'ctrl+shift+alt+K',
                 WYSIWYG: true,
                 chord: false,

--- a/packages/monaco/src/browser/monaco-resolved-keybinding.ts
+++ b/packages/monaco/src/browser/monaco-resolved-keybinding.ts
@@ -49,7 +49,7 @@ export class MonacoResolvedKeybinding extends monaco.keybindings.ResolvedKeybind
     }
 
     public getElectronAccelerator(): string | null {
-        if (this.isChord) {
+        if (this.isChord()) {
             // Electron cannot handle chords
             // eslint-disable-next-line no-null/no-null
             return null;


### PR DESCRIPTION
From the comment, it seems like this was supposed check for chords, rather than checking for the availability of `isChord`.

I tested only by compiling the TypeScript code, since I don't actually know what Theia is/does.

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

#### Review checklist

- [ ] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

