### PR TITLE
GH-8416: Fixed the menu widget layout.

### DIFF
--- a/packages/core/src/browser/style/menus.css
+++ b/packages/core/src/browser/style/menus.css
@@ -49,6 +49,10 @@
   line-height: var(--theia-private-menubar-height);
 }
 
+.p-MenuBar-item .p-MenuBar-itemLabel {
+  white-space: pre;
+}
+
 
 .p-MenuBar-item.p-mod-active {
   background: var(--theia-menubar-selectionBackground);


### PR DESCRIPTION
Do not break line on spaces.

Closes #8416

Signed-off-by: Akos Kitta <kittaakos@typefox.io>

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

This PR fixes the menu widget layout; it does not break lines on non-breaking whitespace.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

Check the `Sample Menu` with the browser example, make the horizontal space small enough so you cannot see the last items (`Debug`, `Terminal`, and `Help`) from the main menu bar.

![screencast 2020-08-24 09-37-03](https://user-images.githubusercontent.com/1405703/91016793-9b13d700-e5ed-11ea-8751-93d820a82770.gif)


#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

