### PR TITLE
[@theia/console] Remove workaround that is no longer necessary

### DIFF
--- a/packages/console/package.json
+++ b/packages/console/package.json
@@ -5,7 +5,7 @@
   "dependencies": {
     "@theia/core": "^1.7.0",
     "@theia/monaco": "^1.7.0",
-    "anser": "^1.4.7"
+    "anser": "^2.0.1"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/console/src/browser/ansi-console-item.tsx
+++ b/packages/console/src/browser/ansi-console-item.tsx
@@ -17,10 +17,7 @@
 import * as React from 'react';
 import { ConsoleItem } from './console-session';
 import { Severity } from '@theia/core/lib/common/severity';
-
-// TODO: Remove this workaround once issue is fixed by anser.
-// REF: https://github.com/IonicaBizau/anser/issues/52
-const { ansiToHtml } = (require('anser') as import('anser').default);
+import Anser = require('anser');
 
 export class AnsiConsoleItem implements ConsoleItem {
 
@@ -30,7 +27,7 @@ export class AnsiConsoleItem implements ConsoleItem {
         public readonly content: string,
         public readonly severity?: Severity
     ) {
-        this.htmlContent = ansiToHtml(this.content, {
+        this.htmlContent = new Anser().ansiToHtml(this.content, {
             use_classes: true,
             remove_empty: true
         });

--- a/yarn.lock
+++ b/yarn.lock
@@ -1911,10 +1911,10 @@ alphanum-sort@^1.0.1, alphanum-sort@^1.0.2:
   resolved "https://registry.yarnpkg.com/alphanum-sort/-/alphanum-sort-1.0.2.tgz#97a1119649b211ad33691d9f9f486a8ec9fbe0a3"
   integrity sha1-l6ERlkmyEa0zaR2fn0hqjsn74KM=
 
-anser@^1.4.7:
-  version "1.4.10"
-  resolved "https://registry.yarnpkg.com/anser/-/anser-1.4.10.tgz#befa3eddf282684bd03b63dcda3927aef8c2e35b"
-  integrity sha512-hCv9AqTQ8ycjpSd3upOJd7vFwW1JaoYQ7tpham03GJ1ca8/65rqn0RpaWpItOAd6ylW9wAw6luXYPJIyPFVOww==
+anser@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/anser/-/anser-2.0.1.tgz#8d9069291fee18306ffaf2e364a690dcc8ed78ad"
+  integrity sha512-4g5Np4CVD3c5c/36Mj0jllEA5bQcuXF0dqakZcuHGeubBzw93EAhwRuQCzgFm4/ZwvyBMzFdtn9BcihOjnxIdQ==
 
 ansi-colors@3.2.3:
   version "3.2.3"


### PR DESCRIPTION
Signed-off-by: Reece Dunham <me@rdil.rocks>

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does

My PR in Anser (https://github.com/IonicaBizau/anser/pull/60) landed, meaning that the misleading TypeScript types no longer exist, so we can just use the proper way of importing Anser.

#### How to test

I've verified that the Theia console still works.

#### Review checklist

- [X] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

