### PR TITLE
plugin-metrics: fix typos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 - [scm] show in the commit textbox the branch to which the commit will go [#6156](https://github.com/eclipse-theia/theia/pull/6156)
 
+<a name="breaking_changes_1.7.0">[Breaking Changes:](#breaking_changes_1.7.0)</a>
+
+- [plugin-metrics] renamed `AnalyticsFromRequests.succesfulResponses` to `AnalyticsFromRequests.successfulResponses` []()
 
 ## v1.6.0 - 24/09/2020
 

--- a/packages/plugin-metrics/src/browser/plugin-metrics-creator.ts
+++ b/packages/plugin-metrics/src/browser/plugin-metrics-creator.ts
@@ -40,7 +40,7 @@ export class PluginMetricsCreator {
      * create a metric.
      *
      * @param pluginID The id of the plugin
-     * @param errorContents The contents that the langauge server error has produced
+     * @param errorContents The contents that the language server error has produced
      */
     async createErrorMetric(requestData: DataFromRequest): Promise<void> {
         if (!requestData.pluginID) {
@@ -49,7 +49,7 @@ export class PluginMetricsCreator {
 
         const method = this.extractMethodFromValue(requestData.errorContentsOrMethod);
 
-        // only log the metric if we can find the method that it occured in
+        // only log the metric if we can find the method that it occurred in
         if (method) {
             const createdMetric = createRequestData(requestData.pluginID, method, requestData.timeTaken);
             this.createMetric(createdMetric, false);
@@ -75,7 +75,7 @@ export class PluginMetricsCreator {
             const currentAnalytics = thisExtension[method];
             if (currentAnalytics) {
                 currentAnalytics.totalRequests -= 1;
-                currentAnalytics.succesfulResponses -= 1;
+                currentAnalytics.successfulResponses -= 1;
             }
         }
     }
@@ -104,7 +104,7 @@ export class PluginMetricsCreator {
             if (currentAnalytic) {
                 currentAnalytic.totalRequests += 1;
                 if (isRequestSuccessful) {
-                    currentAnalytic.succesfulResponses += 1;
+                    currentAnalytic.successfulResponses += 1;
                 }
                 if (isRequestSuccessful) {
                     currentAnalytic.sumOfTimeForSuccess = currentAnalytic.sumOfTimeForSuccess + requestData.timeTaken;

--- a/packages/plugin-metrics/src/browser/plugin-metrics-resolver.ts
+++ b/packages/plugin-metrics/src/browser/plugin-metrics-resolver.ts
@@ -21,7 +21,7 @@ import { PluginMetricsCreator } from './plugin-metrics-creator';
 import { createRequestData } from '../common/plugin-metrics-types';
 
 /**
- * This class helps resolve language server requests into successess or failures
+ * This class helps resolve language server requests into successes or failures
  * and sends the data to the metricsExtractor
  */
 @injectable()

--- a/packages/plugin-metrics/src/common/plugin-metrics-types.ts
+++ b/packages/plugin-metrics/src/common/plugin-metrics-types.ts
@@ -26,7 +26,7 @@ export interface MethodToAnalytics {
 
 export interface AnalyticsFromRequests {
     totalRequests: number;
-    succesfulResponses: number;
+    successfulResponses: number;
     sumOfTimeForSuccess: number;
     sumOfTimeForFailure: number;
 }
@@ -66,14 +66,14 @@ export function createDefaultAnalytics(timeTaken: number, isRequestSuccessful: b
         return {
             sumOfTimeForSuccess: timeTaken,
             sumOfTimeForFailure: 0,
-            succesfulResponses: 0,
+            successfulResponses: 0,
             totalRequests: 0
         };
     } else {
         return {
             sumOfTimeForSuccess: 0,
             sumOfTimeForFailure: timeTaken,
-            succesfulResponses: 0,
+            successfulResponses: 0,
             totalRequests: 0
         };
     }

--- a/packages/plugin-metrics/src/node/metric-output/plugin-metrics-time-count.ts
+++ b/packages/plugin-metrics/src/node/metric-output/plugin-metrics-time-count.ts
@@ -23,12 +23,12 @@ export class PluginMetricTimeCount implements MetricOutput {
     public header = '# HELP language_server_time_count Number of language server requests\n# TYPE language_server_time_count gauge\n';
 
     createMetricOutput(id: string, method: string, requestAnalytics: AnalyticsFromRequests): string {
-        if (requestAnalytics.succesfulResponses < 0) {
-            requestAnalytics.succesfulResponses = 0;
+        if (requestAnalytics.successfulResponses < 0) {
+            requestAnalytics.successfulResponses = 0;
         }
-        const successMetric = `language_server_time_count{id="${id}" method="${method}" result="success"} ${requestAnalytics.succesfulResponses}\n`;
+        const successMetric = `language_server_time_count{id="${id}" method="${method}" result="success"} ${requestAnalytics.successfulResponses}\n`;
 
-        const failedRequests = requestAnalytics.totalRequests - requestAnalytics.succesfulResponses;
+        const failedRequests = requestAnalytics.totalRequests - requestAnalytics.successfulResponses;
         const failureMetric = `language_server_time_count{id="${id}" method="${method}" result="fail"} ${failedRequests}\n`;
         return successMetric + failureMetric;
     }

--- a/packages/plugin-metrics/src/node/metrics-contributor.spec.ts
+++ b/packages/plugin-metrics/src/node/metrics-contributor.spec.ts
@@ -40,7 +40,7 @@ describe('Metrics contributor:', () => {
             const analytics = {
                 sumOfTimeForFailure: 0,
                 sumOfTimeForSuccess: 5,
-                succesfulResponses: 10,
+                successfulResponses: 10,
                 totalRequests: 15
             } as AnalyticsFromRequests;
             const metricExtensionID = 'my_test_metric.test_metric';
@@ -72,7 +72,7 @@ describe('Metrics contributor:', () => {
             const firstClientAnalytics = {
                 sumOfTimeForFailure: 0,
                 sumOfTimeForSuccess: 5,
-                succesfulResponses: 10,
+                successfulResponses: 10,
                 totalRequests: 15
             } as AnalyticsFromRequests;
             const firstClientMetricExtensionID = 'my_test_metric.test_metric';
@@ -86,7 +86,7 @@ describe('Metrics contributor:', () => {
             const secondClientAnalytics = {
                 sumOfTimeForFailure: 0,
                 sumOfTimeForSuccess: 15,
-                succesfulResponses: 20,
+                successfulResponses: 20,
                 totalRequests: 18
             } as AnalyticsFromRequests;
             const secondClientMetricsMap = {
@@ -110,7 +110,7 @@ describe('Metrics contributor:', () => {
             const expectedAnalytics = {
                 sumOfTimeForFailure: 0,
                 sumOfTimeForSuccess: 20,
-                succesfulResponses: 30,
+                successfulResponses: 30,
                 totalRequests: 33
             } as AnalyticsFromRequests;
 
@@ -130,7 +130,7 @@ describe('Metrics contributor:', () => {
             const firstClientAnalytics = {
                 sumOfTimeForFailure: 0,
                 sumOfTimeForSuccess: 5,
-                succesfulResponses: 10,
+                successfulResponses: 10,
                 totalRequests: 15
             } as AnalyticsFromRequests;
             const firstClientMetricExtensionID = 'my_test_metric.test_metric';
@@ -144,7 +144,7 @@ describe('Metrics contributor:', () => {
             const secondClientAnalytics = {
                 sumOfTimeForFailure: 0,
                 sumOfTimeForSuccess: 15,
-                succesfulResponses: 20,
+                successfulResponses: 20,
                 totalRequests: 18
             } as AnalyticsFromRequests;
             const secondClientMetricExtensionID = 'my_other_test_metric.test_metric';
@@ -185,7 +185,7 @@ describe('Metrics contributor:', () => {
             const firstClientAnalytics = {
                 sumOfTimeForFailure: 0,
                 sumOfTimeForSuccess: 5,
-                succesfulResponses: 10,
+                successfulResponses: 10,
                 totalRequests: 15
             } as AnalyticsFromRequests;
             const firstClientMetricExtensionID = 'my_test_metric.test_metric';
@@ -198,7 +198,7 @@ describe('Metrics contributor:', () => {
             const secondClientAnalytics = {
                 sumOfTimeForFailure: 0,
                 sumOfTimeForSuccess: 15,
-                succesfulResponses: 20,
+                successfulResponses: 20,
                 totalRequests: 18
             } as AnalyticsFromRequests;
             const secondClientMetricMethod = 'textDocument/myOthertestMethod';

--- a/packages/plugin-metrics/src/node/metrics-contributor.ts
+++ b/packages/plugin-metrics/src/node/metrics-contributor.ts
@@ -55,7 +55,7 @@ export class PluginMetricsContributor {
                                 newAnalytic.sumOfTimeForSuccess = newAnalytic.sumOfTimeForSuccess + currentAnalytic.sumOfTimeForSuccess;
                                 newAnalytic.sumOfTimeForFailure = newAnalytic.sumOfTimeForFailure + currentAnalytic.sumOfTimeForFailure;
                                 newAnalytic.totalRequests += currentAnalytic.totalRequests;
-                                newAnalytic.succesfulResponses += currentAnalytic.succesfulResponses;
+                                newAnalytic.successfulResponses += currentAnalytic.successfulResponses;
 
                                 reconciledMap[vscodeExtensionID][method] = newAnalytic;
                             }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

The following commit fixes misc typos found in the `@theia/plugin-metrics` extension,
and includes the following breaking change:
- renamed `AnalyticsFromRequests.succesfulResponses` to `AnalyticsFromRequests.successfulResponses`.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

The CI should be green (build and test of `@theia/plugin-metrics`).

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

Signed-off-by: vince-fugnitto <vincent.fugnitto@ericsson.com>
