### PR TITLE
6601 load plugin manifest

### DIFF
--- a/packages/core/src/browser/endpoint.ts
+++ b/packages/core/src/browser/endpoint.ts
@@ -28,7 +28,7 @@ export class Endpoint {
 
     constructor(
         protected readonly options: Endpoint.Options = {},
-        protected readonly location: Endpoint.Location = window.location
+        protected readonly location: Endpoint.Location = self.location
     ) { }
 
     getWebSocketUrl(): URI {

--- a/packages/core/src/electron-main/electron-main-application.ts
+++ b/packages/core/src/electron-main/electron-main-application.ts
@@ -232,7 +232,8 @@ export class ElectronMainApplication {
             minWidth: 200,
             minHeight: 120,
             webPreferences: {
-                nodeIntegration: true // https://github.com/eclipse-theia/theia/issues/2018
+                nodeIntegration: true, // https://github.com/eclipse-theia/theia/issues/2018
+                nodeIntegrationInWorker: true
             },
             ...windowOptionsFromConfig,
         };

--- a/packages/plugin-ext/src/common/plugin-protocol.ts
+++ b/packages/plugin-ext/src/common/plugin-protocol.ts
@@ -58,7 +58,7 @@ export interface PluginPackage {
     icon?: string;
 }
 export namespace PluginPackage {
-    export function toPluginUrl(pck: PluginPackage, relativePath: string): string {
+    export function toPluginUrl(pck: PluginPackage | PluginModel, relativePath: string): string {
         return `hostedPlugin/${getPluginId(pck)}/${encodeURIComponent(relativePath)}`;
     }
 }

--- a/packages/plugin-ext/src/hosted/browser/worker/plugin-manifest-loader.ts
+++ b/packages/plugin-ext/src/hosted/browser/worker/plugin-manifest-loader.ts
@@ -1,0 +1,112 @@
+/********************************************************************************
+ * Copyright (C) 2020 Red Hat, Inc. and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+import { PluginModel, PluginPackage } from '../../../common/plugin-protocol';
+import { Endpoint } from '@theia/core/lib/browser/endpoint';
+import URI from '@theia/core/lib/common/uri';
+
+const NLS_REGEX = /^%([\w\d.-]+)%$/i;
+
+function getUri(pluginModel: PluginModel, relativePath: string): URI {
+    const ownURI = new Endpoint().getRestUrl();
+    return ownURI.parent.resolve(PluginPackage.toPluginUrl(pluginModel, relativePath));
+}
+
+function readPluginFile(pluginModel: PluginModel, relativePath: string): Promise<string> {
+    return readContents(getUri(pluginModel, relativePath).toString());
+}
+
+function readContents(uri: string): Promise<string> {
+    return new Promise((resolve, reject) => {
+        const request = new XMLHttpRequest();
+
+        request.onreadystatechange = function (): void {
+            if (this.readyState === XMLHttpRequest.DONE) {
+                if (this.status === 200) {
+                    resolve(this.response);
+                } else if (this.status === 404) {
+                    reject('NotFound');
+                } else {
+                    reject(new Error('Could not fetch plugin resource'));
+                }
+            }
+        };
+
+        request.open('GET', uri, true);
+        request.send();
+    });
+}
+
+async function readPluginJson(pluginModel: PluginModel, relativePath: string): Promise<any> {
+    const content = await readPluginFile(pluginModel, relativePath);
+    return JSON.parse(content);
+}
+
+export async function loadManifest(pluginModel: PluginModel): Promise<any> {
+    const [manifest, translations] = await Promise.all([
+        readPluginJson(pluginModel, 'package.json'),
+        loadTranslations(pluginModel)
+    ]);
+    // translate vscode builtins, as they are published with a prefix.
+    const built_prefix = '@theia/vscode-builtin-';
+    if (manifest && manifest.name && manifest.name.startsWith(built_prefix)) {
+        manifest.name = manifest.name.substr(built_prefix.length);
+    }
+    return manifest && translations && Object.keys(translations).length ?
+        localize(manifest, translations) :
+        manifest;
+}
+
+async function loadTranslations(pluginModel: PluginModel): Promise<any> {
+    try {
+        return await readPluginJson(pluginModel, 'package.nls.json');
+    } catch (e) {
+        if (e !== 'NotFound') {
+            throw e;
+        }
+        return {};
+    }
+}
+
+function localize(value: any, translations: {
+    [key: string]: string
+}): any {
+    if (typeof value === 'string') {
+        const match = NLS_REGEX.exec(value);
+        return match && translations[match[1]] || value;
+    }
+    if (Array.isArray(value)) {
+        const result = [];
+        for (const item of value) {
+            result.push(localize(item, translations));
+        }
+        return result;
+    }
+    if (value === null) {
+        return value;
+    }
+    if (typeof value === 'object') {
+        const result: { [key: string]: any } = {};
+        // eslint-disable-next-line guard-for-in
+        for (const propertyName in value) {
+            result[propertyName] = localize(value[propertyName], translations);
+        }
+        return result;
+    }
+    return value;
+}


### PR DESCRIPTION
#### What it does
<!-- Include relevant issues and describe how they are addressed. -->
Fixes "Frontend plugins are broken" #6601 by loading the package.json upon initializing the plugin.

Note: I haven't been able to make the electron case work, since I don't know how to compute the proper URI to load package.json. However, since I'm going to be on vacation, I wanted to propose this PR anyway...maybe someone can fix it.

#### How to test
Build a front end plugin (for example https://github.com/eclipse/che-theia-samples/tree/master/samples/hello-world-frontend-plugin) and add the resulting plugin to the theia plugins folder.
Start Theia and ensure that the "Hello World" command has been added via `F1`. 

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

