### PR TITLE
Fixed collapsed state when restoring view container parts

### DIFF
--- a/packages/core/src/browser/view-container.ts
+++ b/packages/core/src/browser/view-container.ts
@@ -369,11 +369,6 @@ export class ViewContainer extends BaseWidget implements StatefulWidget, Applica
         return { parts: partStates, title: this.titleOptions };
     }
 
-    /**
-     * The view container restores the visibility, order and relative sizes of contained
-     * widgets, but _not_ the widgets themselves. In case the set of widgets is not fixed,
-     * it should be restored in the specific subclass or in the widget holding the view container.
-     */
     restoreState(state: ViewContainer.State): void {
         this.lastVisibleState = state;
         this.doRestoreState(state);

--- a/packages/core/src/browser/view-container.ts
+++ b/packages/core/src/browser/view-container.ts
@@ -403,10 +403,8 @@ export class ViewContainer extends BaseWidget implements StatefulWidget, Applica
             const part = parts[index];
             const partState = partStates.find(s => part.partId === s.partId);
             if (partState) {
+                part.setHidden(partState.hidden);
                 part.collapsed = partState.collapsed || !partState.relativeSize;
-                if (part.canHide) {
-                    part.setHidden(partState.hidden);
-                }
             } else if (part.canHide) {
                 part.hide();
             }


### PR DESCRIPTION
#### What it does
Fixes restoration of view container parts state, specifically the `collapsed` state.

#### How to test
Open a view container (e.g. Debug or Extensions), collapse some parts and reload the page.

Before this change: all visible parts are expanded.

After this change: parts are kept collapsed or expanded as before.

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

