### PR TITLE
download-plugins: display errors at the end of the script

### DIFF
--- a/dev-packages/cli/src/download-plugins.ts
+++ b/dev-packages/cli/src/download-plugins.ts
@@ -47,6 +47,10 @@ export interface DownloadPluginsOptions {
 }
 
 export default async function downloadPlugins(options: DownloadPluginsOptions = {}): Promise<void> {
+
+    // Collect the list of failures to be appended at the end of the script.
+    const failures: string[] = [];
+
     const {
         packed = false,
     } = options;
@@ -109,16 +113,15 @@ export default async function downloadPlugins(options: DownloadPluginsOptions = 
             }
         }
         if (lastError) {
-            console.error(red(`x ${plugin}: failed to download, last error:`));
-            console.error(lastError);
+            failures.push(red(`x ${plugin}: failed to download, last error:\n ${lastError}`));
             return;
         }
         if (typeof response === 'undefined') {
-            console.error(red(`x ${plugin}: failed to download (unknown reason)`));
+            failures.push(red(`x ${plugin}: failed to download (unknown reason)`));
             return;
         }
         if (response.status !== 200) {
-            console.error(red(`x ${plugin}: failed to download with: ${response.status} ${response.statusText}`));
+            failures.push(red(`x ${plugin}: failed to download with: ${response.status} ${response.statusText}`));
             return;
         }
 
@@ -144,6 +147,9 @@ export default async function downloadPlugins(options: DownloadPluginsOptions = 
 
         console.warn(green(`+ ${plugin}: downloaded successfully ${attempts > 1 ? `(after ${attempts} attempts)` : ''}`));
     }));
+    failures.forEach(failure => {
+        console.log(failure);
+    });
 }
 
 /**


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

Fixes https://github.com/eclipse-theia/theia/issues/7878

The following commit updates the `download:plugins` script to display errors (download failures) at the end of the script so application developers can easily see the failed downloads together.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

1. update the root's `package.json` to include bogus download links
2. perform `yarn download:plugins`
3. the errors should be displayed at the end of the script:

<details>
<summary>Example</summary>

```
┌─[±][vf/gh-7878 U:1 ✗][theia][]
└─▪ yarn download:plugins
yarn run v1.22.4
$ theia download:plugins
--- downloading plugins ---
+ vscode-builtin-clojure: downloaded successfully 
+ vscode-builtin-csharp: downloaded successfully 
+ vscode-builtin-fsharp: downloaded successfully 
+ vscode-builtin-css: downloaded successfully 
+ vscode-builtin-debug-auto-launch: downloaded successfully 
+ vscode-builtin-bat: downloaded successfully 
+ vscode-builtin-configuration-editing: downloaded successfully 
+ vscode-builtin-grunt: downloaded successfully 
+ vscode-builtin-hlsl: downloaded successfully 
+ vscode-builtin-cpp: downloaded successfully 
+ vscode-builtin-coffeescript: downloaded successfully 
+ vscode-builtin-json: downloaded successfully 
+ vscode-builtin-docker: downloaded successfully 
+ vscode-builtin-handlebars: downloaded successfully 
+ vscode-builtin-perl: downloaded successfully 
+ vscode-builtin-rust: downloaded successfully 
+ vscode-builtin-r: downloaded successfully 
+ vscode-builtin-razor: downloaded successfully 
+ vscode-builtin-pug: downloaded successfully 
+ vscode-builtin-python: downloaded successfully 
+ vscode-builtin-ruby: downloaded successfully 
+ vscode-builtin-shaderlab: downloaded successfully 
+ vscode-builtin-scss: downloaded successfully 
+ vscode-builtin-lua: downloaded successfully 
+ vscode-builtin-groovy: downloaded successfully 
+ vscode-builtin-objective-c: downloaded successfully 
+ vscode-builtin-ini: downloaded successfully 
+ vscode-builtin-log: downloaded successfully 
+ vscode-builtin-java: downloaded successfully 
+ vscode-builtin-go: downloaded successfully 
+ vscode-builtin-powershell: downloaded successfully 
+ vscode-builtin-less: downloaded successfully 
+ vscode-builtin-make: downloaded successfully 
+ vscode-builtin-shellscript: downloaded successfully 
+ vscode-builtin-theme-kimbie-dark: downloaded successfully 
+ vscode-builtin-typescript: downloaded successfully 
+ vscode-builtin-sql: downloaded successfully 
+ vscode-builtin-theme-abyss: downloaded successfully 
+ vscode-builtin-theme-solarized-dark: downloaded successfully 
+ vscode-builtin-theme-monokai-dimmed: downloaded successfully 
+ vscode-builtin-theme-red: downloaded successfully 
+ vscode-builtin-swift: downloaded successfully 
+ vscode-builtin-theme-tomorrow-night-blue: downloaded successfully 
+ vscode-builtin-theme-monokai: downloaded successfully 
+ vscode-builtin-theme-quietlight: downloaded successfully 
+ vscode-builtin-xml: downloaded successfully 
+ vscode-builtin-markdown: downloaded successfully 
+ vscode-builtin-theme-defaults: downloaded successfully 
+ vscode-builtin-yaml: downloaded successfully 
+ vscode-editorconfig: downloaded successfully 
+ vscode-builtin-vb: downloaded successfully 
+ vscode-builtin-jake: downloaded successfully 
+ vscode-builtin-node-debug: downloaded successfully 
+ vscode-builtin-icon-theme-seti: downloaded successfully 
+ vscode-eslint: downloaded successfully 
+ vscode-builtin-node-debug2: downloaded successfully 
+ vscode-builtin-npm: downloaded successfully 
+ vscode-builtin-emmet: downloaded successfully 
+ vscode-references-view: downloaded successfully 
+ vscode-builtin-markdown-language-features: downloaded successfully 
+ vscode-builtin-typescript-language-features: downloaded successfully 
x vscode-builtin-html: failed to download with: 404 Not Found
x vscode-builtin-gulp: failed to download with: 404 Not Found
x vscode-builtin-merge-conflict: failed to download with: 404 Not Found
x vscode-builtin-javascript: failed to download, last error:
 FetchError: request to https://aopen-vsx.org/api/vscode/javascript/1.44.2/file/vscode.javascript-1.44.2.vsix failed, reason: getaddrinfo ENOTFOUND aopen-vsx.org aopen-vsx.org:443
✨  Done in 8.67s.
```

</details>

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

Signed-off-by: vince-fugnitto <vincent.fugnitto@ericsson.com>
