### PR TITLE
outline: fix keybinding collision on linux

### DIFF
--- a/packages/outline-view/src/browser/outline-view-contribution.ts
+++ b/packages/outline-view/src/browser/outline-view-contribution.ts
@@ -22,6 +22,7 @@ import { TabBarToolbarContribution, TabBarToolbarRegistry } from '@theia/core/li
 import { Widget } from '@theia/core/lib/browser/widgets';
 import { OutlineViewWidget } from './outline-view-widget';
 import { CompositeTreeNode } from '@theia/core/lib/browser/tree';
+import { OS } from '@theia/core/lib/common/os';
 
 export const OUTLINE_WIDGET_FACTORY_ID = 'outline-view';
 
@@ -51,7 +52,9 @@ export class OutlineViewContribution extends AbstractViewContribution<OutlineVie
                 rank: 500
             },
             toggleCommandId: 'outlineView:toggle',
-            toggleKeybinding: 'ctrlcmd+shift+i'
+            toggleKeybinding: OS.type() !== OS.Type.Linux
+                ? 'ctrlcmd+shift+i'
+                : undefined
         });
     }
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

Fixes https://github.com/eclipse-theia/theia/issues/6423

The commit fixes a keybinding collision on Linux between:
- toggling the outline-view
- performing the command `format document`

Due to priority, the `format document` will take precedence over being able to toggle the outline view based on the decision taken in the issue: https://github.com/eclipse-theia/theia/issues/6423#issuecomment-621182378

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

**Linux**

1. with a file opened, perform 'format document' using the keyboard shortcut
(it should successfully format the document instead of toggling the outline view)

**Other OS**

1. with a file opened, perform 'format document' using the keyboard shortcut 
(should work correctly)
2. perform 'toggle outline view'  using the keyboard shortcut
 (should successfully open the outline-view)

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

Signed-off-by: Vincent Fugnitto <vincent.fugnitto@ericsson.com>

