### PR TITLE
fix isInSync check to be with latest resource stat

### DIFF
--- a/packages/filesystem/src/browser/file-resource.ts
+++ b/packages/filesystem/src/browser/file-resource.ts
@@ -164,13 +164,14 @@ export class FileResource implements Resource {
     }
 
     protected async sync(): Promise<void> {
-        if (await this.isInSync(this.version && this.version.stat)) {
+        if (await this.isInSync()) {
             return;
         }
         this.onDidChangeContentsEmitter.fire(undefined);
     }
-    protected async isInSync(current: FileStat | undefined): Promise<boolean> {
+    protected async isInSync(): Promise<boolean> {
         const stat = await this.getFileStat();
+        const current = this.version && this.version.stat;
         if (!current) {
             return !stat;
         }


### PR DESCRIPTION

Signed-off-by: Amiram Wingarten <amiram.wingarten@sap.com>

#### What it does
Solves race condition that happens when there are several consecutive calls to saveContentChanges.
Since before this fix, version was passed to isInSync before asynchronously calling getFileStat there were times when it was old on the sync check but current on this.version.
then onDidChangeContentsEmitter.fire was called wrongly.

Also there is no reason to pass a method with this.version as it can get it from the instance.

#### How to test
It's hard to reproduce the issue that was solved. Basically updating the resource content several times could cause sphoradic firing of the above event.

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

