### PR TITLE
[performance] make sure decompress is set to 4.2.0

### DIFF
--- a/packages/plugin-ext/package.json
+++ b/packages/plugin-ext/package.json
@@ -28,7 +28,7 @@
     "@types/mime": "^2.0.1",
     "@types/serve-static": "^1.13.3",
     "connect": "^3.7.0",
-    "decompress": "^4.2.0",
+    "decompress": "4.2.0",
     "escape-html": "^1.0.3",
     "filenamify": "^4.1.0",
     "jsonc-parser": "^2.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4600,7 +4600,7 @@ decompress-unzip@^4.0.1:
     pify "^2.3.0"
     yauzl "^2.4.2"
 
-decompress@^4.2.0:
+decompress@4.2.0:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/decompress/-/decompress-4.2.0.tgz#7aedd85427e5a92dacfe55674a7c505e96d01f9d"
   integrity sha1-eu3YVCflqS2s/lVnSnxQXpbQH50=


### PR DESCRIPTION
decompress 4.2.1 will cause a huge performance degradation in plugins deployment
See: https://github.com/kevva/decompress/issues/77

Signed-off-by: Amiram Wingarten <amiram.wingarten@sap.com>

#### What it does
Set decompress dependency on plugin-ext to 4.2.0 exactly as 4.2.1 brings major performance degredation. This fixed version will make sure that theia and dependent projects don't build their product with 4.2.1.

#### How to test
If yarn.lock is deleted and theia is built with decompress 4.2.1 the loading of vsix files takes very high CPU and takes at least twice compared to current situation.
With current theia yarn.lock decompress is still 4.2.0 so there is no current problem.

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

