### PR TITLE
Fix for #8572, #7752: Previous active tab flicker when navigating the top menu, On webview - navigation getting stuck and menu not collapsed

### DIFF
--- a/packages/plugin-ext/src/main/browser/webview/webview.ts
+++ b/packages/plugin-ext/src/main/browser/webview/webview.ts
@@ -275,10 +275,14 @@ export class WebviewWidget extends BaseWidget implements StatefulWidget {
         this.toHide.push(this.on(WebviewMessageChannels.doUpdateState, (state: any) => {
             this._state = state;
         }));
-        this.toHide.push(this.on(WebviewMessageChannels.didFocus, () =>
+        this.toHide.push(this.on(WebviewMessageChannels.didFocus, () => {
             // emulate the webview focus without actually changing focus
-            this.node.dispatchEvent(new FocusEvent('focus'))
-        ));
+            this.node.dispatchEvent(new FocusEvent('focus'));
+            // We have to dispatch 'mousedown' event in the <webview> in order
+            // to inform 'phosphor' to close the menu if open
+            // ('phosphor' closes the menu when a 'mousedown' event emitted)
+            this.node.dispatchEvent(new MouseEvent('mousedown'));
+        }));
         this.toHide.push(this.on(WebviewMessageChannels.didBlur, () => {
             /* no-op: webview loses focus only if another element gains focus in the main window */
         }));


### PR DESCRIPTION
Signed-off-by: Esther Perelman <esther.perelman@sap.com>

This PR fixes #8572 by removing unnecessary focus on last-focused-element (the last focused element before the menu was opened)
that occurs every time menu closes even though user is still navigating the menu bar.
This is what caused the flickering tab and the navigation on webview to get stuck.

It also fixes #7752 by dispatching a 'mousedown' event on iframe focus (WebviewMessageChannels.didFocus) -
'phosphor' on menu is listening to 'mousedown' events and closes the menu if the event didn't occur inside it, All the elements besides iframe - dispatching a 'mousedown' event automatically on click, But on iframe click - we do have to do it manually.

#### What it does
Fixes #8572 
Fixes #7752 

#### How to test

**For the flicker issue:**
1. Focus on a file
2. Click on any tab inside the top menu
3. Navigate between the menu tabs (by mouse/ keyboard) and see that the last focused tab not flicker.

**For the webview issue:**
1. Open a webview
2. Click on any tab in the top menu
3. Navigate between the menu tabs by keyboard and see that the navigation not getting stuck.
4. Click somewhere on the webview and see that the menu is collapsed.

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

