### PR TITLE
core: Command `Save All` only formats the file if it is dirty

### DIFF
--- a/packages/core/src/browser/common-frontend-contribution.ts
+++ b/packages/core/src/browser/common-frontend-contribution.ts
@@ -52,6 +52,7 @@ import { EncodingRegistry } from './encoding-registry';
 import { UTF8 } from '../common/encodings';
 import { EnvVariablesServer } from '../common/env-variables';
 import { AuthenticationService } from './authentication-service';
+import { FormatType } from './saveable';
 
 export namespace CommonMenus {
 
@@ -754,13 +755,13 @@ export class CommonFrontendContribution implements FrontendApplicationContributi
         });
 
         commandRegistry.registerCommand(CommonCommands.SAVE, {
-            execute: () => this.shell.save()
+            execute: () => this.shell.save({ formatType: FormatType.ON })
         });
         commandRegistry.registerCommand(CommonCommands.SAVE_WITHOUT_FORMATTING, {
-            execute: () => this.shell.save({ skipFormatting: true })
+            execute: () => this.shell.save({ formatType: FormatType.OFF })
         });
         commandRegistry.registerCommand(CommonCommands.SAVE_ALL, {
-            execute: () => this.shell.saveAll()
+            execute: () => this.shell.saveAll({ formatType: FormatType.DIRTY })
         });
         commandRegistry.registerCommand(CommonCommands.ABOUT_COMMAND, {
             execute: () => this.openAbout()

--- a/packages/core/src/browser/saveable.ts
+++ b/packages/core/src/browser/saveable.ts
@@ -179,11 +179,29 @@ export namespace SaveableWidget {
     }
 }
 
+/**
+ * Possible formatting types when saving.
+ */
+export const enum FormatType {
+    /**
+     * Formatting should occur (default).
+     */
+    ON = 1,
+    /**
+     * Formatting should not occur.
+     */
+    OFF,
+    /**
+     * Formatting should only occur if the resource is dirty.
+     */
+    DIRTY
+};
+
 export interface SaveOptions {
     /**
-     * Controls whether formatting should be applied upon saving
+     * Formatting type to apply when saving.
      */
-    readonly skipFormatting?: boolean;
+    readonly formatType?: FormatType;
 }
 
 /**

--- a/packages/core/src/browser/shell/application-shell.ts
+++ b/packages/core/src/browser/shell/application-shell.ts
@@ -1745,8 +1745,8 @@ export class ApplicationShell extends Widget {
     /**
      * Save all dirty widgets.
      */
-    async saveAll(): Promise<void> {
-        await Promise.all(this.tracker.widgets.map(widget => Saveable.save(widget)));
+    async saveAll(options?: SaveOptions): Promise<void> {
+        await Promise.all(this.tracker.widgets.map(widget => Saveable.save(widget, options)));
     }
 
     /**


### PR DESCRIPTION
#### What it does
<!-- Include relevant issues and describe how they are addressed. -->
Fixes #8548 
+ This PR is based on #8551 and #8543 
+ Command `Save All` now only formats the file if it is dirty

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
+ Turn on `formatOnSave`
+ Make the file in a wrong format (ie: wrong indentation, ...)
+ Save without formatting
+ Make sure there's no new change in the current file
+ Run `Save All` from command palette or by using shortcut

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

Signed-off-by: Duc Nguyen <duc.a.nguyen@ericsson.com>
