### PR TITLE
Fix ElectronContextMenuRenderer to use passed in anchor XY values

### DIFF
--- a/packages/core/src/electron-browser/menu/electron-context-menu-renderer.ts
+++ b/packages/core/src/electron-browser/menu/electron-context-menu-renderer.ts
@@ -44,7 +44,9 @@ export class ElectronContextMenuRenderer extends ContextMenuRenderer {
 
     protected doRender({ menuPath, anchor, args, onHide }: RenderContextMenuOptions): ElectronContextMenuAccess {
         const menu = this.menuFactory.createContextMenu(menuPath, args);
-        menu.popup({});
+        const { x, y } = anchor instanceof MouseEvent ? { x: anchor.clientX, y: anchor.clientY } : anchor!;
+        // x and y values must be Ints or else there is a conversion error
+        menu.popup({ x: Math.round(x), y: Math.round(y) });
         // native context menu stops the event loop, so there is no keyboard events
         this.context.resetAltPressed();
         if (onHide) {


### PR DESCRIPTION
Signed-off-by: Kenneth Marut <kenneth.marut@ericsson.com>
Signed-off-by: Colin Grant <colin.grant@ericsson.com>

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

Fixes: #7722

This PR addresses  #7722 which was uncovered in #7105 where the ElectronContextMenuRenderer did not utilize the passed in `anchor` parameter to render the menu at a given X/Y location. This caused the gear-icon and folder-scope context menus to be rendered at the mouse location rather than the passed-in anchor location. This issue is fixed by adding an identical `MouseEvent` check as in: https://github.com/eclipse-theia/theia/blob/cea62337848477b12b61ed7acf30634e12acc52d/packages/core/src/browser/menu/browser-context-menu-renderer.ts#L30

And also by rounding anchor XY values to integer forms (due to a conversion error down the line) and passing the arguments into `menu.popup({ x: Math.round(x), y: Math.round(y) });` in the `electron-menu-context-renderer.ts`

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
1. Pull latest changes from #7105, build, and run in Electron
2. Open new preferences UI with multiroot workspace
3. Click on gear-icon and/or folder scope tab in preferences UI, observe bad behavior of context menu
4. Pull changes from this PR, and rebuild in Electron
5. Relaunch and run steps 2-3
6. Observe context menu behaior

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

