### PR TITLE
Fix for #8933 - Copy and paste file/folder in the same place will duplicate the file/folder

### DIFF
--- a/packages/filesystem/src/browser/file-tree/file-tree-model.ts
+++ b/packages/filesystem/src/browser/file-tree/file-tree-model.ts
@@ -24,6 +24,7 @@ import { FileService } from '../file-service';
 import { FileOperationError, FileOperationResult, FileChangesEvent, FileChangeType, FileChange, FileOperation, FileOperationEvent } from '../../common/files';
 import { MessageService } from '@theia/core/lib/common/message-service';
 import { EnvVariablesServer } from '@theia/core/lib/common/env-variables';
+import { FileSystemUtils } from '../../common';
 
 @injectable()
 export class FileTreeModel extends TreeModelImpl implements LocationService {
@@ -148,8 +149,13 @@ export class FileTreeModel extends TreeModelImpl implements LocationService {
     }
 
     async copy(source: URI, target: Readonly<FileStatNode>): Promise<URI> {
-        const targetUri = target.uri.resolve(source.path.base);
+        let targetUri = target.uri.resolve(source.path.base);
         try {
+            if (source.path.toString() === target.uri.path.toString()) {
+                const parent = await this.fileService.resolve(source.parent);
+                const name = source.path.name + '_copy';
+                targetUri = FileSystemUtils.generateUniqueResourceURI(source.parent, parent, name, source.path.ext);
+            }
             await this.fileService.copy(source, targetUri);
         } catch (e) {
             this.messageService.error(e.message);


### PR DESCRIPTION
Signed-off-by: Ron Nabet <ron.nabet@sap.com>

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does

Fixes #8933
Select file/folder and press 'Ctrl+C' and 'Ctrl+V' and the file/folder will be duplicated instead of an error.

#### How to test

Mark file/folder and press 'Ctrl+C' and 'Ctrl+V'.
Copy a file/folder and paste under the same folder, the file will be created with "_copy" at the end of the filename.


#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

