### PR TITLE
Change successExitCodes and ExpectedErrors to arrays

### DIFF
--- a/packages/git/src/common/git.ts
+++ b/packages/git/src/common/git.ts
@@ -435,13 +435,13 @@ export namespace Git {
              * The exit codes which indicate success to the caller. Unexpected exit codes will be logged and an
              * error thrown. Defaults to `0` if `undefined`.
              */
-            readonly successExitCodes?: ReadonlySet<number>;
+            readonly successExitCodes?: ReadonlyArray<number>;
 
             /**
              * The Git errors which are expected by the caller. Unexpected errors will
              * be logged and an error thrown.
              */
-            readonly expectedErrors?: ReadonlySet<GitError>;
+            readonly expectedErrors?: ReadonlyArray<GitError>;
 
             /**
              * An optional collection of key-value pairs which will be

--- a/packages/git/src/node/dugite-git.spec.ts
+++ b/packages/git/src/node/dugite-git.spec.ts
@@ -385,10 +385,10 @@ describe('git', async function (): Promise<void> {
 
         const init = async (git: Git, repository: Repository) => {
             await git.exec(repository, ['init']);
-            if ((await git.exec(repository, ['config', 'user.name'], { successExitCodes: new Set([0, 1]) })).exitCode !== 0) {
+            if ((await git.exec(repository, ['config', 'user.name'], { successExitCodes: [0, 1] })).exitCode !== 0) {
                 await git.exec(repository, ['config', 'user.name', 'User Name']);
             }
-            if ((await git.exec(repository, ['config', 'user.email'], { successExitCodes: new Set([0, 1]) })).exitCode !== 0) {
+            if ((await git.exec(repository, ['config', 'user.email'], { successExitCodes: [0, 1] })).exitCode !== 0) {
                 await git.exec(repository, ['config', 'user.email', 'user.name@domain.com']);
             }
         };
@@ -546,10 +546,10 @@ describe('git', async function (): Promise<void> {
     describe('diff', async () => {
         const init = async (git: Git, repository: Repository) => {
             await git.exec(repository, ['init']);
-            if ((await git.exec(repository, ['config', 'user.name'], { successExitCodes: new Set([0, 1]) })).exitCode !== 0) {
+            if ((await git.exec(repository, ['config', 'user.name'], { successExitCodes: [0, 1] })).exitCode !== 0) {
                 await git.exec(repository, ['config', 'user.name', 'User Name']);
             }
-            if ((await git.exec(repository, ['config', 'user.email'], { successExitCodes: new Set([0, 1]) })).exitCode !== 0) {
+            if ((await git.exec(repository, ['config', 'user.email'], { successExitCodes: [0, 1] })).exitCode !== 0) {
                 await git.exec(repository, ['config', 'user.email', 'user.name@domain.com']);
             }
         };

--- a/packages/git/src/node/dugite-git.ts
+++ b/packages/git/src/node/dugite-git.ts
@@ -615,6 +615,12 @@ export class DugiteGit implements Git {
                 opts = {
                     ...options
                 };
+                if (options.successExitCodes) {
+                    opts = { ...opts, successExitCodes: new Set(options.successExitCodes) };
+                }
+                if (options.expectedErrors) {
+                    opts = { ...opts, expectedErrors: new Set(options.expectedErrors) };
+                }
             }
             opts = {
                 ...opts,
@@ -660,7 +666,7 @@ export class DugiteGit implements Git {
             args.push(...[file]);
         }
 
-        const successExitCodes = new Set([0, 128]);
+        const successExitCodes = [0, 128];
         let result = await this.exec(repository, args, { successExitCodes });
         if (result.exitCode !== 0) {
             // Note that if no range specified then the 'to revision' defaults to HEAD
@@ -685,7 +691,7 @@ export class DugiteGit implements Git {
 
     async revParse(repository: Repository, options: Git.Options.RevParse): Promise<string | undefined> {
         const ref = options.ref;
-        const successExitCodes = new Set([0, 128]);
+        const successExitCodes = [0, 128];
         const result = await this.exec(repository, ['rev-parse', ref], { successExitCodes });
         if (result.exitCode === 0) {
             return result.stdout; // sha
@@ -734,8 +740,8 @@ export class DugiteGit implements Git {
         const file = (relativePath === '') ? '.' : relativePath;
         if (options && options.errorUnmatch) {
             args.push('--error-unmatch', file);
-            const successExitCodes = new Set([0, 1]);
-            const expectedErrors = new Set([GitError.OutsideRepository]);
+            const successExitCodes = [0, 1];
+            const expectedErrors = [GitError.OutsideRepository];
             const result = await this.exec(repository, args, { successExitCodes, expectedErrors });
             const { exitCode } = result;
             return exitCode === 0;


### PR DESCRIPTION
Currently both successExitCodes and ExpectedErrors Git options are sets.  However the interface is serializable so objects cannot be used here.  This breaks frontend code that uses either of these options.

#### What it does

These two options are changed to arrays.  They are converted to sets in the backend before passing on to Dugite.

#### How to test

Check the existing places that use these options.  Currently these options are only set in the backend.  If you need to test that the arrays can be set from the frontend, I can ask a colleague to test or I can make up some test code.

#### Review checklist

- [x ] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

