### PR TITLE
Exposed `preserveFocus` on `OutputChannel#show`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Change Log
 
+## v1.5.0
+
+<a name="breaking_changes_1.5.0">[Breaking Changes:](#breaking_changes_1.5.0)</a>
+
+- [output] `OutputWidget#setInput` has been removed. The _Output_ view automatically shows the channel when calling `OutputChannel#show`. Moved the `OutputCommands` namespace from the `output-contribution` to its dedicated `output-commands` module to overcome a DI cycle. [#8243](https://github.com/eclipse-theia/theia/pull/8243)
+
+
 ## v1.4.0
 
 - [core] added support for Node.js `12.x` [#7968](https://github.com/eclipse-theia/theia/pull/7968)

--- a/packages/output/src/browser/output-commands.ts
+++ b/packages/output/src/browser/output-commands.ts
@@ -1,0 +1,98 @@
+/********************************************************************************
+ * Copyright (C) 2020 TypeFox and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import { Command } from '@theia/core/lib/common';
+
+export namespace OutputCommands {
+
+    const OUTPUT_CATEGORY = 'Output';
+
+    /* #region VS Code `OutputChannel` API */
+    // Based on: https://github.com/theia-ide/vscode/blob/standalone/0.19.x/src/vs/vscode.d.ts#L4692-L4745
+
+    export const APPEND: Command = {
+        id: 'output:append'
+    };
+
+    export const APPEND_LINE: Command = {
+        id: 'output:appendLine'
+    };
+
+    export const CLEAR: Command = {
+        id: 'output:clear'
+    };
+
+    export const SHOW: Command = {
+        id: 'output:show'
+    };
+
+    export const HIDE: Command = {
+        id: 'output:hide'
+    };
+
+    export const DISPOSE: Command = {
+        id: 'output:dispose'
+    };
+
+    /* #endregion VS Code `OutputChannel` API */
+
+    export const CLEAR__WIDGET: Command = {
+        id: 'output:widget:clear',
+        category: OUTPUT_CATEGORY,
+        iconClass: 'clear-all'
+    };
+
+    export const LOCK__WIDGET: Command = {
+        id: 'output:widget:lock',
+        category: OUTPUT_CATEGORY,
+        iconClass: 'fa fa-unlock'
+    };
+
+    export const UNLOCK__WIDGET: Command = {
+        id: 'output:widget:unlock',
+        category: OUTPUT_CATEGORY,
+        iconClass: 'fa fa-lock'
+    };
+
+    export const CLEAR__QUICK_PICK: Command = {
+        id: 'output:pick-clear',
+        label: 'Clear Output Channel...',
+        category: OUTPUT_CATEGORY
+    };
+
+    export const SHOW__QUICK_PICK: Command = {
+        id: 'output:pick-show',
+        label: 'Show Output Channel...',
+        category: OUTPUT_CATEGORY
+    };
+
+    export const HIDE__QUICK_PICK: Command = {
+        id: 'output:pick-hide',
+        label: 'Hide Output Channel...',
+        category: OUTPUT_CATEGORY
+    };
+
+    export const DISPOSE__QUICK_PICK: Command = {
+        id: 'output:pick-dispose',
+        label: 'Close Output Channel...',
+        category: OUTPUT_CATEGORY
+    };
+
+    export const COPY_ALL: Command = {
+        id: 'output:copy-all',
+    };
+
+}

--- a/packages/output/src/browser/output-toolbar-contribution.tsx
+++ b/packages/output/src/browser/output-toolbar-contribution.tsx
@@ -19,7 +19,8 @@ import { inject, injectable, postConstruct } from 'inversify';
 import { Emitter } from '@theia/core/lib/common/event';
 import { TabBarToolbarContribution, TabBarToolbarRegistry } from '@theia/core/lib/browser/shell/tab-bar-toolbar';
 import { OutputWidget } from './output-widget';
-import { OutputCommands, OutputContribution } from './output-contribution';
+import { OutputCommands } from './output-commands';
+import { OutputContribution } from './output-contribution';
 import { OutputChannelManager } from '../common/output-channel';
 
 @injectable()
@@ -103,7 +104,7 @@ export class OutputToolbarContribution implements TabBarToolbarContribution {
     protected changeChannel = (event: React.ChangeEvent<HTMLSelectElement>) => {
         const channelName = event.target.value;
         if (channelName !== this.NONE) {
-            this.outputChannelManager.selectedChannel = this.outputChannelManager.getChannel(channelName);
+            this.outputChannelManager.getChannel(channelName).show();
         }
     };
 }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

 - Exposed `preserveFocus` on `OutputChannel#show`. From now on, calling `show` with `preserveFocus` `true` will ensure that the Output widget is revealed but not activated. The default behavior remains `preserveFocus` `false` which will reveal and activate the widget.
 - Removed `OutputWidget#setInput`; it is automatically wired into `show`.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

 - Reset the workbench layout.
 - Run `Show channel (command, explicit, preserve-focus)` -> Output view is revealed but not active.
 - Reset the workbench layout.
 - Run `Show channel (API, explicit, preserve-focus)` -> Output view is revealed but not active.
 - Run `Hide Output Channel...`, select the `API Sample: my test channel` ->  The Output is active but the input is **not** the `API Sample: my test channel`.
 - Run `Show Output Channel...`, select the `API Sample: my test channel` ->  The Output is active and the input is the `API Sample: my test channel`.

 - Reset the workbench layout.
 - Run `Show channel (command, implicit, no preserve-focus)` -> Output is active.
 - Reset the workbench layout.
 - Run `Show channel (command, explicit, no preserve focus)` -> Output is active.
 - Reset the workbench layout.
 - Run `Show channel (API, implicit, no preserve-focus)` -> Output is active.
 - Reset the workbench layout.
 - Run `Show channel (API, explicit, no preserve-focus)` -> Output is active.

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

