### PR TITLE
Refactor RPCProtocol

### DIFF
--- a/packages/plugin-ext/src/common/plugin-protocol.ts
+++ b/packages/plugin-ext/src/common/plugin-protocol.ts
@@ -772,7 +772,7 @@ export function buildFrontendModuleName(plugin: PluginPackage | PluginModel): st
 
 export const HostedPluginClient = Symbol('HostedPluginClient');
 export interface HostedPluginClient {
-    postMessage(message: string): Promise<void>;
+    postMessage(pluginHost: string, message: string): Promise<void>;
 
     log(logPart: LogPart): void;
 
@@ -816,9 +816,11 @@ export interface HostedPluginServer extends JsonRpcServer<HostedPluginClient> {
 
     getExtPluginAPI(): Promise<ExtPluginApi[]>;
 
-    onMessage(message: string): Promise<void>;
+    onMessage(targetHost: string, message: string): Promise<void>;
 
 }
+
+export const PLUGIN_HOST_BACKEND = 'main';
 
 export interface WorkspaceStorageKind {
     workspace?: string | undefined;
@@ -851,9 +853,9 @@ export interface PluginServer {
 export const ServerPluginRunner = Symbol('ServerPluginRunner');
 export interface ServerPluginRunner {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    acceptMessage(jsonMessage: any): boolean;
+    acceptMessage(pluginHostId: string, jsonMessage: string): boolean;
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    onMessage(jsonMessage: any): void;
+    onMessage(pluginHostId: string, jsonMessage: string): void;
     setClient(client: HostedPluginClient): void;
     setDefault(defaultRunner: ServerPluginRunner): void;
     clientClosed(): void;

--- a/packages/plugin-ext/src/hosted/browser/hosted-plugin-watcher.ts
+++ b/packages/plugin-ext/src/hosted/browser/hosted-plugin-watcher.ts
@@ -21,7 +21,7 @@ import { LogPart } from '../../common/types';
 
 @injectable()
 export class HostedPluginWatcher {
-    private onPostMessage = new Emitter<string[]>();
+    private onPostMessage = new Emitter<{ pluginHostId: string, message: string }>();
     private onLogMessage = new Emitter<LogPart>();
 
     private readonly onDidDeployEmitter = new Emitter<void>();
@@ -31,8 +31,8 @@ export class HostedPluginWatcher {
         const messageEmitter = this.onPostMessage;
         const logEmitter = this.onLogMessage;
         return {
-            postMessage(message: string): Promise<void> {
-                messageEmitter.fire(JSON.parse(message));
+            postMessage(pluginHostId, message: string): Promise<void> {
+                messageEmitter.fire({ pluginHostId, message });
                 return Promise.resolve();
             },
             log(logPart: LogPart): Promise<void> {
@@ -43,7 +43,7 @@ export class HostedPluginWatcher {
         };
     }
 
-    get onPostMessageEvent(): Event<string[]> {
+    get onPostMessageEvent(): Event<{ pluginHostId: string, message: string }> {
         return this.onPostMessage.event;
     }
 

--- a/packages/plugin-ext/src/hosted/browser/worker/worker-main.ts
+++ b/packages/plugin-ext/src/hosted/browser/worker/worker-main.ts
@@ -40,10 +40,10 @@ const ctx = self as any;
 const pluginsApiImpl = new Map<string, typeof theia>();
 const pluginsModulesNames = new Map<string, Plugin>();
 
-const emitter = new Emitter();
+const emitter = new Emitter<string>();
 const rpc = new RPCProtocolImpl({
     onMessage: emitter.event,
-    send: (m: {}) => {
+    send: (m: string) => {
         ctx.postMessage(m);
     }
 });

--- a/packages/plugin-ext/src/hosted/node/hosted-plugin-process.ts
+++ b/packages/plugin-ext/src/hosted/node/hosted-plugin-process.ts
@@ -18,7 +18,7 @@ import * as cp from 'child_process';
 import { injectable, inject, named } from '@theia/core/shared/inversify';
 import { ILogger, ConnectionErrorHandler, ContributionProvider, MessageService } from '@theia/core/lib/common';
 import { createIpcEnv } from '@theia/core/lib/node/messaging/ipc-protocol';
-import { HostedPluginClient, ServerPluginRunner, PluginHostEnvironmentVariable, DeployedPlugin } from '../../common/plugin-protocol';
+import { HostedPluginClient, ServerPluginRunner, PluginHostEnvironmentVariable, DeployedPlugin, PLUGIN_HOST_BACKEND } from '../../common/plugin-protocol';
 import { MessageType } from '../../common/rpc-protocol';
 import { HostedPluginCliContribution } from './hosted-plugin-cli-contribution';
 import * as psTree from 'ps-tree';
@@ -78,14 +78,14 @@ export class HostedPluginProcess implements ServerPluginRunner {
     }
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    public acceptMessage(jsonMessage: any): boolean {
-        return jsonMessage.type !== undefined && jsonMessage.id;
+    public acceptMessage(pluginHostId: string, message: string): boolean {
+        return pluginHostId === 'main';
     }
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    public onMessage(jsonMessage: any): void {
+    public onMessage(pluginHostId: string, jsonMessage: string): void {
         if (this.childProcess) {
-            this.childProcess.send(JSON.stringify(jsonMessage));
+            this.childProcess.send(jsonMessage);
         }
     }
 
@@ -154,7 +154,7 @@ export class HostedPluginProcess implements ServerPluginRunner {
         });
         this.childProcess.on('message', message => {
             if (this.client) {
-                this.client.postMessage(message);
+                this.client.postMessage(PLUGIN_HOST_BACKEND, message);
             }
         });
     }

--- a/packages/plugin-ext/src/hosted/node/hosted-plugin.ts
+++ b/packages/plugin-ext/src/hosted/node/hosted-plugin.ts
@@ -71,18 +71,17 @@ export class HostedPluginSupport {
         }
     }
 
-    onMessage(message: string): void {
+    onMessage(pluginHostId: string, message: string): void {
         // need to perform routing
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        const jsonMessage: any = JSON.parse(message);
         if (this.pluginRunners.length > 0) {
             this.pluginRunners.forEach(runner => {
-                if (runner.acceptMessage(jsonMessage)) {
-                    runner.onMessage(jsonMessage);
+                if (runner.acceptMessage(pluginHostId, message)) {
+                    runner.onMessage(pluginHostId, message);
                 }
             });
         } else {
-            this.hostedPluginProcess.onMessage(jsonMessage.content);
+            this.hostedPluginProcess.onMessage(pluginHostId, message);
         }
     }
 

--- a/packages/plugin-ext/src/hosted/node/metadata-scanner.ts
+++ b/packages/plugin-ext/src/hosted/node/metadata-scanner.ts
@@ -15,8 +15,7 @@
  ********************************************************************************/
 
 import { injectable, multiInject } from '@theia/core/shared/inversify';
-import { PluginPackage, PluginScanner, PluginMetadata } from '../../common/plugin-protocol';
-
+import { PluginPackage, PluginScanner, PluginMetadata, PLUGIN_HOST_BACKEND } from '../../common/plugin-protocol';
 @injectable()
 export class MetadataScanner {
     private scanners: Map<string, PluginScanner> = new Map();
@@ -32,7 +31,7 @@ export class MetadataScanner {
     getPluginMetadata(plugin: PluginPackage): PluginMetadata {
         const scanner = this.getScanner(plugin);
         return {
-            host: 'main',
+            host: PLUGIN_HOST_BACKEND,
             model: scanner.getModel(plugin),
             lifecycle: scanner.getLifecycle(plugin)
         };

--- a/packages/plugin-ext/src/hosted/node/plugin-host.ts
+++ b/packages/plugin-ext/src/hosted/node/plugin-host.ts
@@ -72,12 +72,12 @@ process.on('rejectionHandled', (promise: Promise<any>) => {
 });
 
 let terminating = false;
-const emitter = new Emitter();
+const emitter = new Emitter<string>();
 const rpc = new RPCProtocolImpl({
     onMessage: emitter.event,
-    send: (m: {}) => {
+    send: (m: string) => {
         if (process.send && !terminating) {
-            process.send(JSON.stringify(m));
+            process.send(m);
         }
     }
 });
@@ -104,7 +104,7 @@ process.on('message', async (message: string) => {
                 process.send(JSON.stringify({ type: MessageType.Terminated }));
             }
         } else {
-            emitter.fire(msg);
+            emitter.fire(message);
         }
     } catch (e) {
         console.error(e);

--- a/packages/plugin-ext/src/hosted/node/plugin-service.ts
+++ b/packages/plugin-ext/src/hosted/node/plugin-service.ts
@@ -105,8 +105,8 @@ export class HostedPluginServerImpl implements HostedPluginServer {
         return plugins;
     }
 
-    onMessage(message: string): Promise<void> {
-        this.hostedPlugin.onMessage(message);
+    onMessage(pluginHostId: string, message: string): Promise<void> {
+        this.hostedPlugin.onMessage(pluginHostId, message);
         return Promise.resolve();
     }
 

--- a/packages/plugin-ext/src/main/browser/plugin-worker.ts
+++ b/packages/plugin-ext/src/main/browser/plugin-worker.ts
@@ -23,7 +23,7 @@ export class PluginWorker {
     private worker: Worker;
     public readonly rpc: RPCProtocol;
     constructor() {
-        const emitter = new Emitter();
+        const emitter = new Emitter<string>();
         this.worker = new (require('../../hosted/browser/worker/worker-main'));
         this.worker.onmessage = message => {
             emitter.fire(message.data);
@@ -32,7 +32,7 @@ export class PluginWorker {
 
         this.rpc = new RPCProtocolImpl({
             onMessage: emitter.event,
-            send: (m: {}) => {
+            send: (m: string) => {
                 this.worker.postMessage(m);
             }
         });


### PR DESCRIPTION
#### What it does
This refactoring clarifies an decouples a bunch of things. This is a pure refactoring which should not change behaviour.

1. Each connection to a plugin host has an explicit host id: we already have this concept in HostedPluginSupport#initRpc, but instead of using the already known host id, we use the id of the first plugin deployed on the plugin host for a connection id. 
2. JsonPlugin(Client|Server) now explicitly reference a plugin host id instead of encoding that in the messages being transferred
3. MessageConnection only handle strings now: we're sending json messages, so this is not really a restriction.
4. RPCMultiplexer now is an implementation detail of RPCProtocol. 
5. RPCProtocol only deals with sending remote invocations over a connection: all things specific to plugin hosts and routing have been removed.

#### How to test
Run Theia with with at least a back-end and one front-end plugin. No exceptions related to rpc processing should appear in neither the back-end nor front-end logs. 
Note: front-end plugins still don't work with electron.

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

