### PR TITLE
Remove slash at the end of extension path

### DIFF
--- a/packages/plugin-ext/src/hosted/node-electron/scanner-theia-electron.ts
+++ b/packages/plugin-ext/src/hosted/node-electron/scanner-theia-electron.ts
@@ -14,16 +14,19 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
+import * as path from 'path';
 import { TheiaPluginScanner } from '../node/scanners/scanner-theia';
 import { injectable } from 'inversify';
 import { PluginPackage, PluginModel } from '../../common/plugin-protocol';
+
 @injectable()
 export class TheiaPluginScannerElectron extends TheiaPluginScanner {
     getModel(plugin: PluginPackage): PluginModel {
         const result = super.getModel(plugin);
         if (result.entryPoint.frontend) {
-            result.entryPoint.frontend = plugin.packagePath + result.entryPoint.frontend;
+            result.entryPoint.frontend = path.resolve(plugin.packagePath, result.entryPoint.frontend);
         }
+
         return result;
     }
 }

--- a/packages/plugin-ext/src/hosted/node/plugin-reader.ts
+++ b/packages/plugin-ext/src/hosted/node/plugin-reader.ts
@@ -92,7 +92,6 @@ export class HostedPluginReader implements BackendApplicationContribution {
         if (!pluginPath) {
             return undefined;
         }
-        pluginPath = path.normalize(pluginPath + '/');
         const manifest = await loadManifest(pluginPath);
         if (!manifest) {
             return undefined;


### PR DESCRIPTION
Signed-off-by: Vitaliy Gulyy <vgulyy@redhat.com>

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->
Removes the last slash from the [extensionPath](https://github.com/eclipse-theia/theia/blob/master/packages/plugin/src/theia.d.ts#L2739), which is passed to the extension withing PluginContext.

I didn't find any rules about the slash at the ending of [PluginContext.extensionPath](https://code.visualstudio.com/api/references/vscode-api#ExtensionContext) on the VS Code API.
A sample `helloworld` extension running in VS Code prints the path without the slash.
```
vscode.window.showInformationMessage(`ExtensionPath [${context.extensionPath}]`);
```

This fix is necessary for some extensions, e.g. [Jira and Bitbucket](https://marketplace.visualstudio.com/items?itemName=Atlassian.atlascode).
Actually we are trying to run this extension inside Che-Theia https://github.com/eclipse/che/issues/17081, but faced the problem, that the extension forms wrong URI to some webview resources (URI contains double slashes in the Path). 
```
https://serverj5kpkbom-jwtproxy-webviews.192.168.99.152.nip.io/webview/theia-resource/file/tmp/vscode-unpacked/atlascode-0.0.0.vsix/extension//build/static/js/vendors~atlascodeCreateIssueScreen~atlascodeOnboardingV2~atlascodeSettingsV2~bitbucketIssuePageV2~cr~8893e30c.755b5343.chunk.js
```
Removing the slash at the end of `extensionPath` solved the issue.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
Currently it's difficult to test how vanilla Theia works with `Jira and Bitbucket` extension.
But the reviewer can build Theia and try to run any extension, which use `PluginContext.extensionPath`.
I don't know such plugin, except Jira&Bitbucket. Any other extensions I know works fine.

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

