### PR TITLE
8757-refresh-toolbar

### DIFF
--- a/packages/core/src/browser/view-container.ts
+++ b/packages/core/src/browser/view-container.ts
@@ -750,13 +750,17 @@ export class ViewContainerPart extends BaseWidget {
         this.collapsedEmitter.fire(collapsed);
     }
 
-    setHidden(hidden: boolean): void {
+    setHidden(hidden: boolean, refreshToolbar?: boolean): void {
         if (!this.canHide) {
             return;
         }
         super.setHidden(hidden);
         if (!this.isHidden) {
             this.collapsed = false;
+            if (refreshToolbar) {
+                this.hideToolbar();
+                this.showToolbar();
+            }
         }
     }
 

--- a/packages/plugin-ext/src/main/browser/view/plugin-view-registry.ts
+++ b/packages/plugin-ext/src/main/browser/view/plugin-view-registry.ts
@@ -169,7 +169,7 @@ export class PluginViewRegistry implements FrontendApplicationContribution {
             return;
         }
         widget.updateViewVisibility(() =>
-            part.setHidden(!this.isViewVisible(viewId))
+            part.setHidden(!this.isViewVisible(viewId), widget.parent?.node.matches(':hover'))
         );
     }
 


### PR DESCRIPTION
Signed-off-by: Dan Arad <dan.arad@sap.com>

#### What it does
Fixes #8757 
When context key is updated, if it was related to a widget, it will refresh widget toolbar if mouse is hovering over widget

#### How to test
As explained in #8757 

#### Review checklist

- [X] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

