### PR TITLE
[monaco] only focus an editor if it's revealed

### DIFF
--- a/packages/editor/src/browser/editor.ts
+++ b/packages/editor/src/browser/editor.ts
@@ -163,6 +163,10 @@ export interface TextEditor extends Disposable, TextEditorSelection, Navigatable
     selection: Range;
     readonly onSelectionChanged: Event<Range>;
 
+    /**
+     * The text editor should be revealed,
+     * otherwise it won't receive the focus.
+     */
     focus(): void;
     blur(): void;
     isFocused(): boolean;

--- a/packages/monaco/src/browser/monaco-command.ts
+++ b/packages/monaco/src/browser/monaco-command.ts
@@ -136,6 +136,10 @@ export class MonacoEditorCommandHandlers implements CommandContribution {
             }
             const handler: CommandHandler = {
                 execute: (...args) => {
+                    /*
+                     * We check monaco focused code editor first since they can contain inline like the debug console and embedded editors like in the peek reference.
+                     * If there is not such then we check last focused editor tracked by us.
+                     */
                     const editor = codeEditorService.getFocusedCodeEditor() || codeEditorService.getActiveCodeEditor();
                     if (editorActions.has(id)) {
                         const action = editor && editor.getAction(id);

--- a/packages/monaco/src/browser/monaco-editor.ts
+++ b/packages/monaco/src/browser/monaco-editor.ts
@@ -268,7 +268,17 @@ export class MonacoEditor extends MonacoEditorServices implements TextEditor {
     }
 
     focus(): void {
-        this.editor.focus();
+        /**
+         * `this.editor.focus` forcefully changes the focus editor state,
+         * regardless whether the textarea actually received the focus.
+         * It could lead to issues like https://github.com/eclipse-theia/theia/issues/7902
+         * Instead we focus the underlying textarea.
+         */
+        const node = this.editor.getDomNode();
+        if (node) {
+            const textarea = node.querySelector('textarea') as HTMLElement;
+            textarea.focus();
+        }
     }
 
     blur(): void {

--- a/packages/monaco/src/typings/monaco/index.d.ts
+++ b/packages/monaco/src/typings/monaco/index.d.ts
@@ -1074,10 +1074,10 @@ declare module monaco.quickOpen {
     // https://github.com/theia-ide/vscode/blob/standalone/0.19.x/src/vs/editor/standalone/browser/quickOpen/editorQuickOpen.ts#L25
     export interface QuickOpenController extends IDisposable {
         static readonly ID: string;
+        dispose(): void;
         run(opts: IQuickOpenControllerOpts): void;
 
-        // https://github.com/theia-ide/vscode/blob/standalone/0.19.x/src/vs/editor/standalone/browser/quickOpen/editorQuickOpen.ts#L168-L169
-        decorateLine(range: Range, editor: monaco.editor.ICodeEditor): void;
+        // https://github.com/theia-ide/vscode/blob/standalone/0.19.x/src/vs/editor/standalone/browser/quickOpen/editorQuickOpen.ts#L169
         clearDecorations(): void;
     }
 }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

- fix #7902: see https://github.com/eclipse-theia/theia/issues/7902#issuecomment-634494744

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

- test that different kind of editors are properly activated and receive keystrokes:
  - editor widget
  - diff editor widget
  - debug console input
  - breakpoint expression editor
  - peek reference editor
- test that switching editors while `Go to Symbol...` or `Go to line` quick palette are opened closes the panel and gives the focus to the proper editor

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

