### PR TITLE
[tree] fix scroll behavior when selecting or expanding a node

### DIFF
--- a/packages/core/src/browser/tree/tree-widget.tsx
+++ b/packages/core/src/browser/tree/tree-widget.tsx
@@ -333,7 +333,7 @@ export class TreeWidget extends ReactWidget implements StatefulWidget {
      * Force deep resizing and rendering of rows.
      * https://github.com/bvaughn/react-virtualized/blob/master/docs/List.md#recomputerowheights-index-number
      */
-    protected forceUpdate({ resize }: TreeWidget.ForceUpdateOptions = { resize: true }): void {
+    protected forceUpdate({ resize }: TreeWidget.ForceUpdateOptions = { resize: false }): void {
         if (this.view && this.view.list) {
             if (resize && this.isVisible) {
                 this.view.cache.clearAll();
@@ -389,7 +389,7 @@ export class TreeWidget extends ReactWidget implements StatefulWidget {
 
     protected onResize(msg: Widget.ResizeMessage): void {
         super.onResize(msg);
-        this.forceUpdate();
+        this.forceUpdate({ resize: true });
     }
 
     protected render(): React.ReactNode {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does

Fixes: https://github.com/eclipse-theia/theia/issues/3347, Fixes: https://github.com/eclipse-theia/theia/issues/1593

The following commit updates the `tree-widget` to fix an issue when trees across the framework (ex: explorer, file dialog) are scrolled and nodes are selected which causes a jump and subsequently a poor user-experience.

The change includes updating the default value of the `resize` parameter in `forceUpdate` to `false` since we should only properly perform a cache `clearAll` only when an explicit resize has occurred.

> **clearAll ()**
> Reset cached measurements for all cells.
> 
> This method should be called when a Grid, List or Table needs to reflow content due to a resizing event for a responsive layout (eg. a window width resize may have an impact on the height of cells).



#### How to test

1. start the application and verify the behavior with multiple trees (ex: explorer, problems, file dialogs, siw, scm)
2. for a given tree-widget, perform a manual scroll and select a node
3. determine that the tree does not jump as reported in the issues #3347 & #1593
4. determine that the `debug console` is properly rendered when resized

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

Signed-off-by: Anas Shahid <muhammad.shahid@ericsson.com>
Signed-off-by: vince-fugnitto <vincent.fugnitto@ericsson.com>

---

_Recordings_:

| Explorer | Debug Console |
|:---:|:---:|
| ![scroll-yay](https://user-images.githubusercontent.com/40359487/87187332-02363000-c2bb-11ea-9f51-eaee97624ed9.gif) | ![debug-yay](https://user-images.githubusercontent.com/40359487/87187328-01050300-c2bb-11ea-8800-4e3aca44388a.gif) |

