### PR TITLE
Removed getScopedKeybindingsForCommand (no references)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,13 +4,14 @@
 
 <a name="breaking_changes_1.5.0">[Breaking Changes:](#breaking_changes_1.5.0)</a>
 
+- [core] removed `KeybindingRegistry#getScopedKeybindingsForCommand` [#8283](https://github.com/eclipse-theia/theia/pull/8283)
 - [application-package] removed `isOutdated` from `ExtensionPackage` [#8295](https://github.com/eclipse-theia/theia/pull/8295)
 - [application-package] removed `getLatestVersion` from `ExtensionPackage` [#8295](https://github.com/eclipse-theia/theia/pull/8295)
 - [application-package] removed `getVersionRange` from `ExtensionPackage` [#8295](https://github.com/eclipse-theia/theia/pull/8295)
 - [application-package] removed `resolveVersionRange` from `ExtensionPackage` [#8295](https://github.com/eclipse-theia/theia/pull/8295)
 - [output] `OutputWidget#setInput` has been removed. The _Output_ view automatically shows the channel when calling `OutputChannel#show`. Moved the `OutputCommands` namespace from the `output-contribution` to its dedicated `output-commands` module to overcome a DI cycle. [#8243](https://github.com/eclipse-theia/theia/pull/8243)
 - [example app] updated yarn.lock so that the latest version of `vscode-ripgrep` is used (`v1.8.0`). This way we can benefit from the recently added support for it using proxy settings when fetching the platform-specific `ripgrep` executable, after npm package install. This should make it a lot easier to build our example application in corporate settings, behind a firewall. [#8280](https://github.com/eclipse-theia/theia/pull/8280)
-  - Note to downstream IDE designers: this change will not have an effect beyond this repo's example application. If it's desirable for your product to have the latest `vscode-ripgrep`, you should do similarly in your own `yarn.lock`. 
+  - Note to downstream IDE designers: this change will not have an effect beyond this repo's example application. If it's desirable for your product to have the latest `vscode-ripgrep`, you should do similarly in your own `yarn.lock`.
 <a name="1.5.0_deprecate_file_sytem"></a>
 - [[filesystem]](#1.5.0_deprecate_file_sytem) `FileSystem` and `FileSystemWatcher` services are deprecated [#7908](https://github.com/eclipse-theia/theia/pull/7908)
   - On the backend there is no anymore `FileSystem` implementation. One has to use Node.js APIs instead.
@@ -25,8 +26,8 @@
 ## v1.4.0
 
 - [core] added support for Node.js `12.x` [#7968](https://github.com/eclipse-theia/theia/pull/7968)
-  - From now on, you can use Node.js `12.x` to build Theia from sources. The recommended minimum version is aligned with `electron` (Node.js `12.14.1`). 
-  - Support for Node.js `10.x` will be dropped in one of the forthcoming releases. 
+  - From now on, you can use Node.js `12.x` to build Theia from sources. The recommended minimum version is aligned with `electron` (Node.js `12.14.1`).
+  - Support for Node.js `10.x` will be dropped in one of the forthcoming releases.
 - [core] fixed handling of environment variables on Windows [#7973](https://github.com/eclipse-theia/theia/pull/7973)
 - [core] fixed issue when selecting a tree node after performing a manual scroll [#8154](https://github.com/eclipse-theia/theia/pull/8154)
 - [debug] added a `select and run` debug statusbar item [#8134](https://github.com/eclipse-theia/theia/pull/8134)
@@ -37,7 +38,7 @@
 - [git] fixed the opening of deleted files [#8107](https://github.com/eclipse-theia/theia/pull/8107)
 - [markers] added `problems.autoReveal` preference to control sync between editors and the problem-view [#8172](https://github.com/eclipse-theia/theia/pull/8172)
 - [monaco] improved extensibility of menu and keybinding contributions [#8188](https://github.com/eclipse-theia/theia/pull/8188)
-- [monaco] normalized base pattern path to support different operating systems [#8268](https://github.com/eclipse-theia/theia/pull/8268) 
+- [monaco] normalized base pattern path to support different operating systems [#8268](https://github.com/eclipse-theia/theia/pull/8268)
 - [monaco] removed unused dependencies [#8109](https://github.com/eclipse-theia/theia/pull/8109)
 - [navigator] added `copy relative path` to the explorer context-menu and command palette [#8092](https://github.com/eclipse-theia/theia/pull/8092)
 - [output] added `copy all` context-menu item for the output-view [#8057](https://github.com/eclipse-theia/theia/pull/8057)

--- a/packages/core/src/browser/keybinding.ts
+++ b/packages/core/src/browser/keybinding.ts
@@ -399,27 +399,6 @@ export class KeybindingRegistry {
         return result;
     }
 
-    /**
-     * Returns a list of keybindings for a command in a specific scope
-     * @param scope specific scope to look for
-     * @param commandId unique id of the command
-     */
-    getScopedKeybindingsForCommand(scope: KeybindingScope, commandId: string): Keybinding[] {
-        const result: Keybinding[] = [];
-
-        if (scope >= KeybindingScope.END) {
-            return [];
-        }
-
-        this.keymaps[scope].forEach(binding => {
-            const command = this.commandRegistry.getCommand(binding.command);
-            if (command && command.id === commandId) {
-                result.push(binding);
-            }
-        });
-        return result;
-    }
-
     protected isActive(binding: Keybinding): boolean {
         /* Pseudo commands like "passthrough" are always active (and not found
            in the command registry).  */


### PR DESCRIPTION
fixes #8270

Signed-off-by: Jonas Helming <jhelming@eclipsesource.com>

#### What it does
PR removes an unreference function: getScopedKeybindingsForCommand (no updates since 3 years), see https://github.com/eclipse-theia/theia/issues/8270#issuecomment-666353519

By removing the function, #8270 is implicitly fixed

#### How to test
Nothing to test, removal, nothign should break, though

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

