### PR TITLE
Save tasks.json after configuring tasks automatically

### DIFF
--- a/packages/preferences/src/browser/folder-preference-provider.ts
+++ b/packages/preferences/src/browser/folder-preference-provider.ts
@@ -14,6 +14,8 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
 import { inject, injectable } from 'inversify';
 import URI from '@theia/core/lib/common/uri';
 import { PreferenceScope } from '@theia/core/lib/browser';

--- a/packages/preferences/src/browser/folder-preference-provider.ts
+++ b/packages/preferences/src/browser/folder-preference-provider.ts
@@ -57,4 +57,13 @@ export class FolderPreferenceProvider extends SectionPreferenceProvider {
     getDomain(): string[] {
         return [this.folderUri.toString()];
     }
+
+    async setPreference(key: string, value: any, resourceUri?: string): Promise<boolean> {
+        const result = await super.setPreference(key, value, resourceUri);
+        if (result && this.model) {
+            // always try to save the preference file
+            await this.model.save();
+        }
+        return result;
+    }
 }

--- a/packages/task/src/browser/task-configurations.ts
+++ b/packages/task/src/browser/task-configurations.ts
@@ -480,7 +480,7 @@ export class TaskConfigurations implements Disposable {
             Object.keys(update).forEach(taskProperty => {
                 task[taskProperty] = update[taskProperty];
             });
-            this.saveTask(scope, task);
+            await this.saveTask(scope, task);
         }
     }
 


### PR DESCRIPTION
#### What it does
Fixes #8979 

When folder preferences have been changed (e.g. the `tasks.json` files), they'll now always be saved. This keeps the `configure tasks` command more in line with vscode where the `tasks.json` file is also saved after using the command.

#### How to test

Reproducing the problem mentioned in #8979 is no longer possible by:

* add the example [vscode-task-provider-example](https://github.com/vince-fugnitto/vscode-task-provider-example/releases/download/0.0.2/vscode-task-provider-example-0.0.1.vsix) extension to the framework
* open a workspace (ensure that no .theia or .vscode folder is present in the workspace
* run the command configure tasks
* repeat the process for all items in the list

Instead of overriding the last task, the newly configured task is correctly added to the `tasks.json` file.

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

