### PR TITLE
workspace.workspaceFolders API should return undefined when no folder is open

### DIFF
--- a/packages/plugin-ext/src/plugin/workspace.ts
+++ b/packages/plugin-ext/src/plugin/workspace.ts
@@ -66,6 +66,9 @@ export class WorkspaceExtImpl implements WorkspaceExt {
     }
 
     get workspaceFolders(): theia.WorkspaceFolder[] | undefined {
+        if (this.folders && this.folders.length === 0) {
+            return undefined;
+        }
         return this.folders;
     }
 


### PR DESCRIPTION
Signed-off-by: Artem Zatsarynnyi <azatsary@redhat.com>

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->
Makes `workspace.workspaceFolders` Plugin API returns `undefined` when no folder is opened. As it is in VS Code.

Closes https://github.com/eclipse-theia/theia/issues/8640

#### How to test
1. Put [the test plugin](https://github.com/azatsarynnyy/ws-api/blob/master/ws-api-0.0.1.vsix) into the `plugins` folder and run Theia.
2. Call `Hello World` command from the Commands Palette when no workspace folder is opened.
3. It must show the message `no workspace folders` which means the API has returned `undefined`.
With a workspace folder opened, it should display the message `ws api returns X workspace folders`

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

