### PR TITLE
Fix API tests on windows and add missing await on ts test

### DIFF
--- a/dev-packages/application-manager/src/expose-loader.ts
+++ b/dev-packages/application-manager/src/expose-loader.ts
@@ -53,14 +53,15 @@ export = function (this: webpack.loader.LoaderContext, source: string, sourceMap
         this.cacheable();
     }
 
-    let modulePackage = modulePackages.find(({ dir }) => this.resourcePath.startsWith(dir + '/'));
+    let modulePackage = modulePackages.find(({ dir }) => this.resourcePath.startsWith(dir + path.sep));
     if (modulePackage) {
         this.callback(undefined, exposeModule(modulePackage, this.resourcePath, source), sourceMap);
         return;
     }
-    const index = this.resourcePath.lastIndexOf('/node_modules');
+    const searchString = path.sep + 'node_modules';
+    const index = this.resourcePath.lastIndexOf(searchString);
     if (index !== -1) {
-        const nodeModulesPath = this.resourcePath.substring(0, index + '/node_modules'.length);
+        const nodeModulesPath = this.resourcePath.substring(0, index + searchString.length);
         let dir = this.resourcePath;
         while ((dir = path.dirname(dir)) !== nodeModulesPath) {
             try {

--- a/examples/api-tests/src/typescript.spec.js
+++ b/examples/api-tests/src/typescript.spec.js
@@ -131,7 +131,7 @@ module.exports = (port, host, argv) => Promise.resolve()
     `
         });
         await pluginService.didStart;
-        Promise.all([typescriptPluginId, referencesPluginId].map(async pluginId => {
+        await Promise.all([typescriptPluginId, referencesPluginId].map(async pluginId => {
             if (!pluginService.getPlugin(pluginId)) {
                 throw new Error(pluginId + ' should be started');
             }

--- a/examples/api-tests/src/typescript.spec.js
+++ b/examples/api-tests/src/typescript.spec.js
@@ -16,7 +16,7 @@
 
 // @ts-check
 describe('TypeScript', function () {
-    this.timeout(45000);
+    this.timeout(30000);
 
     const { assert } = chai;
 
@@ -247,7 +247,12 @@ module.exports = (port, host, argv) => Promise.resolve()
         assert.isTrue(contextKeyService.match('listFocus'));
     }
 
-    async function closePeek() {
+    /**
+     * @param {MonacoEditor} editor
+     */
+    async function closePeek(editor) {
+        await assertPeekOpened(editor);
+
         keybindings.dispatchKeyDown('Escape');
         await waitForAnimation(() => !contextKeyService.match('listFocus'));
         assert.isTrue(contextKeyService.match('editorTextFocus'));
@@ -362,7 +367,7 @@ module.exports = (port, host, argv) => Promise.resolve()
                 // @ts-ignore
                 assert.equal(activeEditor.getControl().getModel().getWordAtPosition({ lineNumber, column }).word, 'container');
 
-                await closePeek();
+                await closePeek(activeEditor);
             });
 
             it(`from ${from} to another editor`, async function () {
@@ -388,7 +393,7 @@ module.exports = (port, host, argv) => Promise.resolve()
                 // @ts-ignore
                 assert.equal(activeEditor.getControl().getModel().getWordAtPosition({ lineNumber, column }).word, 'Container');
 
-                await closePeek();
+                await closePeek(activeEditor);
             });
 
             it(`from ${from} to an editor preview`, async function () {
@@ -412,7 +417,7 @@ module.exports = (port, host, argv) => Promise.resolve()
                 // @ts-ignore
                 assert.equal(activeEditor.getControl().getModel().getWordAtPosition({ lineNumber, column }).word, 'Container');
 
-                await closePeek();
+                await closePeek(activeEditor);
             });
         }
     });
@@ -678,7 +683,7 @@ SPAN {
             if (link) {
                 link.dispatchEvent(new MouseEvent('mouseup', { bubbles: true }));
                 await assertPeekOpened(editor);
-                await closePeek();
+                await closePeek(editor);
             } else {
                 assert.isDefined(link);
             }


### PR DESCRIPTION
Signed-off-by: Amiram Wingarten <amiram.wingarten@sap.com>

#### What it does
Fixes https://github.com/eclipse-theia/theia/issues/7644
Fixes API tests on windows and add missing await on typescript.spec.js.

#### How to test

Run `yarn test:browser` on windows and see that it completes successfuly.

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

