### PR TITLE
Fixed the fallback `font-family` in monaco editor.

### DIFF
--- a/packages/monaco/src/browser/style/index.css
+++ b/packages/monaco/src/browser/style/index.css
@@ -1,6 +1,6 @@
 .monaco-editor {
     padding-bottom: 5.6px;
-    font-family: var(--theia-ui-font-family);
+    font-family: var(--theia-code-font-family);
     font-size: inherit !important;
 }
 


### PR DESCRIPTION
Signed-off-by: Akos Kitta <kittaakos@typefox.io>

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

It fixes the fallback `font-family` in the monaco editor. Instead of falling back to the default UI font, which is
https://github.com/eclipse-theia/theia/blob/1f0689ea13939d0035bcf52ec6b6e7eb2301401b/packages/core/src/browser/style/variables-dark.useable.css#L40

![Screen Shot 2021-03-02 at 18 29 59](https://user-images.githubusercontent.com/1405703/109692588-ffa98300-7b88-11eb-8876-7a6de2e13281.jpg)

we fall back to the desired code editor font, which is
https://github.com/eclipse-theia/theia/blob/1f0689ea13939d0035bcf52ec6b6e7eb2301401b/packages/core/src/browser/style/variables-dark.useable.css#L52

![Screen Shot 2021-03-02 at 18 31 01](https://user-images.githubusercontent.com/1405703/109692567-f9b3a200-7b88-11eb-8e1e-c9a702d58a09.jpg)


#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
 - Open the dev tools,
 - select a `view-lines` element,
 - and disable the default `font-family`.
![Screen Shot 2021-03-02 at 19 05 03](https://user-images.githubusercontent.com/1405703/109693828-68452f80-7b8a-11eb-8865-f578d26c3b3a.jpg)

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

