### PR TITLE
Fix #5812, Replacing a magic number with its css variable

### DIFF
--- a/packages/plugin-ext/src/main/browser/style/comments.css
+++ b/packages/plugin-ext/src/main/browser/style/comments.css
@@ -146,7 +146,7 @@
 }
 
 .monaco-editor .review-widget .body .review-comment .review-comment-contents .author {
-    line-height: 22px;
+    line-height: var(--theia-content-line-height);
 }
 
 .monaco-editor .review-widget .body .review-comment .review-comment-contents .isPending {


### PR DESCRIPTION
Signed-off-by: Beyza Hizli <beyzahizli@gmail.com>

#### What it does

Fixes: #5812 

This pull request fixes issue #5812. The requested variable is already introduced and used, but one instance of the magic number was missed, which is refactored now. 

#### How to test
I followed the 'how to test' guide from this pull request #8870 and inspected the reviewer comment:
![variable-test](https://i.imgur.com/BVxtBB1.png)
It is still correctly applying the line-height.
#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
