### PR TITLE
Fix blank square plugins icon when theia starts

### DIFF
--- a/packages/plugin-ext/src/main/browser/style/index.css
+++ b/packages/plugin-ext/src/main/browser/style/index.css
@@ -34,6 +34,11 @@
     flex-direction: column;
 }
 
+.theia-plugin-view-container {
+    -webkit-mask: url('');
+    mask: url('');
+}
+
 .theia-plugin-test-tab-icon {
     -webkit-mask: url('test.svg');
     mask: url('test.svg');

--- a/packages/plugin-ext/src/main/browser/view/plugin-view-registry.ts
+++ b/packages/plugin-ext/src/main/browser/view/plugin-view-registry.ts
@@ -188,15 +188,16 @@ export class PluginViewRegistry implements FrontendApplicationContribution {
             return Disposable.NULL;
         }
         const toDispose = new DisposableCollection();
+        const containerClass = 'theia-plugin-view-container';
         const iconClass = 'plugin-view-container-icon-' + viewContainer.id;
         const iconUrl = new Endpoint({ path: viewContainer.iconUrl }).getRestUrl().toString();
-        toDispose.push(this.style.insertRule('.' + iconClass, () => `
+        toDispose.push(this.style.insertRule('.' + containerClass + '.' + iconClass, () => `
                 mask: url('${iconUrl}') no-repeat 50% 50%;
                 -webkit-mask: url('${iconUrl}') no-repeat 50% 50%;
             `));
         toDispose.push(this.doRegisterViewContainer(viewContainer.id, location, {
             label: viewContainer.title,
-            iconClass,
+            iconClass: containerClass + ' ' + iconClass,
             closeable: true
         }));
         return toDispose;


### PR DESCRIPTION
Signed-off-by: Doron Nahari <doron.nahari@sap.com>

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->
Fixes #7751 

Purpose a css solution to this issue. because of the life cycle of plugins sync and load, the div of the contributed plugin is loaded before the icon class is ready causes a blank square until then.

My solution is to first create empty mask and when the plugin icon css apply it will override it.

Before: see gif in #7751 
After:
![ezgif com-video-to-gif (2)](https://user-images.githubusercontent.com/24614792/81165027-f6b44900-8f99-11ea-810a-85566dbae27a.gif)

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
1. Deploy a vscode extension that have a side pane such as gitlens.
2. See that new pane added to the left pane.
3. Refresh browser and see that for about 1 second there's *no* blank square and the plugin icon is loaded.
#### Review checklist

- [X] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

