### PR TITLE
[siw] Add `search.searchOnType` preference

### DIFF
--- a/packages/search-in-workspace/src/browser/search-in-workspace-preferences.ts
+++ b/packages/search-in-workspace/src/browser/search-in-workspace-preferences.ts
@@ -30,13 +30,26 @@ export const searchInWorkspacePreferencesSchema: PreferenceSchema = {
             default: 'auto',
             type: 'string',
             enum: ['auto', 'alwaysCollapse', 'alwaysExpand'],
-        }
+        },
+        'search.searchOnType': {
+            description: 'Search all files as you type in the search field.',
+            default: true,
+            type: 'boolean',
+        },
+        'search.searchOnTypeDebouncePeriod': {
+            // eslint-disable-next-line max-len
+            description: 'When `search.searchOnType` is enabled, controls the timeout in milliseconds between a character being typed and the search starting. Has no effect when `search.searchOnType` is disabled.',
+            default: 300,
+            type: 'number',
+        },
     }
 };
 
 export class SearchInWorkspaceConfiguration {
     'search.lineNumbers': boolean;
     'search.collapseResults': string;
+    'search.searchOnType': boolean;
+    'search.searchOnTypeDebouncePeriod': number;
 }
 
 export const SearchInWorkspacePreferences = Symbol('SearchInWorkspacePreferences');


### PR DESCRIPTION
#### What it does

Fixes: https://github.com/eclipse-theia/theia/issues/8774.

+ Add `search.searchOnType` preference to control whether or not to search as a user updating search term.
+ Add `search.searchOnTypeDebouncePeriod` preference to control the timeout in milliseconds between a character being typed and the search starts. Has no effect when `search.searchOnType` is disabled.

> As a user, I want to control if typing in the search input box would trigger the search action. For example, sometimes, it's better if it waits until I have finished formulating the regex query.

#### How to test
+ `search.searchOnType`:
	- Enable `search.searchOnType`
	- Open the search view
	- Typing in the search input box triggers the search and the results appear in the search view
	- Disable `search.searchOnType`, then the search only starts when user press `ENTER` in the search input box

+ `search.searchOntypeDebouncePeriod`:
	- Make sure `searchOnType` is enabled
	- Adjust the value (in milliseconds)
	- Start typing in the search input box
	- When user stopped typing, the search starts after the set debounce period


#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

Co-authored-by: vince-fugnitto <vincent.fugnitto@ericsson.com>
Signed-off-by: Duc Nguyen <duc.a.nguyen@ericsson.com>