### PR TITLE
Fix incomplete data in generated tasks.json

### DIFF
--- a/packages/plugin-ext/src/common/plugin-api-rpc.ts
+++ b/packages/plugin-ext/src/common/plugin-api-rpc.ts
@@ -1255,6 +1255,7 @@ export interface TaskDto {
     // Provide a more specific type when necessary (see ProblemMatcherContribution)
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     problemMatcher?: any;
+    group?: string;
     detail?: string;
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     [key: string]: any;

--- a/packages/plugin-ext/src/plugin/type-converters.spec.ts
+++ b/packages/plugin-ext/src/plugin/type-converters.spec.ts
@@ -21,6 +21,7 @@ import * as types from './types-impl';
 import * as model from '../common/plugin-api-rpc-model';
 import { MarkdownString, isMarkdownString } from './markdown-string';
 import { TaskDto } from '../common/plugin-api-rpc';
+import { TaskGroup } from './types-impl';
 
 describe('Type converters:', () => {
 
@@ -181,6 +182,8 @@ describe('Type converters:', () => {
         const args = ['run', 'build'];
         const cwd = '/projects/theia';
         const additionalProperty = 'some property';
+        const groupDto = 'build';
+        const group = TaskGroup.Build;
 
         const shellTaskDto: TaskDto = {
             type: shellType,
@@ -190,7 +193,8 @@ describe('Type converters:', () => {
             command,
             args,
             options: { cwd },
-            additionalProperty
+            additionalProperty,
+            group: groupDto
         };
 
         const shellTaskDtoWithCommandLine: TaskDto = {
@@ -211,6 +215,7 @@ describe('Type converters:', () => {
                 type: shellType,
                 additionalProperty
             },
+            group,
             execution: {
                 command,
                 args,

--- a/packages/task/src/browser/task-configurations.ts
+++ b/packages/task/src/browser/task-configurations.ts
@@ -317,7 +317,7 @@ export class TaskConfigurations implements Disposable {
 
         const configuredAndCustomizedTasks = await this.getTasks(token);
         if (!configuredAndCustomizedTasks.some(t => this.taskDefinitionRegistry.compareTasks(t, task))) {
-            await this.saveTask(scope, { ...task, problemMatcher: [] });
+            await this.saveTask(scope, task);
         }
 
         try {
@@ -359,6 +359,9 @@ export class TaskConfigurations implements Disposable {
         if (task.group) {
             customization.group = task.group;
         }
+
+        customization.label = task.label;
+
         return { ...customization };
     }
 

--- a/packages/task/src/browser/task-service.ts
+++ b/packages/task/src/browser/task-service.ts
@@ -1105,6 +1105,7 @@ export class TaskService implements TaskConfigurationClient {
      * @param task The task to configure
      */
     async configure(token: number, task: TaskConfiguration): Promise<void> {
+        Object.assign(task, { label: this.taskNameResolver.resolve(task) });
         await this.taskConfigurations.configure(token, task);
     }
 

--- a/packages/task/src/common/task-protocol.ts
+++ b/packages/task/src/common/task-protocol.ts
@@ -113,7 +113,7 @@ export namespace TaskOutputPresentation {
 
 export interface TaskCustomization {
     type: string;
-    group?: 'build' | 'test' | 'none' | { kind: 'build' | 'test' | 'none', isDefault: true };
+    group?: 'build' | 'test' | 'none' | { kind: 'build' | 'test', isDefault: true };
     problemMatcher?: string | ProblemMatcherContribution | (string | ProblemMatcherContribution)[];
     presentation?: TaskOutputPresentation;
     detail?: string;


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

Fixes #8950
Fixes #8980

- Added missing 'group' property to the TaskDto interface
- Added group when converting between TaskDto and TaskConfiguration
- Added group when converting between TaskDto and Task
- Removes clearing of problem matchers (error) to pass the received ones from a given extension
- Aligns TaskCustomization.group with task schema (i.e. remove 'none' when 'isDefault').
- Include provided task 'label' in the generated task.json

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
The steps to reproduce the issue are indicated in issues: 
- https://github.com/eclipse-theia/theia/issues/8950
- https://github.com/eclipse-theia/theia/issues/8980

the same steps can be used to notice the difference after applying the fix.

The following unit test were updated and pass locally:
 - `npx run test @theia/plugin-ext`
 - `npx run test @theia/task`

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

Signed-off-by: Alvaro Sanchez-Leon <alvaro.sanchez-leon@ericsson.com>
