### PR TITLE
[gitpod] Remove unnecessary Node.js version-pinning code

### DIFF
--- a/.gitpod.dockerfile
+++ b/.gitpod.dockerfile
@@ -12,11 +12,3 @@ RUN sudo apt-get update \
     # native-keymap
     && sudo apt-get install -y libx11-dev libxkbfile-dev \
     && sudo rm -rf /var/lib/apt/lists/*
-
-ENV NODE_VERSION="12.14.1"
-RUN bash -c ". .nvm/nvm.sh \
-    && nvm install $NODE_VERSION \
-    && nvm use $NODE_VERSION \
-    && nvm alias default $NODE_VERSION \
-    && npm install -g yarn"
-ENV PATH=$HOME/.nvm/versions/node/v${NODE_VERSION}/bin:$PATH


### PR DESCRIPTION
#### What it does

The installed Node.js version in `.gitpod.dockerfile` is `12.14.1`. This version is now old, and could be upgraded to `12.18.3`.

However, the base image `gitpod/workspace-full-vnc:latest` already installs the latest stable Node.js 12:

https://github.com/gitpod-io/workspace-images/blob/9a5a59f7f351bb0d87f084e7374548ca5d53d944/full/Dockerfile#L184-L197

So, I believe we can remove the pinning code altogether (it was originally added to keep Theia on Node.js 10, which is no longer necessary, since Theia moved to Node.js 12).

#### How to test

Opening this Pull Request in Gitpod should yield a fully functional, prebuilt Theia dev environment.

#### Review checklist

- [ ] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

