### PR TITLE
workspace: normalize paths of workspace roots

### DIFF
--- a/packages/workspace/src/browser/workspace-service.ts
+++ b/packages/workspace/src/browser/workspace-service.ts
@@ -427,7 +427,8 @@ export class WorkspaceService implements FrontendApplicationContribution {
             if (uriStr.endsWith('/')) {
                 uriStr = uriStr.slice(0, -1);
             }
-            const fileStat = await this.fileSystem.getFileStat(uriStr);
+            const normalizedUriStr = new URI(uriStr).normalizePath().toString();
+            const fileStat = await this.fileSystem.getFileStat(normalizedUriStr);
             if (!fileStat) {
                 return undefined;
             }


### PR DESCRIPTION
#### What it does

This is my proposal to fix #7597 .

If you have configured a workspace folder like
```
"path": "../../workspace"
```
you get a Terminal for URI `/workspace/theia/../../workspace` instead of `/workspace`. This commit fixes this by using a normalized path in the terminal cwd selector.

An alternative would be to fix the roots in the workspace service directly so that it benefits everywhere.

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->


<!-- Include relevant issues and describe how they are addressed. -->

#### How to test
see #7597

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

