### PR TITLE
Disable git initialize repository when no open workspace

### DIFF
--- a/packages/git/src/browser/git-contribution.ts
+++ b/packages/git/src/browser/git-contribution.ts
@@ -439,8 +439,8 @@ export class GitContribution implements CommandContribution, MenuContribution, T
         });
         registry.registerCommand(GIT_COMMANDS.INIT_REPOSITORY, {
             execute: () => this.quickOpenService.initRepository(),
-            isEnabled: widget => (!widget || widget instanceof ScmWidget) && !this.repositoryProvider.selectedRepository,
-            isVisible: widget => (!widget || widget instanceof ScmWidget) && !this.repositoryProvider.selectedRepository
+            isEnabled: widget => this.workspaceService.opened && (!widget || widget instanceof ScmWidget) && !this.repositoryProvider.selectedRepository,
+            isVisible: widget => this.workspaceService.opened && (!widget || widget instanceof ScmWidget) && !this.repositoryProvider.selectedRepository
         });
     }
     async amend(): Promise<void> {


### PR DESCRIPTION
Fixes #7487

Signed-off-by: Ulysse McConnell <ulysse.mcconnell+dev@protonmail.com>

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
Disables and hides the git 'Initialize repository' widget when no workspace is open
<!-- Include relevant issues and describe how they are addressed. -->

#### How to test
1. Remove any open workspaces
2. Switch to the source control panel
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

