### PR TITLE
Instantiate the returned FileSystem object for the frontend binding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## v1.6.0
 
 - [core] added functionality for handling context menu for `tab-bars` without activating the shell tab-bar [#6965](https://github.com/eclipse-theia/theia/pull/6965)
+- [filesystem] fixed issue for the deprecated `FileSystem` where the incorrect thing was injected [#8507](https://github.com/eclipse-theia/theia/pull/8507)
 
 <a name="breaking_changes_1.6.0">[Breaking Changes:](#breaking_changes_1.6.0)</a>
 

--- a/packages/filesystem/src/browser/filesystem-frontend-module.ts
+++ b/packages/filesystem/src/browser/filesystem-frontend-module.ts
@@ -82,7 +82,7 @@ export default new ContainerModule(bind => {
             }
             throw error;
         };
-        return class implements FileSystem {
+        return new class implements FileSystem {
             async getFileStat(uri: string): Promise<FileStat | undefined> {
                 try {
                     const stat = await fileService.resolve(new URI(uri), { resolveMetadata: true });


### PR DESCRIPTION
**What it does**

Fixes: #8497

- fixes issue #8497 by returning a new instance of the `FileSystem` class, instead of the class.

**How to test**

With this patch this following code will now work properly:

```ts
@inject(FileSystem)
protected readonly fileSystem: FileSystem;

...

console.log("fileSystem.exists: " + this.fileSystem.exists);
console.log("file system root exists ? " + await this.fileSystem.exists("file:///"));
```

Will now work as expected instead of `this.fileSystem.exists` being `undefined`.

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

Signed-off-by: Samuel HULTGREN <samuel.hultgren@st.com>
