### PR TITLE
vsx-registry: update api-compatibility handling

### DIFF
--- a/packages/vsx-registry/src/browser/vsx-extensions-model.ts
+++ b/packages/vsx-registry/src/browser/vsx-extensions-model.ts
@@ -219,6 +219,10 @@ export class VSXExtensionsModel {
 
     protected async refresh(id: string): Promise<VSXExtension | undefined> {
         try {
+            let extension = this.getExtension(id);
+            if (!this.shouldRefresh(extension)) {
+                return extension;
+            }
             const data = await this.api.getLatestCompatibleExtensionVersion(id);
             if (!data) {
                 return;
@@ -226,7 +230,7 @@ export class VSXExtensionsModel {
             if (data.error) {
                 return this.onDidFailRefresh(id, data.error);
             }
-            const extension = this.setExtension(id);
+            extension = this.setExtension(id);
             extension.update(Object.assign(data, {
                 publisher: data.namespace,
                 downloadUrl: data.files.download,
@@ -239,6 +243,17 @@ export class VSXExtensionsModel {
         } catch (e) {
             return this.onDidFailRefresh(id, e);
         }
+    }
+
+    /**
+     * Determines if the given extension should be refreshed.
+     * @param extension the extension to refresh.
+     */
+    protected shouldRefresh(extension?: VSXExtension): boolean {
+        if (extension === undefined) {
+            return true;
+        }
+        return !extension.builtin;
     }
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/packages/vsx-registry/src/common/vsx-registry-api.ts
+++ b/packages/vsx-registry/src/common/vsx-registry-api.ts
@@ -41,11 +41,6 @@ export namespace VSXResponseError {
     }
 }
 
-/**
- * Namespace reserved for vscode builtin extensions.
- */
-const VSCODE_NAMESPACE = 'vscode';
-
 @injectable()
 export class VSXRegistryAPI {
 
@@ -145,10 +140,7 @@ export class VSXRegistryAPI {
         const extensions = await this.getAllVersions(id);
         for (let i = 0; i < extensions.length; i++) {
             const extension: VSXExtensionRaw = extensions[i];
-            // Skip vscode builtin extensions.
-            if (extension.namespace === VSCODE_NAMESPACE) {
-                return extension;
-            } else if (extension.engines && this.isEngineSupported(extension.engines.vscode)) {
+            if (extension.engines && this.isEngineSupported(extension.engines.vscode)) {
                 return extension;
             }
         }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

The following pull-request updates the logic for determining which extensions from _open-vsx_ are API-compatible.
The changes remove the previous assumption that _vscode-builtin_ extensions could not be downloaded through the _extensions-view_.

The changes also improve the overall performance when dealing with **builtins**:
- [x] startup performance is improved as we no longer need to make requests to open-vsx for their information as all the information we need is local.
- [x] less overall API calls to open-vsx which does not burden them.

The changes include the following behavior updates:
- bundled builtins (added through the `package.json`) behave like today, we skip determining their compatibility as they are controlled by application-developers (use the actual model with `PluginType.System` to determine builtins).
- _vscode-builtin_ extensions searched and fetched from the _extensions-view_ are checked for API-compatibility, and the framework fetches the latest compatible extension.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

1. extensions searched from the _extensions-view_ should be checked for their compatibility.
2. extensions defined in the `package.json` should not be checked for their compatibility (as they are controlled by application developers).

To verify step 1, you can do the following:
1. delete the `plugins` folder - `rm -rf plugins`.
2. start the application at an older API version - `(cd examples/electron && yarn start --vscode-api-version=1.29.0)`.
3. in the extensions-view, search for `typescript` - the `vscode-typescript-language-features` should not be present as there should be no version which supports this API level.

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

Signed-off-by: vince-fugnitto <vincent.fugnitto@ericsson.com>
