### PR TITLE
[menu] don't stingify class instances

### DIFF
--- a/packages/core/src/browser/menu/browser-menu-plugin.ts
+++ b/packages/core/src/browser/menu/browser-menu-plugin.ts
@@ -367,7 +367,6 @@ class MenuCommandRegistry extends PhosphorCommandRegistry {
         const { commandRegistry } = this.services;
         const command = commandRegistry.getCommand(commandId);
         if (!command) {
-            console.warn(`Could not find command '${commandId}'. Skipping node registration: ${JSON.stringify(menu)}.`);
             return;
         }
         const { id } = command;


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

- otherwise it throws at runtime and break all menus:
```
logger-protocol.ts:112 root ERROR Could not start contribution TypeError: Converting circular structure to JSON
    --> starting at object with constructor 'e'
    |     property 'contributionProvider' -> object with constructor 'e'
    |     property 'services' -> object with constructor 'Array'
    |     index 2 -> object with constructor 'e'
    --- property 'labelProvider' closes the circle
    at JSON.stringify (<anonymous>)
    at t.registerActionMenu (http://fffb7c2b-b6f9-4adc-b4b8-23ece59519cb.ws-dev.ak-upgrade-theia.staging.gitpod-dev.com/bundle.js:19:251566)
    at t.e.registerMenu (http://fffb7c2b-b6f9-4adc-b4b8-23ece59519cb.ws-dev.ak-upgrade-theia.staging.gitpod-dev.com/bundle.js:19:244867)
    at t.e.registerMenu (http://fffb7c2b-b6f9-4adc-b4b8-23ece59519cb.ws-dev.ak-upgrade-theia.staging.gitpod-dev.com/bundle.js:19:244976)
    at t.e.registerMenu (http://fffb7c2b-b6f9-4adc-b4b8-23ece59519cb.ws-dev.ak-upgrade-theia.staging.gitpod-dev.com/bundle.js:19:244976)
    at t.e.createMenuCommandRegistry (http://fffb7c2b-b6f9-4adc-b4b8-23ece59519cb.ws-dev.ak-upgrade-theia.staging.gitpod-dev.com/bundle.js:19:244689)
    at t.e.fillMenuBar (http://fffb7c2b-b6f9-4adc-b4b8-23ece59519cb.ws-dev.ak-upgrade-theia.staging.gitpod-dev.com/bundle.js:19:244112)
    at t.e.createMenuBar (http://fffb7c2b-b6f9-4adc-b4b8-23ece59519cb.ws-dev.ak-upgrade-theia.staging.gitpod-dev.com/bundle.js:19:243844)
    at t.createMenuBar (http://fffb7c2b-b6f9-4adc-b4b8-23ece59519cb.ws-dev.ak-upgrade-theia.staging.gitpod-dev.com/bundle.js:90:1068177)
    at e.onStart (http://fffb7c2b-b6f9-4adc-b4b8-23ece59519cb.ws-dev.ak-upgrade-theia.staging.gitpod-dev.com/bundle.js:19:250567)
```
- warning is removed since commands can be registered after menus


#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

- check that menus are visible

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

