### PR TITLE
GH-7767: Added context menu for input and textArea

### DIFF
--- a/packages/core/src/electron-browser/menu/electron-context-menu-renderer.ts
+++ b/packages/core/src/electron-browser/menu/electron-context-menu-renderer.ts
@@ -18,18 +18,58 @@
 
 import * as electron from 'electron';
 import { inject, injectable } from 'inversify';
-import { ContextMenuRenderer, RenderContextMenuOptions, ContextMenuAccess } from '../../browser';
+import { ContextMenuRenderer, RenderContextMenuOptions, ContextMenuAccess, FrontendApplicationContribution, CommonCommands } from '../../browser';
 import { ElectronMainMenuFactory } from './electron-main-menu-factory';
 import { ContextMenuContext } from '../../browser/menu/context-menu-context';
+import { MenuPath, MenuContribution, MenuModelRegistry } from '../../common';
 
 export class ElectronContextMenuAccess extends ContextMenuAccess {
-    constructor(
-        public readonly menu: electron.Menu
-    ) {
+    constructor(readonly menu: electron.Menu) {
         super({
             dispose: () => menu.closePopup()
         });
     }
+}
+
+export namespace ElectronTextInputContextMenu {
+    export const MENU_PATH: MenuPath = ['electron_text_input'];
+    export const UNDO_REDO_EDIT_GROUP = [...MENU_PATH, '0_undo_redo_group'];
+    export const EDIT_GROUP = [...MENU_PATH, '1_edit_group'];
+    export const SELECT_GROUP = [...MENU_PATH, '2_select_group'];
+}
+
+@injectable()
+export class ElectronTextInputContextMenuContribution implements FrontendApplicationContribution, MenuContribution {
+
+    @inject(ContextMenuRenderer)
+    protected readonly contextMenuRenderer: ContextMenuRenderer;
+
+    onStart(): void {
+        window.document.addEventListener('contextmenu', event => {
+            if (event.target instanceof HTMLElement) {
+                const target = <HTMLElement>event.target;
+                if (target.nodeName && (target.nodeName.toLowerCase() === 'input' || target.nodeName.toLowerCase() === 'textarea')) {
+                    event.preventDefault();
+                    event.stopPropagation();
+                    this.contextMenuRenderer.render({
+                        anchor: event,
+                        menuPath: ElectronTextInputContextMenu.MENU_PATH,
+                        onHide: () => target.focus()
+                    });
+                }
+            }
+        });
+    }
+
+    registerMenus(registry: MenuModelRegistry): void {
+        registry.registerMenuAction(ElectronTextInputContextMenu.UNDO_REDO_EDIT_GROUP, { commandId: CommonCommands.UNDO.id });
+        registry.registerMenuAction(ElectronTextInputContextMenu.UNDO_REDO_EDIT_GROUP, { commandId: CommonCommands.REDO.id });
+        registry.registerMenuAction(ElectronTextInputContextMenu.EDIT_GROUP, { commandId: CommonCommands.CUT.id });
+        registry.registerMenuAction(ElectronTextInputContextMenu.EDIT_GROUP, { commandId: CommonCommands.COPY.id });
+        registry.registerMenuAction(ElectronTextInputContextMenu.EDIT_GROUP, { commandId: CommonCommands.PASTE.id });
+        registry.registerMenuAction(ElectronTextInputContextMenu.SELECT_GROUP, { commandId: CommonCommands.SELECT_ALL.id });
+    }
+
 }
 
 @injectable()

--- a/packages/core/src/electron-browser/menu/electron-menu-module.ts
+++ b/packages/core/src/electron-browser/menu/electron-menu-module.ts
@@ -18,7 +18,7 @@ import { ContainerModule } from 'inversify';
 import { CommandContribution, MenuContribution } from '../../common';
 import { FrontendApplicationContribution, ContextMenuRenderer, KeybindingContribution, KeybindingContext } from '../../browser';
 import { ElectronMainMenuFactory } from './electron-main-menu-factory';
-import { ElectronContextMenuRenderer } from './electron-context-menu-renderer';
+import { ElectronContextMenuRenderer, ElectronTextInputContextMenuContribution } from './electron-context-menu-renderer';
 import { ElectronMenuContribution } from './electron-menu-contribution';
 
 export default new ContainerModule(bind => {
@@ -33,4 +33,6 @@ export default new ContainerModule(bind => {
     for (const serviceIdentifier of [FrontendApplicationContribution, KeybindingContribution, CommandContribution, MenuContribution]) {
         bind(serviceIdentifier).toService(ElectronMenuContribution);
     }
+    bind(FrontendApplicationContribution).to(ElectronTextInputContextMenuContribution).inSingletonScope();
+    bind(MenuContribution).to(ElectronTextInputContextMenuContribution).inSingletonScope();
 });


### PR DESCRIPTION
Closes #7767.

Signed-off-by: Akos Kitta <kittaakos@typefox.io>

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

Enables the context menu in `input` and `textArea` elements. For electron only.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
 - You can see the context menu for `input` and `textArea`,
 - You can `Select All`, `Cut`, `Copy`, and `Paste`.

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

Please keep in mind, that the input value will be automatically selected, so when you paste, the original value will be replaced. See here: https://github.com/microsoft/vscode/issues/99126#issuecomment-638216795, I was confused by the `SCM` "input" for instance, but that's a monaco editor eventually.
