### PR TITLE
plugin: support 'deprecated' strikethrough

### DIFF
--- a/packages/plugin-ext/src/common/plugin-api-rpc-model.ts
+++ b/packages/plugin-ext/src/common/plugin-api-rpc-model.ts
@@ -16,6 +16,7 @@
 
 import * as theia from '@theia/plugin';
 import { UriComponents } from './uri-components';
+import { CompletionItemTag } from '../plugin/types-impl';
 
 // Should contains internal Plugin API types
 
@@ -114,6 +115,9 @@ export interface Completion {
     commitCharacters?: string[];
     additionalTextEdits?: SingleEditOperation[];
     command?: Command;
+    tags?: CompletionItemTag[];
+    /** @deprecated use tags instead. */
+    deprecated?: boolean;
 }
 
 export interface SingleEditOperation {

--- a/packages/plugin-ext/src/plugin/languages/completion.ts
+++ b/packages/plugin-ext/src/plugin/languages/completion.ts
@@ -16,7 +16,7 @@
 
 import { URI } from 'vscode-uri';
 import * as theia from '@theia/plugin';
-import { CompletionList, Range, SnippetString } from '../types-impl';
+import { CompletionItemTag, CompletionList, Range, SnippetString } from '../types-impl';
 import { DocumentsExtImpl } from '../documents';
 import * as Converter from '../type-converters';
 import { Position } from '../../common/plugin-api-rpc';
@@ -146,6 +146,10 @@ export class CompletionAdapter {
             };
         }
 
+        const tags = (!!item.tags?.length || item.deprecated === true)
+            ? [CompletionItemTag.Deprecated]
+            : undefined;
+
         return {
             id,
             parentId,
@@ -161,7 +165,8 @@ export class CompletionAdapter {
             range,
             additionalTextEdits: item.additionalTextEdits && item.additionalTextEdits.map(Converter.fromTextEdit),
             command: this.commands.converter.toSafeCommand(item.command, toDispose),
-            commitCharacters: item.commitCharacters
+            commitCharacters: item.commitCharacters,
+            tags
         };
     }
 

--- a/packages/plugin/src/theia.d.ts
+++ b/packages/plugin/src/theia.d.ts
@@ -6490,6 +6490,11 @@ declare module '@theia/plugin' {
         textEdit?: TextEdit;
 
         /**
+         * @deprecated Use `CompletionItem.tags` instead.
+         */
+        deprecated?: boolean;
+
+        /**
          * Creates a new completion item.
          *
          * Completion items must have at least a [label](#CompletionItem.label) which then


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

Fixes: #8552

The following pull-request adds support for the following:
- support for `tags` strikethrough for deprecated completion items.
- support for the deprecated `deprecated` flag for completion items.

Both the `tag` and `deprecated` properties should be visibly different (strikethrough) to indicate deprecated items.

<div align='center'>

![deprecated](https://user-images.githubusercontent.com/40359487/94066755-e8d15a00-fdba-11ea-967c-a805baa4d73f.gif)

</div>

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

1. include the following extesion: [lsp-sample-deprecated](https://github.com/vince-fugnitto/lsp-sample-deprecated/releases/download/1.0.0/lsp-sample-deprecated-item-1.0.0.vsix)
2. start the application
3. create a sample `textfile`
4. trigger auto-suggestion/completion
5. the [deprecated items](https://github.com/vince-fugnitto/lsp-sample-deprecated/blob/79bcdd748062c4844797b200d1026213cc9f3e42/server/src/server.ts#L197-L221) should be striked-through



#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

Signed-off-by: vince-fugnitto <vincent.fugnitto@ericsson.com>
