### PR TITLE
[Fix] Webview is covered with transparent overlay when clicking inside it

### DIFF
--- a/packages/plugin-ext/src/main/browser/webview/webview.ts
+++ b/packages/plugin-ext/src/main/browser/webview/webview.ts
@@ -320,7 +320,7 @@ export class WebviewWidget extends BaseWidget implements StatefulWidget {
 
     protected dispatchMouseEvent(type: string, data: MouseEvent): void {
         const domRect = this.node.getBoundingClientRect();
-        this.node.dispatchEvent(new MouseEvent(type, {
+        document.dispatchEvent(new MouseEvent(type, {
             ...data,
             clientX: domRect.x + data.clientX,
             clientY: domRect.y + data.clientY


### PR DESCRIPTION
Signed-off-by: Shahar Harari <shahar.harari@sap.com>

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
When clicking inside webviews a mousedown event is dispatched on webview node. This logic was added #8633 in order to fix #7752.
The problem is that eventually also application shell mousedown event is fired, which causes the webview to be covered by a transparent overlay:
https://github.com/eclipse-theia/theia/blob/d295e4642d41b79c9f1e51cda6029f80dbba2e22/packages/plugin-ext/src/main/browser/webview/webview.ts#L187-L191
This transparent overlay disrupts interaction with webview UI.
 
The solution is to dispatch the `mousedown` event on document instead of on webview node, and by that prevent the application shell mousedown event from being fired.

Fixes #8702. There can also be similar issues with other webviews. 

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
* See described steps is #8702.
* Check that menus are still closing when clicking inside webviews. see described steps in #7752.

#### Review checklist

- [X] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

