### PR TITLE
8969-upgrade-monaco-editor-core-to-standalone-0.22.x

### DIFF
--- a/packages/editor/src/browser/editor-preferences.ts
+++ b/packages/editor/src/browser/editor-preferences.ts
@@ -35,7 +35,7 @@ const platform = {
     isLinux: OS.type() === OS.Type.Linux
 };
 
-// should be in sync with https://github.com/theia-ide/vscode/blob/standalone/0.20.x/src/vs/editor/common/config/editorOptions.ts#L3042
+// should be in sync with https://github.com/theia-ide/vscode/blob/standalone/0.22.x/src/vs/editor/common/config/editorOptions.ts#L3679
 export const EDITOR_FONT_DEFAULTS = {
     fontFamily: (
         isOSX ? DEFAULT_MAC_FONT_FAMILY : (isWindows ? DEFAULT_WINDOWS_FONT_FAMILY : DEFAULT_LINUX_FONT_FAMILY)
@@ -48,7 +48,7 @@ export const EDITOR_FONT_DEFAULTS = {
     letterSpacing: 0,
 };
 
-// should be in sync with https://github.com/theia-ide/vscode/blob/standalone/0.20.x/src/vs/editor/common/config/editorOptions.ts#L3057
+// should be in sync with https://github.com/theia-ide/vscode/blob/standalone/0.22.x/src/vs/editor/common/config/editorOptions.ts#L3694
 export const EDITOR_MODEL_DEFAULTS = {
     tabSize: 4,
     indentSize: 4,
@@ -64,11 +64,11 @@ export const DEFAULT_WORD_SEPARATORS = '`~!@#$%^&*()-=+[{]}\\|;:\'",.<>/?';
 /* eslint-disable no-null/no-null */
 
 // should be in sync with:
-//        1. https://github.com/theia-ide/vscode/blob/standalone/0.20.x/src/vs/editor/common/config/commonEditorConfig.ts#L441
-//        2. https://github.com/theia-ide/vscode/blob/standalone/0.20.x/src/vs/editor/common/config/commonEditorConfig.ts#L530
+//        1. https://github.com/theia-ide/vscode/blob/standalone/0.22.x/src/vs/editor/common/config/commonEditorConfig.ts#L458
+//        2. https://github.com/theia-ide/vscode/blob/standalone/0.22.x/src/vs/editor/common/config/commonEditorConfig.ts#L577
 
-// 1. Copy from https://github.com/theia-ide/vscode/blob/standalone/0.20.x/src/vs/editor/common/config/commonEditorConfig.ts#L530
-// 2. Align first items with https://github.com/theia-ide/vscode/blob/standalone/0.20.x/src/vs/editor/common/config/commonEditorConfig.ts#L441
+// 1. Copy from https://github.com/theia-ide/vscode/blob/standalone/0.22.x/src/vs/editor/common/config/commonEditorConfig.ts#L577
+// 2. Align first items with https://github.com/theia-ide/vscode/blob/standalone/0.22.x/src/vs/editor/common/config/commonEditorConfig.ts#L458
 // 3. Find -> Use Regular Expressions to clean up data and replace " by ', for example -> nls\.localize\(.*, "(.*)"\) -> "$1"
 // 4. Apply `quotemark` quick fixes
 // 5. Fix the rest manually
@@ -109,9 +109,24 @@ const codeEditorPreferenceProperties = {
         'default': true,
         'description': 'Controls whether completions should be computed based on words in the document.'
     },
+    'editor.wordBasedSuggestionsMode': {
+        'enum': ['currentDocument', 'matchingDocuments', 'allDocuments'],
+        'default': 'matchingDocuments',
+        'enumDescriptions': [
+            'Only suggest words from the active document.',
+            'Suggest words from all open documents of the same language.',
+            'Suggest words from all open documents.'
+        ],
+        'description': 'Controls form what documents word based completions are computed.'
+    },
     'editor.semanticHighlighting.enabled': {
-        'type': 'boolean',
-        'default': true,
+        'enum': [true, false, 'configuredByTheme'],
+        'enumDescriptions': [
+            'Semantic highlighting enabled for all color themes.',
+            'Semantic highlighting disabled for all color themes.',
+            'Semantic highlighting is configured by the current color theme\'s `semanticHighlighting` setting.'
+        ],
+        'default': 'configuredByTheme',
         'description': 'Controls whether the semanticHighlighting is shown for the languages that support it.'
     },
     'editor.stablePeek': {
@@ -137,12 +152,27 @@ const codeEditorPreferenceProperties = {
     'diffEditor.ignoreTrimWhitespace': {
         'type': 'boolean',
         'default': true,
-        'description': 'Controls whether the diff editor shows changes in leading or trailing whitespace as diffs.'
+        'description': 'When enabled, the diff editor ignores changes in leading or trailing whitespace.'
     },
     'diffEditor.renderIndicators': {
         'type': 'boolean',
         'default': true,
         'description': 'Controls whether the diff editor shows +/- indicators for added/removed changes.'
+    },
+    'diffEditor.codeLens': {
+        'type': 'boolean',
+        'default': false,
+        'description': 'Controls whether the editor shows CodeLens.'
+    },
+    'diffEditor.wordWrap': {
+        'type': 'string',
+        'enum': ['off', 'on', 'inherit'],
+        'default': 'inherit',
+        'markdownEnumDescriptions': [
+            'Lines will never wrap.',
+            'Lines will wrap at the viewport width.',
+            'Lines will wrap according to the `#editor.wordWrap#` setting.'
+        ]
     },
     'editor.acceptSuggestionOnCommitCharacter': {
         'markdownDescription': 'Controls whether suggestions should be accepted on commit characters. For example, in JavaScript, the semi-colon (`;`) can be a commit character that accepts a suggestion and types that character.',
@@ -271,10 +301,31 @@ const codeEditorPreferenceProperties = {
         ],
         'default': 'languageDefined'
     },
+    'editor.ariaLabel': {
+        'type': 'string',
+        'description': 'Editor content',
+        'default': 'ariaLabel'
+    },
+    'editor.automaticLayout': {
+        'type': 'boolean',
+        'default': false
+    },
     'editor.codeLens': {
         'description': 'Controls whether the editor shows CodeLens.',
         'type': 'boolean',
         'default': true
+    },
+    'editor.codeLensFontFamily': {
+        'description': 'Controls the font family for CodeLens.',
+        'type': 'string',
+        'default': true
+    },
+    'editor.codeLensFontSize': {
+        'type': 'integer',
+        'default': 0,
+        'minimum': 0,
+        'maximum': 100,
+        'description': 'Controls the font size in pixels for CodeLens. When set to `0`, the 90% of `#editor.fontSize#` is used.'
     },
     'editor.colorDecorators': {
         'description': 'Controls whether the editor should render the inline color decorators and color picker.',
@@ -285,6 +336,15 @@ const codeEditorPreferenceProperties = {
         'type': 'boolean',
         'default': true,
         'description': 'Controls whether a space character is inserted when commenting.'
+    },
+    'editor.comments.ignoreEmptyLines': {
+        'type': 'boolean',
+        'default': true,
+        'description': 'Controls if empty lines should be ignored with toggle, add or remove actions for line comments.'
+    },
+    'editor.contextmenu': {
+        'type': 'boolean',
+        'default': true,
     },
     'editor.copyWithSyntaxHighlighting': {
         'description': 'Controls whether syntax highlighting should be copied into the clipboard.',
@@ -348,6 +408,14 @@ const codeEditorPreferenceProperties = {
         'minimum': 0,
         'maximum': 1073741824
     },
+    'editor.disableLayerHinting': {
+        'type': 'boolean',
+        'default': false
+    },
+    'editor.disableMonospaceOptimizations': {
+        'type': 'boolean',
+        'default': false
+    },
     'editor.dragAndDrop': {
         'description': 'Controls whether the editor should allow moving selections via drag and drop.',
         'type': 'boolean',
@@ -358,10 +426,19 @@ const codeEditorPreferenceProperties = {
         'type': 'boolean',
         'default': true
     },
+    'editor.extraEditorClassName': {
+        'type': 'string',
+        'default': ''
+    },
     'editor.fastScrollSensitivity': {
         'markdownDescription': 'Scrolling speed multiplier when pressing `Alt`.',
         'type': 'number',
         'default': 5
+    },
+    'editor.find.cursorMoveOnType': {
+        'description': 'Controls whether the cursor should jump to find matches while typing.',
+        'type': 'boolean',
+        'default': true
     },
     'editor.find.seedSearchStringFromSelection': {
         'type': 'boolean',
@@ -394,6 +471,15 @@ const codeEditorPreferenceProperties = {
         'default': true,
         'description': 'Controls whether the Find Widget should add extra lines on top of the editor. When true, you can scroll beyond the first line when the Find Widget is visible.'
     },
+    'editor.find.loop': {
+        'type': 'boolean',
+        'default': true,
+        'description': 'Controls whether the search automatically restarts from the beginning (or the end) when no further matches can be found.'
+    },
+    'editor.fixedOverflowWidgets': {
+        'type': 'boolean',
+        'default': false,
+    },
     'editor.folding': {
         'description': 'Controls whether the editor has code folding enabled.',
         'type': 'boolean',
@@ -412,6 +498,11 @@ const codeEditorPreferenceProperties = {
         'description': 'Controls whether the editor should highlight folded ranges.',
         'type': 'boolean',
         'default': true
+    },
+    'editor.unfoldOnClickAfterEndOfLine': {
+        'description': 'Controls whether clicking on the empty content after a folded line will unfold the line.',
+        'type': 'boolean',
+        'default': false
     },
     'editor.fontFamily': {
         'description': 'Controls the font family.',
@@ -602,6 +693,10 @@ const codeEditorPreferenceProperties = {
         'default': true,
         'description': 'Controls whether the hover should remain visible when mouse is moved over it.'
     },
+    'editor.inDiffEditor': {
+        'type': 'boolean',
+        'default': true,
+    },
     'editor.letterSpacing': {
         'description': 'Controls the letter spacing in pixels.',
         'type': 'number',
@@ -635,6 +730,18 @@ const codeEditorPreferenceProperties = {
         ],
         'default': 'on',
         'description': 'Controls the display of line numbers.'
+    },
+    'editor.lineNumbersMinChars': {
+        'description': 'Controls the line height. Use 0 to compute the line height from the font size.',
+        'type': 'integer',
+        'default': 5,
+        'minimum': 1,
+        'maximum': 300
+    },
+    'editor.linkedEditing': {
+        'description': 'Controls whether the editor has linked editing enabled. Depending on the language, related symbols, e.g. HTML tags, are updated while editing.',
+        'type': 'boolean',
+        'default': false
     },
     'editor.links': {
         'description': 'Controls whether the editor should detect links and make them clickable.',
@@ -691,6 +798,11 @@ const codeEditorPreferenceProperties = {
         'default': 120,
         'description': 'Limit the width of the minimap to render at most a certain number of columns.'
     },
+    'editor.mouseStyle': {
+        'type': 'string',
+        'enum': ['text', 'default', 'copy'],
+        'default': 'text'
+    },
     'editor.mouseWheelScrollSensitivity': {
         'markdownDescription': 'A multiplier to be used on the `deltaX` and `deltaY` of mouse wheel scroll events.',
         'type': 'number',
@@ -742,6 +854,26 @@ const codeEditorPreferenceProperties = {
         'type': 'boolean',
         'default': true
     },
+    'editor.overviewRulerLanes': {
+        'type': 'integer',
+        'default': 3,
+        'minimum': 0,
+        'maximum': 3
+    },
+    'editor.padding.top': {
+        'type': 'number',
+        'default': 0,
+        'minimum': 0,
+        'maximum': 1000,
+        'description': 'Controls the amount of space between the top edge of the editor and the first line.'
+    },
+    'editor.padding.bottom': {
+        'type': 'number',
+        'default': 0,
+        'minimum': 0,
+        'maximum': 1000,
+        'description': 'Controls the amount of space between the bottom edge of the editor and the last line.'
+    },
     'editor.parameterHints.enabled': {
         'type': 'boolean',
         'default': true,
@@ -764,6 +896,11 @@ const codeEditorPreferenceProperties = {
             'editor'
         ],
         'default': 'tree'
+    },
+    'editor.definitionLinkOpensInPeek': {
+        'type': 'boolean',
+        'default': false,
+        'description': 'Controls whether the Go to Definition mouse gesture always opens the peek widget.'
     },
     'editor.quickSuggestions': {
         'anyOf': [
@@ -805,6 +942,10 @@ const codeEditorPreferenceProperties = {
         'minimum': 0,
         'maximum': 1073741824
     },
+    'editor.readOnly': {
+        'type': 'boolean',
+        'default': false
+    },
     'editor.rename.enablePreview': {
         'description': 'Controls whether the editor should display refactor preview pane for rename.',
         'type': 'boolean',
@@ -842,6 +983,16 @@ const codeEditorPreferenceProperties = {
         ],
         'default': 'line'
     },
+    'editor.renderLineHighlightOnlyWhenFocus': {
+        'description': 'Controls if the editor should render the current line highlight only when the editor is focused.',
+        'type': 'boolean',
+        'default': false
+    },
+    'editor.renderValidationDecorations': {
+        'type': 'string',
+        'enum': ['editable', 'on', 'off'],
+        'default': 'editable'
+    },
     'editor.renderWhitespace': {
         'enumDescriptions': [
             '',
@@ -858,6 +1009,12 @@ const codeEditorPreferenceProperties = {
             'all'
         ],
         'default': 'none'
+    },
+    'editor.revealHorizontalRightPadding': {
+        'type': 'integer',
+        'default': 30,
+        'minimum': 0,
+        'maximum': 1000
     },
     'editor.roundedSelection': {
         'description': 'Controls whether selections should have rounded corners.',
@@ -884,6 +1041,11 @@ const codeEditorPreferenceProperties = {
         'type': 'boolean',
         'default': true
     },
+    'editor.scrollPredominantAxis': {
+        'description': 'Scroll only along the predominant axis when scrolling both vertically and horizontally at the same time. Prevents horizontal drift when scrolling vertically on a trackpad.',
+        'type': 'boolean',
+        'default': true
+    },
     'editor.selectionClipboard': {
         'description': 'Controls whether the Linux primary clipboard should be supported.',
         'included': platform.isLinux,
@@ -892,6 +1054,10 @@ const codeEditorPreferenceProperties = {
     },
     'editor.selectionHighlight': {
         'description': 'Controls whether the editor should highlight matches similar to the selection.',
+        'type': 'boolean',
+        'default': true
+    },
+    'editor.selectOnLineNumbers': {
         'type': 'boolean',
         'default': true
     },
@@ -908,6 +1074,26 @@ const codeEditorPreferenceProperties = {
         'description': 'Controls fading out of unused code.',
         'type': 'boolean',
         'default': true
+    },
+    'editor.showDeprecated': {
+        'description': 'Controls strikethrough deprecated variables.',
+        'type': 'boolean',
+        'default': true
+    },
+    'editor.inlineHints.enabled': {
+        'type': 'boolean',
+        'default': true,
+        'description': 'Enables the inline hints in the editor.'
+    },
+    'editor.inlineHints.fontSize': {
+        'type': 'number',
+        'default': EDITOR_FONT_DEFAULTS.fontSize,
+        description: 'Controls font size of inline hints in the editor. When set to `0`, the 90% of `#editor.fontSize#` is used.'
+    },
+    'editor.inlineHints.fontFamily': {
+        'type': 'string',
+        'default': EDITOR_FONT_DEFAULTS.fontFamily,
+        'description': 'Controls font family of inline hints in the editor.'
     },
     'editor.snippetSuggestions': {
         'enumDescriptions': [
@@ -926,10 +1112,26 @@ const codeEditorPreferenceProperties = {
         ],
         'default': 'inline'
     },
+    'editor.smartSelect.selectLeadingAndTrailingWhitespace': {
+        'description': 'Whether leading and trailing whitespace should always be selected.',
+        'default': true,
+        'type': 'boolean'
+    },
     'editor.smoothScrolling': {
         'description': 'Controls whether the editor will scroll using an animation.',
         'type': 'boolean',
         'default': false
+    },
+    'editor.stickyTabStops': {
+        'description': 'Emulate selection behaviour of tab characters when using spaces for indentation. Selection will stick to tab stops.',
+        'type': 'boolean',
+        'default': false
+    },
+    'editor.stopRenderingLineAfter': {
+        'type': 'integer',
+        'default': 10000,
+        'minimum': -1,
+        'maximum': 1073741824
     },
     'editor.suggest.insertMode': {
         'type': 'string',
@@ -1170,6 +1372,24 @@ const codeEditorPreferenceProperties = {
         ],
         'default': 'off'
     },
+    'editor.tabIndex': {
+        'markdownDescription': 'Controls the wrapping column of the editor when `#editor.wordWrap#` is `wordWrapColumn` or `bounded`.',
+        'type': 'integer',
+        'default': 0,
+        'minimum': -1,
+        'maximum': 1073741824
+    },
+    'editor.unusualLineTerminators': {
+        'markdownEnumDescriptions': [
+            'Unusual line terminators are automatically removed.',
+            'Unusual line terminators are ignored.',
+            'Unusual line terminators prompt to be removed.'
+        ],
+        'description': 'Remove unusual line terminators that might cause problems.',
+        'type': 'string',
+        'enum': ['auto', 'off', 'prompt'],
+        'default': 'prompt'
+    },
     'editor.useTabStops': {
         'description': 'Inserting and deleting whitespace follows tab stops.',
         'type': 'boolean',
@@ -1197,12 +1417,30 @@ const codeEditorPreferenceProperties = {
         ],
         'default': 'off'
     },
+    'editor.wordWrapBreakAfterCharacters': {
+        'type': 'string',
+        'default': ' \t})]?|/&.,;¢°′″‰℃、。｡､￠，．：；？！％・･ゝゞヽヾーァィゥェォッャュョヮヵヶぁぃぅぇぉっゃゅょゎゕゖㇰㇱㇲㇳㇴㇵㇶㇷㇸㇹㇺㇻㇼㇽㇾㇿ々〻ｧｨｩｪｫｬｭｮｯｰ”〉》」』】〕）］｝｣',
+    },
+    'editor.wordWrapBreakBeforeCharacters': {
+        'type': 'string',
+        'default': '([{‘“〈《「『【〔（［｛｢£¥＄￡￥+＋',
+    },
     'editor.wordWrapColumn': {
         'markdownDescription': 'Controls the wrapping column of the editor when `#editor.wordWrap#` is `wordWrapColumn` or `bounded`.',
         'type': 'integer',
         'default': 80,
         'minimum': 1,
         'maximum': 1073741824
+    },
+    'editor.wordWrapOverride1': {
+        'type': 'string',
+        'enum': ['off', 'on', 'inherit'],
+        'default': 'inherit'
+    },
+    'editor.wordWrapOverride2': {
+        'type': 'string',
+        'enum': ['off', 'on', 'inherit'],
+        'default': 'inherit'
     },
     'editor.wrappingIndent': {
         'enumDescriptions': [

--- a/packages/monaco/src/typings/monaco/index.d.ts
+++ b/packages/monaco/src/typings/monaco/index.d.ts
@@ -62,7 +62,7 @@ declare module monaco.format {
 }
 
 declare module monaco.instantiation {
-    // https://github.com/theia-ide/vscode/blob/standalone/0.20.x/src/vs/platform/instantiation/common/instantiation.ts#L86
+    // https://github.com/theia-ide/vscode/blob/standalone/0.22.x/src/vs/platform/instantiation/common/instantiation.ts#L86
     export interface IInstantiationService {
         invokeFunction: (fn: any, ...args: any) => any
     }
@@ -102,30 +102,57 @@ declare module monaco.editor {
         removeDecorations(decorationTypeKey: string): void;
     }
 
-    // https://github.com/theia-ide/vscode/blob/standalone/0.20.x/src/vs/editor/browser/services/bulkEditService.ts#L14
+    // https://github.com/theia-ide/vscode/blob/standalone/0.22.x/src/vs/platform/undoRedo/common/undoRedo.ts#L92-L111
+    export class UndoRedoSource {
+        private static _ID = 0;
+
+        public readonly id: number;
+        private order: number;
+
+        constructor() {
+            this.id = UndoRedoSource._ID++;
+            this.order = 1;
+        }
+
+        public nextOrder(): number {
+            if (this.id === 0) {
+                return 0;
+            }
+            return this.order++;
+        }
+
+        public static None = new UndoRedoSource();
+    }
+
+    // https://github.com/theia-ide/vscode/blob/standalone/0.22.x/src/vs/editor/browser/services/bulkEditService.ts#L67
     export interface IBulkEditOptions {
         editor?: ICodeEditor;
         progress?: IProgress<IProgressStep>;
+        token?: CancellationToken;
         showPreview?: boolean;
         label?: string;
+        quotableLabel?: string;
+        undoRedoSource?: UndoRedoSource;
+        undoRedoGroupId?: number;
+        confirmBeforeUndo?: boolean;
     }
 
-    // https://github.com/theia-ide/vscode/blob/standalone/0.20.x/src/vs/editor/browser/services/bulkEditService.ts#L21
+    // https://github.com/theia-ide/vscode/blob/standalone/0.22.x/src/vs/editor/browser/services/bulkEditService.ts#L79
     export interface IBulkEditResult {
         ariaSummary: string;
     }
 
-    // https://github.com/theia-ide/vscode/blob/standalone/0.20.x/src/vs/editor/browser/services/bulkEditService.ts#L25
+    // https://github.com/theia-ide/vscode/blob/standalone/0.22.x/src/vs/editor/browser/services/bulkEditService.ts#L83
     export type IBulkEditPreviewHandler = (edit: monaco.languages.WorkspaceEdit, options?: IBulkEditOptions) => Promise<monaco.languages.WorkspaceEdit>;
 
-    // https://github.com/theia-ide/vscode/blob/standalone/0.20.x/src/vs/editor/browser/services/bulkEditService.ts#L27
+    // https://github.com/theia-ide/vscode/blob/standalone/0.22.x/src/vs/editor/browser/services/bulkEditService.ts#L85
     export interface IBulkEditService {
-        apply(edit: monaco.languages.WorkspaceEdit): Promise<IBulkEditResult>;
+        apply(edit: monaco.languages.WorkspaceEdit, options?: IBulkEditOptions): Promise<IBulkEditResult>;
         hasPreviewHandler(): boolean;
         setPreviewHandler(handler: IBulkEditPreviewHandler): monaco.IDisposable;
     }
 
-    // https://github.com/theia-ide/vscode/blob/standalone/0.20.x/src/vs/editor/browser/widget/diffNavigator.ts#L43
+    // https://github.com/theia-ide/vscode/blob/standalone/0.22.x/src/vs/editor/browser/widget/diffNavigator.ts#L43
     export interface IDiffNavigator {
         readonly ranges: IDiffRange[];
         readonly nextIdx: number;
@@ -133,12 +160,12 @@ declare module monaco.editor {
         _initIdx(fwd: boolean): void;
     }
 
-    // https://github.com/theia-ide/vscode/blob/standalone/0.20.x/src/vs/editor/browser/widget/diffNavigator.ts#L16
+    // https://github.com/theia-ide/vscode/blob/standalone/0.22.x/src/vs/editor/browser/widget/diffNavigator.ts#L16
     export interface IDiffRange {
         readonly range: Range;
     }
 
-    // https://github.com/theia-ide/vscode/blob/standalone/0.20.x/src/vs/editor/standalone/browser/standaloneCodeEditor.ts#L206
+    // https://github.com/theia-ide/vscode/blob/standalone/0.22.x/src/vs/editor/standalone/browser/standaloneCodeEditor.ts#L227
     export interface IStandaloneCodeEditor extends CommonCodeEditor {
         setDecorations(decorationTypeKey: string, ranges: IDecorationOptions[]): void;
         setDecorationsFast(decorationTypeKey: string, ranges: IRange[]): void;
@@ -152,7 +179,7 @@ declare module monaco.editor {
         }
     }
 
-    // https://github.com/theia-ide/vscode/blob/standalone/0.20.x/src/vs/editor/browser/widget/codeEditorWidget.ts#L106
+    // https://github.com/theia-ide/vscode/blob/standalone/0.22.x/src/vs/editor/browser/widget/codeEditorWidget.ts#L105
     export interface CommonCodeEditor {
         readonly _commandService: monaco.commands.ICommandService;
         readonly _instantiationService: monaco.instantiation.IInstantiationService;
@@ -169,50 +196,50 @@ declare module monaco.editor {
         } | null;
     }
 
-    // https://github.com/theia-ide/vscode/blob/standalone/0.20.x/src/vs/editor/contrib/codeAction/codeActionCommands.ts#L68
+    // https://github.com/theia-ide/vscode/blob/standalone/0.22.x/src/vs/editor/contrib/codeAction/codeActionCommands.ts#L68
     export interface QuickFixController {
         readonly _ui: {
             rawValue?: CodeActionUi
         }
     }
-    // https://github.com/theia-ide/vscode/blob/standalone/0.20.x/src/vs/editor/contrib/codeAction/codeActionUi.ts#L22
+    // https://github.com/theia-ide/vscode/blob/standalone/0.22.x/src/vs/editor/contrib/codeAction/codeActionUi.ts#L21
     export interface CodeActionUi {
         readonly _lightBulbWidget: {
             rawValue?: LightBulbWidget
         }
     }
-    // https://github.com/theia-ide/vscode/blob/standalone/0.20.x/src/vs/editor/contrib/codeAction/lightBulbWidget.ts#L47
+    // https://github.com/theia-ide/vscode/blob/standalone/0.22.x/src/vs/editor/contrib/codeAction/lightBulbWidget.ts#L48
     export interface LightBulbWidget {
         readonly _domNode: HTMLDivElement;
     }
 
-    // https://github.com/theia-ide/vscode/blob/standalone/0.20.x/src/vs/editor/contrib/codelens/codelensController.ts#L24
+    // https://github.com/theia-ide/vscode/blob/standalone/0.22.x/src/vs/editor/contrib/codelens/codelensController.ts#L28
     export interface CodeLensContribution {
         readonly _lenses: CodeLensWidget[];
     }
 
-    // https://github.com/theia-ide/vscode/blob/standalone/0.20.x/src/vs/editor/contrib/codelens/codelensWidget.ts#L182
+    // https://github.com/theia-ide/vscode/blob/standalone/0.22.x/src/vs/editor/contrib/codelens/codelensWidget.ts#L178
     export interface CodeLensWidget {
         readonly _contentWidget?: CodeLensContentWidget;
     }
 
-    // https://github.com/theia-ide/vscode/blob/standalone/0.20.x/src/vs/editor/contrib/codelens/codelensWidget.ts#L50
+    // https://github.com/theia-ide/vscode/blob/standalone/0.22.x/src/vs/editor/contrib/codelens/codelensWidget.ts#L49
     export interface CodeLensContentWidget {
         readonly _domNode: HTMLElement;
     }
 
-    // https://github.com/theia-ide/vscode/blob/standalone/0.20.x/src/vs/editor/contrib/hover/hover.ts#L31
+    // https://github.com/theia-ide/vscode/blob/standalone/0.22.x/src/vs/editor/contrib/hover/hover.ts#L30
     export interface ModesHoverController {
         readonly contentWidget: ModesContentHoverWidget;
     }
 
-    // https://github.com/theia-ide/vscode/blob/standalone/0.20.x/src/vs/editor/contrib/hover/modesContentHover.ts#L195
+    // https://github.com/theia-ide/vscode/blob/standalone/0.22.x/src/vs/editor/contrib/hover/modesContentHover.ts#L173
     export interface ModesContentHoverWidget {
         readonly isVisible: boolean;
         readonly _domNode: HTMLElement;
     }
 
-    // https://github.com/theia-ide/vscode/blob/standalone/0.20.x/src/vs/editor/common/controller/cursor.ts#L169
+    // https://github.com/theia-ide/vscode/blob/standalone/0.22.x/src/vs/editor/common/controller/cursor.ts#L122
     export interface ICursor {
         trigger(source: string, handlerId: string, payload: any): void;
     }
@@ -226,7 +253,7 @@ declare module monaco.editor {
         contextKeyService?: monaco.contextKeyService.IContextKeyService;
     }
 
-    // https://github.com/theia-ide/vscode/blob/standalone/0.20.x/src/vs/platform/editor/common/editor.ts#L63
+    // https://github.com/theia-ide/vscode/blob/standalone/0.22.x/src/vs/platform/editor/common/editor.ts#L68
     export interface IResourceInput {
         resource: monaco.Uri;
         options?: IResourceInputOptions;
@@ -237,23 +264,23 @@ declare module monaco.editor {
          * Tells the editor to not receive keyboard focus when the editor is being opened. By default,
          * the editor will receive keyboard focus on open.
          */
-        // https://github.com/theia-ide/vscode/blob/standalone/0.20.x/src/vs/platform/editor/common/editor.ts#L132
+        // https://github.com/theia-ide/vscode/blob/standalone/0.22.x/src/vs/platform/editor/common/editor.ts#L137
         readonly preserveFocus?: boolean;
 
         /**
          * Will reveal the editor if it is already opened and visible in any of the opened editor groups.
          */
-        // https://github.com/theia-ide/vscode/blob/standalone/0.20.x/src/vs/platform/editor/common/editor.ts#L157
+        // https://github.com/theia-ide/vscode/blob/standalone/0.22.x/src/vs/platform/editor/common/editor.ts#L162
         readonly revealIfVisible?: boolean;
 
         /**
          * Text editor selection.
          */
-        // https://github.com/theia-ide/vscode/blob/standalone/0.20.x/src/vs/platform/editor/common/editor.ts#L223
+        // https://github.com/theia-ide/vscode/blob/standalone/0.22.x/src/vs/platform/editor/common/editor.ts#L257
         readonly selection?: Partial<monaco.IRange>;
     }
 
-    // https://github.com/theia-ide/vscode/blob/standalone/0.20.x/src/vs/editor/browser/services/codeEditorService.ts#L15
+    // https://github.com/theia-ide/vscode/blob/standalone/0.22.x/src/vs/editor/browser/services/codeEditorService.ts#L16
     export interface ICodeEditorService {
         getActiveCodeEditor(): monaco.editor.ICodeEditor | undefined;
         openCodeEditor(input: monaco.editor.IResourceInput, source?: monaco.editor.ICodeEditor, sideBySide?: boolean): Promise<monaco.editor.CommonCodeEditor | undefined>;
@@ -262,12 +289,12 @@ declare module monaco.editor {
         resolveDecorationOptions(typeKey: string, writable: boolean): IModelDecorationOptions;
     }
 
-    // https://github.com/theia-ide/vscode/blob/standalone/0.20.x/src/vs/base/common/lifecycle.ts#L209
+    // https://github.com/theia-ide/vscode/blob/standalone/0.22.x/src/vs/base/common/lifecycle.ts#L257
     export interface IReference<T> extends monaco.IDisposable {
         readonly object: T;
     }
 
-    // https://github.com/theia-ide/vscode/blob/standalone/0.20.x/src/vs/editor/common/services/resolverService.ts#L14
+    // https://github.com/theia-ide/vscode/blob/standalone/0.22.x/src/vs/editor/common/services/resolverService.ts#L14
     export interface ITextModelService {
         /**
          * Provided a resource URI, it will return a model reference
@@ -281,7 +308,7 @@ declare module monaco.editor {
         registerTextModelContentProvider(scheme: string, provider: ITextModelContentProvider): monaco.IDisposable;
     }
 
-    // https://github.com/theia-ide/vscode/blob/standalone/0.20.x/src/vs/editor/common/services/resolverService.ts#L34
+    // https://github.com/theia-ide/vscode/blob/standalone/0.22.x/src/vs/editor/common/services/resolverService.ts#L34
     export interface ITextModelContentProvider {
         /**
          * Given a resource, return the content of the resource as IModel.
@@ -289,8 +316,8 @@ declare module monaco.editor {
         provideTextContent(resource: monaco.Uri): Promise<monaco.editor.IModel | null> | null;
     }
 
-    // https://github.com/theia-ide/vscode/blob/standalone/0.20.x/src/vs/editor/common/services/resolverService.ts#L42 &&
-    // https://github.com/theia-ide/vscode/blob/standalone/0.20.x/src/vs/platform/editor/common/editor.ts#L9
+    // https://github.com/theia-ide/vscode/blob/standalone/0.22.x/src/vs/editor/common/services/resolverService.ts#L42 &&
+    // https://github.com/theia-ide/vscode/blob/standalone/0.22.x/src/vs/platform/editor/common/editor.ts#L9
     export interface ITextEditorModel {
         readonly onDispose: monaco.IEvent<void>;
         /**
@@ -308,7 +335,7 @@ declare module monaco.editor {
         textEditorModel: monaco.editor.IModel;
     }
 
-    // https://github.com/theia-ide/vscode/blob/standalone/0.20.x/src/vs/base/browser/contextmenu.ts#L25
+    // https://github.com/theia-ide/vscode/blob/standalone/0.22.x/src/vs/base/browser/contextmenu.ts#L17
     export interface IContextMenuDelegate {
         /**
          * Returns with an HTML element or the client coordinates as the anchor of the context menu to open.
@@ -326,7 +353,7 @@ declare module monaco.editor {
         onHide(wasCancelled: boolean): void
     }
 
-    // https://github.com/theia-ide/vscode/blob/standalone/0.20.x/src/vs/base/common/actions.ts#L25
+    // https://github.com/theia-ide/vscode/blob/standalone/0.22.x/src/vs/base/common/actions.ts#L26
     export interface IAction extends IDisposable {
         readonly id: string;
         label: string;
@@ -337,7 +364,7 @@ declare module monaco.editor {
         run(event?: any): Promise<any>;
     }
 
-    // https://github.com/theia-ide/vscode/blob/standalone/0.20.x/src/vs/platform/contextview/browser/contextView.ts#L38
+    // https://github.com/theia-ide/vscode/blob/standalone/0.22.x/src/vs/platform/contextview/browser/contextView.ts#L39
     export interface IContextMenuService {
         /**
          * Shows the native Monaco context menu in the editor.
@@ -345,26 +372,26 @@ declare module monaco.editor {
         showContextMenu(delegate: IContextMenuDelegate): void;
     }
 
-    // https://github.com/theia-ide/vscode/blob/standalone/0.20.x/src/vs/editor/common/editorCommon.ts#L623
+    // https://github.com/theia-ide/vscode/blob/standalone/0.22.x/src/vs/editor/common/editorCommon.ts#L680
     export interface IDecorationOptions {
         range: IRange;
         hoverMessage?: IMarkdownString | IMarkdownString[];
         renderOptions?: IDecorationInstanceRenderOptions;
     }
 
-    // https://github.com/theia-ide/vscode/blob/standalone/0.20.x/src/vs/editor/common/editorCommon.ts#L607
+    // https://github.com/theia-ide/vscode/blob/standalone/0.22.x/src/vs/editor/common/editorCommon.ts#L664
     export interface IThemeDecorationInstanceRenderOptions {
         before?: IContentDecorationRenderOptions;
         after?: IContentDecorationRenderOptions;
     }
 
-    // https://github.com/theia-ide/vscode/blob/standalone/0.20.x/src/vs/editor/common/editorCommon.ts#L615
+    // https://github.com/theia-ide/vscode/blob/standalone/0.22.x/src/vs/editor/common/editorCommon.ts#L672
     export interface IDecorationInstanceRenderOptions extends IThemeDecorationInstanceRenderOptions {
         light?: IThemeDecorationInstanceRenderOptions;
         dark?: IThemeDecorationInstanceRenderOptions;
     }
 
-    // https://github.com/theia-ide/vscode/blob/standalone/0.20.x/src/vs/editor/common/editorCommon.ts#L575
+    // https://github.com/theia-ide/vscode/blob/standalone/0.22.x/src/vs/editor/common/editorCommon.ts#L628
     export interface IContentDecorationRenderOptions {
         contentText?: string;
         contentIconPath?: UriComponents;
@@ -383,7 +410,7 @@ declare module monaco.editor {
         height?: string;
     }
 
-    // https://github.com/theia-ide/vscode/blob/standalone/0.20.x/src/vs/editor/common/editorCommon.ts#L595
+    // https://github.com/theia-ide/vscode/blob/standalone/0.22.x/src/vs/editor/common/editorCommon.ts#L652
     export interface IDecorationRenderOptions extends IThemeDecorationRenderOptions {
         isWholeLine?: boolean;
         rangeBehavior?: TrackedRangeStickiness;
@@ -393,7 +420,7 @@ declare module monaco.editor {
         dark?: IThemeDecorationRenderOptions;
     }
 
-    // https://github.com/theia-ide/vscode/blob/standalone/0.20.x/src/vs/editor/common/editorCommon.ts#L540
+    // https://github.com/theia-ide/vscode/blob/standalone/0.22.x/src/vs/editor/common/editorCommon.ts#L592
     export interface IThemeDecorationRenderOptions {
         backgroundColor?: string | ThemeColor;
 
@@ -426,7 +453,7 @@ declare module monaco.editor {
         after?: IContentDecorationRenderOptions;
     }
 
-    // https://github.com/microsoft/vscode/blob/e683ace9e5acadba0e8bde72d793cb2cb83e58a7/src/vs/editor/common/model.ts#L522
+    // https://github.com/theia-ide/vscode/blob/standalone/0.22.x/src/vs/editor/common/model.ts#L522
     export interface ITextSnapshot {
         read(): string | null;
     }
@@ -437,17 +464,17 @@ declare module monaco.editor {
          * The tokens might be inaccurate. Use `forceTokenization` to ensure accurate tokens.
          * @internal
          */
-        // https://github.com/theia-ide/vscode/blob/standalone/0.19.x/src/vs/editor/common/model.ts#L826-L831
+        // https://github.com/theia-ide/vscode/blob/standalone/0.22.x/src/vs/editor/common/model.ts#L890
         getLineTokens(lineNumber: number): LineTokens;
 
         /**
          * Force tokenization information for `lineNumber` to be accurate.
          * @internal
          */
-        // https://github.com/theia-ide/vscode/blob/standalone/0.19.x/src/vs/editor/common/model.ts#L806-L810
+        // https://github.com/theia-ide/vscode/blob/standalone/0.22.x/src/vs/editor/common/model.ts#L869
         forceTokenization(lineNumber: number): void;
 
-        // https://github.com/microsoft/vscode/blob/e683ace9e5acadba0e8bde72d793cb2cb83e58a7/src/vs/editor/common/model.ts#L623
+        // https://github.com/theia-ide/vscode/blob/standalone/0.22.x/src/vs/editor/common/model.ts#L617
         createSnapshot(): ITextSnapshot | null;
     }
 
@@ -455,18 +482,18 @@ declare module monaco.editor {
 
 declare module monaco.commands {
 
-    // https://github.com/theia-ide/vscode/blob/standalone/0.20.x/src/vs/platform/commands/common/commands.ts#L55
+    // https://github.com/theia-ide/vscode/blob/standalone/0.22.x/src/vs/platform/commands/common/commands.ts#L60
     export const CommandsRegistry: {
         getCommands(): Map<string, { id: string, handler: (...args: any) => any }>;
     };
 
-    // https://github.com/theia-ide/vscode/blob/standalone/0.20.x/src/vs/platform/commands/common/commands.ts#L16
+    // https://github.com/theia-ide/vscode/blob/standalone/0.22.x/src/vs/platform/commands/common/commands.ts#L16
     export interface ICommandEvent {
         commandId: string;
         args: any[];
     }
 
-    // https://github.com/theia-ide/vscode/blob/standalone/0.20.x/src/vs/platform/commands/common/commands.ts#L21
+    // https://github.com/theia-ide/vscode/blob/standalone/0.22.x/src/vs/platform/commands/common/commands.ts#L21
     export interface ICommandService {
         onWillExecuteCommand: monaco.Event<ICommandEvent>;
         onDidExecuteCommand: monaco.Event<ICommandEvent>;
@@ -477,13 +504,13 @@ declare module monaco.commands {
 
 declare module monaco.actions {
 
-    // https://github.com/theia-ide/vscode/blob/standalone/0.20.x/src/vs/platform/actions/common/actions.ts#L17
+    // https://github.com/theia-ide/vscode/blob/standalone/0.22.x/src/vs/platform/actions/common/actions.ts#L21
     export interface ILocalizedString {
         value: string;
         original: string;
     }
 
-    // https://github.com/theia-ide/vscode/blob/standalone/0.20.x/src/vs/platform/actions/common/actions.ts#L22
+    // https://github.com/theia-ide/vscode/blob/standalone/0.22.x/src/vs/platform/actions/common/actions.ts#L41
     export interface ICommandAction {
         id: string;
         title: string | ILocalizedString;
@@ -493,7 +520,7 @@ declare module monaco.actions {
         toggled?: monaco.contextkey.ContextKeyExpr;
     }
 
-    // https://github.com/theia-ide/vscode/blob/standalone/0.20.x/src/vs/platform/actions/common/actions.ts#L35
+    // https://github.com/theia-ide/vscode/blob/standalone/0.22.x/src/vs/platform/actions/common/actions.ts#L53
     export interface IMenuItem {
         command: ICommandAction;
         when?: monaco.contextkey.ContextKeyExpr;
@@ -502,7 +529,7 @@ declare module monaco.actions {
         alt?: ICommandAction;
     }
 
-    // https://github.com/theia-ide/vscode/blob/standalone/0.20.x/src/vs/platform/actions/common/actions.ts#L43
+    // https://github.com/theia-ide/vscode/blob/standalone/0.22.x/src/vs/platform/actions/common/actions.ts#L61
     export interface ISubmenuItem {
         title: string | ILocalizedString;
         submenu: number; // enum MenuId
@@ -511,30 +538,30 @@ declare module monaco.actions {
         order?: number;
     }
 
-    // https://github.com/theia-ide/vscode/blob/standalone/0.20.x/src/vs/platform/actions/common/actions.ts#L137
+    // https://github.com/theia-ide/vscode/blob/standalone/0.22.x/src/vs/platform/actions/common/actions.ts#L186
     export interface IMenuRegistry {
         /**
          * Retrieves all the registered menu items for the given menu.
-         * @param menuId - see https://github.com/theia-ide/vscode/blob/standalone/0.20.x/src/vs/platform/actions/common/actions.ts#L67
+         * @param menuId - see https://github.com/theia-ide/vscode/blob/standalone/0.22.x/src/vs/platform/actions/common/actions.ts#L89
          */
         getMenuItems(menuId: 7 /* EditorContext */ | 8 /* EditorContextPeek */ | 25 /* MenubarSelectionMenu */): IMenuItem | ISubmenuItem[];
     }
 
-    // https://github.com/theia-ide/vscode/blob/standalone/0.20.x/src/vs/platform/actions/common/actions.ts#L51
+    // https://github.com/theia-ide/vscode/blob/standalone/0.22.x/src/vs/platform/actions/common/actions.ts#L70
     export function isIMenuItem(item: IMenuItem | ISubmenuItem): item is IMenuItem;
 
     /**
      * The shared menu registry singleton.
      */
-    // https://github.com/theia-ide/vscode/blob/standalone/0.20.x/src/vs/platform/actions/common/actions.ts#L146
+    // https://github.com/theia-ide/vscode/blob/standalone/0.22.x/src/vs/platform/actions/common/actions.ts#L197
     export const MenuRegistry: IMenuRegistry;
 
-    // https://github.com/theia-ide/vscode/blob/standalone/0.20.x/src/vs/platform/actions/common/actions.ts#L250
+    // https://github.com/theia-ide/vscode/blob/standalone/0.22.x/src/vs/platform/actions/common/actions.ts#L355
     export class MenuItemAction { }
 }
 
 declare module monaco.platform {
-    // https://github.com/theia-ide/vscode/blob/standalone/0.20.x/src/vs/base/common/platform.ts#L206
+    // https://github.com/theia-ide/vscode/blob/standalone/0.22.x/src/vs/base/common/platform.ts#L245
     export const enum OperatingSystem {
         Windows = 1,
         Macintosh = 2,
@@ -545,12 +572,12 @@ declare module monaco.platform {
 
 declare module monaco.keybindings {
 
-    // https://github.com/theia-ide/vscode/blob/standalone/0.20.x/src/vs/platform/keybinding/common/keybindingResolver.ts#L20
+    // https://github.com/theia-ide/vscode/blob/standalone/0.22.x/src/vs/platform/keybinding/common/keybindingResolver.ts#L19
     export class KeybindingResolver {
         static contextMatchesRules(context: monaco.contextKeyService.IContext, rules: monaco.contextkey.ContextKeyExpr | null | undefined): boolean;
     }
 
-    // https://github.com/theia-ide/vscode/blob/standalone/0.20.x/src/vs/base/common/keyCodes.ts#L443
+    // https://github.com/theia-ide/vscode/blob/standalone/0.22.x/src/vs/base/common/keyCodes.ts#L443
     export class SimpleKeybinding {
         public readonly ctrlKey: boolean;
         public readonly shiftKey: boolean;
@@ -562,22 +589,22 @@ declare module monaco.keybindings {
         toChord(): ChordKeybinding;
     }
 
-    // https://github.com/theia-ide/vscode/blob/standalone/0.20.x/src/vs/base/common/keyCodes.ts#L503
+    // https://github.com/theia-ide/vscode/blob/standalone/0.22.x/src/vs/base/common/keyCodes.ts#L503
     export class ChordKeybinding {
         readonly parts: SimpleKeybinding[];
     }
 
-    // https://github.com/theia-ide/vscode/blob/standalone/0.20.x/src/vs/base/common/keyCodes.ts#L540
+    // https://github.com/theia-ide/vscode/blob/standalone/0.22.x/src/vs/base/common/keyCodes.ts#L540
     export type Keybinding = ChordKeybinding;
 
-    // https://github.com/theia-ide/vscode/blob/standalone/0.20.x/src/vs/platform/keybinding/common/keybindingsRegistry.ts#L12
+    // https://github.com/theia-ide/vscode/blob/standalone/0.22.x/src/vs/platform/keybinding/common/keybindingsRegistry.ts#L12
     export interface IKeybindingItem {
         keybinding: Keybinding;
         command: string;
         when?: monaco.contextkey.ContextKeyExpr;
     }
 
-    // https://github.com/theia-ide/vscode/blob/standalone/0.20.x/src/vs/platform/keybinding/common/keybindingsRegistry.ts#L69
+    // https://github.com/theia-ide/vscode/blob/standalone/0.22.x/src/vs/platform/keybinding/common/keybindingsRegistry.ts#L73
     export interface IKeybindingsRegistry {
         /**
          * Returns with all the default, static keybindings.
@@ -585,10 +612,10 @@ declare module monaco.keybindings {
         getDefaultKeybindings(): IKeybindingItem[];
     }
 
-    // https://github.com/theia-ide/vscode/blob/standalone/0.20.x/src/vs/platform/keybinding/common/keybindingsRegistry.ts#L76
+    // https://github.com/theia-ide/vscode/blob/standalone/0.22.x/src/vs/platform/keybinding/common/keybindingsRegistry.ts#L243
     export const KeybindingsRegistry: IKeybindingsRegistry;
 
-    // https://github.com/theia-ide/vscode/blob/standalone/0.20.x/src/vs/base/common/keyCodes.ts#L542
+    // https://github.com/theia-ide/vscode/blob/standalone/0.22.x/src/vs/base/common/keyCodes.ts#L542
     export class ResolvedKeybindingPart {
         readonly ctrlKey: boolean;
         readonly shiftKey: boolean;
@@ -601,7 +628,7 @@ declare module monaco.keybindings {
         constructor(ctrlKey: boolean, shiftKey: boolean, altKey: boolean, metaKey: boolean, kbLabel: string | null, kbAriaLabel: string | null);
     }
 
-    // https://github.com/theia-ide/vscode/blob/standalone/0.20.x/src/vs/base/common/keyCodes.ts#L564
+    // https://github.com/theia-ide/vscode/blob/standalone/0.22.x/src/vs/base/common/keyCodes.ts#L564
     export abstract class ResolvedKeybinding {
         public abstract getLabel(): string | null;
         public abstract getAriaLabel(): string | null;
@@ -613,12 +640,12 @@ declare module monaco.keybindings {
         public abstract getDispatchParts(): (string | null)[];
     }
 
-    // https://github.com/theia-ide/vscode/blob/standalone/0.20.x/src/vs/platform/keybinding/common/usLayoutResolvedKeybinding.ts#L13
+    // https://github.com/theia-ide/vscode/blob/standalone/0.22.x/src/vs/platform/keybinding/common/usLayoutResolvedKeybinding.ts#L13
     export class USLayoutResolvedKeybinding {
         public static getDispatchStr(keybinding: SimpleKeybinding): string | null;
     }
 
-    // https://github.com/theia-ide/vscode/blob/standalone/0.20.x/src/vs/base/common/keybindingLabels.ts#L17
+    // https://github.com/theia-ide/vscode/blob/standalone/0.22.x/src/vs/base/common/keybindingLabels.ts#L17
     export interface Modifiers {
         readonly ctrlKey: boolean;
         readonly shiftKey: boolean;
@@ -626,76 +653,76 @@ declare module monaco.keybindings {
         readonly metaKey: boolean;
     }
 
-    // https://github.com/theia-ide/vscode/blob/standalone/0.20.x/src/vs/base/common/keybindingLabels.ts#L24
+    // https://github.com/theia-ide/vscode/blob/standalone/0.22.x/src/vs/base/common/keybindingLabels.ts#L24
     export interface KeyLabelProvider<T extends Modifiers> {
         (keybinding: T): string | null;
     }
 
-    // https://github.com/theia-ide/vscode/blob/standalone/0.20.x/src/vs/base/common/keybindingLabels.ts#L28
+    // https://github.com/theia-ide/vscode/blob/standalone/0.22.x/src/vs/base/common/keybindingLabels.ts#L28
     export interface ModifierLabelProvider {
         toLabel<T extends Modifiers>(OS: monaco.platform.OperatingSystem, parts: T[], keyLabelProvider: KeyLabelProvider<T>): string | null;
     }
 
-    // https://github.com/theia-ide/vscode/blob/standalone/0.20.x/src/vs/base/common/keybindingLabels.ts#L61
+    // https://github.com/theia-ide/vscode/blob/standalone/0.22.x/src/vs/base/common/keybindingLabels.ts#L61
     export const UILabelProvider: ModifierLabelProvider;
 
-    // https://github.com/theia-ide/vscode/blob/standalone/0.20.x/src/vs/base/common/keybindingLabels.ts#L88
+    // https://github.com/theia-ide/vscode/blob/standalone/0.22.x/src/vs/base/common/keybindingLabels.ts#L88
     export const AriaLabelProvider: ModifierLabelProvider;
 
-    // https://github.com/theia-ide/vscode/blob/standalone/0.20.x/src/vs/base/common/keybindingLabels.ts#L116
+    // https://github.com/theia-ide/vscode/blob/standalone/0.22.x/src/vs/base/common/keybindingLabels.ts#L116
     export const ElectronAcceleratorLabelProvider: ModifierLabelProvider;
 
-    // https://github.com/theia-ide/vscode/blob/standalone/0.20.x/src/vs/base/common/keybindingLabels.ts#L136
+    // https://github.com/theia-ide/vscode/blob/standalone/0.22.x/src/vs/base/common/keybindingLabels.ts#L136
     export const UserSettingsLabelProvider: ModifierLabelProvider;
 
 }
 
 declare module monaco.services {
 
-    // https://github.com/theia-ide/vscode/blob/standalone/0.20.x/src/vs/editor/standalone/browser/standaloneLanguages.ts#L101
+    // https://github.com/theia-ide/vscode/blob/standalone/0.22.x/src/vs/editor/standalone/browser/standaloneLanguages.ts#L107
     export class TokenizationSupport2Adapter implements monaco.modes.ITokenizationSupport {
         constructor(standaloneThemeService: IStandaloneThemeService, languageIdentifier: LanguageIdentifier, actual: monaco.languages.TokensProvider)
         tokenize(line: string, state: monaco.languages.IState, offsetDelta: number): any;
     }
 
-    // https://github.com/theia-ide/vscode/blob/standalone/0.20.x/src/vs/editor/common/services/resolverService.ts#L12
+    // https://github.com/theia-ide/vscode/blob/standalone/0.22.x/src/vs/editor/common/services/resolverService.ts#L12
     export const ITextModelService: any;
 
-    // https://github.com/theia-ide/vscode/blob/standalone/0.20.x/src/vs/platform/opener/common/opener.ts#L13
+    // https://github.com/theia-ide/vscode/blob/standalone/0.22.x/src/vs/platform/opener/common/opener.ts#L15
     export interface OpenInternalOptions {
         readonly openToSide?: boolean;
     }
 
-    // https://github.com/theia-ide/vscode/blob/standalone/0.20.x/src/vs/platform/opener/common/opener.ts#L28
+    // https://github.com/theia-ide/vscode/blob/standalone/0.22.x/src/vs/platform/opener/common/opener.ts#L35
     export interface OpenExternalOptions {
         readonly openExternal?: boolean
     }
 
-    // https://github.com/theia-ide/vscode/blob/standalone/0.20.x/src/vs/platform/opener/common/opener.ts#L38
+    // https://github.com/theia-ide/vscode/blob/standalone/0.22.x/src/vs/platform/opener/common/opener.ts#L49
     export interface IOpener {
         open(resource: monaco.Uri | string, options?: OpenInternalOptions | OpenExternalOptions): Promise<boolean>;
     }
 
-    // https://github.com/theia-ide/vscode/blob/standalone/0.20.x/src/vs/editor/browser/services/openerService.ts#L89
+    // https://github.com/theia-ide/vscode/blob/standalone/0.22.x/src/vs/editor/browser/services/openerService.ts#L94
     export class OpenerService {
         constructor(editorService: monaco.editor.ICodeEditorService, commandService: monaco.commands.ICommandService);
         registerOpener(opener: IOpener): monaco.IDisposable;
         open(resource: monaco.Uri | string, options?: OpenInternalOptions & OpenExternalOptions): Promise<boolean>;
     }
 
-    // https://github.com/theia-ide/vscode/blob/standalone/0.20.x/src/vs/editor/browser/services/codeEditorService.ts#L13
+    // https://github.com/theia-ide/vscode/blob/standalone/0.22.x/src/vs/editor/browser/services/codeEditorService.ts#L14
     export const ICodeEditorService: any;
 
-    // https://github.com/theia-ide/vscode/blob/standalone/0.20.x/src/vs/platform/configuration/common/configuration.ts#L16
+    // https://github.com/theia-ide/vscode/blob/standalone/0.22.x/src/vs/platform/configuration/common/configuration.ts#L16
     export const IConfigurationService: any;
 
-    // https://github.com/theia-ide/vscode/blob/standalone/0.20.x/src/vs/platform/configuration/common/configurationModels.ts#L337
+    // https://github.com/theia-ide/vscode/blob/standalone/0.22.x/src/vs/platform/configuration/common/configurationModels.ts#L377
     export interface Configuration {
         getValue(section: string | undefined, overrides: any, workspace: any | undefined): any;
         toData(): any;
     }
 
-    // https://github.com/theia-ide/vscode/blob/standalone/0.20.x/src/vs/platform/configuration/common/configuration.ts#L30-L37
+    // https://github.com/theia-ide/vscode/blob/standalone/0.22.x/src/vs/platform/configuration/common/configuration.ts#L30-L38
     export const enum ConfigurationTarget {
         USER = 1,
         USER_LOCAL,
@@ -706,13 +733,13 @@ declare module monaco.services {
         MEMORY
     }
 
-    // https://github.com/theia-ide/vscode/blob/standalone/0.20.x/src/vs/platform/configuration/common/configuration.ts#L51
+    // https://github.com/theia-ide/vscode/blob/standalone/0.22.x/src/vs/platform/configuration/common/configuration.ts#L51
     export interface IConfigurationChange {
         keys: string[];
         overrides: [string, string[]][];
     }
 
-    // https://github.com/theia-ide/vscode/blob/b0b47123a5da83d42c2675f2bfff5bb9f1b2673c/src/vs/platform/configuration/common/configuration.ts#L56
+    // https://github.com/theia-ide/vscode/blob/standalone/0.22.x/src/vs/platform/configuration/common/configuration.ts#L56
     export class IConfigurationChangeEvent {
 
         readonly source: ConfigurationTarget;
@@ -722,24 +749,24 @@ declare module monaco.services {
         affectsConfiguration(configuration: string, overrides?: IConfigurationOverrides): boolean;
     }
 
-    // https://github.com/theia-ide/vscode/blob/standalone/0.20.x/src/vs/platform/configuration/common/configuration.ts#L25
+    // https://github.com/theia-ide/vscode/blob/standalone/0.22.x/src/vs/platform/configuration/common/configuration.ts#L25
     export interface IConfigurationOverrides {
         overrideIdentifier?: string | null;
         resource?: monaco.Uri | null;
     }
 
-    // https://github.com/theia-ide/vscode/blob/standalone/0.20.x/src/vs/editor/standalone/browser/simpleServices.ts#L434
+    // https://github.com/theia-ide/vscode/blob/standalone/0.22.x/src/vs/editor/standalone/browser/simpleServices.ts#L435
     export interface IConfigurationService {
         _onDidChangeConfiguration: monaco.Emitter<IConfigurationChangeEvent>;
         _configuration: Configuration;
     }
 
-    // https://github.com/microsoft/vscode/blob/standalone/0.20.x/src/vs/editor/common/services/textResourceConfigurationService.ts#L71
+    // https://github.com/microsoft/vscode/blob/standalone/0.22.x/src/vs/editor/common/services/textResourceConfigurationService.ts#L71
     export interface ITextResourcePropertiesService {
         getEOL(resource: monaco.Uri | undefined, language?: string): string;
     }
 
-    // https://github.com/theia-ide/vscode/blob/standalone/0.20.x/src/vs/editor/browser/services/codeEditorServiceImpl.ts#L58
+    // https://github.com/theia-ide/vscode/blob/standalone/0.22.x/src/vs/editor/browser/services/codeEditorServiceImpl.ts#L84
     export abstract class CodeEditorServiceImpl implements monaco.editor.ICodeEditorService {
         constructor(themeService: IStandaloneThemeService);
         abstract getActiveCodeEditor(): monaco.editor.ICodeEditor | undefined;
@@ -755,7 +782,7 @@ declare module monaco.services {
         getFocusedCodeEditor(): monaco.editor.ICodeEditor | undefined;
     }
 
-    // https://github.com/theia-ide/vscode/blob/standalone/0.20.x/src/vs/editor/standalone/browser/simpleServices.ts#L249
+    // https://github.com/theia-ide/vscode/blob/standalone/0.22.x/src/vs/editor/standalone/browser/simpleServices.ts#L264
     export class StandaloneCommandService implements monaco.commands.ICommandService {
         constructor(instantiationService: monaco.instantiation.IInstantiationService);
         private readonly _onWillExecuteCommand: monaco.Emitter<monaco.commands.ICommandEvent>;
@@ -765,12 +792,12 @@ declare module monaco.services {
         executeCommand(commandId: string, ...args: any[]): Promise<any>;
     }
 
-    // https://github.com/theia-ide/vscode/blob/standalone/0.20.x/src/vs/editor/standalone/browser/standaloneServices.ts#L60
+    // https://github.com/theia-ide/vscode/blob/standalone/0.22.x/src/vs/editor/standalone/browser/standaloneServices.ts#L66
     export class LazyStaticService<T> {
         get(overrides?: monaco.editor.IEditorOverrideServices): T;
     }
 
-    // https://github.com/microsoft/vscode/blob/0eb3a02ca2bcfab5faa3dc6e52d7c079efafcab0/src/vs/platform/theme/common/themeService.ts#L78
+    // https://github.com/theia-ide/vscode/blob/standalone/0.22.x/src/vs/platform/theme/common/themeService.ts#L89
     export interface ITokenStyle {
         readonly foreground?: number;
         readonly bold?: boolean;
@@ -778,55 +805,55 @@ declare module monaco.services {
         readonly italic?: boolean;
     }
 
-    // https://github.com/theia-ide/vscode/blob/standalone/0.20.x/src/vs/editor/standalone/common/standaloneThemeService.ts#L28
+    // https://github.com/theia-ide/vscode/blob/standalone/0.22.x/src/vs/editor/standalone/common/standaloneThemeService.ts#L29
     export interface IStandaloneThemeService extends monaco.theme.IThemeService {
-        // https://github.com/theia-ide/vscode/blob/standalone/0.20.x/src/vs/editor/standalone/browser/standaloneThemeServiceImpl.ts#L178
+        // https://github.com/theia-ide/vscode/blob/standalone/0.22.x/src/vs/editor/standalone/browser/standaloneThemeServiceImpl.ts#L200
         readonly _knownThemes: Map<string, IStandaloneTheme>;
 
         getTheme(): IStandaloneTheme;
     }
 
-    // https://github.com/theia-ide/vscode/blob/standalone/0.20.x/src/vs/editor/standalone/common/standaloneThemeService.ts#L23
+    // https://github.com/theia-ide/vscode/blob/standalone/0.22.x/src/vs/editor/standalone/common/standaloneThemeService.ts#L24
     export interface IStandaloneTheme {
-        // https://github.com/theia-ide/vscode/blob/standalone/0.20.x/src/vs/editor/standalone/browser/standaloneThemeServiceImpl.ts#L31
+        // https://github.com/theia-ide/vscode/blob/standalone/0.22.x/src/vs/editor/standalone/browser/standaloneThemeServiceImpl.ts#L33
         themeData: monaco.editor.IStandaloneThemeData
 
         tokenTheme: TokenTheme;
 
-        // https://github.com/theia-ide/vscode/blob/standalone/0.20.x/src/vs/platform/theme/common/themeService.ts#L98
+        // https://github.com/theia-ide/vscode/blob/standalone/0.22.x/src/vs/platform/theme/common/themeService.ts#L108
         getColor(color: string, useDefault?: boolean): monaco.color.Color | undefined;
 
         getTokenStyleMetadata(type: string, modifiers: string[], modelLanguage: string): ITokenStyle | undefined;
     }
 
-    // https://github.com/theia-ide/vscode/blob/standalone/0.20.x/src/vs/editor/common/modes/supports/tokenization.ts#L188
+    // https://github.com/theia-ide/vscode/blob/standalone/0.22.x/src/vs/editor/common/modes/supports/tokenization.ts#L188
     export interface TokenTheme {
         match(languageId: LanguageId, scope: string): number;
         _match(token: string): any;
         getColorMap(): monaco.color.Color[];
     }
 
-    // https://github.com/theia-ide/vscode/blob/standalone/0.20.x/src/vs/editor/common/modes.ts#L27
+    // https://github.com/theia-ide/vscode/blob/standalone/0.22.x/src/vs/editor/common/modes.ts#L27
     export const enum LanguageId {
         Null = 0,
         PlainText = 1
     }
 
-    // https://github.com/theia-ide/vscode/blob/standalone/0.20.x/src/vs/editor/common/modes.ts#L35
+    // https://github.com/theia-ide/vscode/blob/standalone/0.22.x/src/vs/editor/common/modes.ts#L35
     export class LanguageIdentifier {
         public readonly id: LanguageId;
         readonly language: string;
     }
 
-    // https://github.com/theia-ide/vscode/blob/standalone/0.20.x/src/vs/editor/common/modes.ts#L58
+    // https://github.com/theia-ide/vscode/blob/standalone/0.22.x/src/vs/editor/common/modes.ts#L58
     export interface IMode {
         getId(): string;
         getLanguageIdentifier(): LanguageIdentifier;
     }
 
-    // https://github.com/theia-ide/vscode/blob/standalone/0.20.x/src/vs/editor/common/services/modeService.ts#L30
+    // https://github.com/theia-ide/vscode/blob/standalone/0.22.x/src/vs/editor/common/services/modeService.ts#L30
     export interface IModeService {
-        // https://github.com/theia-ide/vscode/blob/standalone/0.20.x/src/vs/editor/common/services/modeServiceImpl.ts#L46
+        // https://github.com/theia-ide/vscode/blob/standalone/0.22.x/src/vs/editor/common/services/modeServiceImpl.ts#L46
         private readonly _instantiatedModes: { [modeId: string]: IMode; };
         private readonly _onLanguagesMaybeChanged: Emitter<void>;
         readonly onDidCreateMode: monaco.IEvent<IMode>;
@@ -834,17 +861,17 @@ declare module monaco.services {
         getLanguageIdentifier(modeId: string | LanguageId): LanguageIdentifier | null;
     }
 
-    // https://github.com/theia-ide/vscode/blob/standalone/0.20.x/src/vs/editor/common/services/modeService.ts#L25
+    // https://github.com/theia-ide/vscode/blob/standalone/0.22.x/src/vs/editor/common/services/modeService.ts#L25
     export interface ILanguageSelection {
         readonly languageIdentifier: LanguageIdentifier;
     }
 
-    // https://github.com/theia-ide/vscode/blob/standalone/0.20.x/src/vs/platform/instantiation/common/serviceCollection.ts#L9
+    // https://github.com/theia-ide/vscode/blob/standalone/0.22.x/src/vs/platform/instantiation/common/serviceCollection.ts#L9
     export interface ServiceCollection {
         set<T>(id: any, instanceOrDescriptor: T): T;
     }
 
-    // https://github.com/theia-ide/vscode/blob/standalone/0.20.x/src/vs/platform/markers/common/markers.ts#L12
+    // https://github.com/theia-ide/vscode/blob/standalone/0.22.x/src/vs/platform/markers/common/markers.ts#L12
     export interface IMarkerService {
         read(filter?: { owner?: string; resource?: monaco.Uri; severities?: number, take?: number; }): editor.IMarker[];
     }
@@ -855,12 +882,12 @@ declare module monaco.services {
         updateModel(model: monaco.editor.ITextModel, value: string | monaco.editor.ITextBufferFactory): void;
     }
 
-    // https://github.com/microsoft/vscode/blob/standalone/0.20.x/src/vs/editor/common/services/editorWorkerService.ts#L21
+    // https://github.com/microsoft/vscode/blob/standalone/0.22.x/src/vs/editor/common/services/editorWorkerService.ts#L21
     export interface IEditorWorkerService {
         computeMoreMinimalEdits(resource: monaco.Uri, edits: monaco.languages.TextEdit[] | null | undefined): Promise<monaco.languages.TextEdit[] | undefined>;
     }
 
-    // https://github.com/theia-ide/vscode/blob/standalone/0.20.x/src/vs/editor/standalone/browser/standaloneServices.ts#L56
+    // https://github.com/theia-ide/vscode/blob/standalone/0.22.x/src/vs/editor/standalone/browser/standaloneServices.ts#L62
     export module StaticServices {
         export function init(overrides: monaco.editor.IEditorOverrideServices): [ServiceCollection, monaco.instantiation.IInstantiationService];
         export const standaloneThemeService: LazyStaticService<IStandaloneThemeService>;
@@ -876,21 +903,21 @@ declare module monaco.services {
 }
 
 declare module monaco.theme {
-    // https://github.com/theia-ide/vscode/blob/standalone/0.20.x/src/vs/platform/theme/common/themeService.ts#L89
+    // https://github.com/theia-ide/vscode/blob/standalone/0.22.x/src/vs/platform/theme/common/themeService.ts#L96
     export interface ITheme { }
 
-    // https://github.com/theia-ide/vscode/blob/standalone/0.20.x/src/vs/platform/theme/common/themeService.ts#L131
+    // https://github.com/theia-ide/vscode/blob/standalone/0.22.x/src/vs/platform/theme/common/themeService.ts#L146
     export interface IThemeService {
         readonly onThemeChange: monaco.IEvent<ITheme>;
     }
 
-    // https://github.com/theia-ide/vscode/blob/standalone/0.20.x/src/vs/base/common/styler.ts#L10
+    // https://github.com/theia-ide/vscode/blob/standalone/0.22.x/src/vs/base/common/styler.ts#L10
     export interface IThemable { }
 
-    // https://github.com/theia-ide/vscode/blob/standalone/0.20.x/src/vs/platform/theme/common/styler.ts#L166
+    // https://github.com/theia-ide/vscode/blob/standalone/0.22.x/src/vs/platform/theme/common/styler.ts#L170
     export function attachQuickOpenStyler(widget: IThemable, themeService: IThemeService): monaco.IDisposable;
 
-    // https://github.com/theia-ide/vscode/blob/standalone/0.20.x/src/vs/platform/theme/common/themeService.ts#L25
+    // https://github.com/theia-ide/vscode/blob/standalone/0.22.x/src/vs/platform/theme/common/themeService.ts#L38
     export interface ThemeIcon {
         readonly id: string;
     }
@@ -902,7 +929,7 @@ declare module monaco.theme {
 
 declare module monaco.color {
 
-    // https://github.com/theia-ide/vscode/blob/standalone/0.20.x/src/vs/base/common/color.ts#L13
+    // https://github.com/theia-ide/vscode/blob/standalone/0.22.x/src/vs/base/common/color.ts#L13
     export class RGBA {
         readonly r: number;
         readonly g: number;
@@ -912,7 +939,7 @@ declare module monaco.color {
         constructor(r: number, g: number, b: number, a?: number);
     }
 
-    // https://github.com/theia-ide/vscode/blob/standalone/0.20.x/src/vs/base/common/color.ts#L48
+    // https://github.com/theia-ide/vscode/blob/standalone/0.22.x/src/vs/base/common/color.ts#L48
     export class HSLA {
         readonly h: number;
         readonly s: number;
@@ -922,65 +949,65 @@ declare module monaco.color {
         constructor(h: number, s: number, l: number, a: number);
     }
 
-    // https://github.com/theia-ide/vscode/blob/standalone/0.20.x/src/vs/base/common/color.ts#L256
+    // https://github.com/theia-ide/vscode/blob/standalone/0.22.x/src/vs/base/common/color.ts#L256
     export class Color {
         readonly rgba: RGBA;
 
         constructor(arg: RGBA | HSLA);
     }
 
-    // https://github.com/theia-ide/vscode/blob/standalone/0.20.x/src/vs/platform/theme/common/colorRegistry.ts#L20
+    // https://github.com/theia-ide/vscode/blob/standalone/0.22.x/src/vs/platform/theme/common/colorRegistry.ts#L19
     export interface ColorContribution {
         readonly id: string;
     }
 
-    // https://github.com/theia-ide/vscode/blob/standalone/0.20.x/src/vs/platform/theme/common/colorRegistry.ts#L29
+    // https://github.com/theia-ide/vscode/blob/standalone/0.22.x/src/vs/platform/theme/common/colorRegistry.ts#L28
     export type ColorFunction = (theme: monaco.theme.ITheme) => Color | undefined;
 
-    // https://github.com/theia-ide/vscode/blob/standalone/0.20.x/src/vs/platform/theme/common/colorRegistry.ts#L42
+    // https://github.com/theia-ide/vscode/blob/standalone/0.22.x/src/vs/platform/theme/common/colorRegistry.ts#L42
     export type ColorValue = string | Color | ColorFunction;
 
-    // https://github.com/theia-ide/vscode/blob/standalone/0.20.x/src/vs/platform/theme/common/colorRegistry.ts#L33
+    // https://github.com/theia-ide/vscode/blob/standalone/0.22.x/src/vs/platform/theme/common/colorRegistry.ts#L32
     export interface ColorDefaults {
         light?: ColorValue;
         dark?: ColorValue;
         hc?: ColorValue;
     }
 
-    // https://github.com/theia-ide/vscode/blob/standalone/0.20.x/src/vs/platform/theme/common/colorRegistry.ts#L49
+    // https://github.com/theia-ide/vscode/blob/standalone/0.22.x/src/vs/platform/theme/common/colorRegistry.ts#L48
     export interface IColorRegistry {
         getColors(): ColorContribution[];
         registerColor(id: string, defaults: ColorDefaults | undefined, description: string): string;
         deregisterColor(id: string): void;
     }
 
-    // https://github.com/theia-ide/vscode/blob/standalone/0.20.x/src/vs/platform/theme/common/colorRegistry.ts#L173
+    // https://github.com/theia-ide/vscode/blob/standalone/0.22.x/src/vs/platform/theme/common/colorRegistry.ts#L170
     export function getColorRegistry(): IColorRegistry;
-    // https://github.com/theia-ide/vscode/blob/standalone/0.20.x/src/vs/platform/theme/common/colorRegistry.ts#L434
+    // https://github.com/theia-ide/vscode/blob/standalone/0.22.x/src/vs/platform/theme/common/colorRegistry.ts#L471
     export function darken(colorValue: ColorValue, factor: number): ColorFunction;
-    // https://github.com/theia-ide/vscode/blob/standalone/0.20.x/src/vs/platform/theme/common/colorRegistry.ts#L444
+    // https://github.com/theia-ide/vscode/blob/standalone/0.22.x/src/vs/platform/theme/common/colorRegistry.ts#L481
     export function lighten(colorValue: ColorValue, factor: number): ColorFunction;
-    // https://github.com/theia-ide/vscode/blob/standalone/0.20.x/src/vs/platform/theme/common/colorRegistry.ts#L454
+    // https://github.com/theia-ide/vscode/blob/standalone/0.22.x/src/vs/platform/theme/common/colorRegistry.ts#L491
     export function transparent(colorValue: ColorValue, factor: number): ColorFunction;
 }
 
 declare module monaco.referenceSearch {
 
-    // https://github.com/theia-ide/vscode/blob/standalone/0.20.x/src/vs/editor/common/modes.ts#L784
+    // https://github.com/theia-ide/vscode/blob/standalone/0.22.x/src/vs/editor/common/modes.ts#L875
     export interface Location {
         uri: Uri,
         range: IRange
     }
 
-    // https://github.com/theia-ide/vscode/blob/standalone/0.20.x/src/vs/editor/contrib/gotoSymbol/referencesModel.ts#L20
+    // https://github.com/theia-ide/vscode/blob/standalone/0.22.x/src/vs/editor/contrib/gotoSymbol/referencesModel.ts#L22
     export interface OneReference { }
 
-    // https://github.com/theia-ide/vscode/blob/standalone/0.20.x/src/vs/editor/contrib/gotoSymbol/referencesModel.ts#L148
+    // https://github.com/theia-ide/vscode/blob/standalone/0.22.x/src/vs/editor/contrib/gotoSymbol/referencesModel.ts#L142
     export interface ReferencesModel implements IDisposable {
         readonly references: OneReference[]
     }
 
-    // https://github.com/theia-ide/vscode/blob/standalone/0.20.x/src/vs/editor/contrib/gotoSymbol/peek/referencesWidget.ts#L187
+    // https://github.com/theia-ide/vscode/blob/standalone/0.22.x/src/vs/editor/contrib/gotoSymbol/peek/referencesWidget.ts#L193
     export interface ReferenceWidget {
         show(range: IRange): void;
         hide(): void;
@@ -991,13 +1018,13 @@ declare module monaco.referenceSearch {
     }
 
     // it's used as return value for referenceWidget._tree
-    // see https://github.com/theia-ide/vscode/blob/standalone/0.20.x/src/vs/editor/contrib/gotoSymbol/peek/referencesWidget.ts#L198
+    // see https://github.com/theia-ide/vscode/blob/standalone/0.22.x/src/vs/editor/contrib/gotoSymbol/peek/referencesWidget.ts#L204
     export interface ReferenceTree {
         getFocus(): ReferenceTreeElement[]
     }
     export interface ReferenceTreeElement { }
 
-    // https://github.com/theia-ide/vscode/blob/standalone/0.20.x/src/vs/editor/contrib/gotoSymbol/peek/referencesController.ts#L32
+    // https://github.com/theia-ide/vscode/blob/standalone/0.22.x/src/vs/editor/contrib/gotoSymbol/peek/referencesController.ts#L32
     export interface ReferencesController extends IDisposable {
         static readonly ID: string;
         _widget?: ReferenceWidget;
@@ -1012,14 +1039,14 @@ declare module monaco.referenceSearch {
 
 declare module monaco.quickOpen {
 
-    // https://github.com/theia-ide/vscode/blob/standalone/0.20.x/src/vs/base/browser/ui/inputbox/inputBox.ts#L59
+    // https://github.com/theia-ide/vscode/blob/standalone/0.22.x/src/vs/base/browser/ui/inputbox/inputBox.ts#L58
     export interface IMessage {
         content: string;
         formatContent?: boolean; // defaults to false
         type?: 1 /* INFO */ | 2  /* WARNING */ | 3 /* ERROR */;
     }
 
-    // https://github.com/theia-ide/vscode/blob/standalone/0.20.x/src/vs/base/browser/ui/inputbox/inputBox.ts#L91
+    // https://github.com/theia-ide/vscode/blob/standalone/0.22.x/src/vs/base/browser/ui/inputbox/inputBox.ts#L90
     export class InputBox {
         inputElement: HTMLInputElement;
         setPlaceHolder(placeHolder: string): void;
@@ -1027,13 +1054,13 @@ declare module monaco.quickOpen {
         hideMessage(): void;
     }
 
-    // https://github.com/theia-ide/vscode/blob/standalone/0.20.x/src/vs/base/parts/tree/browser/tree.ts#L17
+    // https://github.com/theia-ide/vscode/blob/standalone/0.20.x/src/vs/base/parts/tree/browser/tree.ts#L17 - not found in 0.22.x
     export interface QuickOpenTree {
         onDidChangeFocus: monaco.Event<any>;
         getFocus(): monaco.quickOpen.QuickOpenEntry;
     }
 
-    // https://github.com/theia-ide/vscode/blob/standalone/0.20.x/src/vs/base/parts/quickopen/browser/quickOpenWidget.ts#L96
+    // https://github.com/theia-ide/vscode/blob/standalone/0.20.x/src/vs/base/parts/quickopen/browser/quickOpenWidget.ts#L96 - not found in 0.22.x
     export class QuickOpenWidget implements IDisposable {
         inputBox?: InputBox;
         tree: QuickOpenTree;
@@ -1048,14 +1075,14 @@ declare module monaco.quickOpen {
         hide(reason?: HideReason): void;
     }
 
-    // https://github.com/theia-ide/vscode/blob/standalone/0.20.x/src/vs/base/parts/quickopen/browser/quickOpenWidget.ts#L79
+    // https://github.com/theia-ide/vscode/blob/standalone/0.20.x/src/vs/base/parts/quickopen/browser/quickOpenWidget.ts#L79 - not found in 0.22.x
     export enum HideReason {
         ELEMENT_SELECTED,
         FOCUS_LOST,
         CANCELED
     }
 
-    // https://github.com/theia-ide/vscode/blob/standalone/0.20.x/src/vs/base/parts/quickopen/browser/quickOpenWidget.ts#L28
+    // https://github.com/theia-ide/vscode/blob/standalone/0.20.x/src/vs/base/parts/quickopen/browser/quickOpenWidget.ts#L28 - not found in 0.22.x
     export interface IQuickOpenCallbacks {
         onOk: () => void;
         onCancel: () => void;
@@ -1065,7 +1092,7 @@ declare module monaco.quickOpen {
         onFocusLost?: () => boolean /* veto close */;
     }
 
-    // https://github.com/theia-ide/vscode/blob/standalone/0.20.x/src/vs/base/parts/quickopen/browser/quickOpenWidget.ts#L37
+    // https://github.com/theia-ide/vscode/blob/standalone/0.20.x/src/vs/base/parts/quickopen/browser/quickOpenWidget.ts#L37 - not found in 0.22.x
     export interface IQuickOpenOptions /* extends IQuickOpenStyles */ {
         minItemsToShow?: number;
         maxItemsToShow?: number;
@@ -1075,7 +1102,7 @@ declare module monaco.quickOpen {
         keyboardSupport?: boolean;
     }
 
-    // https://github.com/theia-ide/vscode/blob/standalone/0.20.x/src/vs/base/parts/quickopen/browser/quickOpenWidget.ts#L57
+    // https://github.com/theia-ide/vscode/blob/standalone/0.20.x/src/vs/base/parts/quickopen/browser/quickOpenWidget.ts#L57 - not found in 0.22.x
     export interface IShowOptions {
         quickNavigateConfiguration?: IQuickNavigateConfiguration;
         autoFocus?: IAutoFocus;
@@ -1083,12 +1110,12 @@ declare module monaco.quickOpen {
         value?: string;
     }
 
-    // https://github.com/theia-ide/vscode/blob/standalone/0.20.x/src/vs/base/parts/quickopen/common/quickOpen.ts#L8
+    // https://github.com/theia-ide/vscode/blob/standalone/0.20.x/src/vs/base/parts/quickopen/common/quickOpen.ts#L8 - not found in 0.22.x
     export interface IQuickNavigateConfiguration {
         keybindings: monaco.keybindings.ResolvedKeybinding[];
     }
 
-    // https://github.com/theia-ide/vscode/blob/standalone/0.20.x/src/vs/base/parts/quickopen/common/quickOpen.ts#L12
+    // https://github.com/theia-ide/vscode/blob/standalone/0.20.x/src/vs/base/parts/quickopen/common/quickOpen.ts#L12 - not found in 0.22.x
     export interface IAutoFocus {
 
         /**
@@ -1120,23 +1147,23 @@ declare module monaco.quickOpen {
         autoFocusPrefixMatch?: string;
     }
 
-    // https://github.com/theia-ide/vscode/blob/standalone/0.20.x/src/vs/base/parts/quickopen/common/quickOpen.ts#L43-L47
+    // https://github.com/theia-ide/vscode/blob/standalone/0.20.x/src/vs/base/parts/quickopen/common/quickOpen.ts#L43-L47 - not found in 0.22.x
     export type Mode = 0 /* PREVIEW */ | 1 /* OPEN */ | 2 /* OPEN_IN_BACKGROUND */;
 
-    // https://github.com/theia-ide/vscode/blob/standalone/0.20.x/src/vs/base/parts/quickopen/common/quickOpen.ts#L49
+    // https://github.com/theia-ide/vscode/blob/standalone/0.20.x/src/vs/base/parts/quickopen/common/quickOpen.ts#L49 - not found in 0.22.x
     export interface IEntryRunContext {
         event: any;
         keymods: IKeyMods;
         quickNavigateConfiguration: IQuickNavigateConfiguration | undefined;
     }
 
-    // https://github.com/theia-ide/vscode/blob/standalone/0.20.x/src/vs/base/parts/quickopen/common/quickOpen.ts#L55
+    // https://github.com/theia-ide/vscode/blob/standalone/0.20.x/src/vs/base/parts/quickopen/common/quickOpen.ts#L55 - not found in 0.22.x
     export interface IKeyMods {
         ctrlCmd: boolean;
         alt: boolean;
     }
 
-    // https://github.com/theia-ide/vscode/blob/standalone/0.20.x/src/vs/base/parts/quickopen/common/quickOpen.ts#L60
+    // https://github.com/theia-ide/vscode/blob/standalone/0.20.x/src/vs/base/parts/quickopen/common/quickOpen.ts#L60 - not found in 0.22.x
     export interface IDataSource<T> {
         getId(entry: T): string;
         getLabel(entry: T): string | null;
@@ -1144,7 +1171,7 @@ declare module monaco.quickOpen {
     /**
      * See vs/base/parts/tree/browser/tree.ts - IRenderer
      */
-    // https://github.com/theia-ide/vscode/blob/standalone/0.20.x/src/vs/base/parts/quickopen/common/quickOpen.ts#L68
+    // https://github.com/theia-ide/vscode/blob/standalone/0.20.x/src/vs/base/parts/quickopen/common/quickOpen.ts#L68 - not found in 0.22.x
     export interface IRenderer<T> {
         getHeight(entry: T): number;
         getTemplateId(entry: T): string;
@@ -1153,21 +1180,21 @@ declare module monaco.quickOpen {
         disposeTemplate(templateId: string, templateData: any): void;
     }
 
-    // https://github.com/theia-ide/vscode/blob/standalone/0.20.x/src/vs/base/parts/quickopen/common/quickOpen.ts#L76
+    // https://github.com/theia-ide/vscode/blob/standalone/0.20.x/src/vs/base/parts/quickopen/common/quickOpen.ts#L76 - not found in 0.22.x
     export interface IFilter<T> {
         isVisible(entry: T): boolean;
     }
 
-    // https://github.com/theia-ide/vscode/blob/standalone/0.20.x/src/vs/base/parts/quickopen/common/quickOpen.ts#L80
+    // https://github.com/theia-ide/vscode/blob/standalone/0.20.x/src/vs/base/parts/quickopen/common/quickOpen.ts#L80 - not found in 0.22.x
     export interface IAccessiblityProvider<T> {
         getAriaLabel(entry: T): string;
     }
-    // https://github.com/theia-ide/vscode/blob/standalone/0.20.x/src/vs/base/parts/quickopen/common/quickOpen.ts#L84
+    // https://github.com/theia-ide/vscode/blob/standalone/0.20.x/src/vs/base/parts/quickopen/common/quickOpen.ts#L84 - not found in 0.22.x
     export interface IRunner<T> {
         run(entry: T, mode: Mode, context: IEntryRunContext): boolean;
     }
 
-    // https://github.com/theia-ide/vscode/blob/standalone/0.20.x/src/vs/base/parts/quickopen/common/quickOpen.ts#L88
+    // https://github.com/theia-ide/vscode/blob/standalone/0.20.x/src/vs/base/parts/quickopen/common/quickOpen.ts#L88 - not found in 0.22.x
     export interface IModel<T> {
         entries: T[];
         dataSource: IDataSource<T>;
@@ -1177,13 +1204,13 @@ declare module monaco.quickOpen {
         accessibilityProvider?: IAccessiblityProvider<T>;
     }
 
-    // https://github.com/theia-ide/vscode/blob/standalone/0.20.x/src/vs/base/parts/quickopen/browser/quickOpenModel.ts#L29
+    // https://github.com/theia-ide/vscode/blob/standalone/0.20.x/src/vs/base/parts/quickopen/browser/quickOpenModel.ts#L29 - not found in 0.22.x
     export interface IHighlight {
         start: number;
         end: number;
     }
 
-    // https://github.com/theia-ide/vscode/blob/standalone/0.20.x/src/vs/base/browser/ui/iconLabel/iconLabel.ts#L20
+    // https://github.com/theia-ide/vscode/blob/standalone/0.22.x/src/vs/base/browser/ui/iconLabel/iconLabel.ts#L34
     export interface IIconLabelValueOptions {
         title?: string;
         descriptionTitle?: string;
@@ -1197,7 +1224,7 @@ declare module monaco.quickOpen {
         readonly domId?: string;
     }
 
-    // https://github.com/theia-ide/vscode/blob/standalone/0.20.x/src/vs/base/parts/quickopen/browser/quickOpenModel.ts#L55
+    // https://github.com/theia-ide/vscode/blob/standalone/0.20.x/src/vs/base/parts/quickopen/browser/quickOpenModel.ts#L55 - not found in 0.22.x
     export class QuickOpenEntry {
         constructor(highlights?: IHighlight[]);
         getLabel(): string | undefined;
@@ -1215,7 +1242,7 @@ declare module monaco.quickOpen {
         run(mode: Mode, context: IEntryRunContext): boolean;
     }
 
-    // https://github.com/theia-ide/vscode/blob/standalone/0.20.x/src/vs/base/parts/quickopen/browser/quickOpenModel.ts#L197
+    // https://github.com/theia-ide/vscode/blob/standalone/0.20.x/src/vs/base/parts/quickopen/browser/quickOpenModel.ts#L197 - not found in 0.22.x
     export class QuickOpenEntryGroup extends QuickOpenEntry {
         constructor(entry?: QuickOpenEntry, groupLabel?: string, withBorder?: boolean);
         getGroupLabel(): string | undefined;
@@ -1225,13 +1252,13 @@ declare module monaco.quickOpen {
         getEntry(): QuickOpenEntry | undefined;
     }
 
-    // https://github.com/theia-ide/vscode/blob/standalone/0.20.x/src/vs/base/parts/tree/browser/tree.ts#L571
+    // https://github.com/theia-ide/vscode/blob/standalone/0.20.x/src/vs/base/parts/tree/browser/tree.ts#L571 - not found in 0.22.x
     export interface IActionProvider {
         hasActions(element: any, item: any): boolean;
         getActions(element: any, item: any): ReadonlyArray<monaco.editor.IAction> | null;
     }
 
-    // https://github.com/theia-ide/vscode/blob/standalone/0.20.x/src/vs/base/parts/quickopen/browser/quickOpenModel.ts#L489
+    // https://github.com/theia-ide/vscode/blob/standalone/0.20.x/src/vs/base/parts/quickopen/browser/quickOpenModel.ts#L489 - not found in 0.22.x
     export class QuickOpenModel implements
         IModel<QuickOpenEntry>,
         IDataSource<QuickOpenEntry>,
@@ -1253,63 +1280,63 @@ declare module monaco.quickOpen {
         run(entry: QuickOpenEntry, mode: Mode, context: IEntryRunContext): boolean;
     }
 
-    // https://github.com/theia-ide/vscode/blob/standalone/0.20.x/src/vs/editor/standalone/browser/quickOpen/editorQuickOpen.ts#L19
+    // https://github.com/theia-ide/vscode/blob/standalone/0.20.x/src/vs/editor/standalone/browser/quickOpen/editorQuickOpen.ts#L19 - not found in 0.22.x
     export interface IQuickOpenControllerOpts {
         readonly inputAriaLabel: string;
         getModel(lookFor: string): QuickOpenModel;
         getAutoFocus(lookFor: string): IAutoFocus;
     }
 
-    // https://github.com/theia-ide/vscode/blob/standalone/0.20.x/src/vs/editor/standalone/browser/quickOpen/editorQuickOpen.ts#L25
+    // https://github.com/theia-ide/vscode/blob/standalone/0.20.x/src/vs/editor/standalone/browser/quickOpen/editorQuickOpen.ts#L25 - not found in 0.22.x
     export interface QuickOpenController extends IDisposable {
         static readonly ID: string;
         dispose(): void;
         run(opts: IQuickOpenControllerOpts): void;
 
-        // https://github.com/theia-ide/vscode/blob/standalone/0.20.x/src/vs/editor/standalone/browser/quickOpen/editorQuickOpen.ts#L169
+        // https://github.com/theia-ide/vscode/blob/standalone/0.20.x/src/vs/editor/standalone/browser/quickOpen/editorQuickOpen.ts#L169 - not found in 0.22.x
         clearDecorations(): void;
     }
 }
 
 declare module monaco.filters {
-    // https://github.com/theia-ide/vscode/blob/standalone/0.20.x/src/vs/base/common/filters.ts#L15
+    // https://github.com/theia-ide/vscode/blob/standalone/0.22.x/src/vs/base/common/filters.ts#L15
     export interface IMatch {
         start: number;
         end: number;
     }
 
-    // https://github.com/theia-ide/vscode/blob/standalone/0.20.x/src/vs/base/common/filters.ts#L337
+    // https://github.com/theia-ide/vscode/blob/standalone/0.22.x/src/vs/base/common/filters.ts#L337
     export function matchesFuzzy(word: string, wordToMatchAgainst: string, enableSeparateSubstringMatching?: boolean): IMatch[] | undefined;
 }
 
 declare module monaco.editorExtensions {
 
-    // https://github.com/theia-ide/vscode/blob/standalone/0.20.x/src/vs/editor/browser/editorExtensions.ts#L141
+    // https://github.com/theia-ide/vscode/blob/standalone/0.22.x/src/vs/editor/browser/editorExtensions.ts#L215
     export abstract class EditorCommand {
     }
 
-    // https://github.com/theia-ide/vscode/blob/standalone/0.20.x/src/vs/editor/browser/editorExtensions.ts#L205
+    // https://github.com/theia-ide/vscode/blob/standalone/0.22.x/src/vs/editor/browser/editorExtensions.ts#L279
     export abstract class EditorAction extends EditorCommand {
         id: string;
         label: string;
     }
 
     export module EditorExtensionsRegistry {
-        // https://github.com/theia-ide/vscode/blob/standalone/0.20.x/src/vs/editor/browser/editorExtensions.ts#L395
+        // https://github.com/theia-ide/vscode/blob/standalone/0.22.x/src/vs/editor/browser/editorExtensions.ts#L499
         export function getEditorActions(): EditorAction[];
 
-        // https://github.com/theia-ide/vscode/blob/standalone/0.20.x/src/vs/editor/browser/editorExtensions.ts#L391
+        // https://github.com/theia-ide/vscode/blob/standalone/0.22.x/src/vs/editor/browser/editorExtensions.ts#L495
         export function getEditorCommand(commandId: string): EditorCommand | undefined;
     }
 }
 declare module monaco.modes {
 
-    // https://github.com/theia-ide/vscode/blob/standalone/0.20.x/src/vs/editor/common/modes.ts#L209
+    // https://github.com/theia-ide/vscode/blob/standalone/0.22.x/src/vs/editor/common/modes.ts#L209
     export interface ITokenizationSupport {
         tokenize(line: string, state: monaco.languages.IState, offsetDelta: number): any;
     }
 
-    // https://github.com/theia-ide/vscode/blob/standalone/0.20.x/src/vs/editor/common/modes.ts#L1692
+    // https://github.com/theia-ide/vscode/blob/standalone/0.22.x/src/vs/editor/common/modes.ts#L1846
     export interface TokenizationRegistry {
         get(language: string): ITokenizationSupport | null;
         getColorMap(): monaco.color.Color[] | null;
@@ -1317,7 +1344,7 @@ declare module monaco.modes {
     }
     export const TokenizationRegistry: TokenizationRegistry;
 
-    // https://github.com/microsoft/vscode/blob/0eb3a02ca2bcfab5faa3dc6e52d7c079efafcab0/src/vs/editor/common/modes.ts#L66-L76
+    // https://github.com/theia-ide/vscode/blob/standalone/0.22.x/src/vs/editor/common/modes.ts#L70
     export const enum FontStyle {
         NotSet = -1,
         None = 0,
@@ -1326,7 +1353,7 @@ declare module monaco.modes {
         Underline = 4
     }
 
-    // https://github.com/theia-ide/vscode/blob/standalone/0.20.x/src/vs/editor/common/modes.ts#L148
+    // https://github.com/theia-ide/vscode/blob/standalone/0.22.x/src/vs/editor/common/modes.ts#L148
     export class TokenMetadata {
 
         public static getLanguageId(metadata: number): number;
@@ -1342,13 +1369,13 @@ declare module monaco.modes {
         public static getInlineStyleFromMetadata(metadata: number, colorMap: string[]): string;
     }
 
-    // https://github.com/theia-ide/vscode/blob/standalone/0.20.x/src/vs/base/common/glob.ts#L18
+    // https://github.com/theia-ide/vscode/blob/standalone/0.22.x/src/vs/base/common/glob.ts#L17
     export interface IRelativePattern {
         base: string;
         pattern: string;
     }
 
-    // https://github.com/theia-ide/vscode/blob/standalone/0.20.x/src/vs/editor/common/modes/languageSelector.ts#L9
+    // https://github.com/theia-ide/vscode/blob/standalone/0.22.x/src/vs/editor/common/modes/languageSelector.ts#L10
     export interface LanguageFilter {
         language?: string;
         scheme?: string;
@@ -1360,10 +1387,10 @@ declare module monaco.modes {
         exclusive?: boolean;
     }
 
-    // https://github.com/theia-ide/vscode/blob/standalone/0.20.x/src/vs/editor/common/modes/languageSelector.ts#L20
+    // https://github.com/theia-ide/vscode/blob/standalone/0.22.x/src/vs/editor/common/modes/languageSelector.ts#L21
     export type LanguageSelector = string | LanguageFilter | Array<string | LanguageFilter>;
 
-    // https://github.com/theia-ide/vscode/blob/standalone/0.20.x/src/vs/editor/common/modes/languageFeatureRegistry.ts#L29
+    // https://github.com/theia-ide/vscode/blob/standalone/0.22.x/src/vs/editor/common/modes/languageFeatureRegistry.ts#L32
     export interface LanguageFeatureRegistry<T> {
         has(model: monaco.editor.ITextModel): boolean;
         all(model: monaco.editor.ITextModel): T[];
@@ -1371,46 +1398,46 @@ declare module monaco.modes {
         readonly onDidChange: monaco.IEvent<number>;
     }
 
-    // https://github.com/theia-ide/vscode/blob/standalone/0.20.x/src/vs/editor/common/modes.ts#L1599
+    // https://github.com/theia-ide/vscode/blob/standalone/0.22.x/src/vs/editor/common/modes.ts#L1743
     export const DocumentSymbolProviderRegistry: LanguageFeatureRegistry<monaco.languages.DocumentSymbolProvider>;
 
-    // https://github.com/theia-ide/vscode/blob/standalone/0.20.x/src/vs/editor/common/modes.ts#L1584
+    // https://github.com/theia-ide/vscode/blob/standalone/0.22.x/src/vs/editor/common/modes.ts#L1723
     export const CompletionProviderRegistry: LanguageFeatureRegistry<monaco.languages.CompletionItemProvider>;
 
-    // https://github.com/theia-ide/vscode/blob/standalone/0.20.x/src/vs/editor/common/modes.ts#L1634
+    // https://github.com/theia-ide/vscode/blob/standalone/0.22.x/src/vs/editor/common/modes.ts#L1788
     export const CodeActionProviderRegistry: LanguageFeatureRegistry<monaco.languages.CodeActionProvider & { providedCodeActionKinds?: string[] }>;
 }
 
 declare module monaco.suggest {
 
-    // https://github.com/theia-ide/vscode/blob/standalone/0.20.x/src/vs/editor/contrib/suggest/suggest.ts#L115
+    // https://github.com/theia-ide/vscode/blob/standalone/0.22.x/src/vs/editor/contrib/suggest/suggest.ts#L145
     export const enum SnippetSortOrder {
         Top, Inline, Bottom
     }
 
-    // https://github.com/theia-ide/vscode/blob/standalone/0.20.x/src/vs/editor/contrib/suggest/suggestController.ts#L97
+    // https://github.com/theia-ide/vscode/blob/standalone/0.22.x/src/vs/editor/contrib/suggest/suggestController.ts#L99
     export interface SuggestController {
         readonly widget: {
             getValue(): SuggestWidget
         }
     }
 
-    // https://github.com/theia-ide/vscode/blob/standalone/0.20.x/src/vs/editor/contrib/suggest/suggestWidget.ts#L462
+    // https://github.com/theia-ide/vscode/blob/standalone/0.22.x/src/vs/editor/contrib/suggest/suggestWidget.ts#L634
     export interface SuggestWidget {
         getFocusedItem(): ISelectedSuggestion | undefined;
     }
 
-    // https://github.com/theia-ide/vscode/blob/standalone/0.20.x/src/vs/editor/contrib/suggest/suggestWidget.ts#L456
+    // https://github.com/theia-ide/vscode/blob/standalone/0.22.x/src/vs/editor/contrib/suggest/suggestWidget.ts#L55
     export interface ISelectedSuggestion {
         item: CompletionItem;
     }
 
-    // https://github.com/theia-ide/vscode/blob/standalone/0.20.x/src/vs/editor/contrib/suggest/suggest.ts#L28
+    // https://github.com/theia-ide/vscode/blob/standalone/0.22.x/src/vs/editor/contrib/suggest/suggest.ts#L38
     export interface CompletionItem {
         completion: monaco.languages.CompletionItem;
     }
 
-    // https://github.com/theia-ide/vscode/blob/standalone/0.20.x/src/vs/editor/contrib/suggest/suggest.ts#L119
+    // https://github.com/theia-ide/vscode/blob/standalone/0.22.x/src/vs/editor/contrib/suggest/suggest.ts#L149
     export class CompletionOptions {
 
         constructor(
@@ -1421,7 +1448,7 @@ declare module monaco.suggest {
 
     }
 
-    // https://github.com/theia-ide/vscode/blob/standalone/0.20.x/src/vs/editor/contrib/suggest/suggest.ts#L142
+    // https://github.com/theia-ide/vscode/blob/standalone/0.22.x/src/vs/editor/contrib/suggest/suggest.ts#L192
     export function provideSuggestionItems(
         model: monaco.editor.ITextModel,
         position: Position,
@@ -1430,12 +1457,12 @@ declare module monaco.suggest {
         token?: monaco.CancellationToken
     ): Promise<CompletionItem[]>;
 
-    // https://github.com/theia-ide/vscode/blob/standalone/0.20.x/src/vs/editor/contrib/suggest/suggest.ts#L136
+    // https://github.com/theia-ide/vscode/blob/standalone/0.22.x/src/vs/editor/contrib/suggest/suggest.ts#L166
     export function setSnippetSuggestSupport(support: monaco.languages.CompletionItemProvider): monaco.languages.CompletionItemProvider;
 }
 
 declare module monaco.snippetParser {
-    // https://github.com/theia-ide/vscode/blob/standalone/0.20.x/src/vs/editor/contrib/snippet/snippetParser.ts#L583
+    // https://github.com/theia-ide/vscode/blob/standalone/0.22.x/src/vs/editor/contrib/snippet/snippetParser.ts#L583
     export class SnippetParser {
         parse(value: string): TextmateSnippet;
     }
@@ -1445,16 +1472,16 @@ declare module monaco.snippetParser {
 
 declare module monaco.contextKeyService {
 
-    // https://github.com/theia-ide/vscode/blob/standalone/0.20.x/src/vs/platform/contextkey/common/contextkey.ts#L803
+    // https://github.com/theia-ide/vscode/blob/standalone/0.22.x/src/vs/platform/contextkey/common/contextkey.ts#L1294
     export interface IContextKey<T> {
         set(value: T): void;
         reset(): void;
         get(): T | undefined;
     }
 
-    // https://github.com/theia-ide/vscode/blob/standalone/0.20.x/src/vs/platform/contextkey/common/contextkey.ts#L827
+    // https://github.com/theia-ide/vscode/blob/standalone/0.22.x/src/vs/platform/contextkey/common/contextkey.ts#L1318
     export interface IContextKeyService {
-        // vs code has another object as argument https://github.com/theia-ide/vscode/blob/standalone/0.20.x/src/vs/platform/contextkey/common/contextkey.ts#L809
+        // vs code has another object as argument https://github.com/theia-ide/vscode/blob/standalone/0.22.x/src/vs/platform/contextkey/common/contextkey.ts#L1329
         // which contains restcicted number of HTMLElement methods
         createScoped(target?: HTMLElement): IContextKeyService;
         getContext(target?: HTMLElement): IContext;
@@ -1463,17 +1490,17 @@ declare module monaco.contextKeyService {
         onDidChangeContext: monaco.IEvent<IContextKeyChangeEvent>;
     }
 
-    // https://github.com/theia-ide/vscode/blob/standalone/0.20.x/src/vs/platform/contextkey/common/contextkey.ts#L799
+    // https://github.com/theia-ide/vscode/blob/standalone/0.22.x/src/vs/platform/contextkey/common/contextkey.ts#L1290
     export interface IContext {
         getValue<T>(key: string): T | undefined;
     }
 
-    // https://github.com/theia-ide/vscode/blob/standalone/0.20.x/src/vs/platform/contextkey/common/contextkey.ts#L823
+    // https://github.com/theia-ide/vscode/blob/standalone/0.22.x/src/vs/platform/contextkey/common/contextkey.ts#L1314
     export interface IContextKeyChangeEvent {
         affectsSome(keys: Set<string>): boolean;
     }
 
-    // https://github.com/theia-ide/vscode/blob/standalone/0.20.x/src/vs/platform/contextkey/browser/contextKeyService.ts#L321
+    // https://github.com/theia-ide/vscode/blob/standalone/0.22.x/src/vs/platform/contextkey/browser/contextKeyService.ts#L344
     export class ContextKeyService implements IContextKeyService {
         constructor(configurationService: monaco.services.IConfigurationService);
         createScoped(target?: HTMLElement): IContextKeyService;
@@ -1486,10 +1513,10 @@ declare module monaco.contextKeyService {
 
 declare module monaco.contextkey {
 
-    // https://github.com/theia-ide/vscode/blob/standalone/0.20.x/src/vs/platform/contextkey/common/contextkey.ts#L817
+    // https://github.com/theia-ide/vscode/blob/standalone/0.22.x/src/vs/platform/contextkey/common/contextkey.ts#L1308
     export const IContextKeyService: any;
 
-    // https://github.com/theia-ide/vscode/blob/standalone/0.20.x/src/vs/platform/contextkey/common/contextkey.ts#L29
+    // https://github.com/theia-ide/vscode/blob/standalone/0.22.x/src/vs/platform/contextkey/common/contextkey.ts#L79
     export class ContextKeyExpr {
         keys(): string[];
         static deserialize(when: string): ContextKeyExpr;
@@ -1499,7 +1526,7 @@ declare module monaco.contextkey {
 
 declare module monaco.mime {
 
-    // https://github.com/theia-ide/vscode/blob/standalone/0.20.x/src/vs/base/common/mime.ts#L18
+    // https://github.com/theia-ide/vscode/blob/standalone/0.22.x/src/vs/base/common/mime.ts#L17
     export interface ITextMimeAssociation {
         readonly id: string;
         readonly mime: string;
@@ -1510,30 +1537,30 @@ declare module monaco.mime {
         readonly userConfigured?: boolean;
     }
 
-    // https://github.com/theia-ide/vscode/blob/standalone/0.20.x/src/vs/base/common/mime.ts#L42
+    // https://github.com/theia-ide/vscode/blob/standalone/0.22.x/src/vs/base/common/mime.ts#L41
     export function registerTextMime(association: monaco.mime.ITextMimeAssociation, warnOnOverwrite: boolean): void;
 
-    // https://github.com/theia-ide/vscode/blob/standalone/0.20.x/src/vs/base/common/mime.ts#L98
+    // https://github.com/theia-ide/vscode/blob/standalone/0.22.x/src/vs/base/common/mime.ts#L97
     export function clearTextMimes(onlyUserConfigured?: boolean): void;
 }
 
 declare module monaco.error {
-    // https://github.com/theia-ide/vscode/blob/standalone/0.20.x/src/vs/base/common/errors.ts#L77
+    // https://github.com/theia-ide/vscode/blob/standalone/0.22.x/src/vs/base/common/errors.ts#L77
     export function onUnexpectedError(e: any): undefined;
 }
 
 declare module monaco.path {
-    // https://github.com/microsoft/vscode/blob/320fbada86c113835aef4fb9d7c4bc5b74678166/src/vs/base/common/path.ts#L1494
+    // https://github.com/theia-ide/vscode/blob/standalone/0.22.x/src/vs/base/common/path.ts#L1494
     export function normalize(uriPath: string): string;
 }
 
 declare module monaco.wordHelper {
-    // https://github.com/theia-ide/vscode/blob/standalone/0.19.x/src/vs/editor/common/model/wordHelper.ts#L30
+    // https://github.com/theia-ide/vscode/blob/standalone/0.22.x/src/vs/editor/common/model/wordHelper.ts#L30
     export const DEFAULT_WORD_REGEXP: RegExp;
 }
 
 declare module monaco.strings {
-    // https://github.com/theia-ide/vscode/blob/standalone/0.19.x/src/vs/base/common/strings.ts#L150
+    // https://github.com/theia-ide/vscode/blob/standalone/0.19.x/src/vs/base/common/strings.ts#L384
     export function startsWith(haystack: string, needle: string): boolean;
 
     // https://github.com/theia-ide/vscode/blob/standalone/0.19.x/src/vs/base/common/strings.ts#L171
@@ -1551,7 +1578,7 @@ declare module monaco.async {
 /**
  * overloading languages register functions to accept LanguageSelector,
  * check that all register functions passing a selector to registries:
- * https://github.com/theia-ide/vscode/blob/standalone/0.20.x/src/vs/editor/standalone/browser/standaloneLanguages.ts#L338-L511
+ * https://github.com/theia-ide/vscode/blob/standalone/0.22.x/src/vs/editor/standalone/browser/standaloneLanguages.ts#L368-L546
  */
 declare module monaco.languages {
     export function registerReferenceProvider(selector: monaco.modes.LanguageSelector, provider: ReferenceProvider): IDisposable;


### PR DESCRIPTION
In preparation for upgrading `monaco-editor-core` to `standalone/0.22.x` these changes were implemented:
1) signatures alignment to `standalone/0.22.x`
2) editor preferences synced with `standalone/0.22.x`

Signed-off-by: Dan Arad <dan.arad@sap.com>

#### What it does
This PR updates Theia repo with these changes:
1) signatures alignment to `standalone/0.22.x`
2) editor preferences synced with `standalone/0.22.x`

It is also second part of 8969 where first part is generating `monaco-editor-core@0.22`.
 
#### How to test
1) `How to test` section for the previous PR #8010.
2) Integration tests in: #7265.

#### Review checklist

- [X] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

