### PR TITLE
fix: remove bash login shell when run from task to align with vscode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
   - `{{uuid}}.mini-browser.{{hostname}}` by default.
   - Can be configured via `THEIA_MINI_BROWSER_HOST_PATTERN` environment variable.
   - Clients must setup this new hostname in their DNS resolvers.
+- [task] remove bash login shell when run from task to align with vscode.
 
 ## v1.8.0 - 26/11/2020
 

--- a/packages/task/src/node/process/process-task-runner.ts
+++ b/packages/task/src/node/process/process-task-runner.ts
@@ -177,7 +177,7 @@ export class ProcessTaskRunner implements TaskRunner {
 
             if (/bash(.exe)?$/.test(command)) {
                 quotingFunctions = BashQuotingFunctions;
-                execArgs = ['-l', '-c'];
+                execArgs = ['-c'];
 
             } else if (/wsl(.exe)?$/.test(command)) {
                 quotingFunctions = BashQuotingFunctions;


### PR DESCRIPTION
Following discussion: https://github.com/eclipse-theia/theia/discussions/8818

bash login shell (-l) causing different behavior compared to non login.
for example - it rebuilds the PATH environment and ignore what was defined in theia docker.

this change aligns with vscode that doesn't run with login shell.

Signed-off-by: Amiram Wingarten <amiram.wingarten@sap.com>

#### How to test
1. Start theia from docker with debian and set PATH to add to some new folder
1. Put some executable in the new folder
1. Create simple shell task that runs the executable: 
```
{
	"version": "2.0.0",
	"tasks": [
		{
			"label": "MyTask",
			"type": "shell",
			"command": "<my executable>"
		}
	]
}
```

After this fix the run is successful. Before this fix it fail with error code 127 as the executable is not found.

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

