### PR TITLE
Bug fix (Output-Contextmenu Clear-Command missing)

### DIFF
--- a/packages/output/src/browser/output-toolbar-contribution.tsx
+++ b/packages/output/src/browser/output-toolbar-contribution.tsx
@@ -60,7 +60,7 @@ export class OutputToolbarContribution implements TabBarToolbarContribution {
         toolbarRegistry.registerItem({
             id: OutputCommands.CLEAR__WIDGET.id,
             command: OutputCommands.CLEAR__WIDGET.id,
-            tooltip: OutputCommands.CLEAR__WIDGET.label,
+            tooltip: 'Clear Output',
             priority: 1,
         });
         toolbarRegistry.registerItem({


### PR DESCRIPTION
The Contextmenu was not showing the option to clear the Output,
because seperate Commands for the toolbar and Contextmenu are required.


#### What it does
The option to 'clear Output' is available in the Contextmenu of the output-view. Also a label is shown when hovering over the 'clear Output'-Button in the toolbar.

#### How to test
1. open the output-view
2. hover over the 'clear Output'-Button in the toolbar
3. open the Contextmenu in the output-view

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
