### PR TITLE
chore(github): Automatically set the milestone on merged PRs

### DIFF
--- a/.github/workflows/set-milestone-on-pr.yml
+++ b/.github/workflows/set-milestone-on-pr.yml
@@ -1,0 +1,60 @@
+#
+# Copyright (c) 2020 Red Hat, Inc.  and others.
+# This program and the accompanying materials are made available under the
+# terms of the Eclipse Public License v. 2.0 which is available at
+# http://www.eclipse.org/legal/epl-2.0.
+#
+# This Source Code may also be made available under the following Secondary
+# Licenses when the conditions for such availability set forth in the Eclipse
+# Public License v. 2.0 are satisfied: GNU General Public License, version 2
+# with the GNU Classpath Exception which is available at
+# https://www.gnu.org/software/classpath/license.html.
+#
+# SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+# Set milestone on each pull request by using the next minor version
+# next version is computed using npm version tool
+on:
+  pull_request:
+    branches: [master]
+    types: [closed]
+
+jobs:
+  set-milestone:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+      - id: compute-milestone
+        run: |
+          cd packages/core
+          echo "MILESTONE_NUMBER=$(npm --no-git-tag-version version minor | cut -c 2-)" >> $GITHUB_ENV
+      - id: set
+        uses: actions/github-script@v3
+        with:
+          github-token: ${{secrets.GITHUB_TOKEN}}
+          script: |
+            // get milestone
+            const milestone = process.env.MILESTONE_NUMBER
+            console.log(`Using milestone with name ${milestone}`)
+            // check if milestone exists ?
+            const issuesGetMilestonesParams = context.repo
+
+            // search if milestone is already defined
+            const response = await github.issues.listMilestones(issuesGetMilestonesParams)
+            let githubMilestone = response.data.find(milestoneResponse => milestoneResponse.title === milestone)
+
+            // not defined, create it
+            if (!githubMilestone) {
+              const issuesCreateMilestoneParams = { owner: context.repo.owner, repo:context.repo.repo, title: milestone }
+              const createMilestoneResponse = await github.issues.createMilestone(issuesCreateMilestoneParams)
+              githubMilestone = createMilestoneResponse.data
+            }
+
+            // Grab the milestone number
+            const milestoneNumber = githubMilestone.number
+
+            // sets the milestone from the number
+            const issuesUpdateParams = { owner: context.repo.owner, repo: context.repo.repo, milestone: milestoneNumber, issue_number: context.issue.number }
+            await github.issues.update(issuesUpdateParams)


### PR DESCRIPTION
#### What it does
Automatically set milestone when merging Pull Requests
it's using version stored in `@theia/core` package and bump it using 'minor update`

Fixes https://github.com/eclipse-theia/theia/issues/8453

#### How to test
Merge this PR :-)
(if you want to test, you can copy it on your own repository and merge some PRs)
be sure to have a `packages/core/package.json` file on this repository

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

Change-Id: I24d730cd7f9fd37b928894ad9ccfd360c2d0b6fa
Signed-off-by: Florent Benoit <fbenoit@redhat.com>
