### PR TITLE
fix #8669: .gitignore entries shouldn't be excluded from workspaceContains events

### DIFF
--- a/packages/plugin-ext/src/hosted/browser/hosted-plugin.ts
+++ b/packages/plugin-ext/src/hosted/browser/hosted-plugin.ts
@@ -637,7 +637,8 @@ export class HostedPluginSupport {
                     const result = await this.fileSearchService.find('', {
                         rootUris: this.workspaceService.tryGetRoots().map(r => r.resource.toString()),
                         includePatterns,
-                        limit: 1
+                        limit: 1,
+                        useGitIgnore: false
                     }, tokenSource.token);
                     return result.length > 0;
                 } catch (e) {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->
Fixes #8669: workspaceContains activation event doesn't fire if matched file found in .gitignore, it's expected behavior of ripgrep.

This PR changes arguments for fileSearchService when looking for files matched by workspaceContains pattern, adding useGitIgnore=false, in result ripgrep will run with '-uu' flag and include .gitignore entries in search results.

Impact is limited to workspaceContains activation event behavior.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
1. Create plugin with following activation events:
```
"activationEvents": [
        "workspaceContains:**/compile_commands.json"
]
```

2. Create following folder structure:
```
my-parent-repo/
   .gitignore
   modules/
       my-module/   <- workspace root
          src/
          build/
             compile_commands.json
```
3. Add following entries to .gitignore:
`**/build/*`
4. Load plugin, point workspace root to: my-parent-repo/modules/my-module/
5. Plugin should activate

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

Signed-off-by: Vladimir Fedotov <vfl@ispras.ru>
