### PR TITLE
opening large or binary files

### DIFF
--- a/packages/core/src/common/stream.ts
+++ b/packages/core/src/common/stream.ts
@@ -103,6 +103,14 @@ export namespace Readable {
             }
         };
     }
+    export function toString(readable: Readable<string>): string {
+        let result = '';
+        let chunk: string | null;
+        while ((chunk = readable.read()) != null) {
+            result += chunk;
+        }
+        return result;
+    }
 }
 
 /**

--- a/packages/editor-preview/src/browser/editor-preview-manager.ts
+++ b/packages/editor-preview/src/browser/editor-preview-manager.ts
@@ -140,8 +140,15 @@ export class EditorPreviewManager extends WidgetOpenHandler<EditorPreviewWidget 
         }
     }
 
-    protected openNewPreview(uri: URI, options: PreviewEditorOpenerOptions): Promise<EditorPreviewWidget> {
-        return this.currentEditorPreview = super.open(uri, options) as Promise<EditorPreviewWidget>;
+    protected openNewPreview(uri: URI, options: PreviewEditorOpenerOptions): Promise<EditorPreviewWidget | EditorWidget> {
+        const result = super.open(uri, options);
+        this.currentEditorPreview = result.then(widget => {
+            if (widget instanceof EditorPreviewWidget) {
+                return widget;
+            }
+            return undefined;
+        }, () => undefined);
+        return result;
     }
 
     protected createWidgetOptions(uri: URI, options?: WidgetOpenerOptions): EditorPreviewWidgetOptions {

--- a/packages/filesystem/src/browser/filesystem-preferences.ts
+++ b/packages/filesystem/src/browser/filesystem-preferences.ts
@@ -23,6 +23,13 @@ import {
     PreferenceContribution
 } from '@theia/core/lib/browser/preferences';
 import { SUPPORTED_ENCODINGS } from '@theia/core/lib/browser/supported-encodings';
+import { environment } from '@theia/application-package/lib/environment';
+
+// See https://github.com/Microsoft/vscode/issues/30180
+export const WIN32_MAX_FILE_SIZE_MB = 300; // 300 MB
+export const GENERAL_MAX_FILE_SIZE_MB = 16 * 1024; // 16 GB
+
+export const MAX_FILE_SIZE_MB = environment.electron.is() ? process.arch === 'ia32' ? WIN32_MAX_FILE_SIZE_MB : GENERAL_MAX_FILE_SIZE_MB : 32;
 
 export const filesystemPreferenceSchema: PreferenceSchema = {
     'type': 'object',
@@ -66,6 +73,11 @@ These have precedence over the default associations of the languages installed.'
             type: 'number',
             default: 5000,
             markdownDescription: 'Timeout in milliseconds after which file participants for create, rename, and delete are cancelled. Use `0` to disable participants.'
+        },
+        'files.maxFileSizeMB': {
+            type: 'number',
+            default: MAX_FILE_SIZE_MB,
+            markdownDescription: 'Controls the max file size in MB which is possible to open.'
         }
     }
 };
@@ -78,6 +90,7 @@ export interface FileSystemConfiguration {
     'files.encoding': string;
     'files.autoGuessEncoding': boolean;
     'files.participants.timeout': number;
+    'files.maxFileSizeMB': number;
 }
 
 export const FileSystemPreferences = Symbol('FileSystemPreferences');

--- a/packages/filesystem/src/common/delegating-file-system-provider.ts
+++ b/packages/filesystem/src/common/delegating-file-system-provider.ts
@@ -15,13 +15,16 @@
  ********************************************************************************/
 
 import URI from '@theia/core/lib/common/uri';
-import { Event, Emitter } from '@theia/core/lib/common';
+import { Event, Emitter, CancellationToken } from '@theia/core/lib/common';
 import { Disposable, DisposableCollection } from '@theia/core/lib/common/disposable';
 import {
     FileSystemProvider, FileSystemProviderCapabilities, WatchOptions, FileDeleteOptions, FileOverwriteOptions, FileWriteOptions, FileOpenOptions, FileChange, Stat, FileType,
-    hasReadWriteCapability, hasFileFolderCopyCapability, hasOpenReadWriteCloseCapability, hasAccessCapability, FileUpdateOptions, hasUpdateCapability, FileUpdateResult
+    hasReadWriteCapability, hasFileFolderCopyCapability, hasOpenReadWriteCloseCapability, hasAccessCapability, FileUpdateOptions, hasUpdateCapability, FileUpdateResult,
+    FileReadStreamOptions,
+    hasFileReadStreamCapability
 } from './files';
 import type { TextDocumentContentChangeEvent } from 'vscode-languageserver-protocol';
+import { ReadableStreamEvents } from '@theia/core/lib/common/stream';
 
 export class DelegatingFileSystemProvider implements Required<FileSystemProvider>, Disposable {
 
@@ -88,6 +91,13 @@ export class DelegatingFileSystemProvider implements Required<FileSystemProvider
     readFile(resource: URI): Promise<Uint8Array> {
         if (hasReadWriteCapability(this.delegate)) {
             return this.delegate.readFile(this.options.uriConverter.to(resource));
+        }
+        throw new Error('not supported');
+    }
+
+    readFileStream(resource: URI, opts: FileReadStreamOptions, token: CancellationToken): ReadableStreamEvents<Uint8Array> {
+        if (hasFileReadStreamCapability(this.delegate)) {
+            return this.delegate.readFileStream(this.options.uriConverter.to(resource), opts, token);
         }
         throw new Error('not supported');
     }

--- a/packages/filesystem/src/common/files.ts
+++ b/packages/filesystem/src/common/files.ts
@@ -443,6 +443,14 @@ export interface FileReadStreamOptions {
 	 * will be read.
 	 */
     readonly length?: number;
+
+	/**
+	 * If provided, the size of the file will be checked against the limits.
+	 */
+    limits?: {
+        readonly size?: number;
+        readonly memory?: number;
+    };
 }
 
 export interface FileUpdateOptions {
@@ -694,4 +702,29 @@ export function etag(stat: { mtime: number | undefined, size: number | undefined
     }
 
     return stat.mtime.toString(29) + stat.size.toString(31);
+}
+/**
+ * Helper to format a raw byte size into a human readable label.
+ */
+export class BinarySize {
+    static readonly KB = 1024;
+    static readonly MB = BinarySize.KB * BinarySize.KB;
+    static readonly GB = BinarySize.MB * BinarySize.KB;
+    static readonly TB = BinarySize.GB * BinarySize.KB;
+
+    static formatSize(size: number): string {
+        if (size < BinarySize.KB) {
+            return size + 'B';
+        }
+        if (size < BinarySize.MB) {
+            return (size / BinarySize.KB).toFixed(2) + 'KB';
+        }
+        if (size < BinarySize.GB) {
+            return (size / BinarySize.MB).toFixed(2) + 'MB';
+        }
+        if (size < BinarySize.TB) {
+            return (size / BinarySize.GB).toFixed(2) + 'GB';
+        }
+        return (size / BinarySize.TB).toFixed(2) + 'TB';
+    }
 }

--- a/packages/monaco/src/browser/monaco-loader.ts
+++ b/packages/monaco/src/browser/monaco-loader.ts
@@ -78,7 +78,8 @@ export function loadMonaco(vsRequire: any): Promise<void> {
                 'vs/platform/contextkey/browser/contextKeyService',
                 'vs/editor/common/model/wordHelper',
                 'vs/base/common/errors',
-                'vs/base/common/path'
+                'vs/base/common/path',
+                'vs/editor/common/model/textModel'
             ], (commands: any, actions: any,
                 keybindingsRegistry: any, keybindingResolver: any, resolvedKeybinding: any, keybindingLabels: any,
                 keyCodes: any, mime: any, editorExtensions: any, simpleServices: any,
@@ -91,7 +92,7 @@ export function loadMonaco(vsRequire: any): Promise<void> {
                 markerService: any,
                 contextKey: any, contextKeyService: any,
                 wordHelper: any,
-                error: any, path: any) => {
+                error: any, path: any, textModel: any) => {
                 const global: any = self;
                 global.monaco.commands = commands;
                 global.monaco.actions = actions;
@@ -114,6 +115,7 @@ export function loadMonaco(vsRequire: any): Promise<void> {
                 global.monaco.wordHelper = wordHelper;
                 global.monaco.error = error;
                 global.monaco.path = path;
+                global.monaco.textModel = textModel;
                 resolve();
             });
         });

--- a/packages/monaco/src/typings/monaco/index.d.ts
+++ b/packages/monaco/src/typings/monaco/index.d.ts
@@ -24,7 +24,23 @@ declare module monaco.instantiation {
     }
 }
 
+declare module monaco.textModel {
+    interface ITextStream {
+        on(event: 'data', callback: (data: string) => void): void;
+        on(event: 'error', callback: (err: Error) => void): void;
+        on(event: 'end', callback: () => void): void;
+        on(event: string, callback: any): void;
+    }
+    // https://github.com/microsoft/vscode/blob/e683ace9e5acadba0e8bde72d793cb2cb83e58a7/src/vs/editor/common/model/textModel.ts#L58
+    export function createTextBufferFactoryFromStream(stream: ITextStream, filter?: (chunk: any) => string, validator?: (chunk: any) => Error | undefined): Promise<monaco.editor.ITextBufferFactory>;
+}
+
 declare module monaco.editor {
+
+    // https://github.com/microsoft/vscode/blob/e683ace9e5acadba0e8bde72d793cb2cb83e58a7/src/vs/editor/common/model.ts#L1263
+    export interface ITextBufferFactory {
+        getFirstLineText(lengthLimit: number): string;
+    }
 
     export interface ICodeEditor {
         protected readonly _instantiationService: monaco.instantiation.IInstantiationService;
@@ -344,6 +360,11 @@ declare module monaco.editor {
         after?: IContentDecorationRenderOptions;
     }
 
+    // https://github.com/microsoft/vscode/blob/e683ace9e5acadba0e8bde72d793cb2cb83e58a7/src/vs/editor/common/model.ts#L522
+    export interface ITextSnapshot {
+        read(): string | null;
+    }
+
     export interface ITextModel {
         /**
          * Get the tokens for the line `lineNumber`.
@@ -359,6 +380,9 @@ declare module monaco.editor {
          */
         // https://github.com/theia-ide/vscode/blob/standalone/0.19.x/src/vs/editor/common/model.ts#L806-L810
         forceTokenization(lineNumber: number): void;
+
+        // https://github.com/microsoft/vscode/blob/e683ace9e5acadba0e8bde72d793cb2cb83e58a7/src/vs/editor/common/model.ts#L623
+        createSnapshot(): ITextSnapshot | null;
     }
 
 }
@@ -718,6 +742,12 @@ declare module monaco.services {
         read(filter?: { owner?: string; resource?: monaco.Uri; severities?: number, take?: number; }): editor.IMarker[];
     }
 
+    // https://github.com/microsoft/vscode/blob/e683ace9e5acadba0e8bde72d793cb2cb83e58a7/src/vs/editor/common/services/modelService.ts#L18
+    export interface IModelService {
+        createModel(value: string | monaco.editor.ITextBufferFactory, languageSelection: ILanguageSelection | null, resource?: monaco.URI, isForSimpleWidget?: boolean): monaco.editor.ITextModel;
+        updateModel(model: monaco.editor.ITextModel, value: string | monaco.editor.ITextBufferFactory): void;
+    }
+
     // https://github.com/theia-ide/vscode/blob/standalone/0.19.x/src/vs/editor/standalone/browser/standaloneServices.ts#L56
     export module StaticServices {
         export function init(overrides: monaco.editor.IEditorOverrideServices): [ServiceCollection, monaco.instantiation.IInstantiationService];
@@ -728,6 +758,7 @@ declare module monaco.services {
         export const resourcePropertiesService: LazyStaticService<ITextResourcePropertiesService>;
         export const instantiationService: LazyStaticService<monaco.instantiation.IInstantiationService>;
         export const markerService: LazyStaticService<IMarkerService>;
+        export const modelService: LazyStaticService<IModelService>;
     }
 }
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

fix https://github.com/eclipse-theia/theia/issues/3859, fix https://github.com/eclipse-theia/theia/issues/4731

**Important**: the goal of this PR is to prevent a user to crash the browser tab, it does not aim to improve performance in the electron case. See also: https://github.com/eclipse-theia/theia/pull/8152#issuecomment-656710903

- [x] https://github.com/eclipse-theia/theia/pull/7908 has to be landed
- [x] prompt to open a binary file
- [x] prompt to open a large file
- [x] stream content for Monaco editor to avoid blocking the backend and network communications
- [x] limit incremental file update to several megabytes, it will crash the backend for large files, for such files we have to go with streaming

Out of scope:
- electron: bind disk fs provider directly in the renderer process

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

- try to open binary file, for instance generate a tar file
- try to open/save large file: https://github.com/microsoft/vscode/issues/30180
  - generate medium size ts less than 32 mb, it should be possible to open both in browser and electron
  - generate large size ts more than 32 mb, it should prompt in the browser and can file on load, in electron it should load without the prompt

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

