### PR TITLE
core: call every contribution on unload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@
   - Clients must setup this new hostname in their DNS resolvers.
 - [task] remove bash login shell when run from task to align with vscode.
 - [plugin-ext] TreeViewsMain.$reveal second parameter changed from string element id to string array element parent chain
+- [core] `FrontendApplicationContribution.onWillStop` is now called for every contribution and will not bail early.
+  It will also be called when `application.confirmExit` is set to `never`.
 
 ## v1.8.0 - 26/11/2020
 

--- a/packages/core/src/browser/window/default-window-service.spec.ts
+++ b/packages/core/src/browser/window/default-window-service.spec.ts
@@ -1,0 +1,78 @@
+/********************************************************************************
+ * Copyright (C) 2020 Ericsson and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import { Container } from 'inversify';
+import { ContributionProvider } from '../../common';
+import { CorePreferences } from '../core-preferences';
+import { FrontendApplicationContribution } from '../frontend-application';
+import { DefaultWindowService } from './default-window-service';
+import assert = require('assert');
+
+describe('DefaultWindowService', () => {
+    class TestFrontendApplicationContribution implements FrontendApplicationContribution {
+        constructor(private preventUnload: boolean) { }
+        onWillStopCalled = false;
+        onWillStop(): boolean {
+            this.onWillStopCalled = true;
+            return this.preventUnload;
+        }
+    }
+    function setupWindowService(confirmExit: CorePreferences['application.confirmExit'], frontendContributions: FrontendApplicationContribution[]): DefaultWindowService {
+        const container = new Container();
+        container.bind(DefaultWindowService).toSelf().inSingletonScope();
+        container.bind<Partial<ContributionProvider<FrontendApplicationContribution>>>(ContributionProvider)
+            .toConstantValue({
+                getContributions: () => frontendContributions,
+            })
+            .whenTargetNamed(FrontendApplicationContribution);
+        container.bind<Partial<CorePreferences>>(CorePreferences)
+            .toConstantValue({
+                'application.confirmExit': confirmExit,
+            });
+        return container.get(DefaultWindowService);
+    }
+    it('onWillStop should be called on every contribution (never)', () => {
+        const frontendContributions: TestFrontendApplicationContribution[] = [
+            // preventUnload should be ignored here
+            new TestFrontendApplicationContribution(true),
+        ];
+        const windowService = setupWindowService('never', frontendContributions);
+        assert(frontendContributions.every(contribution => !contribution.onWillStopCalled), 'contributions should not be called yet');
+        assert(windowService.canUnload(), 'canUnload should return true');
+        assert(frontendContributions.every(contribution => contribution.onWillStopCalled), 'contributions should have been called');
+    });
+    it('onWillStop should be called on every contribution (ifRequired)', () => {
+        const frontendContributions: TestFrontendApplicationContribution[] = [
+            new TestFrontendApplicationContribution(true),
+            // canUnload should not stop at the previous contribution
+            new TestFrontendApplicationContribution(false),
+        ];
+        const windowService = setupWindowService('ifRequired', frontendContributions);
+        assert(frontendContributions.every(contribution => !contribution.onWillStopCalled), 'contributions should not be called yet');
+        assert(!windowService.canUnload(), 'canUnload should return false');
+        assert(frontendContributions.every(contribution => contribution.onWillStopCalled), 'contributions should have been called');
+    });
+    it('onWillStop should be called on every contribution (always)', () => {
+        const frontendContributions: TestFrontendApplicationContribution[] = [
+            // canUnload should return false despite preventUnload not being set
+            new TestFrontendApplicationContribution(false),
+        ];
+        const windowService = setupWindowService('always', frontendContributions);
+        assert(frontendContributions.every(contribution => !contribution.onWillStopCalled), 'contributions should not be called yet');
+        assert(!windowService.canUnload(), 'canUnload should return false');
+        assert(frontendContributions.every(contribution => contribution.onWillStopCalled), 'contributions should have been called');
+    });
+});

--- a/packages/core/src/browser/window/default-window-service.ts
+++ b/packages/core/src/browser/window/default-window-service.ts
@@ -50,17 +50,13 @@ export class DefaultWindowService implements WindowService, FrontendApplicationC
 
     canUnload(): boolean {
         const confirmExit = this.corePreferences['application.confirmExit'];
-        if (confirmExit === 'never') {
-            return true;
-        }
+        let preventUnload = confirmExit === 'always';
         for (const contribution of this.contributions.getContributions()) {
-            if (contribution.onWillStop) {
-                if (!!contribution.onWillStop(this.frontendApplication)) {
-                    return false;
-                }
+            if (contribution.onWillStop?.(this.frontendApplication)) {
+                preventUnload = true;
             }
         }
-        return confirmExit !== 'always';
+        return confirmExit === 'never' || !preventUnload;
     }
 
     /**


### PR DESCRIPTION
The current procedure bails early on the first contribution that
prevents unloading. This means that other contributions are not
notified.

This commit makes sure that all contributions are called.

Signed-off-by: Paul Maréchal <paul.marechal@ericsson.com>

#### How to test

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)