### PR TITLE
vsx-registry: fix the search query based on the search parameters

### DIFF
--- a/packages/vsx-registry/src/common/vsx-registry-api.spec.ts
+++ b/packages/vsx-registry/src/common/vsx-registry-api.spec.ts
@@ -1,0 +1,83 @@
+/********************************************************************************
+ * Copyright (C) 2020 Ericsson and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import * as chai from 'chai';
+import { Container } from 'inversify';
+import { VSXRegistryAPI } from './vsx-registry-api';
+import URI from '@theia/core/lib/common/uri';
+import { VSXEnvironment } from './vsx-environment';
+import { VSXSearchParam } from './vsx-registry-types';
+
+const expect = chai.expect;
+
+describe('VSX Registry API', () => {
+
+    let api: VSXRegistryAPI;
+
+    beforeEach(() => {
+        const container = new Container();
+        container.bind(VSXRegistryAPI).toSelf().inSingletonScope();
+        container.bind(VSXEnvironment).toConstantValue(<VSXEnvironment>{
+            async getRegistryApiUri(): Promise<URI> {
+                return new URI('https://open-vsx.org/api');
+            },
+            async getRegistryUri(): Promise<URI> {
+                return new URI('https://open-vsx.org');
+            }
+        });
+        api = container.get<VSXRegistryAPI>(VSXRegistryAPI);
+    });
+
+    describe('#buildSearchUri', () => {
+
+        it('should correctly build the search URI with the single `query` parameter present', async () => {
+            const expected = 'https://open-vsx.org/api/-/search?query=javascript';
+            const param: VSXSearchParam = {
+                query: 'javascript',
+            };
+            const query = await api['buildSearchUri'](param);
+            expect(query).to.eq(expected);
+        });
+
+        it('should correctly build the search URI with the multiple search parameters present', async () => {
+            let expected = 'https://open-vsx.org/api/-/search?query=javascript&category=languages&size=20&offset=10&includeAllVersions=true';
+            let param: VSXSearchParam = {
+                query: 'javascript',
+                category: 'languages',
+                size: 20,
+                offset: 10,
+                includeAllVersions: true,
+            };
+            let query = await api['buildSearchUri'](param);
+            expect(query).to.eq(expected);
+
+            expected = 'https://open-vsx.org/api/-/search?query=javascript&category=languages&size=20&offset=10&sortOrder=desc&sortBy=relevance&includeAllVersions=true';
+            param = {
+                query: 'javascript',
+                category: 'languages',
+                size: 20,
+                offset: 10,
+                sortOrder: 'desc',
+                sortBy: 'relevance',
+                includeAllVersions: true
+            };
+            query = await api['buildSearchUri'](param);
+            expect(query).to.eq(expected);
+        });
+
+    });
+
+});

--- a/packages/vsx-registry/src/common/vsx-registry-api.ts
+++ b/packages/vsx-registry/src/common/vsx-registry-api.ts
@@ -46,27 +46,41 @@ export class VSXRegistryAPI {
     protected readonly environment: VSXEnvironment;
 
     async search(param?: VSXSearchParam): Promise<VSXSearchResult> {
+        const searchUri = await this.buildSearchUri(param);
+        return this.fetchJson<VSXSearchResult>(searchUri);
+    }
+
+    protected async buildSearchUri(param?: VSXSearchParam): Promise<string> {
         const apiUri = await this.environment.getRegistryApiUri();
         let searchUri = apiUri.resolve('-/search').toString();
         if (param) {
-            let query = '';
+            const query: string[] = [];
             if (param.query) {
-                query += 'query=' + encodeURIComponent(param.query);
+                query.push('query=' + encodeURIComponent(param.query));
             }
             if (param.category) {
-                query += 'category=' + encodeURIComponent(param.category);
+                query.push('category=' + encodeURIComponent(param.category));
             }
             if (param.size) {
-                query += 'size=' + param.size;
+                query.push('size=' + param.size);
             }
             if (param.offset) {
-                query += 'offset=' + param.offset;
+                query.push('offset=' + param.offset);
             }
-            if (query) {
-                searchUri += '?' + query;
+            if (param.sortOrder) {
+                query.push('sortOrder=' + encodeURIComponent(param.sortOrder));
+            }
+            if (param.sortBy) {
+                query.push('sortBy=' + encodeURIComponent(param.sortBy));
+            }
+            if (param.includeAllVersions) {
+                query.push('includeAllVersions=' + param.includeAllVersions);
+            }
+            if (query.length > 0) {
+                searchUri += '?' + query.join('&');
             }
         }
-        return this.fetchJson<VSXSearchResult>(searchUri);
+        return searchUri;
     }
 
     async getExtension(id: string): Promise<VSXExtensionRaw> {

--- a/packages/vsx-registry/src/common/vsx-registry-types.ts
+++ b/packages/vsx-registry/src/common/vsx-registry-types.ts
@@ -15,13 +15,41 @@
  ********************************************************************************/
 
 /**
- * Should be aligned with https://github.com/eclipse/openvsx/blob/793d0691258a6029e5ebb8cc8783b366b67d16ca/server/src/main/java/org/eclipse/openvsx/RegistryAPI.java#L192-L196
+ * The possible options when performing a search.
+ *
+ * For available options, and default values consult the `swagger`: https://open-vsx.org/swagger-ui/#/registry-api/searchUsingGET.
+ *
+ * Should be aligned with https://github.com/eclipse/openvsx/blob/b5694a712e07d266801394916bac30609e16d77b/server/src/main/java/org/eclipse/openvsx/RegistryAPI.java#L246-L266
  */
 export interface VSXSearchParam {
+    /**
+     * The query text for searching.
+     */
     query?: string;
+    /**
+     * The extension category.
+     */
     category?: string;
+    /**
+     * The maximum number of entries to return.
+     */
     size?: number;
+    /**
+     * The number of entries to skip (usually a multiple of the page size).
+     */
     offset?: number;
+    /**
+     * The sort order.
+     */
+    sortOrder?: 'asc' | 'desc';
+    /**
+     * The sort key.
+     */
+    sortBy?: 'averageRating' | 'downloadCount' | 'relevance' | 'timestamp';
+    /**
+     * Determines whether to include information regarding all available entries for the entry.
+     */
+    includeAllVersions?: boolean;
 }
 
 /**


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

The following pull-request fixes the _open-vsx_ **search** query which was previously incorrectly built when providing multiple search parameters. 
- [x] fixes the search query to support multiple search parameters.
- [x] adds unit tests for the building of the search query.
- [x] adds support for additional search parameters (`sortBy`, `sortOrder`, and `includeAllVersions`).

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

- the CI should successfully pass (build and test of the newly added unit test file).
- the functionality should work as before:
  - start the application, and navigate to the `extensions` view
  - search for an extension (it should yield results like on master)

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

Signed-off-by: vince-fugnitto <vincent.fugnitto@ericsson.com>
