### PR TITLE
specify order of 'Select for Compare' and 'Compare with Selected'

### DIFF
--- a/packages/navigator/src/browser/navigator-contribution.ts
+++ b/packages/navigator/src/browser/navigator-contribution.ts
@@ -452,16 +452,16 @@ export class FileNavigatorContribution extends AbstractViewContribution<FileNavi
         registry.registerMenuAction(NavigatorContextMenu.MODIFICATION, {
             commandId: FileNavigatorCommands.COLLAPSE_ALL.id,
             label: 'Collapse All',
-            order: 'z2'
+            order: 'z'
         });
 
         registry.registerMenuAction(NavigatorContextMenu.COMPARE, {
             commandId: NavigatorDiffCommands.COMPARE_FIRST.id,
-            order: 'z'
+            order: 'za'
         });
         registry.registerMenuAction(NavigatorContextMenu.COMPARE, {
             commandId: NavigatorDiffCommands.COMPARE_SECOND.id,
-            order: 'z'
+            order: 'zb'
         });
     }
 

--- a/packages/search-in-workspace/src/browser/search-in-workspace-frontend-contribution.ts
+++ b/packages/search-in-workspace/src/browser/search-in-workspace-frontend-contribution.ts
@@ -66,7 +66,7 @@ export namespace SearchInWorkspaceCommands {
     export const CLEAR_ALL: Command = {
         id: 'search-in-workspace.clear-all',
         category: SEARCH_CATEGORY,
-        label: 'Clear All',
+        label: 'Clear Search Results',
         iconClass: 'clear-all'
     };
 }

--- a/packages/search-in-workspace/src/browser/search-in-workspace-frontend-contribution.ts
+++ b/packages/search-in-workspace/src/browser/search-in-workspace-frontend-contribution.ts
@@ -66,7 +66,7 @@ export namespace SearchInWorkspaceCommands {
     export const CLEAR_ALL: Command = {
         id: 'search-in-workspace.clear-all',
         category: SEARCH_CATEGORY,
-        label: 'Clear Search Results',
+        label: 'Clear All',
         iconClass: 'clear-all'
     };
 }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

Both 'Select for Compare' and 'Compare with Selected' had `order: 'z'`. To more clearly specify the order in which navigator menu items are to be displayed, 'Select for Compare' and 'Compare with Selected' were assigned order 'za' and 'zb', respectively.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

When comparing two files in the navigator, observe that when the second file for comparison is chosen, the option 'Compare with Selected' appears below the option 'Select for Compare'"

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

