### PR TITLE
Open editors widget in navigator

### DIFF
--- a/packages/core/src/browser/shell/application-shell.ts
+++ b/packages/core/src/browser/shell/application-shell.ts
@@ -1400,6 +1400,29 @@ export class ApplicationShell extends Widget {
         }
     }
 
+    saveTabs(tabBarOrArea: TabBar<Widget> | ApplicationShell.Area,
+        filter?: (title: Title<Widget>, index: number) => boolean): void {
+        if (tabBarOrArea === 'main') {
+            this.mainAreaTabBars.forEach(tb => this.saveTabs(tb, filter));
+        } else if (tabBarOrArea === 'bottom') {
+            this.bottomAreaTabBars.forEach(tb => this.saveTabs(tb, filter));
+        } else if (typeof tabBarOrArea === 'string') {
+            const tabBar = this.getTabBarFor(tabBarOrArea);
+            if (tabBar) {
+                this.saveTabs(tabBar, filter);
+            }
+        } else if (tabBarOrArea) {
+            const titles = toArray(tabBarOrArea.titles);
+            for (let i = 0; i < titles.length; i++) {
+                if (filter === undefined || filter(titles[i], i)) {
+                    const widget = titles[i].owner;
+                    const saveable = Saveable.get(widget);
+                    saveable?.save();
+                }
+            }
+        }
+    }
+
     async closeWidget(id: string, options?: ApplicationShell.CloseOptions): Promise<Widget | undefined> {
         // TODO handle save for composite widgets, i.e. the preference widget has 2 editors
         const stack = this.toTrackedStack(id);
@@ -1809,6 +1832,12 @@ export namespace ApplicationShell {
      */
     export function isSideArea(area?: string): area is 'left' | 'right' | 'bottom' {
         return area === 'left' || area === 'right' || area === 'bottom';
+    }
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    export function isValidArea(area?: any): area is ApplicationShell.Area {
+        const areas = ['main', 'top', 'left', 'right', 'bottom'];
+        return (area !== undefined && typeof area === 'string' && areas.includes(area));
     }
 
     /**

--- a/packages/editor-preview/compile.tsconfig.json
+++ b/packages/editor-preview/compile.tsconfig.json
@@ -14,6 +14,9 @@
     },
     {
       "path": "../editor/compile.tsconfig.json"
+    },
+    {
+      "path": "../navigator/compile.tsconfig.json"
     }
   ]
 }

--- a/packages/editor-preview/package.json
+++ b/packages/editor-preview/package.json
@@ -4,7 +4,8 @@
   "description": "Theia - Editor Preview Extension",
   "dependencies": {
     "@theia/core": "1.15.0",
-    "@theia/editor": "1.15.0"
+    "@theia/editor": "1.15.0",
+    "@theia/navigator": "1.15.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/editor-preview/src/browser/editor-preview-frontend-module.ts
+++ b/packages/editor-preview/src/browser/editor-preview-frontend-module.ts
@@ -15,7 +15,7 @@
  ********************************************************************************/
 
 import '../../src/browser/style/index.css';
-import { KeybindingContribution, WidgetFactory } from '@theia/core/lib/browser';
+import { FrontendApplicationContribution, KeybindingContribution, WidgetFactory } from '@theia/core/lib/browser';
 import { ContainerModule } from '@theia/core/shared/inversify';
 import { bindEditorPreviewPreferences } from './editor-preview-preferences';
 import { EditorPreviewManager } from './editor-preview-manager';
@@ -23,6 +23,8 @@ import { EditorManager } from '@theia/editor/lib/browser';
 import { EditorPreviewWidgetFactory } from './editor-preview-widget-factory';
 import { EditorPreviewContribution } from './editor-preview-contribution';
 import { CommandContribution, MenuContribution } from '@theia/core/lib/common';
+import { OpenEditorsTreeDecorator } from '@theia/navigator/lib/browser/open-editors-widget/navigator-open-editors-decorator-service';
+import { EditorPreviewTreeDecorator } from './editor-preview-tree-decorator';
 
 export default new ContainerModule((bind, unbind, isBound, rebind) => {
 
@@ -37,5 +39,8 @@ export default new ContainerModule((bind, unbind, isBound, rebind) => {
     bind(KeybindingContribution).toService(EditorPreviewContribution);
     bind(MenuContribution).toService(EditorPreviewContribution);
 
+    bind(EditorPreviewTreeDecorator).toSelf().inSingletonScope();
+    bind(OpenEditorsTreeDecorator).toService(EditorPreviewTreeDecorator);
+    bind(FrontendApplicationContribution).toService(EditorPreviewTreeDecorator);
     bindEditorPreviewPreferences(bind);
 });

--- a/packages/editor-preview/src/browser/editor-preview-tree-decorator.ts
+++ b/packages/editor-preview/src/browser/editor-preview-tree-decorator.ts
@@ -1,0 +1,107 @@
+/********************************************************************************
+ * Copyright (C) 2021 Ericsson and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import { injectable, inject } from '@theia/core/shared/inversify';
+import { TreeDecorator, TreeDecoration } from '@theia/core/lib/browser/tree/tree-decorator';
+import { Emitter } from '@theia/core/lib/common/event';
+import { Tree } from '@theia/core/lib/browser/tree/tree';
+import {
+    ApplicationShell,
+    DepthFirstTreeIterator,
+    FrontendApplication,
+    FrontendApplicationContribution,
+    NavigatableWidget,
+    Saveable,
+    Widget,
+} from '@theia/core/lib/browser';
+import { Disposable } from '@theia/core/lib/common';
+import { OpenEditorNode } from '@theia/navigator/lib/browser/open-editors-widget/navigator-open-editors-tree-model';
+import { EditorPreviewWidget } from './editor-preview-widget';
+import { EditorPreviewManager } from './editor-preview-manager';
+
+@injectable()
+export class EditorPreviewTreeDecorator implements TreeDecorator, FrontendApplicationContribution {
+    @inject(EditorPreviewManager) protected readonly editorPreviewManager: EditorPreviewManager;
+    @inject(ApplicationShell) protected readonly shell: ApplicationShell;
+
+    readonly id = 'theia-open-editors-file-decorator';
+    protected decorationsMap = new Map<string, TreeDecoration.Data>();
+
+    protected readonly decorationsChangedEmitter = new Emitter();
+    readonly onDidChangeDecorations = this.decorationsChangedEmitter.event;
+    protected readonly toDisposeOnDirtyChanged = new Map<string, Disposable>();
+    protected readonly toDisposeOnPreviewPinned = new Map<string, Disposable>();
+
+    onDidInitializeLayout(app: FrontendApplication): void {
+        this.shell.onDidAddWidget(widget => this.registerEditorListeners(widget));
+        this.shell.onDidRemoveWidget(widget => this.unregisterEditorListeners(widget));
+        this.editorWidgets.forEach(widget => this.registerEditorListeners(widget));
+    }
+
+    protected registerEditorListeners(widget: Widget): void {
+        const saveable = Saveable.get(widget);
+        if (saveable) {
+            this.toDisposeOnDirtyChanged.set(widget.id, saveable.onDirtyChanged(() => {
+                this.fireDidChangeDecorations((tree: Tree) => this.collectDecorators(tree));
+            }));
+        }
+        if (widget instanceof EditorPreviewWidget) {
+            this.toDisposeOnPreviewPinned.set(widget.id, widget.onDidChangePreviewState(() => {
+                this.fireDidChangeDecorations((tree: Tree) => this.collectDecorators(tree));
+                this.toDisposeOnPreviewPinned.get(widget.id)?.dispose();
+                this.toDisposeOnDirtyChanged.delete(widget.id);
+            }));
+        }
+    }
+
+    protected unregisterEditorListeners(widget: Widget): void {
+        this.toDisposeOnDirtyChanged.get(widget.id)?.dispose();
+        this.toDisposeOnDirtyChanged.delete(widget.id);
+        this.toDisposeOnPreviewPinned.get(widget.id)?.dispose();
+        this.toDisposeOnPreviewPinned.delete(widget.id);
+    }
+
+    protected get editorWidgets(): NavigatableWidget[] {
+        return this.shell.widgets.filter((widget): widget is NavigatableWidget => NavigatableWidget.is(widget));
+    }
+
+    protected fireDidChangeDecorations(event: (tree: Tree) => Map<string, TreeDecoration.Data>): void {
+        this.decorationsChangedEmitter.fire(event);
+    }
+
+    decorations(tree: Tree): Map<string, TreeDecoration.Data> {
+        return this.collectDecorators(tree);
+    }
+
+    // Add workspace root as caption suffix and italicize if PreviewWidget
+    protected collectDecorators(tree: Tree): Map<string, TreeDecoration.Data> {
+        const result = new Map<string, TreeDecoration.Data>();
+        if (tree.root === undefined) {
+            return result;
+        }
+        for (const node of new DepthFirstTreeIterator(tree.root)) {
+            if (OpenEditorNode.is(node)) {
+                const { widget } = node;
+                const isPreviewWidget = widget instanceof EditorPreviewWidget && widget.isPreview;
+                const decorations: TreeDecoration.Data = {
+                    fontData: { style: isPreviewWidget ? 'italic' : undefined }
+                };
+                result.set(node.id, decorations);
+            }
+        }
+        return result;
+    }
+}

--- a/packages/markers/src/browser/problem/problem-frontend-module.ts
+++ b/packages/markers/src/browser/problem/problem-frontend-module.ts
@@ -32,6 +32,7 @@ import { TabBarDecorator } from '@theia/core/lib/browser/shell/tab-bar-decorator
 import { bindProblemPreferences } from './problem-preferences';
 import { MarkerTreeLabelProvider } from '../marker-tree-label-provider';
 import { ProblemWidgetTabBarDecorator } from './problem-widget-tab-bar-decorator';
+import { OpenEditorsTreeDecorator } from '@theia/navigator/lib/browser/open-editors-widget/navigator-open-editors-decorator-service';
 
 export default new ContainerModule(bind => {
     bindProblemPreferences(bind);
@@ -53,6 +54,7 @@ export default new ContainerModule(bind => {
 
     bind(ProblemDecorator).toSelf().inSingletonScope();
     bind(NavigatorTreeDecorator).toService(ProblemDecorator);
+    bind(OpenEditorsTreeDecorator).toService(ProblemDecorator);
     bind(ProblemTabBarDecorator).toSelf().inSingletonScope();
     bind(TabBarDecorator).toService(ProblemTabBarDecorator);
 

--- a/packages/navigator/src/browser/navigator-container.ts
+++ b/packages/navigator/src/browser/navigator-container.ts
@@ -17,12 +17,11 @@
 import { Container, interfaces } from '@theia/core/shared/inversify';
 import { Tree, TreeModel, TreeProps, defaultTreeProps, TreeDecoratorService } from '@theia/core/lib/browser';
 import { createFileTreeContainer, FileTree, FileTreeModel, FileTreeWidget } from '@theia/filesystem/lib/browser';
-import { bindContributionProvider } from '@theia/core/lib/common/contribution-provider';
 import { FileNavigatorTree } from './navigator-tree';
 import { FileNavigatorModel } from './navigator-model';
 import { FileNavigatorWidget } from './navigator-widget';
 import { NAVIGATOR_CONTEXT_MENU } from './navigator-contribution';
-import { NavigatorDecoratorService, NavigatorTreeDecorator } from './navigator-decorator-service';
+import { NavigatorDecoratorService } from './navigator-decorator-service';
 
 export const FILE_NAVIGATOR_PROPS = <TreeProps>{
     ...defaultTreeProps,
@@ -50,7 +49,6 @@ export function createFileNavigatorContainer(parent: interfaces.Container): Cont
 
     child.bind(NavigatorDecoratorService).toSelf().inSingletonScope();
     child.rebind(TreeDecoratorService).toService(NavigatorDecoratorService);
-    bindContributionProvider(child, NavigatorTreeDecorator);
 
     return child;
 }

--- a/packages/navigator/src/browser/navigator-frontend-module.ts
+++ b/packages/navigator/src/browser/navigator-frontend-module.ts
@@ -15,6 +15,7 @@
  ********************************************************************************/
 
 import '../../src/browser/style/index.css';
+import '../../src/browser/open-editors-widget/open-editors.css';
 
 import { ContainerModule } from '@theia/core/shared/inversify';
 import {
@@ -36,6 +37,10 @@ import { NavigatorLayoutVersion3Migration } from './navigator-layout-migrations'
 import { NavigatorTabBarDecorator } from './navigator-tab-bar-decorator';
 import { TabBarDecorator } from '@theia/core/lib/browser/shell/tab-bar-decorator';
 import { NavigatorWidgetFactory } from './navigator-widget-factory';
+import { bindContributionProvider } from '@theia/core/lib/common';
+import { OpenEditorsTreeDecorator } from './open-editors-widget/navigator-open-editors-decorator-service';
+import { OpenEditorsWidget } from './open-editors-widget/navigator-open-editors-widget';
+import { NavigatorTreeDecorator } from './navigator-decorator-service';
 
 export default new ContainerModule(bind => {
     bindFileNavigatorPreferences(bind);
@@ -56,6 +61,14 @@ export default new ContainerModule(bind => {
         id: FILE_NAVIGATOR_ID,
         createWidget: () => container.get(FileNavigatorWidget)
     })).inSingletonScope();
+    bindContributionProvider(bind, NavigatorTreeDecorator);
+    bindContributionProvider(bind, OpenEditorsTreeDecorator);
+
+    bind(WidgetFactory).toDynamicValue(({ container }) => ({
+        id: OpenEditorsWidget.ID,
+        createWidget: () => OpenEditorsWidget.createWidget(container)
+    })).inSingletonScope();
+
     bind(NavigatorWidgetFactory).toSelf().inSingletonScope();
     bind(WidgetFactory).toService(NavigatorWidgetFactory);
     bind(ApplicationShellLayoutMigration).to(NavigatorLayoutVersion3Migration).inSingletonScope();

--- a/packages/navigator/src/browser/navigator-widget-factory.ts
+++ b/packages/navigator/src/browser/navigator-widget-factory.ts
@@ -22,6 +22,7 @@ import {
     WidgetManager
 } from '@theia/core/lib/browser';
 import { FILE_NAVIGATOR_ID } from './navigator-widget';
+import { OpenEditorsWidget } from './open-editors-widget/navigator-open-editors-widget';
 
 export const EXPLORER_VIEW_CONTAINER_ID = 'explorer-view-container';
 export const EXPLORER_VIEW_CONTAINER_TITLE_OPTIONS: ViewContainerTitleOptions = {
@@ -37,9 +38,19 @@ export class NavigatorWidgetFactory implements WidgetFactory {
 
     readonly id = NavigatorWidgetFactory.ID;
 
+    protected openEditorsWidgetOptions: ViewContainer.Factory.WidgetOptions = {
+        order: 0,
+        canHide: true,
+        initiallyCollapsed: true,
+        // this property currently has no effect (https://github.com/eclipse-theia/theia/issues/7755)
+        weight: 20
+    };
+
     protected fileNavigatorWidgetOptions: ViewContainer.Factory.WidgetOptions = {
+        order: 1,
         canHide: false,
         initiallyCollapsed: false,
+        weight: 80
     };
 
     @inject(ViewContainer.Factory)
@@ -52,8 +63,10 @@ export class NavigatorWidgetFactory implements WidgetFactory {
             progressLocationId: 'explorer'
         });
         viewContainer.setTitleOptions(EXPLORER_VIEW_CONTAINER_TITLE_OPTIONS);
-        const widget = await this.widgetManager.getOrCreateWidget(FILE_NAVIGATOR_ID);
-        viewContainer.addWidget(widget, this.fileNavigatorWidgetOptions);
+        const openEditorsWidget = await this.widgetManager.getOrCreateWidget(OpenEditorsWidget.ID);
+        const navigatorWidget = await this.widgetManager.getOrCreateWidget(FILE_NAVIGATOR_ID);
+        viewContainer.addWidget(openEditorsWidget, this.openEditorsWidgetOptions);
+        viewContainer.addWidget(navigatorWidget, this.fileNavigatorWidgetOptions);
         return viewContainer;
     }
 }

--- a/packages/navigator/src/browser/open-editors-widget/navigator-open-editors-commands.ts
+++ b/packages/navigator/src/browser/open-editors-widget/navigator-open-editors-commands.ts
@@ -1,0 +1,47 @@
+/********************************************************************************
+ * Copyright (C) 2021 Ericsson and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import { Command } from '@theia/core/lib/common';
+
+export namespace OpenEditorsCommands {
+    export const CLOSE_ALL_TABS_FROM_TOOLBAR: Command = {
+        id: 'navigator.close.all.editors.toolbar',
+        category: 'File',
+        label: 'Close All Editors',
+        iconClass: 'codicon codicon-close-all'
+    };
+
+    export const SAVE_ALL_TABS_FROM_TOOLBAR: Command = {
+        id: 'navigator.save.all.editors.toolbar',
+        category: 'File',
+        label: 'Save All Editors',
+        iconClass: 'codicon codicon-save-all'
+    };
+
+    export const CLOSE_ALL_EDITORS_IN_GROUP_FROM_ICON: Command = {
+        id: 'navigator.close.all.in.area.icon',
+        category: 'View',
+        label: 'Close Group',
+        iconClass: 'codicon codicon-close-all'
+    };
+
+    export const SAVE_ALL_IN_GROUP_FROM_ICON: Command = {
+        id: 'navigator.save.all.in.area.icon',
+        category: 'File',
+        label: 'Save All in Group',
+        iconClass: 'codicon codicon-save-all'
+    };
+}

--- a/packages/navigator/src/browser/open-editors-widget/navigator-open-editors-decorator-service.ts
+++ b/packages/navigator/src/browser/open-editors-widget/navigator-open-editors-decorator-service.ts
@@ -1,0 +1,28 @@
+/********************************************************************************
+ * Copyright (C) 2021 Ericsson and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import { inject, injectable, named } from '@theia/core/shared/inversify';
+import { TreeDecorator, AbstractTreeDecoratorService } from '@theia/core/lib/browser/tree/tree-decorator';
+import { ContributionProvider } from '@theia/core/lib/common';
+
+export const OpenEditorsTreeDecorator = Symbol('OpenEditorsTreeDecorator');
+
+@injectable()
+export class OpenEditorsTreeDecoratorService extends AbstractTreeDecoratorService {
+    constructor(@inject(ContributionProvider) @named(OpenEditorsTreeDecorator) protected readonly contributions: ContributionProvider<TreeDecorator>) {
+        super(contributions.getContributions());
+    }
+}

--- a/packages/navigator/src/browser/open-editors-widget/navigator-open-editors-menus.ts
+++ b/packages/navigator/src/browser/open-editors-widget/navigator-open-editors-menus.ts
@@ -1,0 +1,26 @@
+/********************************************************************************
+ * Copyright (C) 2021 Ericsson and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import { MenuPath } from '@theia/core/lib/common';
+
+export const OPEN_EDITORS_CONTEXT_MENU: MenuPath = ['open-editors-context-menu'];
+export namespace OpenEditorsContextMenu {
+    export const NAVIGATION = [...OPEN_EDITORS_CONTEXT_MENU, '1_navigation'];
+    export const CLIPBOARD = [...OPEN_EDITORS_CONTEXT_MENU, '2_clipboard'];
+    export const SAVE = [...OPEN_EDITORS_CONTEXT_MENU, '3_save'];
+    export const COMPARE = [...OPEN_EDITORS_CONTEXT_MENU, '4_compare'];
+    export const MODIFICATION = [...OPEN_EDITORS_CONTEXT_MENU, '5_modification'];
+}

--- a/packages/navigator/src/browser/open-editors-widget/navigator-open-editors-tree-model.ts
+++ b/packages/navigator/src/browser/open-editors-widget/navigator-open-editors-tree-model.ts
@@ -1,0 +1,233 @@
+/********************************************************************************
+ * Copyright (C) 2021 Ericsson and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import { injectable, inject, postConstruct } from '@theia/core/shared/inversify';
+import { FileNode, FileStatNode, FileTreeModel } from '@theia/filesystem/lib/browser';
+import {
+    ApplicationShell,
+    CompositeTreeNode,
+    open,
+    NavigatableWidget,
+    OpenerService,
+    SelectableTreeNode,
+    TreeNode,
+    Widget,
+    ExpandableTreeNode,
+    TabBar
+} from '@theia/core/lib/browser';
+import { WorkspaceService } from '@theia/workspace/lib/browser';
+import debounce = require('@theia/core/shared/lodash.debounce');
+import { DisposableCollection } from '@theia/core/lib/common';
+export interface OpenEditorNode extends FileStatNode {
+    widget: Widget;
+};
+
+export namespace OpenEditorNode {
+    export function is(node: object | undefined): node is OpenEditorNode {
+        return FileStatNode.is(node) && 'widget' in node;
+    }
+}
+
+@injectable()
+export class OpenEditorsModel extends FileTreeModel {
+    static GROUP_NODE_ID_PREFIX = 'group-node';
+    static AREA_NODE_ID_PREFIX = 'area-node';
+
+    @inject(ApplicationShell) protected readonly applicationShell: ApplicationShell;
+    @inject(WorkspaceService) protected readonly workspaceService: WorkspaceService;
+    @inject(OpenerService) protected readonly openerService: OpenerService;
+
+    protected toDisposeOnPreviewWidgetReplaced = new DisposableCollection();
+    // Returns the collection of editors belonging to a tabbar group in the main area
+    protected _editorWidgetsByGroup = new Map<number, { widgets: NavigatableWidget[], tabbar: TabBar<Widget> }>();
+
+    // Returns the collection of editors belonging to an area grouping (main, left, right bottom)
+    protected _editorWidgetsByArea = new Map<ApplicationShell.Area, NavigatableWidget[]>();
+
+    // Last collection of editors before a layout modification, used to detect changes in widget ordering
+    protected _lastEditorWidgetsByArea = new Map<ApplicationShell.Area, NavigatableWidget[]>();
+
+    get editorWidgets(): NavigatableWidget[] {
+        const editorWidgets: NavigatableWidget[] = [];
+        this._editorWidgetsByArea.forEach(widgets => editorWidgets.push(...widgets));
+        return editorWidgets;
+    }
+
+    getTabBarForGroup(id: number): TabBar<Widget> | undefined {
+        return this._editorWidgetsByGroup.get(id)?.tabbar;
+    }
+
+    @postConstruct()
+    protected init(): void {
+        super.init();
+        this.setupHandlers();
+        this.initializeRoot();
+    }
+
+    protected setupHandlers(): void {
+        this.toDispose.push(this.applicationShell.onDidChangeCurrentWidget(({ newValue }) => {
+            const nodeToSelect = this.tree.getNode(newValue?.id);
+            if (nodeToSelect && SelectableTreeNode.is(nodeToSelect)) {
+                this.selectNode(nodeToSelect);
+            }
+        }));
+        this.toDispose.push(this.applicationShell.onDidAddWidget(() => this.updateOpenWidgets()));
+        this.toDispose.push(this.applicationShell.onDidRemoveWidget(() => this.updateOpenWidgets()));
+        // Check for tabs rearranged in main and bottom
+        this.applicationShell.mainPanel.layoutModified.connect(() => this.doUpdateOpenWidgets('main'));
+        this.applicationShell.bottomPanel.layoutModified.connect(() => this.doUpdateOpenWidgets('bottom'));
+    }
+
+    protected async initializeRoot(): Promise<void> {
+        await this.updateOpenWidgets();
+        this.fireChanged();
+    }
+
+    protected updateOpenWidgets = debounce(this.doUpdateOpenWidgets, 250);
+
+    protected async doUpdateOpenWidgets(layoutModifiedArea?: ApplicationShell.Area): Promise<void> {
+        this._lastEditorWidgetsByArea = this._editorWidgetsByArea;
+        this._editorWidgetsByArea = new Map<ApplicationShell.Area, NavigatableWidget[]>();
+        let doRebuild = true;
+        const areas: ApplicationShell.Area[] = ['main', 'bottom', 'left', 'right', 'top'];
+        areas.forEach(area => {
+            const editorWidgetsForArea = this.applicationShell.getWidgets(area).filter((widget): widget is NavigatableWidget => NavigatableWidget.is(widget));
+            if (editorWidgetsForArea.length) {
+                this._editorWidgetsByArea.set(area, editorWidgetsForArea);
+            }
+        });
+        if (this._lastEditorWidgetsByArea.size === 0) {
+            this._lastEditorWidgetsByArea = this._editorWidgetsByArea;
+        }
+        // `layoutModified` can be triggered when tabs are clicked, even if they are not rearraged.
+        // This will check for those instances and prevent a rebuild if it is unnecessary. Rebuilding
+        // the tree if there is no change can cause the tree's selection to flicker.
+        if (layoutModifiedArea) {
+            doRebuild = this.shouldRebuildTreeOnLayoutModified(layoutModifiedArea);
+        }
+        if (doRebuild) {
+            this.root = await this.buildRootFromOpenedWidgets(this._editorWidgetsByArea);
+        }
+    }
+
+    protected shouldRebuildTreeOnLayoutModified(area: ApplicationShell.Area): boolean {
+        const currentOrdering = this._editorWidgetsByArea.get(area);
+        const previousOrdering = this._lastEditorWidgetsByArea.get(area);
+        if (currentOrdering?.length === 1) {
+            return true;
+        }
+        if (currentOrdering?.length !== previousOrdering?.length) {
+            return true;
+        }
+        if (!!currentOrdering && !!previousOrdering) {
+            return !currentOrdering.every((widget, index) => widget === previousOrdering[index]);
+        }
+        return true;
+    }
+
+    protected tryCreateWidgetGroupMap(): Map<Widget, CompositeTreeNode> {
+        const mainTabBars = this.applicationShell.mainAreaTabBars;
+        this._editorWidgetsByGroup = new Map();
+        const widgetGroupMap = new Map<Widget, CompositeTreeNode>();
+        if (mainTabBars.length > 1) {
+            mainTabBars.forEach((tabbar, index) => {
+                const groupNumber = index + 1;
+                const newCaption = `GROUP ${groupNumber}`;
+                const groupNode = {
+                    parent: undefined,
+                    id: `${OpenEditorsModel.GROUP_NODE_ID_PREFIX}:${groupNumber}`,
+                    name: newCaption,
+                    children: []
+                };
+                const widgets: NavigatableWidget[] = [];
+                tabbar.titles.map(title => {
+                    const { owner } = title;
+                    widgetGroupMap.set(owner, groupNode);
+                    if (NavigatableWidget.is(owner)) {
+                        widgets.push(owner);
+                    }
+                });
+                this._editorWidgetsByGroup.set(groupNumber, { widgets, tabbar });
+            });
+        }
+        return widgetGroupMap;
+    }
+
+    protected async buildRootFromOpenedWidgets(widgetsByArea: Map<ApplicationShell.Area, NavigatableWidget[]>): Promise<CompositeTreeNode> {
+        const rootNode: CompositeTreeNode = {
+            id: 'open-editors:root',
+            parent: undefined,
+            visible: false,
+            children: [],
+        };
+
+        const mainAreaWidgetGroups = this.tryCreateWidgetGroupMap();
+
+        for (const [area, widgetsInArea] of widgetsByArea.entries()) {
+            const areaNode: CompositeTreeNode & ExpandableTreeNode = {
+                id: `${OpenEditorsModel.AREA_NODE_ID_PREFIX}:${area}`,
+                parent: rootNode,
+                name: area,
+                expanded: true,
+                children: []
+            };
+            for (const widget of widgetsInArea) {
+                const uri = widget.getResourceUri();
+                if (uri) {
+                    const fileStat = await this.fileService.resolve(uri);
+                    const openEditorNode: OpenEditorNode = {
+                        id: widget.id,
+                        fileStat,
+                        uri,
+                        selected: false,
+                        parent: undefined,
+                        name: widget.title.label,
+                        icon: widget.title.iconClass,
+                        widget
+                    };
+                    // only show groupings for main area widgets if more than one tabbar
+                    if ((area === 'main') && (mainAreaWidgetGroups.size > 1)) {
+                        const groupNode = mainAreaWidgetGroups.get(widget);
+                        if (groupNode) {
+                            CompositeTreeNode.addChild(groupNode, openEditorNode);
+                            CompositeTreeNode.addChild(areaNode, groupNode);
+                        }
+                    } else {
+                        CompositeTreeNode.addChild(areaNode, openEditorNode);
+                    }
+                }
+            }
+            // If widgets are only in the main area and in a single tabbar, then don't show area node
+            if (widgetsByArea.size === 1 && widgetsByArea.has('main') && area === 'main') {
+                areaNode.children.forEach(child => CompositeTreeNode.addChild(rootNode, child));
+            } else {
+                CompositeTreeNode.addChild(rootNode, areaNode);
+            }
+
+        }
+        return rootNode;
+    }
+
+    protected doOpenNode(node: TreeNode): void {
+        if (node.visible === false) {
+            return;
+        } else if (FileNode.is(node)) {
+            open(this.openerService, node.uri);
+        } else {
+            super.doOpenNode(node);
+        }
+    }
+}

--- a/packages/navigator/src/browser/open-editors-widget/navigator-open-editors-widget.tsx
+++ b/packages/navigator/src/browser/open-editors-widget/navigator-open-editors-widget.tsx
@@ -1,0 +1,239 @@
+/********************************************************************************
+ * Copyright (C) 2021 Ericsson and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import * as React from '@theia/core/shared/react';
+import { injectable, interfaces, Container, postConstruct, inject } from '@theia/core/shared/inversify';
+import {
+    ApplicationShell,
+    ContextMenuRenderer,
+    defaultTreeProps,
+    NavigatableWidget,
+    NodeProps,
+    Saveable,
+    TabBar,
+    TreeDecoratorService,
+    TreeModel,
+    TreeNode,
+    TreeProps,
+    TreeWidget,
+    TREE_NODE_CONTENT_CLASS,
+    Widget,
+} from '@theia/core/lib/browser';
+import { OpenEditorNode, OpenEditorsModel } from './navigator-open-editors-tree-model';
+import { createFileTreeContainer, FileTreeModel, FileTreeWidget } from '@theia/filesystem/lib/browser';
+import { OpenEditorsTreeDecoratorService } from './navigator-open-editors-decorator-service';
+import { OPEN_EDITORS_CONTEXT_MENU } from './navigator-open-editors-menus';
+import { CommandService } from '@theia/core/lib/common';
+import { OpenEditorsCommands } from './navigator-open-editors-commands';
+
+export const OPEN_EDITORS_PROPS: TreeProps = {
+    ...defaultTreeProps,
+    virtualized: false,
+    contextMenuPath: OPEN_EDITORS_CONTEXT_MENU,
+};
+
+export interface OpenEditorsNodeRow extends TreeWidget.NodeRow {
+    node: OpenEditorNode;
+}
+@injectable()
+export class OpenEditorsWidget extends FileTreeWidget {
+    static ID = 'theia-open-editors-widget';
+    static LABEL = 'Open Editors';
+
+    @inject(ApplicationShell) protected readonly applicationShell: ApplicationShell;
+    @inject(CommandService) protected readonly commandService: CommandService;
+
+    static createContainer(parent: interfaces.Container): Container {
+        const child = createFileTreeContainer(parent);
+
+        child.unbind(FileTreeModel);
+        child.bind(OpenEditorsModel).toSelf();
+        child.rebind(TreeModel).toService(OpenEditorsModel);
+
+        child.unbind(FileTreeWidget);
+        child.bind(OpenEditorsWidget).toSelf();
+
+        child.rebind(TreeProps).toConstantValue(OPEN_EDITORS_PROPS);
+
+        child.bind(OpenEditorsTreeDecoratorService).toSelf().inSingletonScope();
+        child.rebind(TreeDecoratorService).toService(OpenEditorsTreeDecoratorService);
+        return child;
+    }
+
+    static createWidget(parent: interfaces.Container): OpenEditorsWidget {
+        return OpenEditorsWidget.createContainer(parent).get(OpenEditorsWidget);
+    }
+
+    constructor(
+        @inject(TreeProps) readonly props: TreeProps,
+        @inject(OpenEditorsModel) readonly model: OpenEditorsModel,
+        @inject(ContextMenuRenderer) protected readonly contextMenuRenderer: ContextMenuRenderer
+    ) {
+        super(props, model, contextMenuRenderer);
+    }
+
+    @postConstruct()
+    init(): void {
+        super.init();
+        this.id = OpenEditorsWidget.ID;
+        this.title.label = OpenEditorsWidget.LABEL;
+        this.addClass(OpenEditorsWidget.ID);
+        this.update();
+    }
+
+    get editorWidgets(): NavigatableWidget[] {
+        return this.model.editorWidgets;
+    }
+
+    // eslint-disable-next-line no-null/no-null
+    protected activeTreeNodePrefixElement: string | undefined | null;
+
+    protected renderNode(node: OpenEditorNode, props: NodeProps): React.ReactNode {
+        if (!TreeNode.isVisible(node)) {
+            return undefined;
+        }
+        const attributes = this.createNodeAttributes(node, props);
+        const isEditorNode = !(node.id.startsWith(OpenEditorsModel.GROUP_NODE_ID_PREFIX) || node.id.startsWith(OpenEditorsModel.AREA_NODE_ID_PREFIX));
+        const content = <div className={`${TREE_NODE_CONTENT_CLASS}`}>
+            {this.renderExpansionToggle(node, props)}
+            {isEditorNode && this.renderPrefixIcon(node)}
+            {this.decorateIcon(node, this.renderIcon(node, props))}
+            {this.renderCaptionAffixes(node, props, 'captionPrefixes')}
+            {this.renderCaption(node, props)}
+            {this.renderCaptionAffixes(node, props, 'captionSuffixes')}
+            {this.renderTailDecorations(node, props)}
+            {(this.isGroupNode(node) || this.isAreaNode(node)) && this.renderInteractables(node, props)}
+        </div >;
+        return React.createElement('div', attributes, content);
+    }
+
+    protected isGroupNode(node: OpenEditorNode): boolean {
+        return node.id.startsWith(OpenEditorsModel.GROUP_NODE_ID_PREFIX);
+    }
+
+    protected isAreaNode(node: OpenEditorNode): boolean {
+        return node.id.startsWith(OpenEditorsModel.AREA_NODE_ID_PREFIX);
+    }
+
+    protected doRenderNodeRow({ node, depth }: OpenEditorsNodeRow): React.ReactNode {
+        let groupClass = '';
+        if (this.isGroupNode(node)) {
+            groupClass = 'group-node';
+        } else if (this.isAreaNode(node)) {
+            groupClass = 'area-node';
+        }
+        return <div className={`open-editors-node-row ${this.getPrefixIconClass(node)}${groupClass}`}>
+            {this.renderNode(node, { depth })}
+        </div>;
+    }
+
+    protected renderInteractables(node: OpenEditorNode, props: NodeProps): React.ReactNode {
+        return (<div className='open-editors-inline-actions-container'>
+            <div className='open-editors-inline-action'>
+                <a className='codicon codicon-save-all'
+                    title={OpenEditorsCommands.SAVE_ALL_IN_GROUP_FROM_ICON.label}
+                    onClick={this.handleGroupActionIconClicked}
+                    data-id={node.id}
+                    id={OpenEditorsCommands.SAVE_ALL_IN_GROUP_FROM_ICON.id}
+                />
+            </div>
+            <div className='open-editors-inline-action' >
+                <a className='codicon codicon-close-all'
+                    title={OpenEditorsCommands.CLOSE_ALL_EDITORS_IN_GROUP_FROM_ICON.label}
+                    onClick={this.handleGroupActionIconClicked}
+                    data-id={node.id}
+                    id={OpenEditorsCommands.CLOSE_ALL_EDITORS_IN_GROUP_FROM_ICON.id}
+                />
+            </div>
+        </div>
+        );
+    }
+
+    protected handleGroupActionIconClicked = async (e: React.MouseEvent<HTMLAnchorElement>) => this.doHandleGroupActionIconClicked(e);
+    protected async doHandleGroupActionIconClicked(e: React.MouseEvent<HTMLAnchorElement>): Promise<void> {
+        e.stopPropagation();
+        const groupName = e.currentTarget.getAttribute('data-id');
+        const command = e.currentTarget.id;
+        if (groupName && command) {
+            const groupFromTarget: string | number | undefined = groupName.split(':').pop();
+            const areaOrTabBar = this.sanitizeInputFromClickHandler(groupFromTarget);
+            if (areaOrTabBar) {
+                return this.commandService.executeCommand(command, areaOrTabBar);
+            }
+        }
+    }
+
+    protected sanitizeInputFromClickHandler(groupFromTarget?: string): ApplicationShell.Area | TabBar<Widget> | undefined {
+        let areaOrTabBar: ApplicationShell.Area | TabBar<Widget> | undefined;
+        if (groupFromTarget) {
+            if (ApplicationShell.isValidArea(groupFromTarget)) {
+                areaOrTabBar = groupFromTarget;
+            } else {
+                const groupAsNum = parseInt(groupFromTarget);
+                if (!isNaN(groupAsNum)) {
+                    areaOrTabBar = this.model.getTabBarForGroup(groupAsNum);
+                }
+            }
+        }
+        return areaOrTabBar;
+    }
+
+    protected renderPrefixIcon(node: OpenEditorNode): React.ReactNode {
+        return (
+            <div className='open-editors-prefix-icon-container'>
+                <div data-id={node.id}
+                    className='open-editors-prefix-icon dirty codicon codicon-circle-filled'
+                />
+                <div data-id={node.id}
+                    onClick={this.closeEditor}
+                    className='open-editors-prefix-icon close codicon codicon-close'
+                />
+            </div>);
+    }
+
+    protected getPrefixIconClass(node: OpenEditorNode): string {
+        const saveable = Saveable.get(node.widget);
+        if (saveable) {
+            return saveable.dirty ? 'dirty' : '';
+        }
+        return '';
+    }
+
+    protected closeEditor = async (e: React.MouseEvent<HTMLDivElement>) => this.doCloseEditor(e);
+    protected async doCloseEditor(e: React.MouseEvent<HTMLDivElement>): Promise<void> {
+        const widgetId = e.currentTarget.getAttribute('data-id');
+        if (widgetId) {
+            await this.applicationShell.closeWidget(widgetId);
+        }
+    }
+
+    protected handleClickEvent(node: OpenEditorNode | undefined, event: React.MouseEvent<HTMLElement>): void {
+        if (OpenEditorNode.is(node)) {
+            const { widget } = node;
+            this.applicationShell.activateWidget(widget.id);
+        }
+        super.handleClickEvent(node, event);
+    }
+
+    protected handleContextMenuEvent(node: OpenEditorNode | undefined, event: React.MouseEvent<HTMLElement>): void {
+        super.handleContextMenuEvent(node, event);
+        if (node) {
+            // Since the CommonCommands used in the context menu act on the shell's activeWidget, this is necessary to ensure
+            // that the EditorWidget is activated, not the Navigator itself
+            this.applicationShell.activateWidget(node.widget.id);
+        }
+    }
+}

--- a/packages/navigator/src/browser/open-editors-widget/open-editors.css
+++ b/packages/navigator/src/browser/open-editors-widget/open-editors.css
@@ -1,0 +1,84 @@
+/********************************************************************************
+ * Copyright (C) 2021 Ericsson and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+:root {
+    --theia-open-editors-icon-width: 16px;
+}
+
+.theia-open-editors-widget .theia-caption-suffix {
+    margin-left: var(--theia-ui-padding);
+    font-size: var(--theia-ui-font-size0);
+}
+
+.theia-open-editors-widget .open-editors-node-row .open-editors-prefix-icon-container {
+    min-width: var(--theia-open-editors-icon-width);
+}
+
+.theia-open-editors-widget .open-editors-node-row .open-editors-prefix-icon.dirty,
+.theia-open-editors-widget .open-editors-node-row.dirty:hover .open-editors-prefix-icon.dirty {
+    display: none;
+}
+
+.theia-open-editors-widget .open-editors-node-row.dirty .open-editors-prefix-icon.dirty {
+    display: block;
+}
+
+.theia-open-editors-widget .open-editors-node-row .open-editors-prefix-icon.close {
+    display: none;
+}
+
+.theia-open-editors-widget .open-editors-node-row:hover .open-editors-prefix-icon.close {
+    display: block;
+}
+
+.theia-open-editors-widget .open-editors-node-row.group-node,
+.theia-open-editors-widget .open-editors-node-row.area-node {
+    font-weight: 700;
+    text-transform: uppercase;
+    font-size: var(--theia-ui-font-size0);
+}
+
+.theia-open-editors-widget .open-editors-node-row.area-node {
+    font-style: italic;
+}
+
+.theia-open-editors-widget .open-editors-inline-actions-container {
+    display: flex;
+    justify-content: flex-end;
+    margin-left: 3px;
+    min-height: 16px;
+}
+
+.theia-open-editors-widget .open-editors-inline-action a {
+    color: var(--theia-icon-foreground);
+}
+
+.theia-open-editors-widget .open-editors-inline-action {
+    padding: 0px 3px;
+    font-size: var(--theia-ui-font-size1);
+    margin: 0 2px;
+    cursor: pointer;
+    display: flex;
+    align-items: center;
+}
+
+.theia-open-editors-widget .open-editors-node-row .open-editors-inline-actions-container {
+    visibility: hidden;
+}
+
+.theia-open-editors-widget .open-editors-node-row:hover .open-editors-inline-actions-container {
+    visibility: visible;
+}

--- a/packages/scm/src/browser/scm-frontend-module.ts
+++ b/packages/scm/src/browser/scm-frontend-module.ts
@@ -47,6 +47,7 @@ import { LabelProviderContribution } from '@theia/core/lib/browser/label-provide
 import { bindScmPreferences } from './scm-preferences';
 import { ScmTabBarDecorator } from './decorations/scm-tab-bar-decorator';
 import { TabBarDecorator } from '@theia/core/lib/browser/shell/tab-bar-decorator';
+import { OpenEditorsTreeDecorator } from '@theia/navigator/lib/browser/open-editors-widget/navigator-open-editors-decorator-service';
 
 export default new ContainerModule(bind => {
     bind(ScmContextKeyService).toSelf().inSingletonScope();
@@ -108,7 +109,9 @@ export default new ContainerModule(bind => {
     bind(TabBarToolbarContribution).toService(ScmContribution);
     bind(ColorContribution).toService(ScmContribution);
 
-    bind(NavigatorTreeDecorator).to(ScmNavigatorDecorator).inSingletonScope();
+    bind(ScmNavigatorDecorator).toSelf().inSingletonScope();
+    bind(NavigatorTreeDecorator).toService(ScmNavigatorDecorator);
+    bind(OpenEditorsTreeDecorator).toService(ScmNavigatorDecorator);
     bind(ScmDecorationsService).toSelf().inSingletonScope();
 
     bind(ScmAvatarService).toSelf().inSingletonScope();

--- a/packages/terminal/src/browser/terminal-frontend-contribution.ts
+++ b/packages/terminal/src/browser/terminal-frontend-contribution.ts
@@ -61,6 +61,7 @@ export namespace TerminalMenus {
     export const TERMINAL_TASKS_INFO = [...TERMINAL_TASKS, '3_terminal'];
     export const TERMINAL_TASKS_CONFIG = [...TERMINAL_TASKS, '4_terminal'];
     export const TERMINAL_NAVIGATOR_CONTEXT_MENU = ['navigator-context-menu', 'navigation'];
+    export const TERMINAL_OPEN_EDITORS_CONTEXT_MENU = ['open-editors-context-menu', 'navigation'];
 }
 
 export namespace TerminalCommands {
@@ -400,6 +401,10 @@ export class TerminalFrontendContribution implements TerminalService, CommandCon
             order: '1'
         });
         menus.registerMenuAction(TerminalMenus.TERMINAL_NAVIGATOR_CONTEXT_MENU, {
+            commandId: TerminalCommands.TERMINAL_CONTEXT.id,
+            order: 'z'
+        });
+        menus.registerMenuAction(TerminalMenus.TERMINAL_OPEN_EDITORS_CONTEXT_MENU, {
             commandId: TerminalCommands.TERMINAL_CONTEXT.id,
             order: 'z'
         });


### PR DESCRIPTION
#### What it does

Fixes: #8936 
Adds 'Opened Editors' panel into the Navigator's layout, hidden by default

![grouping-open](https://user-images.githubusercontent.com/62660714/124015206-0797f900-d9aa-11eb-920c-c0137613d522.gif)

Includes the following functionality:
- Shows all opened saveable editors
- Provides SCM, Problem, dirty, and preview state decorators
- Provides caption affix to indicate file's workspace root, as well as relative path
- Adds buttons to close individual editors as well as toolbar buttons to Close All/Save All
- Adds context menu options to tree nodes to perform actions including: Open in Terminal, Copy Path, Save, Compare, Close All, Close Others
- Tracks active editors and will also activate editors when tree nodes are selected, pins preview widget when doubleclicked
- Follows VSCode's grouping convention (i.e. GROUP 1, GROUP 2) to main area editor widgets. If widgets are placed in other shell areas, they are grouped by area (main, bottom, left, right)
- Adds tree node items for "Save All" and "Close All" on group nodes and area nodes
- Will update ordering of widgets when they are rearranged in a tabbar

Known Issues/Areas for Improvement:
- Currently this widget is only tracking NavigatableWidgets (editor widgets) to avoid too much noise, in VSCode it seems that any 'main' area widget is tracked, but this system does not align perfectly with Theia's since we can dock widgets anywhere.
- VSCode provides additional toolbar buttons including 'New Untitled File', and 'Toggle Vertical/Horizontal Layout'
- VSCode will display a badge decoration in the toolbar when there are any unsaved editors:
![image](https://user-images.githubusercontent.com/62660714/113449790-3828c080-93c4-11eb-8c7e-1561868d2eb9.png)
- VSCode auto-sizes its panel layout based on the widget's contents, I'm not quite sure how to achieve this easily with Phosphor's PanelLayout.
- When widgets are rearranged on the left/right toolbars, the ordering will not update (it seems that the left/right DockPanel's `layoutModified` listener behaves differently from the main/bottom dock panel

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
Set Up:
- Pull branch and build
- Open a single-root workspace and open some files
- Right click the file explorer's tabbar and select "Open Editors" to enable the widget

Widget Tracking:
- Open some files and observe that editors are tracked and added
- Click on the nodes and observe the their corresponding widgets are activated
- Close widgets from the tabbar, are they removed from the tree view?
- Dock widgets in different panes, split widgets in the main area, observe the grouping strategy. Does this make sense?
- Try out some of the grouping toolbar items like "Close Group" and "Save All in Group"

Decorations:
- Start editing a file, observe the the file is marked as dirty
- If a widget is opened in Preview mode, it should appear in italics (reflecting the Main Area tabbar state) double click on its node to pin the widget, it should be displayed as normal
- Attempt to close the file using the 'x' icon, does it behave as expected?
- Try these steps in a multiroot workspace, observe that caption suffixes are added that indicate the workspace root as well as its relative path
- Introducing invalid syntax in a file should decorate the node using the problem decorator to match its appearance in the file explorer
- Introducing changes will decorate the node with the SCM decorator

Actions:
- Use the toolbar icons and verify they behave as expected
- Use the context menu and verify the items behave as expected


#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

