### PR TITLE
Pass object field instead of method argument

### DIFF
--- a/packages/plugin-ext/src/plugin/webviews.ts
+++ b/packages/plugin-ext/src/plugin/webviews.ts
@@ -195,7 +195,7 @@ export class WebviewImpl implements theia.Webview {
         this.checkIsDisposed();
         if (this._html !== value) {
             this._html = value;
-            this.proxy.$setHtml(this.viewId, value);
+            this.proxy.$setHtml(this.viewId, this._html);
         }
     }
 


### PR DESCRIPTION
#### What it does
This simple change proposal modifies the behavior of webview html setter to pass object field instead of method argument to the proxy delegator. With this approach it is possible to override current setter via method bind to add custom logic between setter and proxy delegation call.

Signed-off-by: Vladyslav Zhukovskyi <vzhukovs@redhat.com>

#### How to test
Build and run Theia from this PR and try to open any webview. Behavior should be the same as in master branch.

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

