### PR TITLE
Save as command correctly creates a new file before saving

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+<a name="breaking_changes_1.13.0">[Breaking Changes:](#breaking_changes_1.13.0)</a>
+
+- [workspace] The `WorkspaceCommands.SAVE_AS` command no longer accepts an `URI` argument. It now uses the currently selected editor to determine the file to be saved [#9022](https://github.com/eclipse-theia/theia/pull/9022)
+
 ## v1.12.0 - 3/25/2020
 
 [1.12.0 Milestone](https://github.com/eclipse-theia/theia/milestone/17)


### PR DESCRIPTION
#### What it does

Fixes #8373
Fixes #8504
Closes https://github.com/eclipse-theia/theia/pull/8514

When using the "save as" command, a new file will be created with the new changes, and the old file will be unchanged. The text editor will then close the old file and open the new one.

#### How to test

* Open a file and make some changes
* Use "Save as" command
* The text editor will now open the new file created with the changes. The old file will be closed.
* The old file will be unchanged.


#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

