### PR TITLE
Remove dependencies pulled in when writing to output channels

### DIFF
--- a/packages/output/src/browser/output-frontend-module.ts
+++ b/packages/output/src/browser/output-frontend-module.ts
@@ -16,7 +16,6 @@
 
 import { ContainerModule } from 'inversify';
 import { OutputWidget, OUTPUT_WIDGET_KIND } from './output-widget';
-import { CommandContribution } from '@theia/core/lib/common/command';
 import { TabBarToolbarContribution } from '@theia/core/lib/browser/shell/tab-bar-toolbar';
 import { ResourceResolver } from '@theia/core/lib/common';
 import { WidgetFactory, bindViewContribution, OpenHandler } from '@theia/core/lib/browser';
@@ -32,7 +31,6 @@ import { OutputEditorModelFactory } from './output-editor-model-factory';
 
 export default new ContainerModule(bind => {
     bind(OutputChannelManager).toSelf().inSingletonScope();
-    bind(CommandContribution).toService(OutputChannelManager);
     bind(ResourceResolver).toService(OutputChannelManager);
     bind(MonacoEditorFactory).to(OutputEditorFactory).inSingletonScope();
     bind(MonacoEditorModelFactory).to(OutputEditorModelFactory).inSingletonScope();


### PR DESCRIPTION
#### What it does

The changes to add scroll lock to the output view added a large number of dependencies to OutputChannelManager.  While the scroll locking is a great improvement and much appreciated, the extra dependencies make it not possible for extenders to send logging output to the Output view.   An attempt to inject OutputChannelManager into MessageClient causes a circular dependency.  OutputChannelManager depends on QuickPickService which depends on QuickOpenService (bound to MonacoQuickOpenService), which depends on KeyboardLayoutProvider (implemented by BrowserKeyboardLayoutProvider) which depends on ILogger.

The dependencies are caused by the command registrations.  The dependencies can be removed by moving the command registrations to the same place where other output channel commands are registered.  This also removes the command registration from 'common'.

#### How to test

Ensure that no behavior is changed.  All commands are accessible exactly as before.

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

