### PR TITLE
Bind command for handling workbench.action.openRecent request

### DIFF
--- a/packages/plugin-ext-vscode/src/browser/plugin-vscode-commands-contribution.ts
+++ b/packages/plugin-ext-vscode/src/browser/plugin-vscode-commands-contribution.ts
@@ -53,6 +53,7 @@ import { Position } from '@theia/plugin-ext/lib/common/plugin-api-rpc';
 import { URI } from 'vscode-uri';
 import { MonacoEditor } from '@theia/monaco/lib/browser/monaco-editor';
 import { TerminalFrontendContribution } from '@theia/terminal/lib/browser/terminal-frontend-contribution';
+import { QuickOpenWorkspace } from '@theia/workspace/lib/browser/quick-open-workspace';
 
 export namespace VscodeCommands {
     export const OPEN: Command = {
@@ -90,6 +91,8 @@ export class PluginVscodeCommandsContribution implements CommandContribution {
     protected readonly workspaceService: WorkspaceService;
     @inject(TerminalFrontendContribution)
     protected readonly terminalContribution: TerminalFrontendContribution;
+    @inject(QuickOpenWorkspace)
+    protected readonly quickOpenWorkspace: QuickOpenWorkspace;
 
     registerCommands(commands: CommandRegistry): void {
         commands.registerCommand(VscodeCommands.OPEN, {
@@ -570,5 +573,11 @@ export class PluginVscodeCommandsContribution implements CommandContribution {
                     commands.executeCommand<CallHierarchyOutgoingCall[]>('_executeProvideOutgoingCalls', { item }))
             }
         );
+
+        commands.registerCommand({
+            id: 'workbench.action.openRecent'
+        }, {
+            execute: () => this.quickOpenWorkspace.select()
+        });
     }
 }


### PR DESCRIPTION
#### What it does
This changes proposal registers command `workbench.action.openRecent` and redirects call to internal mechanism which opens recently opened items.

Signed-off-by: Vladyslav Zhukovskyi <vzhukovs@redhat.com>

#### How to test
Build Theia from this branch and install [Emacs Friendly Keymap](https://marketplace.visualstudio.com/items?itemName=lfs.vscode-emacs-friendly) extension. Then use combination `Ctrl+X - R`. Recently opened items should be displayed.

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

