### PR TITLE
add isWeb Operating System context when clause

### DIFF
--- a/packages/core/src/browser/common-frontend-contribution.ts
+++ b/packages/core/src/browser/common-frontend-contribution.ts
@@ -342,6 +342,7 @@ export class CommonFrontendContribution implements FrontendApplicationContributi
         this.contextKeyService.createKey<boolean>('isLinux', OS.type() === OS.Type.Linux);
         this.contextKeyService.createKey<boolean>('isMac', OS.type() === OS.Type.OSX);
         this.contextKeyService.createKey<boolean>('isWindows', OS.type() === OS.Type.Windows);
+        this.contextKeyService.createKey<boolean>('isWeb', !this.isElectron());
 
         this.initResourceContextKeys();
         this.registerCtrlWHandling();


### PR DESCRIPTION
Signed-off-by: Mohit Suman <mohit.skn@gmail.com>

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->
It adds `isWeb` Operating System context to the theia API. Fixes #8529 

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
Adds supports same as in vscode API for [when](https://code.visualstudio.com/docs/getstarted/keybindings#_when-clause-contexts) clause. 

If it is running in electron mode, isWeb would return false. And if running on Che/CRW, it would return true.
#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

