### PR TITLE
Fix exception widget covering code lines

### DIFF
--- a/packages/debug/src/browser/style/index.css
+++ b/packages/debug/src/browser/style/index.css
@@ -375,6 +375,7 @@
 /** Breakpoint Widget */
 .theia-debug-breakpoint-widget {
     display: flex;
+    height: calc(100% - 4px);
 }
 
 .theia-debug-breakpoint-select {
@@ -411,6 +412,7 @@
 	white-space: pre-wrap;
 	user-select: text;
     overflow: hidden;
+    height: auto;
 }
 
 .theia-debug-exception-widget .title {

--- a/packages/monaco/src/browser/monaco-editor-zone-widget.ts
+++ b/packages/monaco/src/browser/monaco-editor-zone-widget.ts
@@ -41,9 +41,12 @@ export class MonacoEditorZoneWidget implements Disposable {
         this.toHide
     );
 
+    readonly editorLineHeight: number;
+
     constructor(
         readonly editor: monaco.editor.IStandaloneCodeEditor
     ) {
+        this.editorLineHeight = this.editor.getOption(monaco.editor.EditorOption.lineHeight);
         this.zoneNode.classList.add('zone-widget');
         this.containerNode.classList.add('zone-widget-container');
         this.zoneNode.appendChild(this.containerNode);
@@ -66,7 +69,7 @@ export class MonacoEditorZoneWidget implements Disposable {
 
     show(options: MonacoEditorZoneWidget.Options): void {
         let { afterLineNumber, afterColumn, heightInLines } = this._options = { showFrame: true, ...options };
-        const lineHeight = this.editor.getOption(monaco.editor.EditorOption.lineHeight);
+        const lineHeight = this.editorLineHeight;
         const maxHeightInLines = (this.editor.getLayoutInfo().height / lineHeight) * .8;
         if (heightInLines >= maxHeightInLines) {
             heightInLines = maxHeightInLines;
@@ -130,17 +133,19 @@ export class MonacoEditorZoneWidget implements Disposable {
     }
     protected updateContainerHeight(zoneHeight: number): void {
         const { frameWidth, height } = this.computeContainerHeight(zoneHeight);
-        this.containerNode.style.height = height + 'px';
         this.containerNode.style.borderTopWidth = frameWidth + 'px';
         this.containerNode.style.borderBottomWidth = frameWidth + 'px';
         const width = this.computeWidth();
+        const lineHeight = this.editorLineHeight;
+        const heightInLines = Math.ceil(this.containerNode.offsetHeight / lineHeight);
+        this.layout(heightInLines);
         this.onDidLayoutChangeEmitter.fire({ height, width });
     }
     protected computeContainerHeight(zoneHeight: number): {
         height: number,
         frameWidth: number
     } {
-        const lineHeight = this.editor.getOption(monaco.editor.EditorOption.lineHeight);
+        const lineHeight = this.editorLineHeight;
         const frameWidth = this._options && this._options.frameWidth;
         const frameThickness = this._options && this._options.showFrame ? Math.round(lineHeight / 9) : 0;
         return {


### PR DESCRIPTION
Signed-off-by: Doron Nahari <doron.nahari@sap.com>

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->
Fix exception widget overrides code lines
Fixes one issue in #8225 

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
Create a.js script:

```
var a = 5;
console.log(a);
if (a>2) {
    throw new Error("Error");
}
console.log("End");
```
Create node launcher:
```
{
    "type": "node",
    "request": "launch",
    "name": "Launch Program",
    "program": "${workspaceFolder}/a.js",
    "runtimeExecutable": "node"
}
```
From debug pane set "Uncought Exceptions" breakpoint.
Launch "Launch Program"

Before this pr the exception widget was covering the code
After, the code pushed down:
![ezgif com-video-to-gif](https://user-images.githubusercontent.com/24614792/89836567-b7d0f900-db6f-11ea-8f02-a2f40c5b31ca.gif)

#### Review checklist

- [X] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

