### PR TITLE
Fix issue with default value in workspaceState/globalState

### DIFF
--- a/packages/plugin-ext/src/plugin/plugin-storage.ts
+++ b/packages/plugin-ext/src/plugin/plugin-storage.ts
@@ -51,7 +51,11 @@ export class Memento implements theia.Memento {
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     update(key: string, value: any): Promise<void> {
-        this.cache[key] = value;
+        if (value === undefined) {
+            delete this.cache[key];
+        } else {
+            this.cache[key] = value;
+        }
         return this.storage.setPerPluginData(this.pluginId, this.cache, this.isPluginGlobalData).then(_ => undefined);
     }
 }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->
Fixes issues described in #8435
~~The Issue with parsing JSON happens just after `writeJSON` with correct and valid data, but the file is very empty. Replacement to `writeJSONSync` solves the issue.~~

Another issue with getting value from `workspaceState`/`globalState`, if previously updated with `undefined`. Original [Memento](https://code.visualstudio.com/api/references/vscode-api#Memento) suppose to return `defaultValue` if no previous value or undefined.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
Examples provided in the linked issue
Test code
```
			// Just clear start, completely nothing in globalState, yet
			val = globalState.get('test', "default") || "WTF";

			globalState.update('test1', undefined);
			val1 = globalState.get('test1', "default") || "WTF";

			globalState.update('test2', "somevalue");
			val2 = globalState.get('test2', "default") || "WTF";	
```
Expected values,
```
val="default"
val1="default"
val2="somevalue"
```

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

