### PR TITLE
fix #8106:fix open deleted file in git scm errors

### DIFF
--- a/packages/git/src/browser/git-scm-provider.ts
+++ b/packages/git/src/browser/git-scm-provider.ts
@@ -195,6 +195,13 @@ export class GitScmProvider implements ScmProvider {
 
     getUriToOpen(change: GitFileChange): URI {
         const changeUri: URI = new URI(change.uri);
+        if (change.status === GitFileStatus.Deleted) {
+            if (change.staged) {
+                return changeUri.withScheme(GIT_RESOURCE_SCHEME).withQuery('HEAD');
+            } else {
+                return changeUri.withScheme(GIT_RESOURCE_SCHEME);
+            }
+        }
         if (change.status !== GitFileStatus.New) {
             if (change.staged) {
                 return DiffUris.encode(


### PR DESCRIPTION
Signed-off-by: 二凢 <dingyu.wdy@alibaba-inc.com>

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

Fixes: #8106

There is a bug when try to open deleted files in git scm, it causes errors and can not open anything.

![](https://img.alicdn.com/tfs/TB1YawsaCR26e4jSZFEXXbwuXXa-1620-1068.png)

For more detail, view the [ISSUE #8106](https://github.com/eclipse-theia/theia/issues/8106)

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
1. Delete any file
2. Open git scm view
3. Click the deleted file in CHANGES or STAGED CHANGES

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

