### PR TITLE
Prevent F1 and CtrlCmd+P hotkey in webview iframe

### DIFF
--- a/packages/plugin-ext/src/main/browser/webview/pre/main.js
+++ b/packages/plugin-ext/src/main/browser/webview/pre/main.js
@@ -271,6 +271,8 @@
 		 * @param {KeyboardEvent} e
 		 */
         const handleInnerKeydown = (e) => {
+            preventDefaultBrowserHotkeys(e);
+
             host.postMessage('did-keydown', {
                 key: e.key,
                 keyCode: e.keyCode,
@@ -282,6 +284,15 @@
                 repeat: e.repeat
             });
         };
+
+        function preventDefaultBrowserHotkeys(e) {
+            var isOSX = navigator.platform.toUpperCase().indexOf('MAC')>=0;
+
+            // F1 or CtrlCmd+P
+            if (e.keyCode === 112 || (((e.ctrlKey && !isOSX) || (e.metaKey && isOSX)) && e.keyCode === 80)) {
+                e.preventDefault();
+            }
+        }
 
         let isHandlingScroll = false;
         const handleInnerScroll = (event) => {


### PR DESCRIPTION
#### What it does
Prevent execution default browser hotkeys in webview's iframe, that has focus. Browser opens help context and print dialog by pressing `F1` and `CtrlCmd+P`. These two types of hotkeys with high probability can be executed by user, when the focus might be in webview. This is a hotfix for https://github.com/eclipse-theia/theia/issues/7235 until another option is found.

Signed-off-by: Vladyslav Zhukovskyi <vzhukovs@redhat.com>

#### How to test
Use any webview in theia. Place focus inside iframe, on any element and try to call `F1` or `CtrlCmd+P`. In master, browser will open Help or Print Dialog. With current changes proposal, browser will be prevented from opening Help or Print Dialog.
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

