### PR TITLE
plugin: add workspace file api

### DIFF
--- a/packages/filesystem/src/node/node-filesystem.ts
+++ b/packages/filesystem/src/node/node-filesystem.ts
@@ -263,6 +263,25 @@ export class FileSystemNode implements FileSystem {
     }
 
     async createFile(uri: string, options?: { content?: string, encoding?: string }): Promise<FileStat> {
+        if (this.client) {
+            await this.client.willCreate(uri);
+        }
+        let result: FileStat;
+        let failed = false;
+        try {
+            result = await this.doCreateFile(uri, options);
+        } catch (e) {
+            failed = true;
+            throw e;
+        } finally {
+            if (this.client) {
+                await this.client.didCreate(uri, failed);
+            }
+        }
+        return result;
+    }
+
+    protected async doCreateFile(uri: string, options?: { content?: string, encoding?: string }): Promise<FileStat> {
         const _uri = new URI(uri);
         const parentUri = _uri.parent;
         const [stat, parentStat] = await Promise.all([this.doGetStat(_uri, 0), this.doGetStat(parentUri, 0)]);
@@ -284,6 +303,25 @@ export class FileSystemNode implements FileSystem {
     }
 
     async createFolder(uri: string): Promise<FileStat> {
+        if (this.client) {
+            await this.client.willCreate(uri);
+        }
+        let result: FileStat;
+        let failed = false;
+        try {
+            result = await this.doCreateFolder(uri);
+        } catch (e) {
+            failed = true;
+            throw e;
+        } finally {
+            if (this.client) {
+                await this.client.didCreate(uri, failed);
+            }
+        }
+        return result;
+    }
+
+    async doCreateFolder(uri: string): Promise<FileStat> {
         const _uri = new URI(uri);
         const stat = await this.doGetStat(_uri, 0);
         if (stat) {

--- a/packages/plugin-ext/src/common/plugin-api-rpc-model.ts
+++ b/packages/plugin-ext/src/common/plugin-api-rpc-model.ts
@@ -95,18 +95,6 @@ export interface FileChangeEvent {
     type: FileChangeEventType
 }
 
-export interface FileMoveEvent {
-    subscriberId: string,
-    oldUri: UriComponents,
-    newUri: UriComponents
-}
-
-export interface FileWillMoveEvent {
-    subscriberId: string,
-    oldUri: UriComponents,
-    newUri: UriComponents
-}
-
 export type FileChangeEventType = 'created' | 'updated' | 'deleted';
 
 export enum CompletionTriggerKind {
@@ -546,4 +534,16 @@ export interface CallHierarchyIncomingCall {
 export interface CallHierarchyOutgoingCall {
     to: CallHierarchyItem;
     fromRanges: Range[];
+}
+
+export interface CreateFilesEventDTO {
+    files: UriComponents[]
+}
+
+export interface RenameFilesEventDTO {
+    files: { oldUri: UriComponents, newUri: UriComponents }[]
+}
+
+export interface DeleteFilesEventDTO {
+    files: UriComponents[]
 }

--- a/packages/plugin-ext/src/common/plugin-api-rpc.ts
+++ b/packages/plugin-ext/src/common/plugin-api-rpc.ts
@@ -58,8 +58,6 @@ import {
     Breakpoint,
     ColorPresentation,
     RenameLocation,
-    FileMoveEvent,
-    FileWillMoveEvent,
     SignatureHelpContext,
     CodeAction,
     CodeActionContext,
@@ -67,7 +65,10 @@ import {
     FoldingRange,
     SelectionRange,
     CallHierarchyDefinition,
-    CallHierarchyReference
+    CallHierarchyReference,
+    CreateFilesEventDTO,
+    RenameFilesEventDTO,
+    DeleteFilesEventDTO,
 } from './plugin-api-rpc-model';
 import { ExtPluginApi } from './plugin-ext-api-contribution';
 import { KeysToAnyValues, KeysToKeysToAnyValue } from './types';
@@ -506,8 +507,13 @@ export interface WorkspaceExt {
     $onWorkspaceFoldersChanged(event: WorkspaceRootsChangeEvent): void;
     $provideTextDocumentContent(uri: string): Promise<string | undefined>;
     $fileChanged(event: FileChangeEvent): void;
-    $onFileRename(event: FileMoveEvent): void;
-    $onWillRename(event: FileWillMoveEvent): Promise<any>;
+
+    $onWillCreateFiles(event: CreateFilesEventDTO): Promise<any[]>;
+    $onDidCreateFiles(event: CreateFilesEventDTO): void;
+    $onWillRenameFiles(event: RenameFilesEventDTO): Promise<any[]>;
+    $onDidRenameFiles(event: RenameFilesEventDTO): void;
+    $onWillDeleteFiles(event: DeleteFilesEventDTO): Promise<any[]>;
+    $onDidDeleteFiles(event: DeleteFilesEventDTO): void;
 }
 
 export interface DialogsMain {

--- a/packages/plugin-ext/src/plugin/file-system.ts
+++ b/packages/plugin-ext/src/plugin/file-system.ts
@@ -44,7 +44,6 @@ export class FileSystemExtImpl implements FileSystemExt {
         this.usedSchemes.add(Schemes.DATA);
         this.usedSchemes.add(Schemes.COMMAND);
         this.fileSystem = new InPluginFileSystemProxy(this.proxy);
-
     }
 
     get fs(): theia.FileSystem {

--- a/packages/plugin-ext/src/plugin/plugin-context.ts
+++ b/packages/plugin-ext/src/plugin/plugin-context.ts
@@ -422,6 +422,24 @@ export function createAPIFactory(
             onDidSaveTextDocument(listener, thisArg?, disposables?) {
                 return documents.onDidSaveTextDocument(listener, thisArg, disposables);
             },
+            onWillCreateFiles(listener, thisArg?, disposables?) {
+                return workspaceExt.onWillCreateFiles(listener, thisArg, disposables);
+            },
+            onDidCreateFiles(listener, thisArg?, disposables?) {
+                return workspaceExt.onDidCreateFiles(listener, thisArg, disposables);
+            },
+            onWillRenameFiles(listener, thisArg?, disposables?) {
+                return workspaceExt.onWillRenameFiles(listener, thisArg, disposables);
+            },
+            onDidRenameFiles(listener, thisArg?, disposables?) {
+                return workspaceExt.onDidRenameFiles(listener, thisArg, disposables);
+            },
+            onWillDeleteFiles(listener, thisArg?, disposables?) {
+                return workspaceExt.onWillDeleteFiles(listener, thisArg, disposables);
+            },
+            onDidDeleteFiles(listener, thisArg?, disposables?) {
+                return workspaceExt.onDidDeleteFiles(listener, thisArg, disposables);
+            },
             getConfiguration(section?, resource?): theia.WorkspaceConfiguration {
                 return preferenceRegistryExt.getConfiguration(section, resource);
             },
@@ -481,13 +499,6 @@ export function createAPIFactory(
             registerTaskProvider(type: string, provider: theia.TaskProvider): theia.Disposable {
                 return tasks.registerTaskProvider(type, provider);
             },
-            // Experimental API https://github.com/eclipse-theia/theia/issues/4167
-            onDidRenameFile(listener, thisArg?, disposables?): theia.Disposable {
-                return workspaceExt.onDidRenameFile(listener, thisArg, disposables);
-            },
-            onWillRenameFile(listener, thisArg?, disposables?): theia.Disposable {
-                return workspaceExt.onWillRenameFile(listener, thisArg, disposables);
-            }
         };
 
         const onDidChangeLogLevel = new Emitter<theia.LogLevel>();

--- a/packages/plugin/src/theia-proposed.d.ts
+++ b/packages/plugin/src/theia-proposed.d.ts
@@ -35,21 +35,6 @@ declare module '@theia/plugin' {
         export function stop(id: string): void;
     }
 
-    // Experimental API
-    // https://github.com/Microsoft/vscode/blob/1.30.2/src/vs/vscode.proposed.d.ts#L1015
-    export interface FileRenameEvent {
-        readonly oldUri: Uri;
-        readonly newUri: Uri;
-    }
-
-    // Experimental API
-    // https://github.com/Microsoft/vscode/blob/1.30.2/src/vs/vscode.proposed.d.ts#L1020
-    export interface FileWillRenameEvent {
-        readonly oldUri: Uri;
-        readonly newUri: Uri;
-        waitUntil(thenable: PromiseLike<WorkspaceEdit>): void;
-    }
-
     /**
     * The language contribution interface defines an information about language server which should be registered.
     */
@@ -138,13 +123,6 @@ declare module '@theia/plugin' {
         Windows = 'Windows',
         Linux = 'Linux',
         OSX = 'OSX'
-    }
-
-    export namespace workspace {
-        // Experimental API
-        // https://github.com/Microsoft/vscode/blob/1.30.2/src/vs/vscode.proposed.d.ts#L1026-L1028
-        export const onWillRenameFile: Event<FileWillRenameEvent>;
-        export const onDidRenameFile: Event<FileRenameEvent>;
     }
 
     export namespace env {

--- a/packages/plugin/src/theia.d.ts
+++ b/packages/plugin/src/theia.d.ts
@@ -3391,7 +3391,7 @@ declare module '@theia/plugin' {
         /**
          * Shows a file upload dialog to the user which allows to upload files
          * for various purposes.
-         * 
+         *
          * @param options Options, that control the dialog.
          * @returns A promise that resolves the paths of uploaded files or `undefined`.
          */
@@ -4545,6 +4545,171 @@ declare module '@theia/plugin' {
     }
 
     /**
+     * An event that is fired when files are going to be created.
+     *
+     * To make modifications to the workspace before the files are created,
+     * call the [`waitUntil](#FileWillCreateEvent.waitUntil)-function with a
+     * thenable that resolves to a [workspace edit](#WorkspaceEdit).
+     */
+    export interface FileWillCreateEvent {
+
+        /**
+         * The files that are going to be created.
+         */
+        readonly files: ReadonlyArray<Uri>;
+
+        /**
+         * Allows to pause the event and to apply a [workspace edit](#WorkspaceEdit).
+         *
+         * *Note:* This function can only be called during event dispatch and not
+         * in an asynchronous manner:
+         *
+         * ```ts
+         * workspace.onWillCreateFiles(event => {
+         *     // async, will *throw* an error
+         *     setTimeout(() => event.waitUntil(promise));
+         *
+         *     // sync, OK
+         *     event.waitUntil(promise);
+         * })
+         * ```
+         *
+         * @param thenable A thenable that delays saving.
+         */
+        waitUntil(thenable: Thenable<WorkspaceEdit>): void;
+
+        /**
+         * Allows to pause the event until the provided thenable resolves.
+         *
+         * *Note:* This function can only be called during event dispatch.
+         *
+         * @param thenable A thenable that delays saving.
+         */
+        waitUntil(thenable: Thenable<any>): void;
+    }
+
+    /**
+     * An event that is fired after files are created.
+     */
+    export interface FileCreateEvent {
+
+        /**
+         * The files that got created.
+         */
+        readonly files: ReadonlyArray<Uri>;
+    }
+
+    /**
+     * An event that is fired when files are going to be deleted.
+     *
+     * To make modifications to the workspace before the files are deleted,
+     * call the [`waitUntil](#FileWillCreateEvent.waitUntil)-function with a
+     * thenable that resolves to a [workspace edit](#WorkspaceEdit).
+     */
+    export interface FileWillDeleteEvent {
+
+        /**
+         * The files that are going to be deleted.
+         */
+        readonly files: ReadonlyArray<Uri>;
+
+        /**
+         * Allows to pause the event and to apply a [workspace edit](#WorkspaceEdit).
+         *
+         * *Note:* This function can only be called during event dispatch and not
+         * in an asynchronous manner:
+         *
+         * ```ts
+         * workspace.onWillCreateFiles(event => {
+         *     // async, will *throw* an error
+         *     setTimeout(() => event.waitUntil(promise));
+         *
+         *     // sync, OK
+         *     event.waitUntil(promise);
+         * })
+         * ```
+         *
+         * @param thenable A thenable that delays saving.
+         */
+        waitUntil(thenable: Thenable<WorkspaceEdit>): void;
+
+        /**
+         * Allows to pause the event until the provided thenable resolves.
+         *
+         * *Note:* This function can only be called during event dispatch.
+         *
+         * @param thenable A thenable that delays saving.
+         */
+        waitUntil(thenable: Thenable<any>): void;
+    }
+
+    /**
+     * An event that is fired after files are deleted.
+     */
+    export interface FileDeleteEvent {
+
+        /**
+         * The files that got deleted.
+         */
+        readonly files: ReadonlyArray<Uri>;
+    }
+
+    /**
+     * An event that is fired when files are going to be renamed.
+     *
+     * To make modifications to the workspace before the files are renamed,
+     * call the [`waitUntil](#FileWillCreateEvent.waitUntil)-function with a
+     * thenable that resolves to a [workspace edit](#WorkspaceEdit).
+     */
+    export interface FileWillRenameEvent {
+
+        /**
+         * The files that are going to be renamed.
+         */
+        readonly files: ReadonlyArray<{ oldUri: Uri, newUri: Uri }>;
+
+        /**
+         * Allows to pause the event and to apply a [workspace edit](#WorkspaceEdit).
+         *
+         * *Note:* This function can only be called during event dispatch and not
+         * in an asynchronous manner:
+         *
+         * ```ts
+         * workspace.onWillCreateFiles(event => {
+         *     // async, will *throw* an error
+         *     setTimeout(() => event.waitUntil(promise));
+         *
+         *     // sync, OK
+         *     event.waitUntil(promise);
+         * })
+         * ```
+         *
+         * @param thenable A thenable that delays saving.
+         */
+        waitUntil(thenable: Thenable<WorkspaceEdit>): void;
+
+        /**
+         * Allows to pause the event until the provided thenable resolves.
+         *
+         * *Note:* This function can only be called during event dispatch.
+         *
+         * @param thenable A thenable that delays saving.
+         */
+        waitUntil(thenable: Thenable<any>): void;
+    }
+
+    /**
+     * An event that is fired after files are renamed.
+     */
+    export interface FileRenameEvent {
+
+        /**
+         * The files that got renamed.
+         */
+        readonly files: ReadonlyArray<{ oldUri: Uri, newUri: Uri }>;
+    }
+
+    /**
      * Namespace for dealing with the current workspace. A workspace is the representation
      * of the folder that has been opened. There is no workspace when just a file but not a
      * folder has been opened.
@@ -4660,6 +4825,76 @@ declare module '@theia/plugin' {
          * An event that is emitted when a [text document](#TextDocument) is saved to disk.
          */
         export const onDidSaveTextDocument: Event<TextDocument>;
+
+        /**
+         * An event that is emitted when files are being created.
+         *
+         * *Note 1:* This event is triggered by user gestures, like creating a file from the
+         * explorer, or from the [`workspace.applyEdit`](#workspace.applyEdit)-api. This event is *not* fired when
+         * files change on disk, e.g triggered by another application, or when using the
+         * [`workspace.fs`](#FileSystem)-api.
+         *
+         * *Note 2:* When this event is fired, edits to files thare are being created cannot be applied.
+         */
+        export const onWillCreateFiles: Event<FileWillCreateEvent>;
+
+        /**
+         * An event that is emitted when files have been created.
+         *
+         * *Note:* This event is triggered by user gestures, like creating a file from the
+         * explorer, or from the [`workspace.applyEdit`](#workspace.applyEdit)-api, but this event is *not* fired when
+         * files change on disk, e.g triggered by another application, or when using the
+         * [`workspace.fs`](#FileSystem)-api.
+         */
+        export const onDidCreateFiles: Event<FileCreateEvent>;
+
+        /**
+         * An event that is emitted when files are being deleted.
+         *
+         * *Note 1:* This event is triggered by user gestures, like deleting a file from the
+         * explorer, or from the [`workspace.applyEdit`](#workspace.applyEdit)-api, but this event is *not* fired when
+         * files change on disk, e.g triggered by another application, or when using the
+         * [`workspace.fs`](#FileSystem)-api.
+         *
+         * *Note 2:* When deleting a folder with children only one event is fired.
+         */
+        export const onWillDeleteFiles: Event<FileWillDeleteEvent>;
+
+        /**
+         * An event that is emitted when files have been deleted.
+         *
+         * *Note 1:* This event is triggered by user gestures, like deleting a file from the
+         * explorer, or from the [`workspace.applyEdit`](#workspace.applyEdit)-api, but this event is *not* fired when
+         * files change on disk, e.g triggered by another application, or when using the
+         * [`workspace.fs`](#FileSystem)-api.
+         *
+         * *Note 2:* When deleting a folder with children only one event is fired.
+         */
+        export const onDidDeleteFiles: Event<FileDeleteEvent>;
+
+        /**
+         * An event that is emitted when files are being renamed.
+         *
+         * *Note 1:* This event is triggered by user gestures, like renaming a file from the
+         * explorer, and from the [`workspace.applyEdit`](#workspace.applyEdit)-api, but this event is *not* fired when
+         * files change on disk, e.g triggered by another application, or when using the
+         * [`workspace.fs`](#FileSystem)-api.
+         *
+         * *Note 2:* When renaming a folder with children only one event is fired.
+         */
+        export const onWillRenameFiles: Event<FileWillRenameEvent>;
+
+        /**
+         * An event that is emitted when files have been renamed.
+         *
+         * *Note 1:* This event is triggered by user gestures, like renaming a file from the
+         * explorer, and from the [`workspace.applyEdit`](#workspace.applyEdit)-api, but this event is *not* fired when
+         * files change on disk, e.g triggered by another application, or when using the
+         * [`workspace.fs`](#FileSystem)-api.
+         *
+         * *Note 2:* When renaming a folder with children only one event is fired.
+         */
+        export const onDidRenameFiles: Event<FileRenameEvent>;
 
         /**
          * Opens a document. Will return early if this document is already open. Otherwise

--- a/packages/workspace/src/browser/workspace-delete-handler.ts
+++ b/packages/workspace/src/browser/workspace-delete-handler.ts
@@ -131,7 +131,7 @@ export class WorkspaceDeleteHandler implements UriCommandHandler<URI[]> {
     /**
      * Perform deletion of a given URI.
      *
-     * @param uris URIs of selected resources.
+     * @param uri URI of selected resource.
      */
     protected async delete(uri: URI): Promise<void> {
         try {


### PR DESCRIPTION
#### What it does

Add `on(will|did)(create|rename|delete)Files` to the plugin's workspace
api. This implementation does not handle the `WorkspaceEdit` apis.

Fixes: https://github.com/eclipse-theia/theia/issues/7171

#### How to test

1. include the following [plugin](https://github.com/vince-fugnitto/workspace-event-api/releases/download/v1.0.0/workspace-api-ext-0.0.1.vsix)
2. perform **add / rename / delete** of files through the user-interface and and check that events are correctly fired.

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)