### PR TITLE
9012-registerTerminalLinkProvider-stub: for vscode-java-debug

### DIFF
--- a/packages/plugin-ext/src/plugin/plugin-context.ts
+++ b/packages/plugin-ext/src/plugin/plugin-context.ts
@@ -432,6 +432,9 @@ export function createAPIFactory(
             createInputBox(): theia.InputBox {
                 return quickOpenExt.createInputBox(plugin);
             },
+            registerTerminalLinkProvider(provider: theia.TerminalLinkProvider): void {
+                /* NOOP. To be implemented at later stage */
+            },
             get activeColorTheme(): theia.ColorTheme {
                 return themingExt.activeColorTheme;
             },

--- a/packages/plugin/src/theia.d.ts
+++ b/packages/plugin/src/theia.d.ts
@@ -2872,6 +2872,67 @@ declare module '@theia/plugin' {
     }
 
     /**
+     * Provides information on a line in a terminal in order to provide links for it.
+     */
+    export interface TerminalLinkContext {
+        /**
+         * This is the text from the unwrapped line in the terminal.
+         */
+        line: string;
+
+        /**
+         * The terminal the link belongs to.
+         */
+        terminal: Terminal;
+    }
+
+    /**
+     * A provider that enables detection and handling of links within terminals.
+     */
+    export interface TerminalLinkProvider<T extends TerminalLink = TerminalLink> {
+        /**
+         * Provide terminal links for the given context. Note that this can be called multiple times
+         * even before previous calls resolve, make sure to not share global objects (eg. `RegExp`)
+         * that could have problems when asynchronous usage may overlap.
+         * @param context Information about what links are being provided for.
+         * @param token A cancellation token.
+         * @return A list of terminal links for the given line.
+         */
+        provideTerminalLinks(context: TerminalLinkContext, token: CancellationToken): ProviderResult<T[]>;
+
+        /**
+         * Handle an activated terminal link.
+         * @param link The link to handle.
+         */
+        handleTerminalLink(link: T): ProviderResult<void>;
+    }
+
+    /**
+     * A link on a terminal line.
+     */
+    export interface TerminalLink {
+        /**
+         * The start index of the link on [TerminalLinkContext.line](#TerminalLinkContext.line].
+         */
+        startIndex: number;
+
+        /**
+         * The length of the link on [TerminalLinkContext.line](#TerminalLinkContext.line]
+         */
+        length: number;
+
+        /**
+         * The tooltip text when you hover over this link.
+         *
+         * If a tooltip is provided, is will be displayed in a string that includes instructions on
+         * how to trigger the link, such as `{0} (ctrl + click)`. The specific instructions vary
+         * depending on OS, user settings, and localization.
+         */
+        tooltip?: string;
+    }
+
+
+    /**
      * A type of mutation that can be applied to an environment variable.
      */
     export enum EnvironmentVariableMutatorType {
@@ -3963,6 +4024,14 @@ declare module '@theia/plugin' {
          * @return A new [InputBox](#InputBox).
          */
         export function createInputBox(): InputBox;
+
+
+        /**
+         * Register provider that enables the detection and handling of links within the terminal.
+         * @param provider The provider that provides the terminal links.
+         * @return Disposable that unregisters the provider.
+         */
+        export function registerTerminalLinkProvider(provider: TerminalLinkProvider): void;
 
         /**
          * The currently active color theme as configured in the settings. The active


### PR DESCRIPTION
Signed-off-by: Dan Arad dan.arad@sap.com

Added registerTerminalLinkProvider stub which is invoked upon extension activation.

#### What it does
Fixes first problem of #9012:
vscode-java-debug invokes vscode.window.registerTerminalLinkProvider upon extension activation. This method was not implemented in Theia - added stubs.
For second problem see #9049 

#### How to test
1. Open in Theia java project
2. After load you can run or debug project
![image](https://user-images.githubusercontent.com/71069170/107147624-b4200280-6957-11eb-96f2-56f11a8225b5.png)

Approved CQ (existing already) covering theia.d.ts copied code: https://dev.eclipse.org/ipzilla/show_bug.cgi?id=22677

Note: 
for better behavior change this user setting to "internalConsole" (instead of "integratedTerminal"):
"java.debug.settings.console": "internalConsole"

#### Review checklist

- [X] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

