### PR TITLE
debug: fix vscode-builtin-node-debug

### DIFF
--- a/package.json
+++ b/package.json
@@ -111,7 +111,7 @@
     "vscode-builtin-markdown-language-features": "https://open-vsx.org/api/vscode/markdown-language-features/1.39.1/file/vscode.markdown-language-features-1.39.1.vsix",
     "vscode-builtin-merge-conflict": "https://open-vsx.org/api/vscode/merge-conflict/1.39.1/file/vscode.merge-conflict-1.39.1.vsix",
     "vscode-builtin-npm": "https://open-vsx.org/api/vscode/npm/1.39.1/file/vscode.npm-1.39.1.vsix",
-    "vscode-builtin-node-debug": "https://open-vsx.org/api/ms-vscode/node-debug/1.44.2/file/ms-vscode.node-debug-1.44.2.vsix",
+    "vscode-builtin-node-debug": "https://github.com/theia-ide/vscode-node-debug/releases/download/v1.35.3/node-debug-1.35.3.vsix",
     "vscode-builtin-node-debug2": "https://open-vsx.org/api/ms-vscode/node-debug2/1.33.0/file/ms-vscode.node-debug2-1.33.0.vsix",
     "vscode-builtin-objective-c": "https://open-vsx.org/api/vscode/objective-c/1.39.1/file/vscode.objective-c-1.39.1.vsix",
     "vscode-builtin-perl": "https://open-vsx.org/api/vscode/perl/1.39.1/file/vscode.perl-1.39.1.vsix",


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

Fixes: https://github.com/eclipse-theia/theia/issues/7488

The following pull-request updates the url for **vscode-builtin-node-debug** to point to the GitHub releases instead of `open-vsx` as expressed in the 'Dev Meeting'. Since the version present in `open-vsx` does not work since it hasn't been published properly and the namespace has been claimed by Microsoft, we are temporarily using the GitHub releases version instead.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

1. performing `yarn download:plugins` no longer displays the error when 
downloading **vscode-builtin-node-debug**
2. open a `*spec.ts` file (ex: 'uri.spec.ts')
3. open the debug view, and select 'run mocha test' in the dropdown
4. click on run 'start debugging' (green arrow)
5. the mocha test should successfully execute (not the case on master)

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

Signed-off-by: vince-fugnitto <vincent.fugnitto@ericsson.com>
