### PR TITLE
[SIW] Add support to search in outside workspace content

### DIFF
--- a/packages/search-in-workspace/src/browser/search-in-workspace-service.ts
+++ b/packages/search-in-workspace/src/browser/search-in-workspace-service.ts
@@ -109,7 +109,7 @@ export class SearchInWorkspaceService implements SearchInWorkspaceClient {
 
     // Start a search of the string "what" in the workspace.
     async search(what: string, callbacks: SearchInWorkspaceCallbacks, opts?: SearchInWorkspaceOptions): Promise<number> {
-        if (!this.workspaceService.open) {
+        if (!this.workspaceService.opened) {
             throw new Error('Search failed: no workspace root.');
         }
 


### PR DESCRIPTION
#### What it does
Fixes #6867 
+ `search-in-workspace` now supports searching in files that are opened in an editor but are not in the workspace root.
+ Group those files under a root node folder `Other files` in Search view.
+ **Note:** This PR is a work based on #8579 

#### How to test
+ Open a file that is not in the workspace root directory.
+ Search for content that should be found in that file.
+ **Expected behavior:** The search result comes from that file is displayed under `Other files` node in Search view.
+ `Other files` node is only displayed when there's multi-root in the search result tree (including the `Other files` node)


#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

Signed-off-by: DukeNgn <duc.a.nguyen@ericsson.com>