### PR TITLE
Show message if insufficient file watcher handles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@
   - This change triggers the context menu for a given shell tab-bar without the need to activate it
   - While registering a command, `Event` should be passed down, if not passed, then the commands will not work correctly as they no longer rely on the activation of tab-bar
 - [core] Moved `findTitle()` and `findTabBar()` from `common-frontend-contribution.ts` to `application-shell.ts`  [#6965](https://github.com/eclipse-theia/theia/pull/6965)
-
+- [filesystem] show Linux users a warning when Inotify handles have been exhausted, with link to instructions on how to fix [#8458](https://github.com/eclipse-theia/theia/pull/8458)
 
 ## v1.5.0 - 27/08/2020
 

--- a/packages/filesystem/src/browser/filesystem-frontend-module.ts
+++ b/packages/filesystem/src/browser/filesystem-frontend-module.ts
@@ -34,6 +34,7 @@ import { TextDocumentContentChangeEvent } from 'vscode-languageserver-protocol';
 import { EnvVariablesServer } from '@theia/core/lib/common/env-variables';
 import { bindContributionProvider } from '@theia/core/lib/common/contribution-provider';
 import { RemoteFileServiceContribution } from './remote-file-service-contribution';
+import { FileSystemWatcherErrorHandler } from './filesystem-watcher-error-handler';
 import { UTF8 } from '@theia/core/lib/common/encodings';
 
 export default new ContainerModule(bind => {
@@ -50,6 +51,8 @@ export default new ContainerModule(bind => {
     bind(FileServiceContribution).toService(RemoteFileServiceContribution);
 
     bind(FileSystemWatcher).toSelf().inSingletonScope();
+    bind(FileSystemWatcherErrorHandler).toSelf().inSingletonScope();
+
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     bind(FileSystem).toDynamicValue(({ container }) => {
         const fileService = container.get(FileService);

--- a/packages/filesystem/src/browser/filesystem-watcher-error-handler.ts
+++ b/packages/filesystem/src/browser/filesystem-watcher-error-handler.ts
@@ -1,0 +1,60 @@
+/********************************************************************************
+ * Copyright (C) 2020 Arm and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import { injectable, inject } from 'inversify';
+import { environment } from '@theia/application-package/lib/environment';
+import { MessageService } from '@theia/core';
+import { WindowService } from '@theia/core/lib/browser/window/window-service';
+
+@injectable()
+export class FileSystemWatcherErrorHandler {
+
+    @inject(MessageService) protected readonly messageService: MessageService;
+    @inject(WindowService) protected readonly windowService: WindowService;
+
+    protected watchHandlesExhausted: boolean = false;
+
+    protected get instructionsLink(): string {
+        return 'https://code.visualstudio.com/docs/setup/linux#_visual-studio-code-is-unable-to-watch-for-file-changes-in-this-large-workspace-error-enospc';
+    }
+
+    public async handleError(): Promise<void> {
+        if (!this.watchHandlesExhausted) {
+            this.watchHandlesExhausted = true;
+            if (this.isElectron()) {
+                const instructionsAction = 'Instructions';
+                const action = await this.messageService.warn(
+                    'Unable to watch for file changes in this large workspace.  Please follow the instructions link to resolve this issue.',
+                    { timeout: 60000 },
+                    instructionsAction
+                );
+                if (action === instructionsAction) {
+                    this.windowService.openNewWindow(this.instructionsLink, { external: true });
+                }
+            } else {
+                await this.messageService.warn(
+                    'Unable to watch for file changes in this large workspace.  The information you see may not include recent file changes.',
+                    { timeout: 60000 }
+                );
+            }
+        }
+    }
+
+    protected isElectron(): boolean {
+        return environment.electron.is();
+    }
+
+}

--- a/packages/filesystem/src/common/delegating-file-system-provider.ts
+++ b/packages/filesystem/src/common/delegating-file-system-provider.ts
@@ -31,6 +31,9 @@ export class DelegatingFileSystemProvider implements Required<FileSystemProvider
     private readonly onDidChangeFileEmitter = new Emitter<readonly FileChange[]>();
     readonly onDidChangeFile = this.onDidChangeFileEmitter.event;
 
+    private readonly onFileWatchErrorEmitter = new Emitter<void>();
+    readonly onFileWatchError = this.onFileWatchErrorEmitter.event;
+
     constructor(
         protected readonly delegate: FileSystemProvider,
         protected readonly options: DelegatingFileSystemProvider.Options,
@@ -38,6 +41,8 @@ export class DelegatingFileSystemProvider implements Required<FileSystemProvider
     ) {
         this.toDispose.push(this.onDidChangeFileEmitter);
         this.toDispose.push(delegate.onDidChangeFile(changes => this.handleFileChanges(changes)));
+        this.toDispose.push(this.onFileWatchErrorEmitter);
+        this.toDispose.push(delegate.onFileWatchError(changes => this.onFileWatchErrorEmitter.fire()));
     }
 
     dispose(): void {

--- a/packages/filesystem/src/common/files.ts
+++ b/packages/filesystem/src/common/files.ts
@@ -564,6 +564,7 @@ export interface FileSystemProvider {
     readonly onDidChangeCapabilities: Event<void>;
 
     readonly onDidChangeFile: Event<readonly FileChange[]>;
+    readonly onFileWatchError: Event<void>;
     watch(resource: URI, opts: WatchOptions): IDisposable;
 
     stat(resource: URI): Promise<Stat>;

--- a/packages/filesystem/src/common/filesystem-watcher-protocol.ts
+++ b/packages/filesystem/src/common/filesystem-watcher-protocol.ts
@@ -40,6 +40,11 @@ export interface FileSystemWatcherClient {
      * Notify when files under watched uris are changed.
      */
     onDidFilesChanged(event: DidFilesChangedParams): void;
+
+    /**
+     * Notify when unable to watch files because of Linux handle limit.
+     */
+    onError(): void;
 }
 
 export interface WatchOptions {

--- a/packages/filesystem/src/node/disk-file-system-provider.ts
+++ b/packages/filesystem/src/node/disk-file-system-provider.ts
@@ -95,6 +95,9 @@ export class DiskFileSystemProvider implements Disposable,
     private readonly onDidChangeFileEmitter = new Emitter<readonly FileChange[]>();
     readonly onDidChangeFile = this.onDidChangeFileEmitter.event;
 
+    private readonly onFileWatchErrorEmitter = new Emitter<void>();
+    readonly onFileWatchError = this.onFileWatchErrorEmitter.event;
+
     protected readonly toDispose = new DisposableCollection(
         this.onDidChangeFileEmitter
     );
@@ -112,7 +115,8 @@ export class DiskFileSystemProvider implements Disposable,
             onDidFilesChanged: params => this.onDidChangeFileEmitter.fire(params.changes.map(({ uri, type }) => ({
                 resource: new URI(uri),
                 type
-            })))
+            }))),
+            onError: () => this.onFileWatchErrorEmitter.fire()
         });
     }
 

--- a/packages/filesystem/src/node/filesystem-watcher-client.ts
+++ b/packages/filesystem/src/node/filesystem-watcher-client.ts
@@ -41,6 +41,11 @@ export class FileSystemWatcherServerClient implements FileSystemWatcherServer {
                 if (this.client) {
                     this.client.onDidFilesChanged(e);
                 }
+            },
+            onError: () => {
+                if (this.client) {
+                    this.client.onError();
+                }
             }
         });
         this.toDispose.push(this.remote);

--- a/packages/filesystem/src/node/nsfw-watcher/nsfw-filesystem-watcher.spec.ts
+++ b/packages/filesystem/src/node/nsfw-watcher/nsfw-filesystem-watcher.spec.ts
@@ -57,6 +57,8 @@ describe('nsfw-filesystem-watcher', function (): void {
         const watcherClient = {
             onDidFilesChanged(event: DidFilesChangedParams): void {
                 event.changes.forEach(c => actualUris.add(c.uri.toString()));
+            },
+            onError(): void {
             }
         };
         watcherServer.setClient(watcherClient);
@@ -92,6 +94,8 @@ describe('nsfw-filesystem-watcher', function (): void {
         const watcherClient = {
             onDidFilesChanged(event: DidFilesChangedParams): void {
                 event.changes.forEach(c => actualUris.add(c.uri.toString()));
+            },
+            onError(): void {
             }
         };
         watcherServer.setClient(watcherClient);

--- a/packages/filesystem/src/node/nsfw-watcher/nsfw-filesystem-watcher.ts
+++ b/packages/filesystem/src/node/nsfw-watcher/nsfw-filesystem-watcher.ts
@@ -131,6 +131,11 @@ export class NsfwFileSystemWatcherServer implements FileSystemWatcherServer {
             errorCallback: error => {
                 // see https://github.com/atom/github/issues/342
                 console.warn(`Failed to watch "${basePath}":`, error);
+                if (error === 'Inotify limit reached') {
+                    if (this.client) {
+                        this.client.onError();
+                    }
+                }
                 this.unwatchFileChanges(watcherId);
             },
             ...this.options.nsfwOptions

--- a/packages/plugin-ext/src/main/browser/file-system-main-impl.ts
+++ b/packages/plugin-ext/src/main/browser/file-system-main-impl.ts
@@ -160,6 +160,7 @@ class RemoteFileSystemProvider implements FileSystemProviderWithFileReadWriteCap
     private readonly _registration: IDisposable;
 
     readonly onDidChangeFile: Event<readonly FileChange[]> = this._onDidChange.event;
+    readonly onFileWatchError: Event<void> = new Emitter<void>().event;  // dummy, never fired
 
     readonly capabilities: FileSystemProviderCapabilities;
     readonly onDidChangeCapabilities: Event<void> = Event.None;


### PR DESCRIPTION
#### What it does

Fixes https://github.com/eclipse-theia/theia/issues/938

On Linux the limit for the number of directories that can be watched is by default 8192.  Furthermore, if a watched directory has sub-directories then each sub-directory is counted in this limit.  When this limit is reached, the user is not told.  They simply don't see changes.

This PR shows a message to the user together with instructions on how to increase the limit.

![Screenshot from 2020-09-02 09-30-59](https://user-images.githubusercontent.com/87310/91958362-27fe1500-ecff-11ea-8cb6-ccbb64450bd0.png)

#### How to test

On Linux, set the limit to 8192 (the default) and check that a message appears when the limit is reached.

Check that the message does not appear when the limit is larger, or on Windows or Mac.  Test file watching and filesystem provider plugins to ensure nothing is broken.

Check that it is fine to link to vscode's page, or suggest Theia's own page.

#### Review checklist

- [x ] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

