### PR TITLE
core,mini-browser: server enhancements

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -38,7 +38,8 @@
       ],
       "env": {
         "NODE_ENV": "development",
-        "THEIA_WEBVIEW_EXTERNAL_ENDPOINT": "${env:THEIA_WEBVIEW_EXTERNAL_ENDPOINT}"
+        "THEIA_WEBVIEW_EXTERNAL_ENDPOINT": "${env:THEIA_WEBVIEW_EXTERNAL_ENDPOINT}",
+        "THEIA_MINI_BROWSER_HOST_PATTERN": "${env:THEIA_MINI_BROWSER_HOST_PATTERN}"
       },
       "sourceMaps": true,
       "outFiles": [

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,11 +3,20 @@
 ## v1.9.0
 
 - [plugin-ext-vscode] added support for the command `workbench.extensions.installExtension`. [#8745](https://github.com/eclipse-theia/theia/pull/8745)
+- [core] added `THEIA_HOSTS` environment variable (browser applications only).
+  - Used to filter incoming WebSocket connections: if `Origin` header does not match the list of hosts it will be refused.
+  - Value is a comma-separated list of domain names including the port if not `80` nor `443`.
+  - Example: `app.some.domain.com,app.other.domain:12345`.
 
 <a name="breaking_changes_1.9.0">[Breaking Changes:](#breaking_changes_1.9.0)</a>
 
 - [plugin-ext] `LocalDirectoryPluginDeployerResolver` has moved from `packages/plugin-ext/src/main/node/resolvers/plugin-local-dir-resolver.ts` to `packages/plugin-ext/src/main/node/resolvers/local-file-plugin-deployer-resolver.ts` and now derives from `LocalPluginDeployerResolver`.
 - [`download:plugins`] errors when downloading plugins now result in build failures, unless `--ignore-errors` flag is passed [#8788](https://github.com/eclipse-theia/theia/pull/8788)
+- [core] Deprecated `ElectronMessagingContribution`, token validation is now done in `ElectronTokenValidator` as a `WsRequestValidatorContribution`.
+- [mini-browser] New unique endpoint.
+  - `{{uuid}}.mini-browser.{{hostname}}` by default.
+  - Can be configured via `THEIA_MINI_BROWSER_HOST_PATTERN` environment variable.
+  - Clients must setup this new hostname in their DNS resolvers.
 
 ## v1.8.0 - 26/11/2020
 

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -84,6 +84,16 @@ root INFO [nsfw-watcher: 10734] Started watching: /Users/captain.future/git/thei
 ```
 Where `root` is the name of the logger and `INFO` is the log level. These are optionally followed by the name of a child process and the process ID.
 
+## Environment Variables
+
+- `THEIA_HOSTS`
+  - A comma-separated list of hosts expected to resolve to the current application.
+    - e.g: `theia.app.com,some.other.domain:3000`
+  - The port number is important if your application is not hosted on either `80` or `443`.
+  - If possible, you should set this environment variable:
+    - When not set, Theia will allow any origin to access the WebSocket services.
+    - When set, Theia will only allow the origins defined in this environment variable.
+
 ## Additional Information
 
 - [API documentation for `@theia/core`](https://eclipse-theia.github.io/theia/docs/next/modules/core.html)

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -74,6 +74,10 @@
     {
       "frontendElectron": "lib/electron-browser/token/electron-token-frontend-module",
       "backendElectron": "lib/electron-node/token/electron-token-backend-module"
+    },
+    {
+      "backend": "lib/node/hosting/backend-hosting-module",
+      "backendElectron": "lib/electron-node/hosting/electron-backend-hosting-module"
     }
   ],
   "keywords": [

--- a/packages/core/src/electron-main/electron-main-application-module.ts
+++ b/packages/core/src/electron-main/electron-main-application-module.ts
@@ -25,6 +25,7 @@ import { ElectronMainWindowServiceImpl } from './electron-main-window-service-im
 import { ElectronMessagingContribution } from './messaging/electron-messaging-contribution';
 import { ElectronMessagingService } from './messaging/electron-messaging-service';
 import { ElectronConnectionHandler } from '../electron-common/messaging/electron-connection-handler';
+import { ElectronSecurityTokenService } from './electron-security-token-service';
 
 const electronSecurityToken: ElectronSecurityToken = { value: v4() };
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -34,6 +35,7 @@ export default new ContainerModule(bind => {
     bind(ElectronMainApplication).toSelf().inSingletonScope();
     bind(ElectronMessagingContribution).toSelf().inSingletonScope();
     bind(ElectronSecurityToken).toConstantValue(electronSecurityToken);
+    bind(ElectronSecurityTokenService).toSelf().inSingletonScope();
 
     bindContributionProvider(bind, ElectronConnectionHandler);
     bindContributionProvider(bind, ElectronMessagingService.Contribution);

--- a/packages/core/src/electron-main/electron-main-application.ts
+++ b/packages/core/src/electron-main/electron-main-application.ts
@@ -15,7 +15,7 @@
  ********************************************************************************/
 
 import { inject, injectable, named } from 'inversify';
-import { session, screen, globalShortcut, app, BrowserWindow, BrowserWindowConstructorOptions, Event as ElectronEvent } from 'electron';
+import { screen, globalShortcut, app, BrowserWindow, BrowserWindowConstructorOptions, Event as ElectronEvent } from 'electron';
 import * as path from 'path';
 import { Argv } from 'yargs';
 import { AddressInfo } from 'net';
@@ -27,6 +27,7 @@ import { FileUri } from '../node/file-uri';
 import { Deferred } from '../common/promise-util';
 import { MaybePromise } from '../common/types';
 import { ContributionProvider } from '../common/contribution-provider';
+import { ElectronSecurityTokenService } from './electron-security-token-service';
 import { ElectronSecurityToken } from '../electron-common/electron-token';
 const Storage = require('electron-store');
 const createYargs: (argv?: string[], cwd?: string) => Argv = require('yargs/yargs');
@@ -162,16 +163,21 @@ export class ElectronMainApplication {
     @inject(ElectronMainApplicationGlobals)
     protected readonly globals: ElectronMainApplicationGlobals;
 
-    @inject(ElectronSecurityToken)
-    protected electronSecurityToken: ElectronSecurityToken;
-
     @inject(ElectronMainProcessArgv)
     protected processArgv: ElectronMainProcessArgv;
 
-    protected readonly electronStore = new Storage();
-    protected readonly backendPort = new Deferred<number>();
+    @inject(ElectronSecurityTokenService)
+    protected electronSecurityTokenService: ElectronSecurityTokenService;
 
-    protected _config: FrontendApplicationConfig;
+    @inject(ElectronSecurityToken)
+    protected readonly electronSecurityToken: ElectronSecurityToken;
+
+    protected readonly electronStore = new Storage();
+
+    protected readonly _backendPort = new Deferred<number>();
+    readonly backendPort = this._backendPort.promise;
+
+    protected _config: FrontendApplicationConfig | undefined;
     get config(): FrontendApplicationConfig {
         if (!this._config) {
             throw new Error('You have to start the application first.');
@@ -183,7 +189,7 @@ export class ElectronMainApplication {
         this._config = config;
         this.hookApplicationEvents();
         const port = await this.startBackend();
-        this.backendPort.resolve(port);
+        this._backendPort.resolve(port);
         await app.whenReady();
         await this.attachElectronSecurityToken(port);
         await this.startContributions();
@@ -279,8 +285,8 @@ export class ElectronMainApplication {
     }
 
     protected async createWindowUri(): Promise<URI> {
-        const port = await this.backendPort.promise;
-        return FileUri.create(this.globals.THEIA_FRONTEND_HTML_PATH).withQuery(`port=${port}`);
+        return FileUri.create(this.globals.THEIA_FRONTEND_HTML_PATH)
+            .withQuery(`port=${await this.backendPort}`);
     }
 
     protected getDefaultWindowState(): BrowserWindowConstructorOptions {
@@ -430,12 +436,7 @@ export class ElectronMainApplication {
     }
 
     protected async attachElectronSecurityToken(port: number): Promise<void> {
-        session.defaultSession.cookies.set({
-            url: `http://localhost:${port}/`,
-            name: ElectronSecurityToken,
-            value: JSON.stringify(this.electronSecurityToken),
-            httpOnly: true
-        });
+        await this.electronSecurityTokenService.setElectronSecurityTokenCookie(`http://localhost:${port}`);
     }
 
     protected hookApplicationEvents(): void {

--- a/packages/core/src/electron-main/electron-security-token-service.ts
+++ b/packages/core/src/electron-main/electron-security-token-service.ts
@@ -14,15 +14,22 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
-import { ContainerModule } from 'inversify';
-import { BackendApplicationContribution } from '../../node';
-import { WsRequestValidatorContribution } from '../../node/ws-request-validators';
-import { ElectronTokenBackendContribution } from './electron-token-backend-contribution';
-import { ElectronTokenValidator } from './electron-token-validator';
+import { session } from 'electron';
+import { inject, injectable } from 'inversify';
+import { ElectronSecurityToken } from '../electron-common/electron-token';
 
-export default new ContainerModule((bind, unbind, isBound, rebind) => {
-    bind(ElectronTokenBackendContribution).toSelf().inSingletonScope();
-    bind(BackendApplicationContribution).toService(ElectronTokenBackendContribution);
-    bind(ElectronTokenValidator).toSelf().inSingletonScope();
-    bind(WsRequestValidatorContribution).toService(ElectronTokenValidator);
-});
+@injectable()
+export class ElectronSecurityTokenService {
+
+    @inject(ElectronSecurityToken)
+    protected readonly electronSecurityToken: ElectronSecurityToken;
+
+    async setElectronSecurityTokenCookie(url: string): Promise<void> {
+        await session.defaultSession.cookies.set({
+            url,
+            name: ElectronSecurityToken,
+            value: JSON.stringify(this.electronSecurityToken),
+            httpOnly: true
+        });
+    }
+}

--- a/packages/core/src/electron-node/hosting/electron-backend-hosting-module.ts
+++ b/packages/core/src/electron-node/hosting/electron-backend-hosting-module.ts
@@ -15,14 +15,10 @@
  ********************************************************************************/
 
 import { ContainerModule } from 'inversify';
-import { BackendApplicationContribution } from '../../node';
 import { WsRequestValidatorContribution } from '../../node/ws-request-validators';
-import { ElectronTokenBackendContribution } from './electron-token-backend-contribution';
-import { ElectronTokenValidator } from './electron-token-validator';
+import { ElectronWsOriginValidator } from './electron-ws-origin-validator';
 
-export default new ContainerModule((bind, unbind, isBound, rebind) => {
-    bind(ElectronTokenBackendContribution).toSelf().inSingletonScope();
-    bind(BackendApplicationContribution).toService(ElectronTokenBackendContribution);
-    bind(ElectronTokenValidator).toSelf().inSingletonScope();
-    bind(WsRequestValidatorContribution).toService(ElectronTokenValidator);
+export default new ContainerModule(bind => {
+    bind(ElectronWsOriginValidator).toSelf().inSingletonScope();
+    bind(WsRequestValidatorContribution).toService(ElectronWsOriginValidator);
 });

--- a/packages/core/src/electron-node/hosting/electron-ws-origin-validator.ts
+++ b/packages/core/src/electron-node/hosting/electron-ws-origin-validator.ts
@@ -14,15 +14,16 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
-import { ContainerModule } from 'inversify';
-import { BackendApplicationContribution } from '../../node';
+import * as http from 'http';
+import { injectable } from 'inversify';
 import { WsRequestValidatorContribution } from '../../node/ws-request-validators';
-import { ElectronTokenBackendContribution } from './electron-token-backend-contribution';
-import { ElectronTokenValidator } from './electron-token-validator';
 
-export default new ContainerModule((bind, unbind, isBound, rebind) => {
-    bind(ElectronTokenBackendContribution).toSelf().inSingletonScope();
-    bind(BackendApplicationContribution).toService(ElectronTokenBackendContribution);
-    bind(ElectronTokenValidator).toSelf().inSingletonScope();
-    bind(WsRequestValidatorContribution).toService(ElectronTokenValidator);
-});
+@injectable()
+export class ElectronWsOriginValidator implements WsRequestValidatorContribution {
+
+    allowWsUpgrade(request: http.IncomingMessage): boolean {
+        // On Electron the main page is served from the `file` protocol.
+        // We don't expect the requests to come from anywhere else.
+        return request.headers.origin === 'file://';
+    }
+}

--- a/packages/core/src/electron-node/token/electron-token-messaging-contribution.ts
+++ b/packages/core/src/electron-node/token/electron-token-messaging-contribution.ts
@@ -22,6 +22,7 @@ import { ElectronTokenValidator } from './electron-token-validator';
 
 /**
  * Override the browser MessagingContribution class to refuse connections that do not include a specific token.
+ * @deprecated since 1.8.0
  */
 @injectable()
 export class ElectronMessagingContribution extends MessagingContribution {

--- a/packages/core/src/node/backend-application-module.ts
+++ b/packages/core/src/node/backend-application-module.ts
@@ -29,6 +29,7 @@ import { EnvVariablesServer, envVariablesPath } from './../common/env-variables'
 import { EnvVariablesServerImpl } from './env-variables';
 import { ConnectionContainerModule } from './messaging/connection-container-module';
 import { QuickPickService, quickPickServicePath } from '../common/quick-pick-service';
+import { WsRequestValidator, WsRequestValidatorContribution } from './ws-request-validators';
 
 decorate(injectable(), ApplicationPackage);
 
@@ -81,4 +82,7 @@ export const backendApplicationModule = new ContainerModule(bind => {
         const { projectPath } = container.get(BackendApplicationCliContribution);
         return new ApplicationPackage({ projectPath });
     }).inSingletonScope();
+
+    bind(WsRequestValidator).toSelf().inSingletonScope();
+    bindContributionProvider(bind, WsRequestValidatorContribution);
 });

--- a/packages/core/src/node/hosting/backend-application-hosts.ts
+++ b/packages/core/src/node/hosting/backend-application-hosts.ts
@@ -1,0 +1,60 @@
+/********************************************************************************
+ * Copyright (C) 2020 Ericsson and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import { injectable, postConstruct } from 'inversify';
+
+/**
+ * **Important: This component is not bound on Electron.**
+ *
+ * Component handling the different hosts the Theia backend should be reachable at.
+ *
+ * Hosts should be set through the `THEIA_HOSTS` environment variable as a comma-separated list of hosts.
+ *
+ * If you do not set this variable, we'll consider that we don't know where the application is hosted at.
+ */
+@injectable()
+export class BackendApplicationHosts {
+
+    protected readonly _hosts = new Set<string>();
+    /**
+     * Set of domains that the application is supposed to be reachable at.
+     * If the set is empty it means that we don't know where we are hosted.
+     * You can check for this with `.hasKnownHosts()`.
+     */
+    get hosts(): ReadonlySet<string> {
+        return this._hosts;
+    }
+
+    @postConstruct()
+    protected postConstruct(): void {
+        const theiaHostsEnv = process.env['THEIA_HOSTS'];
+        if (theiaHostsEnv) {
+            theiaHostsEnv.split(',').forEach(host => {
+                const trimmed = host.trim();
+                if (trimmed.length > 0) {
+                    this._hosts.add(trimmed);
+                }
+            });
+        }
+    }
+
+    /**
+     * Do we know where we are hosted?
+     */
+    hasKnownHosts(): boolean {
+        return this._hosts.size > 0;
+    }
+}

--- a/packages/core/src/node/hosting/backend-hosting-module.ts
+++ b/packages/core/src/node/hosting/backend-hosting-module.ts
@@ -15,14 +15,12 @@
  ********************************************************************************/
 
 import { ContainerModule } from 'inversify';
-import { BackendApplicationContribution } from '../../node';
-import { WsRequestValidatorContribution } from '../../node/ws-request-validators';
-import { ElectronTokenBackendContribution } from './electron-token-backend-contribution';
-import { ElectronTokenValidator } from './electron-token-validator';
+import { WsRequestValidatorContribution } from '../ws-request-validators';
+import { BackendApplicationHosts } from './backend-application-hosts';
+import { WsOriginValidator } from './ws-origin-validator';
 
-export default new ContainerModule((bind, unbind, isBound, rebind) => {
-    bind(ElectronTokenBackendContribution).toSelf().inSingletonScope();
-    bind(BackendApplicationContribution).toService(ElectronTokenBackendContribution);
-    bind(ElectronTokenValidator).toSelf().inSingletonScope();
-    bind(WsRequestValidatorContribution).toService(ElectronTokenValidator);
+export default new ContainerModule(bind => {
+    bind(BackendApplicationHosts).toSelf().inSingletonScope();
+    bind(WsOriginValidator).toSelf().inSingletonScope();
+    bind(WsRequestValidatorContribution).toService(WsOriginValidator);
 });

--- a/packages/core/src/node/ws-request-validators.ts
+++ b/packages/core/src/node/ws-request-validators.ts
@@ -1,0 +1,56 @@
+/********************************************************************************
+ * Copyright (C) 2020 Ericsson and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import { inject, injectable, named } from 'inversify';
+import * as http from 'http';
+import { ContributionProvider, MaybePromise } from '../common';
+
+/**
+ * Bind components to this symbol to filter WebSocket connections.
+ */
+export const WsRequestValidatorContribution = Symbol('RequestValidatorContribution');
+export interface WsRequestValidatorContribution {
+    /**
+     * Return `false` to prevent the protocol upgrade from going through, blocking the WebSocket connection.
+     *
+     * @param request The HTTP connection upgrade request received by the server.
+     */
+    allowWsUpgrade(request: http.IncomingMessage): MaybePromise<boolean>;
+}
+
+/**
+ * Central handler of `WsRequestValidatorContribution`.
+ */
+@injectable()
+export class WsRequestValidator {
+
+    @inject(ContributionProvider) @named(WsRequestValidatorContribution)
+    protected readonly requestValidators: ContributionProvider<WsRequestValidatorContribution>;
+
+    /**
+     * Ask all bound `WsRequestValidatorContributions` if the WebSocket connection should be allowed or not.
+     */
+    async allowWsUpgrade(request: http.IncomingMessage): Promise<boolean> {
+        return new Promise(async resolve => {
+            await Promise.all(Array.from(this.requestValidators.getContributions(), async validator => {
+                if (!await validator.allowWsUpgrade(request)) {
+                    resolve(false); // bail on first refusal
+                }
+            }));
+            resolve(true);
+        });
+    }
+}

--- a/packages/mini-browser/README.md
+++ b/packages/mini-browser/README.md
@@ -14,6 +14,13 @@
 
 The `@theia/mini-browser` extension provides a browser widget with the corresponding backend endpoints.
 
+### Environment Variables
+
+- `THEIA_MINI_BROWSER_HOST_PATTERN`
+  - A string pattern possibly containing `{{hostname}}` which will be replaced. This is the host for which the `mini-browser` will serve.
+  - It is a good practice to host the `mini-browser` handlers on a sub-domain as it is more secure.
+  - Defaults to `{{uuid}}.mini-browser.{{hostname}}`.
+
 ## Additional Information
 
 - [API documentation for `@theia/mini-browser`](https://eclipse-theia.github.io/theia/docs/next/modules/mini_browser.html)

--- a/packages/mini-browser/compile.tsconfig.json
+++ b/packages/mini-browser/compile.tsconfig.json
@@ -3,8 +3,7 @@
   "compilerOptions": {
     "composite": true,
     "rootDir": "src",
-    "outDir": "lib",
-    "baseUrl": "."
+    "outDir": "lib"
   },
   "include": [
     "src"

--- a/packages/mini-browser/package.json
+++ b/packages/mini-browser/package.json
@@ -7,7 +7,9 @@
     "@theia/filesystem": "^1.8.0",
     "@types/mime-types": "^2.1.0",
     "mime-types": "^2.1.18",
-    "pdfobject": "^2.0.201604172"
+    "pdfobject": "^2.0.201604172",
+    "vhost": "^3.0.2",
+    "uuid": "^8.0.0"
   },
   "publishConfig": {
     "access": "public"
@@ -15,7 +17,12 @@
   "theiaExtensions": [
     {
       "backend": "lib/node/mini-browser-backend-module",
-      "frontend": "lib/browser/mini-browser-frontend-module"
+      "frontend": "lib/browser/mini-browser-frontend-module",
+      "electronMain": "lib/electron-main/mini-browser-electron-main-module"
+    },
+    {
+      "frontend": "lib/browser/environment/mini-browser-environment-module",
+      "frontendElectron": "lib/electron-browser/environment/electron-mini-browser-environment-module"
     }
   ],
   "keywords": [

--- a/packages/mini-browser/src/browser/environment/mini-browser-environment-module.ts
+++ b/packages/mini-browser/src/browser/environment/mini-browser-environment-module.ts
@@ -14,15 +14,11 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
+import { FrontendApplicationContribution } from '@theia/core/lib/browser';
 import { ContainerModule } from 'inversify';
-import { BackendApplicationContribution } from '../../node';
-import { WsRequestValidatorContribution } from '../../node/ws-request-validators';
-import { ElectronTokenBackendContribution } from './electron-token-backend-contribution';
-import { ElectronTokenValidator } from './electron-token-validator';
+import { MiniBrowserEnvironment } from './mini-browser-environment';
 
-export default new ContainerModule((bind, unbind, isBound, rebind) => {
-    bind(ElectronTokenBackendContribution).toSelf().inSingletonScope();
-    bind(BackendApplicationContribution).toService(ElectronTokenBackendContribution);
-    bind(ElectronTokenValidator).toSelf().inSingletonScope();
-    bind(WsRequestValidatorContribution).toService(ElectronTokenValidator);
+export default new ContainerModule(bind => {
+    bind(MiniBrowserEnvironment).toSelf().inSingletonScope();
+    bind(FrontendApplicationContribution).toService(MiniBrowserEnvironment);
 });

--- a/packages/mini-browser/src/browser/environment/mini-browser-environment.ts
+++ b/packages/mini-browser/src/browser/environment/mini-browser-environment.ts
@@ -1,0 +1,60 @@
+/********************************************************************************
+ * Copyright (C) 2020 Ericsson and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import { EnvVariablesServer } from '@theia/core/lib/common/env-variables';
+import { Endpoint, FrontendApplicationContribution } from '@theia/core/lib/browser';
+import { inject, injectable, postConstruct } from 'inversify';
+import { MiniBrowserEndpoint } from '../../common/mini-browser-endpoint';
+import { v4 } from 'uuid';
+
+/**
+ * Fetch values from the backend's environment.
+ */
+@injectable()
+export class MiniBrowserEnvironment implements FrontendApplicationContribution {
+
+    protected _hostPatternPromise: Promise<string>;
+    protected _hostPattern: string;
+
+    @inject(EnvVariablesServer)
+    protected readonly environment: EnvVariablesServer;
+
+    @postConstruct()
+    protected postConstruct(): void {
+        this._hostPatternPromise = this.environment.getValue(MiniBrowserEndpoint.HOST_PATTERN_ENV)
+            .then(envVar => envVar?.value || MiniBrowserEndpoint.HOST_PATTERN_DEFAULT);
+    }
+
+    async onStart(): Promise<void> {
+        this._hostPattern = await this._hostPatternPromise;
+    }
+
+    getEndpoint(uuid: string, hostname?: string): Endpoint {
+        return new Endpoint({
+            host: this._hostPattern
+                .replace('{{uuid}}', uuid)
+                .replace('{{hostname}}', hostname || this.getDefaultHostname()),
+        });
+    }
+
+    getRandomEndpoint(): Endpoint {
+        return this.getEndpoint(v4());
+    }
+
+    protected getDefaultHostname(): string {
+        return self.location.host;
+    }
+}

--- a/packages/mini-browser/src/browser/location-mapper-service.ts
+++ b/packages/mini-browser/src/browser/location-mapper-service.ts
@@ -19,6 +19,7 @@ import URI from '@theia/core/lib/common/uri';
 import { Endpoint } from '@theia/core/lib/browser';
 import { MaybePromise, Prioritizeable } from '@theia/core/lib/common/types';
 import { ContributionProvider } from '@theia/core/lib/common/contribution-provider';
+import { MiniBrowserEnvironment } from './environment/mini-browser-environment';
 
 /**
  * Contribution for the `LocationMapperService`.
@@ -127,6 +128,9 @@ export class LocationWithoutSchemeMapper implements LocationMapper {
 @injectable()
 export class FileLocationMapper implements LocationMapper {
 
+    @inject(MiniBrowserEnvironment)
+    protected readonly miniBrowserEnvironment: MiniBrowserEnvironment;
+
     canHandle(location: string): MaybePromise<number> {
         return location.startsWith('file://') ? 1 : 0;
     }
@@ -140,11 +144,14 @@ export class FileLocationMapper implements LocationMapper {
         if (rawLocation.charAt(0) === '/') {
             rawLocation = rawLocation.substr(1);
         }
-        return new MiniBrowserEndpoint().getRestUrl().resolve(rawLocation).toString();
+        return this.miniBrowserEnvironment.getRandomEndpoint().getRestUrl().resolve(rawLocation).toString();
     }
 
 }
 
+/**
+ * @deprecated since 1.8.0
+ */
 export class MiniBrowserEndpoint extends Endpoint {
     constructor() {
         super({ path: 'mini-browser' });

--- a/packages/mini-browser/src/browser/mini-browser-open-handler.ts
+++ b/packages/mini-browser/src/browser/mini-browser-open-handler.ts
@@ -91,10 +91,12 @@ export class MiniBrowserOpenHandler extends NavigatableWidgetOpenHandler<MiniBro
     protected readonly locationMapperService: LocationMapperService;
 
     onStart(): void {
-        (async () => (await this.miniBrowserService.supportedFileExtensions()).forEach(entry => {
-            const { extension, priority } = entry;
-            this.supportedExtensions.set(extension, priority);
-        }))();
+        this.miniBrowserService.supportedFileExtensions().then(entries => {
+            entries.forEach(entry => {
+                const { extension, priority } = entry;
+                this.supportedExtensions.set(extension, priority);
+            });
+        });
     }
 
     canHandle(uri: URI): number {

--- a/packages/mini-browser/src/common/mini-browser-endpoint.ts
+++ b/packages/mini-browser/src/common/mini-browser-endpoint.ts
@@ -14,15 +14,14 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
-import { ContainerModule } from 'inversify';
-import { BackendApplicationContribution } from '../../node';
-import { WsRequestValidatorContribution } from '../../node/ws-request-validators';
-import { ElectronTokenBackendContribution } from './electron-token-backend-contribution';
-import { ElectronTokenValidator } from './electron-token-validator';
-
-export default new ContainerModule((bind, unbind, isBound, rebind) => {
-    bind(ElectronTokenBackendContribution).toSelf().inSingletonScope();
-    bind(BackendApplicationContribution).toService(ElectronTokenBackendContribution);
-    bind(ElectronTokenValidator).toSelf().inSingletonScope();
-    bind(WsRequestValidatorContribution).toService(ElectronTokenValidator);
-});
+/**
+ * The mini-browser can now serve content on its own host/origin.
+ *
+ * The virtual host can be configured with this `THEIA_MINI_BROWSER_HOST_PATTERN`
+ * environment variable. `{{hostname}}` reprensents the current host, and `{{uuid}}`
+ * will be replace by a random uuid value.
+ */
+export namespace MiniBrowserEndpoint {
+    export const HOST_PATTERN_ENV = 'THEIA_MINI_BROWSER_HOST_PATTERN';
+    export const HOST_PATTERN_DEFAULT = '{{uuid}}.mini-browser.{{hostname}}';
+}

--- a/packages/mini-browser/src/electron-browser/environment/electron-mini-browser-environment-module.ts
+++ b/packages/mini-browser/src/electron-browser/environment/electron-mini-browser-environment-module.ts
@@ -14,15 +14,12 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
+import { FrontendApplicationContribution } from '@theia/core/lib/browser';
 import { ContainerModule } from 'inversify';
-import { BackendApplicationContribution } from '../../node';
-import { WsRequestValidatorContribution } from '../../node/ws-request-validators';
-import { ElectronTokenBackendContribution } from './electron-token-backend-contribution';
-import { ElectronTokenValidator } from './electron-token-validator';
+import { MiniBrowserEnvironment } from '../../browser/environment/mini-browser-environment';
+import { ElectronMiniBrowserEnvironment } from './electron-mini-browser-environment';
 
-export default new ContainerModule((bind, unbind, isBound, rebind) => {
-    bind(ElectronTokenBackendContribution).toSelf().inSingletonScope();
-    bind(BackendApplicationContribution).toService(ElectronTokenBackendContribution);
-    bind(ElectronTokenValidator).toSelf().inSingletonScope();
-    bind(WsRequestValidatorContribution).toService(ElectronTokenValidator);
+export default new ContainerModule(bind => {
+    bind(MiniBrowserEnvironment).to(ElectronMiniBrowserEnvironment).inSingletonScope();
+    bind(FrontendApplicationContribution).toService(MiniBrowserEnvironment);
 });

--- a/packages/mini-browser/src/electron-browser/environment/electron-mini-browser-environment.ts
+++ b/packages/mini-browser/src/electron-browser/environment/electron-mini-browser-environment.ts
@@ -1,0 +1,56 @@
+/********************************************************************************
+ * Copyright (C) 2020 Ericsson and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import { Endpoint } from '@theia/core/lib/browser';
+import { ElectronSecurityToken } from '@theia/core/lib/electron-common/electron-token';
+import { remote } from 'electron';
+import { inject, injectable } from 'inversify';
+import { MiniBrowserEnvironment } from '../../browser/environment/mini-browser-environment';
+
+@injectable()
+export class ElectronMiniBrowserEnvironment extends MiniBrowserEnvironment {
+
+    @inject(ElectronSecurityToken)
+    protected readonly electronSecurityToken: ElectronSecurityToken;
+
+    getEndpoint(uuid: string, hostname?: string): Endpoint {
+        const endpoint = super.getEndpoint(uuid, hostname);
+        // Note: This call is async, but clients expect sync logic.
+        remote.session.defaultSession.cookies.set({
+            url: endpoint.getRestUrl().toString(true),
+            name: ElectronSecurityToken,
+            value: JSON.stringify(this.electronSecurityToken),
+            httpOnly: true,
+        });
+        return endpoint;
+    }
+
+    protected getDefaultHostname(): string {
+        const query = self.location.search
+            .substr(1)
+            .split('&')
+            .map(entry => entry
+                .split('=', 2)
+                .map(element => decodeURIComponent(element))
+            );
+        for (const [key, value] of query) {
+            if (key === 'port') {
+                return `localhost:${value}`;
+            }
+        }
+        throw new Error('could not resolve Electron\'s backend port');
+    }
+}

--- a/packages/mini-browser/src/electron-main/mini-browser-electron-main-contribution.ts
+++ b/packages/mini-browser/src/electron-main/mini-browser-electron-main-contribution.ts
@@ -1,0 +1,42 @@
+/********************************************************************************
+ * Copyright (C) 2020 Ericsson and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import { ElectronMainApplication, ElectronMainApplicationContribution } from '@theia/core/lib/electron-main/electron-main-application';
+import { ElectronSecurityTokenService } from '@theia/core/lib/electron-main/electron-security-token-service';
+import { inject, injectable } from 'inversify';
+import { MiniBrowserEndpoint } from '../common/mini-browser-endpoint';
+
+/**
+ * Since the mini-browser might serve content from a new origin,
+ * we need to attach the ElectronSecurityToken for the Electron
+ * backend to accept HTTP requests.
+ */
+@injectable()
+export class MiniBrowserElectronMainContribution implements ElectronMainApplicationContribution {
+
+    @inject(ElectronSecurityTokenService)
+    protected readonly electronSecurityTokenService: ElectronSecurityTokenService;
+
+    async onStart(app: ElectronMainApplication): Promise<void> {
+        const url = this.getMiniBrowserEndpoint(await app.backendPort);
+        await this.electronSecurityTokenService.setElectronSecurityTokenCookie(url);
+    }
+
+    protected getMiniBrowserEndpoint(port: number): string {
+        const pattern = process.env[MiniBrowserEndpoint.HOST_PATTERN_ENV] ?? MiniBrowserEndpoint.HOST_PATTERN_DEFAULT;
+        return 'http://' + pattern.replace('{{hostname}}', `localhost:${port}`);
+    }
+}

--- a/packages/mini-browser/src/electron-main/mini-browser-electron-main-module.ts
+++ b/packages/mini-browser/src/electron-main/mini-browser-electron-main-module.ts
@@ -14,15 +14,11 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
+import { ElectronMainApplicationContribution } from '@theia/core/lib/electron-main/electron-main-application';
 import { ContainerModule } from 'inversify';
-import { BackendApplicationContribution } from '../../node';
-import { WsRequestValidatorContribution } from '../../node/ws-request-validators';
-import { ElectronTokenBackendContribution } from './electron-token-backend-contribution';
-import { ElectronTokenValidator } from './electron-token-validator';
+import { MiniBrowserElectronMainContribution } from './mini-browser-electron-main-contribution';
 
-export default new ContainerModule((bind, unbind, isBound, rebind) => {
-    bind(ElectronTokenBackendContribution).toSelf().inSingletonScope();
-    bind(BackendApplicationContribution).toService(ElectronTokenBackendContribution);
-    bind(ElectronTokenValidator).toSelf().inSingletonScope();
-    bind(WsRequestValidatorContribution).toService(ElectronTokenValidator);
+export default new ContainerModule(bind => {
+    bind(MiniBrowserElectronMainContribution).toSelf().inSingletonScope();
+    bind(ElectronMainApplicationContribution).toService(MiniBrowserElectronMainContribution);
 });

--- a/packages/mini-browser/src/node/mini-browser-backend-module.ts
+++ b/packages/mini-browser/src/node/mini-browser-backend-module.ts
@@ -20,10 +20,14 @@ import { BackendApplicationContribution } from '@theia/core/lib/node/backend-app
 import { ConnectionHandler, JsonRpcConnectionHandler } from '@theia/core/lib/common';
 import { MiniBrowserService, MiniBrowserServicePath } from '../common/mini-browser-service';
 import { MiniBrowserEndpoint, MiniBrowserEndpointHandler, HtmlHandler, ImageHandler, PdfHandler, SvgHandler } from './mini-browser-endpoint';
+import { WsRequestValidatorContribution } from '@theia/core/lib/node/ws-request-validators';
+import { MiniBrowserWsRequestValidator } from './mini-browser-ws-validator';
 
 export default new ContainerModule(bind => {
     bind(MiniBrowserEndpoint).toSelf().inSingletonScope();
     bind(BackendApplicationContribution).toService(MiniBrowserEndpoint);
+    bind(MiniBrowserWsRequestValidator).toSelf().inSingletonScope();
+    bind(WsRequestValidatorContribution).toService(MiniBrowserWsRequestValidator);
     bind(MiniBrowserService).toService(MiniBrowserEndpoint);
     bind(ConnectionHandler).toDynamicValue(context => new JsonRpcConnectionHandler(MiniBrowserServicePath, () => context.container.get(MiniBrowserService))).inSingletonScope();
     bindContributionProvider(bind, MiniBrowserEndpointHandler);

--- a/packages/mini-browser/src/node/mini-browser-endpoint.ts
+++ b/packages/mini-browser/src/node/mini-browser-endpoint.ts
@@ -14,17 +14,19 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
+const vhost = require('vhost');
+import express = require('express');
 import * as fs from 'fs-extra';
 import { lookup } from 'mime-types';
 import { injectable, inject, named } from 'inversify';
 import { Application, Request, Response } from 'express';
-import URI from '@theia/core/lib/common/uri';
 import { FileUri } from '@theia/core/lib/node/file-uri';
 import { ILogger } from '@theia/core/lib/common/logger';
 import { MaybePromise } from '@theia/core/lib/common/types';
 import { ContributionProvider } from '@theia/core/lib/common/contribution-provider';
 import { BackendApplicationContribution } from '@theia/core/lib/node/backend-application';
 import { MiniBrowserService } from '../common/mini-browser-service';
+import { MiniBrowserEndpoint as MiniBrowserEndpointNS } from '../common/mini-browser-endpoint';
 
 /**
  * The return type of the `FileSystem#resolveContent` method.
@@ -73,8 +75,12 @@ export class MiniBrowserEndpoint implements BackendApplicationContribution, Mini
 
     /**
      * Endpoint path to handle the request for the given resource.
+     *
+     * @deprecated since 1.8.0
      */
     static HANDLE_PATH = '/mini-browser/';
+
+    private attachRequestHandlerPromise: Promise<void>;
 
     @inject(ILogger)
     protected readonly logger: ILogger;
@@ -86,11 +92,11 @@ export class MiniBrowserEndpoint implements BackendApplicationContribution, Mini
     protected readonly handlers: Map<string, MiniBrowserEndpointHandler> = new Map();
 
     configure(app: Application): void {
-        app.get(`${MiniBrowserEndpoint.HANDLE_PATH}*`, async (request, response) => this.response(await this.getUri(request), response));
+        this.attachRequestHandlerPromise = this.attachRequestHandler(app);
     }
 
     async onStart(): Promise<void> {
-        for (const handler of this.getContributions()) {
+        await Promise.all(Array.from(this.getContributions(), async handler => {
             const extensions = await handler.supportedExtensions();
             for (const extension of (Array.isArray(extensions) ? extensions : [extensions]).map(e => e.toLocaleLowerCase())) {
                 const existingHandler = this.handlers.get(extension);
@@ -98,11 +104,18 @@ export class MiniBrowserEndpoint implements BackendApplicationContribution, Mini
                     this.handlers.set(extension, handler);
                 }
             }
-        }
+        }));
+        await this.attachRequestHandlerPromise;
     }
 
     async supportedFileExtensions(): Promise<Readonly<{ extension: string, priority: number }>[]> {
-        return Array.from(this.handlers.entries()).map(([extension, handler]) => ({ extension, priority: handler.priority() }));
+        return Array.from(this.handlers.entries(), ([extension, handler]) => ({ extension, priority: handler.priority() }));
+    }
+
+    protected async attachRequestHandler(app: Application): Promise<void> {
+        const miniBrowserApp = express();
+        miniBrowserApp.get('*', async (request, response) => this.response(await this.getUri(request), response));
+        app.use(vhost(await this.getVirtualHostRegExp(), miniBrowserApp));
     }
 
     protected async response(uri: string, response: Response): Promise<Response> {
@@ -134,8 +147,7 @@ export class MiniBrowserEndpoint implements BackendApplicationContribution, Mini
     }
 
     protected getUri(request: Request): MaybePromise<string> {
-        const decodedPath = request.path.substr(MiniBrowserEndpoint.HANDLE_PATH.length);
-        return new URI(FileUri.create(decodedPath).toString(true)).toString(true);
+        return FileUri.create(request.path).toString(true);
     }
 
     protected async readContent(uri: string): Promise<FileStatWithContent> {
@@ -186,6 +198,14 @@ export class MiniBrowserEndpoint implements BackendApplicationContribution, Mini
         };
     }
 
+    protected async getVirtualHostRegExp(): Promise<RegExp> {
+        const pattern = process.env[MiniBrowserEndpointNS.HOST_PATTERN_ENV] ?? MiniBrowserEndpointNS.HOST_PATTERN_DEFAULT;
+        const vhostRe = pattern
+            .replace('.', '\\.')
+            .replace('{{uuid}}', '.+')
+            .replace('{{hostname}}', '.+');
+        return new RegExp(vhostRe, 'i');
+    }
 }
 
 // See `EditorManager#canHandle`.

--- a/packages/mini-browser/src/node/mini-browser-ws-validator.ts
+++ b/packages/mini-browser/src/node/mini-browser-ws-validator.ts
@@ -1,0 +1,51 @@
+/********************************************************************************
+ * Copyright (C) 2020 Ericsson and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import { WsRequestValidatorContribution } from '@theia/core/lib/node/ws-request-validators';
+import * as http from 'http';
+import { injectable, postConstruct } from 'inversify';
+import * as url from 'url';
+import { MiniBrowserEndpoint } from '../common/mini-browser-endpoint';
+
+/**
+ * Prevents explicit WebSocket connections from the mini-browser virtual host.
+ */
+@injectable()
+export class MiniBrowserWsRequestValidator implements WsRequestValidatorContribution {
+
+    protected miniBrowserHostRe: RegExp;
+
+    @postConstruct()
+    protected postConstruct(): void {
+        const pattern = process.env[MiniBrowserEndpoint.HOST_PATTERN_ENV] || MiniBrowserEndpoint.HOST_PATTERN_DEFAULT;
+        const vhostRe = pattern
+            .replace('.', '\\.')
+            .replace('{{uuid}}', '.+')
+            .replace('{{hostname}}', '.+');
+        this.miniBrowserHostRe = new RegExp(vhostRe, 'i');
+    }
+
+    async allowWsUpgrade(request: http.IncomingMessage): Promise<boolean> {
+        if (request.headers.origin) {
+            const origin = url.parse(request.headers.origin);
+            if (origin.host && this.miniBrowserHostRe.test(origin.host)) {
+                // If the origin comes from the WebViews, refuse:
+                return false;
+            }
+        }
+        return true;
+    }
+}

--- a/packages/plugin-ext/src/main/node/plugin-ext-backend-module.ts
+++ b/packages/plugin-ext/src/main/node/plugin-ext-backend-module.ts
@@ -17,6 +17,7 @@
 import { interfaces } from 'inversify';
 import { PluginApiContribution } from './plugin-service';
 import { BackendApplicationContribution, CliContribution } from '@theia/core/lib/node';
+import { WsRequestValidatorContribution } from '@theia/core/lib/node/ws-request-validators';
 import { PluginsKeyValueStorage } from './plugins-key-value-storage';
 import { PluginDeployerContribution } from './plugin-deployer-contribution';
 import {
@@ -41,6 +42,7 @@ import { PluginTheiaDeployerParticipant } from './plugin-theia-deployer-particip
 export function bindMainBackend(bind: interfaces.Bind): void {
     bind(PluginApiContribution).toSelf().inSingletonScope();
     bind(BackendApplicationContribution).toService(PluginApiContribution);
+    bind(WsRequestValidatorContribution).toService(PluginApiContribution);
 
     bindContributionProvider(bind, PluginDeployerParticipant);
     bind(PluginDeployer).to(PluginDeployerImpl).inSingletonScope();

--- a/packages/plugin-ext/src/main/node/plugin-service.ts
+++ b/packages/plugin-ext/src/main/node/plugin-service.ts
@@ -14,20 +14,33 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
+import * as http from 'http';
 import * as path from 'path';
+import * as url from 'url';
 import connect = require('connect');
 import serveStatic = require('serve-static');
 const vhost = require('vhost');
 import * as express from 'express';
 import { BackendApplicationContribution } from '@theia/core/lib/node/backend-application';
-import { injectable } from 'inversify';
+import { injectable, postConstruct } from 'inversify';
 import { WebviewExternalEndpoint } from '../common/webview-protocol';
 import { environment } from '@theia/application-package/lib/environment';
+import { WsRequestValidatorContribution } from '@theia/core/lib/node/ws-request-validators';
+import { MaybePromise } from '@theia/core/lib/common';
 
 const pluginPath = (process.env.HOME || process.env.HOMEPATH || process.env.USERPROFILE) + './theia/plugins/';
 
 @injectable()
-export class PluginApiContribution implements BackendApplicationContribution {
+export class PluginApiContribution implements BackendApplicationContribution, WsRequestValidatorContribution {
+
+    protected webviewExternalEndpointRegExp: RegExp;
+
+    @postConstruct()
+    protected postConstruct(): void {
+        const webviewExternalEndpoint = this.webviewExternalEndpoint();
+        console.log(`Configuring to accept webviews on '${webviewExternalEndpoint}' hostname.`);
+        this.webviewExternalEndpointRegExp = new RegExp(webviewExternalEndpoint, 'i');
+    }
 
     configure(app: express.Application): void {
         app.get('/plugin/:path(*)', (req, res) => {
@@ -37,11 +50,23 @@ export class PluginApiContribution implements BackendApplicationContribution {
 
         const webviewApp = connect();
         webviewApp.use('/webview', serveStatic(path.join(__dirname, '../../../src/main/browser/webview/pre')));
-        const webviewExternalEndpoint = this.webviewExternalEndpoint();
-        console.log(`Configuring to accept webviews on '${webviewExternalEndpoint}' hostname.`);
-        app.use(vhost(new RegExp(webviewExternalEndpoint, 'i'), webviewApp));
+        app.use(vhost(this.webviewExternalEndpointRegExp, webviewApp));
     }
 
+    allowWsUpgrade(request: http.IncomingMessage): MaybePromise<boolean> {
+        if (request.headers.origin) {
+            const origin = url.parse(request.headers.origin);
+            if (origin.host && this.webviewExternalEndpointRegExp.test(origin.host)) {
+                // If the origin comes from the WebViews, refuse:
+                return false;
+            }
+        }
+        return true;
+    }
+
+    /**
+     * Returns a RegExp pattern matching the expected WebView endpoint's host.
+     */
     protected webviewExternalEndpoint(): string {
         let endpointPattern;
         if (environment.electron.is()) {
@@ -49,8 +74,8 @@ export class PluginApiContribution implements BackendApplicationContribution {
         } else {
             endpointPattern = process.env[WebviewExternalEndpoint.pattern] || WebviewExternalEndpoint.defaultPattern;
         }
-        return endpointPattern
+        return `^${endpointPattern
             .replace('{{uuid}}', '.+')
-            .replace('{{hostname}}', '.+');
+            .replace('{{hostname}}', '.+')}$`;
     }
 }

--- a/packages/preview/src/browser/preview-link-normalizer.ts
+++ b/packages/preview/src/browser/preview-link-normalizer.ts
@@ -14,20 +14,23 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
-import { injectable } from 'inversify';
+import { injectable, inject } from 'inversify';
 import URI from '@theia/core/lib/common/uri';
-import { MiniBrowserEndpoint } from '@theia/mini-browser/lib/browser/location-mapper-service';
+import { MiniBrowserEnvironment } from '@theia/mini-browser/lib/browser/environment/mini-browser-environment';
 
 @injectable()
 export class PreviewLinkNormalizer {
 
     protected urlScheme = new RegExp('^[a-z][a-z|0-9|\+|\-|\.]*:', 'i');
 
+    @inject(MiniBrowserEnvironment)
+    protected readonly miniBrowserEnvironment: MiniBrowserEnvironment;
+
     normalizeLink(documentUri: URI, link: string): string {
         try {
             if (!this.urlScheme.test(link)) {
                 const location = documentUri.parent.resolve(link).path.toString();
-                return new MiniBrowserEndpoint().getRestUrl().resolve(location).toString();
+                return this.miniBrowserEnvironment.getEndpoint('normalized-link').getRestUrl().resolve(location).toString();
             }
         } catch {
             // ignore


### PR DESCRIPTION
# mini-browser: serve on separate origin

The mini-browser currently hosts its services on the same origin than
Theia's main origin. This commit makes the `mini-browser` serve on its
own origin: `{{uuid}}.mini-browser.{{hostname}}` by default. Can be
configured with a `THEIA_MINI_BROWSER_HOST_PATTERN` environment
variable.

# core: validate ws upgrade origin

Hosting the `mini-browser` on its own origin prevents cross-origin
requests from happening easily, but WebSockets don't benefit from the
same protection. We need to allow/disallow upgrade requests in the
backend application ourselves.

This means that in order to know who to refuse, we need to know where we
are hosted. This is done by specifying the `THEIA_HOSTS` environment
variable. If left empty, no check will be done. But if set, nothing
besides what is written in this var will be allowed. See
`BackendApplicationHosts` to get the hosts extracted from this var. Note
that the latter is not set when running Electron, since there's no need
to deal with arbitrary origins, everything should be local.

No check is done on the HTTP(s) endpoints because we'll rely on the
browser's SOP and CORS policies to take effect.

A new contribution point is added: `WsRequestValidatorContribution`.
An extender can implement this contribution to allow or not WebSocket
connections. Internally used to filter origins and Electron's token as
well as checking the origin of requests to prevent some type of XSS.

Signed-off-by: Paul Maréchal <paul.marechal@ericsson.com>

Fixes: https://bugs.eclipse.org/bugs/show_bug.cgi?id=568018

#### How to test

- The `mini-browser` should work like before:
  - Preview a `.html` file, open the dev-tools and make sure that the file is served from `mini-browser.localhost:3000`.
  - Copy the url of the `iframe` and open it in a new tab.
  - Open the dev-tools and try opening a WebSocket connection to the main Theia application on `ws://localhost:3000/services`.
  - It should fail.
- The backend should be able to refuse connections from wrong hosts:
  - Shutdown the backend, set `THEIA_HOSTS=patate.local:3000`.
  - Edit your `hosts` file to add an entry like `127.0.0.1 patate.local`.
  - Run the backend and try accessing the app on http://localhost:3000.
  - It should not work due to the WebSocket connection being refused.
  - Access the app on http://patate.local:3000.
  - It should work.
- Electron should work like before:
  - Should not be affected by `THEIA_HOSTS`.

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)