### PR TITLE
core: disable nodeIntegrationInWorker

### DIFF
--- a/packages/core/src/electron-main/electron-main-application.ts
+++ b/packages/core/src/electron-main/electron-main-application.ts
@@ -232,8 +232,11 @@ export class ElectronMainApplication {
             minWidth: 200,
             minHeight: 120,
             webPreferences: {
-                nodeIntegration: true, // https://github.com/eclipse-theia/theia/issues/2018
-                nodeIntegrationInWorker: true
+                // https://github.com/eclipse-theia/theia/issues/2018
+                nodeIntegration: true,
+                // Setting the following option to `true` causes some features to break, somehow.
+                // Issue: https://github.com/eclipse-theia/theia/issues/8577
+                nodeIntegrationInWorker: false,
             },
             ...windowOptionsFromConfig,
         };

--- a/packages/plugin-ext/src/hosted/browser/worker/worker-main.ts
+++ b/packages/plugin-ext/src/hosted/browser/worker/worker-main.ts
@@ -19,7 +19,7 @@ import { RPCProtocolImpl } from '../../../common/rpc-protocol';
 import { PluginManagerExtImpl } from '../../../plugin/plugin-manager';
 import { MAIN_RPC_CONTEXT, Plugin, emptyPlugin } from '../../../common/plugin-api-rpc';
 import { createAPIFactory } from '../../../plugin/plugin-context';
-import { getPluginId, PluginMetadata, PluginPackage } from '../../../common/plugin-protocol';
+import { getPluginId, PluginMetadata } from '../../../common/plugin-protocol';
 import * as theia from '@theia/plugin';
 import { PreferenceRegistryExtImpl } from '../../../plugin/preference-registry';
 import { ExtPluginApi } from '../../../common/plugin-ext-api-contribution';
@@ -85,7 +85,12 @@ const pluginManager = new PluginManagerExtImpl({
     async init(rawPluginData: PluginMetadata[]): Promise<[Plugin[], Plugin[]]> {
         const result: Plugin[] = [];
         const foreign: Plugin[] = [];
-        for (const plg of rawPluginData) {
+        // Process the plugins concurrently, making sure to keep the order.
+        const plugins = await Promise.all<{
+            /** Where to push the plugin: `result` or `foreign` */
+            target: Plugin[],
+            plugin: Plugin
+        }>(rawPluginData.map(async plg => {
             const pluginModel = plg.model;
             const pluginLifecycle = plg.lifecycle;
             if (pluginModel.entryPoint!.frontend) {
@@ -96,7 +101,6 @@ const pluginManager = new PluginManagerExtImpl({
                     frontendInitPath = '';
                 }
                 const rawModel = await loadManifest(pluginModel);
-
                 const plugin: Plugin = {
                     pluginPath: pluginModel.entryPoint.frontend!,
                     pluginFolder: pluginModel.packagePath,
@@ -104,23 +108,29 @@ const pluginManager = new PluginManagerExtImpl({
                     lifecycle: pluginLifecycle,
                     rawModel
                 };
-                result.push(plugin);
                 const apiImpl = apiFactory(plugin);
                 pluginsApiImpl.set(plugin.model.id, apiImpl);
                 pluginsModulesNames.set(plugin.lifecycle.frontendModuleName!, plugin);
+                return { target: result, plugin };
             } else {
-                foreign.push({
-                    pluginPath: pluginModel.entryPoint.backend,
-                    pluginFolder: pluginModel.packagePath,
-                    model: pluginModel,
-                    lifecycle: pluginLifecycle,
-                    get rawModel(): PluginPackage {
-                        throw new Error('not supported');
+                return {
+                    target: foreign,
+                    plugin: {
+                        pluginPath: pluginModel.entryPoint.backend,
+                        pluginFolder: pluginModel.packagePath,
+                        model: pluginModel,
+                        lifecycle: pluginLifecycle,
+                        get rawModel(): never {
+                            throw new Error('not supported');
+                        }
                     }
-                });
+                };
             }
+        }));
+        // Collect the ordered plugins and insert them in the target array:
+        for (const { target, plugin } of plugins) {
+            target.push(plugin);
         }
-
         return [result, foreign];
     },
     initExtApi(extApi: ExtPluginApi[]): void {


### PR DESCRIPTION
#### What it does

**core: disable nodeIntegrationInWorker**

The setting was disabled before getting enabled, and now it is causing
issues with features like formatting. But it doesn't seem to be required
for anything special to work.

**plugin-ext: process plugins in concurrent loop**

Using `await` statements in for loops is generally not recommended,
unless the data processing requires it to happen this way.

Switched to a concurrent processing approach.

Fixes https://github.com/eclipse-theia/theia/issues/8577

#### How to test

See https://github.com/eclipse-theia/theia/issues/8577

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)