### PR TITLE
preferences: Fix `problems.decorations.tabbar.enabled`

### DIFF
--- a/packages/markers/src/browser/problem/problem-tabbar-decorator.ts
+++ b/packages/markers/src/browser/problem/problem-tabbar-decorator.ts
@@ -45,6 +45,9 @@ export class ProblemTabBarDecorator implements TabBarDecorator {
     }
 
     decorate(title: Title<Widget>): WidgetDecoration.Data[] {
+        if (!this.preferences['problems.decorations.tabbar.enabled']) {
+            return [];
+        }
         const widget = title.owner;
         if (Navigatable.is(widget)) {
             const resourceUri = widget.getResourceUri();


### PR DESCRIPTION
#### What it does
<!-- Include relevant issues and describe how they are addressed. -->
+ Add a check to properly enable/disable tab bar overlay icon when toggling `problems.decorations.tabbar.enabled`.

#### How to test
+ Open editors, make some errors or warnings. Observe that the markers are displayed on tab bar
ie: 
![image](https://user-images.githubusercontent.com/43587865/107781783-49cfdf00-6d16-11eb-81a0-ed50b10cb1cc.png)

+ Open preferences, toggle the option `problems.decorations.tabbar.enabled`.
+ Observe that the markers disappeared on tab bar.
![image](https://user-images.githubusercontent.com/43587865/107781915-74ba3300-6d16-11eb-9e39-30470c996193.png)



#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)


Signed-off-by: Duc Nguyen <duc.a.nguyen@ericsson.com>