### PR TITLE
download-plugins: report a failure in case of unsupported file type

### DIFF
--- a/dev-packages/cli/src/download-plugins.ts
+++ b/dev-packages/cli/src/download-plugins.ts
@@ -108,7 +108,7 @@ async function downloadPluginAsync(failures: string[], plugin: string, pluginUrl
     } else if (pluginUrl.endsWith('vsix')) {
         fileExt = '.vsix';
     } else {
-        console.error(red(`error: '${plugin}' has an unsupported file type: '${pluginUrl}'`));
+        failures.push(red(`error: '${plugin}' has an unsupported file type: '${pluginUrl}'`));
         return;
     }
     const targetPath = path.join(process.cwd(), pluginsDir, `${plugin}${packed === true ? fileExt : ''}`);


### PR DESCRIPTION

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

If a plugin url listed in theiaPlugins in package.json is not supported,
it should be reported as a failure and not only logged.


#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

Change `theiaPlugins` in package.json to have an incorrect extension
```json
  "theiaPlugins": {
    "vscode-builtin-bat-incorrect-extension": "https://open-vsx.org/api/vscode/bat/1.44.2/file/vscode.bat-1.44.2.vsix.incorrect-extension"
  }
```

Run `yarn download:plugins`, an error should be reported ( with https://github.com/eclipse-theia/theia/pull/8788 is applied, the build should fail )

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

