### PR TITLE
8822-task-type

### DIFF
--- a/packages/plugin-ext/src/plugin/tasks/tasks.ts
+++ b/packages/plugin-ext/src/plugin/tasks/tasks.ts
@@ -78,7 +78,7 @@ export class TasksExtImpl implements TasksExt {
         this.executions.delete(id);
 
         this.onDidTerminateTask.fire({
-            execution: taskExecution
+            execution: this.resetDefinition(taskExecution)
         });
     }
 
@@ -197,5 +197,10 @@ export class TasksExtImpl implements TasksExt {
         };
         this.executions.set(executionId, result);
         return result;
+    }
+
+    private resetDefinition(taskExecution: theia.TaskExecution): theia.TaskExecution {
+        taskExecution.task.definition = Object.assign(taskExecution.task.definition, { type: taskExecution.task.definition.taskType, taskType: undefined });
+        return taskExecution;
     }
 }

--- a/packages/task/src/browser/task-service.ts
+++ b/packages/task/src/browser/task-service.ts
@@ -963,7 +963,7 @@ export class TaskService implements TaskConfigurationClient {
         let resolver = undefined;
         let resolvedTask: TaskConfiguration;
         try {
-            resolver = await this.taskResolverRegistry.getResolver(task.type);
+            resolver = await this.taskResolverRegistry.getResolver(task.taskType || task.type);
             resolvedTask = resolver ? await resolver.resolveTask(task) : task;
         } catch (error) {
             const errMessage = `Error resolving task '${task.label}': ${error}`;
@@ -1022,11 +1022,11 @@ export class TaskService implements TaskConfigurationClient {
 
         const registeredProblemMatchers = this.problemMatcherRegistry.getAll();
         items.push(...registeredProblemMatchers.map(matcher =>
-            ({
-                label: matcher.label,
-                value: { problemMatchers: [matcher] },
-                description: matcher.name.startsWith('$') ? matcher.name : `$${matcher.name}`
-            })
+        ({
+            label: matcher.label,
+            value: { problemMatchers: [matcher] },
+            description: matcher.name.startsWith('$') ? matcher.name : `$${matcher.name}`
+        })
         ));
         return items;
     }


### PR DESCRIPTION
8822-task-type: resetting taskDefinition back to original definition after invocation completed.

Signed-off-by: Dan Arad <dan.arad@sap.com>

#### What it does
Fixes #8822. 
When task is run, we currently update the task definition using `updateDefinitionBasedOnExecution()` function in `types-impl.ts`,  so my solution was to reset taskDefinition back to original setting (in relation to type & taskType props) so that result would correlate to original invocation code defined in task.

#### How to test
See explanation at #8822. 

#### Review checklist

- [X] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

