### PR TITLE
Enable `extensions.json`

### DIFF
--- a/packages/core/src/browser/preferences/preference-service.ts
+++ b/packages/core/src/browser/preferences/preference-service.ts
@@ -265,6 +265,8 @@ export interface PreferenceInspection<T> {
     value: T | undefined;
 }
 
+export type PreferenceInspectionScope = keyof Omit<PreferenceInspection<unknown>, 'preferenceName'>;
+
 /**
  * We cannot load providers directly in the case if they depend on `PreferenceService` somehow.
  * It allows to load them lazily after DI is configured.
@@ -430,7 +432,7 @@ export class PreferenceServiceImpl implements PreferenceService {
         if (provider && await provider.setPreference(preferenceName, value, resourceUri)) {
             return;
         }
-        throw new Error(`Unable to write to ${PreferenceScope.getScopeNames(resolvedScope)[0]} Settings.`);
+        throw new Error(`Unable to write to ${PreferenceScope[resolvedScope]} Settings.`);
     }
 
     getBoolean(preferenceName: string): boolean | undefined;

--- a/packages/preferences/src/browser/user-configs-preference-provider.ts
+++ b/packages/preferences/src/browser/user-configs-preference-provider.ts
@@ -92,14 +92,24 @@ export class UserConfigsPreferenceProvider extends PreferenceProvider {
 
     async setPreference(preferenceName: string, value: any, resourceUri?: string): Promise<boolean> {
         const sectionName = preferenceName.split('.', 1)[0];
-        const configName = this.configurations.isSectionName(sectionName) ? sectionName : this.configurations.getConfigName();
+        const defaultConfigName = this.configurations.getConfigName();
+        const configName = this.configurations.isSectionName(sectionName) ? sectionName : defaultConfigName;
 
-        const providers = this.providers.values();
-
-        for (const provider of providers) {
-            if (this.configurations.getName(provider.getConfigUri()) === configName) {
-                return provider.setPreference(preferenceName, value, resourceUri);
+        const setWithConfigName = async (name: string): Promise<boolean> => {
+            for (const provider of this.providers.values()) {
+                if (this.configurations.getName(provider.getConfigUri()) === name) {
+                    if (await provider.setPreference(preferenceName, value, resourceUri)) {
+                        return true;
+                    }
+                }
             }
+            return false;
+        };
+
+        if (await setWithConfigName(configName)) { // Try in the section we believe it belongs in.
+            return true;
+        } else if (configName !== defaultConfigName) { // Fall back to `settings.json` if that fails.
+            return setWithConfigName(defaultConfigName);
         }
         return false;
     }

--- a/packages/preferences/src/browser/workspace-file-preference-provider.ts
+++ b/packages/preferences/src/browser/workspace-file-preference-provider.ts
@@ -65,13 +65,13 @@ export class WorkspaceFilePreferenceProvider extends AbstractResourcePreferenceP
     }
 
     protected getPath(preferenceName: string): string[] {
-        const firstSegment = preferenceName.split('.')[0];
-        if (firstSegment && this.configurations.isSectionName(firstSegment)) {
+        const firstSegment = preferenceName.split('.', 1)[0];
+        const remainder = preferenceName.slice(firstSegment.length + 1);
+        if (this.belongsInSection(firstSegment, remainder)) {
             // Default to writing sections outside the "settings" object.
             const path = [firstSegment];
-            const pathRemainder = preferenceName.slice(firstSegment.length + 1);
-            if (pathRemainder) {
-                path.push(pathRemainder);
+            if (remainder) {
+                path.push(remainder);
             }
             // If the user has already written this section inside the "settings" object, modify it there.
             if (this.sectionsInsideSettings.has(firstSegment)) {
@@ -80,6 +80,10 @@ export class WorkspaceFilePreferenceProvider extends AbstractResourcePreferenceP
             return path;
         }
         return ['settings', preferenceName];
+    }
+
+    protected belongsInSection(firstSegment: string, remainder: string): boolean {
+        return this.configurations.isSectionName(firstSegment);
     }
 
     protected getScope(): PreferenceScope {

--- a/packages/vsx-registry/compile.tsconfig.json
+++ b/packages/vsx-registry/compile.tsconfig.json
@@ -20,6 +20,12 @@
     },
     {
       "path": "../filesystem/compile.tsconfig.json"
+    },
+    {
+      "path": "../preferences/compile.tsconfig.json"
+    },
+    {
+      "path": "../workspace/compile.tsconfig.json"
     }
   ]
 }

--- a/packages/vsx-registry/package.json
+++ b/packages/vsx-registry/package.json
@@ -7,6 +7,8 @@
     "@theia/filesystem": "1.14.0",
     "@theia/plugin-ext": "1.14.0",
     "@theia/plugin-ext-vscode": "1.14.0",
+    "@theia/preferences": "1.14.0",
+    "@theia/workspace": "1.14.0",
     "@types/bent": "^7.0.1",
     "@types/dompurify": "^2.0.2",
     "@types/sanitize-html": "^2.3.1",

--- a/packages/vsx-registry/src/browser/recommended-extensions/preference-provider-overrides.ts
+++ b/packages/vsx-registry/src/browser/recommended-extensions/preference-provider-overrides.ts
@@ -1,0 +1,99 @@
+/********************************************************************************
+ * Copyright (C) 2021 Ericsson and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import {
+    FolderPreferenceProvider,
+    FolderPreferenceProviderFactory,
+    FolderPreferenceProviderFolder,
+    UserPreferenceProvider,
+    UserPreferenceProviderFactory
+} from '@theia/preferences/lib/browser';
+import { Container, injectable, interfaces } from '@theia/core/shared/inversify';
+import { extensionsConfigurationSchema } from './recommended-extensions-json-schema';
+import {
+    WorkspaceFilePreferenceProvider,
+    WorkspaceFilePreferenceProviderFactory,
+    WorkspaceFilePreferenceProviderOptions
+} from '@theia/preferences/lib/browser/workspace-file-preference-provider';
+import { bindFactory } from '@theia/preferences/lib/browser/preference-bindings';
+import { SectionPreferenceProviderSection, SectionPreferenceProviderUri } from '@theia/preferences/lib/browser/section-preference-provider';
+
+/**
+ * The overrides in this file are required because the base preference providers assume that a
+ * section name (extensions) will not be used as a prefix (extensions.ignoreRecommendations).
+ */
+
+@injectable()
+export class FolderPreferenceProviderWithExtensions extends FolderPreferenceProvider {
+    protected getPath(preferenceName: string): string[] | undefined {
+        const path = super.getPath(preferenceName);
+        if (this.section !== 'extensions' || !path?.length) {
+            return path;
+        }
+        const isExtensionsField = path[0] in extensionsConfigurationSchema.properties!;
+        if (isExtensionsField) {
+            return path;
+        }
+        return undefined;
+    }
+}
+
+@injectable()
+export class UserPreferenceProviderWithExtensions extends UserPreferenceProvider {
+    protected getPath(preferenceName: string): string[] | undefined {
+        const path = super.getPath(preferenceName);
+        if (this.section !== 'extensions' || !path?.length) {
+            return path;
+        }
+        const isExtensionsField = path[0] in extensionsConfigurationSchema.properties!;
+        if (isExtensionsField) {
+            return path;
+        }
+        return undefined;
+    }
+}
+
+@injectable()
+export class WorkspaceFilePreferenceProviderWithExtensions extends WorkspaceFilePreferenceProvider {
+    protected belongsInSection(firstSegment: string, remainder: string): boolean {
+        if (firstSegment === 'extensions') {
+            return remainder in extensionsConfigurationSchema.properties!;
+        }
+        return this.configurations.isSectionName(firstSegment);
+    }
+}
+
+export function bindPreferenceProviderOverrides(bind: interfaces.Bind, unbind: interfaces.Unbind): void {
+    unbind(UserPreferenceProviderFactory);
+    unbind(FolderPreferenceProviderFactory);
+    unbind(WorkspaceFilePreferenceProviderFactory);
+    bindFactory(bind, UserPreferenceProviderFactory, UserPreferenceProviderWithExtensions, SectionPreferenceProviderUri, SectionPreferenceProviderSection);
+    bindFactory(
+        bind,
+        FolderPreferenceProviderFactory,
+        FolderPreferenceProviderWithExtensions,
+        SectionPreferenceProviderUri,
+        SectionPreferenceProviderSection,
+        FolderPreferenceProviderFolder,
+    );
+    bind(WorkspaceFilePreferenceProviderFactory).toFactory(ctx => (options: WorkspaceFilePreferenceProviderOptions) => {
+        const child = new Container({ defaultScope: 'Singleton' });
+        child.parent = ctx.container;
+        child.bind(WorkspaceFilePreferenceProvider).to(WorkspaceFilePreferenceProviderWithExtensions);
+        child.bind(WorkspaceFilePreferenceProviderOptions).toConstantValue(options);
+        return child.get(WorkspaceFilePreferenceProvider);
+    });
+}

--- a/packages/vsx-registry/src/browser/recommended-extensions/recommended-extensions-json-schema.ts
+++ b/packages/vsx-registry/src/browser/recommended-extensions/recommended-extensions-json-schema.ts
@@ -1,0 +1,72 @@
+/********************************************************************************
+ * Copyright (C) 2021 Ericsson and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import { inject, injectable, postConstruct } from '@theia/core/shared/inversify';
+import { InMemoryResources } from '@theia/core';
+import { JsonSchemaContribution, JsonSchemaRegisterContext } from '@theia/core/lib/browser/json-schema-store';
+import { IJSONSchema } from '@theia/core/lib/common/json-schema';
+import URI from '@theia/core/lib/common/uri';
+import { WorkspaceService } from '@theia/workspace/lib/browser';
+
+export const extensionsSchemaID = 'vscode://schemas/extensions';
+export const extensionsConfigurationSchema: IJSONSchema = {
+    $id: extensionsSchemaID,
+    default: { recommendations: [] },
+    type: 'object',
+
+    properties: {
+        recommendations: {
+            title: 'A list of extensions recommended for users of this workspace. Should use the form "<publisher>.<extension name>"',
+            type: 'array',
+            items: {
+                type: 'string',
+                pattern: '^\\w[\\w-]+\\.\\w[\\w-]+$',
+                patternErrorMessage: "Expected format '${publisher}.${name}'. Example: 'eclipse.theia'."
+            },
+            default: [],
+        },
+        unwantedRecommendations: {
+            title: 'A list of extensions recommended by default that should not be recommended to users of this workspace. Should use the form "<publisher>.<extension name>"',
+            type: 'array',
+            items: {
+                type: 'string',
+                pattern: '^\\w[\\w-]+\\.\\w[\\w-]+$',
+                patternErrorMessage: "Expected format '${publisher}.${name}'. Example: 'eclipse.theia'."
+            },
+            default: [],
+        }
+    }
+};
+
+@injectable()
+export class ExtensionSchemaContribution implements JsonSchemaContribution {
+    protected readonly uri = new URI(extensionsSchemaID);
+    @inject(InMemoryResources) protected readonly inmemoryResources: InMemoryResources;
+    @inject(WorkspaceService) protected readonly workspaceService: WorkspaceService;
+
+    @postConstruct()
+    protected init(): void {
+        this.inmemoryResources.add(this.uri, JSON.stringify(extensionsConfigurationSchema));
+    }
+
+    registerSchemas(context: JsonSchemaRegisterContext): void {
+        context.registerSchema({
+            fileMatch: ['extensions.json'],
+            url: this.uri.toString(),
+        });
+        this.workspaceService.updateSchema('extensions', { $ref: this.uri.toString() });
+    }
+}

--- a/packages/vsx-registry/src/browser/recommended-extensions/recommended-extensions-preference-contribution.ts
+++ b/packages/vsx-registry/src/browser/recommended-extensions/recommended-extensions-preference-contribution.ts
@@ -1,0 +1,67 @@
+/********************************************************************************
+ * Copyright (C) 2021 Ericsson and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import { createPreferenceProxy, PreferenceContribution, PreferenceSchema, PreferenceScope, PreferenceService } from '@theia/core/lib/browser';
+import { JsonSchemaContribution } from '@theia/core/lib/browser/json-schema-store';
+import { PreferenceConfiguration } from '@theia/core/lib/browser/preferences/preference-configurations';
+import { interfaces } from '@theia/core/shared/inversify';
+import { ExtensionSchemaContribution, extensionsSchemaID } from './recommended-extensions-json-schema';
+
+export interface RecommendedExtensions {
+    recommendations?: string[];
+    unwantedRecommendations?: string[];
+}
+
+export const recommendedExtensionsPreferencesSchema: PreferenceSchema = {
+    type: 'object',
+    scope: PreferenceScope.Folder,
+    properties: {
+        extensions: {
+            $ref: extensionsSchemaID,
+            description: 'A list of the names of extensions recommended for use in this workspace.',
+            defaultValue: { recommendations: [] },
+        },
+    },
+};
+
+export const IGNORE_RECOMMENDATIONS_ID = 'extensions.ignoreRecommendations';
+
+export const recommendedExtensionNotificationPreferencesSchema: PreferenceSchema = {
+    type: 'object',
+    scope: PreferenceScope.Folder,
+    properties: {
+        [IGNORE_RECOMMENDATIONS_ID]: {
+            description: 'Controls whether notifications are shown for extension recommendations.',
+            default: false,
+            type: 'boolean'
+        }
+    }
+};
+
+export const ExtensionNotificationPreferences = Symbol('ExtensionNotificationPreferences');
+
+export function bindExtensionPreferences(bind: interfaces.Bind): void {
+    bind(ExtensionSchemaContribution).toSelf().inSingletonScope();
+    bind(JsonSchemaContribution).toService(ExtensionSchemaContribution);
+    bind(PreferenceContribution).toConstantValue({ schema: recommendedExtensionsPreferencesSchema });
+    bind(PreferenceConfiguration).toConstantValue({ name: 'extensions' });
+
+    bind(ExtensionNotificationPreferences).toDynamicValue(({ container }) => {
+        const preferenceService = container.get<PreferenceService>(PreferenceService);
+        return createPreferenceProxy(preferenceService, recommendedExtensionNotificationPreferencesSchema);
+    }).inSingletonScope();
+    bind(PreferenceContribution).toConstantValue({ schema: recommendedExtensionNotificationPreferencesSchema });
+}

--- a/packages/vsx-registry/src/browser/vsx-extensions-contribution.ts
+++ b/packages/vsx-registry/src/browser/vsx-extensions-contribution.ts
@@ -14,7 +14,8 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
-import { injectable, inject } from '@theia/core/shared/inversify';
+import { injectable, inject, postConstruct } from '@theia/core/shared/inversify';
+import debounce = require('@theia/core/shared/lodash.debounce');
 import { Command, CommandRegistry } from '@theia/core/lib/common/command';
 import { AbstractViewContribution } from '@theia/core/lib/browser/shell/view-contribution';
 import { VSXExtensionsViewContainer } from './vsx-extensions-view-container';
@@ -26,10 +27,12 @@ import { TabBarToolbarContribution, TabBarToolbarItem, TabBarToolbarRegistry } f
 import { FrontendApplicationContribution, FrontendApplication } from '@theia/core/lib/browser/frontend-application';
 import { MenuModelRegistry, MessageService, Mutable } from '@theia/core/lib/common';
 import { FileDialogService, OpenFileDialogProps } from '@theia/filesystem/lib/browser';
-import { LabelProvider } from '@theia/core/lib/browser';
+import { LabelProvider, PreferenceService } from '@theia/core/lib/browser';
 import { VscodeCommands } from '@theia/plugin-ext-vscode/lib/browser/plugin-vscode-commands-contribution';
 import { VSXExtensionsContextMenu, VSXExtension } from './vsx-extension';
 import { ClipboardService } from '@theia/core/lib/browser/clipboard-service';
+import { RECOMMENDED_QUERY } from './vsx-extensions-search-model';
+import { IGNORE_RECOMMENDATIONS_ID } from './recommended-extensions/recommended-extensions-preference-contribution';
 
 export namespace VSXExtensionsCommands {
 
@@ -53,6 +56,11 @@ export namespace VSXExtensionsCommands {
     export const COPY_EXTENSION_ID: Command = {
         id: 'vsxExtensions.copyExtensionId'
     };
+    export const SHOW_RECOMMENDATIONS: Command = {
+        id: 'vsxExtension.showRecommendations',
+        label: 'Show Recommended Extensions',
+        category: EXTENSIONS_CATEGORY,
+    };
 }
 
 @injectable()
@@ -66,6 +74,7 @@ export class VSXExtensionsContribution extends AbstractViewContribution<VSXExten
     @inject(MessageService) protected readonly messageService: MessageService;
     @inject(LabelProvider) protected readonly labelProvider: LabelProvider;
     @inject(ClipboardService) protected readonly clipboardService: ClipboardService;
+    @inject(PreferenceService) protected readonly preferenceService: PreferenceService;
 
     constructor() {
         super({
@@ -78,6 +87,14 @@ export class VSXExtensionsContribution extends AbstractViewContribution<VSXExten
             toggleCommandId: 'vsxExtensions.toggle',
             toggleKeybinding: 'ctrlcmd+shift+x'
         });
+    }
+
+    @postConstruct()
+    protected init(): void {
+        const oneShotDisposable = this.model.onDidChange(debounce(() => {
+            this.showRecommendedToast();
+            oneShotDisposable.dispose();
+        }, 5000, { trailing: true }));
     }
 
     async initializeLayout(app: FrontendApplication): Promise<void> {
@@ -102,6 +119,10 @@ export class VSXExtensionsContribution extends AbstractViewContribution<VSXExten
 
         commands.registerCommand(VSXExtensionsCommands.COPY_EXTENSION_ID, {
             execute: (extension: VSXExtension) => this.copyExtensionId(extension)
+        });
+
+        commands.registerCommand(VSXExtensionsCommands.SHOW_RECOMMENDATIONS, {
+            execute: () => this.showRecommendedExtensions()
         });
     }
 
@@ -221,5 +242,29 @@ export class VSXExtensionsContribution extends AbstractViewContribution<VSXExten
 
     protected copyExtensionId(extension: VSXExtension): void {
         this.clipboardService.writeText(extension.id);
+    }
+
+    protected async showRecommendedToast(): Promise<void> {
+        if (!this.preferenceService.get(IGNORE_RECOMMENDATIONS_ID, false)) {
+            const recommended = new Set([...this.model.recommended]);
+            for (const installed of this.model.installed) {
+                recommended.delete(installed);
+            }
+            if (recommended.size) {
+                const userResponse = await this.messageService.info('Would you like to install the recommended extensions?', 'Install', 'Show Recommended');
+                if (userResponse === 'Install') {
+                    for (const recommendation of recommended) {
+                        this.model.getExtension(recommendation)?.install();
+                    }
+                } else if (userResponse === 'Show Recommended') {
+                    await this.showRecommendedExtensions();
+                }
+            }
+        }
+    }
+
+    protected async showRecommendedExtensions(): Promise<void> {
+        await this.openView({ activate: true });
+        this.model.search.query = RECOMMENDED_QUERY;
     }
 }

--- a/packages/vsx-registry/src/browser/vsx-extensions-search-model.ts
+++ b/packages/vsx-registry/src/browser/vsx-extensions-search-model.ts
@@ -17,11 +17,23 @@
 import { injectable } from '@theia/core/shared/inversify';
 import { Emitter } from '@theia/core/lib/common/event';
 
+export enum VSXSearchMode {
+    Initial,
+    None,
+    Search,
+    Recommended,
+}
+
+export const RECOMMENDED_QUERY = '@recommended';
+
 @injectable()
 export class VSXExtensionsSearchModel {
 
     protected readonly onDidChangeQueryEmitter = new Emitter<string>();
     readonly onDidChangeQuery = this.onDidChangeQueryEmitter.event;
+    protected readonly specialQueries = new Map<string, VSXSearchMode>([
+        [RECOMMENDED_QUERY, VSXSearchMode.Recommended]
+    ]);
 
     protected _query = '';
     set query(query: string) {
@@ -35,4 +47,9 @@ export class VSXExtensionsSearchModel {
         return this._query;
     }
 
+    getModeForQuery(): VSXSearchMode {
+        return this.query
+            ? this.specialQueries.get(this.query) ?? VSXSearchMode.Search
+            : VSXSearchMode.None;
+    }
 }

--- a/packages/vsx-registry/src/browser/vsx-extensions-source.ts
+++ b/packages/vsx-registry/src/browser/vsx-extensions-source.ts
@@ -23,6 +23,7 @@ export class VSXExtensionsSourceOptions {
     static INSTALLED = 'installed';
     static BUILT_IN = 'builtin';
     static SEARCH_RESULT = 'searchResult';
+    static RECOMMENDED = 'recommended';
     readonly id: string;
 }
 
@@ -47,6 +48,11 @@ export class VSXExtensionsSource extends TreeSource {
             if (!extension) {
                 continue;
             }
+            if (this.options.id === VSXExtensionsSourceOptions.RECOMMENDED) {
+                if (this.model.isInstalled(id)) {
+                    continue;
+                }
+            }
             if (this.options.id === VSXExtensionsSourceOptions.BUILT_IN) {
                 if (extension.builtin) {
                     yield extension;
@@ -60,6 +66,9 @@ export class VSXExtensionsSource extends TreeSource {
     protected doGetElements(): IterableIterator<string> {
         if (this.options.id === VSXExtensionsSourceOptions.SEARCH_RESULT) {
             return this.model.searchResult;
+        }
+        if (this.options.id === VSXExtensionsSourceOptions.RECOMMENDED) {
+            return this.model.recommended;
         }
         return this.model.installed;
     }

--- a/packages/vsx-registry/src/browser/vsx-extensions-widget.ts
+++ b/packages/vsx-registry/src/browser/vsx-extensions-widget.ts
@@ -20,15 +20,15 @@ import { VSXExtensionsSource, VSXExtensionsSourceOptions } from './vsx-extension
 
 @injectable()
 export class VSXExtensionsWidgetOptions extends VSXExtensionsSourceOptions {
+    title?: string;
 }
+
+export const generateExtensionWidgetId = (widgetId: string): string => VSXExtensionsWidget.ID + ':' + widgetId;
 
 @injectable()
 export class VSXExtensionsWidget extends SourceTreeWidget {
 
     static ID = 'vsx-extensions';
-    static INSTALLED_ID = VSXExtensionsWidget.ID + ':' + VSXExtensionsSourceOptions.INSTALLED;
-    static SEARCH_RESULT_ID = VSXExtensionsWidget.ID + ':' + VSXExtensionsSourceOptions.SEARCH_RESULT;
-    static BUILT_IN_ID = VSXExtensionsWidget.ID + ':' + VSXExtensionsSourceOptions.BUILT_IN;
 
     static createWidget(parent: interfaces.Container, options: VSXExtensionsWidgetOptions): VSXExtensionsWidget {
         const child = SourceTreeWidget.createContainer(parent, {
@@ -54,8 +54,8 @@ export class VSXExtensionsWidget extends SourceTreeWidget {
         super.init();
         this.addClass('theia-vsx-extensions');
 
-        this.id = VSXExtensionsWidget.ID + ':' + this.options.id;
-        const title = this.computeTitle();
+        this.id = generateExtensionWidgetId(this.options.id);
+        const title = this.options.title ?? this.computeTitle();
         this.title.label = title;
         this.title.caption = title;
 
@@ -64,13 +64,17 @@ export class VSXExtensionsWidget extends SourceTreeWidget {
     }
 
     protected computeTitle(): string {
-        if (this.id === VSXExtensionsWidget.INSTALLED_ID) {
-            return 'Installed';
+        switch (this.options.id) {
+            case VSXExtensionsSourceOptions.INSTALLED:
+                return 'Installed';
+            case VSXExtensionsSourceOptions.BUILT_IN:
+                return 'Built-in';
+            case VSXExtensionsSourceOptions.RECOMMENDED:
+                return 'Recommended';
+            case VSXExtensionsSourceOptions.SEARCH_RESULT:
+                return 'Open VSX Registry';
+            default:
+                return '';
         }
-        if (this.id === VSXExtensionsWidget.BUILT_IN_ID) {
-            return 'Built-in';
-        }
-        return 'Open VSX Registry';
     }
-
 }

--- a/packages/vsx-registry/src/browser/vsx-registry-frontend-module.ts
+++ b/packages/vsx-registry/src/browser/vsx-registry-frontend-module.ts
@@ -34,8 +34,10 @@ import { VSXEnvironment } from '../common/vsx-environment';
 import { VSXExtensionsSearchModel } from './vsx-extensions-search-model';
 import { VSXApiVersionProviderImpl } from './vsx-api-version-provider-frontend-impl';
 import { VSXApiVersionProvider } from '../common/vsx-api-version-provider';
+import { bindExtensionPreferences } from './recommended-extensions/recommended-extensions-preference-contribution';
+import { bindPreferenceProviderOverrides } from './recommended-extensions/preference-provider-overrides';
 
-export default new ContainerModule(bind => {
+export default new ContainerModule((bind, unbind) => {
     bind(VSXEnvironment).toSelf().inRequestScope();
     bind(VSXRegistryAPI).toSelf().inSingletonScope();
 
@@ -75,7 +77,12 @@ export default new ContainerModule(bind => {
             child.bind(VSXExtensionsViewContainer).toSelf();
             const viewContainer = child.get(VSXExtensionsViewContainer);
             const widgetManager = child.get(WidgetManager);
-            for (const id of [VSXExtensionsSourceOptions.SEARCH_RESULT, VSXExtensionsSourceOptions.INSTALLED, VSXExtensionsSourceOptions.BUILT_IN]) {
+            for (const id of [
+                VSXExtensionsSourceOptions.SEARCH_RESULT,
+                VSXExtensionsSourceOptions.RECOMMENDED,
+                VSXExtensionsSourceOptions.INSTALLED,
+                VSXExtensionsSourceOptions.BUILT_IN,
+            ]) {
                 const widget = await widgetManager.getOrCreateWidget(VSXExtensionsWidget.ID, { id });
                 viewContainer.addWidget(widget, {
                     initiallyCollapsed: id === VSXExtensionsSourceOptions.BUILT_IN
@@ -96,4 +103,6 @@ export default new ContainerModule(bind => {
     bind(VSXApiVersionProviderImpl).toSelf().inSingletonScope();
     bind(FrontendApplicationContribution).toService(VSXApiVersionProviderImpl);
     bind(VSXApiVersionProvider).toService(VSXApiVersionProviderImpl);
+    bindExtensionPreferences(bind);
+    bindPreferenceProviderOverrides(bind, unbind);
 });


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

Fixes #8982 by adding support for `extensions.json` to the preference system.
Also fixes #9034.
Also fixes #8070 (for the @recommended case).

I'd like to see a real solution to #9255, but this PR just creates overrides to be used with this package that adds some extra rules for determining whether a preference should be saved in `extensions.json` or `settings.json`.

Here are the features of VSCode's `extensions.json` system that I'm aware of. Feel free to mention or add any I've missed:
- [x] `extensions.json` recognized by preference system.
  - [x] supports recommendations and anti-recommendations (at the moment Theia doesn't have default recommendations that need to be overridden, but downstream adopters might)
- [x] `Recommended` widget appears in plugin view.
  - [x] Installed plugins don't appear in the `Recommended` widget. 
- [x] Toast when recommended extensions detected in the workspace. 
  - [x] Preference to ignore the toast. (The VSCode preference has the same `extensions` prefix as the name of the file, which will be a bit of a challenge for our preference providers to handle, since they assume that a section name (`extensions`, `tasks`, etc.) should not be used as a prefix in the `settings` object.)
- [x] Support for `@recommended` query in Plugin View search bar
  - [x] Command to show the recommended plugins.
  - [ ] With distinction between workspace and default recommendations 

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

1. Open a workspace (single or multiroot).
2. Create an `extensions.json` file in a `.theia` or `.vscode` folder under the/a root.
3. Add some extensions inside the `recommendations` array of the following structure: `{"recommendations": []}`
4. Observe that the schema warns if your extensions don't follow the format `<alphanumeric or - >.<alphanumeric or - >` (with `-` barred from first position in both alphanumeric groups)
5. Open the plugins view. 
6. Observe that a widget with the heading `Recommended` is present. (May require resetting workbench layout.)
7. Observe that if you add any real plugins to the JSON, they appear in that widget, unless they're already installed (you can check in the `Installed` widget.
8. Of the plugins you've added to `recommendations`, add a few to a new array labeled `unwantedRecommendations` (leaving them in `recommendations`, as well). Observe that any listed under `unwantedRecommendations` do not appear in the `Recommended` widget.
9. You should be able to add an `extensions.json` file to each root of a multi-root workspace, and the `Recommended` widget should aggregate and display (all recommendations) - (all anti-recommendations). That is, an anti-recommendation anywhere will override a recommendation anywhere, even if they aren't the same folder.
10. It should be possible to add an `extensions` object with the same schema to the `settings` object of a workspace file (after #8917, it will be possible to put `extensions` outside the `settings` object.)
11. Open the preferences UI and modify the value of `extensions.ignoreRecommendations`. Observe that the value is set in a `settings.json` file, not an `extensions.json` file.

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)