### PR TITLE
multi-root: fix statusbar color

### DIFF
--- a/packages/workspace/src/browser/workspace-frontend-contribution.ts
+++ b/packages/workspace/src/browser/workspace-frontend-contribution.ts
@@ -67,7 +67,9 @@ export class WorkspaceFrontendContribution implements CommandContribution, Keybi
 
     protected updateStyles(): void {
         document.body.classList.remove('theia-no-open-workspace');
-        if (!this.workspaceService.tryGetRoots().length) {
+        // Display the 'no workspace opened' theme color when no folders are opened (single-root).
+        if (!this.workspaceService.isMultiRootWorkspaceOpened &&
+            !this.workspaceService.tryGetRoots().length) {
             document.body.classList.add('theia-no-open-workspace');
         }
     }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

Fixes: https://github.com/eclipse-theia/theia/issues/7687

Fixes an issue with the theming of the statusbar when in a multiple-root workspace (file) without any roots present. Previously, the application would decorate the statusbar incorrectly as if no workspace is present.

_Single-Root Workspace Opened_:
<div align='center'>

<img width="1179" alt="Screen Shot 2020-04-28 at 1 43 05 PM" src="https://user-images.githubusercontent.com/40359487/80519596-3bb2fc80-8956-11ea-874b-6328364be3c2.png">

</div>

_Multiple-Root Workspace Opened_ (No Roots):
<div align='center'>

<img width="1179" alt="Screen Shot 2020-04-28 at 1 30 23 PM" src="https://user-images.githubusercontent.com/40359487/80519684-5e451580-8956-11ea-8b39-ee3e2dc71298.png">

</div>

_Closed Workspace_:

<div align='center'>

<img width="1179" alt="Screen Shot 2020-04-28 at 1 30 04 PM" src="https://user-images.githubusercontent.com/40359487/80519746-77e65d00-8956-11ea-8696-13927cbbcf79.png">

</div>

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

1. open a multple-root workspace with two roots
2. remove both roots from the workspace (the statusbar should be colored correctly)
3. open `theia` as a workspace (the statusbar should be colored correctly)
4. execute the command `close workspace` (the statusbar should be colored correctly as if no workspace is opened)

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

Signed-off-by: vince-fugnitto <vincent.fugnitto@ericsson.com>

