### PR TITLE
Do not serialize webview if the serializer for the webview is not set

### DIFF
--- a/packages/core/src/browser/shell/shell-layout-restorer.ts
+++ b/packages/core/src/browser/shell/shell-layout-restorer.ts
@@ -34,7 +34,7 @@ export interface StatefulWidget {
     /**
      * Called on unload to store the inner state.
      */
-    storeState(): object;
+    storeState(): object | undefined;
 
     /**
      * Called when the widget got created by the storage service
@@ -208,6 +208,9 @@ export class ShellLayoutRestorer implements CommandContribution {
             let innerState = undefined;
             if (StatefulWidget.is(widget)) {
                 innerState = widget.storeState();
+                if (innerState === undefined) {
+                    return undefined;
+                }
             }
             return {
                 constructionOptions: desc,

--- a/packages/plugin-ext/src/hosted/browser/hosted-plugin.ts
+++ b/packages/plugin-ext/src/hosted/browser/hosted-plugin.ts
@@ -196,19 +196,23 @@ export class HostedPluginSupport {
         this.viewRegistry.onDidExpandView(id => this.activateByView(id));
         this.taskProviderRegistry.onWillProvideTaskProvider(event => this.ensureTaskActivation(event));
         this.taskResolverRegistry.onWillProvideTaskResolver(event => this.ensureTaskActivation(event));
+
         this.widgets.onDidCreateWidget(({ factoryId, widget }) => {
             if (factoryId === WebviewWidget.FACTORY_ID && widget instanceof WebviewWidget) {
                 const storeState = widget.storeState.bind(widget);
                 const restoreState = widget.restoreState.bind(widget);
+
                 widget.storeState = () => {
                     if (this.webviewRevivers.has(widget.viewType)) {
                         return storeState();
                     }
-                    return {};
+
+                    return undefined;
                 };
-                widget.restoreState = oldState => {
-                    if (oldState.viewType) {
-                        restoreState(oldState);
+
+                widget.restoreState = state => {
+                    if (state.viewType) {
+                        restoreState(state);
                         this.preserveWebview(widget);
                     } else {
                         widget.dispose();

--- a/packages/plugin-ext/src/main/browser/view/plugin-view-registry.ts
+++ b/packages/plugin-ext/src/main/browser/view/plugin-view-registry.ts
@@ -505,7 +505,10 @@ export class PluginViewRegistry implements FrontendApplicationContribution {
         const widgets = this.widgetManager.getWidgets(PLUGIN_VIEW_DATA_FACTORY_ID);
         for (const widget of widgets) {
             if (StatefulWidget.is(widget)) {
-                this.viewDataState.set(widget.id, widget.storeState());
+                const state = widget.storeState();
+                if (state) {
+                    this.viewDataState.set(widget.id, state);
+                }
             }
             widget.dispose();
         }
@@ -565,7 +568,10 @@ export class PluginViewRegistry implements FrontendApplicationContribution {
     protected storeViewDataStateOnDispose(viewId: string, widget: Widget & StatefulWidget): void {
         const dispose = widget.dispose.bind(widget);
         widget.dispose = () => {
-            this.viewDataState.set(viewId, widget.storeState());
+            const state = widget.storeState();
+            if (state) {
+                this.viewDataState.set(viewId, state);
+            }
             dispose();
         };
     }

--- a/packages/plugin-ext/src/main/browser/webviews-main.ts
+++ b/packages/plugin-ext/src/main/browser/webviews-main.ts
@@ -34,7 +34,7 @@ export class WebviewsMainImpl implements WebviewsMain, Disposable {
 
     private readonly proxy: WebviewsExt;
     protected readonly shell: ApplicationShell;
-    protected readonly widgets: WidgetManager;
+    protected readonly widgetManager: WidgetManager;
     protected readonly pluginService: HostedPluginSupport;
     protected readonly viewColumnService: ViewColumnService;
     private readonly toDispose = new DisposableCollection();
@@ -43,7 +43,7 @@ export class WebviewsMainImpl implements WebviewsMain, Disposable {
         this.proxy = rpc.getProxy(MAIN_RPC_CONTEXT.WEBVIEWS_EXT);
         this.shell = container.get(ApplicationShell);
         this.viewColumnService = container.get(ViewColumnService);
-        this.widgets = container.get(WidgetManager);
+        this.widgetManager = container.get(WidgetManager);
         this.pluginService = container.get(HostedPluginSupport);
         this.toDispose.push(this.shell.onDidChangeActiveWidget(() => this.updateViewStates()));
         this.toDispose.push(this.shell.onDidChangeCurrentWidget(() => this.updateViewStates()));
@@ -61,7 +61,7 @@ export class WebviewsMainImpl implements WebviewsMain, Disposable {
         showOptions: WebviewPanelShowOptions,
         options: WebviewPanelOptions & WebviewOptions
     ): Promise<void> {
-        const view = await this.widgets.getOrCreateWidget<WebviewWidget>(WebviewWidget.FACTORY_ID, <WebviewWidgetIdentifier>{ id: panelId });
+        const view = await this.widgetManager.getOrCreateWidget<WebviewWidget>(WebviewWidget.FACTORY_ID, <WebviewWidgetIdentifier>{ id: panelId });
         this.hookWebview(view);
         view.viewType = viewType;
         view.title.label = title;
@@ -217,7 +217,7 @@ export class WebviewsMainImpl implements WebviewsMain, Disposable {
     }
 
     protected readonly updateViewStates = debounce(() => {
-        for (const widget of this.widgets.getWidgets(WebviewWidget.FACTORY_ID)) {
+        for (const widget of this.widgetManager.getWidgets(WebviewWidget.FACTORY_ID)) {
             if (widget instanceof WebviewWidget) {
                 this.updateViewState(widget);
             }
@@ -251,7 +251,7 @@ export class WebviewsMainImpl implements WebviewsMain, Disposable {
     }
 
     private async tryGetWebview(id: string): Promise<WebviewWidget | undefined> {
-        return this.widgets.getWidget<WebviewWidget>(WebviewWidget.FACTORY_ID, <WebviewWidgetIdentifier>{ id });
+        return this.widgetManager.getWidget<WebviewWidget>(WebviewWidget.FACTORY_ID, <WebviewWidgetIdentifier>{ id });
     }
 
 }


### PR DESCRIPTION
Signed-off-by: Vitaliy Guliy <vgulyy@redhat.com>

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->
Disables saving of the webview state if the plugin don't register an apropriate theia.WebviewPanelSerializer

Original downstream issue https://github.com/eclipse/che/issues/16352

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

Option 1:
  - write a plugin, which opens a webview but don't register an appropriate theia.WebviewPanelSerializer

Option 2 - Eclipse Che specific:
  - in [Eclipse Che Welcome Plugin](https://github.com/eclipse/che-theia/blob/master/plugins/welcome-plugin/src/welcome-plugin.ts#L116) remove a line where the plugin registers WebviewPanelSerializer

Option 3:
  - will think about it

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

