### PR TITLE
Quick File Open: Support for Search Queries with Whitespaces

### DIFF
--- a/packages/file-search/src/common/file-search-service.ts
+++ b/packages/file-search/src/common/file-search-service.ts
@@ -54,3 +54,5 @@ export namespace FileSearchService {
         defaultIgnorePatterns?: string[]
     }
 }
+
+export const WHITESPACE_QUERY_SEPARATOR = /\s+/;

--- a/packages/file-search/src/node/file-search-service-impl.spec.ts
+++ b/packages/file-search/src/node/file-search-service-impl.spec.ts
@@ -195,4 +195,34 @@ describe('search-service', function (): void {
         });
     });
 
+    describe('search with whitespaces', () => {
+        const rootUri = FileUri.create(path.resolve(__dirname, '../../test-resources')).toString();
+
+        it('should support file searches with whitespaces', async () => {
+            const matches = await service.find('foo sub', { rootUris: [rootUri], fuzzyMatch: true, useGitIgnore: true, limit: 200 });
+
+            expect(matches).to.be.length(2);
+            expect(matches[0].endsWith('subdir1/sub-bar/foo.txt'));
+            expect(matches[1].endsWith('subdir1/sub2/foo.txt'));
+        });
+
+        it('should support fuzzy file searches with whitespaces', async () => {
+            const matchesExact = await service.find('foo sbd2', { rootUris: [rootUri], fuzzyMatch: false, useGitIgnore: true, limit: 200 });
+            const matchesFuzzy = await service.find('foo sbd2', { rootUris: [rootUri], fuzzyMatch: true, useGitIgnore: true, limit: 200 });
+
+            expect(matchesExact).to.be.length(0);
+            expect(matchesFuzzy).to.be.length(1);
+            expect(matchesFuzzy[0].endsWith('subdir1/sub2/foo.txt'));
+        });
+
+        it('should support file searches with whitespaces regardless of order', async () => {
+            const matchesA = await service.find('foo sub', { rootUris: [rootUri], fuzzyMatch: true, useGitIgnore: true, limit: 200 });
+            const matchesB = await service.find('sub foo', { rootUris: [rootUri], fuzzyMatch: true, useGitIgnore: true, limit: 200 });
+
+            expect(matchesA).to.not.be.empty;
+            expect(matchesB).to.not.be.empty;
+            expect(matchesA).to.deep.eq(matchesB);
+        });
+    });
+
 });

--- a/packages/file-search/src/node/file-search-service-impl.ts
+++ b/packages/file-search/src/node/file-search-service-impl.ts
@@ -23,7 +23,7 @@ import URI from '@theia/core/lib/common/uri';
 import { FileUri } from '@theia/core/lib/node/file-uri';
 import { CancellationTokenSource, CancellationToken, ILogger, isWindows } from '@theia/core';
 import { RawProcessFactory } from '@theia/process/lib/node';
-import { FileSearchService } from '../common/file-search-service';
+import { FileSearchService, WHITESPACE_QUERY_SEPARATOR } from '../common/file-search-service';
 import * as path from 'path';
 
 @injectable()
@@ -80,24 +80,38 @@ export class FileSearchServiceImpl implements FileSearchService {
             searchPattern = searchPattern.replace(/\//g, '\\');
         }
 
-        const stringPattern = searchPattern.toLocaleLowerCase();
+        const patterns = searchPattern.toLocaleLowerCase().trim().split(WHITESPACE_QUERY_SEPARATOR);
+
         await Promise.all(Object.keys(roots).map(async root => {
             try {
                 const rootUri = new URI(root);
                 const rootPath = FileUri.fsPath(rootUri);
                 const rootOptions = roots[root];
+
                 await this.doFind(rootUri, rootOptions, candidate => {
+
                     // Convert OS-native candidate path to a file URI string
                     const fileUri = FileUri.create(path.resolve(rootPath, candidate)).toString();
+
                     // Skip results that have already been matched.
                     if (exactMatches.has(fileUri) || fuzzyMatches.has(fileUri)) {
                         return;
                     }
-                    if (!searchPattern || searchPattern === '*' || candidate.toLocaleLowerCase().indexOf(stringPattern) !== -1) {
+
+                    // Determine if the candidate matches any of the patterns exactly or fuzzy
+                    const candidatePattern = candidate.toLocaleLowerCase();
+                    const patternExists = patterns.every(pattern => candidatePattern.indexOf(pattern) !== -1);
+                    if (patternExists) {
                         exactMatches.add(fileUri);
-                    } else if (opts.fuzzyMatch && fuzzy.test(searchPattern, candidate)) {
-                        fuzzyMatches.add(fileUri);
+                    } else if (!searchPattern || searchPattern === '*') {
+                        exactMatches.add(fileUri);
+                    } else {
+                        const fuzzyPatternExists = patterns.every(pattern => fuzzy.test(pattern, candidate));
+                        if (opts.fuzzyMatch && fuzzyPatternExists) {
+                            fuzzyMatches.add(fileUri);
+                        }
                     }
+
                     // Preemptively terminate the search when the list of exact matches reaches the limit.
                     if (exactMatches.size === opts.limit) {
                         cancellationSource.cancel();
@@ -107,6 +121,7 @@ export class FileSearchServiceImpl implements FileSearchService {
                 console.error('Failed to search:', root, e);
             }
         }));
+
         if (clientToken && clientToken.isCancellationRequested) {
             return [];
         }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

Fixes [#8747](https://github.com/eclipse-theia/theia/issues/8747)

- Allows whitespaces to be included in a `quick file open` search query.
- Adds support for whitespaces in the scoring of file search results.
- Adds tests for whitespace queries (considers fuzzy matching and search
  term order).

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

1. `ctrl + p` to `quick file open`
2. Search for a file with a query that includes whitespaces (eg. `readme core`)
3. Observe that whitespaces do not affect the search results

Alternatively, run `@theia/file-search` tests.

Before Changes:

![image](https://user-images.githubusercontent.com/46289281/105739779-77d7b580-5f06-11eb-9ea1-e8c7af380413.png)

After Changes:

![image](https://user-images.githubusercontent.com/46289281/105740008-bd947e00-5f06-11eb-87de-469e9deaadea.png)

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

Signed-off-by: seantan22 <sean.a.tan@ericsson.com>