### PR TITLE
theming: fix preferences 'descriptionForeground

### DIFF
--- a/packages/preferences/src/browser/style/index.css
+++ b/packages/preferences/src/browser/style/index.css
@@ -263,7 +263,7 @@
 
 .theia-settings-container .pref-description {
     padding: var(--theia-ui-padding) 0;
-    color: var(--theia-descriptionforeground);
+    color: var(--theia-descriptionForeground);
     line-height: 18px;
 }
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

The following pull-request fixes an issue where the **preferences** were not correctly applying the `descriptionForeground` theming property resulting in the value not being properly applied.


The following example uses a custom theme [git-neon](https://github.com/vince-fugnitto/git-neon/releases/download/v2.0.0/git-neon-0.0.1.vsix) which sets the `descriptionForeground` theming variable to a 'pink' for illustration purposes:

_Before_:

<div align='center'>

<img width="1208" alt="Screen Shot 2020-05-06 at 10 02 26 AM" src="https://user-images.githubusercontent.com/40359487/81186886-57835780-8f81-11ea-886e-bb1541fa0717.png">

</div>


_After_:


<div align='center'>

<img width="1208" alt="Screen Shot 2020-05-06 at 10 03 51 AM" src="https://user-images.githubusercontent.com/40359487/81186909-5eaa6580-8f81-11ea-8ac7-36a21fc5ef84.png">

</div>


#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

1. verify using a custom theme (ex: [git-neon](https://github.com/vince-fugnitto/git-neon/releases/download/v2.0.0/git-neon-0.0.1.vsix)) if the description foreground of the preferences-view is correctly applied

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

Signed-off-by: vince-fugnitto <vincent.fugnitto@ericsson.com>

