### PR TITLE
core: fix closing confirmation on Electron

### DIFF
--- a/packages/core/src/browser/window/default-window-service.ts
+++ b/packages/core/src/browser/window/default-window-service.ts
@@ -80,7 +80,12 @@ export class DefaultWindowService implements WindowService, FrontendApplicationC
     }
 
     /**
-     * Ask the user to confirm if they want to unload the window. Prevent it if they do not.
+     * Notify the browser that we do not want to unload.
+     *
+     * Notes:
+     *  - Shows a confirmation popup in browsers.
+     *  - Prevents the window from closing without confirmation in electron.
+     *
      * @param event The beforeunload event
      */
     protected preventUnload(event: BeforeUnloadEvent): string | void {


### PR DESCRIPTION
On Electron/Linux, doing `showMessageBoxSync` does not block the
unloading process. This leads to the window closing despite the user
asking to keep it open.

Instead we'll prevent closing right way, ask for confirmation and
finally close.

Signed-off-by: Paul Maréchal <paul.marechal@ericsson.com>

Closes https://github.com/eclipse-theia/theia/issues/8186

#### How to test

- Build and run the Electron example app on Linux.
- Set the `core.confirmExit` preference on `always`.
- Close the window and click on `no`.
- The window should stay open, and you should be able to repeat those steps again.

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

