### PR TITLE
Remove deprecation of permission flags

### DIFF
--- a/packages/filesystem/src/browser/file-service.ts
+++ b/packages/filesystem/src/browser/file-service.ts
@@ -602,6 +602,11 @@ export class FileService {
 
     /**
      * Tests a user's permissions for the given resource.
+     * @param resource `URI` of the resource which should be tested.
+     * @param mode An optional integer that specifies the accessibility checks to be performed.
+     *      Check `FileAccess.Constants` for possible values of mode.
+     *      It is possible to create a mask consisting of the bitwise `OR` of two or more values (e.g. FileAccess.Constants.W_OK | FileAccess.Constants.R_OK).
+     *      If `mode` is not defined, `FileAccess.Constants.F_OK` will be used instead.
      */
     async access(resource: URI, mode?: number): Promise<boolean> {
         const provider = await this.withProvider(resource);

--- a/packages/filesystem/src/common/files.ts
+++ b/packages/filesystem/src/common/files.ts
@@ -698,16 +698,25 @@ export interface FileSystemProvider {
  */
 export interface FileSystemProviderWithAccessCapability extends FileSystemProvider {
     /**
-     * Test if the user has the permission to access the given file in the specified mode.
+     * Tests a user's permissions for the file or directory specified by URI.
      * @param resource The `URI` of the file that should be tested.
-     * @param mode The access mode that should be tested.
+     * @param mode An optional integer that specifies the accessibility checks to be performed.
+     *      Check `FileAccess.Constants` for possible values of mode.
+     *      It is possible to create a mask consisting of the bitwise `OR` of two or more values (e.g. FileAccess.Constants.W_OK | FileAccess.Constants.R_OK).
+     *      If `mode` is not defined, `FileAccess.Constants.F_OK` will be used instead.
      *
      * @returns A promise that resolves if the user has the required permissions, should be rejected otherwise.
      */
     access(resource: URI, mode?: number): Promise<void>;
 
     /**
-     * Derive the platform specific file system path that is represented by the resource.
+     * Returns the path of the given file URI, specific to the backend's operating system.
+     * If the URI is not a file URI, undefined is returned.
+     *
+     * USE WITH CAUTION: You should always prefer URIs to paths if possible, as they are
+     * portable and platform independent. Paths should only be used in cases you directly
+     * interact with the OS, e.g. when running a command on the shell.
+     *
      * @param resource `URI` of the resource to derive the path from.
      *
      * @returns A promise of the corresponding file system path.

--- a/packages/filesystem/src/common/filesystem.ts
+++ b/packages/filesystem/src/common/filesystem.ts
@@ -187,9 +187,6 @@ export interface FileSystem {
     getFsPath(uri: string): Promise<string | undefined>
 }
 
-/**
- * @deprecated since 1.4.0 - in order to support VS Code FS API (https://github.com/eclipse-theia/theia/pull/7908), use `FileService.access` instead
- */
 export namespace FileAccess {
 
     export namespace Constants {


### PR DESCRIPTION
As part of the switch-over to the vscode-compatible file service, the permission flags in FileAccess were deprecated.  However these flags are just as useful for for both `FileService.access` and `FileSystemProvider.access`.

It took me a non-trivial amount of time to figure out what I was supposed to pass as `mode` to the `access` method.  Hopefully the changes in this PR will make it clearer.

Although unrelated to permissions, I also noticed the comments for `fsPath` were misleading, missing the point that the conversion is done on the backend.

#### What it does
- removes the deprecation of the permission flags
- adds more useful comments to `access` and `fsPath`.  These comments are copied over from the original comments in filesystem.ts.

#### How to test
I don't expect any of these changes to affect the runtime.

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

