### PR TITLE
tree-view: respect hidden tree-views when reloading

### DIFF
--- a/packages/plugin-ext/src/main/browser/view/plugin-view-registry.ts
+++ b/packages/plugin-ext/src/main/browser/view/plugin-view-registry.ts
@@ -18,7 +18,7 @@ import { injectable, inject, postConstruct } from 'inversify';
 import {
     ApplicationShell, ViewContainer as ViewContainerWidget, WidgetManager,
     ViewContainerIdentifier, ViewContainerTitleOptions, Widget, FrontendApplicationContribution,
-    StatefulWidget, CommonMenus, BaseWidget
+    StatefulWidget, CommonMenus, BaseWidget, StorageService
 } from '@theia/core/lib/browser';
 import { ViewContainer, View } from '../../../common';
 import { PluginSharedStyle } from '../plugin-shared-style';
@@ -82,6 +82,9 @@ export class PluginViewRegistry implements FrontendApplicationContribution {
 
     @inject(ViewContextKeyService)
     protected readonly viewContextKeys: ViewContextKeyService;
+
+    @inject(StorageService)
+    protected readonly storageService: StorageService;
 
     protected readonly onDidExpandViewEmitter = new Emitter<string>();
     readonly onDidExpandView = this.onDidExpandViewEmitter.event;
@@ -153,6 +156,11 @@ export class PluginViewRegistry implements FrontendApplicationContribution {
             if (this.isViewVisible(viewId)) {
                 await this.openView(viewId);
             }
+            return;
+        }
+        // Suppress updating the visibility of the view if it is hidden explicitly and the layout is not undefined.
+        const layout = await this.storageService.getData<string>('layout');
+        if (layout !== undefined && (!this.isViewVisible(viewId) || widget.isHidden)) {
             return;
         }
         const viewInfo = this.views.get(viewId);


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
Fixes: https://github.com/eclipse-theia/theia/issues/7037

The following pull-request updates the contributed plugin tree-views to respect the hidden and collapsed state when reloading the application (ex: `npm scripts`). With this PR, we ensure not updating the view visibility if the view is explicitly hidden when the state is stored.

#### How to test
1. If the `NPM Scripts` view is hidden, it should stay hidden on reload. 
2. Toggle view for `NPM Scripts` so that its visible 
![toggle](https://user-images.githubusercontent.com/43870550/88815689-9d6b4880-d189-11ea-9f0d-b05bb6d71da1.png)
3. Collapse the `NPM Scripts` view, and refresh the browser window. 
2. Check to see if it remains collapsed on reload.
3. Expand the `NPM Scripts` view, and refresh the browser window.
4. Check to see if it is hidden on reload.
5. Hide the `NPM Scripts` view and perform a `Reset Workbench Layout` command,
6. `NPM Scripts` should get auto-revealed.

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
