### PR TITLE
electron: correctly erase ELECTRON_RUN_AS_NODE

### DIFF
--- a/dev-packages/application-manager/src/generator/backend-generator.ts
+++ b/dev-packages/application-manager/src/generator/backend-generator.ts
@@ -33,6 +33,11 @@ if (typeof process.versions.electron === 'undefined' && typeof process.env.THEIA
     process.versions.electron = process.env.THEIA_ELECTRON_VERSION;
 }`)}
 
+// Erase the ELECTRON_RUN_AS_NODE variable from the environment, else Electron apps started using Theia will pick it up.
+if ('ELECTRON_RUN_AS_NODE' in process.env) {
+    delete process.env.ELECTRON_RUN_AS_NODE;
+}
+
 const path = require('path');
 const express = require('express');
 const { Container } = require('inversify');

--- a/packages/plugin-dev/src/node/hosted-instance-manager.ts
+++ b/packages/plugin-dev/src/node/hosted-instance-manager.ts
@@ -92,7 +92,6 @@ const PROCESS_OPTIONS = {
     cwd: process.cwd(),
     env: { ...process.env }
 };
-delete PROCESS_OPTIONS.env.ELECTRON_RUN_AS_NODE;
 
 @injectable()
 export abstract class AbstractHostedInstanceManager implements HostedInstanceManager {

--- a/packages/plugin-ext/package.json
+++ b/packages/plugin-ext/package.json
@@ -29,6 +29,7 @@
     "decompress": "^4.2.1",
     "escape-html": "^1.0.3",
     "filenamify": "^4.1.0",
+    "is-electron": "^2.2.0",
     "jsonc-parser": "^2.2.0",
     "lodash.clonedeep": "^4.5.0",
     "macaddress": "^0.2.9",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5855,7 +5855,7 @@ is-electron-renderer@^2.0.0:
   resolved "https://registry.yarnpkg.com/is-electron-renderer/-/is-electron-renderer-2.0.1.tgz#a469d056f975697c58c98c6023eb0aa79af895a2"
   integrity sha1-pGnQVvl1aXxYyYxgI+sKp5r4laI=
 
-is-electron@^2.1.0:
+is-electron@^2.1.0, is-electron@^2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/is-electron/-/is-electron-2.2.0.tgz#8943084f09e8b731b3a7a0298a7b5d56f6b7eef0"
   integrity sha512-SpMppC2XR3YdxSzczXReBjqs2zGscWQpBIKqwXYBFic0ERaxNVgwLCHwOLZeESfdJQjX0RDvrJ1lBXX2ij+G1Q==


### PR DESCRIPTION
This environment variable is trickling down various places, causing
issues when spawning Electron applications from terminals or debug
configurations.

Fixes https://github.com/eclipse-theia/theia/issues/7737

#### How to test

- Build the Electron example application from source.
- Open the same sources using the Electron application.
- Run `yarn start:electron` from the Electron application to start another one.

It should work with this patch.

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

