### PR TITLE
GH-7772: Fixed issue with filtered group options. 

### DIFF
--- a/examples/api-samples/src/browser/api-samples-frontend-module.ts
+++ b/examples/api-samples/src/browser/api-samples-frontend-module.ts
@@ -19,10 +19,12 @@ import { bindDynamicLabelProvider } from './label/sample-dynamic-label-provider-
 import { bindSampleUnclosableView } from './view/sample-unclosable-view-contribution';
 import { bindSampleOutputChannelWithSeverity } from './output/sample-output-channel-with-severity';
 import { bindSampleMenu } from './menu/sample-menu-contribution';
+import { bindSampleQuickOpenService } from './quick-open/sample-quick-open-service';
 
 export default new ContainerModule(bind => {
     bindDynamicLabelProvider(bind);
     bindSampleUnclosableView(bind);
     bindSampleOutputChannelWithSeverity(bind);
     bindSampleMenu(bind);
+    bindSampleQuickOpenService(bind);
 });

--- a/examples/api-samples/src/browser/quick-open/sample-quick-open-service.ts
+++ b/examples/api-samples/src/browser/quick-open/sample-quick-open-service.ts
@@ -1,0 +1,100 @@
+/********************************************************************************
+ * Copyright (C) 2020 TypeFox and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+import { inject, injectable, interfaces } from 'inversify';
+import { CommandContribution, CommandRegistry, Command } from '@theia/core/lib/common/command';
+import { QuickOpenItem, QuickOpenModel, QuickOpenGroupItem } from '@theia/core/lib/common/quick-open-model';
+import {
+    QuickOpenService,
+    QuickOpenOptions,
+    QuickOpenItemOptions,
+    QuickOpenContribution,
+    QuickOpenActionProvider,
+    QuickOpenHandlerRegistry,
+    QuickOpenGroupItemOptions
+} from '@theia/core/lib/browser/quick-open';
+
+@injectable()
+export class SampleQuickOpenService implements QuickOpenContribution, QuickOpenModel, CommandContribution, Command {
+
+    readonly description = 'Sample Quick Open';
+    readonly id = 'open:sample-quick-open';
+    readonly label = this.description;
+
+    @inject(QuickOpenService)
+    protected readonly quickOpenService: QuickOpenService;
+
+    registerQuickOpenHandlers(registry: QuickOpenHandlerRegistry): void {
+        registry.registerHandler({ ...this, prefix: '' });
+    }
+
+    getModel(): QuickOpenModel {
+        return this;
+    }
+
+    getOptions(): QuickOpenOptions {
+        return {
+            fuzzyMatchLabel: {
+                enableSeparateSubstringMatching: true
+            }
+        };
+    }
+
+    registerCommands(registry: CommandRegistry): void {
+        registry.registerCommand(this, { execute: () => this.quickOpenService.open(this, this.getOptions()) });
+    }
+
+    protected readonly data = new Map<string, string[]>([
+        ['main', ['Main 1', 'Main 2', 'Main 3']],
+        ['secondary', ['Secondary 1', 'Secondary 2', 'Secondary 3']],
+        ['rest', ['B', 'A', 'AA', 'AAA', 'AAAA']]
+    ]);
+
+    onType(
+        lookFor: string,
+        acceptor: (items: QuickOpenItem<QuickOpenItemOptions>[], actionProvider?: QuickOpenActionProvider) => void): void {
+
+        const toAccept: QuickOpenItem<QuickOpenItemOptions>[] = [];
+        for (const [groupLabel, items] of this.data.entries()) {
+            toAccept.push(...items.map((item, i) => {
+                let group: QuickOpenGroupItemOptions | undefined = undefined;
+                if (i === 0) {
+                    group = { groupLabel, showBorder: toAccept.length > 0 };
+                }
+                return this.toQuickItem(item, group);
+            }));
+        }
+        acceptor(toAccept);
+    }
+
+    protected toQuickItem(label: string, group?: QuickOpenGroupItemOptions): QuickOpenItem<QuickOpenItemOptions> {
+        const options = {
+            label,
+            description: `balbla - ${label}`
+        };
+        if (group) {
+            return new QuickOpenGroupItem<QuickOpenGroupItemOptions>({ ...options, ...group });
+        } else {
+            return new QuickOpenItem<QuickOpenItemOptions>(options);
+        }
+    }
+
+}
+
+export const bindSampleQuickOpenService = (bind: interfaces.Bind) => {
+    bind(SampleQuickOpenService).toSelf().inSingletonScope();
+    bind(CommandContribution).toService(SampleQuickOpenService);
+    bind(QuickOpenContribution).toService(SampleQuickOpenService);
+};

--- a/examples/api-samples/src/browser/quick-open/sample-quick-open-service.ts
+++ b/examples/api-samples/src/browser/quick-open/sample-quick-open-service.ts
@@ -37,7 +37,7 @@ export class SampleQuickOpenService implements QuickOpenContribution, QuickOpenM
     protected readonly quickOpenService: QuickOpenService;
 
     registerQuickOpenHandlers(registry: QuickOpenHandlerRegistry): void {
-        registry.registerHandler({ ...this, prefix: '' });
+        registry.registerHandler({ ...this, prefix: 'blabla' });
     }
 
     getModel(): QuickOpenModel {

--- a/packages/core/src/common/quick-open-model.ts
+++ b/packages/core/src/common/quick-open-model.ts
@@ -51,7 +51,7 @@ export interface QuickOpenGroupItemOptions extends QuickOpenItemOptions {
 export class QuickOpenItem<T extends QuickOpenItemOptions = QuickOpenItemOptions> {
 
     constructor(
-        protected options: T = {} as T
+        readonly options: T = {} as T
     ) { }
 
     getTooltip(): string | undefined {

--- a/packages/task/src/browser/quick-open-task.ts
+++ b/packages/task/src/browser/quick-open-task.ts
@@ -560,7 +560,7 @@ export class TaskConfigureQuickOpenItem extends QuickOpenGroupItem {
         protected readonly taskNameResolver: TaskNameResolver,
         protected readonly workspaceService: WorkspaceService,
         protected readonly isMulti: boolean,
-        protected readonly options: QuickOpenGroupItemOptions
+        readonly options: QuickOpenGroupItemOptions
     ) {
         super(options);
         const stat = this.workspaceService.workspace;


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

Fixes an issue with filtered group options. If a `QuickOpenGroupItemOptions` is filtered out, we merge the group properties into the next non-filtered item.

 - Exposed the `options` from the `QuickOpenItem`.
 - Made `MonacoQuickOpenService#toOpenModel` extensiable.

 Closes #7772

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

Use the sample, search for `A` (make sure `B` is not among the search results), you can still see the `Rest` label and the border for the group.

![screencast 2020-06-15 16-13-18](https://user-images.githubusercontent.com/1405703/84668102-76332180-af23-11ea-8508-6370b319c9eb.gif)

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

