### PR TITLE
Support for VSCode Command workbench.action.revertAndCloseActiveEditor

### DIFF
--- a/packages/plugin-ext-vscode/src/browser/plugin-vscode-commands-contribution.ts
+++ b/packages/plugin-ext-vscode/src/browser/plugin-vscode-commands-contribution.ts
@@ -51,6 +51,7 @@ import { DiffService } from '@theia/workspace/lib/browser/diff-service';
 import { inject, injectable } from 'inversify';
 import { Position } from '@theia/plugin-ext/lib/common/plugin-api-rpc';
 import { URI } from 'vscode-uri';
+import { MonacoEditor } from '@theia/monaco/lib/browser/monaco-editor';
 
 export namespace VscodeCommands {
     export const OPEN: Command = {
@@ -327,6 +328,19 @@ export class PluginVscodeCommandsContribution implements CommandContribution {
         commands.registerCommand({ id: 'workbench.action.reloadWindow' }, {
             execute: () => {
                 window.location.reload();
+            }
+        });
+
+        commands.registerCommand({ id: 'workbench.action.revertAndCloseActiveEditor' }, {
+            execute: async () => {
+                const editor = this.editorManager.currentEditor;
+                if (editor) {
+                    const monacoEditor = MonacoEditor.getCurrent(this.editorManager);
+                    if (monacoEditor) {
+                        await monacoEditor.document.revert();
+                        editor.close();
+                    }
+                }
             }
         });
 


### PR DESCRIPTION
#### What it does
Provides ability to execute the vscode command ```workbench.action.revertAndCloseActiveEditor``` from extensions.

#### How to test
We've tested with the Codetogether extension since it does use this command.

1. Install the extension
2. Start a session via command palette.
3. On the remote session on browser take control and start opening different files.
4. Once the Theia IDE Browser window takes focus you'll see that only the last opened file is open.


