### PR TITLE
fix #7973: Collect env vars lowercase on windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## v1.4.0
+
+- [core] fixed handling of environment variables on Windows [#7973](https://github.com/eclipse-theia/theia/pull/7973)
+
 ## v1.3.0
 
 - [cli] updated the download script to warn about mandatory `theiaPlugins` field [#8058](https://github.com/eclipse-theia/theia/pull/8058)
@@ -48,7 +52,6 @@ Breaking Changes:
 - [task] Widened the scope of some methods in TaskManager and TaskConfigurations from string to TaskConfigurationScope. This is only breaking for extenders, not callers. [#7928](https://github.com/eclipse-theia/theia/pull/7928)
 - [shell] updated `ApplicationShell.TrackableWidgetProvider.getTrackableWidgets` to be synchronous in order to register child widgets in the same tick [#7957](https://github.com/eclipse-theia/theia/pull/7957)
   - use `ApplicationShell.TrackableWidgetProvider.onDidChangeTrackableWidgets` if child widgets are added asynchronously
-
 
 ## v1.2.0
 

--- a/packages/core/src/node/env-variables/env-variables-server.ts
+++ b/packages/core/src/node/env-variables/env-variables-server.ts
@@ -30,7 +30,11 @@ export class EnvVariablesServerImpl implements EnvVariablesServer {
     constructor() {
         const prEnv = process.env;
         Object.keys(prEnv).forEach((key: string) => {
-            this.envs[key] = { 'name': key, 'value': prEnv[key] };
+            let keyName = key;
+            if (isWindows) {
+                keyName = key.toLowerCase();
+            }
+            this.envs[keyName] = { 'name': keyName, 'value': prEnv[key] };
         });
     }
 


### PR DESCRIPTION
#### What it does
- Fix issue #7973 
- Populate local copy of environment variables with lowercase keys if on Windows platform

#### How to test
1. Set two environment variables with different casing:
```cmd
setx var_lower VAR_LOWER_value
setx VAR_UPPER VAR_UPPER_value
```

2. Start Theia locally on Windows and add the following tasks.json:
```json
{
    "version": "2.0.0",
    "tasks": [
        {
            "label": "Echo",
            "type": "shell",
            "command": "echo Test var_lower=${env:var_lower} VAR_UPPER=${env:VAR_UPPER}",
            "problemMatcher": []
        }
    ]
}
```

3. Execute task "Echo".

Output before fix:
```text
Test var_lower=VAR_LOWER_value VAR_UPPER=
```

Output after fix:
```text
Test var_lower=VAR_LOWER_value VAR_UPPER=VAR_UPPER_value
```

#### Review checklist

- [X] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

