### PR TITLE
Exposed `_preview` editor from references widget.

### DIFF
--- a/packages/monaco/src/typings/monaco/index.d.ts
+++ b/packages/monaco/src/typings/monaco/index.d.ts
@@ -987,7 +987,8 @@ declare module monaco.referenceSearch {
         focusOnReferenceTree(): void;
         focusOnPreviewEditor(): void;
         isPreviewEditorFocused(): boolean;
-        _tree: ReferenceTree
+        _tree: ReferenceTree;
+        _preview: ICodeEditor;
     }
 
     // it's used as return value for referenceWidget._tree


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

With the new internal API, one can have better typing when customizing the peek editor from `monaco`. We already have Monaco customization in Theia:

https://github.com/eclipse-theia/theia/blob/eb119cb3328e9faefc670f545f352cb22907977b/packages/monaco/src/browser/monaco-editor-provider.ts#L180-L181

this PR helps to provide other `monaco` customizations.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

