### PR TITLE
Added update milestone step to release checklist

### DIFF
--- a/doc/Publishing.md
+++ b/doc/Publishing.md
@@ -142,3 +142,8 @@ Updating the `yarn.lock` helps identify potential problems with our dependency v
 To successfully complete a `yarn upgrade`, one must:
 - perform `yarn upgrade` at the root of the repository.
 - fix any compilation errors, typing issues, and failing tests that may be introduced.
+
+### Update Milestones
+
+* Close current release [milestone](https://github.com/eclipse-theia/theia/milestones).
+* Create the next two milestones in the case they do not already exist. Generally, the release is performed on the last Thursday of the month, but there may be exceptions (bug fix release, holidays, etc.)


### PR DESCRIPTION
relates to #9232

Signed-off-by: Jonas Helming <jhelming@eclipsesource.com>

Added step to the release checklist to close current milestone and create future milestones. Goal is that committers can assign tickets to milestones to indicate the short term road map.

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

