### PR TITLE
Add 'when' condition for copyFilePath command

### DIFF
--- a/packages/core/src/browser/common-frontend-contribution.ts
+++ b/packages/core/src/browser/common-frontend-contribution.ts
@@ -772,7 +772,8 @@ export class CommonFrontendContribution implements FrontendApplicationContributi
         }
         registry.registerKeybinding({
             command: CommonCommands.COPY_PATH.id,
-            keybinding: isWindows ? 'shift+alt+c' : 'ctrlcmd+alt+c'
+            keybinding: isWindows ? 'shift+alt+c' : 'ctrlcmd+alt+c',
+            when: '!editorFocus'
         });
         registry.registerKeybindings(
             // Edition

--- a/packages/editor/src/browser/editor-menu.ts
+++ b/packages/editor/src/browser/editor-menu.ts
@@ -70,10 +70,6 @@ export class EditorMenuContribution implements MenuContribution {
             commandId: CommonCommands.PASTE.id,
             order: '2'
         });
-        registry.registerMenuAction(EditorContextMenu.CUT_COPY_PASTE, {
-            commandId: CommonCommands.COPY_PATH.id,
-            order: '3'
-        });
 
         // Editor navigation. Go > Back and Go > Forward.
         registry.registerSubmenu(EditorMainMenu.GO, 'Go');


### PR DESCRIPTION
#### What it does
This changes proposal adds `when` condition for `copyFilePath` command and removes extra item from editor's context menu.

Signed-off-by: Vladyslav Zhukovskyi <vzhukovs@redhat.com>

#### How to test
Use hotkey `ctrlcmd+alt+c` in opened editor under macOS. It shouldn't call copy file path command. In opened navigator this hotkey should work as usual.

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

