### PR TITLE
add "id" to ContributedTaskConfiguration interface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Breaking changes:
 Use `PluginManager.configStorage` property instead. [#7265](https://github.com/eclipse-theia/theia/pull/7265#discussion_r399956070)
 - [process] `TerminalProcess` doesn't handle shell quoting, the shell process arguments must be prepared from the caller. Removed all methods related to shell escaping inside this class. You should use functions located in `@theia/process/lib/common/shell-quoting.ts` in order to process arguments for shells.
 - [process/terminal] Moved shell escaping utilities into `@theia/process/lib/common/shell-quoting` and `@theia/process/lib/common/shell-command-builder` for creating shell inputs.
+- [task] added property `id` to interface `ContributedTaskConfiguration` [#7670](https://github.com/eclipse-theia/theia/pull/7670)
 
 ## v1.0.0
 

--- a/packages/task/src/browser/quick-open-task.ts
+++ b/packages/task/src/browser/quick-open-task.ts
@@ -337,8 +337,8 @@ export class QuickOpenTask implements QuickOpenModel, QuickOpenHandler {
                     const taskToRun = (defaultBuildOrTestTask as TaskRunQuickOpenItem).getTask();
                     const scope = this.taskSourceResolver.resolve(taskToRun);
 
-                    if (this.taskDefinitionRegistry && !!this.taskDefinitionRegistry.getDefinition(taskToRun)) {
-                        this.taskService.run(taskToRun.source, taskToRun.label, scope);
+                    if (this.taskService.isDetectedTask(taskToRun)) {
+                        this.taskService.run(taskToRun.id);
                     } else {
                         this.taskService.run(taskToRun._source, taskToRun.label, scope);
                     }
@@ -494,7 +494,7 @@ export class TaskRunQuickOpenItem extends QuickOpenGroupItem {
         if (!this.isMulti) {
             return '';
         }
-        if (this.taskDefinitionRegistry && !!this.taskDefinitionRegistry.getDefinition(this.task)) {
+        if (this.taskService.isDetectedTask(this.task)) {
             if (this.task._scope) {
                 return new URI(this.task._scope).displayName;
             }
@@ -511,8 +511,8 @@ export class TaskRunQuickOpenItem extends QuickOpenGroupItem {
         }
 
         const scope = this.taskSourceResolver.resolve(this.task);
-        if (this.taskDefinitionRegistry && !!this.taskDefinitionRegistry.getDefinition(this.task)) {
-            this.taskService.run(this.task.source || this.task._source, this.task.label, scope);
+        if (this.taskService.isDetectedTask(this.task)) {
+            this.taskService.run(this.task.id);
         } else {
             this.taskService.run(this.task._source, this.task.label, scope);
         }
@@ -578,7 +578,7 @@ export class TaskConfigureQuickOpenItem extends QuickOpenGroupItem {
         if (!this.isMulti) {
             return '';
         }
-        if (this.taskDefinitionRegistry && !!this.taskDefinitionRegistry.getDefinition(this.task)) {
+        if (this.taskService.isDetectedTask(this.task)) {
             if (this.task._scope) {
                 return new URI(this.task._scope).displayName;
             }

--- a/packages/task/src/browser/task-name-resolver.ts
+++ b/packages/task/src/browser/task-name-resolver.ts
@@ -15,9 +15,10 @@
  ********************************************************************************/
 
 import { inject, injectable } from 'inversify';
-import { TaskConfiguration, ContributedTaskConfiguration } from '../common';
+import { TaskConfiguration } from '../common';
 import { TaskDefinitionRegistry } from './task-definition-registry';
 import { TaskConfigurations } from './task-configurations';
+import { ProvidedTaskConfigurations } from './provided-task-configurations';
 
 @injectable()
 export class TaskNameResolver {
@@ -27,12 +28,14 @@ export class TaskNameResolver {
     @inject(TaskConfigurations)
     protected readonly taskConfigurations: TaskConfigurations;
 
+    @inject(ProvidedTaskConfigurations)
+    protected readonly providedTaskConfigurations: ProvidedTaskConfigurations;
     /**
      * Returns task name to display.
      * It is aligned with VS Code.
      */
     resolve(task: TaskConfiguration): string {
-        if (this.isDetectedTask(task)) {
+        if (this.providedTaskConfigurations.isDetectedTask(task)) {
             const scope = task._scope;
             const rawConfigs = this.taskConfigurations.getRawTaskConfigurations(scope);
             const jsonConfig = rawConfigs.find(rawConfig => this.taskDefinitionRegistry.compareTasks({
@@ -47,9 +50,5 @@ export class TaskNameResolver {
 
         // it is a hack, when task is customized but extension is absent
         return task.label || `${task.type}: ${task.task}`;
-    }
-
-    private isDetectedTask(task: TaskConfiguration): task is ContributedTaskConfiguration {
-        return !!this.taskDefinitionRegistry.getDefinition(task);
     }
 }

--- a/packages/task/src/browser/task-schema-updater.ts
+++ b/packages/task/src/browser/task-schema-updater.ts
@@ -166,6 +166,8 @@ export class TaskSchemaUpdater {
             customizedDetectedTask.properties!.presentation = presentation;
             customizedDetectedTask.properties!.options = commandOptionsSchema;
             customizedDetectedTask.properties!.group = group;
+            customizedDetectedTask.properties!.dependsOn = dependsOn;
+            customizedDetectedTask.properties!.dependsOrder = dependsOrder;
             customizedDetectedTask.additionalProperties = true;
             customizedDetectedTasks.push(customizedDetectedTask);
         });
@@ -607,6 +609,40 @@ const taskIdentifier: IJSONSchema = {
     }
 };
 
+const dependsOn: IJSONSchema = {
+    anyOf: [
+        {
+            type: 'string',
+            description: 'Another task this task depends on.'
+        },
+        taskIdentifier,
+        {
+            type: 'array',
+            description: 'The other tasks this task depends on.',
+            items: {
+                anyOf: [
+                    {
+                        type: 'string'
+                    },
+                    taskIdentifier
+                ]
+            }
+        }
+    ],
+    description: 'Either a string representing another task or an array of other tasks that this task depends on.'
+};
+
+const dependsOrder: IJSONSchema = {
+    type: 'string',
+    enum: ['parallel', 'sequence'],
+    enumDescriptions: [
+        'Run all dependsOn tasks in parallel.',
+        'Run all dependsOn tasks in sequence.'
+    ],
+    default: 'parallel',
+    description: 'Determines the order of the dependsOn tasks for this task. Note that this property is not recursive.'
+};
+
 const processTaskConfigurationSchema: IJSONSchema = {
     type: 'object',
     required: ['type', 'label', 'command'],
@@ -619,38 +655,8 @@ const processTaskConfigurationSchema: IJSONSchema = {
             default: false,
             description: 'Whether the executed task is kept alive and is running in the background.'
         },
-        dependsOn: {
-            anyOf: [
-                {
-                    type: 'string',
-                    description: 'Another task this task depends on.'
-                },
-                taskIdentifier,
-                {
-                    type: 'array',
-                    description: 'The other tasks this task depends on.',
-                    items: {
-                        anyOf: [
-                            {
-                                type: 'string'
-                            },
-                            taskIdentifier
-                        ]
-                    }
-                }
-            ],
-            description: 'Either a string representing another task or an array of other tasks that this task depends on.'
-        },
-        dependsOrder: {
-            type: 'string',
-            enum: ['parallel', 'sequence'],
-            enumDescriptions: [
-                'Run all dependsOn tasks in parallel.',
-                'Run all dependsOn tasks in sequence.'
-            ],
-            default: 'parallel',
-            description: 'Determines the order of the dependsOn tasks for this task. Note that this property is not recursive.'
-        },
+        dependsOn,
+        dependsOrder,
         windows: {
             type: 'object',
             description: 'Windows specific command configuration that overrides the command, args, and options',

--- a/packages/task/src/browser/task-source-resolver.ts
+++ b/packages/task/src/browser/task-source-resolver.ts
@@ -15,19 +15,23 @@
  ********************************************************************************/
 
 import { inject, injectable } from 'inversify';
-import { TaskConfiguration, ContributedTaskConfiguration } from '../common';
+import { TaskConfiguration } from '../common';
 import { TaskDefinitionRegistry } from './task-definition-registry';
+import { ProvidedTaskConfigurations } from './provided-task-configurations';
 
 @injectable()
 export class TaskSourceResolver {
     @inject(TaskDefinitionRegistry)
     protected taskDefinitionRegistry: TaskDefinitionRegistry;
 
+    @inject(ProvidedTaskConfigurations)
+    protected readonly providedTaskConfigurations: ProvidedTaskConfigurations;
+
     /**
      * Returns task source to display.
      */
     resolve(task: TaskConfiguration): string | undefined {
-        const isDetectedTask = this.isDetectedTask(task);
+        const isDetectedTask = this.providedTaskConfigurations.isDetectedTask(task);
         let sourceFolderUri: string | undefined;
         if (isDetectedTask) {
             sourceFolderUri = task._scope;
@@ -35,9 +39,5 @@ export class TaskSourceResolver {
             sourceFolderUri = task._source;
         }
         return sourceFolderUri;
-    }
-
-    private isDetectedTask(task: TaskConfiguration): task is ContributedTaskConfiguration {
-        return !!this.taskDefinitionRegistry.getDefinition(task);
     }
 }

--- a/packages/task/src/common/task-protocol.ts
+++ b/packages/task/src/common/task-protocol.ts
@@ -160,8 +160,13 @@ export interface TaskConfiguration extends TaskCustomization {
 
 export interface ContributedTaskConfiguration extends TaskConfiguration {
     /**
+     * ID of the provided/detected task.
+     * This field is not supposed to be used in `tasks.json`.
+     */
+    readonly id: string;
+    /**
      * Source of the task configuration.
-     * For a configured task, it is the name of the root folder, while for a provided task, it is the name of the provider.
+     * For a configured task, it is the name of the root folder, while for a provided/detected task, it is the name of the provider.
      * This field is not supposed to be used in `tasks.json`
      */
     readonly _source: string;


### PR DESCRIPTION
- all detected tasks are associated with unique IDs (https://github.com/eclipse-theia/theia/blob/bda9ff9d4cf15b28b5ffc2e984f11834adfc8f33/packages/plugin-ext/src/plugin/types-impl.ts#L1786-L1800). This pull request adds the "id" property to the ContributedTaskConfiguration interface.

- fixes #7514

Signed-off-by: Liang Huang <lhuang4@ualberta.ca>


#### How to test

1. define detected tasks in the workspace. I added 2 into my package.json:
```
  "scripts": {
    "lintAAB": "eslint .",
    "list": "sleep 1 && ls"
  },
```
2. Customize one of the detected task defined in Step 1. And make it dependent on the other detected task.
This is what I added to my `tasks.json`:
```
        {
            "type": "npm",
            "script": "list",
            "label": "NPM LIST LABEL",
            "problemMatcher": [],
            "dependsOn":["NPM LINT LINT"]
        },
```
3. Check if "dependsOn" works properly on detected tasks.

![Peek 2020-04-26 15-50](https://user-images.githubusercontent.com/37082801/80318110-d33d1180-87d5-11ea-9db7-916cebd91bef.gif)

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)
