### PR TITLE
Allow "Command" type in status bar items

### DIFF
--- a/packages/debug/src/common/debug-model.ts
+++ b/packages/debug/src/common/debug-model.ts
@@ -163,9 +163,17 @@ export interface DebugAdapterContribution {
 
     /**
      * Resolves a [debug configuration](#DebugConfiguration) by filling in missing values
-     * or by adding/changing/removing attributes.
+     * or by adding/changing/removing attributes before variable substitution.
      * @param config The [debug configuration](#DebugConfiguration) to resolve.
      * @returns The resolved debug configuration.
      */
     resolveDebugConfiguration?(config: DebugConfiguration, workspaceFolderUri?: string): MaybePromise<DebugConfiguration | undefined>;
+
+    /**
+     * Resolves a [debug configuration](#DebugConfiguration) by filling in missing values
+     * or by adding/changing/removing attributes with substituted variables.
+     * @param config The [debug configuration](#DebugConfiguration) to resolve.
+     * @returns The resolved debug configuration.
+     */
+    resolveDebugConfigurationWithSubstitutedVariables?(config: DebugConfiguration, workspaceFolderUri?: string): MaybePromise<DebugConfiguration | undefined>;
 }

--- a/packages/debug/src/common/debug-service.ts
+++ b/packages/debug/src/common/debug-service.ts
@@ -72,11 +72,19 @@ export interface DebugService extends Disposable {
 
     /**
      * Resolves a [debug configuration](#DebugConfiguration) by filling in missing values
-     * or by adding/changing/removing attributes.
+     * or by adding/changing/removing attributes before variable substitution.
      * @param debugConfiguration The [debug configuration](#DebugConfiguration) to resolve.
      * @returns The resolved debug configuration.
      */
     resolveDebugConfiguration(config: DebugConfiguration, workspaceFolderUri: string | undefined): Promise<DebugConfiguration>;
+
+    /**
+     * Resolves a [debug configuration](#DebugConfiguration) by filling in missing values
+     * or by adding/changing/removing attributes with substituted variables.
+     * @param debugConfiguration The [debug configuration](#DebugConfiguration) to resolve.
+     * @returns The resolved debug configuration.
+     */
+    resolveDebugConfigurationWithSubstitutedVariables(config: DebugConfiguration, workspaceFolderUri: string | undefined): Promise<DebugConfiguration>;
 
     /**
      * Creates a new [debug adapter session](#DebugAdapterSession).

--- a/packages/debug/src/node/debug-adapter-contribution-registry.ts
+++ b/packages/debug/src/node/debug-adapter-contribution-registry.ts
@@ -92,7 +92,7 @@ export class DebugAdapterContributionRegistry {
 
     /**
      * Resolves a [debug configuration](#DebugConfiguration) by filling in missing values
-     * or by adding/changing/removing attributes.
+     * or by adding/changing/removing attributes before variable substitution.
      * @param debugConfiguration The [debug configuration](#DebugConfiguration) to resolve.
      * @returns The resolved debug configuration.
      */
@@ -102,6 +102,31 @@ export class DebugAdapterContributionRegistry {
             if (contribution.resolveDebugConfiguration) {
                 try {
                     const next = await contribution.resolveDebugConfiguration(config, workspaceFolderUri);
+                    if (next) {
+                        current = next;
+                    } else {
+                        return current;
+                    }
+                } catch (e) {
+                    console.error(e);
+                }
+            }
+        }
+        return current;
+    }
+
+    /**
+     * Resolves a [debug configuration](#DebugConfiguration) by filling in missing values
+     * or by adding/changing/removing attributes with substituted variables.
+     * @param debugConfiguration The [debug configuration](#DebugConfiguration) to resolve.
+     * @returns The resolved debug configuration.
+     */
+    async resolveDebugConfigurationWithSubstitutedVariables(config: DebugConfiguration, workspaceFolderUri?: string): Promise<DebugConfiguration> {
+        let current = config;
+        for (const contribution of this.getContributions(config.type)) {
+            if (contribution.resolveDebugConfigurationWithSubstitutedVariables) {
+                try {
+                    const next = await contribution.resolveDebugConfigurationWithSubstitutedVariables(config, workspaceFolderUri);
                     if (next) {
                         current = next;
                     } else {

--- a/packages/debug/src/node/debug-service-impl.ts
+++ b/packages/debug/src/node/debug-service-impl.ts
@@ -60,6 +60,9 @@ export class DebugServiceImpl implements DebugService {
     async resolveDebugConfiguration(config: DebugConfiguration, workspaceFolderUri?: string): Promise<DebugConfiguration> {
         return this.registry.resolveDebugConfiguration(config, workspaceFolderUri);
     }
+    async resolveDebugConfigurationWithSubstitutedVariables(config: DebugConfiguration, workspaceFolderUri?: string): Promise<DebugConfiguration> {
+        return this.registry.resolveDebugConfigurationWithSubstitutedVariables(config, workspaceFolderUri);
+    }
 
     protected readonly sessions = new Set<string>();
     async createDebugSession(config: DebugConfiguration): Promise<string> {

--- a/packages/plugin-ext/src/common/plugin-api-rpc.ts
+++ b/packages/plugin-ext/src/common/plugin-api-rpc.ts
@@ -361,8 +361,8 @@ export interface StatusBarMessageRegistryMain {
         alignment: theia.StatusBarAlignment,
         color: string | undefined,
         tooltip: string | undefined,
-        command: string | undefined): PromiseLike<void>;
-    $update(id: string, message: string): void;
+        command: string | undefined,
+        args: any[] | undefined): PromiseLike<void>;
     $dispose(id: string): void;
 }
 

--- a/packages/plugin-ext/src/common/plugin-api-rpc.ts
+++ b/packages/plugin-ext/src/common/plugin-api-rpc.ts
@@ -1366,6 +1366,8 @@ export interface DebugExt {
     $sessionDidChange(sessionId: string | undefined): void;
     $provideDebugConfigurations(debugType: string, workspaceFolder: string | undefined): Promise<theia.DebugConfiguration[]>;
     $resolveDebugConfigurations(debugConfiguration: theia.DebugConfiguration, workspaceFolder: string | undefined): Promise<theia.DebugConfiguration | undefined>;
+    $resolveDebugConfigurationWithSubstitutedVariables(debugConfiguration: theia.DebugConfiguration, workspaceFolder: string | undefined):
+        Promise<theia.DebugConfiguration | undefined>;
     $createDebugSession(debugConfiguration: theia.DebugConfiguration): Promise<string>;
     $terminateDebugSession(sessionId: string): Promise<void>;
     $getTerminalCreationOptions(debugType: string): Promise<TerminalOptionsExt | undefined>;

--- a/packages/plugin-ext/src/main/browser/debug/plugin-debug-adapter-contribution.ts
+++ b/packages/plugin-ext/src/main/browser/debug/plugin-debug-adapter-contribution.ts
@@ -45,6 +45,10 @@ export class PluginDebugAdapterContribution {
         return this.debugExt.$resolveDebugConfigurations(config, workspaceFolderUri);
     }
 
+    async resolveDebugConfigurationWithSubstitutedVariables(config: DebugConfiguration, workspaceFolderUri: string | undefined): Promise<DebugConfiguration | undefined> {
+        return this.debugExt.$resolveDebugConfigurationWithSubstitutedVariables(config, workspaceFolderUri);
+    }
+
     async createDebugSession(config: DebugConfiguration): Promise<string> {
         await this.pluginService.activateByDebug('onDebugAdapterProtocolTracker', config.type);
         return this.debugExt.$createDebugSession(config);

--- a/packages/plugin-ext/src/main/browser/debug/plugin-debug-service.ts
+++ b/packages/plugin-ext/src/main/browser/debug/plugin-debug-service.ts
@@ -132,6 +132,28 @@ export class PluginDebugService implements DebugService, PluginDebugAdapterContr
         return this.delegated.resolveDebugConfiguration(resolved, workspaceFolderUri);
     }
 
+    async resolveDebugConfigurationWithSubstitutedVariables(config: DebugConfiguration, workspaceFolderUri: string | undefined): Promise<DebugConfiguration> {
+        let resolved = config;
+
+        // we should iterate over all to handle configuration providers for `*`
+        for (const contributor of this.contributors.values()) {
+            if (contributor) {
+                try {
+                    const next = await contributor.resolveDebugConfigurationWithSubstitutedVariables(resolved, workspaceFolderUri);
+                    if (next) {
+                        resolved = next;
+                    } else {
+                        return resolved;
+                    }
+                } catch (e) {
+                    console.error(e);
+                }
+            }
+        }
+
+        return this.delegated.resolveDebugConfigurationWithSubstitutedVariables(resolved, workspaceFolderUri);
+    }
+
     registerDebugger(contribution: DebuggerContribution): Disposable {
         this.debuggers.push(contribution);
         return Disposable.create(() => {

--- a/packages/plugin-ext/src/main/browser/status-bar-message-registry-main.ts
+++ b/packages/plugin-ext/src/main/browser/status-bar-message-registry-main.ts
@@ -44,14 +44,17 @@ export class StatusBarMessageRegistryMainImpl implements StatusBarMessageRegistr
         alignment: number,
         color: string | undefined,
         tooltip: string | undefined,
-        command: string | undefined): Promise<void> {
+        command: string | undefined,
+         // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        args: any[] | undefined): Promise<void> {
         const entry = {
             text: text || '',
             priority,
             alignment: alignment === types.StatusBarAlignment.Left ? StatusBarAlignment.LEFT : StatusBarAlignment.RIGHT,
             color: color && (this.colorRegistry.getCurrentColor(color) || color),
             tooltip,
-            command
+            command,
+            args
         };
 
         this.entries.set(id, entry);
@@ -60,14 +63,6 @@ export class StatusBarMessageRegistryMainImpl implements StatusBarMessageRegistr
             this.$dispose(id);
         } else {
             this.toDispose.push(Disposable.create(() => this.$dispose(id)));
-        }
-    }
-
-    $update(id: string, message: string): void {
-        const entry = this.entries.get(id);
-        if (entry) {
-            entry.text = message;
-            this.delegate.setElement(id, entry);
         }
     }
 

--- a/packages/plugin-ext/src/plugin/status-bar/status-bar-item.ts
+++ b/packages/plugin-ext/src/plugin/status-bar/status-bar-item.ts
@@ -28,7 +28,7 @@ export class StatusBarItemImpl implements theia.StatusBarItem {
     private _text: string;
     private _tooltip: string;
     private _color: string | ThemeColor;
-    private _command: string;
+    private _command: string | theia.Command;
 
     private _isVisible: boolean;
     private _timeoutHandle: NodeJS.Timer | undefined;
@@ -63,7 +63,7 @@ export class StatusBarItemImpl implements theia.StatusBarItem {
         return this._color;
     }
 
-    public get command(): string {
+    public get command(): string | theia.Command {
         return this._command;
     }
 
@@ -82,7 +82,7 @@ export class StatusBarItemImpl implements theia.StatusBarItem {
         this.update();
     }
 
-    public set command(command: string) {
+    public set command(command: string | theia.Command) {
         this._command = command;
         this.update();
     }
@@ -111,13 +111,16 @@ export class StatusBarItemImpl implements theia.StatusBarItem {
         this._timeoutHandle = setTimeout(() => {
             this._timeoutHandle = undefined;
 
+            const commandId = typeof this.command === 'object' ? this.command.command : this.command;
+            const args = typeof this.command === 'object' ? this.command.arguments : undefined;
             // Set to status bar
             this._proxy.$setMessage(this.id, this.text,
                 this.priority,
                 this.alignment,
                 typeof this.color === 'string' ? this.color : this.color && this.color.id,
                 this.tooltip,
-                this.command);
+                commandId,
+                args);
         }, 0);
     }
 

--- a/packages/plugin/src/theia.d.ts
+++ b/packages/plugin/src/theia.d.ts
@@ -8183,6 +8183,21 @@ declare module '@theia/plugin' {
          * @return The resolved debug configuration or undefined or null.
          */
         resolveDebugConfiguration?(folder: WorkspaceFolder | undefined, debugConfiguration: DebugConfiguration, token?: CancellationToken): ProviderResult<DebugConfiguration>;
+
+		/**
+		 * This hook is directly called after 'resolveDebugConfiguration' but with all variables substituted.
+		 * It can be used to resolve or verify a [debug configuration](#DebugConfiguration) by filling in missing values or by adding/changing/removing attributes.
+		 * If more than one debug configuration provider is registered for the same type, the 'resolveDebugConfigurationWithSubstitutedVariables' calls are chained
+		 * in arbitrary order and the initial debug configuration is piped through the chain.
+		 * Returning the value 'undefined' prevents the debug session from starting.
+		 * Returning the value 'null' prevents the debug session from starting and opens the underlying debug configuration instead.
+		 *
+		 * @param folder The workspace folder from which the configuration originates from or `undefined` for a folderless setup.
+		 * @param debugConfiguration The [debug configuration](#DebugConfiguration) to resolve.
+		 * @param token A cancellation token.
+		 * @return The resolved debug configuration or undefined or null.
+		 */
+        resolveDebugConfigurationWithSubstitutedVariables?(folder: WorkspaceFolder | undefined, debugConfiguration: DebugConfiguration, token?: CancellationToken): ProviderResult<DebugConfiguration>;
     }
 
     /**

--- a/packages/plugin/src/theia.d.ts
+++ b/packages/plugin/src/theia.d.ts
@@ -2366,7 +2366,7 @@ declare module '@theia/plugin' {
         /**
          * The identifier of a command to run on click.
          */
-        command: string | undefined;
+        command: string | Command | undefined;
 
         /**
          * Shows the entry in the status bar.


### PR DESCRIPTION
Signed-off-by: Thomas Mäder <tmader@redhat.com>

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
Aligns the type of `StatusBarItem.command` with the current state of the VS Code API.
fix #8241: Support `Command` Type for StatusBarItem.command

#### How to test
1. Install VS Code Java, VS Code Java debug and VS Code Java Test runner plugins. 
2. Open a test program that contains unit tests, for example https://github.com/che-samples/console-java-simple
3. In the test runner view, run a test
4. Observe: there is a status bar item the first says "running tests" and then gives the number of run and failed tests.
5. Click on the status bar item
6. Observe: the test run report opens in an editor.


#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

