### PR TITLE
fix missing semi-colon

### DIFF
--- a/packages/core/src/browser/shell/split-panels.ts
+++ b/packages/core/src/browser/shell/split-panels.ts
@@ -34,7 +34,7 @@ export interface MoveEntry extends SplitPositionOptions {
     targetSize?: number;
     targetPosition?: number;
     startPosition?: number;
-    startTime?: number
+    startTime?: number;
     resolve?: (position: number) => void;
     reject?: (reason: string) => void;
 }


### PR DESCRIPTION
fix missing semi-colon: `startTime?: number` to `startTime?: number;`

Signed-off-by: Byeongho Jung hobeoung2@gmail.com

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does

fix missing semi-colon: `startTime?: number` to `startTime?: number;`

#### How to test

check build output of split-panels (split-panels.d.ts) exactly same with non-fixed build output

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

