### PR TITLE
Bug fix (theia hanging on long lines)

### DIFF
--- a/packages/editor/src/browser/editor-preferences.ts
+++ b/packages/editor/src/browser/editor-preferences.ts
@@ -110,7 +110,7 @@ const codeEditorPreferenceProperties = {
     },
     'editor.maxTokenizationLineLength': {
         'type': 'integer',
-        'default': 20_000,
+        'default': 400,
         'description': 'Lines above this length will not be tokenized for performance reasons'
     },
     'diffEditor.maxComputationTime': {


### PR DESCRIPTION
editor.maxTokenizationLineLength default value changed back to 400, the value 20000 like in VS Code breaks on browser and some electrons when opening minified files.

Signed-off-by: João Gaião <dactyllo@gmail.com>