### PR TITLE
Sort for quick open entries respecting highlight information

### DIFF
--- a/packages/monaco/src/browser/monaco-comparers.ts
+++ b/packages/monaco/src/browser/monaco-comparers.ts
@@ -1,0 +1,161 @@
+/********************************************************************************
+ * Copyright (C) 2020 Red Hat, Inc. and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+// Copied from https://github.com/microsoft/vscode/blob/standalone/0.17.x/src/vs/base/common/comparers.ts
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import strings = monaco.strings;
+import IdleValue = monaco.async.IdleValue;
+import QuickOpenEntry = monaco.quickOpen.QuickOpenEntry;
+
+let intlFileNameCollator: IdleValue<{ collator: Intl.Collator, collatorIsNumeric: boolean }>;
+
+export function setFileNameComparer(collator: IdleValue<{ collator: Intl.Collator, collatorIsNumeric: boolean }>): void {
+    intlFileNameCollator = collator;
+}
+
+export function compareFileNames(one: string | null, other: string | null, caseSensitive = false): number {
+    if (intlFileNameCollator) {
+        const a = one || '';
+        const b = other || '';
+        const result = intlFileNameCollator.getValue().collator.compare(a, b);
+
+        // Using the numeric option in the collator will
+        // make compare(`foo1`, `foo01`) === 0. We must disambiguate.
+        if (intlFileNameCollator.getValue().collatorIsNumeric && result === 0 && a !== b) {
+            return a < b ? -1 : 1;
+        }
+
+        return result;
+    }
+
+    return noIntlCompareFileNames(one, other, caseSensitive);
+}
+
+const FileNameMatch = /^(.*?)(\.([^.]*))?$/;
+
+export function noIntlCompareFileNames(one: string | null, other: string | null, caseSensitive = false): number {
+    if (!caseSensitive) {
+        one = one && one.toLowerCase();
+        other = other && other.toLowerCase();
+    }
+
+    const [oneName, oneExtension] = extractNameAndExtension(one);
+    const [otherName, otherExtension] = extractNameAndExtension(other);
+
+    if (oneName !== otherName) {
+        return oneName < otherName ? -1 : 1;
+    }
+
+    if (oneExtension === otherExtension) {
+        return 0;
+    }
+
+    return oneExtension < otherExtension ? -1 : 1;
+}
+
+function extractNameAndExtension(str?: string | null): [string, string] {
+    const match = str ? FileNameMatch.exec(str) as Array<string> : ([] as Array<string>);
+
+    return [(match && match[1]) || '', (match && match[3]) || ''];
+}
+
+export function compareAnything(one: string, other: string, lookFor: string): number {
+    const elementAName = one.toLowerCase();
+    const elementBName = other.toLowerCase();
+
+    // Sort prefix matches over non prefix matches
+    const prefixCompare = compareByPrefix(one, other, lookFor);
+    if (prefixCompare) {
+        return prefixCompare;
+    }
+
+    // Sort suffix matches over non suffix matches
+    const elementASuffixMatch = strings.endsWith(elementAName, lookFor);
+    const elementBSuffixMatch = strings.endsWith(elementBName, lookFor);
+    if (elementASuffixMatch !== elementBSuffixMatch) {
+        return elementASuffixMatch ? -1 : 1;
+    }
+
+    // Understand file names
+    const r = compareFileNames(elementAName, elementBName);
+    if (r !== 0) {
+        return r;
+    }
+
+    // Compare by name
+    return elementAName.localeCompare(elementBName);
+}
+
+export function compareByPrefix(one: string, other: string, lookFor: string): number {
+    const elementAName = one.toLowerCase();
+    const elementBName = other.toLowerCase();
+
+    // Sort prefix matches over non prefix matches
+    const elementAPrefixMatch = strings.startsWith(elementAName, lookFor);
+    const elementBPrefixMatch = strings.startsWith(elementBName, lookFor);
+    if (elementAPrefixMatch !== elementBPrefixMatch) {
+        return elementAPrefixMatch ? -1 : 1;
+    } else if (elementAPrefixMatch && elementBPrefixMatch) { // Same prefix: Sort shorter matches to the top to have those on top that match more precisely
+        if (elementAName.length < elementBName.length) {
+            return -1;
+        }
+
+        if (elementAName.length > elementBName.length) {
+            return 1;
+        }
+    }
+
+    return 0;
+}
+
+/**
+ * A good default sort implementation for quick open entries respecting highlight information
+ * as well as associated resources.
+ */
+// copied from vscode: https://github.com/microsoft/vscode/blob/standalone/0.17.x/src/vs/base/parts/quickopen/browser/quickOpenModel.ts#L584
+export function compareEntries(elementA: QuickOpenEntry, elementB: QuickOpenEntry, lookFor: string): number {
+
+    // Give matches with label highlights higher priority over
+    // those with only description highlights
+    const labelHighlightsA = elementA.getHighlights()[0] || [];
+    const labelHighlightsB = elementB.getHighlights()[0] || [];
+    if (labelHighlightsA.length && !labelHighlightsB.length) {
+        return -1;
+    }
+
+    if (!labelHighlightsA.length && labelHighlightsB.length) {
+        return 1;
+    }
+
+    // Fallback to the full path if labels are identical and we have associated resources
+    let nameA = elementA.getLabel()!;
+    let nameB = elementB.getLabel()!;
+    if (nameA === nameB) {
+        const resourceA = elementA.getResource();
+        const resourceB = elementB.getResource();
+
+        if (resourceA && resourceB) {
+            nameA = resourceA.fsPath;
+            nameB = resourceB.fsPath;
+        }
+    }
+
+    return compareAnything(nameA, nameB, lookFor);
+}

--- a/packages/monaco/src/browser/monaco-loader.ts
+++ b/packages/monaco/src/browser/monaco-loader.ts
@@ -80,7 +80,9 @@ export function loadMonaco(vsRequire: any): Promise<void> {
                 'vs/editor/common/model/wordHelper',
                 'vs/base/common/errors',
                 'vs/base/common/path',
-                'vs/editor/common/model/textModel'
+                'vs/editor/common/model/textModel',
+                'vs/base/common/strings',
+                'vs/base/common/async'
             ], (commands: any, actions: any,
                 keybindingsRegistry: any, keybindingResolver: any, resolvedKeybinding: any, keybindingLabels: any,
                 keyCodes: any, mime: any, editorExtensions: any, simpleServices: any,
@@ -94,7 +96,8 @@ export function loadMonaco(vsRequire: any): Promise<void> {
                 markerService: any,
                 contextKey: any, contextKeyService: any,
                 wordHelper: any,
-                error: any, path: any, textModel: any) => {
+                error: any, path: any,
+                textModel: any, strings: any, async: any) => {
                 const global: any = self;
                 global.monaco.commands = commands;
                 global.monaco.actions = actions;
@@ -119,6 +122,8 @@ export function loadMonaco(vsRequire: any): Promise<void> {
                 global.monaco.error = error;
                 global.monaco.path = path;
                 global.monaco.textModel = textModel;
+                global.monaco.strings = strings;
+                global.monaco.async = async;
                 resolve();
             });
         });

--- a/packages/monaco/src/typings/monaco/index.d.ts
+++ b/packages/monaco/src/typings/monaco/index.d.ts
@@ -1196,9 +1196,6 @@ declare module monaco.quickOpen {
         run(mode: Mode, context: IEntryRunContext): boolean;
     }
 
-    // todo https://github.com/eclipse-theia/theia/issues/7899
-    export function compareEntries(elementA: QuickOpenEntry, elementB: QuickOpenEntry, lookFor: string): number;
-
     // https://github.com/theia-ide/vscode/blob/standalone/0.20.x/src/vs/base/parts/quickopen/browser/quickOpenModel.ts#L197
     export class QuickOpenEntryGroup extends QuickOpenEntry {
         constructor(entry?: QuickOpenEntry, groupLabel?: string, withBorder?: boolean);
@@ -1505,6 +1502,22 @@ declare module monaco.path {
 declare module monaco.wordHelper {
     // https://github.com/theia-ide/vscode/blob/standalone/0.19.x/src/vs/editor/common/model/wordHelper.ts#L30
     export const DEFAULT_WORD_REGEXP: RegExp;
+}
+
+declare module monaco.strings {
+    // https://github.com/theia-ide/vscode/blob/standalone/0.19.x/src/vs/base/common/strings.ts#L150
+    export function startsWith(haystack: string, needle: string): boolean;
+
+    // https://github.com/theia-ide/vscode/blob/standalone/0.19.x/src/vs/base/common/strings.ts#L171
+    export function endsWith(haystack: string, needle: string): boolean;
+}
+
+declare module monaco.async {
+    // https://github.com/theia-ide/vscode/blob/standalone/0.19.x/src/vs/base/common/async.ts#L721
+    export class IdleValue<T> {
+        constructor(executor: () => T) { }
+        getValue(): T;
+    }
 }
 
 /**


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
Provide ability to compare quick open entries
Closes https://github.com/eclipse-theia/theia/issues/7899

The PR contains copied functions from VS Code, please see my comment in the issue https://github.com/eclipse-theia/theia/issues/7899#issuecomment-650105843
I'll provide the corresponding CQ if the changes look good
**Update:** the reference to the CQ https://dev.eclipse.org/ipzilla/show_bug.cgi?id=22443

#### How to test
The bug is actual for `master` branch at using the `QuickOpenService` with `true` value for `fuzzySort`property.
So, for testing I used `F1 --> Variable:List All` since it has `true` value for `fuzzySort`property [here](https://github.com/eclipse-theia/theia/blob/84408de86de835e26ca6100f8d69b311e0d0b0a5/packages/variable-resolver/src/browser/variable-quick-open-service.ts#L61)

Please see actual and expected behavior in the issue description https://github.com/eclipse-theia/theia/issues/7899 

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

Signed-off-by: Roman Nikitenko <rnikiten@redhat.com>