### PR TITLE
Allow EditorManager to Navigate to Selection before Attachment

### DIFF
--- a/packages/editor-preview/src/browser/editor-preview-factory.ts
+++ b/packages/editor-preview/src/browser/editor-preview-factory.ts
@@ -19,10 +19,10 @@ import { WidgetFactory, WidgetManager } from '@theia/core/lib/browser';
 import { MaybePromise } from '@theia/core/lib/common/types';
 import { EditorPreviewWidget } from './editor-preview-widget';
 import { inject, injectable } from 'inversify';
-import { EditorManager } from '@theia/editor/lib/browser';
+import { EditorManager, EditorOpenerOptions } from '@theia/editor/lib/browser';
 import { UUID } from '@phosphor/coreutils';
 
-export interface EditorPreviewWidgetOptions {
+export interface EditorPreviewWidgetOptions extends EditorOpenerOptions {
     kind: 'editor-preview-widget',
     id: string,
     initialUri: string,
@@ -53,7 +53,7 @@ export class EditorPreviewWidgetFactory implements WidgetFactory {
 
     protected async doCreate(options: EditorPreviewWidgetOptions): Promise<EditorPreviewWidget> {
         const widget = (options.session === EditorPreviewWidgetFactory.sessionId)
-            ? await this.editorManager.getOrCreateByUri(new URI(options.initialUri))
+            ? await this.editorManager.getOrCreateByUri(new URI(options.initialUri), options)
             : undefined;
         const previewWidget = new EditorPreviewWidget(this.widgetManager, widget);
         previewWidget.id = options.id;

--- a/packages/editor-preview/src/browser/editor-preview-manager.ts
+++ b/packages/editor-preview/src/browser/editor-preview-manager.ts
@@ -21,7 +21,7 @@ import { EditorManager, EditorOpenerOptions, EditorWidget } from '@theia/editor/
 import { EditorPreviewWidget } from './editor-preview-widget';
 import { EditorPreviewWidgetFactory, EditorPreviewWidgetOptions } from './editor-preview-factory';
 import { EditorPreviewPreferences } from './editor-preview-preferences';
-import { WidgetOpenHandler, WidgetOpenerOptions } from '@theia/core/lib/browser';
+import { WidgetOpenHandler } from '@theia/core/lib/browser';
 
 /**
  * Opener options containing an optional preview flag.
@@ -134,7 +134,7 @@ export class EditorPreviewManager extends WidgetOpenHandler<EditorPreviewWidget 
     protected async replaceCurrentPreview(uri: URI, options: PreviewEditorOpenerOptions): Promise<EditorPreviewWidget | undefined> {
         const currentPreview = await this.currentEditorPreview;
         if (currentPreview) {
-            const editorWidget = await this.editorManager.getOrCreateByUri(uri);
+            const editorWidget = await this.editorManager.getOrCreateByUri(uri, options);
             currentPreview.replaceEditorWidget(editorWidget);
             return currentPreview;
         }
@@ -151,12 +151,13 @@ export class EditorPreviewManager extends WidgetOpenHandler<EditorPreviewWidget 
         return result;
     }
 
-    protected createWidgetOptions(uri: URI, options?: WidgetOpenerOptions): EditorPreviewWidgetOptions {
+    protected createWidgetOptions(uri: URI, options?: EditorOpenerOptions): EditorPreviewWidgetOptions {
         return {
             kind: 'editor-preview-widget',
             id: EditorPreviewWidgetFactory.generateUniqueId(),
             initialUri: uri.withoutFragment().toString(),
-            session: EditorPreviewWidgetFactory.sessionId
+            session: EditorPreviewWidgetFactory.sessionId,
+            selection: options?.selection,
         };
     }
 }

--- a/packages/editor/src/browser/editor-manager.ts
+++ b/packages/editor/src/browser/editor-manager.ts
@@ -74,6 +74,22 @@ export class EditorManager extends NavigatableWidgetOpenHandler<EditorWidget> {
         this.updateCurrentEditor();
     }
 
+    async getByUri(uri: URI, options?: EditorOpenerOptions): Promise<EditorWidget | undefined> {
+        const widget = await super.getByUri(uri);
+        if (widget) {
+            this.revealSelection(widget, options, uri)
+        }
+        return widget;
+    }
+
+    async getOrCreateByUri(uri: URI, options?: EditorOpenerOptions): Promise<EditorWidget> {
+        const widget = await super.getOrCreateByUri(uri);
+        if (widget) {
+            this.revealSelection(widget, options, uri)
+        }
+        return widget;
+    }
+
     protected readonly recentlyVisibleIds: string[] = [];
     protected get recentlyVisible(): EditorWidget | undefined {
         const id = this.recentlyVisibleIds[0];
@@ -137,8 +153,8 @@ export class EditorManager extends NavigatableWidgetOpenHandler<EditorWidget> {
     }
 
     async open(uri: URI, options?: EditorOpenerOptions): Promise<EditorWidget> {
-        const editor = await super.open(uri, options);
-        this.revealSelection(editor, options, uri);
+        const editor = await this.getOrCreateByUri(uri, options)
+        await super.open(uri, options);
         return editor;
     }
 


### PR DESCRIPTION
Signed-off-by: Colin Grant <colin.grant@ericsson.com>

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

This PR fixes #8955 by interposing `EditorManager.revealSelection` between the creation of an editor widget and its attachment / opening. Previously, an editor would be attached, either independently or as part of an `EditorPreviewWidget`, and then `revealSelection` would be called. As a consequence, `EditorManager.onCurrentEditorChangedEmitter` was fired when the editor was picked up by the shell, before `revealSelection` had been called, and the top of the file would always be added to the navigation stack. With this PR, `revealSelection` can be called before the widget is picked up by the shell.

Alternative solutions to the problem include:
1. Rigging an event to fire when `revealSelection`, and making the navigation system respond by removing the top of the relevant file from the stack (if it's on top)
2. Preventing the `EditorManager` from firing the `onCurrentEditorChanged` event for a widget that hasn't been `open`ed yet.
3. Any others you think would be cleaner than this modification of the `get(OrCreate)ByUri` mechanism.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

1. Open a workspace with files in a language that provides definitions (e.g. the Theia repository)
2. Find reference to something defined in another file.
3. ctrl/cmd+click through to the definition.
4. Activate the command palette and select `Go back`
5. Observe that you navigate back the first file, without an intermediate stop at the start of the second file.

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

