### PR TITLE
Implementation of SelectionRange and SelectionRangeProvider API

### DIFF
--- a/packages/plugin-ext/src/common/plugin-api-rpc-model.ts
+++ b/packages/plugin-ext/src/common/plugin-api-rpc-model.ts
@@ -471,6 +471,10 @@ export class FoldingRangeKind {
     public constructor(public value: string) { }
 }
 
+export interface SelectionRange {
+    range: Range;
+}
+
 export interface Color {
     readonly red: number;
     readonly green: number;

--- a/packages/plugin-ext/src/common/plugin-api-rpc.ts
+++ b/packages/plugin-ext/src/common/plugin-api-rpc.ts
@@ -65,6 +65,7 @@ import {
     CodeActionContext,
     FoldingContext,
     FoldingRange,
+    SelectionRange,
     CallHierarchyDefinition,
     CallHierarchyReference
 } from './plugin-api-rpc-model';
@@ -1196,6 +1197,7 @@ export interface LanguagesExt {
         context: FoldingContext,
         token: CancellationToken
     ): PromiseLike<FoldingRange[] | undefined>;
+    $provideSelectionRanges(handle: number, resource: UriComponents, positions: Position[], token: CancellationToken): PromiseLike<SelectionRange[][]>;
     $provideDocumentColors(handle: number, resource: UriComponents, token: CancellationToken): PromiseLike<RawColorInfo[]>;
     $provideColorPresentations(handle: number, resource: UriComponents, colorInfo: RawColorInfo, token: CancellationToken): PromiseLike<ColorPresentation[]>;
     $provideRenameEdits(handle: number, resource: UriComponents, position: Position, newName: string, token: CancellationToken): PromiseLike<WorkspaceEditDto | undefined>;
@@ -1241,6 +1243,7 @@ export interface LanguagesMain {
     $registerOutlineSupport(handle: number, pluginInfo: PluginInfo, selector: SerializedDocumentFilter[]): void;
     $registerWorkspaceSymbolProvider(handle: number, pluginInfo: PluginInfo): void;
     $registerFoldingRangeProvider(handle: number, pluginInfo: PluginInfo, selector: SerializedDocumentFilter[]): void;
+    $registerSelectionRangeProvider(handle: number, pluginInfo: PluginInfo, selector: SerializedDocumentFilter[]): void;
     $registerDocumentColorProvider(handle: number, pluginInfo: PluginInfo, selector: SerializedDocumentFilter[]): void;
     $registerRenameProvider(handle: number, pluginInfo: PluginInfo, selector: SerializedDocumentFilter[], supportsResolveInitialValues: boolean): void;
     $registerCallHierarchyProvider(handle: number, selector: SerializedDocumentFilter[]): void;

--- a/packages/plugin-ext/src/main/browser/languages-main.ts
+++ b/packages/plugin-ext/src/main/browser/languages-main.ts
@@ -625,6 +625,23 @@ export class LanguagesMainImpl implements LanguagesMain, Disposable {
         return this.proxy.$provideFoldingRange(handle, model.uri, context, token);
     }
 
+    $registerSelectionRangeProvider(handle: number, pluginInfo: PluginInfo, selector: SerializedDocumentFilter[]): void {
+        const languageSelector = fromLanguageSelector(selector);
+        const provider = this.createSelectionRangeProvider(handle);
+        this.register(handle, monaco.languages.registerSelectionRangeProvider(languageSelector, provider));
+    }
+
+    protected createSelectionRangeProvider(handle: number): monaco.languages.SelectionRangeProvider {
+        return {
+            provideSelectionRanges: (model, positions, token) => this.provideSelectionRanges(handle, model, positions, token)
+        };
+    }
+
+    protected provideSelectionRanges(handle: number, model: monaco.editor.ITextModel,
+        positions: monaco.Position[], token: monaco.CancellationToken): monaco.languages.ProviderResult<monaco.languages.SelectionRange[][]> {
+        return this.proxy.$provideSelectionRanges(handle, model.uri, positions, token);
+    }
+
     $registerDocumentColorProvider(handle: number, pluginInfo: PluginInfo, selector: SerializedDocumentFilter[]): void {
         const languageSelector = fromLanguageSelector(selector);
         const colorProvider = this.createColorProvider(handle);

--- a/packages/plugin-ext/src/plugin/languages.ts
+++ b/packages/plugin-ext/src/plugin/languages.ts
@@ -58,6 +58,7 @@ import {
     CodeActionContext,
     CodeAction,
     FoldingRange,
+    SelectionRange,
     CallHierarchyDefinition,
     CallHierarchyReference
 } from '../common/plugin-api-rpc-model';
@@ -80,6 +81,7 @@ import { ReferenceAdapter } from './languages/reference';
 import { WorkspaceSymbolAdapter } from './languages/workspace-symbol';
 import { SymbolInformation } from 'vscode-languageserver-types';
 import { FoldingProviderAdapter } from './languages/folding';
+import { SelectionRangeProviderAdapter } from './languages/selection-range';
 import { ColorProviderAdapter } from './languages/color';
 import { RenameAdapter } from './languages/rename';
 import { Event } from '@theia/core/lib/common/event';
@@ -106,6 +108,7 @@ type Adapter = CompletionAdapter |
     ReferenceAdapter |
     WorkspaceSymbolAdapter |
     FoldingProviderAdapter |
+    SelectionRangeProviderAdapter |
     ColorProviderAdapter |
     RenameAdapter |
     CallHierarchyAdapter;
@@ -543,6 +546,16 @@ export class LanguagesExtImpl implements LanguagesExt {
         return this.withAdapter(callId, FoldingProviderAdapter, adapter => adapter.provideFoldingRanges(URI.revive(resource), context, token), undefined);
     }
     // ### Folding Range Provider end
+
+    registerSelectionRangeProvider(selector: theia.DocumentSelector, provider: theia.SelectionRangeProvider, pluginInfo: PluginInfo): theia.Disposable {
+        const callId = this.addNewAdapter(new SelectionRangeProviderAdapter(provider, this.documents));
+        this.proxy.$registerSelectionRangeProvider(callId, pluginInfo, this.transformDocumentSelector(selector));
+        return this.createDisposable(callId);
+    }
+
+    $provideSelectionRanges(handle: number, resource: UriComponents, positions: Position[], token: theia.CancellationToken): Promise<SelectionRange[][]> {
+        return this.withAdapter(handle, SelectionRangeProviderAdapter, adapter => adapter.provideSelectionRanges(URI.revive(resource), positions, token), []);
+    }
 
     // ### Rename Provider begin
     registerRenameProvider(selector: theia.DocumentSelector, provider: theia.RenameProvider, pluginInfo: PluginInfo): theia.Disposable {

--- a/packages/plugin-ext/src/plugin/languages/selection-range.ts
+++ b/packages/plugin-ext/src/plugin/languages/selection-range.ts
@@ -1,0 +1,79 @@
+/********************************************************************************
+ * Copyright (C) 2020 Red Hat, Inc. and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+// copied and modified from https://github.com/microsoft/vscode/blob/standalone/0.19.x/src/vs/workbench/api/common/extHostLanguageFeatures.ts#L1107-L1151
+
+import * as theia from '@theia/plugin';
+import { DocumentsExtImpl } from '../documents';
+import { URI } from 'vscode-uri/lib/umd';
+import * as model from '../../common/plugin-api-rpc-model';
+import * as Converter from '../type-converters';
+import * as types from '../types-impl';
+
+export class SelectionRangeProviderAdapter {
+
+    constructor(
+        private readonly provider: theia.SelectionRangeProvider,
+        private readonly documents: DocumentsExtImpl
+    ) { }
+
+    provideSelectionRanges(resource: URI, position: monaco.IPosition[], token: theia.CancellationToken): Promise<model.SelectionRange[][]> {
+        const documentData = this.documents.getDocumentData(resource);
+
+        if (!documentData) {
+            return Promise.reject(new Error(`There are no document for  ${resource}`));
+        }
+
+        const document = documentData.document;
+        const positions = position.map(pos => Converter.toPosition(pos));
+
+        return Promise.resolve(this.provider.provideSelectionRanges(document, positions, token)).then(allProviderRanges => {
+            if (!Array.isArray(allProviderRanges) || allProviderRanges.length === 0) {
+                return [];
+            }
+
+            if (allProviderRanges.length !== positions.length) {
+                return [];
+            }
+
+            const allResults: model.SelectionRange[][] = [];
+            for (let i = 0; i < positions.length; i++) {
+                const oneResult: model.SelectionRange[] = [];
+                allResults.push(oneResult);
+
+                let last: types.Position | theia.Range = positions[i];
+                let selectionRange = allProviderRanges[i];
+
+                while (true) {
+                    if (!selectionRange.range.contains(last)) {
+                        return Promise.reject('INVALID selection range, must contain the previous range');
+                    }
+                    oneResult.push(Converter.fromSelectionRange(selectionRange));
+                    if (!selectionRange.parent) {
+                        break;
+                    }
+                    last = selectionRange.range;
+                    selectionRange = selectionRange.parent;
+                }
+            }
+            return allResults;
+        });
+    }
+}

--- a/packages/plugin-ext/src/plugin/plugin-context.ts
+++ b/packages/plugin-ext/src/plugin/plugin-context.ts
@@ -104,6 +104,7 @@ import {
     FunctionBreakpoint,
     FoldingRange,
     FoldingRangeKind,
+    SelectionRange,
     Color,
     ColorInformation,
     ColorPresentation,
@@ -626,6 +627,9 @@ export function createAPIFactory(
             registerFoldingRangeProvider(selector: theia.DocumentSelector, provider: theia.FoldingRangeProvider): theia.Disposable {
                 return languagesExt.registerFoldingRangeProvider(selector, provider, pluginToPluginInfo(plugin));
             },
+            registerSelectionRangeProvider(selector: theia.DocumentSelector, provider: theia.SelectionRangeProvider): theia.Disposable {
+                return languagesExt.registerSelectionRangeProvider(selector, provider, pluginToPluginInfo(plugin));
+            },
             registerRenameProvider(selector: theia.DocumentSelector, provider: theia.RenameProvider): theia.Disposable {
                 return languagesExt.registerRenameProvider(selector, provider, pluginToPluginInfo(plugin));
             },
@@ -855,6 +859,7 @@ export function createAPIFactory(
             ColorInformation,
             ColorPresentation,
             FoldingRange,
+            SelectionRange,
             FoldingRangeKind,
             OperatingSystem,
             WebviewPanelTargetArea,

--- a/packages/plugin-ext/src/plugin/type-converters.ts
+++ b/packages/plugin-ext/src/plugin/type-converters.ts
@@ -929,6 +929,10 @@ export function toSymbolInformation(symbolInformation: SymbolInformation): theia
     };
 }
 
+export function fromSelectionRange(selectionRange: theia.SelectionRange): model.SelectionRange {
+    return { range: fromRange(selectionRange.range) };
+}
+
 export function fromFoldingRange(foldingRange: theia.FoldingRange): model.FoldingRange {
     const range: model.FoldingRange = {
         start: foldingRange.start + 1,

--- a/packages/plugin-ext/src/plugin/types-impl.ts
+++ b/packages/plugin-ext/src/plugin/types-impl.ts
@@ -2001,6 +2001,21 @@ export enum FoldingRangeKind {
     Region = 3
 }
 
+export class SelectionRange {
+
+	range: Range;
+	parent?: SelectionRange;
+
+	constructor(range: Range, parent?: SelectionRange) {
+		this.range = range;
+		this.parent = parent;
+
+		if (parent && !parent.range.contains(this.range)) {
+			throw new Error('Invalid argument: parent must contain this range');
+		}
+	}
+}
+
 /**
  * Enumeration of the supported operating systems.
  */

--- a/packages/plugin/src/theia.d.ts
+++ b/packages/plugin/src/theia.d.ts
@@ -7289,6 +7289,19 @@ declare module '@theia/plugin' {
         export function registerFoldingRangeProvider(selector: DocumentSelector, provider: FoldingRangeProvider): Disposable;
 
         /**
+         * Register a selection range provider.
+         *
+         * Multiple providers can be registered for a language. In that case providers are asked in
+         * parallel and the results are merged. A failing provider (rejected promise or exception) will
+         * not cause a failure of the whole operation.
+         *
+         * @param selector A selector that defines the documents this provider is applicable to.
+         * @param provider A selection range provider.
+         * @return A [disposable](#Disposable) that unregisters this provider when being disposed.
+         */
+        export function registerSelectionRangeProvider(selector: DocumentSelector, provider: SelectionRangeProvider): Disposable;
+
+        /**
         * Register a reference provider.
         *
         * Multiple providers can be registered for a language. In that case providers are sorted
@@ -9038,6 +9051,48 @@ declare module '@theia/plugin' {
          * @return An instance of [comment controller](#CommentController).
          */
         export function createCommentController(id: string, label: string): CommentController;
+    }
+
+    /**
+	 * A selection range represents a part of a selection hierarchy. A selection range
+	 * may have a parent selection range that contains it.
+	 */
+    export class SelectionRange {
+
+		/**
+		 * The [range](#Range) of this selection range.
+		 */
+        range: Range;
+
+		/**
+		 * The parent selection range containing this range.
+		 */
+        parent?: SelectionRange;
+
+		/**
+		 * Creates a new selection range.
+		 *
+		 * @param range The range of the selection range.
+		 * @param parent The parent of the selection range.
+		 */
+        constructor(range: Range, parent?: SelectionRange);
+    }
+
+    export interface SelectionRangeProvider {
+		/**
+		 * Provide selection ranges for the given positions.
+		 *
+		 * Selection ranges should be computed individually and independent for each position. The editor will merge
+		 * and deduplicate ranges but providers must return hierarchies of selection ranges so that a range
+		 * is [contained](#Range.contains) by its parent.
+		 *
+		 * @param document The document in which the command was invoked.
+		 * @param positions The positions at which the command was invoked.
+		 * @param token A cancellation token.
+		 * @return Selection ranges or a thenable that resolves to such. The lack of a result can be
+		 * signaled by returning `undefined` or `null`.
+		 */
+        provideSelectionRanges(document: TextDocument, positions: Position[], token: CancellationToken): ProviderResult<SelectionRange[]>;
     }
 
     /**


### PR DESCRIPTION
#### What it does
This changes proposal adds missing API for [SelectionRange](https://github.com/Microsoft/vscode/blob/8795a9889db74563ddd43eb0a897a2384129a619/src/vs/vscode.d.ts#L3842) and [SelectionRangeProvider](https://github.com/Microsoft/vscode/blob/8795a9889db74563ddd43eb0a897a2384129a619/src/vs/vscode.d.ts#L3863).

Signed-off-by: Vladyslav Zhukovskyi <vzhukovs@redhat.com>

#### TODO
- [x] Find/create a plugin for testing
- [x] Fix a selection range shifted up one line
- [x] CQ https://dev.eclipse.org/ipzilla/show_bug.cgi?id=21891

#### How to test
See [SelectionRangeProviderSample](https://github.com/vzhukovskii/SelectionRangeProviderSample/tree/master) for full details.

#### Steps to test
* build sample with `yarn` command
* you'll get `eclipse_che_selection_range_provider_sample.theia`
* build Theia from current PR
* move `eclipse_che_selection_range_provider_sample.theia` to Theia's plugins folder
* run Theia
* create simple text file, e.g. `test.txt`
* insert any text into opened editor, e.g. [Lorem Ipsum](https://www.lipsum.com/feed/html)
* tag any piece of text with `{SHOULD_BE_SELECTED}any text{/SHOULD_BE_SELECTED}`

<img width="1504" alt="theia — Theia Browser Example 2020-04-17 12-37-52" src="https://user-images.githubusercontent.com/1968177/79555679-a6d41780-80a8-11ea-87e6-866edd3c7432.png">

* locate cursor between above tags
* call `Expand Selection` command, it will select word under cursor
* call `Expand Selection` command again, it will select the whole piece of text arround tag `SHOULD_BE_SELECTED`

<img width="1493" alt="theia — Theia Browser Example 2020-04-17 12-44-01" src="https://user-images.githubusercontent.com/1968177/79556027-29f56d80-80a9-11ea-8acf-e601b42b7eef.png">

Difference between master and this version:
* in master, Theia will select the word on first execution of `Expand Selection` and then the whole paragraph
* in this PR, Theia will select the word on first execution of `Expand Selection`, on second, piece of text surround by `SHOULD_BE_SELECTED` tag and then the whole paragraph[1]

[1] this works also for multi cursor

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

