### PR TITLE
Prevent serialization of phosphor widgets when command calls from plugin

### DIFF
--- a/packages/plugin-ext/package.json
+++ b/packages/plugin-ext/package.json
@@ -5,6 +5,7 @@
   "main": "lib/common/index.js",
   "typings": "lib/common/index.d.ts",
   "dependencies": {
+    "@phosphor/widgets": "^1.9.3",
     "@theia/callhierarchy": "^1.2.0",
     "@theia/core": "^1.2.0",
     "@theia/debug": "^1.2.0",

--- a/packages/plugin-ext/src/main/browser/command-registry-main.ts
+++ b/packages/plugin-ext/src/main/browser/command-registry-main.ts
@@ -22,6 +22,7 @@ import { CommandRegistryMain, CommandRegistryExt, MAIN_RPC_CONTEXT } from '../..
 import { RPCProtocol } from '../../common/rpc-protocol';
 import { KeybindingRegistry } from '@theia/core/lib/browser';
 import { PluginContributionHandler } from './plugin-contribution-handler';
+import { Widget } from '@phosphor/widgets';
 
 export class CommandRegistryMainImpl implements CommandRegistryMain, Disposable {
     private readonly proxy: CommandRegistryExt;
@@ -77,7 +78,13 @@ export class CommandRegistryMainImpl implements CommandRegistryMain, Disposable 
             throw new Error(`Command with id '${id}' is not registered.`);
         }
         try {
-            return await this.delegate.executeCommand(id, ...args);
+            const result: T | undefined = await this.delegate.executeCommand(id, ...args);
+
+            if (result !== undefined && result instanceof Widget) {
+                return undefined;
+            }
+
+            return result;
         } catch (e) {
             // Command handler may be not active at the moment so the error must be caught. See https://github.com/eclipse-theia/theia/pull/6687#discussion_r354810079
             if ('code' in e && e['code'] === 'NO_ACTIVE_HANDLER') {


### PR DESCRIPTION
#### What it does
This changes proposal adds a check for return value after command been executed from third-party plugin.

The initial problem steps to reproduce:

1. Call from third-party plugin internal command, which returns a widget, e.g. `workbench.files.action.focusFilesExplorer`
[packages/plugin-ext/src/main/browser/command-registry-main.ts#L80](https://github.com/eclipse-theia/theia/blob/master/packages/plugin-ext/src/main/browser/command-registry-main.ts#L80)
2. Executes command which returns a widget:
[packages/navigator/src/browser/navigator-contribution.ts#L241](https://github.com/eclipse-theia/theia/blob/master/packages/navigator/src/browser/navigator-contribution.ts#L241)
3. Phosphor widget tries to be serialized into JSON, to be provided into plugin, but JSON serializer catch exception with message: `TypeError: Converting circular structure to JSON`

We need to check return type of the value that is executed and if there is a phosphor widget, return undefined. Anyway, there is no need to pass the whole widget into plugin as callback value.

Fixes issue: https://github.com/eclipse-theia/theia/issues/7853

Signed-off-by: Vladyslav Zhukovskyi <vzhukovs@redhat.com>

#### How to test
This can be reached by using test plugin, located [here](https://github.com/vzhukovskii/workbench-files-action-focusFilesExplorer).

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

