### PR TITLE
Preventing false positive alarms of offline mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## v1.12.0
 
 - [filesystem] add text input and navigate up icon to file dialog [#8748](https://github.com/eclipse-theia/theia/pull/8748)
+- [core] updated connection status service to prevent false positive alerts about offline mode [#9068](https://github.com/eclipse-theia/theia/pull/9068)
 
 <a name="breaking_changes_1.12.0">[Breaking Changes:](#breaking_changes_1.12.0)</a>
 

--- a/packages/core/src/browser/connection-status-service.spec.ts
+++ b/packages/core/src/browser/connection-status-service.spec.ts
@@ -25,8 +25,19 @@ FrontendApplicationConfigProvider.set({
 });
 
 import { expect } from 'chai';
-import { ConnectionStatus } from './connection-status-service';
+import {
+    ConnectionStatus,
+    ConnectionStatusOptions,
+    FrontendConnectionStatusService,
+    PingService
+} from './connection-status-service';
 import { MockConnectionStatusService } from './test/mock-connection-status-service';
+
+import * as sinon from 'sinon';
+
+import { Container } from 'inversify';
+import { WebSocketConnectionProvider } from './messaging/ws-connection-provider';
+import { ILogger, Emitter, Loggable } from '../common';
 
 disableJSDOM();
 
@@ -71,6 +82,120 @@ describe('connection-status', function (): void {
         expect(connectionStatusService.currentStatus).to.be.equal(ConnectionStatus.ONLINE);
     });
 
+});
+
+describe('frontend-connection-status', function (): void {
+    const OFFLINE_TIMEOUT = 10;
+
+    let testContainer: Container;
+
+    const mockSocketOpenedEmitter: Emitter<void> = new Emitter();
+    const mockSocketClosedEmitter: Emitter<void> = new Emitter();
+    const mockIncomingMessageActivityEmitter: Emitter<void> = new Emitter();
+
+    before(() => {
+        disableJSDOM = enableJSDOM();
+    });
+
+    after(() => {
+        disableJSDOM();
+    });
+
+    let timer: sinon.SinonFakeTimers;
+    let pingSpy: sinon.SinonSpy;
+    beforeEach(() => {
+        const mockWebSocketConnectionProvider = sinon.createStubInstance(WebSocketConnectionProvider);
+        const mockPingService: PingService = <PingService>{
+            ping(): Promise<void> {
+                return Promise.resolve(undefined);
+            }
+        };
+        const mockILogger: ILogger = <ILogger>{
+            error(loggable: Loggable): Promise<void> {
+                return Promise.resolve(undefined);
+            }
+        };
+
+        testContainer = new Container();
+        testContainer.bind(FrontendConnectionStatusService).toSelf().inSingletonScope();
+        testContainer.bind(PingService).toConstantValue(mockPingService);
+        testContainer.bind(ILogger).toConstantValue(mockILogger);
+        testContainer.bind(ConnectionStatusOptions).toConstantValue({ offlineTimeout: OFFLINE_TIMEOUT });
+        testContainer.bind(WebSocketConnectionProvider).toConstantValue(mockWebSocketConnectionProvider);
+
+        sinon.stub(mockWebSocketConnectionProvider, 'onSocketDidOpen').value(mockSocketOpenedEmitter.event);
+        sinon.stub(mockWebSocketConnectionProvider, 'onSocketDidClose').value(mockSocketClosedEmitter.event);
+        sinon.stub(mockWebSocketConnectionProvider, 'onIncomingMessageActivity').value(mockIncomingMessageActivityEmitter.event);
+
+        timer = sinon.useFakeTimers();
+
+        pingSpy = sinon.spy(mockPingService, 'ping');
+    });
+
+    afterEach(() => {
+        pingSpy.restore();
+        timer.restore();
+        testContainer.unbindAll();
+    });
+
+    it('should switch status to offline on websocket close', () => {
+        const frontendConnectionStatusService = testContainer.get<FrontendConnectionStatusService>(FrontendConnectionStatusService);
+        frontendConnectionStatusService['init']();
+        expect(frontendConnectionStatusService.currentStatus).to.be.equal(ConnectionStatus.ONLINE);
+        mockSocketClosedEmitter.fire(undefined);
+        expect(frontendConnectionStatusService.currentStatus).to.be.equal(ConnectionStatus.OFFLINE);
+    });
+
+    it('should switch status to online on websocket established', () => {
+        const frontendConnectionStatusService = testContainer.get<FrontendConnectionStatusService>(FrontendConnectionStatusService);
+        frontendConnectionStatusService['init']();
+        mockSocketClosedEmitter.fire(undefined);
+        expect(frontendConnectionStatusService.currentStatus).to.be.equal(ConnectionStatus.OFFLINE);
+        mockSocketOpenedEmitter.fire(undefined);
+        expect(frontendConnectionStatusService.currentStatus).to.be.equal(ConnectionStatus.ONLINE);
+    });
+
+    it('should switch status to online on any websocket activity', () => {
+        const frontendConnectionStatusService = testContainer.get<FrontendConnectionStatusService>(FrontendConnectionStatusService);
+        frontendConnectionStatusService['init']();
+        mockSocketClosedEmitter.fire(undefined);
+        expect(frontendConnectionStatusService.currentStatus).to.be.equal(ConnectionStatus.OFFLINE);
+        mockIncomingMessageActivityEmitter.fire(undefined);
+        expect(frontendConnectionStatusService.currentStatus).to.be.equal(ConnectionStatus.ONLINE);
+    });
+
+    it('should perform ping request after socket activity', () => {
+        const frontendConnectionStatusService = testContainer.get<FrontendConnectionStatusService>(FrontendConnectionStatusService);
+        frontendConnectionStatusService['init']();
+        mockIncomingMessageActivityEmitter.fire(undefined);
+        expect(frontendConnectionStatusService.currentStatus).to.be.equal(ConnectionStatus.ONLINE);
+        sinon.assert.notCalled(pingSpy);
+        timer.tick(OFFLINE_TIMEOUT);
+        sinon.assert.calledOnce(pingSpy);
+    });
+
+    it('should not perform ping request before desired timeout',  () => {
+        const frontendConnectionStatusService = testContainer.get<FrontendConnectionStatusService>(FrontendConnectionStatusService);
+        frontendConnectionStatusService['init']();
+        mockIncomingMessageActivityEmitter.fire(undefined);
+        expect(frontendConnectionStatusService.currentStatus).to.be.equal(ConnectionStatus.ONLINE);
+        sinon.assert.notCalled(pingSpy);
+        timer.tick(OFFLINE_TIMEOUT - 1);
+        sinon.assert.notCalled(pingSpy);
+    });
+
+    it('should switch to offline mode if ping request was rejected', () => {
+        const pingService = testContainer.get<PingService>(PingService);
+        pingSpy.restore();
+        const stub = sinon.stub(pingService, 'ping').onFirstCall().throws('failed to make a ping request');
+        const frontendConnectionStatusService = testContainer.get<FrontendConnectionStatusService>(FrontendConnectionStatusService);
+        frontendConnectionStatusService['init']();
+        mockIncomingMessageActivityEmitter.fire(undefined);
+        expect(frontendConnectionStatusService.currentStatus).to.be.equal(ConnectionStatus.ONLINE);
+        timer.tick(OFFLINE_TIMEOUT);
+        sinon.assert.calledOnce(stub);
+        expect(frontendConnectionStatusService.currentStatus).to.be.equal(ConnectionStatus.OFFLINE);
+    });
 });
 
 function pause(time: number = 1): Promise<unknown> {

--- a/packages/core/src/browser/messaging/ws-connection-provider.ts
+++ b/packages/core/src/browser/messaging/ws-connection-provider.ts
@@ -15,7 +15,7 @@
  ********************************************************************************/
 
 import { injectable, interfaces, decorate, unmanaged } from 'inversify';
-import { JsonRpcProxyFactory, JsonRpcProxy } from '../../common';
+import { JsonRpcProxyFactory, JsonRpcProxy, Emitter, Event } from '../../common';
 import { WebSocketChannel } from '../../common/messaging/web-socket-channel';
 import { Endpoint } from '../endpoint';
 import ReconnectingWebSocket from 'reconnecting-websocket';
@@ -34,6 +34,12 @@ export interface WebSocketOptions {
 @injectable()
 export class WebSocketConnectionProvider extends AbstractConnectionProvider<WebSocketOptions> {
 
+    protected readonly onSocketDidOpenEmitter: Emitter<void> = new Emitter();
+    readonly onSocketDidOpen: Event<void> = this.onSocketDidOpenEmitter.event;
+
+    protected readonly onSocketDidCloseEmitter: Emitter<void> = new Emitter();
+    readonly onSocketDidClose: Event<void> = this.onSocketDidCloseEmitter.event;
+
     static createProxy<T extends object>(container: interfaces.Container, path: string, arg?: object): JsonRpcProxy<T> {
         return container.get(WebSocketConnectionProvider).createProxy<T>(path, arg);
     }
@@ -45,10 +51,14 @@ export class WebSocketConnectionProvider extends AbstractConnectionProvider<WebS
         const url = this.createWebSocketUrl(WebSocketChannel.wsPath);
         const socket = this.createWebSocket(url);
         socket.onerror = console.error;
+        socket.onopen = () => {
+            this.fireSocketDidOpen();
+        };
         socket.onclose = ({ code, reason }) => {
             for (const channel of [...this.channels.values()]) {
                 channel.close(code, reason);
             }
+            this.fireSocketDidClose();
         };
         socket.onmessage = ({ data }) => {
             this.handleIncomingRawMessage(data);
@@ -96,6 +106,14 @@ export class WebSocketConnectionProvider extends AbstractConnectionProvider<WebS
             maxRetries: Infinity,
             debug: false
         });
+    }
+
+    protected fireSocketDidOpen(): void {
+        this.onSocketDidOpenEmitter.fire(undefined);
+    }
+
+    protected fireSocketDidClose(): void {
+        this.onSocketDidCloseEmitter.fire(undefined);
     }
 
 }


### PR DESCRIPTION
#### What it does
The substance of the current change proposal in modification of mechanism, that is responsible for monitoring the state of client activity. The problem lay in the way that there is a base abstract class, which has the timer, that activates the offline mode within a specified period of time, if there isn't any incoming activity from the client. And there is a class, which listens for websocket incoming activity, which also has another timer, that activates within the same period of time as the previous one, minus one second, to make a ping request and receives the pong response. That's how it's implemented in master. The main challenge is when these timers activates, the client has only one second making a ping request and receive the pong response. If the ping request executes more than one second, the client indicates that the application is in offline mode, when, in fact server responses to requests, but with some delay. This is a false positive trigger. The ping request might executes more than one second, but in that case the host operating system is under heavy system load or has limited resources. It is a very common scenario, when IDE runs as containerized application, for example in kubernetes.


To avoid false positive trigger was invited to refuse to use the timer which is located in an abstract class, which is responsible for triggering the online/offline mode. In the meantime, class, that listens to websocket activity to add an ability to listen to the websocket open and close event. Websocket closing triggers by loosing the connection. This might be the disconnecting the server, losing the internet connection on the user's side. When the user is losing the internet connection, reconnecting-websocket library is trying to restore connections and in the process, fire the event about websocket close and this is a clear message, that we can show offline mode. When the reconnecting-websocket restores the connection, it fires event about websocket open and this is an indicator for online mode.


The problem with lengthy ping request can be easily reproduced by opening the big files in the editor, which are more than 6-7 megabytes. This usecase also was reproduced on master, also on Google Cloud Shell Editor and OpenShift platforms.


The current change proposal also provides test covering common scenarios for the websocket behavior and indicating the application state, in short online/offline mode.

#### Reproduces:


- **Usecase with opening big file in Theia that built from master:**
Screencast: https://drive.google.com/file/d/1alsddSf2pY9XfFL2GQcOGKCI2rpC3eZU/view?usp=sharing

- **Usecase when response for pong request is made with emulated delay:**
Screencast: https://drive.google.com/file/d/1NzaGdH-dkZUbGP3cWjFmTpLVZvOKmyBx/view?usp=sharing
To reproduce this usecase, Theia needs to be patched with the following patchfile and built:
```patch
Index: packages/core/src/node/env-variables/env-variables-server.ts
<+>UTF-8
===================================================================
diff --git a/packages/core/src/node/env-variables/env-variables-server.ts b/packages/core/src/node/env-variables/env-variables-server.ts
--- a/packages/core/src/node/env-variables/env-variables-server.ts	(revision 6798167b50e5df4682ec218294a4eb1f3817904f)
+++ b/packages/core/src/node/env-variables/env-variables-server.ts	(date 1613140075235)
@@ -58,9 +58,18 @@
         if (isWindows) {
             key = key.toLowerCase();
         }
+        if (key === 'does_not_matter') {
+            const delay = Math.floor(Math.random() * (3000 - 800)) + 800;
+            console.log(`Emulate ping response with delay: ${delay}ms`);
+            await this.delay(delay);
+        }
         return this.envs[key];
     }
 
+    delay(ms: number): Promise<void> {
+        return new Promise( resolve => setTimeout(resolve, ms) );
+    }
+
     getConfigDirUri(): Promise<string> {
         return this.configDirUri;
     }
```

- **Usecase with opening big file in Google Cloud Shell Editor that built based on Theia:**
Screencast: https://drive.google.com/file/d/15KiJmLdmNvRBj3hNWmLRvcbLoJKoLJKM/view?usp=sharing

#### Additional context
linked comment: https://github.com/eclipse/che/issues/18472#issuecomment-734872527
fixes: https://github.com/eclipse/che/issues/18723

Signed-off-by: Vladyslav Zhukovskyi <vzhukovs@redhat.com>

#### How to test
Build and run Theia from the current branch. Create a few big files (it would be enough 7-8 megabytes). Try to reopen them sequentially. Additionally, the host operating system can be a bit overloaded by calling the following command in the terminal: 
```
$ yes > /dev/null &
``` 
So there shouldn't any offline marker appeared, because the network connection is not broken.
Screencast: https://drive.google.com/file/d/1xWXQ1uGGqQNJS_miPvEQySDb0aX8HtxN/view?usp=sharing

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

