### PR TITLE
preferences: update 'modified scope'

### DIFF
--- a/packages/preferences/src/browser/style/index.css
+++ b/packages/preferences/src/browser/style/index.css
@@ -346,3 +346,7 @@
 .theia-settings-container .settings-section>li:last-child {
     margin-bottom: 20px;
 }
+
+.theia-settings-container .settings-scope-underlined {
+    text-decoration: underline;
+}


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

The following pull-request updates the **preferences-view** to properly display the 'modified scope' message when a preference is updated from it's default value in a different scope (between `user` and `workspace` only at the moment). 

_Viewing 'User' - 'Workspace' Updated_:

![user-pref](https://user-images.githubusercontent.com/40359487/84821083-8f51d600-afe8-11ea-860c-bb8dbf41de06.png)


_Viewing 'Workspace' - 'User' Updated_:

![workspace-pref](https://user-images.githubusercontent.com/40359487/84821064-895bf500-afe8-11ea-9d2e-864533933192.png)


_Both Scopes Updated_:

![both-pref](https://user-images.githubusercontent.com/40359487/84821080-8eb93f80-afe8-11ea-9526-2fb600b1ad50.png)


The following pull-request updates the `preferences` modified scope
message to display messages in the `user` tab when there are updates to
the preference in the `workspace` scope.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

1. open the preferences-view
2. modify preferences in the `user`, `workspace` scope and verify that the message works properly

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

Signed-off-by: vince-fugnitto <vincent.fugnitto@ericsson.com>
