### PR TITLE
Various output channel-related fixes

### DIFF
--- a/packages/output/src/common/output-channel.ts
+++ b/packages/output/src/common/output-channel.ts
@@ -196,7 +196,7 @@ export class OutputChannelManager implements CommandContribution, Disposable, Re
             this.textModelService.createModelReference(uri).then(ref => editorModelRef.resolve(ref));
         }
 
-        const channel = new OutputChannel(resource, this.preferences);
+        const channel = this.createChannel(resource);
         this.channels.set(name, channel);
         this.toDisposeOnChannelDeletion.set(name, this.registerListeners(channel));
         this.channelAddedEmitter.fire(channel);
@@ -306,6 +306,10 @@ export class OutputChannelManager implements CommandContribution, Disposable, Re
         return new OutputResource(uri, editorModelRef);
     }
 
+    protected createChannel(resource: OutputResource): OutputChannel {
+        return new OutputChannel(resource, this.preferences);
+    }
+
 }
 
 export enum OutputChannelSeverity {
@@ -316,20 +320,21 @@ export enum OutputChannelSeverity {
 
 export class OutputChannel implements Disposable {
 
-    private readonly contentChangeEmitter = new Emitter<void>();
-    private readonly visibilityChangeEmitter = new Emitter<{ isVisible: boolean, preserveFocus?: boolean }>();
-    private readonly disposedEmitter = new Emitter<void>();
-    private readonly toDispose = new DisposableCollection(
+    protected readonly contentChangeEmitter = new Emitter<void>();
+    protected readonly visibilityChangeEmitter = new Emitter<{ isVisible: boolean, preserveFocus?: boolean }>();
+    protected readonly disposedEmitter = new Emitter<void>();
+    protected readonly textModifyQueue = new PQueue({ autoStart: true, concurrency: 1 });
+    protected readonly toDispose = new DisposableCollection(
+        Disposable.create(() => this.textModifyQueue.clear()),
         this.contentChangeEmitter,
         this.visibilityChangeEmitter,
         this.disposedEmitter
     );
 
-    private disposed = false;
-    private visible = true;
-    private _maxLineNumber: number;
-    private decorationIds = new Set<string>();
-    private textModifyQueue = new PQueue({ autoStart: true, concurrency: 1 });
+    protected disposed = false;
+    protected visible = true;
+    protected _maxLineNumber: number;
+    protected decorationIds = new Set<string>();
 
     readonly onVisibilityChange: Event<{ isVisible: boolean, preserveFocus?: boolean }> = this.visibilityChangeEmitter.event;
     readonly onContentChange: Event<void> = this.contentChangeEmitter.event;

--- a/packages/plugin-ext/src/main/browser/output-channel-registry-main.ts
+++ b/packages/plugin-ext/src/main/browser/output-channel-registry-main.ts
@@ -15,84 +15,39 @@
  ********************************************************************************/
 
 import { injectable, inject } from 'inversify';
-import { OutputWidget } from '@theia/output/lib/browser/output-widget';
-import { OutputContribution } from '@theia/output/lib/browser/output-contribution';
-import { OutputChannel, OutputChannelManager } from '@theia/output/lib/common/output-channel';
+import { CommandService } from '@theia/core/lib/common/command';
+import { OutputCommands } from '@theia/output/lib/browser/output-commands';
 import { OutputChannelRegistryMain, PluginInfo } from '../../common/plugin-api-rpc';
 
 @injectable()
 export class OutputChannelRegistryMainImpl implements OutputChannelRegistryMain {
 
-    @inject(OutputChannelManager)
-    private outputChannelManager: OutputChannelManager;
+    @inject(CommandService)
+    protected readonly commandService: CommandService;
 
-    @inject(OutputContribution)
-    private outputContribution: OutputContribution;
-
-    private commonOutputWidget: OutputWidget | undefined;
-
-    private channels: Map<string, OutputChannel> = new Map();
-
-    $append(channelName: string, value: string, pluginInfo: PluginInfo): PromiseLike<void> {
-        const outputChannel = this.getChannel(channelName);
-        if (outputChannel) {
-            outputChannel.append(value);
-        }
-
+    $append(name: string, text: string, pluginInfo: PluginInfo): PromiseLike<void> {
+        this.commandService.executeCommand(OutputCommands.APPEND.id, { name, text });
         return Promise.resolve();
     }
 
-    $clear(channelName: string): PromiseLike<void> {
-        const outputChannel = this.getChannel(channelName);
-        if (outputChannel) {
-            outputChannel.clear();
-        }
-
+    $clear(name: string): PromiseLike<void> {
+        this.commandService.executeCommand(OutputCommands.CLEAR.id, { name });
         return Promise.resolve();
     }
 
-    $dispose(channelName: string): PromiseLike<void> {
-        this.outputChannelManager.deleteChannel(channelName);
-        if (this.channels.has(channelName)) {
-            this.channels.delete(channelName);
-        }
-
+    $dispose(name: string): PromiseLike<void> {
+        this.commandService.executeCommand(OutputCommands.DISPOSE.id, { name });
         return Promise.resolve();
     }
 
-    async $reveal(channelName: string, preserveFocus: boolean): Promise<void> {
-        const outputChannel = this.getChannel(channelName);
-        if (outputChannel) {
-            const activate = !preserveFocus;
-            const reveal = preserveFocus;
-            this.commonOutputWidget = await this.outputContribution.openView({ activate, reveal });
-            outputChannel.setVisibility(true);
-        }
+    async $reveal(name: string, preserveFocus: boolean): Promise<void> {
+        const options = { preserveFocus };
+        this.commandService.executeCommand(OutputCommands.SHOW.id, { name, options });
     }
 
-    $close(channelName: string): PromiseLike<void> {
-        const outputChannel = this.getChannel(channelName);
-        if (outputChannel) {
-            outputChannel.setVisibility(false);
-        }
-        const channels = this.outputChannelManager.getChannels();
-        const isEmpty = channels.findIndex((channel: OutputChannel) => channel.isVisible) === -1;
-        if (isEmpty && this.commonOutputWidget) {
-            this.commonOutputWidget.close();
-        }
-
+    $close(name: string): PromiseLike<void> {
+        this.commandService.executeCommand(OutputCommands.HIDE.id, { name });
         return Promise.resolve();
     }
 
-    private getChannel(channelName: string): OutputChannel | undefined {
-        let outputChannel: OutputChannel | undefined;
-        if (this.channels.has(channelName)) {
-            outputChannel = this.channels.get(channelName);
-        } else {
-            outputChannel = this.outputChannelManager.getChannel(channelName);
-            this.channels.set(channelName, outputChannel);
-        }
-
-        return outputChannel;
-    }
 }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

 - Clear the text modification queue when disposing the output channel,
 - Exposed `private` `OutputChannel` properties with `protected` visibility.
 - From now on, downstreams can customize the output channel instance creation with a template method.
 - Removed the superfluous channel caching for VS Code extensions. Instead of erroneously keeping an extra cache of output channels for the extensions, we delegate into Theia's singleton channel manager via the command API. (Closes #8122)

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

 - This is where it gets tricky, I am way behind with the Theia versions. I still use `@theia/languages`.

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

