### PR TITLE
Add 'onStartupFinished' event to the list of supported activation events

### DIFF
--- a/packages/plugin-ext/src/plugin/plugin-manager.ts
+++ b/packages/plugin-ext/src/plugin/plugin-manager.ts
@@ -83,7 +83,8 @@ export class PluginManagerExtImpl implements PluginManagerExt, PluginManager {
         'onUri',
         'onWebviewPanel',
         'onFileSystem',
-        'onCustomEditor'
+        'onCustomEditor',
+        'onStartupFinished'
     ]);
 
     private configStorage: ConfigStorage | undefined;


### PR DESCRIPTION
Signed-off-by: Igor Vinokur <ivinokur@redhat.com>

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->
Add 'onStartupFinished' event to the list of supported activation events

This fixes an issue which is mentioned here https://github.com/eclipse-theia/theia/pull/8525#issuecomment-796860451
#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

1. Clone any Theia plugin e.g https://github.com/eclipse/che-theia-samples/tree/master/samples/hello-world-backend-plugin
2. Change the activation event in its `package.json` from `*` to `onStartupFinished`
3. Start the plugin.
4. See: `root ERROR [hosted-plugin: 93564] Unsupported activation events: onStartupFinished, please open an issue: https://github.com/eclipse-theia/theia/issues/new` console error is gone.
#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

