### PR TITLE
fixed typos in preference-array.css closing issue #9243

### DIFF
--- a/packages/preferences/src/browser/style/preference-array.css
+++ b/packages/preferences/src/browser/style/preference-array.css
@@ -29,7 +29,7 @@
   -webkit-box-align: center;
   -ms-flex-align   : center;
   align-items      : center;
-  padding          : calc(var(--thiea-ui-padding) / 2) var(--thiea-ui-padding);
+  padding          : calc(var(--theia-ui-padding) / 2) var(--theia-ui-padding);
   border-bottom    : var(--theia-panel-border) 2px solid;
 }
 
@@ -91,6 +91,6 @@
 }
 
 .theia-settings-container .preference-array-input {
-  padding-right: calc(var(--theia-icon-size) + var(--thiea-ui-padding));
+  padding-right: calc(var(--theia-icon-size) + var(--theia-ui-padding));
   width        : 100%;
 }


### PR DESCRIPTION
Signed-off-by: Chadha Degachi C.Degachi@student.tudelft.nl

#### What it does: 

Fixes: #9243 
This request fixes three typos in the preference-array.css file in the padding variable name. 

#### How to test
To test this fix, navigate to the application preferences from File -> Settings -> Open Preferences and scroll to the Custom Data section in the CSS completion section. Add a number of values and inspect (with chrome developer tools) the displayed array to verify correct behaviour.

![padding-fix](https://user-images.githubusercontent.com/22718292/112851232-13260c00-90ab-11eb-9d1c-89b36b50da29.png)

#### Review checklist
- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers
- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

