### PR TITLE
[monaco] non-blocking bulk edits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,9 @@
   - If you implement a custom user storage make sure to check old relative locations, otherwise it can cause user data loss.
 <a name="1_5_0_electron_window_options_ipc">
 - [[electron]](#1_5_0_electron_window_options_ipc) Removed the `set-window-options` and `get-persisted-window-options-additions` Electron IPC handlers from the Electron Main process.
+<a name="1.5.0_non_blocking_bulk_edit"></a>
+- [[monaco]](#1.5.0_non_blocking_bulk_edit) `MonacoWorkspace.applyBulkEdit` does not open any editors anymore to avoid blocking [#8329](https://github.com/eclipse-theia/theia/pull/8329)
+  - Consequently, it does not accept editor opener options, and `MonacoWorkspace.openEditors` and `MonacoWorkspace.toTextEditWithEditor` are removed.
 
 ## v1.4.0
 

--- a/packages/monaco/src/browser/monaco-workspace.ts
+++ b/packages/monaco/src/browser/monaco-workspace.ts
@@ -218,9 +218,12 @@ export class MonacoWorkspace {
             // create a new reference to make sure the model is not disposed before it is
             // acquired by the editor, thus losing the changes that made it dirty.
             this.textModelService.createModelReference(model.textEditorModel.uri).then(ref => {
-                this.editorManager.open(new URI(model.uri), {
-                    mode: 'open',
-                }).then(editor => ref.dispose());
+                (
+                    model.autoSave === 'on' ? new Promise(resolve => model.onDidSaveModel(resolve)) :
+                        this.editorManager.open(new URI(model.uri), { mode: 'open' })
+                ).then(
+                    () => ref.dispose()
+                );
             });
         }
     }

--- a/packages/monaco/src/typings/monaco/index.d.ts
+++ b/packages/monaco/src/typings/monaco/index.d.ts
@@ -748,6 +748,11 @@ declare module monaco.services {
         updateModel(model: monaco.editor.ITextModel, value: string | monaco.editor.ITextBufferFactory): void;
     }
 
+    // https://github.com/microsoft/vscode/blob/2277c8e2a3e1cc630a6397301ba54a1dccd8a60d/src/vs/editor/common/services/editorWorkerService.ts#L21
+    export interface IEditorWorkerService {
+        computeMoreMinimalEdits(resource: monaco.Uri, edits: monaco.languages.TextEdit[] | null | undefined): Promise<monaco.languages.TextEdit[] | undefined>;
+    }
+
     // https://github.com/theia-ide/vscode/blob/standalone/0.19.x/src/vs/editor/standalone/browser/standaloneServices.ts#L56
     export module StaticServices {
         export function init(overrides: monaco.editor.IEditorOverrideServices): [ServiceCollection, monaco.instantiation.IInstantiationService];
@@ -759,6 +764,7 @@ declare module monaco.services {
         export const instantiationService: LazyStaticService<monaco.instantiation.IInstantiationService>;
         export const markerService: LazyStaticService<IMarkerService>;
         export const modelService: LazyStaticService<IModelService>;
+        export const editorWorkerService: LazyStaticService<IEditorWorkerService>;
     }
 }
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

- fix #8328: apply text edits without requiring an editor to be revealed or focused, otherwise it is not guarantee that edits from multiple bulk calls will be applied in the proper order. I've discovered an issue with the private VS Code extension doing modifications in the background, by the time when a window was revealed the document was total mess.
- This PR as well fixes bugs of:
  - marking a document as dirty with changes which lead to the same state, thinking replace the entire doc with the same content;
  - not respecting EOL changes.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

Apply some cross file refactoring for Typescript or Java, like rename type referenced from other files. Other files still should be opened as dirty and changes should be applied.

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

