### PR TITLE
Activity bar Icon should look similar to vscode

### DIFF
--- a/packages/core/src/browser/style/sidepanel.css
+++ b/packages/core/src/browser/style/sidepanel.css
@@ -28,6 +28,7 @@
   --theia-private-sidebar-icon-size: 28px;
 }
 
+
 /*-----------------------------------------------------------------------------
 | SideBars (left and right)
 |----------------------------------------------------------------------------*/
@@ -56,21 +57,19 @@
 }
 
 .p-TabBar.theia-app-left .p-TabBar-tab {
-  border-left: var(--theia-panel-border-width) solid transparent;
+    border-left: var(--theia-panel-border-width) solid transparent;
 }
 
 .p-TabBar.theia-app-left.theia-app-sides {
-  border-right: var(--theia-panel-border-width) solid
-    var(--theia-activityBar-border);
+    border-right: var(--theia-panel-border-width) solid var(--theia-activityBar-border);
 }
 
 .p-TabBar.theia-app-right .p-TabBar-tab {
-  border-right: var(--theia-panel-border-width) solid transparent;
+    border-right: var(--theia-panel-border-width) solid transparent;
 }
 
 .p-Widget.p-TabBar.theia-app-right.theia-app-sides {
-  border-left: var(--theia-panel-border-width) solid
-    var(--theia-activityBar-border);
+    border-left: var(--theia-panel-border-width) solid var(--theia-activityBar-border);
 }
 
 .p-TabBar.theia-app-sides .p-TabBar-tab.p-mod-current,
@@ -83,23 +82,21 @@
 }
 
 .p-TabBar.theia-app-left .p-TabBar-tab.p-mod-current {
-  border-left: var(--theia-panel-border-width) solid
-    var(--theia-activityBar-activeBorder);
+  border-left: var(--theia-panel-border-width) solid var(--theia-activityBar-activeBorder);
   border-top-color: transparent;
 }
 
 .p-TabBar.theia-app-left .p-TabBar-tab.p-mod-current.theia-mod-active {
-  border-left: var(--theia-panel-border-width) solid var(--theia-focusBorder);
+    border-left: var(--theia-panel-border-width) solid var(--theia-focusBorder);
 }
 
 .p-TabBar.theia-app-right .p-TabBar-tab.p-mod-current {
-  border-right: var(--theia-panel-border-width) solid
-    var(--theia-activityBar-activeBorder);
-  border-top-color: transparent;
+    border-right: var(--theia-panel-border-width) solid var(--theia-activityBar-activeBorder);
+    border-top-color: transparent;
 }
 
 .p-TabBar.theia-app-right .p-TabBar-tab.p-mod-current.theia-mod-active {
-  border-right: var(--theia-panel-border-width) solid var(--theia-focusBorder);
+    border-right: var(--theia-panel-border-width) solid var(--theia-focusBorder);
 }
 
 .p-TabBar.theia-app-sides .p-TabBar-tabLabel,
@@ -159,13 +156,11 @@
 }
 
 #theia-left-content-panel > .p-Panel {
-  border-right: var(--theia-panel-border-width) solid
-    var(--theia-activityBar-border);
+    border-right: var(--theia-panel-border-width) solid var(--theia-activityBar-border);
 }
 
 #theia-right-content-panel > .p-Panel {
-  border-left: var(--theia-panel-border-width) solid
-    var(--theia-activityBar-border);
+    border-left: var(--theia-panel-border-width) solid var(--theia-activityBar-border);
 }
 
 .theia-side-panel {
@@ -174,7 +169,7 @@
 
 .p-Widget.theia-side-panel .p-Widget,
 .p-Widget .theia-sidepanel-toolbar {
-  color: var(--theia-sideBar-foreground);
+    color: var(--theia-sideBar-foreground);
 }
 
 .theia-app-sidebar-container {
@@ -200,8 +195,7 @@
 }
 
 .p-Widget.theia-sidebar-bottom-menu i {
-  padding: var(--theia-private-sidebar-tab-padding-top-and-bottom)
-    var(--theia-private-sidebar-tab-padding-left-and-right);
+  padding: var(--theia-private-sidebar-tab-padding-top-and-bottom) var(--theia-private-sidebar-tab-padding-left-and-right);
   display: flex;
   justify-content: center;
   align-items: center;
@@ -224,14 +218,9 @@
   z-index: 1000;
 }
 
-#theia-app-shell .p-TabBar.theia-app-sides > .ps__rail-y > .ps__thumb-y {
+#theia-app-shell .p-TabBar.theia-app-sides > .ps__rail-y  >.ps__thumb-y {
   width: var(--theia-private-sidebar-scrollbar-width);
-  right: calc(
-    (
-        var(--theia-private-sidebar-scrollbar-rail-width) -
-          var(--theia-private-sidebar-scrollbar-width)
-      ) / 2
-  );
+  right: calc((var(--theia-private-sidebar-scrollbar-rail-width) - var(--theia-private-sidebar-scrollbar-width)) / 2);
 }
 
 .p-TabBar.theia-app-sides > .ps__rail-y:hover,
@@ -242,51 +231,46 @@
 .p-TabBar.theia-app-sides > .ps__rail-y:hover > .ps__thumb-y,
 .p-TabBar.theia-app-sides > .ps__rail-y:focus > .ps__thumb-y {
   width: var(--theia-private-sidebar-scrollbar-width);
-  right: calc(
-    (
-        var(--theia-private-sidebar-scrollbar-rail-width) -
-          var(--theia-private-sidebar-scrollbar-width)
-      ) / 2
-  );
+  right: calc((var(--theia-private-sidebar-scrollbar-rail-width) - var(--theia-private-sidebar-scrollbar-width)) / 2);
 }
+
 
 /*-----------------------------------------------------------------------------
 | Bottom content panel
 |----------------------------------------------------------------------------*/
 
 #theia-bottom-content-panel {
-  background: var(--theia-panel-background);
+    background: var(--theia-panel-background);
 }
 
 #theia-bottom-content-panel .theia-input {
-  border-color: var(--theia-panelInput-border);
+    border-color: var(--theia-panelInput-border);
 }
 
-#theia-bottom-content-panel .p-DockPanel-handle[data-orientation="horizontal"] {
-  border-left: var(--theia-border-width) solid var(--theia-panel-border);
+#theia-bottom-content-panel .p-DockPanel-handle[data-orientation='horizontal'] {
+    border-left: var(--theia-border-width) solid var(--theia-panel-border);
 }
 
 #theia-bottom-content-panel .p-TabBar {
-  border-top: var(--theia-border-width) solid var(--theia-panel-border);
-  background: inherit;
+    border-top: var(--theia-border-width) solid var(--theia-panel-border);
+    background: inherit;
 }
 
 #theia-bottom-content-panel .p-TabBar-tab {
-  background: inherit;
+    background: inherit;
 }
 
 #theia-bottom-content-panel .p-TabBar-tab:not(.p-mod-current) {
-  color: var(--theia-panelTitle-inactiveForeground);
+    color: var(--theia-panelTitle-inactiveForeground);
 }
 
 #theia-bottom-content-panel .p-TabBar-tab.p-mod-current {
-  color: var(--theia-panelTitle-activeForeground);
-  border-top: var(--theia-border-width) solid
-    var(--theia-panelTitle-activeBorder);
+    color: var(--theia-panelTitle-activeForeground);
+    border-top: var(--theia-border-width) solid var(--theia-panelTitle-activeBorder);
 }
 
 #theia-bottom-content-panel .p-TabBar-tab.p-mod-current.theia-mod-active {
-  border-top-color: var(--theia-focusBorder);
+    border-top-color: var(--theia-focusBorder);
 }
 
 /*-----------------------------------------------------------------------------
@@ -316,32 +300,29 @@
 |----------------------------------------------------------------------------*/
 
 .theia-sidepanel-toolbar {
-  min-height: calc(
-    var(--theia-private-horizontal-tab-height) +
-      var(--theia-private-horizontal-tab-scrollbar-rail-height) / 2
-  );
-  display: flex;
-  padding-left: 5px;
-  align-items: center;
-  background-color: var(--theia-sideBar-background);
+    min-height: calc(var(--theia-private-horizontal-tab-height) + var(--theia-private-horizontal-tab-scrollbar-rail-height) / 2);
+    display: flex;
+    padding-left: 5px;
+    align-items: center;
+    background-color: var(--theia-sideBar-background);
 }
 
 .theia-sidepanel-toolbar .theia-sidepanel-title {
-  color: var(--theia-settings-headerForeground);
-  flex: 1;
-  margin-left: 14px;
-  text-transform: uppercase;
-  font-size: var(--theia-ui-font-size0);
+    color: var(--theia-settings-headerForeground);
+    flex: 1;
+    margin-left: 14px;
+    text-transform: uppercase;
+    font-size: var(--theia-ui-font-size0);
 }
 
 .theia-sidepanel-toolbar .p-TabBar-toolbar .item {
-  color: var(--theia-icon-foreground);
+    color: var(--theia-icon-foreground);
 }
 
-.theia-sidepanel-toolbar .p-TabBar-toolbar .item > div {
-  height: 18px;
-  width: 18px;
-  background-repeat: no-repeat;
+.theia-sidepanel-toolbar .p-TabBar-toolbar .item > div{
+    height: 18px;
+    width: 18px;
+    background-repeat: no-repeat;
 }
 
 .noWrapInfo {

--- a/packages/core/src/browser/style/sidepanel.css
+++ b/packages/core/src/browser/style/sidepanel.css
@@ -28,7 +28,6 @@
   --theia-private-sidebar-icon-size: 28px;
 }
 
-
 /*-----------------------------------------------------------------------------
 | SideBars (left and right)
 |----------------------------------------------------------------------------*/
@@ -48,7 +47,6 @@
 
 .p-TabBar.theia-app-sides .p-TabBar-tab {
   position: relative;
-  padding: var(--theia-private-sidebar-tab-padding-top-and-bottom) var(--theia-private-sidebar-tab-padding-left-and-right);
   background: var(--theia-activityBar-background);
   flex-direction: column;
   justify-content: center;
@@ -58,19 +56,21 @@
 }
 
 .p-TabBar.theia-app-left .p-TabBar-tab {
-    border-left: var(--theia-panel-border-width) solid transparent;
+  border-left: var(--theia-panel-border-width) solid transparent;
 }
 
 .p-TabBar.theia-app-left.theia-app-sides {
-    border-right: var(--theia-panel-border-width) solid var(--theia-activityBar-border);
+  border-right: var(--theia-panel-border-width) solid
+    var(--theia-activityBar-border);
 }
 
 .p-TabBar.theia-app-right .p-TabBar-tab {
-    border-right: var(--theia-panel-border-width) solid transparent;
+  border-right: var(--theia-panel-border-width) solid transparent;
 }
 
 .p-Widget.p-TabBar.theia-app-right.theia-app-sides {
-    border-left: var(--theia-panel-border-width) solid var(--theia-activityBar-border);
+  border-left: var(--theia-panel-border-width) solid
+    var(--theia-activityBar-border);
 }
 
 .p-TabBar.theia-app-sides .p-TabBar-tab.p-mod-current,
@@ -83,21 +83,23 @@
 }
 
 .p-TabBar.theia-app-left .p-TabBar-tab.p-mod-current {
-  border-left: var(--theia-panel-border-width) solid var(--theia-activityBar-activeBorder);
+  border-left: var(--theia-panel-border-width) solid
+    var(--theia-activityBar-activeBorder);
   border-top-color: transparent;
 }
 
 .p-TabBar.theia-app-left .p-TabBar-tab.p-mod-current.theia-mod-active {
-    border-left: var(--theia-panel-border-width) solid var(--theia-focusBorder);
+  border-left: var(--theia-panel-border-width) solid var(--theia-focusBorder);
 }
 
 .p-TabBar.theia-app-right .p-TabBar-tab.p-mod-current {
-    border-right: var(--theia-panel-border-width) solid var(--theia-activityBar-activeBorder);
-    border-top-color: transparent;
+  border-right: var(--theia-panel-border-width) solid
+    var(--theia-activityBar-activeBorder);
+  border-top-color: transparent;
 }
 
 .p-TabBar.theia-app-right .p-TabBar-tab.p-mod-current.theia-mod-active {
-    border-right: var(--theia-panel-border-width) solid var(--theia-focusBorder);
+  border-right: var(--theia-panel-border-width) solid var(--theia-focusBorder);
 }
 
 .p-TabBar.theia-app-sides .p-TabBar-tabLabel,
@@ -116,8 +118,8 @@
   background-color: var(--theia-activityBar-inactiveForeground);
 
   /* svg */
-  width: var(--theia-private-sidebar-icon-size);
-  height: var(--theia-private-sidebar-icon-size);
+  width: var(--theia-private-sidebar-tab-width);
+  height: var(--theia-private-sidebar-tab-width);
   mask-repeat: no-repeat;
   -webkit-mask-repeat: no-repeat;
   mask-size: var(--theia-private-sidebar-icon-size);
@@ -157,11 +159,13 @@
 }
 
 #theia-left-content-panel > .p-Panel {
-    border-right: var(--theia-panel-border-width) solid var(--theia-activityBar-border);
+  border-right: var(--theia-panel-border-width) solid
+    var(--theia-activityBar-border);
 }
 
 #theia-right-content-panel > .p-Panel {
-    border-left: var(--theia-panel-border-width) solid var(--theia-activityBar-border);
+  border-left: var(--theia-panel-border-width) solid
+    var(--theia-activityBar-border);
 }
 
 .theia-side-panel {
@@ -170,7 +174,7 @@
 
 .p-Widget.theia-side-panel .p-Widget,
 .p-Widget .theia-sidepanel-toolbar {
-    color: var(--theia-sideBar-foreground);
+  color: var(--theia-sideBar-foreground);
 }
 
 .theia-app-sidebar-container {
@@ -196,7 +200,8 @@
 }
 
 .p-Widget.theia-sidebar-bottom-menu i {
-  padding: var(--theia-private-sidebar-tab-padding-top-and-bottom) var(--theia-private-sidebar-tab-padding-left-and-right);
+  padding: var(--theia-private-sidebar-tab-padding-top-and-bottom)
+    var(--theia-private-sidebar-tab-padding-left-and-right);
   display: flex;
   justify-content: center;
   align-items: center;
@@ -219,9 +224,14 @@
   z-index: 1000;
 }
 
-#theia-app-shell .p-TabBar.theia-app-sides > .ps__rail-y  >.ps__thumb-y {
+#theia-app-shell .p-TabBar.theia-app-sides > .ps__rail-y > .ps__thumb-y {
   width: var(--theia-private-sidebar-scrollbar-width);
-  right: calc((var(--theia-private-sidebar-scrollbar-rail-width) - var(--theia-private-sidebar-scrollbar-width)) / 2);
+  right: calc(
+    (
+        var(--theia-private-sidebar-scrollbar-rail-width) -
+          var(--theia-private-sidebar-scrollbar-width)
+      ) / 2
+  );
 }
 
 .p-TabBar.theia-app-sides > .ps__rail-y:hover,
@@ -232,46 +242,51 @@
 .p-TabBar.theia-app-sides > .ps__rail-y:hover > .ps__thumb-y,
 .p-TabBar.theia-app-sides > .ps__rail-y:focus > .ps__thumb-y {
   width: var(--theia-private-sidebar-scrollbar-width);
-  right: calc((var(--theia-private-sidebar-scrollbar-rail-width) - var(--theia-private-sidebar-scrollbar-width)) / 2);
+  right: calc(
+    (
+        var(--theia-private-sidebar-scrollbar-rail-width) -
+          var(--theia-private-sidebar-scrollbar-width)
+      ) / 2
+  );
 }
-
 
 /*-----------------------------------------------------------------------------
 | Bottom content panel
 |----------------------------------------------------------------------------*/
 
 #theia-bottom-content-panel {
-    background: var(--theia-panel-background);
+  background: var(--theia-panel-background);
 }
 
 #theia-bottom-content-panel .theia-input {
-    border-color: var(--theia-panelInput-border);
+  border-color: var(--theia-panelInput-border);
 }
 
-#theia-bottom-content-panel .p-DockPanel-handle[data-orientation='horizontal'] {
-    border-left: var(--theia-border-width) solid var(--theia-panel-border);
+#theia-bottom-content-panel .p-DockPanel-handle[data-orientation="horizontal"] {
+  border-left: var(--theia-border-width) solid var(--theia-panel-border);
 }
 
 #theia-bottom-content-panel .p-TabBar {
-    border-top: var(--theia-border-width) solid var(--theia-panel-border);
-    background: inherit;
+  border-top: var(--theia-border-width) solid var(--theia-panel-border);
+  background: inherit;
 }
 
 #theia-bottom-content-panel .p-TabBar-tab {
-    background: inherit;
+  background: inherit;
 }
 
 #theia-bottom-content-panel .p-TabBar-tab:not(.p-mod-current) {
-    color: var(--theia-panelTitle-inactiveForeground);
+  color: var(--theia-panelTitle-inactiveForeground);
 }
 
 #theia-bottom-content-panel .p-TabBar-tab.p-mod-current {
-    color: var(--theia-panelTitle-activeForeground);
-    border-top: var(--theia-border-width) solid var(--theia-panelTitle-activeBorder);
+  color: var(--theia-panelTitle-activeForeground);
+  border-top: var(--theia-border-width) solid
+    var(--theia-panelTitle-activeBorder);
 }
 
 #theia-bottom-content-panel .p-TabBar-tab.p-mod-current.theia-mod-active {
-    border-top-color: var(--theia-focusBorder);
+  border-top-color: var(--theia-focusBorder);
 }
 
 /*-----------------------------------------------------------------------------
@@ -301,29 +316,32 @@
 |----------------------------------------------------------------------------*/
 
 .theia-sidepanel-toolbar {
-    min-height: calc(var(--theia-private-horizontal-tab-height) + var(--theia-private-horizontal-tab-scrollbar-rail-height) / 2);
-    display: flex;
-    padding-left: 5px;
-    align-items: center;
-    background-color: var(--theia-sideBar-background);
+  min-height: calc(
+    var(--theia-private-horizontal-tab-height) +
+      var(--theia-private-horizontal-tab-scrollbar-rail-height) / 2
+  );
+  display: flex;
+  padding-left: 5px;
+  align-items: center;
+  background-color: var(--theia-sideBar-background);
 }
 
 .theia-sidepanel-toolbar .theia-sidepanel-title {
-    color: var(--theia-settings-headerForeground);
-    flex: 1;
-    margin-left: 14px;
-    text-transform: uppercase;
-    font-size: var(--theia-ui-font-size0);
+  color: var(--theia-settings-headerForeground);
+  flex: 1;
+  margin-left: 14px;
+  text-transform: uppercase;
+  font-size: var(--theia-ui-font-size0);
 }
 
 .theia-sidepanel-toolbar .p-TabBar-toolbar .item {
-    color: var(--theia-icon-foreground);
+  color: var(--theia-icon-foreground);
 }
 
-.theia-sidepanel-toolbar .p-TabBar-toolbar .item > div{
-    height: 18px;
-    width: 18px;
-    background-repeat: no-repeat;
+.theia-sidepanel-toolbar .p-TabBar-toolbar .item > div {
+  height: 18px;
+  width: 18px;
+  background-repeat: no-repeat;
 }
 
 .noWrapInfo {

--- a/packages/core/src/browser/style/tabs.css
+++ b/packages/core/src/browser/style/tabs.css
@@ -189,9 +189,9 @@ body.theia-editor-highlightModifiedTabs
     background-position-y: 3px;
     background: var(--theia-icon-foreground);
     -webkit-mask-repeat: no-repeat;
-    -webkit-mask-size: 13px;
+    -webkit-mask-size: auto 13px;
     mask-repeat: no-repeat;
-    mask-size: 13px;
+    mask-size: auto 13px;
     padding-right: calc(var(--theia-ui-padding)/2);
 }
 

--- a/packages/debug/src/browser/style/index.css
+++ b/packages/debug/src/browser/style/index.css
@@ -156,12 +156,12 @@
 }
 
 .debug-tab-icon {
-    -webkit-mask: url('debug-dark.svg') 50%;
+    -webkit-mask: url('debug-dark.svg') 50% 50% / var(--theia-private-sidebar-icon-size) no-repeat;
     mask: url('debug-dark.svg') 50%;
 }
 
 .theia-debug-console-icon {
-    -webkit-mask: url('repl.svg');
+    -webkit-mask: url('repl.svg') 50% 50% / var(--theia-private-sidebar-icon-size) no-repeat;
     mask: url('repl.svg');
 }
 

--- a/packages/debug/src/browser/style/index.css
+++ b/packages/debug/src/browser/style/index.css
@@ -157,12 +157,12 @@
 
 .debug-tab-icon {
     -webkit-mask: url('debug-dark.svg') 50% 50% / var(--theia-private-sidebar-icon-size) no-repeat;
-    mask: url('debug-dark.svg') 50%;
+    mask: url('debug-dark.svg') 50% 50% / var(--theia-private-sidebar-icon-size) no-repeat;
 }
 
 .theia-debug-console-icon {
     -webkit-mask: url('repl.svg') 50% 50% / var(--theia-private-sidebar-icon-size) no-repeat;
-    mask: url('repl.svg');
+    mask: url('repl.svg') 50% 50% / var(--theia-private-sidebar-icon-size) no-repeat;
 }
 
 /** Console */

--- a/packages/git/src/browser/style/diff.css
+++ b/packages/git/src/browser/style/diff.css
@@ -15,7 +15,7 @@
  ********************************************************************************/
 
 .theia-git-diff-icon {
-    -webkit-mask: url('git-diff.svg');
+    -webkit-mask: url('git-diff.svg') 50% 50% / var(--theia-private-sidebar-icon-size) no-repeat;
     mask: url('git-diff.svg');
 }
 

--- a/packages/git/src/browser/style/diff.css
+++ b/packages/git/src/browser/style/diff.css
@@ -16,7 +16,7 @@
 
 .theia-git-diff-icon {
     -webkit-mask: url('git-diff.svg') 50% 50% / var(--theia-private-sidebar-icon-size) no-repeat;
-    mask: url('git-diff.svg');
+    mask: url('git-diff.svg') 50% 50% / var(--theia-private-sidebar-icon-size) no-repeat;
 }
 
 .theia-git .git-diff-container {

--- a/packages/mini-browser/src/browser/style/index.css
+++ b/packages/mini-browser/src/browser/style/index.css
@@ -25,8 +25,8 @@
 }
 
 .theia-mini-browser-icon {
-    mask: url('mini-browser.svg');
-    -webkit-mask: url('mini-browser.svg');
+    mask: url('mini-browser.svg') 50% 50% / var(--theia-private-sidebar-icon-size) no-repeat;
+    -webkit-mask: url('mini-browser.svg') 50% 50% / var(--theia-private-sidebar-icon-size) no-repeat;
 }
 
 .theia-mini-browser-toolbar {

--- a/packages/navigator/src/browser/style/index.css
+++ b/packages/navigator/src/browser/style/index.css
@@ -44,5 +44,5 @@
 
 .navigator-tab-icon {
     -webkit-mask: url('files.svg') 50% 50% / var(--theia-private-sidebar-icon-size) no-repeat;
-    mask: url('files.svg');
+    mask: url('files.svg') 50% 50% / var(--theia-private-sidebar-icon-size) no-repeat;
 }

--- a/packages/navigator/src/browser/style/index.css
+++ b/packages/navigator/src/browser/style/index.css
@@ -43,6 +43,6 @@
 }
 
 .navigator-tab-icon {
-    -webkit-mask: url('files.svg');
+    -webkit-mask: url('files.svg') 50% 50% / var(--theia-private-sidebar-icon-size) no-repeat;
     mask: url('files.svg');
 }

--- a/packages/plugin-ext/src/main/browser/style/index.css
+++ b/packages/plugin-ext/src/main/browser/style/index.css
@@ -40,8 +40,8 @@
 }
 
 .theia-plugin-test-tab-icon {
-    -webkit-mask: url('test.svg');
-    mask: url('test.svg');
+    -webkit-mask: url('test.svg') 50% 50% / var(--theia-private-sidebar-icon-size) no-repeat;
+    mask: url('test.svg') 50% 50% / var(--theia-private-sidebar-icon-size) no-repeat;
 }
 
 .theia-plugin-file-icon,

--- a/packages/plugin-ext/src/main/browser/view/plugin-view-registry.ts
+++ b/packages/plugin-ext/src/main/browser/view/plugin-view-registry.ts
@@ -193,7 +193,7 @@ export class PluginViewRegistry implements FrontendApplicationContribution {
         const iconUrl = PluginSharedStyle.toExternalIconUrl(viewContainer.iconUrl);
         toDispose.push(this.style.insertRule('.' + containerClass + '.' + iconClass, () => `
                 mask: url('${iconUrl}') no-repeat 50% 50%;
-                -webkit-mask: url('${iconUrl}') no-repeat 50% 50% / var(--theia-private-sidebar-icon-size);
+                -webkit-mask: url('${iconUrl}') no-repeat 50% 50%;
             `));
         toDispose.push(this.doRegisterViewContainer(viewContainer.id, location, {
             label: viewContainer.title,

--- a/packages/plugin-ext/src/main/browser/view/plugin-view-registry.ts
+++ b/packages/plugin-ext/src/main/browser/view/plugin-view-registry.ts
@@ -193,7 +193,7 @@ export class PluginViewRegistry implements FrontendApplicationContribution {
         const iconUrl = PluginSharedStyle.toExternalIconUrl(viewContainer.iconUrl);
         toDispose.push(this.style.insertRule('.' + containerClass + '.' + iconClass, () => `
                 mask: url('${iconUrl}') no-repeat 50% 50%;
-                -webkit-mask: url('${iconUrl}') no-repeat 50% 50%;
+                -webkit-mask: url('${iconUrl}') no-repeat 50% 50% / var(--theia-private-sidebar-icon-size);
             `));
         toDispose.push(this.doRegisterViewContainer(viewContainer.id, location, {
             label: viewContainer.title,

--- a/packages/scm/src/browser/style/index.css
+++ b/packages/scm/src/browser/style/index.css
@@ -247,7 +247,7 @@
 
 .scm-tab-icon {
     -webkit-mask: url('scm.svg') 50% 50% / var(--theia-private-sidebar-icon-size) no-repeat;
-    mask: url('scm.svg');
+    mask: url('scm.svg') 50% 50% / var(--theia-private-sidebar-icon-size) no-repeat;
 }
 
 .theia-scm-inline-actions-container {

--- a/packages/scm/src/browser/style/index.css
+++ b/packages/scm/src/browser/style/index.css
@@ -246,7 +246,7 @@
 }
 
 .scm-tab-icon {
-    -webkit-mask: url('scm.svg');
+    -webkit-mask: url('scm.svg') 50% 50% / var(--theia-private-sidebar-icon-size) no-repeat;
     mask: url('scm.svg');
 }
 

--- a/packages/search-in-workspace/src/browser/styles/index.css
+++ b/packages/search-in-workspace/src/browser/styles/index.css
@@ -369,7 +369,7 @@
 
 .search-in-workspace-tab-icon {
     -webkit-mask: url('search.svg') 50% 50% / var(--theia-private-sidebar-icon-size) no-repeat;
-    mask: url('search.svg');
+    mask: url('search.svg') 50% 50% / var(--theia-private-sidebar-icon-size) no-repeat;
 }
 
 .highlighted-count-container {

--- a/packages/search-in-workspace/src/browser/styles/index.css
+++ b/packages/search-in-workspace/src/browser/styles/index.css
@@ -368,7 +368,7 @@
 }
 
 .search-in-workspace-tab-icon {
-    -webkit-mask: url('search.svg');
+    -webkit-mask: url('search.svg') 50% 50% / var(--theia-private-sidebar-icon-size) no-repeat;
     mask: url('search.svg');
 }
 

--- a/packages/vsx-registry/src/browser/style/index.css
+++ b/packages/vsx-registry/src/browser/style/index.css
@@ -20,7 +20,7 @@
 }
 
 .theia-vsx-extensions-icon {
-    -webkit-mask: url('extensions.svg');
+    -webkit-mask: url('extensions.svg') 50% 50% / var(--theia-private-sidebar-icon-size) no-repeat;
     mask: url('extensions.svg');
 }
 

--- a/packages/vsx-registry/src/browser/style/index.css
+++ b/packages/vsx-registry/src/browser/style/index.css
@@ -21,7 +21,7 @@
 
 .theia-vsx-extensions-icon {
     -webkit-mask: url('extensions.svg') 50% 50% / var(--theia-private-sidebar-icon-size) no-repeat;
-    mask: url('extensions.svg');
+    mask: url('extensions.svg') 50% 50% / var(--theia-private-sidebar-icon-size) no-repeat;
 }
 
 .theia-vsx-extensions {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->
Solves the issue with truncated icons on Activity Bar

Now the icon should look better
![image](https://user-images.githubusercontent.com/1212251/91099819-ace88f00-e66c-11ea-8242-147552dcfa15.png)
![image](https://user-images.githubusercontent.com/1212251/91100209-6d6e7280-e66d-11ea-9079-983d92f0664e.png)


#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
Install extension daimor.vscode-objectscript, keywords: intersystems, objectscript
Check the icon look

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

