### PR TITLE
Support ordering of sub menus

### DIFF
--- a/examples/api-samples/src/browser/api-samples-frontend-module.ts
+++ b/examples/api-samples/src/browser/api-samples-frontend-module.ts
@@ -18,9 +18,11 @@ import { ContainerModule } from 'inversify';
 import { bindDynamicLabelProvider } from './label/sample-dynamic-label-provider-command-contribution';
 import { bindSampleUnclosableView } from './view/sample-unclosable-view-contribution';
 import { bindSampleOutputChannelWithSeverity } from './output/sample-output-channel-with-severity';
+import { bindSampleMenu } from './menu/sample-menu-contribution';
 
 export default new ContainerModule(bind => {
     bindDynamicLabelProvider(bind);
     bindSampleUnclosableView(bind);
     bindSampleOutputChannelWithSeverity(bind);
+    bindSampleMenu(bind);
 });

--- a/examples/api-samples/src/browser/menu/sample-menu-contribution.ts
+++ b/examples/api-samples/src/browser/menu/sample-menu-contribution.ts
@@ -1,0 +1,53 @@
+/********************************************************************************
+ * Copyright (C) 2020 TORO Limited and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import { Command, CommandContribution, CommandRegistry, MAIN_MENU_BAR, MenuContribution, MenuModelRegistry } from '@theia/core/lib/common';
+import { injectable, interfaces } from 'inversify';
+
+const SampleCommand: Command = {
+    id: 'sample-command',
+    label: 'Sample Command'
+};
+
+@injectable()
+export class SampleCommandContribution implements CommandContribution {
+    registerCommands(commands: CommandRegistry): void {
+        commands.registerCommand(SampleCommand, {
+            execute: () => {
+                alert('This is a sample command!');
+            }
+        });
+    }
+
+}
+
+@injectable()
+export class SampleMenuContribution implements MenuContribution {
+    registerMenus(menus: MenuModelRegistry): void {
+        const subMenuPath = [...MAIN_MENU_BAR, 'sample-menu'];
+        menus.registerSubmenu(subMenuPath, 'Sample Menu', {
+            order: '2' // that should put the menu right next to the File menu
+        });
+        menus.registerMenuAction(subMenuPath, {
+            commandId: SampleCommand.id
+        });
+    }
+}
+
+export const bindSampleMenu = (bind: interfaces.Bind) => {
+    bind(CommandContribution).to(SampleCommandContribution).inSingletonScope();
+    bind(MenuContribution).to(SampleMenuContribution).inSingletonScope();
+};

--- a/packages/core/src/common/menu.ts
+++ b/packages/core/src/common/menu.ts
@@ -41,7 +41,8 @@ export namespace MenuAction {
 }
 
 export interface SubMenuOptions {
-    iconClass: string
+    iconClass?: string
+    order?: string
 }
 
 export type MenuPath = string[];
@@ -93,7 +94,7 @@ export class MenuModelRegistry {
         const parent = this.findGroup(groupPath);
         let groupNode = this.findSubMenu(parent, menuId);
         if (!groupNode) {
-            groupNode = new CompositeMenuNode(menuId, label, options ? options.iconClass : undefined);
+            groupNode = new CompositeMenuNode(menuId, label, options);
             return parent.addNode(groupNode);
         } else {
             if (!groupNode.label) {
@@ -101,8 +102,13 @@ export class MenuModelRegistry {
             } else if (groupNode.label !== label) {
                 throw new Error("The group '" + menuPath.join('/') + "' already has a different label.");
             }
-            if (!groupNode.iconClass && options) {
-                groupNode.iconClass = options.iconClass;
+            if (options) {
+                if (!groupNode.iconClass) {
+                    groupNode.iconClass = options.iconClass;
+                }
+                if (!groupNode.order) {
+                    groupNode.order = options.order;
+                }
             }
             return { dispose: () => { } };
         }
@@ -187,11 +193,19 @@ export interface MenuNode {
 
 export class CompositeMenuNode implements MenuNode {
     protected readonly _children: MenuNode[] = [];
+    public iconClass?: string;
+    public order?: string;
+
     constructor(
         public readonly id: string,
         public label?: string,
-        public iconClass?: string
-    ) { }
+        options?: SubMenuOptions
+    ) {
+        if (options) {
+            this.iconClass = options.iconClass;
+            this.order = options.order;
+        }
+    }
 
     get children(): ReadonlyArray<MenuNode> {
         return this._children;
@@ -236,7 +250,7 @@ export class CompositeMenuNode implements MenuNode {
     }
 
     get sortString(): string {
-        return this.id;
+        return this.order || this.id;
     }
 
     get isSubmenu(): boolean {


### PR DESCRIPTION
#### What it does
Fixes #7958.
This PR adds the `order` property to the `SubMenuOptions` interface used when registering sub menus. The `order` property is used to sort the sub menus with the menu actions.

Note that this also allows reordering of existing sub menus like this:
```ts
menus.registerSubmenu(CommonMenus.File, 'File', {
    order: 'z'
})
```

#### How to test
I added a sample file for that called `examples/api-samples/src/browser/menu/sample-menu-contribution.ts`. This contributes a `Sample Menu` to the menu bar with `order` value `'2'` which should place it right next to the `File` menu.

![image](https://user-images.githubusercontent.com/6960133/83771874-5004ba80-a6b5-11ea-8254-7841944a8e22.png)


#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

