### PR TITLE
reuse hosted plugin instance tab

### DIFF
--- a/packages/core/src/browser/window/default-window-service.ts
+++ b/packages/core/src/browser/window/default-window-service.ts
@@ -18,7 +18,7 @@ import { inject, injectable, named } from 'inversify';
 import { CorePreferences } from '../core-preferences';
 import { ContributionProvider } from '../../common/contribution-provider';
 import { FrontendApplicationContribution, FrontendApplication } from '../frontend-application';
-import { WindowService } from './window-service';
+import { WindowService, NewWindowOptions } from './window-service';
 
 @injectable()
 export class DefaultWindowService implements WindowService, FrontendApplicationContribution {
@@ -41,8 +41,9 @@ export class DefaultWindowService implements WindowService, FrontendApplicationC
         });
     }
 
-    openNewWindow(url: string): undefined {
-        window.open(url, undefined, 'noopener');
+    openNewWindow(url: string, options?: NewWindowOptions): undefined {
+        const features = !!options?.opener ? '' : 'noopener';
+        window.open(url, options?.windowName, features);
         return undefined;
     }
 

--- a/packages/core/src/browser/window/window-service.ts
+++ b/packages/core/src/browser/window/window-service.ts
@@ -16,6 +16,8 @@
 
 export interface NewWindowOptions {
     readonly external?: boolean;
+    readonly windowName?: string;
+    readonly opener?: boolean;
 }
 
 /**

--- a/packages/plugin-dev/src/browser/hosted-plugin-manager-client.ts
+++ b/packages/plugin-dev/src/browser/hosted-plugin-manager-client.ts
@@ -298,7 +298,7 @@ export class HostedPluginManagerClient {
 
         if (this.pluginInstanceURL) {
             try {
-                this.windowService.openNewWindow(this.pluginInstanceURL);
+                this.windowService.openNewWindow(this.pluginInstanceURL, { windowName: 'hosted-theia', opener: true });
             } catch (err) {
                 // browser blocked opening of a new tab
                 this.openNewTabAskDialog.showOpenNewTabAskDialog(this.pluginInstanceURL);


### PR DESCRIPTION
Signed-off-by: Doron Nahari <doron.nahari@sap.com>

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->
Reuses an already opened hosted plugin instance tab for a new hosted instance.
If a user start hosted instance and then he start another one, it will be opened on the same tab that the first one was opened on. 

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
run hosted plugin instance one after another and see that they all open in the same tab.
F1 -> start instance, choose theia plugin or vscode extension.
#### Review checklist

- [X] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

