### PR TITLE
Allow EditorManager to Open with Selection before Attachment

### DIFF
--- a/packages/editor/src/browser/editor-manager.ts
+++ b/packages/editor/src/browser/editor-manager.ts
@@ -74,6 +74,24 @@ export class EditorManager extends NavigatableWidgetOpenHandler<EditorWidget> {
         this.updateCurrentEditor();
     }
 
+    async getByUri(uri: URI, options?: EditorOpenerOptions): Promise<EditorWidget | undefined> {
+        const widget = await super.getByUri(uri);
+        if (widget) {
+            // Reveal selection before attachment to manage nav stack. (https://github.com/eclipse-theia/theia/issues/8955)
+            this.revealSelection(widget, options, uri);
+        }
+        return widget;
+    }
+
+    async getOrCreateByUri(uri: URI, options?: EditorOpenerOptions): Promise<EditorWidget> {
+        const widget = await super.getOrCreateByUri(uri);
+        if (widget) {
+            // Reveal selection before attachment to manage nav stack. (https://github.com/eclipse-theia/theia/issues/8955)
+            this.revealSelection(widget, options, uri);
+        }
+        return widget;
+    }
+
     protected readonly recentlyVisibleIds: string[] = [];
     protected get recentlyVisible(): EditorWidget | undefined {
         const id = this.recentlyVisibleIds[0];
@@ -137,8 +155,8 @@ export class EditorManager extends NavigatableWidgetOpenHandler<EditorWidget> {
     }
 
     async open(uri: URI, options?: EditorOpenerOptions): Promise<EditorWidget> {
-        const editor = await super.open(uri, options);
-        this.revealSelection(editor, options, uri);
+        const editor = await this.getOrCreateByUri(uri, options);
+        await super.open(uri, options);
         return editor;
     }
 


### PR DESCRIPTION
Signed-off-by: Colin Grant <colin.grant@ericsson.com>

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

This PR fixes #8955 by interposing `EditorManager.revealSelection` between the creation of an editor widget and its attachment / opening. Previously, an editor would be attached, either independently or as part of an `EditorPreviewWidget`, and then `revealSelection` would be called. As a consequence, `EditorManager.onCurrentEditorChangedEmitter` was fired when the editor was picked up by the shell, before `revealSelection` had been called, and the top of the file would always be added to the navigation stack. With this PR, `revealSelection` can be called before the widget is picked up by the shell.

Alternative solutions to the problem include:
1. Rigging an event to fire when `revealSelection` is run and making the navigation system respond by removing the top of the relevant file from the top of the navigation stack. (Works pretty well)
2. Preventing the `EditorManager` from firing the `onCurrentEditorChanged` event for a widget that hasn't been `open`ed yet. (Haven't tried, EditorPreviews - the most problematic case - do eventually call `open`.)
3. Any others you think would be cleaner than this modification of the `get(OrCreate)ByUri` mechanism.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

1. Open a workspace with files in a language that provides definitions (e.g. TS files in the Theia repository)
2. Find reference to something defined in another file.
3. ctrl/cmd+click through to the definition.
4. Activate the command palette and select `Go back`
5. Observe that you navigate back the first file, without an intermediate stop at the start of the second file.

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)