### PR TITLE
plugin: Add support for `activeColorTheme` and `onDidChangeActiveColorTheme` API

### DIFF
--- a/packages/plugin-ext/src/common/plugin-api-rpc.ts
+++ b/packages/plugin-ext/src/common/plugin-api-rpc.ts
@@ -88,6 +88,8 @@ import type {
     TimelineProviderDescriptor
 } from '@theia/timeline/lib/common/timeline-model';
 import { SerializableEnvironmentVariableCollection } from '@theia/terminal/lib/common/base-terminal-protocol';
+import { ThemeType } from '@theia/core/lib/browser/theming';
+import { Disposable } from '@theia/core/lib/common/disposable';
 
 export interface PreferenceData {
     [scope: number]: any;
@@ -561,6 +563,12 @@ export interface TimelineMain {
     $registerTimelineProvider(provider: TimelineProviderDescriptor): Promise<void>;
     $fireTimelineChanged(e: TimelineChangeEvent): Promise<void>;
     $unregisterTimelineProvider(source: string): Promise<void>;
+}
+
+export interface ThemingExt {
+    $onColorThemeChange(type: ThemeType): void;
+}
+export interface ThemingMain extends Disposable {
 }
 
 export interface DialogsMain {
@@ -1492,7 +1500,8 @@ export const PLUGIN_RPC_CONTEXT = {
     WINDOW_MAIN: createProxyIdentifier<WindowMain>('WindowMain'),
     CLIPBOARD_MAIN: <ProxyIdentifier<ClipboardMain>>createProxyIdentifier<ClipboardMain>('ClipboardMain'),
     LABEL_SERVICE_MAIN: <ProxyIdentifier<LabelServiceMain>>createProxyIdentifier<LabelServiceMain>('LabelServiceMain'),
-    TIMELINE_MAIN: <ProxyIdentifier<TimelineMain>>createProxyIdentifier<TimelineMain>('TimelineMain')
+    TIMELINE_MAIN: <ProxyIdentifier<TimelineMain>>createProxyIdentifier<TimelineMain>('TimelineMain'),
+    THEMING_MAIN: <ProxyIdentifier<ThemingMain>>createProxyIdentifier<ThemingMain>('ThemingMain')
 };
 
 export const MAIN_RPC_CONTEXT = {
@@ -1521,7 +1530,8 @@ export const MAIN_RPC_CONTEXT = {
     SCM_EXT: createProxyIdentifier<ScmExt>('ScmExt'),
     DECORATIONS_EXT: createProxyIdentifier<DecorationsExt>('DecorationsExt'),
     LABEL_SERVICE_EXT: createProxyIdentifier<LabelServiceExt>('LabelServiceExt'),
-    TIMELINE_EXT: createProxyIdentifier<TimelineExt>('TimeLineExt')
+    TIMELINE_EXT: createProxyIdentifier<TimelineExt>('TimeLineExt'),
+    THEMING_EXT: createProxyIdentifier<ThemingExt>('ThemingExt')
 };
 
 export interface TasksExt {

--- a/packages/plugin-ext/src/main/browser/main-context.ts
+++ b/packages/plugin-ext/src/main/browser/main-context.ts
@@ -52,6 +52,7 @@ import { MainFileSystemEventService } from './main-file-system-event-service';
 import { LabelServiceMainImpl } from '../browser/label-service-main';
 import { TimelineMainImpl } from './timeline-main';
 import { AuthenticationMainImpl } from './authentication-main';
+import { ThemingMainImpl } from './theming-main';
 
 export function setUpPluginApi(rpc: RPCProtocol, container: interfaces.Container): void {
     const authenticationMain = new AuthenticationMainImpl(rpc, container);
@@ -159,4 +160,7 @@ export function setUpPluginApi(rpc: RPCProtocol, container: interfaces.Container
 
     const timelineMain = new TimelineMainImpl(rpc, container);
     rpc.set(PLUGIN_RPC_CONTEXT.TIMELINE_MAIN, timelineMain);
+
+    const themingMain = new ThemingMainImpl(rpc);
+    rpc.set(PLUGIN_RPC_CONTEXT.THEMING_MAIN, themingMain);
 }

--- a/packages/plugin-ext/src/main/browser/theming-main.ts
+++ b/packages/plugin-ext/src/main/browser/theming-main.ts
@@ -1,0 +1,46 @@
+/********************************************************************************
+ * Copyright (C) 2020 Ericsson and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import { MAIN_RPC_CONTEXT, ThemingMain, ThemingExt } from '../../common/plugin-api-rpc';
+import { RPCProtocol } from '../../common/rpc-protocol';
+import { ThemeService } from '@theia/core/lib/browser/theming';
+import { Disposable } from '@theia/core/lib/common/disposable';
+
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+// some code copied and modified from https://github.com/microsoft/vscode/blob/bafca191f55a234fad20ab67bb689aacc80e7a1a/src/vs/workbench/api/browser/mainThreadTheming.ts
+
+export class ThemingMainImpl implements ThemingMain {
+
+    private readonly proxy: ThemingExt;
+    private readonly themeChangeListener: Disposable;
+
+    constructor(
+        rpc: RPCProtocol
+    ) {
+        this.proxy = rpc.getProxy(MAIN_RPC_CONTEXT.THEMING_EXT);
+        this.themeChangeListener = ThemeService.get().onThemeChange(e => {
+            this.proxy.$onColorThemeChange(e.newTheme.type);
+        });
+        this.proxy.$onColorThemeChange(ThemeService.get().getCurrentTheme().type);
+    }
+
+    dispose(): void {
+        this.themeChangeListener.dispose();
+    }
+}

--- a/packages/plugin-ext/src/plugin/plugin-context.ts
+++ b/packages/plugin-ext/src/plugin/plugin-context.ts
@@ -128,7 +128,8 @@ import {
     SemanticTokensBuilder,
     SemanticTokens,
     SemanticTokensEdits,
-    SemanticTokensEdit
+    SemanticTokensEdit,
+    ColorThemeKind
 } from './types-impl';
 import { AuthenticationExtImpl } from './authentication-ext';
 import { SymbolKind } from '../common/plugin-api-rpc-model';
@@ -162,6 +163,7 @@ import { WebviewsExtImpl } from './webviews';
 import { ExtHostFileSystemEventService } from './file-system-event-service-ext-impl';
 import { LabelServiceExtImpl } from '../plugin/label-service';
 import { TimelineExtImpl } from './timeline';
+import { ThemingExtImpl } from './theming';
 
 export function createAPIFactory(
     rpc: RPCProtocol,
@@ -197,6 +199,7 @@ export function createAPIFactory(
     const decorationsExt = rpc.set(MAIN_RPC_CONTEXT.DECORATIONS_EXT, new DecorationsExtImpl(rpc));
     const labelServiceExt = rpc.set(MAIN_RPC_CONTEXT.LABEL_SERVICE_EXT, new LabelServiceExtImpl(rpc));
     const timelineExt = rpc.set(MAIN_RPC_CONTEXT.TIMELINE_EXT, new TimelineExtImpl(rpc, commandRegistry));
+    const themingExt = rpc.set(MAIN_RPC_CONTEXT.THEMING_EXT, new ThemingExtImpl(rpc));
     rpc.set(MAIN_RPC_CONTEXT.DEBUG_EXT, debugExt);
 
     return function (plugin: InternalPlugin): typeof theia {
@@ -426,6 +429,12 @@ export function createAPIFactory(
             },
             createInputBox(): theia.InputBox {
                 return quickOpenExt.createInputBox(plugin);
+            },
+            get activeColorTheme(): theia.ColorTheme {
+                return themingExt.activeColorTheme;
+            },
+            onDidChangeActiveColorTheme(listener, thisArg?, disposables?) {
+                return themingExt.onDidChangeActiveColorTheme(listener, thisArg, disposables);
             }
         };
 
@@ -933,7 +942,8 @@ export function createAPIFactory(
             SemanticTokensBuilder,
             SemanticTokens,
             SemanticTokensEdits,
-            SemanticTokensEdit
+            SemanticTokensEdit,
+            ColorThemeKind
         };
     };
 }

--- a/packages/plugin-ext/src/plugin/theming.ts
+++ b/packages/plugin-ext/src/plugin/theming.ts
@@ -1,0 +1,70 @@
+/********************************************************************************
+ * Copyright (C) 2020 Ericsson and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import { ColorTheme, ColorThemeKind } from './types-impl';
+import { Emitter, Event } from '@theia/core/lib/common/event';
+import { ThemingExt } from '../common';
+import { RPCProtocol } from '../common/rpc-protocol';
+import { ThemeType } from '@theia/core/lib/browser/theming';
+
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+// some code copied and modified from https://github.com/microsoft/vscode/blob/5ddbda0172d80bfbb2529987ba9020848e8771f7/src/vs/workbench/api/common/extHostTheming.ts
+
+export class ThemingExtImpl implements ThemingExt {
+
+    private actual: ColorTheme;
+    private ondDidChangeActiveColorTheme: Emitter<ColorTheme>;
+
+    constructor(
+        readonly rpc: RPCProtocol
+    ) {
+        this.actual = new ColorTheme(ColorThemeKind.Dark);
+        this.ondDidChangeActiveColorTheme = new Emitter<ColorTheme>();
+    }
+
+    get activeColorTheme(): ColorTheme {
+        return this.actual;
+    }
+
+    $onColorThemeChange(type: ThemeType): void {
+        this.actual = new ColorTheme(this.convertKind(type));
+        this.ondDidChangeActiveColorTheme.fire(this.actual);
+    }
+
+    protected convertKind(type: ThemeType): ColorThemeKind {
+        let kind: ColorThemeKind;
+        switch (type) {
+            case 'light':
+                kind = ColorThemeKind.Light;
+                break;
+            case 'dark':
+                kind = ColorThemeKind.Dark;
+                break;
+            case 'hc':
+                kind = ColorThemeKind.HighContrast;
+                break;
+        }
+        return kind;
+    }
+
+    get onDidChangeActiveColorTheme(): Event<ColorTheme> {
+        return this.ondDidChangeActiveColorTheme.event;
+    }
+
+}

--- a/packages/plugin-ext/src/plugin/types-impl.ts
+++ b/packages/plugin-ext/src/plugin/types-impl.ts
@@ -96,6 +96,19 @@ export enum ViewColumn {
 }
 
 /**
+ * Represents a color theme kind.
+ */
+export enum ColorThemeKind {
+    Light = 1,
+    Dark = 2,
+    HighContrast = 3
+}
+
+export class ColorTheme implements theia.ColorTheme {
+    constructor(public readonly kind: ColorThemeKind) { }
+}
+
+/**
  * Represents sources that can cause `window.onDidChangeEditorSelection`
  */
 export enum TextEditorSelectionChangeKind {

--- a/packages/plugin/src/theia.d.ts
+++ b/packages/plugin/src/theia.d.ts
@@ -3963,6 +3963,36 @@ declare module '@theia/plugin' {
          * @return A new [InputBox](#InputBox).
          */
         export function createInputBox(): InputBox;
+
+        /**
+         * The currently active color theme as configured in the settings. The active
+         * theme can be changed via the `workbench.colorTheme` setting.
+         */
+        export let activeColorTheme: ColorTheme;
+
+        /**
+         * An [event](#Event) which fires when the active color theme is changed or has changes.
+         */
+        export const onDidChangeActiveColorTheme: Event<ColorTheme>;
+    }
+
+    /**
+     * Represents a color theme kind.
+     */
+    export enum ColorThemeKind {
+        Light = 1,
+        Dark = 2,
+        HighContrast = 3
+    }
+
+    /**
+     * Represents a color theme.
+     */
+    export interface ColorTheme {
+        /**
+         * The kind of this color theme: light, dark or high contrast.
+         */
+        readonly kind: ColorThemeKind;
     }
 
     /**


### PR DESCRIPTION
#### CQ

- [x] CQ **approved**: https://dev.eclipse.org/ipzilla/show_bug.cgi?id=22772

#### What it does
Closes #8635 

+ Supports:
	- `activeColorTheme` API: check what the current theme kind is (`Light`, `Dark`, or `HighContrast`)
	- `onDidChangeActiveColorTheme` API that fires an event when the color theme changed.

#### How to test
+ Download [test extension](https://github.com/vince-fugnitto/active-color-theme/releases/download/0.0.1/theming-0.0.1.vsix) and include it in the `plugins` folder inside theia.
+ Reload the application.

##### Test `activeColorTheme`:
+ Call the command `Echo Theme` via the command palette.
+ Observe a pop-up message with the exact kind of current color theme.

##### Test `onDidChangeActiveColorTheme`:
+ Change theme kind by `Preferences`
+ Observe a pop-up message upon the change of current theme.

Example of a pop-up message:
![image](https://user-images.githubusercontent.com/43587865/98160841-cac44280-1eac-11eb-926d-981d0e42af96.png)
 
#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

Signed-off-by: DukeNgn <duc.a.nguyen@ericsson.com>