### PR TITLE
Fix vscode.window.createTerminal with cwd

### DIFF
--- a/packages/plugin/src/theia.d.ts
+++ b/packages/plugin/src/theia.d.ts
@@ -2781,7 +2781,7 @@ declare module '@theia/plugin' {
         /**
          * Current working directory.
          */
-        cwd?: string;
+        cwd?: string | URI;
 
         /**
          * Environment variables for terminal in format key - value.

--- a/packages/terminal/src/browser/base/terminal-widget.ts
+++ b/packages/terminal/src/browser/base/terminal-widget.ts
@@ -19,6 +19,7 @@ import { BaseWidget } from '@theia/core/lib/browser';
 import { CommandLineOptions } from '@theia/process/lib/common/shell-command-builder';
 import { TerminalSearchWidget } from '../search/terminal-search-widget';
 import { TerminalProcessInfo } from '../../common/base-terminal-protocol';
+import URI from '@theia/core/lib/common/uri';
 
 export interface TerminalDimensions {
     cols: number;
@@ -144,7 +145,7 @@ export interface TerminalWidgetOptions {
     /**
      * Current working directory.
      */
-    readonly cwd?: string;
+    readonly cwd?: string | URI;
 
     /**
      * Environment variables for terminal.

--- a/packages/terminal/src/browser/terminal-widget-impl.ts
+++ b/packages/terminal/src/browser/terminal-widget-impl.ts
@@ -389,7 +389,7 @@ export class TerminalWidgetImpl extends TerminalWidget implements StatefulWidget
     }
 
     protected async createTerminal(): Promise<number> {
-        let rootURI = this.options.cwd;
+        let rootURI = this.options.cwd?.toString();
         if (!rootURI) {
             const root = (await this.workspaceService.roots)[0];
             rootURI = root?.resource?.toString();


### PR DESCRIPTION
Signed-off-by: Vered Constantin <vered.constantin@sap.com>

Fix https://github.com/eclipse-theia/theia/issues/7586  

With this PR, creating terminal with cwd option will make sure the cwd is a string as it should be.
(As specified in TerminalWidgetOptions.cwd )

#### What it does
It makes the createTerminal API more robust even in case the cwd passed by extensions is URI (like happens with vscode-maven extension). VScode still works fine even when extension is passing URI as cwd to this API.

#### How to test
Explained in https://github.com/eclipse-theia/theia/issues/7586:
1. Install vscode-maven, all versions starting from https://open-vsx.org/api/vscjava/vscode-maven/0.21.2/file/vscjava.vscode-maven-0.21.2.vsix 
2. Click on the project context menu: clean/install etc.

Expected Result:
A terminal should be opened with the corresponding command being executed in the terminal

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

