### PR TITLE
Support "when":"true" in 'commandPalette' menus

### DIFF
--- a/packages/core/src/browser/quick-open/quick-command-service.ts
+++ b/packages/core/src/browser/quick-open/quick-command-service.ts
@@ -191,7 +191,10 @@ export class QuickCommandService implements QuickOpenModel, QuickOpenHandler {
         raw.forEach((command: Command) => {
             if (command.label) {
                 const contexts = this.contexts.get(command.id);
-                if (!contexts || contexts.some(when => this.contextKeyService.match(when))) {
+                if (!contexts || contexts.some(when => {
+                    when = when.trim();
+                    return when === 'true' || this.contextKeyService.match(when);
+                })) {
                     valid.push(command);
                 }
             }


### PR DESCRIPTION
Adds a missing check for "true" on contributed "commandPalette" menus

Fixes: #9065

Signed-off-by: Alvaro Sanchez-Leon <alvaro.sanchez-leon@ericsson.com>

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->
Fixes the issue described by #9065, where contributed 'commandPalette' menus including the "when" clause and set to "true"
don't get presented to the user.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
In your test extension add the following commands and menus to your package.json

1) Add some commands to a test plugin e.g. 
```
		"commands": [
			{
				"command": "Alvs-extension.dosomething-true",
				"title": "Alvs do something - true",
				"category": "Alvs"
			},
			{
				"command": "Alvs-extension.dosomething-false",
				"title": "Alvs do something - false",
				"category": "Alvs"
			},
			{
				"command": "Alvs-extension.dosomething-undefined",
				"title": "Alvs do something  - undefined",
				"category": "Alvs"
			}
		]
```
2) Add corresponding 'commandPalette' menus to the commands above
e.g.
```
		  "menus": {
			"commandPalette": [ 
			  {
				"command": "Alvs-extension.dosomething-true",
				"when": "true"
			  },
			  {
				"command": "Alvs-extension.dosomething-false",
				"when": "false"
			  },
			  {
				"command": "Alvs-extension.dosomething-undefined"
			  }
			]
		  }
```
3) Display the available commands via 
 >Ctrl-shft-P and filter by 'Alvs'

4) Before this fix you would only see one entry for 'undefined'
    After applying the fix you shall see two entries 'undefined' and 'true'


#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

