### PR TITLE
respect keybinding scope and registration order during evaluation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Breaking changes:
 
 - [scm] support file tree mode in Source Control view.  Classes that extend ScmWidget will likely require changes [#7505](https://github.com/eclipse-theia/theia/pull/7505)
 - [task] removed `taskId` from `TaskTerminalWidgetOpenerOptions` [#7765](https://github.com/eclipse-theia/theia/pull/7765)
+- [core] `KeybindingRegistry` registers a new keybinding with a higher priority than previously in the same scope [#7839](https://github.com/eclipse-theia/theia/pull/7839)
 
 ## v1.1.0
 

--- a/packages/core/src/browser/keybinding.spec.ts
+++ b/packages/core/src/browser/keybinding.spec.ts
@@ -226,15 +226,15 @@ describe('keybindings', () => {
 
         keybindingRegistry.setKeymap(KeybindingScope.WORKSPACE, keybindingsSpecific);
 
-        let bindings = keybindingRegistry.getKeybindingsForKeySequence([KeyCode.createKeyCode({ first: Key.KEY_A, modifiers: [KeyModifier.CtrlCmd] })]).full;
-        expect(bindings).to.have.lengthOf(1);
+        let match = keybindingRegistry.matchKeybiding([KeyCode.createKeyCode({ first: Key.KEY_A, modifiers: [KeyModifier.CtrlCmd] })]);
+        expect(match && match.kind).to.be.equal('full');
 
-        bindings = keybindingRegistry.getKeybindingsForKeySequence([KeyCode.createKeyCode({ first: Key.KEY_B, modifiers: [KeyModifier.CtrlCmd] })]).full;
-        expect(bindings).to.have.lengthOf(1);
+        match = keybindingRegistry.matchKeybiding([KeyCode.createKeyCode({ first: Key.KEY_B, modifiers: [KeyModifier.CtrlCmd] })]);
+        expect(match && match.kind).to.be.equal('full');
 
-        bindings = keybindingRegistry.getKeybindingsForKeySequence([KeyCode.createKeyCode({ first: Key.KEY_C, modifiers: [KeyModifier.CtrlCmd] })]).full;
-        const keyCode = KeyCode.parse(bindings[0].keybinding);
-        expect(keyCode.key).to.be.equal(validKeyCode.key);
+        match = keybindingRegistry.matchKeybiding([KeyCode.createKeyCode({ first: Key.KEY_C, modifiers: [KeyModifier.CtrlCmd] })]);
+        const keyCode = match && KeyCode.parse(match.binding.keybinding);
+        expect(keyCode?.key).to.be.equal(validKeyCode.key);
     });
 
     it('should return partial keybinding matches', () => {
@@ -249,17 +249,17 @@ describe('keybindings', () => {
         validKeyCodes.push(KeyCode.createKeyCode({ first: Key.KEY_C, modifiers: [KeyModifier.CtrlCmd] }));
         validKeyCodes.push(KeyCode.createKeyCode({ first: Key.KEY_T }));
 
-        const bindings = keybindingRegistry.getKeybindingsForKeySequence(KeySequence.parse('ctrlcmd+x'));
-        expect(bindings.partial.length > 0);
+        const match = keybindingRegistry.matchKeybiding(KeySequence.parse('ctrlcmd+x'));
+        expect(match && match.kind).to.be.equal('partial');
     });
 
-    it('should not register a shadowing keybinding', () => {
-        const validKeyBinding = 'ctrlcmd+b a';
+    it('should possible to override keybinding', () => {
+        const overridenKeybinding = 'ctrlcmd+b a';
         const command = TEST_COMMAND_SHADOW.id;
         const keybindingShadowing: Keybinding[] = [
             {
                 command,
-                keybinding: validKeyBinding
+                keybinding: overridenKeybinding
             },
             {
                 command,
@@ -270,27 +270,27 @@ describe('keybindings', () => {
         keybindingRegistry.registerKeybindings(...keybindingShadowing);
 
         const bindings = keybindingRegistry.getKeybindingsForCommand(command);
-        expect(bindings.length).to.be.equal(1);
-        expect(bindings[0].keybinding).to.be.equal(validKeyBinding);
+        expect(bindings.length).to.be.equal(2);
+        expect(bindings[0].keybinding).to.be.equal('ctrlcmd+b');
+        expect(bindings[1].keybinding).to.be.equal(overridenKeybinding);
     });
 
-    it('shadowed bindings should be returned last', () => {
+    it('overriden bindings should be returned last', () => {
         const keyCode = KeyCode.createKeyCode({ first: Key.KEY_A, modifiers: [KeyModifier.Shift] });
-        let bindings: Keybinding[];
 
-        const ignoredDefaultBinding: Keybinding = {
+        const overridenDefaultBinding: Keybinding = {
             keybinding: keyCode.toString(),
-            command: 'test.ignored-command'
+            command: 'test.overriden-default-command'
         };
 
         const defaultBinding: Keybinding = {
             keybinding: keyCode.toString(),
-            command: 'test.workspace-command'
+            command: 'test.default-command'
         };
 
         const userBinding: Keybinding = {
             keybinding: keyCode.toString(),
-            command: 'test.workspace-command'
+            command: 'test.user-command'
         };
 
         const workspaceBinding: Keybinding = {
@@ -298,35 +298,62 @@ describe('keybindings', () => {
             command: 'test.workspace-command'
         };
 
-        keybindingRegistry.setKeymap(KeybindingScope.DEFAULT, [defaultBinding, ignoredDefaultBinding]);
+        keybindingRegistry.setKeymap(KeybindingScope.DEFAULT, [overridenDefaultBinding, defaultBinding]);
         keybindingRegistry.setKeymap(KeybindingScope.USER, [userBinding]);
         keybindingRegistry.setKeymap(KeybindingScope.WORKSPACE, [workspaceBinding]);
         // now WORKSPACE bindings are overriding the other scopes
 
-        bindings = keybindingRegistry.getKeybindingsForKeySequence([keyCode]).full;
-        expect(bindings).to.have.lengthOf(3);
-        expect(bindings[0].command).to.be.equal(workspaceBinding.command);
+        let match = keybindingRegistry.matchKeybiding([keyCode]);
+        expect(match?.kind).to.be.equal('full');
+        expect(match?.binding?.command).to.be.equal(workspaceBinding.command);
 
         keybindingRegistry.resetKeybindingsForScope(KeybindingScope.WORKSPACE);
         // now it should find USER bindings
 
-        bindings = keybindingRegistry.getKeybindingsForKeySequence([keyCode]).full;
-        expect(bindings).to.have.lengthOf(2);
-        expect(bindings[0].command).to.be.equal(userBinding.command);
+        match = keybindingRegistry.matchKeybiding([keyCode]);
+        expect(match?.kind).to.be.equal('full');
+        expect(match?.binding?.command).to.be.equal(userBinding.command);
 
         keybindingRegistry.resetKeybindingsForScope(KeybindingScope.USER);
         // and finally it should fallback to DEFAULT bindings.
 
-        bindings = keybindingRegistry.getKeybindingsForKeySequence([keyCode]).full;
-        expect(bindings).to.have.lengthOf(1);
-        expect(bindings[0].command).to.be.equal(defaultBinding.command);
+        match = keybindingRegistry.matchKeybiding([keyCode]);
+        expect(match?.kind).to.be.equal('full');
+        expect(match?.binding?.command).to.be.equal(defaultBinding.command);
 
         keybindingRegistry.resetKeybindingsForScope(KeybindingScope.DEFAULT);
         // now the registry should be empty
 
-        bindings = keybindingRegistry.getKeybindingsForKeySequence([keyCode]).full;
-        expect(bindings).to.be.empty;
+        match = keybindingRegistry.matchKeybiding([keyCode]);
+        expect(match).to.be.undefined;
 
+    });
+
+    it('should not match disabled keybindings', () => {
+        const keyCode = KeyCode.createKeyCode({ first: Key.KEY_A, modifiers: [KeyModifier.Shift] });
+
+        const defaultBinding: Keybinding = {
+            keybinding: keyCode.toString(),
+            command: 'test.workspace-command'
+        };
+        const disableDefaultBinding: Keybinding = {
+            keybinding: keyCode.toString(),
+            command: '-test.workspace-command'
+        };
+
+        keybindingRegistry.setKeymap(KeybindingScope.DEFAULT, [defaultBinding]);
+        let match = keybindingRegistry.matchKeybiding([keyCode]);
+        expect(match?.kind).to.be.equal('full');
+        expect(match?.binding?.command).to.be.equal(defaultBinding.command);
+
+        keybindingRegistry.setKeymap(KeybindingScope.USER, [disableDefaultBinding]);
+        match = keybindingRegistry.matchKeybiding([keyCode]);
+        expect(match).to.be.undefined;
+
+        keybindingRegistry.resetKeybindingsForScope(KeybindingScope.USER);
+        match = keybindingRegistry.matchKeybiding([keyCode]);
+        expect(match?.kind).to.be.equal('full');
+        expect(match?.binding?.command).to.be.equal(defaultBinding.command);
     });
 });
 

--- a/packages/monaco/src/browser/monaco-keybinding.ts
+++ b/packages/monaco/src/browser/monaco-keybinding.ts
@@ -29,10 +29,7 @@ export class MonacoKeybindingContribution implements KeybindingContribution {
 
     registerKeybindings(registry: KeybindingRegistry): void {
         const defaultKeybindings = monaco.keybindings.KeybindingsRegistry.getDefaultKeybindings();
-        // register in reverse order to align with Monaco dispatch logic:
-        // https://github.com/TypeFox/vscode/blob/70b8db24a37fafc77247de7f7cb5bb0195120ed0/src/vs/platform/keybinding/common/keybindingResolver.ts#L302
-        for (let i = defaultKeybindings.length - 1; i >= 0; i--) {
-            const item = defaultKeybindings[i];
+        for (const item of defaultKeybindings) {
             const command = this.commands.validate(item.command);
             if (command) {
                 const when = item.when && item.when.serialize();

--- a/packages/monaco/src/typings/monaco/index.d.ts
+++ b/packages/monaco/src/typings/monaco/index.d.ts
@@ -75,7 +75,8 @@ declare module monaco.editor {
             'editor.contrib.referencesController': monaco.referenceSearch.ReferencesController
             'editor.contrib.hover': ModesHoverController
             'css.editor.codeLens': CodeLensContribution
-            'editor.contrib.quickFixController': QuickFixController
+            'editor.contrib.quickFixController': QuickFixController,
+            'editor.contrib.suggestController': monaco.suggest.SuggestController
         }
         readonly _modelData: {
             cursor: ICursor
@@ -1185,6 +1186,19 @@ declare module monaco.suggest {
     // https://github.com/theia-ide/vscode/blob/standalone/0.19.x/src/vs/editor/contrib/suggest/suggest.ts#L106
     export const enum SnippetSortOrder {
         Top, Inline, Bottom
+    }
+
+    // https://github.com/theia-ide/vscode/blob/d24b5f70c69b3e75cd10c6b5247a071265ccdd38/src/vs/editor/contrib/suggest/suggestController.ts#L97
+    export interface SuggestController {
+        readonly widget: {
+            getValue(): SuggestWidget
+        }
+    }
+    export interface SuggestWidget {
+        getFocusedItem(): ISelectedSuggestion | undefined;
+    }
+    export interface ISelectedSuggestion {
+        item: CompletionItem;
     }
 
     // https://github.com/theia-ide/vscode/blob/standalone/0.19.x/src/vs/editor/contrib/suggest/suggest.ts#L28

--- a/packages/plugin-ext/src/main/browser/keybindings/keybindings-contribution-handler.ts
+++ b/packages/plugin-ext/src/main/browser/keybindings/keybindings-contribution-handler.ts
@@ -36,7 +36,7 @@ export class KeybindingsContributionPointHandler {
         for (const raw of contributions.keybindings) {
             const keybinding = this.toKeybinding(raw);
             if (keybinding) {
-                toDispose.push(this.keybindingRegistry.registerKeybinding(keybinding, true));
+                toDispose.push(this.keybindingRegistry.registerKeybinding(keybinding));
             }
         }
         return toDispose;

--- a/packages/terminal/src/browser/terminal-frontend-contribution.ts
+++ b/packages/terminal/src/browser/terminal-frontend-contribution.ts
@@ -397,55 +397,6 @@ export class TerminalFrontendContribution implements TerminalService, CommandCon
     }
 
     registerKeybindings(keybindings: KeybindingRegistry): void {
-        keybindings.registerKeybinding({
-            command: TerminalCommands.NEW.id,
-            keybinding: 'ctrl+shift+`'
-        });
-        keybindings.registerKeybinding({
-            command: TerminalCommands.NEW_ACTIVE_WORKSPACE.id,
-            keybinding: 'ctrl+`'
-        });
-        keybindings.registerKeybinding({
-            command: TerminalCommands.TERMINAL_CLEAR.id,
-            keybinding: 'ctrlcmd+k',
-            context: TerminalKeybindingContexts.terminalActive
-        });
-        keybindings.registerKeybinding({
-            command: TerminalCommands.TERMINAL_FIND_TEXT.id,
-            keybinding: 'ctrlcmd+f',
-            context: TerminalKeybindingContexts.terminalActive
-        });
-        keybindings.registerKeybinding({
-            command: TerminalCommands.TERMINAL_FIND_TEXT_CANCEL.id,
-            keybinding: 'esc',
-            context: TerminalKeybindingContexts.terminalHideSearch
-        });
-        keybindings.registerKeybinding({
-            command: TerminalCommands.SCROLL_LINE_UP.id,
-            keybinding: 'ctrl+shift+up',
-            context: TerminalKeybindingContexts.terminalActive
-        });
-        keybindings.registerKeybinding({
-            command: TerminalCommands.SCROLL_LINE_DOWN.id,
-            keybinding: 'ctrl+shift+down',
-            context: TerminalKeybindingContexts.terminalActive
-        });
-        keybindings.registerKeybinding({
-            command: TerminalCommands.SCROLL_TO_TOP.id,
-            keybinding: 'shift-home',
-            context: TerminalKeybindingContexts.terminalActive
-        });
-        keybindings.registerKeybinding({
-            command: TerminalCommands.SCROLL_PAGE_UP.id,
-            keybinding: 'shift-pageUp',
-            context: TerminalKeybindingContexts.terminalActive
-        });
-        keybindings.registerKeybinding({
-            command: TerminalCommands.SCROLL_PAGE_DOWN.id,
-            keybinding: 'shift-pageDown',
-            context: TerminalKeybindingContexts.terminalActive
-        });
-
         /* Register passthrough keybindings for combinations recognized by
            xterm.js and converted to control characters.
 
@@ -529,6 +480,55 @@ export class TerminalFrontendContribution implements TerminalService, CommandCon
                 context: TerminalKeybindingContexts.terminalActive
             });
         }
+
+        keybindings.registerKeybinding({
+            command: TerminalCommands.NEW.id,
+            keybinding: 'ctrl+shift+`'
+        });
+        keybindings.registerKeybinding({
+            command: TerminalCommands.NEW_ACTIVE_WORKSPACE.id,
+            keybinding: 'ctrl+`'
+        });
+        keybindings.registerKeybinding({
+            command: TerminalCommands.TERMINAL_CLEAR.id,
+            keybinding: 'ctrlcmd+k',
+            context: TerminalKeybindingContexts.terminalActive
+        });
+        keybindings.registerKeybinding({
+            command: TerminalCommands.TERMINAL_FIND_TEXT.id,
+            keybinding: 'ctrlcmd+f',
+            context: TerminalKeybindingContexts.terminalActive
+        });
+        keybindings.registerKeybinding({
+            command: TerminalCommands.TERMINAL_FIND_TEXT_CANCEL.id,
+            keybinding: 'esc',
+            context: TerminalKeybindingContexts.terminalHideSearch
+        });
+        keybindings.registerKeybinding({
+            command: TerminalCommands.SCROLL_LINE_UP.id,
+            keybinding: 'ctrl+shift+up',
+            context: TerminalKeybindingContexts.terminalActive
+        });
+        keybindings.registerKeybinding({
+            command: TerminalCommands.SCROLL_LINE_DOWN.id,
+            keybinding: 'ctrl+shift+down',
+            context: TerminalKeybindingContexts.terminalActive
+        });
+        keybindings.registerKeybinding({
+            command: TerminalCommands.SCROLL_TO_TOP.id,
+            keybinding: 'shift-home',
+            context: TerminalKeybindingContexts.terminalActive
+        });
+        keybindings.registerKeybinding({
+            command: TerminalCommands.SCROLL_PAGE_UP.id,
+            keybinding: 'shift-pageUp',
+            context: TerminalKeybindingContexts.terminalActive
+        });
+        keybindings.registerKeybinding({
+            command: TerminalCommands.SCROLL_PAGE_DOWN.id,
+            keybinding: 'shift-pageDown',
+            context: TerminalKeybindingContexts.terminalActive
+        });
     }
 
     async newTerminal(options: TerminalWidgetOptions): Promise<TerminalWidget> {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

- fix #7836: see explanation https://github.com/eclipse-theia/theia/issues/7836#issuecomment-630634837
- (performance) Also match only first keybinding on keydown, don't traverse over all keybindings.


#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

- Monaco: see tests from https://github.com/eclipse-theia/theia/pull/6170
- Theia extension: see https://github.com/eclipse-theia/theia/issues/7836 on linux/windows
- VS Code extension: see https://github.com/eclipse-theia/theia/pull/6625#discussion_r354832173
  - install emacs extension
  - open some editor
  - use `ctrl+x ctrl+l` on linux/windows it should not cut, but wait for `ctrl+l`

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

