### PR TITLE
GH-7977: [electron]: Execute rename on `Enter`.

### DIFF
--- a/packages/filesystem/src/browser/file-tree/file-tree-widget.tsx
+++ b/packages/filesystem/src/browser/file-tree/file-tree-widget.tsx
@@ -16,7 +16,8 @@
 
 import * as React from 'react';
 import { injectable, inject } from 'inversify';
-import { DisposableCollection, Disposable } from '@theia/core/lib/common';
+import { environment } from '@theia/application-package';
+import { DisposableCollection, Disposable, CommandService } from '@theia/core/lib/common';
 import { UriSelection } from '@theia/core/lib/common/selection';
 import { isCancelled } from '@theia/core/lib/common/cancellation';
 import { ContextMenuRenderer, NodeProps, TreeProps, TreeNode, TreeWidget, CompositeTreeNode } from '@theia/core/lib/browser';
@@ -40,6 +41,9 @@ export class FileTreeWidget extends TreeWidget {
 
     @inject(IconThemeService)
     protected readonly iconThemeService: IconThemeService;
+
+    @inject(CommandService)
+    protected readonly commandService: CommandService;
 
     constructor(
         @inject(TreeProps) readonly props: TreeProps,
@@ -241,6 +245,14 @@ export class FileTreeWidget extends TreeWidget {
             return false;
         }
         return super.needsExpansionTogglePadding(node);
+    }
+
+    protected handleEnter(event: KeyboardEvent): void {
+        if (environment.electron.is()) {
+            this.commandService.executeCommand('file.rename');
+        } else {
+            super.handleEnter(event);
+        }
     }
 
 }


### PR DESCRIPTION
Instead of opening a file in the editor, we mimic VS Code, and perform
the file `Rename` operation when user presses `Enter` in the `Explorer.

Closes #7977

Signed-off-by: Akos Kitta <kittaakos@typefox.io>

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

It aligns the electron UI/UX with VS Code, from now on, pressing `Enter` in the `Explorer` will trigger file rename.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

Start the electron example, select a file in the `Explorer`, press `Enter`, you can see the input dialog for the file rename.

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

