### PR TITLE
fix debug exception height computation

### DIFF
--- a/packages/debug/src/browser/editor/debug-editor-model.ts
+++ b/packages/debug/src/browser/editor/debug-editor-model.ts
@@ -175,7 +175,7 @@ export class DebugEditorModel implements Disposable {
 
     protected async toggleExceptionWidget(): Promise<void> {
         const { currentFrame } = this.sessions;
-        if (!currentFrame) {
+        if (!currentFrame || !currentFrame.source || currentFrame.source.uri.toString() !== this.uri.toString()) {
             this.exceptionWidget.hide();
             return;
         }


### PR DESCRIPTION
Signed-off-by: Anton Kosyakov <anton.kosyakov@typefox.io>


<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

- fix #8225: fix debug exception height computation

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

- create a.js file with following content:
```
var a = 5;
console.log(a);
if (a>2) {
    throw new Error("Error");
}
console.log("End");
```

- use `Launch with Node.js` debug configuration to debug it
- enable exception breakpoint
- rerun the debug configuration again
- the exception breakpoint should not overflow editor content
- it should stay the same when you modify a file
- when you switch to another file the exception widget should not be visible
- but should appear when you come back

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

