### PR TITLE
Run Task related refactoring

### DIFF
--- a/packages/task/src/browser/task-service.ts
+++ b/packages/task/src/browser/task-service.ts
@@ -466,9 +466,9 @@ export class TaskService implements TaskConfigurationClient {
      */
     async run(source: string, taskLabel: string, scope?: string): Promise<TaskInfo | undefined> {
         let task: TaskConfiguration | undefined;
-        task = await this.getProvidedTask(source, taskLabel, scope);
-        if (!task) { // if a detected task cannot be found, search from tasks.json
-            task = this.taskConfigurations.getTask(source, taskLabel);
+        task = this.taskConfigurations.getTask(source, taskLabel);
+        if (!task) { // if a configured task cannot be found, search from detected tasks
+            task = await this.getProvidedTask(source, taskLabel, scope);
             if (!task && scope) { // find from the customized detected tasks
                 task = await this.taskConfigurations.getCustomizedTask(scope, taskLabel);
             }


### PR DESCRIPTION
#### What it does
**1. Change the order of search task configuration at running**
At the moment at running a task the order of search is:
- search a config among `provided`/`detected` tasks
- search a config among `configured` tasks
- search a config among `customized` tasks

It works and sure it founds the corresponding config for running.
The problem is: it does extra requests when it tries to find a `configured` task configuration.

Let's say user runs some `configured` task:
- task service [tries to find](https://github.com/eclipse-theia/theia/blob/4c7275761eba622edee6df2e44c9e9e25f9e4f96/packages/task/src/browser/task-service.ts#L469) a config among `provided` tasks first
- it tries [to get `cached` provided task](https://github.com/eclipse-theia/theia/blob/4c7275761eba622edee6df2e44c9e9e25f9e4f96/packages/task/src/browser/provided-task-configurations.ts#L60) 
- sure, there is no `configured` task among `provided` tasks, so it tries to [get all provided tasks](https://github.com/eclipse-theia/theia/blob/4c7275761eba622edee6df2e44c9e9e25f9e4f96/packages/task/src/browser/provided-task-configurations.ts#L64)
- it gets all providers, [fetches and caches](https://github.com/eclipse-theia/theia/blob/4c7275761eba622edee6df2e44c9e9e25f9e4f96/packages/task/src/browser/provided-task-configurations.ts#L41-L53) all `provided` tasks
- it doesn't find the corresponding config, so next it tries to [get a config among `configured` tasks](https://github.com/eclipse-theia/theia/blob/4c7275761eba622edee6df2e44c9e9e25f9e4f96/packages/task/src/browser/task-service.ts#L471)

I think we can change the order and do search among `configured` tasks first. It will allow to avoid extra requests: it just check [if a task exists in map](https://github.com/eclipse-theia/theia/blob/4c7275761eba622edee6df2e44c9e9e25f9e4f96/packages/task/src/browser/task-configurations.ts#L184) - we don't read `tasks.json` file at this step, so it can not slow down a search.
So:   
- if we are looking for a `configured` task, it finds the corresponding config and do not search among `provided` tasks
- if we are looking for a `provided` task, it  just check [if a task exists in map](https://github.com/eclipse-theia/theia/blob/4c7275761eba622edee6df2e44c9e9e25f9e4f96/packages/task/src/browser/task-configurations.ts#L184), then it tries to find among `provided` tasks 

**2. Separate running a compound task** 
At the moment for any task config we do [extra logic related to running a compound task](https://github.com/eclipse-theia/theia/blob/4c7275761eba622edee6df2e44c9e9e25f9e4f96/packages/task/src/browser/task-service.ts#L509-L524).

But on the next step we need it [if a task is compound](https://github.com/eclipse-theia/theia/blob/4c7275761eba622edee6df2e44c9e9e25f9e4f96/packages/task/src/browser/task-service.ts#L532) only.

My propose is: separate this logic in another method and execute it if it's really required. 

#### How to test
It's just refactoring, so we should avoid a regression.
1. Try to run any `configured` task
2. Try to run any `detected` task
3. Try to run a `compound` task

For `compound` tasks testing I used in `tasks.json` file configurations like:
```
"tasks": [
    {
      "type": "shell",
      "label": "1111",
      "command": "sleep 2 && echo 111111",
      "dependsOn": "2222"
    },
    {
      "type": "shell",
      "label": "2222",
      "command": "sleep 2 && echo 222222",
      "dependsOn": "3333"
    },
    {
      "type": "shell",
      "label": "3333",
      "command": "sleep 2 && echo 33333"
    }
  ]
```

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

