### PR TITLE
Fix ignore minimatch to include folders starting with dot

### DIFF
--- a/packages/filesystem/src/node/nsfw-watcher/nsfw-filesystem-watcher.ts
+++ b/packages/filesystem/src/node/nsfw-watcher/nsfw-filesystem-watcher.ts
@@ -156,7 +156,7 @@ export class NsfwFileSystemWatcherServer implements FileSystemWatcherServer {
             }
         }));
         this.watcherOptions.set(watcherId, {
-            ignored: options.ignored.map(pattern => new Minimatch(pattern))
+            ignored: options.ignored.map(pattern => new Minimatch(pattern, { dot: true }))
         });
     }
 


### PR DESCRIPTION
for example during npm install there is a temp folder called .staging and we don't want to listen to those files.

Signed-off-by: Amiram Wingarten <amiram.wingarten@sap.com>

#### What it does
Add minimatch dot option to make sure also folders starting with dot are excluded from watched. See also https://github.com/isaacs/minimatch#dot
The new behavior complies also with VS Code watch ignore behavior.

#### How to test

1. Change suffix of [helloworld-sample-0.0.1.zip](https://github.com/eclipse-theia/theia/files/4815695/helloworld-sample-0.0.1.zip) to .vsix and deploy it. It prints to output on each package.json changed.
1. Open some node project with node_modules folder.
1. Under node_modules/.bin folder create package.json file.

Before this PR there was an output message to output channel "Package.json Events" which is wrong. After this PR there is no such ourput.


#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

