### PR TITLE
Fixed submenu ordering.

### DIFF
--- a/examples/api-samples/src/browser/menu/sample-menu-contribution.ts
+++ b/examples/api-samples/src/browser/menu/sample-menu-contribution.ts
@@ -21,6 +21,10 @@ const SampleCommand: Command = {
     id: 'sample-command',
     label: 'Sample Command'
 };
+const SampleCommand2: Command = {
+    id: 'sample-command2',
+    label: 'Sample Command2'
+};
 
 @injectable()
 export class SampleCommandContribution implements CommandContribution {
@@ -28,6 +32,11 @@ export class SampleCommandContribution implements CommandContribution {
         commands.registerCommand(SampleCommand, {
             execute: () => {
                 alert('This is a sample command!');
+            }
+        });
+        commands.registerCommand(SampleCommand2, {
+            execute: () => {
+                alert('This is sample command2!');
             }
         });
     }
@@ -42,7 +51,22 @@ export class SampleMenuContribution implements MenuContribution {
             order: '2' // that should put the menu right next to the File menu
         });
         menus.registerMenuAction(subMenuPath, {
-            commandId: SampleCommand.id
+            commandId: SampleCommand.id,
+            order: '0'
+        });
+        menus.registerMenuAction(subMenuPath, {
+            commandId: SampleCommand2.id,
+            order: '2'
+        });
+        const subSubMenuPath = [...subMenuPath, 'sample-sub-menu'];
+        menus.registerSubmenu(subSubMenuPath, 'Sample sub menu', { order: '1' });
+        menus.registerMenuAction(subSubMenuPath, {
+            commandId: SampleCommand.id,
+            order: '0'
+        });
+        menus.registerMenuAction(subSubMenuPath, {
+            commandId: SampleCommand2.id,
+            order: '2'
         });
     }
 }

--- a/packages/core/src/common/menu.ts
+++ b/packages/core/src/common/menu.ts
@@ -91,8 +91,8 @@ export class MenuModelRegistry {
         const index = menuPath.length - 1;
         const menuId = menuPath[index];
         const groupPath = index === 0 ? [] : menuPath.slice(0, index);
-        const parent = this.findGroup(groupPath);
-        let groupNode = this.findSubMenu(parent, menuId);
+        const parent = this.findGroup(groupPath, options);
+        let groupNode = this.findSubMenu(parent, menuId, options);
         if (!groupNode) {
             groupNode = new CompositeMenuNode(menuId, label, options);
             return parent.addNode(groupNode);
@@ -155,15 +155,15 @@ export class MenuModelRegistry {
         recurse(this.root);
     }
 
-    protected findGroup(menuPath: MenuPath): CompositeMenuNode {
+    protected findGroup(menuPath: MenuPath, options?: SubMenuOptions): CompositeMenuNode {
         let currentMenu = this.root;
         for (const segment of menuPath) {
-            currentMenu = this.findSubMenu(currentMenu, segment);
+            currentMenu = this.findSubMenu(currentMenu, segment, options);
         }
         return currentMenu;
     }
 
-    protected findSubMenu(current: CompositeMenuNode, menuId: string): CompositeMenuNode {
+    protected findSubMenu(current: CompositeMenuNode, menuId: string, options?: SubMenuOptions): CompositeMenuNode {
         const sub = current.children.find(e => e.id === menuId);
         if (sub instanceof CompositeMenuNode) {
             return sub;
@@ -171,7 +171,7 @@ export class MenuModelRegistry {
         if (sub) {
             throw new Error(`'${menuId}' is not a menu group.`);
         }
-        const newSub = new CompositeMenuNode(menuId);
+        const newSub = new CompositeMenuNode(menuId, undefined, options);
         current.addNode(newSub);
         return newSub;
     }


### PR DESCRIPTION
Signed-off-by: Akos Kitta <kittaakos@typefox.io>

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

Fixes the submenu ordering. `SubMenuOptions#order` is ignored when registering a submenu. See [here](https://github.com/eclipse-theia/theia/issues/7300#issuecomment-673523069).

Before:
![Screen Shot 2020-08-13 at 17 06 08](https://user-images.githubusercontent.com/1405703/90152322-f93bf100-dd87-11ea-8258-383df257bde4.jpg)
After:
![Screen Shot 2020-08-13 at 17 08 25](https://user-images.githubusercontent.com/1405703/90152339-0062ff00-dd88-11ea-8260-4a884a92cb74.jpg)

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

Check the `Sample Menu` and the [corresponding API-sample code](https://github.com/eclipse-theia/theia/compare/fix--can-order-submenu?expand=1#diff-291ef58fe36fe9639559d9a4eef63acd) change.

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

