### PR TITLE
Correct identification of uri scheme according to rfc3986

### DIFF
--- a/packages/plugin-ext/src/main/browser/webview/webview.ts
+++ b/packages/plugin-ext/src/main/browser/webview/webview.ts
@@ -487,7 +487,7 @@ export class WebviewWidget extends BaseWidget implements StatefulWidget {
 
     protected normalizeRequestUri(requestPath: string): URI {
         const normalizedPath = decodeURIComponent(requestPath);
-        const requestUri = new URI(normalizedPath.replace(/^\/(\w+)\/(.+)$/, (_, scheme, path) => scheme + ':/' + path));
+        const requestUri = new URI(normalizedPath.replace(/^\/([a-zA-Z0-9.\-+]+)\/(.+)$/, (_, scheme, path) => scheme + ':/' + path));
         if (requestUri.scheme !== 'theia-resource' && requestUri.scheme !== 'vscode-resource') {
             return requestUri;
         }


### PR DESCRIPTION
#### What it does
This changes proposal fix identification of uri scheme. The problem is in regular expression, that matches uri scheme, it is trying to find scheme according to pattern `\w+` which matches any word character (alphanumeric and underscore).

According to https://tools.ietf.org/html/rfc3986#section-3.1 underscore cannot be used as part of uri scheme:

> Scheme names consist of a sequence of characters beginning with a
   letter and followed by any combination of letters, digits, plus
   ("+"), period ("."), or hyphen ("-").

Proposed changes is to align matching to rfc specification and use regular expression: `/^\/([a-zA-Z0-9.\-+]+)\/(.+)$/` instead of `/^\/(\w+)\/(.+)$/`.

This might be helpful for extensions, that provides custom resource scheme instead of `vscode-resource://`. Especially when extension that provides webview is located in different container/user machine and content to the remote resource is given by provided scheme.

Signed-off-by: Vladyslav Zhukovskyi <vzhukovs@redhat.com>

#### How to test
To check this Theia has to be run in multi-container environment, like OpenShift: [create and run workspace](http://che.openshift.io/f?url=https://gist.githubusercontent.com/vzhukovs/7eba298a521996a93e2020e8f6611f4f/raw/22995a18f609689e91b162c4325ae498dd1c0fa9/workspace.yaml).
This workspace configuration also provides an extension that runs in dedicate container: [redhat.vscode-didact](https://marketplace.visualstudio.com/items?itemName=redhat.vscode-didact).
After workspace start try to open any sample didact tutorial, resources from this webview (js, css) will be loaded using different uri scheme and webview will be displayed the same way as it runs locally on single node environment. 

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

