### PR TITLE
Removed global shortcuts if window is not focused.

### DIFF
--- a/dev-packages/application-manager/src/generator/frontend-generator.ts
+++ b/dev-packages/application-manager/src/generator/frontend-generator.ts
@@ -157,10 +157,6 @@ const electronSecurityToken = {
 
 app.on('ready', () => {
 
-    if (disallowReloadKeybinding) {
-        globalShortcut.register('CmdOrCtrl+R', () => {});
-    }
-
     // Explicitly set the app name to have better menu items on macOS. ("About", "Hide", and "Quit")
     // See: https://github.com/electron-userland/electron-builder/issues/2468
     app.setName(applicationName);
@@ -211,6 +207,14 @@ app.on('ready', () => {
             newWindow.maximize();
         }
         newWindow.on('ready-to-show', () => newWindow.show());
+        if (disallowReloadKeybinding) {
+            newWindow.on('focus', event => {
+                for (const accelerator of ['CmdOrCtrl+R','F5']) {
+                    globalShortcut.register(accelerator, () => {});
+                }
+            });
+            newWindow.on('blur', event => globalShortcut.unregisterAll());
+        }
 
         // Prevent calls to "window.open" from opening an ElectronBrowser window,
         // and rather open in the OS default web browser.


### PR DESCRIPTION
The `disallowReloadKeybinding` app config should not override the global
shortcuts when none of the electron windows have the focus.

Ref: arduino/arduino-pro-ide#249
Signed-off-by: Akos Kitta <kittaakos@typefox.io>

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->
Removes the refresh/reload electron accelerator from the `globalShortcut` when none of the browser windows have the focus. So that you can still refresh _Chrome_ or another app when the Theia-based electron app does not have the focus.

Ref: https://github.com/arduino/arduino-pro-ide/issues/249

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
 - Change your app config:
```diff
diff --git a/examples/electron/package.json b/examples/electron/package.json
index 513df28d4..9d310f08e 100644
--- a/examples/electron/package.json
+++ b/examples/electron/package.json
@@ -9,7 +9,8 @@
     "target": "electron",
     "frontend": {
       "config": {
-        "applicationName": "Theia Electron Example"
+        "applicationName": "Theia Electron Example",
+        "disallowReloadKeybinding": true
       }
     }
   },
```
 - Start the app, press <kbd>Ctrl/Cmd</kbd>+<kbd>R</kbd>, you cannot refresh the Theia-example, **but** you can refresh a tab in _Chrome_, for example, if the the Theia-example window is not focused.

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

