### PR TITLE
[keybinding] Duplicate keybinding for opening the preferences widget and deleting file on navigator

### DIFF
--- a/packages/navigator/src/browser/navigator-contribution.ts
+++ b/packages/navigator/src/browser/navigator-contribution.ts
@@ -442,16 +442,9 @@ export class FileNavigatorContribution extends AbstractViewContribution<FileNavi
 
         registry.registerKeybinding({
             command: WorkspaceCommands.FILE_DELETE.id,
-            keybinding: 'del',
+            keybinding: isOSX ? 'cmd+backspace' : 'del',
             context: NavigatorKeybindingContexts.navigatorActive
         });
-        if (isOSX) {
-            registry.registerKeybinding({
-                command: WorkspaceCommands.FILE_DELETE.id,
-                keybinding: 'cmd+backspace',
-                context: NavigatorKeybindingContexts.navigatorActive
-            });
-        }
 
         registry.registerKeybinding({
             command: WorkspaceCommands.FILE_RENAME.id,

--- a/packages/preferences/src/browser/preferences-contribution.ts
+++ b/packages/preferences/src/browser/preferences-contribution.ts
@@ -130,16 +130,9 @@ export class PreferencesContribution extends AbstractViewContribution<Preference
     }
 
     registerKeybindings(keybindings: KeybindingRegistry): void {
-        if (isOSX && !isFirefox) {
-            keybindings.registerKeybinding({
-                command: CommonCommands.OPEN_PREFERENCES.id,
-                keybinding: 'cmd+,'
-            });
-        }
-
         keybindings.registerKeybinding({
             command: CommonCommands.OPEN_PREFERENCES.id,
-            keybinding: 'ctrl+,',
+            keybinding: (isOSX && !isFirefox) ? 'cmd+,' : 'ctrl+,'
         });
     }
 


### PR DESCRIPTION

Fixes #8202 
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->
* Made keybindings not duplicated for opening the preferences widget and deleting file on navigator on MacOS

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
* Open preference widget by pressing 'ctrl+,' on Windows
* Delete files on navigator by pressing 'del' on Windows

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

Signed-off-by: Min-young Yang <didalsdud@gmail.com>