### PR TITLE
GH-8186: Workaround for  `application.confirmExit`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 <a name="breaking_changes_1.8.0">[Breaking Changes:](#breaking_changes_1.8.0)</a>
 
 - [file-search] Deprecate dependency on `@theia/process` and replaced its usage by node's `child_process` api.
+- [electron] Removed `attachWillPreventUnload` method from the Electron main application. The `confirmExit` logic is handled on the frontend. [#8732](https://github.com/eclipse-theia/theia/pull/8732)
 
 ## v1.7.0 - 29/10/2020
 

--- a/packages/core/src/browser/frontend-application.ts
+++ b/packages/core/src/browser/frontend-application.ts
@@ -24,6 +24,7 @@ import { ShellLayoutRestorer, ApplicationShellLayoutMigrationError } from './she
 import { FrontendApplicationStateService } from './frontend-application-state';
 import { preventNavigation, parseCssTime, animationFrame } from './browser';
 import { CorePreferences } from './core-preferences';
+import { WindowService } from './window/window-service';
 
 /**
  * Clients can implement to get a callback for contributing widgets to a shell on start.
@@ -95,6 +96,9 @@ export class FrontendApplication {
 
     @inject(CorePreferences)
     protected readonly corePreferences: CorePreferences;
+
+    @inject(WindowService)
+    protected readonly windowsService: WindowService;
 
     constructor(
         @inject(CommandRegistry) protected readonly commands: CommandRegistry,
@@ -182,8 +186,7 @@ export class FrontendApplication {
      */
     protected registerEventListeners(): void {
         this.registerCompositionEventListeners(); /* Hotfix. See above. */
-
-        window.addEventListener('beforeunload', () => {
+        this.windowsService.onUnload(() => {
             this.stateService.state = 'closing_window';
             this.layoutRestorer.storeLayout(this);
             this.stopContributions();

--- a/packages/core/src/browser/window/test/mock-window-service.ts
+++ b/packages/core/src/browser/window/test/mock-window-service.ts
@@ -14,10 +14,12 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 import { injectable } from 'inversify';
+import { Event } from '../../../common/event';
 import { WindowService } from '../window-service';
 
 @injectable()
 export class MockWindowService implements WindowService {
     openNewWindow(): undefined { return undefined; }
     canUnload(): boolean { return true; }
+    get onUnload(): Event<void> { return Event.None; }
 }

--- a/packages/core/src/browser/window/window-service.ts
+++ b/packages/core/src/browser/window/window-service.ts
@@ -14,6 +14,8 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
+import { Event } from '../../common/event';
+
 export interface NewWindowOptions {
     readonly external?: boolean;
 }
@@ -37,5 +39,11 @@ export interface WindowService {
      * event will be canceled if the return value of this method is `false`.
      */
     canUnload(): boolean;
+
+    /**
+     * Fires when the `window` unloads. The unload event is inevitable. On this event, the frontend application can save its state and release resource.
+     * Saving the state and releasing any resources must be a synchronous call. Any asynchronous calls invoked after emitting this event might be ignored.
+     */
+    readonly onUnload: Event<void>;
 
 }

--- a/packages/core/src/electron-main/electron-main-application.ts
+++ b/packages/core/src/electron-main/electron-main-application.ts
@@ -15,7 +15,7 @@
  ********************************************************************************/
 
 import { inject, injectable, named } from 'inversify';
-import { session, screen, globalShortcut, app, BrowserWindow, BrowserWindowConstructorOptions, Event as ElectronEvent, dialog } from 'electron';
+import { session, screen, globalShortcut, app, BrowserWindow, BrowserWindowConstructorOptions, Event as ElectronEvent } from 'electron';
 import * as path from 'path';
 import { Argv } from 'yargs';
 import { AddressInfo } from 'net';
@@ -213,7 +213,6 @@ export class ElectronMainApplication {
         const electronWindow = new BrowserWindow(options);
         this.attachReadyToShow(electronWindow);
         this.attachSaveWindowState(electronWindow);
-        this.attachWillPreventUnload(electronWindow);
         this.attachGlobalShortcuts(electronWindow);
         this.restoreMaximizedState(electronWindow, options);
         return electronWindow;
@@ -337,26 +336,6 @@ export class ElectronMainApplication {
         electronWindow.on('close', saveWindowState);
         electronWindow.on('resize', saveWindowStateDelayed);
         electronWindow.on('move', saveWindowStateDelayed);
-    }
-
-    /**
-     * Catch window closing event and display a confirmation window.
-     */
-    protected attachWillPreventUnload(electronWindow: BrowserWindow): void {
-        // Fired when a beforeunload handler tries to prevent the page unloading
-        electronWindow.webContents.on('will-prevent-unload', async event => {
-            const { response } = await dialog.showMessageBox(electronWindow, {
-                type: 'question',
-                buttons: ['Yes', 'No'],
-                title: 'Confirm',
-                message: 'Are you sure you want to quit?',
-                detail: 'Any unsaved changes will not be saved.'
-            });
-            if (response === 0) { // 'Yes'
-                // This ignores the beforeunload callback, allowing the page to unload
-                event.preventDefault();
-            }
-        });
     }
 
     /**


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

 - Moves the `beforeunload` handling logic to the frontend.
 - Removes the `attachWillPreventUnload` from the main electron app.
 - Closes #8186.

#### How to test

Electron env:

 1.
   - start the electron app in debug mode and open the dev-tools.
   - put a breakpoint to `frontend-application.ts`, line 190 ([inside `this.windowsService.onUnload`](https://github.com/eclipse-theia/theia/blob/76b1ffd8cd04f907cf847792fd66b8a9ef14d53c/packages/core/src/browser/frontend-application.ts#L190)).
   - set `confirmExit` to `never`.
   - refresh the window with `Ctrl/Cmd+R`.
 Expectation:
     - you must hit the breakpoint.
     - the window closes.
 2.
   - start the electron app in debug mode and open the dev-tools.
   - put a breakpoint to `frontend-application.ts`, line 190 ([inside `this.windowsService.onUnload`](https://github.com/eclipse-theia/theia/blob/76b1ffd8cd04f907cf847792fd66b8a9ef14d53c/packages/core/src/browser/frontend-application.ts#L190)).
   - set `confirmExit` to `never`.
   - run the `Reload Window` command.
 Expectation:
     - you must hit the breakpoint.
     - the window closes.
 3.
   - start the electron app in debug mode and open the dev-tools.
   - put a breakpoint to `frontend-application.ts`, line 190 ([inside `this.windowsService.onUnload`](https://github.com/eclipse-theia/theia/blob/76b1ffd8cd04f907cf847792fd66b8a9ef14d53c/packages/core/src/browser/frontend-application.ts#L190)).
   - set `confirmExit` to `never`.
   - quit the app (on macOS with `Cmd+Q`)
 Expectation:
     - you must hit the breakpoint.
     - the window closes.
 4.
   - start the electron app in debug mode and open the dev-tools.
   - put a breakpoint to `frontend-application.ts`, line 190 ([inside `this.windowsService.onUnload`](https://github.com/eclipse-theia/theia/blob/76b1ffd8cd04f907cf847792fd66b8a9ef14d53c/packages/core/src/browser/frontend-application.ts#L190)).
   - set `confirmExit` to `never`.
   - close the window by clicking on the `X`.
 Expectation:
     - you must hit the breakpoint.
     - the window closes.
 5.
   - start the electron app in debug mode and open the dev-tools.
   - put a breakpoint to `frontend-application.ts`, line 190 ([inside `this.windowsService.onUnload`](https://github.com/eclipse-theia/theia/blob/76b1ffd8cd04f907cf847792fd66b8a9ef14d53c/packages/core/src/browser/frontend-application.ts#L190)).
   - set `confirmExit` to `never`.
   - close the window by clicking on the `X`.
 Expectation:
     - you must hit the breakpoint.
     - the window closes.
 6.
   - start the electron app in debug mode and open the dev-tools.
   - put a breakpoint to `frontend-application.ts`, line 190 ([inside `this.windowsService.onUnload`](https://github.com/eclipse-theia/theia/blob/76b1ffd8cd04f907cf847792fd66b8a9ef14d53c/packages/core/src/browser/frontend-application.ts#L190)).
   - set `confirmExit` to `always`.
   - close or refresh the window (it's up to you what pick, we've already verified it in `1. - 5.`).
   - see the modal dialog, select `No`.
 Expectation:
     - you must **not** hit the breakpoint.
     - the window does **not** close. 
     - open `src-gen/frontend/index.js` and verify the LS is still running. Try the content assist.
 7.
   - start the electron app in debug mode and open the dev-tools.
   - put a breakpoint to `frontend-application.ts`, line 190 ([inside `this.windowsService.onUnload`](https://github.com/eclipse-theia/theia/blob/76b1ffd8cd04f907cf847792fd66b8a9ef14d53c/packages/core/src/browser/frontend-application.ts#L190)).
   - set `confirmExit` to `always`.
   - Close or refresh the window (it's up to you what pick, we've already verified it in `1. - 5.`).
   - see the modal dialog, select `Yes`.
 Expectation:
     - you must hit the breakpoint.
     - the window closes.
 7.
   - start the electron app in debug mode and open the dev-tools.
   - put a breakpoint to `frontend-application.ts`, line 190 ([inside `this.windowsService.onUnload`](https://github.com/eclipse-theia/theia/blob/76b1ffd8cd04f907cf847792fd66b8a9ef14d53c/packages/core/src/browser/frontend-application.ts#L190)).
   - set `confirmExit` to `ifRequired`.
   - open `src-gen/frontend/index.js` make sure it's **not** dirty.
   - close or refresh the window (it's up to you what pick, we've already verified it in `1. - 5.`).
 Expectation:
     - you do not see the modal dialog.
     - you must hit the breakpoint.
     - the window closes.
 8.
   - start the electron app in debug mode and open the dev-tools.
   - put a breakpoint to `frontend-application.ts`, line 190 ([inside `this.windowsService.onUnload`](https://github.com/eclipse-theia/theia/blob/76b1ffd8cd04f907cf847792fd66b8a9ef14d53c/packages/core/src/browser/frontend-application.ts#L190)).
   - set `confirmExit` to `ifRequired`.
   - disable the auto-save.
   - open `src-gen/frontend/index.js` and make it dirty.
   - close or refresh the window (it's up to you what pick, we've already verified it in `1. - 5.`).
   - see the modal dialog, select `Yes`.
 Expectation:
     - you must hit the breakpoint.
     - the window closes.
 9.
   - start the electron app in debug mode and open the dev-tools.
   - put a breakpoint to `frontend-application.ts`, line 190 ([inside `this.windowsService.onUnload`](https://github.com/eclipse-theia/theia/blob/76b1ffd8cd04f907cf847792fd66b8a9ef14d53c/packages/core/src/browser/frontend-application.ts#L190)).
   - set `confirmExit` to `ifRequired`.
   - disable the auto-save.
   - open `src-gen/frontend/index.js` and make it dirty.
   - close or refresh the window (it's up to you what pick, we've already verified it in `1. - 5.`).
   - see the modal dialog, select `No`.
 Expectation:
     - you must **not** hit the breakpoint.
     - the window does **not** close. 
     - open `src-gen/frontend/index.js` and verify the LS is still running. Try the content assist.

Browser env:

Essentially, do the same as in electron env. However, there is one case that cannot be verified the same way; when you reload the browser window. In such cases, you won't hit the breakpoint in the browser (I use Brave, but it should behave the same in Chrome) but there is a trick for this use-case. Start the backend in debug mode. Check the backend log; you must see `root INFO Changed application state from 'ready' to 'closing_window'.` when you reload the window even if you do not hit the breakpoint. If you start the backend in debug mode from VS Code, you can even filter the Debug Console with `"Changed application state from"` and you will see the expected state transition logs.

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

