### PR TITLE
open-view: improve 'open view' quick-open

### DIFF
--- a/packages/core/src/browser/quick-view-service.ts
+++ b/packages/core/src/browser/quick-view-service.ts
@@ -15,16 +15,23 @@
  ********************************************************************************/
 
 import { injectable, inject } from 'inversify';
-import { QuickOpenModel, QuickOpenHandler, QuickOpenOptions, QuickOpenItem, QuickOpenMode, QuickOpenContribution, QuickOpenHandlerRegistry } from './quick-open';
+import {
+    QuickOpenModel, QuickOpenHandler, QuickOpenOptions, QuickOpenItem,
+    QuickOpenMode, QuickOpenContribution, QuickOpenHandlerRegistry, QuickOpenGroupItem
+} from './quick-open';
 import { Disposable } from '../common/disposable';
 import { ContextKeyService } from './context-key-service';
+import * as fuzzy from 'fuzzy';
 
 export interface QuickViewItem {
     readonly label: string;
     readonly when?: string;
+    readonly type?: 'view container' | 'view';
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     readonly open: () => any;
 }
+
+export type QuickViewItemType = (QuickOpenItem & { when?: string, type?: 'view container' | 'view' });
 
 @injectable()
 export class QuickViewService implements QuickOpenModel, QuickOpenHandler, QuickOpenContribution {
@@ -33,28 +40,26 @@ export class QuickViewService implements QuickOpenModel, QuickOpenHandler, Quick
 
     readonly description: string = 'Open View';
 
-    protected readonly items: (QuickOpenItem & { when?: string })[] = [];
+    /**
+     * The collection of registered items.
+     */
+    protected readonly registeredItems: QuickViewItemType[] = [];
+    /**
+     * The collection of items for display purposes.
+     */
+    protected items: QuickViewItemType[] = [];
 
     @inject(ContextKeyService)
     protected readonly contextKexService: ContextKeyService;
 
     registerItem(item: QuickViewItem): Disposable {
-        const quickOpenItem = Object.assign(new QuickOpenItem({
-            label: item.label,
-            run: mode => {
-                if (mode !== QuickOpenMode.OPEN) {
-                    return false;
-                }
-                item.open();
-                return true;
-            }
-        }), { when: item.when });
-        this.items.push(quickOpenItem);
-        this.items.sort((a, b) => a.getLabel()!.localeCompare(b.getLabel()!));
+        const quickOpenItem = this.toItem(item);
+        this.registeredItems.push(quickOpenItem);
+        this.updateItems();
         return Disposable.create(() => {
-            const index = this.items.indexOf(quickOpenItem);
+            const index = this.registeredItems.indexOf(quickOpenItem);
             if (index !== -1) {
-                this.items.splice(index, 1);
+                this.registeredItems.splice(index, 1);
             }
         });
     }
@@ -70,7 +75,8 @@ export class QuickViewService implements QuickOpenModel, QuickOpenHandler, Quick
         };
     }
 
-    onType(_: string, acceptor: (items: QuickOpenItem[]) => void): void {
+    onType(lookFor: string, acceptor: (items: QuickOpenItem[]) => void): void {
+        this.updateItems(lookFor);
         const items = this.items.filter(item =>
             item.when === undefined || this.contextKexService.match(item.when)
         );
@@ -81,4 +87,105 @@ export class QuickViewService implements QuickOpenModel, QuickOpenHandler, Quick
         handlers.registerHandler(this);
     }
 
+    /**
+     * Updated the display list of items grouped by their type.
+     * @param lookFor the search term if available.
+     */
+    protected updateItems(lookFor?: string): void {
+        const viewContainerItems = this.getViewContainerItems(lookFor);
+        const viewItems = this.getViewItems(lookFor);
+        const otherItems = this.getOtherItems(lookFor);
+
+        const updatedItems: QuickViewItemType[] = [];
+
+        updatedItems.push(
+            ...viewContainerItems.map((a: QuickViewItemType, index: number) => {
+                const groupItem: QuickOpenGroupItem = new QuickOpenGroupItem({
+                    label: a.getLabel(),
+                    run: mode => a.run(mode),
+                    groupLabel: index === 0 ? a.type : ''
+                });
+                return Object.assign(groupItem, { when: a.when, type: a.type });
+            }),
+            ...viewItems.map((a: QuickViewItemType, index: number) => {
+                const groupItem: QuickOpenGroupItem = new QuickOpenGroupItem({
+                    label: a.getLabel(),
+                    run: mode => a.run(mode),
+                    groupLabel: index === 0 ? a.type : '',
+                    showBorder: viewContainerItems.length <= 0
+                        ? false
+                        : index === 0 ? true : false
+                });
+                return Object.assign(groupItem, { when: a.when, type: a.type });
+            }),
+            ...otherItems.map((a: QuickViewItemType, index: number) => {
+                const groupItem: QuickOpenGroupItem = new QuickOpenGroupItem({
+                    label: a.getLabel(),
+                    run: mode => a.run(mode),
+                    groupLabel: index === 0 ? 'Other' : '',
+                    showBorder: viewContainerItems.length <= 0 && viewItems.length <= 0
+                        ? false
+                        : index === 0 ? true : false
+                });
+                return Object.assign(groupItem, { when: a.when, type: a.type });
+            }),
+        );
+        this.items = updatedItems;
+    }
+
+    /**
+     * Get the list of `view containers` which satisfy the search term.
+     * - If no search term is present, all the view containers are returned.
+     * @param lookFor the search term if available.
+     */
+    protected getViewContainerItems(lookFor?: string): QuickViewItemType[] {
+        const items = this.registeredItems.filter((item: QuickViewItemType) => item.type === 'view container').sort((a, b) => this.sortLabel(a, b));
+        if (lookFor && lookFor.length > 0) {
+            return items.filter((item: QuickViewItemType) => fuzzy.match(lookFor, item.getLabel()!));
+        }
+        return items;
+    }
+
+    /**
+     * Get the list of `views` which satisfy the search term.
+     * - If no search term is present, all the views are returned.
+     * @param lookFor the search term if available.
+     */
+    protected getViewItems(lookFor?: string): QuickViewItemType[] {
+        const items = this.registeredItems.filter((item: QuickViewItemType) => item.type === 'view').sort((a, b) => this.sortLabel(a, b));
+        if (lookFor && lookFor.length > 0) {
+            return items.filter((item: QuickViewItemType) => fuzzy.match(lookFor, item.getLabel()!));
+        }
+        return items;
+    }
+
+    /**
+     * Get the list of `other` items which satisfy the search term.
+     * - If no search term is present, all the other items are returned.
+     * @param lookFor the search term if available.
+     */
+    protected getOtherItems(lookFor?: string): QuickOpenItem[] {
+        const items = this.registeredItems.filter((item: QuickViewItemType) => item.type === undefined).sort((a, b) => this.sortLabel(a, b));
+        if (lookFor && lookFor.length > 0) {
+            return items.filter((item: QuickViewItemType) => fuzzy.match(lookFor, item.getLabel()!));
+        }
+        return items;
+    }
+
+    protected sortLabel(a: QuickViewItemType, b: QuickViewItemType): number {
+        return a.getLabel()!.localeCompare(b.getLabel()!);
+    }
+
+    protected toItem(item: QuickViewItem): QuickViewItemType {
+        return Object.assign(new QuickOpenGroupItem({
+            label: item.label,
+            run: mode => {
+                if (mode !== QuickOpenMode.OPEN) {
+                    return false;
+                }
+                item.open();
+                return true;
+            }
+        }), { when: item.when, type: item.type });
+    }
 }

--- a/packages/core/src/browser/shell/view-contribution.ts
+++ b/packages/core/src/browser/shell/view-contribution.ts
@@ -142,6 +142,7 @@ export abstract class AbstractViewContribution<T extends Widget> implements Comm
         }
         this.quickView.registerItem({
             label: this.viewLabel,
+            type: 'view container',
             open: () => this.openView({ activate: true })
         });
     }

--- a/packages/plugin-ext/src/main/browser/view/plugin-view-registry.ts
+++ b/packages/plugin-ext/src/main/browser/view/plugin-view-registry.ts
@@ -228,6 +228,11 @@ export class PluginViewRegistry implements FrontendApplicationContribution {
             commandId: toggleCommandId,
             label: options.label
         }));
+        toDispose.push(this.quickView.registerItem({
+            label: options.label,
+            type: 'view container',
+            open: () => this.commands.executeCommand(toggleCommandId)
+        }));
         toDispose.push(Disposable.create(async () => {
             const widget = await this.getPluginViewContainer(id);
             if (widget) {
@@ -264,6 +269,7 @@ export class PluginViewRegistry implements FrontendApplicationContribution {
         toDispose.push(this.quickView.registerItem({
             label: view.name,
             when: view.when,
+            type: 'view',
             open: () => this.openView(view.id, { activate: true })
         }));
         toDispose.push(this.commands.registerCommand({ id: `${view.id}.focus` }, {


### PR DESCRIPTION


<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

Fixes: #8016

The following pull-request performs the following updates:
- the plugin system now registers `view containers` (ex: 'gitlens') as part of the `open-view`.
- the `open-view` items are sorted, and grouped based on their type (they have a groupLabel and border which makes the navigation of the menu easier).

**Default (All Registered Items)**

<div align='center'>

![all-items](https://user-images.githubusercontent.com/40359487/84849053-79610700-b022-11ea-9a0a-b1d44bff7b48.png)

</div>

**Search**

<div align='center'>

![search](https://user-images.githubusercontent.com/40359487/84849075-8bdb4080-b022-11ea-8b7e-9db12b056fc3.png)


</div>

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

1. trigger the `open-view` prefix quick-open
  1.1 use the `view` > `open view` menu
  1.2 use the prefix - <kbd>ctrlcmd</kbd>+<kbd>p</kbd> and type `view `
2. verify that the menu lists the appropriate view containers and views
3. include the [gitlens](https://open-vsx.org/extension/eamodio/gitlens) extension, it should be displayed in the `view container` section of the menu

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

Signed-off-by: vince-fugnitto <vincent.fugnitto@ericsson.com>

