### PR TITLE
Support multi-select in Source Control view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## v1.3.0
 
+- [scm] added support for multi-select in the Source Control view [#7900](https://github.com/eclipse-theia/theia/pull/7900)
+
 Breaking Changes:
 
 - [task] Widened the scope of some methods in TaskManager and TaskConfigurations from string to TaskConfigurationScope. This is only breaking for extenders, not callers. [#7928](https://github.com/eclipse-theia/theia/pull/7928)

--- a/packages/git/src/browser/git-contribution.ts
+++ b/packages/git/src/browser/git-contribution.ts
@@ -411,47 +411,38 @@ export class GitContribution implements CommandContribution, MenuContribution, T
             isEnabled: () => !!this.repositoryTracker.selectedRepository
         });
         registry.registerCommand(GIT_COMMANDS.UNSTAGE, {
-            execute: (arg: string |  ScmResource[] | ScmResource) => {
-                const uris =
-                    typeof arg === 'string' ? [ arg ] :
-                    Array.isArray(arg) ? arg.map(r => r.sourceUri.toString()) :
-                    [ arg.sourceUri.toString() ];
+            execute: (...arg: ScmResource[]) => {
+                const resources = arg.filter(r => r.sourceUri).map(r => r.sourceUri.toString());
                 const provider = this.repositoryProvider.selectedScmProvider;
-                return provider && this.withProgress(() => provider.unstage(uris));
+                return provider && this.withProgress(() => provider.unstage(resources));
             },
-            isEnabled: (arg: string |  ScmResource[] | ScmResource) => !!this.repositoryProvider.selectedScmProvider
-                && (!Array.isArray(arg) || arg.length !== 0)
+            isEnabled: (...arg: ScmResource[]) => !!this.repositoryProvider.selectedScmProvider
+                && arg.some(r => r.sourceUri)
         });
         registry.registerCommand(GIT_COMMANDS.STAGE, {
-            execute: (arg: string | ScmResource[] | ScmResource) => {
-                const uris =
-                    typeof arg === 'string' ? [ arg ] :
-                    Array.isArray(arg) ? arg.map(r => r.sourceUri.toString()) :
-                    [ arg.sourceUri.toString() ];
+            execute: (...arg: ScmResource[]) => {
+                const resources = arg.filter(r => r.sourceUri).map(r => r.sourceUri.toString());
                 const provider = this.repositoryProvider.selectedScmProvider;
-                return provider && this.withProgress(() => provider.stage(uris));
+                return provider && this.withProgress(() => provider.stage(resources));
             },
-            isEnabled: (arg: string |  ScmResource[] | ScmResource) => !!this.repositoryProvider.selectedScmProvider
-                && (!Array.isArray(arg) || arg.length !== 0)
+            isEnabled: (...arg: ScmResource[]) => !!this.repositoryProvider.selectedScmProvider
+                && arg.some(r => r.sourceUri)
         });
         registry.registerCommand(GIT_COMMANDS.DISCARD, {
-            execute: (arg: string | ScmResource[] | ScmResource) => {
-                const uris =
-                    typeof arg === 'string' ? [ arg ] :
-                    Array.isArray(arg) ? arg.map(r => r.sourceUri.toString()) :
-                    [ arg.sourceUri.toString() ];
+            execute: (...arg: ScmResource[]) => {
+                const resources = arg.filter(r => r.sourceUri).map(r => r.sourceUri.toString());
                 const provider = this.repositoryProvider.selectedScmProvider;
-                return provider && this.withProgress(() => provider.discard(uris));
+                return provider && this.withProgress(() => provider.discard(resources));
             },
-            isEnabled: (arg: string |  ScmResource[] | ScmResource) => !!this.repositoryProvider.selectedScmProvider
-                && (!Array.isArray(arg) || arg.length !== 0)
+            isEnabled: (...arg: ScmResource[]) => !!this.repositoryProvider.selectedScmProvider
+                    && arg.some(r => r.sourceUri)
         });
         registry.registerCommand(GIT_COMMANDS.OPEN_CHANGED_FILE, {
-            execute: (arg: string | ScmResource) => {
-                const uri = typeof arg === 'string' ? new URI(arg) : arg.sourceUri;
-                this.editorManager.open(uri, { mode: 'reveal' });
-            },
-            isVisible: (arg: string | ScmResource, isFolder: boolean) => !isFolder
+            execute: (...arg: ScmResource[]) => {
+                for (const resource of arg) {
+                    this.editorManager.open(resource.sourceUri, { mode: 'reveal' });
+                }
+            }
         });
         registry.registerCommand(GIT_COMMANDS.STASH, {
             execute: () => this.quickOpenService.stash(),
@@ -862,6 +853,7 @@ export class GitContribution implements CommandContribution, MenuContribution, T
             }
         });
     }
+
 }
 export interface GitOpenFileOptions {
     readonly uri: URI

--- a/packages/scm/src/browser/scm-frontend-module.ts
+++ b/packages/scm/src/browser/scm-frontend-module.ts
@@ -123,7 +123,8 @@ export default new ContainerModule(bind => {
 export function createScmTreeContainer(parent: interfaces.Container): Container {
     const child = createTreeContainer(parent, {
         virtualized: true,
-        search: true
+        search: true,
+        multiSelect: true,
     });
 
     child.unbind(TreeWidget);

--- a/packages/scm/src/browser/scm-tree-model.ts
+++ b/packages/scm/src/browser/scm-tree-model.ts
@@ -69,6 +69,14 @@ export namespace ScmFileChangeNode {
         return 'sourceUri' in node
             && !ScmFileChangeFolderNode.is(node);
     }
+    export function getGroupId(node: ScmFileChangeNode): string {
+        const parentNode = node.parent;
+        if (!(parentNode && (ScmFileChangeFolderNode.is(parentNode) || ScmFileChangeGroupNode.is(parentNode)))) {
+            throw new Error('bad node');
+        }
+        return parentNode.groupId;
+    }
+
 }
 
 @injectable()


### PR DESCRIPTION
fixes https://github.com/eclipse-theia/theia/issues/7659

#### What it does

Adds support for multi-selection in the Source Control view.  When multiple rows are selected, the args to the context menu will include the entire selection, but only if all the nodes in the selection are in the same group and all are files or all folders.

This is different from how vs-code works because vs-code does not have file-specific items in the context menu.  Vs-code will execute the inline actions against all selected items.  With this PR the inline actions only operate on the file or folder associated with the inline action, even when there is a multi-selection.  This makes it consistent with the existing Theia behavior when a file is selected but an inline action is pressed for a different file.  In that situation the inline action applies to the file next to the action, and the selection is left alone on the other file.

This works will with the Theia native git package.  It also works with the vs-code builtin but not so well.  If testing with vscode-git-1.3.0.1.vsix there is no support for vs-code's new folder actions, so those are missing.  (But that is the case without this PR too).  Also notice that to make multi-selection you must press up-arrow or down-arrow while holding shift.  Using the mouse will work but if the second selection is a modified file (M indicator) then vscode-git-1.3.0.1.vsix results in the second range selection to be selected singularly, cancelling the range that had just been set as the selection.  I have not been able to test with git-1.39.1-prel.vsix.
 
#### How to test

Test with both the Theia git extension and the vs-code git builtin.  Ensure that all works well with the Theia git extension.  Ensure that no existing functionality is broken when using any supported git builtin.

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

