### PR TITLE
navigator: add new command 'copy relative path'

### DIFF
--- a/packages/navigator/src/browser/navigator-contribution.ts
+++ b/packages/navigator/src/browser/navigator-contribution.ts
@@ -467,7 +467,7 @@ export class FileNavigatorContribution extends AbstractViewContribution<FileNavi
 
         registry.registerKeybinding({
             command: FileNavigatorCommands.COPY_RELATIVE_FILE_PATH.id,
-            keybinding: isWindows ? 'ctrl+shift+alt+c' : 'ctrlcmd+shift+alt+c',
+            keybinding: isWindows ? 'ctrl+k ctrl+shift+c' : 'ctrlcmd+shift+alt+c',
             when: '!editorFocus'
         });
     }

--- a/packages/plugin-ext-vscode/src/browser/plugin-vscode-commands-contribution.ts
+++ b/packages/plugin-ext-vscode/src/browser/plugin-vscode-commands-contribution.ts
@@ -628,5 +628,10 @@ export class PluginVscodeCommandsContribution implements CommandContribution {
         }, {
             execute: () => commands.executeCommand(CommonCommands.COPY_PATH.id)
         });
+        commands.registerCommand({
+            id: 'copyRelativeFilePath'
+        }, {
+            execute: () => commands.executeCommand(FileNavigatorCommands.COPY_RELATIVE_FILE_PATH.id)
+        });
     }
 }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

Fixes: https://github.com/eclipse-theia/theia/issues/5937
Closes: https://github.com/eclipse-theia/theia/pull/5964

The following commit implements the '**Copy Relative Path**' command (accessible through the explorer's context-menu).
- The command copies the relative paths (according to their respective roots) to the user's clipboard.
- The command supports both single and multiple-root workspaces.
- The `copyRelativeFilePath` command is also exposed to the plugin system.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

1. select a single resource in the explorer, trigger the context-menu and select 'copy relative path'\
(it should be added to the clipboard)
2. repeat step 1 with multiple resources
3. repeat step 1 and 2 with a multiple-root workspace


#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

Signed-off-by: vince-fugnitto <vincent.fugnitto@ericsson.com>