### PR TITLE
Enable clients to persistently change the electron windowOptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## v1.2.0
 
+- [application-manager] enable clients to persistenly change windowOptions [#7787](https://github.com/eclipse-theia/theia/pull/7787)
+
 Breaking changes:
 
 - [scm] support file tree mode in Source Control view.  Classes that extend ScmWidget will likely require changes [#7505](https://github.com/eclipse-theia/theia/pull/7505)

--- a/dev-packages/application-manager/src/generator/frontend-generator.ts
+++ b/dev-packages/application-manager/src/generator/frontend-generator.ts
@@ -188,17 +188,22 @@ app.on('ready', () => {
             width, height, x, y
         });
 
-        let windowOptions = {
-            show: false,
-            title: applicationName,
-            width: windowState.width,
-            height: windowState.height,
-            minWidth: 200,
-            minHeight: 120,
-            x: windowState.x,
-            y: windowState.y,
-            isMaximized: windowState.isMaximized
-        };
+        let windowOptions = electronStore.get('windowOptions');
+
+        if (!windowOptions) {
+            windowOptions = {
+                show: false,
+                title: applicationName,
+                width: windowState.width,
+                height: windowState.height,
+                minWidth: 200,
+                minHeight: 120,
+                x: windowState.x,
+                y: windowState.y,
+                isMaximized: windowState.isMaximized
+            };
+            electronStore.set('windowOptions', windowOptions);
+        }
 
         // Always hide the window, we will show the window when it is ready to be shown in any case.
         const newWindow = new BrowserWindow(windowOptions);
@@ -286,6 +291,12 @@ app.on('ready', () => {
     });
     ipcMain.on('open-external', (event, url) => {
         shell.openExternal(url);
+    });
+    ipcMain.on('set-window-options', (event, options) => {
+        electronStore.set('windowOptions', options);
+    });
+    ipcMain.on('get-window-options', event => {
+        event.returnValue = electronStore.get('windowOptions');
     });
 
     // Check whether we are in bundled application or development mode.


### PR DESCRIPTION
Signed-off-by: Luca Jaeger <owl.jaeger@gmail.com>

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
I think clients should be able to make the electron window borderless. This was implemented by enabling clients to persistently change the electron windowOptions. This also enables clients to change it through the Theia preferences ( they still have to restart the window ). Example for making the window borderless:
```
import { ipcRenderer } from 'electron';

const currentWindowOptions = ipcRenderer.sendSync('get-window-options');
ipcRenderer.send('set-window-options', {
  ...currentWindowOptions,
  frame: false
});
```
<!-- Include relevant issues and describe how they are addressed. -->

#### How to test
1. Modify some frontend-contribution or add a new one. Execute these commands:
```
const currentWindowOptions = ipcRenderer.sendSync('get-window-options');
ipcRenderer.send('set-window-options', {
  ...currentWindowOptions,
  frame: false
});
```
(I've modified packages/core/src/electron-browser/menu/electron-menu-contribution.ts, onStart, for testing)
2. Restart the example.
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

