### PR TITLE
plugin-ext: attach security cookie to webviews

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -66,6 +66,7 @@
       "backendElectron": "lib/electron-node/keyboard/electron-backend-keyboard-module"
     },
     {
+      "frontendElectron": "lib/electron-browser/token/electron-token-frontend-module",
       "backendElectron": "lib/electron-node/token/electron-token-backend-module"
     }
   ],

--- a/packages/core/src/electron-browser/token/electron-token-frontend-module.ts
+++ b/packages/core/src/electron-browser/token/electron-token-frontend-module.ts
@@ -1,0 +1,23 @@
+/********************************************************************************
+ * Copyright (C) 2020 Ericsson and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import * as electron from 'electron';
+import { ContainerModule } from 'inversify';
+import { ElectronSecurityToken } from '../../electron-common/electron-token';
+
+export default new ContainerModule(bind => {
+    bind(ElectronSecurityToken).toConstantValue(electron.remote.getGlobal(ElectronSecurityToken));
+});

--- a/packages/plugin-ext/package.json
+++ b/packages/plugin-ext/package.json
@@ -51,6 +51,9 @@
       "backend": "lib/plugin-ext-backend-module",
       "backendElectron": "lib/plugin-ext-backend-electron-module",
       "frontend": "lib/plugin-ext-frontend-module"
+    },
+    {
+      "frontendElectron": "lib/plugin-ext-frontend-electron-module"
     }
   ],
   "keywords": [

--- a/packages/plugin-ext/src/main/browser/plugin-ext-frontend-module.ts
+++ b/packages/plugin-ext/src/main/browser/plugin-ext-frontend-module.ts
@@ -62,7 +62,7 @@ import { LanguagesMainFactory, OutputChannelRegistryFactory } from '../../common
 import { LanguagesMainImpl } from './languages-main';
 import { OutputChannelRegistryMainImpl } from './output-channel-registry-main';
 import { InPluginFileSystemWatcherManager } from './in-plugin-filesystem-watcher-manager';
-import { WebviewWidget, WebviewWidgetIdentifier, WebviewWidgetExternalEndpoint } from './webview/webview';
+import { WebviewWidget } from './webview/webview';
 import { WebviewEnvironment } from './webview/webview-environment';
 import { WebviewThemeDataProvider } from './webview/webview-theme-data-provider';
 import { bindWebviewPreferences } from './webview/webview-preferences';
@@ -70,6 +70,7 @@ import { WebviewResourceLoader, WebviewResourceLoaderPath } from '../common/webv
 import { WebviewResourceCache } from './webview/webview-resource-cache';
 import { PluginIconThemeService, PluginIconThemeFactory, PluginIconThemeDefinition, PluginIconTheme } from './plugin-icon-theme-service';
 import { PluginTreeViewNodeLabelProvider } from './view/plugin-tree-view-node-label-provider';
+import { WebviewWidgetFactory } from './webview/webview-widget-factory';
 
 export default new ContainerModule((bind, unbind, isBound, rebind) => {
 
@@ -162,21 +163,8 @@ export default new ContainerModule((bind, unbind, isBound, rebind) => {
     ).inSingletonScope();
     bind(WebviewResourceCache).toSelf().inSingletonScope();
     bind(WebviewWidget).toSelf();
-    bind(WidgetFactory).toDynamicValue(({ container }) => ({
-        id: WebviewWidget.FACTORY_ID,
-        createWidget: async (identifier: WebviewWidgetIdentifier) => {
-            const externalEndpoint = await container.get(WebviewEnvironment).externalEndpoint();
-            let endpoint = externalEndpoint.replace('{{uuid}}', identifier.id);
-            if (endpoint[endpoint.length - 1] === '/') {
-                endpoint = endpoint.slice(0, endpoint.length - 1);
-            }
-
-            const child = container.createChild();
-            child.bind(WebviewWidgetIdentifier).toConstantValue(identifier);
-            child.bind(WebviewWidgetExternalEndpoint).toConstantValue(endpoint);
-            return child.get(WebviewWidget);
-        }
-    })).inSingletonScope();
+    bind(WebviewWidgetFactory).toDynamicValue(ctx => new WebviewWidgetFactory(ctx.container)).inSingletonScope();
+    bind(WidgetFactory).toService(WebviewWidgetFactory);
 
     bind(PluginViewWidget).toSelf();
     bind(WidgetFactory).toDynamicValue(({ container }) => ({

--- a/packages/plugin-ext/src/main/browser/webview/webview-widget-factory.ts
+++ b/packages/plugin-ext/src/main/browser/webview/webview-widget-factory.ts
@@ -1,0 +1,43 @@
+/********************************************************************************
+ * Copyright (C) 2020 Ericsson and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import { interfaces } from 'inversify';
+import { WebviewWidget, WebviewWidgetIdentifier, WebviewWidgetExternalEndpoint } from './webview';
+import { WebviewEnvironment } from './webview-environment';
+
+export class WebviewWidgetFactory {
+
+    readonly id = WebviewWidget.FACTORY_ID;
+
+    protected readonly container: interfaces.Container;
+
+    constructor(container: interfaces.Container) {
+        this.container = container;
+    }
+
+    async createWidget(identifier: WebviewWidgetIdentifier): Promise<WebviewWidget> {
+        const externalEndpoint = await this.container.get(WebviewEnvironment).externalEndpoint();
+        let endpoint = externalEndpoint.replace('{{uuid}}', identifier.id);
+        if (endpoint[endpoint.length - 1] === '/') {
+            endpoint = endpoint.slice(0, endpoint.length - 1);
+        }
+        const child = this.container.createChild();
+        child.bind(WebviewWidgetIdentifier).toConstantValue(identifier);
+        child.bind(WebviewWidgetExternalEndpoint).toConstantValue(endpoint);
+        return child.get(WebviewWidget);
+    }
+
+}

--- a/packages/plugin-ext/src/main/electron-browser/plugin-ext-frontend-electron-module.ts
+++ b/packages/plugin-ext/src/main/electron-browser/plugin-ext-frontend-electron-module.ts
@@ -1,0 +1,23 @@
+/********************************************************************************
+ * Copyright (C) 2020 Ericsson and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import { ContainerModule } from 'inversify';
+import { WebviewWidgetFactory } from '../browser/webview/webview-widget-factory';
+import { ElectronWebviewWidgetFactory } from './webview/electron-webview-widget-factory';
+
+export default new ContainerModule((bind, unbind, isBound, rebind) => {
+    rebind(WebviewWidgetFactory).toDynamicValue(ctx => new ElectronWebviewWidgetFactory(ctx.container)).inSingletonScope();
+});

--- a/packages/plugin-ext/src/main/electron-browser/webview/electron-webview-widget-factory.ts
+++ b/packages/plugin-ext/src/main/electron-browser/webview/electron-webview-widget-factory.ts
@@ -1,0 +1,52 @@
+/********************************************************************************
+ * Copyright (C) 2020 Ericsson and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import { remote } from 'electron';
+import { ElectronSecurityToken } from '@theia/core/lib/electron-common/electron-token';
+import { WebviewWidgetFactory } from '../../browser/webview/webview-widget-factory';
+import { WebviewWidgetIdentifier, WebviewWidget } from '../../browser/webview/webview';
+
+export class ElectronWebviewWidgetFactory extends WebviewWidgetFactory {
+
+    async createWidget(identifier: WebviewWidgetIdentifier): Promise<WebviewWidget> {
+        const widget = await super.createWidget(identifier);
+        this.attachElectronSecurityCookie(widget.externalEndpoint);
+        return widget;
+    }
+
+    /**
+     * Attach the ElectronSecurityToken to a cookie that will be sent with each webview request.
+     *
+     * @param endpoint cookie's target url
+     */
+    protected attachElectronSecurityCookie(endpoint: string): Promise<void> {
+        return new Promise((resolve, reject) => {
+            remote.session.defaultSession!.cookies.set({
+                url: endpoint,
+                name: ElectronSecurityToken,
+                value: JSON.stringify(this.container.get(ElectronSecurityToken)),
+                httpOnly: true,
+            }, error => {
+                if (error) {
+                    reject(error);
+                } else {
+                    resolve();
+                }
+            });
+        });
+    }
+
+}

--- a/packages/plugin-ext/src/plugin-ext-frontend-electron-module.ts
+++ b/packages/plugin-ext/src/plugin-ext-frontend-electron-module.ts
@@ -1,0 +1,19 @@
+/********************************************************************************
+ * Copyright (C) 2020 Ericsson and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import mainModule from './main/electron-browser/plugin-ext-frontend-electron-module';
+
+export default mainModule;


### PR DESCRIPTION
When on Electron, we use a cookie to tell if an http client can use the
backend services. Cookies are bound to domains to which requests will be
made, and also subdomains in certain situations. Because we are using
`localhost` the cookie cannot be shared across subdomains. This commit
works around this limitation by passing the security token from
electron-main process to the renderer-process via a global variable,
and the token is then set inside a cookie for each new webview endpoint
created by the plugin system in the frontend.

#### How to test

Install and use https://github.com/vince-fugnitto/webview-example/releases/download/1.0.0/cat-coding-0.0.1.vsix, it should work on Electron.

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

