### PR TITLE
Fixes #9145 in the problem view copy action

### DIFF
--- a/packages/markers/src/browser/problem/problem-contribution.ts
+++ b/packages/markers/src/browser/problem/problem-contribution.ts
@@ -218,7 +218,7 @@ export class ProblemContribution extends AbstractViewContribution<ProblemWidget>
         const marker = selection.marker as ProblemMarker;
         const serializedProblem = JSON.stringify({
             resource: marker.uri,
-            owner: marker.uri,
+            owner: marker.owner,
             code: marker.data.code,
             severity: marker.data.severity,
             message: marker.data.message,


### PR DESCRIPTION
#### What it does
Sets the correct  owner when copying a problem from the problem view
Fixes #9145 

Contributed by STMicroelectronics
Signed-off-by: Niklas DAHLQUIST <niklas.dahlquist@st.com>

#### How to test
* Copy a problem from the problem view
* Paste in a text editor like notepad
* Observe that resource and owner are set to correct values (TypeScript problem in this example)
```
  "resource": <uri>
  "owner": "typescript"  
```

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
