### PR TITLE
[hosted plugin] fix no indication for selecting an invalid node.js project

### DIFF
--- a/packages/plugin-dev/src/node/hosted-instance-manager.ts
+++ b/packages/plugin-dev/src/node/hosted-instance-manager.ts
@@ -233,7 +233,12 @@ export abstract class AbstractHostedInstanceManager implements HostedInstanceMan
         const pckPath = path.join(FileUri.fsPath(uri), 'package.json');
         if (fs.existsSync(pckPath)) {
             const pck = require(pckPath);
-            return !!this.metadata.getScanner(pck);
+            try {
+               return !!this.metadata.getScanner(pck);
+            } catch (e) {
+                console.error(e);
+                return false;
+            }
         }
         return false;
     }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->
When selecting a **node.js project** that is not a valid plugin(vscode ext or theia plugin) for hosted plugin instance, it failed selecting the project as expected but doesn't notify the user.

In the [hosted-plugin-manager-client.js](https://github.com/eclipse-theia/theia/blob/master/packages/plugin-dev/src/browser/hosted-plugin-manager-client.ts#L278) it checks if the plugin is valid. then the [isPluginValid](https://github.com/eclipse-theia/theia/blob/master/packages/plugin-dev/src/node/hosted-instance-manager.ts#L232) function in hosted-instance-manger.js (backend) calling to [getScanner](https://github.com/eclipse-theia/theia/blob/master/packages/plugin-ext/src/hosted/node/metadata-scanner.ts#L59) which throws an error because there's no valid scanner for this project.

I wrote a code to catch this error in the `isPluginValid` function and return `false` to the client accordingly.

Before:
![hosted-before](https://user-images.githubusercontent.com/24614792/79869796-9befee80-83ea-11ea-8fe6-5e53bf675c7f.gif)

After:
![hosted-after](https://user-images.githubusercontent.com/24614792/79870080-13258280-83eb-11ea-88de-15d8e019134b.gif)




#### How to test
Clone node.js project which is not a vscode extension or theia plugin.
Press f1 -> Hosted Plugin: Select Path -> select the project.
See that there's a notification telling the user that the folder is not a valid plugin.

#### Review checklist

- [X] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

