### PR TITLE
[FIX] menus are not closed when clicking inside webviews

### DIFF
--- a/packages/plugin-ext/src/main/browser/webview/pre/main.js
+++ b/packages/plugin-ext/src/main/browser/webview/pre/main.js
@@ -285,6 +285,38 @@
             });
         };
 
+        /**
+        * @param {MouseEvent} e
+        */
+        const handleInnerMousedown = (e) => {
+            host.postMessage('did-mousedown', {
+                altKey: e.altKey,
+                button: e.button,
+                buttons: e.buttons,
+                clientX: e.clientX,
+                clientY: e.clientY,
+                ctrlKey: e.ctrlKey,
+                metaKey: e.metaKey,
+                shiftKey: e.shiftKey
+            });
+        };
+
+        /**
+        * @param {MouseEvent} e
+        */
+        const handleInnerMouseup = (e) => {
+            host.postMessage('did-mouseup', {
+                altKey: e.altKey,
+                button: e.button,
+                buttons: e.buttons,
+                clientX: e.clientX,
+                clientY: e.clientY,
+                ctrlKey: e.ctrlKey,
+                metaKey: e.metaKey,
+                shiftKey: e.shiftKey
+            });
+        };
+
         function preventDefaultBrowserHotkeys(e) {
             var isOSX = navigator.platform.toUpperCase().indexOf('MAC')>=0;
 
@@ -533,6 +565,8 @@
                     newFrame.contentWindow.addEventListener('click', handleInnerClick);
                     newFrame.contentWindow.addEventListener('auxclick', handleAuxClick);
                     newFrame.contentWindow.addEventListener('keydown', handleInnerKeydown);
+                    newFrame.contentWindow.addEventListener('mousedown', handleInnerMousedown);
+                    newFrame.contentWindow.addEventListener('mouseup', handleInnerMouseup);
                     newFrame.contentWindow.addEventListener('contextmenu', e => e.preventDefault());
 
                     if (host.onIframeLoaded) {

--- a/packages/plugin-ext/src/main/browser/webview/webview.ts
+++ b/packages/plugin-ext/src/main/browser/webview/webview.ts
@@ -63,7 +63,9 @@ export const enum WebviewMessageChannels {
     loadResource = 'load-resource',
     loadLocalhost = 'load-localhost',
     webviewReady = 'webview-ready',
-    didKeydown = 'did-keydown'
+    didKeydown = 'did-keydown',
+    didMouseDown = 'did-mousedown',
+    didMouseUp = 'did-mouseup'
 }
 
 export interface WebviewContentOptions {
@@ -293,6 +295,14 @@ export class WebviewWidget extends BaseWidget implements StatefulWidget {
             // keybinding service because these events do not bubble to the parent window anymore.
             this.keybindings.dispatchKeyDown(data, this.element);
         }));
+        this.toHide.push(this.on(WebviewMessageChannels.didMouseDown, (data: MouseEvent) => {
+            // We have to dispatch mousedown events so menus will be closed when clicking inside webviews.
+            // See: https://github.com/eclipse-theia/theia/issues/7752
+            this.dispatchMouseEvent('mousedown', data);
+        }));
+        this.toHide.push(this.on(WebviewMessageChannels.didMouseUp, (data: MouseEvent) => {
+            this.dispatchMouseEvent('mouseup', data);
+        }));
 
         this.style();
         this.toHide.push(this.themeDataProvider.onDidChangeThemeData(() => this.style()));
@@ -306,6 +316,15 @@ export class WebviewWidget extends BaseWidget implements StatefulWidget {
     protected async loadLocalhost(origin: string): Promise<void> {
         const redirect = await this.getRedirect(origin);
         return this.doSend('did-load-localhost', { origin, location: redirect });
+    }
+
+    protected dispatchMouseEvent(type: string, data: MouseEvent): void {
+        const domRect = this.node.getBoundingClientRect();
+        this.node.dispatchEvent(new MouseEvent(type, {
+            ...data,
+            clientX: domRect.x + data.clientX,
+            clientY: domRect.y + data.clientY
+        }));
     }
 
     protected async getRedirect(url: string): Promise<string | undefined> {


### PR DESCRIPTION
Signed-off-by: Shahar Harari <shahar.harari@sap.com>

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
Menus are now closed when clicking inside webviews.
In order to achieve this `mousedown` event needs to be dispatched to main window. 
Fixes #7752 

#### How to test
See described steps in #7752.

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

