### PR TITLE
[vsx-extensions] Adjust width of search box

### DIFF
--- a/packages/vsx-registry/src/browser/style/index.css
+++ b/packages/vsx-registry/src/browser/style/index.css
@@ -34,7 +34,7 @@
 }
 
 .theia-vsx-extensions-search-bar {
-    padding: var(--theia-ui-padding);
+    padding: var(--theia-ui-padding) var(--theia-scrollbar-width) var(--theia-ui-padding) 18px /* expansion toggle padding of tree elements in result list */;
     display: flex;
     align-content: center;
 }


### PR DESCRIPTION
#### What it does
Adjusts the padding around the search input box on the vsx-extension widget.

Before:
<img width="386" alt="Screenshot 2020-06-10 at 10 05 42" src="https://user-images.githubusercontent.com/372735/84243305-4ab6ce00-ab02-11ea-9691-3bdbd77112a7.png">

After:
<img width="373" alt="Screenshot 2020-06-10 at 10 05 52" src="https://user-images.githubusercontent.com/372735/84243293-468ab080-ab02-11ea-9311-a42657675f54.png">


#### Review checklist

- [ ] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

