### PR TITLE
preferences: restore preference state

### DIFF
--- a/packages/preferences/src/browser/views/preference-editor-widget.tsx
+++ b/packages/preferences/src/browser/views/preference-editor-widget.tsx
@@ -27,6 +27,7 @@ import {
     PreferenceItem,
     TreeNode,
     ExpandableTreeNode,
+    StatefulWidget,
 } from '@theia/core/lib/browser';
 import { Message, } from '@theia/core/lib/browser/widgets/widget';
 import { SinglePreferenceDisplayFactory } from './components/single-preference-display-factory';
@@ -36,8 +37,12 @@ import { Emitter } from '@theia/core';
 const HEADER_CLASS = 'settings-section-category-title';
 const SUBHEADER_CLASS = 'settings-section-subcategory-title';
 
+export interface PreferencesEditorState {
+    firstVisibleChildID: string,
+}
+
 @injectable()
-export class PreferencesEditorWidget extends ReactWidget {
+export class PreferencesEditorWidget extends ReactWidget implements StatefulWidget {
     static readonly ID = 'settings.editor';
     static readonly LABEL = 'Settings Editor';
 
@@ -218,4 +223,16 @@ export class PreferencesEditorWidget extends ReactWidget {
             }
         }
     }
+
+    storeState(): PreferencesEditorState {
+        return {
+            firstVisibleChildID: this.firstVisibleChildID,
+        };
+    }
+
+    restoreState(oldState: PreferencesEditorState): void {
+        this.firstVisibleChildID = oldState.firstVisibleChildID;
+        this.handleDisplayChange();
+    }
+
 }

--- a/packages/preferences/src/browser/views/preference-scope-tabbar-widget.tsx
+++ b/packages/preferences/src/browser/views/preference-scope-tabbar-widget.tsx
@@ -16,7 +16,7 @@
 
 import { inject, injectable, postConstruct } from 'inversify';
 import { TabBar, Widget, Title } from '@phosphor/widgets';
-import { PreferenceScope, Message, ContextMenuRenderer, LabelProvider } from '@theia/core/lib/browser';
+import { PreferenceScope, Message, ContextMenuRenderer, LabelProvider, StatefulWidget } from '@theia/core/lib/browser';
 import { WorkspaceService } from '@theia/workspace/lib/browser/workspace-service';
 import URI from '@theia/core/lib/common/uri';
 import { FileStat } from '@theia/filesystem/lib/common/files';
@@ -41,8 +41,12 @@ const SINGLE_FOLDER_TAB_CLASSNAME = `${PREFERENCE_TAB_CLASSNAME} ${GENERAL_FOLDE
 const UNSELECTED_FOLDER_DROPDOWN_CLASSNAME = `${PREFERENCE_TAB_CLASSNAME} ${GENERAL_FOLDER_TAB_CLASSNAME} ${FOLDER_DROPDOWN_CLASSNAME}`;
 const SELECTED_FOLDER_DROPDOWN_CLASSNAME = `${PREFERENCE_TAB_CLASSNAME} ${GENERAL_FOLDER_TAB_CLASSNAME} ${LABELED_FOLDER_TAB_CLASSNAME} ${FOLDER_DROPDOWN_CLASSNAME}`;
 
+export interface PreferencesScopeTabBarState {
+    scopeDetails: Preference.SelectedScopeDetails;
+}
+
 @injectable()
-export class PreferencesScopeTabBar extends TabBar<Widget> {
+export class PreferencesScopeTabBar extends TabBar<Widget> implements StatefulWidget {
 
     static ID = 'preferences-scope-tab-bar';
     @inject(WorkspaceService) protected readonly workspaceService: WorkspaceService;
@@ -247,5 +251,15 @@ export class PreferencesScopeTabBar extends TabBar<Widget> {
 
     protected emitNewScope(): void {
         this.onScopeChangedEmitter.fire(this.currentSelection);
+    }
+
+    storeState(): PreferencesScopeTabBarState {
+        return {
+            scopeDetails: this.currentScope
+        };
+    }
+
+    restoreState(oldState: PreferencesScopeTabBarState): void {
+        this.setNewScopeSelection(oldState.scopeDetails);
     }
 }

--- a/packages/preferences/src/browser/views/preference-searchbar-widget.tsx
+++ b/packages/preferences/src/browser/views/preference-searchbar-widget.tsx
@@ -15,13 +15,17 @@
  ********************************************************************************/
 
 import { injectable, postConstruct } from 'inversify';
-import { ReactWidget } from '@theia/core/lib/browser';
+import { ReactWidget, StatefulWidget } from '@theia/core/lib/browser';
 import * as React from 'react';
 import { debounce } from 'lodash';
 import { Disposable, Emitter } from '@theia/core';
 
+export interface PreferencesSearchbarState {
+    searchTerm: string;
+}
+
 @injectable()
-export class PreferencesSearchbarWidget extends ReactWidget {
+export class PreferencesSearchbarWidget extends ReactWidget implements StatefulWidget {
     static readonly ID = 'settings.header';
     static readonly LABEL = 'Settings Header';
     static readonly SEARCHBAR_ID = 'preference-searchbar';
@@ -110,6 +114,21 @@ export class PreferencesSearchbarWidget extends ReactWidget {
         return !!this.searchbarRef.current?.value;
     }
 
+    protected getSearchTerm(): string {
+        const search = document.getElementById(PreferencesSearchbarWidget.SEARCHBAR_ID) as HTMLInputElement;
+        return search?.value;
+    }
+
+    protected updateSearchTerm(searchTerm: string): void {
+        const search = document.getElementById(PreferencesSearchbarWidget.SEARCHBAR_ID) as HTMLInputElement;
+        if (!search) {
+            return;
+        }
+        search.value = searchTerm;
+        this.search(search.value);
+        this.update();
+    }
+
     render(): React.ReactNode {
         const optionContainer = this.renderOptionContainer();
         return (
@@ -137,5 +156,18 @@ export class PreferencesSearchbarWidget extends ReactWidget {
     updateResultsCount(count: number): void {
         this.resultsCount = count;
         this.update();
+    }
+
+    storeState(): PreferencesSearchbarState {
+        return {
+            searchTerm: this.getSearchTerm()
+        };
+    }
+
+    restoreState(oldState: PreferencesSearchbarState): void {
+        const searchInputExists = this.onDidChangeVisibility(() => {
+            this.updateSearchTerm(oldState.searchTerm || '');
+            searchInputExists.dispose();
+        });
     }
 }

--- a/packages/preferences/src/browser/views/preference-widget.tsx
+++ b/packages/preferences/src/browser/views/preference-widget.tsx
@@ -15,17 +15,23 @@
  ********************************************************************************/
 
 import { postConstruct, injectable, inject } from 'inversify';
-import { Panel, Widget, Message, } from '@theia/core/lib/browser';
-import { PreferencesEditorWidget } from './preference-editor-widget';
+import { Panel, Widget, Message, StatefulWidget, } from '@theia/core/lib/browser';
+import { PreferencesEditorState, PreferencesEditorWidget } from './preference-editor-widget';
 import { PreferencesTreeWidget } from './preference-tree-widget';
-import { PreferencesSearchbarWidget } from './preference-searchbar-widget';
-import { PreferencesScopeTabBar } from './preference-scope-tabbar-widget';
+import { PreferencesSearchbarState, PreferencesSearchbarWidget } from './preference-searchbar-widget';
+import { PreferencesScopeTabBar, PreferencesScopeTabBarState } from './preference-scope-tabbar-widget';
 import { Preference } from '../util/preference-types';
 
 const SHADOW_CLASSNAME = 'with-shadow';
 
+interface PreferencesWidgetState {
+    scopeTabBarState: PreferencesScopeTabBarState,
+    editorState: PreferencesEditorState,
+    searchbarWidgetState: PreferencesSearchbarState,
+}
+
 @injectable()
-export class PreferencesWidget extends Panel {
+export class PreferencesWidget extends Panel implements StatefulWidget {
     /**
      * The widget `id`.
      */
@@ -88,5 +94,19 @@ export class PreferencesWidget extends Panel {
         });
 
         this.update();
+    }
+
+    storeState(): PreferencesWidgetState {
+        return {
+            scopeTabBarState: this.tabBarWidget.storeState(),
+            editorState: this.editorWidget.storeState(),
+            searchbarWidgetState: this.searchbarWidget.storeState(),
+        };
+    }
+
+    restoreState(state: PreferencesWidgetState): void {
+        this.tabBarWidget.restoreState(state.scopeTabBarState);
+        this.editorWidget.restoreState(state.editorState);
+        this.searchbarWidget.restoreState(state.searchbarWidgetState);
     }
 }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

Fixes: https://github.com/eclipse-theia/theia/issues/7746

The following pull-request adds functionality in order to restore the `preferences-view` state when reloading the application.

The state includes:
- restoring the search term and consequently the result.
- restoring the currently selected workspace scope.
- restoring the editor location (through the `firstVisibleChildID`.

_Master_:

https://user-images.githubusercontent.com/40359487/110519912-dd10f000-80db-11eb-8249-73bcb24cbcbb.mov 

_Pull-Request_:

https://user-images.githubusercontent.com/40359487/110519957-e732ee80-80db-11eb-85fd-e5a7daf93e0a.mov

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

_Search Term_

1. start the application, and open the preferences-view
2. enter a search term (ex: `fontSize`)
3. the view should perform a search
4. reload the application, the search term should persist and the results should be updated

_Scope_

1. start the application, and open the preferences-view
2. switch scopes (`user`, `workspace`, `folder` (multi-root))
3. reload the application, the scope should be preserved

_Editor_

1. start the application, and open the preferences-view
2. scroll the editor (ex: to `scss/lint`)
3. reload the application, the editor should be preserved at the last visible child

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

Signed-off-by: vince-fugnitto <vincent.fugnitto@ericsson.com>