### PR TITLE
core: allow customizing CommandQuickOpenItem

### DIFF
--- a/packages/core/src/browser/quick-open/quick-command-service.ts
+++ b/packages/core/src/browser/quick-open/quick-command-service.ts
@@ -16,8 +16,9 @@
 
 import { inject, injectable } from 'inversify';
 import { Command, CommandRegistry, Disposable } from '../../common';
-import { Keybinding, KeybindingRegistry } from '../keybinding';
-import { QuickOpenModel, QuickOpenItem, QuickOpenMode, QuickOpenGroupItem, QuickOpenGroupItemOptions } from './quick-open-model';
+import { Keybinding } from '../../common/keybinding';
+import { KeybindingRegistry } from '../keybinding';
+import { QuickOpenModel, QuickOpenItem, QuickOpenGroupItemOptions, QuickOpenMode, QuickOpenGroupItem } from '../../common/quick-open-model';
 import { QuickOpenOptions } from './quick-open-service';
 import { QuickOpenContribution, QuickOpenHandlerRegistry, QuickOpenHandler } from './prefix-quick-open-service';
 import { ContextKeyService } from '../context-key-service';
@@ -70,10 +71,8 @@ export class QuickCommandService implements QuickOpenModel, QuickOpenHandler {
         const { recent, other } = this.getCommands();
         this.items.push(
             ...recent.map((command, index) =>
-                new CommandQuickOpenItem(
+                this.createCommandQuickOpenItem(
                     command,
-                    this.commands,
-                    this.keybindings,
                     {
                         groupLabel: index === 0 ? 'recently used' : '',
                         showBorder: false,
@@ -81,10 +80,8 @@ export class QuickCommandService implements QuickOpenModel, QuickOpenHandler {
                 )
             ),
             ...other.map((command, index) =>
-                new CommandQuickOpenItem(
+                this.createCommandQuickOpenItem(
                     command,
-                    this.commands,
-                    this.keybindings,
                     {
                         groupLabel: recent.length > 0 && index === 0 ? 'other commands' : '',
                         showBorder: recent.length > 0 && index === 0 ? true : false,
@@ -92,6 +89,10 @@ export class QuickCommandService implements QuickOpenModel, QuickOpenHandler {
                 )
             ),
         );
+    }
+
+    protected createCommandQuickOpenItem(command: Command, commandOptions?: QuickOpenGroupItemOptions | undefined): CommandQuickOpenItem {
+        return new CommandQuickOpenItem(command, this.commands, this.keybindings, commandOptions);
     }
 
     public onType(lookFor: string, acceptor: (items: QuickOpenItem[]) => void): void {


### PR DESCRIPTION
Signed-off-by: Shahar Harari <shahar.harari@sap.com>

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->
* Allow customizing `CommandQuickOpenItem` without rewriting [init](https://github.com/eclipse-theia/theia/blob/master/packages/core/src/browser/quick-open/quick-command-service.ts#L67) method in `QuickCommandService`.
* Removed deprecated API usages in `quick-command-service`.
#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
Check that commands execution from quick-open UI still works.
#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

