### PR TITLE
cli: update 'download:plugins' script

### DIFF
--- a/dev-packages/cli/src/download-plugins.ts
+++ b/dev-packages/cli/src/download-plugins.ts
@@ -65,6 +65,11 @@ export default async function downloadPlugins(options: DownloadPluginsOptions = 
 
     await mkdirpAsPromised(pluginsDir);
 
+    if (!pck.theiaPlugins) {
+        console.log(red('error: missing mandatory \'theiaPlugins\' property.'));
+        return;
+    }
+
     await Promise.all(Object.keys(pck.theiaPlugins).map(async plugin => {
         if (!plugin) {
             return;


### PR DESCRIPTION

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

Fixes: #8053

The following pull-request updates the `download:plugins` script to report a message when the mandatory `theiaPlugins` property is missing from the `package.json` ultimately resulting in 
no plugins being downloaded.


#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

1. execute `yarn download:plugins` (plugins should be successfully downloaded)
2. clean the `plugins` directory (`rm -rf plugins/`)
3. rename `theiaPlugins` to `theiaPluginsTest` (in the `package.json`)
4. execute `yarn download:plugins` (the error message of the mandatory field is logged)

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)



Signed-off-by: vince-fugnitto <vincent.fugnitto@ericsson.com>