### PR TITLE
Correct type guard for FileStat.is

### DIFF
--- a/packages/filesystem/src/common/files.ts
+++ b/packages/filesystem/src/common/files.ts
@@ -241,7 +241,7 @@ export interface FileStat extends BaseStat {
     children?: FileStat[];
 }
 export namespace FileStat {
-    export function is(arg: Object | undefined): arg is BaseStat {
+    export function is(arg: Object | undefined): arg is FileStat {
         return BaseStat.is(arg) &&
             ('isFile' in arg && typeof arg['isFile'] === 'boolean') &&
             ('isDirectory' in arg && typeof arg['isDirectory'] === 'boolean') &&


### PR DESCRIPTION
#### What it does
This is a fix to a copy-and-paste error.  A new test was created a few months back in Theia 1.5 for FileStat.  However the type guard was left at BaseStat, meaning one can't access isDirectory etc. after testing for a FileStat.

#### How to test
This cannot be tested without making modifications to the code.

Although FileStat.is is used a few times in the Theia codebase, in most cases the code does not access FileStat properties afterwards.  In the cases where the FileStat property isDirectory is used, the original type is URI | URIIconReference | FileStat, typescript being smart enough to determine that if the type is BaseStat then it must be FileStat.

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

