### PR TITLE
fix: load vsix with no publisher

### DIFF
--- a/packages/plugin-ext-vscode/src/node/scanner-vscode.ts
+++ b/packages/plugin-ext-vscode/src/node/scanner-vscode.ts
@@ -29,13 +29,15 @@ export class VsCodePluginScanner extends TheiaPluginScanner implements PluginSca
     }
 
     getModel(plugin: PluginPackage): PluginModel {
+        // publisher can be empty on vscode extension development
+        const publisher = plugin.publisher || '';
         const result: PluginModel = {
             packagePath: plugin.packagePath,
             packageUri: FileUri.create(plugin.packagePath).toString(),
             // see id definition: https://github.com/microsoft/vscode/blob/15916055fe0cb9411a5f36119b3b012458fe0a1d/src/vs/platform/extensions/common/extensions.ts#L167-L169
-            id: `${plugin.publisher.toLowerCase()}.${plugin.name.toLowerCase()}`,
+            id: `${publisher.toLowerCase()}.${plugin.name.toLowerCase()}`,
             name: plugin.name,
-            publisher: plugin.publisher,
+            publisher: publisher,
             version: plugin.version,
             displayName: plugin.displayName,
             description: plugin.description,


### PR DESCRIPTION
This is relevant for extension development flow.
Currently when running 'yo code' the extension is created without publisher.
VS code 'Run Extension' launcher is able to run/debug it.
In theia prior to this fix it caused TypeError: Cannot read property 'toLowerCase' of undefined

Signed-off-by: Amiram Wingarten <amiram.wingarten@sap.com>

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
Fix run hosted plugin flow when publisher is missing on the extension project selected.

#### How to test
1. Run `yarn global add yo generator-code`
2. Run `yo code`
3. Run: F1 -> "Hosted Plugin: Start Instance"
4. Select the project created
5. Hosted plugin should now have command "Hello World" and running it create a user notification

Prior to that fix the extension could not be deployed on backend with this stack trace:

```
root ERROR Failed to load plugin metadata from "/workspace/test" TypeError: Cannot read property 'toLowerCase' of undefined
    at VsCodePluginScanner.getModel (/workspace/theia/packages/plugin-ext-vscode/lib/node/scanner-vscode.js:73:34)
    at MetadataScanner.getPluginMetadata (/workspace/theia/packages/plugin-ext/lib/hosted/node/metadata-scanner.js:46:28)
    at HostedPluginReader.readMetadata (/workspace/theia/packages/plugin-ext/lib/hosted/node/plugin-reader.js:171:43)
    at HostedPluginReader.<anonymous> (/workspace/theia/packages/plugin-ext/lib/hosted/node/plugin-reader.js:139:64)
    at step (/workspace/theia/packages/plugin-ext/lib/hosted/node/plugin-reader.js:57:23)
    at Object.next (/workspace/theia/packages/plugin-ext/lib/hosted/node/plugin-reader.js:38:53)
    at fulfilled (/workspace/theia/packages/plugin-ext/lib/hosted/node/plugin-reader.js:29:58)

root ERROR Could not initialize contribution TypeError: Cannot read property 'model' of undefined
    at HostedPluginReader.<anonymous> (/workspace/theia/packages/plugin-dev/lib/node/hosted-plugin-reader.js:87:44)
    at step (/workspace/theia/packages/plugin-dev/lib/node/hosted-plugin-reader.js:57:23)
    at Object.next (/workspace/theia/packages/plugin-dev/lib/node/hosted-plugin-reader.js:38:53)
    at fulfilled (/workspace/theia/packages/plugin-dev/lib/node/hosted-plugin-reader.js:29:58)
```

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

