### PR TITLE
Add PluginContext related API

### DIFF
--- a/packages/plugin-ext/src/plugin/plugin-manager.ts
+++ b/packages/plugin-ext/src/plugin/plugin-manager.ts
@@ -38,6 +38,7 @@ import { ExtPluginApi } from '../common/plugin-ext-api-contribution';
 import { RPCProtocol } from '../common/rpc-protocol';
 import { Emitter } from '@theia/core/lib/common/event';
 import { WebviewsExtImpl } from './webviews';
+import { URI as Uri } from '@theia/core/shared/vscode-uri';
 
 export interface PluginHost {
 
@@ -346,13 +347,16 @@ export class PluginManagerExtImpl implements PluginManagerExt, PluginManager {
         const globalStoragePath = join(configStorage.hostGlobalStoragePath, plugin.model.id);
         const pluginContext: theia.PluginContext = {
             extensionPath: plugin.pluginFolder,
+            extensionUri: Uri.file(plugin.pluginFolder),
             globalState: new Memento(plugin.model.id, true, this.storageProxy),
             workspaceState: new Memento(plugin.model.id, false, this.storageProxy),
             subscriptions: subscriptions,
             asAbsolutePath: asAbsolutePath,
             logPath: logPath,
             storagePath: storagePath,
+            storageUri: storagePath ? Uri.file(storagePath) : undefined,
             globalStoragePath: globalStoragePath,
+            globalStorageUri: Uri.file(globalStoragePath),
             environmentVariableCollection: this.terminalService.getEnvironmentVariableCollection(plugin.model.id)
         };
         this.pluginContextsMap.set(plugin.model.id, pluginContext);

--- a/packages/plugin/src/theia.d.ts
+++ b/packages/plugin/src/theia.d.ts
@@ -3089,6 +3089,11 @@ declare module '@theia/plugin' {
         extensionPath: string;
 
         /**
+         * The uri of the directory containing the extension.
+         */
+        readonly extensionUri: Uri;
+
+        /**
          * Gets the extension's environment variable collection for this workspace, enabling changes
          * to be applied to terminal environment variables.
          */
@@ -3107,19 +3112,49 @@ declare module '@theia/plugin' {
          * can store private state. The directory might not exist on disk and creation is
          * up to the extension. However, the parent directory is guaranteed to be existent.
          *
-         * Use [`workspaceState`](#ExtensionContext.workspaceState) or
-         * [`globalState`](#ExtensionContext.globalState) to store key value data.
+         * Use [`workspaceState`](#PluginContext.workspaceState) or
+         * [`globalState`](#PluginContext.globalState) to store key value data.
+         *
+         * @deprecated Use [storageUri](#PluginContext.storageUri) instead.
          */
         storagePath: string | undefined;
+
+        /**
+         * The uri of a workspace specific directory in which the extension
+         * can store private state. The directory might not exist and creation is
+         * up to the extension. However, the parent directory is guaranteed to be existent.
+         * The value is `undefined` when no workspace nor folder has been opened.
+         *
+         * Use [`workspaceState`](#PluginContext.workspaceState) or
+         * [`globalState`](#PluginContext.globalState) to store key value data.
+         *
+         * @see [`workspace.fs`](#FileSystem) for how to read and write files and folders from
+         *  an uri.
+         */
+        readonly storageUri: Uri | undefined;
 
         /**
          * An absolute file path in which the extension can store global state.
          * The directory might not exist on disk and creation is
          * up to the extension. However, the parent directory is guaranteed to be existent.
          *
-         * Use [`globalState`](#ExtensionContext.globalState) to store key value data.
+         * Use [`globalState`](#PluginContext.globalState) to store key value data.
+         *
+         * @deprecated Use [globalStorageUri](#PluginContext.globalStorageUri) instead.
          */
         readonly globalStoragePath: string;
+
+        /**
+         * The uri of a directory in which the extension can store global state.
+         * The directory might not exist on disk and creation is
+         * up to the extension. However, the parent directory is guaranteed to be existent.
+         *
+         * Use [`globalState`](#PluginContext.globalState) to store key value data.
+         *
+         * @see [`workspace.fs`](#FileSystem) for how to read and write files and folders from
+         *  an uri.
+         */
+        readonly globalStorageUri: Uri;
 
         /**
          * An absolute file path of a directory in which the extension can create log files.


### PR DESCRIPTION
Signed-off-by: Roman Nikitenko <rnikiten@redhat.com>

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->
Add support for the following:
- [`vscode.ExtensionContext.storageUri`](https://github.com/microsoft/vscode/blob/dadb18c39e811d343e0dafc88efdf8cf0ffdc2af/src/vs/vscode.d.ts#L5838-L5850) 
- [`vscode.ExtensionContext.globalStorageUri`](https://github.com/microsoft/vscode/blob/dadb18c39e811d343e0dafc88efdf8cf0ffdc2af/src/vs/vscode.d.ts#L5864-L5874)
- [`vscode.ExtensionContext.extensionUri`](https://github.com/microsoft/vscode/blob/dadb18c39e811d343e0dafc88efdf8cf0ffdc2af/src/vs/vscode.d.ts#L5813)

The related issue: https://github.com/eclipse-theia/theia/issues/8883

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
You can use a VS Code extension which uses the required API.

I prepared a test extension and provided commands for testing: https://github.com/RomanNikitenko/vscode-test-extension.
1. Clone https://github.com/RomanNikitenko/vscode-test-extension.git
2. Build the extension: `cd vscode-test-extension && yarn`.
3. Start `Theia` and open a workspace folder.
4. `F1` => run `Extensions: Install from VSIX...` => select the extension for testing
5. `F1` => run `Test 'storageUri' from vscode.ExtensionContext`
6. `F1` => run `Test 'globalStorageUri' from vscode.ExtensionContext`
7. `F1` => run `Test 'extensionUri' from vscode.ExtensionContext`

The test commands should display a notification with the corresponding Uri.


#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

