### PR TITLE
fix: return right cmd when case ShellQuotedString

### DIFF
--- a/packages/process/src/common/shell-command-builder.ts
+++ b/packages/process/src/common/shell-command-builder.ts
@@ -151,7 +151,8 @@ export class ShellCommandBuilder {
     }
 
     protected buildForDefault(args: Array<string | ShellQuotedString>, cwd?: string, env?: Array<[string, string | null]>): string {
-        return args.join(' ');
+        const stringArgs = args.map(arg => typeof arg === 'string' ? arg : arg.value);
+        return stringArgs.join(' ');
     }
 
 }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->
when the input `args` is an array of `ShellQuotedString`
`args.join(' ')` will return a wrong command like `[object Object] [object Object] [object Object]`

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

