### PR TITLE
Do not store webview if there is no corresponding serializer

### DIFF
--- a/packages/plugin-ext/src/hosted/browser/hosted-plugin.ts
+++ b/packages/plugin-ext/src/hosted/browser/hosted-plugin.ts
@@ -197,19 +197,22 @@ export class HostedPluginSupport {
         this.taskProviderRegistry.onWillProvideTaskProvider(event => this.ensureTaskActivation(event));
         this.taskResolverRegistry.onWillProvideTaskResolver(event => this.ensureTaskActivation(event));
         this.fileService.onWillActivateFileSystemProvider(event => this.ensureFileSystemActivation(event));
+
         this.widgets.onDidCreateWidget(({ factoryId, widget }) => {
             if (factoryId === WebviewWidget.FACTORY_ID && widget instanceof WebviewWidget) {
                 const storeState = widget.storeState.bind(widget);
                 const restoreState = widget.restoreState.bind(widget);
+
                 widget.storeState = () => {
                     if (this.webviewRevivers.has(widget.viewType)) {
                         return storeState();
                     }
-                    return {};
+                    return undefined;
                 };
-                widget.restoreState = oldState => {
-                    if (oldState.viewType) {
-                        restoreState(oldState);
+
+                widget.restoreState = state => {
+                    if (state.viewType) {
+                        restoreState(state);
                         this.preserveWebview(widget);
                     } else {
                         widget.dispose();

--- a/packages/plugin-ext/src/main/browser/view/plugin-view-registry.ts
+++ b/packages/plugin-ext/src/main/browser/view/plugin-view-registry.ts
@@ -505,7 +505,10 @@ export class PluginViewRegistry implements FrontendApplicationContribution {
         const widgets = this.widgetManager.getWidgets(PLUGIN_VIEW_DATA_FACTORY_ID);
         for (const widget of widgets) {
             if (StatefulWidget.is(widget)) {
-                this.viewDataState.set(widget.id, widget.storeState());
+                const state = widget.storeState();
+                if (state) {
+                    this.viewDataState.set(widget.id, state);
+                }
             }
             widget.dispose();
         }
@@ -565,7 +568,10 @@ export class PluginViewRegistry implements FrontendApplicationContribution {
     protected storeViewDataStateOnDispose(viewId: string, widget: Widget & StatefulWidget): void {
         const dispose = widget.dispose.bind(widget);
         widget.dispose = () => {
-            this.viewDataState.set(viewId, widget.storeState());
+            const state = widget.storeState();
+            if (state) {
+                this.viewDataState.set(viewId, state);
+            }
             dispose();
         };
     }

--- a/packages/plugin-ext/src/main/browser/webviews-main.ts
+++ b/packages/plugin-ext/src/main/browser/webviews-main.ts
@@ -34,7 +34,7 @@ export class WebviewsMainImpl implements WebviewsMain, Disposable {
 
     private readonly proxy: WebviewsExt;
     protected readonly shell: ApplicationShell;
-    protected readonly widgets: WidgetManager;
+    protected readonly widgetManager: WidgetManager;
     protected readonly pluginService: HostedPluginSupport;
     protected readonly viewColumnService: ViewColumnService;
     private readonly toDispose = new DisposableCollection();
@@ -43,7 +43,7 @@ export class WebviewsMainImpl implements WebviewsMain, Disposable {
         this.proxy = rpc.getProxy(MAIN_RPC_CONTEXT.WEBVIEWS_EXT);
         this.shell = container.get(ApplicationShell);
         this.viewColumnService = container.get(ViewColumnService);
-        this.widgets = container.get(WidgetManager);
+        this.widgetManager = container.get(WidgetManager);
         this.pluginService = container.get(HostedPluginSupport);
         this.toDispose.push(this.shell.onDidChangeActiveWidget(() => this.updateViewStates()));
         this.toDispose.push(this.shell.onDidChangeCurrentWidget(() => this.updateViewStates()));
@@ -61,7 +61,7 @@ export class WebviewsMainImpl implements WebviewsMain, Disposable {
         showOptions: WebviewPanelShowOptions,
         options: WebviewPanelOptions & WebviewOptions
     ): Promise<void> {
-        const view = await this.widgets.getOrCreateWidget<WebviewWidget>(WebviewWidget.FACTORY_ID, <WebviewWidgetIdentifier>{ id: panelId });
+        const view = await this.widgetManager.getOrCreateWidget<WebviewWidget>(WebviewWidget.FACTORY_ID, <WebviewWidgetIdentifier>{ id: panelId });
         this.hookWebview(view);
         view.viewType = viewType;
         view.title.label = title;
@@ -217,7 +217,7 @@ export class WebviewsMainImpl implements WebviewsMain, Disposable {
     }
 
     protected readonly updateViewStates = debounce(() => {
-        for (const widget of this.widgets.getWidgets(WebviewWidget.FACTORY_ID)) {
+        for (const widget of this.widgetManager.getWidgets(WebviewWidget.FACTORY_ID)) {
             if (widget instanceof WebviewWidget) {
                 this.updateViewState(widget);
             }
@@ -251,7 +251,7 @@ export class WebviewsMainImpl implements WebviewsMain, Disposable {
     }
 
     private async tryGetWebview(id: string): Promise<WebviewWidget | undefined> {
-        return this.widgets.getWidget<WebviewWidget>(WebviewWidget.FACTORY_ID, <WebviewWidgetIdentifier>{ id });
+        return this.widgetManager.getWidget<WebviewWidget>(WebviewWidget.FACTORY_ID, <WebviewWidgetIdentifier>{ id });
     }
 
 }


### PR DESCRIPTION
Signed-off-by: Vitaliy Gulyy <vgulyy@redhat.com>

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

This PR is a duplicate of previously closed https://github.com/eclipse-theia/theia/pull/8473

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->
- Disables saving of the webview state if the plugin don't register an apropriate theia.WebviewPanelSerializer.
- Fixes an error with restoring the editor area when a webview and several editors are opened.

Video demonstrating bug https://www.youtube.com/watch?v=9ir1hTov350

Fixes https://github.com/eclipse-theia/theia/issues/8620 and https://github.com/eclipse-theia/theia/issues/6877

This is another approach in comparing with https://github.com/eclipse-theia/theia/pull/8621
In #8621 Theia stores the empty state for the webview and tries to find the serializer when restoring the state.
In this PR, Theia checks for the theia.WebviewPanelSerializer, and does not store the webview  to the layout at all if the serializer is not found.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

To test it you need to have a plugin which opens a webview, but don't register `vscode.WebviewPanelSerializer` for this webview.
I used this one https://github.com/vitaliy-guliy/greeting-extension, which opens a Greeting webview each time when Theia starts.

Steps to reproduce:
- run Theia with the plugin, open the browser. Greeting plugin will open the webview after startup.
- open few files, Greeting tab must be stay first
- reload the browser

Opened flies must be restored, the order of files must be saved. As the webview is not persisted, after reloading it will be opened again next to active tab.

Follow 'Steps to reproduce' in the original issue https://github.com/eclipse-theia/theia/issues/8620

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

