### PR TITLE
electron: fix killing backend

### DIFF
--- a/packages/core/src/electron-main/electron-main-application.ts
+++ b/packages/core/src/electron-main/electron-main-application.ts
@@ -400,9 +400,21 @@ export class ElectronMainApplication {
                     reject(error);
                 });
                 app.on('quit', () => {
-                    // If we forked the process for the clusters, we need to manually terminate it.
-                    // See: https://github.com/eclipse-theia/theia/issues/835
-                    process.kill(backendProcess.pid);
+                    // Only issue a kill signal if the backend process is running.
+                    // eslint-disable-next-line no-null/no-null
+                    if (backendProcess.exitCode === null && backendProcess.signalCode === null) {
+                        try {
+                            // If we forked the process for the clusters, we need to manually terminate it.
+                            // See: https://github.com/eclipse-theia/theia/issues/835
+                            process.kill(backendProcess.pid);
+                        } catch (error) {
+                            // See https://man7.org/linux/man-pages/man2/kill.2.html#ERRORS
+                            if (error.code === 'ESRCH') {
+                                return;
+                            }
+                            throw error;
+                        }
+                    }
                 });
             });
         }


### PR DESCRIPTION
Gracefully kill the backend process when exiting an Electron app. A
check is made to make sure we only kill the backend if it is running.
The risk else is that we could kill a random process with the same PID
as the backend had before exiting. This should have been rare but not
impossible.

Signed-off-by: Paul <paul.marechal@ericsson.com>

Closes https://github.com/eclipse-theia/theia/issues/8804
Closes https://github.com/eclipse-theia/theia/issues/8534

#### How to test

- Run the electron example.
- Kill the backend process.
- Close all Electron windows.
- No error should show.

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)