### PR TITLE
improve widget focus handling

### DIFF
--- a/packages/core/src/browser/common-frontend-contribution.ts
+++ b/packages/core/src/browser/common-frontend-contribution.ts
@@ -133,6 +133,26 @@ export namespace CommonCommands {
         category: VIEW_CATEGORY,
         label: 'Switch to Previous Tab'
     };
+    export const NEXT_TAB_IN_GROUP: Command = {
+        id: 'core.nextTabInGroup',
+        category: VIEW_CATEGORY,
+        label: 'Switch to Next Tab in Group'
+    };
+    export const PREVIOUS_TAB_IN_GROUP: Command = {
+        id: 'core.previousTabInGroup',
+        category: VIEW_CATEGORY,
+        label: 'Switch to Previous Tab in Group'
+    };
+    export const NEXT_TAB_GROUP: Command = {
+        id: 'core.nextTabGroup',
+        category: VIEW_CATEGORY,
+        label: 'Switch to Next Tab Group'
+    };
+    export const PREVIOUS_TAB_GROUP: Command = {
+        id: 'core.previousTabBar',
+        category: VIEW_CATEGORY,
+        label: 'Switch to Previous Tab Group'
+    };
     export const CLOSE_TAB: Command = {
         id: 'core.close.tab',
         category: VIEW_CATEGORY,
@@ -528,6 +548,22 @@ export class CommonFrontendContribution implements FrontendApplicationContributi
         commandRegistry.registerCommand(CommonCommands.PREVIOUS_TAB, {
             isEnabled: () => this.shell.currentTabBar !== undefined,
             execute: () => this.shell.activatePreviousTab()
+        });
+        commandRegistry.registerCommand(CommonCommands.NEXT_TAB_IN_GROUP, {
+            isEnabled: () => this.shell.nextTabIndexInTabBar() !== -1,
+            execute: () => this.shell.activateNextTabInTabBar()
+        });
+        commandRegistry.registerCommand(CommonCommands.PREVIOUS_TAB_IN_GROUP, {
+            isEnabled: () => this.shell.previousTabIndexInTabBar() !== -1,
+            execute: () => this.shell.activatePreviousTabInTabBar()
+        });
+        commandRegistry.registerCommand(CommonCommands.NEXT_TAB_GROUP, {
+            isEnabled: () => this.shell.nextTabBar() !== undefined,
+            execute: () => this.shell.activateNextTabBar()
+        });
+        commandRegistry.registerCommand(CommonCommands.PREVIOUS_TAB_GROUP, {
+            isEnabled: () => this.shell.previousTabBar() !== undefined,
+            execute: () => this.shell.activatePreviousTabBar()
         });
         commandRegistry.registerCommand(CommonCommands.CLOSE_TAB, {
             isEnabled: (event?: Event) => {

--- a/packages/core/src/browser/shell/application-shell.ts
+++ b/packages/core/src/browser/shell/application-shell.ts
@@ -1620,6 +1620,15 @@ export class ApplicationShell extends Widget {
         return [...this.tracker.widgets];
     }
 
+    getWidgetById(id: string): Widget | undefined {
+        for (const widget of this.tracker.widgets) {
+            if (widget.id === id) {
+                return widget;
+            }
+        }
+        return undefined;
+    }
+
     canToggleMaximized(): boolean {
         const area = this.currentWidget && this.getAreaFor(this.currentWidget);
         return area === 'main' || area === 'bottom';

--- a/packages/markers/src/browser/marker-tree-label-provider.spec.ts
+++ b/packages/markers/src/browser/marker-tree-label-provider.spec.ts
@@ -21,9 +21,9 @@ let disableJSDOM = enableJSDOM();
 import URI from '@theia/core/lib/common/uri';
 import { expect } from 'chai';
 import { Container } from 'inversify';
-import { ContributionProvider } from '@theia/core/lib/common';
+import { ContributionProvider, Event } from '@theia/core/lib/common';
 import { FileStat, FileSystem } from '@theia/filesystem/lib/common';
-import { LabelProvider, LabelProviderContribution, DefaultUriLabelProviderContribution, ApplicationShell } from '@theia/core/lib/browser';
+import { LabelProvider, LabelProviderContribution, DefaultUriLabelProviderContribution, ApplicationShell, WidgetManager } from '@theia/core/lib/browser';
 import { MarkerInfoNode } from './marker-tree';
 import { MarkerTreeLabelProvider } from './marker-tree-label-provider';
 import { Signal } from '@phosphor/signaling';
@@ -46,7 +46,12 @@ before(() => {
     testContainer.bind(WorkspaceService).toConstantValue(workspaceService);
     testContainer.bind(WorkspaceVariableContribution).toSelf().inSingletonScope();
     testContainer.bind(ApplicationShell).toConstantValue({
-        currentChanged: new Signal({})
+        currentChanged: new Signal({}),
+        widgets: () => []
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any);
+    testContainer.bind(WidgetManager).toConstantValue({
+        onDidCreateWidget: Event.None
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
     } as any);
     testContainer.bind(FileSystem).to(MockFilesystem).inSingletonScope();

--- a/packages/workspace/src/browser/workspace-uri-contribution.spec.ts
+++ b/packages/workspace/src/browser/workspace-uri-contribution.spec.ts
@@ -21,7 +21,8 @@ import { expect } from 'chai';
 import * as sinon from 'sinon';
 import { Container } from 'inversify';
 import { Signal } from '@phosphor/signaling';
-import { ApplicationShell } from '@theia/core/lib/browser';
+import { Event } from '@theia/core/lib/common/event';
+import { ApplicationShell, WidgetManager } from '@theia/core/lib/browser';
 import { FileStat, FileSystem } from '@theia/filesystem/lib/common/filesystem';
 import { MockFilesystem } from '@theia/filesystem/lib/common/test';
 import { DefaultUriLabelProviderContribution } from '@theia/core/lib/browser/label-provider';
@@ -44,7 +45,12 @@ beforeEach(() => {
 
     container = new Container();
     container.bind(ApplicationShell).toConstantValue({
-        currentChanged: new Signal({})
+        currentChanged: new Signal({}),
+        widgets: () => []
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any);
+    container.bind(WidgetManager).toConstantValue({
+        onDidCreateWidget: Event.None
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
     } as any);
     const workspaceService = new WorkspaceService();


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

- fix #7170, fix #5027, close #7258 - redefine current editor and resource widgets as last focused or recently visible widgets
- fix #2234 - activate another widget if an active widget is closed:
  - try to use recently used widget in the same group first
  - try to use next widget in the same group
  - try to use a widget from the previous group
  - try to use a widget from the next group
- Adds new commands to navigate between previous/next groups and tabs in the same group to implement the logic above.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

- Close active widget and check that focus is transfered.
- Run the debug session and check language status bar elements it should work even when there is not active widget.
- Try in different layouts.

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

