### PR TITLE
Ensure 'All Files' key present in File Dialog Filters

### DIFF
--- a/packages/filesystem/src/browser/file-dialog/file-dialog-tree-filters-renderer.tsx
+++ b/packages/filesystem/src/browser/file-dialog/file-dialog-tree-filters-renderer.tsx
@@ -36,26 +36,24 @@ export class FileDialogTreeFilters {
 
 export class FileDialogTreeFiltersRenderer extends ReactRenderer {
 
+    readonly appliedFilters: FileDialogTreeFilters;
+
     constructor(
-        readonly filters: FileDialogTreeFilters,
+        readonly suppliedFilters: FileDialogTreeFilters,
         readonly fileDialogTree: FileDialogTree
     ) {
         super();
+        this.appliedFilters = { 'All Files': [], ...suppliedFilters, };
     }
 
     protected readonly handleFilterChanged = (e: React.ChangeEvent<HTMLSelectElement>) => this.onFilterChanged(e);
 
     protected doRender(): React.ReactNode {
-        if (!this.filters) {
+        if (!this.appliedFilters) {
             return undefined;
         }
 
-        const fileTypes = ['All Files'];
-        Object.keys(this.filters).forEach(element => {
-            fileTypes.push(element);
-        });
-
-        const options = fileTypes.map(value => this.renderLocation(value));
+        const options = Object.keys(this.appliedFilters).map(value => this.renderLocation(value));
         return <select className={'theia-select ' + FILE_TREE_FILTERS_LIST_CLASS} onChange={this.handleFilterChanged}>{...options}</select>;
     }
 
@@ -67,7 +65,7 @@ export class FileDialogTreeFiltersRenderer extends ReactRenderer {
         const locationList = this.locationList;
         if (locationList) {
             const value = locationList.value;
-            const filters = this.filters[value];
+            const filters = this.appliedFilters[value];
             this.fileDialogTree.setFilter(filters);
         }
 


### PR DESCRIPTION
Signed-off-by: Colin Grant <colin.grant@ericsson.com>

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

Fixes #8072 by ensuring that a properly formatted 'All Files' key will be present in the filter object. Formerly, 'All Files' was added to an array containing the keys of the filter object, but there was no guarantee that the filter object itself would have an entry corresponding to that value.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

1. Build with this code and start Theia in a browser
1. Open the File menu -> Open Workspace file dialog.
1. At the bottom of the file dialog, select various filter options.
1. Observe that none of them throw an error.

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

