### PR TITLE
fix:prevent  url hash changes when edit keybinding

### DIFF
--- a/packages/keymaps/src/browser/keybindings-widget.tsx
+++ b/packages/keymaps/src/browser/keybindings-widget.tsx
@@ -382,7 +382,10 @@ export class KeybindingWidget extends ReactWidget {
      * @param item the keybinding item for the row.
      */
     protected renderEdit(item: KeybindingItem): React.ReactNode {
-        return <a title='Edit Keybinding' href='#' onClick={a => this.editKeybinding(item)}><i className='fa fa-pencil kb-action-item'></i></a>;
+        return <a title='Edit Keybinding' href='#' onClick={e => {
+            e.preventDefault();
+            this.editKeybinding(item);
+        }}><i className='fa fa-pencil kb-action-item'></i></a>;
     }
 
     /**
@@ -392,7 +395,10 @@ export class KeybindingWidget extends ReactWidget {
      */
     protected renderReset(item: KeybindingItem): React.ReactNode {
         return (item.keybinding && item.keybinding.scope === KeybindingScope.USER)
-            ? <a title='Reset Keybinding' href='#' onClick={a => this.resetKeybinding(item)}><i className='fa fa-undo kb-action-item'></i></a> : '';
+            ? <a title='Reset Keybinding' href='#' onClick={e => {
+                e.preventDefault();
+                this.resetKeybinding(item);
+            }}><i className='fa fa-undo kb-action-item'></i></a> : '';
     }
 
     /**


### PR DESCRIPTION
Signed-off-by: 二凢 <dingyu.wdy@alibaba-inc.com>

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

Prevent MouseEvent when edit or reset keyboard shortcuts.
![Sep-14-2020 14-43-52](https://user-images.githubusercontent.com/5847142/93052543-e83d1300-f698-11ea-8fc2-09ce455340d6.gif)


#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

- Open browser example
- Edit a keybinding, url hash won't change
- Reset a keybinding, url hash won't change
 
![image](https://user-images.githubusercontent.com/5847142/93052230-4caba280-f698-11ea-90c8-c897ec2bc155.png)


#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

