### PR TITLE
[Fix] WorkspaceFrontendContribution is not binded to FrontendApplication

### DIFF
--- a/packages/workspace/src/browser/workspace-frontend-module.ts
+++ b/packages/workspace/src/browser/workspace-frontend-module.ts
@@ -56,7 +56,7 @@ export default new ContainerModule((bind: interfaces.Bind, unbind: interfaces.Un
     }).inSingletonScope();
 
     bind(WorkspaceFrontendContribution).toSelf().inSingletonScope();
-    for (const identifier of [CommandContribution, KeybindingContribution, MenuContribution]) {
+    for (const identifier of [FrontendApplicationContribution, CommandContribution, KeybindingContribution, MenuContribution]) {
         bind(identifier).toService(WorkspaceFrontendContribution);
     }
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
Bind WorkspaceFrontendContribution to FrontendApplication.
Today they are not binded and this causes the `workspaceFrontendContribution.configure()` to not being called.
This make the statusBar color blue (instead of purple) even if workspace is not opened.

<!-- Include relevant issues and describe how they are addressed. -->

#### How to test
Open Theia in browser.
Open browser dev tools.
In the dev tools, open `workspace-frontend-contribution.ts` file and put breakpoint inside the `configure` method.

Before:
`configure()` isn't being called. the debugger doesn't stop inside `configure()` 
After:
`configure()` is called.  the debugger stop inside `configure()` 

Another way:
Open theia without opened workspace or click File -> Close Workspace
Before:
The status bar is blue instead of purple.
After:
The status bar is purple.
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

#### Review checklist

- [X] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

