### PR TITLE
8890-dracula-at-night-theme-failure

### DIFF
--- a/packages/monaco/src/browser/monaco-theming-service.ts
+++ b/packages/monaco/src/browser/monaco-theming-service.ts
@@ -118,6 +118,7 @@ export class MonacoThemingService {
                 return;
             }
         }
+        this.cleanEmpty(json.colors);
         return json;
     }
 
@@ -202,4 +203,12 @@ export class MonacoThemingService {
         return str;
     }
 
+    private cleanEmpty(obj: any): void {
+        for (const key in obj) {
+            // eslint-disable-next-line no-null/no-null
+            if ([null, undefined].includes(obj[key])) {
+                delete obj[key];
+            }
+        }
+    }
 }


### PR DESCRIPTION
Theme Dracula-at-night fails when registering it in Theia because theme colors contain null properties.
Fix: removed null and undefined color props from theme colors upon registration.

Signed-off-by: Dan Arad <dan.arad@sap.com>

#### What it does
Fixes: #8890

#### How to test
1.Install Dracula-at-night theme
2. check console - no relevant errors should be displayed and theme works

#### Review checklist

- [X] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

