### PR TITLE
vsx: add 'engines' handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Breaking Changes:
 
 - [task] Widened the scope of some methods in TaskManager and TaskConfigurations from string to TaskConfigurationScope. This is only breaking for extenders, not callers. [#7928](https://github.com/eclipse-theia/theia/pull/7928)
 - [shell] `ApplicationShell.TrackableWidgetProvider.getTrackableWidgets` is sync to register child widgets in the same tick, use `ApplicationShell.TrackableWidgetProvider.onDidChangeTrackableWidgets` if child widgets are added async
+- [plugin] moved `VSCODE_DEFAULT_API_VERSION` to `@theia/plugin-ext-vscode/src/common/plugin-vscode-environment.ts`
 
 ## v1.2.0
 

--- a/packages/plugin-ext-vscode/src/node/plugin-vscode-cli-contribution.ts
+++ b/packages/plugin-ext-vscode/src/node/plugin-vscode-cli-contribution.ts
@@ -18,7 +18,8 @@ import { injectable } from 'inversify';
 import { Argv, Arguments } from 'yargs';
 import { CliContribution } from '@theia/core/lib/node/cli';
 import { PluginHostEnvironmentVariable } from '@theia/plugin-ext/lib/common';
-import { VSCODE_DEFAULT_API_VERSION } from './plugin-vscode-init';
+import { VSCODE_DEFAULT_API_VERSION } from '../common/plugin-vscode-environment';
+
 /**
  * CLI Contribution allowing to override the VS Code API version which is returned by `vscode.version` API call.
  */

--- a/packages/plugin-ext-vscode/src/node/plugin-vscode-init.ts
+++ b/packages/plugin-ext-vscode/src/node/plugin-vscode-init.ts
@@ -18,8 +18,7 @@
 
 import * as theia from '@theia/plugin';
 import { BackendInitializationFn, PluginAPIFactory, Plugin, emptyPlugin } from '@theia/plugin-ext';
-
-export const VSCODE_DEFAULT_API_VERSION = '1.44.0';
+import { VSCODE_DEFAULT_API_VERSION } from '../common/plugin-vscode-environment';
 
 /** Set up en as a default locale for VS Code extensions using vscode-nls */
 process.env['VSCODE_NLS_CONFIG'] = JSON.stringify({ locale: 'en', availableLanguages: {} });

--- a/packages/vsx-registry/package.json
+++ b/packages/vsx-registry/package.json
@@ -13,6 +13,7 @@
     "p-debounce": "^2.1.0",
     "requestretry": "^3.1.0",
     "sanitize-html": "^1.14.1",
+    "semver": "^5.4.1",
     "showdown": "^1.9.1",
     "uuid": "^8.0.0"
   },

--- a/packages/vsx-registry/src/browser/vsx-extension.tsx
+++ b/packages/vsx-registry/src/browser/vsx-extension.tsx
@@ -350,7 +350,7 @@ export class VSXExtensionEditorComponent extends AbstractVSXExtensionComponent {
     render(): React.ReactNode {
         const {
             builtin, preview, id, iconUrl, publisher, displayName, description,
-            averageRating, downloadCount, repository, license, readme
+            averageRating, downloadCount, repository, license, readme, version
         } = this.props.extension;
         return <React.Fragment>
             <div className='header'>
@@ -374,6 +374,7 @@ export class VSXExtensionEditorComponent extends AbstractVSXExtensionComponent {
                         {averageRating !== undefined && <span className='average-rating' onClick={this.openAverageRating}>{this.renderStars()}</span>}
                         {repository && <span className='repository' onClick={this.openRepository}>Repository</span>}
                         {license && <span className='license' onClick={this.openLicense}>{license}</span>}
+                        {version && <span className='version'>{version}</span>}
                     </div>
                     <div className='description noWrapInfo'>{description}</div>
                     {this.renderAction()}

--- a/packages/vsx-registry/src/browser/vsx-extensions-model.ts
+++ b/packages/vsx-registry/src/browser/vsx-extensions-model.ts
@@ -22,6 +22,7 @@ import { Emitter } from '@theia/core/lib/common/event';
 import { CancellationToken, CancellationTokenSource } from '@theia/core/lib/common/cancellation';
 import { VSXRegistryAPI, VSXResponseError } from '../common/vsx-registry-api';
 import { VSXSearchParam } from '../common/vsx-registry-types';
+import { VSXEnvironment } from '../common/vsx-environment';
 import { HostedPluginSupport } from '@theia/plugin-ext/lib/hosted/browser/hosted-plugin';
 import { VSXExtension, VSXExtensionFactory } from './vsx-extension';
 import { ProgressService } from '@theia/core/lib/common/progress-service';
@@ -48,6 +49,9 @@ export class VSXExtensionsModel {
 
     @inject(VSXExtensionsSearchModel)
     readonly search: VSXExtensionsSearchModel;
+
+    @inject(VSXEnvironment)
+    protected readonly environment: VSXEnvironment;
 
     protected readonly initialized = new Deferred<void>();
 
@@ -139,12 +143,18 @@ export class VSXExtensionsModel {
             const searchResult = new Set<string>();
             for (const data of result.extensions) {
                 const id = data.namespace.toLowerCase() + '.' + data.name.toLowerCase();
+                const extension = await this.api.getLatestCompatibleExtension(id);
+                if (!extension) {
+                    continue;
+                }
+
                 this.setExtension(id).update(Object.assign(data, {
-                    publisher: data.namespace,
-                    downloadUrl: data.files.download,
-                    iconUrl: data.files.icon,
-                    readmeUrl: data.files.readme,
-                    licenseUrl: data.files.license,
+                    publisher: extension.namespace,
+                    downloadUrl: extension.files.download,
+                    iconUrl: extension.files.icon,
+                    readmeUrl: extension.files.readme,
+                    licenseUrl: extension.files.license,
+                    version: extension.version,
                 }));
                 searchResult.add(id);
             }
@@ -212,7 +222,10 @@ export class VSXExtensionsModel {
 
     protected async refresh(id: string): Promise<VSXExtension | undefined> {
         try {
-            const data = await this.api.getExtension(id);
+            const data = await this.api.getLatestCompatibleExtension(id);
+            if (!data) {
+                return;
+            }
             if (data.error) {
                 return this.onDidFailRefresh(id, data.error);
             }
@@ -223,6 +236,7 @@ export class VSXExtensionsModel {
                 iconUrl: data.files.icon,
                 readmeUrl: data.files.readme,
                 licenseUrl: data.files.license,
+                version: data.version
             }));
             return extension;
         } catch (e) {

--- a/packages/vsx-registry/src/common/vsx-registry-types.ts
+++ b/packages/vsx-registry/src/common/vsx-registry-types.ts
@@ -65,6 +65,17 @@ export interface VSXUser {
 }
 
 /**
+ * Should be aligned with https://github.com/eclipse/openvsx/blob/master/server/src/main/java/org/eclipse/openvsx/entities/FileResource.java
+ */
+export interface VSXFiles {
+    download: string;
+    readme?: string;
+    license?: string;
+    icon?: string;
+    manifest?: string;
+}
+
+/**
  * Should be aligned with https://github.com/eclipse/openvsx/blob/master/server/src/main/java/org/eclipse/openvsx/json/ExtensionJson.java
  */
 export interface VSXExtensionRaw {
@@ -75,12 +86,7 @@ export interface VSXExtensionRaw {
     readonly namespace: string;
     readonly publishedBy: VSXUser
     readonly namespaceAccess: VSXExtensionNamespaceAccess;
-    readonly files: {
-        download: string
-        readme?: string
-        license?: string
-        icon?: string
-    }
+    readonly files: VSXFiles;
     readonly allVersions: {
         [version: string]: string
     }
@@ -102,4 +108,6 @@ export interface VSXExtensionRaw {
     readonly galleryColor?: string;
     readonly galleryTheme?: string;
     readonly qna?: string;
+    readonly engines?: string[];
+    readonly versionAlias?: string[];
 }

--- a/packages/vsx-registry/src/common/vsx-utils.ts
+++ b/packages/vsx-registry/src/common/vsx-utils.ts
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (C) 2020 TypeFox and others.
+ * Copyright (C) 2020 Ericsson and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -14,25 +14,19 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
-import { injectable, inject } from 'inversify';
-import { EnvVariablesServer } from '@theia/core/lib/common/env-variables';
-import URI from '@theia/core/lib/common/uri';
+import * as semver from 'semver';
+import { VSCODE_DEFAULT_API_VERSION } from '@theia/plugin-ext-vscode/lib/common/plugin-vscode-environment';
 
-export const VSCODE_DEFAULT_API_VERSION = '1.44.0';
-
-@injectable()
-export class PluginVSCodeEnvironment {
-
-    @inject(EnvVariablesServer)
-    protected readonly environments: EnvVariablesServer;
-
-    protected _extensionsDirUri: URI | undefined;
-    async getExtensionsDirUri(): Promise<URI> {
-        if (!this._extensionsDirUri) {
-            const configDir = new URI(await this.environments.getConfigDirUri());
-            this._extensionsDirUri = configDir.resolve('extensions');
-        }
-        return this._extensionsDirUri;
+/**
+ * Determine if the engine is valid.
+ * @param engine the engine.
+ *
+ * @returns `true` if the engine satisfies the API version.
+ */
+export function isEngineValid(engines: string[]): boolean {
+    const engine = engines.find(e => e.startsWith('vscode'));
+    if (engine) {
+        return engine === '*' || semver.satisfies(VSCODE_DEFAULT_API_VERSION, engine.split('@')[1]);
     }
-
+    return false;
 }

--- a/packages/vsx-registry/src/node/vsx-extension-resolver.ts
+++ b/packages/vsx-registry/src/node/vsx-extension-resolver.ts
@@ -49,7 +49,10 @@ export class VSXExtensionResolver implements PluginDeployerResolver {
             return;
         }
         console.log(`[${id}]: trying to resolve latest version...`);
-        const extension = await this.api.getExtension(id);
+        const extension = await this.api.getLatestCompatibleExtension(id);
+        if (!extension) {
+            return;
+        }
         if (extension.error) {
             throw new Error(extension.error);
         }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does

Fixes: https://github.com/eclipse-theia/theia/issues/7464

The following commit adds additional handling and functionality to the `vsx-registry` extension in order to obtain the latest compatible version of an extension (instead of the latest) by verifying it's **`engines.vscode`** property. A compatible extension is defined as one which respects the default API version of the framework, and is useful to narrow down the list of potential extensions to those advertised as working correctly. The changes are also aligned with vscode which perform similar checks.

The pull-request includes:
- a new API to get the latest compatible version of an extension
- additional handling to process and validate the `engines.vscode` property
- updates to the search, resolve, and install of extensions (to use the compatible version)
- updates to the `vsx-editor` to display the version (similarly to vscode)

#### How to test

For test purposes, the [prettier](https://open-vsx.org/extension/esbenp/prettier-vscode) extension was used:

| Prettier Version | Prettier `engines.vscode` | `VSCODE_DEFAULT_API` |
|:---|:---|:---|
| `5.0.1` | `^1.41.0` ([link](https://github.com/prettier/prettier-vscode/blob/1aa328c948f8604672d0f708a419eae8e12522bf/package.json#L21-L23)) | `1.44.0` |
| `3.20.0` | `^1.34.0` ([link](https://github.com/prettier/prettier-vscode/blob/cd1b3aa1f40f9fb5467a2cc74c2b35d78637de03/package.json#L21-L23)) | `1.40.0` |
| None | None | `1.20.0` |

1. start the application, open the 'extensions view' and search for **prettier**
2. the listed version should satisfy the version present in the above table
3. downgrade the `VSCODE_API_VERSION` (1.40.0) and rebuild the changes
4. repeat steps 1 and 2
5. downgrade the `VSCODE_API_VERSION` (1.20.0) and rebuild the changes
6. **prettier** should no longer appear in the search
7. verify that installation works correctly, and that the editor displays the correct version

<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

