### PR TITLE
Add Trim Trailing Whitespace Preference

### DIFF
--- a/packages/core/src/common/preferences/preference-scope.ts
+++ b/packages/core/src/common/preferences/preference-scope.ts
@@ -60,6 +60,8 @@ export namespace PreferenceScope {
                 return PreferenceScope.Folder;
             case 'resource':
                 return PreferenceScope.Folder;
+            case 'language-overridable':
+                return PreferenceScope.Folder;
         }
     }
 }

--- a/packages/filesystem/src/browser/filesystem-preferences.ts
+++ b/packages/filesystem/src/browser/filesystem-preferences.ts
@@ -78,6 +78,12 @@ These have precedence over the default associations of the languages installed.'
             type: 'number',
             default: MAX_FILE_SIZE_MB,
             markdownDescription: 'Controls the max file size in MB which is possible to open.'
+        },
+        'files.trimTrailingWhitespace': {
+            'type': 'boolean',
+            'default': false,
+            'description': 'When enabled, will trim trailing whitespace when saving a file.',
+            'scope': 'language-overridable'
         }
     }
 };
@@ -91,6 +97,7 @@ export interface FileSystemConfiguration {
     'files.autoGuessEncoding': boolean;
     'files.participants.timeout': number;
     'files.maxFileSizeMB': number;
+    'files.trimTrailingWhitespace': boolean;
 }
 
 export const FileSystemPreferences = Symbol('FileSystemPreferences');

--- a/packages/monaco/src/browser/monaco-editor-provider.ts
+++ b/packages/monaco/src/browser/monaco-editor-provider.ts
@@ -41,6 +41,7 @@ import { MonacoResolvedKeybinding } from './monaco-resolved-keybinding';
 import { HttpOpenHandlerOptions } from '@theia/core/lib/browser/http-open-handler';
 import { MonacoToProtocolConverter } from './monaco-to-protocol-converter';
 import { ProtocolToMonacoConverter } from './protocol-to-monaco-converter';
+import { FileSystemPreferences } from '@theia/filesystem/lib/browser';
 
 export const MonacoEditorFactory = Symbol('MonacoEditorFactory');
 export interface MonacoEditorFactory {
@@ -66,6 +67,9 @@ export class MonacoEditorProvider {
 
     @inject(OpenerService)
     protected readonly openerService: OpenerService;
+
+    @inject(FileSystemPreferences)
+    protected readonly filePreferences: FileSystemPreferences;
 
     protected _current: MonacoEditor | undefined;
     /**
@@ -319,14 +323,17 @@ export class MonacoEditorProvider {
         const overrideIdentifier = editor.document.languageId;
         const uri = editor.uri.toString();
         const formatOnSave = this.editorPreferences.get({ preferenceName: 'editor.formatOnSave', overrideIdentifier }, undefined, uri)!;
-        if (!formatOnSave) {
-            return [];
+        if (formatOnSave) {
+            const formatOnSaveTimeout = this.editorPreferences.get({ preferenceName: 'editor.formatOnSaveTimeout', overrideIdentifier }, undefined, uri)!;
+            await Promise.race([
+                new Promise((_, reject) => setTimeout(() => reject(new Error(`Aborted format on save after ${formatOnSaveTimeout}ms`)), formatOnSaveTimeout)),
+                editor.runAction('editor.action.formatDocument')
+            ]);
         }
-        const formatOnSaveTimeout = this.editorPreferences.get({ preferenceName: 'editor.formatOnSaveTimeout', overrideIdentifier }, undefined, uri)!;
-        await Promise.race([
-            new Promise((_, reject) => setTimeout(() => reject(new Error(`Aborted format on save after ${formatOnSaveTimeout}ms`)), formatOnSaveTimeout)),
-            editor.runAction('editor.action.formatDocument')
-        ]);
+        const shouldRemoveWhiteSpace = this.filePreferences.get({ preferenceName: 'files.trimTrailingWhitespace', overrideIdentifier }, undefined, uri);
+        if (shouldRemoveWhiteSpace) {
+            await editor.runAction('editor.action.trimTrailingWhitespace');
+        }
         return [];
     }
 


### PR DESCRIPTION
Signed-off-by: Colin Grant <colin.grant@ericsson.com>

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

Fixes #8059 by adding a preference an and onWillSaveModel hook to perform the action.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
1. Add lots of trailing whitespace to a file.
1. Save it.
1. Observe that the whitespace is not removed.
1. Open preferences.
1. Set `files.trimTrailingWhitespace` to `true` in the scope of your white-spacey file (or higher scope).
1. Add even more whitespace.
1. Save the file.
1. Observe that the trailing whitespace is removed.

Since the preference name/description etc. are copied from VSCode, this is likely to require a CQ. I'll get started on that.

![trailing-whitespace](https://user-images.githubusercontent.com/62660806/98866034-e772f400-2431-11eb-816b-411b362171e9.gif)

#### Review checklist

- [x ] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

