### PR TITLE
GH-9262: Fixed the double hover issue for the `currentFrame` editor

### DIFF
--- a/packages/debug/src/browser/editor/debug-hover-source.tsx
+++ b/packages/debug/src/browser/editor/debug-hover-source.tsx
@@ -46,13 +46,13 @@ export class DebugHoverSource extends TreeSource {
         this.fireDidChange();
     }
 
-    async evaluate(expression: string): Promise<boolean> {
+    async evaluate(expression: string): Promise<ExpressionItem | DebugVariable | undefined> {
         const evaluated = await this.doEvaluate(expression);
         const elements = evaluated && await evaluated.getElements();
         this._expression = evaluated;
         this.elements = elements ? [...elements] : [];
         this.fireDidChange();
-        return !!evaluated;
+        return evaluated;
     }
     protected async doEvaluate(expression: string): Promise<ExpressionItem | DebugVariable | undefined> {
         const { currentSession } = this.sessions;

--- a/packages/debug/src/browser/style/index.css
+++ b/packages/debug/src/browser/style/index.css
@@ -185,16 +185,19 @@
     color: var(--theia-variable-value-color);
 }
 
+.theia-debug-hover-title.number,
 .theia-debug-console-variable.number {
-    color: var(--theia-number-variable-color);
+    color: var(--theia-variable-number-variable-color);
 }
 
+.theia-debug-hover-title.boolean,
 .theia-debug-console-variable.boolean {
-    color: var(--theia-boolean-variable-color);
+    color: var(--theia-variable-boolean-variable-color);
 }
 
+.theia-debug-hover-title.string,
 .theia-debug-console-variable.string {
-    color: var(--theia-string-variable-color);
+    color: var(--theia-variable-string-variable-color);
 }
 
 .theia-debug-console-variable .name {
@@ -342,14 +345,17 @@
 .theia-debug-hover {
     display: flex;
     flex-direction: column;
-    min-width: 324px;
-    min-height: 324px;
-    width: 324px;
-    height: 324px;
     border: 1px solid var(--theia-editorHoverWidget-border);
     background: var(--theia-editorHoverWidget-background);
     /* TODO color: var(--theia-editorHoverWidget-foreground); with a newer Monaco version */
     color: var(--theia-editorWidget-foreground);
+}
+
+.theia-debug-hover.complex-value {
+    min-width: 324px;
+    min-height: 324px;
+    width: 324px;
+    height: 324px;
 }
 
 .theia-debug-hover .theia-source-tree {
@@ -362,7 +368,6 @@
     white-space: nowrap;
     text-overflow: ellipsis;
     padding: var(--theia-ui-padding);
-    padding-left: calc(var(--theia-ui-padding)*2);
     border-bottom: 1px solid var(--theia-editorHoverWidget-border);
 }
 

--- a/packages/monaco/src/typings/monaco/index.d.ts
+++ b/packages/monaco/src/typings/monaco/index.d.ts
@@ -449,6 +449,14 @@ declare module monaco.editor {
 
         // https://github.com/microsoft/vscode/blob/e683ace9e5acadba0e8bde72d793cb2cb83e58a7/src/vs/editor/common/model.ts#L623
         createSnapshot(): ITextSnapshot | null;
+
+        /**
+         * Get the language associated with this model.
+         * @internal
+         */
+        // https://github.com/theia-ide/vscode/blob/standalone/0.19.x/src/vs/editor/common/model.ts#L833-L837
+        getLanguageIdentifier(): monaco.services.LanguageIdentifier;
+
     }
 
 }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->
 - This PR disables the default editor-contribution hover (such has `textdocument/hover` for JS/TS) from `monaco` for the `currentFrame` editor.
 - Fixes the string, number, and boolean coloring in the debug hover and the _Variables_ view.
 - This PR makes the debug hover content `hidden` when the expression is not complex (`!expression.hasChildren`).

Closes #9262

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

```ts
const x = 'alma';
const y = 36;
const z = true;
const complex = {
    foo: 'bar'
};
const large = {
    ...complex,
    'some string': 1
};

console.log(x, y, z, complex, large);
```

 - Test with the snippet.
 - Before the debug session, verify that you can see the default editor hover.
 - Start a debug session, check that the default hover is not there. (Please also check the color of the variables),
 - Stop the debug session, the default hover is available again.
 - Verify the colors in the _Variables_ view.

![Screen Shot 2021-03-29 at 10 54 26](https://user-images.githubusercontent.com/1405703/112813373-6c2b7b00-907e-11eb-93cc-266f455132ea.jpg)

https://user-images.githubusercontent.com/1405703/112813316-5c139b80-907e-11eb-89f5-f8144cf54146.mp4


#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

