### PR TITLE
[Terminal] Detach TerminalSearchWidget before disposing TerminalWidget

### DIFF
--- a/packages/terminal/src/browser/terminal-widget-impl.ts
+++ b/packages/terminal/src/browser/terminal-widget-impl.ts
@@ -409,6 +409,10 @@ export class TerminalWidgetImpl extends TerminalWidget implements StatefulWidget
         super.onAfterAttach(msg);
         this.update();
     }
+    protected onBeforeDetach(msg: Message): void {
+        Widget.detach(this.searchBox);
+        super.onBeforeDetach(msg);
+    }
     protected onResize(msg: Widget.ResizeMessage): void {
         super.onResize(msg);
         this.needsResize = true;


### PR DESCRIPTION
Signed-off-by: Balaji Vijayakumar <kuttibalaji.v6@gmail.com>

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->
Fixes - #7625
This commit detaches the TerminalSearchWidget before disposing TerminalWidget.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
- Start Theia
- Open one or more terminal(s) ( From the menu or the short key)
- Close a terminal
- No error should reported on the console

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

