### PR TITLE
Made menu and keybinding contributions extensible

### DIFF
--- a/packages/editor/src/browser/editor-frontend-module.ts
+++ b/packages/editor/src/browser/editor-frontend-module.ts
@@ -55,7 +55,8 @@ export default new ContainerModule(bind => {
     bind(KeybindingContext).toService(StrictEditorTextFocusContext);
     bind(KeybindingContext).to(EditorTextFocusContext).inSingletonScope();
     bind(KeybindingContext).to(DiffEditorTextFocusContext).inSingletonScope();
-    bind(KeybindingContribution).to(EditorKeybindingContribution).inSingletonScope();
+    bind(EditorKeybindingContribution).toSelf().inSingletonScope();
+    bind(KeybindingContribution).toService(EditorKeybindingContribution);
 
     bind(EditorContribution).toSelf().inSingletonScope();
     bind(FrontendApplicationContribution).toService(EditorContribution);

--- a/packages/monaco/src/browser/monaco-frontend-module.ts
+++ b/packages/monaco/src/browser/monaco-frontend-module.ts
@@ -122,8 +122,10 @@ export default new ContainerModule((bind, unbind, isBound, rebind) => {
 
     bind(MonacoCommandRegistry).toSelf().inSingletonScope();
     bind(CommandContribution).to(MonacoEditorCommandHandlers).inSingletonScope();
-    bind(MenuContribution).to(MonacoEditorMenuContribution).inSingletonScope();
-    bind(KeybindingContribution).to(MonacoKeybindingContribution).inSingletonScope();
+    bind(MonacoEditorMenuContribution).toSelf().inSingletonScope();
+    bind(MenuContribution).toService(MonacoEditorMenuContribution);
+    bind(MonacoKeybindingContribution).toSelf().inSingletonScope();
+    bind(KeybindingContribution).toService(MonacoKeybindingContribution);
     rebind(StrictEditorTextFocusContext).to(MonacoStrictEditorTextFocusContext).inSingletonScope();
 
     bind(MonacoQuickOpenService).toSelf().inSingletonScope();

--- a/packages/workspace/src/browser/workspace-frontend-module.ts
+++ b/packages/workspace/src/browser/workspace-frontend-module.ts
@@ -72,8 +72,10 @@ export default new ContainerModule((bind: interfaces.Bind, unbind: interfaces.Un
 
     bind(WorkspaceCommandContribution).toSelf().inSingletonScope();
     bind(CommandContribution).toService(WorkspaceCommandContribution);
-    bind(MenuContribution).to(FileMenuContribution).inSingletonScope();
-    bind(MenuContribution).to(EditMenuContribution).inSingletonScope();
+    bind(FileMenuContribution).toSelf().inSingletonScope();
+    bind(MenuContribution).toService(FileMenuContribution);
+    bind(EditMenuContribution).toSelf().inSingletonScope();
+    bind(MenuContribution).toService(EditMenuContribution);
     bind(WorkspaceDeleteHandler).toSelf().inSingletonScope();
     bind(WorkspaceDuplicateHandler).toSelf().inSingletonScope();
     bind(WorkspaceCompareHandler).toSelf().inSingletonScope();


### PR DESCRIPTION
From now on, downstream project can subclass and rebind various menu and
keybinding contributions to overcome a Theia limitation.

See: eclipse-theia/theia#8175

Signed-off-by: Akos Kitta <kittaakos@typefox.io>

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->
 - I built the app, checked the `File` and `Edit` menus: they must be the same as before.
 - I tried a few keybindings in a monaco editor. Such as undo, redo, toggle line comment, delete line.

From now one, one can customize and rebind the `File` and `Edit` menu contributions to overcome #8175.
This PR also makes the generic editor and the monaco keybinding contributions customizable.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

