### PR TITLE
application-package: show warning if user set unknown target and explicitly set it as browser

### DIFF
--- a/dev-packages/application-package/src/application-package.spec.ts
+++ b/dev-packages/application-package/src/application-package.spec.ts
@@ -1,0 +1,62 @@
+/********************************************************************************
+ * Copyright (C) 2020 Maksim Ryzhikov and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import * as assert from 'assert';
+import * as temp from 'temp';
+import * as fs from 'fs-extra';
+import * as path from 'path';
+import { ApplicationPackage } from './application-package';
+import { ApplicationProps } from './application-props';
+import * as sinon from 'sinon';
+
+const track = temp.track();
+const sandbox = sinon.createSandbox();
+
+describe('application-package', function (): void {
+    after((): void => {
+        sandbox.restore();
+        track.cleanupSync();
+    });
+
+    it('should print warning if user set unknown target in package.json and use browser as a default value', function (): void {
+        const warn = sandbox.stub(console, 'warn');
+        const root = createProjectWithTarget('foo');
+        const applicationPackage = new ApplicationPackage({ projectPath: root });
+        assert.equal(applicationPackage.target, ApplicationProps.ApplicationTarget.browser);
+        assert.equal(warn.called, true);
+    });
+
+    it('should set target from package.json', function (): void {
+        const target = 'electron';
+        const root = createProjectWithTarget(target);
+        const applicationPackage = new ApplicationPackage({ projectPath: root });
+        assert.equal(applicationPackage.target, target);
+    });
+
+    it('should prefer target from passed options over target from package.json', function (): void {
+        const pckTarget = 'electron';
+        const optTarget = 'browser';
+        const root = createProjectWithTarget(pckTarget);
+        const applicationPackage = new ApplicationPackage({ projectPath: root, appTarget: optTarget });
+        assert.equal(applicationPackage.target, optTarget);
+    });
+
+    function createProjectWithTarget(target: string): string {
+        const root = track.mkdirSync('foo-project');
+        fs.writeFileSync(path.join(root, 'package.json'), `{"theia": {"target": "${target}"}}`);
+        return root;
+    }
+});

--- a/dev-packages/application-package/src/application-package.ts
+++ b/dev-packages/application-package/src/application-package.ts
@@ -81,6 +81,12 @@ export class ApplicationPackage {
             theia.target = this.options.appTarget;
         }
 
+        if (theia.target && !(theia.target in ApplicationProps.ApplicationTarget)) {
+            const defaultTarget = ApplicationProps.ApplicationTarget.browser;
+            console.warn(`Unknown application target '${theia.target}', '${defaultTarget}' to be used instead`);
+            theia.target = defaultTarget;
+        }
+
         return this._props = { ...ApplicationProps.DEFAULT, ...theia };
     }
 
@@ -205,11 +211,11 @@ export class ApplicationPackage {
     }
 
     isBrowser(): boolean {
-        return this.target === 'browser';
+        return this.target === ApplicationProps.ApplicationTarget.browser;
     }
 
     isElectron(): boolean {
-        return this.target === 'electron';
+        return this.target === ApplicationProps.ApplicationTarget.electron;
     }
 
     ifBrowser<T>(value: T): T | undefined;

--- a/dev-packages/application-package/src/application-props.ts
+++ b/dev-packages/application-package/src/application-props.ts
@@ -63,8 +63,12 @@ export interface ApplicationProps extends NpmRegistryProps {
     readonly generator: Readonly<{ config: GeneratorConfig }>;
 }
 export namespace ApplicationProps {
+    export enum ApplicationTarget {
+        browser = 'browser',
+        electron = 'electron'
+    };
 
-    export type Target = 'browser' | 'electron';
+    export type Target = keyof typeof ApplicationTarget;
 
     export const DEFAULT: ApplicationProps = {
         ...NpmRegistryProps.DEFAULT,


### PR DESCRIPTION

Fixes #7559

Signed-off-by: Maksim Ryzhikov <rv.maksim@gmail.com>

#### What it does

Print warning if user set incorrect theia target and explicitly set it to “browser”

#### How to test

Set incorrect target in package.json or pass it as an option. For example `{“theia”: {“target”: “foo”}}`

#### Review checklist

- [ ] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

