### PR TITLE
fetch detected tasks twice on clicking "Run Tasks"

### DIFF
--- a/packages/task/src/browser/task-configurations.ts
+++ b/packages/task/src/browser/task-configurations.ts
@@ -141,9 +141,13 @@ export class TaskConfigurations implements Disposable {
     async getTasks(): Promise<TaskConfiguration[]> {
         const configuredTasks = Array.from(this.tasksMap.values()).reduce((acc, labelConfigMap) => acc.concat(Array.from(labelConfigMap.values())), [] as TaskConfiguration[]);
         const detectedTasksAsConfigured: TaskConfiguration[] = [];
+        let fetchTasksFromProviders = true;
         for (const [rootFolder, customizations] of Array.from(this.taskCustomizationMap.entries())) {
             for (const cus of customizations) {
-                const detected = await this.providedTaskConfigurations.getTaskToCustomize(cus, rootFolder);
+                const detected = fetchTasksFromProviders
+                    ? await this.providedTaskConfigurations.getTaskToCustomize(cus, rootFolder)
+                    : this.providedTaskConfigurations.getCachedTaskToCustomize(cus, rootFolder);
+                fetchTasksFromProviders = false;
                 if (detected) {
                     detectedTasksAsConfigured.push({ ...detected, ...cus });
                 }


### PR DESCRIPTION
- detected tasks are fetched N+1 times when users click "Run Tasks" from
the menu, where N is the number of customized detected tasks in the
tasks.json.

- fixes #7496

Signed-off-by: Liang Huang <lhuang4@ualberta.ca>


#### What it does
Refactored `TaskConfigurations.getTasks()`.
Instead of fetching detected tasks from providers for every single customized detected task, only fetch from providers for the 1st customized detected task, and from the cache for the rest.

#### How to test

I smoke-tested the following features:

- Open `Terminal -> Run Tasks`, and check if the detected tasks and customzied detected tasks are properly displayed.
- Check if the detected tasks and customzied detected tasks can be started properly.
- Added logging to `ProvidedTaskConfigurations.getTasks()` to ensure it is called once by `TaskConfigurations.getTasks()`, and two times in total when `Terminal -> Run Tasks` is clicked.

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)
