### PR TITLE
Implement workspace.workspaceFile extension API

### DIFF
--- a/packages/plugin-ext/src/common/plugin-api-rpc.ts
+++ b/packages/plugin-ext/src/common/plugin-api-rpc.ts
@@ -552,10 +552,12 @@ export interface WorkspaceMain {
     $unregisterTextDocumentContentProvider(scheme: string): void;
     $onTextDocumentContentChange(uri: string, content: string): void;
     $updateWorkspaceFolders(start: number, deleteCount?: number, ...rootsToAdd: string[]): Promise<void>;
+    $getWorkspace(): Promise<files.FileStat | undefined>;
 }
 
 export interface WorkspaceExt {
     $onWorkspaceFoldersChanged(event: WorkspaceRootsChangeEvent): void;
+    $onWorkspaceLocationChanged(event: files.FileStat | undefined): void;
     $provideTextDocumentContent(uri: string): Promise<string | undefined>;
     $onTextSearchResult(searchRequestId: number, done: boolean, result?: SearchInWorkspaceResult): void;
 }

--- a/packages/plugin-ext/src/main/browser/workspace-main.ts
+++ b/packages/plugin-ext/src/main/browser/workspace-main.ts
@@ -31,6 +31,7 @@ import { Emitter, Event, ResourceResolver, CancellationToken } from '@theia/core
 import { PluginServer } from '../../common/plugin-protocol';
 import { FileSystemPreferences } from '@theia/filesystem/lib/browser';
 import { SearchInWorkspaceService } from '@theia/search-in-workspace/lib/browser/search-in-workspace-service';
+import { FileStat } from '@theia/filesystem/lib/common/files';
 
 export class WorkspaceMainImpl implements WorkspaceMain, Disposable {
 
@@ -73,6 +74,9 @@ export class WorkspaceMainImpl implements WorkspaceMain, Disposable {
         this.toDispose.push(this.workspaceService.onWorkspaceChanged(roots => {
             this.processWorkspaceFoldersChanged(roots.map(root => root.resource.toString()));
         }));
+        this.toDispose.push(this.workspaceService.onWorkspaceLocationChanged(stat => {
+            this.proxy.$onWorkspaceLocationChanged(stat);
+        }));
     }
 
     dispose(): void {
@@ -100,6 +104,10 @@ export class WorkspaceMainImpl implements WorkspaceMain, Disposable {
         }
 
         return this.roots.some((root, index) => root !== roots[index]);
+    }
+
+    async $getWorkspace(): Promise<FileStat | undefined> {
+        return this.workspaceService.workspace;
     }
 
     $pickWorkspaceFolder(options: WorkspaceFolderPickOptionsMain): Promise<theia.WorkspaceFolder | undefined> {

--- a/packages/plugin-ext/src/plugin/plugin-context.ts
+++ b/packages/plugin-ext/src/plugin/plugin-context.ts
@@ -455,6 +455,9 @@ export function createAPIFactory(
             get workspaceFolders(): theia.WorkspaceFolder[] | undefined {
                 return workspaceExt.workspaceFolders;
             },
+            get workspaceFile(): Uri | undefined {
+                return workspaceExt.workspaceFile;
+            },
             get name(): string | undefined {
                 return workspaceExt.name;
             },

--- a/packages/plugin/src/theia.d.ts
+++ b/packages/plugin/src/theia.d.ts
@@ -5146,6 +5146,22 @@ declare module '@theia/plugin' {
         export let workspaceFolders: WorkspaceFolder[] | undefined;
 
         /**
+         * The location of the workspace file, for example:
+         *
+         * `file:///Users/name/Development/myProject.code-workspace`
+         *
+         * Depending on the workspace that is opened, the value will be:
+         *  * `undefined` when no workspace or a single folder is opened
+         *  * the path of the workspace file as `Uri` otherwise.
+         *
+         * **Note:** it is not advised to use `workspace.workspaceFile` to write
+         * configuration data into the file.
+         * 
+         * @readonly
+         */
+        export const workspaceFile: Uri | undefined;
+
+        /**
          * The name of the workspace. `undefined` when no folder
          * has been opened.
          *


### PR DESCRIPTION
This first implementation returns the Uri location of the workspace
file even if it is untitled (i.e. saved on a temporary default
location).

Fixes: https://github.com/eclipse-theia/theia/issues/8994

Signed-off-by: Alvaro Sanchez-Leon <alvaro.sanchez-leon@ericsson.com>

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->
Introduces support for the plugin API: 'vscode.workspace.workspaceFile' 

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
An test plugin that calls this API is available from: [plugin](https://github.com/vince-fugnitto/vscode-workspacefile-api/releases/download/0.0.2/vscode-workspace-file-0.0.1.vsix)

Once installed issue the command: "Test: Echo Workspace"

1) Try the command in multi-root projects and make sure a Uri with the proper location of the workspace file is returned
2) Try the command in a project not using multi-roots and verify that no Uri is provided.
3) Open a project directory and use "Save workspace as" to convert it to a multi-root, try the command and verify it Uri is provided.

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

