### PR TITLE
Fix VS Code API compliance

### DIFF
--- a/packages/plugin-ext-vscode/src/node/plugin-vscode-init.ts
+++ b/packages/plugin-ext-vscode/src/node/plugin-vscode-init.ts
@@ -19,7 +19,7 @@
 import * as theia from '@theia/plugin';
 import { BackendInitializationFn, PluginAPIFactory, Plugin, emptyPlugin } from '@theia/plugin-ext';
 
-export const VSCODE_DEFAULT_API_VERSION = '1.44.0';
+export const VSCODE_DEFAULT_API_VERSION = '1.50.0';
 
 /** Set up en as a default locale for VS Code extensions using vscode-nls */
 process.env['VSCODE_NLS_CONFIG'] = JSON.stringify({ locale: 'en', availableLanguages: {} });

--- a/packages/plugin-ext/src/plugin/tasks/task-provider.ts
+++ b/packages/plugin-ext/src/plugin/tasks/task-provider.ts
@@ -22,7 +22,7 @@ export class TaskProviderAdapter {
 
     constructor(private readonly provider: theia.TaskProvider) { }
 
-    provideTasks(token?: theia.CancellationToken): Promise<TaskDto[] | undefined> {
+    provideTasks(token: theia.CancellationToken): Promise<TaskDto[] | undefined> {
         return Promise.resolve(this.provider.provideTasks(token)).then(tasks => {
             if (!Array.isArray(tasks)) {
                 return undefined;
@@ -40,7 +40,7 @@ export class TaskProviderAdapter {
         });
     }
 
-    resolveTask(task: TaskDto, token?: theia.CancellationToken): Promise<TaskDto | undefined> {
+    resolveTask(task: TaskDto, token: theia.CancellationToken): Promise<TaskDto | undefined> {
         if (typeof this.provider.resolveTask !== 'function') {
             return Promise.resolve(undefined);
         }

--- a/packages/plugin-ext/src/plugin/tasks/tasks.ts
+++ b/packages/plugin-ext/src/plugin/tasks/tasks.ts
@@ -135,7 +135,7 @@ export class TasksExtImpl implements TasksExt {
         throw new Error('Task was not successfully transformed into a task config');
     }
 
-    $provideTasks(handle: number, token?: theia.CancellationToken): Promise<TaskDto[] | undefined> {
+    $provideTasks(handle: number, token: theia.CancellationToken): Promise<TaskDto[] | undefined> {
         const adapter = this.adaptersMap.get(handle);
         if (adapter) {
             return adapter.provideTasks(token);
@@ -144,7 +144,7 @@ export class TasksExtImpl implements TasksExt {
         }
     }
 
-    $resolveTask(handle: number, task: TaskDto, token?: theia.CancellationToken): Promise<TaskDto | undefined> {
+    $resolveTask(handle: number, task: TaskDto, token: theia.CancellationToken): Promise<TaskDto | undefined> {
         const adapter = this.adaptersMap.get(handle);
         if (adapter) {
             return adapter.resolveTask(task, token);

--- a/packages/plugin/src/theia.d.ts
+++ b/packages/plugin/src/theia.d.ts
@@ -3282,7 +3282,7 @@ declare module '@theia/plugin' {
      * webview first becomes visible after the restart, this state is passed to `deserializeWebviewPanel`.
      * The extension can then restore the old `WebviewPanel` from this state.
      */
-    interface WebviewPanelSerializer {
+    interface WebviewPanelSerializer<T = unknown> {
         /**
          * Restore a webview panel from its seriailzed `state`.
          *
@@ -3294,7 +3294,7 @@ declare module '@theia/plugin' {
          *
          * @return PromiseLike indicating that the webview has been fully restored.
          */
-        deserializeWebviewPanel(webviewPanel: WebviewPanel, state: any): PromiseLike<void>;
+        deserializeWebviewPanel(webviewPanel: WebviewPanel, state: T): PromiseLike<void>;
     }
 
     /**
@@ -6510,7 +6510,7 @@ declare module '@theia/plugin' {
      * Represents a collection of [completion items](#CompletionItem) to be presented
      * in the editor.
      */
-    export class CompletionList {
+    export class CompletionList<T extends CompletionItem = CompletionItem> {
 
         /**
          * This list is not complete. Further typing should result in recomputing
@@ -6544,7 +6544,7 @@ declare module '@theia/plugin' {
      * Providers are asked for completions either explicitly by a user gesture or -depending on the configuration-
      * implicitly when typing words or trigger characters.
      */
-    export interface CompletionItemProvider {
+    export interface CompletionItemProvider<T extends CompletionItem = CompletionItem> {
 
         /**
          * Provide completion items for the given position and document.
@@ -6559,9 +6559,8 @@ declare module '@theia/plugin' {
          */
         provideCompletionItems(document: TextDocument,
             position: Position,
-            token: CancellationToken | undefined,
-            context: CompletionContext
-        ): ProviderResult<CompletionItem[] | CompletionList>;
+            token: CancellationToken,
+            context: CompletionContext): ProviderResult<T[] | CompletionList<T>>;
 
         /**
          * Given a completion item fill in more data, like [doc-comment](#CompletionItem.documentation)
@@ -6574,7 +6573,7 @@ declare module '@theia/plugin' {
          * @return The resolved completion item or a thenable that resolves to of such. It is OK to return the given
          * `item`. When no result is returned, the given `item` will be used.
          */
-        resolveCompletionItem?(item: CompletionItem, token?: CancellationToken): ProviderResult<CompletionItem>;
+        resolveCompletionItem?(item: T, token: CancellationToken): ProviderResult<T>;
     }
 
     /**
@@ -6942,7 +6941,7 @@ declare module '@theia/plugin' {
      * A code lens provider adds [commands](#Command) to source text. The commands will be shown
      * as dedicated horizontal lines in between the source text.
      */
-    export interface CodeLensProvider {
+    export interface CodeLensProvider<T extends CodeLens = CodeLens> {
         /**
          * An optional event to signal that the code lenses from this provider have changed.
          */
@@ -6957,7 +6956,7 @@ declare module '@theia/plugin' {
          * @return An array of code lenses or a thenable that resolves to such. The lack of a result can be
          * signaled by returning `undefined`, `null`, or an empty array.
          */
-        provideCodeLenses(document: TextDocument, token: CancellationToken): ProviderResult<CodeLens[]>;
+        provideCodeLenses(document: TextDocument, token: CancellationToken): ProviderResult<T[]>;
         /**
          * This function will be called for each visible code lens, usually when scrolling and after
          * calls to [compute](#CodeLensProvider.provideCodeLenses)-lenses.
@@ -6966,7 +6965,7 @@ declare module '@theia/plugin' {
          * @param token A cancellation token.
          * @return The given, resolved code lens or thenable that resolves to such.
          */
-        resolveCodeLens?(codeLens: CodeLens, token: CancellationToken): ProviderResult<CodeLens>;
+        resolveCodeLens?(codeLens: T, token: CancellationToken): ProviderResult<T>;
     }
 
     /**
@@ -7335,7 +7334,7 @@ declare module '@theia/plugin' {
      * The document link provider defines the contract between extensions and feature of showing
      * links in the editor.
      */
-    export interface DocumentLinkProvider {
+    export interface DocumentLinkProvider<T extends DocumentLink = DocumentLink> {
 
         /**
          * Provide links for the given document. Note that the editor ships with a default provider that detects
@@ -7346,7 +7345,7 @@ declare module '@theia/plugin' {
          * @return An array of [document links](#DocumentLink) or a thenable that resolves to such. The lack of a result
          * can be signaled by returning `undefined`, `null`, or an empty array.
          */
-        provideDocumentLinks(document: TextDocument, token: CancellationToken | undefined): ProviderResult<DocumentLink[]>;
+        provideDocumentLinks(document: TextDocument, token: CancellationToken): ProviderResult<T[]>;
 
         /**
          * Given a link fill in its [target](#DocumentLink.target). This method is called when an incomplete
@@ -7357,7 +7356,7 @@ declare module '@theia/plugin' {
          * @param link The link that is to be resolved.
          * @param token A cancellation token.
          */
-        resolveDocumentLink?(link: DocumentLink, token: CancellationToken | undefined): ProviderResult<DocumentLink>;
+        resolveDocumentLink?(link: T, token: CancellationToken): ProviderResult<T>;
     }
 
     /**
@@ -8999,13 +8998,13 @@ declare module '@theia/plugin' {
         detail?: string;
     }
 
-    export interface TaskProvider {
+    export interface TaskProvider<T extends Task = Task> {
         /**
          * Provides tasks.
          * @param token A cancellation token.
          * @return an array of tasks
          */
-        provideTasks(token?: CancellationToken): ProviderResult<Task[]>;
+        provideTasks(token: CancellationToken): ProviderResult<T[]>;
 
         /**
          * Resolves a task that has no [`execution`](#Task.execution) set. Tasks are
@@ -9017,7 +9016,7 @@ declare module '@theia/plugin' {
          * @param token A cancellation token.
          * @return The resolved task
          */
-        resolveTask(task: Task, token?: CancellationToken): ProviderResult<Task>;
+        resolveTask(task: T, token: CancellationToken): ProviderResult<T>;
     }
 
     /**
@@ -9198,7 +9197,7 @@ declare module '@theia/plugin' {
     /* The workspace symbol provider interface defines the contract between extensions
     * and the [symbol search](https://code.visualstudio.com/docs/editor/intellisense)-feature.
     */
-    export interface WorkspaceSymbolProvider {
+    export interface WorkspaceSymbolProvider<T extends SymbolInformation = SymbolInformation> {
 
         /**
          * Project-wide search for a symbol matching the given query string.
@@ -9218,7 +9217,7 @@ declare module '@theia/plugin' {
          * resolves to such. The lack of a result can be signaled by
          * returning undefined, null, or an empty array.
          */
-        provideWorkspaceSymbols(query: string, token: CancellationToken | undefined): ProviderResult<SymbolInformation[]>;
+        provideWorkspaceSymbols(query: string, token: CancellationToken): ProviderResult<T[]>;
 
         /**
          * Given a symbol fill in its [location](#SymbolInformation.location). This method is called whenever a symbol
@@ -9232,7 +9231,7 @@ declare module '@theia/plugin' {
          * @return The resolved symbol or a thenable that resolves to that. When no result is returned,
          * the given `symbol` is used.
          */
-        resolveWorkspaceSymbol?(symbol: SymbolInformation, token: CancellationToken | undefined): ProviderResult<SymbolInformation>;
+        resolveWorkspaceSymbol?(symbol: T, token: CancellationToken): ProviderResult<T>;
     }
 
     //#region Comments


### PR DESCRIPTION
#### What it does
Upstream vscode has added new constraints on types: https://github.com/microsoft/vscode/commit/876ea864235153f8fcbe0694ab25153970eb005f

Make it compliant

Also update default VS Code API to the current VS Code version

#### How to test
Try out plug-ins like vscode-java etc using some providers, they should work as usual

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

