### PR TITLE
respect editor.maxTokenizationLineLength preference

### DIFF
--- a/packages/monaco/src/browser/textmate/textmate-tokenizer.ts
+++ b/packages/monaco/src/browser/textmate/textmate-tokenizer.ts
@@ -44,13 +44,15 @@ export interface TokenizerOption {
      * If the `lineLimit` is not defined, it means, there are no line length limits. Otherwise, it must be a positive
      * integer or an error will be thrown.
      */
-    readonly lineLimit?: number;
+    lineLimit?: number;
 
 }
 
 export namespace TokenizerOption {
     /**
      * The default TextMate tokenizer option.
+     *
+     * @deprecated Use the current value of `editor.maxTokenizationLineLength` preference instead.
      */
     export const DEFAULT: TokenizerOption = {
         lineLimit: 400


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

- fix #7617

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

- install https://github.com/opencaesar/oml-vscode
  - a link to vsix: https://drive.google.com/file/d/1KfFr3wHP-Yi-4HncRt9V7yF3bjj6Z6rL/view?usp=sharing
- start Theia
- copy and open https://github.com/opencaesar/vocabularies/blob/9b8c1ff9d07803420cebe03f44687a4da253373b/src/imce.jpl.nasa.gov/foundation/base.oml
- it should be highlighted bogusly
- change  `editor.maxTokenizationLineLength` to 800
- close and open the editor for base.oml (reopen is required in VS Code as well)
- it should be highlighted properly

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

