### PR TITLE
Handle open preference files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,28 +4,20 @@
 
 [1.21.0 Milestone](https://github.com/eclipse-theia/theia/milestone/29)
 
-<<<<<<< HEAD
 - [core, editor, editor-preview] additional commands added to tabbar context menu for editor widgets. [#10394](https://github.com/eclipse-theia/theia/pull/10394)
-=======
 - [preferences] Updated `AbstractResourcePreferenceProvider` to handle multiple preference settings in the same tick and handle open preference files. It will save the file exactly once, and prompt the user if the file is dirty when a programmatic setting is attempted. [#7775](https://github.com/eclipse-theia/theia/pull/7775)
->>>>>>> 6583dd0a9d4 (changelog)
 
 <a name="breaking_changes_1.21.0">[Breaking Changes:](#breaking_changes_1.21.0)</a>
 
 - [webpack] Source maps for the frontend renamed from `webpack://[namespace]/[resource-filename]...`
   to `webpack:///[resource-path]?[loaders]` where `resource-path` is the path to the file relative
   to your application package's root.
-<<<<<<< HEAD
 - [core] `SelectionService` added to constructor arguments of `TabBarRenderer`. [#10394](https://github.com/eclipse-theia/theia/pull/10394)
-=======
 - [preferences] Removed `PreferenceProvider#pendingChanges` field. It was previously set unreliably and caused race conditions. If a `PreferenceProvider` needs a mechanism for deferring the resolution of `PreferenceProvider#setPreference`, it should implement its own system. See PR for example implementation in `AbstractResourcePreferenceProvider`. [#7775](https://github.com/eclipse-theia/theia/pull/7775)
->>>>>>> 6583dd0a9d4 (changelog)
 
 ## v1.20.0 - 11/25/2021
 
-[1.20.0 Milestone](https://github.com/eclipse-theia/theia/milestone/26)
-
-- [plugindev] Renamed HostedPlugin(Server|Client) to PluginDev(Server|Client) [#10352](https://github.com/eclipse-theia/theia/pull/10352)
+[1.20.0 Milestone](https://github.com/eclipse-theia/theia/milestone/28)
 
 - [application-manager] added a workaround to the upstream `electron-rebuild` bug [#10429](https://github.com/eclipse-theia/theia/pull/10429)
 - [application-manager] remove unnecessary `font-awesome-webpack` dependency [#10401](https://github.com/eclipse-theia/theia/pull/10401)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,18 +4,28 @@
 
 [1.21.0 Milestone](https://github.com/eclipse-theia/theia/milestone/29)
 
+<<<<<<< HEAD
 - [core, editor, editor-preview] additional commands added to tabbar context menu for editor widgets. [#10394](https://github.com/eclipse-theia/theia/pull/10394)
+=======
+- [preferences] Updated `AbstractResourcePreferenceProvider` to handle multiple preference settings in the same tick and handle open preference files. It will save the file exactly once, and prompt the user if the file is dirty when a programmatic setting is attempted. [#7775](https://github.com/eclipse-theia/theia/pull/7775)
+>>>>>>> 6583dd0a9d4 (changelog)
 
 <a name="breaking_changes_1.21.0">[Breaking Changes:](#breaking_changes_1.21.0)</a>
 
 - [webpack] Source maps for the frontend renamed from `webpack://[namespace]/[resource-filename]...`
   to `webpack:///[resource-path]?[loaders]` where `resource-path` is the path to the file relative
   to your application package's root.
+<<<<<<< HEAD
 - [core] `SelectionService` added to constructor arguments of `TabBarRenderer`. [#10394](https://github.com/eclipse-theia/theia/pull/10394)
+=======
+- [preferences] Removed `PreferenceProvider#pendingChanges` field. It was previously set unreliably and caused race conditions. If a `PreferenceProvider` needs a mechanism for deferring the resolution of `PreferenceProvider#setPreference`, it should implement its own system. See PR for example implementation in `AbstractResourcePreferenceProvider`. [#7775](https://github.com/eclipse-theia/theia/pull/7775)
+>>>>>>> 6583dd0a9d4 (changelog)
 
 ## v1.20.0 - 11/25/2021
 
-[1.20.0 Milestone](https://github.com/eclipse-theia/theia/milestone/28)
+[1.20.0 Milestone](https://github.com/eclipse-theia/theia/milestone/26)
+
+- [plugindev] Renamed HostedPlugin(Server|Client) to PluginDev(Server|Client) [#10352](https://github.com/eclipse-theia/theia/pull/10352)
 
 - [application-manager] added a workaround to the upstream `electron-rebuild` bug [#10429](https://github.com/eclipse-theia/theia/pull/10429)
 - [application-manager] remove unnecessary `font-awesome-webpack` dependency [#10401](https://github.com/eclipse-theia/theia/pull/10401)

--- a/packages/core/src/browser/preferences/preference-provider.ts
+++ b/packages/core/src/browser/preferences/preference-provider.ts
@@ -75,13 +75,6 @@ export abstract class PreferenceProvider implements Disposable {
     }
 
     protected deferredChanges: PreferenceProviderDataChanges | undefined;
-    protected _pendingChanges = new Deferred<boolean>();
-    get pendingChanges(): Promise<boolean> {
-        if (this._pendingChanges.state !== 'unresolved') {
-            this._pendingChanges = new Deferred();
-        }
-        return this._pendingChanges.promise;
-    }
 
     /**
      * Informs the listeners that one or more preferences of this provider are changed.
@@ -124,7 +117,6 @@ export abstract class PreferenceProvider implements Disposable {
         if (changes && Object.keys(changes).length) {
             this.onDidPreferencesChangedEmitter.fire(changes);
         }
-        this._pendingChanges.resolve(true);
         return true;
     }, 0);
 

--- a/packages/core/src/browser/preferences/preference-provider.ts
+++ b/packages/core/src/browser/preferences/preference-provider.ts
@@ -116,8 +116,9 @@ export abstract class PreferenceProvider implements Disposable {
         this.deferredChanges = undefined;
         if (changes && Object.keys(changes).length) {
             this.onDidPreferencesChangedEmitter.fire(changes);
+            return true;
         }
-        return true;
+        return false;
     }, 0);
 
     /**

--- a/packages/core/src/browser/preferences/preference-service.spec.ts
+++ b/packages/core/src/browser/preferences/preference-service.spec.ts
@@ -193,7 +193,6 @@ describe('Preference Service', () => {
         assert.strictEqual(prefService.get('editor.insertSpaces'), undefined, 'get after');
         assert.strictEqual(prefService.get('[go].editor.insertSpaces'), undefined, 'get after overridden');
 
-        assert.strictEqual(await prefSchema.pendingChanges, false);
         assert.deepStrictEqual([], events.map(e => ({
             preferenceName: e.preferenceName,
             newValue: e.newValue,
@@ -488,7 +487,6 @@ describe('Preference Service', () => {
 
         it('onPreferenceChanged #0', async () => {
             const { preferences, schema } = prepareServices();
-            await schema.pendingChanges;
 
             const events: PreferenceChange[] = [];
             preferences.onPreferenceChanged(event => events.push(event));
@@ -511,7 +509,6 @@ describe('Preference Service', () => {
 
         it('onPreferenceChanged #1', async () => {
             const { preferences, schema } = prepareServices();
-            await schema.pendingChanges;
 
             const events: PreferenceChange[] = [];
             preferences.onPreferenceChanged(event => events.push(event));

--- a/packages/monaco/src/browser/monaco-workspace.ts
+++ b/packages/monaco/src/browser/monaco-workspace.ts
@@ -205,14 +205,14 @@ export class MonacoWorkspace {
      * Applies given edits to the given model.
      * The model is saved if no editors is opened for it.
      */
-    applyBackgroundEdit(model: MonacoEditorModel, editOperations: monaco.editor.IIdentifiedSingleEditOperation[]): Promise<void> {
+    applyBackgroundEdit(model: MonacoEditorModel, editOperations: monaco.editor.IIdentifiedSingleEditOperation[], shouldSave = true): Promise<void> {
         return this.suppressOpenIfDirty(model, async () => {
             const editor = MonacoEditor.findByDocument(this.editorManager, model)[0];
             const cursorState = editor && editor.getControl().getSelections() || [];
             model.textEditorModel.pushStackElement();
             model.textEditorModel.pushEditOperations(cursorState, editOperations, () => cursorState);
             model.textEditorModel.pushStackElement();
-            if (!editor) {
+            if (!editor && shouldSave) {
                 await model.save();
             }
         });

--- a/packages/preferences/package.json
+++ b/packages/preferences/package.json
@@ -9,6 +9,7 @@
     "@theia/monaco": "1.20.0",
     "@theia/userstorage": "1.20.0",
     "@theia/workspace": "1.20.0",
+    "async-mutex": "^0.3.1",
     "jsonc-parser": "^2.2.0"
   },
   "publishConfig": {

--- a/packages/preferences/src/browser/abstract-resource-preference-provider.spec.ts
+++ b/packages/preferences/src/browser/abstract-resource-preference-provider.spec.ts
@@ -36,6 +36,7 @@ import { MonacoTextModelService } from '@theia/monaco/lib/browser/monaco-text-mo
 import { Disposable, MessageService } from '@theia/core/lib/common';
 import { MonacoWorkspace } from '@theia/monaco/lib/browser/monaco-workspace';
 import { PreferenceSchemaProvider } from '@theia/core/lib/browser';
+import { EditorManager } from '@theia/editor/lib/browser';
 
 disableJSDOM();
 
@@ -84,6 +85,7 @@ describe('AbstractResourcePreferenceProvider', () => {
         testContainer.bind(<any>MonacoTextModelService).toConstantValue(new MockTextModelService);
         testContainer.bind(<any>MessageService).toConstantValue(undefined);
         testContainer.bind(<any>MonacoWorkspace).toConstantValue(undefined);
+        testContainer.bind(<any>EditorManager).toConstantValue(undefined);
         provider = testContainer.resolve(<any>LessAbstractPreferenceProvider);
     });
 

--- a/packages/preferences/src/browser/abstract-resource-preference-provider.ts
+++ b/packages/preferences/src/browser/abstract-resource-preference-provider.ts
@@ -92,13 +92,9 @@ export abstract class AbstractResourcePreferenceProvider extends PreferenceProvi
         this.toDispose.push(reference);
         this.toDispose.push(Disposable.create(() => this.model = undefined));
 
-        this.toDispose.push(this.model.onDidChangeContent(() => (
-            console.log('READING BECAUSE...CONTENT', this.transactionLock.isLocked()), !this.transactionLock.isLocked() && this.readPreferences()))
-        );
-        this.toDispose.push(this.model.onDirtyChanged(() => (
-            console.log('READING BECAUSE...DIRTY', this.transactionLock.isLocked()), !this.transactionLock.isLocked() && this.readPreferences()))
-        );
-        this.toDispose.push(this.model.onDidChangeValid(() => (console.log('READING BECAUSE...VALID'), this.readPreferences())));
+        this.toDispose.push(this.model.onDidChangeContent(() => !this.transactionLock.isLocked() && this.readPreferences()));
+        this.toDispose.push(this.model.onDirtyChanged(() => !this.transactionLock.isLocked() && this.readPreferences()));
+        this.toDispose.push(this.model.onDidChangeValid(() => this.readPreferences()));
 
         this.toDispose.push(Disposable.create(() => this.reset()));
     }
@@ -210,7 +206,7 @@ export abstract class AbstractResourcePreferenceProvider extends PreferenceProvi
         locks?.releaseChange();
     }
 
-    private getEditOperations(path: string[], value: any): monaco.editor.IIdentifiedSingleEditOperation[] {
+    protected getEditOperations(path: string[], value: any): monaco.editor.IIdentifiedSingleEditOperation[] {
         const textModel = this.model!.textEditorModel;
         const content = this.model!.getText().trim();
         // Everything is already undefined - no need for changes.

--- a/packages/preferences/src/browser/abstract-resource-preference-provider.ts
+++ b/packages/preferences/src/browser/abstract-resource-preference-provider.ts
@@ -71,9 +71,9 @@ export abstract class AbstractResourcePreferenceProvider extends PreferenceProvi
         this.toDispose.push(reference);
         this.toDispose.push(Disposable.create(() => this.model = undefined));
 
-        this.toDispose.push(this.model.onDidChangeContent(() => this.readPreferences()));
-        this.toDispose.push(this.model.onDirtyChanged(() => this.readPreferences()));
-        this.toDispose.push(this.model.onDidChangeValid(() => this.readPreferences()));
+        this.toDispose.push(this.model.onDidChangeContent(() => (console.log('READING BECAUSE...CONTENT'), this.readPreferences())));
+        this.toDispose.push(this.model.onDirtyChanged(() => (console.log('READING BECAUSE...DIRTY'), this.readPreferences())));
+        this.toDispose.push(this.model.onDidChangeValid(() => (console.log('READING BECAUSE...VALID'), this.readPreferences())));
 
         this.toDispose.push(Disposable.create(() => this.reset()));
     }
@@ -152,6 +152,9 @@ export abstract class AbstractResourcePreferenceProvider extends PreferenceProvi
                     text: null,
                     forceMoveMarkers: false
                 });
+            }
+            if (editOperations.length === 0) {
+                return true;
             }
             await this.workspace.applyBackgroundEdit(this.model, editOperations);
             return await this.pendingChanges;
@@ -234,9 +237,7 @@ export abstract class AbstractResourcePreferenceProvider extends PreferenceProvi
             }
         }
 
-        if (prefChanges.length > 0) { // do not emit the change event if the pref value is not changed
-            this.emitPreferencesChangedEvent(prefChanges);
-        }
+        this.emitPreferencesChangedEvent(prefChanges);
     }
 
     protected reset(): void {

--- a/packages/preferences/src/browser/abstract-resource-preference-provider.ts
+++ b/packages/preferences/src/browser/abstract-resource-preference-provider.ts
@@ -195,6 +195,7 @@ export abstract class AbstractResourcePreferenceProvider extends PreferenceProvi
                         success = true;
                     } finally {
                         this.readPreferences();
+                        await this.fireDidPreferencesChanged(); // Ensure all consumers of the event have received it.
                         this.pendingTransaction.resolve(success);
                     }
                 }));

--- a/packages/preferences/src/browser/views/components/preference-node-renderer.ts
+++ b/packages/preferences/src/browser/views/components/preference-node-renderer.ts
@@ -403,7 +403,8 @@ export abstract class PreferenceLeafNodeRenderer<ValueType extends JSONValue, In
     protected setPreferenceWithDebounce = debounce(this.setPreferenceImmediately.bind(this), 500, { leading: false, trailing: true });
 
     protected setPreferenceImmediately(value: ValueType | undefined): Promise<void> {
-        return this.preferenceService.set(this.id, value, this.scopeTracker.currentScope.scope, this.scopeTracker.currentScope.uri);
+        return this.preferenceService.set(this.id, value, this.scopeTracker.currentScope.scope, this.scopeTracker.currentScope.uri)
+            .catch(() => this.handleValueChange());
     }
 
     handleSearchChange(isFiltered = this.model.isFiltered): void {
@@ -420,7 +421,18 @@ export abstract class PreferenceLeafNodeRenderer<ValueType extends JSONValue, In
         this.updateHeadline();
     }
 
+    /**
+     * Should create an HTML element that the user can interact with to change the value of the preference.
+     * @param container the parent element for the interactable. This method is responsible for adding the new element to its parent.
+     */
     protected abstract createInteractable(container: HTMLElement): void;
+    /**
+     * @returns a fallback default value for a preference of the type implemented by a concrete leaf renderer
+     * This function is only called if the default value for a given preference is not specified in its schema.
+     */
     protected abstract getFallbackValue(): ValueType;
+    /**
+     * This function is responsible for reconciling the display of the preference value with the value reported by the PreferenceService.
+     */
     protected abstract doHandleValueChange(): void;
 }


### PR DESCRIPTION
Signed-off-by: Colin Grant <colin.grant@ericsson.com>

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->
This PR moves the preference UI in the direction of VSCode in two respects:

- It fixes #7721 by saving the preference file when an edit is made.
- It fixes #9115 by processing preference settings in sequence.
- It fixes #2547 by prompting the user when the settings file can't be modified.

- It changes the behavior of the `AbstractPreferenceProvider.set` method to ensure that no changes are made to a file when that file is open in a dirty editor. Instead, an error toast is shown.

![image](https://user-images.githubusercontent.com/62660806/81354741-06af5400-9092-11ea-8078-5ac211659aa1.png)

It improves the UI further by resetting the UI to the pre-change-attempt state if a preference change attempt fails.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

1. Open preference UI
1. Open the file corresponding to the current scope (`{}` in upper right)
1. In the UI, change preferences
1. Observe that the file is modified and saved and the change registers in the UI (unless #7685 - better not to rely on `application.confirmExit` as the sole test case)
1. In the file editor, make a change to the file and don't save the change
1. Return to the UI and attempt to change a preference.
1. Observe that a toast appears warning that the change was not made.
1. Make a change to another preference in the UI - the toast should remain.
1. Exit the toast without action.
1. Observe that all preference values reverts to their pre-change state in the UI.
1. Repeat 7-9 selecting one of the toast buttons and observe that the behavior is correct in each case.

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

