### PR TITLE
Allow debug widgets to get updated when not visible

### DIFF
--- a/packages/debug/src/browser/view/debug-session-widget.ts
+++ b/packages/debug/src/browser/view/debug-session-widget.ts
@@ -109,6 +109,11 @@ export class DebugSessionWidget extends BaseWidget implements StatefulWidget, Ap
         this.toolbar.focus();
     }
 
+    protected onAfterShow(msg: Message): void {
+        super.onAfterShow(msg);
+        this.getTrackableWidgets().forEach(w => w.update());
+    }
+
     getTrackableWidgets(): Widget[] {
         return this.viewContainer.getTrackableWidgets();
     }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->
This adds a property `alwaysUpdate` to `TreeWidget` that can be used to force a widget to update even when not visible or attached. This property is used by the Widgets showing debug information to get rendered even when not visible.

Fixes: #8639.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
The easiest way to test this, would be to switch the active panel right after a debug session is terminated. This would normally prevent the debug information to get cleared, because of debug widgets not being visible. With this PR the debug widgets are correctly cleared when the debug session is terminated.

#### Review checklist

- [X] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

