### PR TITLE
GH-6428: Refactored the built-in monaco commands.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 Breaking changes:
 
+- [core] Removed the `core.find` and `core.replace` commands as they did not work without the `@theia/monaco` extension, or an opened Monaco editor. Use the Monaco-specific `actions.find` and `editor.action.startFindReplaceAction` commands instead. [#7474](https://github.com/eclipse-theia/theia/issues/7474)
 - [plugin] removed `configStorage` argument from `PluginManager.registerPlugin`.
 Use `PluginManager.configStorage` property instead. [#7265](https://github.com/eclipse-theia/theia/pull/7265#discussion_r399956070)
 - [process] `TerminalProcess` doesn't handle shell quoting, the shell process arguments must be prepared from the caller. Removed all methods related to shell escaping inside this class. You should use functions located in `@theia/process/lib/common/shell-quoting.ts` in order to process arguments for shells.
@@ -11,6 +12,7 @@ Use `PluginManager.configStorage` property instead. [#7265](https://github.com/e
 
 ## v1.0.0
 
+- [core] `CommandRegistry#getAllHandlers` returns with the reversed order of handlers, so if a command has multiple handlers, any handler is considered to be more specific than the other subsequent handlers in the array. In other words, if `@theia/core` contributes a handler for a particular command and your extension also contributes a handler for the same command, the handler from your extension will have `0` index, and the handler from `@theia/core` will have `1` index when calling `getAllHandlers`.
 - [core] added functionality to ensure that nodes are refreshed properly on tree expansion [#7400](https://github.com/eclipse-theia/theia/pull/7400)
 - [core] added loading state for trees [#7249](https://github.com/eclipse-theia/theia/pull/7249)
 - [core] added the ability to customize the layout of view-containers [#6655](https://github.com/eclipse-theia/theia/pull/6655)

--- a/packages/core/src/browser/frontend-application-module.ts
+++ b/packages/core/src/browser/frontend-application-module.ts
@@ -30,11 +30,11 @@ import {
     InMemoryResources,
     messageServicePath
 } from '../common';
-import { KeybindingRegistry, KeybindingContext, KeybindingContribution } from './keybinding';
+import { KeybindingRegistry, KeybindingContext, KeybindingContribution, NativeTextInputFocusContext } from './keybinding';
 import { FrontendApplication, FrontendApplicationContribution, DefaultFrontendApplicationContribution } from './frontend-application';
 import { DefaultOpenerService, OpenerService, OpenHandler } from './opener-service';
 import { HttpOpenHandler } from './http-open-handler';
-import { CommonFrontendContribution } from './common-frontend-contribution';
+import { CommonFrontendContribution, UndoHandler, RedoHandler, SelectAllHandler } from './common-frontend-contribution';
 import {
     QuickOpenService, QuickCommandService, QuickCommandFrontendContribution, QuickOpenContribution,
     QuickOpenHandlerRegistry, CommandQuickOpenContribution, HelpQuickOpenHandler,
@@ -318,4 +318,11 @@ export const frontendApplicationModule = new ContainerModule((bind, unbind, isBo
     });
 
     bind(ContextMenuContext).toSelf().inSingletonScope();
+
+    bind(UndoHandler).toSelf().inSingletonScope();
+    bind(RedoHandler).toSelf().inSingletonScope();
+    bind(SelectAllHandler).toSelf().inSingletonScope();
+    bind(NativeTextInputFocusContext).toSelf().inSingletonScope();
+    bind(KeybindingContext).toService(NativeTextInputFocusContext);
+
 });

--- a/packages/core/src/browser/keybinding.ts
+++ b/packages/core/src/browser/keybinding.ts
@@ -91,6 +91,26 @@ export namespace KeybindingContexts {
         id: 'default.keybinding.context',
         isEnabled: () => false
     };
+
+}
+
+/**
+ * Keybinding context that is enabled when the focused HTML element is an `input` or a `textArea`.
+ */
+@injectable()
+export class NativeTextInputFocusContext implements KeybindingContext {
+
+    static readonly ID = 'nativeTextInputFocus';
+    readonly id = NativeTextInputFocusContext.ID;
+
+    /**
+     * `true` if the "focused" DOM element (`document.activeElement`) is an `input` or a `textArea`. Otherwise, `false`.
+     */
+    isEnabled(): boolean {
+        const { activeElement } = document;
+        return !!activeElement && ['input', 'textarea'].indexOf(activeElement.tagName.toLocaleLowerCase()) !== -1;
+    }
+
 }
 
 @injectable()

--- a/packages/core/src/browser/menu/browser-menu-plugin.ts
+++ b/packages/core/src/browser/menu/browser-menu-plugin.ts
@@ -14,14 +14,12 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
-/* eslint-disable @typescript-eslint/no-explicit-any */
-
 import { injectable, inject } from 'inversify';
 import { MenuBar, Menu as MenuWidget, Widget } from '@phosphor/widgets';
 import { CommandRegistry as PhosphorCommandRegistry } from '@phosphor/commands';
 import {
     CommandRegistry, ActionMenuNode, CompositeMenuNode,
-    MenuModelRegistry, MAIN_MENU_BAR, MenuPath, ILogger
+    MenuModelRegistry, MAIN_MENU_BAR, MenuPath, DisposableCollection, Disposable
 } from '../../common';
 import { KeybindingRegistry } from '../keybinding';
 import { FrontendApplicationContribution, FrontendApplication } from '../frontend-application';
@@ -38,20 +36,20 @@ export abstract class MenuBarWidget extends MenuBar {
 @injectable()
 export class BrowserMainMenuFactory {
 
-    @inject(ILogger)
-    protected readonly logger: ILogger;
-
     @inject(ContextKeyService)
     protected readonly contextKeyService: ContextKeyService;
 
     @inject(ContextMenuContext)
     protected readonly context: ContextMenuContext;
 
-    constructor(
-        @inject(CommandRegistry) protected readonly commandRegistry: CommandRegistry,
-        @inject(KeybindingRegistry) protected readonly keybindingRegistry: KeybindingRegistry,
-        @inject(MenuModelRegistry) protected readonly menuProvider: MenuModelRegistry
-    ) { }
+    @inject(CommandRegistry)
+    protected readonly commandRegistry: CommandRegistry;
+
+    @inject(KeybindingRegistry)
+    protected readonly keybindingRegistry: KeybindingRegistry;
+
+    @inject(MenuModelRegistry)
+    protected readonly menuProvider: MenuModelRegistry;
 
     createMenuBar(): MenuBarWidget {
         const menuBar = new DynamicMenuBarWidget();
@@ -67,86 +65,77 @@ export class BrowserMainMenuFactory {
 
     protected fillMenuBar(menuBar: MenuBarWidget): void {
         const menuModel = this.menuProvider.getMenu(MAIN_MENU_BAR);
-        const phosphorCommands = this.createPhosphorCommands(menuModel);
-        // for the main menu we want all items to be visible.
-        phosphorCommands.isVisible = () => true;
-
+        const menuCommandRegistry = this.createMenuCommandRegistry(menuModel);
         for (const menu of menuModel.children) {
             if (menu instanceof CompositeMenuNode) {
-                const menuWidget = new DynamicMenuWidget(menu, { commands: phosphorCommands }, this.contextKeyService, this.context);
+                const menuWidget = new DynamicMenuWidget(menu, { commands: menuCommandRegistry }, this.services);
                 menuBar.addMenu(menuWidget);
             }
         }
     }
 
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     createContextMenu(path: MenuPath, args?: any[]): MenuWidget {
         const menuModel = this.menuProvider.getMenu(path);
-        const phosphorCommands = this.createPhosphorCommands(menuModel, args);
-
-        const contextMenu = new DynamicMenuWidget(menuModel, { commands: phosphorCommands }, this.contextKeyService, this.context);
+        const menuCommandRegistry = this.createMenuCommandRegistry(menuModel, args).snapshot();
+        const contextMenu = new DynamicMenuWidget(menuModel, { commands: menuCommandRegistry }, this.services);
         return contextMenu;
     }
 
-    protected createPhosphorCommands(menu: CompositeMenuNode, args: any[] = []): PhosphorCommandRegistry {
-        const commands = new PhosphorCommandRegistry();
-        this.addPhosphorCommands(commands, menu, args);
-        return commands;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    protected createMenuCommandRegistry(menu: CompositeMenuNode, args: any[] = []): MenuCommandRegistry {
+        const menuCommandRegistry = new MenuCommandRegistry(this.services);
+        this.registerMenu(menuCommandRegistry, menu, args);
+        return menuCommandRegistry;
     }
 
-    protected addPhosphorCommands(commands: PhosphorCommandRegistry, menu: CompositeMenuNode, args: any[]): void {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    protected registerMenu(menuCommandRegistry: MenuCommandRegistry, menu: CompositeMenuNode, args: any[]): void {
         for (const child of menu.children) {
             if (child instanceof ActionMenuNode) {
-                this.addPhosphorCommand(commands, child, args);
+                menuCommandRegistry.registerActionMenu(child, args);
                 if (child.altNode) {
-                    this.addPhosphorCommand(commands, child.altNode, args);
+                    menuCommandRegistry.registerActionMenu(child.altNode, args);
                 }
             } else if (child instanceof CompositeMenuNode) {
-                this.addPhosphorCommands(commands, child, args);
+                this.registerMenu(menuCommandRegistry, child, args);
             }
         }
     }
 
-    protected addPhosphorCommand(commands: PhosphorCommandRegistry, menu: ActionMenuNode, args: any[]): void {
-        const command = this.commandRegistry.getCommand(menu.action.commandId);
-        if (!command) {
-            return;
-        }
-        if (commands.hasCommand(command.id)) {
-            // several menu items can be registered for the same command in different contexts
-            return;
-        }
-        commands.addCommand(command.id, {
-            execute: () => this.commandRegistry.executeCommand(command.id, ...args),
-            label: menu.label,
-            icon: menu.icon,
-            isEnabled: () => this.commandRegistry.isEnabled(command.id, ...args),
-            isVisible: () => this.commandRegistry.isVisible(command.id, ...args),
-            isToggled: () => this.commandRegistry.isToggled(command.id, ...args)
-        });
-
-        const bindings = this.keybindingRegistry.getKeybindingsForCommand(command.id);
-
-        /* Only consider the first keybinding. */
-        if (bindings.length > 0) {
-            const binding = bindings[0];
-            const keys = this.keybindingRegistry.acceleratorFor(binding);
-            commands.addKeyBinding({
-                command: command.id,
-                keys,
-                selector: '.p-Widget' // We have the Phosphor.JS dependency anyway.
-            });
-        }
+    private get services(): MenuServices {
+        return {
+            context: this.context,
+            contextKeyService: this.contextKeyService,
+            commandRegistry: this.commandRegistry,
+            keybindingRegistry: this.keybindingRegistry
+        };
     }
+
 }
 
 class DynamicMenuBarWidget extends MenuBarWidget {
+
+    /**
+     * We want to restore the focus after the menu closes.
+     */
+    protected previousFocusedElement: HTMLElement | undefined;
 
     constructor() {
         super();
         // HACK we need to hook in on private method _openChildMenu. Don't do this at home!
         DynamicMenuBarWidget.prototype['_openChildMenu'] = () => {
             if (this.activeMenu instanceof DynamicMenuWidget) {
-                this.activeMenu.aboutToShow();
+                // `childMenu` is `null` if we open the menu. For example, menu is not shown and you click on `Edit`.
+                // However, the `childMenu` is set, when `Edit` was already open and you move the mouse over `Select`.
+                // We want to save the focus object for the former case only.
+                if (!this.childMenu) {
+                    const { activeElement } = document;
+                    if (activeElement instanceof HTMLElement) {
+                        this.previousFocusedElement = activeElement;
+                    }
+                }
+                this.activeMenu.aboutToShow({ previousFocusedElement: this.previousFocusedElement });
             }
             super['_openChildMenu']();
         };
@@ -193,16 +182,28 @@ class DynamicMenuBarWidget extends MenuBarWidget {
     }
 
 }
+
+class MenuServices {
+    readonly commandRegistry: CommandRegistry;
+    readonly keybindingRegistry: KeybindingRegistry;
+    readonly contextKeyService: ContextKeyService;
+    readonly context: ContextMenuContext;
+}
+
 /**
- * A menu widget that would recompute its items on update
+ * A menu widget that would recompute its items on update.
  */
 class DynamicMenuWidget extends MenuWidget {
 
+    /**
+     * We want to restore the focus after the menu closes.
+     */
+    protected previousFocusedElement: HTMLElement | undefined;
+
     constructor(
         protected menu: CompositeMenuNode,
-        protected options: MenuWidget.IOptions,
-        protected readonly contextKeyService: ContextKeyService,
-        protected readonly context: ContextMenuContext
+        protected options: MenuWidget.IOptions & { commands: MenuCommandRegistry },
+        protected services: MenuServices
     ) {
         super(options);
         if (menu.label) {
@@ -214,80 +215,66 @@ class DynamicMenuWidget extends MenuWidget {
         this.updateSubMenus(this, this.menu, this.options.commands);
     }
 
-    public aboutToShow(): void {
+    // Hint: this is not called from the context menu use-case, but is not required.
+    // For the context menu the command registry state is calculated by the factory before `open`.
+    public aboutToShow({ previousFocusedElement }: { previousFocusedElement: HTMLElement | undefined }): void {
+        this.preserveFocusedElement(previousFocusedElement);
         this.clearItems();
-        this.updateSubMenus(this, this.menu, this.options.commands);
+        this.runWithPreservedFocusContext(() => {
+            this.options.commands.snapshot();
+            this.updateSubMenus(this, this.menu, this.options.commands);
+        });
     }
 
     public open(x: number, y: number, options?: MenuWidget.IOpenOptions): void {
-        // we want to restore the focus after the menu closes.
-        const previouslyActive = window.document.activeElement as HTMLElement;
         const cb = () => {
-            previouslyActive.focus({ preventScroll: true });
+            this.restoreFocusedElement();
             this.aboutToClose.disconnect(cb);
         };
         this.aboutToClose.connect(cb);
         super.open(x, y, options);
     }
 
-    private updateSubMenus(
-        parent: MenuWidget,
-        menu: CompositeMenuNode,
-        commands: PhosphorCommandRegistry
-    ): void {
+    private updateSubMenus(parent: MenuWidget, menu: CompositeMenuNode, commands: MenuCommandRegistry): void {
         const items = this.buildSubMenus([], menu, commands);
         for (const item of items) {
             parent.addItem(item);
         }
     }
 
-    private buildSubMenus(
-        items: MenuWidget.IItemOptions[],
-        menu: CompositeMenuNode,
-        commands: PhosphorCommandRegistry
-    ): MenuWidget.IItemOptions[] {
+    private buildSubMenus(items: MenuWidget.IItemOptions[], menu: CompositeMenuNode, commands: MenuCommandRegistry): MenuWidget.IItemOptions[] {
         for (const item of menu.children) {
             if (item instanceof CompositeMenuNode) {
-                if (item.children.length > 0) {
-                    // do not render empty nodes
-
+                if (item.children.length) { // do not render empty nodes
                     if (item.isSubmenu) { // submenu node
-                        const submenu = new DynamicMenuWidget(item, this.options, this.contextKeyService, this.context);
-                        if (submenu.items.length === 0) {
+                        const submenu = new DynamicMenuWidget(item, this.options, this.services);
+                        if (!submenu.items.length) {
                             continue;
                         }
-
                         items.push({
                             type: 'submenu',
                             submenu,
                         });
-
                     } else { // group node
-
                         const submenu = this.buildSubMenus([], item, commands);
-                        if (submenu.length === 0) {
+                        if (!submenu.length) {
                             continue;
                         }
-
-                        if (items.length > 0) {
-                            // do not put a separator above the first group
-
+                        if (items.length) { // do not put a separator above the first group
                             items.push({
                                 type: 'separator'
                             });
                         }
-
-                        // render children
-                        items.push(...submenu);
+                        items.push(...submenu); // render children
                     }
                 }
             } else if (item instanceof ActionMenuNode) {
-                const node = item.altNode && this.context.altPressed ? item.altNode : item;
+                const { context, contextKeyService } = this.services;
+                const node = item.altNode && context.altPressed ? item.altNode : item;
                 const { when } = node.action;
-                if (!(commands.isVisible(node.action.commandId) && (!when || this.contextKeyService.match(when)))) {
+                if (!(commands.isVisible(node.action.commandId) && (!when || contextKeyService.match(when)))) {
                     continue;
                 }
-
                 items.push({
                     command: node.action.commandId,
                     type: 'command'
@@ -295,6 +282,39 @@ class DynamicMenuWidget extends MenuWidget {
             }
         }
         return items;
+    }
+
+    protected preserveFocusedElement(previousFocusedElement: Element | null = document.activeElement): boolean {
+        if (!this.previousFocusedElement && previousFocusedElement instanceof HTMLElement) {
+            this.previousFocusedElement = previousFocusedElement;
+            return true;
+        }
+        return false;
+    }
+
+    protected restoreFocusedElement(): boolean {
+        if (this.previousFocusedElement) {
+            this.previousFocusedElement.focus({ preventScroll: true });
+            this.previousFocusedElement = undefined;
+            return true;
+        }
+        return false;
+    }
+
+    protected runWithPreservedFocusContext(what: () => void): void {
+        let focusToRestore: HTMLElement | undefined = undefined;
+        const { activeElement } = document;
+        if (this.previousFocusedElement && activeElement instanceof HTMLElement && this.previousFocusedElement !== activeElement) {
+            focusToRestore = activeElement;
+            this.previousFocusedElement.focus({ preventScroll: true });
+        }
+        try {
+            what();
+        } finally {
+            if (focusToRestore) {
+                focusToRestore.focus({ preventScroll: true });
+            }
+        }
     }
 
 }
@@ -326,4 +346,83 @@ export class BrowserMenuBarContribution implements FrontendApplicationContributi
         logo.addClass('theia-icon');
         return logo;
     }
+}
+
+/**
+ * Stores Theia-specific action menu nodes instead of PhosphorJS commands with their handlers.
+ */
+class MenuCommandRegistry extends PhosphorCommandRegistry {
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    protected actions = new Map<string, [ActionMenuNode, any[]]>();
+    protected toDispose = new DisposableCollection();
+
+    constructor(protected services: MenuServices) {
+        super();
+    }
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    registerActionMenu(menu: ActionMenuNode, ...args: any[]): void {
+        const { commandId } = menu.action;
+        const { commandRegistry } = this.services;
+        const command = commandRegistry.getCommand(commandId);
+        if (!command) {
+            console.warn(`Could not find command '${commandId}'. Skipping node registration: ${JSON.stringify(menu)}.`);
+            return;
+        }
+        const { id } = command;
+        if (this.actions.has(id)) {
+            return;
+        }
+        this.actions.set(id, [menu, args]);
+    }
+
+    snapshot(): this {
+        this.toDispose.dispose();
+        for (const [menu, args] of this.actions.values()) {
+            this.toDispose.push(this.registerCommand(menu, args));
+        }
+        return this;
+    }
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    protected registerCommand(menu: ActionMenuNode, args: any[]): Disposable {
+        const { commandRegistry, keybindingRegistry } = this.services;
+        const command = commandRegistry.getCommand(menu.action.commandId);
+        if (!command) {
+            return Disposable.NULL;
+        }
+        const { id } = command;
+        if (this.hasCommand(id)) {
+            // several menu items can be registered for the same command in different contexts
+            return Disposable.NULL;
+        }
+
+        // We freeze the `isEnabled`, `isVisible`, and `isToggled` states so they won't change.
+        const enabled = commandRegistry.isEnabled(id, ...args);
+        const visible = commandRegistry.isVisible(id, ...args);
+        const toggled = commandRegistry.isToggled(id, ...args);
+        const unregisterCommand = this.addCommand(id, {
+            execute: () => commandRegistry.executeCommand(id, ...args),
+            label: menu.label,
+            icon: menu.icon,
+            isEnabled: () => enabled,
+            isVisible: () => visible,
+            isToggled: () => toggled
+        });
+
+        const bindings = keybindingRegistry.getKeybindingsForCommand(id);
+        // Only consider the first keybinding.
+        if (bindings.length) {
+            const binding = bindings[0];
+            const keys = keybindingRegistry.acceleratorFor(binding);
+            this.addKeyBinding({
+                command: id,
+                keys,
+                selector: '.p-Widget' // We have the PhosphorJS dependency anyway.
+            });
+        }
+        return Disposable.create(() => unregisterCommand.dispose());
+    }
+
 }

--- a/packages/core/src/common/command.ts
+++ b/packages/core/src/common/command.ts
@@ -310,16 +310,13 @@ export class CommandRegistry implements CommandService {
      */
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     getVisibleHandler(commandId: string, ...args: any[]): CommandHandler | undefined {
-        const handlers = this._handlers[commandId];
-        if (handlers) {
-            for (const handler of handlers) {
-                try {
-                    if (!handler.isVisible || handler.isVisible(...args)) {
-                        return handler;
-                    }
-                } catch (error) {
-                    console.error(error);
+        for (const handler of this.getAllHandlers(commandId)) {
+            try {
+                if (!handler.isVisible || handler.isVisible(...args)) {
+                    return handler;
                 }
+            } catch (error) {
+                console.error(error);
             }
         }
         return undefined;
@@ -330,16 +327,13 @@ export class CommandRegistry implements CommandService {
      */
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     getActiveHandler(commandId: string, ...args: any[]): CommandHandler | undefined {
-        const handlers = this._handlers[commandId];
-        if (handlers) {
-            for (const handler of handlers) {
-                try {
-                    if (!handler.isEnabled || handler.isEnabled(...args)) {
-                        return handler;
-                    }
-                } catch (error) {
-                    console.error(error);
+        for (const handler of this.getAllHandlers(commandId)) {
+            try {
+                if (!handler.isEnabled || handler.isEnabled(...args)) {
+                    return handler;
                 }
+            } catch (error) {
+                console.error(error);
             }
         }
         return undefined;
@@ -350,16 +344,13 @@ export class CommandRegistry implements CommandService {
      */
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     getToggledHandler(commandId: string, ...args: any[]): CommandHandler | undefined {
-        const handlers = this._handlers[commandId];
-        if (handlers) {
-            for (const handler of handlers) {
-                try {
-                    if (handler.isToggled && handler.isToggled(...args)) {
-                        return handler;
-                    }
-                } catch (error) {
-                    console.error(error);
+        for (const handler of this.getAllHandlers(commandId)) {
+            try {
+                if (handler.isToggled && handler.isToggled(...args)) {
+                    return handler;
                 }
+            } catch (error) {
+                console.error(error);
             }
         }
         return undefined;
@@ -371,7 +362,8 @@ export class CommandRegistry implements CommandService {
      */
     getAllHandlers(commandId: string): CommandHandler[] {
         const handlers = this._handlers[commandId];
-        return handlers ? handlers.slice() : [];
+        // We intentionally reverse the array of handlers, so if there are multiple handlers for a command, you can find the more specific, enabled one.
+        return handlers ? handlers.slice().reverse() : [];
     }
 
     /**

--- a/packages/core/src/electron-browser/keyboard/electron-common-commands.ts
+++ b/packages/core/src/electron-browser/keyboard/electron-common-commands.ts
@@ -1,0 +1,46 @@
+/********************************************************************************
+ * Copyright (C) 2020 TypeFox and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import { remote } from 'electron';
+import { injectable } from 'inversify';
+import { UndoHandler, RedoHandler, SelectAllHandler } from '../../browser/common-frontend-contribution';
+
+@injectable()
+export class ElectronUndoHandler extends UndoHandler {
+
+    execute(): void {
+        remote.getCurrentWebContents().undo();
+    }
+
+}
+
+@injectable()
+export class ElectronRedoHandler extends RedoHandler {
+
+    execute(): void {
+        remote.getCurrentWebContents().redo();
+    }
+
+}
+
+@injectable()
+export class ElectronSelectAllHandler extends SelectAllHandler {
+
+    execute(): void {
+        remote.getCurrentWebContents().selectAll();
+    }
+
+}

--- a/packages/core/src/electron-browser/keyboard/electron-keyboard-module.ts
+++ b/packages/core/src/electron-browser/keyboard/electron-keyboard-module.ts
@@ -18,6 +18,8 @@ import { ContainerModule } from 'inversify';
 import { KeyboardLayoutProvider, keyboardPath, KeyboardLayoutChangeNotifier } from '../../common/keyboard/keyboard-layout-provider';
 import { WebSocketConnectionProvider } from '../../browser/messaging/ws-connection-provider';
 import { ElectronKeyboardLayoutChangeNotifier } from './electron-keyboard-layout-change-notifier';
+import { UndoHandler, RedoHandler, SelectAllHandler } from '../../browser/common-frontend-contribution';
+import { ElectronUndoHandler, ElectronRedoHandler, ElectronSelectAllHandler } from './electron-common-commands';
 
 export default new ContainerModule((bind, unbind, isBound, rebind) => {
     bind(KeyboardLayoutProvider).toDynamicValue(ctx =>
@@ -25,4 +27,7 @@ export default new ContainerModule((bind, unbind, isBound, rebind) => {
     ).inSingletonScope();
     bind(ElectronKeyboardLayoutChangeNotifier).toSelf().inSingletonScope();
     bind(KeyboardLayoutChangeNotifier).toService(ElectronKeyboardLayoutChangeNotifier);
+    rebind(UndoHandler).to(ElectronUndoHandler).inSingletonScope();
+    rebind(RedoHandler).to(ElectronRedoHandler).inSingletonScope();
+    rebind(SelectAllHandler).to(ElectronSelectAllHandler).inSingletonScope();
 });

--- a/packages/monaco/src/browser/monaco-command-registry.ts
+++ b/packages/monaco/src/browser/monaco-command-registry.ts
@@ -63,7 +63,6 @@ export class MonacoCommandRegistry {
     protected execute(monacoHandler: MonacoEditorCommandHandler, ...args: any[]): any {
         const editor = this.monacoEditors.current;
         if (editor) {
-            editor.focus();
             return Promise.resolve(monacoHandler.execute(editor, ...args));
         }
         return Promise.resolve();

--- a/packages/monaco/src/browser/monaco-editor-service.ts
+++ b/packages/monaco/src/browser/monaco-editor-service.ts
@@ -56,6 +56,13 @@ export class MonacoEditorService extends monaco.services.CodeEditorServiceImpl {
         return editor && editor.getControl();
     }
 
+    /**
+     * Returns `true` if there is a code editor with focus. The cursor blinks in the editor.
+     */
+    hasFocusedCodeEditor(): boolean {
+        return !!this.getFocusedCodeEditor();
+    }
+
     async openCodeEditor(input: IResourceInput, source?: ICodeEditor, sideBySide?: boolean): Promise<CommonCodeEditor | undefined> {
         const uri = new URI(input.resource.toString());
         const openerOptions = this.createEditorOpenerOptions(input, source, sideBySide);

--- a/packages/monaco/src/browser/monaco-frontend-module.ts
+++ b/packages/monaco/src/browser/monaco-frontend-module.ts
@@ -24,7 +24,7 @@ import { MenuContribution, CommandContribution } from '@theia/core/lib/common';
 import { PreferenceScope } from '@theia/core/lib/common/preferences/preference-scope';
 import {
     QuickOpenService, FrontendApplicationContribution, KeybindingContribution,
-    PreferenceService, PreferenceSchemaProvider, createPreferenceProxy
+    PreferenceService, PreferenceSchemaProvider, createPreferenceProxy, NativeTextInputFocusContext
 } from '@theia/core/lib/browser';
 import { Languages, Workspace } from '@theia/languages/lib/browser';
 import { TextEditorProvider, DiffNavigatorProvider } from '@theia/editor/lib/browser';
@@ -46,7 +46,7 @@ import { MonacoCommandService, MonacoCommandServiceFactory } from './monaco-comm
 import { MonacoCommandRegistry } from './monaco-command-registry';
 import { MonacoQuickOpenService } from './monaco-quick-open-service';
 import { MonacoDiffNavigatorFactory } from './monaco-diff-navigator-factory';
-import { MonacoStrictEditorTextFocusContext } from './monaco-keybinding-contexts';
+import { MonacoStrictEditorTextFocusContext, MonacoNativeTextInputFocusContext } from './monaco-keybinding-contexts';
 import { MonacoFrontendApplicationContribution } from './monaco-frontend-application-contribution';
 import MonacoTextmateModuleBinder from './textmate/monaco-textmate-frontend-bindings';
 import { MonacoSemanticHighlightingService } from './monaco-semantic-highlighting-service';
@@ -122,6 +122,7 @@ export default new ContainerModule((bind, unbind, isBound, rebind) => {
     bind(MenuContribution).to(MonacoEditorMenuContribution).inSingletonScope();
     bind(KeybindingContribution).to(MonacoKeybindingContribution).inSingletonScope();
     rebind(StrictEditorTextFocusContext).to(MonacoStrictEditorTextFocusContext).inSingletonScope();
+    rebind(NativeTextInputFocusContext).to(MonacoNativeTextInputFocusContext).inSingletonScope();
 
     bind(MonacoQuickOpenService).toSelf().inSingletonScope();
     rebind(QuickOpenService).toService(MonacoQuickOpenService);

--- a/packages/monaco/src/browser/monaco-loader.ts
+++ b/packages/monaco/src/browser/monaco-loader.ts
@@ -75,7 +75,8 @@ export function loadMonaco(vsRequire: any): Promise<void> {
                 'vs/platform/markers/common/markerService',
                 'vs/platform/contextkey/common/contextkey',
                 'vs/platform/contextkey/browser/contextKeyService',
-                'vs/base/common/errors'
+                'vs/base/common/errors',
+                'vs/platform/instantiation/common/instantiation'
             ], (css: any, html: any, commands: any, actions: any,
                 keybindingsRegistry: any, keybindingResolver: any, resolvedKeybinding: any, keybindingLabels: any,
                 keyCodes: any, mime: any, editorExtensions: any, simpleServices: any,
@@ -86,7 +87,8 @@ export function loadMonaco(vsRequire: any): Promise<void> {
                 codeEditorService: any, codeEditorServiceImpl: any,
                 markerService: any,
                 contextKey: any, contextKeyService: any,
-                error: any) => {
+                error: any,
+                instantiation: any) => {
                     const global: any = self;
                     global.monaco.commands = commands;
                     global.monaco.actions = actions;
@@ -106,6 +108,7 @@ export function loadMonaco(vsRequire: any): Promise<void> {
                     global.monaco.contextKeyService = contextKeyService;
                     global.monaco.mime = mime;
                     global.monaco.error = error;
+                    global.monaco.instantiation = instantiation;
                     resolve();
                 });
         });

--- a/packages/monaco/src/browser/monaco-menu.ts
+++ b/packages/monaco/src/browser/monaco-menu.ts
@@ -16,9 +16,11 @@
 
 import { injectable, inject } from 'inversify';
 import { MenuContribution, MenuModelRegistry, MAIN_MENU_BAR, MenuPath } from '@theia/core/lib/common';
+import { CommonMenus } from '@theia/core/lib/browser/common-frontend-contribution';
 import { EDITOR_CONTEXT_MENU } from '@theia/editor/lib/browser';
 import { MonacoCommandRegistry } from './monaco-command-registry';
 import MenuRegistry = monaco.actions.MenuRegistry;
+import { MonacoCommands } from './monaco-command';
 
 export interface MonacoActionGroup {
     id: string;
@@ -62,6 +64,20 @@ export class MonacoEditorMenuContribution implements MenuContribution {
                 const order = item.order ? String(item.order) : '';
                 registry.registerMenuAction(menuPath, { commandId, order, label });
             }
+        }
+
+        // Register `Find` and `Replace` to the `Edit` menu.
+        if (this.commands.validate(MonacoCommands.FIND)) {
+            registry.registerMenuAction(CommonMenus.EDIT_FIND, {
+                commandId: MonacoCommands.FIND,
+                order: '0'
+            });
+        }
+        if (this.commands.validate(MonacoCommands.REPLACE)) {
+            registry.registerMenuAction(CommonMenus.EDIT_FIND, {
+                commandId: MonacoCommands.REPLACE,
+                order: '1'
+            });
         }
     }
 

--- a/packages/plugin-ext-vscode/src/browser/plugin-vscode-commands-contribution.ts
+++ b/packages/plugin-ext-vscode/src/browser/plugin-vscode-commands-contribution.ts
@@ -194,13 +194,16 @@ export class PluginVscodeCommandsContribution implements CommandContribution {
             execute: () => commands.executeCommand('editor.action.gotoLine')
         });
         commands.registerCommand({ id: 'actions.find' }, {
-            execute: () => commands.executeCommand(CommonCommands.FIND.id)
+            execute: () => commands.executeCommand('actions.find')
         });
         commands.registerCommand({ id: 'undo' }, {
-            execute: () => commands.executeCommand(CommonCommands.UNDO.id)
+            execute: () => commands.executeCommand('undo')
+        });
+        commands.registerCommand({ id: 'redo' }, {
+            execute: () => commands.executeCommand('redo')
         });
         commands.registerCommand({ id: 'editor.action.startFindReplaceAction' }, {
-            execute: () => commands.executeCommand(CommonCommands.REPLACE.id)
+            execute: () => commands.executeCommand('editor.action.startFindReplaceAction')
         });
         commands.registerCommand({ id: 'workbench.action.quickOpen' }, {
             execute: () => this.quickOpen.open('')


### PR DESCRIPTION
Signed-off-by: Akos Kitta <kittaakos@typefox.io>

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
Changes the way how we handle monaco commands, and hopefully providers a better UX for the `Undo`, `Redo`, and `Select All` commands. It is the fix for electron, as it 

#### How to test

### Test Plan:

- Preconditions:
   - If you are verify this in electron, you have to be avere of the non-dynamic nature of the application menu. (https://github.com/eclipse-theia/theia/issues/6425).
   - Run `Reset Workbench Layout`.
   - Open the SIW widget; the `input` widget has the focus.
- Steps:
   - Type _**foo**_ and press <kbd>Ctrl/⌘</kbd>+<kbd>A</kbd> (`Select All`). Assert: the `input` value is _**foo**_ and is selected.
   - Press <kbd>Del</kbd>. Assert: the `input` is empty.
   - Press <kbd>Ctrl/⌘</kbd>+<kbd>Z</kbd> (`Undo`). Assert: the `input` value is _**foo**_ and is selected.
   - Press <kbd>Ctrl/⌘</kbd>+<kbd>Shift</kbd>+<kbd>Z</kbd> (`Redo`). Assert: the `input` is empty.
   - Type _**bar**_ and select the `Selection` > `Select All` menu item. Assert: the input value is _**bar**_ and is selected.
   - Press <kbd>Del</kbd>. Assert: the `input` is empty.
   - Select the `Edit` > `Undo` menu item. Assert: the input is _**bar**_ and is selected. (Note: there is a bug here. The SIW widget's `input` does not listen on value change and does not re-run the query.)
   - Select the `Edit` > `Redo` menu item. Assert: the input is empty.

-----

- Preconditions:
   - If you are verify this in electron, you have to be avere of the non-dynamic nature of the application menu. (https://github.com/eclipse-theia/theia/issues/6425).
   - Open `theia` as a workspace in Theia.
   - Run `Reset Workbench Layout`.
   - Open the SIW widget; the `input` widget has the focus, type _**baz**_.
   - Open the `os.ts` module via the _Command Palette_. If it is opened in a preview mode, make sure the editor has the focus; the cursor blinks inside the editor.
- Steps:
   - Type _**foo**_ somewhere in the editor and press <kbd>Ctrl/⌘</kbd>+<kbd>Z</kbd> (`Undo`). Assert: _**foo**_ is not there.
   - Press <kbd>Ctrl/⌘</kbd>+<kbd>Shift</kbd>+<kbd>Z</kbd> (`Redo`). Assert: _**foo**_ is there.
   - Press <kbd>Ctrl/⌘</kbd>+<kbd>Z</kbd> (`Undo`). Assert: _**foo**_ is not there.
   - Press <kbd>Ctrl/⌘</kbd>+<kbd>A</kbd> (`Select All`). Assert: the editor content is selected.
   - Press <kbd>Esc</kbd>. Assert: the cursor blinks at the end of the file, nothing is selected.
   - Type _**bar**_ and select the `Edit` > `Undo` menu item. Assert: _**bar**_ is not there.
   - Select the `Edit` > `Redo` menu item. Assert: _**bar**_ is in the editor.
   - Set the focus (single-click) into the SIW's `input`.
   - Press <kbd>Ctrl/⌘</kbd>+<kbd>A</kbd> (`Select All`). Assert: _**baz**_ is selected.
   - Make sure the cursor blinks once again in the editor and select the `Selection` > `Select All` menu item. Assert: the editor content is selected.
   - Press <kbd>Esc</kbd>. Assert: the cursor blinks at the end of the file, nothing is selected.
   - Right-click on `isWindows` in the editor and select `Peek` > `Peek References` from the context menu. Assert: embedded editor is open. The cursor blinks on `isWindows` in the main editor.
   - Press <kbd>Ctrl/⌘</kbd>+<kbd>A</kbd> (`Select All`). Assert: the main editor content is selected.
   - Make sure the cursor blinks this time in the embedded editor and press <kbd>Ctrl/⌘</kbd>+<kbd>A</kbd> (`Select All`). Assert: the embbedded editor content is selected. (Fixes #7483)

----

🎖Let's verify other issues:
 - Inside the `os.ts` module, press <kbd>Ctrl/⌘</kbd>+<kbd>F</kbd>, type `is` into the search widget. If you press <kbd>Enter</kbd> (multiple times) the selection jumps to the next `is` occurrence position in the editor. Bonus: it works inside the embedded editor too. (Fixes #7460) 
 - If you are verifying the changes with the electron example (Fixes #6428), open the _Command Palette_ and make sure you can do `Undo`, `Redo`, and `Select All` from the keyboard. (Fixes #2756)
 - Close all editors and press <kbd>Ctrl/⌘</kbd>+<kbd>F</kbd>. Assert: no errors because of the missing handler for `core.find` command. (Fixes #7474)


----
TODOs:
 - [x] Verify [this](https://github.com/microsoft/vscode/issues/88610). From time to time, I can see the `Commiting pending changes before change accessor leaves due to read access.` warning when running the electron example. Hmm, but the logger code was removed by the VS Code guys in January. Let's double-check it. Verified ✅ (https://github.com/microsoft/vscode/commit/6beb75765e492b47e32554e093b77317fec397a8)

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)


@akosyakov, @RomanNikitenko, here is an early preview of my changes. I am going to verify the behavior locally and write down the verification steps. Please take a look at my changes. Thank you!
