### PR TITLE
fire onDidChangeActiveEmitter when quick-pick is accepted

### DIFF
--- a/packages/core/src/browser/quick-open/quick-pick-service-impl.ts
+++ b/packages/core/src/browser/quick-open/quick-pick-service-impl.ts
@@ -139,6 +139,7 @@ export class QuickPickServiceImpl implements QuickPickService {
                     return false;
                 }
                 this.onDidChangeSelectionEmitter.fire([element]);
+                this.onDidChangeActiveEmitter.fire([element]);
                 this.onDidAcceptEmitter.fire(undefined);
                 resolve(value);
                 return true;


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->
Set selected quick-pick item as active when a quick-pick item is chosen. This fixes a bug when the active items list is not actual on quick-pick accept event.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
1. Compile and start the [sample plugin](https://github.com/vinokurig/quick-pick-test.git) or download the [sample plugin binary](https://github.com/vinokurig/quick-pick-test/releases/download/0.0.1/quick_pick_plugin.theia) to the `plugins` folder.
2. Run `F1 => Test Quick-pick` and chose `Second` or `Third` item.
3. See: chosen item is printed in a notification.

In the current master theia only `First` item is returned.
#### Review checklist

- [ ] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

