### PR TITLE
Do not show the Timeline panel if no Timeline providers were registered

### DIFF
--- a/packages/timeline/src/browser/timeline-contribution.ts
+++ b/packages/timeline/src/browser/timeline-contribution.ts
@@ -63,7 +63,7 @@ export class TimelineContribution implements CommandContribution, TabBarToolbarC
             }
         };
         this.widgetManager.onWillCreateWidget(async event => {
-           if (event.widget.id === EXPLORER_VIEW_CONTAINER_ID) {
+           if (event.widget.id === EXPLORER_VIEW_CONTAINER_ID && this.timelineService.getSources().length > 0) {
                event.waitUntil(attachTimeline(event.widget));
            }
         });


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->
Check if a timeline provider is registered, before adding the `Timeline` panel to the `Explorer`. If no providers were registered, do not add the `Timeline` panel to the `Explorer`.
#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
1. Close the `Explorer` (right mouse button click to the `Explorer` icon => close)
2. Open the `Explorer` (menu `View` => `Explorer`)

See: the `timeline` panel mustn't be present in the `Explorer` part.
#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

