### PR TITLE
Tree search-box UI change to match VS Code - #8541

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,11 @@
 # Change Log
 ## v1.11.0 - 2021
 
+- [core] revamp of tree search-box ui to align with vscode [#9005](https://github.com/eclipse-theia/theia/pull/9005)
+
 <a name="breaking_changes_1.11.0">[Breaking Changes:](#breaking_changes_1.11.0)</a>
 
+- [core] updated `SearchBox.input` field type from `HTMLInputElement` to `HTMLSpanElement`. [#9005](https://github.com/eclipse-theia/theia/pull/9005)
 <a name="1.11.0_user-storage_scheme_updated"></a>
 
 -   [[user-storage]](#1.11.0_user-storage_scheme_updated) `UserStorageUri` scheme was changed from 'user_storage' to 'user-storage' as '\_' is not a valid char in scheme (according to [RFC 3986](https://tools.ietf.org/html/rfc3986#page-17)) [#9049](https://github.com/eclipse-theia/theia/pull/9049)

--- a/packages/core/src/browser/style/search-box.css
+++ b/packages/core/src/browser/style/search-box.css
@@ -14,24 +14,46 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
+:root {
+    --theia-search-box-padding: 3px;
+    --theia-search-box-radius: 2px;
+    --theia-search-box-spacing: 4px;
+    --theia-search-box-max-width: 500px;
+}
+
 .theia-search-box {
     position: absolute;
-    top: 0px;
-    right: 0px;
     display: flex;
-    align-items: baseline;
+    top: var(--theia-search-box-spacing);
+    right: var(--theia-search-box-spacing);
     box-shadow: var(--theia-border-width) var(--theia-border-width) var(--theia-widget-shadow);
-    line-height: var(--theia-private-horizontal-tab-height);
-    background-color: var(--theia-editor-background);
+    background-color: var(--theia-listFilterWidget-background);
     z-index: calc(var(--theia-tabbar-toolbar-z-index) + 1);
-    border: var(--theia-border-width) solid var(--theia-editor-background);
+    border-radius: var(--theia-search-box-radius);
+    padding: var(--theia-search-box-padding);
+    border: var(--theia-border-width) solid rgba(0, 0, 0, 0)
+}
+
+.theia-search-box.no-match {
+    border: var(--theia-border-width) solid var(--theia-inputValidation-errorBorder)
 }
 
 .theia-search-input {
     flex-grow: 1;
-    line-height: calc(var(--theia-private-horizontal-tab-height) * 0.8);
-    max-width: 6rem;
-    background-color: var(--theia-input-background);
+    user-select: none;
+}
+
+.theia-search-box > .theia-search-buttons-wrapper {
+    max-width: 0px;
+    transition: max-width .2s ease-out;
+    display: flex;
+    box-sizing: border-box;
+    align-items: center;
+}
+
+.theia-search-box:hover > .theia-search-buttons-wrapper {  
+    max-width: var(--theia-search-box-max-width);
+    transition: max-width .2s ease-in;
 }
 
 .theia-search-button {
@@ -44,9 +66,9 @@
 }
 
 .theia-search-button.codicon.codicon-filter {
-    line-height: var(--theia-private-horizontal-tab-height);
     color: var(--theia-editorWidget-foreground);
     align-self: flex-end;
+    margin-left: var(--theia-search-box-spacing);
 }
 
 .theia-search-button.codicon-filter:not(.filter-active):before {
@@ -66,7 +88,6 @@
 .theia-search-button-close:hover,
 .theia-search-button.codicon-filter:hover {
     cursor: pointer;
-    background-color: var(--theia-editorHoverWidget-background);
 }
 
 .theia-search-button-next:hover:before {

--- a/packages/core/src/browser/style/view-container.css
+++ b/packages/core/src/browser/style/view-container.css
@@ -84,6 +84,7 @@
     height: var(--theia-view-container-content-height);
     min-width: 50px;
     min-height: 50px;
+    position: relative;
 }
 
 .theia-view-container .part > .body .theia-tree-source-node-placeholder {

--- a/packages/core/src/browser/tree/tree-widget.tsx
+++ b/packages/core/src/browser/tree/tree-widget.tsx
@@ -187,11 +187,19 @@ export class TreeWidget extends ReactWidget implements StatefulWidget {
     protected init(): void {
         if (this.props.search) {
             this.searchBox = this.searchBoxFactory({ ...SearchBoxProps.DEFAULT, showButtons: true, showFilter: true });
+            this.searchBox.node.addEventListener('focus', () => {
+                this.node.focus();
+            });
             this.toDispose.pushAll([
                 this.searchBox,
                 this.searchBox.onTextChange(async data => {
                     await this.treeSearch.filter(data);
                     this.searchHighlights = this.treeSearch.getHighlights();
+                    this.searchBox.updateHighlightInfo({
+                        filterText: data,
+                        total: this.rows.size,
+                        matched: this.searchHighlights.size
+                    });
                     this.update();
                 }),
                 this.searchBox.onClose(data => this.treeSearch.filter(undefined)),


### PR DESCRIPTION
Signed-off-by: Balaji V <kuttibalaji.v6@gmail.com>

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->
The following issues are fixed as a part of this PR 
- Unexpected keyboard behaviour on search-box input field #8541 
- Focus issue when filter, next and previous button is clicked, The following are the steps to reproduce
  - Open a workspace
  - Focus on file explorer
  - Type text to search
  - Click on filter button -> notice the focus is lost from explorer
  - Type new text to search and notice its not being typed / searched

The fix is to make the search-box UI consistent to VSCode UI.

The following are yet to made consistent based on feedback and suggestions,

- Support for drag & drop search box to left or right
- Removing move up and down button from UI
- Support for tooltip with matching results info

#### How to test
Follow the above steps and notice the issues are fixed

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

