### PR TITLE
Fix Git status issues in Source Control view

### DIFF
--- a/packages/git/package.json
+++ b/packages/git/package.json
@@ -13,7 +13,7 @@
     "@types/diff": "^3.2.2",
     "@types/p-queue": "^2.3.1",
     "diff": "^3.4.0",
-    "dugite-extra": "0.1.15",
+    "dugite-no-gpl": "1.69.0",
     "find-git-exec": "^0.0.4",
     "find-git-repositories": "^0.1.1",
     "moment": "2.24.0",

--- a/packages/git/src/browser/git-decoration-provider.ts
+++ b/packages/git/src/browser/git-decoration-provider.ts
@@ -49,18 +49,60 @@ export class GitDecorationProvider implements DecorationsProvider {
     }
 
     private collectDecorationData(changes: GitFileChange[], bucket: Map<string, Decoration>): void {
-        changes.forEach(change => {
-            const color = GitFileStatus.getColor(change.status, change.staged);
-            bucket.set(change.uri, {
-                colorId: color.substring(12, color.length - 1).replace(/-/g, '.'),
-                tooltip: GitFileStatus.toString(change.status),
-                letter: GitFileStatus.toAbbreviation(change.status, change.staged)
-            });
+        const unstagedChanges = changes.filter(change => !change.staged);
+
+        changes.filter(change => change.staged).forEach(stagedChange => {
+            const unstagedChangeIndex = unstagedChanges.findIndex(c => (c.status === GitFileStatus.Renamed ? c.oldUri : c.uri) === stagedChange.uri);
+            if (unstagedChangeIndex !== -1) {
+                // File has both a staged change and an unstaged change
+
+                const removed = unstagedChanges.splice(unstagedChangeIndex, 1);
+                const unstagedChange = removed[0];
+
+                const combinedChange = {
+                    ...stagedChange,
+                    status: this.combineStatuses(stagedChange.status, unstagedChange.status)
+                };
+                const uri = new URI(stagedChange.uri);
+                const stagedDecoration = this.buildDecoration(stagedChange);
+                const unstagedDecoration = this.buildDecoration(unstagedChange);
+                const combinedDecoration = this.buildDecoration(combinedChange);
+                bucket.set(stagedChange.uri, combinedDecoration);
+                bucket.set(uri.withFragment('index').toString(), stagedDecoration);
+                bucket.set(uri.withFragment('workingTree').toString(), unstagedDecoration);
+            } else {
+                // File has only a staged change
+                const decoration = this.buildDecoration(stagedChange);
+                bucket.set(stagedChange.uri, decoration);
+            }
         });
+
+        unstagedChanges.forEach(change => {
+            // File has only an unstanged change
+            const decoration = this.buildDecoration(change);
+            bucket.set(change.uri, decoration);
+        });
+    }
+
+    private buildDecoration(change: GitFileChange): Decoration {
+        const color = GitFileStatus.getColor(change.status, change.staged);
+        return {
+            colorId: color.substring(12, color.length - 1).replace(/-/g, '.'),
+            tooltip: GitFileStatus.toString(change.status),
+            letter: GitFileStatus.toAbbreviation(change.status, change.staged)
+        };
+    }
+
+    private combineStatuses(stagedChange: GitFileStatus, unstagedChange: GitFileStatus): GitFileStatus {
+        // TODO finish this...
+        if (unstagedChange === GitFileStatus.Deleted) {
+            return GitFileStatus.Deleted;
+        } else {
+            return stagedChange;
+        }
     }
 
     provideDecorations(uri: URI, token: CancellationToken): Decoration | Promise<Decoration | undefined> | undefined {
         return this.decorations.get(uri.toString());
     }
 }
-

--- a/packages/git/src/common/git-model.ts
+++ b/packages/git/src/common/git-model.ts
@@ -245,7 +245,9 @@ export interface Remote {
 
 /**
  * The branch type. Either local or remote.
- * The order matters.
+ *
+ * NOTE: The values here matter as they are used to sort
+ * local and remote branches, Local should come before Remote.
  */
 export enum BranchType {
 
@@ -364,7 +366,7 @@ export interface CommitWithChanges extends Commit {
 }
 
 /**
- * A tuple of name, email, and a date for the author or commit info in a commit.
+ * A tuple of name, email, and timestamp information for the author or commit info in a commit.
  */
 export interface CommitIdentity {
 
@@ -382,6 +384,11 @@ export interface CommitIdentity {
      * The date of the commit in ISO format.
      */
     readonly timestamp: string;
+
+    /**
+     * The timezone offet from GMT, in minutes, which can be positive or negative.
+     */
+    readonly tzOffset?: number;
 
 }
 

--- a/packages/git/src/node/git-exec-provider.ts
+++ b/packages/git/src/node/git-exec-provider.ts
@@ -16,7 +16,19 @@
 
 import { injectable } from '@theia/core/shared/inversify';
 import { Disposable, MaybePromise } from '@theia/core/';
-import { IGitExecutionOptions } from 'dugite-extra/lib/core/git';
+import * as fs from 'fs';
+import * as Path from 'path';
+import findGit from 'find-git-exec';
+import {
+    GitProcess,
+    IGitResult as DugiteResult,
+    GitError as DugiteError,
+    IGitExecutionOptions as DugiteExecutionOptions,
+    RepositoryDoesNotExistErrorCode,
+    GitNotFoundErrorCode
+} from 'dugite-no-gpl';
+
+/* eslint-disable no-null/no-null, @typescript-eslint/no-explicit-any */
 
 /**
  * Provides an execution function that will be used to perform the Git commands.
@@ -96,4 +108,301 @@ export class GitExecProvider implements Disposable {
 
 }
 
-export { IGitExecutionOptions };
+const __GIT_PATH__: { gitDir: string | undefined, gitExecPath: string | undefined, searched: boolean } = { gitDir: undefined, gitExecPath: undefined, searched: false };
+
+/**
+ * An extension of the execution options in dugite that
+ * allows us to piggy-back our own configuration options in the
+ * same object.
+ */
+export interface IGitExecutionOptions extends DugiteExecutionOptions {
+    /**
+     * The exit codes which indicate success to the
+     * caller. Unexpected exit codes will be logged and an
+     * error thrown. Defaults to 0 if undefined.
+     */
+    readonly successExitCodes?: ReadonlySet<number>
+
+    /**
+     * The git errors which are expected by the caller. Unexpected errors will
+     * be logged and an error thrown.
+     */
+    readonly expectedErrors?: ReadonlySet<DugiteError>
+
+    /**
+     * `path` is equivalent to `cwd`.
+     * If the `exec` function is set:
+     *   - then this will be called instead of the `child_process.execFile`. Clients will **not** have access to the `stdin`.
+     *   - then the `USE_LOCAL_GIT` must be set to `"true"`. Otherwise, an error will be thrown.
+     *   - the all other properties defined by this option will be ignored except the `env` property.
+     */
+    readonly exec?: IGitExecutionOptions.ExecFunc;
+}
+
+export namespace IGitExecutionOptions {
+    export type ExecFunc = (args: string[], options: { cwd: string, stdin?: string }, callback: (error: Error | null, stdout: string, stderr: string) => void) => void;
+}
+
+/**
+ * The result of using `git`. This wraps dugite's results to provide
+ * the parsed error if one occurs.
+ */
+export interface IGitResult extends DugiteResult {
+    /**
+     * The parsed git error. This will be undefined when the exit code is include in
+     * the `successExitCodes`, or when dugite was unable to parse the
+     * error.
+     */
+    readonly gitError: DugiteError | undefined
+
+    /** The human-readable error description, from which `gitError` was determined. */
+    readonly gitErrorDescription: string | undefined
+}
+
+function getResultMessage(result: IGitResult): string {
+    const description = result.gitErrorDescription;
+    if (description) {
+        return description;
+    }
+
+    if (result.stderr.length) {
+        return result.stderr;
+    } else if (result.stdout.length) {
+        return result.stdout;
+    } else {
+        return 'Unknown error';
+    }
+}
+
+export class GitError extends Error {
+    /** The result from the failed command. */
+    public readonly result: IGitResult;
+
+    /** The args for the failed command. */
+    public readonly args: ReadonlyArray<string>;
+
+    public constructor(result: IGitResult, args: ReadonlyArray<string>) {
+        super(getResultMessage(result));
+
+        this.name = 'GitError';
+        this.result = result;
+        this.args = args;
+    }
+}
+
+function pathExists(path?: string): Boolean {
+    if (path === undefined) {
+        return false;
+    }
+    try {
+        fs.accessSync(path, (fs as any).F_OK);
+        return true;
+    } catch {
+        return false;
+    }
+}
+
+/**
+ * `path` is the `pwd` where the Git command gets executed.
+ */
+function gitExternal(args: string[], path: string, options: IGitExecutionOptions): Promise<DugiteResult> {
+    if (options.exec === undefined) {
+        throw new Error('options.exec must be defined.');
+    }
+    // XXX: this is just to keep the original code from here https://github.com/desktop/dugite/blob/master/lib/git-process.ts#L172-L227
+    const maxBuffer = options.maxBuffer ? options.maxBuffer : 10 * 1024 * 1024;
+    const { exec } = options;
+    return new Promise<DugiteResult>((resolve, reject) => {
+        let stdin: string | undefined = undefined;
+        if (options.stdin !== undefined) {
+            if (typeof options.stdin === 'string') {
+                stdin = options.stdin;
+            } else {
+                stdin = options.stdin.toString('utf8');
+            }
+        }
+        exec(args, { cwd: path, stdin }, (err: Error | null, stdout: string, stderr: string) => {
+            if (!err) {
+                resolve({ stdout, stderr, exitCode: 0 });
+                return;
+            }
+
+            const errWithCode = err as (Error & { code: number | string | undefined });
+
+            let code = errWithCode.code;
+
+            // If the error's code is a string then it means the code isn't the
+            // process's exit code but rather an error coming from Node's bowels,
+            // e.g., ENOENT.
+            if (typeof code === 'string') {
+                if (code === 'ENOENT') {
+                    let message = err.message;
+                    if (pathExists(process.env.LOCAL_GIT_DIRECTORY) === false) {
+                        message = 'Unable to find path to repository on disk.';
+                        code = RepositoryDoesNotExistErrorCode;
+                    } else {
+                        message = `Git could not be found at the expected path: '${process.env.LOCAL_GIT_DIRECTORY
+                            }'. This might be a problem with how the application is packaged, so confirm this folder hasn't been removed when packaging.`;
+                        code = GitNotFoundErrorCode;
+                    }
+
+                    const error = new Error(message) as (Error & { code: number | string | undefined });
+                    error.name = err.name;
+                    error.code = code;
+                    reject(error);
+                } else {
+                    reject(err);
+                }
+
+                return;
+            }
+
+            if (typeof code === 'number') {
+                resolve({ stdout, stderr, exitCode: code });
+                return;
+            }
+
+            // Git has returned an output that couldn't fit in the specified buffer
+            // as we don't know how many bytes it requires, rethrow the error with
+            // details about what it was previously set to...
+            if (err.message === 'stdout maxBuffer exceeded') {
+                reject(
+                    new Error(
+                        `The output from the command could not fit into the allocated stdout buffer. Set options.maxBuffer to a larger value than ${maxBuffer
+                        } bytes`
+                    )
+                );
+            } else {
+                reject(err);
+            }
+        });
+    });
+}
+
+/**
+ * Shell out to git with the given arguments, at the given path.
+ *
+ * @param {args}             The arguments to pass to `git`.
+ *
+ * @param {path}             The working directory path for the execution of the
+ *                           command.
+ *
+ * @param {name}             The name for the command based on its caller's
+ *                           context. This will be used for performance
+ *                           measurements and debugging.
+ *
+ * @param {options}          Configuration options for the execution of git,
+ *                           see IGitExecutionOptions for more information.
+ *
+ * Returns the result. If the command exits with a code not in
+ * `successExitCodes` or an error not in `expectedErrors`, a `GitError` will be
+ * thrown.
+ */
+export async function git(args: string[], path: string, name: string, options?: IGitExecutionOptions): Promise<IGitResult> {
+
+    if (
+        options
+        && options.exec
+        && (typeof process.env.LOCAL_GIT_PATH === 'undefined')) {
+        throw new Error('LOCAL_GIT_PATH must be specified when using an exec function.');
+    }
+
+    const defaultOptions: IGitExecutionOptions = {
+        successExitCodes: new Set([0]),
+        expectedErrors: new Set(),
+    };
+
+    const opts = { ...defaultOptions, ...options };
+    let result: DugiteResult;
+    if (options && options.exec) {
+        result = await gitExternal(args, path, options);
+    } else {
+        await initGitEnv();
+        await configureGitEnv();
+        result = await GitProcess.exec(args, path, options);
+    }
+
+    const exitCode = result.exitCode;
+
+    let gitError: DugiteError | undefined = undefined;
+    let gitErrorDescription: string | undefined = undefined;
+    const acceptableExitCode = opts.successExitCodes ? opts.successExitCodes.has(exitCode) : false;
+    if (!acceptableExitCode) {
+        gitError = GitProcess.parseError(result.stderr) || undefined;
+        if (gitError) {
+            gitErrorDescription = result.stderr;
+        } else {
+            gitError = GitProcess.parseError(result.stdout) || undefined;
+            if (gitError) {
+                gitErrorDescription = result.stdout;
+            }
+        }
+    }
+
+    const gitResult = { ...result, gitError, gitErrorDescription };
+
+    let acceptableError = true;
+    if (gitError && opts.expectedErrors) {
+        acceptableError = opts.expectedErrors.has(gitError);
+    }
+
+    if ((gitError && acceptableError) || acceptableExitCode) {
+        return gitResult;
+    }
+
+    console.error(`The command \`git ${args.join(' ')}\` exited with an unexpected code: ${exitCode}. The caller should either handle this error, or expect that exit code.`);
+    if (result.stdout.length) {
+        console.error(result.stdout);
+    }
+
+    if (result.stderr.length) {
+        console.error(result.stderr);
+    }
+
+    if (gitError) {
+        console.error(`(The error was parsed as ${gitError}: ${gitErrorDescription})`);
+    }
+
+    throw new GitError(gitResult, args);
+}
+
+async function initGitEnv(): Promise<void> {
+    if (process.env.USE_LOCAL_GIT === 'true' && !process.env.LOCAL_GIT_DIRECTORY && !process.env.GIT_EXEC_PATH && !__GIT_PATH__.searched) {
+        console.log("'USE_LOCAL_GIT' is set to true. Trying to use local Git for 'dugite' execution.");
+        try {
+            const gitInfo = await findGit();
+            if (gitInfo && gitInfo.path && gitInfo.execPath) {
+                // We need to traverse up two levels to get the expected Git directory.
+                // `dugite` expects the directory path instead of the executable path.
+                // https://github.com/desktop/dugite/issues/111
+                const gitDir = Path.dirname(Path.dirname(gitInfo.path));
+                if (fs.existsSync(gitDir) && fs.existsSync(gitInfo.execPath)) {
+                    __GIT_PATH__.gitDir = gitDir;
+                    __GIT_PATH__.gitExecPath = gitInfo.execPath;
+                    console.log(`Using external Git executable. Git path: ${gitInfo.path}. Git exec-path: ${gitInfo.execPath}. [Version: ${gitInfo.version}]`);
+                } else {
+                    throw new Error(`Cannot find local Git executable: ${gitInfo}.`);
+                }
+            }
+        } catch (error) {
+            console.error('Cannot find local Git executable.', error);
+            __GIT_PATH__.gitDir = undefined;
+            __GIT_PATH__.gitExecPath = undefined;
+        } finally {
+            __GIT_PATH__.searched = true;
+        }
+    }
+}
+
+async function configureGitEnv(): Promise<void> {
+    if (process.env.USE_LOCAL_GIT === 'true'
+        && !process.env.LOCAL_GIT_DIRECTORY
+        && !process.env.GIT_EXEC_PATH
+        && __GIT_PATH__.searched
+        && __GIT_PATH__.gitDir
+        && __GIT_PATH__.gitExecPath) {
+
+        process.env.LOCAL_GIT_DIRECTORY = __GIT_PATH__.gitDir;
+        process.env.GIT_EXEC_PATH = __GIT_PATH__.gitExecPath;
+    }
+}

--- a/packages/scm/src/browser/scm-tree-widget.tsx
+++ b/packages/scm/src/browser/scm-tree-widget.tsx
@@ -137,7 +137,19 @@ export class ScmTreeWidget extends TreeWidget {
                 (node.parent && ScmFileChangeFolderNode.is(node.parent))
                     ? new URI(node.parent.sourceUri) : new URI(this.model.rootUri);
 
-            const content = <ScmResourceComponent
+            const groupId = ScmFileChangeNode.getGroupId(node);
+            const fragment = (groupId === 'index' || groupId === 'workingTree') ? groupId : undefined;
+
+            let decorations: Decoration[] = [];
+            if (fragment) {
+                decorations = this.decorationsService.getDecoration(new URI(node.sourceUri).withFragment(fragment), true);
+            }
+            if (decorations.length === 0) {
+                decorations = this.decorationsService.getDecoration(new URI(node.sourceUri), true);
+            }
+
+            const content = (
+              <ScmResourceComponent
                 key={node.sourceUri}
                 model={this.model}
                 treeNode={node}
@@ -152,11 +164,12 @@ export class ScmTreeWidget extends TreeWidget {
                     ...this.props,
                     parentPath,
                     sourceUri: node.sourceUri,
-                    decoration: this.decorationsService.getDecoration(new URI(node.sourceUri), true)[0],
+                    decoration: decorations[0],
                     colors: this.colors,
                     renderExpansionToggle: () => this.renderExpansionToggle(node, props),
                 }}
-            />;
+              />
+            );
             return React.createElement('div', attributes, content);
         }
         return super.renderNode(node, props);

--- a/yarn.lock
+++ b/yarn.lock
@@ -4895,16 +4895,6 @@ drivelist@^9.0.2:
     nan "^2.14.0"
     prebuild-install "^5.2.4"
 
-dugite-extra@0.1.15:
-  version "0.1.15"
-  resolved "https://registry.yarnpkg.com/dugite-extra/-/dugite-extra-0.1.15.tgz#322406b628ea5515c5c6fcd65e4d040543d6268a"
-  integrity sha512-beLmQcIXLA8aXqWQZF/ooECoZvYKpBywIFwgqAoYnV04NdWUXDtZ6mMcjQf5eAz5PjXGXAYSuQ31zkPL8J85+A==
-  dependencies:
-    byline "^5.0.0"
-    dugite-no-gpl "1.69.0"
-    find-git-exec "^0.0.4"
-    upath "^2.0.1"
-
 dugite-no-gpl@1.69.0:
   version "1.69.0"
   resolved "https://registry.yarnpkg.com/dugite-no-gpl/-/dugite-no-gpl-1.69.0.tgz#bc9007cf5a595180f563ccc0e4f2cc80ebbaa52e"


### PR DESCRIPTION
#### What it does

Fixes https://github.com/eclipse-theia/theia/issues/7789

Fixes issues with the the Source Control view.
- The list of staged and unstaged files are incorrect
- The status indicators are incorrect

I have attached here four different screen-shots of the same working tree and index.  The following actions were taken:
- FileA was created, staged, then modified
- FileB was created, staged, then deleted
- git-diff-contribution.ts was renamed to git-diff-contributionA.ts, staged, then modified

This is what we see with this PR:

![Screenshot from 2020-07-22 15-44-37](https://user-images.githubusercontent.com/87310/88191409-5209e500-cc33-11ea-9fd8-ef70c26a4ed6.png)

This is what we see in current Theia master.  FileB is missing altogether which is not correct because if the user were to commit then FileB would be committed.  FileA shows as Untracked in the working tree which is incorrect because the file has been staged and the user would expect to be able to see the changes in the file which have not been staged.  git-diff-contributionA.ts shows as a Rename in both groups but it should show as Modified in the unstaged section because it was not renamed again, just modified.

![Screenshot from 2020-07-22 15-58-12](https://user-images.githubusercontent.com/87310/88192085-0a378d80-cc34-11ea-909b-0286eff58c36.png)

This is what we see in VS-Code.  This is not correct.

![Screenshot from 2020-07-22 16-01-25](https://user-images.githubusercontent.com/87310/88192471-731f0580-cc34-11ea-8a47-e55d0f7ad4cc.png)

This is what we see in the git-gui tool (staged and unstaged sections are reversed).  This matches what we see with this PR except that the rename is shown as an add and a delete.  Selecting either of the two modified files in the unstaged changes will show the changes between the working tree and the index.

![Screenshot from 2020-07-22 15-55-19](https://user-images.githubusercontent.com/87310/88191709-a319d900-cc33-11ea-849c-faa1cd6f2cfa.png)

You will notice that this code calls dugite, not dugite-extra, for the status.  This change was made because the status function in dugite-extra has been written to support a simplified UI in which there is no Staged or Unstaged section shown but just a single list of files that can be checked (to include in the commit) or unchecked (to exclude from the commit).  This UI is used, for example, by Github Desktop.  Clients that show separate staged and unstaged sections should use the status as returned by git status.

The initial code to check the git version was copied from dugite-extra.  We could change dugite-extra to expose that code so it is not duplicated.  I don't know about the other clients of dugite-extra so I have not done that.
 
You will notice some of the diffs do not open.  For example if you rename a file and make a change, then stage it.  Selecting the file in the staged section, one would expect to see a diff with the change.  The problem is caused because GitScmProvider.getUriToOpen is not using the old uri for the HEAD uri.  This is changed by https://github.com/eclipse-theia/theia/pull/8084 so will be fixed when that is merged.

#### How to test

The three cases above are not exhaustive.  There are numerous combinations of Rename, Copy, Add, Modify, and Delete that can be in the staged and unstaged sections.  Ideally all these combinations should be tested.

#### Review checklist

- [x ] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

