### PR TITLE
Initial contribution of @theia/external-terminal

### DIFF
--- a/configs/root-compilation.tsconfig.json
+++ b/configs/root-compilation.tsconfig.json
@@ -38,6 +38,9 @@
       "path": "../packages/editor/compile.tsconfig.json"
     },
     {
+      "path": "../packages/external-terminal/compile.tsconfig.json"
+    },
+    {
       "path": "../packages/file-search/compile.tsconfig.json"
     },
     {

--- a/examples/electron/compile.tsconfig.json
+++ b/examples/electron/compile.tsconfig.json
@@ -36,6 +36,9 @@
       "path": "../../packages/editor-preview/compile.tsconfig.json"
     },
     {
+      "path": "../../packages/external-terminal/compile.tsconfig.json"
+    },
+    {
       "path": "../../packages/file-search/compile.tsconfig.json"
     },
     {

--- a/examples/electron/package.json
+++ b/examples/electron/package.json
@@ -23,6 +23,7 @@
     "@theia/editor": "1.11.0",
     "@theia/editor-preview": "1.11.0",
     "@theia/electron": "1.11.0",
+    "@theia/external-terminal": "1.11.0",
     "@theia/file-search": "1.11.0",
     "@theia/filesystem": "1.11.0",
     "@theia/getting-started": "1.11.0",

--- a/packages/external-terminal/.eslintrc.js
+++ b/packages/external-terminal/.eslintrc.js
@@ -1,0 +1,10 @@
+/** @type {import('eslint').Linter.Config} */
+module.exports = {
+    extends: [
+        '../../configs/build.eslintrc.json'
+    ],
+    parserOptions: {
+        tsconfigRootDir: __dirname,
+        project: 'compile.tsconfig.json'
+    }
+};

--- a/packages/external-terminal/README.md
+++ b/packages/external-terminal/README.md
@@ -1,0 +1,46 @@
+<div align='center'>
+
+<br />
+
+<img src='https://raw.githubusercontent.com/eclipse-theia/theia/master/logo/theia.svg?sanitize=true' alt='theia-ext-logo' width='100px' />
+
+<h2>ECLIPSE THEIA - EXTERNAL-TERMINAL EXTENSION</h2>
+
+<hr />
+
+</div>
+
+## Description
+
+The `@theia/external-terminal` extension contributes the ability to spawn external terminals for `electron` applications.
+The extension includes the necessary logic to spawn the appropriate terminal application for each operating system (Windows, Linux, OSX)
+by identifying certain environment variables. The extension also contributes preferences to control this behavior if necessary.
+
+**Note:** The extension does not support browser applications.
+
+## Contributions
+
+### Commands
+
+- `OPEN_NATIVE_CONSOLE`: spawns an external terminal (native console) for different use-cases.
+
+### Preferences
+
+- `terminal.external.windowsExec`: the application executable for Windows.
+- `terminal.external.linuxExec`: the application executable for Linux.
+- `terminal.external.osxExec`: the application executable for OSX.
+
+## Additional Information
+
+- [Theia - GitHub](https://github.com/eclipse-theia/theia)
+- [Theia - Website](https://theia-ide.org/)
+
+## License
+
+-   [Eclipse Public License 2.0](http://www.eclipse.org/legal/epl-2.0/)
+-   [一 (Secondary) GNU General Public License, version 2 with the GNU Classpath Exception](https://projects.eclipse.org/license/secondary-gpl-2.0-cp)
+
+## Trademark
+
+"Theia" is a trademark of the Eclipse Foundation
+https://www.eclipse.org/theia

--- a/packages/external-terminal/compile.tsconfig.json
+++ b/packages/external-terminal/compile.tsconfig.json
@@ -1,0 +1,22 @@
+{
+  "extends": "../../configs/base.tsconfig",
+  "compilerOptions": {
+    "composite": true,
+    "rootDir": "src",
+    "outDir": "lib"
+  },
+  "include": [
+    "src"
+  ],
+  "references": [
+    {
+      "path": "../core/compile.tsconfig.json"
+    },
+    {
+      "path": "../editor/compile.tsconfig.json"
+    },
+    {
+      "path": "../workspace/compile.tsconfig.json"
+    }
+  ]
+}

--- a/packages/external-terminal/package.json
+++ b/packages/external-terminal/package.json
@@ -1,0 +1,48 @@
+{
+  "name": "@theia/external-terminal",
+  "version": "1.11.0",
+  "description": "Theia - External Terminal Extension",
+  "dependencies": {
+    "@theia/core": "1.11.0",
+    "@theia/editor": "1.11.0",
+    "@theia/workspace": "1.11.0"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "theiaExtensions": [
+    {
+      "backendElectron": "lib/electron-node/external-terminal-backend-module",
+      "frontendElectron": "lib/electron-browser/external-terminal-frontend-module"
+    }
+  ],
+  "keywords": [
+    "theia-extension"
+  ],
+  "license": "EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/eclipse-theia/theia.git"
+  },
+  "bugs": {
+    "url": "https://github.com/eclipse-theia/theia/issues"
+  },
+  "homepage": "https://github.com/eclipse-theia/theia",
+  "files": [
+    "lib",
+    "src"
+  ],
+  "scripts": {
+    "lint": "theiaext lint",
+    "build": "theiaext build",
+    "watch": "theiaext watch",
+    "clean": "theiaext clean",
+    "test": "theiaext test"
+  },
+  "devDependencies": {
+    "@theia/ext-scripts": "^1.9.0"
+  },
+  "nyc": {
+    "extends": "../../configs/nyc.json"
+  }
+}

--- a/packages/external-terminal/src/common/external-terminal.ts
+++ b/packages/external-terminal/src/common/external-terminal.ts
@@ -1,0 +1,55 @@
+/********************************************************************************
+ * Copyright (C) 2021 Ericsson and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+export const ExternalTerminalService = Symbol('ExternalTerminalService');
+export const externalTerminalServicePath = '/services/external-terminal';
+
+/**
+ * Represents the external terminal configuration options.
+ */
+export interface ExternalTerminalConfiguration {
+    /**
+     * The external terminal executable for Windows.
+     */
+    'terminal.external.windowsExec': string;
+    /**
+     * The external terminal executable for OSX.
+     */
+    'terminal.external.osxExec': string;
+    /**
+     * The external terminal executable for Linux.
+     */
+    'terminal.external.linuxExec': string;
+}
+
+export interface ExternalTerminalService {
+
+    /**
+     * Open a native terminal in the designated working directory.
+     *
+     * @param configuration the configuration for opening external terminals.
+     * @param cwd the string URI of the current working directory where the terminal should open from.
+     */
+    openTerminal(configuration: ExternalTerminalConfiguration, cwd: string): Promise<void>;
+
+    /**
+     * Get the default executable.
+     *
+     * @returns the default terminal executable.
+     */
+    getDefaultExec(): Promise<string>;
+
+}

--- a/packages/external-terminal/src/electron-browser/external-terminal-contribution.ts
+++ b/packages/external-terminal/src/electron-browser/external-terminal-contribution.ts
@@ -1,0 +1,114 @@
+/********************************************************************************
+ * Copyright (C) 2021 Ericsson and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import { inject, injectable } from 'inversify';
+import { Command, CommandContribution, CommandRegistry } from '@theia/core/lib/common';
+import { EnvVariablesServer } from '@theia/core/lib/common/env-variables';
+import { QuickPickService } from '@theia/core/lib/common/quick-pick-service';
+import { KeybindingContribution, KeybindingRegistry, LabelProvider } from '@theia/core/lib/browser';
+import { EditorManager } from '@theia/editor/lib/browser/editor-manager';
+import { WorkspaceService } from '@theia/workspace/lib/browser';
+import { ExternalTerminalService } from '../common/external-terminal';
+import { ExternalTerminalPreferenceService } from './external-terminal-preference';
+
+export namespace ExternalTerminalCommands {
+    export const OPEN_NATIVE_CONSOLE: Command = {
+        id: 'workbench.action.terminal.openNativeConsole',
+        label: 'Open New External Terminal'
+    };
+}
+
+@injectable()
+export class ExternalTerminalFrontendContribution implements CommandContribution, KeybindingContribution {
+
+    @inject(EditorManager)
+    protected readonly editorManager: EditorManager;
+
+    @inject(EnvVariablesServer)
+    protected readonly envVariablesServer: EnvVariablesServer;
+
+    @inject(LabelProvider)
+    protected readonly labelProvider: LabelProvider;
+
+    @inject(QuickPickService)
+    protected readonly quickPickService: QuickPickService;
+
+    @inject(ExternalTerminalService)
+    protected readonly externalTerminalService: ExternalTerminalService;
+
+    @inject(ExternalTerminalPreferenceService)
+    protected readonly externalTerminalPreferences: ExternalTerminalPreferenceService;
+
+    @inject(WorkspaceService)
+    protected readonly workspaceService: WorkspaceService;
+
+    registerCommands(commands: CommandRegistry): void {
+        commands.registerCommand(ExternalTerminalCommands.OPEN_NATIVE_CONSOLE, {
+            execute: () => this.openExternalTerminal()
+        });
+    }
+
+    registerKeybindings(keybindings: KeybindingRegistry): void {
+        keybindings.registerKeybinding({
+            command: ExternalTerminalCommands.OPEN_NATIVE_CONSOLE.id,
+            keybinding: 'ctrlcmd+shift+c',
+            when: '!terminalFocus'
+        });
+    }
+
+    /**
+     * Open a native console on the host machine.
+     *
+     * - If multi-root workspace is open, displays a quick pick to let users choose which workspace to spawn the terminal.
+     * - If only one workspace is open, the terminal spawns at the root of the current workspace.
+     * - If no workspace is open and there is an active editor, the terminal spawns at the parent folder of that file.
+     * - If no workspace is open and there are no active editors, the terminal spawns at user home directory.
+     */
+    protected async openExternalTerminal(): Promise<void> {
+        const configuration = this.externalTerminalPreferences.getExternalTerminalConfiguration();
+
+        if (this.workspaceService.isMultiRootWorkspaceOpened) {
+            const chosenWorkspaceRoot = await this.selectCwd();
+            if (chosenWorkspaceRoot) {
+                await this.externalTerminalService.openTerminal(configuration, chosenWorkspaceRoot);
+            }
+            return;
+        }
+
+        if (this.workspaceService.opened) {
+            const workspaceRootUri = this.workspaceService.tryGetRoots()[0].resource;
+            await this.externalTerminalService.openTerminal(configuration, workspaceRootUri.toString());
+            return;
+        }
+
+        const fallbackUri = this.editorManager.activeEditor?.editor.uri.parent ?? await this.envVariablesServer.getHomeDirUri();
+        await this.externalTerminalService.openTerminal(configuration, fallbackUri.toString());
+    }
+
+    /**
+     * Display a quick pick for user to choose a target workspace in opened workspaces.
+     */
+    protected async selectCwd(): Promise<string | undefined> {
+        const roots = this.workspaceService.tryGetRoots();
+        return this.quickPickService.show(roots.map(
+            ({ resource }) => ({
+                label: this.labelProvider.getName(resource),
+                description: this.labelProvider.getLongName(resource),
+                value: resource.toString()
+            })
+        ), { placeholder: 'Select current working directory for new external terminal' });
+    }
+}

--- a/packages/external-terminal/src/electron-browser/external-terminal-frontend-module.ts
+++ b/packages/external-terminal/src/electron-browser/external-terminal-frontend-module.ts
@@ -1,0 +1,33 @@
+/********************************************************************************
+ * Copyright (C) 2021 Ericsson and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import { ContainerModule, interfaces } from 'inversify';
+import { CommandContribution } from '@theia/core/lib/common';
+import { KeybindingContribution, WebSocketConnectionProvider } from '@theia/core/lib/browser';
+import { bindExternalTerminalPreferences } from './external-terminal-preference';
+import { ExternalTerminalFrontendContribution } from './external-terminal-contribution';
+import { ExternalTerminalService, externalTerminalServicePath } from '../common/external-terminal';
+
+export default new ContainerModule((bind: interfaces.Bind) => {
+    bind(ExternalTerminalFrontendContribution).toSelf().inSingletonScope();
+    bindExternalTerminalPreferences(bind);
+    [CommandContribution, KeybindingContribution].forEach(serviceIdentifier =>
+        bind(serviceIdentifier).toService(ExternalTerminalFrontendContribution)
+    );
+    bind(ExternalTerminalService).toDynamicValue(ctx =>
+        WebSocketConnectionProvider.createProxy<ExternalTerminalService>(ctx.container, externalTerminalServicePath)
+    ).inSingletonScope();
+});

--- a/packages/external-terminal/src/electron-browser/external-terminal-preference.ts
+++ b/packages/external-terminal/src/electron-browser/external-terminal-preference.ts
@@ -1,0 +1,104 @@
+/********************************************************************************
+ * Copyright (C) 2021 Ericsson and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import { inject, injectable, interfaces, postConstruct } from 'inversify';
+import {
+    createPreferenceProxy,
+    PreferenceSchema,
+    PreferenceService,
+    PreferenceProxy
+} from '@theia/core/lib/browser';
+import { PreferenceSchemaProvider } from '@theia/core/lib/browser/preferences/preference-contribution';
+import { isWindows, isOSX } from '@theia/core/lib/common/os';
+import { ExternalTerminalService, ExternalTerminalConfiguration } from '../common/external-terminal';
+
+export const ExternalTerminalPreferences = Symbol('ExternalTerminalPreferences');
+export type ExternalTerminalPreferences = PreferenceProxy<ExternalTerminalConfiguration>;
+
+export const ExternalTerminalSchemaPromise = Symbol('ExternalTerminalSchemaPromise');
+export type ExternalTerminalSchemaPromise = Promise<PreferenceSchema>;
+
+export function bindExternalTerminalPreferences(bind: interfaces.Bind): void {
+    bind(ExternalTerminalSchemaPromise).toDynamicValue(
+        ctx => getExternalTerminalSchema(ctx.container.get(ExternalTerminalService))
+    ).inSingletonScope();
+    bind(ExternalTerminalPreferences).toDynamicValue(
+        ctx => createPreferenceProxy(
+            ctx.container.get(PreferenceService),
+            ctx.container.get(ExternalTerminalSchemaPromise),
+        )
+    ).inSingletonScope();
+    bind(ExternalTerminalPreferenceService).toSelf().inSingletonScope();
+}
+
+@injectable()
+export class ExternalTerminalPreferenceService {
+
+    @inject(ExternalTerminalPreferences)
+    protected readonly preferences: ExternalTerminalPreferences;
+
+    @inject(PreferenceSchemaProvider)
+    protected readonly preferenceSchemaProvider: PreferenceSchemaProvider;
+
+    @inject(ExternalTerminalSchemaPromise)
+    protected readonly promisedSchema: ExternalTerminalSchemaPromise;
+
+    @postConstruct()
+    protected init(): void {
+        this.promisedSchema.then(schema => this.preferenceSchemaProvider.setSchema(schema));
+    }
+
+    /**
+     * Get the external terminal configurations from preferences.
+     */
+    getExternalTerminalConfiguration(): ExternalTerminalConfiguration {
+        return {
+            'terminal.external.linuxExec': this.preferences['terminal.external.linuxExec'],
+            'terminal.external.osxExec': this.preferences['terminal.external.osxExec'],
+            'terminal.external.windowsExec': this.preferences['terminal.external.windowsExec'],
+        };
+    }
+}
+
+/**
+ * Use the backend {@link ExternalTerminalService} to establish the schema for the `ExternalTerminalPreferences`.
+ *
+ * @param externalTerminalService the external terminal backend service.
+ * @returns a preference schema with the OS default exec set by the backend service.
+ */
+export async function getExternalTerminalSchema(externalTerminalService: ExternalTerminalService): Promise<PreferenceSchema> {
+    const hostExec = await externalTerminalService.getDefaultExec();
+    return {
+        type: 'object',
+        properties: {
+            'terminal.external.windowsExec': {
+                type: 'string',
+                description: 'Customizes which terminal to run on Windows.',
+                default: `${isWindows ? hostExec : 'C:\\WINDOWS\\System32\\cmd.exe'}`
+            },
+            'terminal.external.osxExec': {
+                type: 'string',
+                description: 'Customizes which terminal to run on macOS.',
+                default: `${isOSX ? hostExec : 'Terminal.app'}`
+            },
+            'terminal.external.linuxExec': {
+                type: 'string',
+                description: 'Customizes which terminal to run on Linux.',
+                default: `${!(isWindows || isOSX) ? hostExec : 'xterm'}`
+            }
+        }
+    };
+}

--- a/packages/external-terminal/src/electron-node/external-terminal-backend-module.ts
+++ b/packages/external-terminal/src/electron-node/external-terminal-backend-module.ts
@@ -1,0 +1,40 @@
+/********************************************************************************
+ * Copyright (C) 2021 Ericsson and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import { ContainerModule, interfaces } from 'inversify';
+import { ConnectionHandler, JsonRpcConnectionHandler } from '@theia/core/lib/common';
+import { isWindows, isOSX } from '@theia/core/lib/common/os';
+import { ExternalTerminalService, externalTerminalServicePath } from '../common/external-terminal';
+import { MacExternalTerminalService } from './mac-external-terminal-service';
+import { LinuxExternalTerminalService } from './linux-external-terminal-service';
+import { WindowsExternalTerminalService } from './windows-external-terminal-service';
+
+export function bindExternalTerminalService(bind: interfaces.Bind): void {
+    const serviceProvider: interfaces.ServiceIdentifier<ExternalTerminalService> =
+        isWindows ? WindowsExternalTerminalService : isOSX ? MacExternalTerminalService : LinuxExternalTerminalService;
+    bind(serviceProvider).toSelf().inSingletonScope();
+    bind(ExternalTerminalService).toService(serviceProvider);
+
+    bind(ConnectionHandler).toDynamicValue(ctx =>
+        new JsonRpcConnectionHandler(externalTerminalServicePath, () =>
+            ctx.container.get(ExternalTerminalService)
+        )
+    ).inSingletonScope();
+}
+
+export default new ContainerModule(bind => {
+    bindExternalTerminalService(bind);
+});

--- a/packages/external-terminal/src/electron-node/linux-external-terminal-service.ts
+++ b/packages/external-terminal/src/electron-node/linux-external-terminal-service.ts
@@ -1,0 +1,95 @@
+/********************************************************************************
+ * Copyright (C) 2021 Ericsson and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import * as cp from 'child_process';
+import * as fs from 'fs-extra';
+import { injectable } from 'inversify';
+import { OS } from '@theia/core/lib/common/os';
+import { FileUri } from '@theia/core/lib/node/file-uri';
+import { ExternalTerminalService, ExternalTerminalConfiguration } from '../common/external-terminal';
+
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+// some code copied and modified from https://github.com/microsoft/vscode/blob/1.52.1/src/vs/workbench/contrib/externalTerminal/node/externalTerminalService.ts
+
+@injectable()
+export class LinuxExternalTerminalService implements ExternalTerminalService {
+    protected DEFAULT_TERMINAL_LINUX_READY: Promise<string>;
+
+    async openTerminal(configuration: ExternalTerminalConfiguration, cwd: string): Promise<void> {
+        await this.spawnTerminal(configuration, FileUri.fsPath(cwd));
+    }
+
+    async getDefaultExec(): Promise<string> {
+        return this.getDefaultTerminalLinux();
+    }
+
+    /**
+     * Spawn the external terminal for the given options.
+     * - The method spawns the terminal application based on the preferences, else uses the default value.
+     * @param configuration the preference configuration.
+     * @param cwd the optional current working directory to spawn from.
+     */
+    protected async spawnTerminal(configuration: ExternalTerminalConfiguration, cwd?: string): Promise<void> {
+
+        // Use the executable value from the preferences if available, else fallback to the default.
+        const terminalConfig = configuration['terminal.external.linuxExec'];
+        const execPromise = terminalConfig ? Promise.resolve(terminalConfig) : this.getDefaultTerminalLinux();
+
+        return new Promise<void>((resolve, reject) => {
+            execPromise.then(exec => {
+                const env = cwd ? { cwd } : undefined;
+                const child = cp.spawn(exec, [], env);
+                child.on('error', reject);
+                child.on('exit', resolve);
+            });
+        });
+    }
+
+    /**
+     * Get the default terminal application on Linux.
+     * - The following method uses environment variables to identify the best default possible for each distro.
+     *
+     * @returns the default application on Linux.
+     */
+    protected async getDefaultTerminalLinux(): Promise<string> {
+        if (!this.DEFAULT_TERMINAL_LINUX_READY) {
+            this.DEFAULT_TERMINAL_LINUX_READY = new Promise(async resolve => {
+                if (OS.type() === OS.Type.Linux) {
+                    const isDebian = await fs.pathExists('/etc/debian_version');
+                    if (isDebian) {
+                        resolve('x-terminal-emulator');
+                    } else if (process.env.DESKTOP_SESSION === 'gnome' || process.env.DESKTOP_SESSION === 'gnome-classic') {
+                        resolve('gnome-terminal');
+                    } else if (process.env.DESKTOP_SESSION === 'kde-plasma') {
+                        resolve('konsole');
+                    } else if (process.env.COLORTERM) {
+                        resolve(process.env.COLORTERM);
+                    } else if (process.env.TERM) {
+                        resolve(process.env.TERM);
+                    } else {
+                        resolve('xterm');
+                    }
+                } else {
+                    resolve('xterm');
+                }
+            });
+        }
+        return this.DEFAULT_TERMINAL_LINUX_READY;
+    }
+}

--- a/packages/external-terminal/src/electron-node/mac-external-terminal-service.ts
+++ b/packages/external-terminal/src/electron-node/mac-external-terminal-service.ts
@@ -1,0 +1,70 @@
+/********************************************************************************
+ * Copyright (C) 2021 Ericsson and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import * as cp from 'child_process';
+import { injectable } from 'inversify';
+import { FileUri } from '@theia/core/lib/node/file-uri';
+import { ExternalTerminalService, ExternalTerminalConfiguration } from '../common/external-terminal';
+
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+// some code copied and modified from https://github.com/microsoft/vscode/blob/1.52.1/src/vs/workbench/contrib/externalTerminal/node/externalTerminalService.ts
+
+@injectable()
+export class MacExternalTerminalService implements ExternalTerminalService {
+    protected osxOpener = '/usr/bin/open';
+    protected defaultTerminalApp = 'Terminal.app';
+
+    async openTerminal(configuration: ExternalTerminalConfiguration, cwd: string): Promise<void> {
+        await this.spawnTerminal(configuration, FileUri.fsPath(cwd));
+    }
+
+    async getDefaultExec(): Promise<string> {
+        return this.getDefaultTerminalOSX();
+    }
+
+    /**
+     * Spawn the external terminal for the given options.
+     * - The method spawns the terminal application based on the preferences, else uses the default value.
+     * @param configuration the preference configuration.
+     * @param cwd the optional current working directory to spawn from.
+     */
+    protected async spawnTerminal(configuration: ExternalTerminalConfiguration, cwd?: string): Promise<void> {
+
+        // Use the executable value from the preferences if available, else fallback to the default.
+        const terminalConfig = configuration['terminal.external.osxExec'];
+        const terminalApp = terminalConfig || this.getDefaultTerminalOSX();
+
+        return new Promise<void>((resolve, reject) => {
+            const args = ['-a', terminalApp];
+            if (cwd) {
+                args.push(cwd);
+            }
+            const child = cp.spawn(this.osxOpener, args);
+            child.on('error', reject);
+            child.on('exit', () => resolve());
+        });
+    }
+
+    /**
+     * Get the default terminal app on OSX.
+     */
+    protected getDefaultTerminalOSX(): string {
+        return this.defaultTerminalApp;
+    }
+}

--- a/packages/external-terminal/src/electron-node/windows-external-terminal-service.ts
+++ b/packages/external-terminal/src/electron-node/windows-external-terminal-service.ts
@@ -1,0 +1,110 @@
+/********************************************************************************
+ * Copyright (C) 2021 Ericsson and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import * as cp from 'child_process';
+import * as path from 'path';
+import { injectable } from 'inversify';
+import { FileUri } from '@theia/core/lib/node/file-uri';
+import { ExternalTerminalService, ExternalTerminalConfiguration } from '../common/external-terminal';
+
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+// some code copied and modified from https://github.com/microsoft/vscode/blob/1.52.1/src/vs/workbench/contrib/externalTerminal/node/externalTerminalService.ts
+
+@injectable()
+export class WindowsExternalTerminalService implements ExternalTerminalService {
+    protected readonly CMD = 'cmd.exe';
+    protected DEFAULT_TERMINAL_WINDOWS: string;
+
+    async openTerminal(configuration: ExternalTerminalConfiguration, cwd: string): Promise<void> {
+        await this.spawnTerminal(configuration, FileUri.fsPath(cwd));
+    }
+
+    async getDefaultExec(): Promise<string> {
+        return this.getDefaultTerminalWindows();
+    }
+
+    /**
+     * Spawn the external terminal for the given options.
+     * - The method spawns the terminal application based on the preferences, else uses the default value.
+     * @param configuration the preference configuration.
+     * @param cwd the optional current working directory to spawn from.
+     */
+    protected async spawnTerminal(configuration: ExternalTerminalConfiguration, cwd?: string): Promise<void> {
+
+        // Use the executable value from the preferences if available, else fallback to the default.
+        const terminalConfig = configuration['terminal.external.windowsExec'];
+        const exec = terminalConfig || this.getDefaultTerminalWindows();
+
+        // Make the drive letter uppercase on Windows (https://github.com/microsoft/vscode/issues/9448).
+        if (cwd && cwd[1] === ':') {
+            cwd = cwd[0].toUpperCase() + cwd.substr(1);
+        }
+
+        // cmder ignores the environment cwd and instead opts to always open in %USERPROFILE%
+        // unless otherwise specified.
+        const basename = path.basename(exec).toLowerCase();
+        if (basename === 'cmder' || basename === 'cmder.exe') {
+            cp.spawn(exec, cwd ? [cwd] : undefined);
+            return;
+        }
+
+        const cmdArgs = ['/c', 'start', '/wait'];
+        // The "" argument is the window title. Without this, exec doesn't work when the path contains spaces.
+        if (exec.indexOf(' ') >= 0) {
+            cmdArgs.push('""');
+        }
+
+        cmdArgs.push(exec);
+
+        // Add starting directory parameter for Windows Terminal app.
+        if (basename === 'wt' || basename === 'wt.exe') {
+            cmdArgs.push('-d .');
+        }
+
+        return new Promise<void>(async (resolve, reject) => {
+            const env = cwd ? { cwd } : undefined;
+            const command = this.getWindowsShell();
+            const child = cp.spawn(command, cmdArgs, env);
+            child.on('error', reject);
+            child.on('exit', resolve);
+        });
+    }
+
+    /**
+     * Get the default terminal application on Windows.
+     * - The following method uses environment variables to identify the best default possible value.
+     *
+     * @returns the default application on Windows.
+     */
+    protected getDefaultTerminalWindows(): string {
+        if (!this.DEFAULT_TERMINAL_WINDOWS) {
+            const isWoW64 = !!process.env.hasOwnProperty('PROCESSOR_ARCHITEW6432');
+            this.DEFAULT_TERMINAL_WINDOWS = `${process.env.windir ? process.env.windir : 'C:\\Windows'}\\${isWoW64 ? 'Sysnative' : 'System32'}\\cmd.exe`;
+        }
+        return this.DEFAULT_TERMINAL_WINDOWS;
+    }
+
+    /**
+     * Find the Windows Shell process to start up (defaults to cmd.exe).
+     */
+    protected getWindowsShell(): string {
+        // Find the path to cmd.exe if possible (%compsec% environment variable).
+        return process.env.compsec || this.CMD;
+    }
+}

--- a/packages/external-terminal/src/package.spec.ts
+++ b/packages/external-terminal/src/package.spec.ts
@@ -1,0 +1,29 @@
+/********************************************************************************
+ * Copyright (C) 2021 Ericsson and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+/* note: this bogus test file is required so that
+  we are able to run mocha unit tests on this
+  package, without having any actual unit tests in it.
+  This way a coverage report will be generated,
+  showing 0% coverage, instead of no report.
+  This file can be removed once we have real unit
+  tests in place. */
+
+describe('external-terminal package', () => {
+
+    it('support code coverage statistics', () => true);
+
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -58,6 +58,9 @@
       "@theia/editor/lib/*": [
         "packages/editor/src/*"
       ],
+      "@theia/external-terminal/lib/*": [
+        "packages/external-terminal/src/*"
+      ],
       "@theia/file-search/lib/*": [
         "packages/file-search/src/*"
       ],


### PR DESCRIPTION
## What it does
<!-- Include relevant issues and describe how they are addressed. -->
+ Introduces a new extension: `@theia/external-terminal`. The extension adds support for spawning external terminals from Electron applications. In the future, the extension can be extended to support features such as spawning external terminals during debug sessions.
(**Browser applications should not pull this extension**).

#### Checklist for merging:
- [x] [CQ](https://dev.eclipse.org/ipzilla/show_bug.cgi?id=23140) registered and **approved**
- [x] #9169 needs to be merged first since this PR depends on the ability for late binding in preference proxy.

#### Command:
+ Closes #8712 : Supports opening native terminals by calling `Open New External Terminal` from the command palette. 

#### Preferences:
+ The PR contributes the following preferences:
	- `terminal.external.windowsExec`
	- `terminal.external.osxExec`
	- `terminal.external.linuxExec`
to allow users to customize the desired terminal application to run on their current platform. 
+ On startup, the backend determines the default terminal on the host machine, then sets the default field in the preference schema accordingly.
+ Changing the `Exec` preference of other OS than the current one won't have any effect. (i.e: Changing `osxExec` while running on Windows doesn't have any effect).

## How to test:
+ Start **Theia Electron application**
+ Verify the default `exec` of host OS is displaying the correct terminal.

Calling command `Open New External Terminal` has different behaviors, depending on the current workspace status:

#### No workspaces opened and no current active editor -> Spawn the terminal at the user home directory.

https://user-images.githubusercontent.com/43587865/110700880-76183780-81be-11eb-9a89-a85e73fe18e3.mp4


#### No workspaces opened but has an active editor -> Spawn the terminal at the parent folder of the active editor file.

https://user-images.githubusercontent.com/43587865/110700923-83352680-81be-11eb-9f74-2bedbf28c081.mp4


#### Only one workspace opened -> Spawn the terminal at the root of the current workspace.

https://user-images.githubusercontent.com/43587865/110700788-5bde5980-81be-11eb-99c8-2eacd73f0a72.mp4


#### Multi-root workspace opened -> Displays a quick pick to let users choose which workspace to spawn the terminal.

https://user-images.githubusercontent.com/43587865/110700703-40734e80-81be-11eb-8423-d6e72130b811.mp4


## Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

## Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

Signed-off-by: Duc Nguyen <duc.a.nguyen@ericsson.com>
