### PR TITLE
[7576]: Support for `vscode.workspace.findTextInFiles` API

### DIFF
--- a/packages/core/src/browser/style/sidepanel.css
+++ b/packages/core/src/browser/style/sidepanel.css
@@ -294,3 +294,9 @@
   overflow: hidden;
   text-overflow: ellipsis;
 }
+
+.noWrapInfoTree {
+  white-space: pre;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}

--- a/packages/plugin-ext/src/common/plugin-api-rpc-model.ts
+++ b/packages/plugin-ext/src/common/plugin-api-rpc-model.ts
@@ -551,3 +551,21 @@ export interface RenameFilesEventDTO {
 export interface DeleteFilesEventDTO {
     files: UriComponents[]
 }
+
+export interface SearchInWorkspaceResult {
+    root: string;
+    fileUri: string;
+    matches: SearchMatch[];
+}
+
+export interface SearchMatch {
+    line: number;
+    character: number;
+    length: number;
+    lineText: string | LinePreview;
+
+}
+export interface LinePreview {
+    text: string;
+    character: number;
+}

--- a/packages/plugin-ext/src/common/plugin-api-rpc.ts
+++ b/packages/plugin-ext/src/common/plugin-api-rpc.ts
@@ -69,6 +69,7 @@ import {
     CreateFilesEventDTO,
     RenameFilesEventDTO,
     DeleteFilesEventDTO,
+    SearchInWorkspaceResult
 } from './plugin-api-rpc-model';
 import { ExtPluginApi } from './plugin-ext-api-contribution';
 import { KeysToAnyValues, KeysToKeysToAnyValue } from './types';
@@ -511,6 +512,8 @@ export interface WorkspaceMain {
     $pickWorkspaceFolder(options: WorkspaceFolderPickOptionsMain): Promise<theia.WorkspaceFolder | undefined>;
     $startFileSearch(includePattern: string, includeFolder: string | undefined, excludePatternOrDisregardExcludes: string | false,
         maxResults: number | undefined, token: theia.CancellationToken): PromiseLike<UriComponents[]>;
+    $findTextInFiles(query: theia.TextSearchQuery, options: theia.FindTextInFilesOptions, searchRequestId: number,
+        token?: theia.CancellationToken): Promise<theia.TextSearchComplete>
     $registerTextDocumentContentProvider(scheme: string): Promise<void>;
     $unregisterTextDocumentContentProvider(scheme: string): void;
     $onTextDocumentContentChange(uri: string, content: string): void;
@@ -530,6 +533,7 @@ export interface WorkspaceExt {
     $onDidRenameFiles(event: RenameFilesEventDTO): void;
     $onWillDeleteFiles(event: DeleteFilesEventDTO): Promise<any[]>;
     $onDidDeleteFiles(event: DeleteFilesEventDTO): void;
+    $onTextSearchResult(searchRequestId: number, done: boolean, result?: SearchInWorkspaceResult): void;
 }
 
 export interface DialogsMain {

--- a/packages/plugin-ext/src/main/browser/view/tree-view-widget.tsx
+++ b/packages/plugin-ext/src/main/browser/view/tree-view-widget.tsx
@@ -281,7 +281,7 @@ export class TreeViewWidget extends TreeWidget {
             });
         }
 
-        return <div className='noWrapInfo'>
+        return <div className='noWrapInfoTree'>
             {...nodes}
             {work && <span>{work}</span>}
             {description && <span className='theia-tree-view-description'>

--- a/packages/plugin-ext/src/plugin/plugin-context.ts
+++ b/packages/plugin-ext/src/plugin/plugin-context.ts
@@ -475,6 +475,10 @@ export function createAPIFactory(
             findFiles(include: theia.GlobPattern, exclude?: theia.GlobPattern | null, maxResults?: number, token?: CancellationToken): PromiseLike<Uri[]> {
                 return workspaceExt.findFiles(include, exclude, maxResults, token);
             },
+            findTextInFiles(query: theia.TextSearchQuery, optionsOrCallback: theia.FindTextInFilesOptions | ((result: theia.TextSearchResult) => void),
+                callbackOrToken?: CancellationToken | ((result: theia.TextSearchResult) => void), token?: CancellationToken): Promise<theia.TextSearchComplete> {
+                return workspaceExt.findTextInFiles(query, optionsOrCallback, callbackOrToken, token);
+            },
             saveAll(includeUntitled?: boolean): PromiseLike<boolean> {
                 return editors.saveAll(includeUntitled);
             },

--- a/packages/plugin-ext/src/plugin/workspace.ts
+++ b/packages/plugin-ext/src/plugin/workspace.ts
@@ -32,7 +32,15 @@ import {
 } from '../common/plugin-api-rpc';
 import { Path } from '@theia/core/lib/common/path';
 import { RPCProtocol } from '../common/rpc-protocol';
-import { WorkspaceRootsChangeEvent, FileChangeEvent, CreateFilesEventDTO, RenameFilesEventDTO, DeleteFilesEventDTO } from '../common/plugin-api-rpc-model';
+import {
+    WorkspaceRootsChangeEvent,
+    FileChangeEvent,
+    CreateFilesEventDTO,
+    RenameFilesEventDTO,
+    DeleteFilesEventDTO,
+    SearchInWorkspaceResult,
+    Range
+} from '../common/plugin-api-rpc-model';
 import { EditorsAndDocumentsExtImpl } from './editors-and-documents';
 import { InPluginFileSystemWatcherProxy } from './in-plugin-filesystem-watcher-proxy';
 import { URI } from 'vscode-uri';
@@ -42,6 +50,7 @@ import { relative } from '../common/paths-util';
 import { Schemes } from '../common/uri-components';
 import { toWorkspaceFolder } from './type-converters';
 import { MessageRegistryExt } from './message-registry';
+import * as Converter from './type-converters';
 
 export class WorkspaceExtImpl implements WorkspaceExt {
 
@@ -71,6 +80,8 @@ export class WorkspaceExtImpl implements WorkspaceExt {
 
     private folders: theia.WorkspaceFolder[] | undefined;
     private documentContentProviders = new Map<string, theia.TextDocumentContentProvider>();
+    private searchInWorkspaceEmitter: Emitter<{ result?: theia.TextSearchResult, searchId: number }> = new Emitter<{ result?: theia.TextSearchResult, searchId: number }>();
+    protected workspaceSearchSequence: number = 0;
 
     constructor(rpc: RPCProtocol,
         private editorsAndDocuments: EditorsAndDocumentsExtImpl,
@@ -104,6 +115,31 @@ export class WorkspaceExtImpl implements WorkspaceExt {
         this.folders = newFolders;
 
         this.workspaceFoldersChangedEmitter.fire(delta);
+    }
+
+    $onTextSearchResult(searchRequestId: number, done: boolean, result?: SearchInWorkspaceResult): void {
+        if (result) {
+            result.matches.map(next => {
+                const range: Range = {
+                    endColumn: next.character + next.length,
+                    endLineNumber: next.line + 1,
+                    startColumn: next.character,
+                    startLineNumber: next.line + 1
+                };
+                const tRange = <theia.Range>Converter.toRange(range);
+                const searchResult: theia.TextSearchMatch = {
+                    uri: URI.parse(result.fileUri),
+                    preview: {
+                        text: typeof next.lineText === 'string' ? next.lineText : next.lineText.text,
+                        matches: tRange
+                    },
+                    ranges: tRange
+                };
+                return searchResult;
+            }).forEach(next => this.searchInWorkspaceEmitter.fire({ result: next, searchId: searchRequestId }));
+        } else if (done) {
+            this.searchInWorkspaceEmitter.fire({ searchId: searchRequestId });
+        }
     }
 
     private deltaFolders(currentFolders: theia.WorkspaceFolder[] = [], newFolders: theia.WorkspaceFolder[] = []): {
@@ -180,6 +216,38 @@ export class WorkspaceExtImpl implements WorkspaceExt {
 
         return this.proxy.$startFileSearch(includePattern, includeFolderUri, excludePatternOrDisregardExcludes, maxResults, token)
             .then(data => Array.isArray(data) ? data.map(uri => URI.revive(uri)) : []);
+    }
+
+    findTextInFiles(query: theia.TextSearchQuery, optionsOrCallback: theia.FindTextInFilesOptions | ((result: theia.TextSearchResult) => void),
+        callbackOrToken?: CancellationToken | ((result: theia.TextSearchResult) => void), token?: CancellationToken): Promise<theia.TextSearchComplete> {
+        let options: theia.FindTextInFilesOptions;
+        let callback: (result: theia.TextSearchResult) => void;
+
+        if (typeof optionsOrCallback === 'object') {
+            options = optionsOrCallback;
+            callback = callbackOrToken as (result: theia.TextSearchResult) => void;
+        } else {
+            options = {};
+            callback = optionsOrCallback;
+            token = callbackOrToken as CancellationToken;
+        }
+        const nextSearchID = this.workspaceSearchSequence + 1;
+        this.workspaceSearchSequence = nextSearchID;
+        const disposable = this.searchInWorkspaceEmitter.event(searchResult => {
+            if (searchResult.searchId === nextSearchID) {
+                if (searchResult.result) {
+                    callback(searchResult.result);
+                } else {
+                    disposable.dispose();
+                }
+            }
+        });
+        if (token) {
+            token.onCancellationRequested(() => {
+                disposable.dispose();
+            });
+        }
+        return this.proxy.$findTextInFiles(query, options || {}, nextSearchID, token);
     }
 
     createFileSystemWatcher(globPattern: theia.GlobPattern, ignoreCreateEvents?: boolean, ignoreChangeEvents?: boolean, ignoreDeleteEvents?: boolean): theia.FileSystemWatcher {

--- a/packages/plugin/src/theia-proposed.d.ts
+++ b/packages/plugin/src/theia-proposed.d.ts
@@ -234,4 +234,177 @@ declare module '@theia/plugin' {
         constructor(label: TreeItemLabel, collapsibleState?: TreeItemCollapsibleState);
     }
     //#endregion
+
+    //#region search in workspace
+    /**
+     * The parameters of a query for text search.
+     */
+    export interface TextSearchQuery {
+        /**
+         * The text pattern to search for.
+         */
+        pattern: string;
+
+        /**
+         * Whether or not `pattern` should match multiple lines of text.
+         */
+        isMultiline?: boolean;
+
+        /**
+         * Whether or not `pattern` should be interpreted as a regular expression.
+         */
+        isRegExp?: boolean;
+
+        /**
+         * Whether or not the search should be case-sensitive.
+         */
+        isCaseSensitive?: boolean;
+
+        /**
+         * Whether or not to search for whole word matches only.
+         */
+        isWordMatch?: boolean;
+    }
+
+    /**
+     * Options that can be set on a findTextInFiles search.
+     */
+    export interface FindTextInFilesOptions {
+        /**
+         * A [glob pattern](#GlobPattern) that defines the files to search for. The glob pattern
+         * will be matched against the file paths of files relative to their workspace. Use a [relative pattern](#RelativePattern)
+         * to restrict the search results to a [workspace folder](#WorkspaceFolder).
+         */
+        include?: GlobPattern;
+
+        /**
+         * A [glob pattern](#GlobPattern) that defines files and folders to exclude. The glob pattern
+         * will be matched against the file paths of resulting matches relative to their workspace. When `undefined`, default excludes will
+         * apply.
+         */
+        exclude?: GlobPattern;
+
+        /**
+         * Whether to use the default and user-configured excludes. Defaults to true.
+         */
+        useDefaultExcludes?: boolean;
+
+        /**
+         * The maximum number of results to search for
+         */
+        maxResults?: number;
+
+        /**
+         * Whether external files that exclude files, like .gitignore, should be respected.
+         * See the vscode setting `"search.useIgnoreFiles"`.
+         */
+        useIgnoreFiles?: boolean;
+
+        /**
+         * Whether global files that exclude files, like .gitignore, should be respected.
+         * See the vscode setting `"search.useGlobalIgnoreFiles"`.
+         */
+        useGlobalIgnoreFiles?: boolean;
+
+        /**
+         * Whether symlinks should be followed while searching.
+         * See the vscode setting `"search.followSymlinks"`.
+         */
+        followSymlinks?: boolean;
+
+        /**
+         * Interpret files using this encoding.
+         * See the vscode setting `"files.encoding"`
+         */
+        encoding?: string;
+
+        /**
+         * Options to specify the size of the result text preview.
+         */
+        previewOptions?: TextSearchPreviewOptions;
+
+        /**
+         * Number of lines of context to include before each match.
+         */
+        beforeContext?: number;
+
+        /**
+         * Number of lines of context to include after each match.
+         */
+        afterContext?: number;
+    }
+
+    /**
+     * A match from a text search
+     */
+    export interface TextSearchMatch {
+        /**
+         * The uri for the matching document.
+         */
+        uri: Uri;
+
+        /**
+         * The range of the match within the document, or multiple ranges for multiple matches.
+         */
+        ranges: Range | Range[];
+
+        /**
+         * A preview of the text match.
+         */
+        preview: TextSearchMatchPreview;
+    }
+
+    /**
+     * A preview of the text result.
+     */
+    export interface TextSearchMatchPreview {
+        /**
+         * The matching lines of text, or a portion of the matching line that contains the match.
+         */
+        text: string;
+
+        /**
+         * The Range within `text` corresponding to the text of the match.
+         * The number of matches must match the TextSearchMatch's range property.
+         */
+        matches: Range | Range[];
+    }
+
+    /**
+     * A line of context surrounding a TextSearchMatch.
+     */
+    export interface TextSearchContext {
+        /**
+         * The uri for the matching document.
+         */
+        uri: Uri;
+
+        /**
+         * One line of text.
+         * previewOptions.charsPerLine applies to this
+         */
+        text: string;
+
+        /**
+         * The line number of this line of context.
+         */
+        lineNumber: number;
+    }
+
+    export type TextSearchResult = TextSearchMatch | TextSearchContext;
+
+    /**
+     * Information collected when text search is complete.
+     */
+    export interface TextSearchComplete {
+        /**
+         * Whether the search hit the limit on the maximum number of search results.
+         * `maxResults` on [`TextSearchOptions`](#TextSearchOptions) specifies the max number of results.
+         * - If exactly that number of matches exist, this should be false.
+         * - If `maxResults` matches are returned and more exist, this should be true.
+         * - If search hits an internal limit which is less than `maxResults`, this should be true.
+         */
+        limitHit?: boolean;
+    }
+    //#endregion
 }

--- a/packages/plugin/src/theia.d.ts
+++ b/packages/plugin/src/theia.d.ts
@@ -5132,6 +5132,16 @@ declare module '@theia/plugin' {
         export function findFiles(include: GlobPattern, exclude?: GlobPattern | null, maxResults?: number, token?: CancellationToken): PromiseLike<Uri[]>;
 
         /**
+         * Find text in files across all [workspace folders] in the workspace
+         * @param query What to search 
+         * @param optionsOrCallback 
+         * @param callbackOrToken 
+         * @param token 
+         */
+        export function findTextInFiles(query: TextSearchQuery, optionsOrCallback: FindTextInFilesOptions | ((result: TextSearchResult) => void),
+            callbackOrToken?: CancellationToken | ((result: TextSearchResult) => void), token?: CancellationToken): Promise<TextSearchComplete>
+
+        /**
          * Save all dirty files.
          *
          * @param includeUntitled Also save files that have been created during this session.

--- a/packages/search-in-workspace/src/browser/search-in-workspace-service.ts
+++ b/packages/search-in-workspace/src/browser/search-in-workspace-service.ts
@@ -15,7 +15,12 @@
  ********************************************************************************/
 
 import { injectable, inject, postConstruct } from 'inversify';
-import { SearchInWorkspaceServer, SearchInWorkspaceClient, SearchInWorkspaceResult, SearchInWorkspaceOptions } from '../common/search-in-workspace-interface';
+import {
+    SearchInWorkspaceServer,
+    SearchInWorkspaceClient,
+    SearchInWorkspaceResult,
+    SearchInWorkspaceOptions
+} from '../common/search-in-workspace-interface';
 import { WorkspaceService } from '@theia/workspace/lib/browser';
 import { ILogger } from '@theia/core';
 
@@ -46,7 +51,6 @@ export type SearchInWorkspaceCallbacks = SearchInWorkspaceClient;
 /**
  * Service to search text in the workspace files.
  */
-
 @injectable()
 export class SearchInWorkspaceService implements SearchInWorkspaceClient {
 
@@ -110,7 +114,11 @@ export class SearchInWorkspaceService implements SearchInWorkspaceClient {
         }
 
         const roots = await this.workspaceService.roots;
-        const searchId = await this.searchServer.search(what, roots.map(r => r.uri), opts);
+        return this.doSearch(what, roots.map(r => r.uri), callbacks, opts);
+    }
+
+    protected async doSearch(what: string, rootsUris: string[], callbacks: SearchInWorkspaceCallbacks, opts?: SearchInWorkspaceOptions): Promise<number> {
+        const searchId = await this.searchServer.search(what, rootsUris, opts);
         this.pendingSearches.set(searchId, callbacks);
         this.lastKnownSearchId = searchId;
 
@@ -130,6 +138,10 @@ export class SearchInWorkspaceService implements SearchInWorkspaceClient {
         }
 
         return searchId;
+    }
+
+    async searchWithCallback(what: string, rootsUris: string[], callbacks: SearchInWorkspaceClient, opts?: SearchInWorkspaceOptions | undefined): Promise<number> {
+        return this.doSearch(what, rootsUris, callbacks, opts);
     }
 
     // Cancel an ongoing search.


### PR DESCRIPTION
#### What it does

- fix https://github.com/eclipse-theia/theia/issues/7576: Provides ability to execute the vscode api vscode.workspace.findTextInFiles

#### How to test

This was tested with the Codetogether extension since it does use this api.

1. Install the extension
2. Start a session via command palette.
3. On the remote session on browser go to the search view.
4. Search for some text in the workspace you should see search text results.

Alternatively you can use a test extension (https://github.com/Genuitec/theiatestsearch):
1. Install the extension
2. Invoke the SearchTest: Search from command palette and let the input box know what you are searchig for.
3. On the Search test tree view contribution you should see the search results

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)