### PR TITLE
[markers] Sync problem markers with active editor

### DIFF
--- a/packages/markers/src/browser/problem/problem-preferences.ts
+++ b/packages/markers/src/browser/problem/problem-preferences.ts
@@ -29,13 +29,19 @@ export const ProblemConfigSchema: PreferenceSchema = {
             'type': 'boolean',
             'description': 'Show problem decorators (diagnostic markers) in the tab bars.',
             'default': true
+        },
+        'problems.autoReveal': {
+            'type': 'boolean',
+            'description': 'Controls whether Problems view should reveal markers when file is opened.',
+            'default': true
         }
     }
 };
 
 export interface ProblemConfiguration {
     'problems.decorations.enabled': boolean,
-    'problems.decorations.tabbar.enabled': boolean
+    'problems.decorations.tabbar.enabled': boolean,
+    'problems.autoReveal': boolean
 }
 
 export const ProblemPreferences = Symbol('ProblemPreferences');


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
Fixes: https://github.com/eclipse-theia/theia/issues/7436

Reveals and expands the markers for the active editor.
Added a preference `problems.autoReveal` to control this behavior.

![ezgif com-resize](https://user-images.githubusercontent.com/43870550/87454680-4df61b80-c5d2-11ea-8dd6-9c3ba51c9aab.gif)


Signed-off-by: Muhammad Anas Shahid <muhammad.shahid@ericsson.com>

#### How to test
1. Open multiple editors with Problem markers ( one can create multiple .json files with dummy text) 
2. Change the active editor and check to see if, in the problems view, the active editor markers are selected. 
3. Collapse all markers, then change the active editor, check to see if the markers for active editor are expanded.
4. From the preferences, goto `problems.autoReveal` uncheck it, and check to see if while changing the active editors the markers are expanded or selected. (in ideal case, they should not be expanded or selected)



#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

