### PR TITLE
8965-hosted-plugin-outfiles

### DIFF
--- a/packages/plugin-dev/src/browser/hosted-plugin-manager-client.ts
+++ b/packages/plugin-dev/src/browser/hosted-plugin-manager-client.ts
@@ -181,10 +181,12 @@ export class HostedPluginManagerClient {
 
     async startDebugSessionManager(): Promise<void> {
         let outFiles: string[] | undefined = undefined;
-        if (this.pluginLocation) {
+        if (this.pluginLocation && this.hostedPluginPreferences['hosted-plugin.launchOutFiles'].length > 0) {
             const fsPath = await this.fileService.fsPath(this.pluginLocation);
             if (fsPath) {
-                outFiles = [new Path(fsPath).join('**', '*.js').toString()];
+                outFiles = this.hostedPluginPreferences['hosted-plugin.launchOutFiles'].map(outFile =>
+                    outFile.replace('${pluginPath}', new Path(fsPath).toString())
+                );
             }
         }
         await this.debugSessionManager.start({

--- a/packages/plugin-dev/src/browser/hosted-plugin-preferences.ts
+++ b/packages/plugin-dev/src/browser/hosted-plugin-preferences.ts
@@ -30,6 +30,14 @@ export const HostedPluginConfigSchema: PreferenceSchema = {
             description: 'Using inspect or inspect-brk for Node.js debug',
             default: 'inspect',
             enum: ['inspect', 'inspect-brk']
+        },
+        'hosted-plugin.launchOutFiles': {
+            type: 'array',
+            items: {
+                type: 'string'
+            },
+            description: 'Array of glob patterns for locating generated JavaScript files (`${pluginPath}` will be replaced by plugin actual path).',
+            default: ['${pluginPath}/out/**/*.js']
         }
     }
 };
@@ -37,6 +45,7 @@ export const HostedPluginConfigSchema: PreferenceSchema = {
 export interface HostedPluginConfiguration {
     'hosted-plugin.watchMode': boolean;
     'hosted-plugin.debugMode': string;
+    'hosted-plugin.launchOutFiles': string[];
 }
 
 export const HostedPluginPreferences = Symbol('HostedPluginPreferences');


### PR DESCRIPTION
Hosted Plugin debug session contained entire directory of plugin instead of only the out directory, which resulted in performance warning because it would load all files in that directory.

Remarks: 
1. `vscode-js-debug` is the library that throws the warning. 
2. I tried to increase the timeout till warning but it didn't solve issue when plugin contains a substantial amount of files.

Signed-off-by: Dan Arad <dan.arad@sap.com>

#### What it does
Fixes: #8965 

#### How to test
1. Run Theia, open an extension directory - i.e.  `vscode-extension-samples\custom-editor-sample`
2. Run `Hosted Plugin: Start Instance` and try to debug extension

#### Review checklist

- [X] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

