### PR TITLE
[SIW]: Run search on input change

### DIFF
--- a/packages/search-in-workspace/src/browser/search-in-workspace-widget.tsx
+++ b/packages/search-in-workspace/src/browser/search-in-workspace-widget.tsx
@@ -361,10 +361,13 @@ export class SearchInWorkspaceWidget extends BaseWidget implements StatefulWidge
     protected readonly search = (e: React.KeyboardEvent) => this.doSearch(e);
     protected doSearch(e: React.KeyboardEvent): void {
         if (e.target) {
+            const searchValue = (e.target as HTMLInputElement).value;
             if (Key.ARROW_DOWN.keyCode === e.keyCode) {
                 this.resultTreeWidget.focusFirstResult();
+            } else if (this.searchTerm === searchValue && Key.ENTER.keyCode !== e.keyCode) {
+                return;
             } else {
-                this.searchTerm = (e.target as HTMLInputElement).value;
+                this.searchTerm = searchValue;
                 this.resultTreeWidget.search(this.searchTerm, (this.searchInWorkspaceOptions || {}));
             }
         }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
Fixes: https://github.com/eclipse-theia/theia/issues/7346

Runs a search query only when there is a change in the input field

![SIW](https://user-images.githubusercontent.com/43870550/88311496-f39a4080-ccde-11ea-86fe-991e92c701cc.gif)

Signed-off-by: Anas Shahid <muhammad.shahid@ericsson.com>


#### How to test
1. Search for a string in the workspace
2. Press left or right arrow key to see if the search is re-running
3. Try to toggle search options (like match case) to see if the search is successfully running again
4. Press `ENTER` without changing the input, it should trigger a search. 

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

