### PR TITLE
scm: add 'scm.defaultViewMode' preference

### DIFF
--- a/packages/scm/src/browser/scm-contribution.ts
+++ b/packages/scm/src/browser/scm-contribution.ts
@@ -60,11 +60,11 @@ export namespace SCM_COMMANDS {
         iconClass: 'codicon codicon-list-tree',
         label: 'Toggle to Tree View',
     };
-    export const FLAT_VIEW_MODE = {
-        id: 'scm.viewmode.flat',
-        tooltip: 'Toggle to Flat View',
+    export const LIST_VIEW_MODE = {
+        id: 'scm.viewmode.list',
+        tooltip: 'Toggle to List View',
         iconClass: 'codicon codicon-list-flat',
-        label: 'Toggle to Flat View',
+        label: 'Toggle to List View',
     };
 }
 
@@ -151,7 +151,7 @@ export class ScmContribution extends AbstractViewContribution<ScmWidget> impleme
                 }
             }
         };
-        const registerToggleViewItem = (command: Command, mode: 'tree' | 'flat') => {
+        const registerToggleViewItem = (command: Command, mode: 'tree' | 'list') => {
             const id = command.id;
             const item: TabBarToolbarItem = {
                 id,
@@ -179,7 +179,7 @@ export class ScmContribution extends AbstractViewContribution<ScmWidget> impleme
             registry.registerItem(item);
         };
         registerToggleViewItem(SCM_COMMANDS.TREE_VIEW_MODE, 'tree');
-        registerToggleViewItem(SCM_COMMANDS.FLAT_VIEW_MODE, 'flat');
+        registerToggleViewItem(SCM_COMMANDS.LIST_VIEW_MODE, 'list');
     }
 
     registerKeybindings(keybindings: KeybindingRegistry): void {

--- a/packages/scm/src/browser/scm-frontend-module.ts
+++ b/packages/scm/src/browser/scm-frontend-module.ts
@@ -44,6 +44,7 @@ import { ScmTreeLabelProvider } from './scm-tree-label-provider';
 import { TabBarToolbarContribution } from '@theia/core/lib/browser/shell/tab-bar-toolbar';
 import { ColorContribution } from '@theia/core/lib/browser/color-application-contribution';
 import { LabelProviderContribution } from '@theia/core/lib/browser/label-provider';
+import { bindScmPreferences } from './scm-preferences';
 
 export default new ContainerModule(bind => {
     bind(ScmContextKeyService).toSelf().inSingletonScope();
@@ -115,6 +116,8 @@ export default new ContainerModule(bind => {
 
     bind(ScmTreeLabelProvider).toSelf().inSingletonScope();
     bind(LabelProviderContribution).toService(ScmTreeLabelProvider);
+
+    bindScmPreferences(bind);
 });
 
 export function createFileChangeTreeContainer(parent: interfaces.Container): Container {

--- a/packages/scm/src/browser/scm-preferences.ts
+++ b/packages/scm/src/browser/scm-preferences.ts
@@ -1,0 +1,61 @@
+/********************************************************************************
+ * Copyright (C) 2020 Ericsson and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import { interfaces } from 'inversify';
+import {
+    createPreferenceProxy,
+    PreferenceProxy,
+    PreferenceService,
+    PreferenceSchema,
+    PreferenceContribution
+} from '@theia/core/lib/browser/preferences';
+
+export const scmPreferenceSchema: PreferenceSchema = {
+    type: 'object',
+    properties: {
+        'scm.defaultViewMode': {
+            type: 'string',
+            enum: ['tree', 'list'],
+            enumDescriptions: [
+                'Show the repository changes as a tree.',
+                'Show the repository changes as a list.'
+            ],
+            description: 'Controls the default source control view mode.',
+            default: 'list'
+        }
+    }
+};
+
+export interface ScmConfiguration {
+    'scm.defaultViewMode': 'tree' | 'list'
+}
+
+export const ScmPreferences = Symbol('ScmPreferences');
+export type ScmPreferences = PreferenceProxy<ScmConfiguration>;
+
+export function createScmPreferences(preferences: PreferenceService): ScmPreferences {
+    return createPreferenceProxy(preferences, scmPreferenceSchema);
+}
+
+export function bindScmPreferences(bind: interfaces.Bind): void {
+    bind(ScmPreferences).toDynamicValue((ctx: interfaces.Context) => {
+        const preferences = ctx.container.get<PreferenceService>(PreferenceService);
+        return createScmPreferences(preferences);
+    }).inSingletonScope();
+
+    bind(PreferenceContribution).toConstantValue({ schema: scmPreferenceSchema });
+}
+

--- a/packages/scm/src/browser/scm-tree-model.ts
+++ b/packages/scm/src/browser/scm-tree-model.ts
@@ -83,8 +83,8 @@ export class ScmTreeModel extends TreeModelImpl {
         return this._languageId;
     }
 
-    protected _viewMode: 'tree' | 'flat' = 'flat';
-    set viewMode(id: 'tree' | 'flat') {
+    protected _viewMode: 'tree' | 'list' = 'list';
+    set viewMode(id: 'tree' | 'list') {
         const oldSelection = this.selectedNodes;
         this._viewMode = id;
         if (this._provider) {
@@ -98,7 +98,7 @@ export class ScmTreeModel extends TreeModelImpl {
             }
         }
     }
-    get viewMode(): 'tree' | 'flat' {
+    get viewMode(): 'tree' | 'list' {
         return this._viewMode;
     }
 
@@ -149,7 +149,7 @@ export class ScmTreeModel extends TreeModelImpl {
         };
 
         switch (this._viewMode) {
-            case 'flat':
+            case 'list':
                 groupNode.children = group.resources.map(fileChange => this.toFileChangeNode(fileChange, groupNode));
                 break;
             case 'tree':

--- a/packages/scm/src/browser/scm-tree-widget.tsx
+++ b/packages/scm/src/browser/scm-tree-widget.tsx
@@ -79,10 +79,10 @@ export class ScmTreeWidget extends TreeWidget {
         }));
     }
 
-    set viewMode(id: 'tree' | 'flat') {
+    set viewMode(id: 'tree' | 'list') {
         this.model.viewMode = id;
     }
-    get viewMode(): 'tree' | 'flat' {
+    get viewMode(): 'tree' | 'list' {
         return this.model.viewMode;
     }
 
@@ -409,7 +409,7 @@ export class ScmTreeWidget extends TreeWidget {
 
     restoreState(oldState: any): void {
         const { mode, tree } = oldState;
-        this.model.viewMode = mode === 'tree' ? 'tree' : 'flat';
+        this.model.viewMode = mode === 'tree' ? 'tree' : 'list';
         super.restoreState(tree);
     }
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

Fixes: #7713

The following pull-request adds a new preference for the **scm** extension named 
**scm.defaultViewMode** which is used to control the view mode rendering of the scm widget between displaying results as a tree or a flat list.

_scm.defaultViewMode: list_

<img width="409" alt="Screen Shot 2020-05-01 at 9 47 58 AM" src="https://user-images.githubusercontent.com/40359487/80810013-e878be00-8b90-11ea-96f8-d1d60f9494ab.png">

_scm.defaultViewMode: tree_

<img width="409" alt="Screen Shot 2020-05-01 at 9 47 50 AM" src="https://user-images.githubusercontent.com/40359487/80810012-e7e02780-8b90-11ea-839e-8f9210da3f7c.png">


#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

1. open a workspace with changes under version-control
2. open the **scm** widget
3. update the preference **scm.defaultViewMode**
(the scm widget's view mode should update accordingly)

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

Signed-off-by: vince-fugnitto <vincent.fugnitto@ericsson.com>