### PR TITLE
Bind EditorCommandContribution and EditorMenuContribution toSelf

### DIFF
--- a/packages/editor/src/browser/editor-frontend-module.ts
+++ b/packages/editor/src/browser/editor-frontend-module.ts
@@ -43,8 +43,11 @@ export default new ContainerModule(bind => {
     bind(EditorManager).toSelf().inSingletonScope();
     bind(OpenHandler).toService(EditorManager);
 
-    bind(CommandContribution).to(EditorCommandContribution).inSingletonScope();
-    bind(MenuContribution).to(EditorMenuContribution).inSingletonScope();
+    bind(EditorCommandContribution).toSelf().inSingletonScope();
+    bind(CommandContribution).toService(EditorCommandContribution);
+
+    bind(EditorMenuContribution).toSelf().inSingletonScope();
+    bind(MenuContribution).toService(EditorMenuContribution);
 
     bind(StrictEditorTextFocusContext).toSelf().inSingletonScope();
     bind(KeybindingContext).toService(StrictEditorTextFocusContext);


### PR DESCRIPTION
#### What it does
To make customization of editor commands and menu possible EditorCommandContribution and EditorMenuContribution needed to be rebindable.
For that they are bind toSelf now.

#### How to test
Editor commands should work as before.

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

