### PR TITLE
plugin: include registration of view containers

### DIFF
--- a/packages/plugin-ext/src/main/browser/view/plugin-view-registry.ts
+++ b/packages/plugin-ext/src/main/browser/view/plugin-view-registry.ts
@@ -228,6 +228,15 @@ export class PluginViewRegistry implements FrontendApplicationContribution {
             commandId: toggleCommandId,
             label: options.label
         }));
+        toDispose.push(this.quickView.registerItem({
+            label: options.label,
+            open: async () => {
+                const widget = await this.openViewContainer(id);
+                if (widget) {
+                    this.shell.activateWidget(widget.id);
+                }
+            }
+        }));
         toDispose.push(Disposable.create(async () => {
             const widget = await this.getPluginViewContainer(id);
             if (widget) {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

Fixes: #8016

The following pull-request updates the plugin system to include
the registration of `view containers` in the `open view` prefix menu.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

1. add the [gitlens](https://marketplace.visualstudio.com/items?itemName=eamodio.gitlens) extension
2. close the `gitlens` view if it is visible
3. trigger the `open view` prefix quick-open menu (opened by the `view` > `open view` menu)
4. select `gitlens`, and verify that the view is opened correctly
5. trigger the `open view` again selecting `gitlens` (the view should remain open (not toggle))

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

Signed-off-by: vince-fugnitto <vincent.fugnitto@ericsson.com>
