### PR TITLE
Add indent guidelines to all trees

### DIFF
--- a/packages/callhierarchy/src/browser/callhierarchy-tree/callhierarchy-tree-container.ts
+++ b/packages/callhierarchy/src/browser/callhierarchy-tree/callhierarchy-tree-container.ts
@@ -15,10 +15,10 @@
  ********************************************************************************/
 
 import { interfaces, Container } from 'inversify';
-import { createTreeContainer, Tree, TreeImpl, TreeModel, TreeModelImpl, TreeWidget } from '@theia/core/lib/browser';
+import { createTreeContainer, Tree, TreeImpl, TreeModel, TreeModelImpl, TreeWidget, TreeProps, defaultTreeProps } from '@theia/core/lib/browser';
 import { CallHierarchyTree } from './callhierarchy-tree';
 import { CallHierarchyTreeModel } from './callhierarchy-tree-model';
-import { CallHierarchyTreeWidget } from './callhierarchy-tree-widget';
+import { CallHierarchyTreeWidget, TREE_NODE_INDENT_WIDTH_CALL_HIERARCHY_CLASS } from './callhierarchy-tree-widget';
 
 function createHierarchyTreeContainer(parent: interfaces.Container): Container {
     const child = createTreeContainer(parent);
@@ -33,6 +33,11 @@ function createHierarchyTreeContainer(parent: interfaces.Container): Container {
 
     child.bind(CallHierarchyTreeWidget).toSelf();
     child.rebind(TreeWidget).toService(CallHierarchyTreeWidget);
+
+    child.rebind(TreeProps).toConstantValue({
+        ...defaultTreeProps,
+        nodeIndentWidthClassname: TREE_NODE_INDENT_WIDTH_CALL_HIERARCHY_CLASS
+    });
 
     return child;
 }

--- a/packages/callhierarchy/src/browser/callhierarchy-tree/callhierarchy-tree-widget.tsx
+++ b/packages/callhierarchy/src/browser/callhierarchy-tree/callhierarchy-tree-widget.tsx
@@ -31,6 +31,7 @@ import * as React from 'react';
 export const HIERARCHY_TREE_CLASS = 'theia-CallHierarchyTree';
 export const DEFINITION_NODE_CLASS = 'theia-CallHierarchyTreeNode';
 export const DEFINITION_ICON_CLASS = 'theia-CallHierarchyTreeNodeIcon';
+export const TREE_NODE_INDENT_WIDTH_CALL_HIERARCHY_CLASS = 'theia-tree-node-indent-width-call-hierarchy';
 
 @injectable()
 export class CallHierarchyTreeWidget extends TreeWidget {

--- a/packages/core/src/browser/common-frontend-contribution.ts
+++ b/packages/core/src/browser/common-frontend-contribution.ts
@@ -1090,7 +1090,7 @@ export class CommonFrontendContribution implements FrontendApplicationContributi
             // if not yet contributed by Monaco, check runtime css variables to learn.
             // TODO: Following are not yet supported/no respective elements in theia:
             // list.focusBackground, list.focusForeground, list.inactiveFocusBackground, list.filterMatchBorder,
-            // list.dropBackground, listFilterWidget.outline, listFilterWidget.noMatchesOutline, tree.indentGuidesStroke
+            // list.dropBackground, listFilterWidget.outline, listFilterWidget.noMatchesOutline
             // list.invalidItemForeground,
             // list.warningForeground, list.errorForeground => tree node needs an respective class
             { id: 'list.activeSelectionBackground', defaults: { dark: '#094771', light: '#0074E8' }, description: 'List/Tree background color for the selected item when the list/tree is active. An active list/tree has keyboard focus, an inactive does not.' },
@@ -1100,6 +1100,7 @@ export class CommonFrontendContribution implements FrontendApplicationContributi
             { id: 'list.hoverBackground', defaults: { dark: '#2A2D2E', light: '#F0F0F0' }, description: 'List/Tree background when hovering over items using the mouse.' },
             { id: 'list.hoverForeground', description: 'List/Tree foreground when hovering over items using the mouse.' },
             { id: 'list.filterMatchBackground', defaults: { dark: 'editor.findMatchHighlightBackground', light: 'editor.findMatchHighlightBackground' }, description: 'Background color of the filtered match.' },
+            { id: 'tree.indentGuidesStrokeHover', defaults: { dark: Color.rgba(88, 88, 88, 0.4), light: Color.rgba(169, 169, 169, 0.4), hc: Color.rgba(169, 169, 169, 0.4) }, description: 'Tree Widget\'s stroke color for hovered indent guides.' },
 
             // Editor Group & Tabs colors should be aligned with https://code.visualstudio.com/api/references/theme-color#editor-groups-tabs
             {

--- a/packages/core/src/browser/core-preferences.ts
+++ b/packages/core/src/browser/core-preferences.ts
@@ -72,6 +72,12 @@ export const corePreferenceSchema: PreferenceSchema = {
             'scope': 'language-overridable',
             'enumDescriptions': Object.keys(SUPPORTED_ENCODINGS).map(key => SUPPORTED_ENCODINGS[key].labelLong),
             'included': Object.keys(SUPPORTED_ENCODINGS).length > 1
+        },
+        'workbench.tree.renderIndentGuides': {
+            type: 'string',
+            enum: ['onHover', 'none', 'always'],
+            default: 'onHover',
+            description: 'Controls whether the tree should render indent guides.'
         }
     }
 };
@@ -84,7 +90,8 @@ export interface CoreConfiguration {
     'workbench.colorTheme'?: string;
     'workbench.iconTheme'?: string | null;
     'workbench.silentNotifications': boolean;
-    'files.encoding': string
+    'files.encoding': string;
+    'workbench.tree.renderIndentGuides'?: 'onHover' | 'none' | 'always';
 }
 
 export const CorePreferences = Symbol('CorePreferences');

--- a/packages/core/src/browser/source-tree/source-tree-widget.tsx
+++ b/packages/core/src/browser/source-tree/source-tree-widget.tsx
@@ -17,9 +17,13 @@
 import * as React from 'react';
 import { injectable, postConstruct, interfaces, Container } from 'inversify';
 import { DisposableCollection } from '../../common/disposable';
-import { TreeWidget, TreeNode, createTreeContainer, TreeProps, TreeImpl, Tree, TreeModel } from '../tree';
+import {
+    TreeWidget, TreeNode, createTreeContainer, TreeProps, TreeImpl, Tree, TreeModel, defaultTreeProps
+} from '../tree';
 import { TreeSource, TreeElement } from './tree-source';
 import { SourceTree, TreeElementNode, TreeSourceNode } from './source-tree';
+
+const TREE_NODE_INDENT_WIDTH_SOURCE_CLASS = 'theia-tree-node-indent-width-source';
 
 @injectable()
 export class SourceTreeWidget extends TreeWidget {
@@ -33,6 +37,12 @@ export class SourceTreeWidget extends TreeWidget {
 
         child.unbind(TreeWidget);
         child.bind(SourceTreeWidget).toSelf();
+
+        child.rebind(TreeProps).toConstantValue({
+            ...defaultTreeProps,
+            expansionTogglePadding: 10,
+            nodeIndentWidthClassname: TREE_NODE_INDENT_WIDTH_SOURCE_CLASS
+        });
 
         return child;
     }

--- a/packages/core/src/browser/style/tree.css
+++ b/packages/core/src/browser/style/tree.css
@@ -139,3 +139,57 @@
 .theia-tree-element-node {
     width: 100%
 }
+
+.theia-tree-node-indent {
+    display: flex;
+}
+
+.theia-tree-node-indent-block {
+    width: calc(var(--theia-ui-padding)/6*10);
+    height: var(--theia-content-line-height);
+    border-right: var(--theia-border-width) solid transparent;
+}
+
+.theia-tree-node-indent-width-siw {
+    width: calc(var(--theia-ui-padding)/6*5);
+}
+
+.theia-tree-node-indent-width-source {
+    width: calc(var(--theia-ui-padding)/6*8);
+}
+
+.theia-tree-node-indent-width-call-hierarchy {
+    width: calc(var(--theia-ui-padding)/6*7);
+}
+
+.theia-tree-node-indent-padding-navigator {
+    padding-left: calc(var(--theia-ui-padding)*3);;
+}
+
+.theia-tree-node-indent-padding-outline {
+    padding-left: calc(var(--theia-ui-padding)*3);;
+}
+
+.theia-tree-node-child-right-margin {
+    margin-right: calc(var(--theia-ui-padding)/6*5);
+}
+
+.theia-tree-node-child-left-margin {
+    margin-left: calc(var(--theia-ui-padding)*-3);
+}
+
+.theia-TreeContainer:hover .theia-tree-node-indent-block.theia-indent-guide-on-hover {
+    border-right: var(--theia-border-width) solid var(--theia-tree-indentGuidesStrokeHover);
+}
+
+.theia-TreeContainer .theia-tree-node-indent-block.theia-tree-node-active.theia-indent-guide-on-hover {
+    border-right: var(--theia-border-width) solid var(--theia-tree-indentGuidesStroke);
+}
+
+.theia-TreeContainer .theia-tree-node-indent-block.theia-indent-guide-always {
+    border-right: var(--theia-border-width) solid var(--theia-tree-indentGuidesStrokeHover);
+}
+
+.theia-TreeContainer .theia-tree-node-indent-block.theia-tree-node-active.theia-indent-guide-always {
+    border-right: var(--theia-border-width) solid var(--theia-tree-indentGuidesStroke);
+}

--- a/packages/navigator/src/browser/navigator-container.ts
+++ b/packages/navigator/src/browser/navigator-container.ts
@@ -18,18 +18,20 @@ import { Container, interfaces } from 'inversify';
 import { Tree, TreeModel, TreeProps, defaultTreeProps, TreeDecoratorService } from '@theia/core/lib/browser';
 import { createFileTreeContainer, FileTree, FileTreeModel, FileTreeWidget } from '@theia/filesystem/lib/browser';
 import { bindContributionProvider } from '@theia/core/lib/common/contribution-provider';
-import { FileNavigatorTree } from './navigator-tree';
+import { FileNavigatorTree, TREE_NODE_INDENT_PADDING_NAVIGATOR_CLASS } from './navigator-tree';
 import { FileNavigatorModel } from './navigator-model';
 import { FileNavigatorWidget } from './navigator-widget';
 import { NAVIGATOR_CONTEXT_MENU } from './navigator-contribution';
 import { NavigatorDecoratorService, NavigatorTreeDecorator } from './navigator-decorator-service';
 
-export const FILE_NAVIGATOR_PROPS = <TreeProps>{
+export const FILE_NAVIGATOR_PROPS = <TreeProps> {
     ...defaultTreeProps,
     contextMenuPath: NAVIGATOR_CONTEXT_MENU,
     multiSelect: true,
     search: true,
-    globalSelection: true
+    globalSelection: true,
+    expansionTogglePadding: 0,
+    nodeIndentWidthClassname: TREE_NODE_INDENT_PADDING_NAVIGATOR_CLASS
 };
 
 export function createFileNavigatorContainer(parent: interfaces.Container): Container {

--- a/packages/navigator/src/browser/navigator-tree.ts
+++ b/packages/navigator/src/browser/navigator-tree.ts
@@ -21,6 +21,8 @@ import URI from '@theia/core/lib/common/uri';
 import { TreeNode, CompositeTreeNode, SelectableTreeNode } from '@theia/core/lib/browser';
 import { FileNavigatorFilter } from './navigator-filter';
 
+export const TREE_NODE_INDENT_PADDING_NAVIGATOR_CLASS = 'theia-tree-node-indent-padding-navigator';
+
 @injectable()
 export class FileNavigatorTree extends FileTree {
 

--- a/packages/outline-view/src/browser/outline-view-frontend-module.ts
+++ b/packages/outline-view/src/browser/outline-view-frontend-module.ts
@@ -34,7 +34,7 @@ import { OutlineViewWidgetFactory, OutlineViewWidget } from './outline-view-widg
 import '../../src/browser/styles/index.css';
 import { bindContributionProvider } from '@theia/core/lib/common/contribution-provider';
 import { OutlineDecoratorService, OutlineTreeDecorator } from './outline-decorator-service';
-import { OutlineViewTreeModel } from './outline-view-tree';
+import { OutlineViewTreeModel, TREE_NODE_INDENT_PADDING_OUTLINE_CLASS } from './outline-view-tree';
 
 export default new ContainerModule(bind => {
     bind(OutlineViewWidgetFactory).toFactory(ctx =>
@@ -73,6 +73,12 @@ function createOutlineViewWidget(parent: interfaces.Container): OutlineViewWidge
     child.bind(OutlineDecoratorService).toSelf().inSingletonScope();
     child.rebind(TreeDecoratorService).toDynamicValue(ctx => ctx.container.get(OutlineDecoratorService)).inSingletonScope();
     bindContributionProvider(child, OutlineTreeDecorator);
+
+    child.rebind(TreeProps).toConstantValue({
+        ...defaultTreeProps,
+        expansionTogglePadding: 0,
+        nodeIndentWidthClassname: TREE_NODE_INDENT_PADDING_OUTLINE_CLASS
+    });
 
     return child.get(OutlineViewWidget);
 }

--- a/packages/outline-view/src/browser/outline-view-tree.ts
+++ b/packages/outline-view/src/browser/outline-view-tree.ts
@@ -17,6 +17,8 @@
 import { injectable, inject } from 'inversify';
 import { CompositeTreeNode, TreeModelImpl, TreeExpansionService, ExpandableTreeNode } from '@theia/core/lib/browser';
 
+export const TREE_NODE_INDENT_PADDING_OUTLINE_CLASS = 'theia-tree-node-indent-padding-outline';
+
 @injectable()
 export class OutlineViewTreeModel extends TreeModelImpl {
 

--- a/packages/scm/src/browser/scm-frontend-module.ts
+++ b/packages/scm/src/browser/scm-frontend-module.ts
@@ -22,12 +22,12 @@ import {
     bindViewContribution, FrontendApplicationContribution,
     WidgetFactory, ViewContainer,
     WidgetManager, ApplicationShellLayoutMigration,
-    createTreeContainer, TreeWidget, TreeModel, TreeModelImpl
+    createTreeContainer, TreeWidget, TreeModel, TreeModelImpl, TreeProps, defaultTreeProps
 } from '@theia/core/lib/browser';
 import { ScmService } from './scm-service';
 import { SCM_WIDGET_FACTORY_ID, ScmContribution, SCM_VIEW_CONTAINER_ID, SCM_VIEW_CONTAINER_TITLE_OPTIONS } from './scm-contribution';
 import { ScmWidget } from './scm-widget';
-import { ScmTreeWidget } from './scm-tree-widget';
+import { ScmTreeWidget, TREE_NODE_FIRST_INDENT_PADDING_SCM_CLASS, TREE_NODE_INDENT_PADDING_SCM_CLASS } from './scm-tree-widget';
 import { ScmCommitWidget } from './scm-commit-widget';
 import { ScmAmendWidget } from './scm-amend-widget';
 import { ScmNoRepositoryWidget } from './scm-no-repository-widget';
@@ -141,6 +141,11 @@ export function createScmTreeContainer(parent: interfaces.Container): Container 
 
     child.bind(ScmTreeModelProps).toConstantValue({
         defaultExpansion: 'expanded',
+    });
+    child.rebind(TreeProps).toConstantValue({
+        ...defaultTreeProps,
+        expansionTogglePadding: 0,
+        nodeIndentWidthClassname: [TREE_NODE_FIRST_INDENT_PADDING_SCM_CLASS, TREE_NODE_INDENT_PADDING_SCM_CLASS]
     });
     return child;
 }

--- a/packages/scm/src/browser/style/index.css
+++ b/packages/scm/src/browser/style/index.css
@@ -284,3 +284,14 @@
 .theia-scm-panel {
     overflow: visible;
 }
+
+.theia-tree-node-indent-padding-scm {
+    width: calc(var(--theia-ui-padding)*0);
+    padding-right: calc(var(--theia-ui-padding)/6*10);
+}
+
+.theia-tree-node-first-indent-padding-scm {
+    width: calc(var(--theia-ui-padding)*0);
+    padding-right: calc(var(--theia-ui-padding)/6*7);
+}
+

--- a/packages/search-in-workspace/src/browser/search-in-workspace-frontend-module.ts
+++ b/packages/search-in-workspace/src/browser/search-in-workspace-frontend-module.ts
@@ -20,11 +20,12 @@ import { ContainerModule, interfaces } from 'inversify';
 import { SearchInWorkspaceService, SearchInWorkspaceClientImpl } from './search-in-workspace-service';
 import { SearchInWorkspaceServer, SIW_WS_PATH } from '../common/search-in-workspace-interface';
 import {
-    WebSocketConnectionProvider, WidgetFactory, createTreeContainer, TreeWidget, bindViewContribution, FrontendApplicationContribution, LabelProviderContribution
+    WebSocketConnectionProvider, WidgetFactory, createTreeContainer, TreeWidget, bindViewContribution, FrontendApplicationContribution, LabelProviderContribution,
+    TreeProps, defaultTreeProps
 } from '@theia/core/lib/browser';
 import { ResourceResolver } from '@theia/core';
 import { SearchInWorkspaceWidget } from './search-in-workspace-widget';
-import { SearchInWorkspaceResultTreeWidget } from './search-in-workspace-result-tree-widget';
+import { SearchInWorkspaceResultTreeWidget, TREE_NODE_INDENT_WIDTH_SIW_CLASS } from './search-in-workspace-result-tree-widget';
 import { SearchInWorkspaceFrontendContribution } from './search-in-workspace-frontend-contribution';
 import { InMemoryTextResourceResolver } from './in-memory-text-resource';
 import { SearchInWorkspaceContextKeyService } from './search-in-workspace-context-key-service';
@@ -71,6 +72,11 @@ export function createSearchTreeWidget(parent: interfaces.Container): SearchInWo
 
     child.unbind(TreeWidget);
     child.bind(SearchInWorkspaceResultTreeWidget).toSelf();
+
+    child.rebind(TreeProps).toConstantValue({
+        ...defaultTreeProps,
+        nodeIndentWidthClassname: TREE_NODE_INDENT_WIDTH_SIW_CLASS
+    });
 
     return child.get(SearchInWorkspaceResultTreeWidget);
 }

--- a/packages/search-in-workspace/src/browser/search-in-workspace-result-tree-widget.tsx
+++ b/packages/search-in-workspace/src/browser/search-in-workspace-result-tree-widget.tsx
@@ -45,6 +45,8 @@ import { ColorRegistry } from '@theia/core/lib/browser/color-registry';
 
 const ROOT_ID = 'ResultTree';
 
+export const TREE_NODE_INDENT_WIDTH_SIW_CLASS = 'theia-tree-node-indent-width-siw';
+
 export interface SearchInWorkspaceRoot extends CompositeTreeNode {
     children: SearchInWorkspaceRootFolderNode[];
 }


### PR DESCRIPTION
#### What it does

Fixes #6586
- Add preference to set 'workbench.tree.renderIndentGuides' to 'onHover' (default), 'none' or 'always'
- When nodes are selected, indent guidelines are rendered for all the sibling nodes
- When parent node is selected, indent guidelines are rendered for all the child nodes
- When hovering over a tree, indent guidelines are displayed for all expanded nodes
- Selecting multiple nodes works in a similar fashion

#### How to test
- Set the workspace preference to 'onHover', 'none', 'always' and the rendering of the indent guidelines should change accordingly.
- In different locations in Theia where the tree is being used (for example, in **navigator**, **search in workspace**, **outline**, **problems-view** and **scm** (`list mode` and `tree mode`)), select one/more nodes to test if the indent guidelines are rendered correctly.

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

