### PR TITLE
keymaps: add keybindings-widget context-menu

### DIFF
--- a/packages/keymaps/src/browser/keybindings-dialogs.tsx
+++ b/packages/keymaps/src/browser/keybindings-dialogs.tsx
@@ -1,0 +1,142 @@
+/********************************************************************************
+ * Copyright (C) 2020 Ericsson and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import { inject } from 'inversify';
+import { KeymapsService } from './keymaps-service';
+import { KeybindingItem } from './keybindings-widget';
+import { Key } from '@theia/core/lib/browser/keyboard/keys';
+import { Message } from '@theia/core/lib/browser/widgets/widget';
+import { KeybindingScope } from '@theia/core/lib/browser/keybinding';
+import { SingleTextInputDialog, SingleTextInputDialogProps } from '@theia/core/lib/browser/dialogs';
+
+/**
+ * Dialog used to edit keybindings, and reset custom keybindings.
+ */
+export class EditKeybindingDialog extends SingleTextInputDialog {
+
+    /**
+     * The keybinding item in question.
+     */
+    protected item: KeybindingItem;
+
+    /**
+     * HTMLButtonElement used to reset custom keybindings.
+     * Custom keybindings have a `User` scope (exist in `keymaps.json`).
+     */
+    protected resetButton: HTMLButtonElement | undefined;
+
+    constructor(
+        @inject(SingleTextInputDialogProps) protected readonly props: SingleTextInputDialogProps,
+        @inject(KeymapsService) protected readonly keymapsService: KeymapsService,
+        item: KeybindingItem
+    ) {
+        super(props);
+        this.item = item;
+        this.appendInfo();
+        // Add the `Reset` button if the command currently has a custom keybinding.
+        if (this.item.keybinding && this.item.keybinding.scope === KeybindingScope.USER) {
+            this.appendResetButton();
+        }
+    }
+
+    protected onAfterAttach(msg: Message): void {
+        super.onAfterAttach(msg);
+        if (this.resetButton) {
+            this.addResetAction(this.resetButton, 'click');
+        }
+    }
+
+    /**
+     * Add `Reset` action used to reset a custom keybinding, and close the dialog.
+     * @param element the HTML element in question.
+     * @param additionalEventTypes additional event types.
+     */
+    protected addResetAction<K extends keyof HTMLElementEventMap>(element: HTMLElement, ...additionalEventTypes: K[]): void {
+        this.addKeyListener(element, Key.ENTER, () => {
+            this.reset();
+            this.close();
+        }, ...additionalEventTypes);
+    }
+
+    /**
+     * Adds additional information to the dialog to display the command label.
+     */
+    protected appendInfo(): void {
+        const container = document.createElement('div');
+        const info = document.createElement('span');
+        info.textContent = this.item.command.label || this.item.command.id;
+        info.title = this.item.command.id;
+        container.appendChild(info);
+        this.contentNode.insertBefore(container, this.inputField);
+    }
+
+    /**
+     * Create the `Reset` button, and append it to the dialog.
+     *
+     * @returns the `Reset` button.
+     */
+    protected appendResetButton(): HTMLButtonElement {
+        // Create the `Reset` button.
+        this.resetButton = this.createButton('Reset');
+        // Add the `Reset` button to the dialog control panel, before the `Accept` button.
+        this.controlPanel.insertBefore(this.resetButton, this.acceptButton!);
+        this.resetButton.title = 'Reset Keybinding';
+        this.resetButton.classList.add('secondary');
+        return this.resetButton;
+    }
+
+    /**
+     * Perform keybinding reset.
+     */
+    protected reset(): void {
+        this.keymapsService.removeKeybinding(this.item.command.id);
+    }
+
+}
+
+export class EditWhenContextDialog extends SingleTextInputDialog {
+
+    /**
+     * The keybinding item in question.
+     */
+    protected item: KeybindingItem;
+
+    constructor(
+        @inject(SingleTextInputDialogProps) protected readonly props: SingleTextInputDialogProps,
+        @inject(KeymapsService) protected readonly keymapsService: KeymapsService,
+        item: KeybindingItem
+    ) {
+        super(props);
+        this.item = item;
+        this.appendInfo();
+    }
+
+    protected onAfterAttach(msg: Message): void {
+        super.onAfterAttach(msg);
+    }
+
+    /**
+     * Adds additional information to the dialog to display the command label.
+     */
+    protected appendInfo(): void {
+        const container = document.createElement('div');
+        const info = document.createElement('span');
+        info.textContent = this.item.command.label || this.item.command.id;
+        info.title = this.item.command.id;
+        container.appendChild(info);
+        this.contentNode.insertBefore(container, this.inputField);
+    }
+}

--- a/packages/keymaps/src/browser/keybindings-widget.tsx
+++ b/packages/keymaps/src/browser/keybindings-widget.tsx
@@ -22,10 +22,13 @@ import { Emitter, Event } from '@theia/core/lib/common/event';
 import { CommandRegistry, Command } from '@theia/core/lib/common/command';
 import { ReactWidget } from '@theia/core/lib/browser/widgets/react-widget';
 import {
-    KeybindingRegistry, SingleTextInputDialog, KeySequence, ConfirmDialog, Message, KeybindingScope, SingleTextInputDialogProps, Key, ScopedKeybinding
+    ConfirmDialog, ContextMenuRenderer, KeySequence,
+    KeybindingRegistry, KeybindingScope, Message, ScopedKeybinding
 } from '@theia/core/lib/browser';
 import { KeymapsService } from './keymaps-service';
 import { AlertMessage } from '@theia/core/lib/browser/widgets/alert-message';
+import { KeymapsMenus } from './keymaps-menus';
+import { EditKeybindingDialog, EditWhenContextDialog } from './keybindings-dialogs';
 
 /**
  * Representation of a keybinding item for the view.
@@ -62,6 +65,9 @@ export class KeybindingWidget extends ReactWidget {
 
     @inject(CommandRegistry)
     protected readonly commandRegistry: CommandRegistry;
+
+    @inject(ContextMenuRenderer)
+    protected readonly contextMenuRenderer: ContextMenuRenderer;
 
     @inject(KeybindingRegistry)
     protected readonly keybindingRegistry: KeybindingRegistry;
@@ -350,7 +356,11 @@ export class KeybindingWidget extends ReactWidget {
     protected renderRow(item: KeybindingItem, index: number): React.ReactNode {
         const { command, keybinding } = item;
         // TODO get rid of array functions in event handlers
-        return <tr className='kb-item-row' key={index} onDoubleClick={() => this.editKeybinding(item)}>
+        return <tr
+            className='kb-item-row'
+            key={index}
+            onDoubleClick={this.editKeybinding(item)}
+            onContextMenu={this.handleContextMenu(item)}>
             <td className='kb-actions'>
                 {this.renderActions(item)}
             </td>
@@ -374,7 +384,7 @@ export class KeybindingWidget extends ReactWidget {
      * @param item the keybinding item for the row.
      */
     protected renderActions(item: KeybindingItem): React.ReactNode {
-        return <span className='kb-actions-icons'>{this.renderEdit(item)}{this.renderReset(item)}</span>;
+        return <span className='kb-actions-icons'>{this.renderEdit(item)}</span>;
     }
 
     /**
@@ -382,17 +392,7 @@ export class KeybindingWidget extends ReactWidget {
      * @param item the keybinding item for the row.
      */
     protected renderEdit(item: KeybindingItem): React.ReactNode {
-        return <a title='Edit Keybinding' href='#' onClick={a => this.editKeybinding(item)}><i className='fa fa-pencil kb-action-item'></i></a>;
-    }
-
-    /**
-     * Render the reset action to reset the custom keybinding.
-     * Only visible if a keybinding has a `user` scope.
-     * @param item the keybinding item for the row.
-     */
-    protected renderReset(item: KeybindingItem): React.ReactNode {
-        return (item.keybinding && item.keybinding.scope === KeybindingScope.USER)
-            ? <a title='Reset Keybinding' href='#' onClick={a => this.resetKeybinding(item)}><i className='fa fa-undo kb-action-item'></i></a> : '';
+        return <a title='Edit Keybinding' href='#' onClick={this.editKeybinding(item)}><i className='codicon codicon-edit kb-action-item'></i></a>;
     }
 
     /**
@@ -538,15 +538,27 @@ export class KeybindingWidget extends ReactWidget {
         return labelA.toLowerCase().localeCompare(labelB.toLowerCase());
     }
 
+    public triggerEditKeybinding(item: KeybindingItem): void {
+        this.editKeybinding(item)();
+    };
+
+    public triggerResetKeybinding(item: KeybindingItem): void {
+        this.resetKeybinding(item);
+    }
+
+    public triggerChangeWhenExpression(item: KeybindingItem): void {
+        this.changeWhenExpression(item)();
+    }
+
     /**
      * Prompt users to update the keybinding for the given command.
      * @param item the keybinding item.
      */
-    protected editKeybinding(item: KeybindingItem): void {
+    protected editKeybinding = (item: KeybindingItem) => () => {
         const command = item.command.id;
         const oldKeybinding = item.keybinding && item.keybinding.keybinding;
         const dialog = new EditKeybindingDialog({
-            title: `Edit Keybinding For ${command}`,
+            title: 'Edit Keybinding',
             initialValue: oldKeybinding,
             validate: newKeybinding => this.validateKeybinding(command, oldKeybinding, newKeybinding),
         }, this.keymapsService, item);
@@ -559,7 +571,29 @@ export class KeybindingWidget extends ReactWidget {
                 }, oldKeybinding);
             }
         });
-    }
+    };
+
+    /**
+     * Prompt users to update the `when` expression for the given command.
+     * @param item the keybinding item.
+     */
+    protected changeWhenExpression = (item: KeybindingItem) => () => {
+        const command = item.command.id;
+        const keybinding = item.keybinding?.keybinding || '';
+        const dialog = new EditWhenContextDialog({
+            title: 'Change When Expression',
+            initialValue: item.labels.context
+        }, this.keymapsService, item);
+        dialog.open().then(async when => {
+            console.log(`when: ${when}`);
+            if (when) {
+                await this.keymapsService.setKeybinding(
+                    { ...item.keybinding, command, keybinding, when },
+                    { ...item.keybinding, command, keybinding, when: item.keybinding?.when }
+                );
+            }
+        });
+    };
 
     /**
      * Prompt users for confirmation before resetting.
@@ -669,75 +703,13 @@ export class KeybindingWidget extends ReactWidget {
         }
     }
 
-}
-/**
- * Dialog used to edit keybindings, and reset custom keybindings.
- */
-class EditKeybindingDialog extends SingleTextInputDialog {
-
-    /**
-     * The keybinding item in question.
-     */
-    protected item: KeybindingItem;
-
-    /**
-     * HTMLButtonElement used to reset custom keybindings.
-     * Custom keybindings have a `User` scope (exist in `keymaps.json`).
-     */
-    protected resetButton: HTMLButtonElement | undefined;
-
-    constructor(
-        @inject(SingleTextInputDialogProps) protected readonly props: SingleTextInputDialogProps,
-        @inject(KeymapsService) protected readonly keymapsService: KeymapsService,
-        item: KeybindingItem
-    ) {
-        super(props);
-        this.item = item;
-        // Add the `Reset` button if the command currently has a custom keybinding.
-        if (this.item.keybinding && this.item.keybinding.scope === KeybindingScope.USER) {
-            this.appendResetButton();
-        }
-    }
-
-    protected onAfterAttach(msg: Message): void {
-        super.onAfterAttach(msg);
-        if (this.resetButton) {
-            this.addResetAction(this.resetButton, 'click');
-        }
-    }
-
-    /**
-     * Add `Reset` action used to reset a custom keybinding, and close the dialog.
-     * @param element the HTML element in question.
-     * @param additionalEventTypes additional event types.
-     */
-    protected addResetAction<K extends keyof HTMLElementEventMap>(element: HTMLElement, ...additionalEventTypes: K[]): void {
-        this.addKeyListener(element, Key.ENTER, () => {
-            this.reset();
-            this.close();
-        }, ...additionalEventTypes);
-    }
-
-    /**
-     * Create the `Reset` button, and append it to the dialog.
-     *
-     * @returns the `Reset` button.
-     */
-    protected appendResetButton(): HTMLButtonElement {
-        // Create the `Reset` button.
-        this.resetButton = this.createButton('Reset');
-        // Add the `Reset` button to the dialog control panel, before the `Accept` button.
-        this.controlPanel.insertBefore(this.resetButton, this.acceptButton!);
-        this.resetButton.title = 'Reset Keybinding';
-        this.resetButton.classList.add('secondary');
-        return this.resetButton;
-    }
-
-    /**
-     * Perform keybinding reset.
-     */
-    protected reset(): void {
-        this.keymapsService.removeKeybinding(this.item.command.id);
-    }
-
+    protected handleContextMenu = (item: KeybindingItem) => (e: React.SyntheticEvent) => {
+        const target = e.nativeEvent.target as HTMLElement;
+        const domRect = target.getBoundingClientRect();
+        this.contextMenuRenderer.render({
+            menuPath: KeymapsMenus.KEYBINDINGS_WIDGET_CONTEXT_MENU,
+            anchor: { x: domRect.left, y: domRect.bottom },
+            args: [this, { id: item.command.id, value: item }]
+        });
+    };
 }

--- a/packages/keymaps/src/browser/keymaps-menus.ts
+++ b/packages/keymaps/src/browser/keymaps-menus.ts
@@ -1,0 +1,23 @@
+/********************************************************************************
+ * Copyright (C) 2020 Ericsson and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import { MenuPath } from '@theia/core';
+
+export namespace KeymapsMenus {
+    export const KEYBINDINGS_WIDGET_CONTEXT_MENU: MenuPath = ['keybindings:contextMenu'];
+    export const KEYBINDINGS_WIDGET_COPY: MenuPath = [...KEYBINDINGS_WIDGET_CONTEXT_MENU, 'keybindings.copy'];
+    export const KEYBINDINGS_WIDGET_ACTIONS: MenuPath = [...KEYBINDINGS_WIDGET_CONTEXT_MENU, 'keybindings.widget.actions'];
+}

--- a/packages/keymaps/src/browser/keymaps-service.ts
+++ b/packages/keymaps/src/browser/keymaps-service.ts
@@ -96,7 +96,7 @@ export class KeymapsService {
      * Set the keybinding in the JSON.
      * @param newKeybinding the JSON keybindings.
      */
-    async setKeybinding(newKeybinding: Keybinding, oldKeybinding: string | undefined): Promise<void> {
+    async setKeybinding(newKeybinding: Keybinding, oldKeybinding: Keybinding | string | undefined): Promise<void> {
         if (!this.resource.saveContents) {
             return;
         }
@@ -130,10 +130,10 @@ export class KeymapsService {
             keybindings.push({
                 command: '-' + newKeybinding.command,
                 // TODO key: oldKeybinding, see https://github.com/eclipse-theia/theia/issues/6879
-                keybinding: oldKeybinding,
-                context: newKeybinding.context,
-                when: newKeybinding.when,
-                args: newKeybinding.args
+                keybinding: typeof oldKeybinding === 'string' ? oldKeybinding : oldKeybinding.keybinding,
+                context: typeof oldKeybinding === 'string' ? newKeybinding.context : oldKeybinding.context,
+                when: typeof oldKeybinding === 'string' ? newKeybinding.when : oldKeybinding.when,
+                args: typeof oldKeybinding === 'string' ? newKeybinding.args : oldKeybinding.args,
             });
         }
         // TODO use preference values to get proper json settings

--- a/packages/keymaps/src/browser/style/index.css
+++ b/packages/keymaps/src/browser/style/index.css
@@ -62,17 +62,17 @@
 
 .th-action,
 .kb-actions {
-    padding: 2px 0px 5px 0px;
+    padding: 2px 0px 2px 0px;
 }
 
 .th-keybinding,
 .kb-keybinding {
-    padding: 2px 10px 5px 10px;
+    padding: 2px 10px 2px 10px;
 }
 
 .th-label, .th-source, .th-context, .th-keybinding,
 .kb-label, .kb-source, .kb-context {
-    padding: 2px 10px 5px 10px;
+    padding: 2px 10px 2px 10px;
     min-height: 18px;
     overflow: hidden;
     text-overflow: ellipsis;
@@ -98,6 +98,18 @@
 
 .kb table tbody tr:hover {
     background-color: var(--theia-list-focusBackground);
+}
+
+.kb table tbody tr:active,
+.kb table tbody tr:active .kb-action-item,
+.kb table tbody tr:active td code,
+.kb table tbody tr:active .fuzzy-match {
+    background-color: var(--theia-list-activeSelectionBackground) !important;
+    color: var(--theia-list-activeSelectionForeground) !important;
+}
+
+.kb table tbody tr:active .monaco-keybinding > .monaco-keybinding-key {
+    color: var(--theia-list-activeSelectionForeground) !important;
 }
 
 .kb table tbody tr:hover .kb-action-item {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

The pull-request introduces a context-menu for the **keybindings-widget**:

_Context-Menu Commands_:
- [x] command: `Copy Command`
- [x] command: `Copy Command ID`
- [x] command: `Edit Keybinding`
- [x] command: `Reset Keybinding`
- [x] command: `Change When Expression`

_Other_:
- [x] add `Change When Expression` dialog
- [x] add support for modifying the `when` context in the `keymaps.json`
- [ ] code cleanup (event-handlers, refactoring)

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

TBD.

#### Review checklist

- [ ] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

Signed-off-by: vince-fugnitto <vincent.fugnitto@ericsson.com>
