### PR TITLE
terminal: fix the display of the scrollbar

### DIFF
--- a/packages/terminal/src/browser/style/terminal.css
+++ b/packages/terminal/src/browser/style/terminal.css
@@ -17,7 +17,8 @@
 .terminal-container {
     width:100%;
     height:100%;
-    padding: var(--theia-code-padding);
+    padding-top: var(--theia-code-padding);
+    padding-bottom: var(--theia-code-padding);
     background: var(--theia-terminal-background);
 }
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

Fixes: #8096

The following pull-request fixes the scrollbar issue for the terminal which was small and even hidden on small viewports.
The issue was caused by the padding which would shrink the scrollbar.

<div align='center'>

![scroll](https://user-images.githubusercontent.com/40359487/86016904-602c6300-b9f1-11ea-9ff5-d2aae3227bd6.png)


</div>

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

1. open a terminal
2. create output to show the scrollbar (`ls -al`)
3. resize the terminal and verify the scrollbar has a consistent width

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

Signed-off-by: vince-fugnitto <vincent.fugnitto@ericsson.com>
