### PR TITLE
support contributes.jsonValidation VSCode API.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 - [task] fixed presentation.reveal & focus for detected tasks [#7548](https://github.com/eclipse-theia/theia/pull/7548)
 
+- [json] support `contributes.jsonValidation` VSCode API. [#7545](https://github.com/eclipse-theia/theia/pull/7560)
+
 Breaking changes:
 
 - [core] `CommandRegistry.registerHandler` registers a new handler with a higher priority than previous [#7539](https://github.com/eclipse-theia/theia/pull/7539)
@@ -14,6 +16,7 @@ Use `PluginManager.configStorage` property instead. [#7265](https://github.com/e
 
 ## v1.0.0
 
+- [core] `CommandRegistry#getAllHandlers` returns with the reversed order of handlers, so if a command has multiple handlers, any handler is considered to be more specific than the other subsequent handlers in the array. In other words, if `@theia/core` contributes a handler for a particular command and your extension also contributes a handler for the same command, the handler from your extension will have `0` index, and the handler from `@theia/core` will have `1` index when calling `getAllHandlers`.
 - [core] added functionality to ensure that nodes are refreshed properly on tree expansion [#7400](https://github.com/eclipse-theia/theia/pull/7400)
 - [core] added loading state for trees [#7249](https://github.com/eclipse-theia/theia/pull/7249)
 - [core] added the ability to customize the layout of view-containers [#6655](https://github.com/eclipse-theia/theia/pull/6655)

--- a/packages/json/src/browser/json-frontend-module.ts
+++ b/packages/json/src/browser/json-frontend-module.ts
@@ -18,9 +18,11 @@ import { ContainerModule } from 'inversify';
 import { LanguageClientContribution } from '@theia/languages/lib/browser';
 import { JsonClientContribution } from './json-client-contribution';
 import { bindJsonPreferences } from './json-preferences';
+import { JsonValidationContributionsRegistry } from './json-validation-registry';
 
 export default new ContainerModule(bind => {
     bindJsonPreferences(bind);
 
     bind(LanguageClientContribution).to(JsonClientContribution).inSingletonScope();
+    bind(JsonValidationContributionsRegistry).toSelf().inSingletonScope();
 });

--- a/packages/json/src/browser/json-validation-registry.ts
+++ b/packages/json/src/browser/json-validation-registry.ts
@@ -1,0 +1,39 @@
+/********************************************************************************
+ * Copyright (c) 2020 SAP SE or an SAP affiliate company and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import { injectable } from 'inversify';
+import { Disposable } from '@theia/core/lib/common/disposable';
+import { deepClone } from '@theia/core';
+import { JsonSchemaConfiguration } from '@theia/core/lib/browser/json-schema-store';
+
+@injectable()
+/**
+ * Holds JSON Validation contributions from plugins / VSCode extensions.
+ * -  https://code.visualstudio.com/api/references/contribution-points#contributes.jsonValidation
+ */
+export class JsonValidationContributionsRegistry {
+
+    protected readonly registry: JsonSchemaConfiguration[] = [];
+
+    registerJsonValidation(jsonValidationEntry: JsonSchemaConfiguration): Disposable {
+        this.registry.push(jsonValidationEntry);
+        return Disposable.NULL;
+    }
+
+    getJsonValidations(): JsonSchemaConfiguration[] {
+        return deepClone(this.registry);
+    }
+}

--- a/packages/plugin-ext/compile.tsconfig.json
+++ b/packages/plugin-ext/compile.tsconfig.json
@@ -70,6 +70,9 @@
     },
     {
       "path": "../callhierarchy/compile.tsconfig.json"
+    },
+    {
+      "path": "../json/compile.tsconfig.json"
     }
   ]
 }

--- a/packages/plugin-ext/package.json
+++ b/packages/plugin-ext/package.json
@@ -11,6 +11,7 @@
     "@theia/editor": "^1.0.0",
     "@theia/file-search": "^1.0.0",
     "@theia/filesystem": "^1.0.0",
+    "@theia/json": "^1.0.0",
     "@theia/languages": "^1.0.0",
     "@theia/markers": "^1.0.0",
     "@theia/messages": "^1.0.0",

--- a/packages/plugin-ext/src/common/plugin-protocol.ts
+++ b/packages/plugin-ext/src/common/plugin-protocol.ts
@@ -78,6 +78,7 @@ export interface PluginPackageContribution {
     keybindings?: PluginPackageKeybinding | PluginPackageKeybinding[];
     debuggers?: PluginPackageDebuggersContribution[];
     snippets: PluginPackageSnippetsContribution[];
+    jsonValidation?: PluginJsonValidationContribution[];
     themes?: PluginThemeContribution[];
     iconThemes?: PluginIconThemeContribution[];
     colors?: PluginColorContribution[];
@@ -137,6 +138,11 @@ export interface ScopeMap {
 export interface PluginPackageSnippetsContribution {
     language?: string;
     path?: string;
+}
+
+export interface PluginJsonValidationContribution {
+    fileMatch: string | string[],
+    url: string
 }
 
 export interface PluginColorContribution {
@@ -469,6 +475,7 @@ export interface PluginContribution {
     keybindings?: Keybinding[];
     debuggers?: DebuggerContribution[];
     snippets?: SnippetContribution[];
+    jsonValidations?: JsonValidationContribution[];
     themes?: ThemeContribution[];
     iconThemes?: IconThemeContribution[];
     colors?: ColorDefinition[];
@@ -481,6 +488,11 @@ export interface SnippetContribution {
     uri: string
     source: string
     language?: string
+}
+
+export interface JsonValidationContribution {
+    fileMatch: string,
+    url: string
 }
 
 export type UiTheme = 'vs' | 'vs-dark' | 'hc-black';

--- a/packages/plugin-ext/src/main/browser/plugin-contribution-handler.ts
+++ b/packages/plugin-ext/src/main/browser/plugin-contribution-handler.ts
@@ -34,6 +34,7 @@ import { DebugSchemaUpdater } from '@theia/debug/lib/browser/debug-schema-update
 import { MonacoThemingService } from '@theia/monaco/lib/browser/monaco-theming-service';
 import { ColorRegistry } from '@theia/core/lib/browser/color-registry';
 import { PluginIconThemeService } from './plugin-icon-theme-service';
+import { JsonValidationContributionsRegistry } from '@theia/json/lib/browser/json-validation-registry';
 
 @injectable()
 export class PluginContributionHandler {
@@ -60,6 +61,9 @@ export class PluginContributionHandler {
 
     @inject(MonacoSnippetSuggestProvider)
     protected readonly snippetSuggestProvider: MonacoSnippetSuggestProvider;
+
+    @inject(JsonValidationContributionsRegistry)
+    protected readonly jsonValidationContributionsRegistry: JsonValidationContributionsRegistry;
 
     @inject(CommandRegistry)
     protected readonly commands: CommandRegistry;
@@ -250,6 +254,17 @@ export class PluginContributionHandler {
                 pushContribution(`snippets.${snippet.uri}`, () => this.snippetSuggestProvider.fromURI(snippet.uri, {
                     language: snippet.language,
                     source: snippet.source
+                }));
+            }
+        }
+
+        if (contributions.jsonValidations) {
+            for (const jsonValidation of contributions.jsonValidations) {
+                pushContribution(
+                    `jsonValidation.${jsonValidation.url}`,
+                    () => this.jsonValidationContributionsRegistry.registerJsonValidation( {
+                    url: jsonValidation.url,
+                    fileMatch: [jsonValidation.fileMatch]
                 }));
             }
         }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does

Support VSCode [contributes.jsonValidation](https://code.visualstudio.com/api/references/contribution-points#contributes.jsonValidation) API.

Note that jsonValidation contribution have a **higher** priority than SchemaStore schemas, and a **lower** priority than registered schemas from the preferences
(In case of identical `fileMatch` strings).

#### How to test

- Create a dummy VSCode ext
- Add in its package.json `contributes.jsonValidation` section pointing to some schema from the schema store with an appropriate `fileMatch` property`.
- Bundle your VSCode ext into a VSIX and place it the `plugins` folder.
- Start Theia
- Inspect that the JSON schema is used from the given

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
