### PR TITLE
VSX: Add Toolbar Menu and Support 'Install from VSIX...' Command

### DIFF
--- a/packages/plugin-ext-vscode/src/browser/plugin-vscode-commands-contribution.ts
+++ b/packages/plugin-ext-vscode/src/browser/plugin-vscode-commands-contribution.ts
@@ -45,7 +45,7 @@ import {
 } from '@theia/plugin-ext/lib/common/plugin-api-rpc-model';
 import { DocumentsMainImpl } from '@theia/plugin-ext/lib/main/browser/documents-main';
 import { createUntitledURI } from '@theia/plugin-ext/lib/main/browser/editor/untitled-resource';
-import { toDocumentSymbol } from '@theia/plugin-ext/lib/plugin/type-converters';
+import { isUriComponents, toDocumentSymbol } from '@theia/plugin-ext/lib/plugin/type-converters';
 import { ViewColumn } from '@theia/plugin-ext/lib/plugin/types-impl';
 import { WorkspaceCommands } from '@theia/workspace/lib/browser';
 import { WorkspaceService, WorkspaceInput } from '@theia/workspace/lib/browser/workspace-service';
@@ -65,6 +65,7 @@ import {
 import { FILE_NAVIGATOR_ID, FileNavigatorWidget } from '@theia/navigator/lib/browser';
 import { SelectableTreeNode } from '@theia/core/lib/browser/tree/tree-selection';
 import { UriComponents } from '@theia/plugin-ext/lib/common/uri-components';
+import { FileService } from '@theia/filesystem/lib/browser/file-service';
 
 export namespace VscodeCommands {
     export const OPEN: Command = {
@@ -77,6 +78,10 @@ export namespace VscodeCommands {
 
     export const DIFF: Command = {
         id: 'vscode.diff'
+    };
+
+    export const INSTALL_FROM_VSIX: Command = {
+        id: 'workbench.extensions.installExtension'
     };
 }
 
@@ -110,6 +115,8 @@ export class PluginVscodeCommandsContribution implements CommandContribution {
     protected readonly codeEditorWidgetUtil: CodeEditorWidgetUtil;
     @inject(PluginServer)
     protected readonly pluginServer: PluginServer;
+    @inject(FileService)
+    protected readonly fileService: FileService;
 
     registerCommands(commands: CommandRegistry): void {
         commands.registerCommand(VscodeCommands.OPEN, {
@@ -212,12 +219,13 @@ export class PluginVscodeCommandsContribution implements CommandContribution {
         commands.registerCommand({ id: 'workbench.action.openSettings' }, {
             execute: () => commands.executeCommand(CommonCommands.OPEN_PREFERENCES.id)
         });
-        commands.registerCommand({ id: 'workbench.extensions.installExtension' }, {
-            execute: async (vsixUriOrExtensionId: UriComponents | string) => {
+        commands.registerCommand({ id: VscodeCommands.INSTALL_FROM_VSIX.id }, {
+            execute: async (vsixUriOrExtensionId: TheiaURI | UriComponents | string) => {
                 if (typeof vsixUriOrExtensionId === 'string') {
-                    this.pluginServer.deploy(`vscode:extension/${vsixUriOrExtensionId}`);
+                    await this.pluginServer.deploy(`vscode:extension/${vsixUriOrExtensionId}`);
                 } else {
-                    this.pluginServer.deploy(`local-file:${URI.revive(vsixUriOrExtensionId).fsPath}`);
+                    const uriPath = isUriComponents(vsixUriOrExtensionId) ? URI.revive(vsixUriOrExtensionId).fsPath : await this.fileService.fsPath(vsixUriOrExtensionId);
+                    await this.pluginServer.deploy(`local-file:${uriPath}`);
                 }
             }
         });


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

Fixes #7538

- Adds a `_more_` toolbar menu to the `extensions view` to which additional commands may be registered.
- Adds an `Install from VSIX...` command that supports installation of extensions from a locally available `.vsix` file.

![image](https://user-images.githubusercontent.com/46289281/110365949-a8396600-8013-11eb-8957-026a3aa41e1d.png)

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

1. Visit [open-vsx.org](https://open-vsx.org/) and download an extension as a `.vsix` file.
2. Open the `extensions` view.
3. Select the `_more_` menu item in the toolbar and execute the `Install from VSIX...` command
4. Select a local `.vsix` file in the file dialog and click `Install`.
5. Confirm that the selected extension has been installed by checking the `extensions` view.

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

Signed-off-by: seantan22 <sean.a.tan@ericsson.com>