### PR TITLE
Fix running a task when 'cwd' is not provided

### DIFF
--- a/packages/task/src/node/process/process-task-runner.ts
+++ b/packages/task/src/node/process/process-task-runner.ts
@@ -116,11 +116,6 @@ export class ProcessTaskRunner implements TaskRunner {
         }
 
         const options = systemSpecificCommand.options;
-        // sanity checks:
-        // - we expect the cwd to be set by the client.
-        if (!options || !options.cwd) {
-            throw new Error("Can't run a task when 'cwd' is not provided by the client");
-        }
 
         // Use task's cwd with spawned process and pass node env object to
         // new process, so e.g. we can re-use the system path


### PR DESCRIPTION
Removing a check that seems to be a change leftover from change [2]

The issue was triggered by launching a debug session which includes a
"preLaunchTask" referencing a build task.

The issue happened even if the "cwd" option was present in the tasks.json file

The check triggering the error was removed as the 'cwd' options should not be
mandatory see options under [3].

[1] https://github.com/eclipse-theia/theia/issues/8930
[2] https://github.com/eclipse-theia/theia/pull/5024#issuecomment-502985636
[3] https://code.visualstudio.com/docs/editor/tasks#_custom-tasks

Signed-off-by: Alvaro Sanchez-Leon <alvaro.sanchez-leon@ericsson.com>

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
The check triggering the error was removed as the 'cwd' options should not be
mandatory see options under [3].

[1] https://github.com/eclipse-theia/theia/issues/8930
[2] https://github.com/eclipse-theia/theia/pull/5024#issuecomment-502985636
[3] https://code.visualstudio.com/docs/editor/tasks#_custom-tasks

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
The steps to reproduce the issue and test the fix manually are under issue:
 https://github.com/eclipse-theia/theia/issues/8930

In addition the @theia/tasks and @theia/core tests were executed successfully
#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

