### PR TITLE
debug: fix disabling breakpoints

### DIFF
--- a/packages/debug/src/browser/model/debug-source-breakpoint.tsx
+++ b/packages/debug/src/browser/model/debug-source-breakpoint.tsx
@@ -50,7 +50,7 @@ export class DebugSourceBreakpoint extends DebugBreakpoint<SourceBreakpoint> imp
         const { uri, raw } = this;
         let shouldUpdate = false;
         let breakpoints = raw && this.doRemove(this.origins.filter(origin => !(origin.raw.line === raw.line && origin.raw.column === raw.column)));
-        if (breakpoints) {
+        if (breakpoints?.length) {
             shouldUpdate = true;
         } else {
             breakpoints = this.breakpoints.getBreakpoints(uri);


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

Fixes: https://github.com/eclipse-theia/theia/issues/8222

The following pull-request fixes an issue where attempting to **disable** breakpoints during an **active debug session** would remove the breakpoint rather than disabling it. The fix includes updating the clause which controls whether debug breakpoints should be updated (removed).

![debug](https://user-images.githubusercontent.com/40359487/98978477-08961c00-24e8-11eb-90aa-36003ffdd23c.gif)

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

1. start the application with `theia` as a workspace
2. open a `*.spec.ts` file (ex: `cli.spec.ts`)
3. add a breakpoint(s) in the editor
4. open the debug-view
5. confirm through the debug view that the breakpoint can be disabled/enabled (through the checkbox)
6. select the `run mocha tests` debug configuration
7. confirm that once the debug session hits the breakpoint, step 5 works
8. confirm that disabling all breakpoints still works
9. confirm that removing all breakpoints still works

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

Signed-off-by: vince-fugnitto <vincent.fugnitto@ericsson.com>
