### PR TITLE
Feature/preferences ui tab styling

### DIFF
--- a/packages/preferences/src/browser/style/index.css
+++ b/packages/preferences/src/browser/style/index.css
@@ -58,6 +58,9 @@
 .theia-settings-container .preferences-tabbar-widget {
     grid-area: tabbar;
     margin: 3px 24px 0px 24px;
+}
+
+.theia-settings-container .preferences-tabbar-widget.with-shadow {
     box-shadow: 0px 6px 5px -5px var(--theia-widget-shadow);
 }
 
@@ -67,13 +70,26 @@
 
 #theia-main-content-panel .theia-settings-container #preferences-scope-tab-bar .preferences-scope-tab {
     background: var(--theia-editor-background);
+    border-right: unset;
+    border-bottom: var(--theia-border-width) solid var(--theia-tab-unfocusedInactiveForeground);
+}
+
+#theia-main-content-panel .theia-settings-container .tabbar-underline {
+    width: 100%;
+    position:absolute;
+    top: calc(var(--theia-private-horizontal-tab-height) + var(--theia-private-horizontal-tab-scrollbar-rail-height) / 2 - 1px);
+    border-top: 1px solid var(--theia-tab-unfocusedInactiveForeground);
+    z-index: -1;
 }
 
 #theia-main-content-panel .theia-settings-container #preferences-scope-tab-bar .preferences-scope-tab.p-mod-current {
     color: var(--theia-panelTitle-activeForeground);
-    border-top: var(--theia-border-width) solid var(--theia-panelTitle-activeBorder);
+    border-bottom: var(--theia-border-width) solid var(--theia-panelTitle-activeBorder);
 }
 
+#theia-main-content-panel .theia-settings-container #preferences-scope-tab-bar .preferences-scope-tab.p-mod-current:not(.theia-mod-active) {
+    border-top: unset;
+}
 
 #theia-main-content-panel .theia-settings-container #preferences-scope-tab-bar .preferences-scope-tab.preferences-folder-tab .p-TabBar-tabLabel::after {
     content: 'Folder';

--- a/packages/preferences/src/browser/util/preference-types.ts
+++ b/packages/preferences/src/browser/util/preference-types.ts
@@ -98,6 +98,7 @@ export namespace Preference {
 
     export interface MouseScrollDetails {
         firstVisibleChildId: string;
+        isTop: boolean;
     };
 
     export interface SelectedTreeNode {

--- a/packages/preferences/src/browser/views/preference-editor-widget.tsx
+++ b/packages/preferences/src/browser/views/preference-editor-widget.tsx
@@ -108,10 +108,14 @@ export class PreferencesEditorWidget extends ReactWidget {
 
     protected onScroll = (): void => {
         const scrollContainer = this.node;
+        const scrollIsTop = scrollContainer.scrollTop === 0;
         const visibleChildren: string[] = [];
         this.addFirstVisibleChildId(scrollContainer, visibleChildren);
         if (visibleChildren.length) {
-            this.preferencesEventService.onEditorScroll.fire({ firstVisibleChildId: visibleChildren[0] });
+            this.preferencesEventService.onEditorScroll.fire({
+                firstVisibleChildId: visibleChildren[0],
+                isTop: scrollIsTop
+            });
         }
     };
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

Fixes #7768 

This PR addresses issue #7768 to only show the preferences tabbar shadow when the editor is scrolled, and also provides some additional styling improvements to the preferences tab bar to be more in-line with VSCode including:
- Moving tab highlight to bottom of tab
- Adding a dividing line below tab bar
- Removing residual 'focus' behavior when the 'folders' tab is selected using a mouse click in a multiroot workspace
![tab-shadow2](https://user-images.githubusercontent.com/62660714/81617494-29e84500-93ab-11ea-9c30-35cbb29979a3.gif)
![tab-shadow-light](https://user-images.githubusercontent.com/62660714/81617623-60be5b00-93ab-11ea-9e1c-8f0a33e664da.gif)

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
- Pull changes and open preferences UI in a multi root workspace
- Browse preferences and observe drop shadow behavior tab bar styling improvements when scrolling

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

