### PR TITLE
Filter button in search box

### DIFF
--- a/packages/core/src/browser/style/search-box.css
+++ b/packages/core/src/browser/style/search-box.css
@@ -43,13 +43,28 @@
     color: var(--theia-editorWidget-foreground);
 }
 
+.theia-search-button.codicon.codicon-filter {
+    line-height: var(--theia-private-horizontal-tab-height);
+    color: var(--theia-editorWidget-foreground);
+    align-self: flex-end;
+}
+
+.theia-search-button.codicon-filter:not(.filter-active):before {
+    content: "\eb85";
+}
+
+.theia-search-button.codicon-filter.filter-active:before {
+    content: "\eb83";
+}
+
 .theia-search-button-next:before {
     content: "\f107";
 }
 
 .theia-search-button-next:hover,
 .theia-search-button-previous:hover,
-.theia-search-button-close:hover {
+.theia-search-button-close:hover,
+.theia-search-button.codicon-filter:hover {
     cursor: pointer;
     background-color: var(--theia-editorHoverWidget-background);
 }

--- a/packages/scm/src/browser/scm-tree-widget.tsx
+++ b/packages/scm/src/browser/scm-tree-widget.tsx
@@ -70,6 +70,9 @@ export class ScmTreeWidget extends TreeWidget {
     }
 
     set viewMode(id: 'tree' | 'list') {
+        // Close the search box because the structure of the tree will change dramatically
+        // and the search results will be out of date.
+        this.searchBox.hide();
         this.model.viewMode = id;
     }
     get viewMode(): 'tree' | 'list' {


### PR DESCRIPTION
Signed-off-by: Colin Grant <colin.grant@ericsson.com>

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

This PR fixes #8380 by adding filtering functionality to the tree search box to parallel VSCode's tree search functionality. This makes breaking changes to the logic of the `TreeSearch.filter` function and the `TreeWidget.doUpdateRows` function.

I have a couple of questions:
- I've introduced a new field `_filteredNodesAndParents` in `TreeSearch` to hold all of the nodes that should be visible when the filter is activated. It might be possible to use one of the existing fields (`_filteredNodes`), but it should turned into a hash rather than array to avoid traversing the whole thing for every visibility check.
- I've introduced a `shouldDisplayNode` method in the `TreeWidget` elsewhere @akosyakov has said that visibility in `TreeWidget`s should rely on the node's `.visible` to determine visibility. I don't believe that any current Theia code modifies the `.visible` field of a `TreeNode`, so I opted not to modify it either - especially as that would have required looping over all nodes again after the filter, not just the nodes that pass the filters. In general, there's a division between using a node's fields directly or using a service (e.g. `LabelProvider`) to derive usable data, and I'm not sure on which side to come down. 

![theia-filter](https://user-images.githubusercontent.com/62660806/93782344-161ddc80-fbf0-11ea-9644-e7677dc87723.gif)

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

1. Open a tree widget with a search box (e.g. file explorer).
1. Activate the search box by typing while the Tree Widget is active.
1. Type text that selects some nodes in the tree.
1. Click the filter button to the right of the textbox.
1. Observe that all highlighted children and all their parents remain visible.
1. Observe that you can expand and collapse nodes without losing the search box.
1. Close the search box by clicking the `x` icon or hitting escape.
1. Observe that the tree returns to normal.

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

