### PR TITLE
[filedialog] add option to file dialog props: 'disableAllFilesFilter' …

### DIFF
--- a/packages/filesystem/src/browser/file-dialog/file-dialog-tree-filters-renderer.tsx
+++ b/packages/filesystem/src/browser/file-dialog/file-dialog-tree-filters-renderer.tsx
@@ -40,10 +40,11 @@ export class FileDialogTreeFiltersRenderer extends ReactRenderer {
 
     constructor(
         readonly suppliedFilters: FileDialogTreeFilters,
-        readonly fileDialogTree: FileDialogTree
+        readonly fileDialogTree: FileDialogTree,
+        readonly disableAllFilesFilter?: boolean
     ) {
         super();
-        this.appliedFilters = { 'All Files': [], ...suppliedFilters, };
+        this.appliedFilters = disableAllFilesFilter ? { ...suppliedFilters } : { 'All Files': [], ...suppliedFilters };
     }
 
     protected readonly handleFilterChanged = (e: React.ChangeEvent<HTMLSelectElement>) => this.onFilterChanged(e);

--- a/packages/filesystem/src/browser/file-dialog/file-dialog.ts
+++ b/packages/filesystem/src/browser/file-dialog/file-dialog.ts
@@ -69,6 +69,10 @@ export class FileDialogProps extends DialogProps {
      */
     filters?: FileDialogTreeFilters;
 
+    /**
+     * Disable to show filter that shows all files, defaults to `false`.
+     */
+    disableAllFilesFilter?: boolean;
 }
 
 @injectable()
@@ -163,7 +167,7 @@ export abstract class FileDialog<T> extends AbstractDialog<T> {
 
     protected createFileTreeFiltersRenderer(): FileDialogTreeFiltersRenderer | undefined {
         if (this.props.filters) {
-            return new FileDialogTreeFiltersRenderer(this.props.filters, this.widget.model.tree);
+            return new FileDialogTreeFiltersRenderer(this.props.filters, this.widget.model.tree, this.props.disableAllFilesFilter);
         }
 
         return undefined;

--- a/packages/workspace/src/browser/workspace-frontend-contribution.spec.ts
+++ b/packages/workspace/src/browser/workspace-frontend-contribution.spec.ts
@@ -37,20 +37,20 @@ describe('workspace-frontend-contribution', () => {
 
         ([
 
-            [OS.Type.Linux, 'browser', true, { title, canSelectFiles: true, canSelectFolders: true, filters }],
-            [OS.Type.Linux, 'browser', false, { title, canSelectFiles: false, canSelectFolders: true }],
-            [OS.Type.Linux, 'electron', true, { title, canSelectFiles: true, canSelectFolders: false, filters }],
-            [OS.Type.Linux, 'electron', false, { title, canSelectFiles: false, canSelectFolders: true }],
+            [OS.Type.Linux, 'browser', true, { title, canSelectFiles: true, canSelectFolders: true, filters, disableAllFilesFilter: true }],
+            [OS.Type.Linux, 'browser', false, { title, canSelectFiles: false, canSelectFolders: true, disableAllFilesFilter: true }],
+            [OS.Type.Linux, 'electron', true, { title, canSelectFiles: true, canSelectFolders: false, filters, disableAllFilesFilter: true }],
+            [OS.Type.Linux, 'electron', false, { title, canSelectFiles: false, canSelectFolders: true, disableAllFilesFilter: true }],
 
-            [OS.Type.Windows, 'browser', true, { title, canSelectFiles: true, canSelectFolders: true, filters }],
-            [OS.Type.Windows, 'browser', false, { title, canSelectFiles: false, canSelectFolders: true }],
-            [OS.Type.Windows, 'electron', true, { title, canSelectFiles: true, canSelectFolders: false, filters }],
-            [OS.Type.Windows, 'electron', false, { title, canSelectFiles: false, canSelectFolders: true }],
+            [OS.Type.Windows, 'browser', true, { title, canSelectFiles: true, canSelectFolders: true, filters, disableAllFilesFilter: true }],
+            [OS.Type.Windows, 'browser', false, { title, canSelectFiles: false, canSelectFolders: true, disableAllFilesFilter: true }],
+            [OS.Type.Windows, 'electron', true, { title, canSelectFiles: true, canSelectFolders: false, filters, disableAllFilesFilter: true }],
+            [OS.Type.Windows, 'electron', false, { title, canSelectFiles: false, canSelectFolders: true, disableAllFilesFilter: true }],
 
-            [OS.Type.OSX, 'browser', true, { title, canSelectFiles: true, canSelectFolders: true, filters }],
-            [OS.Type.OSX, 'browser', false, { title, canSelectFiles: false, canSelectFolders: true }],
-            [OS.Type.OSX, 'electron', true, { title, canSelectFiles: true, canSelectFolders: true, filters }],
-            [OS.Type.OSX, 'electron', false, { title, canSelectFiles: true, canSelectFolders: true, filters }]
+            [OS.Type.OSX, 'browser', true, { title, canSelectFiles: true, canSelectFolders: true, filters, disableAllFilesFilter: true }],
+            [OS.Type.OSX, 'browser', false, { title, canSelectFiles: false, canSelectFolders: true, disableAllFilesFilter: true }],
+            [OS.Type.OSX, 'electron', true, { title, canSelectFiles: true, canSelectFolders: true, filters, disableAllFilesFilter: true }],
+            [OS.Type.OSX, 'electron', false, { title, canSelectFiles: true, canSelectFolders: true, filters, disableAllFilesFilter: true }]
 
         ] as [OS.Type, 'browser' | 'electron', boolean, OpenFileDialogProps][]).forEach(test => {
             const [type, environment, supportMultiRootWorkspace, expected] = test;

--- a/packages/workspace/src/browser/workspace-frontend-contribution.ts
+++ b/packages/workspace/src/browser/workspace-frontend-contribution.ts
@@ -485,14 +485,16 @@ export namespace WorkspaceFrontendContribution {
                     title,
                     canSelectFiles: true,
                     canSelectFolders: true,
-                    filters: DEFAULT_FILE_FILTER
+                    filters: DEFAULT_FILE_FILTER,
+                    disableAllFilesFilter: true
                 };
             } else {
                 // otherwise, it is always folders. No files at all.
                 return {
                     title,
                     canSelectFiles: false,
-                    canSelectFolders: true
+                    canSelectFolders: true,
+                    disableAllFilesFilter: true
                 };
             }
         }
@@ -504,7 +506,8 @@ export namespace WorkspaceFrontendContribution {
                 title,
                 canSelectFiles: true,
                 canSelectFolders: true,
-                filters: DEFAULT_FILE_FILTER
+                filters: DEFAULT_FILE_FILTER,
+                disableAllFilesFilter: true
             };
         }
 
@@ -514,7 +517,8 @@ export namespace WorkspaceFrontendContribution {
                 title,
                 canSelectFiles: true,
                 canSelectFolders: false,
-                filters: DEFAULT_FILE_FILTER
+                filters: DEFAULT_FILE_FILTER,
+                disableAllFilesFilter: true
             };
         }
 
@@ -522,7 +526,8 @@ export namespace WorkspaceFrontendContribution {
         return {
             title,
             canSelectFiles: false,
-            canSelectFolders: true
+            canSelectFolders: true,
+            disableAllFilesFilter: true
         };
     }
 


### PR DESCRIPTION
Fixes: #8179


<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->
Add disableAllFilesFilter option to file dialog props.
Set disableAllFilesFilter when 'open workspace...'.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
- do 'open workspace...'

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

Signed-off-by: Min-young Yang <didalsdud@gmail.com>


