### PR TITLE
8992-enabling-view-when-clause

### DIFF
--- a/packages/plugin-ext/src/main/browser/view/plugin-view-registry.ts
+++ b/packages/plugin-ext/src/main/browser/view/plugin-view-registry.ts
@@ -207,7 +207,7 @@ export class PluginViewRegistry implements FrontendApplicationContribution {
             return false;
         }
         const [, view] = viewInfo;
-        return view.when === undefined || this.contextKeyService.match(view.when);
+        return view.when === undefined || view.when === 'true' || this.contextKeyService.match(view.when);
     }
 
     registerViewContainer(location: string, viewContainer: ViewContainer): Disposable {
@@ -285,6 +285,7 @@ export class PluginViewRegistry implements FrontendApplicationContribution {
         }
         const toDispose = new DisposableCollection();
 
+        view.when = view.when?.trim();
         this.views.set(view.id, [viewContainerId, view]);
         toDispose.push(Disposable.create(() => this.views.delete(view.id)));
 
@@ -298,7 +299,7 @@ export class PluginViewRegistry implements FrontendApplicationContribution {
             }
         }));
 
-        if (view.when) {
+        if (view.when && view.when !== 'false' && view.when !== 'true') {
             this.viewClauseContexts.set(view.id, this.contextKeyService.parseKeys(view.when));
             toDispose.push(Disposable.create(() => this.viewClauseContexts.delete(view.id)));
         }


### PR DESCRIPTION
Enabling setting view when clauses with these values: undefined, true, false or expressions.

Signed-off-by: Dan Arad <dan.arad@sap.com>

#### What it does
Fixes: #8992 

#### How to test
follow #8992 explanation - set different test views
- without when clause
- with when = "true"
- with when = "false"
- with when = "{expression}"

i.e.:

```
"views": {
            "explorer": [
                {
                    "id": "testView",
                    "name": "Test View true",
                    "when": "true"
                },
                {
                    "id": "testView2",
                    "name": "Test View2 false",
                    "when": "false"
                },
                {
                    "id": "testView3",
                    "name": "Test View3 undefined"
                },
                {
                    "id": "testView4",
                    "name": "Test View4 expression",
                    "when": "debugConfigurationType == 'pwa-extensionHost'"
                }
            ]
        },
```
#### Review checklist

- [X] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

