### PR TITLE
editor: save dirty editors when toggling auto-save on

### DIFF
--- a/packages/editor/src/browser/editor-command.ts
+++ b/packages/editor/src/browser/editor-command.ts
@@ -14,10 +14,10 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
-import { inject, injectable } from 'inversify';
+import { inject, injectable, postConstruct } from 'inversify';
 import { CommandContribution, CommandRegistry, Command } from '@theia/core/lib/common';
 import URI from '@theia/core/lib/common/uri';
-import { CommonCommands, PreferenceService, QuickPickItem, QuickPickService, LabelProvider, QuickPickValue } from '@theia/core/lib/browser';
+import { CommonCommands, PreferenceService, QuickPickItem, QuickPickService, LabelProvider, QuickPickValue, ApplicationShell } from '@theia/core/lib/browser';
 import { Languages, Language } from '@theia/languages/lib/browser';
 import { EditorManager } from './editor-manager';
 import { EncodingMode } from './editor';
@@ -140,6 +140,9 @@ export class EditorCommandContribution implements CommandContribution {
 
     public static readonly AUTOSAVE_PREFERENCE: string = 'editor.autoSave';
 
+    @inject(ApplicationShell)
+    protected readonly shell: ApplicationShell;
+
     @inject(PreferenceService)
     protected readonly preferencesService: PreferenceService;
 
@@ -162,6 +165,15 @@ export class EditorCommandContribution implements CommandContribution {
 
     @inject(ResourceProvider)
     protected readonly resourceProvider: ResourceProvider;
+
+    @postConstruct()
+    protected init(): void {
+        this.editorPreferences.onPreferenceChanged(e => {
+            if (e.preferenceName === 'editor.autoSave' && e.newValue === 'on') {
+                this.shell.saveAll();
+            }
+        });
+    }
 
     registerCommands(registry: CommandRegistry): void {
         registry.registerCommand(EditorCommands.SHOW_REFERENCES);


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

The following pull-request updates the `toggleAutoSave` method to trigger a `saveAll` (for all dirty content), when the `auto-save` preference value is turned on. This behavior of saving dirty content across multiple editors is consistent with vscode and improves the user-experience.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

1. start the application with a workspace present
2. ensure that `auto-save` is **off**
3. make dirty (unsaved) changes in multiple files
4. update the `auto-save` by enabling it in the `file` menu
5. the dirty editors should be saved


#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

Signed-off-by: vince-fugnitto <vincent.fugnitto@ericsson.com>
