### PR TITLE
Highlight Toggled State of Toolbar Items

### DIFF
--- a/examples/api-samples/src/browser/view/sample-unclosable-view-contribution.ts
+++ b/examples/api-samples/src/browser/view/sample-unclosable-view-contribution.ts
@@ -78,8 +78,8 @@ export class SampleUnclosableViewContribution extends AbstractViewContribution<S
 
 export const bindSampleUnclosableView = (bind: interfaces.Bind) => {
     bindViewContribution(bind, SampleUnclosableViewContribution);
-    bind(SampleViewUnclosableView).toSelf();
     bind(TabBarToolbarContribution).to(SampleUnclosableViewContribution).inSingletonScope();
+    bind(SampleViewUnclosableView).toSelf();
     bind(WidgetFactory).toDynamicValue(ctx => ({
         id: SampleViewUnclosableView.ID,
         createWidget: () => ctx.container.get<SampleViewUnclosableView>(SampleViewUnclosableView)

--- a/packages/core/src/browser/shell/tab-bar-toolbar.tsx
+++ b/packages/core/src/browser/shell/tab-bar-toolbar.tsx
@@ -129,7 +129,13 @@ export class TabBarToolbar extends ReactWidget {
             classNames.push(iconClass);
         }
         const tooltip = item.tooltip || (command && command.label);
+<<<<<<< Updated upstream
         return <div key={item.id} className={`${TabBarToolbar.Styles.TAB_BAR_TOOLBAR_ITEM}${command && this.commandIsEnabled(command.id) ? ' enabled' : ''}`}
+=======
+
+        return <div key={item.id} className={`${TabBarToolbar.Styles.TAB_BAR_TOOLBAR_ITEM}${command &&
+            (this.commandIsEnabled(command.id) ? (this.commandIsToggled(command.id) ? ' enabled toggled' : ' enabled') : '')}`}
+>>>>>>> Stashed changes
             onMouseDown={this.onMouseDownEvent} onMouseUp={this.onMouseUpEvent} onMouseOut={this.onMouseUpEvent} >
             <div id={item.id} className={classNames.join(' ')} onClick={this.executeCommand} title={tooltip}>{innerText}</div>
         </div>;

--- a/packages/core/src/browser/shell/tab-bar-toolbar.tsx
+++ b/packages/core/src/browser/shell/tab-bar-toolbar.tsx
@@ -129,16 +129,30 @@ export class TabBarToolbar extends ReactWidget {
             classNames.push(iconClass);
         }
         const tooltip = item.tooltip || (command && command.label);
-<<<<<<< Updated upstream
-        return <div key={item.id} className={`${TabBarToolbar.Styles.TAB_BAR_TOOLBAR_ITEM}${command && this.commandIsEnabled(command.id) ? ' enabled' : ''}`}
-=======
-
-        return <div key={item.id} className={`${TabBarToolbar.Styles.TAB_BAR_TOOLBAR_ITEM}${command &&
-            (this.commandIsEnabled(command.id) ? (this.commandIsToggled(command.id) ? ' enabled toggled' : ' enabled') : '')}`}
->>>>>>> Stashed changes
-            onMouseDown={this.onMouseDownEvent} onMouseUp={this.onMouseUpEvent} onMouseOut={this.onMouseUpEvent} >
-            <div id={item.id} className={classNames.join(' ')} onClick={this.executeCommand} title={tooltip}>{innerText}</div>
+        const toolbarItemClassNames = this.getToolbarItemClassNames(command?.id);
+        return <div key={item.id}
+            className={toolbarItemClassNames}
+            onMouseDown={this.onMouseDownEvent}
+            onMouseUp={this.onMouseUpEvent}
+            onMouseOut={this.onMouseUpEvent} >
+            <div id={item.id} className={classNames.join(' ')}
+                onClick={this.executeCommand}
+                title={tooltip}>{innerText}
+            </div>
         </div>;
+    }
+
+    protected getToolbarItemClassNames(commandId: string | undefined): string {
+        const classNames = [TabBarToolbar.Styles.TAB_BAR_TOOLBAR_ITEM];
+        if (commandId) {
+            if (this.commandIsEnabled(commandId)) {
+                classNames.push('enabled');
+            }
+            if (this.commandIsToggled(commandId)) {
+                classNames.push('toggled');
+            }
+        }
+        return classNames.join(' ');
     }
 
     protected renderMore(): React.ReactNode {
@@ -181,6 +195,10 @@ export class TabBarToolbar extends ReactWidget {
         return this.commands.isEnabled(command, this.current);
     }
 
+    protected commandIsToggled(command: string): boolean {
+        return this.commands.isToggled(command, this.current);
+    }
+
     protected executeCommand = (e: React.MouseEvent<HTMLElement>) => {
         e.preventDefault();
         e.stopPropagation();
@@ -189,6 +207,7 @@ export class TabBarToolbar extends ReactWidget {
         if (TabBarToolbarItem.is(item)) {
             this.commands.executeCommand(item.command, this.current);
         }
+        this.update();
     };
 
     protected onMouseDownEvent = (e: React.MouseEvent<HTMLElement>) => {

--- a/packages/core/src/browser/style/tabs.css
+++ b/packages/core/src/browser/style/tabs.css
@@ -355,6 +355,11 @@ body.theia-editor-highlightModifiedTabs
     transform: scale(1.272019649);
 }
 
+.p-TabBar-toolbar .item.toggled {
+    border: var(--theia-border-width) var(--theia-inputOption-activeBorder) solid;
+    background-color: var(--theia-inputOption-activeBackground);
+}
+
 .p-TabBar-toolbar .item > div {
     height: 18px;
     width: 18px;


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

Fixes [#8312](https://github.com/eclipse-theia/theia/issues/8312)

- Renders toolbar items with a highlighted background if in a toggled state.
- Adds a sample toolbar item (add icon) to the sample view toolbar that can be toggled for testing.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

1. Go to View  -> Sample Unclosable View
2. Click on the toolbar item (add/plus icon) to toggle and 
observe that a highlighted background appears behind the toolbar icon.

![image](https://user-images.githubusercontent.com/46289281/105373584-d59d9200-5bd4-11eb-9b3a-f930030e9f94.png)

![image](https://user-images.githubusercontent.com/46289281/105373754-0087e600-5bd5-11eb-84cc-e73ac7d3e0b5.png)

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

Signed-off-by: seantan22 <sean.a.tan@ericsson.com>