### PR TITLE
Add UIKind API

### DIFF
--- a/packages/plugin-ext/src/common/plugin-api-rpc.ts
+++ b/packages/plugin-ext/src/common/plugin-api-rpc.ts
@@ -98,10 +98,24 @@ export interface ConfigStorage {
     hostGlobalStoragePath: string;
 }
 
+export enum UIKind {
+
+    /**
+     * Extensions are accessed from a desktop application.
+     */
+    Desktop = 1,
+
+    /**
+     * Extensions are accessed from a web browser.
+     */
+    Web = 2
+}
+
 export interface EnvInit {
     queryParams: QueryParameters;
     language: string;
     shell: string;
+    uiKind: UIKind,
     appName: string;
 }
 

--- a/packages/plugin-ext/src/hosted/browser/hosted-plugin.ts
+++ b/packages/plugin-ext/src/hosted/browser/hosted-plugin.ts
@@ -27,7 +27,7 @@ import { injectable, inject, interfaces, named, postConstruct } from 'inversify'
 import { PluginWorker } from '../../main/browser/plugin-worker';
 import { PluginMetadata, getPluginId, HostedPluginServer, DeployedPlugin } from '../../common/plugin-protocol';
 import { HostedPluginWatcher } from './hosted-plugin-watcher';
-import { MAIN_RPC_CONTEXT, PluginManagerExt, ConfigStorage } from '../../common/plugin-api-rpc';
+import { MAIN_RPC_CONTEXT, PluginManagerExt, ConfigStorage, UIKind } from '../../common/plugin-api-rpc';
 import { setUpPluginApi } from '../../main/browser/main-context';
 import { RPCProtocol, RPCProtocolImpl } from '../../common/rpc-protocol';
 import {
@@ -60,6 +60,7 @@ import { TerminalService } from '@theia/terminal/lib/browser/base/terminal-servi
 import { EnvVariablesServer } from '@theia/core/lib/common/env-variables';
 import URI from '@theia/core/lib/common/uri';
 import { FrontendApplicationConfigProvider } from '@theia/core/lib/browser/frontend-application-config-provider';
+import { environment } from '@theia/application-package/lib/environment';
 
 export type PluginHost = 'frontend' | string;
 export type DebugActivationEvent = 'onDebugResolve' | 'onDebugInitialConfigurations' | 'onDebugAdapterProtocolTracker';
@@ -454,6 +455,7 @@ export class HostedPluginSupport {
                     queryParams: getQueryParameters(),
                     language: navigator.language,
                     shell: defaultShell,
+                    uiKind: environment.electron.is() ? UIKind.Desktop : UIKind.Web,
                     appName: FrontendApplicationConfigProvider.get().applicationName
                 },
                 extApi,

--- a/packages/plugin-ext/src/plugin/env.ts
+++ b/packages/plugin-ext/src/plugin/env.ts
@@ -26,6 +26,7 @@ export abstract class EnvExtImpl {
     private lang: string;
     private applicationName: string;
     private defaultShell: string;
+    private ui: theia.UIKind;
     private envMachineId: string;
     private envSessionId: string;
 
@@ -68,6 +69,10 @@ export abstract class EnvExtImpl {
         this.defaultShell = shell;
     }
 
+    setUIKind(uiKind: theia.UIKind): void {
+        this.ui = uiKind;
+    }
+
     getClientOperatingSystem(): Promise<theia.OperatingSystem> {
         return this.proxy.$getClientOperatingSystem();
     }
@@ -92,5 +97,8 @@ export abstract class EnvExtImpl {
     }
     get shell(): string {
         return this.defaultShell;
+    }
+    get uiKind(): theia.UIKind {
+        return this.ui;
     }
 }

--- a/packages/plugin-ext/src/plugin/plugin-context.ts
+++ b/packages/plugin-ext/src/plugin/plugin-context.ts
@@ -112,6 +112,7 @@ import {
     ColorPresentation,
     OperatingSystem,
     WebviewPanelTargetArea,
+    UIKind,
     FileSystemError,
     CommentThreadCollapsibleState,
     QuickInputButtons,
@@ -511,6 +512,7 @@ export function createAPIFactory(
             get sessionId(): string { return envExt.sessionId; },
             get uriScheme(): string { return envExt.uriScheme; },
             get shell(): string { return envExt.shell; },
+            get uiKind(): theia.UIKind { return envExt.uiKind; },
             clipboard,
             getEnvVariable(envVarName: string): PromiseLike<string | undefined> {
                 return envExt.getEnvVariable(envVarName);
@@ -878,6 +880,7 @@ export function createAPIFactory(
             FoldingRangeKind,
             OperatingSystem,
             WebviewPanelTargetArea,
+            UIKind,
             FileSystemError,
             CommentThreadCollapsibleState,
             QuickInputButtons,

--- a/packages/plugin-ext/src/plugin/plugin-manager.ts
+++ b/packages/plugin-ext/src/plugin/plugin-manager.ts
@@ -186,6 +186,7 @@ export class PluginManagerExtImpl implements PluginManagerExt, PluginManager {
         this.envExt.setQueryParameters(params.env.queryParams);
         this.envExt.setLanguage(params.env.language);
         this.envExt.setShell(params.env.shell);
+        this.envExt.setUIKind(params.env.uiKind);
         this.envExt.setApplicationName(params.env.appName);
 
         this.preferencesManager.init(params.preferences);

--- a/packages/plugin-ext/src/plugin/types-impl.ts
+++ b/packages/plugin-ext/src/plugin/types-impl.ts
@@ -2054,6 +2054,23 @@ export enum WebviewPanelTargetArea {
     Right = 'right',
     Bottom = 'bottom'
 }
+
+/**
+ * Possible kinds of UI that can use extensions.
+ */
+export enum UIKind {
+
+    /**
+     * Extensions are accessed from a desktop application.
+     */
+    Desktop = 1,
+
+    /**
+     * Extensions are accessed from a web browser.
+     */
+    Web = 2
+}
+
 export class CallHierarchyItem {
     _sessionId?: string;
     _itemId?: string;

--- a/packages/plugin/src/theia.d.ts
+++ b/packages/plugin/src/theia.d.ts
@@ -3151,6 +3151,22 @@ declare module '@theia/plugin' {
     }
 
     /**
+     * Possible kinds of UI that can use extensions.
+     */
+    export enum UIKind {
+
+        /**
+         * Extensions are accessed from a desktop application.
+         */
+        Desktop = 1,
+
+        /**
+         * Extensions are accessed from a web browser.
+         */
+        Web = 2
+    }
+
+    /**
      * A uri handler is responsible for handling system-wide [uris](#Uri).
      *
      * @see [window.registerUriHandler](#window.registerUriHandler).
@@ -5294,6 +5310,13 @@ declare module '@theia/plugin' {
          * The detected default shell for the extension host.
          */
         export const shell: string;
+
+        /**
+        * The UI kind property indicates from which UI extensions
+        * are accessed from. For example, extensions could be accessed
+        * from a desktop application or a web browser.
+        */
+        export const uiKind: UIKind;
 
         /**
          * The system clipboard.


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
Adds the vsode.env.UIKind API in order to enable VS Code extensions, for example ti fix:

Java Test Runner extension doesn't activate and icons are not loaded #8007

The idea is that electron => UIKind.Desktop and everything is UIKind.Web.

#### How to test
The tests I ran are that the extensions mentioned in the linked PR are coming up.  @akosyakov are there any compatility tests I could run for this?

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

