### PR TITLE
plugin: fix dialog-main implementation

### DIFF
--- a/packages/filesystem/src/electron-browser/file-dialog/electron-file-dialog-service.ts
+++ b/packages/filesystem/src/electron-browser/file-dialog/electron-file-dialog-service.ts
@@ -153,7 +153,11 @@ export namespace electron {
          */
         export function toDialogProperties(props: OpenFileDialogProps): Array<DialogProperties> {
             if (!isOSX && props.canSelectFiles !== false && props.canSelectFolders === true) {
-                throw new Error(`Illegal props. Cannot have 'canSelectFiles' and 'canSelectFolders' at the same times. Props was: ${JSON.stringify(props)}.`);
+                console.warn(`Cannot have 'canSelectFiles' and 'canSelectFolders' at the same time. Fallback to 'folder' dialog. \nProps was: ${JSON.stringify(props)}.`);
+
+                // Given that both props are set, fallback to using a `folder` dialog.
+                props.canSelectFiles = false;
+                props.canSelectFolders = true;
             }
             const properties: Array<DialogProperties> = [];
             if (!isOSX) {

--- a/packages/plugin-ext/src/common/plugin-api-rpc.ts
+++ b/packages/plugin-ext/src/common/plugin-api-rpc.ts
@@ -401,6 +401,13 @@ export interface QuickOpenExt {
  * Options to configure the behaviour of a file open dialog.
  */
 export interface OpenDialogOptionsMain {
+
+    /**
+     * Dialog title.
+     * This parameter might be ignored, as not all operating systems display a title on open dialogs.
+     */
+    title?: string;
+
     /**
      * The resource the dialog shows when opened.
      */
@@ -443,6 +450,13 @@ export interface OpenDialogOptionsMain {
  * Options to configure the behaviour of a file save dialog.
  */
 export interface SaveDialogOptionsMain {
+
+    /**
+     * Dialog title.
+     * This parameter might be ignored, as not all operating systems display a title on save dialogs.
+     */
+    title?: string;
+
     /**
      * The resource the dialog shows when opened.
      */

--- a/packages/plugin-ext/src/main/browser/dialogs-main.ts
+++ b/packages/plugin-ext/src/main/browser/dialogs-main.ts
@@ -17,9 +17,8 @@
 import { interfaces } from 'inversify';
 import { RPCProtocol } from '../../common/rpc-protocol';
 import { OpenDialogOptionsMain, SaveDialogOptionsMain, DialogsMain, UploadDialogOptionsMain } from '../../common/plugin-api-rpc';
-import { DirNode, OpenFileDialogProps, SaveFileDialogProps, OpenFileDialogFactory, SaveFileDialogFactory, SaveFileDialog } from '@theia/filesystem/lib/browser';
+import { OpenFileDialogProps, SaveFileDialogProps, FileDialogService } from '@theia/filesystem/lib/browser';
 import { WorkspaceService } from '@theia/workspace/lib/browser';
-import { UriSelection } from '@theia/core/lib/common/selection';
 import URI from '@theia/core/lib/common/uri';
 import { FileUploadService } from '@theia/filesystem/lib/browser/file-upload-service';
 import { FileService } from '@theia/filesystem/lib/browser/file-service';
@@ -32,21 +31,18 @@ export class DialogsMainImpl implements DialogsMain {
     private fileService: FileService;
     private environments: EnvVariablesServer;
 
-    private openFileDialogFactory: OpenFileDialogFactory;
-    private saveFileDialogFactory: SaveFileDialogFactory;
+    private fileDialogService: FileDialogService;
     private uploadService: FileUploadService;
 
     constructor(rpc: RPCProtocol, container: interfaces.Container) {
         this.workspaceService = container.get(WorkspaceService);
         this.fileService = container.get(FileService);
         this.environments = container.get(EnvVariablesServer);
-
-        this.openFileDialogFactory = container.get(OpenFileDialogFactory);
-        this.saveFileDialogFactory = container.get(SaveFileDialogFactory);
+        this.fileDialogService = container.get(FileDialogService);
         this.uploadService = container.get(FileUploadService);
     }
 
-    protected async getRootUri(defaultUri: string | undefined): Promise<FileStat | undefined> {
+    protected async getRootStat(defaultUri: string | undefined): Promise<FileStat | undefined> {
         let rootStat: FileStat | undefined;
 
         // Try to use default URI as root
@@ -67,7 +63,7 @@ export class DialogsMainImpl implements DialogsMain {
             }
         }
 
-        // Try to use workspace service root if there is no preconfigured URI
+        // Try to use workspace service root if there is no pre-configured URI
         if (!rootStat) {
             rootStat = (await this.workspaceService.roots)[0];
         }
@@ -84,33 +80,28 @@ export class DialogsMainImpl implements DialogsMain {
     }
 
     async $showOpenDialog(options: OpenDialogOptionsMain): Promise<string[] | undefined> {
-        const rootStat = await this.getRootUri(options.defaultUri ? options.defaultUri : undefined);
-
-        // Fail if root not fount
+        const rootStat = await this.getRootStat(options.defaultUri ? options.defaultUri : undefined);
         if (!rootStat) {
             throw new Error('Unable to find the rootStat');
         }
 
-        // Take the info for root node
-        const rootNode = DirNode.createRoot(rootStat);
-
         try {
-            // Determine proper title for the dialog
             const canSelectFiles = typeof options.canSelectFiles === 'boolean' ? options.canSelectFiles : true;
             const canSelectFolders = typeof options.canSelectFolders === 'boolean' ? options.canSelectFolders : true;
 
-            let title;
-            if (canSelectFiles && canSelectFolders) {
-                title = 'Open';
-            } else {
-                if (canSelectFiles) {
-                    title = 'Open File';
+            let title = options.title;
+            if (!title) {
+                if (canSelectFiles && canSelectFolders) {
+                    title = 'Open';
                 } else {
-                    title = 'Open Folder';
-                }
-
-                if (options.canSelectMany) {
-                    title += '(s)';
+                    if (canSelectFiles) {
+                        title = 'Open File';
+                    } else {
+                        title = 'Open Folder';
+                    }
+                    if (options.canSelectMany) {
+                        title += '(s)';
+                    }
                 }
             }
 
@@ -124,13 +115,8 @@ export class DialogsMainImpl implements DialogsMain {
                 filters: options.filters
             } as OpenFileDialogProps;
 
-            // Show open file dialog
-            const dialog = this.openFileDialogFactory(dialogProps);
-            dialog.model.navigateTo(rootNode);
-            const result = await dialog.open();
-
-            // Return the result
-            return UriSelection.getUris(result).map(uri => uri.path.toString());
+            const result = await this.fileDialogService.showOpenDialog(dialogProps, rootStat);
+            return result ? [result].map(uri => uri.path.toString()) : undefined;
         } catch (error) {
             console.error(error);
         }
@@ -139,15 +125,7 @@ export class DialogsMainImpl implements DialogsMain {
     }
 
     async $showSaveDialog(options: SaveDialogOptionsMain): Promise<string | undefined> {
-        const rootStat = await this.getRootUri(options.defaultUri ? options.defaultUri : undefined);
-
-        // Fail if root not found
-        if (!rootStat) {
-            throw new Error('Unable to find the rootStat');
-        }
-
-        // Take the info for root node
-        const rootNode = DirNode.createRoot(rootStat);
+        const rootStat = await this.getRootStat(options.defaultUri ? options.defaultUri : undefined);
 
         // File name field should be empty unless the URI is a file
         let fileNameValue = '';
@@ -164,22 +142,16 @@ export class DialogsMainImpl implements DialogsMain {
         try {
             // Create save file dialog props
             const dialogProps = {
-                title: 'Save',
+                title: options.title ?? 'Save',
                 saveLabel: options.saveLabel,
                 filters: options.filters,
                 inputValue: fileNameValue
             } as SaveFileDialogProps;
 
-            // Show save file dialog
-            const dialog: SaveFileDialog = this.saveFileDialogFactory(dialogProps);
-            dialog.model.navigateTo(rootNode);
-            const result = await dialog.open();
-
-            // Return the result
+            const result = await this.fileDialogService.showSaveDialog(dialogProps, rootStat);
             if (result) {
                 return result.path.toString();
             }
-
             return undefined;
         } catch (error) {
             console.error(error);
@@ -189,7 +161,7 @@ export class DialogsMainImpl implements DialogsMain {
     }
 
     async $showUploadDialog(options: UploadDialogOptionsMain): Promise<string[] | undefined> {
-        const rootStat = await this.getRootUri(options.defaultUri);
+        const rootStat = await this.getRootStat(options.defaultUri);
 
         // Fail if root not fount
         if (!rootStat) {

--- a/packages/plugin-ext/src/plugin/dialogs.ts
+++ b/packages/plugin-ext/src/plugin/dialogs.ts
@@ -27,6 +27,7 @@ export class DialogsExtImpl {
 
     showOpenDialog(options: OpenDialogOptions): PromiseLike<Uri[] | undefined> {
         const optionsMain = {
+            title: options.title,
             openLabel: options.openLabel,
             defaultUri: options.defaultUri ? options.defaultUri.path : undefined,
             canSelectFiles: options.canSelectFiles ? options.canSelectFiles : true,
@@ -55,6 +56,7 @@ export class DialogsExtImpl {
 
     showSaveDialog(options: SaveDialogOptions): PromiseLike<Uri | undefined> {
         const optionsMain = {
+            title: options.title,
             saveLabel: options.saveLabel,
             defaultUri: options.defaultUri ? options.defaultUri.path : undefined,
             filters: options.filters

--- a/packages/plugin/src/theia.d.ts
+++ b/packages/plugin/src/theia.d.ts
@@ -2649,6 +2649,13 @@ declare module '@theia/plugin' {
      * and the editor then silently adjusts the options to select files.
      */
     export interface OpenDialogOptions {
+
+        /**
+         * Dialog title.
+         * This parameter might be ignored, as not all operating systems display a title on open dialogs.
+         */
+        title?: string;
+
         /**
          * The resource the dialog shows when opened.
          */
@@ -2691,6 +2698,13 @@ declare module '@theia/plugin' {
      * Options to configure the behaviour of a file save dialog.
      */
     export interface SaveDialogOptions {
+
+        /**
+         * Dialog title.
+         * This parameter might be ignored, as not all operating systems display a title on save dialogs.
+         */
+        title?: string;
+
         /**
          * The resource the dialog shows when opened.
          */


### PR DESCRIPTION


<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

Fixes: #9177 

The following commit updates the `dialog` extension API. The changes include updating the use of factories in order to use the
`fileDialogService` which already properly handles the dialog logic, and includes implementations in both the `browser` and `electron`.

The changes also include:
- adding `title` as an available prop
- adding extra handling when using both `canSelectFiles` and
  `canSelectFolders` simultaenously in the electron target.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

Using the following [plugin](https://github.com/vince-fugnitto/vscode-dialog/releases/download/0.0.1/vscode-dialog-0.0.1.vsix) verify that the `browser` and `electron` applications correctly trigger their respective open and save dialogs through the commands:
- `Dialog: Open`
- `Dialog: Save`

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

Signed-off-by: vince-fugnitto <vincent.fugnitto@ericsson.com>
