### PR TITLE
Search-In-Worspace: no more different substrings/duplicates in search result

### DIFF
--- a/packages/search-in-workspace/src/browser/search-in-workspace-result-tree-widget.tsx
+++ b/packages/search-in-workspace/src/browser/search-in-workspace-result-tree-widget.tsx
@@ -212,10 +212,15 @@ export class SearchInWorkspaceResultTreeWidget extends TreeWidget {
         this.cancelIndicator = new CancellationTokenSource();
         const cancelIndicator = this.cancelIndicator;
         const token = this.cancelIndicator.token;
+        const progress = await this.progressService.showProgress({ text: `search: ${searchTerm}`, options: { location: 'search' } });
         token.onCancellationRequested(() => {
+            progress.cancel();
+            if (searchId) {
+                this.searchService.cancel(searchId);
+            }
+            this.cancelIndicator = undefined;
             this.changeEmitter.fire(this.resultTree);
         });
-        const progress = await this.progressService.showProgress({ text: `search: ${searchTerm}`, options: { location: 'search' } });
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         let pendingRefreshTimeout: any;
         const searchId = await this.searchService.search(searchTerm, {
@@ -260,13 +265,6 @@ export class SearchInWorkspaceResultTreeWidget extends TreeWidget {
                 this.refreshModelChildren();
             }
         }, searchOptions).catch(() => undefined);
-        token.onCancellationRequested(() => {
-            progress.cancel();
-            if (searchId) {
-                this.searchService.cancel(searchId);
-            }
-            this.cancelIndicator = undefined;
-        });
     }
 
     focusFirstResult(): void {


### PR DESCRIPTION
#### What it does
It solves the bug described here: #7282.
TL;DR: Sometimes one had different substrings in the search results and so one line shown more than once.

Fixes eclipse-theia/theia#7282

#### How to test
Type into the search box a search term and keep typing while the search is performed in the background. E.g. search for “ContainerModule”. Stop typing and wait for the result list. 
There shouldn't be any duplicates anymore.

#### Review checklist

- [ ] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

