### PR TITLE
plugin: move default api const to common

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 
 Breaking Changes:
 
+- [plugin] moved `VSCODE_DEFAULT_API_VERSION` constant into `common` [#8147](https://github.com/eclipse-theia/theia/pull/8147)
 <a name="1_4_0_replace_json"></a>
 - [[json]](#1_4_0_replace_json) replaced `@theia/json` Theia extension with `vscode.json-language-features` VS Code extension [#8112](https://github.com/eclipse-theia/theia/pull/8112)
   - You can register JSON validations at application startup by implementing `JsonSchemaContribution` Theia contribution point.

--- a/packages/plugin-ext-vscode/src/common/plugin-vscode-environment.ts
+++ b/packages/plugin-ext-vscode/src/common/plugin-vscode-environment.ts
@@ -18,6 +18,8 @@ import { injectable, inject } from 'inversify';
 import { EnvVariablesServer } from '@theia/core/lib/common/env-variables';
 import URI from '@theia/core/lib/common/uri';
 
+export const VSCODE_DEFAULT_API_VERSION = '1.44.0';
+
 @injectable()
 export class PluginVSCodeEnvironment {
 

--- a/packages/plugin-ext-vscode/src/node/plugin-vscode-cli-contribution.ts
+++ b/packages/plugin-ext-vscode/src/node/plugin-vscode-cli-contribution.ts
@@ -18,7 +18,8 @@ import { injectable } from 'inversify';
 import { Argv, Arguments } from 'yargs';
 import { CliContribution } from '@theia/core/lib/node/cli';
 import { PluginHostEnvironmentVariable } from '@theia/plugin-ext/lib/common';
-import { VSCODE_DEFAULT_API_VERSION } from './plugin-vscode-init';
+import { VSCODE_DEFAULT_API_VERSION } from '../common/plugin-vscode-environment';
+
 /**
  * CLI Contribution allowing to override the VS Code API version which is returned by `vscode.version` API call.
  */

--- a/packages/plugin-ext-vscode/src/node/plugin-vscode-init.ts
+++ b/packages/plugin-ext-vscode/src/node/plugin-vscode-init.ts
@@ -18,8 +18,7 @@
 
 import * as theia from '@theia/plugin';
 import { BackendInitializationFn, PluginAPIFactory, Plugin, emptyPlugin } from '@theia/plugin-ext';
-
-export const VSCODE_DEFAULT_API_VERSION = '1.44.0';
+import { VSCODE_DEFAULT_API_VERSION } from '../common/plugin-vscode-environment';
 
 /** Set up en as a default locale for VS Code extensions using vscode-nls */
 process.env['VSCODE_NLS_CONFIG'] = JSON.stringify({ locale: 'en', availableLanguages: {} });


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

The following commit moves the `VSCODE_DEFAULT_API_VERSION` constant to `common` so it can be used by both the `browser` and `node`. This also increases usability for downstream applications and extensions to use the variable as necessary.(ex: making use of the constant to determine API-compatible extensions).

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

Everything should work correctly as before, example build and test of `@theia/plugin-ext-vscode`.

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

Signed-off-by: vince-fugnitto <vincent.fugnitto@ericsson.com>
