### PR TITLE
specify `when` closure for `Run Last Task` keybinding

### DIFF
--- a/packages/task/src/browser/task-frontend-contribution.ts
+++ b/packages/task/src/browser/task-frontend-contribution.ts
@@ -268,8 +268,11 @@ export class TaskFrontendContribution implements CommandContribution, MenuContri
         registry.registerCommand(
             TaskCommands.TASK_RUN_LAST,
             {
-                isEnabled: () => !!this.taskService.getLastTask(),
-                execute: () => this.taskService.runLastTask()
+                execute: async () => {
+                    if (!await this.taskService.runLastTask()) {
+                        await this.quickOpenTask.open();
+                    }
+                }
             }
         );
         registry.registerCommand(
@@ -388,7 +391,8 @@ export class TaskFrontendContribution implements CommandContribution, MenuContri
     registerKeybindings(keybindings: KeybindingRegistry): void {
         keybindings.registerKeybinding({
             command: TaskCommands.TASK_RUN_LAST.id,
-            keybinding: 'ctrlcmd+shift+k'
+            keybinding: 'ctrlcmd+shift+k',
+            when: '!textInputFocus || editorReadonly'
         });
     }
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

fix #7888: specify `when` closure for `Run Last Task` keybinding

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

- use `ctrlcmd+shift+k` when text input focused in not readonly editor
  - it should remove line
- use `ctrlcmd+shift+k` when text input is not focused or editor is readonly
  - it should run the last task or ask to run a new task (that's aligned with VS Code)

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

