### PR TITLE
Fix tree view reveal() behavior

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
   - Can be configured via `THEIA_MINI_BROWSER_HOST_PATTERN` environment variable.
   - Clients must setup this new hostname in their DNS resolvers.
 - [task] remove bash login shell when run from task to align with vscode.
+- [plugin-ext] TreeViewsMain.$reveal second parameter changed from string element id to string array element parent chain
 
 ## v1.8.0 - 26/11/2020
 

--- a/packages/plugin-ext/src/common/plugin-api-rpc.ts
+++ b/packages/plugin-ext/src/common/plugin-api-rpc.ts
@@ -587,7 +587,7 @@ export interface TreeViewsMain {
     $registerTreeDataProvider(treeViewId: string): void;
     $unregisterTreeDataProvider(treeViewId: string): void;
     $refresh(treeViewId: string): Promise<void>;
-    $reveal(treeViewId: string, treeItemId: string, options: TreeViewRevealOptions): Promise<any>;
+    $reveal(treeViewId: string, elementParentChain: string[], options: TreeViewRevealOptions): Promise<any>;
     $setMessage(treeViewId: string, message: string): void;
     $setTitle(treeViewId: string, title: string): void;
 }

--- a/packages/plugin-ext/src/main/browser/view/plugin-view-registry.ts
+++ b/packages/plugin-ext/src/main/browser/view/plugin-view-registry.ts
@@ -292,10 +292,14 @@ export class PluginViewRegistry implements FrontendApplicationContribution {
         return this.widgetManager.getWidget<PluginViewWidget>(PLUGIN_VIEW_FACTORY_ID, this.toPluginViewWidgetIdentifier(viewId));
     }
 
-    async openView(viewId: string, options?: { activate?: boolean }): Promise<PluginViewWidget | undefined> {
+    async openView(viewId: string, options?: { activate?: boolean, reveal?: boolean }): Promise<PluginViewWidget | undefined> {
         const view = await this.doOpenView(viewId);
-        if (view && options && options.activate === true) {
-            await this.shell.activateWidget(view.id);
+        if (view && options) {
+            if (options.activate === true) {
+                await this.shell.activateWidget(view.id);
+            } else if (options.reveal === true) {
+                await this.shell.revealWidget(view.id);
+            }
         }
         return view;
     }


### PR DESCRIPTION
Signed-off-by: Amiram Wingarten <amiram.wingarten@sap.com>

#### What it does

Various fixes to support tree view reveal in several unsupported scenarios and align it with vscode.

- reveal called without focus now opens the view container (left pane) and view (section), without focus
- reveal of a node that its ancestors are collapsed now expand all parents and reveals it
- reveal of a node that was not cached by backend or not fetched by client (for example when showing the tree for the first time) now works
- reveal of a tree element that is not identical (`===`) to cached node now works

#### How to test

- Clone https://github.com/amiramw/vscode-tree-expand
- `yarn && vsce package` to create the vsix file
- Load the vsix in theia
- Test view tree will show in explorer view a tree with nodes **a ➡️ b ➡️ c**


##### Scenarios

First time:
1. Open theia from chrome incognito (like first time).
2. F1 -> Reveal c New Object or F1 -> Reveal c Same Object
3. Test view section is opened, a and b are expanded and c is selected, before this PR nothing happened

From other view container:
1. Go to debug pane.
2. F1 -> Reveal c New Object or F1 -> Reveal c Same Object
3. Explorer is opened. Test view section is opened, a and b are expanded and c is selected, before this PR nothing happened.

From other view container:
1. Go to debug pane.
2. F1 -> Reveal c New Object or F1 -> Reveal c Same Object
3. Explorer is opened. Test view section is opened, a and b are expanded and c is selected, before this PR nothing happened.

With non identical element:
1. Open test view 
2. Expand the tree to show c and then collapse it
3. F1 -> Reveal c New Object or F1 -> Reveal c Same Object
4. Tree is expanded and c is selected. Before this PR only "Reveal c Same Object" worked


#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

