### PR TITLE
VSX: Keep Recently Uninstalled Extensions in View

### DIFF
--- a/packages/vsx-registry/src/browser/vsx-extensions-model.ts
+++ b/packages/vsx-registry/src/browser/vsx-extensions-model.ts
@@ -158,16 +158,17 @@ export class VSXExtensionsModel {
     }
 
     protected async updateInstalled(): Promise<void> {
+        const prevInstalled = this._installed;
         return this.doChange(async () => {
             const plugins = this.pluginSupport.plugins;
-            const installed = new Set<string>();
+            const currInstalled = new Set<string>();
             const refreshing = [];
             for (const plugin of plugins) {
                 if (plugin.model.engine.type === 'vscode') {
                     const id = plugin.model.id;
                     this._installed.delete(id);
                     const extension = this.setExtension(id);
-                    installed.add(extension.id);
+                    currInstalled.add(extension.id);
                     refreshing.push(this.refresh(id));
                 }
             }
@@ -175,6 +176,7 @@ export class VSXExtensionsModel {
                 refreshing.push(this.refresh(id));
             }
             Promise.all(refreshing);
+            const installed = new Set([...prevInstalled, ...currInstalled]);
             const installedSorted = Array.from(installed).sort((a, b) => this.compareExtensions(a, b));
             this._installed = new Set(installedSorted.values());
         });


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

Fixes #9226

- Keeps recently uninstalled extensions present in the `installed` part of the _extensions-view_ until reload.
- Allows for convenient re-installation of an extension without the need to re-search the registry.

https://user-images.githubusercontent.com/46289281/112018182-b784dd00-8b04-11eb-8769-d7ac15121fa1.mp4

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

1. Open the _extensions-view_.
2. Select an extension and click `Uninstall`.
3. Observe that the extension remains in the `installed` part of the view and can be re-installed if needed.
4. Reload the view and observe that the recently uninstalled extension has been removed.

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

Signed-off-by: seantan22 <sean.a.tan@ericsson.com>