### PR TITLE
save scope as part of the `TaskService.lastTask`

### DIFF
--- a/packages/task/src/browser/provided-task-configurations.ts
+++ b/packages/task/src/browser/provided-task-configurations.ts
@@ -106,7 +106,10 @@ export class ProvidedTaskConfigurations {
         if (labelConfigMap) {
             const scopeConfigMap = labelConfigMap.get(taskLabel);
             if (scopeConfigMap) {
-                return scopeConfigMap.get(scope);
+                if (scope) {
+                    return scopeConfigMap.get(scope);
+                }
+                return Array.from(scopeConfigMap.values())[0];
             }
         }
     }

--- a/packages/task/src/browser/task-service.ts
+++ b/packages/task/src/browser/task-service.ts
@@ -90,7 +90,7 @@ export class TaskService implements TaskConfigurationClient {
     /**
      * The last executed task.
      */
-    protected lastTask: { source: string, taskLabel: string } | undefined = undefined;
+    protected lastTask: { source: string, taskLabel: string, scope?: string } | undefined = undefined;
     protected cachedRecentTasks: TaskConfiguration[] = [];
     protected runningTasks = new Map<number, {
         exitCode: Deferred<number | undefined>,
@@ -430,7 +430,7 @@ export class TaskService implements TaskConfigurationClient {
      *
      * @returns the last executed task or `undefined`.
      */
-    getLastTask(): { source: string, taskLabel: string } | undefined {
+    getLastTask(): { source: string, taskLabel: string, scope?: string } | undefined {
         return this.lastTask;
     }
 
@@ -455,8 +455,8 @@ export class TaskService implements TaskConfigurationClient {
         if (!this.lastTask) {
             return;
         }
-        const { source, taskLabel } = this.lastTask;
-        return this.run(source, taskLabel);
+        const { source, taskLabel, scope } = this.lastTask;
+        return this.run(source, taskLabel, scope);
     }
 
     /**
@@ -908,7 +908,7 @@ export class TaskService implements TaskConfigurationClient {
         const taskLabel = resolvedTask.label;
         try {
             const taskInfo = await this.taskServer.run(resolvedTask, this.getContext(), option);
-            this.lastTask = { source, taskLabel };
+            this.lastTask = { source, taskLabel, scope: resolvedTask._scope };
             this.logger.debug(`Task created. Task id: ${taskInfo.taskId}`);
 
             /**


### PR DESCRIPTION
- This change fixes the bug where the command "Run last task" does not work properly for detected tasks. With the new property "scope" added to the "last run task", `ProvidedTaskConfigurations.getTask()` is able to find the detected task that was run most recently.

- fixes #7398

Signed-off-by: Liang Huang <lhuang4@ualberta.ca>


#### How to test

1. defined a detected task. Mine was in `package.json`:
```
"scripts": {
  "list": "sleep 1 && ls"
}
```
2. Start the detected task defined in Step 1, wait till it finishes.
3. Run the task defined in Step 1 by `Terminal -> Run Last Task` from the top menu bar, and check if it starts the right task.
4. Make sure Step 1 - 3 works in both single and multi root workspace.

![Peek 2020-04-12 11-13](https://user-images.githubusercontent.com/37082801/79072531-7c9ce700-7caf-11ea-96f7-2f8e9b492b3a.gif)


#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

