### PR TITLE
fix signatures of vscode.open and vscode.diff

### DIFF
--- a/packages/plugin-ext/src/main/browser/documents-main.ts
+++ b/packages/plugin-ext/src/main/browser/documents-main.ts
@@ -239,8 +239,8 @@ export class DocumentsMainImpl implements DocumentsMain, Disposable {
         if (options.selection) {
             const selection = options.selection;
             range = {
-                start: { line: selection.startLineNumber - 1, character: selection.startColumn - 1 },
-                end: { line: selection.endLineNumber - 1, character: selection.endColumn - 1 }
+                start: { line: selection.startLineNumber, character: selection.startColumn },
+                end: { line: selection.endLineNumber, character: selection.endColumn }
             };
         }
         /* fall back to side group -> split relative to the active widget */


### PR DESCRIPTION
#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

- fix #8333: fix signatures of vscode.open and vscode.diff. Internal `TextDocumentShowOptions` was used instead of `vscode.TextDocumentShowOptions` leading to ignoring the selection all the time.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

- Call `vscode.open` or `vscode.diff` and pass selection. The selection should be properly revealed.

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

