### PR TITLE
preferences:  Support 'Close On File Delete' preference

### DIFF
--- a/packages/core/src/browser/core-preferences.ts
+++ b/packages/core/src/browser/core-preferences.ts
@@ -36,6 +36,12 @@ export const corePreferenceSchema: PreferenceSchema = {
             'description': 'Controls whether a top border is drawn on modified (dirty) editor tabs or not.',
             'default': false
         },
+        'workbench.editor.closeOnFileDelete': {
+            'type': 'boolean',
+            // eslint-disable-next-line max-len
+            'description': 'Controls whether editors showing a file that was opened during the session should close automatically when getting deleted or renamed by some other process. Disabling this will keep the editor open  on such an event. Note that deleting from within the application will always close the editor and that dirty files will never close to preserve your data.',
+            'default': true
+        },
         'application.confirmExit': {
             type: 'string',
             enum: [
@@ -100,6 +106,7 @@ export interface CoreConfiguration {
     'workbench.list.openMode': 'singleClick' | 'doubleClick';
     'workbench.commandPalette.history': number;
     'workbench.editor.highlightModifiedTabs': boolean;
+    'workbench.editor.closeOnFileDelete': boolean;
     'workbench.colorTheme': string;
     'workbench.iconTheme': string | null;
     'workbench.silentNotifications': boolean;

--- a/packages/filesystem/src/browser/filesystem-frontend-contribution.ts
+++ b/packages/filesystem/src/browser/filesystem-frontend-contribution.ts
@@ -22,7 +22,8 @@ import { Command, CommandContribution, CommandRegistry } from '@theia/core/lib/c
 import {
     FrontendApplicationContribution, ApplicationShell,
     NavigatableWidget, NavigatableWidgetOptions,
-    Saveable, WidgetManager, StatefulWidget, FrontendApplication, ExpandableTreeNode, waitForClosed
+    Saveable, WidgetManager, StatefulWidget, FrontendApplication, ExpandableTreeNode, waitForClosed,
+    CorePreferences
 } from '@theia/core/lib/browser';
 import { MimeService } from '@theia/core/lib/browser/mime-service';
 import { TreeWidgetSelection } from '@theia/core/lib/browser/tree/tree-widget-selection';
@@ -62,6 +63,9 @@ export class FileSystemFrontendContribution implements FrontendApplicationContri
 
     @inject(FileSystemPreferences)
     protected readonly preferences: FileSystemPreferences;
+
+    @inject(CorePreferences)
+    protected readonly corePreferences: CorePreferences;
 
     @inject(SelectionService)
     protected readonly selectionService: SelectionService;
@@ -258,7 +262,7 @@ export class FileSystemFrontendContribution implements FrontendApplicationContri
         return targetUri && widget.createMoveToUri(targetUri);
     }
 
-    protected readonly deletedSuffix = ' (deleted from disk)';
+    protected readonly deletedSuffix = ' (deleted)';
     protected async updateWidgets(event: FileChangesEvent): Promise<void> {
         if (!event.gotDeleted() && !event.gotAdded()) {
             return;
@@ -272,7 +276,7 @@ export class FileSystemFrontendContribution implements FrontendApplicationContri
             this.updateWidget(uri, widget, event, { dirty, toClose });
         }
         for (const [uriString, widgets] of toClose.entries()) {
-            if (!dirty.has(uriString)) {
+            if (!dirty.has(uriString) && this.corePreferences['workbench.editor.closeOnFileDelete']) {
                 for (const widget of widgets) {
                     widget.close();
                     pending.push(waitForClosed(widget));
@@ -291,10 +295,10 @@ export class FileSystemFrontendContribution implements FrontendApplicationContri
         if (event.contains(uri, FileChangeType.DELETED)) {
             const uriString = uri.toString();
             if (Saveable.isDirty(widget)) {
-                if (!deleted) {
-                    widget.title.label += this.deletedSuffix;
-                }
                 dirty.add(uriString);
+            }
+            if (!deleted) {
+                widget.title.label += this.deletedSuffix;
             }
             const widgets = toClose.get(uriString) || [];
             widgets.push(widget);


### PR DESCRIPTION
#### What it does
Fixes #8730 
+ Changes `deletedSuffix` to `(deleted)`.
+ Adds new preference `workbench.editor.closeOnFileDelete` (`false` by default) to control whether the editor should be closed if other processes deleted or renamed the file.

#### How to test
+ Start the application and open a file (ex: readme.md).
+ Delete the file on the filesystem.

**Observe**:
**Note**: Regardless of the setting, dirty editors should not be closed when other processes `deleted` or `renamed` the file.

+ If `closeOnFileDelete` is true => the editor is closed.
+ If `closeOnFileDelete` is false => the editor is kept alive with the change in the title (`readme.md (deleted)`)
![image](https://user-images.githubusercontent.com/43587865/98421320-13b7fa80-2057-11eb-845a-c8d6daea81e5.png)

#### Review checklist

- [ ] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

Signed-off-by: Duc Nguyen <duc.a.nguyen@ericsson.com>
