### PR TITLE
execute already registered command in the same tick

### DIFF
--- a/.gitpod.dockerfile
+++ b/.gitpod.dockerfile
@@ -5,6 +5,8 @@ ENV TRIGGER_REBUILD 3
 
 # Install custom tools, runtime, etc.
 RUN sudo apt-get update \
+    # firefox for testing via VNC
+    && sudo apt-get install -y firefox \
     # window manager
     && sudo apt-get install -y jwm \
     # electron

--- a/packages/core/src/browser/keybinding.ts
+++ b/packages/core/src/browser/keybinding.ts
@@ -434,6 +434,8 @@ export class KeybindingRegistry {
     /**
      * Tries to execute a keybinding.
      *
+     * **IMPORTANT:** This method has to be synchronous.
+     *
      * @param binding to execute
      * @param event keyboard event.
      */
@@ -502,6 +504,8 @@ export class KeybindingRegistry {
 
     /**
      * Run the command matching to the given keyboard event.
+     *
+     * **IMPORTANT:** This method has to be synchronous.
      */
     run(event: KeyboardEvent): void {
         if (event.defaultPrevented) {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

- fix #7542: execute already registered command in the same tick, otherwise FF cannot detect that it is triggered by a user action and denies calls to document.executeCommand


#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

- use FF browser, test that you can copy/paste/cut in different input fields and editor

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

