### PR TITLE
Autofix: upgrade-nvm-tools & trailing-spaces

### DIFF
--- a/.gitpod.dockerfile
+++ b/.gitpod.dockerfile
@@ -14,7 +14,7 @@ RUN sudo apt-get update \
     && sudo rm -rf /var/lib/apt/lists/*
 
 # Pin Node.js to v10.
-ENV NODE_VERSION="10.19.0"
+ENV NODE_VERSION="10.21.0"
 RUN bash -c ". .nvm/nvm.sh \
     && nvm install $NODE_VERSION \
     && nvm use $NODE_VERSION \

--- a/.theia/settings.json
+++ b/.theia/settings.json
@@ -11,5 +11,5 @@
     "editor.tabSize": 2
   },
   "typescript.tsdk": "node_modules/typescript/lib",
-  "clang-format.language.typescript.enable": false    
+  "clang-format.language.typescript.enable": false
 }

--- a/LICENSE
+++ b/LICENSE
@@ -266,8 +266,8 @@ with the GNU Classpath Exception which is available at https://www.gnu.org/softw
 
     Exhibit A - Form of Secondary Licenses Notice
 
-    "This Source Code may also be made available under the following 
-    Secondary Licenses when the conditions for such availability set forth 
+    "This Source Code may also be made available under the following
+    Secondary Licenses when the conditions for such availability set forth
     in the Eclipse Public License, v. 2.0 are satisfied: {name license(s),
     version(s), and exceptions or additional permissions here}."
 

--- a/NOTICE.md
+++ b/NOTICE.md
@@ -99,7 +99,7 @@ electron@2.0.14 (2.0.14)
 * License: MIT AND BSD-2-Clause AND Apache-2.0 AND (AFL-2.1 OR BSD-3-Clause)
    AND BSD-3-Clause AND ISC AND X11 AND Public-Domain AND (GPL-2.0 OR MIT) AND
    Unlicense AND IJG AND ICU AND UNICODE-TOU AND NTP AND (MIT OR BSD-3-Clause)
-   AND Libpng AND MPL-2.0 AND LGPL-2.1+ 
+   AND Libpng AND MPL-2.0 AND LGPL-2.1+
 * Project: https://github.com/electron/electron
 * Source: https://github.com/electron/electron/releases/tag/v2.0.14
 
@@ -316,7 +316,7 @@ permitted.
 
 NOTICE:
 
-Please note Electron combines Chromium and Node.js into a single runtime. 
+Please note Electron combines Chromium and Node.js into a single runtime.
 While Electron, Chromium and Node.js are generally licensed under very
 permissive MIT and BSD-3-Clause licenses, both Electron and Chromium distribute
 FFmpeg.  While FFmpeg is under the LGPL-2.1-or-later license it incorporates

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 <div id="badges" align="center">
 
-  [![Gitpod Ready-to-Code](https://img.shields.io/badge/Gitpod-Ready--to--Code-blue?logo=gitpod)](https://gitpod.io/#https://github.com/eclipse-theia/theia) 
+  [![Gitpod Ready-to-Code](https://img.shields.io/badge/Gitpod-Ready--to--Code-blue?logo=gitpod)](https://gitpod.io/#https://github.com/eclipse-theia/theia)
   [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg?style=flat-curved)](https://github.com/eclipse-theia/theia/labels/help%20wanted)
   [![Spectrum](https://img.shields.io/badge/Chat-on%20Spectrum-blue.svg)](https://spectrum.chat/theia)
   [![Build Status](https://travis-ci.com/eclipse-theia/theia.svg?branch=master)](https://travis-ci.com/eclipse-theia/theia)

--- a/dev-packages/electron/native/src/linux-ffmpeg.c
+++ b/dev-packages/electron/native/src/linux-ffmpeg.c
@@ -30,7 +30,7 @@ char *load_ffmpeg_library(struct FFMPEG_Library *library, char *library_path)
     {
         goto error;
     }
-   
+
     struct AVCodecDescriptor *(*avcodec_descriptor_next)(const struct AVCodecDescriptor *) = dlsym(handle, "avcodec_descriptor_next");
     error = dlerror();
     if (error != NULL)

--- a/dev-packages/ext-scripts/README.md
+++ b/dev-packages/ext-scripts/README.md
@@ -1,6 +1,6 @@
 # Shared NPM script for Theia packages.
 
-`theiaext` is a command line tool to run shared npm scripts in Theia packages. 
+`theiaext` is a command line tool to run shared npm scripts in Theia packages.
 
 For instance, if you want add a new `hello` script that prints `Hello World`:
 

--- a/doc/api-management.md
+++ b/doc/api-management.md
@@ -60,7 +60,7 @@ export interface StableInterface {
 
     /**
      * Adding new API to stable API should be explicit.
-     * 
+     *
      * @since 1.1.0
      * @experimental
      */
@@ -111,14 +111,14 @@ It ensures control of API for such adopters and reduces the API surface of the f
 If APIs are based on design decisions that are subject to change, then
 one could postpone finalization before such decisions are resolved.
 
-> Why? Some design decisions are only temporarily subject to change, for instance, 
-which layout framework should be used. After it is resolved, 
+> Why? Some design decisions are only temporarily subject to change, for instance,
+which layout framework should be used. After it is resolved,
 such a design decision becomes fundamental, cannot be changed, and can be adopted.
 
 If it is not possible, then APIs should be refactored to hide such assumptions.
 
-> Why? Some design decisions are changeable by nature, for instance, for the LSP, 
-kind of symbols of a concrete language. In such a case, 
+> Why? Some design decisions are changeable by nature, for instance, for the LSP,
+kind of symbols of a concrete language. In such a case,
 API should be changed to operate abstract symbol data type to hide concrete symbols.
 
 If sufficient adoption and API stability are established,

--- a/doc/api-testing.md
+++ b/doc/api-testing.md
@@ -142,7 +142,7 @@ only when the application is ready, workspace is initialized and all preferences
 
 Since tests are executed within the same process,
 each test suite should take care to bring the application in the proper state.
-For instance, an example test awaits when all editors are closed before testing the open function. 
+For instance, an example test awaits when all editors are closed before testing the open function.
 
 ## Running tests
 

--- a/packages/core/scripts/generate-layout.js
+++ b/packages/core/scripts/generate-layout.js
@@ -30,11 +30,11 @@ const electron = require('electron');
  * --all           Include all keys in the output, not only the relevant ones.
  * --pretty        Pretty-print the JSON output.
  * --output file   Write the output to the given file instead of stdout.
- * 
+ *
  * Hint: keyboard layouts are stored in packages/core/src/common/keyboard/layouts
  * and have the following file name scheme:
  *     <language>-<name>-<hardware>.json
- * 
+ *
  * <language>      A language subtag according to IETF BCP 47
  * <name>          Display name of the keyboard layout (without dashes)
  * <hardware>      `pc` or `mac`

--- a/packages/core/src/browser/style/materialcolors.css
+++ b/packages/core/src/browser/style/materialcolors.css
@@ -2,7 +2,7 @@
  * google-material-color v1.2.6
  * https://github.com/danlevan/google-material-color
  */
-:root { 
+:root {
   --md-red-50: #FFEBEE;
   --md-red-100: #FFCDD2;
   --md-red-200: #EF9A9A;

--- a/packages/core/src/browser/style/search-box.css
+++ b/packages/core/src/browser/style/search-box.css
@@ -26,14 +26,14 @@
     z-index: calc(var(--theia-tabbar-toolbar-z-index) + 1);
     border: var(--theia-border-width) solid var(--theia-editor-background);
 }
-  
+
 .theia-search-input {
     flex-grow: 1;
     line-height: calc(var(--theia-private-horizontal-tab-height) * 0.8);
     max-width: 6rem;
     background-color: var(--theia-input-background);
 }
-  
+
 .theia-search-button {
     min-width: 1rem;
     text-align: center;
@@ -57,7 +57,7 @@
 .theia-search-button-next:hover:before {
     content: "\f107";
 }
-  
+
 .theia-search-button-previous:before {
     content: "\f106";
 }
@@ -65,7 +65,7 @@
 .theia-search-button-previous:hover:before {
     content: "\f106";
 }
-  
+
 .theia-search-button-close:before {
     content: "\f00d";
  }

--- a/packages/core/src/browser/style/tabs.css
+++ b/packages/core/src/browser/style/tabs.css
@@ -112,7 +112,7 @@ body.theia-editor-highlightModifiedTabs
     border-bottom: 1px solid var(--theia-tab-unfocusedActiveBorder);
 }
 
-/* inactive tab in an unfocused group */ 
+/* inactive tab in an unfocused group */
 body.theia-editor-highlightModifiedTabs
 #theia-main-content-panel .p-TabBar .p-TabBar-tab:not(.p-mod-current):not(.theia-mod-active).theia-mod-dirty {
     border-top: 1px solid var(--theia-tab-unfocusedInactiveModifiedBorder);

--- a/packages/debug/src/browser/style/index.css
+++ b/packages/debug/src/browser/style/index.css
@@ -348,7 +348,7 @@
     height: 324px;
     border: 1px solid var(--theia-editorHoverWidget-border);
     background: var(--theia-editorHoverWidget-background);
-    /* TODO color: var(--theia-editorHoverWidget-foreground); with a newer Monaco version */ 
+    /* TODO color: var(--theia-editorHoverWidget-foreground); with a newer Monaco version */
     color: var(--theia-editorWidget-foreground);
 }
 

--- a/packages/filesystem/src/browser/style/file-dialog.css
+++ b/packages/filesystem/src/browser/style/file-dialog.css
@@ -117,7 +117,7 @@
 
 .dialogContent .theia-FileTreeFiltersList {
     width: 427px;
-    height: 21px;    
+    height: 21px;
 }
 
 /*

--- a/packages/filesystem/src/browser/style/index.css
+++ b/packages/filesystem/src/browser/style/index.css
@@ -30,6 +30,6 @@
 
   background: var(--theia-list-activeSelectionBackground);
   color: var(--theia-list-activeSelectionForeground);
-  outline: 1px solid var(--theia-contrastActiveBorder); 
+  outline: 1px solid var(--theia-contrastActiveBorder);
   outline-offset: -1px;
 }

--- a/packages/keymaps/src/browser/style/index.css
+++ b/packages/keymaps/src/browser/style/index.css
@@ -70,7 +70,7 @@
     padding: 2px 10px 5px 10px;
 }
 
-.th-label, .th-source, .th-context, .th-keybinding, 
+.th-label, .th-source, .th-context, .th-keybinding,
 .kb-label, .kb-source, .kb-context {
     padding: 2px 10px 5px 10px;
     min-height: 18px;

--- a/packages/monaco/src/browser/style/index.css
+++ b/packages/monaco/src/browser/style/index.css
@@ -59,7 +59,7 @@
 /* List highlight, see https://github.com/microsoft/vscode/blob/ff5f581425da6230b6f9216ecf19abf6c9d285a6/src/vs/workbench/browser/style.ts#L50 */
 .monaco-tree .monaco-tree-row .monaco-highlighted-label .highlight,
 .monaco-list .monaco-list-row .monaco-highlighted-label .highlight {
-	color: var(--theia-list-highlightForeground) !important; 
+	color: var(--theia-list-highlightForeground) !important;
 }
 
 /* Scrollbars, see https://github.com/microsoft/vscode/blob/ff5f581425da6230b6f9216ecf19abf6c9d285a6/src/vs/workbench/browser/style.ts#L65 */

--- a/packages/plugin-ext/src/main/browser/style/index.css
+++ b/packages/plugin-ext/src/main/browser/style/index.css
@@ -75,7 +75,7 @@
     width: var(--theia-private-sidebar-icon-size) !important;
     height: var(--theia-private-sidebar-icon-size) !important;
     background-size: var(--theia-private-sidebar-icon-size) !important;
-    font-size: var(--theia-private-sidebar-icon-size) !important;	
+    font-size: var(--theia-private-sidebar-icon-size) !important;
 }
 
 

--- a/packages/workspace/README.md
+++ b/packages/workspace/README.md
@@ -12,7 +12,7 @@
 
 ## Description
 
-The `@theia/workspace` extension provides functionality and services to handle workspaces (projects) within the application. 
+The `@theia/workspace` extension provides functionality and services to handle workspaces (projects) within the application.
 
 ## Additional Information
 


### PR DESCRIPTION
#### What it does

Uses [`npx autofix`](https://github.com/autofix-dev/autofix) to fix small issues, like upgrading version strings and removing trailing spaces.

Supersedes #7923 and #7924.

For the Node.js version bump, see also: https://twitter.com/liran_tal/status/1267519052731289600

#### How to test

Fixes should be small enough to not cause any breakage. The `.gitpod.dockerfile` change can be tested by [opening this Pull Request in Gitpod](https://gitpod.io/from-referrer/).

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

