### PR TITLE
Don't paste to active editor when a tab is closed by mouse wheel click

### DIFF
--- a/packages/core/src/browser/shell/tab-bars.ts
+++ b/packages/core/src/browser/shell/tab-bars.ts
@@ -142,7 +142,11 @@ export class TabBarRenderer extends TabBar.Renderer {
             {
                 key, className, id, title: title.caption, style, dataset,
                 oncontextmenu: this.handleContextMenuEvent,
-                ondblclick: this.handleDblClickEvent
+                ondblclick: this.handleDblClickEvent,
+                onauxclick: (e: MouseEvent) => {
+                    // If user closes the tab using mouse wheel, nothing should be pasted to an active editor
+                    e.preventDefault();
+                }
             },
             h.div(
                 { className: 'theia-tab-icon-label' },


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
Fixes a bug

#### How to test
Part A (Bug reproduction, on `master` branch):
1. Open two editor tabs
2. Focus on one tab (cursor should be in editor)
![image](https://user-images.githubusercontent.com/19504461/79198219-d205ff00-7e3b-11ea-956d-5d6b448f1bc1.png)
(In my case my cursor is in the `Landing.vue` editor, I can edit there and I close `launch.json`)
3. Close the other tab with mouse wheel click
4. See that clipboard content was pasted into active editor
Part B (Testing the fix):
1. Try to reproduce bug from part A
2. See that the tab just closes

Tested in Firefox 76

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

