### PR TITLE
8536-compatibility-third-party-themes

### DIFF
--- a/packages/monaco/src/browser/textmate/monaco-theme-registry.ts
+++ b/packages/monaco/src/browser/textmate/monaco-theme-registry.ts
@@ -140,14 +140,13 @@ export class MonacoThemeRegistry {
             return undefined;
         }
         const normalized = String(color).replace(/^\#/, '').slice(0, 6);
-        if (normalized.length < 6) {
+        if (normalized.length < 6 || !(normalized).match(/^[0-9A-Fa-f]{6}$/)) {
             // ignoring not normalized colors to avoid breaking token color indexes between monaco and vscode-textmate
             console.error(`Color '${normalized}' is NOT normalized, it must have 6 positions.`);
             return undefined;
         }
         return '#' + normalized;
     }
-
 }
 
 export namespace MonacoThemeRegistry {


### PR DESCRIPTION
Signed-off-by: Dan Arad <dan.arad@sap.com>

#### What it does
Fixes #8536

#8536 issue is caused because "Atom One Dark" (as example) had settings for foreground color **inherit** and **white** among others. **white** would be replaced by `normalizeColor` function with undefined, while **inherit** would eventually generate exception in [getId](https://github.com/microsoft/vscode/blob/7d57a8f6f546b5e30027e7cfa87bd834eb5c7bbb/src/vs/editor/common/modes/supports/tokenization.ts#L163) function because **inheri** didn't conform to color regexp.

![image](https://user-images.githubusercontent.com/71069170/104936436-3189d000-59b5-11eb-936a-667034e9deb3.png)

#### How to test
See explanation at #8536 

#### Review checklist

- [X] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

