### PR TITLE
download-plugins: raise error in case of errors downloading plugins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 <a name="breaking_changes_1.9.0">[Breaking Changes:](#breaking_changes_1.9.0)</a>
 
 - [plugin-ext] `LocalDirectoryPluginDeployerResolver` has moved from `packages/plugin-ext/src/main/node/resolvers/plugin-local-dir-resolver.ts` to `packages/plugin-ext/src/main/node/resolvers/local-file-plugin-deployer-resolver.ts` and now derives from `LocalPluginDeployerResolver`.
+- [`download:plugins`] errors when downloading plugins now result in build failures, unless `--ignore-errors` flag is passed [#8788](https://github.com/eclipse-theia/theia/pull/8788)
 
 ## v1.8.0 - 26/11/2020
 

--- a/dev-packages/cli/src/download-plugins.ts
+++ b/dev-packages/cli/src/download-plugins.ts
@@ -44,6 +44,12 @@ export interface DownloadPluginsOptions {
      * Defaults to `false`.
      */
     packed?: boolean;
+
+    /**
+     * Determines if failures while downloading plugins should be ignored.
+     * Defaults to `false`.
+     */
+    ignoreErrors?: boolean;
 }
 
 export default async function downloadPlugins(options: DownloadPluginsOptions = {}): Promise<void> {
@@ -53,6 +59,7 @@ export default async function downloadPlugins(options: DownloadPluginsOptions = 
 
     const {
         packed = false,
+        ignoreErrors = false,
     } = options;
 
     console.warn('--- downloading plugins ---');
@@ -77,6 +84,9 @@ export default async function downloadPlugins(options: DownloadPluginsOptions = 
         temp.cleanupSync();
     }
     failures.forEach(console.error);
+    if (!ignoreErrors && failures.length > 0) {
+        throw new Error('Errors downloading some plugins. To make these errors non fatal, re-run with --ignore-errors');
+    }
 }
 
 /**

--- a/dev-packages/cli/src/theia.ts
+++ b/dev-packages/cli/src/theia.ts
@@ -156,6 +156,12 @@ function rebuildCommand(command: string, target: ApplicationProps.Target): yargs
                     describe: 'Controls whether to pack or unpack plugins',
                     boolean: true,
                     default: false,
+                },
+                'ignore-errors': {
+                    alias: 'i',
+                    describe: 'Ignore errors while downloading plugins',
+                    boolean: true,
+                    default: false,
                 }
             },
             handler: async args => {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

Fixes: #7819.

If something went wrong while downloading plugins, the build should be
interrupted, instead of creating an environment where some plugins might
be missing.


#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

One possible way is to add invalid entries in `theiaPlugins` from `package.json`, for example:
```json
  "theiaPlugins": {
    "error-404": "https://open-vsx.org/404",
    "error-invalid-url": "not url"
  }
```
and use `yarn download:plugins`.

Without these changes, the command exits with success status code:

![image](https://user-images.githubusercontent.com/521510/100442460-6a12d900-30eb-11eb-840b-f9164c3c35b2.png)

There are messages in red, yes, but the build report a success.

With the changes from this pull request, the command exit with error status code:

![image](https://user-images.githubusercontent.com/521510/100442572-92023c80-30eb-11eb-8b25-49acb930b4c9.png)




#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

