### PR TITLE
Automatically reconnect on offline event

### DIFF
--- a/packages/core/src/browser/messaging/ws-connection-provider.ts
+++ b/packages/core/src/browser/messaging/ws-connection-provider.ts
@@ -64,6 +64,8 @@ export class WebSocketConnectionProvider extends AbstractConnectionProvider<WebS
             this.handleIncomingRawMessage(data);
         };
         this.socket = socket;
+        window.addEventListener('offline', () => this.tryReconnect());
+        window.addEventListener('online', () => this.tryReconnect());
     }
 
     openChannel(path: string, handler: (channel: WebSocketChannel) => void, options?: WebSocketOptions): void {
@@ -114,6 +116,12 @@ export class WebSocketConnectionProvider extends AbstractConnectionProvider<WebS
 
     protected fireSocketDidClose(): void {
         this.onSocketDidCloseEmitter.fire(undefined);
+    }
+
+    protected tryReconnect(): void {
+        if (this.socket.readyState !== WebSocket.CONNECTING) {
+            this.socket.reconnect();
+        }
     }
 
 }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

Fixes #9298.

As the [bug report over at chromium](https://bugs.chromium.org/p/chromium/issues/detail?id=706002) indicates, listening to the `offline` event of the browser enables us to manually tell the socket to reconnect. This event is usually fired during a change of network.

I tested this behavior on an Ubuntu 20.04 machine. Running a VM on Windows 10 didn't allow me to reproduce the network issue. I also looked for any regression issues under Firefox and Windows, but everything seems to work normally even with the fix in place.

#### How to test

1. Start Theia in a chromium based browser on a Linux distribution.
2. Change to another Wifi network.
3. The websocket connection will be re-established, indicated by the banner changing from online to offline and finally back to online.

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

