### PR TITLE
mini-browser: fix host pattern logic

### DIFF
--- a/packages/mini-browser/src/electron-main/mini-browser-electron-main-contribution.ts
+++ b/packages/mini-browser/src/electron-main/mini-browser-electron-main-contribution.ts
@@ -36,7 +36,7 @@ export class MiniBrowserElectronMainContribution implements ElectronMainApplicat
     }
 
     protected getMiniBrowserEndpoint(port: number): string {
-        const pattern = process.env[MiniBrowserEndpoint.HOST_PATTERN_ENV] ?? MiniBrowserEndpoint.HOST_PATTERN_DEFAULT;
+        const pattern = process.env[MiniBrowserEndpoint.HOST_PATTERN_ENV] || MiniBrowserEndpoint.HOST_PATTERN_DEFAULT;
         return 'http://' + pattern.replace('{{hostname}}', `localhost:${port}`);
     }
 }


### PR DESCRIPTION
When we set environment variables in our launch.json file, we use a
notation like "VAR": "${env:VAR}". VS Code will replace the template in
the value string with the content of the actual env var value, and if
not set it will expand to "". This caused issues with the logic that uses
this value since we expected to get undefined instead of an empty
string.

Closes https://github.com/eclipse-theia/theia/issues/9052

#### How to test

Run the `Launch Electron Backend` debug configuration, it should work with this patch.

Without it should fail with "Failed to get cookie domain".

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)