### PR TITLE
Added pmarker sorting by owner

### DIFF
--- a/packages/markers/src/browser/problem/problem-tree-model.spec.ts
+++ b/packages/markers/src/browser/problem/problem-tree-model.spec.ts
@@ -125,6 +125,15 @@ describe('Problem Tree', () => {
             expect(problemTree['sortMarkers'](nodeB, nodeA)).equals(10);
         });
 
+        it('should sort markers based on owner if their severities, line numbers and columns are equal', () => {
+            const markerA = createMockMarker({ start: { line: 1, character: 10 }, end: { line: 1, character: 10 } }, DiagnosticSeverity.Error, 'A');
+            const markerB = createMockMarker({ start: { line: 1, character: 10 }, end: { line: 1, character: 10 } }, DiagnosticSeverity.Error, 'B');
+            const nodeA = createMockMarkerNode(markerA);
+            const nodeB = createMockMarkerNode(markerB);
+            expect(problemTree['sortMarkers'](nodeA, nodeB)).equals(-1);
+            expect(problemTree['sortMarkers'](nodeB, nodeA)).equals(1);
+        });
+
         it('should not sort if markers are equal', () => {
             const markerA = createMockMarker({ start: { line: 0, character: 10 }, end: { line: 0, character: 10 } }, DiagnosticSeverity.Error);
             const markerB = createMockMarker({ start: { line: 0, character: 10 }, end: { line: 0, character: 10 } }, DiagnosticSeverity.Error);
@@ -158,19 +167,20 @@ function createMockMarkerNode(marker: Marker<Diagnostic>): MarkerNode {
  * Create a mock diagnostic marker.
  * @param range the diagnostic range.
  * @param severity the diagnostic severity.
+ * @param owner the optional owner of the diagnostic
  *
  * @returns a mock diagnostic marker.
  */
-function createMockMarker(range: Range, severity: DiagnosticSeverity): Readonly<Marker<Diagnostic>> {
+function createMockMarker(range: Range, severity: DiagnosticSeverity, owner?: string): Readonly<Marker<Diagnostic>> {
     const data: Diagnostic = {
         range: range,
         severity: severity,
         message: 'message'
     };
     return Object.freeze({
-        uri: name,
+        uri: 'uri',
         kind: 'marker',
-        owner: 'owner',
+        owner: owner ?? 'owner',
         data
     });
 }

--- a/packages/markers/src/browser/problem/problem-tree-model.ts
+++ b/packages/markers/src/browser/problem/problem-tree-model.ts
@@ -42,7 +42,8 @@ export class ProblemTree extends MarkerTree<Diagnostic> {
      * Sort markers based on the following rules:
      * - Markers are fist sorted by `severity`.
      * - Markers are sorted by `line number` if applicable.
-     * - Markers are sorted by `column number` if
+     * - Markers are sorted by `column number` if applicable.
+     * - Markers are then finally sorted by `owner` if applicable.
      * @param a the first marker for comparison.
      * @param b the second marker for comparison.
      */
@@ -64,6 +65,11 @@ export class ProblemTree extends MarkerTree<Diagnostic> {
         const columnNumber = ProblemUtils.columnNumberCompare(markerA, markerB);
         if (columnNumber !== 0) {
             return columnNumber;
+        }
+        // Sort by owner in alphabetical order.
+        const owner = ProblemUtils.ownerCompare(markerA, markerB);
+        if (owner !== 0) {
+            return owner;
         }
         return 0;
     }

--- a/packages/markers/src/browser/problem/problem-utils.ts
+++ b/packages/markers/src/browser/problem/problem-utils.ts
@@ -45,4 +45,12 @@ export namespace ProblemUtils {
      */
     export const columnNumberCompare = (a: Marker<Diagnostic>, b: Marker<Diagnostic>): number => a.data.range.start.character - b.data.range.start.character;
 
+    /**
+     * Comparator for marker owner (source).
+     * - The order is alphabetical.
+     * @param a the first marker for comparison.
+     * @param b the second marker for comparison.
+     */
+     export const ownerCompare = (a: Marker<Diagnostic>, b: Marker<Diagnostic>): number => a.owner.localeCompare(b.owner);
+
 }


### PR DESCRIPTION
fixed #6572

Signed-off-by: Jonas Helming <jhelming@eclipsesource.com>


#### What it does
adds sorting by owner to problem markers (after severity, line and column


#### How to test

- Download test workspace from here: 
- https://github.com/eclipse-theia/theia/files/5859357/problems-view.zip
- Turn on eslint to get two errors in the first line first column of a.ts
- open a.ts
- open problems view
- open settings and change any setting

See also here: https://github.com/eclipse-theia/theia/issues/6572#issuecomment-800668289
#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

