### PR TITLE
Add dynamic badge to scm and problems widget

### DIFF
--- a/packages/core/src/browser/frontend-application-module.ts
+++ b/packages/core/src/browser/frontend-application-module.ts
@@ -81,6 +81,7 @@ import { ProgressService } from '../common/progress-service';
 import { DispatchingProgressClient } from './progress-client';
 import { ProgressStatusBarItem } from './progress-status-bar-item';
 import { TabBarDecoratorService, TabBarDecorator } from './shell/tab-bar-decorator';
+import { WidgetTabBarDecoratorService, WidgetTabBarDecorator } from './shell/widget-tab-bar-decorator';
 import { ContextMenuContext } from './menu/context-menu-context';
 import { bindResourceProvider, bindMessageService, bindPreferenceService } from './frontend-application-bindings';
 import { ColorRegistry } from './color-registry';
@@ -148,11 +149,15 @@ export const frontendApplicationModule = new ContainerModule((bind, unbind, isBo
         const contextMenuRenderer = context.container.get<ContextMenuRenderer>(ContextMenuRenderer);
         const decoratorService = context.container.get<TabBarDecoratorService>(TabBarDecoratorService);
         const iconThemeService = context.container.get<IconThemeService>(IconThemeService);
-        return new TabBarRenderer(contextMenuRenderer, decoratorService, iconThemeService);
+        const widgetDecoratorService = context.container.get<WidgetTabBarDecoratorService>(WidgetTabBarDecoratorService);
+        return new TabBarRenderer(contextMenuRenderer, decoratorService, iconThemeService, widgetDecoratorService);
     });
 
     bindContributionProvider(bind, TabBarDecorator);
     bind(TabBarDecoratorService).toSelf().inSingletonScope();
+
+    bindContributionProvider(bind, WidgetTabBarDecorator);
+    bind(WidgetTabBarDecoratorService).toSelf().inSingletonScope();
 
     bindContributionProvider(bind, OpenHandler);
     bind(DefaultOpenerService).toSelf().inSingletonScope();

--- a/packages/core/src/browser/shell/tab-bars.ts
+++ b/packages/core/src/browser/shell/tab-bars.ts
@@ -28,6 +28,7 @@ import { TheiaDockPanel, MAIN_AREA_ID, BOTTOM_AREA_ID } from './theia-dock-panel
 import { WidgetDecoration } from '../widget-decoration';
 import { TabBarDecoratorService } from './tab-bar-decorator';
 import { IconThemeService } from '../icon-theme-service';
+import { WidgetTabBarDecoratorService } from './widget-tab-bar-decorator';
 
 /** The class name added to hidden content nodes, which are required to render vertical side bars. */
 const HIDDEN_CONTENT_CLASS = 'theia-TabBar-hidden-content';
@@ -77,7 +78,8 @@ export class TabBarRenderer extends TabBar.Renderer {
     constructor(
         protected readonly contextMenuRenderer?: ContextMenuRenderer,
         protected readonly decoratorService?: TabBarDecoratorService,
-        protected readonly iconThemeService?: IconThemeService
+        protected readonly iconThemeService?: IconThemeService,
+        protected readonly widgetDecoratorService?: WidgetTabBarDecoratorService,
     ) {
         super();
         if (this.decoratorService) {
@@ -151,7 +153,8 @@ export class TabBarRenderer extends TabBar.Renderer {
             h.div(
                 { className: 'theia-tab-icon-label' },
                 this.renderIcon(data, isInSidePanel),
-                this.renderLabel(data, isInSidePanel)
+                this.renderLabel(data, isInSidePanel),
+                this.renderBadge(data, isInSidePanel)
             ),
             this.renderCloseIcon(data)
         );
@@ -226,6 +229,18 @@ export class TabBarRenderer extends TabBar.Renderer {
         return h.div({ className: 'p-TabBar-tabLabel', style }, data.title.label);
     }
 
+    renderBadge(data: SideBarRenderData, isInSidePanel?: boolean): VirtualElement {
+        const badge = this.getDecorationData(data.title, 'badge');
+        if (badge && badge.length > 0) {
+            if (isInSidePanel) {
+                return h.div({ className: 'theia-badge-decorator-sidebar' }, `${badge}`);
+            } else if (data.title.label === 'Problems') {
+                return h.div({ className: 'theia-badge-decorator-bottom-panel' }, `${badge}`);
+            }
+        }
+        return h.div({});
+    }
+
     protected readonly decorations = new Map<Title<Widget>, WidgetDecoration.Data[]>();
 
     protected resetDecorations(title?: Title<Widget>): void {
@@ -253,7 +268,9 @@ export class TabBarRenderer extends TabBar.Renderer {
             }
 
             const decorations = this.decorations.get(title) || this.decoratorService.getDecorations(title);
-            this.decorations.set(title, decorations);
+            if (this.widgetDecoratorService) {
+                decorations.push(...this.widgetDecoratorService.getDecorations(title));
+            }
             return decorations;
         }
         return [];

--- a/packages/core/src/browser/shell/widget-tab-bar-decorator.ts
+++ b/packages/core/src/browser/shell/widget-tab-bar-decorator.ts
@@ -1,0 +1,69 @@
+/********************************************************************************
+ * Copyright (C) 2020 Ericsson and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import debounce = require('lodash.debounce');
+import { inject, injectable, named, postConstruct } from 'inversify';
+import { Title, Widget } from '@phosphor/widgets';
+import { Event, Emitter, Disposable, DisposableCollection, ContributionProvider } from '../../common';
+import { WidgetDecoration } from '../widget-decoration';
+
+export const WidgetTabBarDecorator = Symbol('WidgetTabBarDecorator');
+export interface WidgetTabBarDecorator {
+    readonly id: string;
+    readonly onDidChangeDecorations: Event<void>;
+    decorate(title: Title<Widget>): WidgetDecoration.Data[];
+}
+
+@injectable()
+export class WidgetTabBarDecoratorService implements Disposable {
+
+    protected readonly onDidChangeDecorationsEmitter = new Emitter<void>();
+
+    readonly onDidChangeDecorations = this.onDidChangeDecorationsEmitter.event;
+    protected fireDidChangeDecorations = debounce(() => this.onDidChangeDecorationsEmitter.fire(undefined), 150);
+
+    protected readonly toDispose = new DisposableCollection();
+
+    @inject(ContributionProvider) @named(WidgetTabBarDecorator)
+    protected readonly contributions: ContributionProvider<WidgetTabBarDecorator>;
+
+    @postConstruct()
+    protected init(): void {
+        const decorators = this.contributions.getContributions();
+        this.toDispose.pushAll(decorators.map(decorator =>
+            decorator.onDidChangeDecorations(this.fireDidChangeDecorations)
+        ));
+    }
+
+    dispose(): void {
+        this.toDispose.dispose();
+    }
+
+    /**
+     * Assign tabs the decorators provided by all the contributions.
+     * @param {Title<Widget>} title the title
+     * @returns an array of its decoration data.
+     */
+    getDecorations(title: Title<Widget>): WidgetDecoration.Data[] {
+        const decorators = this.contributions.getContributions();
+        let all: WidgetDecoration.Data[] = [];
+        for (const decorator of decorators) {
+            const decorations = decorator.decorate(title);
+            all = all.concat(decorations);
+        }
+        return all;
+    }
+}

--- a/packages/core/src/browser/style/tabs.css
+++ b/packages/core/src/browser/style/tabs.css
@@ -242,6 +242,37 @@ body.theia-editor-highlightModifiedTabs
   display: none !important;
 }
 
+.p-TabBar .theia-badge-decorator-sidebar {
+  background-color:var(--theia-activityBarBadge-background);
+  border-radius: 20px;
+  color: var(--theia-activityBarBadge-foreground);
+  font-size: 9px;
+  font-weight: 600;
+  height: var(--theia-notification-count-height);
+  line-height: 16px;
+  min-width: 8px;
+  padding: 0 4px;
+  position: absolute;
+  right: 8px;
+  text-align: center;
+  top: 24px;
+}
+
+.p-TabBar .theia-badge-decorator-bottom-panel {
+  background-color:var(--theia-activityBarBadge-background);
+  border-radius: 24px;
+  box-sizing: border-box;
+  color: var(--theia-activityBarBadge-foreground);
+  display: inline-block;
+  font-size: calc(var(--theia-ui-font-size0) * 0.8);
+  font-weight: 400;
+  height: var(--theia-notification-count-height);
+  line-height: 8px;
+  margin-left: 6px;
+  padding: 4px;
+  text-align: center;
+}
+
 /*-----------------------------------------------------------------------------
 | Perfect scrollbar
 |----------------------------------------------------------------------------*/

--- a/packages/core/src/browser/widget-decoration.ts
+++ b/packages/core/src/browser/widget-decoration.ts
@@ -34,6 +34,7 @@ export namespace WidgetDecoration {
         export const BOTTOM_RIGHT_SIDEBAR_CLASS = 'theia-bottom-right-sidebar';
         export const BOTTOM_LEFT_CLASS = 'theia-bottom-left';
         export const TOP_LEFT_CLASS = 'theia-top-left';
+        export const BADGE_DECORATOR_SIDEBAR_CLASS = 'theia-badge-decorator-sidebar';
     }
     /**
      * For the sake of simplicity, we have merged the `font-style`, `font-weight`, and the `text-decoration` together.
@@ -330,6 +331,10 @@ export namespace WidgetDecoration {
          * An array of ranges to highlight the caption.
          */
         readonly highlight?: CaptionHighlight;
+        /**
+         * A notification badge for widgets.
+         */
+        readonly badge?: string;
     }
     export namespace Data {
         /**

--- a/packages/markers/src/browser/problem/problem-frontend-module.ts
+++ b/packages/markers/src/browser/problem/problem-frontend-module.ts
@@ -31,6 +31,7 @@ import { ProblemLayoutVersion3Migration } from './problem-layout-migrations';
 import { TabBarDecorator } from '@theia/core/lib/browser/shell/tab-bar-decorator';
 import { bindProblemPreferences } from './problem-preferences';
 import { MarkerTreeLabelProvider } from '../marker-tree-label-provider';
+import { ProblemsWidgetTabBarDecorator } from './problems-view-decorator';
 
 export default new ContainerModule(bind => {
     bindProblemPreferences(bind);
@@ -57,4 +58,7 @@ export default new ContainerModule(bind => {
 
     bind(MarkerTreeLabelProvider).toSelf().inSingletonScope();
     bind(LabelProviderContribution).toService(MarkerTreeLabelProvider);
+
+    bind(ProblemsWidgetTabBarDecorator).toSelf().inSingletonScope();
+    bind(TabBarDecorator).toService(ProblemsWidgetTabBarDecorator);
 });

--- a/packages/markers/src/browser/problem/problems-view-decorator.ts
+++ b/packages/markers/src/browser/problem/problems-view-decorator.ts
@@ -1,0 +1,52 @@
+/********************************************************************************
+ * Copyright (C) 2020 Ericsson and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import { injectable, inject } from 'inversify';
+import { WidgetTabBarDecorator } from '@theia/core/lib/browser/shell/widget-tab-bar-decorator';
+import { WidgetDecoration } from '@theia/core/lib/browser/widget-decoration';
+import { Title, Widget } from '@theia/core/lib/browser';
+import { Event, Emitter } from '@theia/core/lib/common/event';
+import { ProblemManager } from './problem-manager';
+
+@injectable()
+export class ProblemsWidgetTabBarDecorator implements WidgetTabBarDecorator {
+
+    readonly id = 'theia-problems-widget-tabbar-decorator';
+    protected readonly emitter = new Emitter<void>();
+
+    @inject(ProblemManager)
+    protected readonly problemManager: ProblemManager;
+
+    decorate(title: Title<Widget>): WidgetDecoration.Data[] {
+        if (title.owner.id === 'problems') {
+            const stat = this.problemManager.getProblemStat();
+            const markerCount = stat.errors + stat.infos + stat.warnings;
+            return markerCount > 0 ?
+                markerCount > 99 ? [{ badge: '99+' }] : [{ badge: markerCount.toString() }]
+                : [];
+        } else {
+            return [];
+        }
+    }
+
+    get onDidChangeDecorations(): Event<void> {
+        return this.emitter.event;
+    }
+
+    protected fireDidChangeDecorations(): void {
+        this.emitter.fire(undefined);
+    }
+}

--- a/packages/scm/src/browser/decorations/scm-view-decorator.ts
+++ b/packages/scm/src/browser/decorations/scm-view-decorator.ts
@@ -1,0 +1,75 @@
+/********************************************************************************
+ * Copyright (C) 2020 Ericsson and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import { injectable, inject, postConstruct } from 'inversify';
+import { WidgetTabBarDecorator } from '@theia/core/lib/browser/shell/widget-tab-bar-decorator';
+import { WidgetDecoration } from '@theia/core/lib/browser/widget-decoration';
+import { Title, Widget } from '@theia/core/lib/browser';
+import { Event, Emitter } from '@theia/core/lib/common/event';
+import { SCM_VIEW_CONTAINER_ID } from '../scm-contribution';
+import { ScmService } from '../scm-service';
+
+@injectable()
+export class ScmTabBarDecorator implements WidgetTabBarDecorator {
+
+    readonly id = 'theia-scm-tabbar-decorator';
+    protected readonly emitter = new Emitter<void>();
+
+    @inject(ScmService)
+    protected readonly scmService: ScmService;
+
+    @postConstruct()
+    protected init(): void {
+        const repository = this.scmService.selectedRepository;
+        this.scmService.onDidChangeSelectedRepository(() => this.fireDidChangeDecorations());
+        if (repository) {
+            repository.provider.onDidChange(() => this.updateBadgeCount());
+        }
+    }
+
+    decorate(title: Title<Widget>): WidgetDecoration.Data[] {
+        if (title.owner.id === SCM_VIEW_CONTAINER_ID) {
+            const changes: number = this.updateBadgeCount();
+            return changes > 0 ?
+                changes > 99 ? [{ badge: '99+' }] : [{ badge: changes.toString() }]
+                : [];
+        } else {
+            return [];
+        }
+    }
+
+    updateBadgeCount(): number {
+        const repository = this.scmService.selectedRepository;
+        let changes: number = 0;
+        if (!repository) {
+            return 0;
+        }
+        repository.provider.groups.map(group => {
+            if (group.id === 'index' || group.id === 'workingTree') {
+                changes += group.resources.length;
+            }
+        });
+        return changes;
+    }
+
+    get onDidChangeDecorations(): Event<void> {
+        return this.emitter.event;
+    }
+
+    protected fireDidChangeDecorations(): void {
+        this.emitter.fire(undefined);
+    }
+}

--- a/packages/scm/src/browser/scm-frontend-module.ts
+++ b/packages/scm/src/browser/scm-frontend-module.ts
@@ -45,6 +45,8 @@ import { TabBarToolbarContribution } from '@theia/core/lib/browser/shell/tab-bar
 import { ColorContribution } from '@theia/core/lib/browser/color-application-contribution';
 import { LabelProviderContribution } from '@theia/core/lib/browser/label-provider';
 import { bindScmPreferences } from './scm-preferences';
+import { ScmTabBarDecorator } from './decorations/scm-view-decorator';
+import { TabBarDecorator } from '@theia/core/lib/browser/shell/tab-bar-decorator';
 
 export default new ContainerModule(bind => {
     bind(ScmContextKeyService).toSelf().inSingletonScope();
@@ -118,6 +120,9 @@ export default new ContainerModule(bind => {
     bind(LabelProviderContribution).toService(ScmTreeLabelProvider);
 
     bindScmPreferences(bind);
+
+    bind(ScmTabBarDecorator).toSelf().inSingletonScope();
+    bind(TabBarDecorator).toService(ScmTabBarDecorator);
 });
 
 export function createScmTreeContainer(parent: interfaces.Container): Container {


### PR DESCRIPTION
#### What it does
Fix:  #4782, #4311

- Add a dynamic badge decoration for Scm widget tab bar (git changes)
- Add a dynamic badge decoration for Problems widget tab bar (total number of problems)
- Limit the Scm and Problems max badge number to display to be 99 (display 99+ if the value is greater than 99)
- Update base widget decoration to accept a badge property

Co-authored-by: Kaiyue Pan <colin.grant@ericsson.com>
Co-authored-by: vince-fugnitto <vincent.fugnitto@ericsson.com>

Signed-off-by: Kaiyue Pan <kaiyue.pan@ericsson.com>
Signed-off-by: vince-fugnitto <vincent.fugnitto@ericsson.com>

#### How to test
1. 

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

