### PR TITLE
Edited the "Edit Keybinding" pen icon dialog box

### DIFF
--- a/packages/keymaps/src/browser/keybindings-widget.tsx
+++ b/packages/keymaps/src/browser/keybindings-widget.tsx
@@ -552,7 +552,7 @@ export class KeybindingWidget extends ReactWidget {
         const command = item.command.id;
         const oldKeybinding = item.keybinding && item.keybinding.keybinding;
         const dialog = new EditKeybindingDialog({
-            title: `Edit Keybinding For ${command}`,
+            title: `Edit Keybinding for ${command}`,
             initialValue: oldKeybinding,
             validate: newKeybinding => this.validateKeybinding(command, oldKeybinding, newKeybinding),
         }, this.keymapsService, item);


### PR DESCRIPTION
…  "Keyboard Shortcuts" in Settings) to be lowercase instead

Signed-off-by: Dania Suheimat <dania.suheimat@arm.com>

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->
In the Keyboard Shortcuts in settings, after clicking on Edit Keybinding pen icon, the Edit Keybinding For dialog box opens.

"For" should not be capitalised so this pull request changes it to have Edit Keybinding for .

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
Go to File > Settings > Open Keyboard Shortcuts.
Hover over a shortcut and click the Edit Keybinding pen icon.
The Edit Keybinding For dialog box opens.

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

