### PR TITLE
output: improve output display

### DIFF
--- a/packages/core/src/browser/style/variables-bright.useable.css
+++ b/packages/core/src/browser/style/variables-bright.useable.css
@@ -50,7 +50,7 @@ is not optimized for dense, information rich UIs.
   --theia-code-line-height: 17px;
   --theia-code-padding: 5px;
   --theia-code-font-family: Menlo, Monaco, Consolas, "Droid Sans Mono", "Courier New", monospace, "Droid Sans Fallback";
-  --theia-terminal-font-family: monospace;
+  --theia-monospace-font-family: monospace;
   --theia-ui-padding: 6px;
 
   /* Icons */
@@ -87,7 +87,7 @@ is not optimized for dense, information rich UIs.
 
   /* Statusbar */
   --theia-statusBar-font-size: 12px;
- 
+
   /* Opacity for disabled mod  */
   --theia-mod-disabled-opacity: 0.4;
 }

--- a/packages/core/src/browser/style/variables-dark.useable.css
+++ b/packages/core/src/browser/style/variables-dark.useable.css
@@ -50,7 +50,7 @@ is not optimized for dense, information rich UIs.
   --theia-code-line-height: 17px;
   --theia-code-padding: 5px;
   --theia-code-font-family: Menlo, Monaco, Consolas, "Droid Sans Mono", "Courier New", monospace, "Droid Sans Fallback";
-  --theia-terminal-font-family: monospace;
+  --theia-monospace-font-family: monospace;
   --theia-ui-padding: 6px;
 
   /* Icons */

--- a/packages/output/src/browser/output-widget.tsx
+++ b/packages/output/src/browser/output-widget.tsx
@@ -111,11 +111,6 @@ export class OutputWidget extends ReactWidget {
         let id = 0;
         const result = [];
 
-        const style: React.CSSProperties = {
-            whiteSpace: 'pre',
-            fontFamily: 'monospace',
-        };
-
         if (this.outputChannelManager.selectedChannel) {
             for (const outputChannelLine of this.outputChannelManager.selectedChannel.getLines()) {
                 const lines = outputChannelLine.text.split(/[\n\r]+/);
@@ -126,12 +121,12 @@ export class OutputWidget extends ReactWidget {
                     className = 'theia-output-warning';
                 }
                 for (const line of lines) {
-                    result.push(<div style={style} className={className} key={id++}>{line}</div>);
+                    result.push(<div className={`theia-output-lines ${className}`} key={id++}>{line}</div>);
                 }
             }
         }
         if (result.length === 0) {
-            result.push(<div style={style} key={id++}>{'<no output yet>'}</div>);
+            result.push(<div className={'theia-output-lines'} key={id++}>{'<no output yet>'}</div>);
         }
         return result;
     }

--- a/packages/output/src/browser/style/output.css
+++ b/packages/output/src/browser/style/output.css
@@ -32,7 +32,7 @@
 #outputView #outputChannelList {
     line-height: var(--theia-content-line-height);
     font-size: var(--theia-ui-font-size1);
-    
+
     -webkit-appearance: none;
     -moz-appearance: none;
     background-position: calc(100% - 6px) 8px, calc(100% - 2px) 8px, 100% 0;
@@ -58,6 +58,12 @@
 
 #outputView #outputClear.enabled:hover {
     opacity: 1;
+}
+
+#outputView .theia-output-lines {
+    font-family: var( --theia-monospace-font-family);
+    font-weight: 600;
+    white-space: pre;
 }
 
 .output-tab-icon::before {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

The previous font-weight of the ouput-view made the visibility difficult (especially on lighter themes), and this pull-request updates it to be more consistent and easier to use.

The following pull-request updates the **output-view** to improve the output display:
- updates the output-view content (including an update to the font-weight).
- refactors the output-view to make use of css variables.
- renames `--theia-terminal-font-family` to the more generic name `--theia-monospace-font-family` (the variable was previously unused).

<details>

<summary>Before & After</summary>

<br />
_Before_:

<div align='center'>

<img width="1110" alt="Screen Shot 2020-05-15 at 10 07 32 AM" src="https://user-images.githubusercontent.com/40359487/82060136-f2241a80-9694-11ea-895e-4d2680776888.png">

<img width="1110" alt="Screen Shot 2020-05-15 at 10 07 19 AM" src="https://user-images.githubusercontent.com/40359487/82060218-15e76080-9695-11ea-9cd7-ac07abfb7753.png">


</div>

_After_:

<div align='center'>

<img width="1153" alt="Screen Shot 2020-05-15 at 10 04 10 AM" src="https://user-images.githubusercontent.com/40359487/82060152-f8b29200-9694-11ea-8ae5-adf2f24e6684.png">

<img width="1153" alt="Screen Shot 2020-05-15 at 10 04 16 AM" src="https://user-images.githubusercontent.com/40359487/82060238-1b44ab00-9695-11ea-8733-6f545b592a7e.png">

</div>

</details>

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

_master_:
1. start the application, open the output-view and select 'my test channel'
2. view the output under different themes (light + dark) - the output is difficult to see conformably

_pull-request_:
1. perform the same steps above with the pull-request built 

Alternatively you may also set the JSON trace to verbose and open a JSON file (ex: 'package.json') to see much more output.

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

Signed-off-by: vince-fugnitto <vincent.fugnitto@ericsson.com>