### PR TITLE
editor: add "reopen closed editor" command and keybinding

### DIFF
--- a/packages/core/src/common/uri.spec.ts
+++ b/packages/core/src/common/uri.spec.ts
@@ -229,4 +229,37 @@ describe('uri', () => {
         });
     });
 
+    describe('#isEqual', () => {
+        it('should return `true` for `uris` which are equal', () => {
+            const a = new URI('file:///C:/projects/theia/foo/a.ts');
+            const b = new URI('file:///C:/projects/theia/foo/a.ts');
+            expect(a.isEqual(b)).equals(true);
+        });
+        it('should return `false` for `uris` which are not equal', () => {
+            const a = new URI('file:///C:/projects/theia/foo/a.ts');
+            const b = new URI('file:///C:/projects/theia/foo/b.ts');
+            expect(a.isEqual(b)).equals(false);
+        });
+        it('should return `true` for `uris` that are not case-sensitive equal, with case-sensitivity `off`', () => {
+            const a = new URI('file:///C:/projects/theia/foo/a.ts');
+            const b = new URI('file:///C:/projects/theia/foo/A.ts');
+            expect(a.isEqual(b, false)).equals(true);
+        });
+        it('should return `false` for `uris` that are not case-sensitive equal, with case-sensitivity `on`', () => {
+            const a = new URI('file:///C:/projects/theia/foo/a.ts');
+            const b = new URI('file:///C:/projects/theia/foo/A.ts');
+            expect(a.isEqual(b, true)).equals(false);
+        });
+        it('should return `false` for parent paths', () => {
+            const a = new URI('file:///C:/projects/'); // parent uri.
+            const b = new URI('file:///C:/projects/theia/foo');
+            expect(a.isEqual(b)).equals(false);
+        });
+        it('should return `false` for different schemes', () => {
+            const a = new URI('a:///C:/projects/theia/foo/a.ts');
+            const b = new URI('b:///C:/projects/theia/foo/a.ts');
+            expect(a.isEqual(b)).equals(false);
+        });
+    });
+
 });

--- a/packages/core/src/common/uri.ts
+++ b/packages/core/src/common/uri.ts
@@ -199,8 +199,18 @@ export default class URI {
         return this.codeUri.toString(skipEncoding);
     }
 
+    isEqual(uri: URI, caseSensitive: boolean = true): boolean {
+        if (!this.hasSameOrigin(uri)) {
+            return false;
+        }
+
+        return caseSensitive
+            ? this.toString() === uri.toString()
+            : this.toString().toLowerCase() === uri.toString().toLowerCase();
+    }
+
     isEqualOrParent(uri: URI, caseSensitive: boolean = true): boolean {
-        if (this.authority !== uri.authority || this.scheme !== uri.scheme) {
+        if (!this.hasSameOrigin(uri)) {
             return false;
         }
         let left = this.path;
@@ -222,4 +232,7 @@ export default class URI {
         return result;
     }
 
+    private hasSameOrigin(uri: URI): boolean {
+        return (this.authority === uri.authority) && (this.scheme === uri.scheme);
+    }
 }

--- a/packages/editor/src/browser/editor-command.ts
+++ b/packages/editor/src/browser/editor-command.ts
@@ -133,6 +133,14 @@ export namespace EditorCommands {
         category: 'View',
         label: 'Toggle Word Wrap'
     };
+    /**
+     * Command that re-opens the last closed editor.
+     */
+    export const REOPEN_CLOSED_EDITOR: Command = {
+        id: 'workbench.action.reopenClosedEditor',
+        category: 'View',
+        label: 'Reopen Closed Editor'
+    };
 }
 
 @injectable()
@@ -199,6 +207,7 @@ export class EditorCommandContribution implements CommandContribution {
         registry.registerCommand(EditorCommands.TOGGLE_MINIMAP);
         registry.registerCommand(EditorCommands.TOGGLE_RENDER_WHITESPACE);
         registry.registerCommand(EditorCommands.TOGGLE_WORD_WRAP);
+        registry.registerCommand(EditorCommands.REOPEN_CLOSED_EDITOR);
 
         registry.registerCommand(CommonCommands.AUTO_SAVE, {
             isToggled: () => this.isAutoSaveOn(),

--- a/packages/editor/src/browser/editor-keybinding.ts
+++ b/packages/editor/src/browser/editor-keybinding.ts
@@ -15,6 +15,7 @@
  ********************************************************************************/
 
 import { injectable } from '@theia/core/shared/inversify';
+import { environment } from '@theia/core/shared/@theia/application-package/lib/environment';
 import { isOSX, isWindows } from '@theia/core/lib/common/os';
 import { KeybindingContribution, KeybindingRegistry } from '@theia/core/lib/browser/keybinding';
 import { EditorCommands } from './editor-command';
@@ -39,8 +40,16 @@ export class EditorKeybindingContribution implements KeybindingContribution {
             {
                 command: EditorCommands.TOGGLE_WORD_WRAP.id,
                 keybinding: 'alt+z'
+            },
+            {
+                command: EditorCommands.REOPEN_CLOSED_EDITOR.id,
+                keybinding: this.isElectron() ? 'ctrlcmd+shift+t' : 'alt+shift+t'
             }
         );
+    }
+
+    private isElectron(): boolean {
+        return environment.electron.is();
     }
 
 }

--- a/packages/editor/src/browser/editor-preferences.ts
+++ b/packages/editor/src/browser/editor-preferences.ts
@@ -1268,6 +1268,11 @@ export const editorPreferenceSchema: PreferenceSchema = {
             'default': 750,
             'description': 'Timeout in milliseconds after which the formatting that is run on file save is cancelled.'
         },
+        'editor.history.persistClosedEditors': {
+            'type': 'boolean',
+            'default': false,
+            'description': 'Controls whether to persist closed editor history for the workspace across window reloads.'
+        },
         'files.eol': {
             'type': 'string',
             'enum': [
@@ -1299,6 +1304,7 @@ export interface EditorConfiguration extends CodeEditorConfiguration {
     'editor.autoSaveDelay': number
     'editor.formatOnSave': boolean
     'editor.formatOnSaveTimeout': number
+    'editor.history.persistClosedEditors': boolean
     'files.eol': EndOfLinePreference
 }
 export type EndOfLinePreference = '\n' | '\r\n' | 'auto';

--- a/packages/editor/src/browser/navigation/navigation-location-service.spec.ts
+++ b/packages/editor/src/browser/navigation/navigation-location-service.spec.ts
@@ -19,6 +19,7 @@ let disableJSDOM = enableJSDOM();
 
 import { expect } from 'chai';
 import { Container } from '@theia/core/shared/inversify';
+import URI from '@theia/core/lib/common/uri';
 import { ILogger } from '@theia/core/lib/common/logger';
 import { MockLogger } from '@theia/core/lib/common/test/mock-logger';
 import { OpenerService } from '@theia/core/lib/browser/opener-service';
@@ -26,7 +27,7 @@ import { MockOpenerService } from '@theia/core/lib/browser/test/mock-opener-serv
 import { NavigationLocationUpdater } from './navigation-location-updater';
 import { NoopNavigationLocationUpdater } from './test/mock-navigation-location-updater';
 import { NavigationLocationSimilarity } from './navigation-location-similarity';
-import { CursorLocation, Position, NavigationLocation } from './navigation-location';
+import { CursorLocation, Position, NavigationLocation, RecentlyClosedEditor } from './navigation-location';
 import { NavigationLocationService } from './navigation-location-service';
 
 disableJSDOM();
@@ -79,8 +80,28 @@ describe('navigation-location-service', () => {
     });
 
     it('should not exceed the max stack item', () => {
-        stack.register(...[...Array(100).keys()].map(i => createCursorLocation({ line: i * 10, character: i }, `file://${i}`)));
-        expect(stack.locations().length).to.be.lessThan(100);
+        const max = NavigationLocationService['MAX_STACK_ITEMS'];
+        const locations: NavigationLocation[] = [...Array(max + 10).keys()].map(i => createCursorLocation({ line: i * 10, character: i }, `file://${i}`));
+        stack.register(...locations);
+        expect(stack.locations().length).to.not.be.greaterThan(max);
+    });
+
+    it('should successfully clear the history', () => {
+        expect(stack['recentlyClosedEditors'].length).equal(0);
+        const editor = createMockClosedEditor(new URI('file://foo/a.ts'));
+        stack.addClosedEditor(editor);
+        expect(stack['recentlyClosedEditors'].length).equal(1);
+
+        expect(stack['stack'].length).equal(0);
+        stack.register(
+            createCursorLocation(),
+        );
+        expect(stack['stack'].length).equal(1);
+
+        stack['clearHistory']();
+
+        expect(stack['recentlyClosedEditors'].length).equal(0);
+        expect(stack['stack'].length).equal(0);
     });
 
     describe('last-edit-location', async () => {
@@ -132,6 +153,76 @@ describe('navigation-location-service', () => {
 
     });
 
+    describe('recently-closed-editors', () => {
+
+        describe('#getLastClosedEditor', () => {
+
+            it('should return the last closed editor from the history', () => {
+                const uri = new URI('file://foo/a.ts');
+                stack.addClosedEditor(createMockClosedEditor(uri));
+                const editor = stack.getLastClosedEditor();
+                expect(editor?.uri).equal(uri);
+            });
+
+            it('should return `undefined` when no history is found', () => {
+                expect(stack['recentlyClosedEditors'].length).equal(0);
+                const editor = stack.getLastClosedEditor();
+                expect(editor).equal(undefined);
+            });
+
+            it('should not exceed the max history', () => {
+                expect(stack['recentlyClosedEditors'].length).equal(0);
+                const max = NavigationLocationService['MAX_RECENTLY_CLOSED_EDITORS'];
+                for (let i = 0; i < max + 10; i++) {
+                    const uri = new URI(`file://foo/bar-${i}.ts`);
+                    stack.addClosedEditor(createMockClosedEditor(uri));
+                }
+                expect(stack['recentlyClosedEditors'].length <= max).be.true;
+            });
+
+        });
+
+        describe('#addToRecentlyClosedEditors', () => {
+
+            it('should include unique recently closed editors in the history', () => {
+                expect(stack['recentlyClosedEditors'].length).equal(0);
+                const a = createMockClosedEditor(new URI('file://foo/a.ts'));
+                const b = createMockClosedEditor(new URI('file://foo/b.ts'));
+                stack.addClosedEditor(a);
+                stack.addClosedEditor(b);
+                expect(stack['recentlyClosedEditors'].length).equal(2);
+            });
+
+            it('should not include duplicate recently closed editors in the history', () => {
+                const uri = new URI('file://foo/a.ts');
+                [1, 2, 3].forEach(i => {
+                    stack.addClosedEditor(createMockClosedEditor(uri));
+                });
+                expect(stack['recentlyClosedEditors'].length).equal(1);
+            });
+
+        });
+
+        describe('#removeFromRecentlyClosedEditors', () => {
+
+            it('should successfully remove editors from the history that match the given editor uri', () => {
+                expect(stack['recentlyClosedEditors'].length).equal(0);
+                const editor = createMockClosedEditor(new URI('file://foo/a.ts'));
+
+                [1, 2, 3].forEach(() => {
+                    stack['recentlyClosedEditors'].push(editor);
+                });
+                expect(stack['recentlyClosedEditors'].length).equal(3);
+
+                // Remove the given editor from the recently closed history.
+                stack['removeClosedEditor'](editor.uri);
+                expect(stack['recentlyClosedEditors'].length).equal(0);
+            });
+
+        });
+
+    });
+
     function createCursorLocation(context: Position = { line: 0, character: 0, }, uri: string = 'file://path/to/file'): CursorLocation {
         return NavigationLocation.create(uri, context);
     }
@@ -147,6 +238,10 @@ describe('navigation-location-service', () => {
         container.bind(NavigationLocationUpdater).toService(NoopNavigationLocationUpdater);
         container.bind(OpenerService).toService(MockOpenerService);
         return container.get(NavigationLocationService);
+    }
+
+    function createMockClosedEditor(uri: URI): RecentlyClosedEditor {
+        return { uri, viewState: {} };
     }
 
 });

--- a/packages/editor/src/browser/navigation/navigation-location.ts
+++ b/packages/editor/src/browser/navigation/navigation-location.ts
@@ -190,14 +190,62 @@ export namespace NavigationLocation {
         return JSON.stringify(toObject(location));
     }
 
-    function toUri(arg: URI | { uri: URI } | string): URI {
-        if (arg instanceof URI) {
-            return arg;
+}
+
+function toUri(arg: URI | { uri: URI } | string): URI {
+    if (arg instanceof URI) {
+        return arg;
+    }
+    if (typeof arg === 'string') {
+        return new URI(arg);
+    }
+    return arg.uri;
+}
+
+/**
+ * Representation of a closed editor.
+ */
+export interface RecentlyClosedEditor {
+
+    /**
+     * The uri of the closed editor.
+     */
+    readonly uri: URI,
+
+    /**
+     * The serializable view state of the closed editor.
+     */
+    readonly viewState: object
+
+}
+
+export namespace RecentlyClosedEditor {
+
+    /**
+     * Transform a RecentlyClosedEditor into an object for storing.
+     *
+     * @param closedEditor the editor needs to be transformed.
+     */
+    export function toObject(closedEditor: RecentlyClosedEditor): object {
+        const { uri, viewState } = closedEditor;
+        return {
+            uri: uri.toString(),
+            viewState: viewState
+        };
+    }
+
+    /**
+     * Transform the given object to a RecentlyClosedEditor object if possible.
+     */
+    export function fromObject(object: Partial<RecentlyClosedEditor>): RecentlyClosedEditor | undefined {
+        const { uri, viewState } = object;
+        if (uri !== undefined && viewState !== undefined) {
+            return {
+                uri: toUri(uri),
+                viewState: viewState
+            };
         }
-        if (typeof arg === 'string') {
-            return new URI(arg);
-        }
-        return arg.uri;
+        return undefined;
     }
 
 }


### PR DESCRIPTION
#### What it does
+ Add the command `Reopen Closed Editor` which opens the last closed editor (closes #5748). The command can be called from the command palette or by a keyboard shortcut: `alt+shift+t`. The command also restores the before-closed state of the editor.
+ Add `editor.persistClosedEditors` preference that controls whether the history is saved to local-storage when the app stops and is restored when the app starts.

#### How to test

+ Open an editor
+ Close the editor
+ Call the command `Reopen Closed Editor` from either the command palette or the keybinding: `alt+shift+t`
+ The editor is reopened with the same view state as before.

**Additional**: if `editor.persistClosedEditors` is set to true, the command should reopen editor successfully even after restarting the app (history is persisted)

https://user-images.githubusercontent.com/43587865/111495551-defb3480-8715-11eb-9664-2fe335d18bd9.mp4

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

Co-authored-by: vince-fugnitto <vincent.fugnitto@ericsson.com>
Signed-off-by: Duc Nguyen <duc.a.nguyen@ericsson.com>