### PR TITLE
[core][monaco] Implement `Save without Formatting` command

### DIFF
--- a/packages/core/src/browser/common-frontend-contribution.ts
+++ b/packages/core/src/browser/common-frontend-contribution.ts
@@ -230,6 +230,11 @@ export namespace CommonCommands {
         category: FILE_CATEGORY,
         label: 'Save',
     };
+    export const SAVE_WITHOUT_FORMATTING: Command = {
+        id: 'core.saveWithoutFormatting',
+        category: FILE_CATEGORY,
+        label: 'Save without Formatting',
+    };
     export const SAVE_ALL: Command = {
         id: 'core.saveAll',
         category: FILE_CATEGORY,
@@ -444,6 +449,9 @@ export class CommonFrontendContribution implements FrontendApplicationContributi
 
         registry.registerMenuAction(CommonMenus.FILE_SAVE, {
             commandId: CommonCommands.SAVE.id
+        });
+        registry.registerMenuAction(CommonMenus.FILE_SAVE, {
+            commandId: CommonCommands.SAVE_WITHOUT_FORMATTING.id
         });
         registry.registerMenuAction(CommonMenus.FILE_SAVE, {
             commandId: CommonCommands.SAVE_ALL.id
@@ -747,6 +755,9 @@ export class CommonFrontendContribution implements FrontendApplicationContributi
         commandRegistry.registerCommand(CommonCommands.SAVE, {
             execute: () => this.shell.save()
         });
+        commandRegistry.registerCommand(CommonCommands.SAVE_WITHOUT_FORMATTING, {
+            execute: () => this.shell.save({ skipFormatting: true })
+        });
         commandRegistry.registerCommand(CommonCommands.SAVE_ALL, {
             execute: () => this.shell.saveAll()
         });
@@ -923,6 +934,10 @@ export class CommonFrontendContribution implements FrontendApplicationContributi
             {
                 command: CommonCommands.SAVE.id,
                 keybinding: 'ctrlcmd+s'
+            },
+            {
+                command: CommonCommands.SAVE_WITHOUT_FORMATTING.id,
+                keybinding: 'ctrlcmd+k s'
             },
             {
                 command: CommonCommands.SAVE_ALL.id,

--- a/packages/core/src/browser/saveable.ts
+++ b/packages/core/src/browser/saveable.ts
@@ -29,7 +29,7 @@ export interface Saveable {
     /**
      * Saves dirty changes.
      */
-    save(): MaybePromise<void>;
+    save(options?: SaveOptions): MaybePromise<void>;
     /**
      * Reverts dirty changes.
      */
@@ -87,10 +87,10 @@ export namespace Saveable {
         return !!getDirty(arg);
     }
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    export async function save(arg: any): Promise<void> {
+    export async function save(arg: any, options?: SaveOptions): Promise<void> {
         const saveable = get(arg);
         if (saveable) {
-            await saveable.save();
+            await saveable.save(options);
         }
     }
     export function apply(widget: Widget): SaveableWidget | undefined {
@@ -177,6 +177,13 @@ export namespace SaveableWidget {
     export interface CloseOptions {
         shouldSave?(): MaybePromise<boolean | undefined>
     }
+}
+
+export interface SaveOptions {
+    /**
+     * Controls whether formatting should be applied upon saving
+     */
+    readonly skipFormatting?: boolean;
 }
 
 /**

--- a/packages/core/src/browser/shell/application-shell.ts
+++ b/packages/core/src/browser/shell/application-shell.ts
@@ -25,7 +25,7 @@ import { Message } from '@phosphor/messaging';
 import { IDragEvent } from '@phosphor/dragdrop';
 import { RecursivePartial, Event as CommonEvent, DisposableCollection, Disposable } from '../../common';
 import { animationFrame } from '../browser';
-import { Saveable, SaveableWidget } from '../saveable';
+import { Saveable, SaveableWidget, SaveOptions } from '../saveable';
 import { StatusBarImpl, StatusBarEntry, StatusBarAlignment } from '../status-bar/status-bar';
 import { TheiaDockPanel, BOTTOM_AREA_ID, MAIN_AREA_ID } from './theia-dock-panel';
 import { SidePanelHandler, SidePanel, SidePanelHandlerFactory } from './side-panel-handler';
@@ -1731,8 +1731,8 @@ export class ApplicationShell extends Widget {
     /**
      * Save the current widget if it is dirty.
      */
-    async save(): Promise<void> {
-        await Saveable.save(this.currentWidget);
+    async save(options?: SaveOptions): Promise<void> {
+        await Saveable.save(this.currentWidget, options);
     }
 
     /**
@@ -1746,7 +1746,7 @@ export class ApplicationShell extends Widget {
      * Save all dirty widgets.
      */
     async saveAll(): Promise<void> {
-        await Promise.all(this.tracker.widgets.map(Saveable.save));
+        await Promise.all(this.tracker.widgets.map(widget => Saveable.save(widget)));
     }
 
     /**

--- a/packages/monaco/src/browser/monaco-editor-provider.ts
+++ b/packages/monaco/src/browser/monaco-editor-provider.ts
@@ -293,6 +293,9 @@ export class MonacoEditorProvider {
         if (event.reason !== TextDocumentSaveReason.Manual) {
             return [];
         }
+        if (event.options?.skipFormatting) {
+            return [];
+        }
         const overrideIdentifier = editor.document.languageId;
         const uri = editor.uri.toString();
         const formatOnSave = this.editorPreferences.get({ preferenceName: 'editor.formatOnSave', overrideIdentifier }, undefined, uri)!;


### PR DESCRIPTION
#### What it does

Fixes: #8375

+ Implements the command `Save without Formatting` #8375 
+ Adds key binding of `ctrlcmd+k s` to save without formatting

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
+ Make changes to a file (might be in wrong format/convention to better observe the functionality)
+ Use key binding: `ctrlcmd+k s` or choose from the command palette the option `Save without Formatting`
+ **Expected behavior:** The document is saved, but not formatted by the editor.

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

Signed-off-by: Duc Nguyen <duc.a.nguyen@ericsson.com>