### PR TITLE
Fix for DnD files to main area #8739

### DIFF
--- a/packages/navigator/src/browser/navigator-widget.tsx
+++ b/packages/navigator/src/browser/navigator-widget.tsx
@@ -18,7 +18,7 @@ import { injectable, inject, postConstruct } from 'inversify';
 import { Message } from '@phosphor/messaging';
 import URI from '@theia/core/lib/common/uri';
 import { CommandService, SelectionService } from '@theia/core/lib/common';
-import { CorePreferences, Key, TreeModel } from '@theia/core/lib/browser';
+import { CorePreferences, Key, TreeModel, SelectableTreeNode } from '@theia/core/lib/browser';
 import {
     ContextMenuRenderer, ExpandableTreeNode,
     TreeProps, TreeNode
@@ -102,7 +102,12 @@ export class FileNavigatorWidget extends FileTreeWidget {
         const mainPanelNode = this.shell.mainPanel.node;
         this.addEventListener(mainPanelNode, 'drop', async ({ dataTransfer }) => {
             const treeNodes = dataTransfer && this.getSelectedTreeNodesFromData(dataTransfer) || [];
-            treeNodes.filter(FileNode.is).forEach(treeNode => this.commandService.executeCommand(FileNavigatorCommands.OPEN.id, treeNode.uri));
+            treeNodes.filter(FileNode.is).forEach(treeNode => {
+                if (!SelectableTreeNode.isSelected(treeNode)) {
+                    this.model.toggleNode(treeNode);
+                }
+            });
+            this.commandService.executeCommand(FileNavigatorCommands.OPEN.id);
         });
         const handler = (e: DragEvent) => {
             if (e.dataTransfer) {


### PR DESCRIPTION
Signed-off-by: Balaji V <kuttibalaji.v6@gmail.com>

#### What it does

Fixes #8739

The cause of the issue is **FileNavigatorCommands.OPEN command** opens the file based on tree widget selections, before dropping in editor the selection was not updated correctly in navigator-widget. 

The below changes updates the tree selection and then fires the FileNavigatorCommands.OPEN command

#### How to test
1. Open any folder with some files
2. Select file & drag and drop to main area

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)
- [x] Tried with multiple selection from different folders 

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

