### PR TITLE
'Copy all' for context menu in output view

### DIFF
--- a/packages/output/src/browser/output-widget.tsx
+++ b/packages/output/src/browser/output-widget.tsx
@@ -220,6 +220,17 @@ export class OutputWidget extends BaseWidget implements StatefulWidget {
         return undefined;
     }
 
+    getText(): string | undefined {
+        const editor = this.editor;
+        if (editor) {
+            const model = editor.getControl().getModel();
+            if (model) {
+                return model.getValue();
+            }
+        }
+        return undefined;
+    }
+
 }
 
 export namespace OutputWidget {


### PR DESCRIPTION
#### What it does
This adds another option to the context menu of the output view.
It copies everything in the selected channel into the clipboard.

#### How to test
1. Open output view
2. Select a channel with text in it
3. Open context menu and select 'Copy All'

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

