### PR TITLE
fix user storage regressions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,13 +11,16 @@
 - [output] `OutputWidget#setInput` has been removed. The _Output_ view automatically shows the channel when calling `OutputChannel#show`. Moved the `OutputCommands` namespace from the `output-contribution` to its dedicated `output-commands` module to overcome a DI cycle. [#8243](https://github.com/eclipse-theia/theia/pull/8243)
 - [example app] updated yarn.lock so that the latest version of `vscode-ripgrep` is used (`v1.8.0`). This way we can benefit from the recently added support for it using proxy settings when fetching the platform-specific `ripgrep` executable, after npm package install. This should make it a lot easier to build our example application in corporate settings, behind a firewall. [#8280](https://github.com/eclipse-theia/theia/pull/8280)
   - Note to downstream IDE designers: this change will not have an effect beyond this repo's example application. If it's desirable for your product to have the latest `vscode-ripgrep`, you should do similarly in your own `yarn.lock`. 
-<a name="1_4_0_deprecate_file_sytem"></a>
-- [[filesystem]](#1_4_0_deprecate_file_sytem) `FileSystem` and `FileSystemWatcher` services are deprecated [#7908](https://github.com/eclipse-theia/theia/pull/7908)
+<a name="1.5.0_deprecate_file_sytem"></a>
+- [[filesystem]](#1.5.0_deprecate_file_sytem) `FileSystem` and `FileSystemWatcher` services are deprecated [#7908](https://github.com/eclipse-theia/theia/pull/7908)
   - On the backend there is no anymore `FileSystem` implementation. One has to use Node.js APIs instead.
   - On the frontend `FileService` should be used instead. It was ported from VS Code for compatibility with VS Code extensions.
   - On the frontend `EnvVariableServer` should be used instead to access the current user home and available drives.
-<a name="1_4_0_usestorage_as_fs_provider"></a>
-- [[userstorage]](#1_4_0_usestorage_as_fs_provider) `UserStorageService` was replaced by the user data fs provider [#7908](https://github.com/eclipse-theia/theia/pull/7908)
+<a name="1.5.0_usestorage_as_fs_provider"></a>
+- [[userstorage]](#1.5.0_usestorage_as_fs_provider) `UserStorageService` was replaced by the user data fs provider [#7908](https://github.com/eclipse-theia/theia/pull/7908)
+<a name="1.5.0_root_user_storage_uri"></a>
+- [[user-storage]](#1.5.0_root_user_storage_uri) settings URI must start with `/user` root to satisfy expectations of `FileService` []()
+  - If you implement a custom user storage make sure to check old relative locations, otherwise it can cause user data loss.
 
 ## v1.4.0
 

--- a/packages/core/src/browser/keybinding.ts
+++ b/packages/core/src/browser/keybinding.ts
@@ -615,6 +615,10 @@ export class KeybindingRegistry {
             this.keymaps[i] = [];
         }
     }
+
+    getKeybindingsByScope(scope: KeybindingScope): ScopedKeybinding[] {
+        return this.keymaps[scope];
+    }
 }
 
 export namespace KeybindingRegistry {

--- a/packages/core/src/browser/preferences/preference-provider.ts
+++ b/packages/core/src/browser/preferences/preference-provider.ts
@@ -159,11 +159,16 @@ export abstract class PreferenceProvider implements Disposable {
     }
 
     /**
-     * undefined if cannot be provided for the given resource uri
+     * Returns undefined if there is no valid config URI for the given resource URI.
      */
     getConfigUri(resourceUri?: string): URI | undefined {
         return undefined;
     }
+
+    /**
+     * Returns undefined if there is config URI at all for the given resource URI.
+     */
+    getContainingConfigUri?(resourceUri?: string): URI | undefined;
 
     static merge(source: JSONValue | undefined, target: JSONValue): JSONValue {
         if (source === undefined || !JSONExt.isObject(source)) {

--- a/packages/core/src/browser/preferences/preference-service.ts
+++ b/packages/core/src/browser/preferences/preference-service.ts
@@ -88,6 +88,7 @@ export interface PreferenceService extends Disposable {
     overriddenPreferenceName(preferenceName: string): OverridePreferenceName | undefined;
 
     resolve<T>(preferenceName: string, defaultValue?: T, resourceUri?: string): PreferenceResolveResult<T>;
+    getConfigUri(scope: PreferenceScope, resourceUri?: string): URI | undefined;
 }
 
 /**
@@ -358,4 +359,17 @@ export class PreferenceServiceImpl implements PreferenceService {
             value: result.value !== undefined ? deepFreeze(result.value) : defaultValue
         };
     }
+
+    getConfigUri(scope: PreferenceScope, resourceUri?: string): URI | undefined {
+        const provider = this.getProvider(scope);
+        if (!provider) {
+            return undefined;
+        }
+        const configUri = provider.getConfigUri(resourceUri);
+        if (configUri) {
+            return configUri;
+        }
+        return provider.getContainingConfigUri && provider.getContainingConfigUri(resourceUri);
+    }
+
 }

--- a/packages/core/src/browser/preferences/test/mock-preference-service.ts
+++ b/packages/core/src/browser/preferences/test/mock-preference-service.ts
@@ -20,6 +20,7 @@ import { Emitter, Event } from '../../../common';
 import { OverridePreferenceName } from '../preference-contribution';
 import URI from '../../../common/uri';
 import { PreferenceChanges } from '../preference-service';
+import { PreferenceScope } from '../preference-scope';
 
 @injectable()
 export class MockPreferenceService implements PreferenceService {
@@ -60,4 +61,5 @@ export class MockPreferenceService implements PreferenceService {
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     validate(name: string, value: any): boolean { return true; }
+    getConfigUri(scope: PreferenceScope, resourceUri?: string): URI | undefined { return undefined; }
 }

--- a/packages/filesystem/src/browser/file-service.ts
+++ b/packages/filesystem/src/browser/file-service.ts
@@ -1662,7 +1662,7 @@ export class FileService {
      * Converts to an underlying fs provider resource format.
      *
      * For example converting `user-storage` resources to `file` resources under a user home:
-     * user-storage:/settings.json => file://home/.theia/settings.json
+     * user-storage:/user/settings.json => file://home/.theia/settings.json
      */
     async toUnderlyingResource(resource: URI): Promise<URI> {
         let provider = await this.withProvider(resource);

--- a/packages/keymaps/src/browser/keymaps-service.ts
+++ b/packages/keymaps/src/browser/keymaps-service.ts
@@ -15,7 +15,6 @@
  ********************************************************************************/
 
 import { inject, injectable, postConstruct } from 'inversify';
-import URI from '@theia/core/lib/common/uri';
 import { ResourceProvider, Resource, ResourceError } from '@theia/core/lib/common/resource';
 import { OpenerService, open, WidgetOpenerOptions, Widget } from '@theia/core/lib/browser';
 import { KeybindingRegistry, KeybindingScope } from '@theia/core/lib/browser/keybinding';
@@ -46,7 +45,7 @@ export class KeymapsService {
      */
     @postConstruct()
     protected async init(): Promise<void> {
-        this.resource = await this.resourceProvider(new URI().withScheme(UserStorageUri.SCHEME).withPath('/keymaps.json'));
+        this.resource = await this.resourceProvider(UserStorageUri.resolve('keymaps.json'));
         this.reconcile();
         if (this.resource.onDidChangeContents) {
             this.resource.onDidChangeContents(() => this.reconcile());

--- a/packages/plugin-ext-vscode/src/browser/plugin-vscode-contribution.ts
+++ b/packages/plugin-ext-vscode/src/browser/plugin-vscode-contribution.ts
@@ -25,7 +25,7 @@ export class PluginVSCodeContribution implements FileServiceContribution {
 
     registerFileSystemProviders(service: FileService): void {
         this.mapSchemas(service, Schemes.vscodeRemote, 'file');
-        this.mapSchemas(service, Schemes.userData, UserStorageUri.SCHEME);
+        this.mapSchemas(service, Schemes.userData, UserStorageUri.scheme);
     }
 
     protected mapSchemas(service: FileService, from: string, to: string): void {

--- a/packages/preferences/src/browser/preferences-json-schema-contribution.ts
+++ b/packages/preferences/src/browser/preferences-json-schema-contribution.ts
@@ -18,8 +18,9 @@ import { inject, injectable } from 'inversify';
 import URI from '@theia/core/lib/common/uri';
 import { InMemoryResources } from '@theia/core';
 import { JsonSchemaRegisterContext, JsonSchemaContribution } from '@theia/core/lib/browser/json-schema-store';
-import { USER_PREFERENCE_URI } from './user-preference-provider';
 import { PreferenceSchemaProvider } from '@theia/core/lib/browser/preferences/preference-contribution';
+import { PreferenceConfigurations } from '@theia/core/lib/browser/preferences/preference-configurations';
+import { UserStorageUri } from '@theia/userstorage/lib/browser/user-storage-uri';
 
 @injectable()
 export class PreferencesJsonSchemaContribution implements JsonSchemaContribution {
@@ -30,12 +31,17 @@ export class PreferencesJsonSchemaContribution implements JsonSchemaContribution
     @inject(InMemoryResources)
     protected readonly inmemoryResources: InMemoryResources;
 
+    @inject(PreferenceConfigurations)
+    protected readonly preferenceConfigurations: PreferenceConfigurations;
+
     registerSchemas(context: JsonSchemaRegisterContext): void {
         const serializeSchema = () => JSON.stringify(this.schemaProvider.getCombinedSchema());
         const uri = new URI('vscode://schemas/settings/user');
         this.inmemoryResources.add(uri, serializeSchema());
+        const baseName = this.preferenceConfigurations.getConfigName() + '.json';
+        const fileMatch = [baseName, UserStorageUri.resolve(baseName).toString()];
         context.registerSchema({
-            fileMatch: ['settings.json', USER_PREFERENCE_URI.toString()],
+            fileMatch,
             url: uri.toString()
         });
         this.schemaProvider.onDidPreferenceSchemaChanged(() =>

--- a/packages/preferences/src/browser/user-configs-preference-provider.ts
+++ b/packages/preferences/src/browser/user-configs-preference-provider.ts
@@ -23,8 +23,6 @@ import { PreferenceConfigurations } from '@theia/core/lib/browser/preferences/pr
 import { UserStorageUri } from '@theia/userstorage/lib/browser';
 import { UserPreferenceProvider, UserPreferenceProviderFactory } from './user-preference-provider';
 
-export const USER_PREFERENCE_FOLDER = new URI().withScheme(UserStorageUri.SCHEME);
-
 /**
  * Binds together preference section prefs providers for user-level preferences.
  */
@@ -52,7 +50,7 @@ export class UserConfigsPreferenceProvider extends PreferenceProvider {
 
     protected createProviders(): void {
         for (const configName of [...this.configurations.getSectionNames(), this.configurations.getConfigName()]) {
-            const sectionUri = USER_PREFERENCE_FOLDER.withPath('/' + configName + '.json');
+            const sectionUri = UserStorageUri.resolve(configName + '.json');
             const sectionKey = sectionUri.toString();
             if (!this.providers.has(sectionKey)) {
                 const provider = this.createProvider(sectionUri, configName);

--- a/packages/preferences/src/browser/user-preference-provider.ts
+++ b/packages/preferences/src/browser/user-preference-provider.ts
@@ -20,7 +20,7 @@ import { UserStorageUri } from '@theia/userstorage/lib/browser/user-storage-uri'
 import { PreferenceScope } from '@theia/core/lib/browser';
 import { SectionPreferenceProvider } from './section-preference-provider';
 
-export const USER_PREFERENCE_URI = new URI().withScheme(UserStorageUri.SCHEME).withPath('/settings.json');
+export const USER_PREFERENCE_URI = UserStorageUri.resolve('settings.json');
 
 export const UserPreferenceProviderFactory = Symbol('UserPreferenceProviderFactory');
 export interface UserPreferenceProviderFactory {

--- a/packages/preferences/src/browser/user-preference-provider.ts
+++ b/packages/preferences/src/browser/user-preference-provider.ts
@@ -16,11 +16,8 @@
 
 import { injectable } from 'inversify';
 import URI from '@theia/core/lib/common/uri';
-import { UserStorageUri } from '@theia/userstorage/lib/browser/user-storage-uri';
 import { PreferenceScope } from '@theia/core/lib/browser';
 import { SectionPreferenceProvider } from './section-preference-provider';
-
-export const USER_PREFERENCE_URI = UserStorageUri.resolve('settings.json');
 
 export const UserPreferenceProviderFactory = Symbol('UserPreferenceProviderFactory');
 export interface UserPreferenceProviderFactory {

--- a/packages/task/src/browser/task-configurations.ts
+++ b/packages/task/src/browser/task-configurations.ts
@@ -32,7 +32,7 @@ import { Disposable, DisposableCollection } from '@theia/core/lib/common';
 import { FileChangeType } from '@theia/filesystem/lib/common/filesystem-watcher-protocol';
 import { WorkspaceService } from '@theia/workspace/lib/browser';
 import { OpenerService } from '@theia/core/lib/browser';
-import { USER_PREFERENCE_FOLDER } from '@theia/preferences/lib/browser/user-configs-preference-provider';
+import { UserStorageUri } from '@theia/userstorage/lib/browser/user-storage-uri';
 
 export interface TaskConfigurationClient {
     /**
@@ -42,7 +42,7 @@ export interface TaskConfigurationClient {
     taskConfigurationChanged: (event: string[]) => void;
 }
 
-export const USER_TASKS_URI = USER_PREFERENCE_FOLDER.withPath('/tasks.json');
+export const USER_TASKS_URI = UserStorageUri.resolve('tasks.json');
 
 /**
  * Watches a tasks.json configuration file and provides a parsed version of the contained task configurations

--- a/packages/userstorage/src/browser/user-storage-uri.ts
+++ b/packages/userstorage/src/browser/user-storage-uri.ts
@@ -14,7 +14,6 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
-export namespace UserStorageUri {
+import URI from '@theia/core/lib/common/uri';
 
-    export const SCHEME = 'user_storage';
-}
+export const UserStorageUri = new URI('user_storage:/user');


### PR DESCRIPTION
#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

- fix #8302: ensure that user storage URI has a top-level directory. Otherwise `FileService` fails to create the user directory.
- remove hardcoded constants from preferences UI. It is a secret of the preference service to know which config URI should be use for each scope in the context of the given resource.
- fix #8301: use monaco model to handle keymaps. It allows to check whether model is invalid before opening it, in addition keymaps are now updated with minimal edits and preserving user formatting and comments.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

- Start theia app and remove .theia in user home. Try to open keymaps and user settings.
- Try to modify keymaps and check that changes are reflected.
- Try to open settings file for different scopes, i.e. user, workspace, folder as a workspace and workspace folder.

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

