### PR TITLE
make extension deploy command extensible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## v1.10.0
+
+- [plugin] added `createDeployQuickOpenItem` method to create `DeployQuickOpenItem` in order to make extension deploy command extensible [#8919] (https://github.com/eclipse-theia/theia/pull/8919)
+
 ## v1.9.0 - 16/12/2020
 
 - [cli] updated error reporting for the `download-plugins` script [#8798](https://github.com/eclipse-theia/theia/pull/8798)

--- a/packages/plugin-ext/src/main/browser/plugin-ext-deploy-command.ts
+++ b/packages/plugin-ext/src/main/browser/plugin-ext-deploy-command.ts
@@ -65,9 +65,13 @@ export class PluginExtDeployCommandService implements QuickOpenModel {
     public async onType(lookFor: string, acceptor: (items: QuickOpenItem[]) => void): Promise<void> {
         this.items = [];
         if (lookFor || lookFor.length > 0) {
-            this.items.push(new DeployQuickOpenItem(lookFor, this.pluginServer, 'Deploy this plugin'));
+            this.items.push(this.createDeployQuickOpenItem(lookFor, 'Deploy this plugin'));
         }
         acceptor(this.items);
+    }
+
+    protected createDeployQuickOpenItem(name: string, description: string): DeployQuickOpenItem {
+        return new DeployQuickOpenItem(name, this.pluginServer, description);
     }
 
 }


### PR DESCRIPTION
Signed-off-by: odelia <odelia.zehavi@sap.com>

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
Make the extension deploy from command pallet extensible 

#### How to test
- Click cmd+p 
- Enter `> Plugin: Deploy Plugin by Id`
- Enter `vscode:extension/hollowtree.vue-snippets`
- Check that the extension is installed

In this branch you can see the ability in work:
[https://github.com/odeliat/theia/tree/extensible-deploy-cmd-test](https://github.com/odeliat/theia/tree/extensible-deploy-cmd-test)
- Run the branch
- Install the extension as described above
- See in the console the massage - activate injectable method 


#### Review checklist

- [X] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

