### PR TITLE
[scm] Add check to determine which scm-widget should be focused

### DIFF
--- a/packages/scm/src/browser/scm-widget.tsx
+++ b/packages/scm/src/browser/scm-widget.tsx
@@ -150,7 +150,11 @@ export class ScmWidget extends BaseWidget implements StatefulWidget {
     protected onActivateRequest(msg: Message): void {
         super.onActivateRequest(msg);
         this.refresh();
-        this.commitWidget.focus();
+        if (this.commitWidget.isVisible) {
+            this.commitWidget.focus();
+        } else {
+            this.node.focus();
+        }
     }
 
     protected focusInput(): void {


### PR DESCRIPTION
#### What it does
+ Fixes #8471 
+ Add a check to determine if `commitWidget` is visible (means there is a repository in the workspace), then focus is on `commitWidget`
+ Alternatively, Focus should be on node rather than `commitWidget` when there is no repository in the workspace. 

#### How to test
+ When there is no repository in the workspace. There is no warning comes from `scm`

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)


Signed-off-by: Duc Nguyen <duc.a.nguyen@ericsson.com>
Co-authored-by: Vincent Fugnitto <vincent.fugnitto@ericsson.com>
