### PR TITLE
Fix horizontal scrollbar not to disappear

### DIFF
--- a/packages/core/src/browser/style/tabs.css
+++ b/packages/core/src/browser/style/tabs.css
@@ -335,6 +335,7 @@ body.theia-editor-highlightModifiedTabs
 .p-TabBar-content-container {
   display: flex;
   flex: 1;
+  position: relative; /* This is necessary for perfect-scrollbar */
 }
 
 .p-TabBar-toolbar .item {


### PR DESCRIPTION
Signed-off-by: Ken Aoki <ken3574.25@gmail.com>

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->
Fixes #8886.

~The module `perfect-scrollbar` unnecessarily  moves the horizontal scrollbar to right. This PR set position attribute for the horizontal scrollbar to `static` so that it can't be moved.~

This PR adds `position: relative` to style for the scrollbar container as per perfect-scrollbar [README](https://github.com/mdbootstrap/perfect-scrollbar#before-using-perfect-scrollbar).

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

1. Open as many files as the scrollbar appears.
2. Scroll to right.
3. Scrollbar should not disappear (not overflow right). 

![scrollbarfix2](https://user-images.githubusercontent.com/29003390/103145973-a89cc180-4785-11eb-8d58-d37705406198.gif)

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

