### PR TITLE
[vscode] Support all workspace.fs APIs for registered fs providers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## v1.2.0
 
+- [plugin] support all vscode.workspace.fs APIs for registered fs providers only (not yet real file system)
 - [application-manager] enabled clients to add `windowOptions` using an IPC-Event [#7803](https://github.com/eclipse-theia/theia/pull/7803)
 - [application-package] enabled client to change default `windowOptions` [#7803](https://github.com/eclipse-theia/theia/pull/7803)
 

--- a/packages/plugin-ext/src/common/plugin-api-rpc.ts
+++ b/packages/plugin-ext/src/common/plugin-api-rpc.ts
@@ -30,7 +30,7 @@ import {
     QuickInputButton
 } from '../plugin/types-impl';
 import { UriComponents } from './uri-components';
-import { ConfigurationTarget } from '../plugin/types-impl';
+import { ConfigurationTarget, FileType, FileStat } from '../plugin/types-impl';
 import {
     SerializedDocumentFilter,
     CompletionContext,
@@ -1341,13 +1341,25 @@ export interface DebugMain {
 }
 
 export interface FileSystemExt {
+    $stat(handle: number, resource: UriComponents): Promise<FileStat>;
+    $readDirectory(handle: number, resource: UriComponents): Promise<[string, FileType][]>;
+    $createDirectory(handle: number, uri: UriComponents): Promise<void>;
     $readFile(handle: number, resource: UriComponents, options?: { encoding?: string }): Promise<string>;
     $writeFile(handle: number, resource: UriComponents, content: string, options?: { encoding?: string }): Promise<void>;
+    $delete(handle: number, resource: UriComponents, options: { recursive: boolean }): Promise<void>;
+    $rename(handle: number, source: UriComponents, target: UriComponents, options: { overwrite: boolean }): Promise<void>;
+    $copy(handle: number, source: UriComponents, target: UriComponents, options: { overwrite: boolean }): Promise<void>;
 }
 
 export interface FileSystemMain {
+    $stat(uri: UriComponents): Promise<FileStat>
+    $readDirectory(uri: UriComponents): Promise<[string, FileType][]>;
+    $createDirectory(uri: UriComponents): Promise<void>
     $readFile(uri: UriComponents): Promise<string>;
     $writeFile(uri: UriComponents, content: string): Promise<void>;
+    $delete(uri: UriComponents, options: { recursive: boolean }): Promise<void>;
+    $rename(source: UriComponents, target: UriComponents, options: { overwrite: boolean }): Promise<void>;
+    $copy(source: UriComponents, target: UriComponents, options: { overwrite: boolean }): Promise<void>;
     $registerFileSystemProvider(handle: number, scheme: string): void;
     $unregisterProvider(handle: number): void;
 }

--- a/packages/plugin-ext/src/plugin/file-system.ts
+++ b/packages/plugin-ext/src/plugin/file-system.ts
@@ -19,7 +19,7 @@ import * as theia from '@theia/plugin';
 import { PLUGIN_RPC_CONTEXT, FileSystemExt, FileSystemMain } from '../common/plugin-api-rpc';
 import { RPCProtocol } from '../common/rpc-protocol';
 import { UriComponents, Schemes } from '../common/uri-components';
-import { Disposable } from './types-impl';
+import { Disposable, FileStat, FileType } from './types-impl';
 import { InPluginFileSystemProxy } from './in-plugin-filesystem-proxy';
 
 export class FileSystemExtImpl implements FileSystemExt {
@@ -27,7 +27,7 @@ export class FileSystemExtImpl implements FileSystemExt {
     private readonly proxy: FileSystemMain;
     private readonly usedSchemes = new Set<string>();
     private readonly fsProviders = new Map<number, theia.FileSystemProvider>();
-    private fileSystem: InPluginFileSystemProxy;
+    private readonly fileSystem: InPluginFileSystemProxy;
 
     private handlePool: number = 0;
 
@@ -69,21 +69,41 @@ export class FileSystemExtImpl implements FileSystemExt {
         });
     }
 
-    private checkProviderExists(handle: number): void {
-        if (!this.fsProviders.has(handle)) {
+    private safeGetProvider(handle: number): theia.FileSystemProvider {
+        const provider = this.fsProviders.get(handle);
+        if (!provider) {
             const err = new Error();
             err.name = 'ENOPRO';
             err.message = 'no provider';
             throw err;
         }
+        return provider;
     }
 
     // forwarding calls
 
-    $readFile(handle: number, resource: UriComponents, options?: { encoding?: string }): Promise<string> {
-        this.checkProviderExists(handle);
+    $stat(handle: number, resource: UriComponents): Promise<FileStat> {
+        const fileSystemProvider = this.safeGetProvider(handle);
+        const uri = URI.revive(resource);
+        return Promise.resolve(fileSystemProvider.stat(uri));
+    }
 
-        return Promise.resolve(this.fsProviders.get(handle)!.readFile(URI.revive(resource))).then(data => {
+    $readDirectory(handle: number, resource: UriComponents): Promise<[string, FileType][]> {
+        const fileSystemProvider = this.safeGetProvider(handle);
+        const uri = URI.revive(resource);
+        return Promise.resolve(fileSystemProvider.readDirectory(uri));
+    }
+
+    $createDirectory(handle: number, resource: UriComponents): Promise<void> {
+        const fileSystemProvider = this.safeGetProvider(handle);
+        const uri = URI.revive(resource);
+        return Promise.resolve(fileSystemProvider.createDirectory(uri));
+    }
+
+    $readFile(handle: number, resource: UriComponents, options?: { encoding?: string }): Promise<string> {
+        const fileSystemProvider = this.safeGetProvider(handle);
+
+        return Promise.resolve(fileSystemProvider.readFile(URI.revive(resource))).then(data => {
             const buffer = Buffer.isBuffer(data) ? data : Buffer.from(data.buffer, data.byteOffset, data.byteLength);
             const encoding = options === null ? undefined : options && options.encoding;
             return buffer.toString(encoding);
@@ -92,11 +112,32 @@ export class FileSystemExtImpl implements FileSystemExt {
     }
 
     $writeFile(handle: number, resource: UriComponents, content: string, options?: { encoding?: string }): Promise<void> {
-        this.checkProviderExists(handle);
+        const fileSystemProvider = this.safeGetProvider(handle);
         const uri = URI.revive(resource);
         const encoding = options === null ? undefined : options && options.encoding;
         const buffer = Buffer.from(content, encoding);
         const opts = { create: true, overwrite: true };
-        return Promise.resolve(this.fsProviders.get(handle)!.writeFile(uri, buffer, opts));
+        return Promise.resolve(fileSystemProvider.writeFile(uri, buffer, opts));
     }
+
+    $delete(handle: number, resource: UriComponents, options: { recursive: boolean }): Promise<void> {
+        const fileSystemProvider = this.safeGetProvider(handle);
+        const uri = URI.revive(resource);
+        return Promise.resolve(fileSystemProvider.delete(uri, options));
+    }
+
+    $rename(handle: number, source: UriComponents, target: UriComponents, options: { overwrite: boolean }): Promise<void> {
+        const fileSystemProvider = this.safeGetProvider(handle);
+        const sourceUri = URI.revive(source);
+        const targetUri = URI.revive(target);
+        return Promise.resolve(fileSystemProvider.rename(sourceUri, targetUri, options));
+    }
+
+    $copy(handle: number, source: UriComponents, target: UriComponents, options: { overwrite: boolean }): Promise<void> {
+        const fileSystemProvider = this.safeGetProvider(handle);
+        const sourceUri = URI.revive(source);
+        const targetUri = URI.revive(target);
+        return Promise.resolve(fileSystemProvider.copy && fileSystemProvider.copy(sourceUri, targetUri, options));
+    }
+
 }

--- a/packages/plugin-ext/src/plugin/in-plugin-filesystem-proxy.ts
+++ b/packages/plugin-ext/src/plugin/in-plugin-filesystem-proxy.ts
@@ -18,7 +18,8 @@ import * as theia from '@theia/plugin';
 import { TextEncoder, TextDecoder } from 'util';
 import { FileSystemMain } from '../common/plugin-api-rpc';
 import { UriComponents } from '../common/uri-components';
-import { FileSystemError } from './types-impl';
+import { FileSystemError, FileType } from './types-impl';
+import { FileStat, Uri } from '@theia/plugin';
 
 /**
  * This class is managing FileSystem proxy
@@ -31,6 +32,28 @@ export class InPluginFileSystemProxy implements theia.FileSystem {
         this.proxy = proxy;
     }
 
+    async stat(uri: Uri): Promise<FileStat> {
+        try {
+            return this.proxy.$stat(uri);
+        } catch (error) {
+            throw this.handleError(error);
+        }
+    }
+    async readDirectory(uri: UriComponents): Promise<[string, FileType][]> {
+        try {
+            return this.proxy.$readDirectory(uri);
+        } catch (error) {
+            throw this.handleError(error);
+        }
+    }
+    async createDirectory(uri: Uri): Promise<void> {
+        try {
+            return this.proxy.$createDirectory(uri);
+        } catch (error) {
+            throw this.handleError(error);
+        }
+
+    }
     async readFile(uri: UriComponents): Promise<Uint8Array> {
         try {
             const val = await this.proxy.$readFile(uri);
@@ -43,7 +66,28 @@ export class InPluginFileSystemProxy implements theia.FileSystem {
         const encoded = new TextDecoder().decode(content);
 
         try {
-            await this.proxy.$writeFile(uri, encoded);
+            return this.proxy.$writeFile(uri, encoded);
+        } catch (error) {
+            throw this.handleError(error);
+        }
+    }
+    async delete(uri: Uri, options?: { recursive?: boolean, useTrash?: boolean }): Promise<void> {
+        try {
+            return this.proxy.$delete(uri, { ...{ recursive: false }, ...options });
+        } catch (error) {
+            throw this.handleError(error);
+        }
+    }
+    async rename(source: Uri, target: Uri, options?: { overwrite?: boolean }): Promise<void> {
+        try {
+            return this.proxy.$rename(source, target, { ...{ overwrite: false }, ...options });
+        } catch (error) {
+            throw this.handleError(error);
+        }
+    }
+    async copy(source: Uri, target: Uri, options?: { overwrite?: boolean }): Promise<void> {
+        try {
+            return this.proxy.$copy(source, target, { ...{ overwrite: false }, ...options });
         } catch (error) {
             throw this.handleError(error);
         }

--- a/packages/plugin-ext/src/plugin/types-impl.ts
+++ b/packages/plugin-ext/src/plugin/types-impl.ts
@@ -1328,6 +1328,13 @@ export enum FileType {
     SymbolicLink = 64
 }
 
+export interface FileStat {
+    readonly type: FileType;
+    readonly ctime: number;
+    readonly mtime: number;
+    readonly size: number;
+}
+
 export class ProgressOptions {
     /**
      * The location at which progress should show.

--- a/packages/plugin/src/theia.d.ts
+++ b/packages/plugin/src/theia.d.ts
@@ -4528,6 +4528,32 @@ declare module '@theia/plugin' {
     export interface FileSystem {
 
         /**
+         * Retrieve metadata about a file.
+         *
+         * @param uri The uri of the file to retrieve metadata about.
+         * @return The file metadata about the file.
+         */
+        stat(uri: Uri): PromiseLike<FileStat>;
+
+        /**
+         * Retrieve all entries of a [directory](#FileType.Directory).
+         *
+         * @param uri The uri of the folder.
+         * @return An array of name/type-tuples or a PromiseLike that resolves to such.
+         */
+        readDirectory(uri: Uri): PromiseLike<[string, FileType][]>;
+
+        /**
+         * Create a new directory (Note, that new files are created via `write`-calls).
+         *
+         * *Note* that missing directories are created automatically, e.g this call has
+         * `mkdirp` semantics.
+         *
+         * @param uri The uri of the new folder.
+         */
+        createDirectory(uri: Uri): PromiseLike<void>;
+
+        /**
          * Read the entire contents of a file.
          *
          * @param uri The uri of the file.
@@ -4542,6 +4568,32 @@ declare module '@theia/plugin' {
          * @param content The new content of the file.
          */
         writeFile(uri: Uri, content: Uint8Array): PromiseLike<void>;
+
+        /**
+         * Delete a file.
+         *
+         * @param uri The resource that is to be deleted.
+         * @param options Defines if trash can should be used and if deletion of folders is recursive
+         */
+        delete(uri: Uri, options?: { recursive?: boolean, useTrash?: boolean }): PromiseLike<void>;
+
+        /**
+         * Rename a file or folder.
+         *
+         * @param source The existing file.
+         * @param target The new location.
+         * @param options Defines if existing files should be overwritten.
+         */
+        rename(source: Uri, target: Uri, options?: { overwrite?: boolean }): PromiseLike<void>;
+
+        /**
+         * Copy files or folders.
+         *
+         * @param source The existing file.
+         * @param target The destination location.
+         * @param options Defines if existing files should be overwritten.
+         */
+        copy(source: Uri, target: Uri, options?: { overwrite?: boolean }): PromiseLike<void>;
     }
 
     /**


### PR DESCRIPTION

For this phase only support registered file system providers (and not real file system yet)

Signed-off-by: Amiram Wingarten <amiram.wingarten@sap.com>

#### What it does
Support all missing workspace.fs APIs for registered fs providers: stat, readDirectory, createDirectory, delete, rename and copy.

readFile and writeFile were supported already before this PR.

For the scope of this PR the new supported APIs only work with vscode extensions registered file system providers and not yet support real file system.

#### How to test

1. Clone https://github.com/amiramw/vscode-file-system-provider which is a vscode extension that registers inmemory file system provider and exposes commands that test all vscode.workspace.fs methods
1. `yarn`
1. `yarn compile`
1. `vsce package`
1. Deploy the result vsix file to theia
1. Test the following commands from command palette: 
    - FSP: Test vscode.workspace.fs.stat()
    - FSP: Test vscode.workspace.fs.readDirectory()
    - FSP: Test vscode.workspace.fs.readFile()
    - FSP: Test vscode.workspace.fs.createDirectory()
    - FSP: Test vscode.workspace.fs.writeFile()
    - FSP: Test vscode.workspace.fs.rename()
    - FSP: Test vscode.workspace.fs.copy()
    - FSP: Test vscode.workspace.fs.delete()

Prior to this PR only readFile and writeFile worked. After this PR all of them should work.

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

