### PR TITLE
vsx-registry: implement extension compatibility handling

### DIFF
--- a/examples/api-samples/compile.tsconfig.json
+++ b/examples/api-samples/compile.tsconfig.json
@@ -14,6 +14,9 @@
     },
     {
       "path": "../../packages/output/compile.tsconfig.json"
+    },
+    {
+      "path": "../../packages/vsx-registry/compile.tsconfig.json"
     }
   ]
 }

--- a/examples/api-samples/package.json
+++ b/examples/api-samples/package.json
@@ -5,7 +5,8 @@
   "description": "Theia - Example code to demonstrate Theia API",
   "dependencies": {
     "@theia/core": "1.10.0",
-    "@theia/output": "1.10.0"
+    "@theia/output": "1.10.0",
+    "@theia/vsx-registry": "1.10.0"
   },
   "theiaExtensions": [
     {

--- a/examples/api-samples/src/browser/api-samples-frontend-module.ts
+++ b/examples/api-samples/src/browser/api-samples-frontend-module.ts
@@ -20,6 +20,7 @@ import { bindSampleUnclosableView } from './view/sample-unclosable-view-contribu
 import { bindSampleOutputChannelWithSeverity } from './output/sample-output-channel-with-severity';
 import { bindSampleMenu } from './menu/sample-menu-contribution';
 import { bindSampleFileWatching } from './file-watching/sample-file-watching-contribution';
+import { bindVSXCommand } from './vsx/sample-vsx-command-contribution';
 
 import '../../src/browser/style/branding.css';
 
@@ -29,4 +30,5 @@ export default new ContainerModule(bind => {
     bindSampleOutputChannelWithSeverity(bind);
     bindSampleMenu(bind);
     bindSampleFileWatching(bind);
+    bindVSXCommand(bind);
 });

--- a/examples/api-samples/src/browser/vsx/sample-vsx-command-contribution.ts
+++ b/examples/api-samples/src/browser/vsx/sample-vsx-command-contribution.ts
@@ -1,0 +1,48 @@
+/********************************************************************************
+ * Copyright (C) 2020 Ericsson and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import { inject, injectable, interfaces } from 'inversify';
+import { VSXEnvironment } from '@theia/vsx-registry/lib/common/vsx-environment';
+import { Command, CommandContribution, CommandRegistry, MessageService } from '@theia/core/lib/common';
+
+@injectable()
+export class VSXCommandContribution implements CommandContribution {
+
+    @inject(MessageService)
+    protected readonly messageService: MessageService;
+
+    @inject(VSXEnvironment)
+    protected readonly environment: VSXEnvironment;
+
+    protected readonly command: Command = {
+        id: 'vsx.echo-api-version',
+        label: 'VS Code API Version'
+    };
+
+    registerCommands(commands: CommandRegistry): void {
+        commands.registerCommand(this.command, {
+            execute: async () => {
+                const version = await this.environment.getVscodeApiVersion();
+                this.messageService.info(`Supported VS Code API Version: ${version}`);
+            }
+        });
+    }
+
+}
+
+export const bindVSXCommand = (bind: interfaces.Bind) => {
+    bind(CommandContribution).to(VSXCommandContribution).inSingletonScope();
+};

--- a/packages/plugin-ext-vscode/src/common/plugin-vscode-types.ts
+++ b/packages/plugin-ext-vscode/src/common/plugin-vscode-types.ts
@@ -1,0 +1,17 @@
+/********************************************************************************
+ * Copyright (C) 2020 Ericsson and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+export const VSCODE_DEFAULT_API_VERSION = '1.50.0';

--- a/packages/plugin-ext-vscode/src/node/plugin-vscode-cli-contribution.ts
+++ b/packages/plugin-ext-vscode/src/node/plugin-vscode-cli-contribution.ts
@@ -18,7 +18,8 @@ import { injectable } from 'inversify';
 import { Argv, Arguments } from 'yargs';
 import { CliContribution } from '@theia/core/lib/node/cli';
 import { PluginHostEnvironmentVariable } from '@theia/plugin-ext/lib/common';
-import { VSCODE_DEFAULT_API_VERSION } from './plugin-vscode-init';
+import { VSCODE_DEFAULT_API_VERSION } from '../common/plugin-vscode-types';
+
 /**
  * CLI Contribution allowing to override the VS Code API version which is returned by `vscode.version` API call.
  */
@@ -42,6 +43,7 @@ export class PluginVsCodeCliContribution implements CliContribution, PluginHostE
         const arg = args[PluginVsCodeCliContribution.VSCODE_API_VERSION] as string;
         if (arg) {
             this.vsCodeApiVersion = arg;
+            this.process(process.env);
         }
     }
 

--- a/packages/plugin-ext-vscode/src/node/plugin-vscode-init.ts
+++ b/packages/plugin-ext-vscode/src/node/plugin-vscode-init.ts
@@ -18,8 +18,7 @@
 
 import * as theia from '@theia/plugin';
 import { BackendInitializationFn, PluginAPIFactory, Plugin, emptyPlugin } from '@theia/plugin-ext';
-
-export const VSCODE_DEFAULT_API_VERSION = '1.50.0';
+import { VSCODE_DEFAULT_API_VERSION } from '../common/plugin-vscode-types';
 
 /** Set up en as a default locale for VS Code extensions using vscode-nls */
 process.env['VSCODE_NLS_CONFIG'] = JSON.stringify({ locale: 'en', availableLanguages: {} });

--- a/packages/vsx-registry/package.json
+++ b/packages/vsx-registry/package.json
@@ -13,6 +13,7 @@
     "p-debounce": "^2.1.0",
     "requestretry": "^3.1.0",
     "sanitize-html": "^1.14.1",
+    "semver": "^5.4.1",
     "showdown": "^1.9.1",
     "uuid": "^8.0.0"
   },

--- a/packages/vsx-registry/src/browser/vsx-api-version-provider-frontend-impl.ts
+++ b/packages/vsx-registry/src/browser/vsx-api-version-provider-frontend-impl.ts
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (C) 2020 TypeFox and others.
+ * Copyright (C) 2020 Ericsson and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -14,21 +14,25 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
-import { ContainerModule } from 'inversify';
-import { VSXExtensionResolver } from './vsx-extension-resolver';
-import { PluginDeployerResolver } from '@theia/plugin-ext/lib/common/plugin-protocol';
-import { VSXRegistryAPI } from '../common/vsx-registry-api';
+import { inject, injectable } from 'inversify';
 import { VSXEnvironment } from '../common/vsx-environment';
-import { VSXApiVersionProviderImpl } from './vsx-api-version-provider-backend-impl';
 import { VSXApiVersionProvider } from '../common/vsx-api-version-provider';
+import { FrontendApplicationContribution, FrontendApplication } from '@theia/core/lib/browser';
 
-export default new ContainerModule(bind => {
-    bind(VSXEnvironment).toSelf().inRequestScope();
-    bind(VSXRegistryAPI).toSelf().inSingletonScope();
+@injectable()
+export class VSXApiVersionProviderImpl implements VSXApiVersionProvider, FrontendApplicationContribution {
 
-    bind(VSXExtensionResolver).toSelf().inSingletonScope();
-    bind(PluginDeployerResolver).toService(VSXExtensionResolver);
+    @inject(VSXEnvironment)
+    protected readonly vsxEnvironment: VSXEnvironment;
 
-    bind(VSXApiVersionProviderImpl).toSelf().inSingletonScope();
-    bind(VSXApiVersionProvider).toService(VSXApiVersionProviderImpl);
-});
+    protected _apiVersion: string;
+
+    async onStart(_app: FrontendApplication): Promise<void> {
+        this._apiVersion = await this.vsxEnvironment.getVscodeApiVersion();
+    }
+
+    getApiVersion(): string {
+        return this._apiVersion;
+    }
+
+}

--- a/packages/vsx-registry/src/browser/vsx-extensions-model.ts
+++ b/packages/vsx-registry/src/browser/vsx-extensions-model.ts
@@ -128,7 +128,7 @@ export class VSXExtensionsModel {
         this.searchCancellationTokenSource.cancel();
         this.searchCancellationTokenSource = new CancellationTokenSource();
         const query = this.search.query;
-        return this.doUpdateSearchResult({ query }, this.searchCancellationTokenSource.token);
+        return this.doUpdateSearchResult({ query, includeAllVersions: true }, this.searchCancellationTokenSource.token);
     }, 150);
     protected doUpdateSearchResult(param: VSXSearchParam, token: CancellationToken): Promise<void> {
         return this.doChange(async () => {
@@ -139,12 +139,17 @@ export class VSXExtensionsModel {
             const searchResult = new Set<string>();
             for (const data of result.extensions) {
                 const id = data.namespace.toLowerCase() + '.' + data.name.toLowerCase();
+                const extension = this.api.getLatestCompatibleVersion(data.allVersions);
+                if (!extension) {
+                    continue;
+                }
                 this.setExtension(id).update(Object.assign(data, {
                     publisher: data.namespace,
                     downloadUrl: data.files.download,
                     iconUrl: data.files.icon,
                     readmeUrl: data.files.readme,
                     licenseUrl: data.files.license,
+                    version: extension.version
                 }));
                 searchResult.add(id);
             }
@@ -212,7 +217,10 @@ export class VSXExtensionsModel {
 
     protected async refresh(id: string): Promise<VSXExtension | undefined> {
         try {
-            const data = await this.api.getExtension(id);
+            const data = await this.api.getLatestCompatibleExtensionVersion(id);
+            if (!data) {
+                return;
+            }
             if (data.error) {
                 return this.onDidFailRefresh(id, data.error);
             }
@@ -223,6 +231,7 @@ export class VSXExtensionsModel {
                 iconUrl: data.files.icon,
                 readmeUrl: data.files.readme,
                 licenseUrl: data.files.license,
+                version: data.version
             }));
             return extension;
         } catch (e) {

--- a/packages/vsx-registry/src/browser/vsx-registry-frontend-module.ts
+++ b/packages/vsx-registry/src/browser/vsx-registry-frontend-module.ts
@@ -32,6 +32,8 @@ import { VSXExtensionEditorManager } from './vsx-extension-editor-manager';
 import { VSXExtensionsSourceOptions } from './vsx-extensions-source';
 import { VSXEnvironment } from '../common/vsx-environment';
 import { VSXExtensionsSearchModel } from './vsx-extensions-search-model';
+import { VSXApiVersionProviderImpl } from './vsx-api-version-provider-frontend-impl';
+import { VSXApiVersionProvider } from '../common/vsx-api-version-provider';
 
 export default new ContainerModule(bind => {
     bind(VSXEnvironment).toSelf().inRequestScope();
@@ -90,4 +92,8 @@ export default new ContainerModule(bind => {
     bind(FrontendApplicationContribution).toService(VSXExtensionsContribution);
     bind(ColorContribution).toService(VSXExtensionsContribution);
     bind(TabBarToolbarContribution).toService(VSXExtensionsContribution);
+
+    bind(VSXApiVersionProviderImpl).toSelf().inSingletonScope();
+    bind(FrontendApplicationContribution).toService(VSXApiVersionProviderImpl);
+    bind(VSXApiVersionProvider).toService(VSXApiVersionProviderImpl);
 });

--- a/packages/vsx-registry/src/common/vsx-api-version-provider.ts
+++ b/packages/vsx-registry/src/common/vsx-api-version-provider.ts
@@ -1,0 +1,21 @@
+/********************************************************************************
+ * Copyright (C) 2020 Ericsson and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+export const VSXApiVersionProvider = Symbol('VSXApiVersionProvider');
+
+export interface VSXApiVersionProvider {
+    getApiVersion(): string;
+}

--- a/packages/vsx-registry/src/common/vsx-environment.tsx
+++ b/packages/vsx-registry/src/common/vsx-environment.tsx
@@ -17,6 +17,7 @@
 import { injectable, inject } from 'inversify';
 import { EnvVariablesServer } from '@theia/core/lib/common/env-variables';
 import URI from '@theia/core/lib/common/uri';
+import { VSCODE_DEFAULT_API_VERSION } from '@theia/plugin-ext-vscode/lib/common/plugin-vscode-types';
 
 @injectable()
 export class VSXEnvironment {
@@ -36,6 +37,15 @@ export class VSXEnvironment {
     async getRegistryApiUri(): Promise<URI> {
         const registryUri = await this.getRegistryUri();
         return registryUri.resolve('api');
+    }
+
+    protected _apiVersion: string | undefined;
+    async getVscodeApiVersion(): Promise<string> {
+        if (!this._apiVersion) {
+            const apiVersion = await this.environments.getValue('VSCODE_API_VERSION');
+            this._apiVersion = apiVersion?.value || VSCODE_DEFAULT_API_VERSION;
+        }
+        return this._apiVersion;
     }
 
 }

--- a/packages/vsx-registry/src/common/vsx-registry-api.spec.ts
+++ b/packages/vsx-registry/src/common/vsx-registry-api.spec.ts
@@ -15,11 +15,13 @@
  ********************************************************************************/
 
 import * as chai from 'chai';
-import { Container } from 'inversify';
-import { VSXRegistryAPI } from './vsx-registry-api';
 import URI from '@theia/core/lib/common/uri';
+import { Container } from 'inversify';
 import { VSXEnvironment } from './vsx-environment';
+import { VSXRegistryAPI } from './vsx-registry-api';
 import { VSXSearchParam } from './vsx-registry-types';
+import { VSXApiVersionProvider } from './vsx-api-version-provider';
+import { EnvVariablesServer } from '@theia/core/lib/common/env-variables/env-variables-protocol';
 
 const expect = chai.expect;
 
@@ -36,9 +38,39 @@ describe('VSX Registry API', () => {
             },
             async getRegistryUri(): Promise<URI> {
                 return new URI('https://open-vsx.org');
+            },
+            async getVscodeApiVersion(): Promise<string> {
+                return '1.40.0';
+            }
+        });
+        container.bind(EnvVariablesServer).toConstantValue({});
+        container.bind(VSXApiVersionProvider).toConstantValue(<VSXApiVersionProvider>{
+            getApiVersion(): string {
+                return '1.40.0';
             }
         });
         api = container.get<VSXRegistryAPI>(VSXRegistryAPI);
+    });
+
+    describe('isEngineValid', () => {
+
+        it('should return \'true\' for a compatible engine', () => {
+            const a: boolean = api['isEngineSupported']('^1.20.0');
+            const b: boolean = api['isEngineSupported']('^1.40.0');
+            expect(a).to.eq(true);
+            expect(b).to.eq(true);
+        });
+
+        it('should return \'false\' for a incompatible engine', () => {
+            const valid: boolean = api['isEngineSupported']('^1.50.0');
+            expect(valid).to.eq(false);
+        });
+
+        it('should return \'false\' for an undefined engine', () => {
+            const valid: boolean = api['isEngineSupported']();
+            expect(valid).to.eq(false);
+        });
+
     });
 
     describe('#buildSearchUri', () => {
@@ -76,6 +108,49 @@ describe('VSX Registry API', () => {
             };
             query = await api['buildSearchUri'](param);
             expect(query).to.eq(expected);
+        });
+
+    });
+
+    describe('#buildSearchUri', () => {
+
+        it('should correctly build the search URI with the single `query` parameter present', async () => {
+
+            it('should build a proper query with the single `query` parameter present', async () => {
+                const expected = 'https://open-vsx.org/api/-/search?query=javascript';
+                const param: VSXSearchParam = {
+                    query: 'javascript',
+                };
+                const query = await api['buildSearchUri'](param);
+                expect(query).to.eq(expected);
+            });
+
+            it('should correctly build the search URI with the multiple search parameters present', async () => {
+                let expected = 'https://open-vsx.org/api/-/search?query=javascript&category=languages&size=20&offset=10&includeAllVersions=true';
+                let param: VSXSearchParam = {
+                    query: 'javascript',
+                    category: 'languages',
+                    size: 20,
+                    offset: 10,
+                    includeAllVersions: true,
+                };
+                let query = await api['buildSearchUri'](param);
+                expect(query).to.eq(expected);
+
+                expected = 'https://open-vsx.org/api/-/search?query=javascript&category=languages&size=20&offset=10&sortOrder=desc&sortBy=relevance&includeAllVersions=true';
+                param = {
+                    query: 'javascript',
+                    category: 'languages',
+                    size: 20,
+                    offset: 10,
+                    sortOrder: 'desc',
+                    sortBy: 'relevance',
+                    includeAllVersions: true
+                };
+                query = await api['buildSearchUri'](param);
+                expect(query).to.eq(expected);
+            });
+
         });
 
     });

--- a/packages/vsx-registry/src/common/vsx-registry-types.ts
+++ b/packages/vsx-registry/src/common/vsx-registry-types.ts
@@ -61,6 +61,14 @@ export interface VSXSearchResult {
     readonly extensions: VSXSearchEntry[];
 }
 
+export interface VSXAllVersions {
+    url: string,
+    version: string,
+    engines?: {
+        [version: string]: string
+    }
+}
+
 /**
  * Should be aligned with https://github.com/eclipse/openvsx/blob/master/server/src/main/java/org/eclipse/openvsx/json/SearchEntryJson.java
  */
@@ -80,6 +88,7 @@ export interface VSXSearchEntry {
     readonly downloadCount: number;
     readonly displayName?: string;
     readonly description?: string;
+    readonly allVersions: VSXAllVersions[];
 }
 
 export type VSXExtensionNamespaceAccess = 'public' | 'restricted';
@@ -90,6 +99,13 @@ export type VSXExtensionNamespaceAccess = 'public' | 'restricted';
 export interface VSXUser {
     loginName: string
     homepage?: string
+}
+
+export interface VSXExtensionRawFiles {
+    download: string
+    readme?: string
+    license?: string
+    icon?: string
 }
 
 /**
@@ -103,12 +119,7 @@ export interface VSXExtensionRaw {
     readonly namespace: string;
     readonly publishedBy: VSXUser
     readonly namespaceAccess: VSXExtensionNamespaceAccess;
-    readonly files: {
-        download: string
-        readme?: string
-        license?: string
-        icon?: string
-    }
+    readonly files: VSXExtensionRawFiles,
     readonly allVersions: {
         [version: string]: string
     }
@@ -130,4 +141,5 @@ export interface VSXExtensionRaw {
     readonly galleryColor?: string;
     readonly galleryTheme?: string;
     readonly qna?: string;
+    readonly engines?: { [engine: string]: string };
 }

--- a/packages/vsx-registry/src/node/vsx-api-version-provider-backend-impl.ts
+++ b/packages/vsx-registry/src/node/vsx-api-version-provider-backend-impl.ts
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (C) 2020 TypeFox and others.
+ * Copyright (C) 2020 Ericsson and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -14,21 +14,15 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
-import { ContainerModule } from 'inversify';
-import { VSXExtensionResolver } from './vsx-extension-resolver';
-import { PluginDeployerResolver } from '@theia/plugin-ext/lib/common/plugin-protocol';
-import { VSXRegistryAPI } from '../common/vsx-registry-api';
-import { VSXEnvironment } from '../common/vsx-environment';
-import { VSXApiVersionProviderImpl } from './vsx-api-version-provider-backend-impl';
+import { injectable } from 'inversify';
 import { VSXApiVersionProvider } from '../common/vsx-api-version-provider';
+import { VSCODE_DEFAULT_API_VERSION } from '@theia/plugin-ext-vscode/lib/common/plugin-vscode-types';
 
-export default new ContainerModule(bind => {
-    bind(VSXEnvironment).toSelf().inRequestScope();
-    bind(VSXRegistryAPI).toSelf().inSingletonScope();
+@injectable()
+export class VSXApiVersionProviderImpl implements VSXApiVersionProvider {
 
-    bind(VSXExtensionResolver).toSelf().inSingletonScope();
-    bind(PluginDeployerResolver).toService(VSXExtensionResolver);
+    getApiVersion(): string {
+        return process.env['VSCODE_API_VERSION'] || VSCODE_DEFAULT_API_VERSION;
+    }
 
-    bind(VSXApiVersionProviderImpl).toSelf().inSingletonScope();
-    bind(VSXApiVersionProvider).toService(VSXApiVersionProviderImpl);
-});
+}

--- a/packages/vsx-registry/src/node/vsx-extension-resolver.ts
+++ b/packages/vsx-registry/src/node/vsx-extension-resolver.ts
@@ -49,7 +49,10 @@ export class VSXExtensionResolver implements PluginDeployerResolver {
             return;
         }
         console.log(`[${id}]: trying to resolve latest version...`);
-        const extension = await this.api.getExtension(id);
+        const extension = await this.api.getLatestCompatibleExtensionVersion(id);
+        if (!extension) {
+            return;
+        }
         if (extension.error) {
             throw new Error(extension.error);
         }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

Fixes: #7464 

The following pull-request includes extension compatibility handling when searching, and installing extensions from the `open-vsx` view. The changes include using the new `open-vsx` api to determine a compatible version of an extension by parsing the `engines.vscode` property against our supported API version.

The pull-request includes:
- [x] checking for extension compatibility based on the `engines.vscode` property
- [x] obtaining the supported API version through the `cli` (defaults to our default api version)
- [x] handling of installing specific extension versions 
- [x] update search with new open-vsx api (`downloadUrl`): https://github.com/eclipse/openvsx/issues/149
- [x] performance improvements

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

1. start the application (plugins should work correctly as before)
2. the extensions view should search for plugins which are compatible with the current api version
3. installing plugins should work correctly as before
4. the new command should display the current api version correctly
5. using `yarn start --vscode-api-version={version}`, the api version should properly be updated, searching for extensions should still respect the cli argument

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

Signed-off-by: vince-fugnitto <vincent.fugnitto@ericsson.com>