### PR TITLE
Hidden tabs can no longer be clicked

### DIFF
--- a/packages/core/src/browser/shell/tab-bar-toolbar.tsx
+++ b/packages/core/src/browser/shell/tab-bar-toolbar.tsx
@@ -197,7 +197,7 @@ export class TabBarToolbar extends ReactWidget {
     }
 
     shouldHandleMouseEvent(event: MouseEvent): boolean {
-        return event.target instanceof Element && (!!this.inline.get(event.target.id) || event.target.id === '__more__');
+        return event.target instanceof Element && this.node.contains(event.target);
     }
 
     protected commandIsEnabled(command: string): boolean {


### PR DESCRIPTION
Fixes #5199, Fixes #6100

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->
This fixes #5199 and #6100, whereby clicking on the toolbar could trigger a switch to a tab hidden 'behind' the toolbar.

The issue arose because the phosphor.js tabbar event handler only looks at the coordinates of click events, so mustn't be called if the click event is outside the tabbar (but on the hidden tabbar overflow). However, the Theia tabbar click handler was originally passing all click events to the phosphor.js event handler. #5201 partially fixed this by filtering out clicks on the icon buttons, but failed to filter out clicks elsewhere in the toolbar.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
Open enough tabs to overflow the space in the tab bar. Click on elements in the toolbar (including the output select menu and space around the edge of the toolbar).

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

