### PR TITLE
monaco: command `Save All` now formats all open editors

### DIFF
--- a/packages/monaco/src/browser/monaco-editor-provider.ts
+++ b/packages/monaco/src/browser/monaco-editor-provider.ts
@@ -302,7 +302,7 @@ export class MonacoEditorProvider {
         const formatOnSaveTimeout = this.editorPreferences.get({ preferenceName: 'editor.formatOnSaveTimeout', overrideIdentifier }, undefined, uri)!;
         await Promise.race([
             new Promise((_, reject) => setTimeout(() => reject(new Error(`Aborted format on save after ${formatOnSaveTimeout}ms`)), formatOnSaveTimeout)),
-            editor.commandService.executeCommand('editor.action.formatDocument')
+            editor.runAction('editor.action.formatDocument')
         ]);
         return [];
     }


### PR DESCRIPTION
#### What it does
Fixes #8547
+ Command `Save All` now formats all opening editors.
+ Instead of calling `executeCommand` from `commandService`, calling `runAction` to manually format each editor. `runAction` is being used similar to https://github.com/microsoft/monaco-editor/issues/32#issuecomment-228577145
#### How to test
+ Make sure `formatOnSave` is on
+ Opening more than 1 dirty file and in a wrong format/convention
+ Run `Save All` from the command palette or from a shortcut
+ **Expected behavior**: All the opening editors are formatted and saved.

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

Signed-off-by: Duc Nguyen <duc.a.nguyen@ericsson.com>