### PR TITLE
#8574 [vscode][showTextDocument] different behavior from vscode when …

### DIFF
--- a/packages/editor/src/browser/editor-manager.ts
+++ b/packages/editor/src/browser/editor-manager.ts
@@ -127,7 +127,7 @@ export class EditorManager extends NavigatableWidgetOpenHandler<EditorWidget> {
         const widget = this.shell.currentWidget;
         if (widget instanceof EditorWidget) {
             this.setCurrentEditor(widget);
-        } else if (!this._currentEditor || !this._currentEditor.isVisible) {
+        } else if (!this._currentEditor || !this._currentEditor.isVisible || this.currentEditor !== this.recentlyVisible) {
             this.setCurrentEditor(this.recentlyVisible);
         }
     }


### PR DESCRIPTION
…showing sbs editors

#### What it does
Solves issue #8574 

#### How to test
Follow the description in the issue #8574 - with this fix, the exception does not occur anymore and the number of visible editors is being updated.

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

