### PR TITLE
GH-7834: Restored the find widget's "border" color.

### DIFF
--- a/packages/monaco/src/browser/style/index.css
+++ b/packages/monaco/src/browser/style/index.css
@@ -98,3 +98,9 @@
 .monaco-editor .reference-zone-widget .ref-tree .referenceMatch .highlight {
     color: unset !important;
 }
+
+.monaco-editor .find-widget .monaco-inputbox.synthetic-focus {
+    outline: var(--theia-border-width) solid;
+    outline-offset: calc(-1*var(--theia-border-width));
+    outline-color: var(--theia-focusBorder);
+}


### PR DESCRIPTION
`--theia-input-border` as the `outline-color` had no effect: https://github.com/eclipse-theia/theia/pull/7340#discussion_r392844241

Fixes eclipse-theia/theia#7834

Signed-off-by: Akos Kitta <kittaakos@typefox.io>

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

Fixes the border color of the find/replace widget.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

Try the find/replace widget in the editor, set the focus, compare the "border" color with the `master`.

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

