### PR TITLE
fixes for scm view

### DIFF
--- a/packages/scm/src/browser/scm-frontend-module.ts
+++ b/packages/scm/src/browser/scm-frontend-module.ts
@@ -22,7 +22,7 @@ import {
     bindViewContribution, FrontendApplicationContribution,
     WidgetFactory, ViewContainer,
     WidgetManager, ApplicationShellLayoutMigration,
-    createTreeContainer, TreeWidget, TreeModel, TreeModelImpl, TreeProps
+    createTreeContainer, TreeWidget, TreeModel, TreeModelImpl
 } from '@theia/core/lib/browser';
 import { ScmService } from './scm-service';
 import { SCM_WIDGET_FACTORY_ID, ScmContribution, SCM_VIEW_CONTAINER_ID, SCM_VIEW_CONTAINER_TITLE_OPTIONS } from './scm-contribution';
@@ -63,7 +63,7 @@ export default new ContainerModule(bind => {
     })).inSingletonScope();
 
     bind(ScmTreeWidget).toDynamicValue(ctx => {
-        const child = createFileChangeTreeContainer(ctx.container);
+        const child = createScmTreeContainer(ctx.container);
         return child.get(ScmTreeWidget);
     });
     bind(WidgetFactory).toDynamicValue(({ container }) => ({
@@ -120,8 +120,11 @@ export default new ContainerModule(bind => {
     bindScmPreferences(bind);
 });
 
-export function createFileChangeTreeContainer(parent: interfaces.Container): Container {
-    const child = createTreeContainer(parent);
+export function createScmTreeContainer(parent: interfaces.Container): Container {
+    const child = createTreeContainer(parent, {
+        virtualized: true,
+        search: true
+    });
 
     child.unbind(TreeWidget);
     child.bind(ScmTreeWidget).toSelf();
@@ -130,12 +133,6 @@ export function createFileChangeTreeContainer(parent: interfaces.Container): Con
     child.bind(ScmTreeModel).toSelf();
     child.rebind(TreeModel).toService(ScmTreeModel);
 
-    child.rebind(TreeProps).toConstantValue({
-        leftPadding: 8,
-        expansionTogglePadding: 22,
-        virtualized: true,
-        search: true,
-    });
     child.bind(ScmTreeModelProps).toConstantValue({
         defaultExpansion: 'expanded',
     });

--- a/packages/scm/src/browser/scm-tree-widget.tsx
+++ b/packages/scm/src/browser/scm-tree-widget.tsx
@@ -28,7 +28,7 @@ import { ScmResourceGroup, ScmResource, ScmResourceDecorations } from './scm-pro
 import { ScmService } from './scm-service';
 import { CommandRegistry } from '@theia/core/lib/common/command';
 import { ScmRepository } from './scm-repository';
-import { ContextMenuRenderer, LabelProvider, CorePreferences, DiffUris} from '@theia/core/lib/browser';
+import { ContextMenuRenderer, LabelProvider, CorePreferences, DiffUris } from '@theia/core/lib/browser';
 import { ScmContextKeyService } from './scm-context-key-service';
 import { EditorWidget } from '@theia/editor/lib/browser';
 import { EditorManager, DiffNavigatorProvider } from '@theia/editor/lib/browser';
@@ -65,7 +65,7 @@ export class ScmTreeWidget extends TreeWidget {
         @inject(ScmService) protected readonly scmService: ScmService,
     ) {
         super(props, model, contextMenuRenderer);
-        this.id = 'resource_widget';
+        this.id = ScmTreeWidget.ID;
         this.addClass('groups-outer-container');
     }
 
@@ -118,7 +118,7 @@ export class ScmTreeWidget extends TreeWidget {
                 repository={repository}
                 groupId={node.groupId}
                 groupLabel={node.groupLabel}
-                renderExpansionToggle={ () => this.renderExpansionToggle(node, props) }
+                renderExpansionToggle={() => this.renderExpansionToggle(node, props)}
                 contextMenuRenderer={this.contextMenuRenderer}
                 commands={this.commands}
                 menus={this.menus}
@@ -137,7 +137,7 @@ export class ScmTreeWidget extends TreeWidget {
                 path={node.path}
                 node={node}
                 sourceUri={new URI(node.sourceUri)}
-                renderExpansionToggle={ () => this.renderExpansionToggle(node, props) }
+                renderExpansionToggle={() => this.renderExpansionToggle(node, props)}
                 contextMenuRenderer={this.contextMenuRenderer}
                 commands={this.commands}
                 menus={this.menus}
@@ -156,7 +156,7 @@ export class ScmTreeWidget extends TreeWidget {
             const name = this.labelProvider.getName(new URI(node.sourceUri));
             const parentPath =
                 (node.parent && ScmFileChangeFolderNode.is(node.parent))
-                ? new URI(node.parent.sourceUri) : new URI(repository.provider.rootUri);
+                    ? new URI(node.parent.sourceUri) : new URI(repository.provider.rootUri);
 
             const content = <ScmResourceComponent
                 key={node.sourceUri}
@@ -198,8 +198,7 @@ export class ScmTreeWidget extends TreeWidget {
             return {
                 ...super.createContainerAttributes(),
                 onFocus: select,
-                tabIndex: 0,
-                id: ScmTreeWidget.ID,
+                tabIndex: 0
             };
         }
         return super.createContainerAttributes();
@@ -386,6 +385,15 @@ export class ScmTreeWidget extends TreeWidget {
         }
         // fallback to standalone editor
         return standaloneEditor;
+    }
+
+    protected getPaddingLeft(node: TreeNode, props: NodeProps): number {
+        if (this.viewMode === 'list') {
+            if (props.depth === 1) {
+                return this.props.expansionTogglePadding;
+            }
+        }
+        return super.getPaddingLeft(node, props);
     }
 
     protected needsExpansionTogglePadding(node: TreeNode): boolean {
@@ -645,12 +653,12 @@ export class ScmResourceFolderElement extends ScmElement<ScmResourceFolderElemen
         const icon = labelProvider.getIcon(sourceFileStat);
 
         return <div key={String(sourceUri)}
-                className={`scmItem ${TREE_NODE_SEGMENT_GROW_CLASS} ${ScmTreeWidget.Styles.NO_SELECT}`}
-                onContextMenu={this.renderContextMenu}
-                onMouseEnter={this.showHover}
-                onMouseLeave={this.hideHover}
-                ref={this.detectHover}
-            >
+            className={`scmItem ${TREE_NODE_SEGMENT_GROW_CLASS} ${ScmTreeWidget.Styles.NO_SELECT}`}
+            onContextMenu={this.renderContextMenu}
+            onMouseEnter={this.showHover}
+            onMouseLeave={this.hideHover}
+            ref={this.detectHover}
+        >
             {this.props.renderExpansionToggle()}
             <span className={icon + ' file-icon'} />
             <div className={`noWrapInfo ${TREE_NODE_SEGMENT_GROW_CLASS}`} >

--- a/packages/scm/src/browser/style/index.css
+++ b/packages/scm/src/browser/style/index.css
@@ -97,8 +97,7 @@
     line-height: var(--theia-content-line-height);
     resize: none;
     box-sizing: border-box;
-    height: 26px;
-    min-height: 26px;
+    min-height: 32px;
     padding: 4px;
     border: none;
 }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

- fixed restoring last commit message
- fix #7794: fixed min height of input
- align toggle paddings with other trees

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

- check that scm input has always proper min-height as before
- check that on reload scm input is preserved
- check that in the list mode there is no unnecessary left padding for file nodes
- check that in the tree mode left padding is similar to padding for nodes in the navigator

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

