### PR TITLE
Create navigator widget factory

### DIFF
--- a/examples/api-tests/src/menus.spec.js
+++ b/examples/api-tests/src/menus.spec.js
@@ -30,7 +30,7 @@ describe('Menus', function () {
     const { ViewContainer } = require('@theia/core/lib/browser/view-container');
     const { waitForRevealed, waitForHidden } = require('@theia/core/lib/browser/widgets/widget');
     const { CallHierarchyContribution } = require('@theia/callhierarchy/lib/browser/callhierarchy-contribution');
-    const { EXPLORER_VIEW_CONTAINER_ID } = require('@theia/navigator/lib/browser/navigator-widget');
+    const { EXPLORER_VIEW_CONTAINER_ID } = require('@theia/navigator/lib/browser/navigator-widget-factory');
     const { FileNavigatorContribution } = require('@theia/navigator/lib/browser/navigator-contribution');
     const { ScmContribution } = require('@theia/scm/lib/browser/scm-contribution');
     const { ScmHistoryContribution } = require('@theia/scm-extra/lib/browser/history/scm-history-contribution');

--- a/packages/navigator/src/browser/index.ts
+++ b/packages/navigator/src/browser/index.ts
@@ -16,4 +16,5 @@
 
 export * from './navigator-model';
 export * from './navigator-widget';
+export * from './navigator-widget-factory';
 export * from './navigator-decorator-service';

--- a/packages/navigator/src/browser/navigator-contribution.ts
+++ b/packages/navigator/src/browser/navigator-contribution.ts
@@ -49,7 +49,8 @@ import {
     WorkspacePreferences,
     WorkspaceService
 } from '@theia/workspace/lib/browser';
-import { EXPLORER_VIEW_CONTAINER_ID, FILE_NAVIGATOR_ID, FileNavigatorWidget } from './navigator-widget';
+import { EXPLORER_VIEW_CONTAINER_ID } from './navigator-widget-factory';
+import { FILE_NAVIGATOR_ID, FileNavigatorWidget } from './navigator-widget';
 import { FileNavigatorPreferences } from './navigator-preferences';
 import { NavigatorKeybindingContexts } from './navigator-keybinding-context';
 import { FileNavigatorFilter } from './navigator-filter';

--- a/packages/navigator/src/browser/navigator-frontend-module.ts
+++ b/packages/navigator/src/browser/navigator-frontend-module.ts
@@ -19,14 +19,14 @@ import '../../src/browser/style/index.css';
 import { ContainerModule } from 'inversify';
 import {
     KeybindingContext, bindViewContribution,
-    FrontendApplicationContribution, ViewContainer,
+    FrontendApplicationContribution,
     ApplicationShellLayoutMigration
 } from '@theia/core/lib/browser';
-import { FileNavigatorWidget, FILE_NAVIGATOR_ID, EXPLORER_VIEW_CONTAINER_ID, EXPLORER_VIEW_CONTAINER_TITLE_OPTIONS } from './navigator-widget';
+import { FileNavigatorWidget, FILE_NAVIGATOR_ID } from './navigator-widget';
 import { NavigatorActiveContext } from './navigator-keybinding-context';
 import { FileNavigatorContribution } from './navigator-contribution';
 import { createFileNavigatorWidget } from './navigator-container';
-import { WidgetFactory, WidgetManager } from '@theia/core/lib/browser/widget-manager';
+import { WidgetFactory } from '@theia/core/lib/browser/widget-manager';
 import { bindFileNavigatorPreferences } from './navigator-preferences';
 import { FileNavigatorFilter } from './navigator-filter';
 import { NavigatorContextKeyService } from './navigator-context-key-service';
@@ -35,6 +35,7 @@ import { NavigatorDiff } from './navigator-diff';
 import { NavigatorLayoutVersion3Migration } from './navigator-layout-migrations';
 import { NavigatorTabBarDecorator } from './navigator-tab-bar-decorator';
 import { TabBarDecorator } from '@theia/core/lib/browser/shell/tab-bar-decorator';
+import { NavigatorWidgetFactory } from './navigator-widget-factory';
 
 export default new ContainerModule(bind => {
     bindFileNavigatorPreferences(bind);
@@ -55,22 +56,8 @@ export default new ContainerModule(bind => {
         id: FILE_NAVIGATOR_ID,
         createWidget: () => container.get(FileNavigatorWidget)
     })).inSingletonScope();
-    bind(WidgetFactory).toDynamicValue(({ container }) => ({
-        id: EXPLORER_VIEW_CONTAINER_ID,
-        createWidget: async () => {
-            const viewContainer = container.get<ViewContainer.Factory>(ViewContainer.Factory)({
-                id: EXPLORER_VIEW_CONTAINER_ID,
-                progressLocationId: 'explorer'
-            });
-            viewContainer.setTitleOptions(EXPLORER_VIEW_CONTAINER_TITLE_OPTIONS);
-            const widget = await container.get(WidgetManager).getOrCreateWidget(FILE_NAVIGATOR_ID);
-            viewContainer.addWidget(widget, {
-                canHide: false,
-                initiallyCollapsed: false
-            });
-            return viewContainer;
-        }
-    }));
+    bind(NavigatorWidgetFactory).toSelf().inSingletonScope();
+    bind(WidgetFactory).toService(NavigatorWidgetFactory);
     bind(ApplicationShellLayoutMigration).to(NavigatorLayoutVersion3Migration).inSingletonScope();
 
     bind(NavigatorDiff).toSelf().inSingletonScope();

--- a/packages/navigator/src/browser/navigator-layout-migrations.ts
+++ b/packages/navigator/src/browser/navigator-layout-migrations.ts
@@ -16,7 +16,8 @@
 
 import { injectable } from 'inversify';
 import { ApplicationShellLayoutMigration, WidgetDescription, ApplicationShellLayoutMigrationContext } from '@theia/core/lib/browser/shell/shell-layout-restorer';
-import { FILE_NAVIGATOR_ID, EXPLORER_VIEW_CONTAINER_ID, EXPLORER_VIEW_CONTAINER_TITLE_OPTIONS } from './navigator-widget';
+import { EXPLORER_VIEW_CONTAINER_ID, EXPLORER_VIEW_CONTAINER_TITLE_OPTIONS } from './navigator-widget-factory';
+import { FILE_NAVIGATOR_ID } from './navigator-widget';
 
 @injectable()
 export class NavigatorLayoutVersion3Migration implements ApplicationShellLayoutMigration {

--- a/packages/navigator/src/browser/navigator-tab-bar-decorator.ts
+++ b/packages/navigator/src/browser/navigator-tab-bar-decorator.ts
@@ -17,7 +17,7 @@
 import { injectable } from 'inversify';
 import { Emitter, Event } from '@theia/core/lib/common/event';
 import { TabBarDecorator } from '@theia/core/lib/browser/shell/tab-bar-decorator';
-import { EXPLORER_VIEW_CONTAINER_ID } from './navigator-widget';
+import { EXPLORER_VIEW_CONTAINER_ID } from './navigator-widget-factory';
 import { ApplicationShell, FrontendApplication, FrontendApplicationContribution, Saveable, Title, Widget } from '@theia/core/lib/browser';
 import { WidgetDecoration } from '@theia/core/lib/browser/widget-decoration';
 import { Disposable, DisposableCollection } from '@theia/core/lib/common/disposable';

--- a/packages/navigator/src/browser/navigator-widget-factory.ts
+++ b/packages/navigator/src/browser/navigator-widget-factory.ts
@@ -1,0 +1,59 @@
+/********************************************************************************
+ * Copyright (C) 2021 SAP SE or an SAP affiliate company and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import { inject, injectable } from 'inversify';
+import {
+    ViewContainer,
+    ViewContainerTitleOptions,
+    WidgetFactory,
+    WidgetManager
+} from '@theia/core/lib/browser';
+import { FILE_NAVIGATOR_ID } from './navigator-widget';
+
+export const EXPLORER_VIEW_CONTAINER_ID = 'explorer-view-container';
+export const EXPLORER_VIEW_CONTAINER_TITLE_OPTIONS: ViewContainerTitleOptions = {
+    label: 'Explorer',
+    iconClass: 'navigator-tab-icon',
+    closeable: true
+};
+
+@injectable()
+export class NavigatorWidgetFactory implements WidgetFactory {
+
+    static ID = EXPLORER_VIEW_CONTAINER_ID;
+
+    readonly id = NavigatorWidgetFactory.ID;
+
+    protected fileNavigatorWidgetOptions: ViewContainer.Factory.WidgetOptions = {
+        canHide: false,
+        initiallyCollapsed: false,
+    };
+
+    @inject(ViewContainer.Factory)
+    protected readonly viewContainerFactory: ViewContainer.Factory;
+    @inject(WidgetManager) protected readonly widgetManager: WidgetManager;
+
+    async createWidget(): Promise<ViewContainer> {
+        const viewContainer = this.viewContainerFactory({
+            id: EXPLORER_VIEW_CONTAINER_ID,
+            progressLocationId: 'explorer'
+        });
+        viewContainer.setTitleOptions(EXPLORER_VIEW_CONTAINER_TITLE_OPTIONS);
+        const widget = await this.widgetManager.getOrCreateWidget(FILE_NAVIGATOR_ID);
+        viewContainer.addWidget(widget, this.fileNavigatorWidgetOptions);
+        return viewContainer;
+    }
+}

--- a/packages/navigator/src/browser/navigator-widget.tsx
+++ b/packages/navigator/src/browser/navigator-widget.tsx
@@ -18,7 +18,7 @@ import { injectable, inject, postConstruct } from 'inversify';
 import { Message } from '@phosphor/messaging';
 import URI from '@theia/core/lib/common/uri';
 import { CommandService, SelectionService } from '@theia/core/lib/common';
-import { CorePreferences, ViewContainerTitleOptions, Key, TreeModel } from '@theia/core/lib/browser';
+import { CorePreferences, Key, TreeModel } from '@theia/core/lib/browser';
 import {
     ContextMenuRenderer, ExpandableTreeNode,
     TreeProps, TreeNode
@@ -34,13 +34,6 @@ import { NavigatorContextKeyService } from './navigator-context-key-service';
 import { FileNavigatorCommands } from './navigator-contribution';
 
 export const FILE_NAVIGATOR_ID = 'files';
-export const EXPLORER_VIEW_CONTAINER_ID = 'explorer-view-container';
-export const EXPLORER_VIEW_CONTAINER_TITLE_OPTIONS: ViewContainerTitleOptions = {
-    label: 'Explorer',
-    iconClass: 'navigator-tab-icon',
-    closeable: true
-};
-
 export const LABEL = 'No folder opened';
 export const CLASS = 'theia-Files';
 


### PR DESCRIPTION
Signed-off-by: Doron Nahari <doron.nahari@sap.com>

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->
This pr converts the navigator widget creation to be with a new navigator widget factory which is extensible and so we can extend it and configure it as desired.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
extend:
```typescript
@injectable()
export class CustomNavigatorWidget extends NavigatorWidgetFactory {
    async createWidget(): Promise<ViewContainer> {
        this.navigatorWidgetOptions = {
            canHide: true,
            initiallyCollapsed: true,
        };
        return super.createWidget();
    }
}
```
#### Review checklist

- [X] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

