### PR TITLE
Add collapse-all command for SCM tree mode

### DIFF
--- a/packages/scm/src/browser/scm-contribution.ts
+++ b/packages/scm/src/browser/scm-contribution.ts
@@ -67,6 +67,13 @@ export namespace SCM_COMMANDS {
         iconClass: 'codicon codicon-list-flat',
         label: 'Toggle to List View',
     };
+    export const COLLAPSE_ALL = {
+        id: 'scm.collapseAll',
+        category: 'SCM',
+        tooltip: 'Collapse All',
+        iconClass: 'codicon codicon-collapse-all',
+        label: 'Collapse All',
+    };
 }
 
 export namespace ScmColors {
@@ -181,6 +188,27 @@ export class ScmContribution extends AbstractViewContribution<ScmWidget> impleme
         };
         registerToggleViewItem(SCM_COMMANDS.TREE_VIEW_MODE, 'tree');
         registerToggleViewItem(SCM_COMMANDS.LIST_VIEW_MODE, 'list');
+
+        this.commandRegistry.registerCommand(SCM_COMMANDS.COLLAPSE_ALL, {
+            execute: widget => {
+                const scmWidget = extractScmWidget(widget);
+                if (scmWidget && scmWidget.viewMode === 'tree') {
+                    scmWidget.collapseScmTree();
+                }
+            },
+            isVisible: widget => {
+                const scmWidget = extractScmWidget(widget);
+                if (scmWidget) {
+                    return !!this.scmService.selectedRepository && scmWidget.viewMode === 'tree';
+                }
+                return false;
+            }
+        });
+
+        registry.registerItem({
+            ...SCM_COMMANDS.COLLAPSE_ALL,
+            command: SCM_COMMANDS.COLLAPSE_ALL.id
+        });
     }
 
     registerKeybindings(keybindings: KeybindingRegistry): void {

--- a/packages/scm/src/browser/scm-widget.tsx
+++ b/packages/scm/src/browser/scm-widget.tsx
@@ -20,7 +20,7 @@ import { Message } from '@phosphor/messaging';
 import { injectable, inject, postConstruct } from 'inversify';
 import { DisposableCollection } from '@theia/core/lib/common/disposable';
 import {
-    BaseWidget, Widget, StatefulWidget, Panel, PanelLayout, MessageLoop, PreferenceChangeEvent
+    BaseWidget, Widget, StatefulWidget, Panel, PanelLayout, MessageLoop, PreferenceChangeEvent, CompositeTreeNode, SelectableTreeNode,
 } from '@theia/core/lib/browser';
 import { ScmCommitWidget } from './scm-commit-widget';
 import { ScmAmendWidget } from './scm-amend-widget';
@@ -171,4 +171,22 @@ export class ScmWidget extends BaseWidget implements StatefulWidget {
         this.resourceWidget.restoreState(changesTreeState);
     }
 
+    collapseScmTree(): void {
+        const { model } = this.resourceWidget;
+        const root = model.root;
+        if (CompositeTreeNode.is(root)) {
+            root.children.map(group => {
+                if (CompositeTreeNode.is(group)) {
+                    group.children.map(folderNode => {
+                        if (CompositeTreeNode.is(folderNode)) {
+                            model.collapseAll(folderNode);
+                        }
+                        if (SelectableTreeNode.isSelected(folderNode)) {
+                            model.toggleNode(folderNode);
+                        }
+                    });
+                }
+            });
+        }
+    }
 }


### PR DESCRIPTION
#### What it does
Fix: #8124

The following pull-request introduces a **collapse-all** toolbar item and command for the `SCM` when the `view-mode` is set to `tree`.

| Tree Mode | List Mode |
|:---:|:---:|
|  <img width="628" alt="Screen Shot 2020-07-27 at 8 35 56 PM" src="https://user-images.githubusercontent.com/40359487/88605991-7c034300-d049-11ea-8d36-36a8c0a1409e.png"> | <img width="628" alt="Screen Shot 2020-07-27 at 8 38 05 PM" src="https://user-images.githubusercontent.com/40359487/88606005-832a5100-d049-11ea-8738-b751f36a889c.png"> |


#### How to test

1. start the application, make changes to the workspace and open the 'scm' view
2. using the toolbar item to change the view mode, verify that:
    - `list`: the collapse-all item is not visible, and the command is not available using <kbd>F1</kbd> > `SCM: Collapse All`
    - `tree`: the collapse-all item is visible, the command is available
3. verify that the `collapse-all` command successfully collapses the nodes of the tree

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

Signed-off-by: Kaiyue Pan <kaiyuepan@gmail.com>