### PR TITLE
monaco: implement 'isVisible' commands

### DIFF
--- a/packages/monaco/src/browser/monaco-command.ts
+++ b/packages/monaco/src/browser/monaco-command.ts
@@ -165,6 +165,17 @@ export class MonacoEditorCommandHandlers implements CommandContribution {
                         return !!editor;
                     }
                     return true;
+                },
+                isVisible: () => {
+                    const editor = codeEditorService.getFocusedCodeEditor() || codeEditorService.getActiveCodeEditor();
+                    if (editorActions.has(id)) {
+                        const action = editor && editor.getAction(id);
+                        return !!action && action.isSupported();
+                    }
+                    if (!!editorRegistry.getEditorCommand(id)) {
+                        return !!editor;
+                    }
+                    return true;
                 }
             };
             const label = editorActions.get(id);


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

The following pull-request implements `isVisible` for monaco commands (ex: language-server).
The change is useful when running the **electron** target since `isEnabled` is not respected.
This means that end-users see monaco commands which ultimately do nothing. In the browser the `isEnabled` renders the menu items as 'disabled' which gives users cues that the commands are not available.

For example, when editing a markdown file (ex: `README.md`):

_Master_:

<div align='center'>

<img width="1130" alt="Screen Shot 2020-05-22 at 4 47 49 PM" src="https://user-images.githubusercontent.com/40359487/82708668-d26c9380-9c4c-11ea-9745-d483c3d2aadb.png">

</div>

_Pull Request_:

<div align='center'>

<img width="1123" alt="Screen Shot 2020-05-22 at 4 49 16 PM" src="https://user-images.githubusercontent.com/40359487/82708691-e1534600-9c4c-11ea-93e3-5cbe13afc1be.png">

</div>

We can see that the `master` menu is populated with menu items which ultimately do nothing.

**TODO**:
- [ ] find a way to generalize the behavior for all commands in electron (`isVisible` should respect `isEnabled` unless `isVisible` is implemented).
- [ ] find a way to separate the behavior between the **browser** and **electron**
(the `browser` should continue to display items as 'disabled' like today)

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

TBD.

#### Review checklist

- [ ] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

Signed-off-by: vince-fugnitto <vincent.fugnitto@ericsson.com>
