### PR TITLE
[vscode] support for 'pathSeparator' variable substitution

### DIFF
--- a/packages/variable-resolver/src/browser/common-variable-contribution.ts
+++ b/packages/variable-resolver/src/browser/common-variable-contribution.ts
@@ -16,8 +16,10 @@
 
 import { injectable, inject } from 'inversify';
 import { VariableContribution, VariableRegistry } from './variable';
+import { ApplicationServer } from '@theia/core/lib/common/application-protocol';
 import { EnvVariablesServer } from '@theia/core/lib/common/env-variables';
 import { CommandService } from '@theia/core/lib/common/command';
+import { OS } from '@theia/core/lib/common/os';
 import { PreferenceService } from '@theia/core/lib/browser/preferences/preference-service';
 import { ResourceContextKey } from '@theia/core/lib/browser/resource-context-key';
 import { VariableInput } from './variable-input';
@@ -46,11 +48,21 @@ export class CommonVariableContribution implements VariableContribution {
     @inject(QuickPickService)
     protected readonly quickPickService: QuickPickService;
 
+    @inject(ApplicationServer)
+    protected readonly appServer: ApplicationServer;
+
     async registerVariables(variables: VariableRegistry): Promise<void> {
-        const execPath = await this.env.getExecPath();
+        const [execPath, backendOS] = await Promise.all([
+            this.env.getExecPath(),
+            this.appServer.getBackendOS()
+        ]);
         variables.registerVariable({
             name: 'execPath',
             resolve: () => execPath
+        });
+        variables.registerVariable({
+            name: 'pathSeparator',
+            resolve: () => backendOS === OS.Type.Windows ? '\\' : '/'
         });
         variables.registerVariable({
             name: 'env',


### PR DESCRIPTION
Signed-off-by: Alexander Gilin <alexander.gilin@sap.com>

#### What it does
vscode alignment: allow using the predefined variable ${pathSeparator} (the character used by the operating system to separate components in file paths) in Debugging and Task configuration files

#### How to test

Variable substitution is supported inside key and value strings in **launch.json** and **tasks.json** files. 
Expecting result: **${pathSeparator}** - / on macOS or linux, \\ on Windows

- create simple "Hello World" TypeScript project like follows:
	create an empty folder "myProject", generate a tsconfig.json file and open that folder in theia:
		`mkdir myProject`
		`cd myProject`
		`tsc --init`
Now create a 'HelloWorld.ts' file with the following content:
  `function sayHello(name: string): void {`
   `  console.log('Hello ' + name + '!');`
   `}`
 
  `sayHello('Dave');`

- compile the code : `tsc -p .`
- open debug view -> Add configuration -> Node.js Launch Program
In the created configuration change a path to the program like next:
`"program": "${workspaceFolder}${pathSeparator}helloworld.js"`

- run this configuration and verify the program path is resolved correctly.

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/eclipse-theia/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to review in accordance with [the review guidelines](https://github.com/eclipse-theia/theia/blob/master/doc/pull-requests.md#reviewing)

