### PR TITLE
fix #7619: don't wrap menu action args into another array

### DIFF
--- a/packages/core/src/browser/context-menu-renderer.ts
+++ b/packages/core/src/browser/context-menu-renderer.ts
@@ -24,11 +24,14 @@ export function toAnchor(anchor: HTMLElement | { x: number, y: number }): Anchor
     return anchor instanceof HTMLElement ? { x: anchor.offsetLeft, y: anchor.offsetTop } : anchor;
 }
 
+export interface ContextMenuAccess {
+}
+
 export const ContextMenuRenderer = Symbol('ContextMenuRenderer');
 export interface ContextMenuRenderer {
-    render(options: RenderContextMenuOptions): void;
+    render(options: RenderContextMenuOptions): ContextMenuAccess;
     /** @deprecated since 0.7.2 pass `RenderContextMenuOptions` instead */
-    render(menuPath: MenuPath, anchor: Anchor, onHide?: () => void): void;
+    render(menuPath: MenuPath, anchor: Anchor, onHide?: () => void): ContextMenuAccess;
 }
 
 export interface RenderContextMenuOptions {

--- a/packages/core/src/browser/menu/browser-context-menu-renderer.ts
+++ b/packages/core/src/browser/menu/browser-context-menu-renderer.ts
@@ -18,8 +18,15 @@
 
 import { inject, injectable } from 'inversify';
 import { MenuPath } from '../../common/menu';
-import { ContextMenuRenderer, Anchor, RenderContextMenuOptions } from '../context-menu-renderer';
+import { Menu } from '../widgets';
+import { ContextMenuAccess, ContextMenuRenderer, Anchor, RenderContextMenuOptions } from '../context-menu-renderer';
 import { BrowserMainMenuFactory } from './browser-menu-plugin';
+
+export class BrowserContextMenuAccess implements ContextMenuAccess {
+    constructor(
+        public readonly menu: Menu
+    ) { }
+}
 
 @injectable()
 export class BrowserContextMenuRenderer implements ContextMenuRenderer {
@@ -27,7 +34,7 @@ export class BrowserContextMenuRenderer implements ContextMenuRenderer {
     constructor(@inject(BrowserMainMenuFactory) private menuFactory: BrowserMainMenuFactory) {
     }
 
-    render(arg: MenuPath | RenderContextMenuOptions, arg2?: Anchor, arg3?: () => void): void {
+    render(arg: MenuPath | RenderContextMenuOptions, arg2?: Anchor, arg3?: () => void): BrowserContextMenuAccess {
         const { menuPath, anchor, args, onHide } = RenderContextMenuOptions.resolve(arg, arg2, arg3);
         const contextMenu = this.menuFactory.createContextMenu(menuPath, args);
         const { x, y } = anchor instanceof MouseEvent ? { x: anchor.clientX, y: anchor.clientY } : anchor!;
@@ -35,6 +42,7 @@ export class BrowserContextMenuRenderer implements ContextMenuRenderer {
             contextMenu.aboutToClose.connect(() => onHide!());
         }
         contextMenu.open(x, y);
+        return new BrowserContextMenuAccess(contextMenu);
     }
 
 }

--- a/packages/core/src/browser/menu/browser-menu-plugin.ts
+++ b/packages/core/src/browser/menu/browser-menu-plugin.ts
@@ -362,7 +362,7 @@ class MenuCommandRegistry extends PhosphorCommandRegistry {
     }
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    registerActionMenu(menu: ActionMenuNode, ...args: any[]): void {
+    registerActionMenu(menu: ActionMenuNode, args: any[]): void {
         const { commandId } = menu.action;
         const { commandRegistry } = this.services;
         const command = commandRegistry.getCommand(commandId);

--- a/packages/core/src/browser/shell/side-panel-toolbar.ts
+++ b/packages/core/src/browser/shell/side-panel-toolbar.ts
@@ -19,6 +19,7 @@ import { TabBarToolbar, TabBarToolbarRegistry, TabBarToolbarFactory } from './ta
 import { Message } from '@phosphor/messaging';
 import { BaseWidget } from '../widgets';
 import { Emitter } from '../../common/event';
+import { ContextMenuAccess, Anchor } from '../context-menu-renderer';
 
 export class SidePanelToolbar extends BaseWidget {
 
@@ -101,4 +102,13 @@ export class SidePanelToolbar extends BaseWidget {
             this.update();
         }
     }
+
+    /* eslint-disable-next-line @typescript-eslint/no-explicit-any */
+    showMoreContextMenu(anchor: Anchor): ContextMenuAccess {
+        if (this.toolbar) {
+            return this.toolbar.renderMoreContextMenu(anchor);
+        }
+        throw new Error(this.id + ' widget is not attached');
+    }
+
 }

--- a/packages/core/src/browser/shell/tab-bar-toolbar.tsx
+++ b/packages/core/src/browser/shell/tab-bar-toolbar.tsx
@@ -25,7 +25,7 @@ import { CommandRegistry } from '../../common/command';
 import { Disposable, DisposableCollection } from '../../common/disposable';
 import { ContextKeyService } from '../context-key-service';
 import { Event, Emitter } from '../../common/event';
-import { ContextMenuRenderer } from '../context-menu-renderer';
+import { ContextMenuRenderer, Anchor } from '../context-menu-renderer';
 import { MenuModelRegistry } from '../../common/menu';
 
 /**
@@ -145,6 +145,11 @@ export class TabBarToolbar extends ReactWidget {
         event.stopPropagation();
         event.preventDefault();
 
+        this.renderMoreContextMenu(event.nativeEvent);
+    };
+
+    /* eslint-disable-next-line @typescript-eslint/no-explicit-any */
+    renderMoreContextMenu(anchor: Anchor): any {
         const menuPath = ['TAB_BAR_TOOLBAR_CONTEXT_MENU'];
         const toDisposeOnHide = new DisposableCollection();
         for (const [, item] of this.more) {
@@ -154,13 +159,13 @@ export class TabBarToolbar extends ReactWidget {
                 when: item.when
             }));
         }
-        this.contextMenuRenderer.render({
+        return this.contextMenuRenderer.render({
             menuPath,
             args: [this.current],
-            anchor: event.nativeEvent,
+            anchor,
             onHide: () => toDisposeOnHide.dispose()
         });
-    };
+    }
 
     shouldHandleMouseEvent(event: MouseEvent): boolean {
         return event.target instanceof Element && (!!this.inline.get(event.target.id) || event.target.id === '__more__');

--- a/packages/core/src/browser/widgets/widget.ts
+++ b/packages/core/src/browser/widgets/widget.ts
@@ -261,21 +261,37 @@ export function addClipboardListener<K extends 'cut' | 'copy' | 'paste'>(element
     );
 }
 
+/**
+ * Resolves when the given widget is detached and hidden.
+ */
 export function waitForClosed(widget: Widget): Promise<void> {
-    return waitForVisible(widget, false);
+    return waitForVisible(widget, false, false);
 }
 
+/**
+ * Resolves when the given widget is attached and visible.
+ */
 export function waitForRevealed(widget: Widget): Promise<void> {
+    return waitForVisible(widget, true, true);
+}
+
+/**
+ * Resolves when the given widget is hidden regardless of attachment.
+ */
+export function waitForHidden(widget: Widget): Promise<void> {
     return waitForVisible(widget, true);
 }
 
-function waitForVisible(widget: Widget, visible: boolean): Promise<void> {
-    if (widget.isAttached === visible && (widget.isVisible === visible || (widget.node.style.visibility !== 'hidden') === visible)) {
+function waitForVisible(widget: Widget, visible: boolean, attached?: boolean): Promise<void> {
+    if ((typeof attached !== 'boolean' || widget.isAttached === attached) &&
+        (widget.isVisible === visible || (widget.node.style.visibility !== 'hidden') === visible)
+    ) {
         return new Promise(resolve => window.requestAnimationFrame(() => resolve()));
     }
     return new Promise(resolve => {
         const waitFor = () => window.requestAnimationFrame(() => {
-            if (widget.isAttached === visible && (widget.isVisible === visible || (widget.node.style.visibility !== 'hidden') === visible)) {
+            if ((typeof attached !== 'boolean' || widget.isAttached === attached) &&
+                (widget.isVisible === visible || (widget.node.style.visibility !== 'hidden') === visible)) {
                 window.requestAnimationFrame(() => resolve());
             } else {
                 waitFor();

--- a/packages/core/src/electron-browser/menu/electron-context-menu-renderer.ts
+++ b/packages/core/src/electron-browser/menu/electron-context-menu-renderer.ts
@@ -16,11 +16,18 @@
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
+import * as electron from 'electron';
 import { inject, injectable } from 'inversify';
 import { MenuPath } from '../../common';
-import { ContextMenuRenderer, Anchor, RenderContextMenuOptions } from '../../browser';
+import { ContextMenuRenderer, Anchor, RenderContextMenuOptions, ContextMenuAccess } from '../../browser';
 import { ElectronMainMenuFactory } from './electron-main-menu-factory';
 import { ContextMenuContext } from '../../browser/menu/context-menu-context';
+
+export class ElectronContextMenuAccess implements ContextMenuAccess {
+    constructor(
+        public readonly menu: electron.Menu
+    ) { }
+}
 
 @injectable()
 export class ElectronContextMenuRenderer implements ContextMenuRenderer {
@@ -31,7 +38,7 @@ export class ElectronContextMenuRenderer implements ContextMenuRenderer {
     constructor(@inject(ElectronMainMenuFactory) private menuFactory: ElectronMainMenuFactory) {
     }
 
-    render(arg: MenuPath | RenderContextMenuOptions, arg2?: Anchor, arg3?: () => void): void {
+    render(arg: MenuPath | RenderContextMenuOptions, arg2?: Anchor, arg3?: () => void): ElectronContextMenuAccess {
         const { menuPath, args, onHide } = RenderContextMenuOptions.resolve(arg, arg2, arg3);
         const menu = this.menuFactory.createContextMenu(menuPath, args);
         menu.popup({});
@@ -40,6 +47,7 @@ export class ElectronContextMenuRenderer implements ContextMenuRenderer {
         if (onHide) {
             menu.once('menu-will-close', () => onHide());
         }
+        return new ElectronContextMenuAccess(menu);
     }
 
 }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

- add integration tests to reproduce fix #7619
- fix #7619 by removing bogus spreading

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

- integration tests should be green
- test that context menus are properly rendered in different places, i.e. toolbars for view container, views, editors and so on

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

