### PR TITLE
vsx-extensions-view-styling-improvements

### DIFF
--- a/packages/vsx-registry/src/browser/style/index.css
+++ b/packages/vsx-registry/src/browser/style/index.css
@@ -137,18 +137,49 @@
     overflow: hidden;
     display: flex;
     flex-direction: column;
-    padding: var(--theia-ui-padding);
+    padding-top: 0;
+    position: relative;
 }
 
 .theia-vsx-extension-editor .header {
     display: flex;
-    padding: calc(var(--theia-ui-padding)*3) calc(var(--theia-ui-padding)*3) calc(var(--theia-ui-padding)*2);
-    overflow: hidden;
+    padding: calc(var(--theia-ui-padding) * 3) calc(var(--theia-ui-padding) * 3) calc(var(--theia-ui-padding) * 3);
     flex-shrink: 0;
+    border-bottom: 1px solid hsla(0, 0% ,50% ,.5);
+    position: sticky;
+    top: 0;
+    width: 100%;
+    background: var(--theia-editor-background);
+}
+
+.theia-vsx-extension-editor .scroll-container {
+    position: absolute;
+    bottom: 0;
+    padding-top: 0;
+    max-width: 100%;
+    width: 100%;
 }
 
 .theia-vsx-extension-editor .body {
     flex: 1;
+    padding: calc(var(--theia-ui-padding)*2);
+    padding-top: 0;
+    max-width: 1000px;
+    margin: 0 auto;
+}
+
+.theia-vsx-extension-editor .body h2:first-of-type {
+    padding-bottom: var(--theia-ui-padding);
+    border-bottom: 1px solid hsla(0, 0%, 50%, .5);
+    margin-top: calc(var(--theia-ui-padding) * 5);
+}
+
+.theia-vsx-extension-editor .scroll-container .body pre {
+    white-space: normal;
+}
+
+.theia-vsx-extension-editor .body img {
+    max-width: 100%;
 }
 
 .theia-vsx-extension-editor .header .icon-container {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->
This PR introduces some styling improvements to the vsx-extensions view to be more inline with VSCodes respective view, these improvements include:
- Sticky "header" during scroll
- Dividing border lines under header, as well as extension title in body
- Max-width container for body content
- Image resize on width resize
- Repositioned scrollbar to be underneath header

![extensionsstyling](https://user-images.githubusercontent.com/62660714/85612065-24268600-b61e-11ea-855a-17d4bb3624b8.gif)

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
- Pull branch
- Open extensions view
- Search for extensions and double click to view content
- Observe styling changes

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

