### PR TITLE
[badge]: Badge decoration for active debug sessions

### DIFF
--- a/packages/core/src/browser/frontend-application-module.ts
+++ b/packages/core/src/browser/frontend-application-module.ts
@@ -156,6 +156,7 @@ export const frontendApplicationModule = new ContainerModule((bind, unbind, isBo
 
     bindContributionProvider(bind, TabBarDecorator);
     bind(TabBarDecoratorService).toSelf().inSingletonScope();
+    bind(FrontendApplicationContribution).toService(TabBarDecoratorService);
 
     bindContributionProvider(bind, OpenHandler);
     bind(DefaultOpenerService).toSelf().inSingletonScope();

--- a/packages/core/src/browser/shell/tab-bar-decorator.ts
+++ b/packages/core/src/browser/shell/tab-bar-decorator.ts
@@ -16,9 +16,10 @@
 
 import debounce = require('lodash.debounce');
 import { Title, Widget } from '@phosphor/widgets';
-import { inject, injectable, named, postConstruct } from 'inversify';
+import { inject, injectable, named } from 'inversify';
 import { Event, Emitter, ContributionProvider } from '../../common';
 import { WidgetDecoration } from '../widget-decoration';
+import { FrontendApplicationContribution } from '../frontend-application';
 
 export const TabBarDecorator = Symbol('TabBarDecorator');
 
@@ -43,7 +44,7 @@ export interface TabBarDecorator {
 }
 
 @injectable()
-export class TabBarDecoratorService {
+export class TabBarDecoratorService implements FrontendApplicationContribution {
 
     protected readonly onDidChangeDecorationsEmitter = new Emitter<void>();
 
@@ -52,8 +53,7 @@ export class TabBarDecoratorService {
     @inject(ContributionProvider) @named(TabBarDecorator)
     protected readonly contributions: ContributionProvider<TabBarDecorator>;
 
-    @postConstruct()
-    protected init(): void {
+    initialize(): void {
         this.contributions.getContributions().map(decorator => decorator.onDidChangeDecorations(this.fireDidChangeDecorations));
     }
 

--- a/packages/debug/src/browser/debug-frontend-module.ts
+++ b/packages/debug/src/browser/debug-frontend-module.ts
@@ -57,6 +57,8 @@ import { MonacoEditorService } from '@theia/monaco/lib/browser/monaco-editor-ser
 import { DebugBreakpointWidget } from './editor/debug-breakpoint-widget';
 import { DebugInlineValueDecorator } from './editor/debug-inline-value-decorator';
 import { JsonSchemaContribution } from '@theia/core/lib/browser/json-schema-store';
+import { TabBarDecorator } from '@theia/core/lib/browser/shell/tab-bar-decorator';
+import { DebugTabBarDecorator } from './debug-tab-bar-decorator';
 
 export default new ContainerModule((bind: interfaces.Bind) => {
     bind(DebugCallStackItemTypeKey).toDynamicValue(({ container }) =>
@@ -116,4 +118,7 @@ export default new ContainerModule((bind: interfaces.Bind) => {
     bindLaunchPreferences(bind);
 
     bind(DebugWatchManager).toSelf().inSingletonScope();
+
+    bind(DebugTabBarDecorator).toSelf().inSingletonScope();
+    bind(TabBarDecorator).toService(DebugTabBarDecorator);
 });

--- a/packages/debug/src/browser/debug-tab-bar-decorator.ts
+++ b/packages/debug/src/browser/debug-tab-bar-decorator.ts
@@ -1,0 +1,57 @@
+/********************************************************************************
+ * Copyright (C) 2020 Ericsson and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import { injectable, inject, postConstruct } from 'inversify';
+import { DebugSessionManager } from './debug-session-manager';
+import { DebugWidget } from './view/debug-widget';
+import { Emitter, Event } from '@theia/core/lib/common/event';
+import { TabBarDecorator } from '@theia/core/lib/browser/shell/tab-bar-decorator';
+import { Title, Widget } from '@theia/core/lib/browser';
+import { WidgetDecoration } from '@theia/core/lib/browser/widget-decoration';
+import { DisposableCollection } from '@theia/core/lib/common';
+
+@injectable()
+export class DebugTabBarDecorator implements TabBarDecorator {
+    readonly id = 'theia-debug-tabbar-decorator';
+
+    protected readonly emitter = new Emitter<void>();
+    protected toDispose = new DisposableCollection();
+
+    @inject(DebugSessionManager)
+    protected readonly debugSessionManager: DebugSessionManager;
+
+    @postConstruct()
+    protected init(): void {
+        this.toDispose.pushAll([
+            this.debugSessionManager.onDidStartDebugSession(() => this.fireDidChangeDecorations()),
+            this.debugSessionManager.onDidDestroyDebugSession(() => this.fireDidChangeDecorations())
+        ]);
+    }
+
+    decorate(title: Title<Widget>): WidgetDecoration.Data[] {
+        return (title.owner.id === DebugWidget.ID)
+            ? [{ badge: this.debugSessionManager.sessions.length }]
+            : [];
+    }
+
+    get onDidChangeDecorations(): Event<void> {
+        return this.emitter.event;
+    }
+
+    protected fireDidChangeDecorations(): void {
+        this.emitter.fire(undefined);
+    }
+}


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
Fixes: https://github.com/eclipse-theia/theia/issues/8303

Decorates the debug tab-bar with active debug sessions.

![testt](https://user-images.githubusercontent.com/43870550/89813536-d56e7600-db0f-11ea-85aa-0f7c3dd7ff39.PNG)

#### How to test
|   #	| Test Cases  	|Expected Result   |
|---	|---	|--- |
|  1 	|   Open a `.spec` file from Theia, run the config `Run Mocha Test` and check to see if the badge for debug reflects it|Badge on Debug icon will show `1` active session |
|   2	|   Check to see when the session is over, the badge decoration is updated	| The badge should decrement by 1 |
|   3	|   Stop an active session in middle, check to see if the badge decoration is updated	| The badge should decrement by 1  |

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

