### PR TITLE
7738-view-data-not-populated

### DIFF
--- a/packages/plugin-ext/src/main/browser/view/plugin-view-registry.ts
+++ b/packages/plugin-ext/src/main/browser/view/plugin-view-registry.ts
@@ -470,15 +470,19 @@ export class PluginViewRegistry implements FrontendApplicationContribution {
                 part.onDidChangeVisibility(() => widget.suppressUpdateViewVisibility = part.isHidden);
 
                 const tryFireOnDidExpandView = () => {
-                    if (!part.collapsed && part.isVisible) {
+                    if (widget.widgets.length === 0) {
+                        if (!part.collapsed && part.isVisible) {
+                            this.onDidExpandViewEmitter.fire(viewId);
+                        }
+                    } else {
                         toFire.dispose();
                     }
                 };
                 const toFire = new DisposableCollection(
-                    Disposable.create(() => this.onDidExpandViewEmitter.fire(viewId)),
                     part.onCollapsed(tryFireOnDidExpandView),
                     part.onDidChangeVisibility(tryFireOnDidExpandView)
                 );
+
                 tryFireOnDidExpandView();
             }
         }


### PR DESCRIPTION
switching between view containers could cause view not to be populated with data

Signed-off-by: Dan Arad <dan.arad@sap.com>


#### What it does
Fixes: #7738

#### How to test
1. Load Theia when on `Explorer` tab and when "NPM scripts" section is expanded
![image](https://user-images.githubusercontent.com/71069170/111992044-a5fbff00-8b1d-11eb-8699-ea59f5ffe8be.png)
2. before NPM scripts are populated with data, switch to "Search"  tab and let it finish loading
3. Return to "Explorer" tab - "NPM scripts" should populate shortly.

#### Review checklist

- [X] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

