### PR TITLE
Add 'Find' option to output panel context menu

### DIFF
--- a/packages/output/src/browser/output-contribution.ts
+++ b/packages/output/src/browser/output-contribution.ts
@@ -226,6 +226,10 @@ export class OutputContribution extends AbstractViewContribution<OutputWidget> i
             label: 'Copy All'
         });
         registry.registerMenuAction(OutputContextMenu.COMMAND_GROUP, {
+            commandId: CommonCommands.FIND.id,
+            label: 'Find'
+        });
+        registry.registerMenuAction(OutputContextMenu.COMMAND_GROUP, {
             commandId: quickCommand.id,
             label: 'Find Command...'
         });


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
This adds a 'Find' option to the output view context menu.

Currently this functionality is hard to discover. It can be accessed when the output view is focused, either by using the Ctrl+F shortcut or the via the 'Edit' menu. Normally these controls open a different search menu, so it isn't clear that the output area has its own search functionality.
<!-- Include relevant issues and describe how they are addressed. -->

#### How to test
1. Open the output view
2. Open the context menu and select 'Find'
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

