### PR TITLE
9012-vscode-java-debug-error

### DIFF
--- a/packages/plugin-ext/src/plugin/plugin-context.ts
+++ b/packages/plugin-ext/src/plugin/plugin-context.ts
@@ -432,6 +432,9 @@ export function createAPIFactory(
             createInputBox(): theia.InputBox {
                 return quickOpenExt.createInputBox(plugin);
             },
+            registerTerminalLinkProvider(provider: theia.TerminalLinkProvider): void {
+                /* NOOP */
+            },
             get activeColorTheme(): theia.ColorTheme {
                 return themingExt.activeColorTheme;
             },

--- a/packages/plugin/src/theia.d.ts
+++ b/packages/plugin/src/theia.d.ts
@@ -2872,6 +2872,71 @@ declare module '@theia/plugin' {
     }
 
     /**
+     * Provides information on a line in a terminal in order to provide links for it.
+     */
+    // copied from https://github.com/microsoft/vscode/blob/bd20a720fba05f87ddb53c11c6af66936fd88a55/src/vs/vscode.d.ts#L5563-L5576
+    export interface TerminalLinkContext {
+        /**
+         * This is the text from the unwrapped line in the terminal.
+         */
+        line: string;
+
+        /**
+         * The terminal the link belongs to.
+         */
+        terminal: Terminal;
+    }
+
+    /**
+     * A provider that enables detection and handling of links within terminals.
+     */
+    // copied from https://github.com/microsoft/vscode/blob/bd20a720fba05f87ddb53c11c6af66936fd88a55/src/vs/vscode.d.ts#L5578-L5597
+
+    export interface TerminalLinkProvider<T extends TerminalLink = TerminalLink> {
+        /**
+         * Provide terminal links for the given context. Note that this can be called multiple times
+         * even before previous calls resolve, make sure to not share global objects (eg. `RegExp`)
+         * that could have problems when asynchronous usage may overlap.
+         * @param context Information about what links are being provided for.
+         * @param token A cancellation token.
+         * @return A list of terminal links for the given line.
+         */
+        provideTerminalLinks(context: TerminalLinkContext, token: CancellationToken): ProviderResult<T[]>;
+
+        /**
+         * Handle an activated terminal link.
+         * @param link The link to handle.
+         */
+        handleTerminalLink(link: T): ProviderResult<void>;
+    }
+
+    /**
+     * A link on a terminal line.
+     */
+    // copied from https://github.com/microsoft/vscode/blob/bd20a720fba05f87ddb53c11c6af66936fd88a55/src/vs/vscode.d.ts#L5599-L5621
+    export interface TerminalLink {
+        /**
+         * The start index of the link on [TerminalLinkContext.line](#TerminalLinkContext.line].
+         */
+        startIndex: number;
+
+        /**
+         * The length of the link on [TerminalLinkContext.line](#TerminalLinkContext.line]
+         */
+        length: number;
+
+        /**
+         * The tooltip text when you hover over this link.
+         *
+         * If a tooltip is provided, is will be displayed in a string that includes instructions on
+         * how to trigger the link, such as `{0} (ctrl + click)`. The specific instructions vary
+         * depending on OS, user settings, and localization.
+         */
+        tooltip?: string;
+    }
+
+
+    /**
      * A type of mutation that can be applied to an environment variable.
      */
     export enum EnvironmentVariableMutatorType {
@@ -3963,6 +4028,15 @@ declare module '@theia/plugin' {
          * @return A new [InputBox](#InputBox).
          */
         export function createInputBox(): InputBox;
+
+
+        /**
+         * Register provider that enables the detection and handling of links within the terminal.
+         * @param provider The provider that provides the terminal links.
+         * @return Disposable that unregisters the provider.
+         */
+        // copied from https://github.com/microsoft/vscode/blob/e790b931385d72cf5669fcefc51cdf65990efa5d/src/vs/vscode.d.ts#L8302-8307
+        export function registerTerminalLinkProvider(provider: TerminalLinkProvider): void;
 
         /**
          * The currently active color theme as configured in the settings. The active

--- a/packages/preferences/src/browser/preferences-json-schema-contribution.ts
+++ b/packages/preferences/src/browser/preferences-json-schema-contribution.ts
@@ -23,7 +23,7 @@ import { PreferenceConfigurations } from '@theia/core/lib/browser/preferences/pr
 import { PreferenceScope } from '@theia/core/lib/browser';
 
 const PREFERENCE_URI_PREFIX = 'vscode://schemas/settings/';
-const USER_STORAGE_PREFIX = 'user_storage:/';
+const USER_STORAGE_PREFIX = 'user-storage:/';
 
 @injectable()
 export class PreferencesJsonSchemaContribution implements JsonSchemaContribution {

--- a/packages/userstorage/src/browser/user-storage-uri.ts
+++ b/packages/userstorage/src/browser/user-storage-uri.ts
@@ -16,4 +16,4 @@
 
 import URI from '@theia/core/lib/common/uri';
 
-export const UserStorageUri = new URI('user_storage:/user');
+export const UserStorageUri = new URI('user-storage:/user');

--- a/packages/workspace/src/browser/workspace-uri-contribution.spec.ts
+++ b/packages/workspace/src/browser/workspace-uri-contribution.spec.ts
@@ -79,7 +79,7 @@ describe('WorkspaceUriLabelProviderContribution class', () => {
 
     describe('canHandle()', () => {
         it('should return 0 if the passed in argument is not a FileStat or URI with the "file" scheme', () => {
-            expect(labelProvider.canHandle(new URI('user_storage:settings.json'))).eq(0);
+            expect(labelProvider.canHandle(new URI('user-storage:settings.json'))).eq(0);
             expect(labelProvider.canHandle({ uri: 'file:///home/settings.json' })).eq(0);
         });
 


### PR DESCRIPTION
Signed-off-by: Dan Arad <dan.arad@sap.com>


#### What it does
(a) Fixes #9012 
(b) this PR solves:
1) vscode-java-debug invokes vscode.window.registerTerminalLinkProvider upon extension activation. This method was not implemented in Theia - added it but implementation itself seems like an entire PR and don't know if it is wanted at all.
2) after crossing this first problem, second problem was that JDTUtils threw exception when receiving file changed event where URI scheme was user_storage - illegal schema name (contains "_") - therefore I changed `user_storage` to `user-storage` scheme name

#### How to test
1. Open in Theia java project
2. After load you can run or debug project
![image](https://user-images.githubusercontent.com/71069170/107147624-b4200280-6957-11eb-96f2-56f11a8225b5.png)

![image](https://user-images.githubusercontent.com/71069170/107147826-cc445180-6958-11eb-9364-e1ab13a64d62.png)

#### Review checklist

- [X] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

