### PR TITLE
7989-refactor-preview: Support for Refactor Preview functionality

### DIFF
--- a/configs/root-compilation.tsconfig.json
+++ b/configs/root-compilation.tsconfig.json
@@ -17,6 +17,9 @@
       "path": "../dev-packages/cli/compile.tsconfig.json"
     },
     {
+      "path": "../packages/bulk-edit/compile.tsconfig.json"
+    },
+    {
       "path": "../packages/callhierarchy/compile.tsconfig.json"
     },
     {

--- a/examples/browser/package.json
+++ b/examples/browser/package.json
@@ -15,6 +15,7 @@
   },
   "dependencies": {
     "@theia/api-samples": "1.10.0",
+    "@theia/bulk-edit": "1.10.0",
     "@theia/callhierarchy": "1.10.0",
     "@theia/console": "1.10.0",
     "@theia/core": "1.10.0",

--- a/examples/electron/compile.tsconfig.json
+++ b/examples/electron/compile.tsconfig.json
@@ -15,6 +15,9 @@
       "path": "../api-samples/compile.tsconfig.json"
     },
     {
+      "path": "../../packages/bulk-edit/compile.tsconfig.json"
+    },
+    {
       "path": "../../packages/callhierarchy/compile.tsconfig.json"
     },
     {

--- a/examples/electron/package.json
+++ b/examples/electron/package.json
@@ -15,6 +15,7 @@
   },
   "dependencies": {
     "@theia/api-samples": "1.10.0",
+    "@theia/bulk-edit": "1.10.0",
     "@theia/callhierarchy": "1.10.0",
     "@theia/console": "1.10.0",
     "@theia/core": "1.10.0",

--- a/packages/bulk-edit/.eslintrc.js
+++ b/packages/bulk-edit/.eslintrc.js
@@ -1,0 +1,10 @@
+/** @type {import('eslint').Linter.Config} */
+module.exports = {
+    extends: [
+        '../../configs/build.eslintrc.json'
+    ],
+    parserOptions: {
+        tsconfigRootDir: __dirname,
+        project: 'compile.tsconfig.json'
+    }
+};

--- a/packages/bulk-edit/README.md
+++ b/packages/bulk-edit/README.md
@@ -1,0 +1,30 @@
+<div align='center'>
+
+<br />
+
+<img src='https://raw.githubusercontent.com/eclipse-theia/theia/master/logo/theia.svg?sanitize=true' alt='theia-ext-logo' width='100px' />
+
+<h2>ECLIPSE THEIA - BULK EDIT EXTENSION</h2>
+
+<hr />
+
+</div>
+
+## Description
+
+The `@theia/bulk-edit` extension contributes a `Refactor Preview` widget to the application that displays WorkspaceEdits to end-users.
+
+## Additional Information
+
+- [API documentation for `@theia/bulk-edit`](https://eclipse-theia.github.io/theia/docs/next/modules/bulk-edit.html)
+- [Theia - GitHub](https://github.com/eclipse-theia/theia)
+- [Theia - Website](https://theia-ide.org/)
+
+## License
+
+- [Eclipse Public License 2.0](http://www.eclipse.org/legal/epl-2.0/)
+- [一 (Secondary) GNU General Public License, version 2 with the GNU Classpath Exception](https://projects.eclipse.org/license/secondary-gpl-2.0-cp)
+
+## Trademark
+"Theia" is a trademark of the Eclipse Foundation
+https://www.eclipse.org/theia

--- a/packages/bulk-edit/compile.tsconfig.json
+++ b/packages/bulk-edit/compile.tsconfig.json
@@ -3,12 +3,7 @@
   "compilerOptions": {
     "composite": true,
     "rootDir": "src",
-    "outDir": "lib",
-    "lib": [
-      "es6",
-      "dom",
-      "webworker"
-    ]
+    "outDir": "lib"
   },
   "include": [
     "src"
@@ -21,16 +16,10 @@
       "path": "../editor/compile.tsconfig.json"
     },
     {
+      "path": "../filesystem/compile.tsconfig.json"
+    },
+    {
       "path": "../monaco/compile.tsconfig.json"
-    },
-    {
-      "path": "../plugin/compile.tsconfig.json"
-    },
-    {
-      "path": "../plugin-ext/compile.tsconfig.json"
-    },
-    {
-      "path": "../userstorage/compile.tsconfig.json"
     },
     {
       "path": "../workspace/compile.tsconfig.json"

--- a/packages/bulk-edit/package.json
+++ b/packages/bulk-edit/package.json
@@ -1,0 +1,49 @@
+{
+  "name": "@theia/bulk-edit",
+  "version": "1.10.0",
+  "description": "Theia - Bulk Edit Extension",
+  "dependencies": {
+    "@theia/core": "^1.10.0",
+    "@theia/editor": "^1.10.0",
+    "@theia/filesystem": "^1.10.0",
+    "@theia/monaco": "^1.10.0",
+    "@theia/workspace": "^1.10.0"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "theiaExtensions": [
+    {
+      "frontend": "lib/browser/bulk-edit-frontend-module"
+    }
+  ],
+  "keywords": [
+    "theia-extension"
+  ],
+  "license": "EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/eclipse-theia/theia.git"
+  },
+  "bugs": {
+    "url": "https://github.com/eclipse-theia/theia/issues"
+  },
+  "homepage": "https://github.com/eclipse-theia/theia",
+  "files": [
+    "lib",
+    "src"
+  ],
+  "scripts": {
+    "lint": "theiaext lint",
+    "build": "theiaext build",
+    "watch": "theiaext watch",
+    "clean": "theiaext clean",
+    "test": "theiaext test"
+  },
+  "devDependencies": {
+    "@theia/ext-scripts": "^1.10.0"
+  },
+  "nyc": {
+    "extends": "../../configs/nyc.json"
+  }
+}

--- a/packages/bulk-edit/src/browser/bulk-edit-commands.ts
+++ b/packages/bulk-edit/src/browser/bulk-edit-commands.ts
@@ -1,0 +1,33 @@
+/********************************************************************************
+ * Copyright (c) 2021 SAP SE or an SAP affiliate company and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import { Command } from '@theia/core/lib/common';
+
+export namespace BulkEditCommands {
+    export const TOGGLE_VIEW: Command = {
+        id: 'bulk-edit:toggleView'
+    };
+
+    export const APPLY: Command = {
+        id: 'bulk-edit:apply',
+        iconClass: 'codicon codicon-check'
+    };
+
+    export const DISCARD: Command = {
+        id: 'bulk-edit:discard',
+        iconClass: 'clear-all'
+    };
+}

--- a/packages/bulk-edit/src/browser/bulk-edit-contribution.ts
+++ b/packages/bulk-edit/src/browser/bulk-edit-contribution.ts
@@ -1,0 +1,114 @@
+/********************************************************************************
+ * Copyright (c) 2021 SAP SE or an SAP affiliate company and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import { injectable, inject } from 'inversify';
+import { Widget } from '@theia/core/lib/browser/widgets/widget';
+import { CommandRegistry } from '@theia/core/lib/common';
+import { AbstractViewContribution } from '@theia/core/lib/browser/shell/view-contribution';
+import { BulkEditCommands } from './bulk-edit-commands';
+import { MonacoBulkEditService } from '@theia/monaco/lib/browser/monaco-bulk-edit-service';
+import { TabBarToolbarContribution, TabBarToolbarRegistry } from '@theia/core/lib/browser/shell/tab-bar-toolbar';
+import { BulkEditTreeWidget, BULK_EDIT_TREE_WIDGET_ID } from './bulk-edit-tree';
+import { QuickViewService } from '@theia/core/lib/browser/quick-view-service';
+
+export const BULK_EDIT_WIDGET_NAME = 'Refactor Preview';
+
+@injectable()
+export class BulkEditContribution extends AbstractViewContribution<BulkEditTreeWidget> implements TabBarToolbarContribution {
+    private workspaceEdit: monaco.languages.WorkspaceEdit;
+
+    @inject(QuickViewService)
+    protected readonly quickView: QuickViewService;
+
+    constructor(private readonly bulkEditService: MonacoBulkEditService) {
+        super({
+            widgetId: BULK_EDIT_TREE_WIDGET_ID,
+            widgetName: BULK_EDIT_WIDGET_NAME,
+            defaultWidgetOptions: {
+                area: 'bottom'
+            }
+        });
+        this.bulkEditService.setPreviewHandler((edits: monaco.languages.WorkspaceEdit) => this.previewEdit(edits));
+    }
+
+    registerCommands(registry: CommandRegistry): void {
+        super.registerCommands(registry);
+        this.quickView.hideItem(BULK_EDIT_WIDGET_NAME);
+
+        registry.registerCommand(BulkEditCommands.APPLY, {
+            isEnabled: widget => this.withWidget(widget, () => true),
+            isVisible: widget => this.withWidget(widget, () => true),
+            execute: widget => this.withWidget(widget, () => this.apply())
+        });
+        registry.registerCommand(BulkEditCommands.DISCARD, {
+            isEnabled: widget => this.withWidget(widget, () => true),
+            isVisible: widget => this.withWidget(widget, () => true),
+            execute: widget => this.withWidget(widget, () => this.discard())
+        });
+    }
+
+    async registerToolbarItems(toolbarRegistry: TabBarToolbarRegistry): Promise<void> {
+        toolbarRegistry.registerItem({
+            id: BulkEditCommands.APPLY.id,
+            command: BulkEditCommands.APPLY.id,
+            tooltip: 'Apply Refactoring',
+            priority: 0,
+        });
+        toolbarRegistry.registerItem({
+            id: BulkEditCommands.DISCARD.id,
+            command: BulkEditCommands.DISCARD.id,
+            tooltip: 'Discard Refactoring',
+            priority: 1,
+        });
+    }
+
+    protected withWidget<T>(widget: Widget | undefined = this.tryGetWidget(), cb: (bulkEdit: BulkEditTreeWidget) => T): T | false {
+        if (widget instanceof BulkEditTreeWidget) {
+            return cb(widget);
+        }
+        return false;
+    }
+
+    private async previewEdit(workspaceEdit: monaco.languages.WorkspaceEdit): Promise<monaco.languages.WorkspaceEdit> {
+        const widget = await this.openView({ activate: true });
+
+        if (widget) {
+            this.workspaceEdit = workspaceEdit;
+            await widget.initModel(workspaceEdit);
+        }
+
+        return workspaceEdit;
+    }
+
+    private apply(): void {
+        if (this.workspaceEdit?.edits) {
+            this.workspaceEdit.edits.forEach(edit => {
+                if (edit.metadata) {
+                    edit.metadata.needsConfirmation = false;
+                }
+            });
+            this.bulkEditService.apply(this.workspaceEdit);
+        }
+        this.closeView();
+    }
+
+    private discard(): void {
+        if (this.workspaceEdit) {
+            this.workspaceEdit.edits = [];
+        }
+        this.closeView();
+    }
+}

--- a/packages/bulk-edit/src/browser/bulk-edit-frontend-module.ts
+++ b/packages/bulk-edit/src/browser/bulk-edit-frontend-module.ts
@@ -1,0 +1,44 @@
+/********************************************************************************
+ * Copyright (c) 2021 SAP SE or an SAP affiliate company and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+import { ContainerModule } from 'inversify';
+import { WidgetFactory } from '@theia/core/lib/browser/widget-manager';
+import { BulkEditTreeWidget, BULK_EDIT_TREE_WIDGET_ID, createBulkEditTreeWidget, InMemoryTextResourceResolver } from './bulk-edit-tree';
+import { FrontendApplicationContribution, LabelProviderContribution } from '@theia/core/lib/browser';
+import { bindViewContribution } from '@theia/core/lib/browser';
+import { BulkEditContribution } from './bulk-edit-contribution';
+import { TabBarToolbarContribution } from '@theia/core/lib/browser/shell/tab-bar-toolbar';
+import { BulkEditTreeLabelProvider } from './bulk-edit-tree-label-provider';
+import { ResourceResolver } from '@theia/core/lib/common';
+import '../../src/browser/style/bulk-edit.css';
+
+export default new ContainerModule(bind => {
+    bind(BulkEditTreeWidget).toDynamicValue(ctx =>
+        createBulkEditTreeWidget(ctx.container)
+    );
+    bind(WidgetFactory).toDynamicValue(context => ({
+        id: BULK_EDIT_TREE_WIDGET_ID,
+        createWidget: () => context.container.get(BulkEditTreeWidget)
+    }));
+    bindViewContribution(bind, BulkEditContribution);
+    bind(FrontendApplicationContribution).toService(BulkEditContribution);
+    bind(TabBarToolbarContribution).toService(BulkEditContribution);
+
+    bind(BulkEditTreeLabelProvider).toSelf().inSingletonScope();
+    bind(LabelProviderContribution).toService(BulkEditTreeLabelProvider);
+
+    bind(InMemoryTextResourceResolver).toSelf().inSingletonScope();
+    bind(ResourceResolver).toService(InMemoryTextResourceResolver);
+});

--- a/packages/bulk-edit/src/browser/bulk-edit-tree-label-provider.ts
+++ b/packages/bulk-edit/src/browser/bulk-edit-tree-label-provider.ts
@@ -1,0 +1,71 @@
+/********************************************************************************
+ * Copyright (c) 2021 SAP SE or an SAP affiliate company and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import { injectable, inject } from 'inversify';
+import { LabelProvider, LabelProviderContribution, DidChangeLabelEvent } from '@theia/core/lib/browser/label-provider';
+import { BulkEditInfoNode } from './bulk-edit-tree';
+import { TreeLabelProvider } from '@theia/core/lib/browser/tree/tree-label-provider';
+import { WorkspaceService } from '@theia/workspace/lib/browser';
+
+@injectable()
+export class BulkEditTreeLabelProvider implements LabelProviderContribution {
+
+    @inject(LabelProvider)
+    protected readonly labelProvider: LabelProvider;
+
+    @inject(TreeLabelProvider)
+    protected readonly treeLabelProvider: TreeLabelProvider;
+
+    @inject(WorkspaceService)
+    protected readonly workspaceService: WorkspaceService;
+
+    canHandle(element: object): number {
+        return BulkEditInfoNode.is(element) ?
+            this.treeLabelProvider.canHandle(element) + 1 :
+            0;
+    }
+
+    getIcon(node: BulkEditInfoNode): string {
+        return this.labelProvider.getIcon(node.uri);
+    }
+
+    getName(node: BulkEditInfoNode): string {
+        return this.labelProvider.getName(node.uri);
+    }
+
+    getLongName(node: BulkEditInfoNode): string {
+        const description: string[] = [];
+        const rootUri = this.workspaceService.getWorkspaceRootUri(node.uri);
+        // In a multiple-root workspace include the root name to the label before the parent directory.
+        if (this.workspaceService.isMultiRootWorkspaceOpened && rootUri) {
+            description.push(this.labelProvider.getName(rootUri));
+        }
+        // If the given resource is not at the workspace root, include the parent directory to the label.
+        if (rootUri?.toString() !== node.uri.parent.toString()) {
+            description.push(this.labelProvider.getLongName(node.uri.parent));
+        }
+        return description.join(' ● ');
+    }
+
+    getDescription(node: BulkEditInfoNode): string {
+        return this.labelProvider.getLongName(node.uri.parent);
+    }
+
+    affects(node: BulkEditInfoNode, event: DidChangeLabelEvent): boolean {
+        return event.affects(node.uri) || event.affects(node.uri.parent);
+    }
+
+}

--- a/packages/bulk-edit/src/browser/bulk-edit-tree/bulk-edit-node-selection.ts
+++ b/packages/bulk-edit/src/browser/bulk-edit-tree/bulk-edit-node-selection.ts
@@ -1,0 +1,42 @@
+/********************************************************************************
+ * Copyright (c) 2021 SAP SE or an SAP affiliate company and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import { SelectionService } from '@theia/core/lib/common/selection-service';
+import { SelectionCommandHandler } from '@theia/core/lib/common/selection-command-handler';
+
+export interface BulkEditNodeSelection {
+    bulkEdit: monaco.languages.WorkspaceTextEdit | monaco.languages.WorkspaceFileEdit;
+}
+export namespace BulkEditNodeSelection {
+    export function is(arg: Object | undefined): arg is BulkEditNodeSelection {
+        return typeof arg === 'object' && ('bulkEdit' in arg);
+    }
+
+    export class CommandHandler extends SelectionCommandHandler<BulkEditNodeSelection> {
+
+        constructor(
+            protected readonly selectionService: SelectionService,
+            protected readonly options: SelectionCommandHandler.Options<BulkEditNodeSelection>
+        ) {
+            super(
+                selectionService,
+                arg => BulkEditNodeSelection.is(arg) ? arg : undefined,
+                options
+            );
+        }
+    }
+
+}

--- a/packages/bulk-edit/src/browser/bulk-edit-tree/bulk-edit-tree-container.ts
+++ b/packages/bulk-edit/src/browser/bulk-edit-tree/bulk-edit-tree-container.ts
@@ -1,0 +1,43 @@
+/********************************************************************************
+ * Copyright (c) 2021 SAP SE or an SAP affiliate company and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import { interfaces, Container } from 'inversify';
+import { BulkEditTreeWidget } from './bulk-edit-tree-widget';
+import { BulkEditTree } from './bulk-edit-tree';
+import { BulkEditTreeModel } from './bulk-edit-tree-model';
+import { TreeWidget, TreeProps, defaultTreeProps, TreeModel, createTreeContainer, TreeModelImpl, TreeImpl, Tree } from '@theia/core/lib/browser';
+
+export function createBulkEditContainer(parent: interfaces.Container): Container {
+    const child = createTreeContainer(parent);
+
+    child.unbind(TreeImpl);
+    child.bind(BulkEditTree).toSelf();
+    child.rebind(Tree).toService(BulkEditTree);
+
+    child.unbind(TreeWidget);
+    child.bind(BulkEditTreeWidget).toSelf();
+
+    child.unbind(TreeModelImpl);
+    child.bind(BulkEditTreeModel).toSelf();
+    child.rebind(TreeModel).toService(BulkEditTreeModel);
+    child.rebind(TreeProps).toConstantValue(defaultTreeProps);
+
+    return child;
+}
+
+export function createBulkEditTreeWidget(parent: interfaces.Container): BulkEditTreeWidget {
+    return createBulkEditContainer(parent).get(BulkEditTreeWidget);
+}

--- a/packages/bulk-edit/src/browser/bulk-edit-tree/bulk-edit-tree-model.ts
+++ b/packages/bulk-edit/src/browser/bulk-edit-tree/bulk-edit-tree-model.ts
@@ -1,0 +1,41 @@
+/********************************************************************************
+ * Copyright (c) 2021 SAP SE or an SAP affiliate company and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import { injectable, inject } from 'inversify';
+import { BulkEditNode, BulkEditTree } from './bulk-edit-tree';
+import { TreeModelImpl, OpenerService, open, TreeNode } from '@theia/core/lib/browser';
+
+@injectable()
+export class BulkEditTreeModel extends TreeModelImpl {
+    @inject(BulkEditTree) protected readonly tree: BulkEditTree;
+    @inject(OpenerService) protected readonly openerService: OpenerService;
+
+    protected doOpenNode(node: TreeNode): void {
+        if (BulkEditNode.is(node)) {
+            open(this.openerService, node.uri, undefined);
+        } else {
+            super.doOpenNode(node);
+        }
+    }
+
+    revealNode(node: TreeNode): void {
+        this.doOpenNode(node);
+    }
+
+    async initModel(workspaceEdit: monaco.languages.WorkspaceEdit, fileContents: Map<string, string>): Promise<void> {
+        this.tree.initTree(workspaceEdit, fileContents);
+    }
+}

--- a/packages/bulk-edit/src/browser/bulk-edit-tree/bulk-edit-tree-widget.tsx
+++ b/packages/bulk-edit/src/browser/bulk-edit-tree/bulk-edit-tree-widget.tsx
@@ -1,0 +1,230 @@
+/********************************************************************************
+ * Copyright (c) 2021 SAP SE or an SAP affiliate company and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import { injectable, inject } from 'inversify';
+import {
+    TreeWidget, TreeProps, ContextMenuRenderer, TreeNode, TreeModel,
+    CompositeTreeNode, NodeProps
+} from '@theia/core/lib/browser';
+import * as React from 'react';
+import { BulkEditInfoNode, BulkEditNode } from './bulk-edit-tree';
+import { BulkEditTreeModel } from './bulk-edit-tree-model';
+import { FileResourceResolver } from '@theia/filesystem/lib/browser';
+import URI from '@theia/core/lib/common/uri';
+import { EditorWidget, EditorManager, EditorOpenerOptions } from '@theia/editor/lib/browser';
+import { DiffUris } from '@theia/core/lib/browser';
+import { MEMORY_TEXT } from './in-memory-text-resource';
+import { Disposable } from '@theia/core/lib/common/disposable';
+import { QuickViewService } from '@theia/core/lib/browser/quick-view-service';
+
+export const BULK_EDIT_TREE_WIDGET_ID = 'bulkedit';
+export const BULK_EDIT_WIDGET_NAME = 'Refactor Preview';
+
+@injectable()
+export class BulkEditTreeWidget extends TreeWidget {
+    private editorWidgets: EditorWidget[] = [];
+
+    @inject(FileResourceResolver)
+    protected readonly fileResourceResolver: FileResourceResolver;
+
+    @inject(EditorManager)
+    protected readonly editorManager: EditorManager;
+
+    @inject(QuickViewService)
+    protected readonly quickView: QuickViewService;
+
+    constructor(
+        @inject(TreeProps) readonly treeProps: TreeProps,
+        @inject(BulkEditTreeModel) readonly model: BulkEditTreeModel,
+        @inject(ContextMenuRenderer) readonly contextMenuRenderer: ContextMenuRenderer
+    ) {
+        super(treeProps, model, contextMenuRenderer);
+
+        this.id = BULK_EDIT_TREE_WIDGET_ID;
+        this.title.label = BULK_EDIT_WIDGET_NAME;
+        this.title.caption = BULK_EDIT_WIDGET_NAME;
+        this.title.closable = true;
+        this.addClass('theia-bulk-edit-container');
+
+        this.toDispose.push(Disposable.create(() => {
+            this.disposeEditors();
+        }));
+    }
+
+    async initModel(workspaceEdit: monaco.languages.WorkspaceEdit): Promise<void> {
+        await this.model.initModel(workspaceEdit, await this.getFileContentsMap(workspaceEdit));
+        this.quickView.showItem(BULK_EDIT_WIDGET_NAME);
+    }
+
+    protected handleClickEvent(node: TreeNode | undefined, event: React.MouseEvent<HTMLElement>): void {
+        super.handleClickEvent(node, event);
+        if (BulkEditNode.is(node)) {
+            this.doOpen(node);
+        }
+    }
+
+    protected handleDown(event: KeyboardEvent): void {
+        const node = this.model.getNextSelectableNode();
+        super.handleDown(event);
+        if (BulkEditNode.is(node)) {
+            this.doOpen(node);
+        }
+    }
+
+    protected handleUp(event: KeyboardEvent): void {
+        const node = this.model.getPrevSelectableNode();
+        super.handleUp(event);
+        if (BulkEditNode.is(node)) {
+            this.doOpen(node);
+        }
+    }
+
+    protected renderTree(model: TreeModel): React.ReactNode {
+        if (CompositeTreeNode.is(model.root) && model.root.children.length > 0) {
+            return super.renderTree(model);
+        }
+        return <div className='theia-widget-noInfo noEdits'>No edits have been detected in the workspace so far.</div>;
+    }
+
+    protected renderCaption(node: TreeNode, props: NodeProps): React.ReactNode {
+        if (BulkEditInfoNode.is(node)) {
+            return this.decorateBulkEditInfoNode(node);
+        } else if (BulkEditNode.is(node)) {
+            return this.decorateBulkEditNode(node);
+        }
+        return 'caption';
+    }
+
+    protected decorateBulkEditNode(node: BulkEditNode): React.ReactNode {
+        if (node?.parent && node?.bulkEdit && ('edit' in node?.bulkEdit)) {
+            const bulkEdit = node.bulkEdit;
+            const parent = node.parent as BulkEditInfoNode;
+
+            if (parent?.fileContents) {
+                const lines = parent.fileContents.split('\n');
+                const startLineNum = +bulkEdit.edit.range.startLineNumber;
+
+                if (lines.length > startLineNum) {
+                    const startColumn = +bulkEdit.edit.range.startColumn;
+                    const endColumn = +bulkEdit.edit.range.endColumn;
+                    const lineText = lines[startLineNum - 1];
+                    const beforeMatch = (startColumn > 26 ? '... ' : '') + lineText.substr(0, startColumn - 1).substr(-25);
+                    const replacedText = lineText.substring(startColumn - 1, endColumn - 1);
+                    const afterMatch = lineText.substr(startColumn - 1 + replacedText.length, 75);
+
+                    return <div className='bulkEditNode'>
+                        <div className='message'>
+                            {beforeMatch}
+                            <span className="replaced-text">{replacedText}</span>
+                            <span className="inserted-text">{bulkEdit.edit.text}</span>
+                            {afterMatch}
+                        </div>
+                    </div>;
+                }
+            }
+        }
+    }
+
+    protected decorateBulkEditInfoNode(node: BulkEditInfoNode): React.ReactNode {
+        const icon = this.toNodeIcon(node);
+        const name = this.toNodeName(node);
+        const description = this.toNodeDescription(node);
+        const path = this.labelProvider.getLongName(node.uri.withScheme('bulkedit'));
+        return <div title={path} className='bulkEditInfoNode'>
+            {icon && <div className={icon + ' file-icon'}></div>}
+            <div className='name'>{name}</div>
+            <div className='path'>{description}</div>
+        </div>;
+    }
+
+    private async getFileContentsMap(workspaceEdit: monaco.languages.WorkspaceEdit): Promise<Map<string, string>> {
+        const fileContentMap = new Map<string, string>();
+
+        if (workspaceEdit?.edits) {
+            for (const element of workspaceEdit.edits) {
+                if (element) {
+                    const filePath = (('newUri' in element) && element?.newUri?.path) || (('resource' in element) && element?.resource?.path);
+
+                    if (filePath && !fileContentMap.has(filePath)) {
+                        const fileUri = new URI(filePath).withScheme('file');
+                        const resource = await this.fileResourceResolver.resolve(fileUri);
+                        fileContentMap.set(filePath, await resource.readContents());
+                    }
+                }
+            }
+        }
+        return fileContentMap;
+    }
+
+    private async doOpen(node: BulkEditNode): Promise<void> {
+        if (node && node.parent && node.bulkEdit && ('edit' in node.bulkEdit)) {
+            const resultNode = node.parent as BulkEditInfoNode;
+            const leftUri = node.uri;
+            const rightUri = await this.createReplacePreview(resultNode);
+            const diffUri = DiffUris.encode(leftUri, rightUri);
+            const editorWidget = await this.editorManager.open(diffUri, this.getEditorOptions(node));
+            this.editorWidgets.push(editorWidget);
+        }
+    }
+
+    private async createReplacePreview(bulkEditInfoNode: BulkEditInfoNode): Promise<URI> {
+        const fileUri = bulkEditInfoNode.uri;
+        let lines: string[] = [];
+        if (bulkEditInfoNode?.fileContents) {
+            lines = bulkEditInfoNode.fileContents.split('\n');
+            bulkEditInfoNode.children.map((node: BulkEditNode) => {
+                if (node.bulkEdit && ('edit' in node.bulkEdit)) {
+                    const startLineNum = node.bulkEdit.edit.range.startLineNumber;
+                    if (lines.length > startLineNum) {
+                        const startColumn = node.bulkEdit.edit.range.startColumn;
+                        const endColumn = node.bulkEdit.edit.range.endColumn;
+                        const lineText = lines[startLineNum - 1];
+                        const beforeMatch = lineText.substr(0, startColumn - 1);
+                        const replacedText = lineText.substring(startColumn - 1, endColumn - 1);
+                        const afterMatch = lineText.substr(startColumn - 1 + replacedText.length);
+                        lines[startLineNum - 1] = beforeMatch + node.bulkEdit.edit.text + afterMatch;
+                    }
+                }
+            });
+        }
+
+        return fileUri.withScheme(MEMORY_TEXT).withQuery(lines.join('\n'));
+    }
+
+    private getEditorOptions(node: BulkEditNode): EditorOpenerOptions {
+        let options = {};
+        if (('edit' in node.bulkEdit) && node?.bulkEdit?.edit?.range) {
+            options = {
+                selection: {
+                    start: {
+                        line: node.bulkEdit.edit.range.startLineNumber - 1,
+                        character: node.bulkEdit.edit.range.startColumn - 1
+                    },
+                    end: {
+                        line: node.bulkEdit.edit.range.endLineNumber - 1,
+                        character: node.bulkEdit.edit.range.endColumn - 1
+                    }
+                }
+            };
+        }
+        return options;
+    }
+
+    private disposeEditors(): void {
+        this.editorWidgets.forEach(w => w.dispose());
+        this.quickView.hideItem(BULK_EDIT_WIDGET_NAME);
+    }
+}

--- a/packages/bulk-edit/src/browser/bulk-edit-tree/bulk-edit-tree.spec.ts
+++ b/packages/bulk-edit/src/browser/bulk-edit-tree/bulk-edit-tree.spec.ts
@@ -1,0 +1,88 @@
+/********************************************************************************
+ * Copyright (c) 2021 SAP SE or an SAP affiliate company and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import { enableJSDOM } from '@theia/core/lib/browser/test/jsdom';
+import * as chai from 'chai';
+import * as sinon from 'sinon';
+
+let disableJSDOM = enableJSDOM();
+
+import { FrontendApplicationConfigProvider } from '@theia/core/lib/browser/frontend-application-config-provider';
+import { ApplicationProps } from '@theia/application-package/lib/application-props';
+FrontendApplicationConfigProvider.set({
+    ...ApplicationProps.DEFAULT.frontend.config
+});
+
+import { Container } from 'inversify';
+import { BulkEditInfoNode, BulkEditTree } from './bulk-edit-tree';
+
+global.monaco = sinon.stub() as unknown as typeof monaco;
+global.monaco.Uri = sinon.stub() as unknown as typeof monaco.Uri;
+global.monaco.Uri.isUri = sinon.stub().returns(true) as unknown as typeof monaco.Uri.isUri;
+
+const expect = chai.expect;
+let bulkEditTree: BulkEditTree;
+let testContainer: Container;
+const fileContextsMap = new Map<string, string>();
+let workspaceEdit: monaco.languages.WorkspaceEdit;
+
+disableJSDOM();
+
+before(() => {
+    disableJSDOM = enableJSDOM();
+
+    testContainer = new Container();
+    testContainer.bind(BulkEditTree).toSelf();
+    bulkEditTree = testContainer.get(BulkEditTree);
+
+    fileContextsMap.set('/c:/test1.ts', 'aaaaaaaaaaaaaaaaaaa');
+    fileContextsMap.set('/c:/test2.ts', 'bbbbbbbbbbbbbbbbbbb');
+
+    workspaceEdit = <monaco.languages.WorkspaceEdit><unknown>{
+        'edits': [
+            {
+                'resource': {
+                    '$mid': 1,
+                    'path': '/c:/test1.ts',
+                    'scheme': 'file'
+                },
+                'edit': {
+                    'text': 'AAAAA', 'range': { 'startLineNumber': 1, 'startColumn': 5, 'endLineNumber': 1, 'endColumn': 10 }
+                }
+            },
+            {
+                'resource': {
+                    '$mid': 1,
+                    'path': '/c:/test2.ts',
+                    'scheme': 'file'
+                }, 'edit': {
+                    'text': 'BBBBBB', 'range': { 'startLineNumber': 1, 'startColumn': 3, 'endLineNumber': 1, 'endColumn': 8 }
+                }
+            }
+        ]
+    };
+});
+
+after(() => {
+    disableJSDOM();
+});
+
+describe('bulk-edit-tree', () => {
+    it('initialize tree', () => {
+        bulkEditTree.initTree(workspaceEdit, fileContextsMap);
+        expect((bulkEditTree.root as BulkEditInfoNode).children.length).is.equal(2);
+    });
+});

--- a/packages/bulk-edit/src/browser/bulk-edit-tree/bulk-edit-tree.ts
+++ b/packages/bulk-edit/src/browser/bulk-edit-tree/bulk-edit-tree.ts
@@ -1,0 +1,108 @@
+/********************************************************************************
+ * Copyright (c) 2021 SAP SE or an SAP affiliate company and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import { injectable } from 'inversify';
+import { TreeNode, CompositeTreeNode, SelectableTreeNode, ExpandableTreeNode, TreeImpl } from '@theia/core/lib/browser';
+import { UriSelection } from '@theia/core/lib/common/selection';
+import { BulkEditNodeSelection } from './bulk-edit-node-selection';
+import URI from '@theia/core/lib/common/uri';
+import { WorkspaceFileEdit, WorkspaceTextEdit } from '@theia/monaco/lib/browser/monaco-workspace';
+
+@injectable()
+export class BulkEditTree extends TreeImpl {
+    public async initTree(workspaceEdit: monaco.languages.WorkspaceEdit, fileContents: Map<string, string>): Promise<void> {
+        this.root = <CompositeTreeNode>{
+            visible: false,
+            id: 'theia-bulk-edit-tree-widget',
+            name: 'BulkEditTree',
+            children: this.getChildren(workspaceEdit, fileContents),
+            parent: undefined
+        };
+    }
+
+    private getChildren(workspaceEdit: monaco.languages.WorkspaceEdit, fileContentsMap: Map<string, string>): BulkEditInfoNode[] {
+        let bulkEditInfos: BulkEditInfoNode[] = [];
+        if (workspaceEdit.edits) {
+            bulkEditInfos = workspaceEdit.edits
+                .map(edit => this.getResourcePath(edit))
+                .filter((path, index, arr) => path && arr.indexOf(path) === index)
+                .map((path: string) => this.createBulkEditInfo(path, new URI(path), fileContentsMap.get(path)))
+                .filter(Boolean);
+
+            if (bulkEditInfos.length > 0) {
+                bulkEditInfos.forEach(editInfo => {
+                    editInfo.children = workspaceEdit.edits.filter(edit => ((('resource' in edit) && edit?.resource?.path === editInfo.id)) ||
+                        (('newUri' in edit) && edit?.newUri?.path === editInfo.id))
+                        .map((edit, index) => this.createBulkEditNode(edit, index, editInfo));
+                });
+            }
+        }
+        return bulkEditInfos;
+    }
+
+    private createBulkEditNode(bulkEdit: monaco.languages.WorkspaceTextEdit | monaco.languages.WorkspaceFileEdit, index: number, parent: BulkEditInfoNode): BulkEditNode {
+        const id = parent.id + '_' + index;
+        const existing = this.getNode(id);
+        if (BulkEditNode.is(existing)) {
+            existing.bulkEdit = bulkEdit;
+            return existing;
+        }
+        return {
+            id,
+            name: 'bulkEdit',
+            parent,
+            selected: false,
+            uri: parent.uri,
+            bulkEdit
+        };
+    }
+
+    private createBulkEditInfo(id: string, uri: URI, fileContents: string | undefined): BulkEditInfoNode {
+        return {
+            id,
+            uri,
+            expanded: true,
+            selected: false,
+            parent: this.root as BulkEditInfoNode,
+            fileContents,
+            children: []
+        };
+    }
+
+    private getResourcePath(edit: monaco.languages.WorkspaceTextEdit | monaco.languages.WorkspaceFileEdit): string | undefined {
+        return WorkspaceTextEdit.is(edit) ? edit.resource.path : WorkspaceFileEdit.is(edit) && edit.newUri ? edit.newUri.path : undefined;
+    }
+}
+
+export interface BulkEditNode extends UriSelection, SelectableTreeNode {
+    parent: CompositeTreeNode;
+    bulkEdit: monaco.languages.WorkspaceTextEdit | monaco.languages.WorkspaceFileEdit;
+}
+export namespace BulkEditNode {
+    export function is(node: TreeNode | undefined): node is BulkEditNode {
+        return UriSelection.is(node) && SelectableTreeNode.is(node) && BulkEditNodeSelection.is(node);
+    }
+}
+
+export interface BulkEditInfoNode extends UriSelection, SelectableTreeNode, ExpandableTreeNode {
+    parent: CompositeTreeNode;
+    fileContents?: string;
+}
+export namespace BulkEditInfoNode {
+    export function is(node: Object | undefined): node is BulkEditInfoNode {
+        return ExpandableTreeNode.is(node) && UriSelection.is(node) && 'fileContents' in node;
+    }
+}

--- a/packages/bulk-edit/src/browser/bulk-edit-tree/in-memory-text-resource.ts
+++ b/packages/bulk-edit/src/browser/bulk-edit-tree/in-memory-text-resource.ts
@@ -1,0 +1,47 @@
+/********************************************************************************
+ * Copyright (c) 2021 SAP SE or an SAP affiliate company and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import { injectable } from 'inversify';
+import URI from '@theia/core/lib/common/uri';
+import { Resource, ResourceResolver } from '@theia/core/lib/common';
+import { MaybePromise } from '@theia/core';
+
+export const MEMORY_TEXT = 'mem-txt';
+
+/**
+ * Resource implementation for 'mem-txt' URI scheme where content is saved in URI query.
+ */
+export class InMemoryTextResource implements Resource {
+    constructor(readonly uri: URI) { }
+
+    async readContents(options?: { encoding?: string | undefined; } | undefined): Promise<string> {
+        return this.uri.query || '';
+    }
+    dispose(): void { }
+}
+
+/**
+ * ResourceResolver implementation for 'mem-txt' URI scheme.
+ */
+@injectable()
+export class InMemoryTextResourceResolver implements ResourceResolver {
+    resolve(uri: URI): MaybePromise<Resource> {
+        if (uri.scheme !== MEMORY_TEXT) {
+            throw new Error(`Expected a URI with ${MEMORY_TEXT} scheme. Was: ${uri}.`);
+        }
+        return new InMemoryTextResource(uri);
+    }
+}

--- a/packages/bulk-edit/src/browser/bulk-edit-tree/index.ts
+++ b/packages/bulk-edit/src/browser/bulk-edit-tree/index.ts
@@ -1,0 +1,22 @@
+/********************************************************************************
+ * Copyright (c) 2021 SAP SE or an SAP affiliate company and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+export * from './bulk-edit-tree';
+export * from './bulk-edit-tree-model';
+export * from './bulk-edit-node-selection';
+export * from './bulk-edit-tree-widget';
+export * from './bulk-edit-tree-container';
+export * from './in-memory-text-resource';

--- a/packages/bulk-edit/src/browser/style/bulk-edit.css
+++ b/packages/bulk-edit/src/browser/style/bulk-edit.css
@@ -1,0 +1,66 @@
+/********************************************************************************
+ * Copyright (c) 2021 SAP SE or an SAP affiliate company and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+.theia-bulk-edit-container {
+  font-size: var(--theia-ui-font-size1);
+}
+
+.theia-bulk-edit-container .bulkEditNode,
+.theia-bulk-edit-container .bulkEditInfoNode {
+  display: flex;
+  align-items: center;
+}
+
+.theia-bulk-edit-container .bulkEditNode,
+.theia-bulk-edit-container .bulkEditInfoNode {
+  width: calc(100% - 32px);
+}
+
+.theia-bulk-edit-container .bulkEditNode div,
+.theia-bulk-edit-container .bulkEditInfoNode div {
+  margin-right: 5px;
+}
+
+.theia-bulk-edit-container .bulkEditInfoNode .name,
+.theia-bulk-edit-container .bulkEditInfoNode .path {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.theia-bulk-edit-container .bulkEditInfoNode .path {
+  font-size: var(--theia-ui-font-size0);
+  color: var(--theia-descriptionForeground);
+  align-self: flex-end;
+  white-space: nowrap;
+}
+
+.theia-bulk-edit-container .bulkEditNode .message {
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.theia-bulk-edit-container .bulkEditNode .message .replaced-text {
+  text-decoration: line-through;
+  background: var(--theia-diffEditor-removedTextBackground);
+  border-color: var(--theia-diffEditor-removedTextBorder);
+}
+
+.theia-bulk-edit-container .bulkEditNode .message .inserted-text {
+  background: var(--theia-diffEditor-insertedTextBackground);
+  border: 1p solid var(--theia-diffEditor-insertedTextBorder);
+}

--- a/packages/core/src/browser/keyboard/keyboard-layout-service.ts
+++ b/packages/core/src/browser/keyboard/keyboard-layout-service.ts
@@ -99,7 +99,7 @@ export class KeyboardLayoutService {
         const layout = this.currentLayout;
         if (layout) {
             const value = layout.code2Character[key.code];
-            if (value) {
+            if (value && value.replace(/[\n\r\t]/g, '')) {
                 return value;
             }
         }

--- a/packages/editor/src/browser/editor-preferences.ts
+++ b/packages/editor/src/browser/editor-preferences.ts
@@ -805,6 +805,11 @@ const codeEditorPreferenceProperties = {
         'minimum': 0,
         'maximum': 1073741824
     },
+    'editor.rename.enablePreview': {
+        'description': 'Controls whether the editor should display refactor preview pane for rename.',
+        'type': 'boolean',
+        'default': true
+    },
     'editor.renderControlCharacters': {
         'description': 'Controls whether the editor should render control characters.',
         'type': 'boolean',

--- a/packages/monaco/src/browser/monaco-bulk-edit-service.ts
+++ b/packages/monaco/src/browser/monaco-bulk-edit-service.ts
@@ -25,8 +25,13 @@ export class MonacoBulkEditService implements monaco.editor.IBulkEditService {
 
     private _previewHandler?: monaco.editor.IBulkEditPreviewHandler;
 
-    apply(edit: monaco.languages.WorkspaceEdit): Promise<monaco.editor.IBulkEditResult & { success: boolean }> {
-        return this.workspace.applyBulkEdit(edit);
+    async apply(workspaceEdit: monaco.languages.WorkspaceEdit, options?: monaco.editor.IBulkEditOptions): Promise<monaco.editor.IBulkEditResult & { success: boolean }> {
+        if (this._previewHandler && (options?.showPreview || workspaceEdit.edits.some(value => value.metadata?.needsConfirmation))) {
+            workspaceEdit = await this._previewHandler(workspaceEdit, options);
+            return { ariaSummary: '', success: true };
+        } else {
+            return this.workspace.applyBulkEdit(workspaceEdit);
+        }
     }
 
     hasPreviewHandler(): boolean {

--- a/packages/monaco/src/browser/style/index.css
+++ b/packages/monaco/src/browser/style/index.css
@@ -105,3 +105,7 @@
     outline-offset: calc(-1*var(--theia-border-width));
     outline-color: var(--theia-focusBorder);
 }
+
+.monaco-editor .rename-box input {
+    color: var(--theia-editor-foreground);
+}

--- a/packages/monaco/src/typings/monaco/index.d.ts
+++ b/packages/monaco/src/typings/monaco/index.d.ts
@@ -102,6 +102,14 @@ declare module monaco.editor {
         removeDecorations(decorationTypeKey: string): void;
     }
 
+    // https://github.com/theia-ide/vscode/blob/standalone/0.20.x/src/vs/editor/browser/services/bulkEditService.ts#L14
+    export interface IBulkEditOptions {
+        editor?: ICodeEditor;
+        progress?: IProgress<IProgressStep>;
+        showPreview?: boolean;
+        label?: string;
+    }
+
     // https://github.com/theia-ide/vscode/blob/standalone/0.20.x/src/vs/editor/browser/services/bulkEditService.ts#L21
     export interface IBulkEditResult {
         ariaSummary: string;

--- a/packages/plugin-ext/compile.tsconfig.json
+++ b/packages/plugin-ext/compile.tsconfig.json
@@ -15,6 +15,12 @@
   ],
   "references": [
     {
+      "path": "../bulk-edit/compile.tsconfig.json"
+    },
+    {
+      "path": "../callhierarchy/compile.tsconfig.json"
+    },
+    {
       "path": "../core/compile.tsconfig.json"
     },
     {
@@ -63,13 +69,10 @@
       "path": "../terminal/compile.tsconfig.json"
     },
     {
-      "path": "../workspace/compile.tsconfig.json"
-    },
-    {
-      "path": "../callhierarchy/compile.tsconfig.json"
-    },
-    {
       "path": "../timeline/compile.tsconfig.json"
+    },
+    {
+      "path": "../workspace/compile.tsconfig.json"
     }
   ]
 }

--- a/packages/plugin-ext/package.json
+++ b/packages/plugin-ext/package.json
@@ -5,6 +5,7 @@
   "main": "lib/common/index.js",
   "typings": "lib/common/index.d.ts",
   "dependencies": {
+    "@theia/bulk-edit": "1.10.0",
     "@theia/callhierarchy": "1.10.0",
     "@theia/core": "1.10.0",
     "@theia/debug": "1.10.0",

--- a/packages/plugin-ext/src/common/plugin-api-rpc-model.ts
+++ b/packages/plugin-ext/src/common/plugin-api-rpc-model.ts
@@ -352,16 +352,31 @@ export interface CodeActionProvider {
     providedCodeActionKinds?: string[];
 }
 
+// copied from https://github.com/microsoft/vscode/blob/b165e20587dd0797f37251515bc9e4dbe513ede8/src/vs/editor/common/modes.ts
+export interface WorkspaceEditMetadata {
+    needsConfirmation: boolean;
+    label: string;
+    description?: string;
+    iconPath?: {
+        id: string;
+    } | {
+        light: UriComponents;
+        dark: UriComponents;
+    };
+}
+
 export interface WorkspaceFileEdit {
     oldUri?: UriComponents;
     newUri?: UriComponents;
     options?: { overwrite?: boolean, ignoreIfNotExists?: boolean, ignoreIfExists?: boolean, recursive?: boolean };
+    metadata?: WorkspaceEditMetadata;
 }
 
 export interface WorkspaceTextEdit {
     resource: UriComponents;
     modelVersionId?: number;
     edit: TextEdit;
+    metadata?: WorkspaceEditMetadata;
 }
 
 export interface WorkspaceEdit {

--- a/packages/plugin-ext/src/common/plugin-api-rpc.ts
+++ b/packages/plugin-ext/src/common/plugin-api-rpc.ts
@@ -1213,16 +1213,31 @@ export interface CodeActionDto {
     disabled?: string;
 }
 
+export interface WorkspaceEditMetadataDto {
+    needsConfirmation: boolean;
+    label: string;
+    description?: string;
+    iconPath?: {
+        id: string;
+    } | {
+        light: UriComponents;
+        dark: UriComponents;
+    };
+}
+
 export interface WorkspaceFileEditDto {
     oldUri?: UriComponents;
     newUri?: UriComponents;
     options?: FileOperationOptions;
+    metadata?: WorkspaceEditMetadataDto;
 }
 
 export interface WorkspaceTextEditDto {
     resource: UriComponents;
     modelVersionId?: number;
     edit: TextEdit;
+    metadata?: WorkspaceEditMetadataDto;
+
 }
 export namespace WorkspaceTextEditDto {
     export function is(arg: WorkspaceTextEditDto | WorkspaceFileEditDto): arg is WorkspaceTextEditDto {

--- a/packages/plugin-ext/src/main/browser/languages-main.ts
+++ b/packages/plugin-ext/src/main/browser/languages-main.ts
@@ -1017,9 +1017,15 @@ export function toMonacoWorkspaceEdit(data: WorkspaceEditDto | undefined): monac
     return {
         edits: (data && data.edits || []).map(edit => {
             if (WorkspaceTextEditDto.is(edit)) {
-                return { resource: monaco.Uri.revive(edit.resource), edit: edit.edit };
+                return <monaco.languages.WorkspaceTextEdit>{
+                    resource: monaco.Uri.revive(edit.resource),
+                    edit: edit.edit, metadata: edit.metadata
+                };
             } else {
-                return { newUri: monaco.Uri.revive(edit.newUri), oldUri: monaco.Uri.revive(edit.oldUri), options: edit.options };
+                return <monaco.languages.WorkspaceFileEdit>{
+                    newUri: monaco.Uri.revive(edit.newUri), oldUri: monaco.Uri.revive(edit.oldUri),
+                    options: edit.options, metadata: edit.metadata
+                };
             }
         })
     };

--- a/packages/plugin-ext/src/plugin/type-converters.ts
+++ b/packages/plugin-ext/src/plugin/type-converters.ts
@@ -506,10 +506,10 @@ export function fromWorkspaceEdit(value: theia.WorkspaceEdit, documents?: any): 
         if (Array.isArray(uriOrEdits)) {
             // text edits
             const doc = documents ? documents.getDocument(uri.toString()) : undefined;
-            result.edits.push(<WorkspaceTextEditDto>{ resource: uri, modelVersionId: doc && doc.version, edit: uriOrEdits.map(fromTextEdit)[0] }); // todo
+            result.edits.push(<WorkspaceTextEditDto>{ resource: uri, modelVersionId: doc && doc.version, edit: uriOrEdits.map(fromTextEdit)[0], metadata: entry[2] });
         } else {
             // resource edits
-            result.edits.push(<WorkspaceFileEditDto>{ oldUri: uri, newUri: uriOrEdits, options: entry[2] });
+            result.edits.push(<WorkspaceFileEditDto>{ oldUri: uri, newUri: uriOrEdits, options: entry[2], metadata: entry[3] });
         }
     }
     return result;

--- a/packages/plugin/src/theia.d.ts
+++ b/packages/plugin/src/theia.d.ts
@@ -7243,6 +7243,34 @@ declare module '@theia/plugin' {
     }
 
     /**
+     * Additional data for entries of a workspace edit. Supports to label entries and marks entries
+     * as needing confirmation by the user. The editor groups edits with equal labels into tree nodes,
+     * for instance all edits labelled with "Changes in Strings" would be a tree node.
+     */
+    export interface WorkspaceEditEntryMetadata {
+
+        /**
+         * A flag which indicates that user confirmation is needed.
+         */
+        needsConfirmation: boolean;
+
+        /**
+         * A human-readable string which is rendered prominent.
+         */
+        label: string;
+
+        /**
+         * A human-readable string which is rendered less prominent on the same line.
+         */
+        description?: string;
+
+        /**
+         * The icon path or [ThemeIcon](#ThemeIcon) for the edit.
+         */
+        iconPath?: Uri | { light: Uri; dark: Uri } | ThemeIcon;
+    }
+
+    /**
      * A workspace edit is a collection of textual and files changes for
      * multiple resources and documents.
      *
@@ -7261,8 +7289,9 @@ declare module '@theia/plugin' {
          * @param uri A resource identifier.
          * @param range A range.
          * @param newText A string.
+         * @param metadata Optional metadata for the entry.
          */
-        replace(uri: Uri, range: Range, newText: string): void;
+        replace(uri: Uri, range: Range, newText: string, metadata?: WorkspaceEditEntryMetadata): void;
 
         /**
          * Insert the given text at the given position.
@@ -7270,16 +7299,18 @@ declare module '@theia/plugin' {
          * @param uri A resource identifier.
          * @param position A position.
          * @param newText A string.
+         * @param metadata Optional metadata for the entry.
          */
-        insert(uri: Uri, position: Position, newText: string): void;
+        insert(uri: Uri, position: Position, newText: string, metadata?: WorkspaceEditEntryMetadata): void;
 
         /**
          * Delete the text at the given range.
          *
          * @param uri A resource identifier.
          * @param range A range.
+         * @param metadata Optional metadata for the entry.
          */
-        delete(uri: Uri, range: Range): void;
+        delete(uri: Uri, range: Range, metadata?: WorkspaceEditEntryMetadata): void;
 
         /**
          * Check if a text edit for a resource exists.
@@ -7311,15 +7342,17 @@ declare module '@theia/plugin' {
          * @param uri Uri of the new file..
          * @param options Defines if an existing file should be overwritten or be
          * ignored. When overwrite and ignoreIfExists are both set overwrite wins.
+         * @param metadata Optional metadata for the entry.
          */
-        createFile(uri: Uri, options?: { overwrite?: boolean, ignoreIfExists?: boolean }): void;
+        createFile(uri: Uri, options?: { overwrite?: boolean, ignoreIfExists?: boolean }, metadata?: WorkspaceEditEntryMetadata): void;
 
         /**
          * Delete a file or folder.
          *
          * @param uri The uri of the file that is to be deleted.
+         * @param metadata Optional metadata for the entry.
          */
-        deleteFile(uri: Uri, options?: { recursive?: boolean, ignoreIfNotExists?: boolean }): void;
+        deleteFile(uri: Uri, options?: { recursive?: boolean, ignoreIfNotExists?: boolean }, metadata?: WorkspaceEditEntryMetadata): void;
 
         /**
          * Rename a file or folder.
@@ -7328,8 +7361,9 @@ declare module '@theia/plugin' {
          * @param newUri The new location.
          * @param options Defines if existing files should be overwritten or be
          * ignored. When overwrite and ignoreIfExists are both set overwrite wins.
+         * @param metadata Optional metadata for the entry.
          */
-        renameFile(oldUri: Uri, newUri: Uri, options?: { overwrite?: boolean, ignoreIfExists?: boolean }): void;
+        renameFile(oldUri: Uri, newUri: Uri, options?: { overwrite?: boolean, ignoreIfExists?: boolean }, metadata?: WorkspaceEditEntryMetadata): void;
 
         /**
          * Get all text edits grouped by resource.

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -37,6 +37,9 @@
       "@theia/ext-scripts/*": [
         "dev-packages/ext-scripts/*"
       ],
+      "@theia/bulk-edit/lib/*": [
+        "packages/bulk-edit/src/*"
+      ],
       "@theia/callhierarchy/lib/*": [
         "packages/callhierarchy/src/*"
       ],


### PR DESCRIPTION
Signed-off-by: Dan Arad <dan.arad@sap.com>

#### What it does
Resolves #7989 - Adds Refactor Preview functionality.

Remarks:
These features existing in vscode were not implemented currently in this PR:
1. Checkboxes for selecting which changes to implement
2. Upon right clicking on text line in Refactor Preview pane - context menu is not displayed like in vscode.

CQ: https://dev.eclipse.org/ipzilla/show_bug.cgi?id=23016

#### How to test
1. Open ts file, click F2 for renaming a function
2. Enter new name and press Shift+Enter
3. Refactor Preview pane should open in bottom with changes
4. Press V button on pane toolbar to accept and apply changes
5. Press X button to discard changes

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

