### PR TITLE
Generalized Output APIs.

### DIFF
--- a/packages/output/src/browser/output-editor-factory.ts
+++ b/packages/output/src/browser/output-editor-factory.ts
@@ -32,7 +32,7 @@ export class OutputEditorFactory implements MonacoEditorFactory {
     @inject(OutputContextMenuService)
     protected readonly contextMenuService: MonacoContextMenuService;
 
-    readonly scheme = OutputUri.SCHEME;
+    readonly scheme: string = OutputUri.SCHEME;
 
     create(model: MonacoEditorModel, defaultsOptions: MonacoEditor.IOptions, defaultOverrides: monaco.editor.IEditorOverrideServices): MonacoEditor {
         const uri = new URI(model.uri);

--- a/packages/output/src/browser/output-editor-model-factory.ts
+++ b/packages/output/src/browser/output-editor-model-factory.ts
@@ -31,7 +31,7 @@ export class OutputEditorModelFactory implements MonacoEditorModelFactory {
     @inject(ProtocolToMonacoConverter)
     protected readonly p2m: ProtocolToMonacoConverter;
 
-    readonly scheme = OutputUri.SCHEME;
+    readonly scheme: string = OutputUri.SCHEME;
 
     createModel(
         resource: Resource


### PR DESCRIPTION
So that extenders can subclass and change the `scheme`.

Signed-off-by: Akos Kitta <kittaakos@typefox.io>

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

Generalizes the _Output_ APIs. The `scheme` should have a type of `string` instead of `'output'`.

Basically, I want to do something like this:
```ts
class MyEditorModelFactory extends OutputEditorModelFactory { readonly scheme: 'my-schem'; }
```

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

The code should compile.

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

