### PR TITLE
Increase Font-Weight on Toolbar Titles

### DIFF
--- a/packages/core/src/browser/style/view-container.css
+++ b/packages/core/src/browser/style/view-container.css
@@ -58,6 +58,7 @@
     line-height: var(--theia-view-container-title-height);
     z-index: 10;
     color: var(--theia-sideBarSectionHeader-foreground);
+    font-weight: 700;
 }
 
 .theia-view-container .part > .header .theia-ExpansionToggle {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

- Increase font-weight of toolbar titles from 450 to 700 to align with VSCode.

Theia:
![image](https://user-images.githubusercontent.com/46289281/106308061-2b55e800-622e-11eb-8f5c-54d3fe8ec304.png)

VSCode:
![image](https://user-images.githubusercontent.com/46289281/106308097-3872d700-622e-11eb-814c-97993188974c.png)

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

Signed-off-by: seantan22 <sean.a.tan@ericsson.com>