### PR TITLE
cli: improve plugin download logic

### DIFF
--- a/dev-packages/cli/src/theia.ts
+++ b/dev-packages/cli/src/theia.ts
@@ -153,7 +153,14 @@ function rebuildCommand(command: string, target: ApplicationProps.Target): yargs
                     default: false,
                 }
             },
-            handler: args => downloadPlugins(args),
+            handler: async args => {
+                try {
+                    await downloadPlugins(args);
+                } catch (err) {
+                    console.error(err);
+                    process.exit(1);
+                }
+            },
         }).command({
             command: 'test',
             builder: {


### PR DESCRIPTION
#### Fixes:

Fixes: #7501
Fixes: #7624

#### What it does:

The following commit addresses the robustness of the `download:plugins` script which is used to download plugins as '.vsix' from URLs (such as 'open-vsx'). The changes include properly performing `requestretry` calls and properly waiting for responses.

The main issues with the previous implementation was the fact that we did not wait for requests to finish properly before attempting to write the downloaded plugins to disk. There was also an added complexity with the fact that `requestretry` prevented us to easily use the response stream asynchronously. In order to fix the issue, additional logic was adding making the overall script more robust by buffering the response stream, and only then writing to disk if the request was successful.

At a high-level, the following was achieved:
- more robust when processing responses and writing to disk.
- better error reporting for unsupported file types.
- better error reporting for plugins which could not be successfully downloaded.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
1. perform `yarn download:plugins`
    - plugins should be successfully downloaded, any plugins which can not be downloaded should be reported as such.
2. modify the root `package.json` to include mock data (ex: incorrect url)
   - an error message should be reported for the entry that the plugin could not be downloaded
3. modify the root `package.json` to include an unsupported file ext (ex: 'foo')
  - an error message should be reported for the entry that the plugin has an unsupported file type

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

#### Authors

Co-authored-by: Paul Maréchal <paul.marechal@ericsson.com>
Co-authored-by: Vincent Fugnitto <vincent.fugnitto@ericsson.com>
