### PR TITLE
fix presentation.reveal & focus for detected tasks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## v1.1.0
 
+- [task] fixed presentation.reveal & focus for detected tasks [#7548](https://github.com/eclipse-theia/theia/pull/7548)
+
 Breaking changes:
 
 - [core] Removed the `core.find` and `core.replace` commands as they did not work without the `@theia/monaco` extension, or an opened Monaco editor. Use the Monaco-specific `actions.find` and `editor.action.startFindReplaceAction` commands instead. [#7474](https://github.com/eclipse-theia/theia/issues/7474)

--- a/packages/task/src/browser/task-service.ts
+++ b/packages/task/src/browser/task-service.ts
@@ -47,7 +47,8 @@ import {
     TaskIdentifier,
     DependsOrder,
     RevealKind,
-    ApplyToKind
+    ApplyToKind,
+    TaskOutputPresentation
 } from '../common';
 import { TaskWatcher } from '../common/task-watcher';
 import { ProvidedTaskConfigurations } from './provided-task-configurations';
@@ -701,10 +702,10 @@ export class TaskService implements TaskConfigurationClient {
             const terminalId = matchedRunningTaskInfo.terminalId;
             if (terminalId) {
                 const terminal = this.terminalService.getByTerminalId(terminalId);
-                if (terminal && task.presentation) {
-                    if (task.presentation.focus) { // assign focus to the terminal if presentation.focus is true
+                if (terminal) {
+                    if (TaskOutputPresentation.shouldSetFocusToTerminal(task)) { // assign focus to the terminal if presentation.focus is true
                         this.terminalService.open(terminal, { mode: 'activate' });
-                    } else if (task.presentation.reveal === RevealKind.Always) { // show the terminal but not assign focus
+                    } else if (TaskOutputPresentation.shouldAlwaysRevealTerminal(task)) { // show the terminal but not assign focus
                         this.terminalService.open(terminal, { mode: 'reveal' });
                     }
                 }
@@ -991,8 +992,8 @@ export class TaskService implements TaskConfigurationClient {
                 this.messageService.error('Task is already running in terminal');
                 return this.terminalService.open(terminalWidget, { mode: 'activate' });
             }
-            if (taskInfo.config.presentation && taskInfo.config.presentation.reveal === RevealKind.Always) {
-                if (taskInfo.config.presentation.focus) { // assign focus to the terminal if presentation.focus is true
+            if (TaskOutputPresentation.shouldAlwaysRevealTerminal(taskInfo.config)) {
+                if (TaskOutputPresentation.shouldSetFocusToTerminal(taskInfo.config)) { // assign focus to the terminal if presentation.focus is true
                     widgetOpenMode = 'activate';
                 } else { // show the terminal but not assign focus
                     widgetOpenMode = 'reveal';

--- a/packages/task/src/common/task-protocol.ts
+++ b/packages/task/src/common/task-protocol.ts
@@ -49,15 +49,19 @@ export interface TaskOutputPresentation {
     [name: string]: any;
 }
 export namespace TaskOutputPresentation {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    export function fromJson(task: any): TaskOutputPresentation {
-        let outputPresentation = {
+    export function getDefault(): TaskOutputPresentation {
+        return {
             reveal: RevealKind.Always,
             focus: false,
             panel: PanelKind.Shared,
             showReuseMessage: true,
             clear: false
         };
+    }
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    export function fromJson(task: any): TaskOutputPresentation {
+        let outputPresentation = getDefault();
         if (task && task.presentation) {
             if (task.presentation.reveal) {
                 let reveal = RevealKind.Always;
@@ -85,6 +89,10 @@ export namespace TaskOutputPresentation {
             };
         }
         return outputPresentation;
+    }
+
+    export function shouldAlwaysRevealTerminal(task: TaskCustomization): boolean {
+        return !task.presentation || task.presentation.reveal === undefined || task.presentation.reveal === RevealKind.Always;
     }
 
     export function shouldSetFocusToTerminal(task: TaskCustomization): boolean {


### PR DESCRIPTION
- default values of the taskConfig.presentation object are not taken
into consideration when detected tasks are started. This pull request
fixes the bug.
- fixes #7547

Signed-off-by: Liang Huang <lhuang4@ualberta.ca>

#### How to test

1. define a detected task, e.g., `npm run list`
```
"scripts": {
  "list": "sleep 1 && ls"
}
```
2. make sure npm run list is not customized in `tasks.json`
3. run `npm run list` as a detected task. Check if the terminal widget is revealed
4. customize the `npm run list` in `tasks.json` by adding the `presentation` object.
5. Re-run the customized task, and see if the `presentation` works as expected.

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)
