### PR TITLE
[gitpod] increase yarn network timeout to fix prebuilds

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,21 +1,21 @@
 image:
   file: .gitpod.dockerfile
 ports:
-- port: 3000 # Theia
-- port: 3030 # VS Code extension tests
-- port: 9229 # Node.js debug port
-  onOpen: ignore
-- port: 9339 # Node.js debug port
-  onOpen: ignore
-- port: 6080
-  onOpen: ignore
-- port: 5900
-  onOpen: ignore
+  - port: 3000 # Theia
+  - port: 3030 # VS Code extension tests
+  - port: 5900
+    onOpen: ignore
+  - port: 6080
+    onOpen: ignore
+  - port: 9229 # Node.js debug port
+    onOpen: ignore
+  - port: 9339 # Node.js debug port
+    onOpen: ignore
 tasks:
-- init: yarn
-  command: >
-    jwm &
-    yarn --cwd examples/browser start ../.. --hostname=0.0.0.0
+  - init: yarn --network-timeout 100000
+    command: >
+      jwm &
+      yarn --cwd examples/browser start ../.. --hostname=0.0.0.0
 github:
   prebuilds:
     pullRequestsFromForks: true


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

yarn is not stable, Gitpod CI does not have anything like retry yet, so increase network timeout, prebuilds can take longer, but will be successful eventually

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

- a workspace should start from the prebuild

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

