### PR TITLE
align max listeners check with VS Code extensions' expectations

### DIFF
--- a/packages/core/src/browser/preferences/preference-service.ts
+++ b/packages/core/src/browser/preferences/preference-service.ts
@@ -138,8 +138,6 @@ export class PreferenceServiceImpl implements PreferenceService {
     @postConstruct()
     protected init(): void {
         this.toDispose.push(Disposable.create(() => this._ready.reject(new Error('preference service is disposed'))));
-        this.onPreferenceChanged.maxListeners = 64;
-        this.onPreferencesChanged.maxListeners = 64;
         this.initializeProviders();
     }
 

--- a/packages/core/src/common/disposable.ts
+++ b/packages/core/src/common/disposable.ts
@@ -44,6 +44,10 @@ export class DisposableCollection implements Disposable {
         toDispose.forEach(d => this.push(d));
     }
 
+    /**
+     * This event is fired only once
+     * on first dispose of not empty collection.
+     */
     get onDispose(): Event<void> {
         return this.onDisposeEmitter.event;
     }
@@ -51,6 +55,7 @@ export class DisposableCollection implements Disposable {
     protected checkDisposed(): void {
         if (this.disposed && !this.disposingElements) {
             this.onDisposeEmitter.fire(undefined);
+            this.onDisposeEmitter.dispose();
         }
     }
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

- fix #6659

Since we support multi root workspaces and VS Code extensions we started seeing many false positive leaking emitters. This PR addresses it in similar approach as VS Code does:
- increase the max listeners threshold to 175 listeners
- only warn on first exceed and then every time the limit is exceeded by 50% again. So only real leaking emitter will be reported more than once.
- report the top stack trace

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

- For leaking configurations: install python, java and go VS Code extensions (use Extensions view) and open typescript, python, java and go files
- For leaking FS wathcing: add more than 6 workspace roots.
- Check that you don't have many repetitive warning in both cases.
- Check for leaking editors: https://github.com/eclipse-theia/theia/pull/7508#issuecomment-610303923

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

