### PR TITLE
9012-updating-userstorageuri-scheme

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,12 @@
 # Change Log
+## v1.11.0 - 2021
+
+<a name="breaking_changes_1.11.0">[Breaking Changes:](#breaking_changes_1.11.0)</a>
+
+<a name="1.11.0_user-storage_scheme_updated"></a>
+
+-   [[user-storage]](#1.11.0_user-storage_scheme_updated) `UserStorageUri` scheme was changed from 'user_storage' to 'user-storage' as '\_' is not a valid char in scheme (according to [RFC 3986](https://tools.ietf.org/html/rfc3986#page-17)) [#9049](https://github.com/eclipse-theia/theia/pull/9049)
+
 
 ## v1.10.0 - 1/28/2021
 

--- a/packages/preferences/src/browser/preferences-json-schema-contribution.ts
+++ b/packages/preferences/src/browser/preferences-json-schema-contribution.ts
@@ -23,7 +23,7 @@ import { PreferenceConfigurations } from '@theia/core/lib/browser/preferences/pr
 import { PreferenceScope } from '@theia/core/lib/browser';
 
 const PREFERENCE_URI_PREFIX = 'vscode://schemas/settings/';
-const USER_STORAGE_PREFIX = 'user_storage:/';
+const USER_STORAGE_PREFIX = 'user-storage:/';
 
 @injectable()
 export class PreferencesJsonSchemaContribution implements JsonSchemaContribution {

--- a/packages/userstorage/src/browser/user-storage-uri.ts
+++ b/packages/userstorage/src/browser/user-storage-uri.ts
@@ -16,4 +16,4 @@
 
 import URI from '@theia/core/lib/common/uri';
 
-export const UserStorageUri = new URI('user_storage:/user');
+export const UserStorageUri = new URI('user-storage:/user');

--- a/packages/workspace/src/browser/workspace-uri-contribution.spec.ts
+++ b/packages/workspace/src/browser/workspace-uri-contribution.spec.ts
@@ -79,7 +79,7 @@ describe('WorkspaceUriLabelProviderContribution class', () => {
 
     describe('canHandle()', () => {
         it('should return 0 if the passed in argument is not a FileStat or URI with the "file" scheme', () => {
-            expect(labelProvider.canHandle(new URI('user_storage:settings.json'))).eq(0);
+            expect(labelProvider.canHandle(new URI('user-storage:settings.json'))).eq(0);
             expect(labelProvider.canHandle({ uri: 'file:///home/settings.json' })).eq(0);
         });
 


### PR DESCRIPTION
scheme was changed from 'user_storage' to 'user-storage' as '\_' is not a valid char in scheme (according to [RFC 3986](https://tools.ietf.org/html/rfc3986#page-17))

#### What it does
Fixes second problem in #9012 where JDTUtils threw exception when receiving file changed event whose URI scheme was user_storage -which is an illegal scheme name (contains underscore).
Therefore changed `user_storage` to `user-storage` scheme name.

For first problem in #9012 see #9048

#### How to test
1. Pre-requisite:  #9048 is merged
2. Open in Theia java project
3. After load you can run or debug project
![image](https://user-images.githubusercontent.com/71069170/107147624-b4200280-6957-11eb-96f2-56f11a8225b5.png)

![image](https://user-images.githubusercontent.com/71069170/107147826-cc445180-6958-11eb-9364-e1ab13a64d62.png)

Note: 
for better behavior change this user setting to "internalConsole" (instead of "integratedTerminal"):
"java.debug.settings.console": "internalConsole".

#### Review checklist

- [X] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

