### PR TITLE
Add devfile to develop Theia in Che

### DIFF
--- a/devfile.yaml
+++ b/devfile.yaml
@@ -1,0 +1,69 @@
+# A devfile to setup Theia project in Che.
+# For developers who work on Theia core.
+
+apiVersion: 1.0.0
+metadata:
+  name: theia-dev
+projects:
+  - name: theia
+    source:
+      type: git
+      location: "https://github.com/eclipse-theia/theia.git"
+components:
+  - alias: che-dev
+    type: dockerimage
+    image: "quay.io/eclipse/che-theia-dev:next"
+    mountSources: true
+    endpoints:
+      - name: "theia-dev-flow"
+        port: 3000
+        attributes:
+          protocol: http
+          public: "true"
+    memoryLimit: "3Gi"
+  - id: che-incubator/typescript/latest
+    type: chePlugin
+    memoryLimit: 2048M
+  - type: cheEditor
+    alias: theia-editor
+    id: eclipse/che-theia/next
+    memoryLimit: "1Gi"
+commands:
+  - name: >
+      theia: Build Sources
+    actions:
+      - type: exec
+        component: che-dev
+        command: >
+          killall node;
+          yarn
+        workdir: ${workspaceRoot}/theia
+  - name: >
+      theia: Launch Browser Backend
+    actions:
+      - type: exec
+        component: che-dev
+        command: >
+          test -f /tmp/node_theiadev.pid && kill `cat /tmp/node_theiadev.pid`;
+          mkdir -p /tmp/theiadev_projects &&
+          export NODE_ENV=development &&
+          node src-gen/backend/main.js /tmp/theiadev_projects --hostname=0.0.0.0 --port=3000 --no-cluster --plugins=${workspaceRoot}/theia/plugins --hosted-plugin-inspect=9339 & echo $!> /tmp/node_theiadev.pid ; wait `cat /tmp/node_theiadev.pid`
+        workdir: ${workspaceRoot}/theia/examples/browser
+  - name: >
+      theia: Watch Core Packages
+    actions:
+      - type: exec
+        component: che-dev
+        command: >
+          killall node;
+          yarn watch
+        workdir: ${workspaceRoot}/theia
+  - name: >
+      theia: Watch Browser Example
+    actions:
+      - type: exec
+        component: che-dev
+        command: >
+          killall node;
+          yarn watch
+        workdir: ${workspaceRoot}/theia/examples/browser


### PR DESCRIPTION
#### What it does
This changes proposal provides workspace configuration file which sets up Che environment to develop Theia. This configuration is represented as devfile.

For the detailed explanation of all devfile components assignment and possible values, please see the following resources:
 - [Specification repository](https://github.com/redhat-developer/devfile)  
 - [detailed json-schema documentation](https://redhat-developer.github.io/devfile/devfile).

Signed-off-by: Vladyslav Zhukovskyi <vzhukovs@redhat.com>

#### How to test
[![Contribute](https://che.openshift.io/factory/resources/factory-contribute.svg)](https://che.openshift.io/f?url=https://github.com/vzhukovskii/theia)

The simplest way to use devfile is to have it deployed into GitHub source repository and then create factory from this repo.

```
https://<your-che-host>/f?url=https://github.com/vzhukovskii/theia
```

Also, it is possible to execute devfile by constructing the factory with the URL to it's raw content, for example:

```
https://<your-che-host>/f?url=https://raw.githubusercontent.com/vzhukovskii/theia/master/devfile.yaml
```

If you're a user of [chectl](https://github.com/che-incubator/chectl/) tool, it is also possible to execute workspace from devfile, using workspace:start command parameter as follows:

```
chectl workspace:start --devfile=https://raw.githubusercontent.com/vzhukovskii/theia/master/devfile.yaml
```

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

