### PR TITLE
[preferences] Fix opening json

### DIFF
--- a/packages/preferences/src/browser/preference-contribution.ts
+++ b/packages/preferences/src/browser/preference-contribution.ts
@@ -153,7 +153,7 @@ export class PreferencesContribution extends AbstractViewContribution<Preference
     }
 
     protected async openPreferencesJSON(preferenceNode: Preference.NodeWithValueInAllScopes): Promise<void> {
-        const wasOpenedFromEditor = preferenceNode.constructor.name !== 'PreferencesWidget';
+        const wasOpenedFromEditor = preferenceNode.constructor !== PreferencesWidget;
         const { scope, activeScopeIsFolder, uri } = this.preferencesScope;
         const preferenceId = wasOpenedFromEditor ? preferenceNode.id : '';
         // when opening from toolbar, widget is passed as arg by default (we don't need this info)


### PR DESCRIPTION
#### What it does
Current code depends on symbol names which are changed
by webpack in production mode. This change fixes it.


#### How to test
- build theia in production mode
- open preferences
- try open json (top right icon)

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

