### PR TITLE
plugins: update download script to include colors

### DIFF
--- a/dev-packages/cli/package.json
+++ b/dev-packages/cli/package.json
@@ -38,6 +38,7 @@
     "@types/requestretry": "^1.12.3",
     "@types/tar": "^4.0.3",
     "chai": "^4.2.0",
+    "colors": "^1.4.0",
     "mkdirp": "^0.5.0",
     "mocha": "^7.0.0",
     "puppeteer": "^2.0.0",


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

The commit updates the logging performed by the `download:script` by coloring the output so it is more visible and also updates the error message to be more descriptive:
- green: download successful.
- red: errors or could not download plugin.

<div align='center'>

<img width="1106" alt="Screen Shot 2020-04-22 at 10 49 13 AM" src="https://user-images.githubusercontent.com/40359487/79997941-1753ad80-8488-11ea-8640-deb96e24b8a6.png">


</div>

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

Signed-off-by: vince-fugnitto <vincent.fugnitto@ericsson.com>