### PR TITLE
4016-debug-extension: support debugging of extensions using Debug panel 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -121,6 +121,7 @@
 - [core] updated `nsfw` dependency to `^2.1.2` [#9267](https://github.com/eclipse-theia/theia/pull/9267)
 - [debug] fixed hover issues for the `currentFrame` editor [#9256](https://github.com/eclipse-theia/theia/pull/9256)
 - [debug] improved error messages [#9386](https://github.com/eclipse-theia/theia/pull/9386)
+- [debug] added support for managing debug sessions for extensions from debug panel (previously only possible using `Hosted Plugin` commands) [#8706](https://github.com/eclipse-theia/theia/pull/8706)
 - [documentation] added roadmap information to the readme [#9308](https://github.com/eclipse-theia/theia/pull/9308)
 - [documentation] updated pre-publishing steps [#9257](https://github.com/eclipse-theia/theia/pull/9257)
 - [editor-preview] updated logic to activate editor-preview editors only if already active [#9346](https://github.com/eclipse-theia/theia/pull/9346)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 [1.16.0 Milestone](https://github.com/eclipse-theia/theia/milestone/22)
 
  - [workspace] added support for multiple selections in 'Add folder to workspace' dialog. [#9684](https://github.com/eclipse-theia/theia/pull/9684)
+ - [debug] added support for managing debug sessions for extensions from debug panel (previously only possible using `Hosted Plugin` commands) [#8706](https://github.com/eclipse-theia/theia/pull/8706)
 
 <a name="breaking_changes_1.16.0">[Breaking Changes:](#breaking_changes_1.16.0)</a>
 
@@ -121,7 +122,6 @@
 - [core] updated `nsfw` dependency to `^2.1.2` [#9267](https://github.com/eclipse-theia/theia/pull/9267)
 - [debug] fixed hover issues for the `currentFrame` editor [#9256](https://github.com/eclipse-theia/theia/pull/9256)
 - [debug] improved error messages [#9386](https://github.com/eclipse-theia/theia/pull/9386)
-- [debug] added support for managing debug sessions for extensions from debug panel (previously only possible using `Hosted Plugin` commands) [#8706](https://github.com/eclipse-theia/theia/pull/8706)
 - [documentation] added roadmap information to the readme [#9308](https://github.com/eclipse-theia/theia/pull/9308)
 - [documentation] updated pre-publishing steps [#9257](https://github.com/eclipse-theia/theia/pull/9257)
 - [editor-preview] updated logic to activate editor-preview editors only if already active [#9346](https://github.com/eclipse-theia/theia/pull/9346)

--- a/packages/debug/src/browser/debug-contribution.ts
+++ b/packages/debug/src/browser/debug-contribution.ts
@@ -1,0 +1,49 @@
+/********************************************************************************
+ * Copyright (c) 2021 SAP SE or an SAP affiliate company and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import { DebugProtocol } from 'vscode-debugprotocol';
+import { DebugSessionConnection } from './debug-session-connection';
+
+export const DebugContribution = Symbol('DebugContribution');
+
+export interface DebugContribution {
+    register(configType: string, connection: DebugSessionConnection): void;
+}
+
+export interface DebugPluginConfiguration {
+    debugMode?: string;
+    pluginLocation?: string;
+    debugPort?: string;
+}
+
+// copied from https://github.com/microsoft/vscode-node-debug2/blob/bcd333ef87642b817ac96d28fde7ab96fee3f6a9/src/nodeDebugInterfaces.d.ts
+export interface LaunchVSCodeRequest extends DebugProtocol.Request {
+    arguments: LaunchVSCodeArguments;
+}
+
+export interface LaunchVSCodeArguments {
+    args: LaunchVSCodeArgument[];
+    env?: { [key: string]: string | null; };
+}
+
+export interface LaunchVSCodeArgument {
+    prefix?: string;
+    path?: string;
+}
+
+export interface LaunchVSCodeResult {
+    rendererDebugPort?: number;
+}

--- a/packages/debug/src/browser/debug-frontend-application-contribution.ts
+++ b/packages/debug/src/browser/debug-frontend-application-contribution.ts
@@ -611,11 +611,11 @@ export class DebugFrontendApplicationContribution extends AbstractViewContributi
             execute: (config?: DebugSessionOptions) => this.start(true, config)
         });
         registry.registerCommand(DebugCommands.STOP, {
-            execute: () => this.manager.currentSession && this.manager.currentSession.terminate(),
+            execute: () => this.manager.terminateSessions(),
             isEnabled: () => this.manager.state !== DebugState.Inactive
         });
         registry.registerCommand(DebugCommands.RESTART, {
-            execute: () => this.manager.restart(),
+            execute: () => this.manager.restartSessions(),
             isEnabled: () => this.manager.state !== DebugState.Inactive
         });
 

--- a/packages/debug/src/browser/debug-frontend-module.ts
+++ b/packages/debug/src/browser/debug-frontend-module.ts
@@ -60,8 +60,11 @@ import { JsonSchemaContribution } from '@theia/core/lib/browser/json-schema-stor
 import { TabBarDecorator } from '@theia/core/lib/browser/shell/tab-bar-decorator';
 import { DebugTabBarDecorator } from './debug-tab-bar-decorator';
 import { QuickAccessContribution } from '@theia/core/lib/browser/quick-input/quick-access-contribution';
+import { DebugContribution } from './debug-contribution';
 
 export default new ContainerModule((bind: interfaces.Bind) => {
+    bindContributionProvider(bind, DebugContribution);
+
     bind(DebugCallStackItemTypeKey).toDynamicValue(({ container }) =>
         container.get(ContextKeyService).createKey('callStackItemType', undefined)
     ).inSingletonScope();

--- a/packages/debug/src/browser/debug-session-contribution.ts
+++ b/packages/debug/src/browser/debug-session-contribution.ts
@@ -30,6 +30,7 @@ import { IWebSocket } from '@theia/core/shared/vscode-ws-jsonrpc';
 import { DebugAdapterPath } from '../common/debug-service';
 import { ContributionProvider } from '@theia/core/lib/common/contribution-provider';
 import { FileService } from '@theia/filesystem/lib/browser/file-service';
+import { DebugContribution } from './debug-contribution';
 
 /**
  * DebugSessionContribution symbol for DI.
@@ -50,7 +51,6 @@ export interface DebugSessionContribution {
      */
     debugSessionFactory(): DebugSessionFactory;
 }
-
 /**
  * DebugSessionContributionRegistry symbol for DI.
  */
@@ -95,7 +95,6 @@ export interface DebugSessionFactory {
 
 @injectable()
 export class DefaultDebugSessionFactory implements DebugSessionFactory {
-
     @inject(WebSocketConnectionProvider)
     protected readonly connectionProvider: WebSocketConnectionProvider;
     @inject(TerminalService)
@@ -114,6 +113,8 @@ export class DefaultDebugSessionFactory implements DebugSessionFactory {
     protected readonly debugPreferences: DebugPreferences;
     @inject(FileService)
     protected readonly fileService: FileService;
+    @inject(ContributionProvider) @named(DebugContribution)
+    protected readonly debugContributionProvider: ContributionProvider<DebugContribution>;
 
     get(sessionId: string, options: DebugSessionOptions): DebugSession {
         const connection = new DebugSessionConnection(
@@ -133,7 +134,8 @@ export class DefaultDebugSessionFactory implements DebugSessionFactory {
             this.breakpoints,
             this.labelProvider,
             this.messages,
-            this.fileService);
+            this.fileService,
+            this.debugContributionProvider);
     }
 
     protected getTraceOutputChannel(): OutputChannel | undefined {

--- a/packages/debug/src/browser/debug-session-manager.ts
+++ b/packages/debug/src/browser/debug-session-manager.ts
@@ -306,6 +306,16 @@ export class DebugSessionManager {
         return this.start(options);
     }
 
+    async terminateSessions(): Promise<void> {
+        this.updateCurrentSession(undefined);
+        this.currentSession?.terminate();
+    }
+
+    async restartSessions(): Promise<void> {
+        this.updateCurrentSession(undefined);
+        this.currentSession?.restart();
+    }
+
     protected remove(sessionId: string): void {
         this._sessions.delete(sessionId);
         const { currentSession } = this;

--- a/packages/debug/src/browser/debug-session.tsx
+++ b/packages/debug/src/browser/debug-session.tsx
@@ -19,7 +19,7 @@
 import * as React from '@theia/core/shared/react';
 import { LabelProvider } from '@theia/core/lib/browser';
 import { DebugProtocol } from 'vscode-debugprotocol';
-import { Emitter, Event, DisposableCollection, Disposable, MessageClient, MessageType, Mutable } from '@theia/core/lib/common';
+import { Emitter, Event, DisposableCollection, Disposable, MessageClient, MessageType, Mutable, ContributionProvider } from '@theia/core/lib/common';
 import { TerminalService } from '@theia/terminal/lib/browser/base/terminal-service';
 import { EditorManager } from '@theia/editor/lib/browser';
 import { CompositeTreeElement } from '@theia/core/lib/browser/source-tree';
@@ -39,6 +39,7 @@ import { SourceBreakpoint, ExceptionBreakpoint } from './breakpoint/breakpoint-m
 import { TerminalWidgetOptions, TerminalWidget } from '@theia/terminal/lib/browser/base/terminal-widget';
 import { DebugFunctionBreakpoint } from './model/debug-function-breakpoint';
 import { FileService } from '@theia/filesystem/lib/browser/file-service';
+import { DebugContribution } from './debug-contribution';
 
 export enum DebugState {
     Inactive,
@@ -49,7 +50,6 @@ export enum DebugState {
 
 // FIXME: make injectable to allow easily inject services
 export class DebugSession implements CompositeTreeElement {
-
     protected readonly onDidChangeEmitter = new Emitter<void>();
     readonly onDidChange: Event<void> = this.onDidChangeEmitter.event;
     protected fireDidChange(): void {
@@ -73,8 +73,12 @@ export class DebugSession implements CompositeTreeElement {
         protected readonly breakpoints: BreakpointManager,
         protected readonly labelProvider: LabelProvider,
         protected readonly messages: MessageClient,
-        protected readonly fileService: FileService) {
+        protected readonly fileService: FileService,
+        protected readonly debugContributionProvider: ContributionProvider<DebugContribution>
+    ) {
         this.connection.onRequest('runInTerminal', (request: DebugProtocol.RunInTerminalRequest) => this.runInTerminal(request));
+        this.registerDebugContributions(options.configuration.type, this.connection);
+
         this.toDispose.pushAll([
             this.onDidChangeEmitter,
             this.onDidChangeBreakpointsEmitter,
@@ -115,9 +119,11 @@ export class DebugSession implements CompositeTreeElement {
         this.sources.set(uri, source);
         return source;
     }
+
     getSourceForUri(uri: URI): DebugSource | undefined {
         return this.sources.get(uri.toString());
     }
+
     async toSource(uri: URI): Promise<DebugSource> {
         const source = this.getSourceForUri(uri);
         if (source) {
@@ -149,9 +155,11 @@ export class DebugSession implements CompositeTreeElement {
     get threads(): IterableIterator<DebugThread> {
         return this._threads.values();
     }
+
     get threadCount(): number {
         return this._threads.size;
     }
+
     *getThreads(filter: (thread: DebugThread) => boolean): IterableIterator<DebugThread> {
         for (const thread of this.threads) {
             if (filter(thread)) {
@@ -159,9 +167,11 @@ export class DebugSession implements CompositeTreeElement {
             }
         }
     }
+
     get runningThreads(): IterableIterator<DebugThread> {
         return this.getThreads(thread => !thread.stopped);
     }
+
     get stoppedThreads(): IterableIterator<DebugThread> {
         return this.getThreads(thread => thread.stopped);
     }
@@ -238,6 +248,7 @@ export class DebugSession implements CompositeTreeElement {
         await this.initialize();
         await this.launchOrAttach();
     }
+
     protected async initialize(): Promise<void> {
         const response = await this.connection.sendRequest('initialize', {
             clientID: 'Theia',
@@ -251,15 +262,12 @@ export class DebugSession implements CompositeTreeElement {
             supportsVariablePaging: false,
             supportsRunInTerminalRequest: true
         });
-        this.updateCapabilities(response.body || {});
+        this.updateCapabilities(response?.body || {});
     }
+
     protected async launchOrAttach(): Promise<void> {
         try {
-            if (this.configuration.request === 'attach') {
-                await this.sendRequest('attach', this.configuration);
-            } else {
-                await this.sendRequest('launch', this.configuration);
-            }
+            await this.sendRequest((this.configuration.request as keyof DebugRequestTypes), this.configuration);
         } catch (reason) {
             this.fireExited(reason);
             await this.messages.showMessage({
@@ -272,6 +280,7 @@ export class DebugSession implements CompositeTreeElement {
             throw reason;
         }
     }
+
     protected initialized = false;
     protected async configure(): Promise<void> {
         if (this.capabilities.exceptionBreakpointFilters) {
@@ -302,22 +311,27 @@ export class DebugSession implements CompositeTreeElement {
             await this.disconnect(restart);
         }
     }
+
     protected async disconnect(restart?: boolean): Promise<void> {
-        try {
-            await this.sendRequest('disconnect', { restart });
-        } catch (reason) {
-            this.fireExited(reason);
-            return;
-        }
-        const timeout = 500;
-        if (!await this.exited(timeout)) {
-            this.fireExited(new Error(`timeout after ${timeout} ms`));
-        }
+        const TIMEOUT_MS = 1000;
+        Promise.race([
+            this.sendRequest('disconnect', { restart }),
+            new Promise(reject => setTimeout(reject, TIMEOUT_MS, new Error('TIMEOUT_ERR')))
+        ]).then(res => {
+            if (res instanceof Error) {
+                this.fireExited(res);
+            }
+        }).catch(this.fireExited);
     }
 
     protected fireExited(reason?: Error): void {
-        this.connection['fire']('exited', { reason });
+        try {
+            this.connection['fire']('exited', { reason });
+        } catch (e) {
+            console.error(e);
+        }
     }
+
     protected exited(timeout: number): Promise<boolean> {
         return new Promise<boolean>(resolve => {
             const listener = this.on('exited', () => {
@@ -398,6 +412,7 @@ export class DebugSession implements CompositeTreeElement {
         }
         this.updateCurrentThread();
     }
+
     protected clearThread(threadId: number): void {
         const thread = this._threads.get(threadId);
         if (thread) {
@@ -408,6 +423,7 @@ export class DebugSession implements CompositeTreeElement {
 
     protected readonly scheduleUpdateThreads = debounce(() => this.updateThreads(undefined), 100);
     protected pendingThreads = Promise.resolve();
+
     updateThreads(stoppedDetails: StoppedDetails | undefined): Promise<void> {
         return this.pendingThreads = this.pendingThreads.then(async () => {
             try {
@@ -420,6 +436,7 @@ export class DebugSession implements CompositeTreeElement {
             }
         });
     }
+
     protected doUpdateThreads(threads: DebugProtocol.Thread[], stoppedDetails?: StoppedDetails): void {
         const existing = this._threads;
         this._threads = new Map();
@@ -515,7 +532,9 @@ export class DebugSession implements CompositeTreeElement {
             this.fireDidChangeBreakpoints(new URI(uri));
         }
     }
+
     protected updatingBreakpoints = false;
+
     protected updateBreakpoint(body: DebugProtocol.BreakpointEvent['body']): void {
         this.updatingBreakpoints = true;
         try {
@@ -687,6 +706,7 @@ export class DebugSession implements CompositeTreeElement {
         const distinct = this.dedupSourceBreakpoints(breakpoints);
         this.setBreakpoints(uri, distinct);
     }
+
     protected dedupSourceBreakpoints(all: DebugSourceBreakpoint[]): DebugSourceBreakpoint[] {
         const positions = new Map<string, DebugSourceBreakpoint>();
         for (const breakpoint of all) {
@@ -702,6 +722,7 @@ export class DebugSession implements CompositeTreeElement {
         }
         return [...positions.values()];
     }
+
     protected *getAffectedUris(uri?: URI): IterableIterator<URI> {
         if (uri) {
             yield uri;
@@ -762,6 +783,12 @@ export class DebugSession implements CompositeTreeElement {
             this.scheduleUpdateThreads();
         } else if (reason === 'exited') {
             this.clearThread(threadId);
+        }
+    };
+
+    protected registerDebugContributions(configType: string, connection: DebugSessionConnection): void {
+        for (const contrib of this.debugContributionProvider.getContributions()) {
+            contrib.register(configType, connection);
         }
     };
 }

--- a/packages/debug/src/browser/debug-session.tsx
+++ b/packages/debug/src/browser/debug-session.tsx
@@ -321,7 +321,7 @@ export class DebugSession implements CompositeTreeElement {
             if (res instanceof Error) {
                 this.fireExited(res);
             }
-        }).catch(this.fireExited);
+        }).catch(() => this.fireExited());
     }
 
     protected fireExited(reason?: Error): void {

--- a/packages/debug/src/browser/view/debug-toolbar-widget.tsx
+++ b/packages/debug/src/browser/view/debug-toolbar-widget.tsx
@@ -82,7 +82,7 @@ export class DebugToolBar extends ReactWidget {
 
     protected start = () => this.model.start();
     protected restart = () => this.model.restart();
-    protected stop = () => this.model.currentSession && this.model.currentSession.terminate();
+    protected stop = () => this.model.terminate();
     protected continue = () => this.model.currentThread && this.model.currentThread.continue();
     protected pause = () => this.model.currentThread && this.model.currentThread.pause();
     protected stepOver = () => this.model.currentThread && this.model.currentThread.stepOver();

--- a/packages/debug/src/browser/view/debug-view-model.ts
+++ b/packages/debug/src/browser/view/debug-view-model.ts
@@ -189,6 +189,10 @@ export class DebugViewModel implements Disposable {
         this.fireDidChange();
     }
 
+    async terminate(): Promise<void> {
+        this.manager.terminateSessions();
+    }
+
     get watchExpressions(): IterableIterator<DebugWatchExpression> {
         return this._watchExpressions.values();
     }

--- a/packages/plugin-dev/src/browser/hosted-plugin-controller.ts
+++ b/packages/plugin-dev/src/browser/hosted-plugin-controller.ts
@@ -229,7 +229,7 @@ export class HostedPluginController implements FrontendApplicationContribution {
                     try {
                         await this.hostedPluginServer.stopWatchCompilation(event.pluginLocation.toString());
                     } catch (error) {
-                        this.messageService.error(this.getErrorMessage(error.message));
+                        this.messageService.error(this.getErrorMessage(error));
                     }
                 }
             }
@@ -246,8 +246,9 @@ export class HostedPluginController implements FrontendApplicationContribution {
         }
     }
 
-    private getErrorMessage(error: Error): string {
-        return error.message.substring(error.message.indexOf(':') + 1);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    private getErrorMessage(error: any): string {
+        return error?.message?.substring(error.message.indexOf(':') + 1) || '';
     }
 
     /**

--- a/packages/plugin-dev/src/browser/plugin-dev-frontend-module.ts
+++ b/packages/plugin-dev/src/browser/plugin-dev-frontend-module.ts
@@ -25,11 +25,13 @@ import { HostedPluginFrontendContribution } from './hosted-plugin-frontend-contr
 import { CommandContribution } from '@theia/core/lib/common/command';
 import { HostedPluginServer, hostedServicePath } from '../common/plugin-dev-protocol';
 import { HostedPluginWatcher } from '@theia/plugin-ext/lib/hosted/browser/hosted-plugin-watcher';
+import { DebugContribution } from '@theia/debug/lib/browser/debug-contribution';
 
 export default new ContainerModule((bind, unbind, isBound, rebind) => {
     bindHostedPluginPreferences(bind);
     bind(HostedPluginLogViewer).toSelf().inSingletonScope();
     bind(HostedPluginManagerClient).toSelf().inSingletonScope();
+    bind(DebugContribution).toService(HostedPluginManagerClient);
 
     bind(FrontendApplicationContribution).to(HostedPluginInformer).inSingletonScope();
     bind(FrontendApplicationContribution).to(HostedPluginController).inSingletonScope();

--- a/packages/plugin-dev/src/common/plugin-dev-protocol.ts
+++ b/packages/plugin-dev/src/common/plugin-dev-protocol.ts
@@ -15,6 +15,7 @@
  ********************************************************************************/
 
 import { JsonRpcServer } from '@theia/core/lib/common/messaging/proxy-factory';
+import { DebugPluginConfiguration } from '@theia/debug/lib/browser/debug-contribution';
 import { PluginMetadata } from '@theia/plugin-ext/lib/common/plugin-protocol';
 
 export const hostedServicePath = '/services/plugin-dev';
@@ -22,7 +23,7 @@ export const HostedPluginServer = Symbol('HostedPluginServer');
 export interface HostedPluginServer extends JsonRpcServer<HostedPluginClient> {
     getHostedPlugin(): Promise<PluginMetadata | undefined>;
     runHostedPluginInstance(uri: string): Promise<string>;
-    runDebugHostedPluginInstance(uri: string, debugConfig: DebugConfiguration): Promise<string>;
+    runDebugHostedPluginInstance(uri: string, debugConfig: DebugPluginConfiguration): Promise<string>;
     terminateHostedPluginInstance(): Promise<void>;
     isHostedPluginInstanceRunning(): Promise<boolean>;
     getHostedPluginInstanceURI(): Promise<string>;
@@ -36,9 +37,4 @@ export interface HostedPluginServer extends JsonRpcServer<HostedPluginClient> {
 }
 
 export interface HostedPluginClient {
-}
-
-export interface DebugConfiguration {
-    port?: number;
-    debugMode?: string;
 }

--- a/packages/plugin-dev/src/node/hosted-instance-manager.ts
+++ b/packages/plugin-dev/src/node/hosted-instance-manager.ts
@@ -24,13 +24,15 @@ import * as request from 'request';
 import URI from '@theia/core/lib/common/uri';
 import { ContributionProvider } from '@theia/core/lib/common/contribution-provider';
 import { HostedPluginUriPostProcessor, HostedPluginUriPostProcessorSymbolName } from './hosted-plugin-uri-postprocessor';
-import { DebugConfiguration } from '../common';
 import { environment } from '@theia/core';
 import { FileUri } from '@theia/core/lib/node/file-uri';
 import { LogType } from '@theia/plugin-ext/lib/common/types';
 import { HostedPluginSupport } from '@theia/plugin-ext/lib/hosted/node/hosted-plugin';
 import { MetadataScanner } from '@theia/plugin-ext/lib/hosted/node/metadata-scanner';
+import { DebugPluginConfiguration } from '@theia/debug/lib/browser/debug-contribution';
 import { HostedPluginProcess } from '@theia/plugin-ext/lib/hosted/node/hosted-plugin-process';
+
+const DEFAULT_HOSTED_PLUGIN_PORT = 3030;
 
 export const HostedInstanceManager = Symbol('HostedInstanceManager');
 
@@ -58,7 +60,7 @@ export interface HostedInstanceManager {
      * @param debugConfig debug configuration
      * @returns uri where new Theia instance is run
      */
-    debug(pluginUri: URI, debugConfig: DebugConfiguration): Promise<URI>;
+    debug(pluginUri: URI, debugConfig: DebugPluginConfiguration): Promise<URI>;
 
     /**
      * Terminates hosted plugin instance.
@@ -118,11 +120,11 @@ export abstract class AbstractHostedInstanceManager implements HostedInstanceMan
         return this.doRun(pluginUri, port);
     }
 
-    async debug(pluginUri: URI, debugConfig: DebugConfiguration): Promise<URI> {
+    async debug(pluginUri: URI, debugConfig: DebugPluginConfiguration): Promise<URI> {
         return this.doRun(pluginUri, undefined, debugConfig);
     }
 
-    private async doRun(pluginUri: URI, port?: number, debugConfig?: DebugConfiguration): Promise<URI> {
+    private async doRun(pluginUri: URI, port?: number, debugConfig?: DebugPluginConfiguration): Promise<URI> {
         if (this.isPluginRunning) {
             this.hostedPluginSupport.sendLog({ data: 'Hosted plugin instance is already running.', type: LogType.Info });
             throw new Error('Hosted instance is already running.');
@@ -142,8 +144,7 @@ export abstract class AbstractHostedInstanceManager implements HostedInstanceMan
             throw new Error('Not supported plugin location: ' + pluginUri.toString());
         }
 
-        this.instanceUri = await this.postProcessInstanceUri(
-            await this.runHostedPluginTheiaInstance(command, processOptions));
+        this.instanceUri = await this.postProcessInstanceUri(await this.runHostedPluginTheiaInstance(command, processOptions));
         this.pluginUri = pluginUri;
         // disable redirect to grab the release
         this.instanceOptions = {
@@ -215,11 +216,7 @@ export abstract class AbstractHostedInstanceManager implements HostedInstanceMan
             const url = this.instanceUri.toString();
             request.head(url, this.instanceOptions).on('response', res => {
                 // Wait that the status is OK
-                if (res.statusCode === 200) {
-                    resolve(true);
-                } else {
-                    resolve(false);
-                }
+                resolve(res.statusCode === 200);
             }).on('error', error => {
                 resolve(false);
             });
@@ -240,7 +237,7 @@ export abstract class AbstractHostedInstanceManager implements HostedInstanceMan
         return false;
     }
 
-    protected async getStartCommand(port?: number, debugConfig?: DebugConfiguration): Promise<string[]> {
+    protected async getStartCommand(port?: number, debugConfig?: DebugPluginConfiguration): Promise<string[]> {
 
         const processArguments = process.argv;
         let command: string[];
@@ -267,19 +264,7 @@ export abstract class AbstractHostedInstanceManager implements HostedInstanceMan
         }
 
         if (debugConfig) {
-            let debugString = '--hosted-plugin-';
-            if (debugConfig.debugMode) {
-                debugString += debugConfig.debugMode;
-            } else {
-                debugString += 'inspect';
-            }
-
-            debugString += '=0.0.0.0';
-
-            if (debugConfig.port) {
-                debugString += ':' + debugConfig.port;
-            }
-            command.push(debugString);
+            command.push(`--hosted-plugin-${debugConfig.debugMode || 'inspect'}=0.0.0.0${debugConfig.debugPort ? ':' + debugConfig.debugPort : ''}`);
         }
         return command;
     }
@@ -373,17 +358,14 @@ export class NodeHostedPluginRunner extends AbstractHostedInstanceManager {
         return options;
     }
 
-    protected async getStartCommand(port?: number, config?: DebugConfiguration): Promise<string[]> {
+    protected async getStartCommand(port?: number, debugConfig?: DebugPluginConfiguration): Promise<string[]> {
         if (!port) {
-            if (process.env.HOSTED_PLUGIN_PORT) {
-                port = Number(process.env.HOSTED_PLUGIN_PORT);
-            } else {
-                port = 3030;
-            }
+            port = process.env.HOSTED_PLUGIN_PORT ?
+                Number(process.env.HOSTED_PLUGIN_PORT) :
+                (debugConfig?.debugPort ? Number(debugConfig.debugPort) : DEFAULT_HOSTED_PLUGIN_PORT);
         }
-        return super.getStartCommand(port, config);
+        return super.getStartCommand(port, debugConfig);
     }
-
 }
 
 @injectable()

--- a/packages/plugin-dev/src/node/hosted-plugin-service.ts
+++ b/packages/plugin-dev/src/node/hosted-plugin-service.ts
@@ -14,7 +14,7 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
-import { HostedPluginServer, DebugConfiguration, HostedPluginClient } from '../common/plugin-dev-protocol';
+import { HostedPluginServer, HostedPluginClient } from '../common/plugin-dev-protocol';
 import { injectable, inject } from '@theia/core/shared/inversify';
 import { HostedInstanceManager } from './hosted-instance-manager';
 import { PluginMetadata } from '@theia/plugin-ext/lib/common/plugin-protocol';
@@ -22,6 +22,7 @@ import URI from '@theia/core/lib/common/uri';
 import { HostedPluginReader } from './hosted-plugin-reader';
 import { HostedPluginsManager } from './hosted-plugins-manager';
 import { HostedPluginSupport } from '@theia/plugin-ext/lib/hosted/node/hosted-plugin';
+import { DebugPluginConfiguration } from '@theia/debug/lib/browser/debug-contribution';
 
 @injectable()
 export class HostedPluginServerImpl implements HostedPluginServer {
@@ -64,7 +65,7 @@ export class HostedPluginServerImpl implements HostedPluginServer {
         return this.uriToStrPromise(this.hostedInstanceManager.run(new URI(uri)));
     }
 
-    runDebugHostedPluginInstance(uri: string, debugConfig: DebugConfiguration): Promise<string> {
+    runDebugHostedPluginInstance(uri: string, debugConfig: DebugPluginConfiguration): Promise<string> {
         return this.uriToStrPromise(this.hostedInstanceManager.debug(new URI(uri), debugConfig));
     }
 

--- a/packages/plugin-ext/src/main/browser/debug/debug-main.ts
+++ b/packages/plugin-ext/src/main/browser/debug/debug-main.ts
@@ -50,6 +50,8 @@ import { PluginDebugAdapterContributionRegistrator, PluginDebugService } from '.
 import { HostedPluginSupport } from '../../../hosted/browser/hosted-plugin';
 import { DebugFunctionBreakpoint } from '@theia/debug/lib/browser/model/debug-function-breakpoint';
 import { FileService } from '@theia/filesystem/lib/browser/file-service';
+import { ContributionProvider } from '@theia/core/lib/common';
+import { DebugContribution } from '@theia/debug/lib/browser/debug-contribution';
 
 export class DebugMainImpl implements DebugMain, Disposable {
     private readonly debugExt: DebugExt;
@@ -68,6 +70,7 @@ export class DebugMainImpl implements DebugMain, Disposable {
     private readonly adapterContributionRegistrator: PluginDebugAdapterContributionRegistrator;
     private readonly fileService: FileService;
     private readonly pluginService: HostedPluginSupport;
+    private readonly debugContributionProvider: ContributionProvider<DebugContribution>;
 
     private readonly debuggerContributions = new Map<string, DisposableCollection>();
     private readonly toDispose = new DisposableCollection();
@@ -86,6 +89,7 @@ export class DebugMainImpl implements DebugMain, Disposable {
         this.debugPreferences = container.get(DebugPreferences);
         this.adapterContributionRegistrator = container.get(PluginDebugService);
         this.sessionContributionRegistrator = container.get(PluginDebugSessionContributionRegistry);
+        this.debugContributionProvider = container.getNamed(ContributionProvider, DebugContribution);
         this.fileService = container.get(FileService);
         this.pluginService = container.get(HostedPluginSupport);
 
@@ -141,7 +145,8 @@ export class DebugMainImpl implements DebugMain, Disposable {
                 return new PluginWebSocketChannel(connection);
             },
             this.fileService,
-            terminalOptionsExt
+            terminalOptionsExt,
+            this.debugContributionProvider
         );
 
         const toDispose = new DisposableCollection(

--- a/packages/plugin-ext/src/main/browser/debug/plugin-debug-service.ts
+++ b/packages/plugin-ext/src/main/browser/debug/plugin-debug-service.ts
@@ -23,7 +23,8 @@ import { injectable, inject, postConstruct } from '@theia/core/shared/inversify'
 import { WebSocketConnectionProvider } from '@theia/core/lib/browser/messaging/ws-connection-provider';
 import { WorkspaceService } from '@theia/workspace/lib/browser';
 import { DebuggerContribution } from '../../../common/plugin-protocol';
-
+import { DebugRequestTypes } from '@theia/debug/lib/browser/debug-session-connection';
+import * as theia from '@theia/plugin';
 /**
  * Debug adapter contribution registrator.
  */
@@ -101,7 +102,7 @@ export class PluginDebugService implements DebugService, PluginDebugAdapterContr
         return [...debugTypes];
     }
 
-    async provideDebugConfigurations(debugType: string, workspaceFolderUri: string | undefined): Promise<DebugConfiguration[]> {
+    async provideDebugConfigurations(debugType: keyof DebugRequestTypes, workspaceFolderUri: string | undefined): Promise<theia.DebugConfiguration[]> {
         const contributor = this.contributors.get(debugType);
         if (contributor) {
             return contributor.provideDebugConfigurations && contributor.provideDebugConfigurations(workspaceFolderUri) || [];

--- a/packages/plugin-ext/src/main/browser/debug/plugin-debug-session-factory.ts
+++ b/packages/plugin-ext/src/main/browser/debug/plugin-debug-session-factory.ts
@@ -29,6 +29,8 @@ import { IWebSocket } from '@theia/core/shared/vscode-ws-jsonrpc';
 import { TerminalWidgetOptions, TerminalWidget } from '@theia/terminal/lib/browser/base/terminal-widget';
 import { TerminalOptionsExt } from '../../../common/plugin-api-rpc';
 import { FileService } from '@theia/filesystem/lib/browser/file-service';
+import { DebugContribution } from '@theia/debug/lib/browser/debug-contribution';
+import { ContributionProvider } from '@theia/core';
 
 export class PluginDebugSession extends DebugSession {
     constructor(
@@ -41,8 +43,9 @@ export class PluginDebugSession extends DebugSession {
         protected readonly labelProvider: LabelProvider,
         protected readonly messages: MessageClient,
         protected readonly fileService: FileService,
-        protected readonly terminalOptionsExt: TerminalOptionsExt | undefined) {
-        super(id, options, connection, terminalServer, editorManager, breakpoints, labelProvider, messages, fileService);
+        protected readonly terminalOptionsExt: TerminalOptionsExt | undefined,
+        protected readonly debugContributionProvider: ContributionProvider<DebugContribution>) {
+        super(id, options, connection, terminalServer, editorManager, breakpoints, labelProvider, messages, fileService, debugContributionProvider);
     }
 
     protected async doCreateTerminal(terminalWidgetOptions: TerminalWidgetOptions): Promise<TerminalWidget> {
@@ -66,7 +69,8 @@ export class PluginDebugSessionFactory extends DefaultDebugSessionFactory {
         protected readonly debugPreferences: DebugPreferences,
         protected readonly connectionFactory: (sessionId: string) => Promise<IWebSocket>,
         protected readonly fileService: FileService,
-        protected readonly terminalOptionsExt: TerminalOptionsExt | undefined
+        protected readonly terminalOptionsExt: TerminalOptionsExt | undefined,
+        protected readonly debugContributionProvider: ContributionProvider<DebugContribution>
     ) {
         super();
     }
@@ -87,6 +91,8 @@ export class PluginDebugSessionFactory extends DefaultDebugSessionFactory {
             this.labelProvider,
             this.messages,
             this.fileService,
-            this.terminalOptionsExt);
+            this.terminalOptionsExt,
+            this.debugContributionProvider
+        );
     }
 }


### PR DESCRIPTION
Signed-off-by: Dan Arad <dan.arad@sap.com>

#### What it does
fixed #4016 with this functionality:
1. Supports start, restart, stop of pwa-extensionHost launch type on debug toolbar.
2. Utilizes Hosted Plugin functionality.

#### How to test
_**Note**: can only be tested on `browser` as `electron` doesn't support Hosted Plugin functionality currently (see #2868)_

1. Add pwa-extensionHost configuration to launch configurations like so:
![image](https://user-images.githubusercontent.com/71069170/97988704-0cd68100-1de6-11eb-85ec-7dc9c456185f.png)
2. start debugging from debug toolbar
3. two threads will eventually appear after the hosted plugin windows will be opened - like so:
![image](https://user-images.githubusercontent.com/71069170/97988834-40b1a680-1de6-11eb-93cf-ee18312caeee.png)
4. you can choose restart or stop in debug toolbar.

Approved CQ for copied code: https://dev.eclipse.org/ipzilla/show_bug.cgi?id=22801

#### Review checklist

- [X] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

