### PR TITLE
siw: respect 'files.exclude' preference

### DIFF
--- a/packages/search-in-workspace/src/node/ripgrep-search-in-workspace-server.slow-spec.ts
+++ b/packages/search-in-workspace/src/node/ripgrep-search-in-workspace-server.slow-spec.ts
@@ -681,6 +681,20 @@ describe('ripgrep-search-in-workspace-server', function (): void {
         ripgrepServer.search(pattern, [rootDirAUri], { include: ['*.txt'], matchWholeWord: true });
     });
 
+    it('should return 1 result when searching for "test" while ignoring all ".txt" files', done => {
+        const pattern = 'test';
+
+        const client = new ResultAccumulator(() => {
+            const expected: SearchInWorkspaceExpectation[] = [
+                { root: rootDirAUri, fileUri: 'glob', line: 1, character: 1, length: pattern.length, lineText: '' },
+            ];
+            compareSearchResults(expected, client.results);
+            done();
+        });
+        ripgrepServer.setClient(client);
+        ripgrepServer.search(pattern, [rootDirAUri, rootDirBUri], { exclude: ['*.txt'] });
+    });
+
     // Try searching in an UTF-8 file.
     it('should search in a UTF-8 file', done => {
         const pattern = ' jag';


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

Fixes: https://github.com/eclipse-theia/theia/issues/7273

The following pull-request updates the `search-in-workspace` search to respect the `files.exclude` preference (which describes glob patterns for exclusion). Currently, the `files.exclude` preference is not respected and the search yields incorrect results such as `**/*.git`.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

- [x] searching through the `search-in-workspace` should work correctly.
- [x] searching should not yield results which are described by the `files.exclude` globs.
- [x] overriding the default globs (using the boolean value) should work.
- [x] the newly added test case to test exclusion should work correctly.

_Examples_:

| Exclude: `**/*.git` = `true` | Exclude: `**/*.git` = `false` |
|:---:|:---:|
| <img width="1349" alt="Screen Shot 2020-08-25 at 6 30 24 PM" src="https://user-images.githubusercontent.com/40359487/91234423-35187400-e701-11ea-889a-6037d0c2144f.png"> | <img width="1349" alt="Screen Shot 2020-08-25 at 6 30 38 PM" src="https://user-images.githubusercontent.com/40359487/91234434-3ba6eb80-e701-11ea-99d5-8c48c1dae7ed.png"> |

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

