### PR TITLE
Fix plugin icon URLs in electron & Fix custom icon themes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,12 @@
 
 ## v1.1.0
 
+- [plugin-ext] fixed custom Icon Themes & plugin Icons [#7583](https://github.com/eclipse-theia/theia/pull/7583)
 - [task] fixed presentation.reveal & focus for detected tasks [#7548](https://github.com/eclipse-theia/theia/pull/7548)
 
 Breaking changes:
 
+- [plugin-ext] `PluginModel.packagePath` deprecated. `PluginModel.packageUri` should be used instead.
 - [core] `CommandRegistry.registerHandler` registers a new handler with a higher priority than previous [#7539](https://github.com/eclipse-theia/theia/pull/7539)
 - [plugin] removed `configStorage` argument from `PluginManager.registerPlugin`.
 Use `PluginManager.configStorage` property instead. [#7265](https://github.com/eclipse-theia/theia/pull/7265#discussion_r399956070)

--- a/packages/plugin-ext-vscode/src/node/scanner-vscode.ts
+++ b/packages/plugin-ext-vscode/src/node/scanner-vscode.ts
@@ -17,6 +17,7 @@
 import { injectable } from 'inversify';
 import { PluginScanner, PluginEngine, PluginPackage, PluginModel, PluginLifecycle } from '@theia/plugin-ext';
 import { TheiaPluginScanner } from '@theia/plugin-ext/lib/hosted/node/scanners/scanner-theia';
+import { FileUri } from '@theia/core/lib/node/file-uri';
 
 @injectable()
 export class VsCodePluginScanner extends TheiaPluginScanner implements PluginScanner {
@@ -30,6 +31,7 @@ export class VsCodePluginScanner extends TheiaPluginScanner implements PluginSca
     getModel(plugin: PluginPackage): PluginModel {
         const result: PluginModel = {
             packagePath: plugin.packagePath,
+            packageUri: FileUri.create(plugin.packagePath).toString(),
             // see id definition: https://github.com/microsoft/vscode/blob/15916055fe0cb9411a5f36119b3b012458fe0a1d/src/vs/platform/extensions/common/extensions.ts#L167-L169
             id: `${plugin.publisher.toLowerCase()}.${plugin.name.toLowerCase()}`,
             name: plugin.name,

--- a/packages/plugin-ext/src/common/plugin-api-rpc.ts
+++ b/packages/plugin-ext/src/common/plugin-api-rpc.ts
@@ -139,6 +139,7 @@ export const emptyPlugin: Plugin = {
             version: 'empty'
         },
         packagePath: 'empty',
+        packageUri: 'empty',
         entryPoint: {
 
         }

--- a/packages/plugin-ext/src/common/plugin-protocol.ts
+++ b/packages/plugin-ext/src/common/plugin-protocol.ts
@@ -442,6 +442,11 @@ export interface PluginModel {
         version: string;
     };
     entryPoint: PluginEntryPoint;
+    packageUri: string;
+    /**
+     * @deprecated since 1.1.0 - because it lead to problems with getting a relative path
+     * needed by Icon Themes to correcty load Fonts, use packageUri instead.
+     */
     packagePath: string;
     iconUrl?: string;
     readmeUrl?: string;

--- a/packages/plugin-ext/src/hosted/node/scanners/scanner-theia.ts
+++ b/packages/plugin-ext/src/hosted/node/scanners/scanner-theia.ts
@@ -90,6 +90,7 @@ export class TheiaPluginScanner implements PluginScanner {
     getModel(plugin: PluginPackage): PluginModel {
         const result: PluginModel = {
             packagePath: plugin.packagePath,
+            packageUri: FileUri.create(plugin.packagePath).toString(),
             // see id definition: https://github.com/microsoft/vscode/blob/15916055fe0cb9411a5f36119b3b012458fe0a1d/src/vs/platform/extensions/common/extensions.ts#L167-L169
             id: `${plugin.publisher.toLowerCase()}.${plugin.name.toLowerCase()}`,
             name: plugin.name,

--- a/packages/plugin-ext/src/main/browser/plugin-shared-style.ts
+++ b/packages/plugin-ext/src/main/browser/plugin-shared-style.ts
@@ -19,6 +19,7 @@ import { Disposable, DisposableCollection } from '@theia/core/lib/common/disposa
 import { ThemeService, Theme } from '@theia/core/lib/browser/theming';
 import { IconUrl } from '../../common/plugin-protocol';
 import { Reference, SyncReferenceCollection } from '@theia/core/lib/common/reference';
+import { Endpoint } from '@theia/core/lib/browser/endpoint';
 
 export interface PluginIconKey {
     url: IconUrl
@@ -101,8 +102,8 @@ export class PluginSharedStyle {
     protected createPluginIcon(key: PluginIconKey): PluginIcon {
         const iconUrl = key.url;
         const size = key.size;
-        const darkIconUrl = typeof iconUrl === 'object' ? iconUrl.dark : iconUrl;
-        const lightIconUrl = typeof iconUrl === 'object' ? iconUrl.light : iconUrl;
+        const darkIconUrl = new Endpoint({ path: `${typeof iconUrl === 'object' ? iconUrl.dark : iconUrl}` }).getRestUrl().toString();
+        const lightIconUrl = new Endpoint({ path: `${typeof iconUrl === 'object' ? iconUrl.light : iconUrl}` }).getRestUrl().toString();
         const iconClass = 'plugin-icon-' + this.iconSequence++;
         const toDispose = new DisposableCollection();
         toDispose.push(this.insertRule('.' + iconClass, theme => `

--- a/packages/plugin-ext/src/main/browser/view/plugin-view-registry.ts
+++ b/packages/plugin-ext/src/main/browser/view/plugin-view-registry.ts
@@ -18,7 +18,7 @@ import { injectable, inject, postConstruct } from 'inversify';
 import {
     ApplicationShell, ViewContainer as ViewContainerWidget, WidgetManager,
     ViewContainerIdentifier, ViewContainerTitleOptions, Widget, FrontendApplicationContribution,
-    StatefulWidget, CommonMenus, BaseWidget
+    StatefulWidget, CommonMenus, BaseWidget, Endpoint
 } from '@theia/core/lib/browser';
 import { ViewContainer, View } from '../../../common';
 import { PluginSharedStyle } from '../plugin-shared-style';
@@ -189,9 +189,10 @@ export class PluginViewRegistry implements FrontendApplicationContribution {
         }
         const toDispose = new DisposableCollection();
         const iconClass = 'plugin-view-container-icon-' + viewContainer.id;
+        const iconUrl = new Endpoint({ path: viewContainer.iconUrl }).getRestUrl().toString();
         toDispose.push(this.style.insertRule('.' + iconClass, () => `
-                mask: url('${viewContainer.iconUrl}') no-repeat 50% 50%;
-                -webkit-mask: url('${viewContainer.iconUrl}') no-repeat 50% 50%;
+                mask: url('${iconUrl}') no-repeat 50% 50%;
+                -webkit-mask: url('${iconUrl}') no-repeat 50% 50%;
             `));
         toDispose.push(this.doRegisterViewContainer(viewContainer.id, location, {
             label: viewContainer.title,


### PR DESCRIPTION
Signed-off-by: Luca Jaeger <owl.jaeger@gmail.com>

#### What it does
Fixes Issues:
- #6834 
- #7040 

#6834 Fixed by:
- [plugin-protocol.ts](https://github.com/eclipse-theia/theia/pull/7583/files#diff-2a5766562161792548814f3e490b89ff):
  - Replace `PluginModel.packagePath` with a backend-created `FileUri` passed on as `PluginModel.packageUri` instead of `PluginModel.packagePath`
- [scanner-vscode.ts](https://github.com/eclipse-theia/theia/pull/7583/files#diff-2894f6e74c355c6d2c8a958123199bc4) & [scanner-theia.ts](https://github.com/eclipse-theia/theia/pull/7583/files#diff-eff368badd61fda201e6cbcf60009afe):
  - Pass on a backend-generated `FileUri` through the `PluginModel.packageUri` property.
- [plugin-api-rpc.ts](https://github.com/eclipse-theia/theia/pull/7583/files#diff-7eea09f2b0c581de589cb87e1127fb80):
  - Updated the empty Model to include `packageUri`
- [plugin-icon-theme-service.ts](https://github.com/eclipse-theia/theia/compare/master...owlJaeger:master#diff-fd906c4e43a8828ebde6f8d5fa9cd22f):
  - Updated to use `packageUri` instead of `packagePath` and fix the `relativePath` being `undefined` on Windows.
  - Using `Endpoint`s to fix it for electron specifically.

#7040 Fixed by:
- Using `Endpoint`s in these files:
  - [plugin-shared-style.ts](https://github.com/eclipse-theia/theia/compare/master...owlJaeger:master#diff-fa8282987c4c581621df7483622e5f95)
  - [plugin-view-registry.ts](https://github.com/eclipse-theia/theia/compare/master...owlJaeger:master#diff-b643d2a05314e4c09a9d102ca71aced3)

#### How to test
- #6834: Test by building the `electron` and `browser` [example apps](https://github.com/eclipse-theia/theia/tree/master/examples) in the [theia](https://github.com/eclipse-theia/theia) repository and using the Seti File Icon Theme or download other icon themes through `vsx-registry`.
- #7040: Test by building the `electron` [example app](https://github.com/eclipse-theia/theia/tree/master/examples/electron) in the [theia](https://github.com/eclipse-theia/theia) repository and install an extension like `Gitlens`.

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

