### PR TITLE
Add environmentVariableCollection to PluginContext

### DIFF
--- a/packages/plugin-ext/src/common/plugin-api-rpc.ts
+++ b/packages/plugin-ext/src/common/plugin-api-rpc.ts
@@ -87,6 +87,7 @@ import type {
     TimelineChangeEvent,
     TimelineProviderDescriptor
 } from '@theia/timeline/lib/common/timeline-model';
+import { SerializableEnvironmentVariableCollection } from '@theia/terminal/lib/common/base-terminal-protocol';
 
 export interface PreferenceData {
     [scope: number]: any;
@@ -245,6 +246,8 @@ export interface TerminalServiceExt {
     $terminalOnInput(id: string, data: string): void;
     $terminalSizeChanged(id: string, cols: number, rows: number): void;
     $currentTerminalChanged(id: string | undefined): void;
+    $initEnvironmentVariableCollections(collections: [string, SerializableEnvironmentVariableCollection][]): void;
+    getEnvironmentVariableCollection(extensionIdentifier: string): theia.EnvironmentVariableCollection;
 }
 export interface OutputChannelRegistryExt {
     createOutputChannel(name: string, pluginInfo: PluginInfo): theia.OutputChannel
@@ -312,6 +315,8 @@ export interface TerminalServiceMain {
      * @param id - terminal id.
      */
     $dispose(id: string): void;
+
+    $setEnvironmentVariableCollection(extensionIdentifier: string, persistent: boolean, collection: SerializableEnvironmentVariableCollection | undefined): void;
 }
 
 export interface AutoFocus {

--- a/packages/plugin-ext/src/hosted/browser/worker/worker-main.ts
+++ b/packages/plugin-ext/src/hosted/browser/worker/worker-main.ts
@@ -17,7 +17,7 @@
 import { Emitter } from '@theia/core/lib/common/event';
 import { RPCProtocolImpl } from '../../../common/rpc-protocol';
 import { PluginManagerExtImpl } from '../../../plugin/plugin-manager';
-import { MAIN_RPC_CONTEXT, Plugin, emptyPlugin } from '../../../common/plugin-api-rpc';
+import { MAIN_RPC_CONTEXT, Plugin, emptyPlugin, TerminalServiceExt } from '../../../common/plugin-api-rpc';
 import { createAPIFactory } from '../../../plugin/plugin-context';
 import { getPluginId, PluginMetadata } from '../../../common/plugin-protocol';
 import * as theia from '@theia/plugin';
@@ -32,6 +32,7 @@ import { ClipboardExt } from '../../../plugin/clipboard-ext';
 import { KeyValueStorageProxy } from '../../../plugin/plugin-storage';
 import { WebviewsExtImpl } from '../../../plugin/webviews';
 import { loadManifest } from './plugin-manifest-loader';
+import { TerminalServiceExtImpl } from '../../../plugin/terminal-ext';
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const ctx = self as any;
@@ -62,6 +63,7 @@ const preferenceRegistryExt = new PreferenceRegistryExtImpl(rpc, workspaceExt);
 const debugExt = createDebugExtStub(rpc);
 const clipboardExt = new ClipboardExt(rpc);
 const webviewExt = new WebviewsExtImpl(rpc, workspaceExt);
+const terminalService: TerminalServiceExt = new TerminalServiceExtImpl(rpc);
 
 const pluginManager = new PluginManagerExtImpl({
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -146,7 +148,7 @@ const pluginManager = new PluginManagerExtImpl({
             }
         }
     }
-}, envExt, storageProxy, preferenceRegistryExt, webviewExt, rpc);
+}, envExt, terminalService, storageProxy, preferenceRegistryExt, webviewExt, rpc);
 
 const apiFactory = createAPIFactory(
     rpc,

--- a/packages/plugin-ext/src/hosted/node/plugin-host-rpc.ts
+++ b/packages/plugin-ext/src/hosted/node/plugin-host-rpc.ts
@@ -30,6 +30,7 @@ import { ClipboardExt } from '../../plugin/clipboard-ext';
 import { loadManifest } from './plugin-manifest-loader';
 import { KeyValueStorageProxy } from '../../plugin/plugin-storage';
 import { WebviewsExtImpl } from '../../plugin/webviews';
+import { TerminalServiceExtImpl } from '../../plugin/terminal-ext';
 
 /**
  * Handle the RPC calls.
@@ -54,7 +55,8 @@ export class PluginHostRPC {
         const preferenceRegistryExt = new PreferenceRegistryExtImpl(this.rpc, workspaceExt);
         const clipboardExt = new ClipboardExt(this.rpc);
         const webviewExt = new WebviewsExtImpl(this.rpc, workspaceExt);
-        this.pluginManager = this.createPluginManager(envExt, storageProxy, preferenceRegistryExt, webviewExt, this.rpc);
+        const terminalService = new TerminalServiceExtImpl(this.rpc);
+        this.pluginManager = this.createPluginManager(envExt, terminalService, storageProxy, preferenceRegistryExt, webviewExt, this.rpc);
         this.rpc.set(MAIN_RPC_CONTEXT.HOSTED_PLUGIN_MANAGER_EXT, this.pluginManager);
         this.rpc.set(MAIN_RPC_CONTEXT.EDITORS_AND_DOCUMENTS_EXT, editorsAndDocumentsExt);
         this.rpc.set(MAIN_RPC_CONTEXT.WORKSPACE_EXT, workspaceExt);
@@ -93,7 +95,7 @@ export class PluginHostRPC {
     }
 
     createPluginManager(
-        envExt: EnvExtImpl, storageProxy: KeyValueStorageProxy, preferencesManager: PreferenceRegistryExtImpl, webview: WebviewsExtImpl,
+        envExt: EnvExtImpl, terminalService: TerminalServiceExtImpl, storageProxy: KeyValueStorageProxy, preferencesManager: PreferenceRegistryExtImpl, webview: WebviewsExtImpl,
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         rpc: any): PluginManagerExtImpl {
         const { extensionTestsPath } = process.env;
@@ -225,7 +227,7 @@ export class PluginHostRPC {
                     `Path ${extensionTestsPath} does not point to a valid extension test runner.`
                 );
             } : undefined
-        }, envExt, storageProxy, preferencesManager, webview, rpc);
+        }, envExt, terminalService, storageProxy, preferencesManager, webview, rpc);
         return pluginManager;
     }
 }

--- a/packages/plugin-ext/src/plugin/plugin-context.ts
+++ b/packages/plugin-ext/src/plugin/plugin-context.ts
@@ -122,7 +122,8 @@ import {
     CallHierarchyItem,
     CallHierarchyIncomingCall,
     CallHierarchyOutgoingCall,
-    TimelineItem
+    TimelineItem,
+    EnvironmentVariableMutatorType
 } from './types-impl';
 import { AuthenticationExtImpl } from './authentication-ext';
 import { SymbolKind } from '../common/plugin-api-rpc-model';
@@ -913,7 +914,8 @@ export function createAPIFactory(
             CallHierarchyItem,
             CallHierarchyIncomingCall,
             CallHierarchyOutgoingCall,
-            TimelineItem
+            TimelineItem,
+            EnvironmentVariableMutatorType
         };
     };
 }

--- a/packages/plugin-ext/src/plugin/plugin-manager.ts
+++ b/packages/plugin-ext/src/plugin/plugin-manager.ts
@@ -25,7 +25,8 @@ import {
     PluginAPI,
     ConfigStorage,
     PluginManagerInitializeParams,
-    PluginManagerStartParams
+    PluginManagerStartParams,
+    TerminalServiceExt
 } from '../common/plugin-api-rpc';
 import { PluginMetadata, PluginJsonValidationContribution } from '../common/plugin-protocol';
 import * as theia from '@theia/plugin';
@@ -106,6 +107,7 @@ export class PluginManagerExtImpl implements PluginManagerExt, PluginManager {
     constructor(
         private readonly host: PluginHost,
         private readonly envExt: EnvExtImpl,
+        private readonly terminalService: TerminalServiceExt,
         private readonly storageProxy: KeyValueStorageProxy,
         private readonly preferencesManager: PreferenceRegistryExtImpl,
         private readonly webview: WebviewsExtImpl,
@@ -355,7 +357,8 @@ export class PluginManagerExtImpl implements PluginManagerExt, PluginManager {
             asAbsolutePath: asAbsolutePath,
             logPath: logPath,
             storagePath: storagePath,
-            globalStoragePath: globalStoragePath
+            globalStoragePath: globalStoragePath,
+            environmentVariableCollection: this.terminalService.getEnvironmentVariableCollection(plugin.model.id)
         };
         this.pluginContextsMap.set(plugin.model.id, pluginContext);
 

--- a/packages/plugin-ext/src/plugin/terminal-ext.ts
+++ b/packages/plugin-ext/src/plugin/terminal-ext.ts
@@ -17,9 +17,11 @@ import { UUID } from '@phosphor/coreutils/lib/uuid';
 import { Terminal, TerminalOptions, PseudoTerminalOptions } from '@theia/plugin';
 import { TerminalServiceExt, TerminalServiceMain, PLUGIN_RPC_CONTEXT } from '../common/plugin-api-rpc';
 import { RPCProtocol } from '../common/rpc-protocol';
-import { Emitter } from '@theia/core/lib/common/event';
+import { Event, Emitter } from '@theia/core/lib/common/event';
 import { Deferred } from '@theia/core/lib/common/promise-util';
 import * as theia from '@theia/plugin';
+import { EnvironmentVariableMutatorType } from './types-impl';
+import { SerializableEnvironmentVariableCollection } from '@theia/terminal/lib/common/base-terminal-protocol';
 
 /**
  * Provides high level terminal plugin api to use in the Theia plugins.
@@ -41,6 +43,8 @@ export class TerminalServiceExtImpl implements TerminalServiceExt {
 
     private readonly onDidChangeActiveTerminalEmitter = new Emitter<Terminal | undefined>();
     readonly onDidChangeActiveTerminal: theia.Event<Terminal | undefined> = this.onDidChangeActiveTerminalEmitter.event;
+
+    protected environmentVariableCollections: Map<string, EnvironmentVariableCollection> = new Map();
 
     constructor(rpc: RPCProtocol) {
         this.proxy = rpc.getProxy(PLUGIN_RPC_CONTEXT.TERMINAL_MAIN);
@@ -151,6 +155,108 @@ export class TerminalServiceExtImpl implements TerminalServiceExt {
         this.onDidChangeActiveTerminalEmitter.fire(this.activeTerminal);
     }
 
+    /*---------------------------------------------------------------------------------------------
+     *  Copyright (c) Microsoft Corporation. All rights reserved.
+     *  Licensed under the MIT License. See License.txt in the project root for license information.
+     *--------------------------------------------------------------------------------------------*/
+    // some code copied and modified from https://github.com/microsoft/vscode/blob/1.49.0/src/vs/workbench/api/common/extHostTerminalService.ts
+
+    getEnvironmentVariableCollection(extensionIdentifier: string): theia.EnvironmentVariableCollection {
+        let collection = this.environmentVariableCollections.get(extensionIdentifier);
+        if (!collection) {
+            collection = new EnvironmentVariableCollection();
+            this.setEnvironmentVariableCollection(extensionIdentifier, collection);
+        }
+        return collection;
+    }
+
+    private syncEnvironmentVariableCollection(extensionIdentifier: string, collection: EnvironmentVariableCollection): void {
+        const serialized = [...collection.map.entries()];
+        this.proxy.$setEnvironmentVariableCollection(extensionIdentifier, collection.persistent, serialized.length === 0 ? undefined : serialized);
+    }
+
+    private setEnvironmentVariableCollection(extensionIdentifier: string, collection: EnvironmentVariableCollection): void {
+        this.environmentVariableCollections.set(extensionIdentifier, collection);
+        collection.onDidChangeCollection(() => {
+            // When any collection value changes send this immediately, this is done to ensure
+            // following calls to createTerminal will be created with the new environment. It will
+            // result in more noise by sending multiple updates when called but collections are
+            // expected to be small.
+            this.syncEnvironmentVariableCollection(extensionIdentifier, collection);
+        });
+    }
+
+    $initEnvironmentVariableCollections(collections: [string, SerializableEnvironmentVariableCollection][]): void {
+        collections.forEach(entry => {
+            const extensionIdentifier = entry[0];
+            const collection = new EnvironmentVariableCollection(entry[1]);
+            this.setEnvironmentVariableCollection(extensionIdentifier, collection);
+        });
+    }
+
+}
+
+export class EnvironmentVariableCollection implements theia.EnvironmentVariableCollection {
+    readonly map: Map<string, theia.EnvironmentVariableMutator> = new Map();
+    private _persistent: boolean = true;
+
+    public get persistent(): boolean { return this._persistent; }
+    public set persistent(value: boolean) {
+        this._persistent = value;
+        this.onDidChangeCollectionEmitter.fire();
+    }
+
+    protected readonly onDidChangeCollectionEmitter: Emitter<void> = new Emitter<void>();
+    onDidChangeCollection: Event<void> = this.onDidChangeCollectionEmitter.event;
+
+    constructor(
+        serialized?: SerializableEnvironmentVariableCollection
+    ) {
+        this.map = new Map(serialized);
+    }
+
+    get size(): number {
+        return this.map.size;
+    }
+
+    replace(variable: string, value: string): void {
+        this._setIfDiffers(variable, { value, type: EnvironmentVariableMutatorType.Replace });
+    }
+
+    append(variable: string, value: string): void {
+        this._setIfDiffers(variable, { value, type: EnvironmentVariableMutatorType.Append });
+    }
+
+    prepend(variable: string, value: string): void {
+        this._setIfDiffers(variable, { value, type: EnvironmentVariableMutatorType.Prepend });
+    }
+
+    private _setIfDiffers(variable: string, mutator: theia.EnvironmentVariableMutator): void {
+        const current = this.map.get(variable);
+        if (!current || current.value !== mutator.value || current.type !== mutator.type) {
+            this.map.set(variable, mutator);
+            this.onDidChangeCollectionEmitter.fire();
+        }
+    }
+
+    get(variable: string): theia.EnvironmentVariableMutator | undefined {
+        return this.map.get(variable);
+    }
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    forEach(callback: (variable: string, mutator: theia.EnvironmentVariableMutator, collection: theia.EnvironmentVariableCollection) => any, thisArg?: any): void {
+        this.map.forEach((value, key) => callback.call(thisArg, key, value, this));
+    }
+
+    delete(variable: string): void {
+        this.map.delete(variable);
+        this.onDidChangeCollectionEmitter.fire();
+    }
+
+    clear(): void {
+        this.map.clear();
+        this.onDidChangeCollectionEmitter.fire();
+    }
 }
 
 export class TerminalExtImpl implements Terminal {

--- a/packages/plugin-ext/src/plugin/types-impl.ts
+++ b/packages/plugin-ext/src/plugin/types-impl.ts
@@ -450,6 +450,12 @@ export enum EndOfLine {
     CRLF = 2
 }
 
+export enum EnvironmentVariableMutatorType {
+    Replace = 1,
+    Append = 2,
+    Prepend = 3
+}
+
 export class SnippetString {
 
     static isSnippetString(thing: {}): thing is SnippetString {

--- a/packages/plugin/src/theia.d.ts
+++ b/packages/plugin/src/theia.d.ts
@@ -2872,6 +2872,113 @@ declare module '@theia/plugin' {
     }
 
     /**
+     * A type of mutation that can be applied to an environment variable.
+     */
+    export enum EnvironmentVariableMutatorType {
+        /**
+         * Replace the variable's existing value.
+         */
+        Replace = 1,
+        /**
+         * Append to the end of the variable's existing value.
+         */
+        Append = 2,
+        /**
+         * Prepend to the start of the variable's existing value.
+         */
+        Prepend = 3
+    }
+
+    /**
+     * A type of mutation and its value to be applied to an environment variable.
+     */
+    export interface EnvironmentVariableMutator {
+        /**
+         * The type of mutation that will occur to the variable.
+         */
+        readonly type: EnvironmentVariableMutatorType;
+
+        /**
+         * The value to use for the variable.
+         */
+        readonly value: string;
+    }
+
+    /**
+     * A collection of mutations that an extension can apply to a process environment.
+     */
+    export interface EnvironmentVariableCollection {
+        /**
+         * Whether the collection should be cached for the workspace and applied to the terminal
+         * across window reloads. When true the collection will be active immediately such when the
+         * window reloads. Additionally, this API will return the cached version if it exists. The
+         * collection will be invalidated when the extension is uninstalled or when the collection
+         * is cleared. Defaults to true.
+         */
+        persistent: boolean;
+
+        /**
+         * Replace an environment variable with a value.
+         *
+         * Note that an extension can only make a single change to any one variable, so this will
+         * overwrite any previous calls to replace, append or prepend.
+         *
+         * @param variable The variable to replace.
+         * @param value The value to replace the variable with.
+         */
+        replace(variable: string, value: string): void;
+
+        /**
+         * Append a value to an environment variable.
+         *
+         * Note that an extension can only make a single change to any one variable, so this will
+         * overwrite any previous calls to replace, append or prepend.
+         *
+         * @param variable The variable to append to.
+         * @param value The value to append to the variable.
+         */
+        append(variable: string, value: string): void;
+
+        /**
+         * Prepend a value to an environment variable.
+         *
+         * Note that an extension can only make a single change to any one variable, so this will
+         * overwrite any previous calls to replace, append or prepend.
+         *
+         * @param variable The variable to prepend.
+         * @param value The value to prepend to the variable.
+         */
+        prepend(variable: string, value: string): void;
+
+        /**
+         * Gets the mutator that this collection applies to a variable, if any.
+         *
+         * @param variable The variable to get the mutator for.
+         */
+        get(variable: string): EnvironmentVariableMutator | undefined;
+
+        /**
+         * Iterate over each mutator in this collection.
+         *
+         * @param callback Function to execute for each entry.
+         * @param thisArg The `this` context used when invoking the handler function.
+         */
+        forEach(callback: (variable: string, mutator: EnvironmentVariableMutator, collection: EnvironmentVariableCollection) => any, thisArg?: any): void;
+
+        /**
+         * Deletes this collection's mutator for a variable.
+         *
+         * @param variable The variable to delete the mutator for.
+         */
+        delete(variable: string): void;
+
+        /**
+         * Clears all mutators from this collection.
+         */
+        clear(): void;
+    }
+
+    /**
      * A plug-in context is a collection of utilities private to a
      * plug-in.
      *
@@ -2902,6 +3009,12 @@ declare module '@theia/plugin' {
          * The absolute file path of the directory containing the extension.
          */
         extensionPath: string;
+
+        /**
+         * Gets the extension's environment variable collection for this workspace, enabling changes
+         * to be applied to terminal environment variables.
+         */
+        readonly environmentVariableCollection: EnvironmentVariableCollection;
 
         /**
          * Get the absolute path of a resource contained in the extension.

--- a/packages/terminal/src/common/terminal-watcher.ts
+++ b/packages/terminal/src/common/terminal-watcher.ts
@@ -16,7 +16,11 @@
 
 import { injectable } from 'inversify';
 import { Emitter, Event } from '@theia/core/lib/common/event';
-import { IBaseTerminalClient, IBaseTerminalExitEvent, IBaseTerminalErrorEvent } from './base-terminal-protocol';
+import {
+    IBaseTerminalClient,
+    IBaseTerminalExitEvent,
+    IBaseTerminalErrorEvent
+} from './base-terminal-protocol';
 
 @injectable()
 export class TerminalWatcher {
@@ -24,7 +28,15 @@ export class TerminalWatcher {
     getTerminalClient(): IBaseTerminalClient {
         const exitEmitter = this.onTerminalExitEmitter;
         const errorEmitter = this.onTerminalErrorEmitter;
+        const storeTerminalEnvVariablesEmitter = this.onStoreTerminalEnvVariablesRequestedEmitter;
+        const updateTerminalEnvVariablesEmitter = this.onUpdateTerminalEnvVariablesRequestedEmitter;
         return {
+            storeTerminalEnvVariables(data: string): void {
+                storeTerminalEnvVariablesEmitter.fire(data);
+            },
+            updateTerminalEnvVariables(): void {
+                updateTerminalEnvVariablesEmitter.fire(undefined);
+            },
             onTerminalExitChanged(event: IBaseTerminalExitEvent): void {
                 exitEmitter.fire(event);
             },
@@ -36,6 +48,8 @@ export class TerminalWatcher {
 
     private onTerminalExitEmitter = new Emitter<IBaseTerminalExitEvent>();
     private onTerminalErrorEmitter = new Emitter<IBaseTerminalErrorEvent>();
+    private onStoreTerminalEnvVariablesRequestedEmitter = new Emitter<string>();
+    private onUpdateTerminalEnvVariablesRequestedEmitter = new Emitter<undefined>();
 
     get onTerminalExit(): Event<IBaseTerminalExitEvent> {
         return this.onTerminalExitEmitter.event;
@@ -43,5 +57,13 @@ export class TerminalWatcher {
 
     get onTerminalError(): Event<IBaseTerminalErrorEvent> {
         return this.onTerminalErrorEmitter.event;
+    }
+
+    get onStoreTerminalEnvVariablesRequested(): Event<string> {
+        return this.onStoreTerminalEnvVariablesRequestedEmitter.event;
+    }
+
+    get onUpdateTerminalEnvVariablesRequested(): Event<undefined> {
+        return this.onUpdateTerminalEnvVariablesRequestedEmitter.event;
     }
 }

--- a/packages/terminal/src/node/base-terminal-server.ts
+++ b/packages/terminal/src/node/base-terminal-server.ts
@@ -15,8 +15,21 @@
  ********************************************************************************/
 
 import { inject, injectable, named } from 'inversify';
-import { ILogger, DisposableCollection } from '@theia/core/lib/common';
-import { IBaseTerminalServer, IBaseTerminalServerOptions, IBaseTerminalClient, TerminalProcessInfo } from '../common/base-terminal-protocol';
+import { ILogger, DisposableCollection, isWindows } from '@theia/core/lib/common';
+import {
+    IBaseTerminalServer,
+    IBaseTerminalServerOptions,
+    IBaseTerminalClient,
+    TerminalProcessInfo,
+    EnvironmentVariableCollection,
+    MergedEnvironmentVariableCollection,
+    SerializableEnvironmentVariableCollection,
+    EnvironmentVariableMutator,
+    ExtensionOwnedEnvironmentVariableMutator,
+    EnvironmentVariableMutatorType,
+    EnvironmentVariableCollectionWithPersistence,
+    SerializableExtensionEnvironmentVariableCollection
+} from '../common/base-terminal-protocol';
 import { TerminalProcess, ProcessManager } from '@theia/process/lib/node';
 import { ShellProcess } from './shell-process';
 
@@ -24,6 +37,9 @@ import { ShellProcess } from './shell-process';
 export abstract class BaseTerminalServer implements IBaseTerminalServer {
     protected client: IBaseTerminalClient | undefined = undefined;
     protected terminalToDispose = new Map<number, DisposableCollection>();
+
+    readonly collections: Map<string, EnvironmentVariableCollectionWithPersistence> = new Map();
+    mergedCollection: MergedEnvironmentVariableCollection;
 
     constructor(
         @inject(ProcessManager) protected readonly processManager: ProcessManager,
@@ -36,6 +52,7 @@ export abstract class BaseTerminalServer implements IBaseTerminalServer {
                 this.terminalToDispose.delete(id);
             }
         });
+        this.mergedCollection = this.resolveMergedCollection();
     }
 
     abstract create(options: IBaseTerminalServerOptions): Promise<number>;
@@ -106,6 +123,10 @@ export abstract class BaseTerminalServer implements IBaseTerminalServer {
     /* Set the client to receive notifications on.  */
     setClient(client: IBaseTerminalClient | undefined): void {
         this.client = client;
+        if (!this.client) {
+            return;
+        }
+        this.client.updateTerminalEnvVariables();
     }
 
     protected postCreate(term: TerminalProcess): void {
@@ -135,4 +156,112 @@ export abstract class BaseTerminalServer implements IBaseTerminalServer {
         this.terminalToDispose.set(term.id, toDispose);
     }
 
+    /*---------------------------------------------------------------------------------------------
+     *  Copyright (c) Microsoft Corporation. All rights reserved.
+     *  Licensed under the MIT License. See License.txt in the project root for license information.
+     *--------------------------------------------------------------------------------------------*/
+    // some code copied and modified from https://github.com/microsoft/vscode/blob/1.49.0/src/vs/workbench/contrib/terminal/common/environmentVariableService.ts
+
+    setCollection(extensionIdentifier: string, persistent: boolean, collection: SerializableEnvironmentVariableCollection): void {
+        const translatedCollection = { persistent, map: new Map<string, EnvironmentVariableMutator>(collection) };
+        this.collections.set(extensionIdentifier, translatedCollection);
+        this.updateCollections();
+    }
+
+    deleteCollection(extensionIdentifier: string): void {
+        this.collections.delete(extensionIdentifier);
+        this.updateCollections();
+    }
+
+    private updateCollections(): void {
+        this.persistCollections();
+        this.mergedCollection = this.resolveMergedCollection();
+    }
+
+    protected persistCollections(): void {
+        const collectionsJson: SerializableExtensionEnvironmentVariableCollection[] = [];
+        this.collections.forEach((collection, extensionIdentifier) => {
+            if (collection.persistent) {
+                collectionsJson.push({
+                    extensionIdentifier,
+                    collection: [...this.collections.get(extensionIdentifier)!.map.entries()]
+                });
+            }
+        });
+        if (this.client) {
+            const stringifiedJson = JSON.stringify(collectionsJson);
+            this.client.storeTerminalEnvVariables(stringifiedJson);
+        }
+    }
+
+    private resolveMergedCollection(): MergedEnvironmentVariableCollection {
+        return new MergedEnvironmentVariableCollectionImpl(this.collections);
+    }
+
+}
+
+/*---------------------------------------------------------------------------------------------
+     *  Copyright (c) Microsoft Corporation. All rights reserved.
+     *  Licensed under the MIT License. See License.txt in the project root for license information.
+     *--------------------------------------------------------------------------------------------*/
+// some code copied and modified from https://github.com/microsoft/vscode/blob/1.49.0/src/vs/workbench/contrib/terminal/common/environmentVariableCollection.ts
+
+export class MergedEnvironmentVariableCollectionImpl implements MergedEnvironmentVariableCollection {
+    readonly map: Map<string, ExtensionOwnedEnvironmentVariableMutator[]> = new Map();
+
+    constructor(collections: Map<string, EnvironmentVariableCollection>) {
+        collections.forEach((collection, extensionIdentifier) => {
+            const it = collection.map.entries();
+            let next = it.next();
+            while (!next.done) {
+                const variable = next.value[0];
+                let entry = this.map.get(variable);
+                if (!entry) {
+                    entry = [];
+                    this.map.set(variable, entry);
+                }
+
+                // If the first item in the entry is replace ignore any other entries as they would
+                // just get replaced by this one.
+                if (entry.length > 0 && entry[0].type === EnvironmentVariableMutatorType.Replace) {
+                    next = it.next();
+                    continue;
+                }
+
+                // Mutators get applied in the reverse order than they are created
+                const mutator = next.value[1];
+                entry.unshift({
+                    extensionIdentifier,
+                    value: mutator.value,
+                    type: mutator.type
+                });
+
+                next = it.next();
+            }
+        });
+    }
+
+    applyToProcessEnvironment(env: { [key: string]: string | null }): void {
+        let lowerToActualVariableNames: { [lowerKey: string]: string | undefined } | undefined;
+        if (isWindows) {
+            lowerToActualVariableNames = {};
+            Object.keys(env).forEach(e => lowerToActualVariableNames![e.toLowerCase()] = e);
+        }
+        this.map.forEach((mutators, variable) => {
+            const actualVariable = isWindows ? lowerToActualVariableNames![variable.toLowerCase()] || variable : variable;
+            mutators.forEach(mutator => {
+                switch (mutator.type) {
+                    case EnvironmentVariableMutatorType.Append:
+                        env[actualVariable] = (env[actualVariable] || '') + mutator.value;
+                        break;
+                    case EnvironmentVariableMutatorType.Prepend:
+                        env[actualVariable] = mutator.value + (env[actualVariable] || '');
+                        break;
+                    case EnvironmentVariableMutatorType.Replace:
+                        env[actualVariable] = mutator.value;
+                        break;
+                }
+            });
+        });
+    }
 }

--- a/packages/terminal/src/node/shell-terminal-server.ts
+++ b/packages/terminal/src/node/shell-terminal-server.ts
@@ -35,6 +35,8 @@ export class ShellTerminalServer extends BaseTerminalServer {
 
     create(options: IShellTerminalServerOptions): Promise<number> {
         try {
+            options.env = options.env ? options.env : {};
+            this.mergedCollection.applyToProcessEnvironment(options.env);
             const term = this.shellFactory(options);
             this.postCreate(term);
             return Promise.resolve(term.id);


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->
Add `environmentVariableCollection` to `PluginContext` to align it with [`ExtensionContext`](https://github.com/microsoft/vscode/blob/f0283ed23950bd5c729ded6964874452c593994f/src/vs/vscode.d.ts#L5527-L5604) from vscode.

related CQ: https://dev.eclipse.org/ipzilla/show_bug.cgi?id=22598
fixes https://github.com/eclipse-theia/theia/issues/8405
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
#### How to test
1. Clone the [test plugin](https://github.com/vinokurig/environment-variable.git) and compile it, or download the [vsix](https://github.com/vinokurig/environment-variable/releases/download/0.0.1/environment-variable-plugin-0.0.1.vsix) file
2. Start the plugin and run `F1 => Environment variable: Open terminal`. This command opens a new terminal with predefined environment variables and changes them with the help of the `environmentVariableCollection` plugin API: 
```
        collection = context.environmentVariableCollection;
        collection.replace('A', '~a2~');
        collection.append('B', '~b2~');
        collection.prepend('C', '~c2~');

        const terminal = theia.window.createTerminal({
            env: {
                A: 'a1',
                B: 'b1',
                C: 'c1'
            }
        });
        terminal.show();
        terminal.sendText('echo $A');
        terminal.sendText('echo $B');
        terminal.sendText('echo $C');
```
See : 
```
echo $A
echo $B
echo $C
[ivinokur@localhost environment-variable]$ echo $A
~a2~
[ivinokur@localhost environment-variable]$ echo $B
b1~b2~
[ivinokur@localhost environment-variable]$ echo $C
~c2~c1
[ivinokur@localhost environment-variable]$ 
```
3. The environment variable collection is stored by default, to test it stop the plugin and then start it again, open a new terminal and type `echo $A $B $C`, see: 
```
~a2~ ~b2~ ~c2~
```
4. Run `F1 => Environment variable: Clear collection`, open a new terminal and type `echo $A $B $C`: see an empty line.
#### Review checklist

- [ ] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

