### PR TITLE
[output] add severity/color to appendLine method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## v1.1.0
 
 - [task] fixed presentation.reveal & focus for detected tasks [#7548](https://github.com/eclipse-theia/theia/pull/7548)
+- [output] added optional argument `severity` to `OutputChannel.appendLine` method for coloring.
 
 Breaking changes:
 

--- a/examples/api-samples/compile.tsconfig.json
+++ b/examples/api-samples/compile.tsconfig.json
@@ -11,6 +11,9 @@
   "references": [
     {
       "path": "../../packages/core/compile.tsconfig.json"
+    },
+    {
+      "path": "../../packages/output/compile.tsconfig.json"
     }
   ]
 }

--- a/examples/api-samples/package.json
+++ b/examples/api-samples/package.json
@@ -4,7 +4,8 @@
   "version": "1.0.0",
   "description": "Theia - Example code to demonstrate Theia API",
   "dependencies": {
-    "@theia/core": "^1.0.0"
+    "@theia/core": "^1.0.0",
+    "@theia/output": "^1.0.0"
   },
   "theiaExtensions": [
     {

--- a/examples/api-samples/src/browser/api-samples-frontend-module.ts
+++ b/examples/api-samples/src/browser/api-samples-frontend-module.ts
@@ -17,8 +17,10 @@
 import { ContainerModule } from 'inversify';
 import { bindDynamicLabelProvider } from './label/sample-dynamic-label-provider-command-contribution';
 import { bindSampleUnclosableView } from './view/sample-unclosable-view-contribution';
+import { bindSampleOutputChannelWithSeverity } from './output/sample-output-channel-with-severity';
 
 export default new ContainerModule(bind => {
     bindDynamicLabelProvider(bind);
     bindSampleUnclosableView(bind);
+    bindSampleOutputChannelWithSeverity(bind);
 });

--- a/examples/api-samples/src/browser/output/sample-output-channel-with-severity.ts
+++ b/examples/api-samples/src/browser/output/sample-output-channel-with-severity.ts
@@ -1,0 +1,37 @@
+/********************************************************************************
+ * Copyright (c) 2020 SAP SE or an SAP affiliate company and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+import { FrontendApplicationContribution } from '@theia/core/lib/browser';
+import { inject, injectable, interfaces } from 'inversify';
+import { OutputChannelManager, OutputChannelSeverity } from '@theia/output/lib/common/output-channel';
+
+@injectable()
+export class SampleOutputChannelWithSeverity
+    implements FrontendApplicationContribution {
+    @inject(OutputChannelManager)
+    protected readonly outputChannelManager: OutputChannelManager;
+    public onStart(): void {
+        const channel = this.outputChannelManager.getChannel('my test channel');
+        channel.appendLine('hello info1'); // showed without color
+        channel.appendLine('hello info2', OutputChannelSeverity.Info);
+        channel.appendLine('hello error', OutputChannelSeverity.Error);
+        channel.appendLine('hello warning', OutputChannelSeverity.Warning);
+    }
+}
+export const bindSampleOutputChannelWithSeverity = (bind: interfaces.Bind) => {
+    bind(FrontendApplicationContribution)
+        .to(SampleOutputChannelWithSeverity)
+        .inSingletonScope();
+};

--- a/packages/output/src/browser/output-widget.tsx
+++ b/packages/output/src/browser/output-widget.tsx
@@ -16,7 +16,7 @@
 
 import { inject, injectable, postConstruct } from 'inversify';
 import { Message } from '@theia/core/lib/browser';
-import { OutputChannelManager, OutputChannel } from '../common/output-channel';
+import { OutputChannel, OutputChannelManager, OutputChannelSeverity } from '../common/output-channel';
 import { ReactWidget } from '@theia/core/lib/browser/widgets/react-widget';
 import * as React from 'react';
 
@@ -117,10 +117,16 @@ export class OutputWidget extends ReactWidget {
         };
 
         if (this.outputChannelManager.selectedChannel) {
-            for (const text of this.outputChannelManager.selectedChannel.getLines()) {
-                const lines = text.split(/[\n\r]+/);
+            for (const outputChannelLine of this.outputChannelManager.selectedChannel.getLines()) {
+                const lines = outputChannelLine.text.split(/[\n\r]+/);
+                let className;
+                if (outputChannelLine.severity === OutputChannelSeverity.Error) {
+                    className = 'theia-output-error';
+                } else if (outputChannelLine.severity === OutputChannelSeverity.Warning) {
+                    className = 'theia-output-warning';
+                }
                 for (const line of lines) {
-                    result.push(<div style={style} key={id++}>{line}</div>);
+                    result.push(<div style={style} className={className} key={id++}>{line}</div>);
                 }
             }
         }

--- a/packages/output/src/browser/style/output.css
+++ b/packages/output/src/browser/style/output.css
@@ -63,3 +63,11 @@
 .output-tab-icon::before {
     content: "\f024"
 }
+
+.theia-output-error {
+    color: var(--theia-errorForeground);
+}
+
+.theia-output-warning {
+    color: var(--theia-editorWarning-foreground);
+}


### PR DESCRIPTION
Signed-off-by: Amiram Wingarten <amiram.wingarten@sap.com>

Fixes #7504 

#### What it does
Add severity to append methods of output channel. This allow to color output lines for errors and warnings.

#### How to test
For some output channel call `appendLine` with severities info, warning and error.
The output lines should color accordingly, warning in yellow and error in red.

Call `append` method - it should behave as info.

See example examples/api-samples/src/browser/output/sample-output-channel-with-severity.ts

Also test application can be found in https://github.com/eclipse-theia/theia/pull/7600

https://github.com/eclipse-theia/theia/blob/d26c403391d05d1bfb59c59c3dd9de154d034b9f/packages/output/src/browser/test-app.ts#L26-L32

The expected output channel "my test channel" should look like this after theia start:

![image](https://user-images.githubusercontent.com/9420921/79574549-004c3e80-80c9-11ea-9515-eb6718ee4f38.png)

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

