### PR TITLE
vsx: set the extensions-view as a default view

### DIFF
--- a/packages/vsx-registry/src/browser/vsx-extensions-contribution.ts
+++ b/packages/vsx-registry/src/browser/vsx-extensions-contribution.ts
@@ -23,6 +23,7 @@ import { VSXExtensionsModel } from './vsx-extensions-model';
 import { ColorContribution } from '@theia/core/lib/browser/color-application-contribution';
 import { ColorRegistry, Color } from '@theia/core/lib/browser/color-registry';
 import { TabBarToolbarContribution, TabBarToolbarRegistry } from '@theia/core/lib/browser/shell/tab-bar-toolbar';
+import { FrontendApplicationContribution, FrontendApplication } from '@theia/core/lib/browser/frontend-application';
 
 export namespace VSXExtensionsCommands {
     export const CLEAR_ALL: Command = {
@@ -34,7 +35,8 @@ export namespace VSXExtensionsCommands {
 }
 
 @injectable()
-export class VSXExtensionsContribution extends AbstractViewContribution<VSXExtensionsViewContainer> implements ColorContribution, TabBarToolbarContribution {
+export class VSXExtensionsContribution extends AbstractViewContribution<VSXExtensionsViewContainer>
+    implements ColorContribution, FrontendApplicationContribution, TabBarToolbarContribution {
 
     @inject(VSXExtensionsModel)
     protected readonly model: VSXExtensionsModel;
@@ -50,6 +52,10 @@ export class VSXExtensionsContribution extends AbstractViewContribution<VSXExten
             toggleCommandId: 'vsxExtensions.toggle',
             toggleKeybinding: 'ctrlcmd+shift+x'
         });
+    }
+
+    async initializeLayout(app: FrontendApplication): Promise<void> {
+        await this.openView({ activate: false });
     }
 
     registerCommands(commands: CommandRegistry): void {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

The following commit adds the `extensions` view (open-vsx) as part of the default widgets present when the application is started.

<div align='center'>

![Screenshot from 2020-06-02 15-55-35](https://user-images.githubusercontent.com/40359487/83563967-f43a0600-a4e9-11ea-86b1-c5f26c2c0e8d.png)

</div>

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

1. start the application, the extensions-view should be present on the sidepanel
2. execute `View: Reset Workbench Layout`
3. verify that the extensions-view is present on the sidepanel

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

Signed-off-by: vince-fugnitto <vincent.fugnitto@ericsson.com>
