### PR TITLE
Implement VS Code workbench.view.explorer command

### DIFF
--- a/packages/plugin-ext-vscode/src/browser/plugin-vscode-commands-contribution.ts
+++ b/packages/plugin-ext-vscode/src/browser/plugin-vscode-commands-contribution.ts
@@ -55,6 +55,7 @@ import { MonacoEditor } from '@theia/monaco/lib/browser/monaco-editor';
 import { TerminalFrontendContribution } from '@theia/terminal/lib/browser/terminal-frontend-contribution';
 import { QuickOpenWorkspace } from '@theia/workspace/lib/browser/quick-open-workspace';
 import { TerminalService } from '@theia/terminal/lib/browser/base/terminal-service';
+import { FileNavigatorCommands } from '@theia/navigator/lib/browser/navigator-contribution';
 
 export namespace VscodeCommands {
     export const OPEN: Command = {
@@ -616,6 +617,11 @@ export class PluginVscodeCommandsContribution implements CommandContribution {
 
                 currentTerminal.dispose();
             }
+        });
+        commands.registerCommand({
+            id: 'workbench.view.explorer'
+        }, {
+            execute: () => commands.executeCommand(FileNavigatorCommands.FOCUS.id)
         });
         commands.registerCommand({
             id: 'copyFilePath'


### PR DESCRIPTION
#### What it does
This changes proposal adds simple implementation for the VS Code `workbench.view.explorer command` command. [1]

[1] [microsoft/vscode/src/vs/workbench/contrib/files/browser/files.contribution.ts#L44-L57](https://github.com/microsoft/vscode/blob/0e2cce10298f1106cca7518706fba05735708b77/src/vs/workbench/contrib/files/browser/files.contribution.ts#L44-L57)

Signed-off-by: Vladyslav Zhukovskyi <vzhukovs@redhat.com>

#### How to test
There is two ways to check the PR:

1. Using custom plugin that calls this command: [workbench-files-action-focusFilesExplorer](https://github.com/vzhukovskii/workbench-files-action-focusFilesExplorer)

2. Using [Didact](https://marketplace.visualstudio.com/items?itemName=redhat.vscode-didact) extension. It will call under the hood this command and the previously implemented `copyFilePath`:

![explorer](https://user-images.githubusercontent.com/1968177/83781683-8df2e600-a697-11ea-886f-aee80839c624.gif)

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

