### PR TITLE
Support plugin tasks using 'TaskScope.Workspace'

### DIFF
--- a/packages/plugin/src/theia.d.ts
+++ b/packages/plugin/src/theia.d.ts
@@ -9722,7 +9722,7 @@ declare module '@theia/plugin' {
     }
 
     export enum TaskScope {
-        /** The task is a global task */
+        /** The task is a global task. Global tasks are currently not supported. */
         Global = 1,
 
         /** The task is a workspace task */

--- a/packages/task/src/browser/quick-open-task.ts
+++ b/packages/task/src/browser/quick-open-task.ts
@@ -246,7 +246,7 @@ export class QuickOpenTask implements QuickOpenModel, QuickOpenHandler {
         if (this.workspaceService.opened) {
             const roots = await this.workspaceService.roots;
             scopes.push(...roots.map(rootStat => rootStat.resource.toString()));
-            if (this.workspaceService.saved) {
+            if (this.workspaceService.saved || groupedTasks.get(TaskScope.Workspace.toString())?.length) {
                 scopes.push(TaskScope.Workspace);
             }
         }

--- a/packages/task/src/browser/task-configurations.ts
+++ b/packages/task/src/browser/task-configurations.ts
@@ -302,12 +302,8 @@ export class TaskConfigurations implements Disposable {
     /** Adds given task to a config file and opens the file to provide ability to edit task configuration. */
     async configure(token: number, task: TaskConfiguration): Promise<void> {
         const scope = task._scope;
-        if (scope === TaskScope.Global || scope === TaskScope.Workspace) {
-            return this.taskConfigurationManager.openConfiguration(scope);
-        } else if (typeof scope !== 'string') {
-            console.error('Global task cannot be customized');
-            // TODO detected tasks of scope workspace or user could be customized in those preferences.
-            return;
+        if (scope === TaskScope.Global) {
+            return this.openUserTasks();
         }
 
         const workspace = this.workspaceService.workspace;

--- a/packages/task/src/browser/task-definition-registry.ts
+++ b/packages/task/src/browser/task-definition-registry.ts
@@ -114,8 +114,13 @@ export class TaskDefinitionRegistry {
         }
         const def = this.getDefinition(one);
         if (def) {
-            // scope is either a string or an enum value. Anyway...the must exactly match
-            return def.properties.all.every(p => p === 'type' || one[p] === other[p]) && one._scope === other._scope;
+            // scope is either a string or an enum value. Anyway...they must exactly match
+            // "_scope" may hold the Uri to the associated workspace whereas
+            // "scope" reflects the original TaskConfigurationScope as provided by plugins,
+            // Matching "_scope" or "scope" are both accepted in order to correlate provided task
+            // configurations (e.g. TaskScope.Workspace) against already configured tasks.
+            return def.properties.all.every(p => p === 'type' || one[p] === other[p])
+                && (one._scope === other._scope || one.scope === other.scope);
         }
         return one.label === other.label && one._source === other._source;
     }

--- a/packages/task/src/common/task-protocol.ts
+++ b/packages/task/src/common/task-protocol.ts
@@ -149,10 +149,14 @@ export namespace TaskCustomization {
 }
 
 export enum TaskScope {
-    Workspace,
-    Global
+    Global = 1,
+    Workspace = 2
 }
 
+/**
+ * The task configuration scopes.
+ * - `string` represents the associated workspace folder uri.
+ */
 export type TaskConfigurationScope = string | TaskScope.Workspace | TaskScope.Global;
 
 export interface TaskConfiguration extends TaskCustomization {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

Fixes #7931 

- Aligns the TaskScope enum definition with vscode and Theia plugins API see issue #7931 and corresponding schemas for Theia [2] and vscode [3]
- Supports processing of task configurations provided by plugins with
the scope set to TaskScope.Workspace.
- Ignores processing of task configurations provided by plugins with the scope set to TaskScope.Global i.e. User tasks.

In addition to the general description above.
1) Updates quick-open-task to add Workspace tasks provided by plugins to the list of available task to configure (see main menu Terminal -> Configure Tasks ....
2) Workspace tasks provided by plugins are now stored under the workspace file (for multi-root projects) and on the first root tasks.json file for not multi-root projects.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
-  Install the test plugin [1] under your plugins folder, or use one of your own.
-  Use a plugin task provider that contributes tasks configurations of scope Folder, Workspace and Global (e.g. [1] **branch** TaskScope.workspace, **version** 0.0.10) and make sure the tasks are presented when selecting from the main menu Terminal -> Configure Tasks... 

<br />

![workspace_tasks](https://user-images.githubusercontent.com/76971376/111320196-1fd34a80-863d-11eb-9500-4332e873fd34.gif)

- Check that provided tasks of Scope Workspace are presented for projects using a workspace e.g. multi-root 
- Check that the selected and provided tasks of scope WorkSpace are stored in the tasks.json file in a root/.theia folder for non multi-root projects.
-  Note that Global tasks defined by the user are still available, but no Global tasks from the plugin provider shall be available as they are not supported via providers.

#### References
1) [Plugin used to test, note: **branch** TaskScope.workspace, **version** 0.0.10](https://github.com/alvsan09/vscode-task-provider-example/tree/TaskScope.workspace)
2) [TaskScope, Theia plugin schema](https://github.com/eclipse-theia/theia/blob/2aa2fa1ab091ec36ef851c4e364b322301cddb40/packages/plugin/src/theia.d.ts#L8637)
3) [TaskScope, vscode extensions schema](https://github.com/microsoft/vscode/blob/50f907f0ba9b0c799a7c1d2f28a625bf30041636/src/vs/vscode.d.ts#L5923)
4) Make sure that selected tasks are configured and are runnable
5) Make sure that Global tasks defined by the user still work as before this change

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

Signed-off-by: Alvaro Sanchez-Leon <alvaro.sanchez-leon@ericsson.com>

