### PR TITLE
[WIP] Use FIPS-approved SHA256 instead of weak MD5

### DIFF
--- a/packages/plugin-ext/src/plugin/types-impl.ts
+++ b/packages/plugin-ext/src/plugin/types-impl.ts
@@ -25,7 +25,6 @@
 import { UUID } from '@phosphor/coreutils/lib/uuid';
 import { illegalArgument } from '../common/errors';
 import * as theia from '@theia/plugin';
-import * as crypto from 'crypto';
 import { URI } from 'vscode-uri';
 import { relative } from '../common/paths-util';
 import { startsWithIgnoreCase } from '@theia/core/lib/common/strings';
@@ -1401,6 +1400,14 @@ export enum ProgressLocation {
     Notification = 15
 }
 
+function computeTaskExecutionId(values: string[]): string {
+    let id: string = '';
+    for (let i = 0; i < values.length; i++) {
+        id += values[i].replace(/,/g, ',,') + ',';
+    }
+    return id;
+}
+
 export class ProcessExecution {
     private executionProcess: string;
     private arguments: string[];
@@ -1457,17 +1464,17 @@ export class ProcessExecution {
     }
 
     public computeId(): string {
-        const hash = crypto.createHash('md5');
-        hash.update('process');
+        const props: string[] = [];
+        props.push('process');
         if (this.executionProcess !== undefined) {
-            hash.update(this.executionProcess);
+            props.push(this.executionProcess);
         }
         if (this.arguments && this.arguments.length > 0) {
             for (const arg of this.arguments) {
-                hash.update(arg);
+                props.push(arg);
             }
         }
-        return hash.digest('hex');
+        return computeTaskExecutionId(props);
     }
 
     public static is(value: theia.ShellExecution | theia.ProcessExecution): boolean {
@@ -1562,20 +1569,20 @@ export class ShellExecution {
     }
 
     public computeId(): string {
-        const hash = crypto.createHash('md5');
-        hash.update('shell');
+        const props: string[] = [];
+        props.push('shell');
         if (this.shellCommandLine !== undefined) {
-            hash.update(this.shellCommandLine);
+            props.push(this.shellCommandLine);
         }
         if (this.shellCommand !== undefined) {
-            hash.update(typeof this.shellCommand === 'string' ? this.shellCommand : this.shellCommand.value);
+            props.push(typeof this.shellCommand === 'string' ? this.shellCommand : this.shellCommand.value);
         }
         if (this.arguments && this.arguments.length > 0) {
             for (const arg of this.arguments) {
-                hash.update(typeof arg === 'string' ? arg : arg.value);
+                props.push(typeof arg === 'string' ? arg : arg.value);
             }
         }
-        return hash.digest('hex');
+        return computeTaskExecutionId(props);
     }
 
     public static is(value: theia.ShellExecution | theia.ProcessExecution): boolean {


### PR DESCRIPTION
Signed-off-by: Artem Zatsarynnyi <azatsary@redhat.com>

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->
Fixes https://github.com/eclipse-theia/theia/issues/8378 by removing MD5 usage.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
The simplest variant to test it is to run Theia and see that there's no unusual error logged, frontend is loaded as usual and Task of types `process/shell` works as expected.

If it's possible, you can check the same in an OS with FIPS mode enabled. E.g. [here's the instructions](https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/7/html/security_guide/chap-federal_standards_and_regulations#sec-Enabling-FIPS-Mode) for Red Hat Enterprise Linux 7.

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

