### PR TITLE
core: add unit tests for 'isEqualOrParent`

### DIFF
--- a/packages/core/src/common/uri.spec.ts
+++ b/packages/core/src/common/uri.spec.ts
@@ -187,4 +187,46 @@ describe('uri', () => {
             expect(String(path)).equals('node_modules/typescript/lib');
         });
     });
+
+    describe('#isEqualOrParent()', () => {
+        it('should return `true` for `uris` which are equal', () => {
+            const a = new URI('file:///C:/projects/theia/foo/a.ts');
+            const b = new URI('file:///C:/projects/theia/foo/a.ts');
+            expect(a.isEqualOrParent(b)).equals(true);
+        });
+        it('should return `false` for `uris` which are not equal', () => {
+            const a = new URI('file:///C:/projects/theia/foo/a.ts');
+            const b = new URI('file:///C:/projects/theia/foo/b.ts');
+            expect(a.isEqualOrParent(b)).equals(false);
+        });
+
+        it('should return `false` for `uris` which are not the same scheme', () => {
+            const a = new URI('a:///C:/projects/theia/foo/a.ts');
+            const b = new URI('b:///C:/projects/theia/foo/a.ts');
+            expect(a.isEqualOrParent(b)).equals(false);
+        });
+
+        it('should return `true` for `uris` that are not case-sensitive equal, with case-sensitivity `off`', () => {
+            const a = new URI('file:///C:/projects/theia/foo/a.ts');
+            const b = new URI('file:///C:/projects/theia/foo/A.ts');
+            expect(a.isEqualOrParent(b, false)).equals(true);
+        });
+        it('should return `false` for `uris` that are not case-sensitive equal, with case-sensitivity `on`', () => {
+            const a = new URI('file:///C:/projects/theia/foo/a.ts');
+            const b = new URI('file:///C:/projects/theia/foo/A.ts');
+            expect(a.isEqualOrParent(b, true)).equals(false);
+        });
+
+        it('should return `true` for parent paths', () => {
+            const a = new URI('file:///C:/projects/'); // parent uri.
+            const b = new URI('file:///C:/projects/theia/foo');
+            expect(a.isEqualOrParent(b)).equals(true);
+        });
+        it('should return `false` for non-parent paths', () => {
+            const a = new URI('file:///C:/projects/a/'); // non-parent uri.
+            const b = new URI('file:///C:/projects/theia/foo');
+            expect(a.isEqualOrParent(b)).equals(false);
+        });
+    });
+
 });


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

The following commit adds unit tests for `uri.isEqualOrParent()` which is untested today.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

Verify that the `@theia/core` unit-tests pass (CI or locally):

```bash
$ npx run test @theia/core
```

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

Signed-off-by: vince-fugnitto <vincent.fugnitto@ericsson.com>