### PR TITLE
Fix Highlighting in SCM Tree

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 - [plugin] added `createDeployQuickOpenItem` method to create `DeployQuickOpenItem` in order to make extension deploy command extensible [#8919] (https://github.com/eclipse-theia/theia/pull/8919)
 - [dependencies] updated to use fixed versions when publishing, `"x.y.z"` instead of `"^x.y.z"` in dependencies [#8880](https://github.com/eclipse-theia/theia/pull/8880)
+- [scm] update code required to highlight nodes on search in the `ScmTreeWidget` [#8929](https://github.com/eclipse-theia/theia/pull/8929)
+
+<a name="breaking_changes_1.10.0">[Breaking Changes:](#breaking_changes_1.10.0)</a>
+
+- [scm] add `caption` field to `ScmTreeWidget.Props` interface. Remove `name` from `ScmResourceComponent.Props`, `groupLabel` from `ScmResourceGroupComponent.Props`, and `path` from `ScmResourceFolderElement.Props` interfaces. [#8929](https://github.com/eclipse-theia/theia/pull/8929)
+
 
 ## v1.9.0 - 16/12/2020
 

--- a/packages/core/src/browser/tree/tree-widget.tsx
+++ b/packages/core/src/browser/tree/tree-widget.tsx
@@ -608,10 +608,10 @@ export class TreeWidget extends ReactWidget implements StatefulWidget {
                 backgroundColor: highlight.backgroundColor
             };
         }
-        const createChildren = (fragment: TreeDecoration.CaptionHighlight.Fragment) => {
+        const createChildren = (fragment: TreeDecoration.CaptionHighlight.Fragment, index: number) => {
             const { data } = fragment;
             if (fragment.highlight) {
-                return <mark className={TreeDecoration.Styles.CAPTION_HIGHLIGHT_CLASS} style={style}>{data}</mark>;
+                return <mark className={TreeDecoration.Styles.CAPTION_HIGHLIGHT_CLASS} style={style} key={index}>{data}</mark>;
             } else {
                 return data;
             }

--- a/packages/scm/src/browser/scm-tree-label-provider.ts
+++ b/packages/scm/src/browser/scm-tree-label-provider.ts
@@ -18,7 +18,7 @@ import { inject, injectable } from 'inversify';
 import URI from '@theia/core/lib/common/uri';
 import { LabelProviderContribution, LabelProvider } from '@theia/core/lib/browser/label-provider';
 import { TreeNode } from '@theia/core/lib/browser/tree';
-import { ScmFileChangeFolderNode, ScmFileChangeNode } from './scm-tree-model';
+import { ScmFileChangeFolderNode, ScmFileChangeNode, ScmFileChangeGroupNode } from './scm-tree-model';
 
 @injectable()
 export class ScmTreeLabelProvider implements LabelProviderContribution {
@@ -26,10 +26,19 @@ export class ScmTreeLabelProvider implements LabelProviderContribution {
     @inject(LabelProvider) protected readonly labelProvider: LabelProvider;
 
     canHandle(element: object): number {
-        return TreeNode.is(element) && (ScmFileChangeFolderNode.is(element) || ScmFileChangeNode.is(element)) ? 60 : 0;
+        return TreeNode.is(element) && (ScmFileChangeGroupNode.is(element) || ScmFileChangeFolderNode.is(element) || ScmFileChangeNode.is(element)) ? 60 : 0;
     }
 
     getName(node: ScmFileChangeFolderNode | ScmFileChangeNode): string {
-        return this.labelProvider.getName(new URI(node.sourceUri));
+        if (ScmFileChangeGroupNode.is(node)) {
+            return node.groupLabel;
+        }
+        if (ScmFileChangeFolderNode.is(node)) {
+            return node.path;
+        }
+        if (ScmFileChangeNode.is(node)) {
+            return this.labelProvider.getName(new URI(node.sourceUri));
+        }
+        return '';
     }
 }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

This PR fixes #8581 by adjusting the `ScmTreeLabelProvider` class to provide labels for all of the `ScmTreeWidget` node types and then using the `searchHighlights` map to produce a highlighted caption. This introduces adjustments to the interfaces of the various `ScmTreeWidget` node types, but those could be made non-breaking by adding `| ReactNode` to the previous specifications, if that is desirable.

![image](https://user-images.githubusercontent.com/62660806/104063719-3505a600-51c2-11eb-8cea-b3d7ac4ea1fd.png)


#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
1. start the application in a source-controlled workspace
2. perform changes and open the scm view
1. type to start the tree-search
1. notice that highlights are present

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

