### PR TITLE
Handle case of empty command id with arguments

### DIFF
--- a/packages/plugin-ext/src/common/rpc-protocol.ts
+++ b/packages/plugin-ext/src/common/rpc-protocol.ts
@@ -552,6 +552,10 @@ function safeStringify(obj: any, replacer?: JSONStringifyReplacer): string {
     try {
         return JSON.stringify(obj, replacer);
     } catch (err) {
+        console.warn('error stringifying response: ' + err);
+        if (err && err.stack) {
+            console.error(err.stack);
+        }
         return 'null';
     }
 }

--- a/packages/plugin-ext/src/common/rpc-protocol.ts
+++ b/packages/plugin-ext/src/common/rpc-protocol.ts
@@ -552,10 +552,7 @@ function safeStringify(obj: any, replacer?: JSONStringifyReplacer): string {
     try {
         return JSON.stringify(obj, replacer);
     } catch (err) {
-        console.warn('error stringifying response: ' + err);
-        if (err && err.stack) {
-            console.error(err.stack);
-        }
+        console.error('error stringifying response: ', err);
         return 'null';
     }
 }

--- a/packages/plugin-ext/src/plugin/command-registry.ts
+++ b/packages/plugin-ext/src/plugin/command-registry.ts
@@ -129,7 +129,7 @@ export class CommandRegistryImpl implements CommandRegistryExt {
         if (handler) {
             return handler<T>(...args.map(arg => this.argumentProcessors.reduce((r, p) => p.processArgument(r), arg)));
         } else {
-            throw new Error(`Command ${id} doesn't exist`);
+            throw new Error(`No handler exists for command '${id}'`);
         }
     }
 
@@ -171,6 +171,7 @@ export class CommandsConverter {
         if (!command) {
             return undefined;
         }
+
         const result = this.toInternalCommand(command);
         if (KnownCommands.mapped(result.id)) {
             return result;
@@ -181,7 +182,7 @@ export class CommandsConverter {
             this.isSafeCommandRegistered = true;
         }
 
-        if (command.command && command.arguments && command.arguments.length > 0) {
+        if (command.arguments && command.arguments.length > 0) {
             const id = this.handle++;
             this.commandsMap.set(id, command);
             disposables.push(new Disposable(() => this.commandsMap.delete(id)));
@@ -197,19 +198,19 @@ export class CommandsConverter {
         // Existing code will have compiled against a non - optional version of the field, so asserting it to exist is ok
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         return KnownCommands.map((external.command || external.id)!, external.arguments, (mappedId: string, mappedArgs: any[]) =>
-            ({
-                id: mappedId,
-                title: external.title || external.label || ' ',
-                tooltip: external.tooltip,
-                arguments: mappedArgs
-            }));
+        ({
+            id: mappedId,
+            title: external.title || external.label || ' ',
+            tooltip: external.tooltip,
+            arguments: mappedArgs
+        }));
     }
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     private executeSafeCommand<R>(...args: any[]): PromiseLike<R | undefined> {
         const command = this.commandsMap.get(args[0]);
         if (!command || !command.command) {
-            return Promise.reject('command NOT FOUND');
+            return Promise.reject(`command ${args[0]} not found`);
         }
         return this.commands.executeCommand(command.command, ...(command.arguments || []));
     }


### PR DESCRIPTION
Signed-off-by: Thomas Mäder <tmader@redhat.com>

#### What it does
This issue fixes the case where a command is transferred that has a non-empty argument list, but an empty command id. This is supposed to fix https://github.com/eclipse/che/issues/18921 in Eclipse Che. The case of the git plugin is not reproducible for me in plain Theia (looks like it's timing-dependent), so I made an example with code actions to reproduce the problem. 

#### How to test
1. Add the attached vsix to a theia instance and start Theia
[prefs-explorer-0.0.1.vsix.zip](https://github.com/eclipse-theia/theia/files/6171058/prefs-explorer-0.0.1.vsix.zip)
2. Open a any text file and select some text
3. You should get a code action labeled "bogus title".

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

