### PR TITLE
added task id to task config interface

### DIFF
--- a/packages/plugin-ext/src/common/plugin-api-rpc.ts
+++ b/packages/plugin-ext/src/common/plugin-api-rpc.ts
@@ -1162,7 +1162,14 @@ export interface CommandProperties {
     };
 }
 
+export interface TaskDefinitionDto {
+    type: string;
+    [name: string]: any;
+}
+
 export interface TaskDto {
+    id: string;
+    definition: TaskDefinitionDto;
     type: string;
     label: string;
     source?: string;

--- a/packages/plugin-ext/src/common/plugin-protocol.ts
+++ b/packages/plugin-ext/src/common/plugin-protocol.ts
@@ -22,7 +22,7 @@ import { ExtPluginApi } from './plugin-ext-api-contribution';
 import { IJSONSchema, IJSONSchemaSnippet } from '@theia/core/lib/common/json-schema';
 import { RecursivePartial } from '@theia/core/lib/common/types';
 import { PreferenceSchema, PreferenceSchemaProperties } from '@theia/core/lib/common/preferences/preference-schema';
-import { ProblemMatcherContribution, ProblemPatternContribution, TaskDefinition } from '@theia/task/lib/common';
+import { ProblemMatcherContribution, ProblemPatternContribution, TaskDefinitionContibution } from '@theia/task/lib/common';
 import { FileStat } from '@theia/filesystem/lib/common';
 import { ColorDefinition } from '@theia/core/lib/browser/color-registry';
 
@@ -477,7 +477,7 @@ export interface PluginContribution {
     themes?: ThemeContribution[];
     iconThemes?: IconThemeContribution[];
     colors?: ColorDefinition[];
-    taskDefinitions?: TaskDefinition[];
+    taskDefinitions?: TaskDefinitionContibution[];
     problemMatchers?: ProblemMatcherContribution[];
     problemPatterns?: ProblemPatternContribution[];
 }

--- a/packages/plugin-ext/src/hosted/node/scanners/scanner-theia.ts
+++ b/packages/plugin-ext/src/hosted/node/scanners/scanner-theia.ts
@@ -58,7 +58,7 @@ import { deepClone } from '@theia/core/lib/common/objects';
 import { FileUri } from '@theia/core/lib/node/file-uri';
 import { PreferenceSchema, PreferenceSchemaProperties } from '@theia/core/lib/common/preferences/preference-schema';
 import { RecursivePartial } from '@theia/core/lib/common/types';
-import { ProblemMatcherContribution, ProblemPatternContribution, TaskDefinition } from '@theia/task/lib/common/task-protocol';
+import { ProblemMatcherContribution, ProblemPatternContribution, TaskDefinitionContibution } from '@theia/task/lib/common/task-protocol';
 import { ColorDefinition } from '@theia/core/lib/browser/color-registry';
 
 namespace nls {
@@ -547,7 +547,7 @@ export class TheiaPluginScanner implements PluginScanner {
         return result;
     }
 
-    private readTaskDefinition(pluginName: string, definitionContribution: PluginTaskDefinitionContribution): TaskDefinition {
+    private readTaskDefinition(pluginName: string, definitionContribution: PluginTaskDefinitionContribution): TaskDefinitionContibution {
         const propertyKeys = definitionContribution.properties ? Object.keys(definitionContribution.properties) : [];
         return {
             taskType: definitionContribution.type,

--- a/packages/plugin-ext/src/main/browser/plugin-contribution-handler.ts
+++ b/packages/plugin-ext/src/main/browser/plugin-contribution-handler.ts
@@ -274,7 +274,7 @@ export class PluginContributionHandler {
         if (contributions.taskDefinitions) {
             for (const taskDefinition of contributions.taskDefinitions) {
                 pushContribution(`taskDefinitions.${taskDefinition.taskType}`,
-                    () => this.taskDefinitionRegistry.register(taskDefinition)
+                    () => this.taskDefinitionRegistry.register({ ...taskDefinition, pluginOrExtensionId: plugin.metadata.model.id })
                 );
             }
         }

--- a/packages/plugin-ext/src/plugin/type-converters.spec.ts
+++ b/packages/plugin-ext/src/plugin/type-converters.spec.ts
@@ -178,8 +178,15 @@ describe('Type converters:', () => {
         const args = ['run', 'build'];
         const cwd = '/projects/theia';
         const additionalProperty = 'some property';
+        const id = 'id';
 
         const shellTaskDto: TaskDto = {
+            id,
+            definition: {
+                id,
+                type: shellType,
+                additionalProperty
+            },
             type: shellType,
             label,
             source,
@@ -191,6 +198,12 @@ describe('Type converters:', () => {
         };
 
         const shellTaskDtoWithCommandLine: TaskDto = {
+            id,
+            definition: {
+                type: shellType,
+                id,
+                additionalProperty
+            },
             type: shellType,
             label,
             source,
@@ -206,6 +219,7 @@ describe('Type converters:', () => {
             scope: 1,
             definition: {
                 type: shellType,
+                id,
                 additionalProperty
             },
             execution: {
@@ -222,6 +236,7 @@ describe('Type converters:', () => {
             source,
             scope: 2,
             definition: {
+                id,
                 type: shellType,
                 additionalProperty
             },
@@ -233,12 +248,29 @@ describe('Type converters:', () => {
             }
         };
 
-        const customTaskDto: TaskDto = { ...shellTaskDto, type: customType };
+        const customTaskDto: TaskDto = {
+            ...shellTaskDto,
+            type: customType,
+            definition: {
+                type: customType,
+                id,
+                additionalProperty
+            }
+        };
 
-        const customTaskDtoWithCommandLine: TaskDto = { ...shellTaskDtoWithCommandLine, type: customType };
+        const customTaskDtoWithCommandLine: TaskDto = {
+            ...shellTaskDtoWithCommandLine,
+            type: customType,
+            definition: {
+                type: customType,
+                id,
+                additionalProperty
+            }
+        };
 
         const customPluginTask: theia.Task = {
             ...shellPluginTask, definition: {
+                id,
                 type: customType,
                 additionalProperty
             }
@@ -249,6 +281,7 @@ describe('Type converters:', () => {
             source,
             scope: 2,
             definition: {
+                id,
                 type: customType,
                 additionalProperty
             },

--- a/packages/plugin-ext/src/plugin/type-converters.ts
+++ b/packages/plugin-ext/src/plugin/type-converters.ts
@@ -20,7 +20,7 @@ import { URI } from 'vscode-uri';
 import * as rpc from '../common/plugin-api-rpc';
 import {
     DecorationOptions, EditorPosition, PickOpenItem, Plugin, Position, ResourceFileEditDto,
-    ResourceTextEditDto, Selection, TaskDto, WorkspaceEditDto
+    ResourceTextEditDto, Selection, TaskDto, WorkspaceEditDto, TaskDefinitionDto
 } from '../common/plugin-api-rpc';
 import * as model from '../common/plugin-api-rpc-model';
 import { LanguageFilter, LanguageSelector, RelativePattern } from '@theia/languages/lib/common/language-selector';
@@ -720,6 +720,7 @@ export function fromTask(task: theia.Task): TaskDto | undefined {
     }
 
     taskDto.type = taskDefinition.type;
+    taskDto.definition = { ...taskDefinition };
     const { type, ...properties } = taskDefinition;
     for (const key in properties) {
         if (properties.hasOwnProperty(key)) {
@@ -748,7 +749,7 @@ export function toTask(taskDto: TaskDto): theia.Task {
         throw new Error('Task should be provided for converting');
     }
 
-    const { type, label, source, scope, command, args, options, windows, ...properties } = taskDto;
+    const { type, label, source, scope, command, args, options, windows, definition, ...properties } = taskDto;
     const result = {} as theia.Task;
     result.name = label;
     result.source = source;
@@ -764,7 +765,8 @@ export function toTask(taskDto: TaskDto): theia.Task {
     }
 
     const taskType = type;
-    const taskDefinition: theia.TaskDefinition = {
+    const taskDefinition: TaskDefinitionDto = {
+        ...definition,
         type: taskType
     };
 

--- a/packages/plugin-ext/src/plugin/types-impl.ts
+++ b/packages/plugin-ext/src/plugin/types-impl.ts
@@ -1608,6 +1608,10 @@ export enum TaskScope {
 }
 
 export class Task {
+    private static ProcessType: string = 'process';
+    private static ShellType: string = 'shell';
+    private static EmptyType: string = '$empty';
+
     private taskDefinition: theia.TaskDefinition;
     private taskScope: theia.TaskScope.Global | theia.TaskScope.Workspace | theia.WorkspaceFolder | undefined;
     private taskName: string;
@@ -1794,14 +1798,20 @@ export class Task {
     private updateDefinitionBasedOnExecution(): void {
         if (this.taskExecution instanceof ProcessExecution) {
             Object.assign(this.taskDefinition, {
-                type: 'process',
+                type: Task.ProcessType,
                 id: this.taskExecution.computeId(),
                 taskType: this.taskDefinition!.type
             });
         } else if (this.taskExecution instanceof ShellExecution) {
             Object.assign(this.taskDefinition, {
-                type: 'shell',
+                type: Task.ShellType,
                 id: this.taskExecution.computeId(),
+                taskType: this.taskDefinition!.type
+            });
+        } else {
+            Object.assign(this.taskDefinition, {
+                type: Task.EmptyType,
+                id: UUID.uuid4(),
                 taskType: this.taskDefinition!.type
             });
         }

--- a/packages/task/src/browser/provided-task-configurations.spec.ts
+++ b/packages/task/src/browser/provided-task-configurations.spec.ts
@@ -34,7 +34,9 @@ describe('provided-task-configurations', () => {
         const providerRegistry = container.get(TaskProviderRegistry);
         providerRegistry.register('test', {
             provideTasks(): Promise<TaskConfiguration[]> {
-                return Promise.resolve([{ type: 'test', label: 'task from test', _source: 'test', _scope: 'test' } as TaskConfiguration]);
+                return Promise.resolve([{
+                    id: { _key: 'id', type: 'test' }, type: 'test', label: 'task from test', _source: 'test', _scope: 'test'
+                } as TaskConfiguration]);
             }
         });
 

--- a/packages/task/src/browser/provided-task-configurations.ts
+++ b/packages/task/src/browser/provided-task-configurations.ts
@@ -17,7 +17,7 @@
 import { inject, injectable } from 'inversify';
 import { TaskProviderRegistry } from './task-contribution';
 import { TaskDefinitionRegistry } from './task-definition-registry';
-import { TaskConfiguration, TaskCustomization, TaskOutputPresentation, TaskConfigurationScope } from '../common';
+import { TaskConfiguration, TaskCustomization, TaskOutputPresentation, TaskConfigurationScope, KeyedTaskIdentifier } from '../common';
 
 @injectable()
 export class ProvidedTaskConfigurations {
@@ -62,6 +62,17 @@ export class ProvidedTaskConfigurations {
         } else {
             await this.getTasks();
             return this.getCachedTask(source, taskLabel, scope);
+        }
+    }
+
+    /** returns the task configuration for a given id or undefined if none */
+    async getTaskById(id: KeyedTaskIdentifier): Promise<TaskConfiguration | undefined> {
+        const task = this.getCachedTaskById(id);
+        if (task) {
+            return task;
+        } else {
+            await this.getTasks();
+            return this.getCachedTaskById(id);
         }
     }
 
@@ -118,6 +129,18 @@ export class ProvidedTaskConfigurations {
                     return scopeConfigMap.get(scope.toString());
                 }
                 return Array.from(scopeConfigMap.values())[0];
+            }
+        }
+    }
+
+    protected getCachedTaskById(id: KeyedTaskIdentifier): TaskConfiguration | undefined {
+        for (const labelConfigMap of this.tasksMap.values()) {
+            for (const scopeConfigMap of labelConfigMap.values()) {
+                for (const taskConfig of scopeConfigMap.values()) {
+                    if (taskConfig.id._key === id._key) {
+                        return taskConfig;
+                    }
+                }
             }
         }
     }

--- a/packages/task/src/browser/quick-open-task.ts
+++ b/packages/task/src/browser/quick-open-task.ts
@@ -334,13 +334,7 @@ export class QuickOpenTask implements QuickOpenModel, QuickOpenHandler {
                 if (defaultBuildOrTestTasks.length === 1) { // run the default build / test task
                     const defaultBuildOrTestTask = defaultBuildOrTestTasks[0];
                     const taskToRun = (defaultBuildOrTestTask as TaskRunQuickOpenItem).getTask();
-                    const scope = taskToRun._scope;
-
-                    if (this.taskDefinitionRegistry && !!this.taskDefinitionRegistry.getDefinition(taskToRun)) {
-                        this.taskService.run(taskToRun.source, taskToRun.label, scope);
-                    } else {
-                        this.taskService.run(taskToRun._source, taskToRun.label, scope);
-                    }
+                    this.taskService.run(taskToRun.id);
                     return;
                 }
 
@@ -419,7 +413,10 @@ export class QuickOpenTask implements QuickOpenModel, QuickOpenHandler {
 
         const filteredRecentTasks: TaskConfiguration[] = [];
         recentTasks.forEach(recent => {
-            const originalTaskConfig = [...configuredTasks, ...providedTasks].find(t => this.taskDefinitionRegistry.compareTasks(recent, t));
+            let originalTaskConfig = [...configuredTasks, ...providedTasks].find(t => t.id._key === recent.id._key);
+            if (!originalTaskConfig) {
+                originalTaskConfig = [...configuredTasks, ...providedTasks].find(t => this.taskDefinitionRegistry.compareTasks(recent, t));
+            }
             if (originalTaskConfig) {
                 filteredRecentTasks.push(originalTaskConfig);
             }
@@ -427,7 +424,7 @@ export class QuickOpenTask implements QuickOpenModel, QuickOpenHandler {
 
         const filteredProvidedTasks: TaskConfiguration[] = [];
         providedTasks.forEach(provided => {
-            const exist = [...filteredRecentTasks, ...configuredTasks].some(t => this.taskDefinitionRegistry.compareTasks(provided, t));
+            const exist = [...filteredRecentTasks, ...configuredTasks].some(t => t.id._key === provided.id._key);
             if (!exist) {
                 filteredProvidedTasks.push(provided);
             }
@@ -435,7 +432,7 @@ export class QuickOpenTask implements QuickOpenModel, QuickOpenHandler {
 
         const filteredConfiguredTasks: TaskConfiguration[] = [];
         configuredTasks.forEach(configured => {
-            const exist = filteredRecentTasks.some(t => this.taskDefinitionRegistry.compareTasks(configured, t));
+            const exist = filteredRecentTasks.some(t => t.id._key === configured.id._key);
             if (!exist) {
                 filteredConfiguredTasks.push(configured);
             }
@@ -497,13 +494,7 @@ export class TaskRunQuickOpenItem extends QuickOpenGroupItem {
         if (mode !== QuickOpenMode.OPEN) {
             return false;
         }
-
-        const scope = this.task._scope;
-        if (this.taskDefinitionRegistry && !!this.taskDefinitionRegistry.getDefinition(this.task)) {
-            this.taskService.run(this.task.source || this.task._source, this.task.label, scope);
-        } else {
-            this.taskService.run(this.task._source, this.task.label, scope);
-        }
+        this.taskService.run(this.task.id);
         return true;
     }
 }

--- a/packages/task/src/browser/task-configuration-manager.ts
+++ b/packages/task/src/browser/task-configuration-manager.ts
@@ -24,7 +24,7 @@ import { QuickPickService } from '@theia/core/lib/common/quick-pick-service';
 import { WorkspaceService } from '@theia/workspace/lib/browser/workspace-service';
 import { TaskConfigurationModel } from './task-configuration-model';
 import { TaskTemplateSelector } from './task-templates';
-import { TaskCustomization, TaskConfiguration, TaskConfigurationScope, TaskScope } from '../common/task-protocol';
+import { TaskCustomization, TaskConfiguration, TaskConfigurationScope, TaskScope, CustomizedTaskTemplate } from '../common/task-protocol';
 import { WorkspaceVariableContribution } from '@theia/workspace/lib/browser/workspace-variable-contribution';
 import { FileSystem, FileSystemError } from '@theia/filesystem/lib/common';
 import { FileChangeType } from '@theia/filesystem/lib/common/filesystem-watcher-protocol';
@@ -139,7 +139,7 @@ export class TaskConfigurationManager {
         }
     }
 
-    async addTaskConfiguration(scope: TaskConfigurationScope, taskConfig: TaskCustomization): Promise<boolean> {
+    async addTaskConfiguration(scope: TaskConfigurationScope, taskConfig: CustomizedTaskTemplate): Promise<boolean> {
         const taskPrefModel = this.getModel(scope);
         if (taskPrefModel) {
             const configurations = taskPrefModel.configurations;
@@ -148,7 +148,7 @@ export class TaskConfigurationManager {
         return false;
     }
 
-    async setTaskConfigurations(scope: TaskConfigurationScope, taskConfigs: (TaskCustomization | TaskConfiguration)[]): Promise<boolean> {
+    async setTaskConfigurations(scope: TaskConfigurationScope, taskConfigs: CustomizedTaskTemplate[]): Promise<boolean> {
         const taskPrefModel = this.getModel(scope);
         if (taskPrefModel) {
             return taskPrefModel.setConfigurations(taskConfigs);

--- a/packages/task/src/browser/task-definition-registry.spec.ts
+++ b/packages/task/src/browser/task-definition-registry.spec.ts
@@ -83,8 +83,9 @@ describe('TaskDefinitionRegistry', () => {
         it('should return undefined if the given task configuration does not match any registered definitions', () => {
             registry.register(definitionContributionA);
             registry.register(definitionContributionB);
+            const type = definitionContributionA.taskType;
             const defs = registry.getDefinition({
-                type: definitionContributionA.taskType, label: 'grunt task', task: 'build'
+                type, label: 'grunt task', task: 'build', id: { type, _key: '' }
             });
             expect(defs).to.be.not.ok;
         });
@@ -92,14 +93,15 @@ describe('TaskDefinitionRegistry', () => {
         it('should return the best match if there is one or more registered definitions match the given task configuration', () => {
             registry.register(definitionContributionA);
             registry.register(definitionContributionB);
+            const type = definitionContributionA.taskType;
             const defs = registry.getDefinition({
-                type: definitionContributionA.taskType, label: 'extension task', extensionType: 'extensionType', taskLabel: 'taskLabel'
+                type, label: 'extension task', extensionType: 'extensionType', taskLabel: 'taskLabel', id: { type, _key: '' }
             });
             expect(defs).to.be.ok;
             expect(defs!.taskType).to.be.eq(definitionContributionA.taskType);
 
             const defs2 = registry.getDefinition({
-                type: definitionContributionA.taskType, label: 'extension task', extensionType: 'extensionType', taskLabel: 'taskLabel', taskDetailedLabel: 'taskDetailedLabel'
+                type, label: 'extension task', extensionType: 'extensionType', taskLabel: 'taskLabel', taskDetailedLabel: 'taskDetailedLabel', id: { type, _key: '' }
             });
             expect(defs2).to.be.ok;
             expect(defs2!.taskType).to.be.eq(definitionContributionB.taskType);

--- a/packages/task/src/browser/task-frontend-contribution.ts
+++ b/packages/task/src/browser/task-frontend-contribution.ts
@@ -303,7 +303,10 @@ export class TaskFrontendContribution implements CommandContribution, MenuContri
         registry.registerCommand(
             TaskCommands.TASK_CLEAR_HISTORY,
             {
-                execute: () => this.taskService.clearRecentTasks()
+                execute: () => {
+                    this.taskService.clearRecentTasks();
+                    this.taskService.clearLastTask();
+                }
             }
         );
 

--- a/packages/task/src/browser/task-frontend-module.ts
+++ b/packages/task/src/browser/task-frontend-module.ts
@@ -38,6 +38,7 @@ import '../../src/browser/style/index.css';
 import './tasks-monaco-contribution';
 import { TaskNameResolver } from './task-name-resolver';
 import { TaskSourceResolver } from './task-source-resolver';
+import { TaskIdentifierResolver } from './task-identifier-resolver';
 import { TaskTemplateSelector } from './task-templates';
 import { TaskTerminalWidgetManager } from './task-terminal-widget-manager';
 
@@ -77,6 +78,7 @@ export default new ContainerModule(bind => {
     bind(TaskSchemaUpdater).toSelf().inSingletonScope();
     bind(TaskNameResolver).toSelf().inSingletonScope();
     bind(TaskSourceResolver).toSelf().inSingletonScope();
+    bind(TaskIdentifierResolver).toSelf().inSingletonScope();
     bind(TaskTemplateSelector).toSelf().inSingletonScope();
     bind(TaskTerminalWidgetManager).toSelf().inSingletonScope();
 

--- a/packages/task/src/browser/task-identifier-resolver.ts
+++ b/packages/task/src/browser/task-identifier-resolver.ts
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (C) 2017 Ericsson and others.
+ * Copyright (C) 2020 Ericsson and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -14,10 +14,17 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
-export * from './task-service';
-export * from './task-contribution';
-export * from './task-definition-registry';
-export * from './task-problem-matcher-registry';
-export * from './task-problem-pattern-registry';
-export * from './task-schema-updater';
-export * from './task-identifier-resolver';
+import { inject, injectable } from 'inversify';
+import { TaskIdentifier, KeyedTaskIdentifier } from '../common/task-protocol';
+import { TaskDefinitionRegistry } from './task-definition-registry';
+
+@injectable()
+export class TaskIdentifierResolver {
+    @inject(TaskDefinitionRegistry)
+    protected taskDefinitionRegistry: TaskDefinitionRegistry;
+
+    createKeyedIdentifier(identifier: TaskIdentifier): KeyedTaskIdentifier {
+        const definition = this.taskDefinitionRegistry.getDefinitions(identifier.type)[0];
+        return KeyedTaskIdentifier.createKeyedIdentifier(identifier, definition);
+    }
+}

--- a/packages/task/src/node/task-server.slow-spec.ts
+++ b/packages/task/src/node/task-server.slow-spec.ts
@@ -370,6 +370,7 @@ describe('Task server / back-end', function (): void {
 
 function createTaskConfig(taskType: string, command: string, args: string[]): TaskConfiguration {
     const options: TaskConfiguration = {
+        id: { _key: 'id', type: taskType },
         label: 'test task',
         type: taskType,
         _source: '/source/folder',
@@ -383,6 +384,7 @@ function createTaskConfig(taskType: string, command: string, args: string[]): Ta
 
 function createProcessTaskConfig(processType: ProcessType, command: string, args?: string[], cwd: string = wsRoot): TaskConfiguration {
     return <ProcessTaskConfiguration>{
+        id: { _key: 'id', type: processType },
         label: 'test task',
         type: processType,
         _source: '/source/folder',
@@ -406,6 +408,7 @@ function createProcessTaskConfig2(processType: ProcessType, command: string, arg
 
 function createTaskConfigTaskLongRunning(processType: ProcessType): TaskConfiguration {
     return <ProcessTaskConfiguration>{
+        id: { _key: 'id', type: processType },
         label: '[Task] long running test task (~300s)',
         type: processType,
         _source: '/source/folder',


### PR DESCRIPTION
- "Run task" and "Run task group" use task label, source folder, and scope to "guess" which task is the one that users want to run.
  With this change, the task identification is added to the task config interface, and it is used to search tasks.
- Reset "Last task" when "Task: Clear history" is executed.
- "Run last task" uses task id to search the most recent task, if not found, use the task type, label, and source to perform one more search.
- With the introduction of task id, Theia supports defining configured tasks that have same labels. However, to comply with VS Code, if a contributed task is customized more than once, the last customization overwrites the prior ones.
- make sure $fetchTasks() does not return duplicated contributed tasks that are customized.
- added extension / plugin id to the TaskDefintion interface.



Signed-off-by: Liang Huang <lhuang4@ualberta.ca>

#### How to test

- Theia should support the definiton of multiple tasks that have the same label
- Theia should NOT support having multiple customizations for the same contributed task. If there are more than one customizations, the last customization overwrites the priors.
- "Last task" should be reset after "Task: Clear history" is executed.

Smoke test the followings:
- Run a task
- Configure a configured / contributed task
- Run last task
- Run build / test task

#### Review checklist

- [x] Approval of CQ https://dev.eclipse.org/ipzilla/show_bug.cgi?id=22251
- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)
