### PR TITLE
replace throw with warning when storage is set without workspace

### DIFF
--- a/packages/plugin-ext/src/main/node/plugins-key-value-storage.ts
+++ b/packages/plugin-ext/src/main/node/plugins-key-value-storage.ts
@@ -56,7 +56,8 @@ export class PluginsKeyValueStorage {
     async set(key: string, value: KeysToAnyValues, kind: PluginStorageKind): Promise<boolean> {
         const dataPath = await this.getDataPath(kind);
         if (!dataPath) {
-            throw new Error('Cannot save data: no opened workspace');
+            console.warn('Cannot save data: no opened workspace');
+            return false;
         }
 
         const data = await this.readFromFile(dataPath);


### PR DESCRIPTION
The functionality is not expected to work according to API, however it doesn't fail in VS Code

Signed-off-by: Amiram Wingarten <amiram.wingarten@sap.com>

#### What it does
Fixed #8963 

#### How to test
1. add SQLTOOLS plugin to Theia.
2. close Workspace and open a file
3. close file and no " Cannot save data: no opened workspace" error in terminal.

#### Review checklist

- [X] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

