### PR TITLE
Bugfix/Stringify Task ENUMs for Presentation and PanelKind

### DIFF
--- a/packages/task/src/common/task-protocol.ts
+++ b/packages/task/src/common/task-protocol.ts
@@ -28,15 +28,15 @@ export enum DependsOrder {
 }
 
 export enum RevealKind {
-    Always,
-    Silent,
-    Never
+    Always = 'always',
+    Silent = 'silent',
+    Never = 'never'
 }
 
 export enum PanelKind {
-    Shared,
-    Dedicated,
-    New
+    Shared = 'shared',
+    Dedicated = 'dedicated',
+    New = 'new'
 }
 
 export interface TaskOutputPresentation {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->
This PR addresses #7956 where `ENUM` values for `PanelKind` and `RevealKind` were not properly being stringified to their values defined in the `task-schema-updated.ts` (referenced below) when using `.setTaskConfigurations()` to write tasks to a `tasks.json` file, causing an `Invalid task configurations are found` error :
https://github.com/eclipse-theia/theia/blob/309b21892eedfadf0cd559afff64a26750933c4f/packages/task/src/browser/task-schema-updater.ts#L572
https://github.com/eclipse-theia/theia/blob/309b21892eedfadf0cd559afff64a26750933c4f/packages/task/src/browser/task-schema-updater.ts#L583

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
- Create an extension that injects the TaskConfigurationManager
- Build an object of type TaskConfiguration with some values (fill in proper scope/source value), use 
enum types for presentation panel and reveal, for example:
``` 
       const pendingTaskConfiguration: TaskConfiguration = {
            label: 'my task',
            type: 'shell',
            command: 'top',
            problemMatcher: [],
            args: '',
            _scope: 2,
            _source: scopeURI,
            options: {
                cwd: '',
            },
            presentation: {
                reveal: RevealKind.Always,
                panel: PanelKind.Shared
            },
        };
```
- Attempt to call this.taskConfigurationManager.setTaskConfigurations(scopeURI, [pendingTaskConfiguration])

- Open corresponding tasks.json file and observe that reveal and panel values have been properly set to their string values and no errors are thrown.

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

