### PR TITLE
Render initial preview for empty documents

### DIFF
--- a/packages/preview/src/browser/preview-widget.ts
+++ b/packages/preview/src/browser/preview-widget.ts
@@ -165,11 +165,11 @@ export class PreviewWidget extends BaseWidget implements Navigatable {
     }
 
     protected forceUpdate(): void {
-        this.previousContent = '';
+        this.previousContent = undefined;
         this.update();
     }
 
-    protected previousContent: string = '';
+    protected previousContent: string | undefined = undefined;
     protected async performUpdate(): Promise<void> {
         if (!this.resource) {
             return;


### PR DESCRIPTION
Improves preview-widget to also render previews for empty documents.

Fixes #8728 

Signed-off-by: Stefan Dirix <sdirix@eclipsesource.com>
Contributed on behalf of STMicroelectronics

#### What it does
The preview-widget checks whether the content of the underlying text document changed before rerendering its content. In case of empty documents this check prevented the initial rendering of the preview. This is now fixed by distinguishing between empty and non-existing content.

#### How to test
1. Implement a new `PreviewHandler` which renders content for empty documents
2. Open preview on empty document
3. Check whether the preview shows the content returned above

You can use this `PreviewHandler` for testing:
```typescript
@injectable()
class MyPreviewHandler implements PreviewHandler {
  canHandle(uri: URI) {
    return 1000;
  }
  renderContent() {
    const div = document.createElement("div");
    div.innerText = "my preview";
    return div;
  }
}
```

![Preview_Content_Shown](https://user-images.githubusercontent.com/8998368/98385589-6c839500-204f-11eb-9f68-75b6e6d3d805.png)

#### Review checklist

- [X] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

