### PR TITLE
Removed obsolete `@types/p-debounce` dependency.

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -15,7 +15,6 @@
     "@types/fs-extra": "^4.0.2",
     "@types/lodash.debounce": "4.0.3",
     "@types/lodash.throttle": "^4.1.3",
-    "@types/p-debounce": "^1.0.1",
     "@types/react": "^16.4.1",
     "@types/react-dom": "^16.0.6",
     "@types/react-virtualized": "^9.18.3",

--- a/packages/debug/package.json
+++ b/packages/debug/package.json
@@ -19,7 +19,6 @@
     "@theia/userstorage": "^1.0.0",
     "@theia/variable-resolver": "^1.0.0",
     "@theia/workspace": "^1.0.0",
-    "@types/p-debounce": "^1.0.1",
     "jsonc-parser": "^2.0.2",
     "mkdirp": "^0.5.0",
     "p-debounce": "^2.1.0",

--- a/packages/scm/package.json
+++ b/packages/scm/package.json
@@ -8,7 +8,6 @@
     "@theia/filesystem": "^1.0.0",
     "@theia/navigator": "^1.0.0",
     "@types/diff": "^3.2.2",
-    "@types/p-debounce": "^1.0.1",
     "diff": "^3.4.0",
     "p-debounce": "^2.1.0",
     "react-autosize-textarea": "^7.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1303,13 +1303,6 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-10.3.6.tgz#ea8aab9439b59f40d19ec5f13b44642344872b11"
   integrity sha512-h7VDRFL8IhdPw1JjiNVvhr+WynfKW09q2BOflIOA0yeuXNeXBP1bIRuBrysSryH4keaJ5bYUNp63aIyQL9YpDQ==
 
-"@types/p-debounce@^1.0.1":
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/@types/p-debounce/-/p-debounce-1.0.1.tgz#c9956067a240dffedf2682a24d0712ffa5e3c8fe"
-  integrity sha512-zlAn04fH4cGYPAjmYW8Tst/vxn78IJmD3PVMxxBnl3IYAG+9aGKWCu/311fPHnePJMwyxGeOhi63neSiSgM+iw==
-  dependencies:
-    p-debounce "*"
-
 "@types/p-queue@^2.3.1":
   version "2.3.2"
   resolved "https://registry.yarnpkg.com/@types/p-queue/-/p-queue-2.3.2.tgz#16bc5fece69ef85efaf2bce8b13f3ebe39c5a1c8"
@@ -9411,7 +9404,7 @@ p-cancelable@^0.4.0:
   resolved "https://registry.yarnpkg.com/p-cancelable/-/p-cancelable-0.4.1.tgz#35f363d67d52081c8d9585e37bcceb7e0bbcb2a0"
   integrity sha512-HNa1A8LvB1kie7cERyy21VNeHb2CWJJYqyyC2o3klWFfMGlFmWv2Z7sFgZH8ZiaYL95ydToKTFVXgMV/Os0bBQ==
 
-p-debounce@*, p-debounce@^2.1.0:
+p-debounce@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/p-debounce/-/p-debounce-2.1.0.tgz#e79f70c6e325cbb9bddbcbec0b81025084671ad3"
   integrity sha512-M9bMt62TTnozdZhqFgs+V7XD2MnuKCaz+7fZdlu2/T7xruI3uIE5CicQ0vx1hV7HIUYF0jF+4/R1AgfOkl74Qw==


### PR DESCRIPTION
It is available from `p-debounce`.
Ref: https://github.com/eclipse-theia/theia/commit/9286ffe58f5b10fe29831ac6c634a25c80a95ce4#r38849385

Signed-off-by: Akos Kitta <kittaakos@typefox.io>

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

