### PR TITLE
[cli] refine test filter to exclude only test args

### DIFF
--- a/dev-packages/cli/src/theia.ts
+++ b/dev-packages/cli/src/theia.ts
@@ -218,7 +218,7 @@ function rebuildCommand(command: string, target: ApplicationProps.Target): yargs
                 try {
                     await runTest({
                         start: async () => new Promise((resolve, reject) => {
-                            const serverArgs = commandArgs('test').filter(a => a.indexOf('test-') === -1);
+                            const serverArgs = commandArgs('test').filter(a => a.indexOf('--test-') !== 0);
                             const serverProcess = manager.start(serverArgs);
                             serverProcess.on('message', resolve);
                             serverProcess.on('error', reject);


### PR DESCRIPTION
and avoid excluding --plugins=local-dir:path/to/test-integration/folder

Signed-off-by: Amiram Wingarten <amiram.wingarten@sap.com>


#### What it does
Make the filtering condition for --test-* arguments be more accurate

#### How to test
Run test command with plugin folder in a path that contain the string "test-" and make sure this plugin folder is passed through to the server.
`theia test . --plugins=local-dir:../../test-plugins --test-spec=../api-tests/**/*.spec.js`

#### Review checklist

- [ ] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

