### PR TITLE
8769-user-keybinding: propagating Theia overriden keybindings into VS Code editor

### DIFF
--- a/packages/core/src/browser/keybinding.ts
+++ b/packages/core/src/browser/keybinding.ts
@@ -54,6 +54,12 @@ export interface ResolvedKeybinding extends common.Keybinding {
     resolved?: KeyCode[];
 }
 
+export namespace ResolvedKeybinding {
+    export function is(arg: ResolvedKeybinding): arg is ResolvedKeybinding {
+        return common.Keybinding.is(arg) && 'resolved' in arg;
+    }
+}
+
 export interface ScopedKeybinding extends common.Keybinding {
     /** Current keybinding scope */
     scope: KeybindingScope;

--- a/packages/monaco/src/browser/monaco-editor-provider.ts
+++ b/packages/monaco/src/browser/monaco-editor-provider.ts
@@ -176,7 +176,6 @@ export class MonacoEditorProvider {
         return editor;
     }
 
-
     protected addDynamicKeybindings(editor: MonacoEditor, standaloneCommandService: monaco.services.StandaloneCommandService, scope: KeybindingScope): void {
         const keybindings = this.keybindingRegistry.getKeybindingsByScope(scope);
         if (keybindings.length > 0) {

--- a/packages/monaco/src/typings/monaco/index.d.ts
+++ b/packages/monaco/src/typings/monaco/index.d.ts
@@ -178,11 +178,13 @@ declare module monaco.editor {
         setDecorationsFast(decorationTypeKey: string, ranges: IRange[]): void;
         trigger(source: string, handlerId: string, payload: any): void
         _standaloneKeybindingService: {
+            _commandService: monaco.services.StandaloneCommandService;
             _store: {
                 _toDispose: monaco.IDisposable[]
             }
             resolveKeybinding(keybinding: monaco.keybindings.ChordKeybinding): monaco.keybindings.ResolvedKeybinding[];
             resolveKeyboardEvent(keyboardEvent: monaco.IKeyboardEvent): monaco.keybindings.ResolvedKeybinding;
+            addDynamicKeybinding(commandId: string, _keybinding: number, handler: ICommandHandler, when: monaco.contextkey.ContextKeyExpr | undefined): IDisposable;
         }
     }
 


### PR DESCRIPTION
Signed-off-by: Dan Arad <dan.arad@sap.com>

#### What it does
Fixes #8769  
VS Code/monaco editor uses default vscode keybindings if no dynamicKeybindings are set. Theia keybindings overriden by user were not propagated into VS Code because they weren't added to dynamicKeybindings array using addDynamicKeybinding method.

On VS Code' side,  **_getResolver** is responsible for merging default keybindings with overriden ones ( = dynamicKeybindings)
![image](https://user-images.githubusercontent.com/71069170/99404049-d7588a00-28f3-11eb-8f12-4afbf85a1983.png)

#### How to test
After PR [8589](https://github.com/eclipse-theia/theia/pull/8589) is merged:
a. Update Keyboard shortcuts for "acceptRenameInput" & "acceptRenameInputWithPreview":
![image](https://user-images.githubusercontent.com/71069170/109813150-a186a980-7c35-11eb-827b-6c4578fc73dd.png)
b. click F2 to rename a function - rename input field is displayed with updated keyboard settings
![image](https://user-images.githubusercontent.com/71069170/109813373-f0344380-7c35-11eb-9ea2-67b9f666b446.png)

#### Review checklist

- [X] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

