### PR TITLE
Make FileSystemCommands.UPLOAD to return FileUploadResult

### DIFF
--- a/packages/filesystem/src/browser/filesystem-frontend-contribution.ts
+++ b/packages/filesystem/src/browser/filesystem-frontend-contribution.ts
@@ -29,7 +29,7 @@ import { MimeService } from '@theia/core/lib/browser/mime-service';
 import { TreeWidgetSelection } from '@theia/core/lib/browser/tree/tree-widget-selection';
 import { FileSystemPreferences } from './filesystem-preferences';
 import { FileSelection } from './file-selection';
-import { FileUploadService } from './file-upload-service';
+import { FileUploadService, FileUploadResult } from './file-upload-service';
 import { FileService, UserFileOperationEvent } from './file-service';
 import { FileChangesEvent, FileChangeType, FileOperation } from '../common/files';
 import { Deferred } from '@theia/core/lib/common/promise-util';
@@ -128,13 +128,14 @@ export class FileSystemFrontendContribution implements FrontendApplicationContri
         return !environment.electron.is() && fileStat.isDirectory;
     }
 
-    protected async upload(selection: FileSelection): Promise<void> {
+    protected async upload(selection: FileSelection): Promise<FileUploadResult | undefined> {
         try {
             const source = TreeWidgetSelection.getSource(this.selectionService.selection);
-            await this.uploadService.upload(selection.fileStat.resource);
+            const fileUploadResult = await this.uploadService.upload(selection.fileStat.resource);
             if (ExpandableTreeNode.is(selection) && source) {
                 await source.model.expandNode(selection);
             }
+            return fileUploadResult;
         } catch (e) {
             if (!isCancelled(e)) {
                 console.error(e);


### PR DESCRIPTION
Signed-off-by: Tomer Epstein <tomer.epstein@sap.com>

#### What it does
Make FileSystemCommands.UPLOAD to return FileUploadResult

#### How to test
git clone https://github.com/tomer-epstein/vscode-theia-tomer.git
cd vscode-theia-tomer
npm i && npm run package
copy vscode-theia-tomer-0.0.1.vsix to plugins folder
Right click on a folder in the Explorer, choose 'Open Theia Upload Dialog'.

![image](https://user-images.githubusercontent.com/57438361/99829772-63bdb380-2b65-11eb-93f2-de6336f94101.png)

![image](https://user-images.githubusercontent.com/57438361/99829881-910a6180-2b65-11eb-8839-81f7386a9e2d.png)


#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

