### PR TITLE
Change few terminal logs from error to warning

### DIFF
--- a/packages/terminal/src/browser/terminal-widget-impl.ts
+++ b/packages/terminal/src/browser/terminal-widget-impl.ts
@@ -382,7 +382,7 @@ export class TerminalWidgetImpl extends TerminalWidget implements StatefulWidget
         if (IBaseTerminalServer.validateId(terminalId)) {
             return terminalId;
         }
-        this.logger.error(`Error attaching to terminal id ${id}, the terminal is most likely gone. Starting up a new terminal instead.`);
+        this.logger.warn(`Failed attaching to terminal id ${id}, the terminal is most likely gone. Starting up a new terminal instead.`);
         if (this.kind === 'user') {
             return this.createTerminal();
         } else {

--- a/packages/terminal/src/node/base-terminal-server.ts
+++ b/packages/terminal/src/node/base-terminal-server.ts
@@ -63,7 +63,7 @@ export abstract class BaseTerminalServer implements IBaseTerminalServer {
         if (term && term instanceof TerminalProcess) {
             return term.id;
         } else {
-            this.logger.error(`Couldn't attach - can't find terminal with id: ${id} `);
+            this.logger.warn(`Couldn't attach - can't find terminal with id: ${id} `);
             return -1;
         }
     }
@@ -116,7 +116,7 @@ export abstract class BaseTerminalServer implements IBaseTerminalServer {
         if (term && term instanceof TerminalProcess) {
             term.resize(cols, rows);
         } else {
-            console.error("Couldn't resize terminal " + id + ", because it doesn't exist.");
+            console.warn("Couldn't resize terminal " + id + ", because it doesn't exist.");
         }
     }
 


### PR DESCRIPTION
Signed-off-by: Doron Nahari <doron.nahari@sap.com>

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
Change few "terminal gone" related logs from error to warning, because when terminal is gone, Theia starts a new terminal instead.
#### Review checklist

- [X] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

