### PR TITLE
fix #7680 remove css escape for html class attribute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## v1.4.0
 
 - [core] fixed handling of environment variables on Windows [#7973](https://github.com/eclipse-theia/theia/pull/7973)
+- [plugin-ext] fix file-icon incorrectly displays name icon with a dot in name [#7680](https://github.com/eclipse-theia/theia/pull/7680)
 
 ## v1.3.0
 

--- a/packages/plugin-ext/src/main/browser/plugin-icon-theme-service.ts
+++ b/packages/plugin-ext/src/main/browser/plugin-icon-theme-service.ts
@@ -337,16 +337,11 @@ export class PluginIconTheme extends PluginIconThemeDefinition implements IconTh
     }
 
     protected escapeCSS(value: string): string {
-        try {
-            return CSS.escape(value);
-        } catch {
-            // Edge and Safari on iOS does not support `CSS.escape` yet, remove it when they do
-            value = value.replace(/[^\-a-zA-Z0-9]/g, '-');
-            if (value.charAt(0).match(/[0-9\-]/)) {
-                value = '-' + value;
-            }
-            return value;
+        value = value.replace(/[^\-a-zA-Z0-9]/g, '-');
+        if (value.charAt(0).match(/[0-9\-]/)) {
+            value = '-' + value;
         }
+        return value;
     }
 
     protected readonly fileIcon = 'theia-plugin-file-icon';


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
- Fix issue #7680
- replace escaped dots in class names used for html class attribute only.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
1. Start Theia on gitpod & install Material Icon Theme from open vsx registry

Without fix:
![Sélection_061](https://user-images.githubusercontent.com/2135565/85537284-1ec43e00-b614-11ea-8447-f99190de01b9.png)

With fix:
![Sélection_062](https://user-images.githubusercontent.com/2135565/85537340-2ab00000-b614-11ea-8edb-05e3ecc63559.png)


#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

