### PR TITLE
search-in-workspace: Perform workspace search in dirty file content

### DIFF
--- a/packages/editor/src/browser/editor-preferences.ts
+++ b/packages/editor/src/browser/editor-preferences.ts
@@ -58,6 +58,8 @@ export const EDITOR_MODEL_DEFAULTS = {
     largeFileOptimizations: true
 };
 
+export const DEFAULT_WORD_SEPARATORS = '`~!@#$%^&*()-=+[{]}\\|;:\'",.<>/?';
+
 /* eslint-disable max-len */
 /* eslint-disable no-null/no-null */
 
@@ -1171,7 +1173,7 @@ const codeEditorPreferenceProperties = {
     'editor.wordSeparators': {
         'description': 'Characters that will be used as word separators when doing word related navigations or operations.',
         'type': 'string',
-        'default': '`~!@#$%^&*()-=+[{]}\\|;:\'",.<>/?'
+        'default': DEFAULT_WORD_SEPARATORS
     },
     'editor.wordWrap': {
         'markdownEnumDescriptions': [

--- a/packages/editor/src/browser/editor.ts
+++ b/packages/editor/src/browser/editor.ts
@@ -31,6 +31,10 @@ export type TextEditorProvider = (uri: URI) => Promise<TextEditor>;
 export interface TextEditorDocument extends lsp.TextDocument, Saveable, Disposable {
     getLineContent(lineNumber: number): string;
     getLineMaxColumn(lineNumber: number): number;
+    /**
+     * @since 1.8.0
+     */
+    findMatches?(options: FindMatchesOptions): FindMatch[];
 }
 
 // Refactoring
@@ -148,6 +152,46 @@ export const enum EncodingMode {
      * Instructs the encoding support to decode the current input with the provided encoding
      */
     Decode
+}
+
+/**
+ * Options for searching in an editor.
+ */
+export interface FindMatchesOptions {
+    /**
+     * The string used to search. If it is a regular expression, set `isRegex` to true.
+     */
+    searchString: string;
+    /**
+     * Used to indicate that `searchString` is a regular expression.
+     */
+    isRegex: boolean;
+    /**
+     * Force the matching to match lower/upper case exactly.
+     */
+    matchCase: boolean;
+    /**
+     * Force the matching to match entire words only.
+     */
+    matchWholeWord: boolean;
+    /**
+     * Limit the number of results.
+     */
+    limitResultCount?: number;
+}
+
+/**
+ * Representation of a find match.
+ */
+export interface FindMatch {
+    /**
+     * The textual match.
+     */
+    readonly matches: string[];
+    /**
+     * The range for the given match.
+     */
+    readonly range: Range;
 }
 
 export interface TextEditor extends Disposable, TextEditorSelection, Navigatable {

--- a/packages/monaco/src/browser/monaco-text-model-service.ts
+++ b/packages/monaco/src/browser/monaco-text-model-service.ts
@@ -128,7 +128,7 @@ export class MonacoTextModelService implements monaco.editor.ITextModelService {
 
     protected createModel(resource: Resource): MaybePromise<MonacoEditorModel> {
         const factory = this.factories.getContributions().find(({ scheme }) => resource.uri.scheme === scheme);
-        return factory ? factory.createModel(resource) : new MonacoEditorModel(resource, this.m2p, this.p2m, this.logger);
+        return factory ? factory.createModel(resource) : new MonacoEditorModel(resource, this.m2p, this.p2m, this.logger, this.editorPreferences);
     }
 
     protected readonly modelOptions: { [name: string]: (keyof monaco.editor.ITextModelUpdateOptions | undefined) } = {

--- a/packages/search-in-workspace/package.json
+++ b/packages/search-in-workspace/package.json
@@ -9,6 +9,7 @@
     "@theia/navigator": "^1.7.0",
     "@theia/process": "^1.7.0",
     "@theia/workspace": "^1.7.0",
+    "minimatch": "^3.0.4",
     "vscode-ripgrep": "^1.2.4"
   },
   "publishConfig": {

--- a/packages/search-in-workspace/src/browser/search-in-workspace-widget.tsx
+++ b/packages/search-in-workspace/src/browser/search-in-workspace-widget.tsx
@@ -25,6 +25,7 @@ import { WorkspaceService } from '@theia/workspace/lib/browser';
 import { SearchInWorkspaceContextKeyService } from './search-in-workspace-context-key-service';
 import { CancellationTokenSource } from '@theia/core';
 import { ProgressBarFactory } from '@theia/core/lib/browser/progress-bar-factory';
+import { EditorManager } from '@theia/editor/lib/browser';
 
 export interface SearchFieldState {
     className: string;
@@ -85,6 +86,8 @@ export class SearchInWorkspaceWidget extends BaseWidget implements StatefulWidge
 
     @inject(ProgressBarFactory)
     protected readonly progressBarFactory: ProgressBarFactory;
+
+    @inject(EditorManager) protected readonly editorManager: EditorManager;
 
     @postConstruct()
     protected init(): void {
@@ -334,9 +337,9 @@ export class SearchInWorkspaceWidget extends BaseWidget implements StatefulWidge
     }
 
     protected renderNotification(): React.ReactNode {
-        if (this.workspaceService.tryGetRoots().length <= 0) {
+        if (this.workspaceService.tryGetRoots().length <= 0 && this.editorManager.all.length <= 0) {
             return <div className='search-notification show'>
-                <div>Cannot search without an active workspace present.</div>
+                <div>You have not opened or specified a folder. Only open files are currently searched.</div>
             </div>;
         }
         return <div


### PR DESCRIPTION
#### What it does
Fixes: #5609
Closes: #5651

+ `Search In Workspace` can now search content in dirty files and display the results in search view.
+ Utilizes `findMatches` function from `monaco editor` to get the search matches.
+ The message alert in search view now only shows up when neither workspace nor editor present.

**Note:** PR #5651 can be safely closed if this PR get merged since this PR is an enhancement. 

#### How to test
+ Open editor files in a workspace
+ Make changes in the editors without saving (make sure `auto save` is off)
+ Open `Search-in-Workspace` (`ctrl/cmd` + `shift` + `f`) and search for a certain keyword.
   - The results should correctly reflect the current state of the dirty editors.
   - The unsaved content in the editors should be shown in the search results, and properly highlighted in the editors.

![searchInDirty2](https://user-images.githubusercontent.com/43587865/94863152-08463380-0408-11eb-9fcd-e6ace2834b45.gif)

#### Checklist when testing with search options

- [x] `Match Case`
- [x] `Match Whole Word`
- [x] `Use Regular Expression`
- [x] `Include Ignored Files`

- [x] `files to include`
- [x] `files to exclude`

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

Co-authored-by: fangnx <naxin.fang@ericsson.com>
Co-authored-by: vince-fugnitto <vincent.fugnitto@ericsson.com>
Signed-off-by: DukeNgn <duc.a.nguyen@ericsson.com>