### PR TITLE
Added ability to change windowOptions & it's defaults. Moved disallowReloadKeybinding inside electron subsection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,15 @@
 
 ## v1.2.0
 
+- [application-manager] enabled clients to add `windowOptions` using an IPC-Event [#7803](https://github.com/eclipse-theia/theia/pull/7803)
+- [application-package] enabled client to change default `windowOptions` [#7803](https://github.com/eclipse-theia/theia/pull/7803)
+
 Breaking changes:
 
 - [scm] support file tree mode in Source Control view.  Classes that extend ScmWidget will likely require changes [#7505](https://github.com/eclipse-theia/theia/pull/7505)
 - [task] removed `taskId` from `TaskTerminalWidgetOpenerOptions` [#7765](https://github.com/eclipse-theia/theia/pull/7765)
 - [core] `KeybindingRegistry` registers a new keybinding with a higher priority than previously in the same scope [#7839](https://github.com/eclipse-theia/theia/pull/7839)
+- [application-package] moved `disallowReloadKeybinding` under the `electron` subsection [#7803](https://github.com/eclipse-theia/theia/pull/7803)
 
 ## v1.1.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,6 @@
 
 ## v1.2.0
 
-- [application-manager] enable clients to persistenly change windowOptions [#7787](https://github.com/eclipse-theia/theia/pull/7787)
-
 Breaking changes:
 
 - [scm] support file tree mode in Source Control view.  Classes that extend ScmWidget will likely require changes [#7505](https://github.com/eclipse-theia/theia/pull/7505)

--- a/dev-packages/application-manager/src/generator/frontend-generator.ts
+++ b/dev-packages/application-manager/src/generator/frontend-generator.ts
@@ -184,22 +184,17 @@ app.on('ready', () => {
             width, height, x, y
         });
 
-        let windowOptions = electronStore.get('windowOptions');
-
-        if (!windowOptions) {
-            windowOptions = {
-                show: false,
-                title: applicationName,
-                width: windowState.width,
-                height: windowState.height,
-                minWidth: 200,
-                minHeight: 120,
-                x: windowState.x,
-                y: windowState.y,
-                isMaximized: windowState.isMaximized
-            };
-            electronStore.set('windowOptions', windowOptions);
-        }
+        let windowOptions = {
+            show: false,
+            title: applicationName,
+            width: windowState.width,
+            height: windowState.height,
+            minWidth: 200,
+            minHeight: 120,
+            x: windowState.x,
+            y: windowState.y,
+            isMaximized: windowState.isMaximized
+        };
 
         // Always hide the window, we will show the window when it is ready to be shown in any case.
         const newWindow = new BrowserWindow(windowOptions);
@@ -295,12 +290,6 @@ app.on('ready', () => {
     });
     ipcMain.on('open-external', (event, url) => {
         shell.openExternal(url);
-    });
-    ipcMain.on('set-window-options', (event, options) => {
-        electronStore.set('windowOptions', options);
-    });
-    ipcMain.on('get-window-options', event => {
-        event.returnValue = electronStore.get('windowOptions');
     });
 
     // Check whether we are in bundled application or development mode.

--- a/dev-packages/application-package/src/application-props.ts
+++ b/dev-packages/application-package/src/application-props.ts
@@ -14,6 +14,8 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
+import type { BrowserWindowConstructorOptions } from 'electron';
+
 export interface NpmRegistryProps {
 
     /**
@@ -114,11 +116,23 @@ export interface FrontendApplicationConfig extends ApplicationConfig {
     readonly applicationName: string;
 
     /**
+     * Electron specific configuration.
+     */
+    readonly electron?: Readonly<ElectronFrontendApplicationConfig>;
+}
+
+export interface ElectronFrontendApplicationConfig {
+
+    /**
      * If set to `true`, reloading the current browser window won't be possible with the `Ctrl/Cmd + R` keybinding.
      * It is `false` by default. Has no effect if not in an electron environment.
      */
     readonly disallowReloadKeybinding?: boolean;
 
+    /**
+     * Override or add properties to the electron `windowOptions`.
+     */
+    readonly windowOptions?: BrowserWindowConstructorOptions;
 }
 
 /**


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does

Fixes https://github.com/eclipse-theia/theia/issues/7811

My preferred alternative to #7787 with overall better handling of `windowOptions`.
Clients can override `windowOptions` by using the IPC-Event (frontend):
```
import { ipcRenderer } from 'electron';

ipcRenderer.send('set-window-options', {
  frame: false
});
```
This will add `frame: false` to the `windowOptions`. If a property is already specified by the defaults, setting it will override the default:
```
import { ipcRenderer } from 'electron';

ipcRenderer.send('set-window-options', {
  minWidth: 300
});

// instead of 200 (default)
```

This PR has the advantage, that the windowState problem described [here](https://github.com/eclipse-theia/theia/pull/7787/files/da0226fc69952ca38a1ea2507acc8b28f786987b#diff-e6697ec7c0f7ddbbfd9e8365baacf132) is not existent because only **changes** to the default `windowOptions` will be stored. This PR also enables clients to change these default options through the `package.json` like this:
```
"theia": {
  "target": "electron",
  "frontend": {
    "config": {
      "applicationName": "Theia Electron Example",
      "electron": {
        "windowOptions": {
          "frame": false
        }
      }
    }
  }
},
```

Preferred (top to bottom):
  1. Options set through IPC-Event
  2. Options set inside `package.json`
  3. Built-in options.

It also moves `disallowReloadKeybinding` into the new `electron` subsection:
```
"theia": {
  "target": "electron",
  "frontend": {
    "config": {
      "applicationName": "Theia Electron Example",
      "electron": {
        "disallowReloadKeybinding": true
      }
    }
  }
},
```
<!-- Include relevant issues and describe how they are addressed. -->

#### How to test
Modify the electron example:
```
"theia": {
  "target": "electron",
  "frontend": {
    "config": {
      "applicationName": "Theia Electron Example",
      "electron": {
        "disallowReloadKeybinding": true,
        "windowOptions": {
          "frame": false
        }
      }
    }
  }
},
```
If the window starts without a frame and can't be reloaded by using the keybinding (Ctrl+r on windows), the changes work.
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

