### PR TITLE
Fix tab bar alignment and styling issues

### DIFF
--- a/packages/core/src/browser/shell/tab-bars.ts
+++ b/packages/core/src/browser/shell/tab-bars.ts
@@ -241,9 +241,9 @@ export class TabBarRenderer extends TabBar.Renderer {
             return h.div({});
         }
         const limitedBadge = totalBadge >= 100 ? '99+' : totalBadge;
-        return isInSidePanel
-            ? h.div({ className: 'theia-badge-decorator-sidebar' }, `${limitedBadge}`)
-            : h.div({ className: 'theia-badge-decorator-horizontal' }, `${limitedBadge}`);
+        const location = isInSidePanel ? 'sidebar' : 'horizontal';
+        return h.div({ className: `theia-badge-decorator-${location} notification-count-container` },
+            h.span({ className: 'notification-count' }, `${limitedBadge}`));
     }
 
     protected readonly decorations = new Map<Title<Widget>, WidgetDecoration.Data[]>();

--- a/packages/core/src/browser/style/notification.css
+++ b/packages/core/src/browser/style/notification.css
@@ -16,7 +16,6 @@
 
 :root {
     --theia-notification-count-height: 15.5px;
-    --theia-notification-count-width: 15.5px;
 }
 
 .notification-count-container {

--- a/packages/core/src/browser/style/sidepanel.css
+++ b/packages/core/src/browser/style/sidepanel.css
@@ -20,14 +20,12 @@
 
 :root {
   --theia-private-sidebar-tab-width: 48px;
-  --theia-private-sidebar-tab-height: 32px;
   --theia-private-sidebar-tab-padding-top-and-bottom: 11px;
   --theia-private-sidebar-tab-padding-left-and-right: 10px;
   --theia-private-sidebar-scrollbar-rail-width: 7px;
   --theia-private-sidebar-scrollbar-width: 5px;
   --theia-private-sidebar-icon-size: 24px;
 }
-
 
 /*-----------------------------------------------------------------------------
 | SideBars (left and right)
@@ -56,51 +54,52 @@
   flex-direction: column;
   justify-content: center;
   align-items: center;
-  min-height: var(--theia-private-sidebar-tab-height);
   cursor: pointer;
 }
 
 .p-TabBar.theia-app-left .p-TabBar-tab {
-    border-left: var(--theia-panel-border-width) solid transparent;
+  border-left: var(--theia-panel-border-width) solid transparent;
 }
 
 .p-TabBar.theia-app-left.theia-app-sides {
-    border-right: var(--theia-panel-border-width) solid var(--theia-activityBar-border);
+  border-right: var(--theia-panel-border-width) solid
+    var(--theia-activityBar-border);
 }
 
 .p-TabBar.theia-app-right .p-TabBar-tab {
-    border-right: var(--theia-panel-border-width) solid transparent;
+  border-right: var(--theia-panel-border-width) solid transparent;
 }
 
 .p-Widget.p-TabBar.theia-app-right.theia-app-sides {
-    border-left: var(--theia-panel-border-width) solid var(--theia-activityBar-border);
+  border-left: var(--theia-panel-border-width) solid
+    var(--theia-activityBar-border);
 }
 
 .p-TabBar.theia-app-sides .p-TabBar-tab.p-mod-current,
 .p-TabBar.theia-app-sides .p-TabBar-tab:hover {
   color: var(--theia-activityBar-foreground);
   background-color: var(--theia-activityBar-activeBackground);
-  min-height: var(--theia-private-sidebar-tab-height);
-  height: var(--theia-private-sidebar-tab-height);
   border-top: none;
 }
 
 .p-TabBar.theia-app-left .p-TabBar-tab.p-mod-current {
-  border-left: var(--theia-panel-border-width) solid var(--theia-activityBar-activeBorder);
+  border-left: var(--theia-panel-border-width) solid
+    var(--theia-activityBar-activeBorder);
   border-top-color: transparent;
 }
 
 .p-TabBar.theia-app-left .p-TabBar-tab.p-mod-current.theia-mod-active {
-    border-left: var(--theia-panel-border-width) solid var(--theia-focusBorder);
+  border-left: var(--theia-panel-border-width) solid var(--theia-focusBorder);
 }
 
 .p-TabBar.theia-app-right .p-TabBar-tab.p-mod-current {
-    border-right: var(--theia-panel-border-width) solid var(--theia-activityBar-activeBorder);
-    border-top-color: transparent;
+  border-right: var(--theia-panel-border-width) solid
+    var(--theia-activityBar-activeBorder);
+  border-top-color: transparent;
 }
 
 .p-TabBar.theia-app-right .p-TabBar-tab.p-mod-current.theia-mod-active {
-    border-right: var(--theia-panel-border-width) solid var(--theia-focusBorder);
+  border-right: var(--theia-panel-border-width) solid var(--theia-focusBorder);
 }
 
 .p-TabBar.theia-app-sides .p-TabBar-tabLabel,
@@ -171,11 +170,13 @@
 }
 
 #theia-left-content-panel > .p-Panel {
-    border-right: var(--theia-panel-border-width) solid var(--theia-activityBar-border);
+  border-right: var(--theia-panel-border-width) solid
+    var(--theia-activityBar-border);
 }
 
 #theia-right-content-panel > .p-Panel {
-    border-left: var(--theia-panel-border-width) solid var(--theia-activityBar-border);
+  border-left: var(--theia-panel-border-width) solid
+    var(--theia-activityBar-border);
 }
 
 .theia-side-panel {
@@ -184,7 +185,7 @@
 
 .p-Widget.theia-side-panel .p-Widget,
 .p-Widget .theia-sidepanel-toolbar {
-    color: var(--theia-sideBar-foreground);
+  color: var(--theia-sideBar-foreground);
 }
 
 .theia-app-sidebar-container {
@@ -210,7 +211,8 @@
 }
 
 .p-Widget.theia-sidebar-menu i {
-  padding: var(--theia-private-sidebar-tab-padding-top-and-bottom) var(--theia-private-sidebar-tab-padding-left-and-right);
+  padding: var(--theia-private-sidebar-tab-padding-top-and-bottom)
+    var(--theia-private-sidebar-tab-padding-left-and-right);
   display: flex;
   justify-content: center;
   align-items: center;
@@ -237,9 +239,14 @@
   z-index: 1000;
 }
 
-#theia-app-shell .p-TabBar.theia-app-sides > .ps__rail-y  >.ps__thumb-y {
+#theia-app-shell .p-TabBar.theia-app-sides > .ps__rail-y > .ps__thumb-y {
   width: var(--theia-private-sidebar-scrollbar-width);
-  right: calc((var(--theia-private-sidebar-scrollbar-rail-width) - var(--theia-private-sidebar-scrollbar-width)) / 2);
+  right: calc(
+    (
+        var(--theia-private-sidebar-scrollbar-rail-width) -
+          var(--theia-private-sidebar-scrollbar-width)
+      ) / 2
+  );
 }
 
 .p-TabBar.theia-app-sides > .ps__rail-y:hover,
@@ -250,46 +257,53 @@
 .p-TabBar.theia-app-sides > .ps__rail-y:hover > .ps__thumb-y,
 .p-TabBar.theia-app-sides > .ps__rail-y:focus > .ps__thumb-y {
   width: var(--theia-private-sidebar-scrollbar-width);
-  right: calc((var(--theia-private-sidebar-scrollbar-rail-width) - var(--theia-private-sidebar-scrollbar-width)) / 2);
+  right: calc(
+    (
+        var(--theia-private-sidebar-scrollbar-rail-width) -
+          var(--theia-private-sidebar-scrollbar-width)
+      ) / 2
+  );
 }
-
 
 /*-----------------------------------------------------------------------------
 | Bottom content panel
 |----------------------------------------------------------------------------*/
 
 #theia-bottom-content-panel {
-    background: var(--theia-panel-background);
+  background: var(--theia-panel-background);
 }
 
 #theia-bottom-content-panel .theia-input {
-    border-color: var(--theia-panelInput-border);
+  border-color: var(--theia-panelInput-border);
 }
 
-#theia-bottom-content-panel .p-DockPanel-handle[data-orientation='horizontal'] {
-    border-left: var(--theia-border-width) solid var(--theia-panel-border);
+#theia-bottom-content-panel .p-DockPanel-handle[data-orientation="horizontal"] {
+  border-left: var(--theia-border-width) solid var(--theia-panel-border);
 }
 
 #theia-bottom-content-panel .p-TabBar {
-    border-top: var(--theia-border-width) solid var(--theia-panel-border);
-    background: inherit;
+  border-top: var(--theia-border-width) solid var(--theia-panel-border);
+  background: inherit;
 }
 
+/* Default empty border to ensure consistent vertical alignment */
 #theia-bottom-content-panel .p-TabBar-tab {
-    background: inherit;
+  border-top: var(--theia-border-width) solid transparent;
+  border-bottom: var(--theia-border-width) solid transparent;
+  background: inherit;
 }
 
 #theia-bottom-content-panel .p-TabBar-tab:not(.p-mod-current) {
-    color: var(--theia-panelTitle-inactiveForeground);
+  color: var(--theia-panelTitle-inactiveForeground);
 }
 
 #theia-bottom-content-panel .p-TabBar-tab.p-mod-current {
-    color: var(--theia-panelTitle-activeForeground);
-    border-top: var(--theia-border-width) solid var(--theia-panelTitle-activeBorder);
+  color: var(--theia-panelTitle-activeForeground);
+  border-top-color: var(--theia-panelTitle-activeBorder);
 }
 
 #theia-bottom-content-panel .p-TabBar-tab.p-mod-current.theia-mod-active {
-    border-top-color: var(--theia-focusBorder);
+  border-top-color: var(--theia-focusBorder);
 }
 
 /*-----------------------------------------------------------------------------
@@ -319,29 +333,32 @@
 |----------------------------------------------------------------------------*/
 
 .theia-sidepanel-toolbar {
-    min-height: calc(var(--theia-private-horizontal-tab-height) + var(--theia-private-horizontal-tab-scrollbar-rail-height) / 2);
-    display: flex;
-    padding-left: 5px;
-    align-items: center;
-    background-color: var(--theia-sideBar-background);
+  min-height: calc(
+    var(--theia-private-horizontal-tab-height) +
+      var(--theia-private-horizontal-tab-scrollbar-rail-height) / 2
+  );
+  display: flex;
+  padding-left: 5px;
+  align-items: center;
+  background-color: var(--theia-sideBar-background);
 }
 
 .theia-sidepanel-toolbar .theia-sidepanel-title {
-    color: var(--theia-settings-headerForeground);
-    flex: 1;
-    margin-left: 14px;
-    text-transform: uppercase;
-    font-size: var(--theia-ui-font-size0);
+  color: var(--theia-settings-headerForeground);
+  flex: 1;
+  margin-left: 14px;
+  text-transform: uppercase;
+  font-size: var(--theia-ui-font-size0);
 }
 
 .theia-sidepanel-toolbar .p-TabBar-toolbar .item {
-    color: var(--theia-icon-foreground);
+  color: var(--theia-icon-foreground);
 }
 
-.theia-sidepanel-toolbar .p-TabBar-toolbar .item > div{
-    height: 18px;
-    width: 18px;
-    background-repeat: no-repeat;
+.theia-sidepanel-toolbar .p-TabBar-toolbar .item > div {
+  height: 18px;
+  width: 18px;
+  background-repeat: no-repeat;
 }
 
 .noWrapInfo {

--- a/packages/core/src/browser/style/tabs.css
+++ b/packages/core/src/browser/style/tabs.css
@@ -9,8 +9,22 @@
   --theia-private-horizontal-tab-scrollbar-height: 5px;
   --theia-tabbar-toolbar-z-index: 1001;
   --theia-toolbar-active-transform-scale: 1.272019649;
-  --theia-horizontal-toolbar-height: calc(var(--theia-private-horizontal-tab-height) + var(--theia-private-horizontal-tab-scrollbar-rail-height) / 2);
+  --theia-horizontal-toolbar-height: calc(
+    var(--theia-private-horizontal-tab-height) +
+      var(--theia-private-horizontal-tab-scrollbar-rail-height) / 2
+  );
   --theia-dragover-tab-border-width: 2px;
+
+  /* Most of these colors are overridden in CommonFrontendContribution.registerColors */
+  --theia-panelTitle-activeBorder: transparent;
+  --theia-tab-activeModifiedBorder: transparent;
+  --theia-tab-activeBorderTop: transparent;
+  --theia-tab-activeBorder: transparent;
+  --theia-tab-inactiveModifiedBorder: transparent;
+  --theia-tab-unfocusedActiveModifiedBorder: transparent;
+  --theia-tab-unfocusedActiveBorderTop: transparent;
+  --theia-tab-unfocusedActiveBorder: transparent;
+  --theia-tab-unfocusedInactiveModifiedBorder: transparent;
 }
 
 /*-----------------------------------------------------------------------------
@@ -21,17 +35,18 @@
   font-size: var(--theia-ui-font-size1);
 }
 
-.p-TabBar[data-orientation='horizontal'] {
+.p-TabBar[data-orientation="horizontal"] {
   overflow-x: hidden;
   overflow-y: hidden;
+  box-sizing: content-box;
   min-height: var(--theia-horizontal-toolbar-height);
 }
 
-.p-TabBar .p-TabBar-content {
+.p-TabBar .p-TabBar-content > li {
   cursor: pointer;
 }
 
-.p-TabBar[data-orientation='horizontal'] .p-TabBar-tab {
+.p-TabBar[data-orientation="horizontal"] .p-TabBar-tab {
   flex: none;
   height: var(--theia-horizontal-toolbar-height);
   min-width: 35px;
@@ -40,26 +55,25 @@
   align-items: center;
 }
 
-.p-TabBar[data-orientation='vertical'] .p-TabBar-tab {
+.p-TabBar[data-orientation="vertical"] .p-TabBar-tab {
   border-top: var(--theia-dragover-tab-border-width) solid transparent !important;
   border-bottom: var(--theia-dragover-tab-border-width) solid transparent !important;
 }
 
-.p-TabBar[data-orientation='vertical'] .p-TabBar-tab.drop-target-top {
+.p-TabBar[data-orientation="vertical"] .p-TabBar-tab.drop-target-top {
   border-top-color: var(--theia-activityBar-activeBorder) !important;
 }
 
-.p-TabBar[data-orientation='vertical'] .p-TabBar-tab.drop-target-bottom {
+.p-TabBar[data-orientation="vertical"] .p-TabBar-tab.drop-target-bottom {
   border-bottom-color: var(--theia-activityBar-activeBorder) !important;
 }
 
-.p-TabBar[data-orientation='horizontal'] .p-TabBar-tab .theia-tab-icon-label,
-.p-TabBar-tab.p-mod-drag-image .theia-tab-icon-label  {
-    display: flex;
-    line-height: var(--theia-content-line-height);
-    align-items: center;
+.p-TabBar[data-orientation="horizontal"] .p-TabBar-tab .theia-tab-icon-label,
+.p-TabBar-tab.p-mod-drag-image .theia-tab-icon-label {
+  display: flex;
+  line-height: var(--theia-content-line-height);
+  align-items: center;
 }
-
 
 /*-----------------------------------------------------------------------------
 | Tabs in the center area (main and bottom)
@@ -67,92 +81,116 @@
 
 #theia-main-content-panel,
 #theia-main-content-panel .p-Widget.p-DockPanel-widget {
-    background: var(--theia-editor-background);
+  background: var(--theia-editor-background);
 }
 
-#theia-main-content-panel .p-DockPanel-handle[data-orientation='horizontal'] {
-    border-left: var(--theia-border-width) solid var(--theia-editorGroup-border);
+#theia-main-content-panel .p-DockPanel-handle[data-orientation="horizontal"] {
+  border-left: var(--theia-border-width) solid var(--theia-editorGroup-border);
 }
 
-#theia-main-content-panel .p-DockPanel-handle[data-orientation='vertical'] + .p-TabBar {
-    border-top: var(--theia-border-width) solid var(--theia-editorGroup-border);
+#theia-main-content-panel
+  .p-DockPanel-handle[data-orientation="vertical"]
+  + .p-TabBar {
+  border-top: var(--theia-border-width) solid var(--theia-editorGroup-border);
 }
 
 #theia-main-content-panel .p-TabBar .p-TabBar-tab {
-    border-right: 1px solid var(--theia-tab-border);
+  border-right: 1px solid var(--theia-tab-border);
 }
 
 #theia-main-content-panel .p-TabBar .p-TabBar-tab:hover.theia-mod-active {
-    background: var(--theia-tab-hoverBackground) !important;
-    box-shadow: var(--theia-tab-hoverBorder) 0 -1px inset !important;
+  background: var(--theia-tab-hoverBackground) !important;
+  box-shadow: var(--theia-tab-hoverBorder) 0 -1px inset !important;
 }
 
 #theia-main-content-panel .p-TabBar .p-TabBar-tab:hover:not(.theia-mod-active) {
-    background: var(--theia-tab-unfocusedHoverBackground) !important;
-    box-shadow: var(--theia-tab-unfocusedHoverBorder) 0 -1px inset !important;
+  background: var(--theia-tab-unfocusedHoverBackground) !important;
+  box-shadow: var(--theia-tab-unfocusedHoverBorder) 0 -1px inset !important;
+}
+
+/* Default empty border for all tabs to ensure consistent vertical alignment */
+#theia-main-content-panel .p-TabBar-tab {
+  border-top: 1px solid transparent;
+  border-bottom: 1px solid transparent;
 }
 
 /* active tab in an active group */
 body.theia-editor-highlightModifiedTabs
-#theia-main-content-panel .p-TabBar .p-TabBar-tab.p-mod-current.theia-mod-active.theia-mod-dirty {
-    border-top: 1px solid var(--theia-tab-activeModifiedBorder);
+  #theia-main-content-panel
+  .p-TabBar
+  .p-TabBar-tab.p-mod-current.theia-mod-active.theia-mod-dirty {
+  border-top-color: var(--theia-tab-activeModifiedBorder);
 }
 
-#theia-main-content-panel .p-TabBar .p-TabBar-tab.p-mod-current.theia-mod-active {
-    background: var(--theia-tab-activeBackground);
-    color: var(--theia-tab-activeForeground);
-    border-top: 1px solid var(--theia-tab-activeBorderTop);
-    border-bottom: 1px solid var(--theia-tab-activeBorder);
+#theia-main-content-panel
+  .p-TabBar
+  .p-TabBar-tab.p-mod-current.theia-mod-active {
+  background: var(--theia-tab-activeBackground);
+  color: var(--theia-tab-activeForeground);
+  border-top-color: var(--theia-tab-activeBorderTop);
+  border-bottom-color: var(--theia-tab-activeBorder);
 }
 
 /* inactive tab in an active group */
 body.theia-editor-highlightModifiedTabs
-#theia-main-content-panel .p-TabBar .p-TabBar-tab:not(.p-mod-current).theia-mod-active.theia-mod-dirty {
-    border-top: 1px solid var(--theia-tab-inactiveModifiedBorder);
+  #theia-main-content-panel
+  .p-TabBar
+  .p-TabBar-tab:not(.p-mod-current).theia-mod-active.theia-mod-dirty {
+  border-top-color: var(--theia-tab-inactiveModifiedBorder);
 }
 
-#theia-main-content-panel .p-TabBar .p-TabBar-tab:not(.p-mod-current).theia-mod-active {
-    background: var(--theia-tab-inactiveBackground);
-    color: var(--theia-tab-inactiveForeground);
+#theia-main-content-panel
+  .p-TabBar
+  .p-TabBar-tab:not(.p-mod-current).theia-mod-active {
+  background: var(--theia-tab-inactiveBackground);
+  color: var(--theia-tab-inactiveForeground);
 }
 
 /* active tab in an unfocused group */
 body.theia-editor-highlightModifiedTabs
-#theia-main-content-panel .p-TabBar .p-TabBar-tab.p-mod-current:not(.theia-mod-active).theia-mod-dirty {
-    border-top: 1px solid var(--theia-tab-unfocusedActiveModifiedBorder);
+  #theia-main-content-panel
+  .p-TabBar
+  .p-TabBar-tab.p-mod-current:not(.theia-mod-active).theia-mod-dirty {
+  border-top-color: var(--theia-tab-unfocusedActiveModifiedBorder);
 }
 
-#theia-main-content-panel .p-TabBar .p-TabBar-tab.p-mod-current:not(.theia-mod-active) {
-    background: var(--theia-tab-unfocusedActiveBackground);
-    color: var(--theia-tab-unfocusedActiveForeground);
-    border-top: 1px solid var(--theia-tab-unfocusedActiveBorderTop);
-    border-bottom: 1px solid var(--theia-tab-unfocusedActiveBorder);
+#theia-main-content-panel
+  .p-TabBar
+  .p-TabBar-tab.p-mod-current:not(.theia-mod-active) {
+  background: var(--theia-tab-unfocusedActiveBackground);
+  color: var(--theia-tab-unfocusedActiveForeground);
+  border-top-color: var(--theia-tab-unfocusedActiveBorderTop);
+  border-bottom-color: var(--theia-tab-unfocusedActiveBorder);
 }
 
 /* inactive tab in an unfocused group */
 body.theia-editor-highlightModifiedTabs
-#theia-main-content-panel .p-TabBar .p-TabBar-tab:not(.p-mod-current):not(.theia-mod-active).theia-mod-dirty {
-    border-top: 1px solid var(--theia-tab-unfocusedInactiveModifiedBorder);
+  #theia-main-content-panel
+  .p-TabBar
+  .p-TabBar-tab:not(.p-mod-current):not(.theia-mod-active).theia-mod-dirty {
+  border-top-color: var(--theia-tab-unfocusedInactiveModifiedBorder);
 }
 
-#theia-main-content-panel .p-TabBar .p-TabBar-tab:not(.p-mod-current):not(.theia-mod-active) {
-    background: var(--theia-tab-inactiveBackground);
-    color: var(--theia-tab-inactiveForeground);
+#theia-main-content-panel
+  .p-TabBar
+  .p-TabBar-tab:not(.p-mod-current):not(.theia-mod-active) {
+  background: var(--theia-tab-inactiveBackground);
+  color: var(--theia-tab-inactiveForeground);
 }
 
 .p-TabBar.theia-app-centers {
-    background: var(--theia-editorGroupHeader-tabsBackground);
+  background: var(--theia-editorGroupHeader-tabsBackground);
 }
 
 .p-TabBar.theia-app-centers::after {
-	content: '';
-	position: absolute;
-	bottom: 0;
-	left: 0;
-	pointer-events: none;
-	background-color: var(--theia-editorGroupHeader-tabsBorder);
-	width: 100%;
-	height: 1px;
+  content: "";
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  pointer-events: none;
+  background-color: var(--theia-editorGroupHeader-tabsBorder);
+  width: 100%;
+  height: 1px;
 }
 
 .p-TabBar.theia-app-centers .p-TabBar-tabIcon,
@@ -183,7 +221,12 @@ body.theia-editor-highlightModifiedTabs
 
   -webkit-appearance: none;
   -moz-appearance: none;
-  background-image: linear-gradient(45deg, transparent 50%, var(--theia-icon-foreground) 50%), linear-gradient(135deg, var(--theia-icon-foreground) 50%, transparent 50%);
+  background-image: linear-gradient(
+      45deg,
+      transparent 50%,
+      var(--theia-icon-foreground) 50%
+    ),
+    linear-gradient(135deg, var(--theia-icon-foreground) 50%, transparent 50%);
   background-position: calc(100% - 6px) 8px, calc(100% - 2px) 8px, 100% 0;
   background-size: 4px 5px;
   background-repeat: no-repeat;
@@ -192,49 +235,51 @@ body.theia-editor-highlightModifiedTabs
 
 .p-TabBar .p-TabBar-tabIcon,
 .p-TabBar-tab.p-mod-drag-image .p-TabBar-tabIcon {
-    width: 15px;
-    line-height: 1.7;
-    font-size: 12px;
-    text-align: center;
-    background-repeat: no-repeat;
+  width: 15px;
+  line-height: 1.7;
+  font-size: 12px;
+  text-align: center;
+  background-repeat: no-repeat;
 }
 
 /* common icons */
 .p-TabBar.theia-app-centers .p-TabBar-tabIcon,
 .p-TabBar-tab.p-mod-drag-image .p-TabBar-tabIcon {
-    min-height: 14px;
-    background-size: 13px;
-    background-position-y: 3px;
-    background: var(--theia-icon-foreground);
-    -webkit-mask-repeat: no-repeat;
-    -webkit-mask-size: auto 13px;
-    mask-repeat: no-repeat;
-    mask-size: auto 13px;
-    padding-right: 8px;
+  min-height: 14px;
+  background-size: 13px;
+  background-position-y: 3px;
+  background: var(--theia-icon-foreground);
+  -webkit-mask-repeat: no-repeat;
+  -webkit-mask-size: auto 13px;
+  mask-repeat: no-repeat;
+  mask-size: auto 13px;
+  padding-right: 8px;
 }
 
 /* codicons */
 .p-TabBar.theia-app-centers .p-TabBar-tabIcon.codicon,
 .p-TabBar-tab.p-mod-drag-image .p-TabBar-tabIcon.codicon {
-    background: none;
+  background: none;
 }
 
 /* file icons */
-.p-TabBar[data-orientation='horizontal'] .p-TabBar-tabIcon.file-icon,
+.p-TabBar[data-orientation="horizontal"] .p-TabBar-tabIcon.file-icon,
 .p-TabBar-tab.p-mod-drag-image .p-TabBar-tabIcon.file-icon {
-    background: none;
-    padding-bottom: 0px;
-    min-height: 20px;
+  background: none;
+  padding-bottom: 0px;
+  min-height: 20px;
 }
 
-.p-TabBar[data-orientation='horizontal'] .p-TabBar-tabIcon.fa,
+.p-TabBar[data-orientation="horizontal"] .p-TabBar-tabIcon.fa,
 .p-TabBar-tab.p-mod-drag-image .p-TabBar-tabIcon.fa {
-    background: none;
-    min-height: 0;
-    height: inherit;
+  background: none;
+  min-height: 0;
+  height: inherit;
 }
 
-.p-TabBar.theia-app-centers .p-TabBar-tab.p-mod-closable > .p-TabBar-tabCloseIcon {
+.p-TabBar.theia-app-centers
+  .p-TabBar-tab.p-mod-closable
+  > .p-TabBar-tabCloseIcon {
   padding: 2px;
   margin-top: 2px;
   margin-left: 4px;
@@ -252,7 +297,9 @@ body.theia-editor-highlightModifiedTabs
   -ms-user-select: none;
 }
 
-.p-TabBar.theia-app-centers .p-TabBar-tab.p-mod-closable > .p-TabBar-tabCloseIcon:hover {
+.p-TabBar.theia-app-centers
+  .p-TabBar-tab.p-mod-closable
+  > .p-TabBar-tabCloseIcon:hover {
   border-radius: 5px;
   background-color: rgba(50%, 50%, 50%, 0.2);
 }
@@ -261,84 +308,108 @@ body.theia-editor-highlightModifiedTabs
   padding-right: 4px;
 }
 
-.p-TabBar.theia-app-centers .p-TabBar-tab.p-mod-current > .theia-tab-icon-label > .p-TabBar-tabIcon {
+.p-TabBar.theia-app-centers
+  .p-TabBar-tab.p-mod-current
+  > .theia-tab-icon-label
+  > .p-TabBar-tabIcon {
   margin-top: -2px;
 }
 
-.p-TabBar.theia-app-centers .p-TabBar-tab.p-mod-current > .p-TabBar-tabCloseIcon {
+.p-TabBar.theia-app-centers
+  .p-TabBar-tab.p-mod-current
+  > .p-TabBar-tabCloseIcon {
   margin-top: 0px;
 }
 
-.p-TabBar.theia-app-centers .p-TabBar-tab.p-mod-closable:not(.theia-mod-dirty):hover > .p-TabBar-tabCloseIcon:before,
-.p-TabBar.theia-app-centers .p-TabBar-tab.p-mod-closable:not(.theia-mod-dirty).p-TabBar-tab.p-mod-current > .p-TabBar-tabCloseIcon:before,
-.p-TabBar.theia-app-centers .p-TabBar-tab.p-mod-closable.theia-mod-dirty > .p-TabBar-tabCloseIcon:hover:before { 
-  content: "\ea76" 
+.p-TabBar.theia-app-centers
+  .p-TabBar-tab.p-mod-closable:not(.theia-mod-dirty):hover
+  > .p-TabBar-tabCloseIcon:before,
+.p-TabBar.theia-app-centers
+  .p-TabBar-tab.p-mod-closable:not(.theia-mod-dirty).p-TabBar-tab.p-mod-current
+  > .p-TabBar-tabCloseIcon:before,
+.p-TabBar.theia-app-centers
+  .p-TabBar-tab.p-mod-closable.theia-mod-dirty
+  > .p-TabBar-tabCloseIcon:hover:before {
+  content: "\ea76";
 }
 
-.p-TabBar.theia-app-centers .p-TabBar-tab.p-mod-closable.theia-mod-dirty > .p-TabBar-tabCloseIcon:before { 
-  content: "\ea71" 
+.p-TabBar.theia-app-centers
+  .p-TabBar-tab.p-mod-closable.theia-mod-dirty
+  > .p-TabBar-tabCloseIcon:before {
+  content: "\ea71";
 }
 
 .p-TabBar-tabIcon.no-icon {
-  display: none !important;
+  visibility: hidden;
 }
 
 .p-TabBar .theia-badge-decorator-sidebar {
   background-color: var(--theia-activityBarBadge-background);
-  border-radius: 20px;
   color: var(--theia-activityBarBadge-foreground);
-  font-size: calc(var(--theia-ui-font-size0) * 0.85);
   font-weight: 600;
-  height: var(--theia-notification-count-height);
-  width: var(--theia-notification-count-width);
-  padding: calc(var(--theia-ui-padding)/6);
-  line-height: calc(var(--theia-content-line-height) * 0.70);
   position: absolute;
-  top: calc(var(--theia-ui-padding) * 4);
-  right: calc(var(--theia-ui-padding) * 1.33);
-  text-align: center;
+  top: 50%;
+  left: 50%;
+  margin-left: 0;
 }
 
-.p-TabBar .theia-badge-decorator-horizontal {
-  background-color:var(--theia-badge-background);
-  border-radius: 20px;
-  box-sizing: border-box;
-  color: var(--theia-activityBarBadge-foreground);
-  font-size: calc(var(--theia-ui-font-size0) * 0.8);
-  font-weight: 400;
-  height: var(--theia-notification-count-height);
-  width: var(--theia-notification-count-width);
-  padding: calc(var(--theia-ui-padding)/6);
-  line-height: calc(var(--theia-content-line-height) * 0.61);
+/* theia-badge-decorator-sidebar class applies while dragging out of the sidebar */
+.theia-badge-decorator-sidebar,
+.theia-badge-decorator-horizontal {
   margin-left: var(--theia-ui-padding);
-  text-align: center;
 }
 
 /*-----------------------------------------------------------------------------
 | Perfect scrollbar
 |----------------------------------------------------------------------------*/
 
-.p-TabBar[data-orientation='horizontal'] .p-TabBar-content-container > .ps__rail-x {
+.p-TabBar[data-orientation="horizontal"]
+  .p-TabBar-content-container
+  > .ps__rail-x {
   height: var(--theia-private-horizontal-tab-scrollbar-rail-height);
   z-index: 1000;
 }
 
-.p-TabBar[data-orientation='horizontal'] .p-TabBar-content-container > .ps__rail-x  > .ps__thumb-x {
+.p-TabBar[data-orientation="horizontal"]
+  .p-TabBar-content-container
+  > .ps__rail-x
+  > .ps__thumb-x {
   height: var(--theia-private-horizontal-tab-scrollbar-height) !important;
-  bottom: calc((var(--theia-private-horizontal-tab-scrollbar-rail-height) - var(--theia-private-horizontal-tab-scrollbar-height)) / 2);
+  bottom: calc(
+    (
+        var(--theia-private-horizontal-tab-scrollbar-rail-height) -
+          var(--theia-private-horizontal-tab-scrollbar-height)
+      ) / 2
+  );
 }
 
-.p-TabBar[data-orientation='horizontal'] .p-TabBar-content-container > .ps__rail-x:hover,
-.p-TabBar[data-orientation='horizontal'] .p-TabBar-content-container > .ps__rail-x:focus {
+.p-TabBar[data-orientation="horizontal"]
+  .p-TabBar-content-container
+  > .ps__rail-x:hover,
+.p-TabBar[data-orientation="horizontal"]
+  .p-TabBar-content-container
+  > .ps__rail-x:focus {
   height: var(--theia-private-horizontal-tab-scrollbar-rail-height) !important;
 }
 
-.p-TabBar[data-orientation='horizontal'] .p-TabBar-content-container > .ps__rail-x:hover > .ps__thumb-x,
-.p-TabBar[data-orientation='horizontal'] .p-TabBar-content-container > .ps__rail-x:focus > .ps__thumb-x {
-  height: calc(var(--theia-private-horizontal-tab-scrollbar-height) / 2) !important;
-  bottom: calc((var(--theia-private-horizontal-tab-scrollbar-rail-height) - var(--theia-private-horizontal-tab-scrollbar-height)) / 2);
+.p-TabBar[data-orientation="horizontal"]
+  .p-TabBar-content-container
+  > .ps__rail-x:hover
+  > .ps__thumb-x,
+.p-TabBar[data-orientation="horizontal"]
+  .p-TabBar-content-container
+  > .ps__rail-x:focus
+  > .ps__thumb-x {
+  height: calc(
+    var(--theia-private-horizontal-tab-scrollbar-height) / 2
+  ) !important;
+  bottom: calc(
+    (
+        var(--theia-private-horizontal-tab-scrollbar-rail-height) -
+          var(--theia-private-horizontal-tab-scrollbar-height)
+      ) / 2
+  );
 }
-
 
 /*-----------------------------------------------------------------------------
 | Dragged tabs
@@ -364,12 +435,16 @@ body.theia-editor-highlightModifiedTabs
 |----------------------------------------------------------------------------*/
 
 .p-TabBar-toolbar {
-  z-index: var(--theia-tabbar-toolbar-z-index); /* Due to the scrollbar (`z-index: 1000;`) it has a greater `z-index`. */
+  z-index: var(
+    --theia-tabbar-toolbar-z-index
+  ); /* Due to the scrollbar (`z-index: 1000;`) it has a greater `z-index`. */
   display: flex;
   flex-direction: row-reverse;
   padding: 4px;
   padding-left: 0px;
   margin-right: 4px;
+  align-items: center;
+  line-height: var(--theia-content-line-height);
 }
 
 .p-TabBar-content-container {
@@ -387,8 +462,8 @@ body.theia-editor-highlightModifiedTabs
 }
 
 .p-TabBar-toolbar .item.enabled {
-    opacity: 1.0;
-    cursor: pointer;
+  opacity: 1;
+  cursor: pointer;
 }
 
 .p-TabBar-toolbar :not(.item.enabled) .action-item {
@@ -397,15 +472,15 @@ body.theia-editor-highlightModifiedTabs
 }
 
 .p-TabBar-toolbar .item.toggled {
-    border: var(--theia-border-width) var(--theia-inputOption-activeBorder) solid;
-    background-color: var(--theia-inputOption-activeBackground);
+  border: var(--theia-border-width) var(--theia-inputOption-activeBorder) solid;
+  background-color: var(--theia-inputOption-activeBackground);
 }
 
 .p-TabBar-toolbar .item > div {
-    height: 18px;
-    width: 18px;
-    background-repeat: no-repeat;
-    line-height: 18px;
+  height: 18px;
+  width: 18px;
+  background-repeat: no-repeat;
+  line-height: 18px;
 }
 
 .p-TabBar-toolbar .item .collapse-all {
@@ -432,8 +507,10 @@ body.theia-editor-highlightModifiedTabs
   min-width: 100%;
 }
 
-.p-TabBar.theia-tabBar-multirow[data-orientation='horizontal'] {
-  min-height: calc(var(--theia-breadcrumbs-height) + var(--theia-horizontal-toolbar-height));
+.p-TabBar.theia-tabBar-multirow[data-orientation="horizontal"] {
+  min-height: calc(
+    var(--theia-breadcrumbs-height) + var(--theia-horizontal-toolbar-height)
+  );
   flex-direction: column;
 }
 

--- a/packages/debug/src/browser/console/debug-console-contribution.tsx
+++ b/packages/debug/src/browser/console/debug-console-contribution.tsx
@@ -182,7 +182,7 @@ export class DebugConsoleContribution extends AbstractViewContribution<ConsoleWi
         Severity.toArray().forEach(s => severityElements.push(<option value={s} key={s}>{s}</option>));
         const selectedValue = Severity.toString(this.consoleSessionManager.severity || Severity.Ignore);
 
-        return <select
+        return <div><select
             className='theia-select'
             id={'debugConsoleSeverity'}
             key={'debugConsoleSeverity'}
@@ -190,7 +190,7 @@ export class DebugConsoleContribution extends AbstractViewContribution<ConsoleWi
             onChange={this.changeSeverity}
         >
             {severityElements}
-        </select>;
+        </select></div>;
     }
 
     protected renderDebugConsoleSelector(widget: Widget | undefined): React.ReactNode {

--- a/packages/output/src/browser/output-toolbar-contribution.tsx
+++ b/packages/output/src/browser/output-toolbar-contribution.tsx
@@ -91,7 +91,7 @@ export class OutputToolbarContribution implements TabBarToolbarContribution {
         if (channelOptionElements.length === 0) {
             channelOptionElements.push(<option key={this.NONE} value={this.NONE}>{this.NONE}</option>);
         }
-        return <select
+        return <div><select
             className='theia-select'
             id='outputChannelList'
             key='outputChannelList'
@@ -99,7 +99,7 @@ export class OutputToolbarContribution implements TabBarToolbarContribution {
             onChange={this.changeChannel}
         >
             {channelOptionElements}
-        </select>;
+        </select></div>;
     }
 
     protected changeChannel = (event: React.ChangeEvent<HTMLSelectElement>) => {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->
This fixes a few styling and alignment issues within the tab bar:
- Tab labels no longer move 0.5px up or down depending on tab focus, and are now centred in the tab (which also used to overflow the tab bar by 1px).
- Select elements (in the Output and Debug Console widgets) are now aligned vertically to match the tab labels.
- Badge decorators styling is responsive to changes in content width (and by default will share styling with the counter inside the widget).
- Badge decorator styling is applied when the tab is being dragged.
- Badge decorator styling in the sidebar now uses more sensible variables, rather than arbitrary variables that happened to give the right alignment with default styling.
- Tab labels without icons in the sidebar now have the same height as other tabs.
- Pointer cursor is used only when hovering over tabs, instead of over the entire containing element.

#### Comparison of current and new styling
<img width="258" alt="output-current" src="https://user-images.githubusercontent.com/11681428/108891223-60bfdc80-7606-11eb-9bb3-81286e0f1607.png">
<img width="240" alt="output-new" src="https://user-images.githubusercontent.com/11681428/108891226-61587300-7606-11eb-86d1-1046591f9aff.png">
<img width="144" alt="problems-current" src="https://user-images.githubusercontent.com/11681428/108891227-61587300-7606-11eb-8410-b805445965c3.png">
<img width="154" alt="problems-new" src="https://user-images.githubusercontent.com/11681428/108891230-61f10980-7606-11eb-8ec6-18e781c02775.png">
<img width="32" alt="sidebar-current" src="https://user-images.githubusercontent.com/11681428/108891231-61f10980-7606-11eb-963c-e684e0d46450.png">
<img width="69" alt="sidebar-new" src="https://user-images.githubusercontent.com/11681428/108891233-61f10980-7606-11eb-80d8-d09ff045c1c7.png">
<img width="76" alt="drag-current" src="https://user-images.githubusercontent.com/11681428/108891217-60274600-7606-11eb-99c4-85c8be242012.png">
<img width="91" alt="drag-new" src="https://user-images.githubusercontent.com/11681428/108891220-60bfdc80-7606-11eb-9c45-9554fad38704.png">

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
This can be tested visually by switching between different tabs, and dragging them between the different tab bars.

Notification badges can be tested by adding unrecognised settings in `.theia/settings.json`.

Element positioning can be checked with subpixel precision by using browser developer tools, selecting an element, and then running `$0.getBoundingClientRect()` in the console. (Instructions may differ for some browsers.)

I've tested this visually on Windows 10 using both the electron version and the browser in Edge and Chrome.

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

