### PR TITLE
electron: fix 'save as...' cwd

### DIFF
--- a/packages/filesystem/src/browser/file-dialog/file-dialog-service.ts
+++ b/packages/filesystem/src/browser/file-dialog/file-dialog-service.ts
@@ -83,14 +83,12 @@ export class DefaultFileDialogService implements FileDialogService {
             resource: new URI(await this.environments.getHomeDirUri()),
             isDirectory: true
         };
-        if (folder) {
-            const folderUri = folder.resource;
-            const rootUri = folder.isDirectory ? folderUri : folderUri.parent;
-            try {
-                const rootStat = await this.fileService.resolve(rootUri);
-                return DirNode.createRoot(rootStat);
-            } catch { }
-        }
+        const folderUri = folder.resource;
+        const rootUri = folder.isDirectory ? folderUri : folderUri.parent;
+        try {
+            const rootStat = await this.fileService.resolve(rootUri);
+            return DirNode.createRoot(rootStat);
+        } catch { }
         return undefined;
     }
 }

--- a/packages/filesystem/src/electron-browser/file-dialog/electron-file-dialog-service.ts
+++ b/packages/filesystem/src/electron-browser/file-dialog/electron-file-dialog-service.ts
@@ -108,7 +108,10 @@ export class ElectronFileDialogService extends DefaultFileDialogService {
 
     protected toSaveDialogOptions(uri: URI, props: SaveFileDialogProps): SaveDialogOptions {
         const buttonLabel = props.saveLabel;
-        const defaultPath = props.inputValue;
+        if (props.inputValue) {
+            uri = uri.resolve(props.inputValue);
+        }
+        const defaultPath = FileUri.fsPath(uri);
         return { ...this.toDialogOptions(uri, props, 'Save'), buttonLabel, defaultPath };
     }
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

Fixes https://github.com/eclipse-theia/theia/issues/9133

The following commit fixes the `defaultPath` when performing a `save as...` in `electron`. Previously, the `defaultPath` was incorrect leading the dialog to always open where the application started. With these changes, the dialog will open at the current location where the `save as...` is performed.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

1. start the example-electron application
2. open a file (different sublevels to test fully)
3. perform `save as...`
4. confirm that the dialog is opened at the correct path, and the filename is correctly populated in the input

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

Signed-off-by: vince-fugnitto <vincent.fugnitto@ericsson.com>

