### PR TITLE
custom-editor: remove 'editor-preview` coupling

### DIFF
--- a/packages/plugin-ext/compile.tsconfig.json
+++ b/packages/plugin-ext/compile.tsconfig.json
@@ -73,9 +73,6 @@
     },
     {
       "path": "../workspace/compile.tsconfig.json"
-    },
-    {
-      "path": "../editor-preview/compile.tsconfig.json"
     }
   ]
 }

--- a/packages/plugin-ext/package.json
+++ b/packages/plugin-ext/package.json
@@ -10,7 +10,6 @@
     "@theia/core": "1.12.0",
     "@theia/debug": "1.12.0",
     "@theia/editor": "1.12.0",
-    "@theia/editor-preview": "1.12.0",
     "@theia/file-search": "1.12.0",
     "@theia/filesystem": "1.12.0",
     "@theia/markers": "1.12.0",

--- a/packages/plugin-ext/src/main/browser/custom-editors/custom-editor-opener.tsx
+++ b/packages/plugin-ext/src/main/browser/custom-editors/custom-editor-opener.tsx
@@ -15,7 +15,6 @@
  ********************************************************************************/
 
 import { inject } from '@theia/core/shared/inversify';
-import { PreviewEditorOpenerOptions } from '@theia/editor-preview/lib/browser';
 import URI from '@theia/core/lib/common/uri';
 import { ApplicationShell, OpenerOptions, OpenHandler, Widget, WidgetManager } from '@theia/core/lib/browser';
 import { CustomEditorPriority, CustomEditorSelector } from '../../../common';
@@ -42,7 +41,7 @@ export class CustomEditorOpener implements OpenHandler {
         this.label = this.editor.displayName;
     }
 
-    canHandle(uri: URI, options?: PreviewEditorOpenerOptions): number {
+    canHandle(uri: URI): number {
         if (this.matches(this.editor.selector, uri)) {
             return this.getPriority();
         }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

Fixes: #9300

The following pull-request updates the breaking changes introduced by #8910 (support for `custom-editors`) which included new coupling to `@theia/editor-preview`. The coupling meant that downstream applications would unnecessarily pull `@theia/editor-preview` without expecting it, and would not be able to easily opt-out (or would require new customizations).

The changes include removing the dependency, and removing the unused typing as part of the `canHandle` since it was unused.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

- Verify that CI successfully builds.
- Verify that `custom-editors` still work correctly (using the [vscode-cat-customs plugin](https://github.com/microsoft/vscode-extension-samples/tree/main/custom-editor-sample)).

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

Signed-off-by: vince-fugnitto <vincent.fugnitto@ericsson.com>

