### PR TITLE
9075-Fix fetching of values from workspace config

### DIFF
--- a/packages/monaco/src/browser/monaco-frontend-module.ts
+++ b/packages/monaco/src/browser/monaco-frontend-module.ts
@@ -155,7 +155,7 @@ export function createMonacoConfigurationService(container: interfaces.Container
 
     _configuration.getValue = (section, overrides) => {
         const overrideIdentifier = overrides && 'overrideIdentifier' in overrides && overrides['overrideIdentifier'] as string || undefined;
-        const resourceUri = overrides && 'resource' in overrides && !!overrides['resource'] && overrides['resource'].toString();
+        const resourceUri: string | undefined = overrides && 'resource' in overrides && !!overrides['resource'] ? overrides['resource'].toString() : undefined;
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         const proxy = createPreferenceProxy<{ [key: string]: any }>(preferences, preferenceSchemaProvider.getCombinedSchema(), {
             resourceUri, overrideIdentifier, style: 'both'

--- a/packages/plugin-ext/src/main/browser/menus/menus-contribution-handler.ts
+++ b/packages/plugin-ext/src/main/browser/menus/menus-contribution-handler.ts
@@ -123,14 +123,12 @@ export class MenusContributionPointHandler {
                     if (!action.command) {
                         continue;
                     }
-                    toDispose.push(this.registerTitleAction(location, { ...action, when: undefined }, {
+                    toDispose.push(this.registerTitleAction(location, action, {
                         execute: widget => widget instanceof PluginViewWidget && this.commands.executeCommand(action.command!),
                         isEnabled: widget => widget instanceof PluginViewWidget &&
-                            this.viewContextKeys.with({ view: widget.options.viewId }, () =>
-                                this.commands.isEnabled(action.command!) && this.viewContextKeys.match(action.when)),
+                            this.commands.isEnabled(action.command!) && this.viewContextKeys.match(action.when),
                         isVisible: widget => widget instanceof PluginViewWidget &&
-                            this.viewContextKeys.with({ view: widget.options.viewId }, () =>
-                                this.commands.isVisible(action.command!) && this.viewContextKeys.match(action.when))
+                            this.commands.isVisible(action.command!) && this.viewContextKeys.match(action.when)
                     }));
                 }
             } else if (location === 'view/item/context') {

--- a/packages/plugin-ext/src/main/browser/view/plugin-view-registry.ts
+++ b/packages/plugin-ext/src/main/browser/view/plugin-view-registry.ts
@@ -465,6 +465,9 @@ export class PluginViewRegistry implements FrontendApplicationContribution {
             }
             const part = containerWidget.getPartFor(widget);
             if (part) {
+                part.node.addEventListener('mouseenter', () => {
+                    this.viewContextKeys.view.set(viewId);
+                });
                 // if a view is explicitly hidden then suppress updating visibility based on `when` closure
                 part.onDidChangeVisibility(() => widget.suppressUpdateViewVisibility = part.isHidden);
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->
The changes fixes #9075. 
The root cause of the issue is resourceUri is set as false if resource is not present in overrides.
https://github.com/eclipse-theia/theia/blob/f3a15db2e364549922a843f195371f5a19a1a403/packages/monaco/src/browser/monaco-frontend-module.ts#L158
Due to this preference proxy is returning the default value which is flat.
#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
**Setup**
Add the change from #8967 for reloading toolbar based on ToolbarItem.onDidChange.

Test 1 - To test if toolbar items are reloaded on configuration change 
Follow the steps mentioned under the issue #9075

Test 2 - To test if toolbar items are reloaded on context change
Follow the steps mentioned under the issue #8757 

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)
- [x] Update workspace config using preference UI and notice icon is getting updated
- [x] Clear `maven.view` from workspace config and update `maven.view` in user config and notice the behaviour is working fine

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

