### PR TITLE
support user-defined labels for detected tasks

### DIFF
--- a/packages/task/src/browser/task-definition-registry.ts
+++ b/packages/task/src/browser/task-definition-registry.ts
@@ -107,7 +107,7 @@ export class TaskDefinitionRegistry {
         });
     }
 
-    compareTasks(one: TaskConfiguration, other: TaskConfiguration): boolean {
+    compareTasks(one: TaskConfiguration | TaskCustomization, other: TaskConfiguration | TaskCustomization): boolean {
         const oneType = one.taskType || one.type;
         const otherType = other.taskType || other.type;
         if (oneType !== otherType) {

--- a/packages/task/src/browser/task-schema-updater.ts
+++ b/packages/task/src/browser/task-schema-updater.ts
@@ -161,6 +161,7 @@ export class TaskSchemaUpdater {
                 }
                 customizedDetectedTask.properties![taskProp] = { ...def.properties.schema.properties![taskProp] };
             });
+            customizedDetectedTask.properties!.label = taskLabel;
             customizedDetectedTask.properties!.problemMatcher = problemMatcher;
             customizedDetectedTask.properties!.presentation = presentation;
             customizedDetectedTask.properties!.options = commandOptionsSchema;

--- a/packages/task/src/browser/task-service.ts
+++ b/packages/task/src/browser/task-service.ts
@@ -465,9 +465,13 @@ export class TaskService implements TaskConfigurationClient {
      * It looks for configured and detected tasks.
      */
     async run(source: string, taskLabel: string, scope?: string): Promise<TaskInfo | undefined> {
-        let task = await this.getProvidedTask(source, taskLabel, scope);
+        let task: TaskConfiguration | undefined;
+        task = await this.getProvidedTask(source, taskLabel, scope);
         if (!task) { // if a detected task cannot be found, search from tasks.json
             task = this.taskConfigurations.getTask(source, taskLabel);
+            if (!task && scope) { // find from the customized detected tasks
+                task = await this.taskConfigurations.getCustomizedTask(scope, taskLabel);
+            }
             if (!task) {
                 this.logger.error(`Can't get task launch configuration for label: ${taskLabel}`);
                 return;


### PR DESCRIPTION
- With this change users would be able to define labels in the task configs to overwrite the task names from providers.
- fixes #6507
- fixes #7515

Signed-off-by: Liang Huang <lhuang4@ualberta.ca>


#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

1. define a detected task in your workspace. Mine was defined in `package.json` as follows:
```
  "scripts": {
    "list": "sleep 1 && ls"
  },
```
2. the task defined in Step 1 should show up in the task list as `npm: list`.
3. customize the label. I added the following config into `tasks.json`
```
        {
            "type": "npm",
            "script": "list",
            "label": "NPM LIST CUSTOMIZED LABEL",
            "problemMatcher": []
        },
```
4. The customized `npm: list` should show up as `NPM LIST CUSTOMIZED LABEL` in the task list
5. Check if the customized detected task can be run.

![Peek 2020-04-14 16-48](https://user-images.githubusercontent.com/37082801/79272880-0c898f00-7e70-11ea-915d-98bb9af016c5.gif)

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)


