### PR TITLE
editor: fix 'auto-save' listener

### DIFF
--- a/packages/editor/src/browser/editor-command.ts
+++ b/packages/editor/src/browser/editor-command.ts
@@ -168,9 +168,13 @@ export class EditorCommandContribution implements CommandContribution {
 
     @postConstruct()
     protected init(): void {
-        this.editorPreferences.onPreferenceChanged(e => {
-            if (e.preferenceName === 'editor.autoSave' && e.newValue === 'on') {
-                this.shell.saveAll();
+        this.editorPreferences.onPreferenceChanged(({ preferenceName, oldValue, newValue }) => {
+            if (preferenceName === 'editor.autoSave') {
+                const autoSaveWasOnBeforeChange = !oldValue || oldValue === 'on';
+                const autoSaveIsOnAfterChange = !newValue || newValue === 'on';
+                if (!autoSaveWasOnBeforeChange && autoSaveIsOnAfterChange) {
+                    this.shell.saveAll();
+                }
             }
         });
     }


### PR DESCRIPTION




<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

Fixes: https://github.com/eclipse-theia/theia/issues/8722

The following pull-request addresses an issue with the preference change event for `editor.autoSave` which would incorrectly process the event on app startup leading to an incorrect `shell.saveAll()` call. The logic for handling the event has been updated to only execute the handler when the `autoSave` preference is actually updated.

Thanks to @kittaakos for finding the bug and providing a quick fix. 

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

1. start the application with `autoSave` **off** - the listener should not call `shell.autoSave` on startup
2. start the application with `autoSave` **on** - the listener should not call `shell.autoSave` on startup
3. start the application with `autoSave` **off**
4. make some changes to editors, and keep them dirty
5. update `autoSave` to **on**
6. the dirty editors should be saved 

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

Signed-off-by: vince-fugnitto <vincent.fugnitto@ericsson.com>
Co-authored-by: Akos Kitta <kittaakos@typefox.io>
