### PR TITLE
Support tasks presentation options received from plugins

### DIFF
--- a/packages/plugin-ext/src/common/plugin-api-rpc.ts
+++ b/packages/plugin-ext/src/common/plugin-api-rpc.ts
@@ -1319,8 +1319,17 @@ export interface TaskDto {
     problemMatcher?: any;
     group?: string;
     detail?: string;
+    presentation?: TaskPresentationOptionsDTO;
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     [key: string]: any;
+}
+
+export interface TaskPresentationOptionsDTO {
+    reveal?: number;
+    focus?: boolean;
+    echo?: boolean;
+    panel?: number;
+    showReuseMessage?: boolean;
 }
 
 export interface TaskExecutionDto {

--- a/packages/plugin-ext/src/plugin/type-converters.spec.ts
+++ b/packages/plugin-ext/src/plugin/type-converters.spec.ts
@@ -194,6 +194,10 @@ describe('Type converters:', () => {
             args,
             options: { cwd },
             additionalProperty,
+            presentation: {
+                reveal: 3,
+                focus: true
+            },
             group: groupDto
         };
 
@@ -214,6 +218,10 @@ describe('Type converters:', () => {
             definition: {
                 type: shellType,
                 additionalProperty
+            },
+            presentationOptions: {
+                reveal: types.TaskRevealKind.Never,
+                focus: true
             },
             group,
             execution: {

--- a/packages/plugin-ext/src/plugin/type-converters.ts
+++ b/packages/plugin-ext/src/plugin/type-converters.ts
@@ -708,6 +708,7 @@ export function fromTask(task: theia.Task): TaskDto | undefined {
     const taskDto = {} as TaskDto;
     taskDto.label = task.name;
     taskDto.source = task.source;
+
     if ((task as types.Task).hasProblemMatchers) {
         taskDto.problemMatcher = task.problemMatchers;
     }
@@ -718,6 +719,10 @@ export function fromTask(task: theia.Task): TaskDto | undefined {
         taskDto.scope = task.scope.uri.toString();
     } else if (typeof task.scope === 'number') {
         taskDto.scope = task.scope;
+    }
+
+    if (task.presentationOptions) {
+        taskDto.presentation = task.presentationOptions;
     }
 
     const group = task.group;
@@ -761,7 +766,7 @@ export function toTask(taskDto: TaskDto): theia.Task {
         throw new Error('Task should be provided for converting');
     }
 
-    const { type, label, source, scope, problemMatcher, detail, command, args, options, windows, group, ...properties } = taskDto;
+    const { type, label, source, scope, problemMatcher, detail, command, args, options, windows, group, presentation, ...properties } = taskDto;
     const result = {} as theia.Task;
     result.name = label;
     result.source = source;
@@ -801,6 +806,10 @@ export function toTask(taskDto: TaskDto): theia.Task {
         } else if (group === TEST_GROUP) {
             result.group = TaskGroup.Test;
         }
+    }
+
+    if (presentation) {
+        result.presentationOptions = presentation;
     }
 
     if (!properties) {

--- a/packages/plugin-ext/src/plugin/types-impl.ts
+++ b/packages/plugin-ext/src/plugin/types-impl.ts
@@ -1710,7 +1710,7 @@ export class Task {
     private isTaskBackground: boolean;
     private taskSource: string;
     private taskGroup: TaskGroup | undefined;
-    private taskPresentationOptions: theia.TaskPresentationOptions | undefined;
+    private taskPresentationOptions: theia.TaskPresentationOptions;
     constructor(
         taskDefinition: theia.TaskDefinition,
         scope: theia.WorkspaceFolder | theia.TaskScope.Global | theia.TaskScope.Workspace,
@@ -1774,6 +1774,7 @@ export class Task {
             this.hasTaskProblemMatchers = false;
         }
         this.isTaskBackground = false;
+        this.presentationOptions = Object.create(null);
     }
 
     get definition(): theia.TaskDefinition {
@@ -1873,13 +1874,13 @@ export class Task {
         this.taskGroup = value;
     }
 
-    get presentationOptions(): theia.TaskPresentationOptions | undefined {
+    get presentationOptions(): theia.TaskPresentationOptions {
         return this.taskPresentationOptions;
     }
 
-    set presentationOptions(value: theia.TaskPresentationOptions | undefined) {
-        if (value === null) {
-            value = undefined;
+    set presentationOptions(value: theia.TaskPresentationOptions) {
+        if (value === null || value === undefined) {
+            value = Object.create(null);
         }
         this.taskPresentationOptions = value;
     }


### PR DESCRIPTION
Support tasks presentation options received from plugins

This expands the functionality introduced in pull request #6814

The following presentation options are now available for use by
plugins:

presentationOptions.reveal
presentationOptions.focus
presentationOptions.echo
presentationOptions.showReuseMessage
presentationOptions.panel
presentationOptions.clear

Fixes: #9239

Signed-off-by: Alvaro Sanchez-Leon <alvaro.sanchez-leon@ericsson.com>

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->
* Enables transferring task presentation options from plugins
* Translates between numerical values and 'RevealKind' and 'PanelKind' string values to convert to/from DTO

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
1) Prepare a plugin that provides tasks with all available presentation options, you can use the following as an example: 
[plugin example](https://github.com/alvsan09/vscode-task-provider-example.git) , **checkout branch: presentation-options**
2) you can install your plugin source repository under the plugins folder of your theia installation or a .vsix (generated via vsce package)
3) Update your presentation options and compile the plugin
4) Start your theia application and run the task provided by your plugin, verify the behavior of the presentation options apply.
see [Expected Output behaviour](https://code.visualstudio.com/docs/editor/tasks#_output-behavior)
5) Update your plugin provided options and repeat from step 3.

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

