### PR TITLE
Fix modal dialog max-width and text wrapping

### DIFF
--- a/packages/plugin-ext/src/main/browser/dialogs/modal-notification.ts
+++ b/packages/plugin-ext/src/main/browser/dialogs/modal-notification.ts
@@ -64,7 +64,7 @@ export class ModalNotification extends AbstractDialog<string | undefined> {
 
         const textContainer = messageNode.appendChild(document.createElement('div'));
         textContainer.classList.add(TEXT);
-        const textElement = textContainer.appendChild(document.createElement('pre'));
+        const textElement = textContainer.appendChild(document.createElement('p'));
         textElement.textContent = text;
 
         actions.forEach((action: MainMessageItem) => {

--- a/packages/plugin-ext/src/main/browser/dialogs/style/modal-notification.css
+++ b/packages/plugin-ext/src/main/browser/dialogs/style/modal-notification.css
@@ -26,8 +26,8 @@
     clear: both;
     box-sizing: border-box;
     position: relative;
-    width: 100%;
     min-width: 200px;
+    max-width: min(66vw, 800px);
     background-color: var(--theia-editorWidget-background);
     min-height: 35px;
     margin-bottom: 1px;
@@ -60,22 +60,22 @@
 .modal-Notification .text {
     order: 2;
     display: inline-block;
-    max-height: calc(100vh - 100px);
-    max-width: calc(100vw - 100px);
+    max-height: min(66vh, 600px);
     -webkit-user-select: text;
     -moz-user-select: text;
     -ms-user-select: text;
     user-select: text;
     align-self: center;
     flex: 1 100%;
-    height: 100%;
     padding: 10px;
     overflow: auto;
+    white-space: pre-wrap;
 }
 
 .modal-Notification .text > p {
     margin: 0;
     font-size: var(--theia-ui-font-size1);
+    font-family: var(--theia-ui-font-family);
     vertical-align: middle;
 }
 
@@ -105,9 +105,4 @@
 
 .modal-Notification .buttons > button:hover {
     background-color: var(--theia-button-hoverBackground);
-}
-
-.modal-Notification pre {
-    font-family: var(--theia-ui-font-family);
-    font-size: var(--theia-ui-font-size1);
 }


### PR DESCRIPTION
Signed-off-by: Tim Etchells <timetchells@ibm.com>

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->
Fixes https://github.com/eclipse-theia/theia/issues/8071
- use `p` instead of `pre` so that the text will wrap to fit in the modal, but add `white-space: pre-wrap` so that newlines are still preserved and spaces are not collapsed
- adds max-width and max-height to modal

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
Install the vsix from https://github.com/tetchel/theia-modal-wrap and run the command it contributes

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

Screenshot:
![image](https://user-images.githubusercontent.com/8888438/85435984-49e85800-b556-11ea-9432-d8049b31ee4b.png)
