### PR TITLE
refactor the task terminal widget option

### DIFF
--- a/packages/task/src/browser/task-service.ts
+++ b/packages/task/src/browser/task-service.ts
@@ -62,7 +62,7 @@ import { TaskConfigurationManager } from './task-configuration-manager';
 import { PROBLEMS_WIDGET_ID, ProblemWidget } from '@theia/markers/lib/browser/problem/problem-widget';
 import { TaskNode } from './task-node';
 import { MonacoWorkspace } from '@theia/monaco/lib/browser/monaco-workspace';
-import { TaskTerminalWidgetManager, TaskTerminalWidgetOpenerOptions } from './task-terminal-widget-manager';
+import { TaskTerminalWidgetManager } from './task-terminal-widget-manager';
 
 export interface QuickPickProblemMatcherItem {
     problemMatchers: NamedProblemMatcher[] | undefined;
@@ -1001,20 +1001,19 @@ export class TaskService implements TaskConfigurationClient {
         }
 
         // Create / find a terminal widget to display an execution output of a task that was launched as a command inside a shell.
-        const widget = await this.taskTerminalWidgetManager.open(
-            <TaskTerminalWidgetOpenerOptions>{
-                created: new Date().toString(),
-                taskId,
-                id: this.getTerminalWidgetId(terminalId),
-                title: taskInfo
-                    ? `Task: ${taskInfo.config.label}`
-                    : `Task: #${taskId}`,
-                destroyTermOnClose: true,
-                widgetOptions: { area: 'bottom' },
-                mode: widgetOpenMode,
-                taskConfig: taskInfo ? taskInfo.config : undefined
-            }
-        );
+        const widget = await this.taskTerminalWidgetManager.open({
+            created: new Date().toString(),
+            id: this.getTerminalWidgetId(terminalId),
+            title: taskInfo
+                ? `Task: ${taskInfo.config.label}`
+                : `Task: #${taskId}`,
+            destroyTermOnClose: true
+        }, {
+            taskId,
+            widgetOptions: { area: 'bottom' },
+            mode: widgetOpenMode,
+            taskConfig: taskInfo ? taskInfo.config : undefined
+        });
         widget.start(terminalId);
     }
 


### PR DESCRIPTION
- opener options are passed from task extension to terminal extension as
part of the terminal widget option. It works but it should not be
implemented this way because opener options are not need to recreate
widgets. This change separates the widget options and opener options for
task terminal.

- resolves #7438

Signed-off-by: Liang Huang <lhuang4@ualberta.ca>

#### How to test

Smoke test the terminals created by the task extension. Verify if this change breaks anything. 

What I tested includes:

- Start a task
- Attach a running task 
- Play with the terminal creation with different values of `task.presentation.panel`
- Check if a terminal can be properly recreated. This includes the recreation of a user terminal that has a shell, and a task terminal that is running a long-running task.

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)
