### PR TITLE
Change Debug Panel reveal to false

### DIFF
--- a/packages/debug/src/browser/debug-frontend-application-contribution.ts
+++ b/packages/debug/src/browser/debug-frontend-application-contribution.ts
@@ -447,7 +447,8 @@ export class DebugFrontendApplicationContribution extends AbstractViewContributi
             if (internalConsoleOptions === 'openOnSessionStart' ||
                 (internalConsoleOptions === 'openOnFirstSessionStart' && this.firstSessionStart)) {
                 this.console.openView({
-                    reveal: true
+                    reveal: true,
+                    activate: false,
                 });
             }
             if (!noDebug && (openDebug === 'openOnSessionStart' || (openDebug === 'openOnFirstSessionStart' && this.firstSessionStart))) {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->
When Debug console is launched it will open but won't reveal. Syncs with VSCode behavior. 

Discussed in https://github.com/eclipse-theia/theia/discussions/8085.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
Load this plugin in Theia: https://github.com/vincentjocodes/theia-hello-world-plugin. 
Load this plugin in VSCode: https://github.com/kittaakos/output-channel-example. 

You will notice that the Debug Panel will not show but only the Output Panel on both.

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

