### PR TITLE
ci: add retry on publishing step

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -103,14 +103,23 @@ jobs:
         with:
           python-version: '2.x'
 
-      - name: Publish npm
+      - name: Pre-Publish
         run: |
           yarn --skip-integrity-check --network-timeout 100000
           yarn docs
-          yarn publish:next
         env:
           NODE_OPTIONS: --max_old_space_size=4096
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # https://github.com/microsoft/vscode-ripgrep/issues/9
+
+      - name: Publish NPM
+        uses: nick-invision/retry@v2
+        with:
+          timeout_minutes: 5
+          retry_wait_seconds: 30
+          max_attempts: 3
+          retry_on: error
+          command: yarn publish:next
+        env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }} # The variable name comes from here: https://github.com/actions/setup-node/blob/70b9252472eee7495c93bb1588261539c3c2b98d/src/authutil.ts#L48
 
       - name: Publish GH Pages


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

The following pull-request introduces a `retry` on the publishing step to NPM which can sometimes fail due to errors such as network problems or false negatives. The `retry` allows the workflow to re-publish after a short delay for `n` amount of times before reporting a failure.

Example error:
- https://github.com/eclipse-theia/theia/runs/1492436138

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

Difficult to test unless merged.

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

Signed-off-by: vince-fugnitto <vincent.fugnitto@ericsson.com>
