### PR TITLE
GH-8350: Fixed bogus app config defaults.

### DIFF
--- a/dev-packages/application-package/package.json
+++ b/dev-packages/application-package/package.json
@@ -33,6 +33,7 @@
     "@types/semver": "^5.4.0",
     "@types/write-json-file": "^2.2.1",
     "changes-stream": "^2.2.0",
+    "deepmerge": "2.0.1",
     "fs-extra": "^4.0.2",
     "is-electron": "^2.1.0",
     "request": "^2.82.0",

--- a/dev-packages/application-package/src/application-package.ts
+++ b/dev-packages/application-package/src/application-package.ts
@@ -20,6 +20,7 @@ import { NpmRegistry, NodePackage, PublishedNodePackage, sortByKey } from './npm
 import { Extension, ExtensionPackage, RawExtensionPackage } from './extension-package';
 import { ExtensionPackageCollector } from './extension-package-collector';
 import { ApplicationProps } from './application-props';
+const merge = require('deepmerge');
 
 // tslint:disable:no-implicit-dependencies
 
@@ -87,7 +88,7 @@ export class ApplicationPackage {
             theia.target = defaultTarget;
         }
 
-        return this._props = { ...ApplicationProps.DEFAULT, ...theia };
+        return this._props = merge(ApplicationProps.DEFAULT, theia);
     }
 
     protected _pck: NodePackage | undefined;

--- a/dev-packages/application-package/src/application-props.ts
+++ b/dev-packages/application-package/src/application-props.ts
@@ -111,7 +111,7 @@ export interface FrontendApplicationConfig extends ApplicationConfig {
     readonly defaultTheme?: string;
 
     /**
-     * The name of the application. `Theia` by default.
+     * The name of the application. `Eclipse Theia` by default.
      */
     readonly applicationName: string;
 


### PR DESCRIPTION
Closes #8350

Signed-off-by: Akos Kitta <kittaakos@typefox.io>

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

Fixes the bogus default handling for application props.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

 - Delete the `applicationName` from `examples/browser/package.json`,
 - `yarn --cwd ./examples/browser build`,
 - Verify that the `applicationName` is `Eclipse Theia` in the generated `examples/browser/src-gen/frontend/index.js`.

Or verify it with a VS Code extension. See [here](https://github.com/eclipse-theia/theia/issues/8350#issuecomment-672154559).

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

