### PR TITLE
feat(plugin): Use product applicationName to return the value to plugins env.appName

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - [task] fixed presentation.reveal & focus for detected tasks [#7548](https://github.com/eclipse-theia/theia/pull/7548)
 - [output] added optional argument `severity` to `OutputChannel.appendLine` method for coloring.
+- [plugin] env.appName is now reusing the value from `applicationName` defined in package.json under `theia/frontend/config/applicatioName` for example. It allows to customize the value with a single change.
 
 Breaking changes:
 

--- a/packages/plugin-ext/src/common/plugin-api-rpc.ts
+++ b/packages/plugin-ext/src/common/plugin-api-rpc.ts
@@ -102,6 +102,7 @@ export interface EnvInit {
     queryParams: QueryParameters;
     language: string;
     shell: string;
+    appName: string;
 }
 
 export interface PluginAPI {

--- a/packages/plugin-ext/src/hosted/browser/hosted-plugin.ts
+++ b/packages/plugin-ext/src/hosted/browser/hosted-plugin.ts
@@ -59,6 +59,7 @@ import { WidgetManager } from '@theia/core/lib/browser/widget-manager';
 import { TerminalService } from '@theia/terminal/lib/browser/base/terminal-service';
 import { EnvVariablesServer } from '@theia/core/lib/common/env-variables';
 import URI from '@theia/core/lib/common/uri';
+import { FrontendApplicationConfigProvider } from '@theia/core/lib/browser/frontend-application-config-provider';
 
 export type PluginHost = 'frontend' | string;
 export type DebugActivationEvent = 'onDebugResolve' | 'onDebugInitialConfigurations' | 'onDebugAdapterProtocolTracker';
@@ -452,7 +453,8 @@ export class HostedPluginSupport {
                 env: {
                     queryParams: getQueryParameters(),
                     language: navigator.language,
-                    shell: defaultShell
+                    shell: defaultShell,
+                    appName: FrontendApplicationConfigProvider.get().applicationName
                 },
                 extApi,
                 webview: {

--- a/packages/plugin-ext/src/plugin/env.ts
+++ b/packages/plugin-ext/src/plugin/env.ts
@@ -24,11 +24,10 @@ export abstract class EnvExtImpl {
     private proxy: EnvMain;
     private queryParameters: QueryParameters;
     private lang: string;
+    private applicationName: string;
     private defaultShell: string;
     private envMachineId: string;
     private envSessionId: string;
-
-    public static readonly APP_NAME = 'Eclipse Theia';
 
     constructor(rpc: RPCProtocol) {
         this.proxy = rpc.getProxy(PLUGIN_RPC_CONTEXT.ENV_MAIN);
@@ -57,6 +56,10 @@ export abstract class EnvExtImpl {
         this.queryParameters = queryParams;
     }
 
+    setApplicationName(applicationName: string): void {
+        this.applicationName = applicationName;
+    }
+
     setLanguage(lang: string): void {
         this.lang = lang;
     }
@@ -70,7 +73,7 @@ export abstract class EnvExtImpl {
     }
 
     get appName(): string {
-        return EnvExtImpl.APP_NAME;
+        return this.applicationName;
     }
 
     abstract get appRoot(): string;

--- a/packages/plugin-ext/src/plugin/plugin-manager.ts
+++ b/packages/plugin-ext/src/plugin/plugin-manager.ts
@@ -186,6 +186,7 @@ export class PluginManagerExtImpl implements PluginManagerExt, PluginManager {
         this.envExt.setQueryParameters(params.env.queryParams);
         this.envExt.setLanguage(params.env.language);
         this.envExt.setShell(params.env.shell);
+        this.envExt.setApplicationName(params.env.appName);
 
         this.preferencesManager.init(params.preferences);
 


### PR DESCRIPTION
#### What it does
Use product applicationName to return the value to plugins env.appName
Thus branding is applied everywhere.


#### How to test
Clone a java project and takes a plug-in using the `appName` like Red Hat vscode-java
https://github.com/redhat-developer/vscode-java/releases/download/v0.55.1/redhat.java-0.55.1.vsix

Starts the examples/browser and notice the new name
![image](https://user-images.githubusercontent.com/436777/79890131-54c02880-83ff-11ea-9cdc-6b8bb8f7cac0.png)

Now, remove `theia` element of `examples/browser/package.json` 
```yaml
"theia": {
    "frontend": {
      "config": {
        "applicationName": "Theia Browser Example",
        "preferences": {
          "files.enableTrash": false
        }
      }
    }
  },
```

and check default `Theia` value is used (which is also the name seen in about/dialog)
![image](https://user-images.githubusercontent.com/436777/79890414-bda7a080-83ff-11ea-92b8-02b14f0e3401.png)



#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

Change-Id: Ifdda9b5cd64ea34de8292bd16703b87d81700c39
Signed-off-by: Florent Benoit <fbenoit@redhat.com>
