### PR TITLE
Preprocess HTML: wrap `Content-Security-Policy` meta tag into comment

### DIFF
--- a/packages/plugin-ext/src/main/browser/webview/webview.ts
+++ b/packages/plugin-ext/src/main/browser/webview/webview.ts
@@ -365,7 +365,14 @@ export class WebviewWidget extends BaseWidget implements StatefulWidget {
     }
 
     protected preprocessHtml(value: string): string {
-        return value
+        // Comment <meta http-equiv="Content-Security-Policy" /> tag in HEAD section
+        let html = value
+            .replace(/<\s*meta([^>]+?(?=Content-Security-Policy)[^>]+)\/?>/gsm, (_, group) => {
+                return `<!-- meta ${group} -->`;
+            });
+
+        // Update all links, using 'vscode-resource:' and 'theia-resource:' scheme 
+        return html
             .replace(/(["'])(?:vscode|theia)-resource:(\/\/([^\s\/'"]+?)(?=\/))?([^\s'"]+?)(["'])/gi, (_, startQuote, _1, scheme, path, endQuote) => {
                 if (scheme) {
                     return `${startQuote}${this.externalEndpoint}/theia-resource/${scheme}${path}${endQuote}`;


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->
Wraps into comment (disables) `Content-Security-Policy` meta tag in HEAD section in webview HTML.
It needs for [Jira and Bitbucket](https://marketplace.visualstudio.com/items?itemName=Atlassian.atlascode) extension, which use webviews to display some pages.

The extension opens a webview with [initial HTML](https://bitbucket.org/atlassianlabs/atlascode/src/devel/resources/html/reactWebview.html):
```
<!DOCTYPE html>
<html lang="en">
    <head>
        <meta charset="utf-8" />
        <base href="vscode-resource:/tmp/vscode-unpacked/atlascode-0.0.0.vsix/extension/" />
        <!-- <meta name="viewport" content="width=device-width,initial-scale=0,shrink-to-fit=no" /> -->
        <meta name="theme-color" content="#000000" />
        <meta id="reactView" name="reactView" content="atlascodeSettingsV2" />
        <title>Atlassian Webview</title>
        <meta
            http-equiv="Content-Security-Policy"
            content="
                default-src https://api.atlassian.com ; 
                img-src data: vscode-resource: http: https: blob:; 
                object-src data:; 
                script-src vscode-resource:;
                style-src vscode-resource: 'unsafe-inline' blob: http: https: data:;"
        />
    </head>

    <body>
        <noscript>You need to enable JavaScript to run this app.</noscript>

        <div id="root"></div>
        <script src="vscode-resource:/tmp/vscode-unpacked/atlascode-0.0.0.vsix/extension/build/static/js/mui.454e318f.js"></script>
    </body>
</html>
```

Java script `src` refers on the resource using `vscode-resource:` scheme in the URI. To have such resource being loaded, Theia [pre-processes the URI](https://github.com/eclipse-theia/theia/blob/master/packages/plugin-ext/src/main/browser/webview/webview.ts#L367) before inserting the HTML.
But if the webview has restrictions (`script-src vscode-resource:`) provided by `Content-Security-Policy` meta tag, the browser blocks all the requests to that resources.

![Screenshot from 2020-06-03 12-51-25](https://user-images.githubusercontent.com/1655894/83622664-f5763c00-a598-11ea-945e-3934fa1addc9.png)

The idea is to temporary wrapping into comment such meta tags while we don't have any solution how to handle resources with `vscode-resource:` and `theia-resource:` schemes.

Original issue describing the problem https://github.com/eclipse/che/issues/17081

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
In any webview
- use an image or script with `vscode-resource:` or `theia-resource:` scheme in the URI
- add the following meta tag to the head

```
        <meta
            http-equiv="Content-Security-Policy"
            content="
                default-src https://api.atlassian.com ; 
                img-src vscode-resource: theia-resource:;  
                script-src vscode-resource: theia-resource:;
                style-src vscode-resource: theia-resource:;"
        />
```

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)
