### PR TITLE
Fix missing commit and amend widgets on opening new workspace

### DIFF
--- a/packages/scm/src/browser/scm-amend-widget.tsx
+++ b/packages/scm/src/browser/scm-amend-widget.tsx
@@ -15,7 +15,6 @@
  ********************************************************************************/
 
 import { injectable, inject } from 'inversify';
-import { Message } from '@phosphor/messaging';
 import { SelectionService } from '@theia/core/lib/common';
 import * as React from 'react';
 import {
@@ -49,13 +48,6 @@ export class ScmAmendWidget extends ReactWidget {
         };
         this.addClass('theia-scm-commit-container');
         this.id = ScmAmendWidget.ID;
-    }
-
-    protected onUpdateRequest(msg: Message): void {
-        if (!this.isAttached || !this.isVisible) {
-            return;
-        }
-        super.onUpdateRequest(msg);
     }
 
     protected render(): React.ReactNode {

--- a/packages/scm/src/browser/scm-commit-widget.tsx
+++ b/packages/scm/src/browser/scm-commit-widget.tsx
@@ -16,12 +16,11 @@
 
 import { injectable, inject } from 'inversify';
 import { Message } from '@phosphor/messaging';
-import { SelectionService } from '@theia/core/lib/common';
 import * as React from 'react';
 import TextareaAutosize from 'react-autosize-textarea';
 import { ScmInput } from './scm-input';
 import {
-    ContextMenuRenderer, ReactWidget, LabelProvider, KeybindingRegistry, StatefulWidget} from '@theia/core/lib/browser';
+    ContextMenuRenderer, ReactWidget, KeybindingRegistry, StatefulWidget} from '@theia/core/lib/browser';
 import { ScmService } from './scm-service';
 
 @injectable()
@@ -30,8 +29,6 @@ export class ScmCommitWidget extends ReactWidget implements StatefulWidget {
     static ID = 'scm-commit-widget';
 
     @inject(ScmService) protected readonly scmService: ScmService;
-    @inject(SelectionService) protected readonly selectionService: SelectionService;
-    @inject(LabelProvider) protected readonly labelProvider: LabelProvider;
     @inject(KeybindingRegistry) protected readonly keybindings: KeybindingRegistry;
 
     protected shouldScrollToRow = true;
@@ -58,13 +55,6 @@ export class ScmCommitWidget extends ReactWidget implements StatefulWidget {
 
     public focus(): void {
         (this.inputRef.current || this.node).focus();
-    }
-
-    protected onUpdateRequest(msg: Message): void {
-        if (!this.isAttached || !this.isVisible) {
-            return;
-        }
-        super.onUpdateRequest(msg);
     }
 
     protected render(): React.ReactNode {

--- a/packages/scm/src/browser/scm-widget.tsx
+++ b/packages/scm/src/browser/scm-widget.tsx
@@ -130,9 +130,6 @@ export class ScmWidget extends BaseWidget implements StatefulWidget {
     }
 
     protected onUpdateRequest(msg: Message): void {
-        if (!this.isAttached || !this.isVisible) {
-            return;
-        }
         MessageLoop.sendMessage(this.commitWidget, msg);
         MessageLoop.sendMessage(this.resourceWidget, msg);
         MessageLoop.sendMessage(this.amendWidget, msg);


### PR DESCRIPTION
Fixes https://github.com/eclipse-theia/theia/issues/7734

The issue was caused because the commit and amend components were being rendered before the repository was set.  Adding the repository listener in itself did not fix the problem.  The reason is that the widget may be flagged as hidden when the update occurs.

One might think that updating the widgets by inserting `this.commitWidget.update()`  after  `this.commitWidget.show()` in scm-widget would work.  However the 'show' is done asynchronously and the widget is still marked as hidden when the onUpdateRequest is called.  Thus the most reliable solution is to simply remove the test for isVisible (and isAttached).

There is a further change to also remove this test in ScmWidget.  If that is not done then the ScmNoRepositoryWidget can fail to appear, resulting in a blank view instead of the Alert.

Unrelated to the issue, I have also removed a couple of unused injections.

#### How to test

Test the condition detailed in the issue.  Test around the whole process of switching repositories and workspaces.  Check the Alert shows when no repository.

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

