### PR TITLE
[problems] Implemented clear-all in problems view.

### DIFF
--- a/packages/markers/src/browser/problem/problem-contribution.ts
+++ b/packages/markers/src/browser/problem/problem-contribution.ts
@@ -49,6 +49,12 @@ export namespace ProblemsCommands {
     export const COPY_MESSAGE: Command = {
         id: 'problems.copy.message',
     };
+    export const CLEAR_ALL: Command = {
+        id: 'problems.clear.all',
+        category: 'Problems',
+        label: 'Clear All',
+        iconClass: 'clear-all'
+    };
 }
 
 @injectable()
@@ -145,6 +151,11 @@ export class ProblemContribution extends AbstractViewContribution<ProblemWidget>
                 execute: selection => this.copyMessage(selection)
             })
         );
+        commands.registerCommand(ProblemsCommands.CLEAR_ALL, {
+            isEnabled: widget => this.withWidget(widget, () => true),
+            isVisible: widget => this.withWidget(widget, () => true),
+            execute: widget => this.withWidget(widget, () => this.problemManager.cleanAllMarkers())
+        });
     }
 
     registerMenus(menus: MenuModelRegistry): void {
@@ -172,6 +183,12 @@ export class ProblemContribution extends AbstractViewContribution<ProblemWidget>
             command: ProblemsCommands.COLLAPSE_ALL_TOOLBAR.id,
             tooltip: 'Collapse All',
             priority: 0,
+        });
+        toolbarRegistry.registerItem({
+            id: ProblemsCommands.CLEAR_ALL.id,
+            command: ProblemsCommands.CLEAR_ALL.id,
+            tooltip: 'Clear All',
+            priority: 1,
         });
     }
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
Fixes: https://github.com/eclipse-theia/theia/issues/7979

Added a `Clear-All` toolbar item, which clears all the existing problem
markers

Tested the icon doesn't leak to other views such as: 
1. Terminal
2. Output Channel
3. Search in Workspace
4. Extensions.

Signed-off-by: Anas Shahid <muhammad.shahid@ericsson.com>


#### How to test
1. create multiple json files, with `lorem ispum`, it will generate problem markers
2. Click on the icon on the toolbar to clear all the markers. 
3. Close the file and re-open it to see if the markers are present.
4. Test to see if the icon is leaking to any other view.(like siw)

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

