### PR TITLE
core: fix progress documentation

### DIFF
--- a/packages/core/src/common/message-service-protocol.ts
+++ b/packages/core/src/common/message-service-protocol.ts
@@ -68,7 +68,7 @@ export interface MessageOptions {
 
 export interface ProgressMessageOptions extends MessageOptions {
     /**
-     * Default: `true`
+     * Default: `false`
      */
     readonly cancelable?: boolean;
     /**


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

The following pull-request fixes a documentation issue caused by the breaking changes of https://github.com/eclipse-theia/theia/pull/8479.

The following commit updates the **default** value documentation for `ProgressMessageOptions.cancelable` which was
not updated when we introduced a breaking change. This change was caught by a downstream theia extension who noticed the breaking changes, and the documentation was incorrect. 

Alternatively, we could have updated the default on the plugin-side to support vscode, and not break our downstream extensions.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

Verify that the documentation now accurately reflects the changes present in https://github.com/eclipse-theia/theia/pull/8479.

Namely:

https://github.com/eclipse-theia/theia/blob/b74355fd3c133f8b2fe826b756b6a4851bc17961/packages/core/src/common/message-service-protocol.ts#L54-L59


#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

Signed-off-by: vince-fugnitto <vincent.fugnitto@ericsson.com>

