### PR TITLE
Always set exact version when publishing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## v1.10.0
 
 - [plugin] added `createDeployQuickOpenItem` method to create `DeployQuickOpenItem` in order to make extension deploy command extensible [#8919] (https://github.com/eclipse-theia/theia/pull/8919)
+- [dependencies] updated to use fixed versions when publishing, `"x.y.z"` instead of `"^x.y.z"` in dependencies [#8880](https://github.com/eclipse-theia/theia/pull/8880)
 
 ## v1.9.0 - 16/12/2020
 

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "rebuild:electron": "theia rebuild:electron",
     "rebuild:electron:debug": "DEBUG=electron-rebuild && yarn rebuild:electron",
     "publish": "yarn && yarn test && yarn publish:latest",
-    "publish:latest": "lerna publish && yarn publish:check",
+    "publish:latest": "lerna publish --exact && yarn publish:check",
     "publish:next": "yarn next:publish && yarn next:publish --skip-npm && yarn publish:check",
     "next:publish": "lerna publish --exact --canary=next --npm-tag=next --yes",
     "publish:check": "node scripts/check-publish.js",


### PR DESCRIPTION
#### What it does
The patch promotes usage of a specific version number for each future Theia publication. Solves issue #8879.

We add use of the --exact option to lerna, see this link:
https://github.com/lerna/lerna/tree/main/commands/version#--exact

Fixes #8879

#### How to test
Run $ yarn publish:latest
Observe that all Theia extensions uses a specific version number on Theia dependencies.

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

