### PR TITLE
file-search: fix whitespace unit-test

### DIFF
--- a/packages/file-search/src/node/file-search-service-impl.spec.ts
+++ b/packages/file-search/src/node/file-search-service-impl.spec.ts
@@ -221,7 +221,10 @@ describe('search-service', function (): void {
 
             expect(matchesA).to.not.be.empty;
             expect(matchesB).to.not.be.empty;
-            expect(matchesA).to.deep.eq(matchesB);
+            expect(matchesA.length).to.equal(matchesB.length);
+
+            // Due to ripgrep parallelism we cannot deepEqual the matches since order is not guaranteed.
+            expect(matchesA).to.have.members(matchesB);
         });
     });
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

The following pull-request updates the `file-search` unit-test which tests for whitespace searches regardless of query order.
Previously, due to `ripgrep` parallelism, it is not guaranteed that two searches produce the same order of matches which would ultimately fail with `deepEqual`.

The commit updates the assertions to instead determine if the two results are equal in a different manner.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

Verify that the CI successfully passes for the _"should support file searches with whitespaces regardless of order"_ unit-test.

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

