### PR TITLE
download-plugins: fix logging of failures

### DIFF
--- a/dev-packages/cli/src/download-plugins.ts
+++ b/dev-packages/cli/src/download-plugins.ts
@@ -83,7 +83,7 @@ export default async function downloadPlugins(options: DownloadPluginsOptions = 
     } finally {
         temp.cleanupSync();
     }
-    failures.forEach(console.error);
+    failures.forEach(e => { console.error(e); });
     if (!ignoreErrors && failures.length > 0) {
         throw new Error('Errors downloading some plugins. To make these errors non fatal, re-run with --ignore-errors');
     }


### PR DESCRIPTION

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->
Because Array.forEach(f) calls f with (currentValue, index, array), the output
was not only the messages, but also the index and full array.

This changes to log only the message. 

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

Change `theiaPlugins` in `package.json` to something like this:
```json
  "theiaPlugins": {
    "error-404": "https://open-vsx.org/404.vsix",
    "another-error": "https://open-vsx.org/404.vsix"
  }
```

run `yarn download:plugins`. Without this change, in the output there is the index and the array of failures, it looks like this:
![image](https://user-images.githubusercontent.com/521510/100560214-8172e180-32f8-11eb-9d63-195545cb1775.png)

After this change, the output is:

![image](https://user-images.githubusercontent.com/521510/100560253-99e2fc00-32f8-11eb-9173-67fefe72f820.png)


#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

