### PR TITLE
vsx-registry: fix the 'licenseUrl' link

### DIFF
--- a/packages/vsx-registry/src/browser/vsx-extension.tsx
+++ b/packages/vsx-registry/src/browser/vsx-extension.tsx
@@ -190,12 +190,16 @@ export class VSXExtension implements VSXExtensionData, TreeElement {
     }
 
     get licenseUrl(): string | undefined {
-        const plugin = this.plugin;
-        const licenseUrl = plugin && plugin.metadata.model.licenseUrl;
+        let licenseUrl = this.data['licenseUrl'];
         if (licenseUrl) {
-            return new Endpoint({ path: licenseUrl }).getRestUrl().toString();
+            return licenseUrl;
+        } else {
+            const plugin = this.plugin;
+            licenseUrl = plugin && plugin.metadata.model.licenseUrl;
+            if (licenseUrl) {
+                return new Endpoint({ path: licenseUrl }).getRestUrl().toString();
+            }
         }
-        return this.data['licenseUrl'];
     }
 
     get repository(): string | undefined {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

Fixes: #8094 

The following pull-request fixes the `licenseUrl` link when attempting to open an extension's license from the vsx-editor.
Previously, the url was incorrect as it would refer to the local `hosted` path. If the data is available, use it directly to open the link.

<div align='center'>

<img width="647" alt="Screen Shot 2020-06-25 at 8 48 32 PM" src="https://user-images.githubusercontent.com/40359487/85809262-43f4a180-b725-11ea-8598-4ff03aee38ea.png">

</div>

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

1. open the 'extensions-view'
2. perform the same test for a `builtin`, `installed` and `search result` extension:
   - open the extension's info (header & readme), click the license link and verify the link works correctly

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

Signed-off-by: vince-fugnitto <vincent.fugnitto@ericsson.com>
