### PR TITLE
[ip] pin jschardet to v1.6.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
   },
   "resolutions": {
     "**/@types/node": "~10.3.6",
-    "**/node-abi": "^2.18.0"
+    "**/node-abi": "^2.18.0",
+    "jschardet": "1.6.0"
   },
   "devDependencies": {
     "@types/chai-string": "^1.4.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7904,10 +7904,10 @@ jsbn@~0.1.0:
   resolved "https://registry.yarnpkg.com/jsbn/-/jsbn-0.1.1.tgz#a5e654c2e5a2deb5f201d96cefbca80c0ef2f513"
   integrity sha1-peZUwuWi3rXyAdls77yoDA7y9RM=
 
-jschardet@^2.1.1:
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/jschardet/-/jschardet-2.1.1.tgz#af6f8fd0b3b0f5d46a8fd9614a4fce490575c184"
-  integrity sha512-pA5qG9Zwm8CBpGlK/lo2GE9jPxwqRgMV7Lzc/1iaPccw6v4Rhj8Zg2BTyrdmHmxlJojnbLupLeRnaPLsq03x6Q==
+jschardet@1.6.0, jschardet@^2.1.1:
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/jschardet/-/jschardet-1.6.0.tgz#c7d1a71edcff2839db2f9ec30fc5d5ebd3c1a678"
+  integrity sha512-xYuhvQ7I9PDJIGBWev9xm0+SMSed3ZDBAmvVjbFR1ZRLAF+vlXcQu6cRI9uAlj81rzikElRVteehwV7DuX2ZmQ==
 
 jscodeshift@^0.4.0:
   version "0.4.1"


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->
Our jschardet has been stepped to a new major version and we missed
it. Since this dependency is licensed under the LGPL, it requires a
special permission from the Eclipse Board, before we are allowed
to use a new version, as part of a release.

There is only a bit more than 2 weeks before our next release, and
I do not know when the next board meeting may happen. So it looks
like we might have to delay the release or momentarily go back to
the previous, approved, dependency version.

This is what this PR does, using a resolution.

CQ (need to be committer to see):
https://dev.eclipse.org/ipzilla/show_bug.cgi?id=22481


#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
Check that CI passes and that the example application still works correctly.

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

