### PR TITLE
Added preferences for shell & shell arguments

### DIFF
--- a/packages/terminal/src/browser/terminal-preferences.ts
+++ b/packages/terminal/src/browser/terminal-preferences.ts
@@ -107,6 +107,44 @@ export const TerminalConfigSchema: PreferenceSchema = {
             type: 'number',
             default: 1
         },
+        'terminal.integrated.shell.windows': {
+            type: ['string', 'null'],
+            description: 'The path of the shell that the terminal uses on Windows. (default: C:\\Windows\\System32\\cmd.exe).',
+            markdownDescription: 'The path of the shell that the terminal uses on Windows. (default: C:\\Windows\\System32\\cmd.exe).',
+            default: undefined
+        },
+        'terminal.integrated.shell.osx': {
+            type: ['string', 'null'],
+            description: `The path of the shell that the terminal uses on macOS (default: ${process.env.SHELL || '/bin/bash'}).`,
+            markdownDescription: `The path of the shell that the terminal uses on macOS (default: ${process.env.SHELL || '/bin/bash'}).`,
+            default: undefined
+        },
+        'terminal.integrated.shell.linux': {
+            type: ['string', 'null'],
+            description: `The path of the shell that the terminal uses on Linux (default: ${process.env.SHELL || '/bin/bash'}).`,
+            markdownDescription: `The path of the shell that the terminal uses on Linux (default: ${process.env.SHELL || '/bin/bash'}).`,
+            default: undefined
+        },
+        'terminal.integrated.shellArgs.windows': {
+            type: 'array',
+            description: 'The command line arguments to use when on the Windows terminal.',
+            markdownDescription: 'The command line arguments to use when on the Windows terminal.',
+            default: []
+        },
+        'terminal.integrated.shellArgs.osx': {
+            type: 'array',
+            description: 'The command line arguments to use when on the macOS terminal.',
+            markdownDescription: 'The command line arguments to use when on the macOS terminal.',
+            default: [
+                '-l'
+            ]
+        },
+        'terminal.integrated.shellArgs.linux': {
+            type: 'array',
+            description: 'The command line arguments to use when on the Linux terminal.',
+            markdownDescription: 'The command line arguments to use when on the Linux terminal.',
+            default: []
+        },
     }
 };
 
@@ -126,7 +164,13 @@ export interface TerminalConfiguration {
     'terminal.integrated.copyOnSelection': boolean,
     'terminal.integrated.cursorBlinking': boolean,
     'terminal.integrated.cursorStyle': CursorStyleVSCode,
-    'terminal.integrated.cursorWidth': number
+    'terminal.integrated.cursorWidth': number,
+    'terminal.integrated.shell.windows': string | undefined,
+    'terminal.integrated.shell.osx': string | undefined,
+    'terminal.integrated.shell.linux': string | undefined,
+    'terminal.integrated.shellArgs.windows': string[],
+    'terminal.integrated.shellArgs.osx': string[],
+    'terminal.integrated.shellArgs.linux': string[],
 }
 
 type FontWeight = 'normal' | 'bold' | '100' | '200' | '300' | '400' | '500' | '600' | '700' | '800' | '900';

--- a/packages/terminal/src/browser/terminal-widget-impl.ts
+++ b/packages/terminal/src/browser/terminal-widget-impl.ts
@@ -21,7 +21,7 @@ import { ContributionProvider, Disposable, Event, Emitter, ILogger, DisposableCo
 import { Widget, Message, WebSocketConnectionProvider, StatefulWidget, isFirefox, MessageLoop, KeyCode } from '@theia/core/lib/browser';
 import { isOSX } from '@theia/core/lib/common';
 import { WorkspaceService } from '@theia/workspace/lib/browser';
-import { ShellTerminalServerProxy } from '../common/shell-terminal-protocol';
+import { ShellTerminalServerProxy, IShellTerminalPreferences } from '../common/shell-terminal-protocol';
 import { terminalsPath } from '../common/terminal-protocol';
 import { IBaseTerminalServer, TerminalProcessInfo } from '../common/base-terminal-protocol';
 import { TerminalWatcher } from '../common/terminal-watcher';
@@ -368,6 +368,7 @@ export class TerminalWidgetImpl extends TerminalWidget implements StatefulWidget
         const { cols, rows } = this.term;
 
         const terminalId = await this.shellTerminalServer.create({
+            shellPreferences: this.shellPreferences,
             shell: this.options.shellPath,
             args: this.options.shellArgs,
             env: this.options.env,
@@ -579,6 +580,21 @@ export class TerminalWidgetImpl extends TerminalWidget implements StatefulWidget
 
     protected get enablePaste(): boolean {
         return this.preferences['terminal.enablePaste'];
+    }
+
+    protected get shellPreferences(): IShellTerminalPreferences {
+        return {
+            shell: {
+                Windows: this.preferences['terminal.integrated.shell.windows'],
+                Linux: this.preferences['terminal.integrated.shell.linux'],
+                OSX: this.preferences['terminal.integrated.shell.osx'],
+            },
+            shellArgs: {
+                Windows: this.preferences['terminal.integrated.shellArgs.windows'],
+                Linux: this.preferences['terminal.integrated.shellArgs.linux'],
+                OSX: this.preferences['terminal.integrated.shellArgs.osx'],
+            }
+        };
     }
 
     protected customKeyHandler(event: KeyboardEvent): boolean {

--- a/packages/terminal/src/common/shell-terminal-protocol.ts
+++ b/packages/terminal/src/common/shell-terminal-protocol.ts
@@ -16,6 +16,7 @@
 
 import { JsonRpcProxy } from '@theia/core';
 import { IBaseTerminalServer, IBaseTerminalServerOptions } from './base-terminal-protocol';
+import { OS } from '@theia/core/lib/common/os';
 
 export const IShellTerminalServer = Symbol('IShellTerminalServer');
 
@@ -25,7 +26,17 @@ export interface IShellTerminalServer extends IBaseTerminalServer {
 
 export const shellTerminalPath = '/services/shell-terminal';
 
+export type ShellTerminalOSPreferences<T> = {
+    [key in OS.Type]: T
+};
+
+export interface IShellTerminalPreferences {
+    shell: ShellTerminalOSPreferences<string | undefined>,
+    shellArgs: ShellTerminalOSPreferences<string[]>
+};
+
 export interface IShellTerminalServerOptions extends IBaseTerminalServerOptions {
+    shellPreferences?: IShellTerminalPreferences,
     shell?: string,
     args?: string[],
     rootURI?: string,


### PR DESCRIPTION
Signed-off-by: Luca Jaeger <owl.jaeger@gmail.com>

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->
Adds an easy way to control what shell or what shell arguments to use for the Terminal by adding preferences and prefer these over `this.options.shellPath` and `this.options.shellArgs`.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
Add `terminal.integrated.shell.{os}` or `terminal.integrated.shellArgs.{os}` to the preferences.
Example:
```
{
  "terminal.integrated.shell.windows": "pwsh.exe",
  "terminal.integrated.shellArgs.windows": [
    "-nop"
  ]
}
```
I have `pwsh.exe` in my path env variable, but absolute paths work too.

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

