### PR TITLE
Register 'workbench.action.files.openFileFolder' VS Code command

### DIFF
--- a/packages/plugin-ext-vscode/src/browser/plugin-vscode-commands-contribution.ts
+++ b/packages/plugin-ext-vscode/src/browser/plugin-vscode-commands-contribution.ts
@@ -14,7 +14,7 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
-import { Command, CommandContribution, CommandRegistry } from '@theia/core';
+import { Command, CommandContribution, CommandRegistry, environment, isOSX } from '@theia/core';
 import {
     ApplicationShell,
     CommonCommands,
@@ -194,6 +194,13 @@ export class PluginVscodeCommandsContribution implements CommandContribution {
         commands.registerCommand({ id: 'workbench.action.files.newUntitledFile' }, {
             execute: () => open(this.openerService, createUntitledURI())
         });
+
+        if (!environment.electron.is() || isOSX) {
+            commands.registerCommand({ id: 'workbench.action.files.openFileFolder' }, {
+                execute: () => commands.executeCommand(WorkspaceCommands.OPEN.id)
+            });
+        }
+
         commands.registerCommand({ id: 'workbench.action.files.openFile' }, {
             execute: () => commands.executeCommand(WorkspaceCommands.OPEN_FILE.id)
         });


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->
Add support for `workbench.action.files.openFileFolder` built-in command: https://github.com/eclipse-theia/theia/issues/8750

The command should be available for running for:
- the browser version since `Theia` dialog supports the feature
- the Electron version if the system is OSX

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
 
My test extension can be used for testing: 
1. Clone https://github.com/RomanNikitenko/vscode-test-extension.git
2. Build the extension using yarn and copy it to `theia/plugins` folder.
3. Start `Theia` and open a workspace folder.
4. `F1` => run `Test 'workbench.action.files.openFileFolder'`

a dialog should be displayed which allows to open a file or a directory

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

Signed-off-by: Roman Nikitenko <rnikiten@redhat.com>