### PR TITLE
Update uuid to v8

### DIFF
--- a/dev-packages/application-manager/src/generator/frontend-generator.ts
+++ b/dev-packages/application-manager/src/generator/frontend-generator.ts
@@ -130,7 +130,7 @@ if (process.env.LC_ALL) {
 }
 process.env.LC_NUMERIC = 'C';
 
-const uuid = require('uuid');
+const { v4 } = require('uuid');
 const electron = require('electron');
 const { join, resolve } = require('path');
 const { fork } = require('child_process');
@@ -152,7 +152,7 @@ const Storage = require('electron-store');
 const electronStore = new Storage();
 
 const electronSecurityToken = {
-    value: uuid.v4(),
+    value: v4(),
 };
 
 app.on('ready', () => {

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "@types/node": "~10.3.6",
     "@types/sinon": "^2.3.5",
     "@types/temp": "^0.8.29",
-    "@types/uuid": "^3.4.3",
+    "@types/uuid": "^7.0.3",
     "@typescript-eslint/eslint-plugin": "^2.16.0",
     "@typescript-eslint/eslint-plugin-tslint": "^2.16.0",
     "@typescript-eslint/parser": "^2.16.0",
@@ -38,7 +38,7 @@
     "typedoc": "^0.15.0-0",
     "typedoc-plugin-external-module-map": "^1.0.0",
     "typescript": "~3.5.3",
-    "uuid": "^3.2.1"
+    "uuid": "^8.0.0"
   },
   "scripts": {
     "preinstall": "node-gyp install",

--- a/packages/filesystem/package.json
+++ b/packages/filesystem/package.json
@@ -9,7 +9,7 @@
     "@types/rimraf": "^2.0.2",
     "@types/tar-fs": "^1.16.1",
     "@types/touch": "0.0.1",
-    "@types/uuid": "^3.4.3",
+    "@types/uuid": "^7.0.3",
     "body-parser": "^1.18.3",
     "drivelist": "^6.4.3",
     "http-status-codes": "^1.3.0",
@@ -21,7 +21,7 @@
     "tar-fs": "^1.16.2",
     "touch": "^3.1.0",
     "trash": "^4.0.1",
-    "uuid": "^3.2.1",
+    "uuid": "^8.0.0",
     "zip-dir": "^1.0.2"
   },
   "publishConfig": {

--- a/packages/languages/package.json
+++ b/packages/languages/package.json
@@ -9,9 +9,9 @@
     "@theia/output": "^1.1.0",
     "@theia/process": "^1.1.0",
     "@theia/workspace": "^1.1.0",
-    "@types/uuid": "^3.4.3",
+    "@types/uuid": "^7.0.3",
     "monaco-languageclient": "^0.13.0",
-    "uuid": "^3.2.1"
+    "uuid": "^8.0.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/plugin-ext/package.json
+++ b/packages/plugin-ext/package.json
@@ -38,7 +38,7 @@
     "ps-tree": "^1.2.0",
     "request": "^2.82.0",
     "serve-static": "^1.14.1",
-    "uuid": "^3.2.1",
+    "uuid": "^8.0.0",
     "vhost": "^3.0.2",
     "vscode-debugprotocol": "^1.32.0",
     "vscode-textmate": "^4.0.1"

--- a/packages/typehierarchy/package.json
+++ b/packages/typehierarchy/package.json
@@ -6,8 +6,8 @@
     "@theia/core": "^1.1.0",
     "@theia/editor": "^1.1.0",
     "@theia/languages": "^1.1.0",
-    "@types/uuid": "^3.4.3",
-    "uuid": "^3.2.1"
+    "@types/uuid": "^7.0.3",
+    "uuid": "^8.0.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/vsx-registry/package.json
+++ b/packages/vsx-registry/package.json
@@ -14,7 +14,7 @@
     "requestretry": "^3.1.0",
     "sanitize-html": "^1.14.1",
     "showdown": "^1.9.1",
-    "uuid": "^3.2.1"
+    "uuid": "^8.0.0"
   },
   "publishConfig": {
     "access": "public"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1471,12 +1471,10 @@
   dependencies:
     source-map "^0.6.1"
 
-"@types/uuid@^3.4.3":
-  version "3.4.6"
-  resolved "https://registry.yarnpkg.com/@types/uuid/-/uuid-3.4.6.tgz#d2c4c48eb85a757bf2927f75f939942d521e3016"
-  integrity sha512-cCdlC/1kGEZdEglzOieLDYBxHsvEOIg7kp/2FYyVR9Pxakq+Qf/inL3RKQ+PA8gOlI/NnL+fXmQH12nwcGzsHw==
-  dependencies:
-    "@types/node" "*"
+"@types/uuid@^7.0.3":
+  version "7.0.3"
+  resolved "https://registry.yarnpkg.com/@types/uuid/-/uuid-7.0.3.tgz#45cd03e98e758f8581c79c535afbd4fc27ba7ac8"
+  integrity sha512-PUdqTZVrNYTNcIhLHkiaYzoOIaUi5LFg/XLerAdgvwQrUCx+oSbtoBze1AMyvYbcwzUSNC+Isl58SM4Sm/6COw==
 
 "@types/webpack-sources@*":
   version "0.1.5"
@@ -12764,10 +12762,15 @@ uuid@^2.0.1:
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-2.0.3.tgz#67e2e863797215530dff318e5bf9dcebfd47b21a"
   integrity sha1-Z+LoY3lyFVMN/zGOW/nc6/1Hsho=
 
-uuid@^3.0.1, uuid@^3.1.0, uuid@^3.2.1, uuid@^3.3.2, uuid@^3.3.3:
+uuid@^3.0.1, uuid@^3.1.0, uuid@^3.3.2, uuid@^3.3.3:
   version "3.3.3"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.3.3.tgz#4568f0216e78760ee1dbf3a4d2cf53e224112866"
   integrity sha512-pW0No1RGHgzlpHJO1nsVrHKpOEIxkGg1xB+v0ZmdNH5OAeAwzAVrCnI2/6Mtx+Uys6iaylxa+D3g4j63IKKjSQ==
+
+uuid@^8.0.0:
+  version "8.0.0"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.0.0.tgz#bc6ccf91b5ff0ac07bbcdbf1c7c4e150db4dbb6c"
+  integrity sha512-jOXGuXZAWdsTH7eZLtyXMqUb9EcWMGZNbL9YcGBJl4MH4nrxHmZJhEHvyLFrkxo+28uLb/NYRcStH48fnD0Vzw==
 
 v8-compile-cache@^1.1.2:
   version "1.1.2"


### PR DESCRIPTION
Signed-off-by: Reece Dunham <me@rdil.rocks>

#### What it does
Updates `uuid` from v3 to v8.  In comparison, v8 uses more modern Javascript and cleaner code, so it should be easier to work with. 

It also updates the types to the latest version.

I have confirmed there are **no license changes**, as outlined [in this wiki page](https://github.com/eclipse-theia/theia/wiki/Registering-CQs#case-new-or-updated-npm-production-dependency).

#### How to test

This contains no functional breaking changes.  In application-manager, I had to fix the fact that a default export is no longer provided, but other than that it should have no visible changes.  I also ran the Jest tests and ESLint, which both reported no errors.  

#### Review checklist

- [X] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)