### PR TITLE
ensure that only one context menu can be opened

### DIFF
--- a/packages/core/src/browser/menu/browser-context-menu-renderer.ts
+++ b/packages/core/src/browser/menu/browser-context-menu-renderer.ts
@@ -17,25 +17,26 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
 import { inject, injectable } from 'inversify';
-import { MenuPath } from '../../common/menu';
 import { Menu } from '../widgets';
-import { ContextMenuAccess, ContextMenuRenderer, Anchor, RenderContextMenuOptions } from '../context-menu-renderer';
+import { ContextMenuAccess, ContextMenuRenderer, RenderContextMenuOptions } from '../context-menu-renderer';
 import { BrowserMainMenuFactory } from './browser-menu-plugin';
 
-export class BrowserContextMenuAccess implements ContextMenuAccess {
+export class BrowserContextMenuAccess extends ContextMenuAccess {
     constructor(
         public readonly menu: Menu
-    ) { }
+    ) {
+        super(menu);
+    }
 }
 
 @injectable()
-export class BrowserContextMenuRenderer implements ContextMenuRenderer {
+export class BrowserContextMenuRenderer extends ContextMenuRenderer {
 
     constructor(@inject(BrowserMainMenuFactory) private menuFactory: BrowserMainMenuFactory) {
+        super();
     }
 
-    render(arg: MenuPath | RenderContextMenuOptions, arg2?: Anchor, arg3?: () => void): BrowserContextMenuAccess {
-        const { menuPath, anchor, args, onHide } = RenderContextMenuOptions.resolve(arg, arg2, arg3);
+    protected doRender({ menuPath, anchor, args, onHide }: RenderContextMenuOptions): BrowserContextMenuAccess {
         const contextMenu = this.menuFactory.createContextMenu(menuPath, args);
         const { x, y } = anchor instanceof MouseEvent ? { x: anchor.clientX, y: anchor.clientY } : anchor!;
         if (onHide) {

--- a/packages/core/src/electron-browser/menu/electron-context-menu-renderer.ts
+++ b/packages/core/src/electron-browser/menu/electron-context-menu-renderer.ts
@@ -18,28 +18,31 @@
 
 import * as electron from 'electron';
 import { inject, injectable } from 'inversify';
-import { MenuPath } from '../../common';
-import { ContextMenuRenderer, Anchor, RenderContextMenuOptions, ContextMenuAccess } from '../../browser';
+import { ContextMenuRenderer, RenderContextMenuOptions, ContextMenuAccess } from '../../browser';
 import { ElectronMainMenuFactory } from './electron-main-menu-factory';
 import { ContextMenuContext } from '../../browser/menu/context-menu-context';
 
-export class ElectronContextMenuAccess implements ContextMenuAccess {
+export class ElectronContextMenuAccess extends ContextMenuAccess {
     constructor(
         public readonly menu: electron.Menu
-    ) { }
+    ) {
+        super({
+            dispose: () => menu.closePopup()
+        });
+    }
 }
 
 @injectable()
-export class ElectronContextMenuRenderer implements ContextMenuRenderer {
+export class ElectronContextMenuRenderer extends ContextMenuRenderer {
 
     @inject(ContextMenuContext)
     protected readonly context: ContextMenuContext;
 
     constructor(@inject(ElectronMainMenuFactory) private menuFactory: ElectronMainMenuFactory) {
+        super();
     }
 
-    render(arg: MenuPath | RenderContextMenuOptions, arg2?: Anchor, arg3?: () => void): ElectronContextMenuAccess {
-        const { menuPath, args, onHide } = RenderContextMenuOptions.resolve(arg, arg2, arg3);
+    protected doRender({ menuPath, anchor, args, onHide }: RenderContextMenuOptions): ElectronContextMenuAccess {
         const menu = this.menuFactory.createContextMenu(menuPath, args);
         menu.popup({});
         // native context menu stops the event loop, so there is no keyboard events


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

- fix #7635: tests are failing because programmatically without any user input one could open many context menus. This PR makes sure that current context menu is closed before a new is opened.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

- CI should be green
- test context menus manually

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

