### PR TITLE
Support api keybinding test on mac

### DIFF
--- a/examples/api-tests/src/monaco-api.spec.js
+++ b/examples/api-tests/src/monaco-api.spec.js
@@ -61,27 +61,55 @@ describe('Monaco API', async function () {
             const chord = resolvedKeybinding.isChord();
             const parts = resolvedKeybinding.getParts();
             const dispatchParts = resolvedKeybinding.getDispatchParts();
+
+            const platform = window.navigator.platform;
+            let expected;
+            if (platform.includes("Mac")){
+                // Mac os
+                expected = {
+                    label: '⌃⇧⌥⌘K',
+                    ariaLabel: "⌃⇧⌥⌘K",
+                    electronAccelerator: 'Ctrl+Shift+Alt+Cmd+K',
+                    userSettingsLabel: 'ctrl+shift+alt+cmd+K',
+                    WYSIWYG: true,
+                    chord: false,
+                    parts: [{
+                        altKey: true,
+                        ctrlKey: true,
+                        keyAriaLabel: 'K',
+                        keyLabel: 'K',
+                        metaKey: true,
+                        shiftKey: true
+                    }],
+                    dispatchParts: [
+                        'ctrl+shift+alt+meta+K'
+                    ]
+                }
+            } else {
+                expected = {
+                    label: 'Ctrl+Shift+Alt+K',
+                    ariaLabel: 'Ctrl+Shift+Alt+K',
+                    electronAccelerator: 'Ctrl+Shift+Alt+K',
+                    userSettingsLabel: 'ctrl+shift+alt+K',
+                    WYSIWYG: true,
+                    chord: false,
+                    parts: [{
+                        altKey: true,
+                        ctrlKey: true,
+                        keyAriaLabel: 'K',
+                        keyLabel: 'K',
+                        metaKey: false,
+                        shiftKey: true
+                    }],
+                    dispatchParts: [
+                        'ctrl+shift+alt+K'
+                    ]
+                }
+            }
+
             assert.deepStrictEqual({
                 label, ariaLabel, electronAccelerator, userSettingsLabel, WYSIWYG, chord, parts, dispatchParts
-            }, {
-                label: 'Ctrl+Shift+Alt+K',
-                ariaLabel: 'Ctrl+Shift+Alt+K',
-                electronAccelerator: 'Ctrl+Shift+Alt+K',
-                userSettingsLabel: 'ctrl+shift+alt+K',
-                WYSIWYG: true,
-                chord: false,
-                parts: [{
-                    altKey: true,
-                    ctrlKey: true,
-                    keyAriaLabel: 'K',
-                    keyLabel: 'K',
-                    metaKey: false,
-                    shiftKey: true
-                }],
-                dispatchParts: [
-                    'ctrl+shift+alt+K'
-                ]
-            });
+            }, expected);
         } else {
             assert.fail(`resolvedKeybinding must be of ${MonacoResolvedKeybinding.name} type`);
         }


### PR DESCRIPTION
Signed-off-by: Doron Nahari <doron.nahari@sap.com>

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->
The new api test framework fails on keybinding test on Mac OS. This pr check if the OS is some kind of Mac OS and change the expected keybindings accordingly.

Should fix at least part of #7646 

Before:
![image](https://user-images.githubusercontent.com/24614792/81269917-acdb6980-9052-11ea-8061-ba0f31164472.png)

After:
![image](https://user-images.githubusercontent.com/24614792/81268427-992f0380-9050-11ea-8178-30038b2ec17e.png)


![image](https://user-images.githubusercontent.com/24614792/81268093-2a51aa80-9050-11ea-9b0c-78f7215d8dd6.png)


#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
Run the api test on Mac OS

#### Review checklist

- [X] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

