### PR TITLE
normalize base of language filter pattern to support clients on another OS

### DIFF
--- a/packages/monaco/src/browser/monaco-loader.ts
+++ b/packages/monaco/src/browser/monaco-loader.ts
@@ -76,7 +76,8 @@ export function loadMonaco(vsRequire: any): Promise<void> {
                 'vs/platform/contextkey/common/contextkey',
                 'vs/platform/contextkey/browser/contextKeyService',
                 'vs/editor/common/model/wordHelper',
-                'vs/base/common/errors'
+                'vs/base/common/errors',
+                'vs/base/common/path'
             ], (commands: any, actions: any,
                 keybindingsRegistry: any, keybindingResolver: any, resolvedKeybinding: any, keybindingLabels: any,
                 keyCodes: any, mime: any, editorExtensions: any, simpleServices: any,
@@ -89,7 +90,7 @@ export function loadMonaco(vsRequire: any): Promise<void> {
                 markerService: any,
                 contextKey: any, contextKeyService: any,
                 wordHelper: any,
-                error: any) => {
+                error: any, path: any) => {
                 const global: any = self;
                 global.monaco.commands = commands;
                 global.monaco.actions = actions;
@@ -111,6 +112,7 @@ export function loadMonaco(vsRequire: any): Promise<void> {
                 global.monaco.mime = mime;
                 global.monaco.wordHelper = wordHelper;
                 global.monaco.error = error;
+                global.monaco.path = path;
                 resolve();
             });
         });

--- a/packages/monaco/src/typings/monaco/index.d.ts
+++ b/packages/monaco/src/typings/monaco/index.d.ts
@@ -1349,6 +1349,11 @@ declare module monaco.error {
     export function onUnexpectedError(e: any): undefined;
 }
 
+declare module monaco.path {
+    // https://github.com/microsoft/vscode/blob/320fbada86c113835aef4fb9d7c4bc5b74678166/src/vs/base/common/path.ts#L1494
+    export function normalize(path: string): string;
+}
+
 declare module monaco.wordHelper {
     // https://github.com/theia-ide/vscode/blob/standalone/0.19.x/src/vs/editor/common/model/wordHelper.ts#L30
     export const DEFAULT_WORD_REGEXP: RegExp;

--- a/packages/plugin-ext/src/plugin/type-converters.ts
+++ b/packages/plugin-ext/src/plugin/type-converters.ts
@@ -316,24 +316,6 @@ export function fromTextEdit(edit: theia.TextEdit): model.TextEdit {
     };
 }
 
-export function fromLanguageSelector(selector: undefined): undefined;
-export function fromLanguageSelector(selector: theia.DocumentSelector): LanguageSelector;
-export function fromLanguageSelector(selector: undefined | theia.DocumentSelector): undefined | LanguageSelector {
-    if (!selector) {
-        return undefined;
-    } else if (Array.isArray(selector)) {
-        return <LanguageSelector>selector.map(fromLanguageSelector);
-    } else if (typeof selector === 'string') {
-        return selector;
-    } else {
-        return <LanguageFilter>{
-            language: selector.language,
-            scheme: selector.scheme,
-            pattern: fromGlobPattern(selector.pattern!)
-        };
-    }
-}
-
 export function convertDiagnosticToMarkerData(diagnostic: theia.Diagnostic): model.MarkerData {
     return {
         code: convertCode(diagnostic.code),


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

- fix #8261: normalize pattern base to support  clients on another OS
- it also removes pulling the plugin host code into the browser process


#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

- deploy Theia on Linux and test on Windows client (on Linux as well for regressions)
  - gitpod backend is Linux if someone with Windows machine wants to try quickly
- install Java Test Runner extension from `Extensions` view
- check out and open https://github.com/che-samples/console-java-simple
- run code lenses

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

