### PR TITLE
Enable Workspace-Scoped Tasks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,15 @@
 
 - [filesystem] add text input and navigate up icon to file dialog [#8748](https://github.com/eclipse-theia/theia/pull/8748)
 - [core] updated connection status service to prevent false positive alerts about offline mode [#9068](https://github.com/eclipse-theia/theia/pull/9068)
+- [tasks] add support for workspace-scoped task configurations. [#8917](https://github.com/eclipse-theia/theia/pull/8917)
+- [workspace] add support for configurations outside the `settings` object and add `WorkspaceSchemaUpdater` to allow configurations sections to be contributed by extensions. [#8917](https://github.com/eclipse-theia/theia/pull/8917)
 
 <a name="breaking_changes_1.12.0">[Breaking Changes:](#breaking_changes_1.12.0)</a>
 
 - [filesystem] `FileDialog` and `LocationListRenderer` now require `FileService` to be passed into constructor for text-based file dialog navigation in browser [#8748](https://github.com/eclipse-theia/theia/pull/8748)
+- [core] `PreferenceService` and `PreferenceProvider` `getConfigUri` and `getContainingConfigUri` methods accept `sectionName` argument to retrieve URI's for non-settings configurations. [#8917](https://github.com/eclipse-theia/theia/pull/8917)
+- [tasks] `TaskConfigurationModel.scope` field now protected. `TaskConfigurationManager` setup changed to accommodate workspace-scoped tasks. [#8917](https://github.com/eclipse-theia/theia/pull/8917)
+- [workspace] `WorkspaceData` interface modified and workspace file schema updated to allow for `tasks` outside of `settings` object. `WorkspaceData.buildWorkspaceData` `settings` argument now accepts an object with any of the keys of the workspace schema. [#8917](https://github.com/eclipse-theia/theia/pull/8917)
 
 ## v1.11.0 - 2/25/2021
 

--- a/examples/api-tests/src/task-configurations.spec.js
+++ b/examples/api-tests/src/task-configurations.spec.js
@@ -1,0 +1,112 @@
+/********************************************************************************
+ * Copyright (C) 2021 Ericsson and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+// @ts-check
+
+describe('The Task Configuration Manager', function () {
+    this.timeout(5000);
+
+    const { assert } = chai;
+
+    const { WorkspaceService } = require('@theia/workspace/lib/browser/workspace-service');
+    const { TaskScope, TaskConfigurationScope } = require('@theia/task/lib/common/task-protocol');
+    const { TaskConfigurationManager } = require('@theia/task/lib/browser/task-configuration-manager');
+    const container = window.theia.container;
+    const workspaceService = container.get(WorkspaceService);
+    const taskConfigurationManager = container.get(TaskConfigurationManager);
+
+    const baseWorkspaceURI = workspaceService.tryGetRoots()[0].resource;
+    const baseWorkspaceRoot = baseWorkspaceURI.toString();
+
+    const basicTaskConfig = {
+        label: 'task',
+        type: 'shell',
+        command: 'top',
+    };
+
+    /** @type {Set<TaskConfigurationScope>} */
+    const scopesToClear = new Set();
+
+    describe('in a single-root workspace', () => {
+        beforeEach(() => clearTasks());
+        after(() => clearTasks());
+
+        setAndRetrieveTasks(() => TaskScope.Global, 'user');
+        setAndRetrieveTasks(() => TaskScope.Workspace, 'workspace');
+        setAndRetrieveTasks(() => baseWorkspaceRoot, 'folder');
+    });
+
+    async function clearTasks() {
+        await Promise.all(Array.from(scopesToClear, async scope => {
+            if (!!scope || scope === 0) {
+                await taskConfigurationManager.setTaskConfigurations(scope, []);
+            }
+        }));
+        scopesToClear.clear();
+    }
+
+    /**
+     * @param {() => TaskConfigurationScope} scopeGenerator a function to allow lazy evaluation of the second workspace root.
+     * @param {string} scopeLabel
+     * @param {boolean} only
+     */
+    function setAndRetrieveTasks(scopeGenerator, scopeLabel, only = false) {
+        const testFunction = only ? it.only : it;
+        testFunction(`successfully handles ${scopeLabel} scope`, async () => {
+            const scope = scopeGenerator();
+            scopesToClear.add(scope);
+            const initialTasks = taskConfigurationManager.getTasks(scope);
+            assert.deepEqual(initialTasks, []);
+            await taskConfigurationManager.setTaskConfigurations(scope, [basicTaskConfig]);
+            const newTasks = taskConfigurationManager.getTasks(scope);
+            assert.deepEqual(newTasks, [basicTaskConfig]);
+        });
+    }
+
+    /* UNCOMMENT TO RUN MULTI-ROOT TESTS */
+    // const { FileService } = require('@theia/filesystem/lib/browser/file-service');
+    // const { EnvVariablesServer } = require('@theia/core/lib/common/env-variables');
+    // const URI = require('@theia/core/lib/common/uri').default;
+
+    // const fileService = container.get(FileService);
+    // /** @type {EnvVariablesServer} */
+    // const envVariables = container.get(EnvVariablesServer);
+
+    // describe('in a multi-root workspace', () => {
+    //     let secondWorkspaceRoot = '';
+    //     before(async () => {
+    //         const configLocation = await envVariables.getConfigDirUri();
+    //         const secondWorkspaceRootURI = new URI(configLocation).parent.resolve(`test-root-${Date.now()}`);
+    //         secondWorkspaceRoot = secondWorkspaceRootURI.toString();
+    //         await fileService.createFolder(secondWorkspaceRootURI);
+    //         /** @type {Promise<void>} */
+    //         const waitForEvent = new Promise(resolve => {
+    //             const listener = taskConfigurationManager.onDidChangeTaskConfig(() => {
+    //                 listener.dispose();
+    //                 resolve();
+    //             });
+    //         });
+    //         workspaceService.addRoot(secondWorkspaceRootURI);
+    //         return waitForEvent;
+    //     });
+    //     beforeEach(() => clearTasks());
+    //     after(() => clearTasks());
+    //     setAndRetrieveTasks(() => TaskScope.Global, 'user');
+    //     setAndRetrieveTasks(() => TaskScope.Workspace, 'workspace');
+    //     setAndRetrieveTasks(() => baseWorkspaceRoot, 'folder (1)');
+    //     setAndRetrieveTasks(() => secondWorkspaceRoot, 'folder (2)');
+    // });
+});

--- a/packages/core/src/browser/preferences/preference-configurations.ts
+++ b/packages/core/src/browser/preferences/preference-configurations.ts
@@ -55,6 +55,10 @@ export class PreferenceConfigurations {
         return this.getSectionNames().indexOf(name) !== -1;
     }
 
+    isAnyConfig(name: string): boolean {
+        return [...this.getSectionNames(), this.getConfigName()].includes(name);
+    }
+
     isSectionUri(configUri: URI | undefined): boolean {
         return !!configUri && this.isSectionName(this.getName(configUri));
     }

--- a/packages/core/src/browser/preferences/preference-provider.ts
+++ b/packages/core/src/browser/preferences/preference-provider.ts
@@ -191,10 +191,11 @@ export abstract class PreferenceProvider implements Disposable {
     /**
      * Retrieve the configuration URI for the given resource URI.
      * @param resourceUri the uri of the resource or `undefined`.
+     * @param sectionName the section to return the URI for, e.g. `tasks` or `launch`. Defaults to settings.
      *
      * @returns the corresponding resource URI or `undefined` if there is no valid URI.
      */
-    getConfigUri(resourceUri?: string): URI | undefined {
+    getConfigUri(resourceUri?: string, sectionName?: string): URI | undefined {
         return undefined;
     }
 
@@ -205,7 +206,7 @@ export abstract class PreferenceProvider implements Disposable {
      * @returns the first valid configuration URI contained by the given resource `undefined`
      * if there is no valid configuration URI at all.
      */
-    getContainingConfigUri?(resourceUri?: string): URI | undefined;
+    getContainingConfigUri?(resourceUri?: string, sectionName?: string): URI | undefined;
 
     static merge(source: JSONValue | undefined, target: JSONValue): JSONValue {
         if (source === undefined || !JSONExt.isObject(source)) {

--- a/packages/core/src/browser/preferences/preference-service.ts
+++ b/packages/core/src/browser/preferences/preference-service.ts
@@ -213,11 +213,12 @@ export interface PreferenceService extends Disposable {
      *
      * @param scope the PreferenceScope to query for.
      * @param resourceUri the optional uri of the resource-specific preference handling
+     * @param sectionName the optional preference section to query for.
      *
      * @returns the uri of the configuration resource for the given scope and optional resource uri it it exists,
      * `undefined` otherwise.
      */
-    getConfigUri(scope: PreferenceScope, resourceUri?: string): URI | undefined;
+    getConfigUri(scope: PreferenceScope, resourceUri?: string, sectionName?: string): URI | undefined;
 }
 
 /**
@@ -512,16 +513,15 @@ export class PreferenceServiceImpl implements PreferenceService {
         };
     }
 
-    getConfigUri(scope: PreferenceScope, resourceUri?: string): URI | undefined {
+    getConfigUri(scope: PreferenceScope, resourceUri?: string, sectionName: string = this.configurations.getConfigName()): URI | undefined {
         const provider = this.getProvider(scope);
-        if (!provider) {
+        if (!provider || !this.configurations.isAnyConfig(sectionName)) {
             return undefined;
         }
-        const configUri = provider.getConfigUri(resourceUri);
+        const configUri = provider.getConfigUri(resourceUri, sectionName);
         if (configUri) {
             return configUri;
         }
-        return provider.getContainingConfigUri && provider.getContainingConfigUri(resourceUri);
+        return provider.getContainingConfigUri && provider.getContainingConfigUri(resourceUri, sectionName);
     }
-
 }

--- a/packages/debug/src/browser/debug-schema-updater.ts
+++ b/packages/debug/src/browser/debug-schema-updater.ts
@@ -22,6 +22,7 @@ import URI from '@theia/core/lib/common/uri';
 import { DebugService } from '../common/debug-service';
 import { debugPreferencesSchema } from './debug-preferences';
 import { inputsSchema } from '@theia/variable-resolver/lib/browser/variable-input-schema';
+import { WorkspaceService } from '@theia/workspace/lib/browser';
 
 @injectable()
 export class DebugSchemaUpdater implements JsonSchemaContribution {
@@ -29,6 +30,7 @@ export class DebugSchemaUpdater implements JsonSchemaContribution {
     protected readonly uri = new URI(launchSchemaId);
 
     @inject(InMemoryResources) protected readonly inmemoryResources: InMemoryResources;
+    @inject(WorkspaceService) protected readonly workspaceService: WorkspaceService;
     @inject(DebugService) protected readonly debug: DebugService;
 
     @postConstruct()
@@ -41,6 +43,7 @@ export class DebugSchemaUpdater implements JsonSchemaContribution {
             fileMatch: ['launch.json'],
             url: this.uri.toString()
         });
+        this.workspaceService.updateSchema('launch', { $ref: this.uri.toString() });
     }
 
     async update(): Promise<void> {

--- a/packages/preferences/src/browser/folders-preferences-provider.ts
+++ b/packages/preferences/src/browser/folders-preferences-provider.ts
@@ -77,20 +77,20 @@ export class FoldersPreferencesProvider extends PreferenceProvider {
         }
     }
 
-    getConfigUri(resourceUri?: string): URI | undefined {
+    getConfigUri(resourceUri?: string, sectionName: string = this.configurations.getConfigName()): URI | undefined {
         for (const provider of this.getFolderProviders(resourceUri)) {
             const configUri = provider.getConfigUri(resourceUri);
-            if (this.configurations.isConfigUri(configUri)) {
+            if (configUri && this.configurations.getName(configUri) === sectionName) {
                 return configUri;
             }
         }
         return undefined;
     }
 
-    getContainingConfigUri(resourceUri?: string): URI | undefined {
+    getContainingConfigUri(resourceUri?: string, sectionName: string = this.configurations.getConfigName()): URI | undefined {
         for (const provider of this.getFolderProviders(resourceUri)) {
             const configUri = provider.getConfigUri();
-            if (this.configurations.isConfigUri(configUri) && provider.contains(resourceUri)) {
+            if (provider.contains(resourceUri) && this.configurations.getName(configUri) === sectionName) {
                 return configUri;
             }
         }

--- a/packages/preferences/src/browser/section-preference-provider.ts
+++ b/packages/preferences/src/browser/section-preference-provider.ts
@@ -75,8 +75,8 @@ export abstract class SectionPreferenceProvider extends AbstractResourcePreferen
         if (preferenceName === this.section) {
             return [];
         }
-        if (preferenceName.startsWith(this.section + '.')) {
-            return [preferenceName.substr(this.section!.length + 1)];
+        if (preferenceName.startsWith(`${this.section}.`)) {
+            return [preferenceName.slice(this.section.length + 1)];
         }
         return undefined;
     }

--- a/packages/preferences/src/browser/user-configs-preference-provider.ts
+++ b/packages/preferences/src/browser/user-configs-preference-provider.ts
@@ -59,10 +59,10 @@ export class UserConfigsPreferenceProvider extends PreferenceProvider {
         }
     }
 
-    getConfigUri(resourceUri?: string): URI | undefined {
+    getConfigUri(resourceUri?: string, sectionName: string = this.configurations.getConfigName()): URI | undefined {
         for (const provider of this.providers.values()) {
             const configUri = provider.getConfigUri(resourceUri);
-            if (this.configurations.isConfigUri(configUri)) {
+            if (configUri && this.configurations.getName(configUri) === sectionName) {
                 return configUri;
             }
         }

--- a/packages/preferences/src/browser/workspace-preference-provider.ts
+++ b/packages/preferences/src/browser/workspace-preference-provider.ts
@@ -42,9 +42,9 @@ export class WorkspacePreferenceProvider extends PreferenceProvider {
         this.workspaceService.onWorkspaceLocationChanged(() => this.ensureDelegateUpToDate());
     }
 
-    getConfigUri(resourceUri: string | undefined = this.ensureResourceUri()): URI | undefined {
+    getConfigUri(resourceUri: string | undefined = this.ensureResourceUri(), sectionName?: string): URI | undefined {
         const delegate = this.delegate;
-        return delegate && delegate.getConfigUri(resourceUri);
+        return delegate && delegate.getConfigUri(resourceUri, sectionName);
     }
 
     protected _delegate: PreferenceProvider | undefined;

--- a/packages/task/src/browser/quick-open-task.ts
+++ b/packages/task/src/browser/quick-open-task.ts
@@ -234,77 +234,41 @@ export class QuickOpenTask implements QuickOpenModel, QuickOpenHandler {
     async configure(): Promise<void> {
         this.items = [];
         this.actionProvider = undefined;
-        const isMulti: boolean = this.workspaceService.isMultiRootWorkspaceOpened;
 
         const token: number = this.taskService.startUserAction();
 
         const configuredTasks = await this.taskService.getConfiguredTasks(token);
         const providedTasks = await this.taskService.getProvidedTasks(token);
-
-        // check if tasks.json exists. If not, display "Create tasks.json file from template"
-        // If tasks.json exists and empty, display 'Open tasks.json file'
-        let isFirstGroup = true;
         const { filteredConfiguredTasks, filteredProvidedTasks } = this.getFilteredTasks([], configuredTasks, providedTasks);
         const groupedTasks = this.getGroupedTasksByWorkspaceFolder([...filteredConfiguredTasks, ...filteredProvidedTasks]);
-        if (groupedTasks.has(TaskScope.Global.toString())) {
-            const configs = groupedTasks.get(TaskScope.Global.toString())!;
-            this.items.push(
-                ...configs.map(taskConfig => {
-                    const item = new TaskConfigureQuickOpenItem(
-                        token,
-                        taskConfig,
-                        this.taskService,
-                        this.taskNameResolver,
-                        this.workspaceService,
-                        isMulti,
-                        { showBorder: false }
-                    );
-                    item['taskDefinitionRegistry'] = this.taskDefinitionRegistry;
-                    return item;
-                })
-            );
-            isFirstGroup = false;
+
+        const scopes: TaskConfigurationScope[] = [TaskScope.Global];
+        if (this.workspaceService.opened) {
+            const roots = await this.workspaceService.roots;
+            scopes.push(...roots.map(rootStat => rootStat.resource.toString()));
+            if (this.workspaceService.saved) {
+                scopes.push(TaskScope.Workspace);
+            }
         }
 
-        const rootUris = (await this.workspaceService.roots).map(rootStat => rootStat.resource.toString());
-        for (const rootFolder of rootUris) {
-            const folderName = new URI(rootFolder).displayName;
-            if (groupedTasks.has(rootFolder)) {
-                const configs = groupedTasks.get(rootFolder.toString())!;
-                this.items.push(
-                    ...configs.map((taskConfig, index) => {
-                        const item = new TaskConfigureQuickOpenItem(
-                            token,
-                            taskConfig,
-                            this.taskService,
-                            this.taskNameResolver,
-                            this.workspaceService,
-                            isMulti,
-                            {
-                                groupLabel: index === 0 && isMulti ? folderName : '',
-                                showBorder: !isFirstGroup && index === 0
-                            }
-                        );
-                        item['taskDefinitionRegistry'] = this.taskDefinitionRegistry;
-                        return item;
-                    })
-                );
+        let isFirstGroup = true;
+        let groupLabel = '';
+        const optionsGenerator = (index: number): QuickOpenGroupItemOptions => ({
+            showBorder: !isFirstGroup && index === 0,
+            groupLabel: index === 0 ? groupLabel : '',
+            description: groupLabel,
+        });
+
+        for (const scope of scopes) {
+            groupLabel = typeof scope === 'string' ? this.labelProvider.getName(new URI(scope)) : TaskScope[scope];
+
+            const configs = groupedTasks.get(scope.toString());
+            if (configs?.length) {
+                this.items.push(...this.getTaskConfigureQuickOpenItems(configs, token, optionsGenerator));
             } else {
-                const { configUri } = this.preferences.resolve('tasks', [], rootFolder);
-                const existTaskConfigFile = !!configUri;
-                this.items.push(new QuickOpenGroupItem({
-                    label: existTaskConfigFile ? 'Open tasks.json file' : 'Create tasks.json file from template',
-                    run: (mode: QuickOpenMode): boolean => {
-                        if (mode !== QuickOpenMode.OPEN) {
-                            return false;
-                        }
-                        setTimeout(() => this.taskConfigurationManager.openConfiguration(rootFolder));
-                        return true;
-                    },
-                    showBorder: !isFirstGroup,
-                    groupLabel: isMulti ? folderName : ''
-                }));
+                this.items.push(this.getOpenFileItem(scope, optionsGenerator.bind(this, 0)));
             }
+
             isFirstGroup = false;
         }
 
@@ -319,6 +283,40 @@ export class QuickOpenTask implements QuickOpenModel, QuickOpenHandler {
             placeholder: 'Select a task to configure',
             fuzzyMatchLabel: true,
             fuzzySort: false
+        });
+    }
+
+    protected getTaskConfigureQuickOpenItems(
+        configs: TaskConfiguration[],
+        token: number,
+        optionsGenerator: (index: number) => QuickOpenGroupItemOptions
+    ): TaskConfigureQuickOpenItem[] {
+        return configs.map((taskConfig, index) => {
+            const item = new TaskConfigureQuickOpenItem(
+                token,
+                taskConfig,
+                this.taskService,
+                this.taskNameResolver,
+                this.workspaceService,
+                this.workspaceService.isMultiRootWorkspaceOpened,
+                optionsGenerator(index),
+            );
+            item['taskDefinitionRegistry'] = this.taskDefinitionRegistry;
+            return item;
+        });
+    }
+
+    protected getOpenFileItem(scope: TaskConfigurationScope, optionsGenerator: () => QuickOpenGroupItemOptions): QuickOpenGroupItem {
+        return new QuickOpenGroupItem({
+            label: 'Configure new task.',
+            run: (mode: QuickOpenMode): boolean => {
+                if (mode !== QuickOpenMode.OPEN) {
+                    return false;
+                }
+                setTimeout(() => this.taskConfigurationManager.openConfiguration(scope));
+                return true;
+            },
+            ...optionsGenerator(),
         });
     }
 
@@ -502,7 +500,7 @@ export class TaskRunQuickOpenItem extends QuickOpenGroupItem {
     }
 
     getDescription(): string {
-        return renderScope(this.task._scope, this.isMulti);
+        return this.options.description || renderScope(this.task._scope, this.isMulti);
     }
 
     run(mode: QuickOpenMode): boolean {

--- a/packages/task/src/browser/task-configuration-model.ts
+++ b/packages/task/src/browser/task-configuration-model.ts
@@ -36,7 +36,7 @@ export class TaskConfigurationModel implements Disposable {
     );
 
     constructor(
-        readonly scope: TaskConfigurationScope,
+        protected readonly scope: TaskConfigurationScope,
         readonly preferences: PreferenceProvider
     ) {
         this.reconcile();

--- a/packages/task/src/browser/task-configurations.ts
+++ b/packages/task/src/browser/task-configurations.ts
@@ -302,8 +302,8 @@ export class TaskConfigurations implements Disposable {
     /** Adds given task to a config file and opens the file to provide ability to edit task configuration. */
     async configure(token: number, task: TaskConfiguration): Promise<void> {
         const scope = task._scope;
-        if (scope === TaskScope.Global) {
-            return this.openUserTasks();
+        if (scope === TaskScope.Global || scope === TaskScope.Workspace) {
+            return this.taskConfigurationManager.openConfiguration(scope);
         } else if (typeof scope !== 'string') {
             console.error('Global task cannot be customized');
             // TODO detected tasks of scope workspace or user could be customized in those preferences.

--- a/packages/task/src/browser/task-preferences.ts
+++ b/packages/task/src/browser/task-preferences.ts
@@ -27,6 +27,7 @@ export const taskPreferencesSchema: PreferenceSchema = {
             $ref: taskSchemaId,
             description: 'Task definition file',
             defaultValue: {
+                version: '2.0.0',
                 tasks: []
             }
         }

--- a/packages/task/src/browser/task-schema-updater.ts
+++ b/packages/task/src/browser/task-schema-updater.ts
@@ -32,6 +32,7 @@ import { ProblemMatcherRegistry } from './task-problem-matcher-registry';
 import { TaskDefinitionRegistry } from './task-definition-registry';
 import { TaskServer } from '../common';
 import { UserStorageUri } from '@theia/userstorage/lib/browser';
+import { WorkspaceService } from '@theia/workspace/lib/browser';
 
 export const taskSchemaId = 'vscode://schemas/tasks';
 
@@ -49,6 +50,9 @@ export class TaskSchemaUpdater implements JsonSchemaContribution {
 
     @inject(TaskServer)
     protected readonly taskServer: TaskServer;
+
+    @inject(WorkspaceService)
+    protected readonly workspaceService: WorkspaceService;
 
     protected readonly onDidChangeTaskSchemaEmitter = new Emitter<void>();
     readonly onDidChangeTaskSchema = this.onDidChangeTaskSchemaEmitter.event;
@@ -77,6 +81,7 @@ export class TaskSchemaUpdater implements JsonSchemaContribution {
             fileMatch: ['tasks.json', UserStorageUri.resolve('tasks.json').toString()],
             url: this.uri.toString()
         });
+        this.workspaceService.updateSchema('tasks', { $ref: this.uri.toString() });
     }
 
     readonly update = debounce(() => this.doUpdate(), 0);
@@ -181,12 +186,14 @@ export class TaskSchemaUpdater implements JsonSchemaContribution {
     }
 
     /** Returns the task's JSON schema */
-    protected getTaskSchema(): IJSONSchema {
+    getTaskSchema(): IJSONSchema {
         return {
             type: 'object',
+            default: { version: '2.0.0', tasks: [] },
             properties: {
                 version: {
-                    type: 'string'
+                    type: 'string',
+                    default: '2.0.0'
                 },
                 tasks: {
                     type: 'array',

--- a/packages/workspace/src/browser/workspace-commands.ts
+++ b/packages/workspace/src/browser/workspace-commands.ts
@@ -129,6 +129,11 @@ export namespace WorkspaceCommands {
         category: WORKSPACE_CATEGORY,
         label: 'Save Workspace As...'
     };
+    export const OPEN_WORKSPACE_FILE: Command = {
+        id: 'workspace:openConfigFile',
+        category: WORKSPACE_CATEGORY,
+        label: 'Open Workspace Configuration File'
+    };
     export const SAVE_AS: Command = {
         id: 'file.saveAs',
         category: 'File',

--- a/packages/workspace/src/browser/workspace-frontend-contribution.ts
+++ b/packages/workspace/src/browser/workspace-frontend-contribution.ts
@@ -153,6 +153,14 @@ export class WorkspaceFrontendContribution implements CommandContribution, Keybi
             UriAwareCommandHandler.MonoSelect(this.selectionService, {
                 execute: (uri: URI) => this.saveAs(uri),
             }));
+        commands.registerCommand(WorkspaceCommands.OPEN_WORKSPACE_FILE, {
+            isEnabled: () => this.workspaceService.saved,
+            execute: () => {
+                if (this.workspaceService.saved && this.workspaceService.workspace) {
+                    open(this.openerService, this.workspaceService.workspace.resource);
+                }
+            }
+        });
     }
 
     registerMenus(menus: MenuModelRegistry): void {

--- a/packages/workspace/src/browser/workspace-frontend-module.ts
+++ b/packages/workspace/src/browser/workspace-frontend-module.ts
@@ -44,6 +44,8 @@ import { WorkspaceDuplicateHandler } from './workspace-duplicate-handler';
 import { WorkspaceUtils } from './workspace-utils';
 import { WorkspaceCompareHandler } from './workspace-compare-handler';
 import { DiffService } from './diff-service';
+import { JsonSchemaContribution } from '@theia/core/lib/browser/json-schema-store';
+import { WorkspaceSchemaUpdater } from './workspace-schema-updater';
 
 export default new ContainerModule((bind: interfaces.Bind, unbind: interfaces.Unbind, isBound: interfaces.IsBound, rebind: interfaces.Rebind) => {
     bindWorkspacePreferences(bind);
@@ -91,4 +93,7 @@ export default new ContainerModule((bind: interfaces.Bind, unbind: interfaces.Un
     bind(QuickOpenWorkspace).toSelf().inSingletonScope();
 
     bind(WorkspaceUtils).toSelf().inSingletonScope();
+
+    bind(WorkspaceSchemaUpdater).toSelf().inSingletonScope();
+    bind(JsonSchemaContribution).toService(WorkspaceSchemaUpdater);
 });

--- a/packages/workspace/src/browser/workspace-schema-updater.ts
+++ b/packages/workspace/src/browser/workspace-schema-updater.ts
@@ -1,0 +1,148 @@
+/********************************************************************************
+ * Copyright (C) 2021 Ericsson and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import { inject, injectable, postConstruct } from 'inversify';
+import { JsonSchemaContribution, JsonSchemaRegisterContext } from '@theia/core/lib/browser/json-schema-store';
+import { InMemoryResources } from '@theia/core/lib/common';
+import { IJSONSchema } from '@theia/core/lib/common/json-schema';
+import URI from '@theia/core/lib/common/uri';
+import { Deferred } from '@theia/core/lib/common/promise-util';
+
+export interface SchemaUpdateMessage {
+    key: string,
+    schema?: IJSONSchema,
+    deferred: Deferred<boolean>;
+}
+
+export namespace AddKeyMessage {
+    export const is = (message: SchemaUpdateMessage | undefined): message is Required<SchemaUpdateMessage> => !!message && message.schema !== undefined;
+}
+
+@injectable()
+export class WorkspaceSchemaUpdater implements JsonSchemaContribution {
+
+    protected readonly uri = new URI(workspaceSchemaId);
+    protected readonly editQueue: SchemaUpdateMessage[] = [];
+    protected safeToHandleQueue = new Deferred();
+
+    @inject(InMemoryResources) protected readonly inmemoryResources: InMemoryResources;
+
+    @postConstruct()
+    protected init(): void {
+        this.inmemoryResources.add(this.uri, JSON.stringify(workspaceSchema));
+        this.safeToHandleQueue.resolve();
+    }
+
+    registerSchemas(context: JsonSchemaRegisterContext): void {
+        context.registerSchema({
+            fileMatch: ['*.theia-workspace', '*.code-workspace'],
+            url: this.uri.toString()
+        });
+    }
+
+    protected async retrieveCurrent(): Promise<WorkspaceSchema> {
+        const current = await this.inmemoryResources.resolve(this.uri).readContents();
+
+        const content = JSON.parse(current);
+
+        if (!WorkspaceSchema.is(content)) {
+            throw new Error('Failed to retrieve current workspace schema.');
+        }
+
+        return content;
+    }
+
+    async updateSchema(message: Omit<SchemaUpdateMessage, 'deferred'>): Promise<boolean> {
+        const doHandle = this.editQueue.length === 0;
+        const deferred = new Deferred<boolean>();
+        this.editQueue.push({ ...message, deferred });
+        if (doHandle) {
+            this.handleQueue();
+        }
+        return deferred.promise;
+    }
+
+    protected async handleQueue(): Promise<void> {
+        await this.safeToHandleQueue.promise;
+        this.safeToHandleQueue = new Deferred();
+        const cache = await this.retrieveCurrent();
+        while (this.editQueue.length) {
+            const nextMessage = this.editQueue.shift();
+            if (AddKeyMessage.is(nextMessage)) {
+                this.addKey(nextMessage, cache);
+            } else if (nextMessage) {
+                this.removeKey(nextMessage, cache);
+            }
+        }
+        this.inmemoryResources.update(this.uri, JSON.stringify(cache));
+        this.safeToHandleQueue.resolve();
+    }
+
+    protected addKey({ key, schema, deferred }: Required<SchemaUpdateMessage>, cache: WorkspaceSchema): void {
+        if (key in cache.properties) {
+            return deferred.resolve(false);
+        }
+
+        cache.properties[key] = schema;
+        deferred.resolve(true);
+    }
+
+    protected removeKey({ key, deferred }: SchemaUpdateMessage, cache: WorkspaceSchema): void {
+        const canDelete = !cache.required.includes(key);
+        if (!canDelete) {
+            return deferred.resolve(false);
+        }
+
+        const keyPresent = delete cache.properties[key];
+        deferred.resolve(keyPresent);
+    }
+}
+
+export type WorkspaceSchema = Required<Pick<IJSONSchema, 'properties' | 'required'>>;
+
+export namespace WorkspaceSchema {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    export const is = (candidate: any): candidate is WorkspaceSchema => !!candidate
+        && typeof candidate === 'object'
+        && 'properties' in candidate
+        && typeof candidate.properties === 'object'
+        && 'required' in candidate
+        && Array.isArray(candidate.required);
+}
+
+export const workspaceSchemaId = 'vscode://schemas/workspace';
+export const workspaceSchema: IJSONSchema = {
+    $id: workspaceSchemaId,
+    type: 'object',
+    title: 'Workspace File',
+    required: ['folders'],
+    default: { folders: [{ path: '' }], settings: {} },
+    properties: {
+        folders: {
+            description: 'Root folders in the workspace',
+            type: 'array',
+            items: {
+                type: 'object',
+                properties: {
+                    path: {
+                        type: 'string',
+                    }
+                },
+                required: ['path']
+            }
+        }
+    },
+};


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->
Fixes #8519
Fixes #8991 (thanks for noting that, @RomanNikitenko)
This PR sets up the necessary infrastructure to read and write tasks to a workspace file. In particular it:
 - modifies the way a `WorkspaceFilePreferenceProvider` reads and writes non-settings preferences. (breaking changes to bring Theia's workspace file schema into harmony with VSCode's)
 - modifies helper methods in `workspace-service.ts` for writing workspace files to accommodate fields other than `folders` and `settings` (breaking changes for anyone calling those file-builder methods)
 - removes some explicit references to the preference system in the workspace package.
 - adds a `WorkspaceSchemaUpdater` service to allow packages that contribute extensions to the schema of the workspace file (tasks, debug) to register their extensions
 - injects workspace scope related functionality into the `TaskConfigurationManager`

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
1. Add a properly formatted `tasks` field to a workspace file. (`"tasks": {"tasks": [...]}` - has be double `"tasks"`, one for the 'file' label (`tasks.json`) and one for the tasks inside)
2. Open that file as your workspace.
3. Open the `Terminal` menu and select `Run Task...`
4. Observe that your tasks are available and run (or fail) as expected
5. Modify the file (e.g. add a new task configuration)
6. Repeat 3-4, and observe that the task list updated correctly.
---
1. Use task quick picks (commands `tasks configure`, `tasks run`) and confirm that they still work in each scope in single- and multi-root workspaces.
> NB: running very short-lived tasks (e.g. a `shell` task that just runs `echo`) can behave unexpectedly, with no terminal ever opening. This behavior is also found on `master`.

#### Changes

This PR has grown to touch quite a number of files, so it might be useful for reviewers if I explain why each change was necessary:
- Core
  - `preference-configurations.ts`: add an `isAnyConfig` convenience method equivalent to checking `isSectionName() || isConfigName()`
  - `preference-contribution.ts`: change schema update logic to respect the superset / subset relationships among scopes. See https://github.com/eclipse-theia/theia/pull/8917#issuecomment-767592610.
  - `preference-provider.ts`, `preference-service.ts`: add section name argument to `getConfigUri` and `getContainingConfigUri` to allow callers to find the URI of all preference files, not just `settings.json`. This is more systematic than the current implementation, and obviates workarounds using `PreferenceService.resolve` to find the URI for non-settings sections.
- Debug
  - `debug-schema-updater.ts`: add `launch` to the workspace file schema.
- Preferences
  - `folders-preference-provider.ts`, `user-configs-preference-provider.ts`, `workspace-preference-provider`: update `getConfigUri` and `getContainingConfigUri` to accommodate section name.
  - `section-preference-provider.ts`: minor cleanup to remove a non-null assertion.
  - `workspace-file-preference-provider.ts`: changes to handle sections other than `settings`, and to accommodate sections both inside the `settings` object and outside.
- Tasks
  - `quick-open-tasks.ts`: refactor the `configure` method to accommodate workspace-scoped tasks.
  - `task-configuration-manager.ts`: rewrite logic to accommodate workspace-scoped tasks.
  - `task-configuration-model.ts`: make scope protected because in the case of workspace scope it becomes unreliable (sometimes pointing to folder, sometimes pointing to workspace file). It wasn't being accessed, and the only way to get access to a model is to know the scope you're interested in, so you shouldn't have to ask the model for that information.
  - `task-configurations.ts`: change to allow configure to work in workspace scope.
  - `task-preferences.ts`: better default value for preferences.
  - `task-schema-updater.ts`: make the basic schema for tasks publicly accessible (it is for preferences) so that it can be used for any defaulting. Also add tasks the workspace-file schema.
- Workspace
  - `workspace-commands.ts`, `workspace-frontend-contribution.ts`: add a command to open the workspace file. It exists in VSCode and is parallel to commands to open e.g. the user-scope `tasks.json`.
  - `workspace-schema-updater.ts`, `workspace-frontend-module.ts`, `workspace-service.ts`: add a `WorkspaceSchemaUpdater` that can be accessed and updated by external packages (debug, tasks, preferences) to allow them to register their subschemas for the workspace file. Modify helper functions that assume that the schema will only ever include `settings`.

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

