### PR TITLE
Bind command for explorer.newFolder

### DIFF
--- a/packages/plugin-ext-vscode/src/browser/plugin-vscode-commands-contribution.ts
+++ b/packages/plugin-ext-vscode/src/browser/plugin-vscode-commands-contribution.ts
@@ -579,5 +579,10 @@ export class PluginVscodeCommandsContribution implements CommandContribution {
         }, {
             execute: () => this.quickOpenWorkspace.select()
         });
+        commands.registerCommand({
+            id: 'explorer.newFolder'
+        }, {
+            execute: () => commands.executeCommand(WorkspaceCommands.NEW_FOLDER.id)
+        });
     }
 }


### PR DESCRIPTION
#### What it does
This changes proposal adds bind for VS Code built-in command `explorer.newFolder` [1].

[1] [microsoft/vscode/src/vs/workbench/contrib/files/browser/fileActions.ts#L112-L131](https://github.com/microsoft/vscode/blob/dc1746e790f693660dc1eccce8c096b8ab1ae408/src/vs/workbench/contrib/files/browser/fileActions.ts#L112-L131)

Signed-off-by: Vladyslav Zhukovskyi <vzhukovs@redhat.com>

#### How to test
Needed for [Didact](https://marketplace.visualstudio.com/items?itemName=redhat.vscode-didact) extension. 

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

