### PR TITLE
Allow extenders to modify preferences

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## v1.11.0
+
+- [preferences] preferences schemas can now be modified or completely removed from the UI by downstream packages [#8626](https://github.com/eclipse-theia/theia/pull/8626)
+
 ## v1.10.0 - 1/28/2021
 
 - [api-samples] added example on how to contribute toggleable toolbar items [#8968](https://github.com/eclipse-theia/theia/pull/8968)

--- a/packages/core/src/browser/preferences/preference-contribution.ts
+++ b/packages/core/src/browser/preferences/preference-contribution.ts
@@ -20,12 +20,16 @@ import { ContributionProvider, bindContributionProvider, escapeRegExpCharacters,
 import { PreferenceScope } from './preference-scope';
 import { PreferenceProvider, PreferenceProviderDataChange } from './preference-provider';
 import {
-    PreferenceSchema, PreferenceSchemaProperties, PreferenceDataSchema, PreferenceItem, PreferenceSchemaProperty, PreferenceDataProperty, JsonType
+    PreferenceSchema, PreferenceSchemaProperties, PreferenceDataSchema, PreferenceItem, PreferenceSchemaProperty, PreferenceDataProperty, JsonType,
+    PreferenceSchemaModification, PreferenceSchemaPropertyModifications, PreferenceSchemaPropertyModification
 } from '../../common/preferences/preference-schema';
 import { FrontendApplicationConfigProvider } from '../frontend-application-config-provider';
 import { FrontendApplicationConfig } from '@theia/application-package/lib/application-props';
 import { bindPreferenceConfigurations, PreferenceConfigurations } from './preference-configurations';
-export { PreferenceSchema, PreferenceSchemaProperties, PreferenceDataSchema, PreferenceItem, PreferenceSchemaProperty, PreferenceDataProperty, JsonType };
+export {
+    PreferenceSchema, PreferenceSchemaProperties, PreferenceDataSchema, PreferenceItem, PreferenceSchemaProperty, PreferenceDataProperty, JsonType,
+    PreferenceSchemaModification
+};
 import { Mutable } from '../../common/types';
 
 /* eslint-disable guard-for-in, @typescript-eslint/no-explicit-any */
@@ -60,10 +64,16 @@ export interface PreferenceContribution {
     readonly schema: PreferenceSchema;
 }
 
+export const PreferenceModificationContribution = Symbol('PreferenceModificationContribution');
+export interface PreferenceModificationContribution {
+    readonly schemaModification: PreferenceSchemaModification;
+}
+
 export function bindPreferenceSchemaProvider(bind: interfaces.Bind): void {
     bindPreferenceConfigurations(bind);
     bind(PreferenceSchemaProvider).toSelf().inSingletonScope();
     bindContributionProvider(bind, PreferenceContribution);
+    bindContributionProvider(bind, PreferenceModificationContribution);
 }
 
 export interface OverridePreferenceName {
@@ -108,9 +118,13 @@ export class PreferenceSchemaProvider extends PreferenceProvider {
     protected readonly combinedSchema: PreferenceDataSchema = { properties: {}, patternProperties: {} };
     protected readonly workspaceSchema: PreferenceDataSchema = { properties: {}, patternProperties: {} };
     protected readonly folderSchema: PreferenceDataSchema = { properties: {}, patternProperties: {} };
+    protected readonly modifications: PreferenceSchemaPropertyModifications = {};
 
     @inject(ContributionProvider) @named(PreferenceContribution)
     protected readonly preferenceContributions: ContributionProvider<PreferenceContribution>;
+
+    @inject(ContributionProvider) @named(PreferenceModificationContribution)
+    protected readonly preferenceModificationContributions: ContributionProvider<PreferenceModificationContribution>;
 
     @inject(PreferenceConfigurations)
     protected readonly configurations: PreferenceConfigurations;
@@ -123,6 +137,9 @@ export class PreferenceSchemaProvider extends PreferenceProvider {
 
     @postConstruct()
     protected init(): void {
+        this.preferenceModificationContributions.getContributions().forEach(contrib => {
+            this.doSetSchemaModification(contrib.schemaModification);
+        });
         this.preferenceContributions.getContributions().forEach(contrib => {
             this.doSetSchema(contrib.schema);
         });
@@ -233,7 +250,8 @@ export class PreferenceSchemaProvider extends PreferenceProvider {
                 }
                 this.updateSchemaProps(preferenceName, schemaProps);
 
-                const value = schemaProps.defaultValue = this.getDefaultValue(schemaProps, preferenceName);
+                const modifiedProperties = this.schema(preferenceName, schemaProps);
+                const value = schemaProps.defaultValue = this.getDefaultValue(modifiedProperties, preferenceName);
                 if (this.testOverrideValue(preferenceName, value)) {
                     for (const overriddenPreferenceName in value) {
                         const overrideValue = value[overriddenPreferenceName];
@@ -289,8 +307,66 @@ export class PreferenceSchemaProvider extends PreferenceProvider {
         return null;
     }
 
+    protected doSetSchemaModification(schemaModification: PreferenceSchemaModification): void {
+        for (const preferenceName of Object.keys(schemaModification.properties)) {
+            const modifiableProperties = this.combinedSchema.properties[preferenceName];
+            const previousModifications = this.modifications[preferenceName] ?? {};
+            const newModifications: PreferenceSchemaPropertyModification = schemaModification.properties[preferenceName];
+            this.modifications[preferenceName] = { ...previousModifications, ...newModifications };
+
+            // Validate that the modifications only constrain the schema, cannot allow extra values
+            const modifiedEnum = newModifications.enum;
+            if (modifiedEnum !== undefined) {
+                if (modifiableProperties) {
+                    if (modifiableProperties.type !== 'string') {
+                        console.warn(`Override of preference ${preferenceName} cannot constrain to enum values because the property is not string type.`);
+                        continue;
+                    }
+                    if (modifiableProperties.enum && modifiableProperties.enum.some(v => !modifiedEnum.includes(v))) {
+                        console.warn(`Override of preference enum ${preferenceName} cannot add enum values, it can only constrain the set of values.`);
+                        continue;
+                    }
+                }
+            }
+            const modifiedMinimum = newModifications.minimum;
+            if (modifiedMinimum !== undefined) {
+                if (modifiableProperties) {
+                    if (modifiableProperties.minimum && modifiedMinimum < modifiableProperties.minimum) {
+                        console.warn(`Override of preference minimum ${preferenceName} cannot reduce the minimum, it can only increase it.`);
+                        continue;
+                    }
+                }
+            }
+        }
+    }
+
+    protected schema(preferenceName: string, propertySchema: PreferenceDataProperty): PreferenceDataProperty {
+        const modifications = this.modifications[preferenceName];
+        return modifications ? { ...propertySchema, ...modifications } : propertySchema;
+    }
+
     getCombinedSchema(): PreferenceDataSchema {
-        return this.combinedSchema;
+        const properties: { [key: string]: PreferenceDataProperty; } = {};
+        for (const preferenceName of Object.keys(this.combinedSchema.properties)) {
+            const value = this.combinedSchema.properties[preferenceName];
+            const modifications = this.modifications[preferenceName];
+            if (modifications) {
+                if (!modifications.hidden) {
+                    const modifiedValue = this.schema(preferenceName, value);
+                    properties[preferenceName] = modifiedValue;
+                }
+            } else {
+                properties[preferenceName] = value;
+            }
+        }
+        return { ...this.combinedSchema, properties };
+    }
+
+    getPropertySchema(preferenceName: string): PreferenceDataProperty | undefined {
+        const property = this.combinedSchema.properties[preferenceName];
+        if (property) {
+            return this.schema(preferenceName, property);
+        }
     }
 
     getSchema(scope: PreferenceScope): PreferenceDataSchema {
@@ -343,10 +419,10 @@ export class PreferenceSchemaProvider extends PreferenceProvider {
             }
             if (!property) {
                 // try from overridden value
-                property = this.combinedSchema.properties[overridden.preferenceName];
+                property = this.getPropertySchema(overridden.preferenceName);
             }
         } else {
-            property = this.combinedSchema.properties[preferenceName];
+            property = this.getPropertySchema(preferenceName);
         }
         return property && property.scope! >= scope;
     }
@@ -361,7 +437,7 @@ export class PreferenceSchemaProvider extends PreferenceProvider {
     }
 
     *getOverridePreferenceNames(preferenceName: string): IterableIterator<string> {
-        const preference = this.combinedSchema.properties[preferenceName];
+        const preference = this.getPropertySchema(preferenceName);
         if (preference && preference.overridable) {
             for (const overrideIdentifier of this.overrideIdentifiers) {
                 yield this.overridePreferenceName({ preferenceName, overrideIdentifier });
@@ -415,5 +491,10 @@ export class PreferenceSchemaProvider extends PreferenceProvider {
                 delete this.folderSchema.properties[key];
                 break;
         }
+    }
+
+    isPropertyHidden(preferenceName: string): boolean {
+        const modifications = this.modifications[preferenceName];
+        return modifications && !!modifications.hidden;
     }
 }

--- a/packages/core/src/common/preferences/preference-schema.ts
+++ b/packages/core/src/common/preferences/preference-schema.ts
@@ -76,6 +76,7 @@ export interface PreferenceItem {
     additionalProperties?: object | boolean;
     [name: string]: any;
     overridable?: boolean;
+    hidden?: boolean;
 }
 
 export interface PreferenceSchemaProperty extends PreferenceItem {
@@ -98,6 +99,22 @@ export namespace PreferenceDataProperty {
         }
         return <PreferenceDataProperty>schemaProps;
     }
+}
+
+export interface PreferenceSchemaModification {
+    properties: PreferenceSchemaPropertyModifications
+}
+
+export interface PreferenceSchemaPropertyModifications {
+    [name: string]: PreferenceSchemaPropertyModification
+}
+
+export interface PreferenceSchemaPropertyModification {
+    minimum?: number;
+    default?: any;
+    enum?: string[];
+    description?: string;
+    hidden?: boolean;
 }
 
 export type JsonType = 'string' | 'array' | 'number' | 'integer' | 'object' | 'boolean' | 'null';

--- a/packages/preferences/src/browser/abstract-resource-preference-provider.ts
+++ b/packages/preferences/src/browser/abstract-resource-preference-provider.ts
@@ -229,7 +229,7 @@ export abstract class AbstractResourcePreferenceProvider extends PreferenceProvi
         for (const prefName of prefNames.values()) {
             const oldValue = oldPrefs[prefName];
             const newValue = newPrefs[prefName];
-            const schemaProperties = this.schemaProvider.getCombinedSchema().properties[prefName];
+            const schemaProperties = this.schemaProvider.getPropertySchema(prefName);
             if (schemaProperties) {
                 const scope = schemaProperties.scope;
                 // do not emit the change event if the change is made out of the defined preference scope


### PR DESCRIPTION
What it does

These changes add the ability for packages to modify the preference schema for preferences added by others.  This allows extenders to make modifications to the schema for preferences added either by other packages or by plugins.  See https://community.theia-ide.org/t/hidden-settings/821 .

An additional property has been added to the preference schema: 'hidden'.  This allows extenders to remove a preference altogether from the UI.  It won't show in the preference view nor will it be included in the counts shown in that view.

Note that when a preference is created, the code reading that preference is going to assume that the preference exists and that the value meets the constraints specified in the schema.  Therefore the preference is still there, even if hidden.  Furthermore changes cannot violate the original schema.  The following changes are allowed:

- the description can be changed.
- if an enum, the enum list can be replaced by a subset.  However extra values cannot be added to the enum because that might break readers of the preference.
- if a string preference then an enum can be set to limit the string to certain values
- a minimum value can be set for numbers.  However if the preference already has a minimum then the new minimum cannot be less.
- the 'hidden' flag can be turned on or off.
- the default value can be changed (note that this can also be changed in packages.json)

#### How to test

Checkout branch modifying-prefs-test.  This branch contains an extra commit with various preferences modified.

Some of these modifications are to preferences in the git built-in plugin.  Start up without the git plugin, then install it.  You will see the plugin's preferences but with the modifications.  Uninstall the plugin and its preferences disappear.  Install the plugin and they come back again with the modifications.

Modifications always override the original preference schema, even if there is no package dependency.  However package dependency does prioritize appropriately where multiple packages are modifying the same preference.
  
#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

