### PR TITLE
9158-bug-right-click-on-explorer-throws-exception

### DIFF
--- a/packages/workspace/src/browser/workspace-commands.ts
+++ b/packages/workspace/src/browser/workspace-commands.ts
@@ -345,8 +345,8 @@ export class WorkspaceCommandContribution implements CommandContribution {
                 this.openers = await this.openerService.getOpeners();
             });
         }
-        const openers = await this.openerService.getOpeners();
-        for (const opener of openers) {
+        this.openers = await this.openerService.getOpeners();
+        for (const opener of this.openers) {
             const openWithCommand = WorkspaceCommands.FILE_OPEN_WITH(opener);
             registry.registerCommand(openWithCommand, this.newUriAwareCommandHandler({
                 execute: uri => opener.open(uri),


### PR DESCRIPTION
Right-click on file or folder in explorer panel throws exception

Signed-off-by: Dan Arad <dan.arad@sap.com>

#### What it does
Fixes #9158 

#### How to test
1. Right-click on file or folder in `explorer` panel - to display context menu.
2. Check console - see no exception exists

#### Review checklist

- [X] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

