### PR TITLE
ci: add 'fail-fast' to false

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,6 +17,7 @@ jobs:
     name: ${{ matrix.os }}, Node.js v${{ matrix.node }}, Python ${{ matrix.python }}
 
     strategy:
+      fail-fast: false
       matrix:
         os: [windows-2019, ubuntu-18.04, macos-10.15]
         node: ['12.x']


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

The following pull-request updates the `github actions` strategy to **not** `fail-fast` when there is an error in the matrix so all operating systems have a chance to build and not be cancelled by one another.

The default value for [`fail-fast`](https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-syntax-for-github-actions#jobsjob_idstrategyfail-fast) is `true`.

_Example:_

<div align='center'>

![image](https://user-images.githubusercontent.com/40359487/100755335-14c01b80-33ba-11eb-9472-d2aced7ecf28.png)

</div>

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

Verify that CI successfully passes. When there is an error in a build, all operating systems should run.

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

Signed-off-by: vince-fugnitto <vincent.fugnitto@ericsson.com>

