### PR TITLE
Fix syntax highlighting by bumping onigasm

### DIFF
--- a/packages/monaco/package.json
+++ b/packages/monaco/package.json
@@ -16,7 +16,7 @@
     "jsonc-parser": "^2.0.2",
     "monaco-css": "^2.5.0",
     "monaco-html": "^2.5.2",
-    "onigasm": "2.2.1",
+    "onigasm": "^2.2.0",
     "vscode-textmate": "^4.0.1"
   },
   "publishConfig": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -9274,12 +9274,13 @@ onetime@^5.1.0:
   dependencies:
     mimic-fn "^2.1.0"
 
-onigasm@2.2.1:
-  version "2.2.1"
-  resolved "https://registry.yarnpkg.com/onigasm/-/onigasm-2.2.1.tgz#d56da809d63d3bb25510e8b8e447ffe98e56bebb"
-  integrity sha512-pa361CpVfsWOk0MQ1jLuJ1GvEJMHEHgZmaBpOIfBbvbp2crkDHacXB6mA4vgEfO7fL0OEMUSuZjX0Q9yTx6jTg==
+onigasm@^2.2.0:
+  version "2.2.4"
+  resolved "https://registry.yarnpkg.com/onigasm/-/onigasm-2.2.4.tgz#b0ad97e3d7c3080476a1e5daae4b4579a976cbba"
+  integrity sha512-BJKxCTsK0mrLh+A6AuNzknxaULZRKM5uywA2goluMLLCjfMm/PTUa0M7oSH1Ltb6CT1oKXn2atHR75Y3JQ0SSg==
   dependencies:
-    lru-cache "^4.1.1"
+    lru-cache "^5.1.1"
+    tslint "^5.20.1"
 
 oniguruma@^7.2.0:
   version "7.2.1"
@@ -12372,7 +12373,7 @@ tslib@^1.8.0, tslib@^1.8.1, tslib@^1.9.0:
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.10.0.tgz#c3c19f95973fb0a62973fb09d90d961ee43e5c8a"
   integrity sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ==
 
-tslint@^5.12.0:
+tslint@^5.12.0, tslint@^5.20.1:
   version "5.20.1"
   resolved "https://registry.yarnpkg.com/tslint/-/tslint-5.20.1.tgz#e401e8aeda0152bc44dd07e614034f3f80c67b7d"
   integrity sha512-EcMxhzCFt8k+/UP5r8waCf/lzmeSyVlqxqMEDQE7rWYiQky8KpIBz1JAoYXfROHrPZ1XXd43q8yQnULOLiBRQg==


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
onigasm version requirement was tightened at https://github.com/eclipse-theia/theia/commit/cd3a35a1e15d3c0d68d04258c87dc71f53c065f9 to fix syntax highlighting but that did not work for me with Rust code. I assume the bug is now fixed upstream, onigasm latest version of 2.x series being 2.2.4.

#### How to test
Copy this folder: <https://github.com/microsoft/vscode/tree/master/extensions/rust> into Theia's tree plugins folder

Run Theia e.g. `yarn start:browser`

Open: http://localhost:3000

Observe syntax highlighting of a Rust project, e.g. clone: https://github.com/BurntSushi/ripgrep

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

