### PR TITLE
Set the upstream remote branch when pushing

### DIFF
--- a/packages/git/src/browser/git-quick-open-service.ts
+++ b/packages/git/src/browser/git-quick-open-service.ts
@@ -147,7 +147,7 @@ export class GitQuickOpenService {
                     await this.git.pull(repository, { remote: defaultRemote });
                     console.log(`Git Pull: successfully completed from ${defaultRemote}.`);
                 } else if (action === GitAction.PUSH) {
-                    await this.git.push(repository, { remote: defaultRemote });
+                    await this.git.push(repository, { remote: defaultRemote, setUpstream: true });
                     console.log(`Git Push: successfully completed to ${defaultRemote}.`);
                 }
             } catch (error) {
@@ -165,7 +165,7 @@ export class GitQuickOpenService {
             const [remotes, currentBranch] = await Promise.all([this.getRemotes(), this.getCurrentBranch()]);
             const execute = async (item: QuickOpenItem) => {
                 try {
-                    await this.git.push(repository, { remote: item.getLabel() });
+                    await this.git.push(repository, { remote: item.getLabel(), setUpstream: true });
                 } catch (error) {
                     this.gitErrorHandler.handleError(error);
                 }


### PR DESCRIPTION
## What it does

fixes https://github.com/eclipse-theia/theia/issues/7596

The issue reported against Gitpod has also been reported against Mbed Studio.

This is a very simple fix that always ensures the remote branch is set when pushing.  If the user pushes to a different remote then the remote branch will be switched to that remote.

This was a problem with the Git Theia extension only.  The vs-code Git builtin asks the user to confirm that the branch should be published.
 
#### How to test
Create a new branch and push.  Then try pulling from that branch.  Check other workflows to ensure that we are not interfering with existing workflows by always setting the remote tracking branch.

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

