### PR TITLE
Implement vscode navigateBack, navigateForward, and navigateToLastEditLocation commands

### DIFF
--- a/packages/plugin-ext-vscode/src/browser/plugin-vscode-commands-contribution.ts
+++ b/packages/plugin-ext-vscode/src/browser/plugin-vscode-commands-contribution.ts
@@ -28,7 +28,7 @@ import { ContextKeyService } from '@theia/core/lib/browser/context-key-service';
 import { ApplicationShellMouseTracker } from '@theia/core/lib/browser/shell/application-shell-mouse-tracker';
 import { CommandService } from '@theia/core/lib/common/command';
 import TheiaURI from '@theia/core/lib/common/uri';
-import { EditorManager } from '@theia/editor/lib/browser';
+import { EditorManager, EditorCommands } from '@theia/editor/lib/browser';
 import {
     CodeEditorWidgetUtil
 } from '@theia/plugin-ext/lib/main/browser/menus/menus-contribution-handler';
@@ -363,6 +363,15 @@ export class PluginVscodeCommandsContribution implements CommandContribution {
         });
         commands.registerCommand({ id: 'workbench.action.previousEditor' }, {
             execute: () => this.shell.activatePreviousTab()
+        });
+        commands.registerCommand({ id: 'workbench.action.navigateBack' }, {
+            execute: () => commands.executeCommand(EditorCommands.GO_BACK.id)
+        });
+        commands.registerCommand({ id: 'workbench.action.navigateForward' }, {
+            execute: () => commands.executeCommand(EditorCommands.GO_FORWARD.id)
+        });
+        commands.registerCommand({ id: 'workbench.action.navigateToLastEditLocation' }, {
+            execute: () => commands.executeCommand(EditorCommands.GO_LAST_EDIT.id)
         });
 
         commands.registerCommand({ id: 'openInTerminal' }, {


### PR DESCRIPTION
Signed-off-by: Daniel Ku <daniel.ku@ericsson.com>

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->
This PR maps the VS Code commands `navigateBack`, `navigateForward`, and `navigateToLastEditLocation`  to their respective Theia commands. Closes #8956 

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
1. Install the [Back & Forth extension](https://open-vsx.org/extension/nick-rudenko/back-n-forth)
2. Open some files and navigate around a codebase
3. Use the back and forward buttons in the editor tabbar
4. Confirm that the back and forward buttons are working as expected

![theia-back-forth](https://user-images.githubusercontent.com/14880569/104785088-5d0b8100-574f-11eb-93bc-be6da5e5061b.gif)


#### Review checklist

- [X] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

