### PR TITLE
[preferences] only apply array component for string items

### DIFF
--- a/packages/preferences/src/browser/views/components/preference-array-input.tsx
+++ b/packages/preferences/src/browser/views/components/preference-array-input.tsx
@@ -24,7 +24,14 @@ interface PreferenceArrayInputProps {
 }
 
 export const PreferenceArrayInput: React.FC<PreferenceArrayInputProps> = ({ preferenceDisplayNode, setPreference }) => {
-    const values = preferenceDisplayNode.preference.value || [] as string[];
+    const values: string[] = [];
+    if (Array.isArray(preferenceDisplayNode.preference.value)) {
+        for (const preferenceValue of preferenceDisplayNode.preference.value) {
+            if (typeof preferenceValue === 'string') {
+                values.push(preferenceValue);
+            }
+        }
+    }
     const { id: preferenceID } = preferenceDisplayNode;
     const [value, setValue] = React.useState('');
 

--- a/packages/preferences/src/browser/views/components/preference-boolean-input.tsx
+++ b/packages/preferences/src/browser/views/components/preference-boolean-input.tsx
@@ -24,7 +24,7 @@ interface PreferenceBooleanInputProps {
 
 export const PreferenceBooleanInput: React.FC<PreferenceBooleanInputProps> = ({ preferenceDisplayNode, setPreference }) => {
     const { id } = preferenceDisplayNode;
-    const value = preferenceDisplayNode.preference.value as boolean | undefined;
+    const value = typeof preferenceDisplayNode.preference.value === 'boolean' ? preferenceDisplayNode.preference.value : undefined;
 
     // Tracks local state for quicker refreshes on user click.
     const [checked, setChecked] = React.useState<boolean>(!!value);

--- a/packages/preferences/src/browser/views/components/single-preference-wrapper.tsx
+++ b/packages/preferences/src/browser/views/components/single-preference-wrapper.tsx
@@ -179,15 +179,15 @@ export class SinglePreferenceWrapper extends React.Component<SinglePreferenceWra
                 setPreference={this.setPreference}
             />;
         } if (type === 'array') {
-            if (items && items.type === 'object') {
-                return <PreferenceJSONInput
+            if (items && items.type === 'string') {
+                return <PreferenceArrayInput
                     preferenceDisplayNode={preferenceDisplayNode}
-                    onClick={this.openJSONForCurrentPreference}
+                    setPreference={this.setPreference}
                 />;
             }
-            return <PreferenceArrayInput
+            return <PreferenceJSONInput
                 preferenceDisplayNode={preferenceDisplayNode}
-                setPreference={this.setPreference}
+                onClick={this.openJSONForCurrentPreference}
             />;
         } if (type === 'object') {
             return <PreferenceJSONInput


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

fix #7874: 
- only apply array component for string items
- replace down casting with proper runtime type checking to handle unexpected preferences.


#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

- see https://github.com/eclipse-theia/theia/issues/7874#issuecomment-633536413

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

