### PR TITLE
Move createAPIFactory to $init() of PluginManager

### DIFF
--- a/packages/plugin-ext/src/hosted/node/hosted-plugin-process.ts
+++ b/packages/plugin-ext/src/hosted/node/hosted-plugin-process.ts
@@ -155,6 +155,8 @@ export class HostedPluginProcess implements ServerPluginRunner {
         this.childProcess.on('message', message => {
             if (this.client) {
                 this.client.postMessage(message);
+            } else {
+                this.logger.error('Dropping message: ' + JSON.stringify(message));
             }
         });
     }

--- a/packages/plugin-ext/src/main/browser/main-context.ts
+++ b/packages/plugin-ext/src/main/browser/main-context.ts
@@ -54,7 +54,7 @@ import { TimelineMainImpl } from './timeline-main';
 import { AuthenticationMainImpl } from './authentication-main';
 import { ThemingMainImpl } from './theming-main';
 
-export function setUpPluginApi(rpc: RPCProtocol, container: interfaces.Container): void {
+export function setUpPluginApi(rpc: RPCProtocol, container: interfaces.Container): () => void {
     const authenticationMain = new AuthenticationMainImpl(rpc, container);
     rpc.set(PLUGIN_RPC_CONTEXT.AUTHENTICATION_MAIN, authenticationMain);
 
@@ -91,9 +91,6 @@ export function setUpPluginApi(rpc: RPCProtocol, container: interfaces.Container
     const monacoEditorService = container.get(MonacoEditorService);
     const editorsMain = new TextEditorsMainImpl(editorsAndDocuments, rpc, bulkEditService, monacoEditorService);
     rpc.set(PLUGIN_RPC_CONTEXT.TEXT_EDITORS_MAIN, editorsMain);
-
-    // start listening only after all clients are subscribed to events
-    editorsAndDocuments.listen();
 
     const statusBarMessageRegistryMain = new StatusBarMessageRegistryMainImpl(container);
     rpc.set(PLUGIN_RPC_CONTEXT.STATUS_BAR_MESSAGE_REGISTRY_MAIN, statusBarMessageRegistryMain);
@@ -163,4 +160,9 @@ export function setUpPluginApi(rpc: RPCProtocol, container: interfaces.Container
 
     const themingMain = new ThemingMainImpl(rpc);
     rpc.set(PLUGIN_RPC_CONTEXT.THEMING_MAIN, themingMain);
+
+    return () => {
+        // start listening only after all clients are subscribed to events
+        editorsAndDocuments.listen();
+    };
 }

--- a/packages/plugin-ext/src/plugin/plugin-context.ts
+++ b/packages/plugin-ext/src/plugin/plugin-context.ts
@@ -175,7 +175,8 @@ export function createAPIFactory(
     workspaceExt: WorkspaceExtImpl,
     messageRegistryExt: MessageRegistryExt,
     clipboard: ClipboardExt,
-    webviewExt: WebviewsExtImpl
+    webviewExt: WebviewsExtImpl,
+    terminalExt: TerminalServiceExtImpl
 ): PluginAPIFactory {
 
     const authenticationExt = rpc.set(MAIN_RPC_CONTEXT.AUTHENTICATION_EXT, new AuthenticationExtImpl(rpc));
@@ -187,7 +188,6 @@ export function createAPIFactory(
     const editors = rpc.set(MAIN_RPC_CONTEXT.TEXT_EDITORS_EXT, new TextEditorsExtImpl(rpc, editorsAndDocumentsExt));
     const documents = rpc.set(MAIN_RPC_CONTEXT.DOCUMENTS_EXT, new DocumentsExtImpl(rpc, editorsAndDocumentsExt));
     const statusBarMessageRegistryExt = new StatusBarMessageRegistryExt(rpc);
-    const terminalExt = rpc.set(MAIN_RPC_CONTEXT.TERMINAL_EXT, new TerminalServiceExtImpl(rpc));
     const outputChannelRegistryExt = rpc.set(MAIN_RPC_CONTEXT.OUTPUT_CHANNEL_REGISTRY_EXT, new OutputChannelRegistryExtImpl(rpc));
     const languagesExt = rpc.set(MAIN_RPC_CONTEXT.LANGUAGES_EXT, new LanguagesExtImpl(rpc, documents, commandRegistry));
     const treeViewsExt = rpc.set(MAIN_RPC_CONTEXT.TREE_VIEWS_EXT, new TreeViewsExtImpl(rpc, commandRegistry));
@@ -200,7 +200,6 @@ export function createAPIFactory(
     const labelServiceExt = rpc.set(MAIN_RPC_CONTEXT.LABEL_SERVICE_EXT, new LabelServiceExtImpl(rpc));
     const timelineExt = rpc.set(MAIN_RPC_CONTEXT.TIMELINE_EXT, new TimelineExtImpl(rpc, commandRegistry));
     const themingExt = rpc.set(MAIN_RPC_CONTEXT.THEMING_EXT, new ThemingExtImpl(rpc));
-    rpc.set(MAIN_RPC_CONTEXT.DEBUG_EXT, debugExt);
 
     return function (plugin: InternalPlugin): typeof theia {
         const authentication: typeof theia.authentication = {


### PR DESCRIPTION
Signed-off-by: Thomas Mäder <tmader@redhat.com>
#### What it does
Fixes Timing issues when starting plugin hosts #8429 by moving the initialization of the ext-side services (for example in `createAPIFactory` to PluginManagerExtImpl#$init(). In this way, the main-side services (LanguagesMain, etc.) will already be listening when the services try to call them in their constructor (like in `TasksExtImpl`). Currently, the request to fetch task executions will be silently ignored.

#### How to test
1. Build Theia
2. Add a front-end and back-end plugin to the installation (for example https://github.com/eclipse/che-theia-samples/tree/master/samples/hello-world-frontend-plugin)
3. Put a breakpoint on line 159 of hosted-plugin-process.ts
4. Start debugging the back-end process (note that front-end plugins are still broken in the electron version, so remove the front end plugin before testing https://github.com/eclipse-theia/theia/issues/6601)
5. Make sure both plugins are activated correctly
6. Make sure the breakpoint is not hit and the error message on that line is not in the log.

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

