### PR TITLE
Preferences - Responsive Scope Changes

### DIFF
--- a/packages/preferences/src/browser/util/preference-event-service.ts
+++ b/packages/preferences/src/browser/util/preference-event-service.ts
@@ -23,5 +23,5 @@ export class PreferencesEventService {
     onSearch = new Emitter<Preference.SearchQuery>();
     onEditorScroll = new Emitter<Preference.MouseScrollDetails>();
     onNavTreeSelection = new Emitter<Preference.SelectedTreeNode>();
-    onDisplayChanged = new Emitter<void>();
+    onDisplayChanged = new Emitter<boolean>();
 }

--- a/packages/preferences/src/browser/views/preference-editor-widget.tsx
+++ b/packages/preferences/src/browser/views/preference-editor-widget.tsx
@@ -60,7 +60,7 @@ export class PreferencesEditorWidget extends ReactWidget {
         this.preferenceValueRetrievalService.onPreferenceChanged((preferenceChange): void => {
             this.update();
         });
-        this.preferencesEventService.onDisplayChanged.event(() => this.handleChangeDisplay());
+        this.preferencesEventService.onDisplayChanged.event(didChangeTree => this.handleChangeDisplay(didChangeTree));
         this.preferencesEventService.onNavTreeSelection.event(e => this.scrollToEditorElement(e.nodeID));
         this.currentDisplay = this.preferenceTreeProvider.currentTree;
         this.properties = this.preferenceTreeProvider.propertyList;
@@ -98,11 +98,12 @@ export class PreferencesEditorWidget extends ReactWidget {
         );
     }
 
-    protected handleChangeDisplay = (): void => {
-        // This is here to avoid using the synthetic event asynchronously
-        this.currentDisplay = this.preferenceTreeProvider.currentTree;
-        this.properties = this.preferenceTreeProvider.propertyList;
-        this.node.scrollTop = 0;
+    protected handleChangeDisplay = (didGenerateNewTree: boolean): void => {
+        if (didGenerateNewTree) {
+            this.currentDisplay = this.preferenceTreeProvider.currentTree;
+            this.properties = this.preferenceTreeProvider.propertyList;
+            this.node.scrollTop = 0;
+        }
         this.update();
     };
 
@@ -180,7 +181,8 @@ export class PreferencesEditorWidget extends ReactWidget {
         if (nodeID) {
             const el = document.getElementById(`${nodeID}-editor`);
             if (el) {
-                el.scrollIntoView();
+                // Timeout to allow render cycle to finish.
+                setTimeout(() => el.scrollIntoView());
             }
         }
     }


### PR DESCRIPTION
Signed-off-by: Colin Grant <colin.grant@ericsson.com>

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

Fixes #7887 by limiting the regeneration of the tree to cases when the visibility of elements is affected (search, preference schema change, or scope change from User/Workspace <---> Folder). If tree is not regenerated, only displayed values are changed. If tree is regenerated, a check is made to see whether the formerly selected element is still visible, and if it is, it is scrolled into view.

In reviewing some of the widget code, I've also added a bit of handling for errors that shouldn't occur, but could conceivably occur.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

1. Open preferences in User scope
1. Select some element in the ToC
1. Make a preference change in the visible field.
1. Change to Workspace scope.
1. Observe that the value is updated, but that the refresh is nearly instantaneous.
1. Open a multi-root workspace, open preferences, and select a folder scope.
1. Do 2-5
1. Observe that after the scope change, a moment passes and then the tree is scrolled to the appropriate item.
1. Do the reverse (Workspace -> folder scope) and observe that, if the item is available in folder scope, it is scrolled to. Otherwise, the editor scrolls to top.

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

