### PR TITLE
terminal: fix xterm opacity issue

### DIFF
--- a/packages/terminal/src/browser/style/terminal.css
+++ b/packages/terminal/src/browser/style/terminal.css
@@ -25,3 +25,9 @@
   /* fix random 1px white border on terminal in Firefox. See https://github.com/eclipse-theia/theia/issues/4665 */
   border: 1px solid var(--theia-terminal-background);
 }
+
+
+.terminal-container .xterm .xterm-helper-textarea {
+  /* fix secondary cursor-like issue. See https://github.com/eclipse-theia/theia/issues/8158 */
+  opacity: 0 !important;
+}


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

Fixes: #8158

The following pull-request addresses an issue present in newer versions of `xterm` which displayed a secondary cursor-like border caused by our global `:focus` class. The fix includes updating the styling of the `xterm` textarea to force an opacity consistent with their sources and resolve the UI error.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
1. start the application and open a new terminal (the terminal should behave like today with one cursor)
2. update the `xterm` dependency to version `^4.8.0` and consequently update the `yarn.lock` as well (or use a resolution block to pin the version of xterm)
3. identify if the issue is fixed for newer versions (secondary cursor)


#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

Signed-off-by: vince-fugnitto <vincent.fugnitto@ericsson.com>
