### PR TITLE
[Fix] onDidEndTaskProcess event is not fired for plugins when task ends

### DIFF
--- a/packages/task/src/node/task-server.ts
+++ b/packages/task/src/node/task-server.ts
@@ -103,7 +103,7 @@ export class TaskServerImpl implements TaskServer, Disposable {
         this.toDispose.get(task.id)!.push(
             task.onExit(event => {
                 this.taskManager.delete(task);
-                this.fireTaskExitedEvent(event);
+                this.fireTaskExitedEvent(event, task);
                 this.removedCachedProblemCollector(event.ctx || '', event.taskId);
                 this.disposeByTaskId(event.taskId);
             })
@@ -171,15 +171,15 @@ export class TaskServerImpl implements TaskServer, Disposable {
     protected fireTaskExitedEvent(event: TaskExitedEvent, task?: Task): void {
         this.logger.debug(log => log('task has exited:', event));
 
-        this.clients.forEach(client => {
-            client.onTaskExit(event);
-        });
-
-        if (task && task instanceof ProcessTask && task.processType === 'process') {
+        if (task instanceof ProcessTask) {
             this.clients.forEach(client => {
                 client.onDidEndTaskProcess(event);
             });
         }
+
+        this.clients.forEach(client => {
+            client.onTaskExit(event);
+        });
     }
 
     protected fireTaskCreatedEvent(event: TaskInfo, task?: Task): void {


### PR DESCRIPTION
Signed-off-by: Tal Sapan <tal.sapan@sap.com>

#### What it does
According to [VSCode documentation](https://code.visualstudio.com/api/references/vscode-api#tasks), when a task ends, the events `onDidEndTask` and `onDidEndTaskProcess` events are fired. `onDidEndTaskProcess` is only fired for tasks that execute an underlying process.
However, the `onDidEndTaskProcess` event is not fired in Theia.
This PR fixes this issue by firing the event for all tasks of type `ProcessTask`.

Note that the order of firing the two events is important: `onDidEndTaskProcess` must be fired first because when `onDidEndTask` is fired, the task execution is removed from the list of currently running task executions in `$onDidEndTask` and not recognized in `$onDidEndTaskProcess`:
https://github.com/eclipse-theia/theia/blob/bc16fc18ab16a34e8818ae525c6f8a20133baeae/packages/plugin-ext/src/plugin/tasks/tasks.ts#L78

#### How to test
1. Run this plugin in theia: https://github.com/tal-sapan/logtaskendprocessevent (or use the `vsix` I will attach in a comment).
2. Run any `shell` or `process` task, for example:
```json
{
    "label": "Hello World",
    "type": "shell",
    "command": "echo hello"
}
```
3. Open the `LogTaskEndProcessEvent` output channel and see in the output:
`Task process ended with exit code 0: Hello World`

Without this PR nothing is printed to the channel output.

#### Review checklist

- [X] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

