### PR TITLE
vsx: add version field

### DIFF
--- a/packages/vsx-registry/src/browser/vsx-extension.tsx
+++ b/packages/vsx-registry/src/browser/vsx-extension.tsx
@@ -350,7 +350,7 @@ export class VSXExtensionEditorComponent extends AbstractVSXExtensionComponent {
     render(): React.ReactNode {
         const {
             builtin, preview, id, iconUrl, publisher, displayName, description,
-            averageRating, downloadCount, repository, license, readme
+            averageRating, downloadCount, repository, license, readme, version
         } = this.props.extension;
         return <React.Fragment>
             <div className='header'>
@@ -374,6 +374,7 @@ export class VSXExtensionEditorComponent extends AbstractVSXExtensionComponent {
                         {averageRating !== undefined && <span className='average-rating' onClick={this.openAverageRating}>{this.renderStars()}</span>}
                         {repository && <span className='repository' onClick={this.openRepository}>Repository</span>}
                         {license && <span className='license' onClick={this.openLicense}>{license}</span>}
+                        {version && <span className='version'>{version}</span>}
                     </div>
                     <div className='description noWrapInfo'>{description}</div>
                     {this.renderAction()}


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

The following pull-request adds the `version` field when viewing the content of an extension (vsx-editor with readme).
Adding the field helps end-users identify more easily the specific version of their extension and it also aligns with the same behavior present in vscode:

<div align='center'>

<img width="700" alt="Screen Shot 2020-06-24 at 3 43 08 PM" src="https://user-images.githubusercontent.com/40359487/85620830-53df8900-b632-11ea-9c6d-f4fedb5fbf9e.png">

</div>

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

1. open the extensions-view
2. search for an extension, and open it (opening the readme info)
3. the version should be displayed along with the other information
4. select a builtin extension, and open it (opening the readme info)
5. the version should be displayed along with the other information


#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

Signed-off-by: vince-fugnitto <vincent.fugnitto@ericsson.com>

