### PR TITLE
Add theia.Uri.joinPath and theia.PluginContext.extensionUri API

### DIFF
--- a/packages/plugin-ext/src/plugin/plugin-context.ts
+++ b/packages/plugin-ext/src/plugin/plugin-context.ts
@@ -136,7 +136,6 @@ import { SymbolKind } from '../common/plugin-api-rpc-model';
 import { EditorsAndDocumentsExtImpl } from './editors-and-documents';
 import { TextEditorsExtImpl } from './text-editors';
 import { DocumentsExtImpl } from './documents';
-import { URI as Uri } from 'vscode-uri';
 import { TextEditorCursorStyle } from '../common/editor-options';
 import { PreferenceRegistryExtImpl } from './preference-registry';
 import { OutputChannelRegistryExtImpl } from './output-channel-registry';
@@ -166,6 +165,7 @@ import { TimelineExtImpl } from './timeline';
 import { ThemingExtImpl } from './theming';
 import { CommentsExtImpl } from './comments';
 import { CustomEditorsExtImpl } from './custom-editors';
+import { URI as Uri} from './uri';
 
 export function createAPIFactory(
     rpc: RPCProtocol,

--- a/packages/plugin-ext/src/plugin/plugin-manager.ts
+++ b/packages/plugin-ext/src/plugin/plugin-manager.ts
@@ -38,6 +38,7 @@ import { ExtPluginApi } from '../common/plugin-ext-api-contribution';
 import { RPCProtocol } from '../common/rpc-protocol';
 import { Emitter } from '@theia/core/lib/common/event';
 import { WebviewsExtImpl } from './webviews';
+import { URI } from 'vscode-uri';
 
 export interface PluginHost {
 
@@ -345,6 +346,7 @@ export class PluginManagerExtImpl implements PluginManagerExt, PluginManager {
         const globalStoragePath = join(configStorage.hostGlobalStoragePath, plugin.model.id);
         const pluginContext: theia.PluginContext = {
             extensionPath: plugin.pluginFolder,
+            extensionUri: URI.file(plugin.pluginFolder),
             globalState: new Memento(plugin.model.id, true, this.storageProxy),
             workspaceState: new Memento(plugin.model.id, false, this.storageProxy),
             subscriptions: subscriptions,

--- a/packages/plugin-ext/src/plugin/uri.ts
+++ b/packages/plugin-ext/src/plugin/uri.ts
@@ -1,0 +1,37 @@
+/********************************************************************************
+ * Copyright (C) 2021 Red Hat, Inc. and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import { URI as Uri } from 'vscode-uri';
+import * as nodePath from 'path';
+
+const posixPath = nodePath.posix || nodePath;
+
+/**
+ * Compatible class with vscode.Uri (API).
+ */
+export class URI extends Uri {
+    /**
+     * Joins one or more input paths to the path of URI.
+     * '/' is used as the directory separation character.
+     *
+     * @param uri The input URI.
+     * @param paths The paths to be joined with the path of URI.
+     * @returns A URI with the joined path. All other properties of the URI (scheme, authority, query, fragments, ...) will be taken from the input URI.
+     */
+     static joinPath(uri: Uri, ...paths: string[]): Uri {
+       return uri.with({ path: posixPath.join(uri.path, ...paths) });
+     }
+}

--- a/packages/plugin/src/theia.d.ts
+++ b/packages/plugin/src/theia.d.ts
@@ -1333,6 +1333,15 @@ declare module '@theia/plugin' {
         with(change: { scheme?: string; authority?: string; path?: string; query?: string; fragment?: string }): Uri;
 
         /**
+        * Joins one or more input paths to the path of URI.
+        * '/' is used as the directory separation character.
+        * @param uri The input URI.
+        * @param paths The paths to be joined with the path of URI.
+        * @returns A URI with the joined path. All other properties of the URI (scheme, authority, query, fragments, ...) will be taken from the input URI.
+        */
+        static joinPath(uri: Uri, ...paths: string[]): Uri;
+
+        /**
          * Returns a string representation of this Uri. The representation and normalization
          * of a URI depends on the scheme. The resulting string can be safely used with
          * [Uri.parse](#Uri.parse).
@@ -3070,6 +3079,11 @@ declare module '@theia/plugin' {
          * The absolute file path of the directory containing the extension.
          */
         extensionPath: string;
+
+        /**
+		 * The uri of the directory containing the extension.
+		 */
+		extensionUri: Uri;
 
         /**
          * Gets the extension's environment variable collection for this workspace, enabling changes


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->
- Adds `extensionUri` into PluginContext API
- Adds `joinPath` into Uri API (https://github.com/eclipse-theia/theia/issues/8752)

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

1. Clone https://github.com/RomanNikitenko/vscode-test-extension.git
2. Build the extension using yarn and copy it to theia/plugins folder.
3. Start Theia and open Theia project as a workspace folder - it's required to have some files for testing.
4. F1 => run Test 'vscode.Uri.joinPath'

The command for testing should just display a notification with info about path to package.json file.

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

