### PR TITLE
Only execute file open command during drag-and-drop for dragged files

### DIFF
--- a/packages/navigator/src/browser/navigator-widget.tsx
+++ b/packages/navigator/src/browser/navigator-widget.tsx
@@ -107,7 +107,9 @@ export class FileNavigatorWidget extends FileTreeWidget {
                     this.model.toggleNode(treeNode);
                 }
             });
-            this.commandService.executeCommand(FileNavigatorCommands.OPEN.id);
+            if (treeNodes.length > 0) {
+                this.commandService.executeCommand(FileNavigatorCommands.OPEN.id);
+            }
         });
         const handler = (e: DragEvent) => {
             if (e.dataTransfer) {


### PR DESCRIPTION
#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

Fix for DnD files to main area #8739

Solves issue introduced in f840f60fb2f44aad4aa7c69627e499f80057d056

Contributed by STMicroelectronics
Signed-off-by: Samuel HULTGREN <samuel.hultgren@st.com>

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->


#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
1, Select text in the "Problems" view, drag into the main area
2, Observe crash in the developer console without the patch:
```
command.ts:298 Uncaught (in promise) Error: The command 'navigator.open' cannot be executed. There are no active handlers available for the command.
    at CommandRegistry.<anonymous> (command.ts:298)
    at step (command.ts:15)
    at Object.next (command.ts:15)
    at command.ts:15
    at new Promise (<anonymous>)
    at ../../packages/core/lib/common/command.js.__awaiter (command.ts:15)
    at CommandRegistry.../../packages/core/lib/common/command.js.CommandRegistry.executeCommand (command.ts:290)
    at FileNavigatorWidget.<anonymous> (navigator-widget.tsx:110)
    at step (navigator-widget.tsx:15)
    at Object.next (navigator-widget.tsx:15)
```

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

