### PR TITLE
Fix log on failure of command execution.

### DIFF
--- a/packages/core/src/common/command.ts
+++ b/packages/core/src/common/command.ts
@@ -295,9 +295,7 @@ export class CommandRegistry implements CommandService {
             this.onDidExecuteCommandEmitter.fire({ commandId, args });
             return result;
         }
-        const argsMessage = args && args.length > 0 ? ` (args: ${JSON.stringify(args)})` : '';
-        // eslint-disable-next-line max-len
-        throw Object.assign(new Error(`The command '${commandId}' cannot be executed. There are no active handlers available for the command.${argsMessage}`), { code: 'NO_ACTIVE_HANDLER' });
+        throw Object.assign(new Error(`The command '${commandId}' cannot be executed. There are no active handlers available for the command.`), { code: 'NO_ACTIVE_HANDLER' });
     }
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any


### PR DESCRIPTION
Signed-off-by: Colin Grant <colin.grant@ericsson.com>

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->
Fixes #8974 by removing the args from the log for the failed command execution.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

It isn't easy to reproduce the bug, but it should be clear that this code can no longer fail due to problems with `JSON.stringify`. See discussion on #8974 on the decision to simply remove the args.

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

