### PR TITLE
vsx: add 'engines.vscode' handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Breaking Changes:
 
 - [task] Widened the scope of some methods in TaskManager and TaskConfigurations from string to TaskConfigurationScope. This is only breaking for extenders, not callers. [#7928](https://github.com/eclipse-theia/theia/pull/7928)
 - [shell] `ApplicationShell.TrackableWidgetProvider.getTrackableWidgets` is sync to register child widgets in the same tick, use `ApplicationShell.TrackableWidgetProvider.onDidChangeTrackableWidgets` if child widgets are added async
+- [plugin] moved `VSCODE_DEFAULT_API_VERSION` to `@theia/plugin-ext-vscode/src/common/plugin-vscode-environment.ts`
 
 ## v1.2.0
 

--- a/packages/plugin-ext-vscode/src/node/plugin-vscode-cli-contribution.ts
+++ b/packages/plugin-ext-vscode/src/node/plugin-vscode-cli-contribution.ts
@@ -18,7 +18,8 @@ import { injectable } from 'inversify';
 import { Argv, Arguments } from 'yargs';
 import { CliContribution } from '@theia/core/lib/node/cli';
 import { PluginHostEnvironmentVariable } from '@theia/plugin-ext/lib/common';
-import { VSCODE_DEFAULT_API_VERSION } from './plugin-vscode-init';
+import { VSCODE_DEFAULT_API_VERSION } from '../common/plugin-vscode-environment';
+
 /**
  * CLI Contribution allowing to override the VS Code API version which is returned by `vscode.version` API call.
  */

--- a/packages/plugin-ext-vscode/src/node/plugin-vscode-init.ts
+++ b/packages/plugin-ext-vscode/src/node/plugin-vscode-init.ts
@@ -18,8 +18,7 @@
 
 import * as theia from '@theia/plugin';
 import { BackendInitializationFn, PluginAPIFactory, Plugin, emptyPlugin } from '@theia/plugin-ext';
-
-export const VSCODE_DEFAULT_API_VERSION = '1.44.0';
+import { VSCODE_DEFAULT_API_VERSION } from '../common/plugin-vscode-environment';
 
 /** Set up en as a default locale for VS Code extensions using vscode-nls */
 process.env['VSCODE_NLS_CONFIG'] = JSON.stringify({ locale: 'en', availableLanguages: {} });

--- a/packages/vsx-registry/package.json
+++ b/packages/vsx-registry/package.json
@@ -13,6 +13,7 @@
     "p-debounce": "^2.1.0",
     "requestretry": "^3.1.0",
     "sanitize-html": "^1.14.1",
+    "semver": "^5.4.1",
     "showdown": "^1.9.1",
     "uuid": "^8.0.0"
   },

--- a/packages/vsx-registry/src/browser/vsx-extension.tsx
+++ b/packages/vsx-registry/src/browser/vsx-extension.tsx
@@ -350,7 +350,7 @@ export class VSXExtensionEditorComponent extends AbstractVSXExtensionComponent {
     render(): React.ReactNode {
         const {
             builtin, preview, id, iconUrl, publisher, displayName, description,
-            averageRating, downloadCount, repository, license, readme
+            averageRating, downloadCount, repository, license, readme, version
         } = this.props.extension;
         return <React.Fragment>
             <div className='header'>
@@ -374,6 +374,7 @@ export class VSXExtensionEditorComponent extends AbstractVSXExtensionComponent {
                         {averageRating !== undefined && <span className='average-rating' onClick={this.openAverageRating}>{this.renderStars()}</span>}
                         {repository && <span className='repository' onClick={this.openRepository}>Repository</span>}
                         {license && <span className='license' onClick={this.openLicense}>{license}</span>}
+                        {version && <span className='version'>{version}</span>}
                     </div>
                     <div className='description noWrapInfo'>{description}</div>
                     {this.renderAction()}

--- a/packages/vsx-registry/src/common/vsx-registry-types.ts
+++ b/packages/vsx-registry/src/common/vsx-registry-types.ts
@@ -102,4 +102,6 @@ export interface VSXExtensionRaw {
     readonly galleryColor?: string;
     readonly galleryTheme?: string;
     readonly qna?: string;
+    readonly engines?: string[];
+    readonly versionAlias?: string[];
 }

--- a/packages/vsx-registry/src/common/vsx-utils.ts
+++ b/packages/vsx-registry/src/common/vsx-utils.ts
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (C) 2020 TypeFox and others.
+ * Copyright (C) 2020 Ericsson and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -14,25 +14,19 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
-import { injectable, inject } from 'inversify';
-import { EnvVariablesServer } from '@theia/core/lib/common/env-variables';
-import URI from '@theia/core/lib/common/uri';
+import * as semver from 'semver';
+import { VSCODE_DEFAULT_API_VERSION } from '@theia/plugin-ext-vscode/lib/common/plugin-vscode-environment';
 
-export const VSCODE_DEFAULT_API_VERSION = '1.44.0';
-
-@injectable()
-export class PluginVSCodeEnvironment {
-
-    @inject(EnvVariablesServer)
-    protected readonly environments: EnvVariablesServer;
-
-    protected _extensionsDirUri: URI | undefined;
-    async getExtensionsDirUri(): Promise<URI> {
-        if (!this._extensionsDirUri) {
-            const configDir = new URI(await this.environments.getConfigDirUri());
-            this._extensionsDirUri = configDir.resolve('extensions');
-        }
-        return this._extensionsDirUri;
+/**
+ * Determine if the engine is valid.
+ * @param engine the engine.
+ *
+ * @returns `true` if the engine satisfies the API version.
+ */
+export function isEngineValid(engines: string[]): boolean {
+    const engine = engines.find(e => e.startsWith('vscode'));
+    if (engine) {
+        return engine === '*' || semver.satisfies(VSCODE_DEFAULT_API_VERSION, engine.split('@')[1]);
     }
-
+    return false;
 }

--- a/packages/vsx-registry/src/node/vsx-extension-resolver.ts
+++ b/packages/vsx-registry/src/node/vsx-extension-resolver.ts
@@ -49,7 +49,10 @@ export class VSXExtensionResolver implements PluginDeployerResolver {
             return;
         }
         console.log(`[${id}]: trying to resolve latest version...`);
-        const extension = await this.api.getExtension(id);
+        const extension = await this.api.getLatestCompatibleExtension(id);
+        if (!extension) {
+            return;
+        }
         if (extension.error) {
             throw new Error(extension.error);
         }


### PR DESCRIPTION
The following commit updates the `vsx-registry` to perform checks on
vscode extensions to ensure that they meet the `engines.vscode`
requirement that the default API version declares.

The pull request:
- fetches the latest compatible extension from the marketplace (instead
  of the latest)
- adds handling to determine if a `engines.vscode` is valid
- includes the version to the `vsx-editor`.

Co-authored-by: Kaiyue Pan <kaiyue.pan@ericsson.com>
Co-authored-by: Anas Shahid <muhammad.shahid@ericsson.com>
Co-authored-by: vince-fugnitto <vincent.fugnitto@ericsson.com>

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

#### Review checklist

- [ ] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

