### PR TITLE
Log grammar collisions without a stack trace.

### DIFF
--- a/packages/monaco/src/browser/textmate/textmate-registry.ts
+++ b/packages/monaco/src/browser/textmate/textmate-registry.ts
@@ -56,7 +56,7 @@ export class TextmateRegistry {
         if (existingProvider) {
             Promise.all([existingProvider.getGrammarDefinition(), provider.getGrammarDefinition()]).then(([a, b]) => {
                 if (a.location !== b.location || !a.location && !b.location) {
-                    console.warn(new Error(`a registered grammar provider for '${scope}' scope is overridden`));
+                    console.warn(`a registered grammar provider for '${scope}' scope is overridden`);
                 }
             });
         }
@@ -79,7 +79,7 @@ export class TextmateRegistry {
         const scopes = this.languageIdToScope.get(languageId) || [];
         const existingScope = scopes[0];
         if (typeof existingScope === 'string') {
-            console.warn(new Error(`'${languageId}' language is remapped from '${existingScope}' to '${scope}' scope`));
+            console.warn(`'${languageId}' language is remapped from '${existingScope}' to '${scope}' scope`);
         }
         scopes.unshift(scope);
         this.languageIdToScope.set(languageId, scopes);
@@ -109,7 +109,7 @@ export class TextmateRegistry {
         const configs = this.languageToConfig.get(languageId) || [];
         const existingConfig = configs[0];
         if (existingConfig) {
-            console.warn(new Error(`a registered grammar configuration for '${languageId}' language is overridden`));
+            console.warn(`a registered grammar configuration for '${languageId}' language is overridden`);
         }
         configs.unshift(config);
         this.languageToConfig.set(languageId, configs);
@@ -125,4 +125,5 @@ export class TextmateRegistry {
         const configs = this.languageToConfig.get(languageId);
         return configs && configs[0] || {};
     }
+
 }


### PR DESCRIPTION
Signed-off-by: Akos Kitta <kittaakos@typefox.io>

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

From now on, TextMate grammar collisions are logged without a stack trace.

Before:
```
logger-protocol.ts:112 root WARN Error: 'cpp' language is remapped from 'source.cpp.embedded.macro' to 'source.cpp' scope
    at TextmateRegistry.push.../../packages/monaco/lib/browser/textmate/textmate-registry.js.TextmateRegistry.mapLanguageIdToTextmateGrammar (file:///Users/akos.kitta/git/theia/examples/electron/lib/43.bundle.js:2259:26)
    at file:///Users/akos.kitta/git/theia/examples/electron/lib/53.bundle.js:7275:125
    at pushContribution (file:///Users/akos.kitta/git/theia/examples/electron/lib/53.bundle.js:7133:32)
    at _loop_15 (file:///Users/akos.kitta/git/theia/examples/electron/lib/53.bundle.js:7275:21)
    at file:///Users/akos.kitta/git/theia/examples/electron/lib/53.bundle.js:7284:25
logger-protocol.ts:112 root WARN Error: a registered grammar configuration for 'cpp' language is overridden
    at TextmateRegistry.push.../../packages/monaco/lib/browser/textmate/textmate-registry.js.TextmateRegistry.registerGrammarConfiguration (file:///Users/akos.kitta/git/theia/examples/electron/lib/43.bundle.js:2297:26)
    at file:///Users/akos.kitta/git/theia/examples/electron/lib/53.bundle.js:7276:133
    at pushContribution (file:///Users/akos.kitta/git/theia/examples/electron/lib/53.bundle.js:7133:32)
    at _loop_15 (file:///Users/akos.kitta/git/theia/examples/electron/lib/53.bundle.js:7276:21)
    at file:///Users/akos.kitta/git/theia/examples/electron/lib/53.bundle.js:7284:25
```

After:
```
logger-protocol.ts:112 root WARN 'cpp' language is remapped from 'source.cpp.embedded.macro' to 'source.cpp' scope
logger-protocol.ts:112 root WARN a registered grammar configuration for 'cpp' language is overridden
```

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

Start the app and check the browser logs.

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

