### PR TITLE
fix view welcome empty condition

### DIFF
--- a/packages/plugin-ext/src/main/browser/view/tree-view-widget.tsx
+++ b/packages/plugin-ext/src/main/browser/view/tree-view-widget.tsx
@@ -128,7 +128,7 @@ export class PluginTree extends TreeImpl {
         try {
             const children = await proxy.$getChildren(this.identifier.id, parent.id);
             const oldEmpty = this._isEmpty;
-            this._isEmpty = !children || children.length === 0;
+            this._isEmpty = !parent.id && (!children || children.length === 0);
             if (oldEmpty !== this._isEmpty) {
                 this.onDidChangeWelcomeStateEmitter.fire();
             }


### PR DESCRIPTION
Tree view is considered empty when there are no children for the root node.
Before there was a race condition as any empty fetch children response for any node marked the view as empty.

Signed-off-by: Amiram Wingarten <amiram.wingarten@sap.com>

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
Fix the condition for marking tree view as empty (which affect whether view welcome is shown).

#### How to test
1. Deploy vscode extension 
[vscode-wing-run-config-5.4.1.zip](https://github.com/eclipse-theia/theia/files/5953939/vscode-wing-run-config-5.4.1.zip)
2. Open run configuration view
3. Execute there "Create Configuration"
4. Choose defaults

Expected behavior: Welcome view button disappears and the tree is shown, even when clicking on tree nodes the tree still shows.

Before this PR the tree appears and immediately replaced by the welcome view as a result of fetching empty children for the created tree node.



#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

