### PR TITLE
Fixed custom debug request handling.

### DIFF
--- a/packages/plugin-ext/src/plugin/node/debug/debug.ts
+++ b/packages/plugin-ext/src/plugin/node/debug/debug.ts
@@ -282,7 +282,13 @@ export class DebugExtImpl implements DebugExt {
             type: debugConfiguration.type,
             name: debugConfiguration.name,
             configuration: debugConfiguration,
-            customRequest: (command: string, args?: any) => this.proxy.$customRequest(sessionId, command, args)
+            customRequest: async (command: string, args?: any) => {
+                const response = await this.proxy.$customRequest(sessionId, command, args);
+                if (response && response.success) {
+                    return response.body;
+                }
+                return Promise.reject(new Error(response.message ?? 'custom request failed'));
+            }
         };
 
         const tracker = await this.createDebugAdapterTracker(theiaSession);


### PR DESCRIPTION
Forward the `body` instead of the `response` object.

Signed-off-by: Akos Kitta <kittaakos@typefox.io>

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

Fixes the custom debug message handling. Instead of forwarding the `response` object, it forwards the `body` of a `success` response.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

Try with the [Cortex-Debug](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug) VS Code extension, you should see reasonable responses, instead of an error:

Error:
```
ERROR [hosted-plugin: 45346] Promise rejection not handled in one second: TypeError: regInfo.forEach is not a function , reason: TypeError: regInfo.forEach is not a function
With stack trace: TypeError: regInfo.forEach is not a function
    at RegisterTreeProvider.createRegisters (/path/to/my/app/plugins/cortex-debug/extension/dist/extension.js:48309:33)
    at /path/to/my/app/plugins/cortex-debug/extension/dist/extension.js:48281:42
    at processTicksAndRejections (internal/process/task_queues.js:94:5)
```

Related code in VS Code extension:
https://github.com/Marus/cortex-debug/blob/35f42186726063bcb150f2e4132556a7528eea60/src/frontend/views/registers.ts#L27-L30

With the fix, you can see the custom view contribution with the content from the `cortex-debug` VSX:

![Screen Shot 2021-03-01 at 10 24 27](https://user-images.githubusercontent.com/1405703/109477531-6c812800-7a78-11eb-9769-779c19349692.jpg)


#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

