### PR TITLE
Fix Issue 8463 - calling extension activate() by other extension

### DIFF
--- a/packages/plugin-ext/src/plugin/plugin-manager.ts
+++ b/packages/plugin-ext/src/plugin/plugin-manager.ts
@@ -30,7 +30,6 @@ import {
 import { PluginMetadata, PluginJsonValidationContribution } from '../common/plugin-protocol';
 import * as theia from '@theia/plugin';
 import { join } from 'path';
-import { Deferred } from '@theia/core/lib/common/promise-util';
 import { EnvExtImpl } from './env';
 import { PreferenceRegistryExtImpl } from './preference-registry';
 import { Memento, KeyValueStorageProxy } from './plugin-storage';
@@ -91,7 +90,6 @@ export class PluginManagerExtImpl implements PluginManagerExt, PluginManager {
     /** promises to whether loading each plugin has been successful */
     private readonly loadedPlugins = new Map<string, Promise<boolean>>();
     private readonly activatedPlugins = new Map<string, ActivatedPlugin>();
-    private readonly pluginActivationPromises = new Map<string, Deferred<void>>();
     private readonly pluginContextsMap = new Map<string, theia.PluginContext>();
 
     private onDidChangeEmitter = new Emitter<void>();
@@ -120,7 +118,6 @@ export class PluginManagerExtImpl implements PluginManagerExt, PluginManager {
             return this.stopAll();
         }
         this.registry.delete(pluginId);
-        this.pluginActivationPromises.delete(pluginId);
         this.pluginContextsMap.delete(pluginId);
         this.loadedPlugins.delete(pluginId);
         const plugin = this.activatedPlugins.get(pluginId);
@@ -144,7 +141,6 @@ export class PluginManagerExtImpl implements PluginManagerExt, PluginManager {
         this.registry.clear();
         this.loadedPlugins.clear();
         this.activatedPlugins.clear();
-        this.pluginActivationPromises.clear();
         this.pluginContextsMap.clear();
         await Promise.all(promises);
     }
@@ -295,9 +291,6 @@ export class PluginManagerExtImpl implements PluginManagerExt, PluginManager {
                     await this.startPlugin(plugin, configStorage, pluginMain);
                     return true;
                 } catch (err) {
-                    if (this.pluginActivationPromises.has(plugin.model.id)) {
-                        this.pluginActivationPromises.get(plugin.model.id)!.reject(err);
-                    }
                     const message = `Activating extension '${plugin.model.displayName || plugin.model.name}' failed:`;
                     this.messageRegistryProxy.$showMessage(MainMessageType.Error, message + ' ' + err.message, {}, []);
                     console.error(message, err);
@@ -367,12 +360,6 @@ export class PluginManagerExtImpl implements PluginManagerExt, PluginManager {
         if (typeof pluginMain[plugin.lifecycle.startMethod] === 'function') {
             const pluginExport = await pluginMain[plugin.lifecycle.startMethod].apply(getGlobal(), [pluginContext]);
             this.activatedPlugins.set(plugin.model.id, new ActivatedPlugin(pluginContext, pluginExport, stopFn));
-
-            // resolve activation promise
-            if (this.pluginActivationPromises.has(plugin.model.id)) {
-                this.pluginActivationPromises.get(plugin.model.id)!.resolve();
-                this.pluginActivationPromises.delete(plugin.model.id);
-            }
         } else {
             // https://github.com/TypeFox/vscode/blob/70b8db24a37fafc77247de7f7cb5bb0195120ed0/src/vs/workbench/api/common/extHostExtensionService.ts#L400-L401
             console.log(`plugin ${id}, ${plugin.lifecycle.startMethod} method is undefined so the module is the extension's exports`);
@@ -404,17 +391,7 @@ export class PluginManagerExtImpl implements PluginManagerExt, PluginManager {
     }
 
     activatePlugin(pluginId: string): PromiseLike<void> {
-        if (this.pluginActivationPromises.has(pluginId)) {
-            return this.pluginActivationPromises.get(pluginId)!.promise;
-        }
-
-        const deferred = new Deferred<void>();
-
-        if (this.activatedPlugins.get(pluginId)) {
-            deferred.resolve();
-        }
-        this.pluginActivationPromises.set(pluginId, deferred);
-        return deferred.promise;
+        return this.$activatePlugin(pluginId);
     }
 
     get onDidChange(): theia.Event<void> {


### PR DESCRIPTION
Fix Issue 8463 - calling extension activate() by other extension doesn't work.

Signed-off-by: Tomer Epstein <tomer.epstein@sap.com>

Issue: https://github.com/eclipse-theia/theia/issues/8463

#### What it does
This change proposal adds a call to activate plugin when ext isn't active and developer  called extension.activate() method.

#### How to test

1. git clone https://github.com/tomer-epstein/vscode-extension-activate.git
2. Pack (create vsix) for https://github.com/tomer-epstein/vscode-extension-activate/tree/master/vscode-manager
3. Pack (create vsix) for https://github.com/tomer-epstein/vscode-extension-activate/tree/master/vscode-contrib1
4. execute 'extension.activateContributor' command.

![image](https://user-images.githubusercontent.com/57438361/93850127-23050380-fcb6-11ea-80e7-778325112c4c.png)
![image](https://user-images.githubusercontent.com/57438361/93850136-2ac4a800-fcb6-11ea-8397-d8f16837176c.png)
![image](https://user-images.githubusercontent.com/57438361/93850152-31ebb600-fcb6-11ea-98b7-a75fadf5f203.png)


#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

