### PR TITLE
Fix mini-browser-endpoint missing resource response

### DIFF
--- a/packages/mini-browser/src/node/mini-browser-endpoint.ts
+++ b/packages/mini-browser/src/node/mini-browser-endpoint.ts
@@ -180,7 +180,7 @@ export class MiniBrowserEndpoint implements BackendApplicationContribution, Mini
     protected missingResourceHandler(): (uri: string, response: Response) => MaybePromise<Response> {
         return async (uri: string, response: Response) => {
             this.logger.error(`Cannot handle missing resource. URI: ${uri}.`);
-            return response.send();
+            return response.sendStatus(404);
         };
     }
 


### PR DESCRIPTION
Signed-off-by: Doron Nahari <doron.nahari@sap.com>

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->
Fix mini-browser-endpoint missing resource response.
When requiring a resource from the mini-browser such as `<theia-url>/mini-browser/<path-to-resource>`
it returns:
![image](https://user-images.githubusercontent.com/24614792/102221889-63f26a00-3eeb-11eb-9468-5c42aa1b48c5.png)

And after this fix:
![image](https://user-images.githubusercontent.com/24614792/102221450-dc0c6000-3eea-11eb-9bae-ca612cd683f7.png)

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
 - Run Theia locally.
 - Open browser dev-tools and go to network tab.
 - Enter this url in the browser:
`localhost:3000/mini-browser/<path-to-resource-non-existing-resource>`

Before the fix you'll get `200` response code and with the fix you'll get `404`
#### Review checklist

- [X] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

