### PR TITLE
feat(branding): Change default name to 'Eclipse Theia' instead of 'Theia'

### DIFF
--- a/dev-packages/application-package/src/application-props.ts
+++ b/dev-packages/application-package/src/application-props.ts
@@ -78,7 +78,7 @@ export namespace ApplicationProps {
         },
         frontend: {
             config: {
-                applicationName: 'Theia'
+                applicationName: 'Eclipse Theia'
             }
         },
         generator: {


### PR DESCRIPTION
#### What it does
Change default name from `Theia` to `Eclipse Theia`
following comment https://github.com/eclipse-theia/theia/pull/7642#issuecomment-617631782

#### How to test
remove `theia` element of `examples/browser/package.json` 
```yaml
"theia": {
    "frontend": {
      "config": {
        "applicationName": "Theia Browser Example",
        "preferences": {
          "files.enableTrash": false
        }
      }
    }
  },
```

Use Help/About menu
![image](https://user-images.githubusercontent.com/436777/80069591-e5068680-8541-11ea-9db5-1e78ccf27bb4.png)



#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)


Change-Id: I3cb908805fd9050404d2b433e5cbd2dcfd433e70
Signed-off-by: Florent Benoit <fbenoit@redhat.com>

