### PR TITLE
Fix bind multiple Contribution using `for of` instead `foreach`

### DIFF
--- a/packages/core/src/browser/frontend-application-module.ts
+++ b/packages/core/src/browser/frontend-application-module.ts
@@ -224,18 +224,18 @@ export const frontendApplicationModule = new ContainerModule((bind, unbind, isBo
 
     bind(ResourceContextKey).toSelf().inSingletonScope();
     bind(CommonFrontendContribution).toSelf().inSingletonScope();
-    [FrontendApplicationContribution, CommandContribution, KeybindingContribution, MenuContribution, ColorContribution].forEach(serviceIdentifier =>
-        bind(serviceIdentifier).toService(CommonFrontendContribution)
-    );
+    for (const identifier of [FrontendApplicationContribution, CommandContribution, KeybindingContribution, MenuContribution, ColorContribution]) {
+        bind(identifier).toService(CommonFrontendContribution);
+    }
 
     bind(QuickOpenService).toSelf().inSingletonScope();
     bind(QuickInputService).toSelf().inSingletonScope();
     bind(QuickTitleBar).toSelf().inSingletonScope();
     bind(QuickCommandService).toSelf().inSingletonScope();
     bind(QuickCommandFrontendContribution).toSelf().inSingletonScope();
-    [CommandContribution, KeybindingContribution, MenuContribution].forEach(serviceIdentifier =>
-        bind(serviceIdentifier).toService(QuickCommandFrontendContribution)
-    );
+    for (const identifier of [CommandContribution, KeybindingContribution, MenuContribution]) {
+        bind(identifier).toService(QuickCommandFrontendContribution);
+    }
 
     bind(QuickPickService).to(QuickPickServiceImpl).inSingletonScope().onActivation(({ container }, quickPickService: QuickPickService) => {
         WebSocketConnectionProvider.createProxy(container, quickPickServicePath, quickPickService);

--- a/packages/core/src/browser/keybinding.spec.ts
+++ b/packages/core/src/browser/keybinding.spec.ts
@@ -69,9 +69,9 @@ before(async () => {
         bindContributionProvider(bind, KeybindingContribution);
 
         bind(TestContribution).toSelf().inSingletonScope();
-        [CommandContribution, KeybindingContribution].forEach(serviceIdentifier =>
-            bind(serviceIdentifier).toService(TestContribution)
-        );
+        for (const identifier of [CommandContribution, KeybindingContribution]) {
+            bind(identifier).toService(TestContribution);
+        }
 
         bind(KeybindingContext).toConstantValue({
             id: 'testContext',

--- a/packages/editor/src/browser/editor-frontend-module.ts
+++ b/packages/editor/src/browser/editor-frontend-module.ts
@@ -68,9 +68,9 @@ export default new ContainerModule(bind => {
 
     bind(VariableContribution).to(EditorVariableContribution).inSingletonScope();
 
-    [CommandContribution, KeybindingContribution, QuickOpenContribution].forEach(serviceIdentifier => {
-        bind(serviceIdentifier).toService(EditorContribution);
-    });
+    for (const identifier of [CommandContribution, KeybindingContribution, QuickOpenContribution]) {
+        bind(identifier).toService(EditorContribution);
+    }
     bind(EditorQuickOpenService).toSelf().inSingletonScope();
 
     bind(CurrentEditorAccess).toSelf().inSingletonScope();

--- a/packages/file-search/src/browser/file-search-frontend-module.ts
+++ b/packages/file-search/src/browser/file-search-frontend-module.ts
@@ -28,9 +28,9 @@ export default new ContainerModule((bind: interfaces.Bind) => {
     }).inSingletonScope();
 
     bind(QuickFileOpenFrontendContribution).toSelf().inSingletonScope();
-    [CommandContribution, KeybindingContribution, QuickOpenContribution].forEach(serviceIdentifier =>
-        bind(serviceIdentifier).toService(QuickFileOpenFrontendContribution)
-    );
+    for (const identifier of [CommandContribution, KeybindingContribution, QuickOpenContribution]) {
+        bind(identifier).toService(QuickFileOpenFrontendContribution);
+    }
 
     bind(QuickFileOpenService).toSelf().inSingletonScope();
 });

--- a/packages/preview/src/browser/preview-frontend-module.ts
+++ b/packages/preview/src/browser/preview-frontend-module.ts
@@ -51,7 +51,7 @@ export default new ContainerModule(bind => {
     })).inSingletonScope();
 
     bind(PreviewContribution).toSelf().inSingletonScope();
-    [CommandContribution, MenuContribution, OpenHandler, FrontendApplicationContribution, TabBarToolbarContribution].forEach(serviceIdentifier =>
-        bind(serviceIdentifier).toService(PreviewContribution)
-    );
+    for (const identifier of [CommandContribution, MenuContribution, OpenHandler, FrontendApplicationContribution, TabBarToolbarContribution]) {
+        bind(identifier).toService(PreviewContribution);
+    }
 });


### PR DESCRIPTION
Fix to use `for of` instead `Array.foreach` when bind multiple Contribution in frontend module in common

Signed-off-by: Byeongho Jung <hobeoung2@gmail.com>

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->
When bind multiple contribution someone use `for of` (ex. monaco-frontend-module, terminal-frontend-module, etc) and others use `foreach` (ex. frontend-application-module, editor-frontend-module). So, I fix them to use `for of` in common. Cause this logic bind designated Contribution rather than processing Array element, I think it is natural to use `for of`.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
I Just check working well and check correct parameter passed to bind() using logging.  

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

