### PR TITLE
Views: Support contributing welcome-views to empty tree view

### DIFF
--- a/packages/core/src/browser/style/tree.css
+++ b/packages/core/src/browser/style/tree.css
@@ -14,6 +14,12 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
+:root {
+    --theia-welcomeView-horizontal-padding: 20px;
+    --theia-welcomeView-elements-margin: 13px;
+    --theia-welcomeView-button-maxWidth: 260px;
+}
+
 .theia-Tree {
     overflow: hidden;
     font-size: var(--theia-ui-font-size1);
@@ -151,4 +157,35 @@
 }
 .theia-tree-node-indent.active {
     border-color: var(--theia-tree-indentGuidesStroke);
+}
+
+.theia-TreeContainer .theia-WelcomeView {
+    padding-top: var(--theia-ui-padding);
+    padding-right: var(--theia-welcomeView-horizontal-padding);
+    padding-left: var(--theia-welcomeView-horizontal-padding);
+}
+
+.theia-TreeContainer .theia-WelcomeView > * {
+    margin: var(--theia-welcomeView-elements-margin) 0;
+}
+
+.theia-TreeContainer .theia-WelcomeView .theia-WelcomeViewButtonWrapper {
+    display: flex;
+    padding: 0 var(--theia-ui-padding);
+}
+
+.theia-TreeContainer .theia-WelcomeView .theia-WelcomeViewButton {
+    width: 100%;
+    max-width: var(--theia-welcomeView-button-maxWidth);
+    margin: auto;
+}
+
+.theia-TreeContainer .theia-WelcomeView .theia-WelcomeViewCommandLink {
+    cursor: pointer;
+}
+
+.theia-TreeContainer .theia-WelcomeView .theia-WelcomeViewCommandLink.disabled {
+    pointer-events: none;
+    cursor: default;
+    opacity: var(--theia-mod-disabled-opacity);
 }

--- a/packages/core/src/browser/tree/index.ts
+++ b/packages/core/src/browser/tree/index.ts
@@ -21,6 +21,7 @@ export * from './tree-navigation';
 export * from './tree-iterator';
 export * from './tree-model';
 export * from './tree-widget';
+export * from './tree-view-welcome-widget';
 export * from './tree-container';
 export * from './tree-decorator';
 export * from './tree-search';

--- a/packages/core/src/browser/tree/tree-container.ts
+++ b/packages/core/src/browser/tree/tree-container.ts
@@ -27,6 +27,7 @@ import { TreeSearch } from './tree-search';
 import { FuzzySearch } from './fuzzy-search';
 import { SearchBox, SearchBoxFactory, SearchBoxProps } from './search-box';
 import { SearchBoxDebounce } from './search-box-debounce';
+import { TreeViewWelcomeWidget } from './tree-view-welcome-widget';
 
 export function createTreeContainer(parent: interfaces.Container, props?: Partial<TreeProps>): Container {
     const child = new Container({ defaultScope: 'Singleton' });
@@ -51,6 +52,8 @@ export function createTreeContainer(parent: interfaces.Container, props?: Partia
         ...defaultTreeProps,
         ...props
     });
+
+    child.bind(TreeViewWelcomeWidget).toSelf();
 
     child.bind(TreeSearch).toSelf().inSingletonScope();
     child.bind(FuzzySearch).toSelf().inSingletonScope();

--- a/packages/core/src/browser/tree/tree-view-welcome-widget.tsx
+++ b/packages/core/src/browser/tree/tree-view-welcome-widget.tsx
@@ -1,0 +1,263 @@
+/********************************************************************************
+ * Copyright (c) 2020 SAP SE or an SAP affiliate company and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+/*---------------------------------------------------------------------------------------------
+*  Copyright (c) Microsoft Corporation. All rights reserved.
+*  Licensed under the MIT License. See License.txt in the project root for license information.
+*--------------------------------------------------------------------------------------------*/
+// some code is copied and modified from: https://github.com/microsoft/vscode/blob/573e5145ae3b50523925a6f6315d373e649d1b06/src/vs/base/common/linkedText.ts
+
+import React = require('react');
+import { inject, injectable } from 'inversify';
+import { CommandRegistry } from '../../common';
+import { ContextKeyService } from '../context-key-service';
+import { TreeModel } from './tree-model';
+import { TreeWidget } from './tree-widget';
+import { WindowService } from '../window/window-service';
+
+interface ViewWelcome {
+    readonly view: string;
+    readonly content: string;
+    readonly when?: string;
+    readonly order: number;
+}
+
+interface IItem {
+    readonly welcomeInfo: ViewWelcome;
+    visible: boolean;
+}
+
+interface ILink {
+    readonly label: string;
+    readonly href: string;
+    readonly title?: string;
+}
+
+type LinkedTextItem = string | ILink;
+
+@injectable()
+export class TreeViewWelcomeWidget extends TreeWidget {
+
+    @inject(CommandRegistry)
+    protected readonly commands: CommandRegistry;
+
+    @inject(ContextKeyService)
+    protected readonly contextService: ContextKeyService;
+
+    @inject(WindowService)
+    protected readonly windowService: WindowService;
+
+    protected viewWelcomeNodes: React.ReactNode[] = [];
+    protected defaultItem: IItem | undefined;
+    protected items: IItem[] = [];
+    get visibleItems(): ViewWelcome[] {
+        const visibleItems = this.items.filter(v => v.visible);
+        if (visibleItems.length && this.defaultItem) {
+            return [this.defaultItem.welcomeInfo];
+        }
+        return visibleItems.map(v => v.welcomeInfo);
+    }
+
+    protected renderTree(model: TreeModel): React.ReactNode {
+        if (this.shouldShowWelcomeView() && this.visibleItems.length) {
+            return this.renderViewWelcome();
+        }
+        return super.renderTree(model);
+    }
+
+    protected shouldShowWelcomeView(): boolean {
+        return false;
+    }
+
+    protected renderViewWelcome(): React.ReactNode {
+        return (
+            <div className='theia-WelcomeView'>
+                {...this.viewWelcomeNodes}
+            </div>
+        );
+    }
+
+    handleViewWelcomeContentChange(viewWelcomes: ViewWelcome[]): void {
+        this.items = [];
+        for (const welcomeInfo of viewWelcomes) {
+            if (welcomeInfo.when === 'default') {
+                this.defaultItem = { welcomeInfo, visible: true };
+            } else {
+                const visible = welcomeInfo.when === undefined || this.contextService.match(welcomeInfo.when);
+                this.items.push({ welcomeInfo, visible });
+            }
+        }
+        this.updateViewWelcomeNodes();
+        this.update();
+    }
+
+    handleWelcomeContextChange(): void {
+        let didChange = false;
+
+        for (const item of this.items) {
+            if (!item.welcomeInfo.when || item.welcomeInfo.when === 'default') {
+                continue;
+            }
+
+            const visible = item.welcomeInfo.when === undefined || this.contextService.match(item.welcomeInfo.when);
+
+            if (item.visible === visible) {
+                continue;
+            }
+
+            item.visible = visible;
+            didChange = true;
+        }
+
+        if (didChange) {
+            this.updateViewWelcomeNodes();
+            this.update();
+        }
+    }
+
+    protected updateViewWelcomeNodes(): void {
+        this.viewWelcomeNodes = [];
+        const items = this.visibleItems.sort((a, b) => a.order - b.order);
+
+        for (const [iIndex, { content }] of items.entries()) {
+            const lines = content.split('\n');
+
+            for (let [lIndex, line] of lines.entries()) {
+                const lineKey = `${iIndex}-${lIndex}`;
+                line = line.trim();
+
+                if (!line) {
+                    continue;
+                }
+
+                const linkedTextItems = this.parseLinkedText(line);
+
+                if (linkedTextItems.length === 1 && typeof linkedTextItems[0] !== 'string') {
+                    this.viewWelcomeNodes.push(
+                        this.renderButtonNode(linkedTextItems[0], lineKey)
+                    );
+                } else {
+                    const linkedTextNodes: React.ReactNode[] = [];
+
+                    for (const [nIndex, node] of linkedTextItems.entries()) {
+                        const linkedTextKey = `${lineKey}-${nIndex}`;
+
+                        if (typeof node === 'string') {
+                            linkedTextNodes.push(
+                                this.renderTextNode(node, linkedTextKey)
+                            );
+                        } else {
+                            linkedTextNodes.push(
+                                this.renderCommandLinkNode(node, linkedTextKey)
+                            );
+                        }
+                    }
+
+                    this.viewWelcomeNodes.push(
+                        <div key={`line-${lineKey}`}>
+                            {...linkedTextNodes}
+                        </div>
+                    );
+                }
+            }
+        }
+    }
+
+    protected renderButtonNode(node: ILink, lineKey: string): React.ReactNode {
+        return (
+            <div key={`line-${lineKey}`} className='theia-WelcomeViewButtonWrapper'>
+                <button title={node.title}
+                    className='theia-button theia-WelcomeViewButton'
+                    disabled={!this.isEnabledClick(node.href)}
+                    onClick={e => this.openLinkOrCommand(e, node.href)}>
+                    {node.label}
+                </button>
+            </div>
+        );
+    }
+
+    protected renderTextNode(node: string, textKey: string): React.ReactNode {
+        return <span key={`text-${textKey}`}>{node}</span>;
+    }
+
+    protected renderCommandLinkNode(node: ILink, linkKey: string): React.ReactNode {
+        return (
+            <a key={`link-${linkKey}`}
+                className={this.getLinkClassName(node.href)}
+                title={node.title || ''}
+                onClick={e => this.openLinkOrCommand(e, node.href)}>
+                {node.label}
+            </a>
+        );
+    }
+
+    protected getLinkClassName(href: string): string {
+        const classNames = ['theia-WelcomeViewCommandLink'];
+        if (!this.isEnabledClick(href)) {
+            classNames.push('disabled');
+        }
+        return classNames.join(' ');
+    }
+
+    protected isEnabledClick(href: string): boolean {
+        if (href.startsWith('command:')) {
+            const command = href.replace('command:', '');
+            return this.commands.isEnabled(command);
+        }
+        return true;
+    }
+
+    protected openLinkOrCommand = (event: React.MouseEvent, href: string): void => {
+        event.stopPropagation();
+
+        if (href.startsWith('command:')) {
+            const command = href.replace('command:', '');
+            this.commands.executeCommand(command);
+        } else {
+            this.windowService.openNewWindow(href, { external: true });
+        }
+    };
+
+    protected parseLinkedText(text: string): LinkedTextItem[] {
+        const result: LinkedTextItem[] = [];
+
+        const linkRegex = /\[([^\]]+)\]\(((?:https?:\/\/|command:)[^\)\s]+)(?: ("|')([^\3]+)(\3))?\)/gi;
+        let index = 0;
+        let match: RegExpExecArray | null;
+
+        while (match = linkRegex.exec(text)) {
+            if (match.index - index > 0) {
+                result.push(text.substring(index, match.index));
+            }
+
+            const [, label, href, , title] = match;
+
+            if (title) {
+                result.push({ label, href, title });
+            } else {
+                result.push({ label, href });
+            }
+
+            index = match.index + match[0].length;
+        }
+
+        if (index < text.length) {
+            result.push(text.substring(index));
+        }
+
+        return result;
+    }
+}

--- a/packages/filesystem/src/browser/file-tree/file-tree-widget.tsx
+++ b/packages/filesystem/src/browser/file-tree/file-tree-widget.tsx
@@ -20,7 +20,7 @@ import { DisposableCollection, Disposable } from '@theia/core/lib/common/disposa
 import URI from '@theia/core/lib/common/uri';
 import { UriSelection } from '@theia/core/lib/common/selection';
 import { isCancelled } from '@theia/core/lib/common/cancellation';
-import { ContextMenuRenderer, NodeProps, TreeProps, TreeNode, TreeWidget, CompositeTreeNode } from '@theia/core/lib/browser';
+import { ContextMenuRenderer, NodeProps, TreeProps, TreeNode, CompositeTreeNode, TreeViewWelcomeWidget } from '@theia/core/lib/browser';
 import { FileUploadService } from '../file-upload-service';
 import { DirNode, FileStatNode, FileStatNodeData } from './file-tree';
 import { FileTreeModel } from './file-tree-model';
@@ -33,7 +33,7 @@ export const DIR_NODE_CLASS = 'theia-DirNode';
 export const FILE_STAT_ICON_CLASS = 'theia-FileStatIcon';
 
 @injectable()
-export class FileTreeWidget extends TreeWidget {
+export class FileTreeWidget extends TreeViewWelcomeWidget {
 
     protected readonly toCancelNodeExpansion = new DisposableCollection();
 

--- a/packages/plugin-ext/src/common/plugin-protocol.ts
+++ b/packages/plugin-ext/src/common/plugin-protocol.ts
@@ -73,6 +73,7 @@ export interface PluginPackageContribution {
     grammars?: PluginPackageGrammarsContribution[];
     viewsContainers?: { [location: string]: PluginPackageViewContainer[] };
     views?: { [location: string]: PluginPackageView[] };
+    viewsWelcome?: PluginPackageViewWelcome[];
     commands?: PluginPackageCommand | PluginPackageCommand[];
     menus?: { [location: string]: PluginPackageMenu[] };
     keybindings?: PluginPackageKeybinding | PluginPackageKeybinding[];
@@ -97,6 +98,12 @@ export interface PluginPackageViewContainer {
 export interface PluginPackageView {
     id: string;
     name: string;
+    when?: string;
+}
+
+export interface PluginPackageViewWelcome {
+    view: string;
+    contents: string;
     when?: string;
 }
 
@@ -476,6 +483,7 @@ export interface PluginContribution {
     grammars?: GrammarsContribution[];
     viewsContainers?: { [location: string]: ViewContainer[] };
     views?: { [location: string]: View[] };
+    viewsWelcome?: ViewWelcome[];
     commands?: PluginCommand[]
     menus?: { [location: string]: Menu[] };
     keybindings?: Keybinding[];
@@ -611,6 +619,16 @@ export interface View {
     id: string;
     name: string;
     when?: string;
+}
+
+/**
+ * View Welcome contribution
+ */
+export interface ViewWelcome {
+    view: string;
+    content: string;
+    when?: string;
+    order: number;
 }
 
 export interface PluginCommand {

--- a/packages/plugin-ext/src/main/browser/plugin-contribution-handler.ts
+++ b/packages/plugin-ext/src/main/browser/plugin-contribution-handler.ts
@@ -253,6 +253,14 @@ export class PluginContributionHandler {
             }
         }
 
+        if (contributions.viewsWelcome) {
+            for (const [index, viewWelcome] of contributions.viewsWelcome.entries()) {
+                pushContribution(`viewsWelcome.${viewWelcome.view}.${index}`,
+                    () => this.viewRegistry.registerViewWelcome(viewWelcome)
+                );
+            }
+        }
+
         if (contributions.snippets) {
             for (const snippet of contributions.snippets) {
                 pushContribution(`snippets.${snippet.uri}`, () => this.snippetSuggestProvider.fromURI(snippet.uri, {

--- a/packages/plugin-ext/src/main/browser/view/plugin-view-registry.ts
+++ b/packages/plugin-ext/src/main/browser/view/plugin-view-registry.ts
@@ -18,14 +18,14 @@ import { injectable, inject, postConstruct } from 'inversify';
 import {
     ApplicationShell, ViewContainer as ViewContainerWidget, WidgetManager,
     ViewContainerIdentifier, ViewContainerTitleOptions, Widget, FrontendApplicationContribution,
-    StatefulWidget, CommonMenus, BaseWidget
+    StatefulWidget, CommonMenus, BaseWidget, TreeViewWelcomeWidget
 } from '@theia/core/lib/browser';
-import { ViewContainer, View } from '../../../common';
+import { ViewContainer, View, ViewWelcome } from '../../../common';
 import { PluginSharedStyle } from '../plugin-shared-style';
 import { DebugWidget } from '@theia/debug/lib/browser/view/debug-widget';
 import { PluginViewWidget, PluginViewWidgetIdentifier } from './plugin-view-widget';
 import { SCM_VIEW_CONTAINER_ID, ScmContribution } from '@theia/scm/lib/browser/scm-contribution';
-import { EXPLORER_VIEW_CONTAINER_ID } from '@theia/navigator/lib/browser';
+import { EXPLORER_VIEW_CONTAINER_ID, FileNavigatorWidget, FILE_NAVIGATOR_ID } from '@theia/navigator/lib/browser';
 import { FileNavigatorContribution } from '@theia/navigator/lib/browser/navigator-contribution';
 import { DebugFrontendApplicationContribution } from '@theia/debug/lib/browser/debug-frontend-application-contribution';
 import { Disposable, DisposableCollection } from '@theia/core/lib/common/disposable';
@@ -40,12 +40,13 @@ import { PROBLEMS_WIDGET_ID } from '@theia/markers/lib/browser/problem/problem-w
 import { OUTPUT_WIDGET_KIND } from '@theia/output/lib/browser/output-widget';
 import { DebugConsoleContribution } from '@theia/debug/lib/browser/console/debug-console-contribution';
 import { TERMINAL_WIDGET_FACTORY_ID } from '@theia/terminal/lib/browser/terminal-widget-impl';
+import { TreeViewWidget } from './tree-view-widget';
 
 export const PLUGIN_VIEW_FACTORY_ID = 'plugin-view';
 export const PLUGIN_VIEW_CONTAINER_FACTORY_ID = 'plugin-view-container';
 export const PLUGIN_VIEW_DATA_FACTORY_ID = 'plugin-view-data';
 
-export type ViewDataProvider = (params: { state?: object, viewInfo: View }) => Promise<Widget>;
+export type ViewDataProvider = (params: { state?: object, viewInfo: View }) => Promise<TreeViewWidget>;
 
 @injectable()
 export class PluginViewRegistry implements FrontendApplicationContribution {
@@ -87,6 +88,7 @@ export class PluginViewRegistry implements FrontendApplicationContribution {
     readonly onDidExpandView = this.onDidExpandViewEmitter.event;
 
     private readonly views = new Map<string, [string, View]>();
+    private readonly viewsWelcome = new Map<string, ViewWelcome[]>();
     private readonly viewContainers = new Map<string, [string, ViewContainerTitleOptions]>();
     private readonly containerViews = new Map<string, string[]>();
     private readonly viewClauseContexts = new Map<string, Set<string>>();
@@ -132,6 +134,16 @@ export class PluginViewRegistry implements FrontendApplicationContribution {
                 waitUntil(this.prepareView(widget));
             }
         });
+        this.widgetManager.onDidCreateWidget(event => {
+            if (event.widget instanceof FileNavigatorWidget) {
+                this.registerViewWelcome({
+                    view: 'explorer',
+                    // eslint-disable-next-line max-len
+                    content: 'You have not yet opened a folder.\n[Open Folder](command:workbench.action.files.openFolder)',
+                    order: 0
+                });
+            }
+        });
         this.doRegisterViewContainer('test', 'left', {
             label: 'Test',
             iconClass: 'theia-plugin-test-tab-icon',
@@ -144,7 +156,23 @@ export class PluginViewRegistry implements FrontendApplicationContribution {
                     this.updateViewVisibility(view.id);
                 }
             }
+            for (const [viewId, viewWelcomes] of this.viewsWelcome) {
+                for (const [index] of viewWelcomes.entries()) {
+                    const viewWelcomeId = this.toViewWelcomeId(index, viewId);
+                    const clauseContext = this.viewClauseContexts.get(viewWelcomeId);
+                    if (clauseContext && e.affects(clauseContext)) {
+                        this.updateViewWelcomeVisibility(viewId);
+                    }
+                }
+            }
         });
+    }
+
+    protected async updateViewWelcomeVisibility(viewId: string): Promise<void> {
+        const widget = await this.getTreeViewWelcomeWidget(viewId);
+        if (widget) {
+            widget.handleWelcomeContextChange();
+        }
     }
 
     protected async updateViewVisibility(viewId: string): Promise<void> {
@@ -283,6 +311,50 @@ export class PluginViewRegistry implements FrontendApplicationContribution {
             execute: () => this.openView(view.id, { activate: true })
         }));
         return toDispose;
+    }
+
+    registerViewWelcome(viewWelcome: ViewWelcome): Disposable {
+        const toDispose = new DisposableCollection();
+
+        const viewsWelcome = this.viewsWelcome.get(viewWelcome.view) || [];
+        viewsWelcome.push(viewWelcome);
+        this.viewsWelcome.set(viewWelcome.view, viewsWelcome);
+        this.handleViewWelcomeChange(viewWelcome.view);
+        toDispose.push(Disposable.create(() => {
+            const index = viewsWelcome.indexOf(viewWelcome);
+            if (index !== -1) {
+                viewsWelcome.splice(index, 1);
+            }
+            this.handleViewWelcomeChange(viewWelcome.view);
+        }));
+
+        if (viewWelcome.when) {
+            const index = viewsWelcome.indexOf(viewWelcome);
+            const viewWelcomeId = this.toViewWelcomeId(index, viewWelcome.view);
+            this.viewClauseContexts.set(viewWelcomeId, this.contextKeyService.parseKeys(viewWelcome.when));
+            toDispose.push(Disposable.create(() => this.viewClauseContexts.delete(viewWelcomeId)));
+        }
+        return toDispose;
+    }
+
+    async handleViewWelcomeChange(viewId: string): Promise<void> {
+        const widget = await this.getTreeViewWelcomeWidget(viewId);
+        if (widget) {
+            widget.handleViewWelcomeContentChange(this.getViewWelcomes(viewId));
+        }
+    }
+
+    protected async getTreeViewWelcomeWidget(viewId: string): Promise<TreeViewWelcomeWidget | undefined> {
+        switch (viewId) {
+            case 'explorer':
+                return this.widgetManager.getWidget<TreeViewWelcomeWidget>(FILE_NAVIGATOR_ID);
+            default:
+                return this.widgetManager.getWidget<TreeViewWelcomeWidget>(PLUGIN_VIEW_DATA_FACTORY_ID, { id: viewId });
+        }
+    }
+
+    getViewWelcomes(viewId: string): ViewWelcome[] {
+        return this.viewsWelcome.get(viewId) || [];
     }
 
     async getView(viewId: string): Promise<PluginViewWidget | undefined> {
@@ -497,6 +569,10 @@ export class PluginViewRegistry implements FrontendApplicationContribution {
         return identifier.viewId;
     }
 
+    protected toViewWelcomeId(index: number, viewId: string): string {
+        return `view-welcome.${viewId}.${index}`;
+    }
+
     /**
      * retrieve restored layout state from previous user session but close widgets
      * widgets should be opened only when view data providers are registered
@@ -557,6 +633,7 @@ export class PluginViewRegistry implements FrontendApplicationContribution {
         const [, viewInfo] = view;
         const state = this.viewDataState.get(viewId);
         const widget = await provider({ state, viewInfo });
+        widget.handleViewWelcomeContentChange(this.getViewWelcomes(viewId));
         if (StatefulWidget.is(widget)) {
             this.storeViewDataStateOnDispose(viewId, widget);
         } else {


### PR DESCRIPTION
Signed-off-by: Esther Perelman <esther.perelman@sap.com>

Welcome-views can be contributed by extensions in order to be applied to empty tree views, A view is considered empty if the tree has no children.
see vscode doc: [vs-code-contributes.viewsWelcome](https://code.visualstudio.com/api/references/contribution-points#contributes.viewsWelcome)
#### What it does
Partially solves #7178  #8667  (For now supports contributing to custom-views and 'explorer' view but not the other built-in views: 'scm', 'debugger', 'test').
#### How to test
1. Deploy test extension [run-configuration.zip](https://github.com/eclipse-theia/theia/files/5452263/run-configuration.zip)
When opening it from the left menu - you should see the contributed welcome-view:
<img width="781" alt="Screenshot 2020-10-28 155722" src="https://user-images.githubusercontent.com/71729183/97446028-9691d480-1936-11eb-9e14-96a3148bf2bf.png">
2. You can now contribute more welcome-views to the run-configuration view 
by adding a viewWelcome to any extension package.json under "contributes" key, For example:

   "viewsWelcome": [{
       "view": runConfigurations,
       "contents": "In order to use git features, you can open a folder containing a git repository or clone from a URL.\n[Open Folder](command:vscode.openFolder)\n[Clone Repository](command:git.clone)\nTo learn more about how to use git and source control in VS Code [read our docs](https://aka.ms/vscode-scm).",
      }]

Now it should look like this:
<img width="712" alt="Screenshot 2020-10-28 161547" src="https://user-images.githubusercontent.com/71729183/97448188-0c973b00-1939-11eb-82d8-fc4bb0049db9.png">

You can play around... (add when clause etc...)

3. open theia without opening a workspace/folder - you should see a new welcome view in the Explorer tab, You can contribute additional views-welcome to the Explorer view by specifying "view": "explorer" .

The contentns are rendered like this: 
'/n' - for new line.
'[here goes the label](here goes a command or a link)' - If there's only a command/link in a line without any other text - it will be displayed as a button, Otherwise as a link.

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

