### PR TITLE
plugin-ext: fix non-awaited promise

### DIFF
--- a/packages/plugin-ext/src/main/electron-browser/webview/electron-webview-widget-factory.ts
+++ b/packages/plugin-ext/src/main/electron-browser/webview/electron-webview-widget-factory.ts
@@ -23,7 +23,7 @@ export class ElectronWebviewWidgetFactory extends WebviewWidgetFactory {
 
     async createWidget(identifier: WebviewWidgetIdentifier): Promise<WebviewWidget> {
         const widget = await super.createWidget(identifier);
-        this.attachElectronSecurityCookie(widget.externalEndpoint);
+        await this.attachElectronSecurityCookie(widget.externalEndpoint);
         return widget;
     }
 


### PR DESCRIPTION
The factory was not waiting for the electron security token to be set
before handing over the widget, this could lead to a race condition
where the cookie is missing and the webview wouldn't work.

#### How to test

@kittaakos ?

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)