### PR TITLE
core: fix origin checks problems

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -68,7 +68,8 @@
       ],
       "env": {
         "NODE_ENV": "development",
-        "THEIA_WEBVIEW_EXTERNAL_ENDPOINT": "${env:THEIA_WEBVIEW_EXTERNAL_ENDPOINT}"
+        "THEIA_WEBVIEW_EXTERNAL_ENDPOINT": "${env:THEIA_WEBVIEW_EXTERNAL_ENDPOINT}",
+        "THEIA_MINI_BROWSER_HOST_PATTERN": "${env:THEIA_MINI_BROWSER_HOST_PATTERN}"
       },
       "sourceMaps": true,
       "outFiles": [
@@ -110,7 +111,8 @@
       ],
       "env": {
         "NODE_ENV": "development",
-        "THEIA_WEBVIEW_EXTERNAL_ENDPOINT": "${env:THEIA_WEBVIEW_EXTERNAL_ENDPOINT}"
+        "THEIA_WEBVIEW_EXTERNAL_ENDPOINT": "${env:THEIA_WEBVIEW_EXTERNAL_ENDPOINT}",
+        "THEIA_MINI_BROWSER_HOST_PATTERN": "${env:THEIA_MINI_BROWSER_HOST_PATTERN}"
       },
       "sourceMaps": true,
       "outFiles": [
@@ -173,7 +175,8 @@
       ],
       "env": {
         "THEIA_DEFAULT_PLUGINS": "local-dir:${workspaceFolder}/plugins",
-        "THEIA_WEBVIEW_EXTERNAL_ENDPOINT": "${env:THEIA_WEBVIEW_EXTERNAL_ENDPOINT}"
+        "THEIA_WEBVIEW_EXTERNAL_ENDPOINT": "${env:THEIA_WEBVIEW_EXTERNAL_ENDPOINT}",
+        "THEIA_MINI_BROWSER_HOST_PATTERN": "${env:THEIA_MINI_BROWSER_HOST_PATTERN}"
       },
       "stopOnEntry": false,
       "sourceMaps": true,

--- a/packages/mini-browser/src/browser/environment/mini-browser-environment.ts
+++ b/packages/mini-browser/src/browser/environment/mini-browser-environment.ts
@@ -44,6 +44,7 @@ export class MiniBrowserEnvironment implements FrontendApplicationContribution {
 
     getEndpoint(uuid: string, hostname?: string): Endpoint {
         return new Endpoint({
+            path: MiniBrowserEndpoint.PATH,
             host: this._hostPattern
                 .replace('{{uuid}}', uuid)
                 .replace('{{hostname}}', hostname || this.getDefaultHostname()),

--- a/packages/mini-browser/src/common/mini-browser-endpoint.ts
+++ b/packages/mini-browser/src/common/mini-browser-endpoint.ts
@@ -22,6 +22,7 @@
  * will be replace by a random uuid value.
  */
 export namespace MiniBrowserEndpoint {
+    export const PATH = '/mini-browser';
     export const HOST_PATTERN_ENV = 'THEIA_MINI_BROWSER_HOST_PATTERN';
     export const HOST_PATTERN_DEFAULT = '{{uuid}}.mini-browser.{{hostname}}';
 }

--- a/packages/mini-browser/src/node/mini-browser-endpoint.ts
+++ b/packages/mini-browser/src/node/mini-browser-endpoint.ts
@@ -115,7 +115,7 @@ export class MiniBrowserEndpoint implements BackendApplicationContribution, Mini
     protected async attachRequestHandler(app: Application): Promise<void> {
         const miniBrowserApp = express();
         miniBrowserApp.get('*', async (request, response) => this.response(await this.getUri(request), response));
-        app.use(vhost(await this.getVirtualHostRegExp(), miniBrowserApp));
+        app.use(MiniBrowserEndpointNS.PATH, vhost(await this.getVirtualHostRegExp(), miniBrowserApp));
     }
 
     protected async response(uri: string, response: Response): Promise<Response> {


### PR DESCRIPTION
Both `mini-browser` and `plugin-ext` contributes WebSocket checks refuse
WebSocket connections originating from within their served content, but
it prevented all connections when serving from the `{{hostname}}`
pattern.

This commit handles the case when such a pattern is used and disables
the origin check in such a case.

This is not totally fool-proof as some host/pattern combinations can
still lead to problems.

e.g. host is `sweet-potato.com` and the pattern is
`{{uuid}}-{{hostname}}`. The generated regex will be `^.+-.+$` which
still matches `sweet-potato.com`.

You should always include a unique string inside the pattern to avoid
such situations, like `{{uuid}}-webview-{{hostname}}`.

This commit also moves the `mini-browser` file serving to
`/mini-browser` to avoid conflicts when hosting on the same root origin.

Signed-off-by: Paul <paul.marechal@ericsson.com>

Closes https://github.com/eclipse-theia/theia/issues/8852

#### How to test

- Set `THEIA_MINI_BROWSER_HOST_PATTERN={{hostname}}`.
- Start the browser application.
- It should work, master doesn't.

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

