### PR TITLE
debug: add run statusbar item

### DIFF
--- a/packages/debug/src/browser/debug-preferences.ts
+++ b/packages/debug/src/browser/debug-preferences.ts
@@ -44,6 +44,11 @@ export const debugPreferencesSchema: PreferenceSchema = {
             type: 'boolean',
             default: false,
             description: 'Show variable values inline in editor while debugging.'
+        },
+        'debug.showInStatusBar': {
+            enum: ['never', 'always', 'onFirstSessionStart'],
+            description: 'Controls when the debug status bar should be visible.',
+            default: 'onFirstSessionStart'
         }
     }
 };
@@ -54,6 +59,7 @@ export class DebugConfiguration {
     'debug.openDebug': 'neverOpen' | 'openOnSessionStart' | 'openOnFirstSessionStart' | 'openOnDebugBreak';
     'debug.internalConsoleOptions': 'neverOpen' | 'openOnSessionStart' | 'openOnFirstSessionStart';
     'debug.inlineValues': boolean;
+    'debug.showInStatusBar': 'never' | 'always' | 'onFirstSessionStart';
 }
 
 export const DebugPreferences = Symbol('DebugPreferences');


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

Fixes: #5156

The following pull-request implements the _select and run_ debug statusbar item:
- includes a new preference `debug.showInStatusBar`
- the statusbar item triggers the prefix select and run command
- the statusbar item reflects the current debug configuration, and updates when the config changes, and when the preference value is updated

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

Verify that the debug status bar item is updated accordingly based on the preference value, and the configuration updates:
1. start the application, and open the debug view
2. preferences:
  - `never`: the debug status bar item is never displayed, if previously displayed it will be removed
  - `always`: the debug status bar item is always displayed (on app start as well)
  - `onFirstSessionStart`: the debug status bar item is displayed on a debug session is first started
3. verify that the debug status bar item is updated when a configuration is updated (label), and when the preference value is updated

---

_Example: updating the configuration changes the label_

<div align='center'>

![debug-sb](https://user-images.githubusercontent.com/40359487/86486152-925aff00-bd28-11ea-9946-7b481ab2b4f4.gif)

</div>

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

Signed-off-by: vince-fugnitto <vincent.fugnitto@ericsson.com>
