### PR TITLE
[Devfile] Fix running 'watch' commands in the same container

### DIFF
--- a/devfile.yaml
+++ b/devfile.yaml
@@ -55,7 +55,6 @@ commands:
       - type: exec
         component: che-dev
         command: >
-          killall node;
           yarn watch
         workdir: ${workspaceRoot}/theia
   - name: >
@@ -64,6 +63,5 @@ commands:
       - type: exec
         component: che-dev
         command: >
-          killall node;
           yarn watch
         workdir: ${workspaceRoot}/theia/examples/browser


### PR DESCRIPTION
Signed-off-by: Artem Zatsarynnyi <azatsary@redhat.com>

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
As watch commands are typically running in the same container, `killall node` prevents from running them simultaneously. So, `killall node` is not needed in Devfile.

#### How to test
Go to https://che.openshift.io/ and run a Workspace from the Devfile. Run both `watch` commands `theia: Watch Core Packages` and `theia: Watch Browser Example`. The commands should be run.

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
