### PR TITLE
Fix border for search-in-workspace replace items

### DIFF
--- a/packages/search-in-workspace/src/browser/styles/index.css
+++ b/packages/search-in-workspace/src/browser/styles/index.css
@@ -244,7 +244,7 @@
 
 .t-siw-search-container .resultLine .replace-term {
     background: var(--theia-diffEditor-insertedTextBackground);
-    border: 1p solid var(--theia-diffEditor-insertedTextBorder);
+    border: 1px solid var(--theia-diffEditor-insertedTextBorder);
 }
 .theia-hc
 .t-siw-search-container .resultLine .replace-term {


### PR DESCRIPTION

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->
Fixes border for replaced items in the Search-in-workspace feature.

Contributed by STMicroelectronics
Signed-off-by: Samuel HULTGREN <samuel.hultgren@st.com>

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
1, Change to high-contrast dark theme
2, Search in workspace with a replace term
3, Observe that the border is green with the patch, white without the patch.

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

