### PR TITLE
support presentation.echo in task config

### DIFF
--- a/packages/task/src/browser/task-schema-updater.ts
+++ b/packages/task/src/browser/task-schema-updater.ts
@@ -539,6 +539,7 @@ const problemMatcher = {
 const presentation: IJSONSchema = {
     type: 'object',
     default: {
+        echo: true,
         reveal: 'always',
         focus: false,
         panel: 'shared',
@@ -548,6 +549,11 @@ const presentation: IJSONSchema = {
     description: 'Configures the panel that is used to present the task\'s output and reads its input.',
     additionalProperties: true,
     properties: {
+        echo: {
+            type: 'boolean',
+            default: true,
+            description: 'Controls whether the executed command is echoed to the panel. Default is true.'
+        },
         focus: {
             type: 'boolean',
             default: false,

--- a/packages/task/src/browser/task-service.ts
+++ b/packages/task/src/browser/task-service.ts
@@ -1000,7 +1000,6 @@ export class TaskService implements TaskConfigurationClient {
                 }
             }
         }
-
         // Create / find a terminal widget to display an execution output of a task that was launched as a command inside a shell.
         const widget = await this.taskTerminalWidgetManager.open({
             created: new Date().toString(),
@@ -1013,7 +1012,7 @@ export class TaskService implements TaskConfigurationClient {
             taskId,
             widgetOptions: { area: 'bottom' },
             mode: widgetOpenMode,
-            taskConfig: taskInfo ? taskInfo.config : undefined
+            taskInfo
         });
         widget.start(terminalId);
     }

--- a/packages/task/src/common/process/task-protocol.ts
+++ b/packages/task/src/common/process/task-protocol.ts
@@ -78,14 +78,14 @@ export interface ProcessTaskConfiguration extends TaskConfiguration, CommandProp
 }
 
 export interface ProcessTaskInfo extends TaskInfo {
-    /** terminal id. Defined if task is run as a terminal process */
-    readonly terminalId?: number;
     /** process id. Defined if task is run as a process */
     readonly processId?: number;
+    /** process task command */
+    readonly command?: string;
 }
 export namespace ProcessTaskInfo {
     export function is(info: TaskInfo): info is ProcessTaskInfo {
-        return info['terminalId'] !== undefined || info['processId'] !== undefined;
+        return info['processId'] !== undefined;
     }
 }
 

--- a/packages/task/src/common/task-protocol.ts
+++ b/packages/task/src/common/task-protocol.ts
@@ -40,6 +40,7 @@ export enum PanelKind {
 }
 
 export interface TaskOutputPresentation {
+    echo?: boolean;
     focus?: boolean;
     reveal?: RevealKind;
     panel?: PanelKind;
@@ -51,6 +52,7 @@ export interface TaskOutputPresentation {
 export namespace TaskOutputPresentation {
     export function getDefault(): TaskOutputPresentation {
         return {
+            echo: true,
             reveal: RevealKind.Always,
             focus: false,
             panel: PanelKind.Shared,
@@ -83,6 +85,7 @@ export namespace TaskOutputPresentation {
             }
             outputPresentation = {
                 ...outputPresentation,
+                echo: task.presentation.echo === undefined || task.presentation.echo,
                 focus: shouldSetFocusToTerminal(task),
                 showReuseMessage: shouldShowReuseMessage(task),
                 clear: shouldClearTerminalBeforeRun(task)

--- a/packages/task/src/node/process/process-task.ts
+++ b/packages/task/src/node/process/process-task.ts
@@ -48,6 +48,7 @@ export const TaskProcessOptions = Symbol('TaskProcessOptions');
 export interface TaskProcessOptions extends TaskOptions {
     process: Process;
     processType: ProcessType;
+    command?: string;
 }
 
 export const TaskFactory = Symbol('TaskFactory');
@@ -56,6 +57,8 @@ export type TaskFactory = (options: TaskProcessOptions) => ProcessTask;
 /** Represents a Task launched as a process by `ProcessTaskRunner`. */
 @injectable()
 export class ProcessTask extends Task {
+
+    protected command: string | undefined;
 
     constructor(
         @inject(TaskManager) protected readonly taskManager: TaskManager,
@@ -92,6 +95,8 @@ export class ProcessTask extends Task {
                 });
             }
         });
+
+        this.command = this.options.command;
         this.logger.info(`Created new task, id: ${this.id}, process id: ${this.options.process.id}, OS PID: ${this.process.pid}, context: ${this.context}`);
     }
 
@@ -128,6 +133,7 @@ export class ProcessTask extends Task {
             config: this.options.config,
             terminalId: this.process.id,
             processId: this.process.id,
+            command: this.command
         };
     }
 


### PR DESCRIPTION
- add the suppport of having `echo` property in the `presentation` object in the task configuration. When `echo` is false, Theia does not print the executed command in the terminal.

- resolves #5332

Signed-off-by: Liang Huang <lhuang4@ualberta.ca>


#### How to test

1. Start a task whose configuration does not have the `presentation` or `presentation.echo` defined. Verify that the executed command should be printed as the first line of the terminal.

2. add `presentation.echo = false` to the task config, rerun the task. Verify that the executed command should NOT be printed in the terminal.

3. Verify the Theia behavior for 
- both `shell` and `process` tasks.
- both configured and detected tasks.

![Peek 2020-04-05 17-15](https://user-images.githubusercontent.com/37082801/78510302-394bf100-7762-11ea-9817-97cef9cf9c93.gif)


#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)
