### PR TITLE
Apply problem matchers specified by task provider

### DIFF
--- a/packages/plugin-ext/src/common/plugin-api-rpc.ts
+++ b/packages/plugin-ext/src/common/plugin-api-rpc.ts
@@ -1213,6 +1213,9 @@ export interface TaskDto {
     label: string;
     source?: string;
     scope: string | number;
+    // Provide a more specific type when necessary (see ProblemMatcherContribution)
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    problemMatcher?: any;
     detail?: string;
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     [key: string]: any;

--- a/packages/plugin-ext/src/plugin/type-converters.ts
+++ b/packages/plugin-ext/src/plugin/type-converters.ts
@@ -705,6 +705,9 @@ export function fromTask(task: theia.Task): TaskDto | undefined {
     const taskDto = {} as TaskDto;
     taskDto.label = task.name;
     taskDto.source = task.source;
+    if ((task as types.Task).hasProblemMatchers) {
+        taskDto.problemMatcher = task.problemMatchers;
+    }
     if ('detail' in task) {
         taskDto.detail = (task as theia.Task2).detail;
     }
@@ -748,7 +751,7 @@ export function toTask(taskDto: TaskDto): theia.Task {
         throw new Error('Task should be provided for converting');
     }
 
-    const { type, label, source, scope, detail, command, args, options, windows, ...properties } = taskDto;
+    const { type, label, source, scope, problemMatcher, detail, command, args, options, windows, ...properties } = taskDto;
     const result = {} as theia.Task;
     result.name = label;
     result.source = source;


### PR DESCRIPTION
#### What it does
Fixes #8755. The `problemMatchers` array from the Task object created by the task provider is copied to the `problemMatcher` field in TaskDto to be transferred to the frontend.

Caveat: `problemMatcher` is not yet defined in `TaskDto`, but it has a catch-all signature `[key: string]: any`. Adding that field explicitly to `TaskDto` leads to problems because the type is also used to transfer task data from frontend to backend, and the respective field in `TaskCustomization` is not compatible.

#### How to test
See reproduction steps in #8755.

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

