### PR TITLE
don't activate plugin eagerly on unsupported event

### DIFF
--- a/packages/plugin-ext/src/plugin/plugin-manager.ts
+++ b/packages/plugin-ext/src/plugin/plugin-manager.ts
@@ -245,15 +245,12 @@ export class PluginManagerExtImpl implements PluginManagerExt, PluginManager {
             const unsupportedActivationEvents = plugin.rawModel.activationEvents.filter(e => !PluginManagerExtImpl.SUPPORTED_ACTIVATION_EVENTS.has(e.split(':')[0]));
             if (unsupportedActivationEvents.length) {
                 console.warn(`Unsupported activation events: ${unsupportedActivationEvents.join(', ')}, please open an issue: https://github.com/eclipse-theia/theia/issues/new`);
-                console.warn(`${plugin.model.id} extension will be activated eagerly.`);
-                this.setActivation('*', activation);
-            } else {
-                for (let activationEvent of plugin.rawModel.activationEvents) {
-                    if (activationEvent === 'onUri') {
-                        activationEvent = `onUri:theia://${plugin.model.id}`;
-                    }
-                    this.setActivation(activationEvent, activation);
+            }
+            for (let activationEvent of plugin.rawModel.activationEvents) {
+                if (activationEvent === 'onUri') {
+                    activationEvent = `onUri:theia://${plugin.model.id}`;
                 }
+                this.setActivation(activationEvent, activation);
             }
         }
     }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

- fix #8394: don't activate plugin eagerly on unsupported event

When we did not support many activation events it was useful to activate some extensions eagerly. But by now we support most popular and remaining either secondary or lead to bad experience like missing support of native notebooks or custom editors. This PR does not activate extensions eagerly anymore to prevent such effects.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

- Start a fresh Theia, don nothing but install python extension from `Extensions` view.
- Check that after installation python extension is not activated, but you see that some events are logged as unsupported in the backend log.
- Now open python file or create a new notebook. At this moment the python extension should activate, enable features and show the welcome page.
- Close everything and reload the page.
- Again open python file or new notebook. This time the python extension should activate, enable features, but welcome page should not be shown.

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

