### PR TITLE
Store keybindings properly in keymaps.json and improve conflict checking

### DIFF
--- a/packages/core/src/browser/keybinding.ts
+++ b/packages/core/src/browser/keybinding.ts
@@ -278,7 +278,7 @@ export class KeybindingRegistry {
      */
     containsKeybindingInScope(binding: common.Keybinding, scope = KeybindingScope.USER): boolean {
         const bindingKeySequence = this.resolveKeybinding(binding);
-        const collisions = this.getKeySequenceCollisions(this.keymaps[scope], bindingKeySequence)
+        const collisions = this.getKeySequenceCollisions(this.getUsableBindings(this.keymaps[scope]), bindingKeySequence)
             .filter(b => b.context === binding.context && !b.when && !binding.when);
         if (collisions.full.length > 0) {
             return true;
@@ -564,7 +564,7 @@ export class KeybindingRegistry {
                 return false;
             }
             const { command, context, when, keybinding } = binding;
-            if (binding.command.charAt(0) === '-') {
+            if (!this.isUsable(binding)) {
                 disabled = disabled || new Set<string>();
                 disabled.add(JSON.stringify({ command: command.substr(1), context, when, keybinding }));
                 return false;
@@ -585,6 +585,22 @@ export class KeybindingRegistry {
             }
         }
         return undefined;
+    }
+
+    /**
+     * Returns true if the binding is usable
+     * @param binding Binding to be checked
+     */
+    protected isUsable(binding: common.Keybinding): boolean {
+        return binding.command.charAt(0) !== '-';
+    }
+
+    /**
+     * Return a new filtered array containing only the usable bindings among the input bindings
+     * @param bindings Bindings to filter
+     */
+    protected getUsableBindings<T extends common.Keybinding>(bindings: T[]): T[] {
+        return bindings.filter(binding => this.isUsable(binding));
     }
 
     /**

--- a/packages/core/src/common/keybinding.ts
+++ b/packages/core/src/common/keybinding.ts
@@ -51,6 +51,22 @@ export interface Keybinding {
 export namespace Keybinding {
 
     /**
+     * Returns a new object only containing properties which
+     * are described on the `Keybinding` API.
+     *
+     * @param binding the binding to create an API object for.
+     */
+    export function apiObjectify(binding: Keybinding): Keybinding {
+        return {
+            command: binding.command,
+            keybinding: binding.keybinding,
+            context: binding.context,
+            when: binding.when,
+            args: binding.args
+        };
+    }
+
+    /**
      * Returns with the string representation of the binding.
      * Any additional properties which are not described on
      * the `Keybinding` API will be ignored.
@@ -58,14 +74,7 @@ export namespace Keybinding {
      * @param binding the binding to stringify.
      */
     export function stringify(binding: Keybinding): string {
-        const copy: Keybinding = {
-            command: binding.command,
-            keybinding: binding.keybinding,
-            context: binding.context,
-            when: binding.when,
-            args: binding.args
-        };
-        return JSON.stringify(copy);
+        return JSON.stringify(apiObjectify(binding));
     }
 
     /* Determine whether object is a KeyBinding */

--- a/packages/core/src/common/keybinding.ts
+++ b/packages/core/src/common/keybinding.ts
@@ -51,6 +51,25 @@ export interface Keybinding {
 export namespace Keybinding {
 
     /**
+     * Compares two keybindings for equality.
+     * Can optionally ignore the keybinding and/or args property in the comparison.
+     * @param a The first Keybinding in the comparison
+     * @param b The second Keybinding in the comparison
+     * @param ignoreKeybinding Ignore the 'keybinding' property in the comparison
+     * @param ignoreArgs Ignore the 'args' property in the comparison
+     */
+    export function equals(a: Keybinding, b: Keybinding, ignoreKeybinding: boolean = false, ignoreArgs: boolean = false): boolean {
+        if (a.command === b.command &&
+            (a.context || '') === (b.context || '') &&
+            (a.when || '') === (b.when || '') &&
+            (ignoreKeybinding || a.keybinding === b.keybinding) &&
+            (ignoreArgs || (a.args || '') === (b.args || ''))) {
+            return true;
+        }
+        return false;
+    }
+
+    /**
      * Returns a new object only containing properties which
      * are described on the `Keybinding` API.
      *

--- a/packages/keymaps/src/browser/keymaps-service.ts
+++ b/packages/keymaps/src/browser/keymaps-service.ts
@@ -189,7 +189,7 @@ export class KeymapsService {
                 const textModel = model.textEditorModel;
                 const { insertSpaces, tabSize, defaultEOL } = textModel.getOptions();
                 const editOperations: monaco.editor.IIdentifiedSingleEditOperation[] = [];
-                for (const edit of jsoncparser.modify(content, [], keybindings, {
+                for (const edit of jsoncparser.modify(content, [], keybindings.map(binding => Keybinding.apiObjectify(binding)), {
                     formattingOptions: {
                         insertSpaces,
                         tabSize,


### PR DESCRIPTION
Fixes issue #9087
Fixes issue #9094

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->
* Make sure that we only store API relevant information in the keymaps.json to avoid issues when re-creating the bindings from the keymaps.json #9087 #9094
* Make sure disablements for keymappings are only stored once in keymaps.json. #9094
* Only check conflicting keybindings against usable keybindings. #9094

Contributed by STMicroelectronics

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
Change some shortcuts (at least 2), observe that no "resolved" properties are stored in the keymaps.
Also, follow steps in #9094.

For example, without this patch keymaps.json might contain:
```
  {
    "command": "textEditor.commands.go.lastEdit",
    "keybinding": "ctrl+alt+left",
    "resolved": [
      {
        "key": {
          "code": "ArrowLeft",
          "keyCode": 37,
          "easyString": "left"
        },
        "ctrl": true,
        "shift": false,
        "alt": true,
        "meta": false
      }
    ],
    "scope": 1
  },
```

With this patch, keymaps.json will contain instead:
```
  {
    "command": "textEditor.commands.go.lastEdit",
    "keybinding": "ctrl+alt+left"
  },
```

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

