### PR TITLE
Add command Copy Path and bind handler for native VS Code command

### DIFF
--- a/packages/editor/src/browser/editor-menu.ts
+++ b/packages/editor/src/browser/editor-menu.ts
@@ -70,6 +70,10 @@ export class EditorMenuContribution implements MenuContribution {
             commandId: CommonCommands.PASTE.id,
             order: '2'
         });
+        registry.registerMenuAction(EditorContextMenu.CUT_COPY_PASTE, {
+            commandId: CommonCommands.COPY_PATH.id,
+            order: '3'
+        });
 
         // Editor navigation. Go > Back and Go > Forward.
         registry.registerSubmenu(EditorMainMenu.GO, 'Go');

--- a/packages/navigator/src/browser/navigator-contribution.ts
+++ b/packages/navigator/src/browser/navigator-contribution.ts
@@ -347,6 +347,10 @@ export class FileNavigatorContribution extends AbstractViewContribution<FileNavi
             order: 'b'
         });
         registry.registerMenuAction(NavigatorContextMenu.CLIPBOARD, {
+            commandId: CommonCommands.COPY_PATH.id,
+            order: 'c'
+        });
+        registry.registerMenuAction(NavigatorContextMenu.CLIPBOARD, {
             commandId: FileDownloadCommands.COPY_DOWNLOAD_LINK.id,
             order: 'z'
         });

--- a/packages/plugin-ext-vscode/src/browser/plugin-vscode-commands-contribution.ts
+++ b/packages/plugin-ext-vscode/src/browser/plugin-vscode-commands-contribution.ts
@@ -617,5 +617,10 @@ export class PluginVscodeCommandsContribution implements CommandContribution {
                 currentTerminal.dispose();
             }
         });
+        commands.registerCommand({
+            id: 'copyFilePath'
+        }, {
+            execute: () => commands.executeCommand(CommonCommands.COPY_PATH.id)
+        });
     }
 }


### PR DESCRIPTION
#### What it does
This changes proposal provides ability to copy absolute path to the file. This can be reached by calling `Copy Path` item in context menu of explorer or opened editor. Also, this proposal provides additional command `copyFilePath`, which is bridge between Theia and VS Code extension [1].

[1] [microsoft/vscode/src/vs/workbench/contrib/files/browser/fileCommands.ts#L247-L259](https://github.com/microsoft/vscode/blob/bde31da263a9a478e1a32c38c700fb723723a0d7/src/vs/workbench/contrib/files/browser/fileCommands.ts#L247-L259)

Use case 1.
Copy Path call from Project Explorer:
![copyFilePath_usecase_1](https://user-images.githubusercontent.com/1968177/83407680-ec129580-a419-11ea-86a5-dc817a429fee.gif)

Use case 2.
Copy Path call from Opened Editor:
![copyFilePath_usecase_2](https://user-images.githubusercontent.com/1968177/83407716-fdf43880-a419-11ea-9fdd-c10536065ee8.gif)

Use case 3.
Call VS Code's command `copyFilePath` from third-party plugin:
![copyFilePath_usecase_3](https://user-images.githubusercontent.com/1968177/83407782-1a907080-a41a-11ea-9e1a-4087276f0b50.gif)

Use case 4.
Call VS Code's command `copyFilePath` from third-party plugin when everything hidden:
![copyFilePath_usecase_4](https://user-images.githubusercontent.com/1968177/83407856-3dbb2000-a41a-11ea-8d88-717df88eb222.gif)

Needed for [Didact](https://marketplace.visualstudio.com/items?itemName=redhat.vscode-didact) extension, but temporary can't be reached in the last one because of [dependent issue](https://github.com/eclipse-theia/theia/issues/7853). So there is another way to check this PR.

Signed-off-by: Vladyslav Zhukovskyi <vzhukovs@redhat.com>

#### How to test
Plugin to check the changes can be reached [here](https://github.com/vzhukovskii/copyFilePath).
For the calling items from context menus, it's enough to build Theia from the PR and try to copy file path.

#### Review checklist

- [ ] Need to check on windows hotkey combination `shift+alt+c`, because of lack windows machine I can't be 100% sure, that this hotkey is free.

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

