### PR TITLE
git: skip flaky chronological branch test

### DIFF
--- a/packages/git/src/node/dugite-git.spec.ts
+++ b/packages/git/src/node/dugite-git.spec.ts
@@ -719,7 +719,8 @@ describe('git', async function (): Promise<void> {
 
     describe('branch', () => {
 
-        it('should list the branch in chronological order', async function (): Promise<void> {
+        // Skip the test case as it is dependent on the git version.
+        it.skip('should list the branch in chronological order', async function (): Promise<void> {
             if (isWindows) {
                 this.skip(); // https://github.com/eclipse-theia/theia/issues/8023
                 return;


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

Fixes: #8215

The following commit skips a flaky git test (which tests the branches are in chronological order) which seems dependent on the git version present on the machine. This causes issues for downstream applications which run the suite and fail.

The test case is kept (only skipped) so that it can be potentially fixed in the future.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

1. the CI should successfully pass
2. the test-case should be listed as 'skipped'

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

Signed-off-by: vince-fugnitto <vincent.fugnitto@ericsson.com>

