### PR TITLE
Use 'viewId' as progress location

### DIFF
--- a/packages/plugin-ext/src/main/browser/view/plugin-view-registry.ts
+++ b/packages/plugin-ext/src/main/browser/view/plugin-view-registry.ts
@@ -484,7 +484,7 @@ export class PluginViewRegistry implements FrontendApplicationContribution {
     }
 
     protected toViewContainerIdentifier(viewContainerId: string): ViewContainerIdentifier {
-        return { id: PLUGIN_VIEW_CONTAINER_FACTORY_ID + ':' + viewContainerId };
+        return { id: PLUGIN_VIEW_CONTAINER_FACTORY_ID + ':' + viewContainerId, progressLocationId: viewContainerId };
     }
     protected toViewContainerId(identifier: ViewContainerIdentifier): string {
         return identifier.id.substr(PLUGIN_VIEW_CONTAINER_FACTORY_ID.length + 1);

--- a/packages/plugin-ext/src/plugin/notification.ts
+++ b/packages/plugin-ext/src/plugin/notification.ts
@@ -48,8 +48,12 @@ export class NotificationExtImpl implements NotificationExt {
         return progress;
     }
 
-    protected mapLocation(pluginLocation: ProgressLocation): string | undefined {
-        switch (pluginLocation) {
+    protected mapLocation(location: ProgressLocation | { viewId: string }): string | undefined {
+        if (typeof location === 'object') {
+            return location.viewId;
+        }
+
+        switch (location) {
             case ProgressLocation.Notification: return 'notification';
             case ProgressLocation.SourceControl: return 'scm';
             case ProgressLocation.Window: return 'window';

--- a/packages/plugin/src/theia.d.ts
+++ b/packages/plugin/src/theia.d.ts
@@ -4181,7 +4181,7 @@ declare module '@theia/plugin' {
         /**
          * The location at which progress should show.
          */
-        location: ProgressLocation;
+        location: ProgressLocation | { viewId: string };
         /**
          * A human-readable string which will be used to describe the
          * operation.


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->
At the moment it's possible to use [ProgressLocation](https://github.com/eclipse-theia/theia/blob/bdc9aa276cb55e5cf3dc8d7cb6e795ed8ffba998/packages/plugin/src/theia.d.ts#L4172-L4185) enum only as a location at which progress should show.
The PR is aligning [location field](https://github.com/eclipse-theia/theia/blob/bdc9aa276cb55e5cf3dc8d7cb6e795ed8ffba998/packages/plugin/src/theia.d.ts#L4154) to [the corresponding field](https://github.com/microsoft/vscode/blob/ad1dc7f87a94edc1d06cbeb2261459f2764b2c43/src/vs/vscode.d.ts#L9181) of VS Code to provide an opportunity to use `viewId` as progress location.


#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

I created a [test plugin](https://github.com/RomanNikitenko/progress-test-plugin), it contains [commands](https://github.com/RomanNikitenko/progress-test-plugin/blob/bbed24e827e73ee4ae41391010eeb3abb7ea0f25/src/progress-test-plugin-backend.ts#L31-L57) for testing
1. Please clone the plugin and build it using yarn.
2. Copy the plugin to `theia/plugins` folder. 
3. Use the following commands from Command Palette (F1) for testing: 
- Start progress for Explorer view
- Start progress for Search view
- Start progress for Debug view
- Start progress for SCM view

First 3 commands use `viewId` (new behavior) to show progress while running the given callback, the last command uses [ProgressLocation](https://github.com/eclipse-theia/theia/blob/bdc9aa276cb55e5cf3dc8d7cb6e795ed8ffba998/packages/plugin/src/theia.d.ts#L4172-L4185) enum to show progress for SCM view (existed behavior). 

![progress_API](https://user-images.githubusercontent.com/5676062/97958753-88b8d500-1db6-11eb-8d24-e3fbf5600d4c.gif)

4. Use case for a custom view is described here https://github.com/eclipse-theia/theia/pull/8700#issuecomment-721078069 - thanks a lot @kittaakos for the case and the extension for testing 
#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

Signed-off-by: Roman Nikitenko <rnikiten@redhat.com>