### PR TITLE
8963-globalstorage-improvement-for-sqltools

### DIFF
--- a/packages/plugin-ext/src/main/browser/plugin-storage.ts
+++ b/packages/plugin-ext/src/main/browser/plugin-storage.ts
@@ -43,13 +43,12 @@ export class StorageMainImpl implements StorageMain {
     }
 
     protected toKind(isGlobal: boolean): PluginStorageKind {
-        if (isGlobal) {
-            return undefined;
+        if (!isGlobal && this.workspaceService.workspace) {
+            return {
+                workspace: this.workspaceService.workspace.resource.toString(),
+                roots: this.workspaceService.tryGetRoots().map(root => root.resource.toString())
+            };
         }
-        return {
-            workspace: this.workspaceService.workspace?.resource.toString(),
-            roots: this.workspaceService.tryGetRoots().map(root => root.resource.toString())
-        };
+        return undefined;
     }
-
 }


### PR DESCRIPTION
Signed-off-by: Dan Arad dan.arad@sap.com

added code improvement for case where extension sends incorrect argument for isGlobal in StorageMain.$set method.

#### What it does
Fixed #8963 

#### How to test
1. add SQLTOOLS plugin to Theia.
2. close Workspace and open a file
3. close file and no " Cannot save data: no opened workspace" error in terminal.

#### Review checklist

- [X] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

