### PR TITLE
Add preference to fall back to using `keyCode` for keybindings

### DIFF
--- a/packages/core/src/browser/core-preferences.ts
+++ b/packages/core/src/browser/core-preferences.ts
@@ -81,12 +81,22 @@ export const corePreferenceSchema: PreferenceSchema = {
             enum: ['onHover', 'none', 'always'],
             default: 'onHover',
             description: 'Controls whether the tree should render indent guides.'
-        }
+        },
+        'keyboard.dispatch': {
+            type: 'string',
+            enum: [
+                'code',
+                'keyCode',
+            ],
+            default: 'code',
+            description: 'Whether to interpret keypresses by the `code` of the physical key, or by the `keyCode` provided by the OS.'
+        },
     }
 };
 
 export interface CoreConfiguration {
     'application.confirmExit': 'never' | 'ifRequired' | 'always';
+    'keyboard.dispatch': 'code' | 'keyCode';
     'workbench.list.openMode': 'singleClick' | 'doubleClick';
     'workbench.commandPalette.history': number;
     'workbench.editor.highlightModifiedTabs': boolean;

--- a/packages/core/src/browser/keybinding.spec.ts
+++ b/packages/core/src/browser/keybinding.spec.ts
@@ -30,6 +30,7 @@ import { MockLogger } from '../common/test/mock-logger';
 import { StatusBar, StatusBarImpl } from './status-bar/status-bar';
 import { FrontendApplicationStateService } from './frontend-application-state';
 import { ContextKeyService } from './context-key-service';
+import { CorePreferences } from './core-preferences';
 import * as os from '../common/os';
 import * as chai from 'chai';
 import * as sinon from 'sinon';
@@ -84,6 +85,7 @@ before(async () => {
         bind(LabelParser).toSelf().inSingletonScope();
         bind(ContextKeyService).toSelf().inSingletonScope();
         bind(FrontendApplicationStateService).toSelf().inSingletonScope();
+        bind(CorePreferences).toConstantValue(<CorePreferences>{});
     });
 
     testContainer.load(module);

--- a/packages/core/src/browser/keybinding.ts
+++ b/packages/core/src/browser/keybinding.ts
@@ -25,6 +25,7 @@ import { ContributionProvider } from '../common/contribution-provider';
 import { ILogger } from '../common/logger';
 import { StatusBarAlignment, StatusBar } from './status-bar/status-bar';
 import { ContextKeyService } from './context-key-service';
+import { CorePreferences } from './core-preferences';
 import * as common from '../common/keybinding';
 
 export enum KeybindingScope {
@@ -100,6 +101,9 @@ export class KeybindingRegistry {
 
     protected readonly contexts: { [id: string]: KeybindingContext } = {};
     protected readonly keymaps: ScopedKeybinding[][] = [...Array(KeybindingScope.length)].map(() => []);
+
+    @inject(CorePreferences)
+    protected readonly corePreferences: CorePreferences;
 
     @inject(KeyboardLayoutService)
     protected readonly keyboardLayoutService: KeyboardLayoutService;
@@ -497,7 +501,8 @@ export class KeybindingRegistry {
             return;
         }
 
-        const keyCode = KeyCode.createKeyCode(event);
+        const eventDispatch = this.corePreferences['keyboard.dispatch'];
+        const keyCode = KeyCode.createKeyCode(event, eventDispatch);
         /* Keycode is only a modifier, next keycode will be modifier + key.
            Ignore this one.  */
         if (keyCode.isModifierOnly()) {

--- a/packages/core/src/browser/keyboard/keys.spec.ts
+++ b/packages/core/src/browser/keyboard/keys.spec.ts
@@ -148,6 +148,15 @@ describe('keys api', () => {
         stub.restore();
     });
 
+    it('should properly handle eventDispatch', () => {
+        const event = new KeyboardEvent('keydown', {
+            code: Key.CAPS_LOCK.code,
+        });
+        Object.defineProperty(event, 'keyCode', { get: () => Key.ESCAPE.keyCode });
+        expect(KeyCode.createKeyCode(event, 'code').toString()).to.be.equal(Key.CAPS_LOCK.easyString);
+        expect(KeyCode.createKeyCode(event, 'keyCode').toString()).to.be.equal(Key.ESCAPE.easyString);
+    });
+
     it('should serialize a keycode properly with a + M4', () => {
         const stub = sinon.stub(os, 'isOSX').value(true);
         const keyCode = KeyCode.createKeyCode({ first: Key.KEY_A, modifiers: [KeyModifier.MacCtrl] });

--- a/packages/core/src/browser/keyboard/keys.ts
+++ b/packages/core/src/browser/keyboard/keys.ts
@@ -177,7 +177,7 @@ export class KeyCode {
     /**
      * Create a KeyCode from one of several input types.
      */
-    public static createKeyCode(input: KeyboardEvent | Keystroke | KeyCodeSchema | string): KeyCode {
+    public static createKeyCode(input: KeyboardEvent | Keystroke | KeyCodeSchema | string, eventDispatch: 'code' | 'keyCode' = 'code'): KeyCode {
         if (typeof input === 'string') {
             const parts = input.split('+');
             if (!KeyCode.isModifierString(parts[0])) {
@@ -188,7 +188,7 @@ export class KeyCode {
             }
             return KeyCode.createKeyCode({ modifiers: parts as KeyModifier[] });
         } else if (KeyCode.isKeyboardEvent(input)) {
-            const key = KeyCode.toKey(input);
+            const key = KeyCode.toKey(input, eventDispatch);
             return new KeyCode({
                 key: Key.isModifier(key.code) ? undefined : key,
                 meta: isOSX && input.metaKey,
@@ -344,9 +344,9 @@ export namespace KeyCode {
      * `keyIdentifier` is used to access this deprecated field:
      * https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/keyIdentifier
      */
-    export function toKey(event: KeyboardEvent): Key {
+    export function toKey(event: KeyboardEvent, dispatch: 'code' | 'keyCode' = 'code'): Key {
         const code = event.code;
-        if (code) {
+        if (code && dispatch === 'code') {
             if (isOSX) {
                 // https://github.com/eclipse-theia/theia/issues/4986
                 const char = event.key;


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
By default, Theia interprets all [`KeyboardEvent`]()s by the `code`, property instead of `key` or `keyCode`. On Mac (#7919) and Linux (#7654), due to not handling specific user keymap customizations, this interpretation can sometimes be incorrect.

I added the preference `keyboard.dispatch` to [`CorePreferences`](https://github.com/eclipse-theia/theia/blob/fd7d9d2ff0a8c2909b7459865c06a0f447e1734f/packages/core/src/browser/core-preferences.ts#L22), which can be either `code` to use the default handling, or `keyCode` to fall back to using the `keyCode` property of `KeyboardEvent`s. This is the same workaround that is used in VSCode, due to an underlying issue with [`native-keymap`](https://www.npmjs.com/package/native-keymap) as discussed in microsoft/vscode/issues/23991.

The main logic where the keyboard event is interpreted resides in [`KeyCode.createKeyCode`](https://github.com/eclipse-theia/theia/blob/fd7d9d2ff0a8c2909b7459865c06a0f447e1734f/packages/core/src/browser/keyboard/keys.ts#L180) and [`KeyCode.toKey(event)`](https://github.com/eclipse-theia/theia/blob/fd7d9d2ff0a8c2909b7459865c06a0f447e1734f/packages/core/src/browser/keyboard/keys.ts#L347), which are static methods. Because of this I wasn't able to inject the `CorePreferences`, so I added a parameter with a default value to the methods instead. I then injected `CorePreferences` into [`KeybindingRegistry`](https://github.com/eclipse-theia/theia/blob/fd7d9d2ff0a8c2909b7459865c06a0f447e1734f/packages/core/src/browser/keybinding.ts#L96), and used the `keyboard.dispatch` preference to pass into the [callsite](https://github.com/eclipse-theia/theia/blob/fd7d9d2ff0a8c2909b7459865c06a0f447e1734f/packages/core/src/browser/keybinding.ts#L500) of `KeyCode.createKeyCode` when responding to `KeyboardEvent`s. 

There is additional code in other packages in this repo that would need to be updated to use this new parameter, however I figured I'd just do the basics to start before I get feedback on the approach I took. Maybe it would also make sense to have the key decoding handled by a service in some non static context, such as how VSCode does it? I would also be willing to give that a shot if it seems like the right direction to go.

I am new to both this codebase and TypeScript/Inversify.js, so please let me know if I'm not doing something right or if I should make any changes!

#### How to test
With `keyboard.dispatch` set to `keyCode`, #7654 and #7919 should no longer be reproducible. I was only able to test #7654 on my machine.

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

