### PR TITLE
GH-7948: Fixed incorrect handler enablement logic.

### DIFF
--- a/packages/output/src/browser/output-contribution.ts
+++ b/packages/output/src/browser/output-contribution.ts
@@ -122,8 +122,8 @@ export class OutputContribution extends AbstractViewContribution<OutputWidget> i
     registerCommands(registry: CommandRegistry): void {
         super.registerCommands(registry);
         registry.registerCommand(OutputCommands.CLEAR__WIDGET, {
-            isEnabled: () => this.withWidget(),
-            isVisible: () => this.withWidget(),
+            isEnabled: widget => this.withWidget(widget),
+            isVisible: widget => this.withWidget(widget),
             execute: () => this.widget.then(widget => widget.clear())
         });
         registry.registerCommand(OutputCommands.LOCK__WIDGET, {
@@ -167,7 +167,7 @@ export class OutputContribution extends AbstractViewContribution<OutputWidget> i
     }
 
     protected withWidget(
-        widget: Widget | undefined = this.tryGetWidget(),
+        widget: Widget | undefined,
         predicate: (output: OutputWidget) => boolean = () => true
     ): boolean | false {
 


### PR DESCRIPTION
Closes #7948.

Signed-off-by: Akos Kitta <kittaakos@typefox.io>

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

It fixes the incorrect `isVisible/isEnable` handler logic of one of the Output commands.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
 - You cannot see duplicate `Clear` actions in the Git view, you cannot see `Clear`  action in the Explorer,
 - You can see the `Clear` action in the Output view, you can clean the output content in the `my test channel`

#### Review checklist

- [ ] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

