### PR TITLE
[Fix] Webview is not focused after cancelling quick open widget

### DIFF
--- a/packages/plugin-ext/src/main/browser/webview/webview.ts
+++ b/packages/plugin-ext/src/main/browser/webview/webview.ts
@@ -199,6 +199,15 @@ export class WebviewWidget extends BaseWidget implements StatefulWidget {
         this.toDisposeOnDetach.push(Disposable.create(() => this.forceHide()));
     }
 
+    protected onAfterAttach(msg: Message): void {
+        super.onAfterAttach(msg);
+        this.addEventListener(this.node, 'focus', () => {
+            if (this.element) {
+                this.doSend('focus');
+            }
+        });
+    }
+
     protected onBeforeShow(msg: Message): void {
         super.onBeforeShow(msg);
         this.doShow();
@@ -376,14 +385,7 @@ export class WebviewWidget extends BaseWidget implements StatefulWidget {
 
     protected onActivateRequest(msg: Message): void {
         super.onActivateRequest(msg);
-        this.focus();
-    }
-
-    focus(): void {
         this.node.focus();
-        if (this.element) {
-            this.doSend('focus');
-        }
     }
 
     reload(): void {


### PR DESCRIPTION
Signed-off-by: Shahar Harari <shahar.harari@sap.com>

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
Fixes the following issue:
When quick open widget is triggered while some webview is focused, cancelling the quick open widget doesn't bring focus back to webview. As a result, when triggering quick open widget again by pressing `F1` a new browser tab is opened instead.

Root cause of this issue:
When closing quick open widget by pressing escape or changing focus, focus is set to the `previousFocusElement`:
https://github.com/eclipse-theia/theia/blob/7a88d2865504b36b9fdac1255beae8c9a20831de/packages/monaco/src/browser/monaco-quick-open-service.ts#L235-L238
`previuosFocusElement` is webview main frame(The one with `webview` class) in case webview was focused before triggering the quick open widget, so it's being focused, but since `keydown` handler is registered on the inner frame (The one with `active-frame` id) `keydown` events will stop work from this point until the inner frame is focused manually:
https://github.com/eclipse-theia/theia/blob/7a88d2865504b36b9fdac1255beae8c9a20831de/packages/plugin-ext/src/main/browser/webview/pre/main.js#L535

My solution is register to `focus` events on main webview node and send focus message to inner frame in this case. 

#### How to test
1. Install [GitLens](https://marketplace.visualstudio.com/items?itemName=eamodio.gitlens) VS Code extension.
2. Open Git Lens welcome page by pressing `F1` and choose `GitLens: Welcome` from the command palette.
3. Focus Git Lens welcome page.
4. Press `F1` and then press `Esc` key or mouse left click outside the quick open widget.
5.  Press `F1` again - the quick open widget should be opened again. **Without the fix a new browser tab will be opened instead.**  

Before:
![before](https://user-images.githubusercontent.com/16555289/86529856-d1ba5480-bebc-11ea-9933-99ddd76f01a0.gif)

After:
![after](https://user-images.githubusercontent.com/16555289/86529859-d979f900-bebc-11ea-9b79-a46e160f46e4.gif)

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

