### PR TITLE
[vscode] don't require non existing plugin main

### DIFF
--- a/packages/plugin-ext/src/common/plugin-api-rpc.ts
+++ b/packages/plugin-ext/src/common/plugin-api-rpc.ts
@@ -84,7 +84,7 @@ export interface PreferenceData {
 }
 
 export interface Plugin {
-    pluginPath: string;
+    pluginPath: string | undefined;
     pluginFolder: string;
     model: PluginModel;
     rawModel: PluginPackage;

--- a/packages/plugin-ext/src/hosted/browser/worker/worker-main.ts
+++ b/packages/plugin-ext/src/hosted/browser/worker/worker-main.ts
@@ -65,10 +65,12 @@ const webviewExt = new WebviewsExtImpl(rpc, workspaceExt);
 const pluginManager = new PluginManagerExtImpl({
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     loadPlugin(plugin: Plugin): any {
-        if (isElectron()) {
-            ctx.importScripts(plugin.pluginPath);
-        } else {
-            ctx.importScripts('/hostedPlugin/' + getPluginId(plugin.model) + '/' + plugin.pluginPath);
+        if (plugin.pluginPath) {
+            if (isElectron()) {
+                ctx.importScripts(plugin.pluginPath);
+            } else {
+                ctx.importScripts('/hostedPlugin/' + getPluginId(plugin.model) + '/' + plugin.pluginPath);
+            }
         }
 
         if (plugin.lifecycle.frontendModuleName) {
@@ -107,7 +109,7 @@ const pluginManager = new PluginManagerExtImpl({
                 pluginsModulesNames.set(plugin.lifecycle.frontendModuleName!, plugin);
             } else {
                 foreign.push({
-                    pluginPath: pluginModel.entryPoint.backend!,
+                    pluginPath: pluginModel.entryPoint.backend,
                     pluginFolder: pluginModel.packagePath,
                     model: pluginModel,
                     lifecycle: pluginLifecycle,

--- a/packages/plugin-ext/src/hosted/node/plugin-host-rpc.ts
+++ b/packages/plugin-ext/src/hosted/node/plugin-host-rpc.ts
@@ -99,7 +99,8 @@ export class PluginHostRPC {
         const { extensionTestsPath } = process.env;
         const self = this;
         const pluginManager = new PluginManagerExtImpl({
-            loadPlugin(plugin: Plugin): void {
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            loadPlugin(plugin: Plugin): any {
                 console.log('PLUGIN_HOST(' + process.pid + '): PluginManagerExtImpl/loadPlugin(' + plugin.pluginPath + ')');
                 try {
                     // cleaning the cache for all files of that plug-in.
@@ -137,7 +138,9 @@ export class PluginHostRPC {
                         }
 
                     });
-                    return require(plugin.pluginPath);
+                    if (plugin.pluginPath) {
+                        return require(plugin.pluginPath);
+                    }
                 } catch (e) {
                     console.error(e);
                 }


### PR DESCRIPTION
#### What it does
Avoids logging errors when plugin-host-rpc tries to load non existing plugin entry scripts.

#### How to test
Install an extension without a main entry point.
E.g. https://marketplace.visualstudio.com/items?itemName=wingrunr21.vscode-ruby

#### Review checklist

- [ ] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

