### PR TITLE
Synchronize the state of the workspace file and runtime workspace folders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - [git] the changes in the commit details (opened from the history view) and in the diff view (opened with 'Compare With...' on a folder's context menu) are now switchable between 'list' and 'tree' modes [#8084](https://github.com/eclipse-theia/theia/pull/8084)
 - [scm] show in the commit textbox the branch to which the commit will go [#6156](https://github.com/eclipse-theia/theia/pull/6156)
+- [workspace] fixed issue where folders were incorrectly added to workspace when calling WorkspaceService.addRoot() in quick succession [8605](https://github.com/eclipse-theia/theia/pull/8605)
 
 <a name="breaking_changes_1.7.0">[Breaking Changes:](#breaking_changes_1.7.0)</a>
 

--- a/packages/workspace/src/browser/workspace-service.ts
+++ b/packages/workspace/src/browser/workspace-service.ts
@@ -417,6 +417,7 @@ export class WorkspaceService implements FrontendApplicationContribution {
             const edits = jsoncparser.format(data, undefined, { tabSize: 3, insertSpaces: true, eol: '' });
             const result = jsoncparser.applyEdits(data, edits);
             await this.fileService.write(workspaceFile.resource, result);
+            await this.updateRoots();
             return this.fileService.resolve(workspaceFile.resource);
         }
     }


### PR DESCRIPTION
Synchronize the state of the workspace file and WorkspaceService._roots when writing the workspace file

This allows calling workspaceService.addRoot() in quick succession.



Contributed by STMicroelectronics
Signed-off-by: Samuel HULTGREN <samuel.hultgren@st.com>

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
Fixes #5820

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
Run the following:
``` typescript
       for (let folder of folders) {
            await this.workspaceService.addRoot(FileUri.create(folder));
        }
```
See that all folders were correctly added to workspace

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

