### PR TITLE
[plugin] handle plugin host activation exceptions

### DIFF
--- a/packages/plugin-ext/src/plugin/plugin-manager.ts
+++ b/packages/plugin-ext/src/plugin/plugin-manager.ts
@@ -269,20 +269,13 @@ export class PluginManagerExtImpl implements PluginManagerExt, PluginManager {
                     if (plugin.rawModel.extensionDependencies) {
                         for (const dependencyId of plugin.rawModel.extensionDependencies) {
                             const dependency = this.registry.get(dependencyId.toLowerCase());
-                            const id = plugin.model.displayName || plugin.model.id;
                             if (dependency) {
-                                const depId = dependency.model.displayName || dependency.model.id;
                                 const loadedSuccessfully = await this.loadPlugin(dependency, configStorage, visited);
                                 if (!loadedSuccessfully) {
-                                    const message = `Cannot activate extension '${id}' because it depends on extension '${depId}', which failed to activate.`;
-                                    this.messageRegistryProxy.$showMessage(MainMessageType.Error, message, {}, []);
-                                    return false;
+                                    throw new Error(`Dependent extension '${dependency.model.displayName || dependency.model.id}' failed to activate.`);
                                 }
                             } else {
-                                const message = `Cannot activate the '${id}' extension because it depends on the '${dependencyId}' extension, which is not installed.`;
-                                this.messageRegistryProxy.$showMessage(MainMessageType.Error, message, {}, []);
-                                console.warn(message);
-                                return false;
+                                throw new Error(`Dependent extension '${dependencyId}' is not installed.`);
                             }
                         }
                     }
@@ -290,7 +283,16 @@ export class PluginManagerExtImpl implements PluginManagerExt, PluginManager {
                     let pluginMain = this.host.loadPlugin(plugin);
                     // see https://github.com/TypeFox/vscode/blob/70b8db24a37fafc77247de7f7cb5bb0195120ed0/src/vs/workbench/api/common/extHostExtensionService.ts#L372-L376
                     pluginMain = pluginMain || {};
-                    return await this.startPlugin(plugin, configStorage, pluginMain);
+                    await this.startPlugin(plugin, configStorage, pluginMain);
+                    return true;
+                } catch (err) {
+                    if (this.pluginActivationPromises.has(plugin.model.id)) {
+                        this.pluginActivationPromises.get(plugin.model.id)!.reject(err);
+                    }
+                    const message = `Activating extension '${plugin.model.displayName || plugin.model.name}' failed: ${err.message}`;
+                    this.messageRegistryProxy.$showMessage(MainMessageType.Error, message, {}, []);
+                    console.error(message);
+                    return false;
                 } finally {
                     this.notificationMain.$stopProgress(progressId);
                 }
@@ -330,7 +332,7 @@ export class PluginManagerExtImpl implements PluginManagerExt, PluginManager {
     }
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    private async startPlugin(plugin: Plugin, configStorage: ConfigStorage, pluginMain: any): Promise<boolean> {
+    private async startPlugin(plugin: Plugin, configStorage: ConfigStorage, pluginMain: any): Promise<void> {
         const subscriptions: theia.Disposable[] = [];
         const asAbsolutePath = (relativePath: string): string => join(plugin.pluginFolder, relativePath);
         const logPath = join(configStorage.hostLogPath, plugin.model.id); // todo check format
@@ -354,29 +356,19 @@ export class PluginManagerExtImpl implements PluginManagerExt, PluginManager {
         }
         const id = plugin.model.displayName || plugin.model.id;
         if (typeof pluginMain[plugin.lifecycle.startMethod] === 'function') {
-            try {
-                const pluginExport = await pluginMain[plugin.lifecycle.startMethod].apply(getGlobal(), [pluginContext]);
-                this.activatedPlugins.set(plugin.model.id, new ActivatedPlugin(pluginContext, pluginExport, stopFn));
+            const pluginExport = await pluginMain[plugin.lifecycle.startMethod].apply(getGlobal(), [pluginContext]);
+            this.activatedPlugins.set(plugin.model.id, new ActivatedPlugin(pluginContext, pluginExport, stopFn));
 
-                // resolve activation promise
-                if (this.pluginActivationPromises.has(plugin.model.id)) {
-                    this.pluginActivationPromises.get(plugin.model.id)!.resolve();
-                    this.pluginActivationPromises.delete(plugin.model.id);
-                }
-            } catch (err) {
-                if (this.pluginActivationPromises.has(plugin.model.id)) {
-                    this.pluginActivationPromises.get(plugin.model.id)!.reject(err);
-                }
-                this.messageRegistryProxy.$showMessage(MainMessageType.Error, `Activating extension ${id} failed: ${err.message}.`, {}, []);
-                console.error(`Error on activation of ${plugin.model.name}`, err);
-                return false;
+            // resolve activation promise
+            if (this.pluginActivationPromises.has(plugin.model.id)) {
+                this.pluginActivationPromises.get(plugin.model.id)!.resolve();
+                this.pluginActivationPromises.delete(plugin.model.id);
             }
         } else {
             // https://github.com/TypeFox/vscode/blob/70b8db24a37fafc77247de7f7cb5bb0195120ed0/src/vs/workbench/api/common/extHostExtensionService.ts#L400-L401
             console.log(`plugin ${id}, ${plugin.lifecycle.startMethod} method is undefined so the module is the extension's exports`);
             this.activatedPlugins.set(plugin.model.id, new ActivatedPlugin(pluginContext, pluginMain));
         }
-        return true;
     }
 
     getAllPlugins(): Plugin[] {


### PR DESCRIPTION
Signed-off-by: Rob Moran <rob.moran@arm.com>

#### What it does
Resolves #8018 

Added catch to plugin host to handle exceptions thrown while resolving dependencies in plugins.

- Activation promise rejected if it exists
- Exception logged and shown to user in notification.

#### How to test
Follow steps in #8018 

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

