### PR TITLE
Preferences: on scroll, ensure selection is visible

### DIFF
--- a/packages/preferences/src/browser/views/preference-tree-widget.tsx
+++ b/packages/preferences/src/browser/views/preference-tree-widget.tsx
@@ -106,7 +106,7 @@ export class PreferencesTreeWidget extends TreeWidget {
                 selectionAncestor = this.model.getNode(subgroupID) as SelectableTreeNode;
             } else {
                 // The last selectable child that precedes the visible item alphabetically
-                selectionAncestor = [...expansionAncestor.children].reverse().find(child => child.id < visibleNodeID) as SelectableTreeNode || expansionAncestor;
+                selectionAncestor = [...expansionAncestor.children].reverse().find(child => child.visible && child.id < visibleNodeID) as SelectableTreeNode || expansionAncestor;
             }
         }
         return { selectionAncestor, expansionAncestor };


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

Fixes #7770 by ensuring that only visible elements are selected on scroll. Formerly, it was possible for the function determining the selected element to return an element that was not visible, leading to invisible selections.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

1. Open preferences
1. Search for 'cursor'
1. Scroll in editor pane (right pane)
1. Observe that, once something is selected, there are no subsequent gaps in selection.

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

Co-authored-by: Colin Grant <colin.grant@ericsson.com>
Co-authored-by: Kenneth Marut <kenneth.marut@ericsson.com>

Signed-off-by: Colin Grant <colin.grant@ericsson.com>
Signed-off-by: Kenneth Marut <kenneth.marut@ericsson.com>