### PR TITLE
plugins: sort plugins in the plugins-view

### DIFF
--- a/packages/plugin-ext/src/main/browser/plugin-ext-widget.tsx
+++ b/packages/plugin-ext/src/main/browser/plugin-ext-widget.tsx
@@ -78,7 +78,7 @@ export class PluginWidget extends ReactWidget {
 
     protected renderPlugins(plugins: PluginMetadata[]): React.ReactNode {
         return <div id='pluginListContainer'>
-            {plugins.map(plugin => this.renderPlugin(plugin))}
+            {plugins.sort((a, b) => this.compareMetadata(a, b)).map(plugin => this.renderPlugin(plugin))}
         </div>;
     }
 
@@ -105,5 +105,24 @@ export class PluginWidget extends ReactWidget {
     protected createPluginClassName(plugin: PluginMetadata): string {
         const classNames = ['pluginHeaderContainer'];
         return classNames.join(' ');
+    }
+
+    /**
+     * Compare two plugins based on their names, and publishers.
+     * @param a the first plugin metadata.
+     * @param b the second plugin metadata.
+     */
+    protected compareMetadata(a: PluginMetadata, b: PluginMetadata): number {
+        // Determine the name of the plugins.
+        const nameA = a.model.name.toLowerCase();
+        const nameB = b.model.name.toLowerCase();
+
+        // Determine the publisher of the plugin (when names are equal).
+        const publisherA = a.model.publisher.toLowerCase();
+        const publisherB = b.model.publisher.toLowerCase();
+
+        return (nameA === nameA)
+            ? nameA.localeCompare(nameB)
+            : publisherA.localeCompare(publisherB);
     }
 }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

I generally use the `plugins-view` when debugging features to quickly determine which plugins are currently being consumed, however on `master` the list of plugins are unsorted making their discovery more difficult. I thought I'd do a quick-fix to correctly sort them for end-users.

The following commit adds a comparator method to the `plugins-view` so that plugins are sorted based on `name`, and `publisher` if required.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

1. open the `plugins-view` and determine if plugins are successfully sorted by name (if the name is equal, verify that they are sorted by publisher name).

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

Signed-off-by: vince-fugnitto <vincent.fugnitto@ericsson.com>
