### PR TITLE
Add `onStartupFinished` plugin activation event

### DIFF
--- a/packages/plugin-ext/src/hosted/browser/hosted-plugin.ts
+++ b/packages/plugin-ext/src/hosted/browser/hosted-plugin.ts
@@ -420,6 +420,7 @@ export class HostedPluginSupport {
             })());
         }
         await Promise.all(thenable);
+        await this.activateByEvent('onStartupFinished');
         if (toDisconnect.disposed) {
             return;
         }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->
Add `onStartupFinished` plugin activation event

fixes https://github.com/eclipse-theia/theia/issues/8488
#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
1. Clone any Theia plugin e.g https://github.com/eclipse/che-theia-samples/tree/master/samples/hello-world-backend-plugin
2. Change the activation event in its `package.json` from `*` to `onStartupFinished`
3. Start the plugin.

#### Review checklist

- [ ] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

