### PR TITLE
Give more flexibility for tasks related sub classes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 Breaking changes:
 
 - [scm] support file tree mode in Source Control view.  Classes that extend ScmWidget will likely require changes [#7505](https://github.com/eclipse-theia/theia/pull/7505)
+- [task] removed `taskId` from `TaskTerminalWidgetOpenerOptions` [#7765](https://github.com/eclipse-theia/theia/pull/7765)
 
 ## v1.1.0
 

--- a/packages/task/src/browser/task-service.ts
+++ b/packages/task/src/browser/task-service.ts
@@ -326,7 +326,7 @@ export class TaskService implements TaskConfigurationClient {
         });
     }
 
-    private getTaskIdentifier(taskConfig: TaskConfiguration): string {
+    protected getTaskIdentifier(taskConfig: TaskConfiguration): string {
         const taskName = this.taskNameResolver.resolve(taskConfig);
         const sourceStrUri = this.taskSourceResolver.resolve(taskConfig);
         return `${taskName} (${this.labelProvider.getName(new URI(sourceStrUri))})`;
@@ -896,7 +896,7 @@ export class TaskService implements TaskConfigurationClient {
         return customizationObject;
     }
 
-    private async removeProblemMarkers(option?: RunTaskOption): Promise<void> {
+    protected async removeProblemMarkers(option?: RunTaskOption): Promise<void> {
         if (option && option.customization) {
             const matchersFromOption = option.customization.problemMatcher || [];
             for (const matcher of matchersFromOption) {
@@ -910,7 +910,7 @@ export class TaskService implements TaskConfigurationClient {
         }
     }
 
-    private async getResolvedTask(task: TaskConfiguration): Promise<TaskConfiguration | undefined> {
+    protected async getResolvedTask(task: TaskConfiguration): Promise<TaskConfiguration | undefined> {
         let resolver = undefined;
         let resolvedTask: TaskConfiguration;
         try {
@@ -930,7 +930,7 @@ export class TaskService implements TaskConfigurationClient {
      * @param resolvedTask the resolved task
      * @param option options to run the resolved task
      */
-    private async runResolvedTask(resolvedTask: TaskConfiguration, option?: RunTaskOption): Promise<TaskInfo | undefined> {
+    protected async runResolvedTask(resolvedTask: TaskConfiguration, option?: RunTaskOption): Promise<TaskInfo | undefined> {
         const source = resolvedTask._source;
         const taskLabel = resolvedTask.label;
         try {
@@ -955,7 +955,7 @@ export class TaskService implements TaskConfigurationClient {
         }
     }
 
-    private getCustomizeProblemMatcherItems(): QuickPickItem<QuickPickProblemMatcherItem>[] {
+    protected getCustomizeProblemMatcherItems(): QuickPickItem<QuickPickProblemMatcherItem>[] {
         const items: QuickPickItem<QuickPickProblemMatcherItem>[] = [];
         items.push({
             label: 'Continue without scanning the task output',
@@ -1035,7 +1035,6 @@ export class TaskService implements TaskConfigurationClient {
                 : `Task: #${taskId}`,
             destroyTermOnClose: true
         }, {
-            taskId,
             widgetOptions: { area: 'bottom' },
             mode: widgetOpenMode,
             taskInfo


### PR DESCRIPTION
#### What it does
1. Replace `private` modifier by `protected` for `TaskTerminalWidgetManager` and `TaskService` methods.
2. Add separated method as ability to create `task` terminal from `TaskService` for example
3. Some changes for `TaskTerminalWidgetOpenerOptions`
I didn't find where required property `taskId` is used, instead we everywhere use task config.
So, I moved `taskId` to optional property and added `taskConfig` (optional as well)

#### How to test
I don't think these changes can break something, but you could try:
1. Run any `configured` task
2. Run any `detected` task


#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

Signed-off-by: Roman Nikitenko <rnikiten@redhat.com>