### PR TITLE
fix file icons in explorer are not aligned if file name is truncated

### DIFF
--- a/packages/filesystem/src/browser/style/file-icons.css
+++ b/packages/filesystem/src/browser/style/file-icons.css
@@ -28,7 +28,7 @@
 }
 
 .theia-file-icons-js.file-icon {
-    width: var(--theia-icon-size);
+    min-width: var(--theia-icon-size);
     height: var(--theia-icon-size);
     display: flex;
     justify-content: center;


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->
Fixes #7720 

before: see gif in #7720
after:
![Screen-Recording-2020-05-04-at-0 45 37](https://user-images.githubusercontent.com/24614792/80926546-b047ca00-8da0-11ea-82c2-3c976f853869.gif)
all stay in place


#### Review checklist

- [X] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

