### PR TITLE
[preferences]: Input field validation for numerical inputs

### DIFF
--- a/packages/preferences/src/browser/style/index.css
+++ b/packages/preferences/src/browser/style/index.css
@@ -295,8 +295,36 @@
     border: 1px solid var(--theia-dropdown-border);
 }
 
-.theia-settings-container .theia-input[type="checkbox"]:focus {
+.theia-settings-container .theia-input[type="checkbox"]:focus, 
+.theia-settings-container .theia-input[type="number"]:focus {
     outline-width: 2px;
+}
+
+/* Remove the spinners from input[type = number] on Firefox. */
+.theia-settings-container .theia-input[type="number"] {
+    -webkit-appearance: textfield;
+    border: 1px solid var(--theia-dropdown-border);
+}
+
+/* Remove the webkit spinners from input[type = number] on all browsers except Firefox. */
+.theia-settings-container input::-webkit-outer-spin-button,
+.theia-settings-container input::-webkit-inner-spin-button {
+  -webkit-appearance: none;
+  margin: 0;
+}
+
+.theia-settings-container .pref-content-container .pref-input .pref-input-container .pref-error-notification {
+    border-style: solid;
+    border-color: var(--theia-inputValidation-errorBorder);
+    background-color: var(--theia-inputValidation-errorBackground);
+    width: 100%;
+    box-sizing: border-box;
+    padding: var(--theia-ui-padding);
+}
+
+.theia-settings-container .pref-content-container .pref-input .pref-input-container {
+    display: flex;
+    flex-direction: column;
 }
 
 .theia-settings-container .pref-content-container a.theia-json-input {

--- a/packages/preferences/src/browser/views/components/preference-number-input.tsx
+++ b/packages/preferences/src/browser/views/components/preference-number-input.tsx
@@ -31,27 +31,63 @@ export const PreferenceNumberInput: React.FC<PreferenceNumberInputProps> = ({ pr
 
     const [currentTimeout, setCurrentTimetout] = React.useState<number>(0);
     const [currentValue, setCurrentValue] = React.useState<string>(externalValue);
+    const [validationMessage, setValidationMessage] = React.useState<string>('');
 
     React.useEffect(() => {
         setCurrentValue(externalValue);
     }, [externalValue]);
 
+    const onBlur = React.useCallback(() => {
+        setCurrentValue(externalValue);
+        setValidationMessage('');
+    }, [externalValue]);
+
     const onChange = React.useCallback(e => {
-        const { value: newValue } = e.target;
         clearTimeout(currentTimeout);
-        const newTimeout = setTimeout(() => setPreference(id, Number(newValue)), 750);
-        setCurrentTimetout(Number(newTimeout));
+        const { value: newValue } = e.target;
         setCurrentValue(newValue);
+        const preferenceValue: number = Number(newValue);
+        const { isValid, message } = getInputValidation(preferenceValue);
+        setValidationMessage(message);
+        if (isValid) {
+            const newTimeout = setTimeout(() => setPreference(id, preferenceValue), 750);
+            setCurrentTimetout(Number(newTimeout));
+        }
     }, [currentTimeout]);
 
+    /**
+     * Validates the input.
+     * @param input the input value.
+     */
+    const getInputValidation = (input: number | undefined): { isValid: boolean, message: string } => {
+        const errorMessages: string[] = [];
+        if (!input) {
+            return { isValid: false, message: 'Value must be a number.' };
+        };
+        if (data.minimum && input < data.minimum) {
+            errorMessages.push(`Value must be greater than or equal to ${data.minimum}.`);
+        };
+        if (data.maximum && input > data.maximum) {
+            errorMessages.push(`Value must be less than or equal to ${data.maximum}.`);
+        };
+        if (data.type === 'integer' && input % 1 !== 0) {
+            errorMessages.push('Value must be an integer.');
+        }
+        return { isValid: !errorMessages.length, message: errorMessages.join(' ') };
+    };
+
     return (
-        <input
-            type="text"
-            className="theia-input"
-            pattern="[0-9]*"
-            value={currentValue}
-            onChange={onChange}
-            data-preference-id={id}
-        />
+        <div className='pref-input-container'>
+            <input
+                type="number"
+                className="theia-input"
+                pattern="[0-9]*"
+                value={currentValue}
+                onChange={onChange}
+                onBlur={onBlur}
+                data-preference-id={id}
+            />
+            {!!validationMessage.length ? <div className='pref-error-notification'>{validationMessage}</div> : undefined}
+        </div>
     );
 };


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
Fixes: https://github.com/eclipse-theia/theia/issues/7741

- Added a numerical input field validation in the preference widget.
- Updated the input field type to be `number` instead of `text` for numerical fields.

| ![1](https://user-images.githubusercontent.com/43870550/88827986-9b5cb600-d198-11ea-8577-9982001c0abd.png) | ![2](https://user-images.githubusercontent.com/43870550/88827987-9b5cb600-d198-11ea-871f-eaaaf2441926.png)|![3](https://user-images.githubusercontent.com/43870550/88827983-9ac41f80-d198-11ea-9a28-75f223af6da9.png)|
| ------------- | ------------- |------------- |

#### How to test
|#|Test Case|Example|Result|
|:----:|:--------:|:---------:|:-------:|
|1|Input a value below the min range defined by the preference | Input -2 in `Font Size` preference | Should show an error message regarding the range |
|2|Leave the preference value empty | Remove an input in `Font Size` preference| Should show an error message regarding input being a number |
|3|Input a value above the max range defined by the preference | Input 151 in `Font Size` preference | Should show an error message regarding the range |
|4|Input a value that is not an integer | Input 1.5 in `Line Height` preference | Should show an error message regarding the type being an integer |
|5|Make sure an error is generated, focus out of the input| - | Should get rid of the error and reset the value to last set value|
|6|Make sure an error is generated, reset the setting | - | Should reset the setting input to default, and also get rid of the error |
|7|Generate multiple errors together| Input 1111111111111.12 in `Line Height` preference | Should concat different validation error messages|


Signed-off-by: Anas Shahid <muhammad.shahid@ericsson.com>
#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

