### PR TITLE
Remove extraneous entries in Source Control view for nested Git repos

### DIFF
--- a/packages/git/src/node/dugite-git.ts
+++ b/packages/git/src/node/dugite-git.ts
@@ -877,7 +877,14 @@ export class DugiteGit implements Git {
     }
 
     private async mapFileChanges(toMap: DugiteStatus, repositoryPath: string): Promise<GitFileChange[]> {
-        return Promise.all(toMap.files.map(file => this.mapFileChange(file, repositoryPath)));
+        return Promise.all(toMap.files
+            .filter(file => !this.isNestedGitRepository(file))
+            .map(file => this.mapFileChange(file, repositoryPath))
+        );
+    }
+
+    private isNestedGitRepository(fileChange: DugiteFileChange): boolean {
+        return fileChange.path.endsWith('/');
     }
 
     private async mapFileChange(toMap: DugiteFileChange, repositoryPath: string): Promise<GitFileChange> {


### PR DESCRIPTION
This PR brings @theia/git behavior into line with the vs-code Git built-in.  If a Git repository has a nested Git repository then @theia/git returns a single change resource for that repository.  This results in an entry in the Source Control view that does not really make sense.  Such entries do not appear when using the Git built-in, and of course would not appear in vs-code.

#### What it does

This PR filters out change resources that represent nested Git repositories.  These are the only change resources returned by 'git status' that are folder URIs, so can be easily identified by a trailing '/'.

#### How to test

Create a Git repository with one or more nested Git repositories.  On master branch, Open the Source Control view with @theia/git and with vs-code builtin.  Note the extraneous entries only with @theia/git.  Now test with this PR and the extraneous entries should be gone.

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

