### PR TITLE
core: gracefully kill process tree on exit

### DIFF
--- a/dev-packages/application-manager/src/application-package-manager.ts
+++ b/dev-packages/application-manager/src/application-package-manager.ts
@@ -92,13 +92,16 @@ export class ApplicationPackageManager {
             );
         }
 
-        const { mainArgs, options } = this.adjustArgs([ appPath, ...args ]);
+        const { mainArgs, options } = this.adjustArgs([appPath, ...args]);
         const electronCli = require.resolve('electron/cli.js', { paths: [this.pck.projectPath] });
         return this.__process.fork(electronCli, mainArgs, options);
     }
 
     startBrowser(args: string[]): cp.ChildProcess {
         const { mainArgs, options } = this.adjustArgs(args);
+        // The backend must be a process group leader on UNIX in order to kill the tree later.
+        // See https://nodejs.org/api/child_process.html#child_process_options_detached
+        options.detached = process.platform !== 'win32';
         return this.__process.fork(this.pck.backend('main.js'), mainArgs, options);
     }
 

--- a/packages/core/src/electron-main/electron-main-application.ts
+++ b/packages/core/src/electron-main/electron-main-application.ts
@@ -428,6 +428,9 @@ export class ElectronMainApplication {
 
     protected async getForkOptions(): Promise<ForkOptions> {
         return {
+            // The backend must be a process group leader on UNIX in order to kill the tree later.
+            // See https://nodejs.org/api/child_process.html#child_process_options_detached
+            detached: process.platform !== 'win32',
             env: {
                 ...process.env,
                 [ElectronSecurityToken]: JSON.stringify(this.electronSecurityToken),

--- a/packages/core/src/node/backend-application-module.ts
+++ b/packages/core/src/node/backend-application-module.ts
@@ -34,6 +34,7 @@ import { KeytarService, keytarServicePath } from '../common/keytar-protocol';
 import { KeytarServiceImpl } from './keytar-server';
 import { ContributionFilterRegistry, ContributionFilterRegistryImpl } from '../common/contribution-filter';
 import { EnvironmentUtils } from './environment-utils';
+import { ProcessUtils } from './process-utils';
 
 decorate(injectable(), ApplicationPackage);
 
@@ -107,4 +108,5 @@ export const backendApplicationModule = new ContainerModule(bind => {
     bind(ContributionFilterRegistry).to(ContributionFilterRegistryImpl).inSingletonScope();
 
     bind(EnvironmentUtils).toSelf().inSingletonScope();
+    bind(ProcessUtils).toSelf().inSingletonScope();
 });

--- a/packages/core/src/node/process-utils.spec.ts
+++ b/packages/core/src/node/process-utils.spec.ts
@@ -1,0 +1,48 @@
+/********************************************************************************
+ * Copyright (C) 2021 Ericsson and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import { expect } from 'chai';
+import { Container } from 'inversify';
+import { ProcessUtils } from './process-utils';
+
+/** PPID, PID */
+const mockPsOutput = `\
+     5     6
+    40     7
+     1     2
+     1     3
+     2    40
+     2     5
+     0     1
+`;
+
+describe('ProcessUtils', () => {
+
+    let coreProcessManager: ProcessUtils;
+
+    beforeEach(() => {
+        const container = new Container();
+        container.bind(ProcessUtils).toSelf().inSingletonScope();
+        coreProcessManager = container.get(ProcessUtils);
+    });
+
+    it('ProcessUtils#unixGetChildrenRecursive', () => {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        coreProcessManager['spawnSync'] = () => ({ stdout: mockPsOutput }) as any;
+        const pids = coreProcessManager['unixGetChildrenRecursive'](2);
+        expect(Array.from(pids)).members([40, 5, 6, 7]);
+    });
+});

--- a/packages/core/src/node/process-utils.ts
+++ b/packages/core/src/node/process-utils.ts
@@ -1,0 +1,102 @@
+/********************************************************************************
+ * Copyright (C) 2021 Ericsson and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import * as cp from 'child_process';
+import { injectable } from 'inversify';
+
+/**
+ * `@theia/core` service with some process-related utilities.
+ */
+@injectable()
+export class ProcessUtils {
+
+    terminateProcessTree(ppid: number): void {
+        if (process.platform === 'win32') {
+            this.winTerminateProcessTree(ppid);
+        } else {
+            this.unixTerminateProcessTree(ppid);
+        }
+    }
+
+    protected winTerminateProcessTree(ppid: number): void {
+        this.spawnSync('taskkill.exe', ['/f', '/t', '/pid', ppid.toString(10)]);
+    }
+
+    protected unixTerminateProcessTree(ppid: number): void {
+        for (const pid of this.unixGetChildrenRecursive(ppid)) {
+            // Prevent killing the current process:
+            if (pid !== process.pid) {
+                // Don't stop if a process fails to be killed (keep on killing the others):
+                try {
+                    process.kill(pid);
+                } catch (error) {
+                    console.error(error);
+                }
+            }
+        }
+        if (ppid === this.unixGetPGID(ppid)) {
+            // When a process pgid === pid this means the the process is a group leader.
+            // We can then kill every process part of its group by doing `kill(-pgid)`.
+            // This can catch leaked processes under `init` that are still part of the group.
+            process.kill(-ppid);
+        }
+        process.kill(ppid);
+    }
+
+    protected unixGetPGID(pid: number): number {
+        const { stdout } = this.spawnSync('ps', ['-p', pid.toString(10), '-o', 'pgid=']);
+        return Number.parseInt(stdout, 10);
+    }
+
+    protected unixGetChildrenRecursive(ppid: number): Set<number> {
+        const { stdout } = this.spawnSync('ps', ['ax', '-o', 'ppid=,pid=']);
+        const pids = new Set<number>([ppid]);
+        const matcher = /(\d+)\s+(\d+)/;
+        const psList = stdout
+            .trim()
+            .split('\n')
+            .map(line => {
+                const match = line.match(matcher)!;
+                return {
+                    ppid: Number.parseInt(match[1], 10),
+                    pid: Number.parseInt(match[2], 10),
+                };
+            });
+        // Keep looking for parent/child relationships while we keep finding new parents:
+        let size; do {
+            size = pids.size;
+            for (const child of psList) {
+                if (pids.has(child.ppid)) {
+                    pids.add(child.pid);
+                }
+            }
+        } while (size !== pids.size);
+        // Exclude the requested parent id:
+        pids.delete(ppid);
+        return pids;
+    }
+
+    protected spawnSync(file: string, argv: string[], options?: cp.SpawnSyncOptions): cp.SpawnSyncReturns<string> {
+        const result = cp.spawnSync(file, argv, { ...options, encoding: 'utf8' });
+        if (result.error) {
+            throw result.error;
+        }
+        if (result.status !== 0) {
+            throw new Error(`${JSON.stringify(file)} exited with ${result.status ?? result.signal}. Output:\n${JSON.stringify(result.output)}`);
+        }
+        return result;
+    }
+}

--- a/packages/task/src/node/test/task-test-container.ts
+++ b/packages/task/src/node/test/task-test-container.ts
@@ -24,6 +24,7 @@ import workspaceServer from '@theia/workspace/lib/node/workspace-backend-module'
 import { messagingBackendModule } from '@theia/core/lib/node/messaging/messaging-backend-module';
 import { ApplicationPackage } from '@theia/core/shared/@theia/application-package';
 import { TerminalProcess } from '@theia/process/lib/node';
+import { ProcessUtils } from '@theia/core/lib/node/process-utils';
 
 export function createTaskTestContainer(): Container {
     const testContainer = new Container();
@@ -41,6 +42,10 @@ export function createTaskTestContainer(): Container {
 
     // Make it easier to debug processes.
     testContainer.rebind(TerminalProcess).to(TestTerminalProcess);
+
+    testContainer.rebind(ProcessUtils).toConstantValue(new class extends ProcessUtils {
+        terminateProcessTree(): void { } // don't actually kill the tree, it breaks the tests.
+    });
 
     return testContainer;
 }

--- a/packages/terminal/src/node/test/terminal-test-container.ts
+++ b/packages/terminal/src/node/test/terminal-test-container.ts
@@ -20,12 +20,16 @@ import processBackendModule from '@theia/process/lib/node/process-backend-module
 import { messagingBackendModule } from '@theia/core/lib/node/messaging/messaging-backend-module';
 import terminalBackendModule from '../terminal-backend-module';
 import { ApplicationPackage } from '@theia/core/shared/@theia/application-package';
+import { ProcessUtils } from '@theia/core/lib/node/process-utils';
 
 export function createTerminalTestContainer(): Container {
     const container = new Container();
 
     container.load(backendApplicationModule);
     container.rebind(ApplicationPackage).toConstantValue({} as ApplicationPackage);
+    container.rebind(ProcessUtils).toConstantValue(new class extends ProcessUtils {
+        terminateProcessTree(): void { }
+    });
 
     bindLogger(container.bind.bind(container));
     container.load(messagingBackendModule);


### PR DESCRIPTION
#### What it does

See commit messages.

Fixes https://github.com/eclipse-theia/theia/issues/8946

#### How to test

(Linux and maybe Mac)

1. Run the Theia backend
2. Connect with your browser to the backend in order to spawn the plugin host process
3. Send SIGTERM to the backend process
4. You can use `htop` to see that the plugin-host process is not running anymore.

On Windows I don't really know if this is an issue. But if anything, nothing should be broken on Windows.

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)