### PR TITLE
core: fix recently used quick-commands

### DIFF
--- a/packages/core/src/browser/quick-open/quick-command-service.ts
+++ b/packages/core/src/browser/quick-open/quick-command-service.ts
@@ -86,8 +86,8 @@ export class QuickCommandService implements QuickOpenModel, QuickOpenHandler {
                     this.commands,
                     this.keybindings,
                     {
-                        groupLabel: recent.length <= 0 ? '' : index === 0 ? 'other commands' : '',
-                        showBorder: recent.length <= 0 ? false : index === 0 ? true : false,
+                        groupLabel: recent.length > 0 && index === 0 ? 'other commands' : '',
+                        showBorder: recent.length > 0 && index === 0 ? true : false,
                     }
                 )
             ),
@@ -160,13 +160,13 @@ export class QuickCommandService implements QuickOpenModel, QuickOpenHandler {
 
     /**
      * Normalizes a list of commands.
-     * Normalization includes obtaining commands that have labels and are visible.
+     * Normalization includes obtaining commands that have labels, are visible, and are enabled.
      *
      * @param commands the list of commands.
      * @returns the list of normalized commands.
      */
     private normalize(commands: Command[]): Command[] {
-        return commands.filter((a: Command) => a.label && this.commands.isVisible(a.id));
+        return commands.filter((a: Command) => a.label && (this.commands.isVisible(a.id) && this.commands.isEnabled(a.id)));
     }
 
     /**

--- a/packages/core/src/common/command.spec.ts
+++ b/packages/core/src/common/command.spec.ts
@@ -141,6 +141,48 @@ describe('Commands', () => {
         expect(commandRegistry.getAllHandlers('id').length).to.be.equal(2);
     });
 
+    describe('compareCommands', () => {
+
+        it('should sort command \'a\' before command \'b\' with categories', () => {
+            const a: Command = { id: 'a', category: 'a', label: 'a' };
+            const b: Command = { id: 'b', category: 'b', label: 'b' };
+            expect(Command.compareCommands(a, b)).to.equal(-1);
+            expect(Command.compareCommands(b, a)).to.equal(1);
+        });
+
+        it('should sort command \'a\' before command \'b\' without categories', () => {
+            const a: Command = { id: 'a', label: 'a' };
+            const b: Command = { id: 'b', label: 'b' };
+            expect(Command.compareCommands(a, b)).to.equal(-1);
+            expect(Command.compareCommands(b, a)).to.equal(1);
+        });
+
+        it('should sort command \'a\' before command \'b\' with mix-match categories', () => {
+            const a: Command = { id: 'a', category: 'a', label: 'a' };
+            const b: Command = { id: 'b', label: 'a' };
+            expect(Command.compareCommands(a, b)).to.equal(1);
+            expect(Command.compareCommands(b, a)).to.equal(-1);
+        });
+
+        it('should sort irregardless of casing', () => {
+            const lowercase: Command = { id: 'a', label: 'a' };
+            const uppercase: Command = { id: 'a', label: 'A' };
+            expect(Command.compareCommands(lowercase, uppercase)).to.equal(0);
+        });
+
+        it('should not sort if commands are equal', () => {
+            const a: Command = { id: 'a', label: 'a' };
+            expect(Command.compareCommands(a, a)).to.equal(0);
+        });
+
+        it('should not sort commands without labels', () => {
+            const a: Command = { id: 'a' };
+            const b: Command = { id: 'b' };
+            expect(Command.compareCommands(a, b)).to.equal(0);
+        });
+
+    });
+
 });
 
 class EmptyContributionProvider implements ContributionProvider<CommandContribution> {

--- a/packages/core/src/common/command.ts
+++ b/packages/core/src/common/command.ts
@@ -53,8 +53,8 @@ export namespace Command {
     /** Comparator function for when sorting commands */
     export function compareCommands(a: Command, b: Command): number {
         if (a.label && b.label) {
-            const aCommand = (a.category) ? a.category + a.label : a.label;
-            const bCommand = (b.category) ? b.category + b.label : b.label;
+            const aCommand = (a.category ? `${a.category}: ${a.label}` : a.label).toLowerCase();
+            const bCommand = (b.category ? `${b.category}: ${b.label}` : b.label).toLowerCase();
             return (aCommand).localeCompare(bCommand);
         } else {
             return 0;


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

Fixes #7561

The following commit updates the quick-commands:
- sort commands based on their display name (category and label) if applicable.
- adds additional tests to verify sorting behavior.
- fixes issue where recently used commands did not display the border separator and name.

<div align='center'>

<img width="1005" alt="Screen Shot 2020-04-13 at 2 29 56 PM" src="https://user-images.githubusercontent.com/40359487/79148327-4d5fa600-7d93-11ea-8a27-427388fe1c4e.png">

</div>

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

Refer #7561

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

Signed-off-by: vince-fugnitto <vincent.fugnitto@ericsson.com>
