### PR TITLE
tasks: Add `CancellationToken` to `provideTasks()`

### DIFF
--- a/packages/plugin-ext/src/plugin/tasks/tasks.ts
+++ b/packages/plugin-ext/src/plugin/tasks/tasks.ts
@@ -27,6 +27,7 @@ import { Disposable } from '../types-impl';
 import { RPCProtocol, ConnectionClosedError } from '../../common/rpc-protocol';
 import { TaskProviderAdapter } from './task-provider';
 import { Emitter, Event } from '@theia/core/lib/common/event';
+import { CancellationToken } from '@theia/core/lib/common/cancellation';
 
 export class TasksExtImpl implements TasksExt {
     private proxy: TasksMain;
@@ -135,7 +136,7 @@ export class TasksExtImpl implements TasksExt {
         throw new Error('Task was not successfully transformed into a task config');
     }
 
-    $provideTasks(handle: number, token: theia.CancellationToken): Promise<TaskDto[] | undefined> {
+    $provideTasks(handle: number, token: theia.CancellationToken = CancellationToken.None): Promise<TaskDto[] | undefined> {
         const adapter = this.adaptersMap.get(handle);
         if (adapter) {
             return adapter.provideTasks(token);


### PR DESCRIPTION
#### What it does
Fixes #8662 
+ Add `CancellationToken` default value to `provideTasks()`

#### How to test
+ Download v 1.50.1 of [TypeScript and JavaScript Language Features](https://open-vsx.org/extension/vscode/typescript-language-features)
+ Replace the built-ins in your /plugins folder with that version
+ Start a workspace containing a typescript plugin
+ No errors output

#### Review checklist

- [ ] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

Signed-off-by: Duc Nguyen <duc.a.nguyen@ericsson.com>