### PR TITLE
Extract plugin uri generation to injectable class

### DIFF
--- a/packages/plugin-ext-vscode/src/node/scanner-vscode.ts
+++ b/packages/plugin-ext-vscode/src/node/scanner-vscode.ts
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (C) 2015-2018 Red Hat, Inc.
+ * Copyright (C) 2015-2021 Red Hat, Inc.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -17,7 +17,6 @@
 import { injectable } from 'inversify';
 import { PluginScanner, PluginEngine, PluginPackage, PluginModel, PluginLifecycle } from '@theia/plugin-ext';
 import { TheiaPluginScanner } from '@theia/plugin-ext/lib/hosted/node/scanners/scanner-theia';
-import { FileUri } from '@theia/core/lib/node/file-uri';
 
 @injectable()
 export class VsCodePluginScanner extends TheiaPluginScanner implements PluginScanner {
@@ -33,7 +32,7 @@ export class VsCodePluginScanner extends TheiaPluginScanner implements PluginSca
         const publisher = plugin.publisher || '';
         const result: PluginModel = {
             packagePath: plugin.packagePath,
-            packageUri: FileUri.create(plugin.packagePath).toString(),
+            packageUri: this.pluginUriFactory.createUri(plugin).toString(),
             // see id definition: https://github.com/microsoft/vscode/blob/15916055fe0cb9411a5f36119b3b012458fe0a1d/src/vs/platform/extensions/common/extensions.ts#L167-L169
             id: `${publisher.toLowerCase()}.${plugin.name.toLowerCase()}`,
             name: plugin.name,

--- a/packages/plugin-ext/src/hosted/node/plugin-ext-hosted-backend-module.ts
+++ b/packages/plugin-ext/src/hosted/node/plugin-ext-hosted-backend-module.ts
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (C) 2018 Red Hat, Inc. and others.
+ * Copyright (C) 2018-2021 Red Hat, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -31,6 +31,8 @@ import { HostedPluginProcess, HostedPluginProcessConfiguration } from './hosted-
 import { ExtPluginApiProvider } from '../../common/plugin-ext-api-contribution';
 import { HostedPluginCliContribution } from './hosted-plugin-cli-contribution';
 import { HostedPluginDeployerHandler } from './hosted-plugin-deployer-handler';
+import { PluginUriFactory } from './scanners/plugin-uri-factory';
+import { FilePluginUriFactory } from './scanners/file-plugin-uri-factory';
 
 const commonHostedConnectionModule = ConnectionContainerModule.create(({ bind, bindBackendService }) => {
     bind(HostedPluginProcess).toSelf().inSingletonScope();
@@ -63,6 +65,7 @@ export function bindCommonHostedBackend(bind: interfaces.Bind): void {
     bind(HostedPluginProcessConfiguration).toConstantValue({ path: path.resolve(__dirname, 'plugin-host.js') });
 
     bind(ConnectionContainerModule).toConstantValue(commonHostedConnectionModule);
+    bind(PluginUriFactory).to(FilePluginUriFactory).inSingletonScope();
 }
 
 export function bindHostedBackend(bind: interfaces.Bind): void {

--- a/packages/plugin-ext/src/hosted/node/scanners/file-plugin-uri-factory.ts
+++ b/packages/plugin-ext/src/hosted/node/scanners/file-plugin-uri-factory.ts
@@ -1,0 +1,32 @@
+/********************************************************************************
+ * Copyright (C) 2021 Red Hat, Inc.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import { injectable } from 'inversify';
+import * as path from 'path';
+import URI from '@theia/core/lib/common/uri';
+import { FileUri } from '@theia/core/lib/node/file-uri';
+import { PluginPackage } from '../../../common';
+import { PluginUriFactory } from './plugin-uri-factory';
+/**
+ * The default implementation of PluginUriFactory simply returns a File URI from the concatenated
+ * package path and relative path.
+ */
+@injectable()
+export class FilePluginUriFactory implements PluginUriFactory {
+    createUri(pkg: PluginPackage, pkgRelativePath?: string): URI {
+        return FileUri.create(pkgRelativePath ? path.join(pkg.packagePath, pkgRelativePath) : pkg.packagePath);
+    }
+}

--- a/packages/plugin-ext/src/hosted/node/scanners/plugin-uri-factory.ts
+++ b/packages/plugin-ext/src/hosted/node/scanners/plugin-uri-factory.ts
@@ -1,0 +1,33 @@
+/********************************************************************************
+ * Copyright (C) 2021 Red Hat, Inc.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import URI from '@theia/core/lib/common/uri';
+import { PluginPackage } from '../../../common';
+
+export const PluginUriFactory = Symbol('PluginUriFactory');
+/**
+ * Creates URIs for resources used in plugin contributions. Projects where plugin host is not located on the back-end
+ * machine and therefor resources cannot be loaded from the local file system in the back end can override the factory.
+ */
+export interface PluginUriFactory {
+    /**
+     * Returns a URI that allows a file to be loaded given a plugin package and a path relative to the plugin's package path
+     *
+     * @param pkg the package this the file is contained in
+     * @param pkgRelativePath the path of the file relative to the package path, e.g. 'resources/snippets.json'
+     */
+    createUri(pkg: PluginPackage, pkgRelativePath?: string): URI;
+}

--- a/packages/plugin-ext/src/hosted/node/scanners/scanner-theia.ts
+++ b/packages/plugin-ext/src/hosted/node/scanners/scanner-theia.ts
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (C) 2015-2018 Red Hat, Inc.
+ * Copyright (C) 2015-2021 Red Hat, Inc.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -59,7 +59,6 @@ import { CharacterPair } from '../../../common/plugin-api-rpc';
 import * as jsoncparser from 'jsonc-parser';
 import { IJSONSchema } from '@theia/core/lib/common/json-schema';
 import { deepClone } from '@theia/core/lib/common/objects';
-import { FileUri } from '@theia/core/lib/node/file-uri';
 import { PreferenceSchema, PreferenceSchemaProperties } from '@theia/core/lib/common/preferences/preference-schema';
 import { RecursivePartial } from '@theia/core/lib/common/types';
 import {
@@ -69,6 +68,7 @@ import {
 } from '@theia/task/lib/common/task-protocol';
 import { ColorDefinition } from '@theia/core/lib/browser/color-registry';
 import { ResourceLabelFormatter } from '@theia/core/lib/common/label-protocol';
+import { PluginUriFactory } from './plugin-uri-factory';
 
 namespace nls {
     export function localize(key: string, _default: string): string {
@@ -92,6 +92,9 @@ export class TheiaPluginScanner implements PluginScanner {
     @inject(GrammarsReader)
     private readonly grammarsReader: GrammarsReader;
 
+    @inject(PluginUriFactory)
+    protected readonly pluginUriFactory: PluginUriFactory;
+
     get apiType(): PluginEngine {
         return this._apiType;
     }
@@ -99,7 +102,7 @@ export class TheiaPluginScanner implements PluginScanner {
     getModel(plugin: PluginPackage): PluginModel {
         const result: PluginModel = {
             packagePath: plugin.packagePath,
-            packageUri: FileUri.create(plugin.packagePath).toString(),
+            packageUri: this.pluginUriFactory.createUri(plugin).toString(),
             // see id definition: https://github.com/microsoft/vscode/blob/15916055fe0cb9411a5f36119b3b012458fe0a1d/src/vs/platform/extensions/common/extensions.ts#L167-L169
             id: `${plugin.publisher.toLowerCase()}.${plugin.name.toLowerCase()}`,
             name: plugin.name,
@@ -400,7 +403,7 @@ export class TheiaPluginScanner implements PluginScanner {
             if (contribution.path) {
                 result.push({
                     id: contribution.id,
-                    uri: FileUri.create(path.join(pck.packagePath, contribution.path)).toString(),
+                    uri: this.pluginUriFactory.createUri(pck, contribution.path).toString(),
                     description: contribution.description,
                     label: contribution.label,
                     uiTheme: contribution.uiTheme
@@ -426,7 +429,7 @@ export class TheiaPluginScanner implements PluginScanner {
             }
             result.push({
                 id: contribution.id,
-                uri: FileUri.create(path.join(pck.packagePath, contribution.path)).toString(),
+                uri: this.pluginUriFactory.createUri(pck, contribution.path).toString(),
                 description: contribution.description,
                 label: contribution.label,
                 uiTheme: contribution.uiTheme
@@ -445,7 +448,7 @@ export class TheiaPluginScanner implements PluginScanner {
                 result.push({
                     language: contribution.language,
                     source: pck.displayName || pck.name,
-                    uri: FileUri.create(path.join(pck.packagePath, contribution.path)).toString()
+                    uri: this.pluginUriFactory.createUri(pck, contribution.path).toString()
                 });
             }
         }


### PR DESCRIPTION
Signed-off-by: Thomas Mäder <tmader@redhat.com>

#### What it does
Extracts the generation of URIs for contribution files referenced in package.json (like snippet contribution files) to an overrideable class. This would simplify handling remote plugin hosts in Che while not greatly impacting the Theia code.
See https://github.com/eclipse/che/issues/16502

#### How to test
Run theia built from this PR (both electron and browser) and verify that things like snippets, etc. (see https://code.visualstudio.com/api/references/contribution-points) still work.

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

