### PR TITLE
electron: use inversify in main process

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## v1.5.0
 
+<a name="1_5_0_electron_main_extension"></a>
+- [[electron]](#1_5_0_electron_main_extension) Electron applications can now be configured/extended through `inversify`. Added new `electronMain` extension points to provide inversify container modules. [#8076](https://github.com/eclipse-theia/theia/pull/8076)
+
 <a name="breaking_changes_1.5.0">[Breaking Changes:](#breaking_changes_1.5.0)</a>
 
 - [application-package] removed `isOutdated` from `ExtensionPackage` [#8295](https://github.com/eclipse-theia/theia/pull/8295)
@@ -21,6 +24,8 @@
 <a name="1.5.0_root_user_storage_uri"></a>
 - [[user-storage]](#1.5.0_root_user_storage_uri) settings URI must start with `/user` root to satisfy expectations of `FileService` []()
   - If you implement a custom user storage make sure to check old relative locations, otherwise it can cause user data loss.
+<a name="1_5_0_electron_window_options_ipc">
+- [[electron]](#1_5_0_electron_window_options_ipc) Removed the `set-window-options` and `get-persisted-window-options-additions` Electron IPC handlers from the Electron Main process.
 
 ## v1.4.0
 

--- a/dev-packages/application-manager/src/generator/abstract-generator.ts
+++ b/dev-packages/application-manager/src/generator/abstract-generator.ts
@@ -48,6 +48,10 @@ export abstract class AbstractGenerator {
         return this.compileModuleImports(modules, 'require');
     }
 
+    protected compileElectronMainModuleImports(modules?: Map<string, string>): string {
+        return modules && this.compileModuleImports(modules, 'require') || '';
+    }
+
     protected compileModuleImports(modules: Map<string, string>, fn: 'import' | 'require'): string {
         if (modules.size === 0) {
             return '';

--- a/dev-packages/application-manager/src/generator/frontend-generator.ts
+++ b/dev-packages/application-manager/src/generator/frontend-generator.ts
@@ -26,7 +26,8 @@ export class FrontendGenerator extends AbstractGenerator {
         await this.write(this.pck.frontend('index.html'), this.compileIndexHtml(frontendModules));
         await this.write(this.pck.frontend('index.js'), this.compileIndexJs(frontendModules));
         if (this.pck.isElectron()) {
-            await this.write(this.pck.frontend('electron-main.js'), this.compileElectronMain());
+            const electronMainModules = this.pck.targetElectronMainModules;
+            await this.write(this.pck.frontend('electron-main.js'), this.compileElectronMain(electronMainModules));
         }
     }
 
@@ -112,8 +113,10 @@ module.exports = Promise.resolve()${this.compileFrontendModuleImports(frontendMo
     });`;
     }
 
-    protected compileElectronMain(): string {
+    protected compileElectronMain(electronMainModules?: Map<string, string>): string {
         return `// @ts-check
+
+require('reflect-metadata');
 
 // Useful for Electron/NW.js apps as GUI apps on macOS doesn't inherit the \`$PATH\` define
 // in your dotfiles (.bashrc/.bash_profile/.zshrc/etc).
@@ -130,18 +133,14 @@ if (process.env.LC_ALL) {
 }
 process.env.LC_NUMERIC = 'C';
 
-const { v4 } = require('uuid');
-const electron = require('electron');
-const { join, resolve } = require('path');
-const { fork } = require('child_process');
-const { app, dialog, shell, BrowserWindow, ipcMain, Menu, globalShortcut } = electron;
-const { ElectronSecurityToken } = require('@theia/core/lib/electron-common/electron-token');
+const { default: electronMainApplicationModule } = require('@theia/core/lib/electron-main/electron-main-application-module');
+const { ElectronMainApplication, ElectronMainApplicationGlobals } = require('@theia/core/lib/electron-main/electron-main-application');
+const { Container } = require('inversify');
+const { resolve } = require('path');
+const { app } = require('electron');
 
-const applicationName = \`${this.pck.props.frontend.config.applicationName}\`;
+const config = ${this.prettyStringify(this.pck.props.frontend.config)};
 const isSingleInstance = ${this.pck.props.backend.config.singleInstance === true ? 'true' : 'false'};
-const disallowReloadKeybinding = ${this.pck.props.frontend.config.electron?.disallowReloadKeybinding === true ? 'true' : 'false'};
-const defaultWindowOptionsAdditions = ${this.prettyStringify(this.pck.props.frontend.config.electron?.windowOptions || {})};
-
 
 if (isSingleInstance && !app.requestSingleInstanceLock()) {
     // There is another instance running, exit now. The other instance will request focus.
@@ -149,249 +148,32 @@ if (isSingleInstance && !app.requestSingleInstanceLock()) {
     return;
 }
 
-const nativeKeymap = require('native-keymap');
-const Storage = require('electron-store');
-const electronStore = new Storage();
-
-const electronSecurityToken = {
-    value: v4(),
-};
-
-// Make it easy for renderer process to fetch the ElectronSecurityToken:
-global[ElectronSecurityToken] = electronSecurityToken;
-
-app.on('ready', () => {
-
-    // Explicitly set the app name to have better menu items on macOS. ("About", "Hide", and "Quit")
-    // See: https://github.com/electron-userland/electron-builder/issues/2468
-    app.setName(applicationName);
-
-    const { screen } = electron;
-
-    // Remove the default electron menus, waiting for the application to set its own.
-    Menu.setApplicationMenu(Menu.buildFromTemplate([{
-        role: 'help', submenu: [{ role: 'toggleDevTools' }]
-    }]));
-
-    function createNewWindow(theUrl) {
-
-        // We must center by hand because \`browserWindow.center()\` fails on multi-screen setups
-        // See: https://github.com/electron/electron/issues/3490
-        const { bounds } = screen.getDisplayNearestPoint(screen.getCursorScreenPoint());
-        const height = Math.floor(bounds.height * (2/3));
-        const width = Math.floor(bounds.width * (2/3));
-
-        const y = Math.floor(bounds.y + (bounds.height - height) / 2);
-        const x = Math.floor(bounds.x + (bounds.width - width) / 2);
-
-        const WINDOW_STATE = 'windowstate';
-        const windowState = electronStore.get(WINDOW_STATE, {
-            width, height, x, y
-        });
-
-        const persistedWindowOptionsAdditions = electronStore.get('windowOptions', {});
-
-        const windowOptionsAdditions = {
-            ...defaultWindowOptionsAdditions,
-            ...persistedWindowOptionsAdditions
-        };
-
-        let windowOptions = {
-            show: false,
-            title: applicationName,
-            width: windowState.width,
-            height: windowState.height,
-            minWidth: 200,
-            minHeight: 120,
-            x: windowState.x,
-            y: windowState.y,
-            isMaximized: windowState.isMaximized,
-            ...windowOptionsAdditions,
-            webPreferences: {
-                nodeIntegration: true
-            }
-        };
-
-        // Always hide the window, we will show the window when it is ready to be shown in any case.
-        const newWindow = new BrowserWindow(windowOptions);
-        if (windowOptions.isMaximized) {
-            newWindow.maximize();
-        }
-        newWindow.on('ready-to-show', () => newWindow.show());
-        if (disallowReloadKeybinding) {
-            newWindow.on('focus', event => {
-                for (const accelerator of ['CmdOrCtrl+R','F5']) {
-                    globalShortcut.register(accelerator, () => {});
-                }
-            });
-            newWindow.on('blur', event => globalShortcut.unregisterAll());
-        }
-
-        // Prevent calls to "window.open" from opening an ElectronBrowser window,
-        // and rather open in the OS default web browser.
-        newWindow.webContents.on('new-window', (event, url) => {
-            event.preventDefault();
-            shell.openExternal(url);
-        });
-
-        // Save the window geometry state on every change
-        const saveWindowState = () => {
-            try {
-                let bounds;
-                if (newWindow.isMaximized()) {
-                    bounds = electronStore.get(WINDOW_STATE, {});
-                } else {
-                    bounds = newWindow.getBounds();
-                }
-                electronStore.set(WINDOW_STATE, {
-                    isMaximized: newWindow.isMaximized(),
-                    width: bounds.width,
-                    height: bounds.height,
-                    x: bounds.x,
-                    y: bounds.y
-                });
-            } catch (e) {
-                console.error("Error while saving window state.", e);
-            }
-        };
-        let delayedSaveTimeout;
-        const saveWindowStateDelayed = () => {
-            if (delayedSaveTimeout) {
-                clearTimeout(delayedSaveTimeout);
-            }
-            delayedSaveTimeout = setTimeout(saveWindowState, 1000);
-        };
-        newWindow.on('close', saveWindowState);
-        newWindow.on('resize', saveWindowStateDelayed);
-        newWindow.on('move', saveWindowStateDelayed);
-
-        // Fired when a beforeunload handler tries to prevent the page unloading
-        newWindow.webContents.on('will-prevent-unload', async event => {
-            const { response } = await dialog.showMessageBox(newWindow, {
-                type: 'question',
-                buttons: ['Yes', 'No'],
-                title: 'Confirm',
-                message: 'Are you sure you want to quit?',
-                detail: 'Any unsaved changes will not be saved.'
-            });
-            if (response === 0) { // 'Yes'
-                // This ignores the beforeunload callback, allowing the page to unload
-                event.preventDefault();
-            }
-        });
-
-        // Notify the renderer process on keyboard layout change
-        nativeKeymap.onDidChangeKeyboardLayout(() => {
-            if (!newWindow.isDestroyed()) {
-                const newLayout = {
-                    info: nativeKeymap.getCurrentKeyboardLayout(),
-                    mapping: nativeKeymap.getKeyMap()
-                };
-                newWindow.webContents.send('keyboardLayoutChanged', newLayout);
-            }
-        });
-
-        if (!!theUrl) {
-            newWindow.loadURL(theUrl);
-        }
-        return newWindow;
-    }
-
-    app.on('window-all-closed', () => {
-        app.quit();
-    });
-    ipcMain.on('create-new-window', (event, url) => {
-        createNewWindow(url);
-    });
-    ipcMain.on('open-external', (event, url) => {
-        shell.openExternal(url);
-    });
-    ipcMain.on('set-window-options', (event, options) => {
-        electronStore.set('windowOptions', options);
-    });
-    ipcMain.on('get-persisted-window-options-additions', event => {
-        event.returnValue = electronStore.get('windowOptions', {});
-    });
-
-    // Check whether we are in bundled application or development mode.
-    // @ts-ignore
-    const devMode = process.defaultApp || /node_modules[\/]electron[\/]/.test(process.execPath);
-    // Check if we should run everything as one process.
-    const noBackendFork = process.argv.includes('--no-cluster');
-    const mainWindow = createNewWindow();
-
-    if (isSingleInstance) {
-        app.on('second-instance', (event, commandLine, workingDirectory) => {
-            // Someone tried to run a second instance, we should focus our window.
-            if (mainWindow && !mainWindow.isDestroyed()) {
-                if (mainWindow.isMinimized()) {
-                    mainWindow.restore();
-                }
-                mainWindow.focus()
-            }
-        })
-    }
-
-    const setElectronSecurityToken = async port => {
-        await electron.session.defaultSession.cookies.set({
-            url: \`http://localhost:\${port}/\`,
-            name: ElectronSecurityToken,
-            value: JSON.stringify(electronSecurityToken),
-            httpOnly: true
-        });
-    };
-
-    const loadMainWindow = port => {
-        if (!mainWindow.isDestroyed()) {
-            mainWindow.loadURL('file://' + join(__dirname, '../../lib/index.html') + '?port=' + port);
-        }
-    };
-
-    // We cannot use the \`process.cwd()\` as the application project path (the location of the \`package.json\` in other words)
-    // in a bundled electron application because it depends on the way we start it. For instance, on OS X, these are a differences:
-    // https://github.com/eclipse-theia/theia/issues/3297#issuecomment-439172274
-    process.env.THEIA_APP_PROJECT_PATH = resolve(__dirname, '..', '..');
-
-    // Set the electron version for both the dev and the production mode. (https://github.com/eclipse-theia/theia/issues/3254)
-    // Otherwise, the forked backend processes will not know that they're serving the electron frontend.
-    // The forked backend should patch its \`process.versions.electron\` with this value if it is missing.
-    process.env.THEIA_ELECTRON_VERSION = process.versions.electron;
-
-    const mainPath = join(__dirname, '..', 'backend', 'main');
-    // We spawn a separate process for the backend for Express to not run in the Electron main process.
-    // See: https://github.com/eclipse-theia/theia/pull/7361#issuecomment-601272212
-    // But when in debugging we want to run everything in the same process to make things easier.
-    if (noBackendFork) {
-        process.env[ElectronSecurityToken] = JSON.stringify(electronSecurityToken);
-        require(mainPath).then(async (address) => {
-            await setElectronSecurityToken(address.port);
-            loadMainWindow(address.port);
-        }).catch((error) => {
-            console.error(error);
-            app.exit(1);
-        });
-    } else {
-        // We want to pass flags passed to the Electron app to the backend process.
-        // Quirk: When developing from sources, we execute Electron as \`electron.exe electron-main.js ...args\`, but when bundled,
-        // the command looks like \`bundled-application.exe ...args\`.
-        const cp = fork(mainPath, process.argv.slice(devMode ? 2 : 1), { env: Object.assign({
-            [ElectronSecurityToken]: JSON.stringify(electronSecurityToken),
-        }, process.env) });
-        cp.on('message', async (address) => {
-            await setElectronSecurityToken(address.port);
-            loadMainWindow(address.port);
-        });
-        cp.on('error', (error) => {
-            console.error(error);
-            app.exit(1);
-        });
-        app.on('quit', () => {
-            // If we forked the process for the clusters, we need to manually terminate it.
-            // See: https://github.com/eclipse-theia/theia/issues/835
-            process.kill(cp.pid);
-        });
-    }
+const container = new Container();
+container.load(electronMainApplicationModule);
+container.bind(ElectronMainApplicationGlobals).toConstantValue({
+    THEIA_APP_PROJECT_PATH: resolve(__dirname, '..', '..'),
+    THEIA_BACKEND_MAIN_PATH: resolve(__dirname, '..', 'backend', 'main.js'),
+    THEIA_FRONTEND_HTML_PATH: resolve(__dirname, '..', '..', 'lib', 'index.html'),
 });
+
+function load(raw) {
+    return Promise.resolve(raw.default).then(module =>
+        container.load(module)
+    );
+}
+
+async function start() {
+    const application = container.get(ElectronMainApplication);
+    await application.start(config);
+}
+
+module.exports = Promise.resolve()${this.compileElectronMainModuleImports(electronMainModules)}
+    .then(start).catch(reason => {
+        console.error('Failed to start the electron application.');
+        if (reason) {
+            console.error(reason);
+        }
+    });
 `;
     }
 

--- a/dev-packages/application-package/src/application-package.ts
+++ b/dev-packages/application-package/src/application-package.ts
@@ -102,6 +102,7 @@ export class ApplicationPackage {
     protected _frontendElectronModules: Map<string, string> | undefined;
     protected _backendModules: Map<string, string> | undefined;
     protected _backendElectronModules: Map<string, string> | undefined;
+    protected _electronMainModules: Map<string, string> | undefined;
     protected _extensionPackages: ReadonlyArray<ExtensionPackage> | undefined;
 
     /**
@@ -161,6 +162,13 @@ export class ApplicationPackage {
             this._backendElectronModules = this.computeModules('backendElectron', 'backend');
         }
         return this._backendElectronModules;
+    }
+
+    get electronMainModules(): Map<string, string> {
+        if (!this._electronMainModules) {
+            this._electronMainModules = this.computeModules('electronMain');
+        }
+        return this._electronMainModules;
     }
 
     protected computeModules<P extends keyof Extension, S extends keyof Extension = P>(primary: P, secondary?: S): Map<string, string> {
@@ -236,6 +244,10 @@ export class ApplicationPackage {
 
     get targetFrontendModules(): Map<string, string> {
         return this.ifBrowser(this.frontendModules, this.frontendElectronModules);
+    }
+
+    get targetElectronMainModules(): Map<string, string> {
+        return this.ifElectron(this.electronMainModules, new Map());
     }
 
     setDependency(name: string, version: string | undefined): boolean {

--- a/dev-packages/application-package/src/extension-package.ts
+++ b/dev-packages/application-package/src/extension-package.ts
@@ -24,6 +24,7 @@ export interface Extension {
     frontendElectron?: string;
     backend?: string;
     backendElectron?: string;
+    electronMain?: string;
 }
 
 export class ExtensionPackage {

--- a/examples/api-samples/package.json
+++ b/examples/api-samples/package.json
@@ -10,6 +10,10 @@
   "theiaExtensions": [
     {
       "frontend": "lib/browser/api-samples-frontend-module"
+    },
+    {
+      "electronMain": "lib/electron-main/update/sample-updater-main-module",
+      "frontendElectron": "lib/electron-browser/updater/sample-updater-frontend-module"
     }
   ],
   "keywords": [

--- a/examples/api-samples/src/common/updater/sample-updater.ts
+++ b/examples/api-samples/src/common/updater/sample-updater.ts
@@ -1,0 +1,37 @@
+/********************************************************************************
+ * Copyright (C) 2020 TypeFox and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+import { JsonRpcServer } from '@theia/core/lib/common/messaging/proxy-factory';
+
+export enum UpdateStatus {
+    InProgress = 'in-progress',
+    Available = 'available',
+    NotAvailable = 'not-available'
+}
+
+export const SampleUpdaterPath = '/services/sample-updater';
+export const SampleUpdater = Symbol('SampleUpdater');
+export interface SampleUpdater extends JsonRpcServer<SampleUpdaterClient> {
+    checkForUpdates(): Promise<{ status: UpdateStatus }>;
+    onRestartToUpdateRequested(): void;
+    disconnectClient(client: SampleUpdaterClient): void;
+
+    setUpdateAvailable(available: boolean): Promise<void>; // Mock
+}
+
+export const SampleUpdaterClient = Symbol('SampleUpdaterClient');
+export interface SampleUpdaterClient {
+    notifyReadyToInstall(): void;
+}

--- a/examples/api-samples/src/electron-browser/updater/sample-updater-frontend-contribution.ts
+++ b/examples/api-samples/src/electron-browser/updater/sample-updater-frontend-contribution.ts
@@ -1,0 +1,182 @@
+/********************************************************************************
+ * Copyright (C) 2020 TypeFox and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import { remote, Menu, BrowserWindow } from 'electron';
+import { inject, injectable, postConstruct } from 'inversify';
+import { isOSX } from '@theia/core/lib/common/os';
+import { CommonMenus } from '@theia/core/lib/browser';
+import {
+    Emitter,
+    Command,
+    MenuPath,
+    MessageService,
+    MenuModelRegistry,
+    MenuContribution,
+    CommandRegistry,
+    CommandContribution
+} from '@theia/core/lib/common';
+import { ElectronMainMenuFactory } from '@theia/core/lib/electron-browser/menu/electron-main-menu-factory';
+import { FrontendApplicationConfigProvider } from '@theia/core/lib/browser/frontend-application-config-provider';
+import { SampleUpdater, UpdateStatus, SampleUpdaterClient } from '../../common/updater/sample-updater';
+
+export namespace SampleUpdaterCommands {
+
+    const category = 'Electron Updater Sample';
+
+    export const CHECK_FOR_UPDATES: Command = {
+        id: 'electron-sample:check-for-updates',
+        label: 'Check for Updates...',
+        category
+    };
+
+    export const RESTART_TO_UPDATE: Command = {
+        id: 'electron-sample:restart-to-update',
+        label: 'Restart to Update',
+        category
+    };
+
+    // Mock
+    export const MOCK_UPDATE_AVAILABLE: Command = {
+        id: 'electron-sample:mock-update-available',
+        label: 'Mock - Available',
+        category
+    };
+
+    export const MOCK_UPDATE_NOT_AVAILABLE: Command = {
+        id: 'electron-sample:mock-update-not-available',
+        label: 'Mock - Not Available',
+        category
+    };
+
+}
+
+export namespace SampleUpdaterMenu {
+    export const MENU_PATH: MenuPath = [...CommonMenus.FILE_SETTINGS_SUBMENU, '3_settings_submenu_update'];
+}
+
+@injectable()
+export class SampleUpdaterClientImpl implements SampleUpdaterClient {
+
+    protected readonly onReadyToInstallEmitter = new Emitter<void>();
+    readonly onReadyToInstall = this.onReadyToInstallEmitter.event;
+
+    notifyReadyToInstall(): void {
+        this.onReadyToInstallEmitter.fire();
+    }
+
+}
+
+// Dynamic menus aren't yet supported by electron: https://github.com/eclipse-theia/theia/issues/446
+@injectable()
+export class ElectronMenuUpdater {
+
+    @inject(ElectronMainMenuFactory)
+    protected readonly factory: ElectronMainMenuFactory;
+
+    public update(): void {
+        this.setMenu();
+    }
+
+    private setMenu(menu: Menu = this.factory.createMenuBar(), electronWindow: BrowserWindow = remote.getCurrentWindow()): void {
+        if (isOSX) {
+            remote.Menu.setApplicationMenu(menu);
+        } else {
+            electronWindow.setMenu(menu);
+        }
+    }
+
+}
+
+@injectable()
+export class SampleUpdaterFrontendContribution implements CommandContribution, MenuContribution {
+
+    @inject(MessageService)
+    protected readonly messageService: MessageService;
+
+    @inject(ElectronMenuUpdater)
+    protected readonly menuUpdater: ElectronMenuUpdater;
+
+    @inject(SampleUpdater)
+    protected readonly updater: SampleUpdater;
+
+    @inject(SampleUpdaterClientImpl)
+    protected readonly updaterClient: SampleUpdaterClientImpl;
+
+    protected readyToUpdate = false;
+
+    @postConstruct()
+    protected init(): void {
+        this.updaterClient.onReadyToInstall(async () => {
+            this.readyToUpdate = true;
+            this.menuUpdater.update();
+            this.handleUpdatesAvailable();
+        });
+    }
+
+    registerCommands(registry: CommandRegistry): void {
+        registry.registerCommand(SampleUpdaterCommands.CHECK_FOR_UPDATES, {
+            execute: async () => {
+                const { status } = await this.updater.checkForUpdates();
+                switch (status) {
+                    case UpdateStatus.Available: {
+                        this.handleUpdatesAvailable();
+                        break;
+                    }
+                    case UpdateStatus.NotAvailable: {
+                        const { applicationName } = FrontendApplicationConfigProvider.get();
+                        this.messageService.info(`[Not Available]: You’re all good. You’ve got the latest version of ${applicationName}.`, { timeout: 3000 });
+                        break;
+                    }
+                    case UpdateStatus.InProgress: {
+                        this.messageService.warn('[Downloading]: Work in progress...', { timeout: 3000 });
+                        break;
+                    }
+                    default: throw new Error(`Unexpected status: ${status}`);
+                }
+            },
+            isEnabled: () => !this.readyToUpdate,
+            isVisible: () => !this.readyToUpdate
+        });
+        registry.registerCommand(SampleUpdaterCommands.RESTART_TO_UPDATE, {
+            execute: () => this.updater.onRestartToUpdateRequested(),
+            isEnabled: () => this.readyToUpdate,
+            isVisible: () => this.readyToUpdate
+        });
+        registry.registerCommand(SampleUpdaterCommands.MOCK_UPDATE_AVAILABLE, {
+            execute: () => this.updater.setUpdateAvailable(true)
+        });
+        registry.registerCommand(SampleUpdaterCommands.MOCK_UPDATE_NOT_AVAILABLE, {
+            execute: () => this.updater.setUpdateAvailable(false)
+        });
+    }
+
+    registerMenus(registry: MenuModelRegistry): void {
+        registry.registerMenuAction(SampleUpdaterMenu.MENU_PATH, {
+            commandId: SampleUpdaterCommands.CHECK_FOR_UPDATES.id
+        });
+        registry.registerMenuAction(SampleUpdaterMenu.MENU_PATH, {
+            commandId: SampleUpdaterCommands.RESTART_TO_UPDATE.id
+        });
+    }
+
+    protected async handleUpdatesAvailable(): Promise<void> {
+        const answer = await this.messageService.info('[Available]: Found updates, do you want update now?', 'No', 'Yes');
+        if (answer === 'Yes') {
+            this.updater.onRestartToUpdateRequested();
+        }
+    }
+
+}

--- a/examples/api-samples/src/electron-browser/updater/sample-updater-frontend-module.ts
+++ b/examples/api-samples/src/electron-browser/updater/sample-updater-frontend-module.ts
@@ -1,0 +1,34 @@
+/********************************************************************************
+ * Copyright (C) 2020 TypeFox and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import { ContainerModule } from 'inversify';
+import { ElectronIpcConnectionProvider } from '@theia/core/lib/electron-browser/messaging/electron-ipc-connection-provider';
+import { CommandContribution, MenuContribution } from '@theia/core/lib/common';
+import { SampleUpdater, SampleUpdaterPath, SampleUpdaterClient } from '../../common/updater/sample-updater';
+import { SampleUpdaterFrontendContribution, ElectronMenuUpdater, SampleUpdaterClientImpl } from './sample-updater-frontend-contribution';
+
+export default new ContainerModule(bind => {
+    bind(ElectronMenuUpdater).toSelf().inSingletonScope();
+    bind(SampleUpdaterClientImpl).toSelf().inSingletonScope();
+    bind(SampleUpdaterClient).toService(SampleUpdaterClientImpl);
+    bind(SampleUpdater).toDynamicValue(context => {
+        const client = context.container.get(SampleUpdaterClientImpl);
+        return ElectronIpcConnectionProvider.createProxy(context.container, SampleUpdaterPath, client);
+    }).inSingletonScope();
+    bind(SampleUpdaterFrontendContribution).toSelf().inSingletonScope();
+    bind(MenuContribution).toService(SampleUpdaterFrontendContribution);
+    bind(CommandContribution).toService(SampleUpdaterFrontendContribution);
+});

--- a/examples/api-samples/src/electron-main/update/sample-updater-impl.ts
+++ b/examples/api-samples/src/electron-main/update/sample-updater-impl.ts
@@ -1,0 +1,91 @@
+/********************************************************************************
+ * Copyright (C) 2020 TypeFox and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import { injectable } from 'inversify';
+import { ElectronMainApplication, ElectronMainApplicationContribution } from '@theia/core/lib/electron-main/electron-main-application';
+import { SampleUpdater, SampleUpdaterClient, UpdateStatus } from '../../common/updater/sample-updater';
+
+@injectable()
+export class SampleUpdaterImpl implements SampleUpdater, ElectronMainApplicationContribution {
+
+    protected clients: Array<SampleUpdaterClient> = [];
+    protected inProgressTimer: NodeJS.Timer | undefined;
+    protected available = false;
+
+    async checkForUpdates(): Promise<{ status: UpdateStatus }> {
+        if (this.inProgressTimer) {
+            return { status: UpdateStatus.InProgress };
+        }
+        return { status: this.available ? UpdateStatus.Available : UpdateStatus.NotAvailable };
+    }
+
+    onRestartToUpdateRequested(): void {
+        console.info("'Update to Restart' was requested by the frontend.");
+        // Here comes your install and restart implementation. For example: `autoUpdater.quitAndInstall();`
+    }
+
+    async setUpdateAvailable(available: boolean): Promise<void> {
+        if (this.inProgressTimer) {
+            clearTimeout(this.inProgressTimer);
+        }
+        if (!available) {
+            this.inProgressTimer = undefined;
+            this.available = false;
+        } else {
+            this.inProgressTimer = setTimeout(() => {
+                this.inProgressTimer = undefined;
+                this.available = true;
+                for (const client of this.clients) {
+                    client.notifyReadyToInstall();
+                }
+            }, 5000);
+        }
+    }
+
+    onStart(application: ElectronMainApplication): void {
+        // Called when the contribution is starting. You can use both async and sync code from here.
+    }
+
+    onStop(application: ElectronMainApplication): void {
+        // Invoked when the contribution is stopping. You can clean up things here. You are not allowed call async code from here.
+    }
+
+    setClient(client: SampleUpdaterClient | undefined): void {
+        if (client) {
+            this.clients.push(client);
+            console.info('Registered a new sample updater client.');
+        } else {
+            console.warn("Couldn't register undefined client.");
+        }
+    }
+
+    disconnectClient(client: SampleUpdaterClient): void {
+        const index = this.clients.indexOf(client);
+        if (index !== -1) {
+            this.clients.splice(index, 1);
+            console.info('Disposed a sample updater client.');
+        } else {
+            console.warn("Couldn't dispose client; it was not registered.");
+        }
+    }
+
+    dispose(): void {
+        console.info('>>> Disposing sample updater service...');
+        this.clients.forEach(this.disconnectClient.bind(this));
+        console.info('>>> Disposed sample updater service.');
+    }
+
+}

--- a/examples/api-samples/src/electron-main/update/sample-updater-main-module.ts
+++ b/examples/api-samples/src/electron-main/update/sample-updater-main-module.ts
@@ -1,0 +1,36 @@
+/********************************************************************************
+ * Copyright (C) 2020 TypeFox and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import { ContainerModule } from 'inversify';
+import { JsonRpcConnectionHandler } from '@theia/core/lib/common/messaging/proxy-factory';
+import { ElectronMainApplicationContribution } from '@theia/core/lib/electron-main/electron-main-application';
+import { ElectronConnectionHandler } from '@theia/core/lib/electron-common/messaging/electron-connection-handler';
+import { SampleUpdaterPath, SampleUpdater, SampleUpdaterClient } from '../../common/updater/sample-updater';
+import { SampleUpdaterImpl } from './sample-updater-impl';
+
+export default new ContainerModule(bind => {
+    bind(SampleUpdaterImpl).toSelf().inSingletonScope();
+    bind(SampleUpdater).toService(SampleUpdaterImpl);
+    bind(ElectronMainApplicationContribution).toService(SampleUpdater);
+    bind(ElectronConnectionHandler).toDynamicValue(context =>
+        new JsonRpcConnectionHandler<SampleUpdaterClient>(SampleUpdaterPath, client => {
+            const server = context.container.get<SampleUpdater>(SampleUpdater);
+            server.setClient(client);
+            client.onDidCloseConnection(() => server.disconnectClient(client));
+            return server;
+        })
+    ).inSingletonScope();
+});

--- a/examples/electron/package.json
+++ b/examples/electron/package.json
@@ -21,6 +21,7 @@
     "@theia/debug": "^1.4.0",
     "@theia/editor": "^1.4.0",
     "@theia/editor-preview": "^1.4.0",
+    "@theia/electron": "^1.4.0",
     "@theia/file-search": "^1.4.0",
     "@theia/filesystem": "^1.4.0",
     "@theia/getting-started": "^1.4.0",

--- a/packages/core/src/browser/messaging/ws-connection-provider.ts
+++ b/packages/core/src/browser/messaging/ws-connection-provider.ts
@@ -15,11 +15,11 @@
  ********************************************************************************/
 
 import { injectable, interfaces, decorate, unmanaged } from 'inversify';
-import { createWebSocketConnection, Logger, ConsoleLogger } from 'vscode-ws-jsonrpc/lib';
-import { ConnectionHandler, JsonRpcProxyFactory, JsonRpcProxy, Emitter, Event } from '../../common';
+import { JsonRpcProxyFactory, JsonRpcProxy } from '../../common';
 import { WebSocketChannel } from '../../common/messaging/web-socket-channel';
 import { Endpoint } from '../endpoint';
 import ReconnectingWebSocket from 'reconnecting-websocket';
+import { AbstractConnectionProvider } from '../../common/messaging/abstract-connection-provider';
 
 decorate(injectable(), JsonRpcProxyFactory);
 decorate(unmanaged(), JsonRpcProxyFactory, 0);
@@ -32,33 +32,16 @@ export interface WebSocketOptions {
 }
 
 @injectable()
-export class WebSocketConnectionProvider {
+export class WebSocketConnectionProvider extends AbstractConnectionProvider<WebSocketOptions> {
 
-    /**
-     * Create a proxy object to remote interface of T type
-     * over a web socket connection for the given path and proxy factory.
-     */
-    static createProxy<T extends object>(container: interfaces.Container, path: string, factory: JsonRpcProxyFactory<T>): JsonRpcProxy<T>;
-    /**
-     * Create a proxy object to remote interface of T type
-     * over a web socket connection for the given path.
-     *
-     * An optional target can be provided to handle
-     * notifications and requests from a remote side.
-     */
-    static createProxy<T extends object>(container: interfaces.Container, path: string, target?: object): JsonRpcProxy<T>;
     static createProxy<T extends object>(container: interfaces.Container, path: string, arg?: object): JsonRpcProxy<T> {
         return container.get(WebSocketConnectionProvider).createProxy<T>(path, arg);
     }
 
-    protected channelIdSeq = 0;
     protected readonly socket: ReconnectingWebSocket;
-    protected readonly channels = new Map<number, WebSocketChannel>();
-
-    protected readonly onIncomingMessageActivityEmitter: Emitter<void> = new Emitter();
-    public onIncomingMessageActivity: Event<void> = this.onIncomingMessageActivityEmitter.event;
 
     constructor() {
+        super();
         const url = this.createWebSocketUrl(WebSocketChannel.wsPath);
         const socket = this.createWebSocket(url);
         socket.onerror = console.error;
@@ -68,54 +51,14 @@ export class WebSocketConnectionProvider {
             }
         };
         socket.onmessage = ({ data }) => {
-            const message: WebSocketChannel.Message = JSON.parse(data);
-            const channel = this.channels.get(message.id);
-            if (channel) {
-                channel.handleMessage(message);
-            } else {
-                console.error('The ws channel does not exist', message.id);
-            }
-            this.onIncomingMessageActivityEmitter.fire(undefined);
+            this.handleIncomingRawMessage(data);
         };
         this.socket = socket;
     }
 
-    /**
-     * Create a proxy object to remote interface of T type
-     * over a web socket connection for the given path and proxy factory.
-     */
-    createProxy<T extends object>(path: string, factory: JsonRpcProxyFactory<T>): JsonRpcProxy<T>;
-    /**
-     * Create a proxy object to remote interface of T type
-     * over a web socket connection for the given path.
-     *
-     * An optional target can be provided to handle
-     * notifications and requests from a remote side.
-     */
-    createProxy<T extends object>(path: string, target?: object): JsonRpcProxy<T>;
-    createProxy<T extends object>(path: string, arg?: object): JsonRpcProxy<T> {
-        const factory = arg instanceof JsonRpcProxyFactory ? arg : new JsonRpcProxyFactory<T>(arg);
-        this.listen({
-            path,
-            onConnection: c => factory.listen(c)
-        });
-        return factory.createProxy();
-    }
-
-    /**
-     * Install a connection handler for the given path.
-     */
-    listen(handler: ConnectionHandler, options?: WebSocketOptions): void {
-        this.openChannel(handler.path, channel => {
-            const connection = createWebSocketConnection(channel, this.createLogger());
-            connection.onDispose(() => channel.close());
-            handler.onConnection(connection);
-        }, options);
-    }
-
     openChannel(path: string, handler: (channel: WebSocketChannel) => void, options?: WebSocketOptions): void {
         if (this.socket.readyState === WebSocket.OPEN) {
-            this.doOpenChannel(path, handler, options);
+            super.openChannel(path, handler, options);
         } else {
             const openChannel = () => {
                 this.socket.removeEventListener('open', openChannel);
@@ -125,34 +68,12 @@ export class WebSocketConnectionProvider {
         }
     }
 
-    protected doOpenChannel(path: string, handler: (channel: WebSocketChannel) => void, options?: WebSocketOptions): void {
-        const id = this.channelIdSeq++;
-        const channel = this.createChannel(id);
-        this.channels.set(id, channel);
-        channel.onClose(() => {
-            if (this.channels.delete(channel.id)) {
-                const { reconnecting } = { reconnecting: true, ...options };
-                if (reconnecting) {
-                    this.openChannel(path, handler, options);
-                }
-            } else {
-                console.error('The ws channel does not exist', channel.id);
-            }
-        });
-        channel.onOpen(() => handler(channel));
-        channel.open(path);
-    }
-
     protected createChannel(id: number): WebSocketChannel {
         return new WebSocketChannel(id, content => {
             if (this.socket.readyState < WebSocket.CLOSING) {
                 this.socket.send(content);
             }
         });
-    }
-
-    protected createLogger(): Logger {
-        return new ConsoleLogger();
     }
 
     /**

--- a/packages/core/src/common/messaging/abstract-connection-provider.ts
+++ b/packages/core/src/common/messaging/abstract-connection-provider.ts
@@ -1,0 +1,122 @@
+/********************************************************************************
+ * Copyright (C) 2020 Ericsson and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import { injectable, interfaces } from 'inversify';
+import { ConsoleLogger, createWebSocketConnection, Logger } from 'vscode-ws-jsonrpc';
+import { Emitter, Event } from '../event';
+import { ConnectionHandler } from './handler';
+import { JsonRpcProxy, JsonRpcProxyFactory } from './proxy-factory';
+import { WebSocketChannel } from './web-socket-channel';
+
+/**
+ * Factor common logic according to `ElectronIpcConnectionProvider` and
+ * `WebSocketConnectionProvider`. This class handles channels in a somewhat
+ * generic way.
+ */
+@injectable()
+export abstract class AbstractConnectionProvider<AbstractOptions extends object> {
+
+    /**
+     * Create a proxy object to remote interface of T type
+     * over an electron ipc connection for the given path and proxy factory.
+     */
+    static createProxy<T extends object>(container: interfaces.Container, path: string, factory: JsonRpcProxyFactory<T>): JsonRpcProxy<T>;
+    /**
+     * Create a proxy object to remote interface of T type
+     * over an electron ipc connection for the given path.
+     *
+     * An optional target can be provided to handle
+     * notifications and requests from a remote side.
+     */
+    static createProxy<T extends object>(container: interfaces.Container, path: string, target?: object): JsonRpcProxy<T> {
+        throw new Error('abstract');
+    }
+
+    protected channelIdSeq = 0;
+    protected readonly channels = new Map<number, WebSocketChannel>();
+
+    protected readonly onIncomingMessageActivityEmitter: Emitter<void> = new Emitter();
+    public onIncomingMessageActivity: Event<void> = this.onIncomingMessageActivityEmitter.event;
+
+    /**
+     * Create a proxy object to remote interface of T type
+     * over a web socket connection for the given path and proxy factory.
+     */
+    createProxy<T extends object>(path: string, factory: JsonRpcProxyFactory<T>): JsonRpcProxy<T>;
+    /**
+     * Create a proxy object to remote interface of T type
+     * over a web socket connection for the given path.
+     *
+     * An optional target can be provided to handle
+     * notifications and requests from a remote side.
+     */
+    createProxy<T extends object>(path: string, target?: object): JsonRpcProxy<T>;
+    createProxy<T extends object>(path: string, arg?: object): JsonRpcProxy<T> {
+        const factory = arg instanceof JsonRpcProxyFactory ? arg : new JsonRpcProxyFactory<T>(arg);
+        this.listen({
+            path,
+            onConnection: c => factory.listen(c)
+        });
+        return factory.createProxy();
+    }
+
+    /**
+     * Install a connection handler for the given path.
+     */
+    listen(handler: ConnectionHandler, options?: AbstractOptions): void {
+        this.openChannel(handler.path, channel => {
+            const connection = createWebSocketConnection(channel, this.createLogger());
+            connection.onDispose(() => channel.close());
+            handler.onConnection(connection);
+        }, options);
+    }
+
+    openChannel(path: string, handler: (channel: WebSocketChannel) => void, options?: AbstractOptions): void {
+        const id = this.channelIdSeq++;
+        const channel = this.createChannel(id);
+        this.channels.set(id, channel);
+        channel.onClose(() => {
+            if (this.channels.delete(channel.id)) {
+                const { reconnecting } = { reconnecting: true, ...options };
+                if (reconnecting) {
+                    this.openChannel(path, handler, options);
+                }
+            } else {
+                console.error('The ws channel does not exist', channel.id);
+            }
+        });
+        channel.onOpen(() => handler(channel));
+        channel.open(path);
+    }
+
+    protected abstract createChannel(id: number): WebSocketChannel;
+
+    protected handleIncomingRawMessage(data: string): void {
+        const message: WebSocketChannel.Message = JSON.parse(data);
+        const channel = this.channels.get(message.id);
+        if (channel) {
+            channel.handleMessage(message);
+        } else {
+            console.error('The ws channel does not exist', message.id);
+        }
+        this.onIncomingMessageActivityEmitter.fire(undefined);
+    }
+
+    protected createLogger(): Logger {
+        return new ConsoleLogger();
+    }
+
+}

--- a/packages/core/src/electron-browser/messaging/electron-ipc-connection-provider.ts
+++ b/packages/core/src/electron-browser/messaging/electron-ipc-connection-provider.ts
@@ -1,0 +1,50 @@
+/********************************************************************************
+ * Copyright (C) 2018 TypeFox and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import { injectable, interfaces } from 'inversify';
+import { Event as ElectronEvent, ipcRenderer } from 'electron';
+import { JsonRpcProxy } from '../../common/messaging';
+import { WebSocketChannel } from '../../common/messaging/web-socket-channel';
+import { AbstractConnectionProvider } from '../../common/messaging/abstract-connection-provider';
+import { THEIA_ELECTRON_IPC_CHANNEL_NAME } from '../../electron-common/messaging/electron-connection-handler';
+
+export interface ElectronIpcOptions {
+}
+
+/**
+ * Connection provider between the Theia frontend and the electron-main process via IPC.
+ */
+@injectable()
+export class ElectronIpcConnectionProvider extends AbstractConnectionProvider<ElectronIpcOptions> {
+
+    static createProxy<T extends object>(container: interfaces.Container, path: string, arg?: object): JsonRpcProxy<T> {
+        return container.get(ElectronIpcConnectionProvider).createProxy<T>(path, arg);
+    }
+
+    constructor() {
+        super();
+        ipcRenderer.on(THEIA_ELECTRON_IPC_CHANNEL_NAME, (event: ElectronEvent, data: string) => {
+            this.handleIncomingRawMessage(data);
+        });
+    }
+
+    protected createChannel(id: number): WebSocketChannel {
+        return new WebSocketChannel(id, content => {
+            ipcRenderer.send(THEIA_ELECTRON_IPC_CHANNEL_NAME, content);
+        });
+    }
+
+}

--- a/packages/core/src/electron-browser/messaging/electron-messaging-frontend-module.ts
+++ b/packages/core/src/electron-browser/messaging/electron-messaging-frontend-module.ts
@@ -18,9 +18,11 @@ import { ContainerModule } from 'inversify';
 import { FrontendApplicationContribution } from '../../browser/frontend-application';
 import { WebSocketConnectionProvider } from '../../browser/messaging/ws-connection-provider';
 import { ElectronWebSocketConnectionProvider } from './electron-ws-connection-provider';
+import { ElectronIpcConnectionProvider } from './electron-ipc-connection-provider';
 
 export const messagingFrontendModule = new ContainerModule(bind => {
     bind(ElectronWebSocketConnectionProvider).toSelf().inSingletonScope();
     bind(FrontendApplicationContribution).toService(ElectronWebSocketConnectionProvider);
     bind(WebSocketConnectionProvider).toService(ElectronWebSocketConnectionProvider);
+    bind(ElectronIpcConnectionProvider).toSelf().inSingletonScope();
 });

--- a/packages/core/src/electron-browser/messaging/electron-ws-connection-provider.ts
+++ b/packages/core/src/electron-browser/messaging/electron-ws-connection-provider.ts
@@ -19,6 +19,11 @@ import { WebSocketChannel } from '../../common/messaging/web-socket-channel';
 import { WebSocketConnectionProvider, WebSocketOptions } from '../../browser/messaging/ws-connection-provider';
 import { FrontendApplicationContribution } from '../../browser/frontend-application';
 
+/**
+ * Customized connection provider between the frontend and the backend in electron environment.
+ * This customized connection provider makes sure the websocket connection does not try to reconnect
+ * once the electron-browser window is refreshed. Otherwise, backend resources are not disposed.
+ */
 @injectable()
 export class ElectronWebSocketConnectionProvider extends WebSocketConnectionProvider implements FrontendApplicationContribution {
 

--- a/packages/core/src/electron-browser/window/electron-window-module.ts
+++ b/packages/core/src/electron-browser/window/electron-window-module.ts
@@ -20,8 +20,13 @@ import { ElectronWindowService } from './electron-window-service';
 import { FrontendApplicationContribution } from '../../browser/frontend-application';
 import { ElectronClipboardService } from '../electron-clipboard-service';
 import { ClipboardService } from '../../browser/clipboard-service';
+import { ElectronMainWindowService, electronMainWindowServicePath } from '../../electron-common/electron-main-window-service';
+import { ElectronIpcConnectionProvider } from '../messaging/electron-ipc-connection-provider';
 
 export default new ContainerModule(bind => {
+    bind(ElectronMainWindowService).toDynamicValue(context =>
+        ElectronIpcConnectionProvider.createProxy(context.container, electronMainWindowServicePath)
+    ).inSingletonScope();
     bind(WindowService).to(ElectronWindowService).inSingletonScope();
     bind(FrontendApplicationContribution).toService(WindowService);
     bind(ClipboardService).to(ElectronClipboardService).inSingletonScope();

--- a/packages/core/src/electron-common/electron-main-window-service.ts
+++ b/packages/core/src/electron-common/electron-main-window-service.ts
@@ -1,0 +1,23 @@
+/********************************************************************************
+ * Copyright (C) 2020 Ericsson and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import { NewWindowOptions } from '../browser/window/window-service';
+
+export const electronMainWindowServicePath = '/services/electron-window';
+export const ElectronMainWindowService = Symbol('ElectronMainWindowService');
+export interface ElectronMainWindowService {
+    openNewWindow(url: string, options?: NewWindowOptions): undefined;
+}

--- a/packages/core/src/electron-common/messaging/electron-connection-handler.ts
+++ b/packages/core/src/electron-common/messaging/electron-connection-handler.ts
@@ -1,0 +1,30 @@
+/********************************************************************************
+ * Copyright (C) 2020 Ericsson and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import { ConnectionHandler } from '../../common/messaging/handler';
+
+/**
+ * Name of the channel used with `ipcMain.on/emit`.
+ */
+export const THEIA_ELECTRON_IPC_CHANNEL_NAME = 'theia-electron-ipc';
+
+/**
+ * Electron-IPC-specific connection handler.
+ * Use this if you want to establish communication between the frontend and the electron-main process.
+ */
+export const ElectronConnectionHandler = Symbol('ElectronConnectionHandler');
+export interface ElectronConnectionHandler extends ConnectionHandler {
+}

--- a/packages/core/src/electron-main/electron-main-application-module.ts
+++ b/packages/core/src/electron-main/electron-main-application-module.ts
@@ -1,0 +1,51 @@
+/********************************************************************************
+ * Copyright (C) 2020 Ericsson and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import { ContainerModule } from 'inversify';
+import { v4 } from 'uuid';
+import { bindContributionProvider } from '../common/contribution-provider';
+import { JsonRpcConnectionHandler } from '../common/messaging/proxy-factory';
+import { ElectronSecurityToken } from '../electron-common/electron-token';
+import { ElectronMainWindowService, electronMainWindowServicePath } from '../electron-common/electron-main-window-service';
+import { ElectronMainApplication, ElectronMainApplicationContribution, ElectronMainProcessArgv } from './electron-main-application';
+import { ElectronMainWindowServiceImpl } from './electron-main-window-service-impl';
+import { ElectronMessagingContribution } from './messaging/electron-messaging-contribution';
+import { ElectronMessagingService } from './messaging/electron-messaging-service';
+import { ElectronConnectionHandler } from '../electron-common/messaging/electron-connection-handler';
+
+const electronSecurityToken: ElectronSecurityToken = { value: v4() };
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+(global as any)[ElectronSecurityToken] = electronSecurityToken;
+
+export default new ContainerModule(bind => {
+    bind(ElectronMainApplication).toSelf().inSingletonScope();
+    bind(ElectronMessagingContribution).toSelf().inSingletonScope();
+    bind(ElectronSecurityToken).toConstantValue(electronSecurityToken);
+
+    bindContributionProvider(bind, ElectronConnectionHandler);
+    bindContributionProvider(bind, ElectronMessagingService.Contribution);
+    bindContributionProvider(bind, ElectronMainApplicationContribution);
+
+    bind(ElectronMainApplicationContribution).toService(ElectronMessagingContribution);
+
+    bind(ElectronMainWindowService).to(ElectronMainWindowServiceImpl).inSingletonScope();
+    bind(ElectronConnectionHandler).toDynamicValue(context =>
+        new JsonRpcConnectionHandler(electronMainWindowServicePath,
+            () => context.container.get(ElectronMainWindowService))
+    ).inSingletonScope();
+
+    bind(ElectronMainProcessArgv).toSelf().inSingletonScope();
+});

--- a/packages/core/src/electron-main/electron-main-application.ts
+++ b/packages/core/src/electron-main/electron-main-application.ts
@@ -1,0 +1,489 @@
+/********************************************************************************
+ * Copyright (C) 2020 Ericsson and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import { inject, injectable, named } from 'inversify';
+import { session, screen, globalShortcut, app, BrowserWindow, BrowserWindowConstructorOptions, Event as ElectronEvent, dialog } from 'electron';
+import * as path from 'path';
+import { Argv } from 'yargs';
+import { AddressInfo } from 'net';
+import { promises as fs } from 'fs';
+import { fork, ForkOptions } from 'child_process';
+import { FrontendApplicationConfig } from '@theia/application-package/lib/application-props';
+import URI from '../common/uri';
+import { FileUri } from '../node/file-uri';
+import { Deferred } from '../common/promise-util';
+import { MaybePromise } from '../common/types';
+import { ContributionProvider } from '../common/contribution-provider';
+import { ElectronSecurityToken } from '../electron-common/electron-token';
+const Storage = require('electron-store');
+const createYargs: (argv?: string[], cwd?: string) => Argv = require('yargs/yargs');
+
+/**
+ * Theia tracks the maximized state of Electron Browser Windows.
+ */
+export interface TheiaBrowserWindowOptions extends BrowserWindowConstructorOptions {
+    isMaximized?: boolean;
+}
+
+/**
+ * Options passed to the main/default command handler.
+ */
+export interface ElectronMainCommandOptions {
+
+    /**
+     * By default, the first positional argument. Should be either a relative or absolute file-system path pointing to a file or a folder.
+     */
+    readonly file?: string;
+
+}
+
+/**
+ * Fields related to a launch event.
+ *
+ * This kind of event is triggered in two different contexts:
+ *  1. The app is launched for the first time, `secondInstance` is false.
+ *  2. The app is already running but user relaunches it, `secondInstance` is true.
+ */
+export interface ElectronMainExecutionParams {
+    readonly secondInstance: boolean;
+    readonly argv: string[];
+    readonly cwd: string;
+}
+
+export const ElectronMainApplicationGlobals = Symbol('ElectronMainApplicationGlobals');
+export interface ElectronMainApplicationGlobals {
+    readonly THEIA_APP_PROJECT_PATH: string
+    readonly THEIA_BACKEND_MAIN_PATH: string
+    readonly THEIA_FRONTEND_HTML_PATH: string
+}
+
+/**
+ * The default entrypoint will handle a very rudimentary CLI to open workspaces by doing `app path/to/workspace`. To override this behavior, you can extend and rebind the
+ * `ElectronMainApplication` class and overriding the `launch` method.
+ * A JSON-RPC communication between the Electron Main Process and the Renderer Processes is available: You can bind services using the `ElectronConnectionHandler` and
+ * `ElectronIpcConnectionProvider` APIs, example:
+ *
+ * From an `electron-main` module:
+ *
+ *     bind(ElectronConnectionHandler).toDynamicValue(context =>
+ *          new JsonRpcConnectionHandler(electronMainWindowServicePath,
+ *          () => context.container.get(ElectronMainWindowService))
+ *     ).inSingletonScope();
+ *
+ * And from the `electron-browser` module:
+ *
+ *     bind(ElectronMainWindowService).toDynamicValue(context =>
+ *          ElectronIpcConnectionProvider.createProxy(context.container, electronMainWindowServicePath)
+ *     ).inSingletonScope();
+ */
+export const ElectronMainApplicationContribution = Symbol('ElectronMainApplicationContribution');
+export interface ElectronMainApplicationContribution {
+    /**
+     * The application is ready and is starting. This is the time to initialize
+     * services global to this process.
+     *
+     * Invoked when the electron-main process starts for the first time.
+     */
+    onStart?(application: ElectronMainApplication): MaybePromise<void>;
+    /**
+     * The application is stopping. Contributions must perform only synchronous operations.
+     */
+    onStop?(application: ElectronMainApplication): void;
+}
+
+// Extracted and modified the functionality from `yargs@15.4.0-beta.0`.
+// Based on https://github.com/yargs/yargs/blob/522b019c9a50924605986a1e6e0cb716d47bcbca/lib/process-argv.ts
+@injectable()
+export class ElectronMainProcessArgv {
+
+    protected get processArgvBinIndex(): number {
+        // The binary name is the first command line argument for:
+        // - bundled Electron apps: bin argv1 argv2 ... argvn
+        if (this.isBundledElectronApp) {
+            return 0;
+        }
+        // or the second one (default) for:
+        // - standard node apps: node bin.js argv1 argv2 ... argvn
+        // - unbundled Electron apps: electron bin.js argv1 arg2 ... argvn
+        return 1;
+    }
+
+    protected get isBundledElectronApp(): boolean {
+        // process.defaultApp is either set by electron in an electron unbundled app, or undefined
+        // see https://github.com/electron/electron/blob/master/docs/api/process.md#processdefaultapp-readonly
+        return this.isElectronApp && !(process as ElectronMainProcessArgv.ElectronMainProcess).defaultApp;
+    }
+
+    protected get isElectronApp(): boolean {
+        // process.versions.electron is either set by electron, or undefined
+        // see https://github.com/electron/electron/blob/master/docs/api/process.md#processversionselectron-readonly
+        return !!(process as ElectronMainProcessArgv.ElectronMainProcess).versions.electron;
+    }
+
+    getProcessArgvWithoutBin(argv = process.argv): Array<string> {
+        return argv.slice(this.processArgvBinIndex + 1);
+    }
+
+    getProcessArgvBin(argv = process.argv): string {
+        return argv[this.processArgvBinIndex];
+    }
+
+}
+
+export namespace ElectronMainProcessArgv {
+    export interface ElectronMainProcess extends NodeJS.Process {
+        readonly defaultApp: boolean;
+        readonly versions: NodeJS.ProcessVersions & {
+            readonly electron: string;
+        };
+    }
+}
+
+@injectable()
+export class ElectronMainApplication {
+
+    @inject(ContributionProvider)
+    @named(ElectronMainApplicationContribution)
+    protected readonly contributions: ContributionProvider<ElectronMainApplicationContribution>;
+
+    @inject(ElectronMainApplicationGlobals)
+    protected readonly globals: ElectronMainApplicationGlobals;
+
+    @inject(ElectronSecurityToken)
+    protected electronSecurityToken: ElectronSecurityToken;
+
+    @inject(ElectronMainProcessArgv)
+    protected processArgv: ElectronMainProcessArgv;
+
+    protected readonly electronStore = new Storage();
+    protected readonly backendPort = new Deferred<number>();
+
+    protected _config: FrontendApplicationConfig;
+    get config(): FrontendApplicationConfig {
+        if (!this._config) {
+            throw new Error('You have to start the application first.');
+        }
+        return this._config;
+    }
+
+    async start(config: FrontendApplicationConfig): Promise<void> {
+        this._config = config;
+        this.hookApplicationEvents();
+        const port = await this.startBackend();
+        this.backendPort.resolve(port);
+        await app.whenReady();
+        await this.attachElectronSecurityToken(port);
+        await this.startContributions();
+        await this.launch({
+            secondInstance: false,
+            argv: this.processArgv.getProcessArgvWithoutBin(process.argv),
+            cwd: process.cwd()
+        });
+    }
+
+    protected async launch(params: ElectronMainExecutionParams): Promise<void> {
+        createYargs(params.argv, params.cwd)
+            .command('$0 [file]', false,
+                cmd => cmd
+                    .positional('file', { type: 'string' }),
+                args => this.handleMainCommand(params, { file: args.file }),
+            ).parse();
+    }
+
+    /**
+     * Use this rather than creating `BrowserWindow` instances from scratch, since some security parameters need to be set, this method will do it.
+     *
+     * @param options
+     */
+    async createWindow(asyncOptions: MaybePromise<TheiaBrowserWindowOptions> = this.getDefaultBrowserWindowOptions()): Promise<BrowserWindow> {
+        const options = await asyncOptions;
+        const electronWindow = new BrowserWindow(options);
+        this.attachReadyToShow(electronWindow);
+        this.attachSaveWindowState(electronWindow);
+        this.attachWillPreventUnload(electronWindow);
+        this.attachGlobalShortcuts(electronWindow);
+        this.restoreMaximizedState(electronWindow, options);
+        return electronWindow;
+    }
+
+    protected async getDefaultBrowserWindowOptions(): Promise<TheiaBrowserWindowOptions> {
+        const windowOptionsFromConfig = this.config.electron?.windowOptions || {};
+        let windowState: TheiaBrowserWindowOptions | undefined = this.electronStore.get('windowstate', undefined);
+        if (!windowState) {
+            windowState = this.getDefaultWindowState();
+        }
+        return {
+            ...windowState,
+            show: false,
+            title: this.config.applicationName,
+            minWidth: 200,
+            minHeight: 120,
+            webPreferences: {
+                nodeIntegration: true // https://github.com/eclipse-theia/theia/issues/2018
+            },
+            ...windowOptionsFromConfig,
+        };
+    }
+
+    protected async openDefaultWindow(): Promise<BrowserWindow> {
+        const [uri, electronWindow] = await Promise.all([this.createWindowUri(), this.createWindow()]);
+        electronWindow.loadURL(uri.toString(true));
+        return electronWindow;
+    }
+
+    protected async openWindowWithWorkspace(workspacePath: string): Promise<BrowserWindow> {
+        const [uri, electronWindow] = await Promise.all([this.createWindowUri(), this.createWindow()]);
+        electronWindow.loadURL(uri.withFragment(workspacePath).toString(true));
+        return electronWindow;
+    }
+
+    /**
+     * "Gently" close all windows, application will not stop if a `beforeunload` handler returns `false`.
+     */
+    requestStop(): void {
+        app.quit();
+    }
+
+    protected async handleMainCommand(params: ElectronMainExecutionParams, options: ElectronMainCommandOptions): Promise<void> {
+        if (options.file === undefined) {
+            await this.openDefaultWindow();
+        } else {
+            let workspacePath: string | undefined;
+            try {
+                workspacePath = await fs.realpath(path.resolve(params.cwd, options.file));
+            } catch {
+                console.error(`Could not resolve the workspace path. "${options.file}" is not a valid 'file' option. Falling back to the default workspace location.`);
+            }
+            if (workspacePath === undefined) {
+                await this.openDefaultWindow();
+            } else {
+                await this.openWindowWithWorkspace(workspacePath);
+            }
+        }
+    }
+
+    protected async createWindowUri(): Promise<URI> {
+        const port = await this.backendPort.promise;
+        return FileUri.create(this.globals.THEIA_FRONTEND_HTML_PATH).withQuery(`port=${port}`);
+    }
+
+    protected getDefaultWindowState(): BrowserWindowConstructorOptions {
+        // The `screen` API must be required when the application is ready.
+        // See: https://electronjs.org/docs/api/screen#screen
+        // We must center by hand because `browserWindow.center()` fails on multi-screen setups
+        // See: https://github.com/electron/electron/issues/3490
+        const { bounds } = screen.getDisplayNearestPoint(screen.getCursorScreenPoint());
+        const height = Math.floor(bounds.height * (2 / 3));
+        const width = Math.floor(bounds.width * (2 / 3));
+        const y = Math.floor(bounds.y + (bounds.height - height) / 2);
+        const x = Math.floor(bounds.x + (bounds.width - width) / 2);
+        return { width, height, x, y };
+    }
+
+    /**
+     * Only show the window when the content is ready.
+     */
+    protected attachReadyToShow(electronWindow: BrowserWindow): void {
+        electronWindow.on('ready-to-show', () => electronWindow.show());
+    }
+
+    /**
+     * Save the window geometry state on every change.
+     */
+    protected attachSaveWindowState(electronWindow: BrowserWindow): void {
+        const saveWindowState = () => {
+            try {
+                let bounds;
+                if (electronWindow.isMaximized()) {
+                    bounds = this.electronStore.get('windowstate', {});
+                } else {
+                    bounds = electronWindow.getBounds();
+                }
+                this.electronStore.set('windowstate', {
+                    isMaximized: electronWindow.isMaximized(),
+                    width: bounds.width,
+                    height: bounds.height,
+                    x: bounds.x,
+                    y: bounds.y
+                });
+            } catch (e) {
+                console.error('Error while saving window state:', e);
+            }
+        };
+        let delayedSaveTimeout: NodeJS.Timer | undefined;
+        const saveWindowStateDelayed = () => {
+            if (delayedSaveTimeout) {
+                clearTimeout(delayedSaveTimeout);
+            }
+            delayedSaveTimeout = setTimeout(saveWindowState, 1000);
+        };
+        electronWindow.on('close', saveWindowState);
+        electronWindow.on('resize', saveWindowStateDelayed);
+        electronWindow.on('move', saveWindowStateDelayed);
+    }
+
+    /**
+     * Catch window closing event and display a confirmation window.
+     */
+    protected attachWillPreventUnload(electronWindow: BrowserWindow): void {
+        // Fired when a beforeunload handler tries to prevent the page unloading
+        electronWindow.webContents.on('will-prevent-unload', async event => {
+            const { response } = await dialog.showMessageBox(electronWindow, {
+                type: 'question',
+                buttons: ['Yes', 'No'],
+                title: 'Confirm',
+                message: 'Are you sure you want to quit?',
+                detail: 'Any unsaved changes will not be saved.'
+            });
+            if (response === 0) { // 'Yes'
+                // This ignores the beforeunload callback, allowing the page to unload
+                event.preventDefault();
+            }
+        });
+    }
+
+    /**
+     * Catch certain keybindings to prevent reloading the window using keyboard shortcuts.
+     */
+    protected attachGlobalShortcuts(electronWindow: BrowserWindow): void {
+        if (this.config.electron?.disallowReloadKeybinding) {
+            const accelerators = ['CmdOrCtrl+R', 'F5'];
+            electronWindow.on('focus', () => {
+                for (const accelerator of accelerators) {
+                    globalShortcut.register(accelerator, () => { });
+                }
+            });
+            electronWindow.on('blur', () => {
+                for (const accelerator of accelerators) {
+                    globalShortcut.unregister(accelerator);
+                }
+            });
+        }
+    }
+
+    protected restoreMaximizedState(electronWindow: BrowserWindow, options: TheiaBrowserWindowOptions): void {
+        if (options.isMaximized) {
+            electronWindow.maximize();
+        } else {
+            electronWindow.unmaximize();
+        }
+    }
+
+    /**
+     * Start the NodeJS backend server.
+     *
+     * @return Running server's port promise.
+     */
+    protected async startBackend(): Promise<number> {
+        // Check if we should run everything as one process.
+        const noBackendFork = process.argv.indexOf('--no-cluster') !== -1;
+        // We cannot use the `process.cwd()` as the application project path (the location of the `package.json` in other words)
+        // in a bundled electron application because it depends on the way we start it. For instance, on OS X, these are a differences:
+        // https://github.com/eclipse-theia/theia/issues/3297#issuecomment-439172274
+        process.env.THEIA_APP_PROJECT_PATH = this.globals.THEIA_APP_PROJECT_PATH;
+        // Set the electron version for both the dev and the production mode. (https://github.com/eclipse-theia/theia/issues/3254)
+        // Otherwise, the forked backend processes will not know that they're serving the electron frontend.
+        process.env.THEIA_ELECTRON_VERSION = process.versions.electron;
+        if (noBackendFork) {
+            process.env[ElectronSecurityToken] = JSON.stringify(this.electronSecurityToken);
+            // The backend server main file is supposed to export a promise resolving with the port used by the http(s) server.
+            const address: AddressInfo = await require(this.globals.THEIA_BACKEND_MAIN_PATH);
+            return address.port;
+        } else {
+            const backendProcess = fork(
+                this.globals.THEIA_BACKEND_MAIN_PATH,
+                this.processArgv.getProcessArgvWithoutBin(),
+                await this.getForkOptions(),
+            );
+            return new Promise((resolve, reject) => {
+                // The backend server main file is also supposed to send the resolved http(s) server port via IPC.
+                backendProcess.on('message', (address: AddressInfo) => {
+                    resolve(address.port);
+                });
+                backendProcess.on('error', error => {
+                    reject(error);
+                });
+                app.on('quit', () => {
+                    // If we forked the process for the clusters, we need to manually terminate it.
+                    // See: https://github.com/eclipse-theia/theia/issues/835
+                    process.kill(backendProcess.pid);
+                });
+            });
+        }
+    }
+
+    protected async getForkOptions(): Promise<ForkOptions> {
+        return {
+            env: {
+                ...process.env,
+                [ElectronSecurityToken]: JSON.stringify(this.electronSecurityToken),
+            },
+        };
+    }
+
+    protected async attachElectronSecurityToken(port: number): Promise<void> {
+        session.defaultSession.cookies.set({
+            url: `http://localhost:${port}/`,
+            name: ElectronSecurityToken,
+            value: JSON.stringify(this.electronSecurityToken),
+            httpOnly: true
+        });
+    }
+
+    protected hookApplicationEvents(): void {
+        app.on('will-quit', this.onWillQuit.bind(this));
+        app.on('second-instance', this.onSecondInstance.bind(this));
+        app.on('window-all-closed', this.onWindowAllClosed.bind(this));
+    }
+
+    protected onWillQuit(event: ElectronEvent): void {
+        this.stopContributions();
+    }
+
+    protected async onSecondInstance(event: ElectronEvent, argv: string[], cwd: string): Promise<void> {
+        const electronWindows = BrowserWindow.getAllWindows();
+        if (electronWindows.length > 0) {
+            const electronWindow = electronWindows[0];
+            if (electronWindow.isMinimized()) {
+                electronWindow.restore();
+            }
+            electronWindow.focus();
+        }
+    }
+
+    protected onWindowAllClosed(event: ElectronEvent): void {
+        this.requestStop();
+    }
+
+    protected async startContributions(): Promise<void> {
+        const promises = [];
+        for (const contribution of this.contributions.getContributions()) {
+            if (contribution.onStart) {
+                promises.push(contribution.onStart(this));
+            }
+        }
+        await Promise.all(promises);
+    }
+
+    protected stopContributions(): void {
+        for (const contribution of this.contributions.getContributions()) {
+            if (contribution.onStop) {
+                contribution.onStop(this);
+            }
+        }
+    }
+
+}

--- a/packages/core/src/electron-main/electron-main-window-service-impl.ts
+++ b/packages/core/src/electron-main/electron-main-window-service-impl.ts
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (C) 2017 TypeFox and others.
+ * Copyright (C) 2020 Ericsson and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -14,25 +14,27 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
+import { shell } from 'electron';
 import { injectable, inject } from 'inversify';
-import { NewWindowOptions } from '../../browser/window/window-service';
-import { DefaultWindowService } from '../../browser/window/default-window-service';
-import { ElectronMainWindowService } from '../../electron-common/electron-main-window-service';
+import { ElectronMainWindowService } from '../electron-common/electron-main-window-service';
+import { ElectronMainApplication } from './electron-main-application';
+import { NewWindowOptions } from '../browser/window/window-service';
 
 @injectable()
-export class ElectronWindowService extends DefaultWindowService {
+export class ElectronMainWindowServiceImpl implements ElectronMainWindowService {
 
-    @inject(ElectronMainWindowService)
-    protected readonly delegate: ElectronMainWindowService;
+    @inject(ElectronMainApplication)
+    protected readonly app: ElectronMainApplication;
 
-    openNewWindow(url: string, { external }: NewWindowOptions = {}): undefined {
-        this.delegate.openNewWindow(url, { external });
+    openNewWindow(url: string, { external }: NewWindowOptions): undefined {
+        if (external) {
+            shell.openExternal(url);
+        } else {
+            this.app.createWindow().then(electronWindow => {
+                electronWindow.loadURL(url);
+            });
+        }
         return undefined;
-    }
-
-    protected preventUnload(event: BeforeUnloadEvent): string | void {
-        // The user will be shown a confirmation dialog by the will-prevent-unload handler in the Electron main script
-        event.returnValue = false;
     }
 
 }

--- a/packages/core/src/electron-main/electron-native-keymap.ts
+++ b/packages/core/src/electron-main/electron-native-keymap.ts
@@ -1,0 +1,40 @@
+/********************************************************************************
+ * Copyright (C) 2020 Ericsson and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import { webContents } from 'electron';
+import { injectable } from 'inversify';
+import { ElectronMainApplication, ElectronMainApplicationContribution } from './electron-main-application';
+const nativeKeymap = require('native-keymap');
+
+@injectable()
+export class ElectronNativeKeymap implements ElectronMainApplicationContribution {
+
+    /**
+     * Notify all renderer processes on keyboard layout change.
+     */
+    onStart(application: ElectronMainApplication): void {
+        nativeKeymap.onDidChangeKeyboardLayout(() => {
+            const newLayout = {
+                info: nativeKeymap.getCurrentKeyboardLayout(),
+                mapping: nativeKeymap.getKeyMap()
+            };
+            for (const webContent of webContents.getAllWebContents()) {
+                webContent.send('keyboardLayoutChanged', newLayout);
+            }
+        });
+    }
+
+}

--- a/packages/core/src/electron-main/messaging/electron-messaging-contribution.ts
+++ b/packages/core/src/electron-main/messaging/electron-messaging-contribution.ts
@@ -1,0 +1,132 @@
+/********************************************************************************
+ * Copyright (C) 2020 Ericsson and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import { IpcMainEvent, ipcMain, WebContents } from 'electron';
+import { inject, injectable, named, postConstruct } from 'inversify';
+import { MessageConnection } from 'vscode-jsonrpc';
+import { createWebSocketConnection } from 'vscode-ws-jsonrpc/lib/socket/connection';
+import { ContributionProvider } from '../../common/contribution-provider';
+import { WebSocketChannel } from '../../common/messaging/web-socket-channel';
+import { MessagingContribution } from '../../node/messaging/messaging-contribution';
+import { ConsoleLogger } from '../../node/messaging/logger';
+import { THEIA_ELECTRON_IPC_CHANNEL_NAME } from '../../electron-common/messaging/electron-connection-handler';
+import { ElectronMainApplicationContribution } from '../electron-main-application';
+import { ElectronMessagingService } from './electron-messaging-service';
+import { ElectronConnectionHandler } from '../../electron-common/messaging/electron-connection-handler';
+
+/**
+ * This component replicates the role filled by `MessagingContribution` but for Electron.
+ * Unlike the WebSocket based implementation, we do not expect to receive
+ * connection events. Instead, we'll create channels based on incoming `open`
+ * events on the `ipcMain` channel.
+ *
+ * This component allows communication between renderer process (frontend) and electron main process.
+ */
+@injectable()
+export class ElectronMessagingContribution implements ElectronMainApplicationContribution, ElectronMessagingService {
+
+    @inject(ContributionProvider) @named(ElectronMessagingService.Contribution)
+    protected readonly messagingContributions: ContributionProvider<ElectronMessagingService.Contribution>;
+
+    @inject(ContributionProvider) @named(ElectronConnectionHandler)
+    protected readonly connectionHandlers: ContributionProvider<ElectronConnectionHandler>;
+
+    protected readonly channelHandlers = new MessagingContribution.ConnectionHandlers<WebSocketChannel>();
+    protected readonly windowChannels = new Map<number, Map<number, WebSocketChannel>>();
+
+    @postConstruct()
+    protected init(): void {
+        ipcMain.on(THEIA_ELECTRON_IPC_CHANNEL_NAME, (event: IpcMainEvent, data: string) => {
+            this.handleIpcMessage(event, data);
+        });
+    }
+
+    onStart(): void {
+        for (const contribution of this.messagingContributions.getContributions()) {
+            contribution.configure(this);
+        }
+        for (const connectionHandler of this.connectionHandlers.getContributions()) {
+            this.channelHandlers.push(connectionHandler.path, (params, channel) => {
+                const connection = createWebSocketConnection(channel, new ConsoleLogger());
+                connectionHandler.onConnection(connection);
+            });
+        }
+    }
+
+    listen(spec: string, callback: (params: ElectronMessagingService.PathParams, connection: MessageConnection) => void): void {
+        this.ipcChannel(spec, (params, channel) => {
+            const connection = createWebSocketConnection(channel, new ConsoleLogger());
+            callback(params, connection);
+        });
+    }
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    ipcChannel(spec: string, callback: (params: any, channel: WebSocketChannel) => void): void {
+        this.channelHandlers.push(spec, callback);
+    }
+
+    protected handleIpcMessage(event: IpcMainEvent, data: string): void {
+        const sender = event.sender;
+        try {
+            // Get the channel map for a given window id
+            let channels = this.windowChannels.get(sender.id)!;
+            if (!channels) {
+                this.windowChannels.set(sender.id, channels = new Map<number, WebSocketChannel>());
+            }
+            // Start parsing the message to extract the channel id and route
+            const message: WebSocketChannel.Message = JSON.parse(data.toString());
+            // Someone wants to open a logical channel
+            if (message.kind === 'open') {
+                const { id, path } = message;
+                const channel = this.createChannel(id, sender);
+                if (this.channelHandlers.route(path, channel)) {
+                    channel.ready();
+                    channels.set(id, channel);
+                    channel.onClose(() => channels.delete(id));
+                } else {
+                    console.error('Cannot find a service for the path: ' + path);
+                }
+            } else {
+                const { id } = message;
+                const channel = channels.get(id);
+                if (channel) {
+                    channel.handleMessage(message);
+                } else {
+                    console.error('The ipc channel does not exist', id);
+                }
+            }
+            const close = () => {
+                for (const channel of Array.from(channels.values())) {
+                    channel.close(undefined, 'webContent destroyed');
+                }
+                channels.clear();
+            };
+            sender.once('did-navigate', close); // When refreshing the browser window.
+            sender.once('destroyed', close); // When closing the browser window.
+        } catch (error) {
+            console.error('IPC: Failed to handle message', { error, data });
+        }
+    }
+
+    protected createChannel(id: number, sender: WebContents): WebSocketChannel {
+        return new WebSocketChannel(id, content => {
+            if (!sender.isDestroyed()) {
+                sender.send(THEIA_ELECTRON_IPC_CHANNEL_NAME, content);
+            }
+        });
+    }
+
+}

--- a/packages/core/src/electron-main/messaging/electron-messaging-service.ts
+++ b/packages/core/src/electron-main/messaging/electron-messaging-service.ts
@@ -1,0 +1,40 @@
+/********************************************************************************
+ * Copyright (C) 2020 Ericsson and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import type { MessageConnection } from 'vscode-jsonrpc';
+import type { WebSocketChannel } from '../../common/messaging/web-socket-channel';
+
+export interface ElectronMessagingService {
+    /**
+     * Accept a JSON-RPC connection on the given path.
+     * A path supports the route syntax: https://github.com/rcs/route-parser#what-can-i-use-in-my-routes.
+     */
+    listen(path: string, callback: (params: ElectronMessagingService.PathParams, connection: MessageConnection) => void): void;
+    /**
+     * Accept an ipc channel on the given path.
+     * A path supports the route syntax: https://github.com/rcs/route-parser#what-can-i-use-in-my-routes.
+     */
+    ipcChannel(path: string, callback: (params: ElectronMessagingService.PathParams, socket: WebSocketChannel) => void): void;
+}
+export namespace ElectronMessagingService {
+    export interface PathParams {
+        [name: string]: string
+    }
+    export const Contribution = Symbol('ElectronMessagingService.Contribution');
+    export interface Contribution {
+        configure(service: ElectronMessagingService): void;
+    }
+}


### PR DESCRIPTION
Closes #3364
Closes #7406
Closes #7964

Combined work with @kittaakos.

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

This PR contributes a JSON-RPC communication scheme between the `electron-main` process and the `renderer` processes. It is reusing the same architecture as the websocket-based connection between frontend/backend, but adapted to work over electron's ipc apis. Currently there isn't scoped connections, meaning that each renderer process will interact with the same singleton in the electron-main process, but for the current use-cases this is sufficient.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

To verify:
 - `yarn --cwd ./examples/electron start` -> Should open previous workspace, if any. Otherwise, opens a no-workspace app.
 - `yarn --cwd ./examples/electron start ~/Desktop/` -> Opens your app with a workspace to the `Desktop`.
 - `yarn --cwd ./examples/electron start ../..` -> Opens the app to with Theia as the workspace.
 - `yarn --cwd ./examples/electron start path/to/missing` -> Opens the app without a workspace. See log: `Could not resolve the workspace path.`
 - `mkdir ~/Desktop/path\ with\ space && yarn --cwd ./examples/electron start ~/Desktop/path\ with\ space` -> Open the app with the desired workspace. The workspace contains spaces in the FS path.

----

 - Check updater sample
 - Check `File` > `Settings` > `Check for Update...` -> You will see, there are no updates.
 - Execute the _Electron Updater Sample: Mock - Available_ command and wait a bit.
 - You should receive a notification, about new updates. Click on yes, the electron-main process should print something to the backend console.
 - Refresh the browser window, you should see `Disposed a sample updater client.` AND `Registered a new sample updater client.`
 - Open a second workspace, you should see `Registered a new sample updater client.`. Close the new window, you should see `Disposed a sample updater client.`

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)