### PR TITLE
[debug] Save the dirty editor when starting launch config

### DIFF
--- a/packages/debug/src/browser/debug-session-manager.ts
+++ b/packages/debug/src/browser/debug-session-manager.ts
@@ -17,7 +17,7 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
 import { DisposableCollection, Emitter, Event, MessageService, ProgressService, WaitUntilEvent } from '@theia/core';
-import { LabelProvider } from '@theia/core/lib/browser';
+import { LabelProvider, ApplicationShell } from '@theia/core/lib/browser';
 import { ContextKey, ContextKeyService } from '@theia/core/lib/browser/context-key-service';
 import URI from '@theia/core/lib/common/uri';
 import { EditorManager } from '@theia/editor/lib/browser';
@@ -141,6 +141,9 @@ export class DebugSessionManager {
     @inject(QuickOpenTask)
     protected readonly quickOpenTask: QuickOpenTask;
 
+    @inject(ApplicationShell)
+    protected readonly shell: ApplicationShell;
+
     protected debugTypeKey: ContextKey<string>;
     protected inDebugModeKey: ContextKey<boolean>;
 
@@ -166,6 +169,7 @@ export class DebugSessionManager {
     async start(options: DebugSessionOptions): Promise<DebugSession | undefined> {
         return this.progressService.withProgress('Start...', 'debug', async () => {
             try {
+                await this.shell.saveAll();
                 await this.fireWillStartDebugSession();
                 const resolved = await this.resolveConfiguration(options);
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
Fixes: https://github.com/eclipse-theia/theia/issues/7938

Saves all the editors when starting to debug in Theia.

#### How to test
1. Open `Theia` as a workspace.
2. Make changes to a test file(make sure the test fails), and without saving use the debugger to `Run Mocha Test` 
3. Check your filesystem to see if the changes for the file are saved or not.
4. Check to see if the test is failing

Signed-off-by: Anas Shahid <muhammad.shahid@ericsson.com>

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

