### PR TITLE
watchers: use singleton server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,12 +4,16 @@
 
 - [git] the changes in the commit details (opened from the history view) and in the diff view (opened with 'Compare With...' on a folder's context menu) are now switchable between 'list' and 'tree' modes [#8084](https://github.com/eclipse-theia/theia/pull/8084)
 - [scm] show in the commit textbox the branch to which the commit will go [#6156](https://github.com/eclipse-theia/theia/pull/6156)
+- [filesystem] file watchers refactoring:
+  - Added `FileSystemWatcherService` component that should be a singleton centralizing watch requests for all clients.
+  - Added `FileSystemWatcherServiceDispatcher` to register yourself and listen to file change events.
 
 <a name="breaking_changes_1.7.0">[Breaking Changes:](#breaking_changes_1.7.0)</a>
 
 - [plugin-metrics] renamed `AnalyticsFromRequests.succesfulResponses` to `AnalyticsFromRequests.successfulResponses` []()
 - [core] change progress notification cancelable property default from true to false [#8479](https://github.com/eclipse-theia/theia/pull/8479)
 - [messages] empty notifications and progress notifications will not be shown [#8479](https://github.com/eclipse-theia/theia/pull/8479)
+- [filesystem] `NsfwFileSystemWatcherServer` is deprecated and no longer used.
 
 ## v1.6.0 - 24/09/2020
 

--- a/examples/api-samples/src/browser/api-samples-frontend-module.ts
+++ b/examples/api-samples/src/browser/api-samples-frontend-module.ts
@@ -19,6 +19,7 @@ import { bindDynamicLabelProvider } from './label/sample-dynamic-label-provider-
 import { bindSampleUnclosableView } from './view/sample-unclosable-view-contribution';
 import { bindSampleOutputChannelWithSeverity } from './output/sample-output-channel-with-severity';
 import { bindSampleMenu } from './menu/sample-menu-contribution';
+import { bindSampleFileWatching } from './file-watching/sample-file-watching-contribution';
 
 import '../../src/browser/style/branding.css';
 
@@ -27,4 +28,5 @@ export default new ContainerModule(bind => {
     bindSampleUnclosableView(bind);
     bindSampleOutputChannelWithSeverity(bind);
     bindSampleMenu(bind);
+    bindSampleFileWatching(bind);
 });

--- a/examples/api-samples/src/browser/file-watching/sample-file-watching-contribution.ts
+++ b/examples/api-samples/src/browser/file-watching/sample-file-watching-contribution.ts
@@ -1,0 +1,92 @@
+/********************************************************************************
+ * Copyright (C) 2020 Ericsson and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import { postConstruct, injectable, inject, interfaces } from 'inversify';
+import {
+    createPreferenceProxy, FrontendApplicationContribution, LabelProvider,
+    PreferenceContribution, PreferenceProxy, PreferenceSchema, PreferenceService
+} from '@theia/core/lib/browser';
+import { FileService } from '@theia/filesystem/lib/browser/file-service';
+import { WorkspaceService } from '@theia/workspace/lib/browser';
+
+export function bindSampleFileWatching(bind: interfaces.Bind): void {
+    bind(FrontendApplicationContribution).to(SampleFileWatchingContribution).inSingletonScope();
+    bind(PreferenceContribution).toConstantValue({ schema: FileWatchingPreferencesSchema });
+    bind(FileWatchingPreferences).toDynamicValue(
+        ctx => createPreferenceProxy(ctx.container.get(PreferenceService), FileWatchingPreferencesSchema)
+    );
+}
+
+const FileWatchingPreferences = Symbol('FileWatchingPreferences');
+type FileWatchingPreferences = PreferenceProxy<FileWatchingPreferencesSchema>;
+
+interface FileWatchingPreferencesSchema {
+    'sample.file-watching.verbose': boolean
+}
+const FileWatchingPreferencesSchema: PreferenceSchema = {
+    type: 'object',
+    properties: {
+        'sample.file-watching.verbose': {
+            type: 'boolean',
+            default: false,
+            description: 'Enable verbose file watching logs.'
+        }
+    }
+};
+
+@injectable()
+class SampleFileWatchingContribution implements FrontendApplicationContribution {
+
+    protected verbose: boolean;
+
+    @inject(FileService)
+    protected readonly fileService: FileService;
+
+    @inject(LabelProvider)
+    protected readonly labelProvider: LabelProvider;
+
+    @inject(WorkspaceService)
+    protected readonly workspaceService: WorkspaceService;
+
+    @inject(FileWatchingPreferences)
+    protected readonly fileWatchingPreferences: FileWatchingPreferences;
+
+    @postConstruct()
+    protected postConstruct(): void {
+        this.verbose = this.fileWatchingPreferences['sample.file-watching.verbose'];
+        this.fileWatchingPreferences.onPreferenceChanged(e => {
+            if (e.preferenceName === 'sample.file-watching.verbose') {
+                this.verbose = e.newValue!;
+            }
+        });
+    }
+
+    onStart(): void {
+        this.fileService.onDidFilesChange(event => {
+            // Only log if the verbose preference is set.
+            if (this.verbose) {
+                // Get the workspace roots for the current frontend:
+                const roots = this.workspaceService.tryGetRoots();
+                // Create some name to help find out which frontend logged the message:
+                const workspace = roots.length > 0
+                    ? roots.map(root => this.labelProvider.getLongName(root.resource)).join('+')
+                    : '<no workspace>';
+                console.log(`Sample File Watching: ${event.changes.length} file(s) changed! ${workspace}`);
+            }
+        });
+    }
+
+}

--- a/packages/filesystem/compile.tsconfig.json
+++ b/packages/filesystem/compile.tsconfig.json
@@ -9,6 +9,9 @@
       "mv": [
         "src/typings/mv"
       ],
+      "nsfw": [
+        "src/typings/nsfw"
+      ],
       "trash": [
         "src/typings/trash"
       ]

--- a/packages/filesystem/src/common/filesystem-watcher-protocol.ts
+++ b/packages/filesystem/src/common/filesystem-watcher-protocol.ts
@@ -19,6 +19,47 @@ import { JsonRpcServer, JsonRpcProxy } from '@theia/core';
 import { FileChangeType } from './files';
 export { FileChangeType };
 
+export const FileSystemWatcherService = Symbol('FileSystemWatcherServer2');
+/**
+ * Singleton implementation of the watch server.
+ *
+ * Since multiple clients all make requests to this service, we need to track those individually via a `clientId`.
+ */
+export interface FileSystemWatcherService extends JsonRpcServer<FileSystemWatcherServiceClient> {
+    /**
+     * @param clientId arbitrary id used to identify a client.
+     * @param uri the path to watch.
+     * @param options optional parameters.
+     * @returns promise to a unique `number` handle for this request.
+     */
+    watchFileChanges(clientId: number, uri: string, options?: WatchOptions): Promise<number>;
+    /**
+     * @param watcherId handle mapping to a previous `watchFileChanges` request.
+     */
+    unwatchFileChanges(watcherId: number): Promise<void>;
+}
+
+export interface FileSystemWatcherServiceClient {
+    /** Listen for change events emitted by the watcher. */
+    onDidFilesChanged(event: DidFilesChangedParams): void;
+    /** The watcher can crash in certain conditions. */
+    onError(event: FileSystemWatcherErrorParams): void;
+}
+
+export interface DidFilesChangedParams {
+    /** Clients to route the events to. */
+    clients?: number[];
+    /** FileSystem changes that occured. */
+    changes: FileChange[];
+}
+
+export interface FileSystemWatcherErrorParams {
+    /** Clients to route the events to. */
+    clients: number[];
+    /** The uri that originated the error. */
+    uri: string;
+}
+
 export const FileSystemWatcherServer = Symbol('FileSystemWatcherServer');
 export interface FileSystemWatcherServer extends JsonRpcServer<FileSystemWatcherClient> {
     /**
@@ -32,7 +73,7 @@ export interface FileSystemWatcherServer extends JsonRpcServer<FileSystemWatcher
      * Stop file watching for the given id.
      * Resolve when watching is stopped.
      */
-    unwatchFileChanges(watcher: number): Promise<void>;
+    unwatchFileChanges(watcherId: number): Promise<void>;
 }
 
 export interface FileSystemWatcherClient {
@@ -50,11 +91,6 @@ export interface FileSystemWatcherClient {
 export interface WatchOptions {
     ignored: string[];
 }
-
-export interface DidFilesChangedParams {
-    changes: FileChange[];
-}
-
 export interface FileChange {
     uri: string;
     type: FileChangeType;
@@ -63,6 +99,9 @@ export interface FileChange {
 export const FileSystemWatcherServerProxy = Symbol('FileSystemWatcherServerProxy');
 export type FileSystemWatcherServerProxy = JsonRpcProxy<FileSystemWatcherServer>;
 
+/**
+ * @deprecated not used internally anymore.
+ */
 @injectable()
 export class ReconnectingFileSystemWatcherServer implements FileSystemWatcherServer {
 

--- a/packages/filesystem/src/common/remote-file-system-provider.ts
+++ b/packages/filesystem/src/common/remote-file-system-provider.ts
@@ -103,6 +103,11 @@ export class RemoteFileSystemProxyFactory<T extends object> extends JsonRpcProxy
     }
 }
 
+/**
+ * Frontend component.
+ *
+ * Wraps the remote filesystem provider living on the backend.
+ */
 @injectable()
 export class RemoteFileSystemProvider implements Required<FileSystemProvider>, Disposable {
 
@@ -129,6 +134,10 @@ export class RemoteFileSystemProvider implements Required<FileSystemProvider>, D
     );
 
     protected watcherSequence = 0;
+    /**
+     * We'll track the currently allocated watchers, in order to re-allocate them
+     * with the same options once we reconnect to the backend after a disconnection.
+     */
     protected readonly watchOptions = new Map<number, {
         uri: string;
         options: WatchOptions
@@ -137,11 +146,12 @@ export class RemoteFileSystemProvider implements Required<FileSystemProvider>, D
     private _capabilities: FileSystemProviderCapabilities = 0;
     get capabilities(): FileSystemProviderCapabilities { return this._capabilities; }
 
-    protected readonly deferredReady = new Deferred<void>();
-    get ready(): Promise<void> {
-        return this.deferredReady.promise;
-    }
+    protected readonly readyDeferred = new Deferred<void>();
+    readonly ready = this.readyDeferred.promise;
 
+    /**
+     * Wrapped remote filesystem.
+     */
     @inject(RemoteFileSystemServer)
     protected readonly server: JsonRpcProxy<RemoteFileSystemServer>;
 
@@ -149,8 +159,8 @@ export class RemoteFileSystemProvider implements Required<FileSystemProvider>, D
     protected init(): void {
         this.server.getCapabilities().then(capabilities => {
             this._capabilities = capabilities;
-            this.deferredReady.resolve(undefined);
-        }, this.deferredReady.reject);
+            this.readyDeferred.resolve();
+        }, this.readyDeferred.reject);
         this.server.setClient({
             notifyDidChangeFile: ({ changes }) => {
                 this.onDidChangeFileEmitter.fire(changes.map(event => ({ resource: new URI(event.resource), type: event.type })));
@@ -286,19 +296,23 @@ export class RemoteFileSystemProvider implements Required<FileSystemProvider>, D
     }
 
     watch(resource: URI, options: WatchOptions): Disposable {
-        const watcher = this.watcherSequence++;
+        const watcherId = this.watcherSequence++;
         const uri = resource.toString();
-        this.watchOptions.set(watcher, { uri, options });
-        this.server.watch(watcher, uri, options);
-
+        this.watchOptions.set(watcherId, { uri, options });
+        this.server.watch(watcherId, uri, options);
         const toUnwatch = Disposable.create(() => {
-            this.watchOptions.delete(watcher);
-            this.server.unwatch(watcher);
+            this.watchOptions.delete(watcherId);
+            this.server.unwatch(watcherId);
         });
         this.toDispose.push(toUnwatch);
         return toUnwatch;
     }
 
+    /**
+     * When a frontend disconnects (e.g. bad connection) the backend resources will be cleared.
+     *
+     * This means that we need to re-allocate the watchers when a frontend reconnects.
+     */
     protected reconnect(): void {
         for (const [watcher, { uri, options }] of this.watchOptions.entries()) {
             this.server.watch(watcher, uri, options);
@@ -308,12 +322,19 @@ export class RemoteFileSystemProvider implements Required<FileSystemProvider>, D
 }
 
 /**
+ * Backend component.
+ *
  * JSON-RPC server exposing a wrapped file system provider remotely.
  */
 @injectable()
 export class FileSystemProviderServer implements RemoteFileSystemServer {
 
     private readonly BUFFER_SIZE = 64 * 1024;
+
+    /**
+     * Mapping of `watcherId` to a disposable watcher handle.
+     */
+    protected watchers = new Map<number, Disposable>();
 
     protected readonly toDispose = new DisposableCollection();
     dispose(): void {
@@ -325,6 +346,9 @@ export class FileSystemProviderServer implements RemoteFileSystemServer {
         this.client = client;
     }
 
+    /**
+     * Wrapped file system provider.
+     */
     @inject(FileSystemProvider)
     protected readonly provider: FileSystemProvider & Partial<Disposable>;
 
@@ -450,18 +474,19 @@ export class FileSystemProviderServer implements RemoteFileSystemServer {
         throw new Error('not supported');
     }
 
-    protected watchers = new Map<number, Disposable>();
-
-    async watch(req: number, resource: string, opts: WatchOptions): Promise<void> {
+    async watch(requestedWatcherId: number, resource: string, opts: WatchOptions): Promise<void> {
+        if (this.watchers.has(requestedWatcherId)) {
+            throw new Error('watcher id is already allocated!');
+        }
         const watcher = this.provider.watch(new URI(resource), opts);
-        this.watchers.set(req, watcher);
-        this.toDispose.push(Disposable.create(() => this.unwatch(req)));
+        this.watchers.set(requestedWatcherId, watcher);
+        this.toDispose.push(Disposable.create(() => this.unwatch(requestedWatcherId)));
     }
 
-    async unwatch(req: number): Promise<void> {
-        const watcher = this.watchers.get(req);
+    async unwatch(watcherId: number): Promise<void> {
+        const watcher = this.watchers.get(watcherId);
         if (watcher) {
-            this.watchers.delete(req);
+            this.watchers.delete(watcherId);
             watcher.dispose();
         }
     }

--- a/packages/filesystem/src/node/disk-file-system-provider.ts
+++ b/packages/filesystem/src/node/disk-file-system-provider.ts
@@ -804,18 +804,35 @@ export class DiskFileSystemProvider implements Disposable,
     // #region File Watching
 
     watch(resource: URI, opts: WatchOptions): Disposable {
-        const toUnwatch = new DisposableCollection(Disposable.create(() => { /* mark as not disposed */ }));
-        this.watcher.watchFileChanges(resource.toString(), {
+        const watcherService = this.watcher;
+        /**
+         * Disposable handle. Can be disposed early (before the watcher is allocated.)
+         */
+        const handle = {
+            disposed: false,
+            watcherId: undefined as number | undefined,
+            dispose(): void {
+                if (this.disposed) {
+                    return;
+                }
+                if (this.watcherId !== undefined) {
+                    watcherService.unwatchFileChanges(this.watcherId);
+                }
+                this.disposed = true;
+            },
+        };
+        watcherService.watchFileChanges(resource.toString(), {
+            // Convert from `files.WatchOptions` to internal `watcher-protocol.WatchOptions`:
             ignored: opts.excludes
-        }).then(watcher => {
-            if (toUnwatch.disposed) {
-                this.watcher.unwatchFileChanges(watcher);
+        }).then(watcherId => {
+            if (handle.disposed) {
+                watcherService.unwatchFileChanges(watcherId);
             } else {
-                toUnwatch.push(Disposable.create(() => this.watcher.unwatchFileChanges(watcher)));
+                handle.watcherId = watcherId;
             }
         });
-        this.toDispose.push(toUnwatch);
-        return toUnwatch;
+        this.toDispose.push(handle);
+        return handle;
     }
 
     // #endregion

--- a/packages/filesystem/src/node/filesystem-backend-module.ts
+++ b/packages/filesystem/src/node/filesystem-backend-module.ts
@@ -14,11 +14,12 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
+import * as path from 'path';
 import { ContainerModule, interfaces } from 'inversify';
 import { ConnectionHandler, JsonRpcConnectionHandler, ILogger } from '@theia/core/lib/common';
-import { FileSystemWatcherServer } from '../common/filesystem-watcher-protocol';
+import { FileSystemWatcherServer, FileSystemWatcherService } from '../common/filesystem-watcher-protocol';
 import { FileSystemWatcherServerClient } from './filesystem-watcher-client';
-import { NsfwFileSystemWatcherServer } from './nsfw-watcher/nsfw-filesystem-watcher';
+import { NsfwFileSystemWatcherService } from './nsfw-watcher/nsfw-filesystem-service';
 import { MessagingService } from '@theia/core/lib/node/messaging/messaging-service';
 import { NodeFileUploadService } from './node-file-upload-service';
 import { NsfwOptions } from './nsfw-watcher/nsfw-options';
@@ -28,25 +29,67 @@ import {
 } from '../common/remote-file-system-provider';
 import { FileSystemProvider } from '../common/files';
 import { EncodingService } from '@theia/core/lib/common/encoding-service';
+import { IPCConnectionProvider } from '@theia/core/lib/node';
+import { JsonRpcProxyFactory, ConnectionErrorHandler } from '@theia/core';
+import { FileSystemWatcherServiceDispatcher } from './filesystem-watcher-dispatcher';
 
 const SINGLE_THREADED = process.argv.indexOf('--no-cluster') !== -1;
+const NSFW_WATCHER_VERBOSE = process.argv.indexOf('--nsfw-watcher-verbose') !== -1;
 
 export function bindFileSystemWatcherServer(bind: interfaces.Bind, { singleThreaded }: { singleThreaded: boolean } = { singleThreaded: SINGLE_THREADED }): void {
-    bind(NsfwOptions).toConstantValue({});
+    bind<NsfwOptions>(NsfwOptions).toConstantValue({});
+
+    bind(FileSystemWatcherServiceDispatcher).toSelf().inSingletonScope();
+
+    bind(FileSystemWatcherServerClient).toSelf();
+    bind(FileSystemWatcherServer).toService(FileSystemWatcherServerClient);
 
     if (singleThreaded) {
-        bind(FileSystemWatcherServer).toDynamicValue(ctx => {
+        // Bind and run the watch server in the current process:
+        bind<FileSystemWatcherService>(FileSystemWatcherService).toDynamicValue(ctx => {
             const logger = ctx.container.get<ILogger>(ILogger);
             const nsfwOptions = ctx.container.get<NsfwOptions>(NsfwOptions);
-            return new NsfwFileSystemWatcherServer({
+            const dispatcher = ctx.container.get<FileSystemWatcherServiceDispatcher>(FileSystemWatcherServiceDispatcher);
+            const server = new NsfwFileSystemWatcherService({
                 nsfwOptions,
+                verbose: NSFW_WATCHER_VERBOSE,
                 info: (message, ...args) => logger.info(message, ...args),
                 error: (message, ...args) => logger.error(message, ...args)
             });
-        });
+            server.setClient(dispatcher);
+            return server;
+        }).inSingletonScope();
     } else {
-        bind(FileSystemWatcherServerClient).toSelf();
-        bind(FileSystemWatcherServer).toService(FileSystemWatcherServerClient);
+        // Run the watch server in a child process.
+        // Bind to a proxy forwarding calls to the child process.
+        bind<FileSystemWatcherService>(FileSystemWatcherService).toDynamicValue(ctx => {
+            const serverName = 'nsfw-watcher';
+            const logger = ctx.container.get<ILogger>(ILogger);
+            const nsfwOptions = ctx.container.get<NsfwOptions>(NsfwOptions);
+            const ipcConnectionProvider = ctx.container.get<IPCConnectionProvider>(IPCConnectionProvider);
+            const dispatcher = ctx.container.get<FileSystemWatcherServiceDispatcher>(FileSystemWatcherServiceDispatcher);
+            const proxyFactory = new JsonRpcProxyFactory<FileSystemWatcherService>();
+            const serverProxy = proxyFactory.createProxy();
+            // We need to call `.setClient` before listening, else the JSON-RPC calls won't go through.
+            serverProxy.setClient(dispatcher);
+            const args: string[] = [
+                `--nsfwOptions=${JSON.stringify(nsfwOptions)}`
+            ];
+            if (NSFW_WATCHER_VERBOSE) {
+                args.push('--verbose');
+            }
+            ipcConnectionProvider.listen({
+                serverName,
+                entryPoint: path.resolve(__dirname, serverName),
+                errorHandler: new ConnectionErrorHandler({
+                    serverName,
+                    logger,
+                }),
+                env: process.env,
+                args,
+            }, connection => proxyFactory.listen(connection));
+            return serverProxy;
+        }).inSingletonScope();
     }
 }
 
@@ -65,7 +108,6 @@ export default new ContainerModule(bind => {
             return server;
         }, RemoteFileSystemProxyFactory)
     ).inSingletonScope();
-
     bind(NodeFileUploadService).toSelf().inSingletonScope();
     bind(MessagingService.Contribution).toService(NodeFileUploadService);
 });

--- a/packages/filesystem/src/node/filesystem-watcher-dispatcher.ts
+++ b/packages/filesystem/src/node/filesystem-watcher-dispatcher.ts
@@ -1,0 +1,82 @@
+/********************************************************************************
+ * Copyright (C) 2020 Ericsson and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import { injectable } from 'inversify';
+import {
+    FileSystemWatcherClient, FileSystemWatcherServiceClient,
+    DidFilesChangedParams, FileSystemWatcherErrorParams
+} from '../common/filesystem-watcher-protocol';
+
+/**
+ * This component routes watch events to the right clients.
+ */
+@injectable()
+export class FileSystemWatcherServiceDispatcher implements FileSystemWatcherServiceClient {
+
+    /**
+     * Mapping of `clientId` to actual clients.
+     */
+    protected readonly clients = new Map<number, FileSystemWatcherClient>();
+
+    onDidFilesChanged(event: DidFilesChangedParams): void {
+        for (const client of this.iterRegisteredClients(event.clients)) {
+            client.onDidFilesChanged(event);
+        }
+    }
+
+    onError(event: FileSystemWatcherErrorParams): void {
+        for (const client of this.iterRegisteredClients(event.clients)) {
+            client.onError();
+        }
+    }
+
+    /**
+     * Listen for events targeted at `clientId`.
+     */
+    registerClient(clientId: number, client: FileSystemWatcherClient): void {
+        if (this.clients.has(clientId)) {
+            console.warn(`FileSystemWatcherServer2Dispatcher: a client was already registered! clientId=${clientId}`);
+        }
+        this.clients.set(clientId, client);
+    }
+
+    unregisterClient(clientId: number): void {
+        if (!this.clients.has(clientId)) {
+            console.warn(`FileSystemWatcherServer2Dispatcher: tried to remove unknown client! clientId=${clientId}`);
+        }
+        this.clients.delete(clientId);
+    }
+
+    /**
+     * Only yield registered clients for the given `clientIds`.
+     *
+     * If clientIds is empty, will return all clients.
+     */
+    protected *iterRegisteredClients(clientIds?: number[]): Iterable<FileSystemWatcherClient> {
+        if (!Array.isArray(clientIds) || clientIds.length === 0) {
+            // If we receive an event targeted to "no client",
+            // interpret that as notifying all clients:
+            yield* this.clients.values();
+        } else {
+            for (const clientId of clientIds) {
+                const client = this.clients.get(clientId);
+                if (client !== undefined) {
+                    yield client;
+                }
+            }
+        }
+    }
+}

--- a/packages/filesystem/src/node/nsfw-watcher/index.ts
+++ b/packages/filesystem/src/node/nsfw-watcher/index.ts
@@ -16,8 +16,8 @@
 
 import * as yargs from 'yargs';
 import { JsonRpcProxyFactory } from '@theia/core';
-import { FileSystemWatcherClient } from '../../common/filesystem-watcher-protocol';
-import { NsfwFileSystemWatcherServer } from './nsfw-filesystem-watcher';
+import { FileSystemWatcherServiceClient } from '../../common/filesystem-watcher-protocol';
+import { NsfwFileSystemWatcherService } from './nsfw-filesystem-service';
 import { IPCEntryPoint } from '@theia/core/lib/node/messaging/ipc-protocol';
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
@@ -38,8 +38,8 @@ const options: {
     .argv as any;
 
 export default <IPCEntryPoint>(connection => {
-    const server = new NsfwFileSystemWatcherServer(options);
-    const factory = new JsonRpcProxyFactory<FileSystemWatcherClient>(server);
+    const server = new NsfwFileSystemWatcherService(options);
+    const factory = new JsonRpcProxyFactory<FileSystemWatcherServiceClient>(server);
     server.setClient(factory.createProxy());
     factory.listen(connection);
 });

--- a/packages/filesystem/src/node/nsfw-watcher/nsfw-filesystem-service.ts
+++ b/packages/filesystem/src/node/nsfw-watcher/nsfw-filesystem-service.ts
@@ -1,0 +1,481 @@
+/********************************************************************************
+ * Copyright (C) 2017-2018 TypeFox and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import * as nsfw from 'nsfw';
+import { join } from 'path';
+import { promises as fsp } from 'fs';
+import { IMinimatch, Minimatch } from 'minimatch';
+import { FileUri } from '@theia/core/lib/node/file-uri';
+import {
+    FileChangeType, FileSystemWatcherService, FileSystemWatcherServiceClient, WatchOptions
+} from '../../common/filesystem-watcher-protocol';
+import { FileChangeCollection } from '../file-change-collection';
+import { Deferred } from '@theia/core/lib/common/promise-util';
+
+export interface NsfwWatcherOptions {
+    ignored: IMinimatch[]
+}
+
+export interface NsfwFileSystemWatcherServerOptions {
+    verbose: boolean;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    info: (message: string, ...args: any[]) => void;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    error: (message: string, ...args: any[]) => void;
+    nsfwOptions: nsfw.Options;
+}
+
+/**
+ * This is a flag value passed around upon disposal.
+ */
+export const WatcherDisposal = Symbol('WatcherDisposal');
+
+/**
+ * Because URIs can be watched by different clients, we'll track
+ * how many are listening for a given URI.
+ *
+ * This component wraps the whole start/stop process given some
+ * reference count.
+ *
+ * Once there are no more references the handle
+ * will wait for some time before destroying its resources.
+ */
+export class NsfwWatcher {
+
+    protected static debugIdSequence = 0;
+
+    protected disposed = false;
+
+    /**
+     * Used for debugging to keep track of the watchers.
+     */
+    protected debugId = NsfwWatcher.debugIdSequence++;
+
+    /**
+     * When this field is set, it means the nsfw instance was successfully started.
+     */
+    protected nsfw: nsfw.NSFW | undefined;
+
+    /**
+     * When the ref count hits zero, we schedule this watch handle to be disposed.
+     */
+    protected deferredDisposalTimer: NodeJS.Timer | undefined;
+
+    /**
+     * This deferred only rejects with `WatcherDisposal` and never resolves.
+     */
+    protected readonly deferredDisposalDeferred = new Deferred<never>();
+
+    /**
+     * We count each reference made to this watcher, per client.
+     *
+     * We do this to know where to send events via the network.
+     *
+     * An entry should be removed when its value hits zero.
+     */
+    protected readonly refsPerClient = new Map<number, { value: number }>();
+
+    /**
+     * Ensures that events are processed in the order they are emitted,
+     * despite being processed async.
+     */
+    protected nsfwEventProcessingQueue: Promise<void> = Promise.resolve();
+
+    /**
+     * Resolves once this handle disposed itself and its resources. Never throws.
+     */
+    readonly whenDisposed: Promise<void> = this.deferredDisposalDeferred.promise.catch(() => undefined);
+
+    /**
+     * Promise that resolves when the watcher is fully started, or got disposed.
+     *
+     * Will reject if an error occurred while starting.
+     *
+     * @returns `true` if successfully started, `false` if disposed early.
+     */
+    readonly whenStarted: Promise<boolean>;
+
+    constructor(
+        /** Initial reference to this handle. */
+        initialClientId: number,
+        /** Filesystem path to be watched. */
+        readonly fsPath: string,
+        /** Watcher-specific options */
+        readonly watcherOptions: NsfwWatcherOptions,
+        /** Logging and Nsfw options */
+        protected readonly nsfwFileSystemWatchServerOptions: NsfwFileSystemWatcherServerOptions,
+        /** The client to forward events to. */
+        protected readonly fileSystemWatcherClient: FileSystemWatcherServiceClient,
+        /** Amount of time in ms to wait once this handle ins't referenced anymore. */
+        protected readonly deferredDisposalTimeout = 10_000,
+    ) {
+        this.refsPerClient.set(initialClientId, { value: 1 });
+        this.whenStarted = this.start().then(() => true, error => {
+            if (error === WatcherDisposal) {
+                return false;
+            }
+            this._dispose();
+            this.fireError();
+            throw error;
+        });
+        this.debug('NEW', `initialClientId=${initialClientId}`);
+    }
+
+    addRef(clientId: number): void {
+        let refs = this.refsPerClient.get(clientId);
+        if (typeof refs === 'undefined') {
+            this.refsPerClient.set(clientId, refs = { value: 1 });
+        } else {
+            refs.value += 1;
+        }
+        const totalRefs = this.getTotalReferences();
+        // If it was zero before, 1 means we were revived:
+        const revived = totalRefs === 1;
+        if (revived) {
+            this.onRefsRevive();
+        }
+        this.debug('REF++', `clientId=${clientId}, clientRefs=${refs.value}, totalRefs=${totalRefs}. revived=${revived}`);
+    }
+
+    removeRef(clientId: number): void {
+        const refs = this.refsPerClient.get(clientId);
+        if (typeof refs === 'undefined') {
+            this.info('WARN REF--', `removed one too many reference: clientId=${clientId}`);
+            return;
+        }
+        refs.value -= 1;
+        // We must remove the key from `this.clientReferences` because
+        // we list active clients by reading the keys of this map.
+        if (refs.value === 0) {
+            this.refsPerClient.delete(clientId);
+        }
+        const totalRefs = this.getTotalReferences();
+        const dead = totalRefs === 0;
+        if (dead) {
+            this.onRefsReachZero();
+        }
+        this.debug('REF--', `clientId=${clientId}, clientRefs=${refs.value}, totalRefs=${totalRefs}, dead=${dead}`);
+    }
+
+    /**
+     * All clients with at least one active reference.
+     */
+    getClientIds(): number[] {
+        return Array.from(this.refsPerClient.keys());
+    }
+
+    /**
+     * Add the references for each client together.
+     */
+    getTotalReferences(): number {
+        let total = 0;
+        for (const refs of this.refsPerClient.values()) {
+            total += refs.value;
+        }
+        return total;
+    }
+
+    /**
+     * Returns true if at least one client listens to this handle.
+     */
+    isInUse(): boolean {
+        return this.refsPerClient.size > 0;
+    }
+
+    /**
+     * When starting a watcher, we'll first check and wait for the path to exists
+     * before running an NSFW watcher.
+     */
+    protected async start(): Promise<void> {
+        while (await this.orCancel(fsp.stat(this.fsPath).then(() => false, () => true))) {
+            await this.orCancel(new Promise(resolve => setTimeout(resolve, 500)));
+        }
+        const watcher = await this.orCancel(this.createNsfw());
+        await this.orCancel(watcher.start().then(() => {
+            this.debug('STARTED', `diposed=${this.disposed}`);
+            // The watcher could be disposed while it was starting, make sure to check for this:
+            if (this.disposed) {
+                this.stopNsfw(watcher);
+            }
+        }));
+        this.nsfw = watcher;
+    }
+
+    /**
+     * Given a started nsfw instance, gracefully shut it down.
+     */
+    protected async stopNsfw(watcher: nsfw.NSFW): Promise<void> {
+        await watcher.stop()
+            .then(() => 'success=true', error => error)
+            .then(status => this.debug('STOPPED', status));
+    }
+
+    protected async createNsfw(): Promise<nsfw.NSFW> {
+        const fsPath = await fsp.realpath(this.fsPath);
+        return nsfw(fsPath, events => this.handleNsfwEvents(events), {
+            ...this.nsfwFileSystemWatchServerOptions.nsfwOptions,
+            // The errorCallback is called whenever NSFW crashes *while* watching.
+            // See https://github.com/atom/github/issues/342
+            errorCallback: error => {
+                console.error(`NSFW service error on "${fsPath}":`, error);
+                this._dispose();
+                this.fireError();
+                // Make sure to call user's error handling code:
+                if (this.nsfwFileSystemWatchServerOptions.nsfwOptions.errorCallback) {
+                    this.nsfwFileSystemWatchServerOptions.nsfwOptions.errorCallback(error);
+                }
+            },
+        });
+    }
+
+    protected handleNsfwEvents(events: nsfw.ChangeEvent[]): void {
+        // Only process events if someone is listening.
+        if (this.isInUse()) {
+            // This callback is async, but nsfw won't wait for it to finish before firing the next one.
+            // We will use a lock/queue to make sure everything is processed in the order it arrives.
+            this.nsfwEventProcessingQueue = this.nsfwEventProcessingQueue.then(async () => {
+                const fileChangeCollection = new FileChangeCollection();
+                await Promise.all(events.map(async event => {
+                    if (event.action === nsfw.actions.RENAMED) {
+                        const [oldPath, newPath] = await Promise.all([
+                            this.resolveEventPath(event.directory, event.oldFile!),
+                            this.resolveEventPath(event.newDirectory || event.directory, event.newFile!),
+                        ]);
+                        this.pushFileChange(fileChangeCollection, FileChangeType.DELETED, oldPath);
+                        this.pushFileChange(fileChangeCollection, FileChangeType.ADDED, newPath);
+                    } else {
+                        const path = await this.resolveEventPath(event.directory, event.file!);
+                        if (event.action === nsfw.actions.CREATED) {
+                            this.pushFileChange(fileChangeCollection, FileChangeType.ADDED, path);
+                        } else if (event.action === nsfw.actions.DELETED) {
+                            this.pushFileChange(fileChangeCollection, FileChangeType.DELETED, path);
+                        } else if (event.action === nsfw.actions.MODIFIED) {
+                            this.pushFileChange(fileChangeCollection, FileChangeType.UPDATED, path);
+                        }
+                    }
+                }));
+                const changes = fileChangeCollection.values();
+                // If all changes are part of the ignored files, the collection will be empty.
+                if (changes.length > 0) {
+                    this.fileSystemWatcherClient.onDidFilesChanged({
+                        clients: this.getClientIds(),
+                        changes,
+                    });
+                }
+            }, console.error);
+        }
+    }
+
+    protected async resolveEventPath(directory: string, file: string): Promise<string> {
+        const path = join(directory, file);
+        try {
+            return await fsp.realpath(path);
+        } catch {
+            try {
+                // file does not exist try to resolve directory
+                return join(await fsp.realpath(directory), file);
+            } catch {
+                // directory does not exist fall back to symlink
+                return path;
+            }
+        }
+    }
+
+    protected pushFileChange(changes: FileChangeCollection, type: FileChangeType, path: string): void {
+        if (!this.isIgnored(path)) {
+            const uri = FileUri.create(path).toString();
+            changes.push({ type, uri });
+        }
+    }
+
+    protected fireError(): void {
+        this.fileSystemWatcherClient.onError({
+            clients: this.getClientIds(),
+            uri: this.fsPath,
+        });
+    }
+
+    /**
+     * Wrap a promise to reject as soon as this handle gets disposed.
+     */
+    protected async orCancel<T>(promise: Promise<T>): Promise<T> {
+        return Promise.race<T>([this.deferredDisposalDeferred.promise, promise]);
+    }
+
+    /**
+     * When references hit zero, we'll schedule disposal for a bit later.
+     *
+     * This allows new references to reuse this watcher instead of creating a new one.
+     *
+     * e.g. A frontend disconnects for a few milliseconds before reconnecting again.
+     */
+    protected onRefsReachZero(): void {
+        this.deferredDisposalTimer = setTimeout(() => this._dispose(), this.deferredDisposalTimeout);
+    }
+
+    /**
+     * If we get new references after hitting zero, let's unschedule our disposal and keep watching.
+     */
+    protected onRefsRevive(): void {
+        if (this.deferredDisposalTimer) {
+            clearTimeout(this.deferredDisposalTimer);
+            this.deferredDisposalTimer = undefined;
+        }
+    }
+
+    protected isIgnored(path: string): boolean {
+        return this.watcherOptions.ignored.length > 0
+            && this.watcherOptions.ignored.some(m => m.match(path));
+    }
+
+    /**
+     * Internal disposal mechanism.
+     */
+    protected async _dispose(): Promise<void> {
+        if (!this.disposed) {
+            this.disposed = true;
+            this.deferredDisposalDeferred.reject(WatcherDisposal);
+            if (this.nsfw) {
+                this.stopNsfw(this.nsfw);
+                this.nsfw = undefined;
+            }
+            this.debug('DISPOSED');
+        }
+    }
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    protected info(prefix: string, ...params: any[]): void {
+        this.nsfwFileSystemWatchServerOptions.info(`${prefix} NsfwWatcher(${this.debugId} at "${this.fsPath}"):`, ...params);
+    }
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    protected debug(prefix: string, ...params: any[]): void {
+        if (this.nsfwFileSystemWatchServerOptions.verbose) {
+            this.info(prefix, ...params);
+        }
+    }
+}
+
+/**
+ * Each time a client makes a watchRequest, we generate a unique watcherId for it.
+ *
+ * This watcherId will map to this handle type which keeps track of the clientId that made the request.
+ */
+export interface NsfwWatcherHandle {
+    clientId: number;
+    watcher: NsfwWatcher;
+}
+
+export class NsfwFileSystemWatcherService implements FileSystemWatcherService {
+
+    protected client: FileSystemWatcherServiceClient | undefined;
+
+    protected watcherId = 0;
+    protected readonly watchers = new Map<string, NsfwWatcher>();
+    protected readonly watcherHandles = new Map<number, NsfwWatcherHandle>();
+
+    protected readonly options: NsfwFileSystemWatcherServerOptions;
+
+    /**
+     * `this.client` is undefined until someone sets it.
+     */
+    protected readonly maybeClient: FileSystemWatcherServiceClient = {
+        onDidFilesChanged: event => this.client?.onDidFilesChanged(event),
+        onError: event => this.client?.onError(event),
+    };
+
+    constructor(options?: Partial<NsfwFileSystemWatcherServerOptions>) {
+        this.options = {
+            nsfwOptions: {},
+            verbose: false,
+            info: (message, ...args) => console.info(message, ...args),
+            error: (message, ...args) => console.error(message, ...args),
+            ...options
+        };
+    }
+
+    setClient(client: FileSystemWatcherServiceClient | undefined): void {
+        this.client = client;
+    }
+
+    /**
+     * A specific client requests us to watch a given `uri` according to some `options`.
+     *
+     * We internally re-use all the same `(uri, options)` pairs.
+     */
+    async watchFileChanges(clientId: number, uri: string, options?: WatchOptions): Promise<number> {
+        const resolvedOptions = this.resolveWatchOptions(options);
+        const watcherKey = this.getWatcherKey(uri, resolvedOptions);
+        let watcher = this.watchers.get(watcherKey);
+        if (watcher === undefined) {
+            const fsPath = FileUri.fsPath(uri);
+            const watcherOptions: NsfwWatcherOptions = {
+                ignored: resolvedOptions.ignored
+                    .map(pattern => new Minimatch(pattern, { dot: true })),
+            };
+            watcher = new NsfwWatcher(clientId, fsPath, watcherOptions, this.options, this.maybeClient);
+            watcher.whenDisposed.then(() => this.watchers.delete(watcherKey));
+            this.watchers.set(watcherKey, watcher);
+        } else {
+            watcher.addRef(clientId);
+        }
+        const watcherId = this.watcherId++;
+        this.watcherHandles.set(watcherId, { clientId, watcher });
+        watcher.whenDisposed.then(() => this.watcherHandles.delete(watcherId));
+        return watcherId;
+    }
+
+    async unwatchFileChanges(watcherId: number): Promise<void> {
+        const handle = this.watcherHandles.get(watcherId);
+        if (handle === undefined) {
+            console.warn(`tried to de-allocate a disposed watcher: watcherId=${watcherId}`);
+        } else {
+            this.watcherHandles.delete(watcherId);
+            handle.watcher.removeRef(handle.clientId);
+        }
+    }
+
+    /**
+     * Given some `URI` and some `WatchOptions`, generate a unique key.
+     */
+    protected getWatcherKey(uri: string, options: WatchOptions): string {
+        return [
+            uri,
+            options.ignored.slice(0).sort().join()  // use a **sorted copy** of `ignored` as part of the key
+        ].join();
+    }
+
+    /**
+     * Return fully qualified options.
+     */
+    protected resolveWatchOptions(options?: WatchOptions): WatchOptions {
+        return {
+            ignored: [],
+            ...options,
+        };
+    }
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    protected debug(message: string, ...params: any[]): void {
+        if (this.options.verbose) {
+            this.options.info(message, ...params);
+        }
+    }
+
+    dispose(): void {
+        // Singletons shouldn't be disposed...
+    }
+}

--- a/packages/filesystem/src/node/nsfw-watcher/nsfw-filesystem-watcher.spec.ts
+++ b/packages/filesystem/src/node/nsfw-watcher/nsfw-filesystem-watcher.spec.ts
@@ -20,7 +20,7 @@ import * as fs from 'fs-extra';
 import * as assert from 'assert';
 import URI from '@theia/core/lib/common/uri';
 import { FileUri } from '@theia/core/lib/node';
-import { NsfwFileSystemWatcherServer } from './nsfw-filesystem-watcher';
+import { NsfwFileSystemWatcherService } from './nsfw-filesystem-service';
 import { DidFilesChangedParams } from '../../common/filesystem-watcher-protocol';
 /* eslint-disable no-unused-expressions */
 
@@ -30,27 +30,26 @@ const track = temp.track();
 describe('nsfw-filesystem-watcher', function (): void {
 
     let root: URI;
-    let watcherServer: NsfwFileSystemWatcherServer;
+    let watcherService: NsfwFileSystemWatcherService;
     let watcherId: number;
 
     this.timeout(10000);
 
     beforeEach(async () => {
         root = FileUri.create(fs.realpathSync(temp.mkdirSync('node-fs-root')));
-        watcherServer = createNsfwFileSystemWatcherServer();
-        watcherId = await watcherServer.watchFileChanges(root.toString());
+        watcherService = createNsfwFileSystemWatcherService();
+        watcherId = await watcherService.watchFileChanges(0, root.toString());
         await sleep(2000);
     });
 
     afterEach(async () => {
         track.cleanupSync();
-        watcherServer.dispose();
+        watcherService.dispose();
     });
 
     it('Should receive file changes events from in the workspace by default.', async function (): Promise<void> {
         if (process.platform === 'win32') {
             this.skip();
-            return;
         }
         const actualUris = new Set<string>();
 
@@ -61,7 +60,7 @@ describe('nsfw-filesystem-watcher', function (): void {
             onError(): void {
             }
         };
-        watcherServer.setClient(watcherClient);
+        watcherService.setClient(watcherClient);
 
         const expectedUris = [
             root.resolve('foo').toString(),
@@ -87,7 +86,6 @@ describe('nsfw-filesystem-watcher', function (): void {
     it('Should not receive file changes events from in the workspace by default if unwatched', async function (): Promise<void> {
         if (process.platform === 'win32') {
             this.skip();
-            return;
         }
         const actualUris = new Set<string>();
 
@@ -98,10 +96,10 @@ describe('nsfw-filesystem-watcher', function (): void {
             onError(): void {
             }
         };
-        watcherServer.setClient(watcherClient);
+        watcherService.setClient(watcherClient);
 
         /* Unwatch root */
-        watcherServer.unwatchFileChanges(watcherId);
+        watcherService.unwatchFileChanges(watcherId);
 
         fs.mkdirSync(FileUri.fsPath(root.resolve('foo')));
         expect(fs.statSync(FileUri.fsPath(root.resolve('foo'))).isDirectory()).to.be.true;
@@ -118,8 +116,8 @@ describe('nsfw-filesystem-watcher', function (): void {
         assert.deepEqual(0, actualUris.size);
     });
 
-    function createNsfwFileSystemWatcherServer(): NsfwFileSystemWatcherServer {
-        return new NsfwFileSystemWatcherServer({
+    function createNsfwFileSystemWatcherService(): NsfwFileSystemWatcherService {
+        return new NsfwFileSystemWatcherService({
             verbose: true
         });
     }

--- a/packages/filesystem/src/node/nsfw-watcher/nsfw-filesystem-watcher.ts
+++ b/packages/filesystem/src/node/nsfw-watcher/nsfw-filesystem-watcher.ts
@@ -33,10 +33,16 @@ const debounce = require('lodash.debounce');
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
+/**
+ * @deprecated since 1.6.0
+ */
 export interface WatcherOptions {
     ignored: IMinimatch[]
 }
 
+/**
+ * @deprecated since 1.6.0 use `NsfwFileSystemWatcherService` instead.
+ */
 export class NsfwFileSystemWatcherServer implements FileSystemWatcherServer {
 
     protected client: FileSystemWatcherClient | undefined;


### PR DESCRIPTION
Theia spawns as many nsfw servers as there are clients, maybe more.

This commit replaces this behaviour by centralizing everything into the
same service process in order to optimize resources (watch handles are a
limited resource on a given Linux host).

Some notes on the current design:
- Every time someone requests to watch an `(uri, options)` couple we will
re-use the same watch handle (and actual nsfw instance). This allows for
resource allocation optimizations.
- Since a given service can only serve a single client, I added an event
dispatcher named `FileSystemWatcherServerDispatcher`. You must register
yourself with some unique id you will use to make requests.
- The new `.watchUriChanges` function now takes a `clientId` so that
when events are sent to the dispatcher it then gets routed back to your
own client.
- Added a `--nsfw-watcher-verbose` backend argument to enable verbose
logging for the watcher server.

Signed-off-by: Paul Maréchal <paul.marechal@ericsson.com>

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### How to test

- Enable the `sample.file-watching.verbose` preference.
- Run `yarn --cwd examples/browser start --nsfw-watcher-verbose`
- Watch for the different logs coming out of the watcher server:
  - There shouldn't be new watchers without a frontend opened.
  - Once you open a frontend on a given workspace for the first time, you should see `NEW` log notifications.
  - If you open a second frontend on the same workspace, you should see `REF++` log notifications
  - Closing one of the two frontend should emit `REF--` log notifications.
  - Closing the last frontend should schedule the watcher de-allocation about 10s later.
    - But if you re-open a frontend before 10s, it should reference the watchers again and not dispose of them.
- Comparing with master:
  - Run the backend.
  - Run `lsof | grep inotify | wc -l` a couple of times before opening a frontend and note the general value.
  - Open frontends on some big workspace (your home maybe?) while noting the new value for `lsof | grep inotify | wc -l` each time.
  - The conclusion should be that on master the number increases with each frontend, but not with these changes.
- Running the `@theia/example-browser` app:
  - Open 2 tabs on different workspaces.
  - Create and delete files in the respective workspaces.
  - Make sure that a log is only reported from the frontend that was watching the modified workspace.
    - `Sample File Watching: X file(s) changed! <workspace>`

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

