### PR TITLE
preferences: improve category headers and leaf

### DIFF
--- a/packages/preferences/src/browser/style/index.css
+++ b/packages/preferences/src/browser/style/index.css
@@ -189,13 +189,17 @@
     text-decoration: underline;
 }
 
-
-
-.theia-settings-container .settings-section-title {
+.theia-settings-container .settings-section-category-title {
     font-weight: bold;
     font-size: var(--theia-ui-font-size3);
     padding-left: calc(2 * var(--theia-ui-padding));
-}
+  }
+  
+.theia-settings-container .settings-section-subcategory-title {
+    font-weight: bold;
+    font-size: var(--theia-ui-font-size2);
+    padding-left: calc(2 * var(--theia-ui-padding));
+  }
 
 .theia-settings-container .settings-section>li {
     list-style-type: none;

--- a/packages/preferences/src/browser/util/preference-tree-generator.spec.ts
+++ b/packages/preferences/src/browser/util/preference-tree-generator.spec.ts
@@ -30,6 +30,7 @@ import { Container } from 'inversify';
 import { PreferenceTreeGenerator } from './preference-tree-generator';
 import { PreferenceSchemaProvider } from '@theia/core/lib/browser';
 import { PreferenceConfigurations } from '@theia/core/lib/browser/preferences/preference-configurations';
+import { Preference } from './preference-types';
 
 disableJSDOM();
 
@@ -51,4 +52,38 @@ describe('preference-tree-generator', () => {
         expect(preferenceTreeGenerator['split'](testString)).deep.eq(testString.split(splitter));
     });
 
+    it('PreferenceTreeGenerator.format', () => {
+        const testString = 'aaaBbbCcc Dddd eee';
+        expect(preferenceTreeGenerator['formatString'](testString)).eq('Aaa Bbb Ccc Dddd Eee');
+    });
+
+    describe('PreferenceTreeGenerator.createLeafNode', () => {
+        it('when property constructs of three parts the third part is the leaf', () => {
+            const property = 'category-name.subcategory.leaf';
+            const expectedName = 'Leaf';
+            testLeafName(property, expectedName);
+        });
+
+        it('when property constructs of two parts the second part is the leaf', () => {
+            const property = 'category-name.leaf';
+            const expectedName = 'Leaf';
+            testLeafName(property, expectedName);
+        });
+
+        function testLeafName(property: string, expectedName: string): void {
+            const preferencesGroups: Preference.Branch[] = [];
+            const root = preferenceTreeGenerator['createRootNode'](preferencesGroups);
+            const preferencesGroup = preferenceTreeGenerator['createPreferencesGroup']('group', root);
+
+            const expectedSelectableTreeNode = {
+                id: property,
+                name: expectedName,
+                parent: preferencesGroup,
+                visible: true,
+                selected: false,
+            };
+            expect(preferenceTreeGenerator['createLeafNode'](property, preferencesGroup)).deep.eq(expectedSelectableTreeNode);
+        }
+
+    });
 });

--- a/packages/preferences/src/browser/util/preference-tree-generator.ts
+++ b/packages/preferences/src/browser/util/preference-tree-generator.ts
@@ -69,8 +69,8 @@ export class PreferenceTreeGenerator {
     });
 
     protected createLeafNode = (property: string, preferencesGroup: Preference.Branch): SelectableTreeNode => {
-        const propertySpecifier = this.split(property).slice(1);
-        const name = propertySpecifier.map(word => word.slice(0, 1).toLocaleUpperCase() + word.slice(1)).join(' ').trim();
+        const rawLeaf = property.split('.').pop();
+        const name = this.formatString(rawLeaf!);
         return {
             id: property,
             name,
@@ -119,4 +119,8 @@ export class PreferenceTreeGenerator {
         return split;
     }
 
+    private formatString(string: string): string {
+        const specifier = this.split(string);
+        return specifier.map(word => word.slice(0, 1).toLocaleUpperCase() + word.slice(1)).join(' ').trim();
+    }
 }

--- a/packages/preferences/src/browser/views/preference-editor-widget.tsx
+++ b/packages/preferences/src/browser/views/preference-editor-widget.tsx
@@ -154,13 +154,15 @@ export class PreferencesEditorWidget extends ReactWidget {
 
     protected renderCategory(category: Preference.Branch): React.ReactNode {
         const children = category.children.concat(category.leaves).sort((a, b) => this.sort(a.id, b.id));
+        const isCategory = category.parent?.parent === undefined;
+        const categoryLevelClass = isCategory ? 'settings-section-category-title' : 'settings-section-subcategory-title';
         return category.visible && (
             <ul
                 className="settings-section"
                 key={`${category.id}-editor`}
                 id={`${category.id}-editor`}
             >
-                <li className="settings-section-title" data-id={category.id}>{category.name}</li>
+                <li className={categoryLevelClass} data-id={category.id}>{category.name}</li>
                 {children.map((preferenceNode: SelectableTreeNode | Preference.Branch) => {
                     if (Preference.Branch.is(preferenceNode)) {
                         return this.renderCategory(preferenceNode);


### PR DESCRIPTION
Fixes issue: #7745

1. Fixed category bug in the leaf. When the category contains more than one word the leaf contains category words.
2. Added colon after the subcategory in the leaf
3. Changed the size of the category and the subcategory

Before
![image](https://user-images.githubusercontent.com/6076791/93356593-101ea900-f848-11ea-9cc4-fb05da984780.png)


After
![image](https://user-images.githubusercontent.com/6076791/93356296-ad2d1200-f847-11ea-9507-ab3a613ad90f.png)


#### How to test
Open the preferences

Signed-off-by: Lior Frenkel <lior.frenkel@sap.com>

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

