### PR TITLE
file-seach: improve handling of command

### DIFF
--- a/packages/file-search/src/browser/quick-file-open-contribution.ts
+++ b/packages/file-search/src/browser/quick-file-open-contribution.ts
@@ -39,8 +39,7 @@ export class QuickFileOpenFrontendContribution implements CommandContribution, K
                 } else {
                     this.quickFileOpenService.open();
                 }
-            },
-            isEnabled: () => this.quickFileOpenService.isEnabled()
+            }
         });
     }
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

Fixes #7844

This pull-request contributes the following items:
- introduces the `workspaceState` when context which can ultimately be used by new commands
- improves the handling of the **quick-file open**:
   - enables the command in all cases (even when no workspace is opened)
   - adds proper handling when no results are found (`No matching results`) 

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

1. start the application without a workspace opened
2. execute the `file-search` command (<kbd>ctrlcmd</kbd>+<kbd>p</kbd>)
3. the quick-file-open should be properly displayed
4. searching for results will yield the `No matching results` item
5. open a workspace
6. execute the `file-search` command (<kbd>ctrlcmd</kbd>+<kbd>p</kbd>)
7. searching should yield results in the quick-file open
8. search for a random string (ex: `adsaasdadsadad`) it should yield the `No matching results` item

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

Signed-off-by: vince-fugnitto <vincent.fugnitto@ericsson.com>

