### PR TITLE
tree indent guidelines support

### DIFF
--- a/packages/core/src/browser/common-frontend-contribution.ts
+++ b/packages/core/src/browser/common-frontend-contribution.ts
@@ -1090,7 +1090,7 @@ export class CommonFrontendContribution implements FrontendApplicationContributi
             // if not yet contributed by Monaco, check runtime css variables to learn.
             // TODO: Following are not yet supported/no respective elements in theia:
             // list.focusBackground, list.focusForeground, list.inactiveFocusBackground, list.filterMatchBorder,
-            // list.dropBackground, listFilterWidget.outline, listFilterWidget.noMatchesOutline, tree.indentGuidesStroke
+            // list.dropBackground, listFilterWidget.outline, listFilterWidget.noMatchesOutline
             // list.invalidItemForeground,
             // list.warningForeground, list.errorForeground => tree node needs an respective class
             { id: 'list.activeSelectionBackground', defaults: { dark: '#094771', light: '#0074E8' }, description: 'List/Tree background color for the selected item when the list/tree is active. An active list/tree has keyboard focus, an inactive does not.' },
@@ -1100,6 +1100,7 @@ export class CommonFrontendContribution implements FrontendApplicationContributi
             { id: 'list.hoverBackground', defaults: { dark: '#2A2D2E', light: '#F0F0F0' }, description: 'List/Tree background when hovering over items using the mouse.' },
             { id: 'list.hoverForeground', description: 'List/Tree foreground when hovering over items using the mouse.' },
             { id: 'list.filterMatchBackground', defaults: { dark: 'editor.findMatchHighlightBackground', light: 'editor.findMatchHighlightBackground' }, description: 'Background color of the filtered match.' },
+            { id: 'tree.inactiveIndentGuidesStroke', defaults: { dark: Color.transparent('tree.indentGuidesStroke', 0.4), light: Color.transparent('tree.indentGuidesStroke', 0.4), hc: Color.transparent('tree.indentGuidesStroke', 0.4) }, description: 'Tree stroke color for the inactive indentation guides.' },
 
             // Editor Group & Tabs colors should be aligned with https://code.visualstudio.com/api/references/theme-color#editor-groups-tabs
             {

--- a/packages/core/src/browser/core-preferences.ts
+++ b/packages/core/src/browser/core-preferences.ts
@@ -72,6 +72,12 @@ export const corePreferenceSchema: PreferenceSchema = {
             'scope': 'language-overridable',
             'enumDescriptions': Object.keys(SUPPORTED_ENCODINGS).map(key => SUPPORTED_ENCODINGS[key].labelLong),
             'included': Object.keys(SUPPORTED_ENCODINGS).length > 1
+        },
+        'workbench.tree.renderIndentGuides': {
+            type: 'string',
+            enum: ['onHover', 'none', 'always'],
+            default: 'onHover',
+            description: 'Controls whether the tree should render indent guides.'
         }
     }
 };
@@ -85,6 +91,7 @@ export interface CoreConfiguration {
     'workbench.iconTheme'?: string | null;
     'workbench.silentNotifications': boolean;
     'files.encoding': string
+    'workbench.tree.renderIndentGuides': 'onHover' | 'none' | 'always';
 }
 
 export const CorePreferences = Symbol('CorePreferences');

--- a/packages/core/src/browser/style/tree.css
+++ b/packages/core/src/browser/style/tree.css
@@ -139,3 +139,16 @@
 .theia-tree-element-node {
     width: 100%
 }
+
+.theia-tree-node-indent {
+    position: absolute;
+    height: var(--theia-content-line-height);
+    border-right: var(--theia-border-width) solid transparent;
+}
+.theia-tree-node-indent.always,
+.theia-TreeContainer:hover .theia-tree-node-indent.hover {
+    border-color: var(--theia-tree-inactiveIndentGuidesStroke);
+}
+.theia-tree-node-indent.active {
+    border-color: var(--theia-tree-indentGuidesStroke);
+}


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

- Fixes #6586:
  - Add preference to set 'workbench.tree.renderIndentGuides' to 'onHover' (default), 'none' or 'always'
  - When nodes are selected, indent guidelines are rendered for all the sibling nodes
  - When parent node is selected, indent guidelines are rendered for all the child nodes
  - When hovering over a tree, indent guidelines are displayed for all expanded nodes
  - Selecting multiple nodes works in a similar fashion

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

- Set the workspace preference to 'onHover', 'none', 'always' and the rendering of the indent guidelines should change accordingly.
- In different locations in Theia where the tree is being used (for example, in navigator, search in workspace, outline, problems-view and scm (list mode and tree mode)), select one/more nodes to test if the indent guidelines are rendered correctly.

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

