### PR TITLE
Show file changes as a tree in Source Control view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## v1.2.0
+
+Breaking changes:
+
+- [scm] support file tree mode in Source Control view.  Classes that extend ScmWidget will likely require changes [#7505](https://github.com/eclipse-theia/theia/pull/7505)
+
 ## v1.1.0
 
 - [application-manager] added meta tag to enable fullscreen on iOS devices [#7663](https://github.com/eclipse-theia/theia/pull/7663)

--- a/packages/plugin-ext/src/main/browser/menus/menus-contribution-handler.ts
+++ b/packages/plugin-ext/src/main/browser/menus/menus-contribution-handler.ts
@@ -31,6 +31,7 @@ import { DebugStackFramesWidget } from '@theia/debug/lib/browser/view/debug-stac
 import { DebugThreadsWidget } from '@theia/debug/lib/browser/view/debug-threads-widget';
 import { TreeWidgetSelection } from '@theia/core/lib/browser/tree/tree-widget-selection';
 import { ScmWidget } from '@theia/scm/lib/browser/scm-widget';
+import { ScmTreeWidget } from '@theia/scm/lib/browser/scm-tree-widget';
 import { ScmService } from '@theia/scm/lib/browser/scm-service';
 import { ScmRepository } from '@theia/scm/lib/browser/scm-repository';
 import { PluginScmProvider, PluginScmResourceGroup, PluginScmResource } from '../scm-main';
@@ -131,13 +132,19 @@ export class MenusContributionPointHandler {
             } else if (location === 'scm/resourceGroup/context') {
                 for (const menu of allMenus[location]) {
                     const inline = menu.group && /^inline/.test(menu.group) || false;
-                    const menuPath = inline ? ScmWidget.RESOURCE_GROUP_INLINE_MENU : ScmWidget.RESOURCE_GROUP_CONTEXT_MENU;
+                    const menuPath = inline ? ScmTreeWidget.RESOURCE_GROUP_INLINE_MENU : ScmTreeWidget.RESOURCE_GROUP_CONTEXT_MENU;
+                    toDispose.push(this.registerScmMenuAction(menuPath, menu));
+                }
+            } else if (location === 'scm/resourceFolder/context') {
+                for (const menu of allMenus[location]) {
+                    const inline = menu.group && /^inline/.test(menu.group) || false;
+                    const menuPath = inline ? ScmTreeWidget.RESOURCE_FOLDER_INLINE_MENU : ScmTreeWidget.RESOURCE_FOLDER_CONTEXT_MENU;
                     toDispose.push(this.registerScmMenuAction(menuPath, menu));
                 }
             } else if (location === 'scm/resourceState/context') {
                 for (const menu of allMenus[location]) {
                     const inline = menu.group && /^inline/.test(menu.group) || false;
-                    const menuPath = inline ? ScmWidget.RESOURCE_INLINE_MENU : ScmWidget.RESOURCE_CONTEXT_MENU;
+                    const menuPath = inline ? ScmTreeWidget.RESOURCE_INLINE_MENU : ScmTreeWidget.RESOURCE_CONTEXT_MENU;
                     toDispose.push(this.registerScmMenuAction(menuPath, menu));
                 }
             } else if (location === 'debug/callstack/context') {

--- a/packages/scm/src/browser/scm-amend-component.tsx
+++ b/packages/scm/src/browser/scm-amend-component.tsx
@@ -25,7 +25,6 @@ import { ScmRepository } from './scm-repository';
 import { ScmAmendSupport, ScmCommit } from './scm-provider';
 
 export interface ScmAmendComponentProps {
-    id: string,
     style: React.CSSProperties | undefined,
     repository: ScmRepository,
     scmAmendSupport: ScmAmendSupport,
@@ -288,7 +287,7 @@ export class ScmAmendComponent extends React.Component<ScmAmendComponentProps, S
             };
 
         return (
-            <div className={ScmAmendComponent.Styles.COMMIT_CONTAINER + ' no-select'} style={style} id={this.props.id}>
+            <div className={ScmAmendComponent.Styles.COMMIT_CONTAINER + ' no-select'} style={style}>
                 {
                     this.state.amendingCommits.length > 0 || (this.state.lastCommit && this.state.transition.state !== 'none' && this.state.transition.direction === 'down')
                         ? this.renderAmendingCommits()
@@ -297,7 +296,7 @@ export class ScmAmendComponent extends React.Component<ScmAmendComponentProps, S
                 {
                     this.state.lastCommit ?
                         <div>
-                            <div id='lastCommit' className='changesContainer'>
+                            <div id='lastCommit' className='theia-scm-amend'>
                                 <div className='theia-header scm-theia-header'>
                                     HEAD Commit
                                 </div>

--- a/packages/scm/src/browser/scm-amend-widget.tsx
+++ b/packages/scm/src/browser/scm-amend-widget.tsx
@@ -1,0 +1,86 @@
+/********************************************************************************
+ * Copyright (C) 2020 Arm and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import { injectable, inject } from 'inversify';
+import { Message } from '@phosphor/messaging';
+import { SelectionService } from '@theia/core/lib/common';
+import * as React from 'react';
+import {
+    ContextMenuRenderer, ReactWidget, LabelProvider, KeybindingRegistry, StorageService
+} from '@theia/core/lib/browser';
+import { ScmService } from './scm-service';
+import { ScmAvatarService } from './scm-avatar-service';
+import { ScmAmendComponent } from './scm-amend-component';
+
+@injectable()
+export class ScmAmendWidget extends ReactWidget {
+
+    static ID = 'scm-amend-widget';
+
+    @inject(ScmService) protected readonly scmService: ScmService;
+    @inject(ScmAvatarService) protected readonly avatarService: ScmAvatarService;
+    @inject(StorageService) protected readonly storageService: StorageService;
+    @inject(SelectionService) protected readonly selectionService: SelectionService;
+    @inject(LabelProvider) protected readonly labelProvider: LabelProvider;
+    @inject(KeybindingRegistry) protected readonly keybindings: KeybindingRegistry;
+
+    protected shouldScrollToRow = true;
+
+    constructor(
+        @inject(ContextMenuRenderer) protected readonly contextMenuRenderer: ContextMenuRenderer,
+    ) {
+        super();
+        this.scrollOptions = {
+            suppressScrollX: true,
+            minScrollbarLength: 35
+        };
+        this.addClass('theia-scm-commit-container');
+        this.id = ScmAmendWidget.ID;
+    }
+
+    protected onUpdateRequest(msg: Message): void {
+        if (!this.isAttached || !this.isVisible) {
+            return;
+        }
+        super.onUpdateRequest(msg);
+    }
+
+    protected render(): React.ReactNode {
+        const repository = this.scmService.selectedRepository;
+        if (repository && repository.provider.amendSupport) {
+            return React.createElement(
+                ScmAmendComponent,
+                {
+                    key: `amend:${repository.provider.rootUri}`,
+                    style: { flexGrow: 0 },
+                    repository: repository,
+                    scmAmendSupport: repository.provider.amendSupport,
+                    setCommitMessage: this.setInputValue,
+                    avatarService: this.avatarService,
+                    storageService: this.storageService,
+                }
+            );
+        }
+    }
+
+    protected setInputValue = (event: React.FormEvent<HTMLTextAreaElement> | React.ChangeEvent<HTMLTextAreaElement> | string) => {
+        const repository = this.scmService.selectedRepository;
+        if (repository) {
+            repository.input.value = typeof event === 'string' ? event : event.currentTarget.value;
+        }
+    };
+
+}

--- a/packages/scm/src/browser/scm-commit-widget.tsx
+++ b/packages/scm/src/browser/scm-commit-widget.tsx
@@ -1,0 +1,164 @@
+/********************************************************************************
+ * Copyright (C) 2018 TypeFox and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import { injectable, inject } from 'inversify';
+import { Message } from '@phosphor/messaging';
+import { SelectionService } from '@theia/core/lib/common';
+import * as React from 'react';
+import TextareaAutosize from 'react-autosize-textarea';
+import { ScmInput } from './scm-input';
+import {
+    ContextMenuRenderer, ReactWidget, LabelProvider, KeybindingRegistry, StatefulWidget} from '@theia/core/lib/browser';
+import { ScmService } from './scm-service';
+
+@injectable()
+export class ScmCommitWidget extends ReactWidget implements StatefulWidget {
+
+    static ID = 'scm-commit-widget';
+
+    @inject(ScmService) protected readonly scmService: ScmService;
+    @inject(SelectionService) protected readonly selectionService: SelectionService;
+    @inject(LabelProvider) protected readonly labelProvider: LabelProvider;
+    @inject(KeybindingRegistry) protected readonly keybindings: KeybindingRegistry;
+
+    protected shouldScrollToRow = true;
+
+    /** don't modify DOM use React! only exposed for `focusInput` */
+    protected readonly inputRef = React.createRef<HTMLTextAreaElement>();
+
+    constructor(
+        @inject(ContextMenuRenderer) protected readonly contextMenuRenderer: ContextMenuRenderer,
+    ) {
+        super();
+        this.scrollOptions = {
+            suppressScrollX: true,
+            minScrollbarLength: 35
+        };
+        this.addClass('theia-scm-commit');
+        this.id = ScmCommitWidget.ID;
+    }
+
+    protected onActivateRequest(msg: Message): void {
+        super.onActivateRequest(msg);
+        this.focus();
+    }
+
+    public focus(): void {
+        (this.inputRef.current || this.node).focus();
+    }
+
+    protected onUpdateRequest(msg: Message): void {
+        if (!this.isAttached || !this.isVisible) {
+            return;
+        }
+        super.onUpdateRequest(msg);
+    }
+
+    protected render(): React.ReactNode {
+        const repository = this.scmService.selectedRepository;
+        if (repository) {
+            return React.createElement('div', this.createContainerAttributes(), this.renderInput(repository.input));
+        }
+    }
+
+    /**
+     * Create the container attributes for the widget.
+     */
+    protected createContainerAttributes(): React.HTMLAttributes<HTMLElement> {
+        return {
+            style: { flexGrow: 0 }
+        };
+    }
+
+    protected renderInput(input: ScmInput): React.ReactNode {
+        const validationStatus = input.issue ? input.issue.type : 'idle';
+        const validationMessage = input.issue ? input.issue.message : '';
+        const format = (value: string, ...args: string[]): string => {
+            if (args.length !== 0) {
+                return value.replace(/{(\d+)}/g, (found, n) => {
+                    const i = parseInt(n);
+                    return isNaN(i) || i < 0 || i >= args.length ? found : args[i];
+                });
+            }
+            return value;
+        };
+
+        const keybinding = this.keybindings.acceleratorFor(this.keybindings.getKeybindingsForCommand('scm.acceptInput')[0]).join('+');
+        const message = format(input.placeholder || '', keybinding);
+        return <div className={ScmCommitWidget.Styles.INPUT_MESSAGE_CONTAINER}>
+            <TextareaAutosize
+                className={`${ScmCommitWidget.Styles.INPUT_MESSAGE} theia-input theia-scm-input-message-${validationStatus}`}
+                id={ScmCommitWidget.Styles.INPUT_MESSAGE}
+                placeholder={message}
+                autoFocus={true}
+                value={input.value}
+                onChange={this.setInputValue}
+                ref={this.inputRef}
+                rows={1}
+                maxRows={6} /* from VS Code */>
+            </TextareaAutosize>
+            <div
+                className={
+                    `${ScmCommitWidget.Styles.VALIDATION_MESSAGE} ${ScmCommitWidget.Styles.NO_SELECT}
+                    theia-scm-validation-message-${validationStatus} theia-scm-input-message-${validationStatus}`
+                }
+                style={{
+                    display: !!input.issue ? 'block' : 'none'
+                }}>{validationMessage}</div>
+        </div>;
+    }
+
+    protected setInputValue = (event: React.FormEvent<HTMLTextAreaElement> | React.ChangeEvent<HTMLTextAreaElement> | string) => {
+        const repository = this.scmService.selectedRepository;
+        if (repository) {
+            repository.input.value = typeof event === 'string' ? event : event.currentTarget.value;
+        }
+    };
+
+    /**
+     * Store the tree state.
+     */
+    storeState(): object {
+        const message = this.inputRef.current ? this.inputRef.current.value : '';
+        const state: object = {
+            message
+        };
+        return state;
+    }
+
+    /**
+     * Restore the state.
+     * @param oldState the old state object.
+     */
+    restoreState(oldState: object): void {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const { message } = (oldState as any);
+        if (message && this.inputRef.current) {
+            this.inputRef.current.value = message;
+        }
+    }
+
+}
+
+export namespace ScmCommitWidget {
+
+    export namespace Styles {
+        export const INPUT_MESSAGE_CONTAINER = 'theia-scm-input-message-container';
+        export const INPUT_MESSAGE = 'theia-scm-input-message';
+        export const VALIDATION_MESSAGE = 'theia-scm-input-validation-message';
+        export const NO_SELECT = 'no-select';
+    }
+}

--- a/packages/scm/src/browser/scm-no-repository-widget.tsx
+++ b/packages/scm/src/browser/scm-no-repository-widget.tsx
@@ -1,0 +1,40 @@
+/********************************************************************************
+ * Copyright (C) 2020 Arm and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import { injectable } from 'inversify';
+import * as React from 'react';
+import { ReactWidget } from '@theia/core/lib/browser';
+import { AlertMessage } from '@theia/core/lib/browser/widgets/alert-message';
+
+@injectable()
+export class ScmNoRepositoryWidget extends ReactWidget {
+
+    static ID = 'scm-no-repository-widget';
+
+    constructor() {
+        super();
+        this.addClass('theia-scm-no-repository');
+        this.id = ScmNoRepositoryWidget.ID;
+    }
+
+    protected render(): React.ReactNode {
+        return <AlertMessage
+            type='WARNING'
+            header='No repository found'
+        />;
+    }
+
+}

--- a/packages/scm/src/browser/scm-provider.ts
+++ b/packages/scm/src/browser/scm-provider.ts
@@ -35,6 +35,7 @@ export interface ScmProvider extends Disposable {
     readonly amendSupport?: ScmAmendSupport;
 }
 
+export const ScmResourceGroup = Symbol('ScmResourceGroup');
 export interface ScmResourceGroup extends Disposable {
     readonly id: string;
     readonly label: string;

--- a/packages/scm/src/browser/scm-repository.ts
+++ b/packages/scm/src/browser/scm-repository.ts
@@ -14,11 +14,9 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
-/* eslint-disable @typescript-eslint/no-explicit-any */
-
 import { Disposable, DisposableCollection, Emitter } from '@theia/core/lib/common';
 import { ScmInput, ScmInputOptions } from './scm-input';
-import { ScmProvider, ScmResource } from './scm-provider';
+import { ScmProvider } from './scm-provider';
 
 export interface ScmProviderOptions {
     input?: ScmInputOptions
@@ -42,63 +40,13 @@ export class ScmRepository implements Disposable {
     ) {
         this.toDispose.pushAll([
             this.provider,
-            this.provider.onDidChange(() => this.updateResources()),
             this.input = new ScmInput(options.input),
             this.input.onDidChange(() => this.fireDidChange())
         ]);
-        this.updateResources();
     }
 
     dispose(): void {
         this.toDispose.dispose();
-    }
-
-    // TODO replace by TreeModel
-    protected readonly _resources: ScmResource[] = [];
-    get resources(): ScmResource[] {
-        return this._resources;
-    }
-    protected updateResources(): void {
-        this._resources.length = 0;
-        for (const group of this.provider.groups) {
-            this._resources.push(...group.resources);
-        }
-        this.updateSelection();
-    }
-
-    protected selectedIndex: number = -1;
-    get selectedResource(): ScmResource | undefined {
-        return this._resources[this.selectedIndex];
-    }
-    set selectedResource(selectedResource: ScmResource | undefined) {
-        this.selectedIndex = selectedResource ? this._resources.indexOf(selectedResource) : -1;
-        this.fireDidChange();
-    }
-    protected updateSelection(): void {
-        this.selectedResource = this.selectedResource;
-    }
-
-    selectNextResource(): ScmResource | undefined {
-        const lastIndex = this._resources.length - 1;
-        if (this.selectedIndex >= 0 && this.selectedIndex < lastIndex) {
-            this.selectedIndex++;
-            this.fireDidChange();
-        } else if (this._resources.length && (this.selectedIndex === -1 || this.selectedIndex === lastIndex)) {
-            this.selectedIndex = 0;
-            this.fireDidChange();
-        }
-        return this.selectedResource;
-    }
-
-    selectPreviousResource(): ScmResource | undefined {
-        if (this.selectedIndex > 0) {
-            this.selectedIndex--;
-            this.fireDidChange();
-        } else if (this.selectedIndex === 0) {
-            this.selectedIndex = this._resources.length - 1;
-            this.fireDidChange();
-        }
-        return this.selectedResource;
     }
 
 }

--- a/packages/scm/src/browser/scm-service.ts
+++ b/packages/scm/src/browser/scm-service.ts
@@ -66,9 +66,7 @@ export class ScmService {
         }
         this.toDisposeOnSelected.dispose();
         this._selectedRepository = repository;
-        this.updateContextKeys();
         if (this._selectedRepository) {
-            this.toDisposeOnSelected.push(this._selectedRepository.onDidChange(() => this.updateContextKeys()));
             if (this._selectedRepository.provider.onDidChangeStatusBarCommands) {
                 this.toDisposeOnSelected.push(this._selectedRepository.provider.onDidChangeStatusBarCommands(() => this.fireDidChangeStatusBarCommands()));
             }
@@ -105,16 +103,6 @@ export class ScmService {
             this.selectedRepository = repository;
         }
         return repository;
-    }
-
-    protected updateContextKeys(): void {
-        if (this._selectedRepository) {
-            this.contextKeys.scmProvider.set(this._selectedRepository.provider.id);
-            this.contextKeys.scmResourceGroup.set(this._selectedRepository.selectedResource && this._selectedRepository.selectedResource.group.id);
-        } else {
-            this.contextKeys.scmProvider.reset();
-            this.contextKeys.scmResourceGroup.reset();
-        }
     }
 
 }

--- a/packages/scm/src/browser/scm-tree-label-provider.ts
+++ b/packages/scm/src/browser/scm-tree-label-provider.ts
@@ -1,0 +1,35 @@
+/********************************************************************************
+ * Copyright (C) 2020 Arm and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import { inject, injectable } from 'inversify';
+import URI from '@theia/core/lib/common/uri';
+import { LabelProviderContribution, LabelProvider } from '@theia/core/lib/browser/label-provider';
+import { TreeNode } from '@theia/core/lib/browser/tree';
+import { ScmFileChangeFolderNode, ScmFileChangeNode } from './scm-tree-model';
+
+@injectable()
+export class ScmTreeLabelProvider implements LabelProviderContribution {
+
+    @inject(LabelProvider) protected readonly labelProvider: LabelProvider;
+
+    canHandle(element: object): number {
+        return TreeNode.is(element) && (ScmFileChangeFolderNode.is(element) || ScmFileChangeNode.is(element)) ? 60 : 0;
+    }
+
+    getName(node: ScmFileChangeFolderNode | ScmFileChangeNode): string {
+        return this.labelProvider.getName(new URI(node.sourceUri));
+    }
+}

--- a/packages/scm/src/browser/scm-tree-model.ts
+++ b/packages/scm/src/browser/scm-tree-model.ts
@@ -1,0 +1,301 @@
+/********************************************************************************
+ * Copyright (C) 2020 Arm and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import { injectable, inject } from 'inversify';
+import { DisposableCollection } from '@theia/core/lib/common/disposable';
+import { TreeModelImpl, TreeNode, TreeProps, CompositeTreeNode, SelectableTreeNode, ExpandableTreeNode } from '@theia/core/lib/browser/tree';
+import URI from '@theia/core/lib/common/uri';
+import { ScmResourceGroup, ScmResource, ScmResourceDecorations } from './scm-provider';
+import { ScmRepository } from './scm-repository';
+import { ScmProvider } from './scm-provider';
+
+export const ScmTreeModelProps = Symbol('ScmTreeModelProps');
+export interface ScmTreeModelProps {
+    defaultExpansion?: 'collapsed' | 'expanded';
+    nestingThreshold?: number;
+}
+
+export interface ScmFileChangeRootNode extends CompositeTreeNode {
+    rootUri: string;
+    children: ScmFileChangeGroupNode[];
+}
+
+export interface ScmFileChangeGroupNode extends ExpandableTreeNode {
+    groupId: string;
+    children: (ScmFileChangeFolderNode | ScmFileChangeNode)[];
+}
+
+export namespace ScmFileChangeGroupNode {
+    export function is(node: TreeNode): node is ScmFileChangeGroupNode {
+        return 'groupId' in node && 'children' in node
+            && !ScmFileChangeFolderNode.is(node);
+    }
+}
+
+export interface ScmFileChangeFolderNode extends ExpandableTreeNode, SelectableTreeNode {
+    groupId: string;
+    path: string;
+    sourceUri: string;
+    children: (ScmFileChangeFolderNode | ScmFileChangeNode)[];
+}
+
+export namespace ScmFileChangeFolderNode {
+    export function is(node: TreeNode): node is ScmFileChangeFolderNode {
+        return 'groupId' in node && 'sourceUri' in node && 'path' in node && 'children' in node;
+    }
+}
+
+export interface ScmFileChangeNode extends SelectableTreeNode {
+    sourceUri: string;
+    decorations?: ScmResourceDecorations;
+}
+
+export namespace ScmFileChangeNode {
+    export function is(node: TreeNode): node is ScmFileChangeNode {
+        return 'sourceUri' in node
+            && !ScmFileChangeFolderNode.is(node);
+    }
+}
+
+@injectable()
+export class ScmTreeModel extends TreeModelImpl {
+
+    private _languageId: string | undefined;
+
+    protected readonly toDisposeOnRepositoryChange = new DisposableCollection();
+
+    @inject(TreeProps) protected readonly props: ScmTreeModelProps;
+
+    get languageId(): string | undefined {
+        return this._languageId;
+    }
+
+    protected _viewMode: 'tree' | 'flat' = 'flat';
+    set viewMode(id: 'tree' | 'flat') {
+        const oldSelection = this.selectedNodes;
+        this._viewMode = id;
+        if (this._provider) {
+            this.root = this.createTree();
+
+            for (const oldSelectedNode of oldSelection) {
+                const newNode = this.getNode(oldSelectedNode.id);
+                if (SelectableTreeNode.is(newNode)) {
+                    this.revealNode(newNode);  // this call can run asynchronously
+                }
+            }
+        }
+    }
+    get viewMode(): 'tree' | 'flat' {
+        return this._viewMode;
+    }
+
+    protected _provider: ScmProvider | undefined;
+    set repository(repository: ScmRepository | undefined) {
+        this.toDisposeOnRepositoryChange.dispose();
+        if (repository) {
+            this._provider = repository.provider;
+            if (this._provider) {
+                this.toDisposeOnRepositoryChange.push(this._provider.onDidChange(() => {
+                    this.root = this.createTree();
+                }));
+            }
+        } else {
+            this._provider = undefined;
+        }
+        this.root = this.createTree();
+    }
+
+    protected createTree(): ScmFileChangeRootNode | undefined {
+        if (!this._provider) {
+            return;
+        }
+        const root = {
+            id: 'file-change-tree-root',
+            parent: undefined,
+            visible: false,
+            rootUri: this._provider.rootUri,
+            children: []
+        } as ScmFileChangeRootNode;
+
+        const { groups } = this._provider;
+        const groupNodes = groups
+            .filter(group => !!group.resources.length || !group.hideWhenEmpty)
+            .map(group => this.toGroupNode(group, root));
+        root.children = groupNodes;
+
+        return root;
+    }
+
+    protected toGroupNode(group: ScmResourceGroup, parent: CompositeTreeNode): ScmFileChangeGroupNode {
+        const groupNode: ScmFileChangeGroupNode = {
+            id: `${group.id}`,
+            groupId: group.id,
+            parent,
+            children: [],
+            expanded: true,
+        };
+
+        switch (this._viewMode) {
+            case 'flat':
+                groupNode.children = group.resources.map(fileChange => this.toFileChangeNode(fileChange, groupNode));
+                break;
+            case 'tree':
+                const rootUri = group.provider.rootUri;
+                if (rootUri) {
+                    const resourcePaths = group.resources.map(resource => {
+                        const relativePath = new URI(rootUri).relative(resource.sourceUri);
+                        const pathParts = relativePath ? relativePath.toString().split('/') : [];
+                        return { resource, pathParts };
+                    });
+                    groupNode.children = this.buildFileChangeTree(resourcePaths, 0, group.resources.length, 0, groupNode);
+                }
+                break;
+        }
+
+        return groupNode;
+    }
+
+    protected buildFileChangeTree(
+        resources: { resource: ScmResource, pathParts: string[] }[],
+        start: number,
+        end: number,
+        level: number,
+        parent: (ScmFileChangeGroupNode | ScmFileChangeFolderNode)
+    ): (ScmFileChangeFolderNode | ScmFileChangeNode)[] {
+        const result: (ScmFileChangeFolderNode | ScmFileChangeNode)[] = [];
+
+        let folderStart = start;
+        while (folderStart < end) {
+            const firstFileChange = resources[folderStart];
+            if (level === firstFileChange.pathParts.length - 1) {
+                result.push(this.toFileChangeNode(firstFileChange.resource, parent));
+                folderStart++;
+            } else {
+                let index = folderStart + 1;
+                while (index < end) {
+                    if (resources[index].pathParts[level] !== firstFileChange.pathParts[level]) {
+                        break;
+                    }
+                    index++;
+                }
+                const folderEnd = index;
+
+                const nestingThreshold = this.props.nestingThreshold || 1;
+                if (folderEnd - folderStart < nestingThreshold) {
+                    // Inline these (i.e. do not create another level in the tree)
+                    for (let i = folderStart; i < folderEnd; i++) {
+                        result.push(this.toFileChangeNode(resources[i].resource, parent));
+                    }
+                } else {
+                    const firstFileParts = firstFileChange.pathParts;
+                    const lastFileParts = resources[folderEnd - 1].pathParts;
+                    // Multiple files with first folder.
+                    // See if more folder levels match and include those if so.
+                    let thisLevel = level + 1;
+                    while (thisLevel < firstFileParts.length - 1 && thisLevel < lastFileParts.length - 1 && firstFileParts[thisLevel] === lastFileParts[thisLevel]) {
+                        thisLevel++;
+                    }
+                    const nodeRelativePath = firstFileParts.slice(level, thisLevel).join('/');
+                    result.push(this.toFileChangeFolderNode(resources, folderStart, folderEnd, thisLevel, nodeRelativePath, parent));
+                }
+                folderStart = folderEnd;
+            }
+        };
+        return result.sort(this.compareNodes);
+    }
+
+    protected compareNodes = (a: ScmFileChangeFolderNode | ScmFileChangeNode, b: ScmFileChangeFolderNode | ScmFileChangeNode) => this.doCompareNodes(a, b);
+    protected doCompareNodes(a: ScmFileChangeFolderNode | ScmFileChangeNode, b: ScmFileChangeFolderNode | ScmFileChangeNode): number {
+        const isFolderA = ScmFileChangeFolderNode.is(a);
+        const isFolderB = ScmFileChangeFolderNode.is(b);
+        if (isFolderA && !isFolderB) {
+            return -1;
+        }
+        if (isFolderB && !isFolderA) {
+            return 1;
+        }
+        return a.sourceUri.localeCompare(b.sourceUri);
+    }
+
+    protected toFileChangeFolderNode(
+        resources: { resource: ScmResource, pathParts: string[] }[],
+        start: number,
+        end: number,
+        level: number,
+        nodeRelativePath: string,
+        parent: (ScmFileChangeGroupNode | ScmFileChangeFolderNode)
+    ): ScmFileChangeFolderNode {
+        const rootUri = this.getRoot(parent).rootUri;
+        let parentPath: string = rootUri;
+        if (ScmFileChangeFolderNode.is(parent)) {
+            parentPath = parent.sourceUri;
+        }
+        const sourceUri = new URI(parentPath).resolve(nodeRelativePath);
+
+        const defaultExpansion = this.props.defaultExpansion ? (this.props.defaultExpansion === 'expanded') : true;
+        const id = `${parent.groupId}:${String(sourceUri)}`;
+        const oldNode = this.getNode(id);
+        const folderNode: ScmFileChangeFolderNode = {
+                id,
+                groupId: parent.groupId,
+                path: nodeRelativePath,
+                sourceUri: String(sourceUri),
+                children: [],
+                parent,
+                expanded: ExpandableTreeNode.is(oldNode) ? oldNode.expanded : defaultExpansion,
+                selected: SelectableTreeNode.is(oldNode) && oldNode.selected,
+        };
+        folderNode.children = this.buildFileChangeTree(resources, start, end, level, folderNode);
+        return folderNode;
+    }
+
+    protected getRoot(node: ScmFileChangeGroupNode | ScmFileChangeFolderNode): ScmFileChangeRootNode {
+        let parent = node.parent!;
+        while (ScmFileChangeGroupNode.is(parent) && ScmFileChangeFolderNode.is(parent)) {
+            parent = parent.parent!;
+        }
+        return parent as ScmFileChangeRootNode;
+    }
+
+    protected toFileChangeNode(resource: ScmResource, parent: CompositeTreeNode): ScmFileChangeNode {
+        const id = `${resource.group.id}:${String(resource.sourceUri)}`;
+        const oldNode = this.getNode(id);
+        const node = {
+            id,
+            sourceUri: String(resource.sourceUri),
+            decorations: resource.decorations,
+            parent,
+            selected: SelectableTreeNode.is(oldNode) && oldNode.selected,
+        };
+        if (node.selected) {
+            this.selectionService.addSelection(node);
+        }
+        return node;
+    }
+
+    protected async revealNode(node: TreeNode): Promise<void> {
+        if (ScmFileChangeFolderNode.is(node) || ScmFileChangeNode.is(node)) {
+            const parentNode = node.parent;
+            if (ExpandableTreeNode.is(parentNode)) {
+            await this.revealNode(parentNode);
+                if (!parentNode.expanded) {
+                    await this.expandNode(parentNode);
+                }
+            }
+        }
+    }
+
+}

--- a/packages/scm/src/browser/scm-tree-widget.tsx
+++ b/packages/scm/src/browser/scm-tree-widget.tsx
@@ -1,0 +1,738 @@
+/********************************************************************************
+ * Copyright (C) 2020 Arm and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+/* eslint-disable no-null/no-null, @typescript-eslint/no-explicit-any */
+
+import * as React from 'react';
+import { injectable, inject, postConstruct } from 'inversify';
+import URI from '@theia/core/lib/common/uri';
+import { DisposableCollection, Disposable } from '@theia/core/lib/common/disposable';
+import { TreeWidget, TreeNode, TreeProps, NodeProps, TREE_NODE_SEGMENT_GROW_CLASS } from '@theia/core/lib/browser/tree';
+import { ScmTreeModel } from './scm-tree-model';
+import { MenuModelRegistry, ActionMenuNode, CompositeMenuNode, MenuPath } from '@theia/core/lib/common/menu';
+import { ScmResourceGroup, ScmResource, ScmResourceDecorations } from './scm-provider';
+import { ScmService } from './scm-service';
+import { CommandRegistry } from '@theia/core/lib/common/command';
+import { ScmRepository } from './scm-repository';
+import { ContextMenuRenderer, LabelProvider, CorePreferences, DiffUris} from '@theia/core/lib/browser';
+import { ScmContextKeyService } from './scm-context-key-service';
+import { EditorWidget } from '@theia/editor/lib/browser';
+import { EditorManager, DiffNavigatorProvider } from '@theia/editor/lib/browser';
+import { FileStat } from '@theia/filesystem/lib/common';
+import { IconThemeService } from '@theia/core/lib/browser/icon-theme-service';
+import { ScmFileChangeGroupNode, ScmFileChangeFolderNode, ScmFileChangeNode } from './scm-tree-model';
+
+@injectable()
+export class ScmTreeWidget extends TreeWidget {
+
+    static ID = 'scm-resource-widget';
+
+    static RESOURCE_GROUP_CONTEXT_MENU = ['RESOURCE_GROUP_CONTEXT_MENU'];
+    static RESOURCE_GROUP_INLINE_MENU = ['RESOURCE_GROUP_INLINE_MENU'];
+
+    static RESOURCE_FOLDER_CONTEXT_MENU = ['RESOURCE_FOLDER_CONTEXT_MENU'];
+    static RESOURCE_FOLDER_INLINE_MENU = ['RESOURCE_FOLDER_INLINE_MENU'];
+
+    static RESOURCE_INLINE_MENU = ['RESOURCE_INLINE_MENU'];
+    static RESOURCE_CONTEXT_MENU = ['RESOURCE_CONTEXT_MENU'];
+
+    @inject(MenuModelRegistry) protected readonly menus: MenuModelRegistry;
+    @inject(CommandRegistry) protected readonly commands: CommandRegistry;
+    @inject(CorePreferences) protected readonly corePreferences: CorePreferences;
+    @inject(ScmContextKeyService) protected readonly contextKeys: ScmContextKeyService;
+    @inject(EditorManager) protected readonly editorManager: EditorManager;
+    @inject(DiffNavigatorProvider) protected readonly diffNavigatorProvider: DiffNavigatorProvider;
+    @inject(IconThemeService) protected readonly iconThemeService: IconThemeService;
+
+    constructor(
+        @inject(TreeProps) readonly props: TreeProps,
+        @inject(ScmTreeModel) readonly model: ScmTreeModel,
+        @inject(ContextMenuRenderer) protected readonly contextMenuRenderer: ContextMenuRenderer,
+        @inject(ScmService) protected readonly scmService: ScmService,
+    ) {
+        super(props, model, contextMenuRenderer);
+        this.id = 'resource_widget';
+    }
+
+    @postConstruct()
+    protected init(): void {
+        super.init();
+        this.addClass('groups-outer-container');
+
+        this.refreshOnRepositoryChange();
+        this.toDispose.push(this.scmService.onDidChangeSelectedRepository(() => {
+            this.refreshOnRepositoryChange();
+            this.forceUpdate();
+        }));
+    }
+
+    set viewMode(id: 'tree' | 'flat') {
+        this.model.viewMode = id;
+    }
+    get viewMode(): 'tree' | 'flat' {
+        return this.model.viewMode;
+    }
+
+    protected refreshOnRepositoryChange(): void {
+        const repository = this.scmService.selectedRepository;
+        this.model.repository = repository;
+        if (repository) {
+            this.contextKeys.scmProvider.set(repository.provider.id);
+        } else {
+            this.contextKeys.scmProvider.reset();
+        }
+    }
+
+    /**
+     * Render the node given the tree node and node properties.
+     * @param node the tree node.
+     * @param props the node properties.
+     */
+    protected renderNode(node: TreeNode, props: NodeProps): React.ReactNode {
+        const repository = this.scmService.selectedRepository;
+        if (!repository) {
+            return undefined;
+        }
+
+        if (!TreeNode.isVisible(node)) {
+            return undefined;
+        }
+
+        const attributes = this.createNodeAttributes(node, props);
+
+        if (ScmFileChangeGroupNode.is(node)) {
+            const group = repository.provider.groups.find(g => g.id === node.groupId)!;
+            const content = <ScmResourceGroupElement
+                key={`${node.groupId}`}
+                repository={repository}
+                group={group}
+                renderExpansionToggle={ () => this.renderExpansionToggle(node, props) }
+                contextMenuRenderer={this.contextMenuRenderer}
+                commands={this.commands}
+                menus={this.menus}
+                contextKeys={this.contextKeys}
+                labelProvider={this.labelProvider}
+                corePreferences={this.corePreferences} />;
+
+            return React.createElement('div', attributes, content);
+
+        }
+        if (ScmFileChangeFolderNode.is(node)) {
+            const group = repository.provider.groups.find(g => g.id === node.groupId)!;
+            const content = <ScmResourceFolderElement
+                key={String(node.sourceUri)}
+                repository={repository}
+                group={group}
+                path={node.path}
+                node={node}
+                sourceUri={new URI(node.sourceUri)}
+                renderExpansionToggle={ () => this.renderExpansionToggle(node, props) }
+                contextMenuRenderer={this.contextMenuRenderer}
+                commands={this.commands}
+                menus={this.menus}
+                contextKeys={this.contextKeys}
+                labelProvider={this.labelProvider}
+                corePreferences={this.corePreferences} />;
+
+            return React.createElement('div', attributes, content);
+        }
+        if (ScmFileChangeNode.is(node)) {
+            const parentNode = node.parent;
+            if (!(parentNode && (ScmFileChangeFolderNode.is(parentNode) || ScmFileChangeGroupNode.is(parentNode)))) {
+                return '';
+            }
+            const groupId = parentNode.groupId;
+            const group = repository.provider.groups.find(g => g.id === groupId)!;
+            const name = this.labelProvider.getName(new URI(node.sourceUri));
+            const parentPath =
+                (node.parent && ScmFileChangeFolderNode.is(node.parent))
+                ? new URI(node.parent.sourceUri) : new URI(repository.provider.rootUri);
+
+            const content = <ScmResourceComponent
+                key={node.sourceUri}
+                repository={repository}
+                contextMenuRenderer={this.contextMenuRenderer}
+                commands={this.commands}
+                menus={this.menus}
+                contextKeys={this.contextKeys}
+                labelProvider={this.labelProvider}
+                corePreferences={this.corePreferences}
+                {...{
+                    ...this.props,
+                    name,
+                    parentPath,
+                    group,
+                    sourceUri: node.sourceUri,
+                    decorations: node.decorations,
+                    renderExpansionToggle: () => this.renderExpansionToggle(node, props),
+                }}
+            />;
+            return React.createElement('div', attributes, content);
+        }
+        return super.renderNode(node, props);
+    }
+
+    protected createContainerAttributes(): React.HTMLAttributes<HTMLElement> {
+        const repository = this.scmService.selectedRepository;
+        if (repository) {
+            const select = () => {
+                const selectedResource = this.selectionService.selection;
+                if (!TreeNode.is(selectedResource) || !ScmFileChangeFolderNode.is(selectedResource) && !ScmFileChangeNode.is(selectedResource)) {
+                    const nonEmptyGroup = repository.provider.groups
+                        .find(g => g.resources.length !== 0);
+                    if (nonEmptyGroup) {
+                        this.selectionService.selection = nonEmptyGroup.resources[0];
+                    }
+                }
+            };
+            return {
+                ...super.createContainerAttributes(),
+                onFocus: select,
+                tabIndex: 0,
+                id: ScmTreeWidget.ID,
+            };
+        }
+        return super.createContainerAttributes();
+    }
+
+    /**
+     * The ARROW_LEFT key controls both the movement around the file tree and also
+     * the movement through the change chunks within a file.
+     *
+     * If the selected tree node is a folder then the ARROW_LEFT key behaves exactly
+     * as it does in explorer.  It collapses the tree node if the folder is expanded and
+     * it moves the selection up to the parent folder if the folder is collapsed (no-op if no parent folder, as
+     * group headers are not selectable).  This behavior is the default behavior implemented
+     * in the TreeWidget super class.
+     *
+     * If the selected tree node is a file then the ARROW_LEFT key moves up through the
+     * change chunks within each file.  If the selected chunk is the first chunk in the file
+     * then the file selection is moved to the previous file (no-op if no previous file).
+     *
+     * Note that when cursoring through change chunks, the ARROW_LEFT key cannot be used to
+     * move up through the parent folders of the file tree.  If users want to do this, using
+     * keys only, then they must press ARROW_UP repeatedly until the selected node is the folder
+     * node and then press ARROW_LEFT.
+     */
+    protected async handleLeft(event: KeyboardEvent): Promise<void> {
+        const repository = this.scmService.selectedRepository;
+        if (!repository) {
+            return;
+        }
+        if (this.model.selectedNodes.length === 1) {
+            const selectedNode = this.model.selectedNodes[0];
+            if (ScmFileChangeNode.is(selectedNode)) {
+                const selectedResource = this.getResourceFromNode(selectedNode);
+                if (!selectedResource) {
+                    return super.handleLeft(event);
+                }
+                const widget = await this.openResource(selectedResource);
+
+                if (widget) {
+                    const diffNavigator = this.diffNavigatorProvider(widget.editor);
+                    if (diffNavigator.canNavigate() && diffNavigator.hasPrevious()) {
+                        diffNavigator.previous();
+                    } else {
+                        const previousNode = this.moveToPreviousFileNode();
+                        if (previousNode) {
+                            const previousResource = this.getResourceFromNode(previousNode);
+                            if (previousResource) {
+                                this.openResource(previousResource);
+                            }
+                        }
+                    }
+                    return;
+                }
+            }
+        }
+        return super.handleLeft(event);
+    }
+
+    /**
+     * The ARROW_RIGHT key controls both the movement around the file tree and also
+     * the movement through the change chunks within a file.
+     *
+     * If the selected tree node is a folder then the ARROW_RIGHT key behaves exactly
+     * as it does in explorer.  It expands the tree node if the folder is collapsed and
+     * it moves the selection to the first child node if the folder is expanded.
+     * This behavior is the default behavior implemented
+     * in the TreeWidget super class.
+     *
+     * If the selected tree node is a file then the ARROW_RIGHT key moves down through the
+     * change chunks within each file.  If the selected chunk is the last chunk in the file
+     * then the file selection is moved to the next file (no-op if no next file).
+     */
+    protected async handleRight(event: KeyboardEvent): Promise<void> {
+        const repository = this.scmService.selectedRepository;
+        if (!repository) {
+            return;
+        }
+        if (this.model.selectedNodes.length === 1) {
+            const selectedNode = this.model.selectedNodes[0];
+            if (ScmFileChangeNode.is(selectedNode)) {
+                const selectedResource = this.getResourceFromNode(selectedNode);
+                if (!selectedResource) {
+                    return super.handleRight(event);
+                }
+                const widget = await this.openResource(selectedResource);
+
+                if (widget) {
+                    const diffNavigator = this.diffNavigatorProvider(widget.editor);
+                    if (diffNavigator.canNavigate() && diffNavigator.hasNext()) {
+                        diffNavigator.next();
+                    } else {
+                        const nextNode = this.moveToNextFileNode();
+                        if (nextNode) {
+                            const nextResource = this.getResourceFromNode(nextNode);
+                            if (nextResource) {
+                                this.openResource(nextResource);
+                            }
+                        }
+                    }
+                }
+                return;
+            }
+        }
+        return super.handleRight(event);
+    }
+
+    protected handleEnter(event: KeyboardEvent): void {
+        if (this.model.selectedNodes.length === 1) {
+            const selectedNode = this.model.selectedNodes[0];
+            if (ScmFileChangeNode.is(selectedNode)) {
+                const selectedResource = this.getResourceFromNode(selectedNode);
+                if (selectedResource) {
+                    this.openResource(selectedResource);
+                }
+                return;
+            }
+        }
+        super.handleEnter(event);
+    }
+
+    protected getResourceFromNode(node: ScmFileChangeNode): ScmResource | undefined {
+        const repository = this.scmService.selectedRepository;
+        if (!repository) {
+            return;
+        }
+        const parentNode = node.parent;
+        if (!(parentNode && (ScmFileChangeFolderNode.is(parentNode) || ScmFileChangeGroupNode.is(parentNode)))) {
+            return;
+        }
+        const groupId = parentNode.groupId;
+        const group = repository.provider.groups.find(g => g.id === groupId)!;
+        return group.resources.find(r => String(r.sourceUri) === node.sourceUri)!;
+    }
+
+    protected moveToPreviousFileNode(): ScmFileChangeNode | undefined {
+        let previousNode = this.model.getPrevSelectableNode();
+        while (previousNode) {
+            if (ScmFileChangeNode.is(previousNode)) {
+                this.model.selectNode(previousNode);
+                return previousNode;
+            }
+            this.model.selectNode(previousNode);
+            previousNode = this.model.getPrevSelectableNode();
+        };
+    }
+
+    protected moveToNextFileNode(): ScmFileChangeNode | undefined {
+        let nextNode = this.model.getNextSelectableNode();
+        while (nextNode) {
+            if (ScmFileChangeNode.is(nextNode)) {
+                this.model.selectNode(nextNode);
+                return nextNode;
+            }
+            this.model.selectNode(nextNode);
+            nextNode = this.model.getNextSelectableNode();
+        };
+    }
+
+    protected async openResource(resource: ScmResource): Promise<EditorWidget | undefined> {
+        try {
+            await resource.open();
+        } catch (e) {
+            console.error('Failed to open a SCM resource', e);
+            return undefined;
+        }
+
+        let standaloneEditor: EditorWidget | undefined;
+        const resourcePath = resource.sourceUri.path.toString();
+        for (const widget of this.editorManager.all) {
+            const resourceUri = widget.getResourceUri();
+            const editorResourcePath = resourceUri && resourceUri.path.toString();
+            if (resourcePath === editorResourcePath) {
+                if (widget.editor.uri.scheme === DiffUris.DIFF_SCHEME) {
+                    // prefer diff editor
+                    return widget;
+                } else {
+                    standaloneEditor = widget;
+                }
+            }
+            if (widget.editor.uri.scheme === DiffUris.DIFF_SCHEME
+                && String(widget.getResourceUri()) === resource.sourceUri.toString()) {
+                return widget;
+            }
+        }
+        // fallback to standalone editor
+        return standaloneEditor;
+    }
+
+    protected needsExpansionTogglePadding(node: TreeNode): boolean {
+        const theme = this.iconThemeService.getDefinition(this.iconThemeService.current);
+        if (theme && (theme.hidesExplorerArrows || (theme.hasFileIcons && !theme.hasFolderIcons))) {
+            return false;
+        }
+        return super.needsExpansionTogglePadding(node);
+    }
+
+    storeState(): any {
+        const state: object = {
+            mode: this.model.viewMode,
+            tree: super.storeState(),
+        };
+        return state;
+    }
+
+    restoreState(oldState: any): void {
+        const { mode, tree } = oldState;
+        this.model.viewMode = mode === 'tree' ? 'tree' : 'flat';
+        super.restoreState(tree);
+    }
+
+}
+
+export namespace ScmTreeWidget {
+    export namespace Styles {
+        export const NO_SELECT = 'no-select';
+    }
+
+    // This is an 'abstract' base interface for all the element component props.
+    export interface Props {
+        repository: ScmRepository;
+        commands: CommandRegistry;
+        menus: MenuModelRegistry;
+        contextKeys: ScmContextKeyService;
+        labelProvider: LabelProvider;
+        contextMenuRenderer: ContextMenuRenderer;
+        corePreferences?: CorePreferences;
+    }
+}
+
+export abstract class ScmElement<P extends ScmElement.Props = ScmElement.Props> extends React.Component<P, ScmElement.State> {
+
+    constructor(props: P) {
+        super(props);
+        this.state = {
+            hover: false
+        };
+
+        const setState = this.setState.bind(this);
+        this.setState = newState => {
+            if (!this.toDisposeOnUnmount.disposed) {
+                setState(newState);
+            }
+        };
+    }
+
+    protected readonly toDisposeOnUnmount = new DisposableCollection();
+    componentDidMount(): void {
+        this.toDisposeOnUnmount.push(Disposable.create(() => { /* mark as mounted */ }));
+    }
+    componentWillUnmount(): void {
+        this.toDisposeOnUnmount.dispose();
+    }
+
+    protected detectHover = (element: HTMLElement | null) => {
+        if (element) {
+            window.requestAnimationFrame(() => {
+                const hover = element.matches(':hover');
+                this.setState({ hover });
+            });
+        }
+    };
+    protected showHover = () => this.setState({ hover: true });
+    protected hideHover = () => this.setState({ hover: false });
+
+    protected renderContextMenu = (event: React.MouseEvent<HTMLElement>) => {
+        event.preventDefault();
+        const { group, contextKeys, contextMenuRenderer } = this.props;
+        const currentScmResourceGroup = contextKeys.scmResourceGroup.get();
+        contextKeys.scmResourceGroup.set(group.id);
+        try {
+            contextMenuRenderer.render({
+                menuPath: this.contextMenuPath,
+                anchor: event.nativeEvent,
+                args: this.contextMenuArgs
+            });
+        } finally {
+            contextKeys.scmResourceGroup.set(currentScmResourceGroup);
+        }
+    };
+
+    protected abstract get contextMenuPath(): MenuPath;
+    protected abstract get contextMenuArgs(): any[];
+
+}
+export namespace ScmElement {
+    export interface Props extends ScmTreeWidget.Props {
+        group: ScmResourceGroup
+        renderExpansionToggle: () => React.ReactNode
+    }
+    export interface State {
+        hover: boolean
+    }
+}
+
+export class ScmResourceComponent extends ScmElement<ScmResourceComponent.Props> {
+
+    render(): JSX.Element | undefined {
+        const { hover } = this.state;
+        const { name, group, parentPath, sourceUri, decorations, labelProvider, commands, menus, contextKeys } = this.props;
+        const resourceUri = new URI(sourceUri);
+
+        const icon = labelProvider.getIcon(resourceUri);
+        const color = decorations && decorations.color || '';
+        const letter = decorations && decorations.letter || '';
+        const tooltip = decorations && decorations.tooltip || '';
+        const relativePath = parentPath.relative(resourceUri.parent);
+        const path = relativePath ? relativePath.toString() : labelProvider.getLongName(resourceUri.parent);
+        return <div key={sourceUri}
+            className={`scmItem ${TREE_NODE_SEGMENT_GROW_CLASS}`}
+            onContextMenu={this.renderContextMenu}
+            onMouseEnter={this.showHover}
+            onMouseLeave={this.hideHover}
+            ref={this.detectHover}
+            onClick={this.handleClick}
+            onDoubleClick={this.handleDoubleClick} >
+            <span className={icon + ' file-icon'} />
+            {this.props.renderExpansionToggle()}
+            <div className={`noWrapInfo ${TREE_NODE_SEGMENT_GROW_CLASS}`} >
+                <span className='name'>{name}</span>
+                <span className='path'>{path}</span>
+            </div>
+            <ScmInlineActions {...{
+                hover,
+                menu: menus.getMenu(ScmTreeWidget.RESOURCE_INLINE_MENU),
+                args: this.contextMenuArgs,
+                commands,
+                contextKeys,
+                group
+            }}>
+                <div title={tooltip} className='status' style={{ color }}>
+                    {letter}
+                </div>
+            </ScmInlineActions>
+        </div >;
+    }
+
+    protected open = () => {
+        const selectedResource = this.props.group.resources.find(r => String(r.sourceUri) === this.props.sourceUri)!;
+        selectedResource.open();
+    };
+
+    protected readonly contextMenuPath = ScmTreeWidget.RESOURCE_CONTEXT_MENU;
+    protected get contextMenuArgs(): any[] {
+        const selectedResource = this.props.group.resources.find(r => String(r.sourceUri) === this.props.sourceUri)!;
+        return [selectedResource, false];  // TODO support multiselection
+    }
+
+    /**
+     * Handle the single clicking of nodes present in the widget.
+     */
+    protected handleClick = () => {
+        // Determine the behavior based on the preference value.
+        const isSingle = this.props.corePreferences && this.props.corePreferences['workbench.list.openMode'] === 'singleClick';
+        if (isSingle) {
+            this.open();
+        }
+    };
+
+    /**
+     * Handle the double clicking of nodes present in the widget.
+     */
+    protected handleDoubleClick = () => {
+        // Determine the behavior based on the preference value.
+        const isDouble = this.props.corePreferences && this.props.corePreferences['workbench.list.openMode'] === 'doubleClick';
+        // Nodes should only be opened through double clicking if the correct preference is set.
+        if (isDouble) {
+            this.open();
+        }
+    };
+}
+export namespace ScmResourceComponent {
+    export interface Props extends ScmElement.Props {
+        name: string;
+        parentPath: URI;
+        sourceUri: string;
+        decorations?: ScmResourceDecorations;
+    }
+}
+
+export class ScmResourceGroupElement extends ScmElement {
+
+    render(): JSX.Element {
+        const { hover } = this.state;
+        const { group, menus, commands, contextKeys } = this.props;
+        return <div className={`theia-header scm-theia-header ${TREE_NODE_SEGMENT_GROW_CLASS}`}
+            onContextMenu={this.renderContextMenu}
+            onMouseEnter={this.showHover}
+            onMouseLeave={this.hideHover}
+            ref={this.detectHover}>
+            {this.props.renderExpansionToggle()}
+            <div className={`noWrapInfo ${TREE_NODE_SEGMENT_GROW_CLASS}`}>{group.label}</div>
+            <ScmInlineActions {...{
+                hover,
+                args: this.contextMenuArgs,
+                menu: menus.getMenu(ScmTreeWidget.RESOURCE_GROUP_INLINE_MENU),
+                commands,
+                contextKeys,
+                group
+            }}>
+                {this.renderChangeCount()}
+            </ScmInlineActions>
+        </div>;
+    }
+
+    protected renderChangeCount(): React.ReactNode {
+        return <div className='notification-count-container scm-change-count'>
+            <span className='notification-count'>{this.props.group.resources.length}</span>
+        </div>;
+    }
+
+    protected readonly contextMenuPath = ScmTreeWidget.RESOURCE_GROUP_CONTEXT_MENU;
+    protected get contextMenuArgs(): any[] {
+        return [this.props.group];
+    }
+}
+
+export class ScmResourceFolderElement extends ScmElement<ScmResourceFolderElement.Props> {
+
+    render(): JSX.Element {
+        const { hover } = this.state;
+        const { group, sourceUri, path, labelProvider, commands, menus, contextKeys } = this.props;
+        const sourceFileStat: FileStat = { uri: String(sourceUri), isDirectory: true, lastModification: 0 };
+        const icon = labelProvider.getIcon(sourceFileStat);
+
+        return <div key={String(sourceUri)}
+                className={`scmItem ${TREE_NODE_SEGMENT_GROW_CLASS} ${ScmTreeWidget.Styles.NO_SELECT}`}
+                onContextMenu={this.renderContextMenu}
+                onMouseEnter={this.showHover}
+                onMouseLeave={this.hideHover}
+                ref={this.detectHover}
+            >
+            {this.props.renderExpansionToggle()}
+            <span className={icon + ' file-icon'} />
+            <div className={`noWrapInfo ${TREE_NODE_SEGMENT_GROW_CLASS}`} >
+                <span className='name'>{path}</span>
+            </div>
+            <ScmInlineActions {...{
+                hover,
+                menu: menus.getMenu(ScmTreeWidget.RESOURCE_FOLDER_INLINE_MENU),
+                args: this.contextMenuArgs,
+                commands,
+                contextKeys,
+                group
+            }}>
+            </ScmInlineActions>
+        </div >;
+
+    }
+
+    protected readonly contextMenuPath = ScmTreeWidget.RESOURCE_FOLDER_CONTEXT_MENU;
+    protected get contextMenuArgs(): any[] {
+        const uris: ScmResource[] = [];
+        this.collectUris(uris, this.props.node);
+        return [uris, true];
+    }
+
+    protected collectUris(uris: ScmResource[], node: TreeNode): void {
+        if (ScmFileChangeFolderNode.is(node)) {
+            for (const child of node.children) {
+                this.collectUris(uris, child);
+            }
+        } else if (ScmFileChangeNode.is(node)) {
+            const resource = this.props.group.resources.find(r => String(r.sourceUri) === node.sourceUri)!;
+            uris.push(resource);
+        }
+    }
+}
+
+export namespace ScmResourceFolderElement {
+    export interface Props extends ScmElement.Props {
+        node: ScmFileChangeFolderNode;
+        sourceUri: URI;
+        path: string;
+    }
+}
+
+export class ScmInlineActions extends React.Component<ScmInlineActions.Props> {
+    render(): React.ReactNode {
+        const { hover, menu, args, commands, group, contextKeys, children } = this.props;
+        return <div className='theia-scm-inline-actions-container'>
+            <div className='theia-scm-inline-actions'>
+                {hover && menu.children
+                    .map((node, index) => node instanceof ActionMenuNode && <ScmInlineAction key={index} {...{ node, args, commands, group, contextKeys }} />)}
+            </div>
+            {children}
+        </div>;
+    }
+}
+export namespace ScmInlineActions {
+    export interface Props {
+        hover: boolean;
+        menu: CompositeMenuNode;
+        commands: CommandRegistry;
+        group: ScmResourceGroup;
+        contextKeys: ScmContextKeyService;
+        args: any[];
+        children?: React.ReactNode;
+    }
+}
+
+export class ScmInlineAction extends React.Component<ScmInlineAction.Props> {
+    render(): React.ReactNode {
+        const { node, args, commands, group, contextKeys } = this.props;
+        const currentScmResourceGroup = contextKeys.scmResourceGroup.get();
+        contextKeys.scmResourceGroup.set(group.id);
+        try {
+            if (!commands.isVisible(node.action.commandId, ...args) || !contextKeys.match(node.action.when)) {
+                return false;
+            }
+            return <div className='theia-scm-inline-action'>
+                <a className={node.icon} title={node.label} onClick={this.execute} />
+            </div>;
+        } finally {
+            contextKeys.scmResourceGroup.set(currentScmResourceGroup);
+        }
+    }
+
+    protected execute = (event: React.MouseEvent) => {
+        event.stopPropagation();
+
+        const { commands, node, args } = this.props;
+        commands.executeCommand(node.action.commandId, ...args);
+    };
+}
+export namespace ScmInlineAction {
+    export interface Props {
+        node: ActionMenuNode;
+        commands: CommandRegistry;
+        group: ScmResourceGroup;
+        contextKeys: ScmContextKeyService;
+        args: any[];
+    }
+}

--- a/packages/scm/src/browser/style/index.css
+++ b/packages/scm/src/browser/style/index.css
@@ -13,6 +13,14 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
+
+.theia-scm-commit {
+    overflow: hidden;
+    font-size: var(--theia-ui-font-size1);
+    max-height: calc(100% - var(--theia-border-width));
+    position: relative;
+}
+
 .theia-scm {
     padding: 5px;
     box-sizing: border-box;
@@ -48,7 +56,7 @@
     font-weight: bold;
 }
 
-.theia-scm .changesContainer {
+.theia-scm .theia-scm-amend {
     margin: 5px 0;
 }
 
@@ -190,8 +198,6 @@
 }
 
 .theia-scm .scmItem:hover {
-    background-color: var(--theia-list-hoverBackground);
-    color: var(--theia-list-hoverForeground);
     cursor: pointer;
 }
 
@@ -233,13 +239,10 @@
 }
 
 .scm-theia-header {
-    padding: calc(var(--theia-ui-padding)/2);
     display: flex;
 }
 
 .scm-theia-header:hover {
-    background-color: var(--theia-list-hoverBackground);
-    color: var(--theia-list-hoverForeground);
     cursor: pointer;
 }
 
@@ -277,4 +280,8 @@
     height: var(--theia-icon-size);
     width: 12px;
     background: var(--theia-icon-open-file) no-repeat center center;
+}
+
+.theia-scm-panel {
+    overflow: visible;
 }

--- a/packages/search-in-workspace/src/browser/styles/index.css
+++ b/packages/search-in-workspace/src/browser/styles/index.css
@@ -284,7 +284,7 @@
     align-self: center;
 }
 
-.theia-TreeNode:hover .notification-count-container {
+.theia-TreeNode:hover .result-head .notification-count-container {
     display: none;
 }
 


### PR DESCRIPTION
Replaces file change list in Source Control view with tree view.  This fixes https://github.com/eclipse-theia/theia/issues/4835

#### What it does
The change lists are replaced by a single tree that uses TreeWidget.  A toggle button has been added so the user can toggle between a flat view and a tree view.

#### What will not be covered by this PR
The diff widget

#### How to test
Try out the Source Control view.  This is the only view that should have changed.  The 'flat' mode should look mostly the same but even in flat mode it is now in a tree, with each group (staged, unstaged etc) being collapsable.  Test with both the Git vs-code built-in and with the native Git extension.

#### Review checklist

- [x ] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

