### PR TITLE
Make CodeEditorWidget predicate injectable

### DIFF
--- a/packages/plugin-ext-vscode/src/browser/plugin-vscode-commands-contribution.ts
+++ b/packages/plugin-ext-vscode/src/browser/plugin-vscode-commands-contribution.ts
@@ -29,7 +29,9 @@ import { ApplicationShellMouseTracker } from '@theia/core/lib/browser/shell/appl
 import { CommandService } from '@theia/core/lib/common/command';
 import TheiaURI from '@theia/core/lib/common/uri';
 import { EditorManager } from '@theia/editor/lib/browser';
-import { CodeEditorWidget } from '@theia/plugin-ext/lib/main/browser/menus/menus-contribution-handler';
+import {
+    CodeEditorWidgetUtil
+} from '@theia/plugin-ext/lib/main/browser/menus/menus-contribution-handler';
 import {
     TextDocumentShowOptions,
     Location,
@@ -102,6 +104,8 @@ export class PluginVscodeCommandsContribution implements CommandContribution {
     protected readonly quickOpenWorkspace: QuickOpenWorkspace;
     @inject(TerminalService)
     protected readonly terminalService: TerminalService;
+    @inject(CodeEditorWidgetUtil)
+    protected readonly codeEditorWidgetUtil: CodeEditorWidgetUtil;
 
     registerCommands(commands: CommandRegistry): void {
         commands.registerCommand(VscodeCommands.OPEN, {
@@ -233,7 +237,7 @@ export class PluginVscodeCommandsContribution implements CommandContribution {
                         return (resourceUri && resourceUri.toString()) === uriString;
                     });
                 }
-                if (CodeEditorWidget.is(widget)) {
+                if (this.codeEditorWidgetUtil.is(widget)) {
                     await this.shell.closeWidget(widget.id);
                 }
             }
@@ -249,7 +253,7 @@ export class PluginVscodeCommandsContribution implements CommandContribution {
                     });
                 }
                 for (const widget of this.shell.widgets) {
-                    if (CodeEditorWidget.is(widget) && widget !== editor) {
+                    if (this.codeEditorWidgetUtil.is(widget) && widget !== editor) {
                         await this.shell.closeWidget(widget.id);
                     }
                 }
@@ -269,7 +273,7 @@ export class PluginVscodeCommandsContribution implements CommandContribution {
                     const tabBar = this.shell.getTabBarFor(editor);
                     if (tabBar) {
                         this.shell.closeTabs(tabBar,
-                            ({ owner }) => CodeEditorWidget.is(owner)
+                            ({ owner }) => this.codeEditorWidgetUtil.is(owner)
                         );
                     }
                 }
@@ -283,7 +287,7 @@ export class PluginVscodeCommandsContribution implements CommandContribution {
                     for (const tabBar of this.shell.allTabBars) {
                         if (tabBar !== editorTabBar) {
                             this.shell.closeTabs(tabBar,
-                                ({ owner }) => CodeEditorWidget.is(owner)
+                                ({ owner }) => this.codeEditorWidgetUtil.is(owner)
                             );
                         }
                     }
@@ -303,7 +307,7 @@ export class PluginVscodeCommandsContribution implements CommandContribution {
                                     left = false;
                                     return false;
                                 }
-                                return left && CodeEditorWidget.is(owner);
+                                return left && this.codeEditorWidgetUtil.is(owner);
                             }
                         );
                     }
@@ -323,7 +327,7 @@ export class PluginVscodeCommandsContribution implements CommandContribution {
                                     left = false;
                                     return false;
                                 }
-                                return !left && CodeEditorWidget.is(owner);
+                                return !left && this.codeEditorWidgetUtil.is(owner);
                             }
                         );
                     }
@@ -334,7 +338,7 @@ export class PluginVscodeCommandsContribution implements CommandContribution {
             execute: async () => {
                 const promises = [];
                 for (const widget of this.shell.widgets) {
-                    if (CodeEditorWidget.is(widget)) {
+                    if (this.codeEditorWidgetUtil.is(widget)) {
                         promises.push(this.shell.closeWidget(widget.id));
                     }
                 }

--- a/packages/plugin-ext/src/main/browser/menus/menus-contribution-handler.ts
+++ b/packages/plugin-ext/src/main/browser/menus/menus-contribution-handler.ts
@@ -45,11 +45,12 @@ import { TIMELINE_ITEM_CONTEXT_MENU } from '@theia/timeline/lib/browser/timeline
 import { TimelineItem } from '@theia/timeline/lib/common/timeline-model';
 
 type CodeEditorWidget = EditorWidget | WebviewWidget;
-export namespace CodeEditorWidget {
-    export function is(arg: any): arg is CodeEditorWidget {
+@injectable()
+export class CodeEditorWidgetUtil {
+    is(arg: any): arg is CodeEditorWidget {
         return arg instanceof EditorWidget || arg instanceof WebviewWidget;
     }
-    export function getResourceUri(editor: CodeEditorWidget): CodeUri | undefined {
+    getResourceUri(editor: CodeEditorWidget): CodeUri | undefined {
         const resourceUri = Navigatable.is(editor) && editor.getResourceUri();
         return resourceUri ? resourceUri['codeUri'] : undefined;
     }
@@ -88,6 +89,9 @@ export class MenusContributionPointHandler {
     @inject(ContextKeyService)
     protected readonly contextKeyService: ContextKeyService;
 
+    @inject(CodeEditorWidgetUtil)
+    protected readonly codeEditorWidgetUtil: CodeEditorWidgetUtil;
+
     handle(plugin: DeployedPlugin): Disposable {
         const allMenus = plugin.contributes && plugin.contributes.menus;
         if (!allMenus) {
@@ -104,9 +108,9 @@ export class MenusContributionPointHandler {
             } else if (location === 'editor/title') {
                 for (const action of allMenus[location]) {
                     toDispose.push(this.registerTitleAction(location, action, {
-                        execute: widget => CodeEditorWidget.is(widget) && this.commands.executeCommand(action.command, CodeEditorWidget.getResourceUri(widget)),
-                        isEnabled: widget => CodeEditorWidget.is(widget) && this.commands.isEnabled(action.command, CodeEditorWidget.getResourceUri(widget)),
-                        isVisible: widget => CodeEditorWidget.is(widget) && this.commands.isVisible(action.command, CodeEditorWidget.getResourceUri(widget))
+                        execute: widget => this.codeEditorWidgetUtil.is(widget) && this.commands.executeCommand(action.command, this.codeEditorWidgetUtil.getResourceUri(widget)),
+                        isEnabled: widget => this.codeEditorWidgetUtil.is(widget) && this.commands.isEnabled(action.command, this.codeEditorWidgetUtil.getResourceUri(widget)),
+                        isVisible: widget => this.codeEditorWidgetUtil.is(widget) && this.commands.isVisible(action.command, this.codeEditorWidgetUtil.getResourceUri(widget))
                     }));
                 }
             } else if (location === 'view/title') {

--- a/packages/plugin-ext/src/main/browser/plugin-ext-frontend-module.ts
+++ b/packages/plugin-ext/src/main/browser/plugin-ext-frontend-module.ts
@@ -35,7 +35,7 @@ import { PluginFrontendViewContribution } from './plugin-frontend-view-contribut
 import { PluginExtDeployCommandService } from './plugin-ext-deploy-command';
 import { EditorModelService } from './text-editor-model-service';
 import { UntitledResourceResolver } from './editor/untitled-resource';
-import { MenusContributionPointHandler } from './menus/menus-contribution-handler';
+import { CodeEditorWidgetUtil, MenusContributionPointHandler } from './menus/menus-contribution-handler';
 import { PluginContributionHandler } from './plugin-contribution-handler';
 import { PluginViewRegistry, PLUGIN_VIEW_CONTAINER_FACTORY_ID, PLUGIN_VIEW_FACTORY_ID, PLUGIN_VIEW_DATA_FACTORY_ID } from './view/plugin-view-registry';
 import { TextContentResourceResolver } from './workspace-main';
@@ -185,6 +185,7 @@ export default new ContainerModule((bind, unbind, isBound, rebind) => {
     bind(LabelProviderContribution).toService(PluginIconThemeService);
 
     bind(MenusContributionPointHandler).toSelf().inSingletonScope();
+    bind(CodeEditorWidgetUtil).toSelf().inSingletonScope();
     bind(KeybindingsContributionPointHandler).toSelf().inSingletonScope();
     bind(PluginContributionHandler).toSelf().inSingletonScope();
 


### PR DESCRIPTION
Signed-off-by: Amiram Wingarten <amiram.wingarten@sap.com>

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
Make CodeEditorWidget predicate injectable instead of static namespace today.

This allows downstream projects to add custom editors (not text) to the predicate and support the following scenarios for those editors:
- editor/title contribution
- command workbench.action.closeActiveEditor
- command workbench.action.closeOtherEditors
- command workbench.action.closeEditorsInGroup
- command workbench.action.closeEditorsInOtherGroups
- command workbench.action.closeEditorsToTheLeft
- command workbench.action.closeEditorsToTheRight
- command workbench.action.closeAllEditors



#### How to test

There shouldn't be any change in current behavior. Only refactor that allow customization in downstream projects.

1. git clone https://github.com/tomer-epstein/vscode-close-editor.git
2. cd vscode-close-editor && npm run compile && npm run package
3. dsploy vscode-close-editor-0.0.1.vsix to theia

- inspect that all ❤️ icon editor/title contributions still work corrently and exist only on editor and webview widgets
- inspect that all these commands still work correnctly and only affect editor and webview widgets. For example if you drag some pane into the center pane it is not affected by these command, just like before.

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

