### PR TITLE
Use Error object instead of simple string message

### DIFF
--- a/packages/plugin-ext/src/plugin/languages/selection-range.ts
+++ b/packages/plugin-ext/src/plugin/languages/selection-range.ts
@@ -63,7 +63,7 @@ export class SelectionRangeProviderAdapter {
 
                 while (true) {
                     if (!selectionRange.range.contains(last)) {
-                        return Promise.reject('INVALID selection range, must contain the previous range');
+                        return Promise.reject(new Error('INVALID selection range, must contain the previous range'));
                     }
                     oneResult.push(Converter.fromSelectionRange(selectionRange));
                     if (!selectionRange.parent) {


### PR DESCRIPTION
#### What it does
Update reject construction to use Error object instead on simple string.

Fix for the comment: https://github.com/eclipse-theia/theia/commit/ebf7b78923feb28b2068ec28fd47e3e817873307#r38560694

Signed-off-by: Vladyslav Zhukovskyi <vzhukovs@redhat.com>

#### How to test
N/A

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

