### PR TITLE
[plugin] return cloned preference to serialize not a clone function

### DIFF
--- a/packages/plugin-ext/src/plugin/preference-registry.ts
+++ b/packages/plugin-ext/src/plugin/preference-registry.ts
@@ -109,7 +109,7 @@ export class PreferenceRegistryExtImpl implements PreferenceRegistryExt {
                         let clonedTarget: any = undefined;
                         const cloneTarget = () => {
                             clonedConfig = clonedConfig ? clonedConfig : cloneDeep(preferences);
-                            clonedTarget = clonedTarget ? cloneTarget : lookUp(clonedConfig, accessor);
+                            clonedTarget = clonedTarget ? clonedTarget : lookUp(clonedConfig, accessor);
                         };
 
                         if (!isObject(target)) {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

- fix #8255: return cloned preference to serialize not a clone function

I really don't get how we end up with such bugs :( This code just should have been copied from VS Code. It takes so much time to track and then figure out that there is a typo in copied code :see_no_evil:

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

- install ruby extensions from the open vsx: https://github.com/eclipse-theia/theia/issues/8255#issuecomment-665042460
- configure ruby extension to use language server by adding in user settings:
```json
    "ruby.useLanguageServer": true,
    "ruby.lint": {
        "rubocop": {
            "useBundler": false
        }
    }
```
- create `a.rb` file with the following content:
```rb
Live Demo
#!/usr/bin/ruby

print "Hello World"
print "Good Morning"
```
- open this file and check that document is linted, you should wait a bit, `rubocop` is not always fast

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

