### PR TITLE
Fix #7752: Menu not collapsed when clicking on webviews

### DIFF
--- a/packages/plugin-ext/src/main/browser/webview/webview.ts
+++ b/packages/plugin-ext/src/main/browser/webview/webview.ts
@@ -275,9 +275,14 @@ export class WebviewWidget extends BaseWidget implements StatefulWidget {
         this.toHide.push(this.on(WebviewMessageChannels.doUpdateState, (state: any) => {
             this._state = state;
         }));
-        this.toHide.push(this.on(WebviewMessageChannels.didFocus, () =>
+        this.toHide.push(this.on(WebviewMessageChannels.didFocus, () => {
             // emulate the webview focus without actually changing focus
-            this.node.dispatchEvent(new FocusEvent('focus'))
+            this.node.dispatchEvent(new FocusEvent('focus'));
+            // We have to dispatch 'mousedown' event in the <webview> in order
+            // to inform 'phosphor' to close the menu if open
+            // ('phosphor' closes the menu when a 'mousedown' event emitted)
+            this.node.dispatchEvent(new MouseEvent('mousedown'));
+        }
         ));
         this.toHide.push(this.on(WebviewMessageChannels.didBlur, () => {
             /* no-op: webview loses focus only if another element gains focus in the main window */


### PR DESCRIPTION
Signed-off-by: Esther Perelman esther.perelman@sap.com

#### What it does

Fixes #7752 

Solution description: 'phosphor' is listening to widgets 'mousedown' event and so knows that the menu should be closed, All the other widgets except the webview - dispatching a 'mousedown' event automatically on user click but on iframe click - the node not dispatching 'mousedown' event - so we need to do it manually. (on WebviewMessageChannels.didFocus - dispatching node 'mousedown').

#### How to test

1. Open some webview.
2. Click on the 'file' top menu item/ Click on the 'settings' icon on the bottom left.
3. Click somewhere on the webview and see the the menu is collapsed.

Please note: Because of #8572 - after this fix the menu sometimes closes while navigating because the webview getting the focus, Fixing #8572 will solve it too.

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

