### PR TITLE
Electron main customisation: second-instance event handling

### DIFF
--- a/dev-packages/application-manager/src/generator/frontend-generator.ts
+++ b/dev-packages/application-manager/src/generator/frontend-generator.ts
@@ -140,13 +140,6 @@ const { resolve } = require('path');
 const { app } = require('electron');
 
 const config = ${this.prettyStringify(this.pck.props.frontend.config)};
-const isSingleInstance = ${this.pck.props.backend.config.singleInstance === true ? 'true' : 'false'};
-
-if (isSingleInstance && !app.requestSingleInstanceLock()) {
-    // There is another instance running, exit now. The other instance will request focus.
-    app.quit();
-    return;
-}
 
 const container = new Container();
 container.load(electronMainApplicationModule);

--- a/dev-packages/application-package/src/application-props.ts
+++ b/dev-packages/application-package/src/application-props.ts
@@ -140,11 +140,6 @@ export interface ElectronFrontendApplicationConfig {
  */
 export interface BackendApplicationConfig extends ApplicationConfig {
 
-    /**
-     * If true and in Electron mode, only one instance of the application is allowed to run at a time.
-     */
-    singleInstance?: boolean;
-
 }
 
 /**

--- a/packages/core/src/electron-main/electron-main-application.ts
+++ b/packages/core/src/electron-main/electron-main-application.ts
@@ -174,6 +174,7 @@ export class ElectronMainApplication {
 
     async start(config: FrontendApplicationConfig): Promise<void> {
         this._config = config;
+        await this.checkSingleInstance();
         this.hookApplicationEvents();
         const port = await this.startBackend();
         this.backendPort.resolve(port);
@@ -185,6 +186,15 @@ export class ElectronMainApplication {
             argv: this.processArgv.getProcessArgvWithoutBin(process.argv),
             cwd: process.cwd()
         });
+    }
+
+    protected async checkSingleInstance(): Promise<void> {
+        const gotLock = app.requestSingleInstanceLock();
+
+        if (!gotLock) {
+            // There is another instance running, exit now. The other instance will open a new window.
+            app.quit();
+        }
     }
 
     protected async launch(params: ElectronMainExecutionParams): Promise<void> {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

Suggestion to improve https://github.com/eclipse-theia/theia/pull/8125.

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

Moved `app.requestSingleInstanceLock` call from electron-main entry point to the `ElectronMainApplication` class and removed the `singleInstance` property from the backend config.

- This fixes the default `second-instance` event handling in https://github.com/eclipse-theia/theia/pull/8125. If `requestSingleInstanceLock` is not called, then the `second-instance` event is not fired in the original instance.
- It is now possible to customise single instance handling by overriding `ElectronMainApplication`.

If an application really only wants one window, it can override `onSecondInstance` to a no-op. If it wants every application launch to start a new main process, it can override `checkSingleInstance` to a no-op. The out-of-box behaviour is to open a new `BrowserWindow` for the original main process when the user launches the app a second time.

Question: is it okay to remove the `singleInstance` property and replace with `ElectronMainApplication`, or is it best to keep it for backwards compatibility?

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

As https://github.com/eclipse-theia/theia/pull/8125

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

