### PR TITLE
bulk-edit: fix spelling mistake in border value

### DIFF
--- a/packages/bulk-edit/src/browser/style/bulk-edit.css
+++ b/packages/bulk-edit/src/browser/style/bulk-edit.css
@@ -62,5 +62,5 @@
 
 .theia-bulk-edit-container .bulkEditNode .message .inserted-text {
   background: var(--theia-diffEditor-insertedTextBackground);
-  border: 1p solid var(--theia-diffEditor-insertedTextBorder);
+  border: 1px solid var(--theia-diffEditor-insertedTextBorder);
 }


### PR DESCRIPTION
#### What it does

Fixes: #9216 
Fixed bulk-edit extension's spelling mistake in border value

#### How to test
Spelling mistake changes only

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

Signed-off-by: zhaomenghuan zhaomenghuan02@meituan.com

