### PR TITLE
Fix: Plugins folders are created with exclamation mark, which breaks webpack

### DIFF
--- a/packages/plugin-ext-vscode/src/node/plugin-vscode-file-handler.ts
+++ b/packages/plugin-ext-vscode/src/node/plugin-vscode-file-handler.ts
@@ -58,7 +58,7 @@ export class PluginVsCodeFileHandler implements PluginDeployerFileHandler {
         if (context.pluginEntry().type === PluginType.User) {
             extensionsDirUri = await this.environment.getExtensionsDirUri();
         }
-        return FileUri.fsPath(extensionsDirUri.resolve(filenamify(context.pluginEntry().id())));
+        return FileUri.fsPath(extensionsDirUri.resolve(filenamify(context.pluginEntry().id(), { replacement: '_' })));
     }
 
     protected async decompress(extensionDir: string, context: PluginDeployerFileHandlerContext): Promise<void> {

--- a/packages/plugin-ext/src/main/node/handlers/plugin-theia-file-handler.ts
+++ b/packages/plugin-ext/src/main/node/handlers/plugin-theia-file-handler.ts
@@ -53,6 +53,6 @@ export class PluginTheiaFileHandler implements PluginDeployerFileHandler {
         if (context.pluginEntry().type === PluginType.User) {
             pluginsDirUri = await this.environment.getPluginsDirUri();
         }
-        return FileUri.fsPath(pluginsDirUri.resolve(filenamify(context.pluginEntry().id())));
+        return FileUri.fsPath(pluginsDirUri.resolve(filenamify(context.pluginEntry().id(), { replacement: '_' })));
     }
 }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->
Currently when loading Theia plugin / VS code extension, illegal characters are replaced with `!` on plugin folder creation.  This is done because [filenamify](https://www.npmjs.com/package/filenamify) library is used to create legal folder names for plugins, and `!` is the default replacement character.

i.e.: Loading theia with the following vsix:
https://github.com/streetsidesoftware/vscode-spell-checker/releases/download/v1.9.0-alpha.1/code-spell-checker-1.9.0-alpha.1.vsix
will cause `https!github.com!streetsidesoftware!vscode-spell-checker!releases!download!v1.9.0-alpha.1!code-spell-checker-1.9.0-alpha.1.vsix` folder to be created.

In case webpack is used in runtime by some extension it will break because `!` is reserved for webpack loaders mechanism.
See:
https://github.com/webpack/webpack/issues/6742
https://github.com/byzyk/webpack/blob/master/schemas/ajv.absolutePath.js#L38

In order to fix this issue `_` is passed as a replacement character to `filenamify` instead of the default `!`.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
Load Theia with both VS Code extension and Theia plugin from URL:
```powershell
yarn
cd examples/browser
export THEIA_PLUGINS=https://github.com/streetsidesoftware/vscode-spell-checker/releases/download/v1.9.0-alpha.1/code-spell-checker-1.9.0-alpha.1.vsix,https://github.com/redhat-developer/netcoredbg-theia-plugin/releases/download/v0.0.3/netcoredbg_theia_plugin.theia
yarn start
```
* `https_github.com_streetsidesoftware_vscode-spell-checker_releases_download_v1.9.0-alpha.1_code-spell` folder should be created under `vscode-unpacked` folder.
* `https_github.com_redhat-developer_netcoredbg-theia-plugin_releases_download_v0.0.3_netcoredbg_theia_` folder should be created under `theia-unpacked` folder.

VS Code extension should be activated:
![vscode](https://user-images.githubusercontent.com/16555289/81698713-0edf0900-946f-11ea-8486-20cba2f6c332.png)

Theia plugin should be activated:
![theia](https://user-images.githubusercontent.com/16555289/81698748-18687100-946f-11ea-9392-1906ce8a9225.png)
 
#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

Signed-off-by: Shahar Harari <shahar.harari@sap.com>