### PR TITLE
cli: use `decompress` to decompress plugins

### DIFF
--- a/dev-packages/cli/package.json
+++ b/dev-packages/cli/package.json
@@ -40,6 +40,7 @@
     "@types/tar": "^4.0.3",
     "chai": "^4.2.0",
     "colors": "^1.4.0",
+    "decompress": "^4.2.1",
     "https-proxy-agent": "^5.0.0",
     "mkdirp": "^0.5.0",
     "mocha": "^7.0.0",
@@ -47,9 +48,7 @@
     "proxy-from-env": "^1.1.0",
     "puppeteer": "^2.0.0",
     "puppeteer-to-istanbul": "^1.2.2",
-    "tar": "^4.0.0",
     "temp": "^0.9.1",
-    "unzip-stream": "^0.3.0",
     "yargs": "^11.1.0"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -4860,6 +4860,20 @@ decompress@4.2.0:
     pify "^2.3.0"
     strip-dirs "^2.0.0"
 
+decompress@^4.2.1:
+  version "4.2.1"
+  resolved "https://registry.yarnpkg.com/decompress/-/decompress-4.2.1.tgz#007f55cc6a62c055afa37c07eb6a4ee1b773f118"
+  integrity sha512-e48kc2IjU+2Zw8cTb6VZcJQ3lgVbS4uuB1TfCHbiZIP/haNXm+SVyhu+87jts5/3ROpd82GSVCoNs/z8l4ZOaQ==
+  dependencies:
+    decompress-tar "^4.0.0"
+    decompress-tarbz2 "^4.0.0"
+    decompress-targz "^4.0.0"
+    decompress-unzip "^4.0.1"
+    graceful-fs "^4.1.10"
+    make-dir "^1.0.0"
+    pify "^2.3.0"
+    strip-dirs "^2.0.0"
+
 dedent@^0.7.0:
   version "0.7.0"
   resolved "https://registry.yarnpkg.com/dedent/-/dedent-0.7.0.tgz#2495ddbaf6eb874abb0e1be9df22d2e5a544326c"


### PR DESCRIPTION
`unzip-stream` does not restore file permissions when decompressing
archives.

This commit replaces this library by `decompress` which restores file
permissions as stored in the archives.

Signed-off-by: Paul Maréchal <paul.marechal@ericsson.com>

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does

Fixes https://github.com/eclipse-theia/theia/issues/8306

#### How to test

- You should not be able to reproduce the following issue: https://github.com/eclipse-theia/theia/issues/8306
- Nothing should be left in the temp storage (resources used by the script, prefixed by `theia-plugin-download`).

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

