### PR TITLE
Use IndexedDB for Themes if Available (#6999)

### DIFF
--- a/packages/core/src/browser/frontend-application-module.ts
+++ b/packages/core/src/browser/frontend-application-module.ts
@@ -54,7 +54,7 @@ import { LabelParser } from './label-parser';
 import { LabelProvider, LabelProviderContribution, DefaultUriLabelProviderContribution } from './label-provider';
 import { PreferenceService } from './preferences';
 import { ContextMenuRenderer } from './context-menu-renderer';
-import { ThemeService, BuiltinThemeProvider } from './theming';
+import { ThemeService } from './theming';
 import { ConnectionStatusService, FrontendConnectionStatusService, ApplicationConnectionStatusContribution, PingService } from './connection-status-service';
 import { DiffUriLabelProviderContribution } from './diff-uris';
 import { ApplicationServer, applicationPath } from '../common/application-protocol';
@@ -103,10 +103,6 @@ export { bindResourceProvider, bindMessageService, bindPreferenceService };
 ColorApplicationContribution.initBackground();
 
 export const frontendApplicationModule = new ContainerModule((bind, unbind, isBound, rebind) => {
-    const themeService = ThemeService.get();
-    themeService.register(...BuiltinThemeProvider.themes);
-    themeService.startupTheme();
-
     bind(NoneIconTheme).toSelf().inSingletonScope();
     bind(LabelProviderContribution).toService(NoneIconTheme);
     bind(IconThemeService).toSelf().inSingletonScope();

--- a/packages/core/src/browser/theming.ts
+++ b/packages/core/src/browser/theming.ts
@@ -40,20 +40,21 @@ export interface ThemeChangeEvent {
 
 export class ThemeService {
 
-    private themes: { [id: string]: Theme } = {};
-    private activeTheme: Theme | undefined;
-    private readonly themeChange = new Emitter<ThemeChangeEvent>();
+    protected themes: { [id: string]: Theme } = {};
+    protected activeTheme: Theme | undefined;
+    protected readonly themeChange = new Emitter<ThemeChangeEvent>();
 
     readonly onThemeChange: Event<ThemeChangeEvent> = this.themeChange.event;
 
     static get(): ThemeService {
         const global = window as any; // eslint-disable-line @typescript-eslint/no-explicit-any
-        return global[ThemeServiceSymbol] || new ThemeService();
-    }
-
-    protected constructor() {
-        const global = window as any; // eslint-disable-line @typescript-eslint/no-explicit-any
-        global[ThemeServiceSymbol] = this;
+        if (!global[ThemeServiceSymbol]) {
+            const themeService = new ThemeService();
+            themeService.register(...BuiltinThemeProvider.themes);
+            themeService.startupTheme();
+            global[ThemeServiceSymbol] = themeService;
+        }
+        return global[ThemeServiceSymbol];
     }
 
     register(...themes: Theme[]): Disposable {

--- a/packages/monaco/src/browser/monaco-theming-service.ts
+++ b/packages/monaco/src/browser/monaco-theming-service.ts
@@ -19,11 +19,11 @@
 import { injectable, inject } from '@theia/core/shared/inversify';
 import * as jsoncparser from 'jsonc-parser';
 import * as plistparser from 'fast-plist';
-import { ThemeService, BuiltinThemeProvider } from '@theia/core/lib/browser/theming';
+import { ThemeService } from '@theia/core/lib/browser/theming';
 import URI from '@theia/core/lib/common/uri';
 import { Disposable, DisposableCollection } from '@theia/core/lib/common/disposable';
 import { MonacoThemeRegistry } from './textmate/monaco-theme-registry';
-import { getThemes, putTheme, MonacoThemeState } from './monaco-indexed-db';
+import { getThemes, putTheme, MonacoThemeState, stateToTheme } from './monaco-indexed-db';
 import { FileService } from '@theia/filesystem/lib/browser/file-service';
 
 export interface MonacoTheme {
@@ -161,23 +161,8 @@ export class MonacoThemingService {
     }
 
     protected static doRegister(state: MonacoThemeState): Disposable {
-        const { id, label, description, uiTheme, data } = state;
-        const type = uiTheme === 'vs' ? 'light' : uiTheme === 'vs-dark' ? 'dark' : 'hc';
-        const builtInTheme = uiTheme === 'vs' ? BuiltinThemeProvider.lightCss : BuiltinThemeProvider.darkCss;
         return new DisposableCollection(
-            ThemeService.get().register({
-                type,
-                id,
-                label,
-                description: description,
-                editorTheme: data.name!,
-                activate(): void {
-                    builtInTheme.use();
-                },
-                deactivate(): void {
-                    builtInTheme.unuse();
-                }
-            }),
+            ThemeService.get().register(stateToTheme(state)),
             putTheme(state)
         );
     }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

This PR fixes one part of #6999 by using the IndexedDB to recover theme definitions provided by plugins.

Previously, if the first call to `ThemeService.loadUserTheme()` occurred before all plugins had registered themes, then the default theme would be shown until the `PreferenceService` found the correct setting in a `settings.json` and reset the setting after plugins had loaded and registered their themes. This PR exploits the fact that we are already storing plugin-contributed theme definitions in an IndexedDB because they are too large for local storage. That storage is persistent, so it is possible to retrieve those themes again before the plugin that contributed them is loaded by the current instance of the application.

The bad news is that the `ThemeService` has an idiosyncratic initialization strategy - it stores an instance of itself in the `window` object - so this PR works by monkey patching the method that performs that assignment, which is less than excellent.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

Signed-off-by: Colin Grant <colin.grant@ericsson.com>