### PR TITLE
open-vsx: update 'markdown-language-features'

### DIFF
--- a/package.json
+++ b/package.json
@@ -115,7 +115,7 @@
     "vscode-builtin-lua": "https://open-vsx.org/api/vscode/lua/1.45.1/file/vscode.lua-1.45.1.vsix",
     "vscode-builtin-make": "https://open-vsx.org/api/vscode/make/1.45.1/file/vscode.make-1.45.1.vsix",
     "vscode-builtin-markdown": "https://open-vsx.org/api/vscode/markdown/1.45.1/file/vscode.markdown-1.45.1.vsix",
-    "vscode-builtin-markdown-language-features": "https://open-vsx.org/api/vscode/markdown-language-features/1.45.1/file/vscode.markdown-language-features-1.45.1.vsix",
+    "vscode-builtin-markdown-language-features": "https://open-vsx.org/api/vscode/markdown-language-features/1.39.2/file/vscode.markdown-language-features-1.39.2.vsix",
     "vscode-builtin-merge-conflict": "https://open-vsx.org/api/vscode/merge-conflict/1.45.1/file/vscode.merge-conflict-1.45.1.vsix",
     "vscode-builtin-npm": "https://open-vsx.org/api/vscode/npm/1.45.1/file/vscode.npm-1.45.1.vsix",
     "vscode-builtin-node-debug": "https://open-vsx.org/api/ms-vscode/node-debug/1.44.8/file/ms-vscode.node-debug-1.44.8.vsix",


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

The following commit updates the [vscode.markdown-language-features](https://open-vsx.org/extension/vscode/markdown-language-features/1.39.2) builtin extension from the incompatible `1.45.1` to `1.39.2`. The incompatible version made use of the `CustomEditor` API which is not yet supported by the framework, and resulted in the extension failing to activate.

The changes were tested on both the `browser` and `electron` targets.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

1. ensure that the builtin can be successfully downloaded (through the command `yarn download:plugins`)
2. start the `browser` or `electron` application
3. open a `markdown` file and ensure that there are no activation errors
4. attempt to `preview` the file (using the vscode command) and ensure that previewing works as intended

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

Signed-off-by: vince-fugnitto <vincent.fugnitto@ericsson.com>
