### PR TITLE
Improve include/exclude search in workspace

### DIFF
--- a/packages/search-in-workspace/src/node/ripgrep-search-in-workspace-server.ts
+++ b/packages/search-in-workspace/src/node/ripgrep-search-in-workspace-server.ts
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (C) 2017-2018 Ericsson and others.
+ * Copyright (C) 2017-2021 Ericsson and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -14,6 +14,8 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
+import * as fs from '@theia/core/shared/fs-extra';
+import * as path from 'path';
 import { ILogger } from '@theia/core';
 import { RawProcess, RawProcessFactory, RawProcessOptions } from '@theia/process/lib/node';
 import { FileUri } from '@theia/core/lib/node/file-uri';
@@ -94,49 +96,129 @@ export class RipgrepSearchInWorkspaceServer implements SearchInWorkspaceServer {
     }
 
     protected getArgs(options?: SearchInWorkspaceOptions): string[] {
-        const args = ['--hidden', '--json'];
-        args.push(options && options.matchCase ? '--case-sensitive' : '--ignore-case');
-        if (options && options.includeIgnored) {
-            args.push('--no-ignore');
-        }
-        if (options && options.maxFileSize) {
-            args.push('--max-filesize=' + options.maxFileSize.trim());
+        const args = new Set<string>();
+
+        args.add('--hidden');
+        args.add('--json');
+
+        if (options?.matchCase) {
+            args.add('--case-sensitive');
         } else {
-            args.push('--max-filesize=20M');
+            args.add('--ignore-case');
         }
-        if (options && options.include) {
-            for (const include of options.include) {
-                if (include !== '') {
-                    args.push('--glob=**/' + include);
-                }
-            }
+
+        if (options?.includeIgnored) {
+            args.add('--no-ignore');
         }
-        if (options && options.exclude) {
-            for (const exclude of options.exclude) {
-                if (exclude !== '') {
-                    args.push('--glob=!**/' + exclude);
-                }
-            }
-        }
-        if (options && options.useRegExp || options && options.matchWholeWord) {
-            args.push('--regexp');
+        if (options?.maxFileSize) {
+            args.add('--max-filesize=' + options.maxFileSize.trim());
         } else {
-            args.push('--fixed-strings');
-            args.push('--');
+            args.add('--max-filesize=20M');
         }
-        return args;
+
+        if (options?.include) {
+            this.addGlobArgs(args, options.include, false);
+        }
+
+        if (options?.exclude) {
+            this.addGlobArgs(args, options.exclude, true);
+        }
+
+        if (options?.useRegExp || options?.matchWholeWord) {
+            args.add('--regexp');
+        } else {
+            args.add('--fixed-strings');
+            args.add('--');
+        }
+
+        return Array.from(args);
     }
 
-    // Search for the string WHAT in directories ROOTURIS.  Return the assigned search id.
-    search(what: string, rootUris: string[], opts?: SearchInWorkspaceOptions): Promise<number> {
+    /**
+     * Add glob patterns to ripgrep's arguments
+     * @param args ripgrep set of arguments
+     * @param patterns patterns to include as globs
+     * @param exclude whether to negate the glob pattern or not
+     */
+    protected addGlobArgs(args: Set<string>, patterns: string[], exclude: boolean = false): void {
+        const sanitizedPatterns = patterns.map(pattern => pattern.trim()).filter(pattern => pattern.length > 0);
+        for (let pattern of sanitizedPatterns) {
+            // make sure the pattern always starts with `**/`
+            if (pattern.startsWith('/')) {
+                pattern = '**' + pattern;
+            } else if (!pattern.startsWith('**/')) {
+                pattern = '**/' + pattern;
+            }
+            // add the exclusion prefix
+            if (exclude) {
+                pattern = '!' + pattern;
+            }
+            args.add(`--glob=${pattern}`);
+            // add a generic glob cli argument entry to include files inside a given directory
+            if (!pattern.endsWith('*')) {
+                // ensure the new pattern ends with `/*`
+                pattern += pattern.endsWith('/') ? '*' : '/*';
+                args.add(`--glob=${pattern}`);
+            }
+        }
+    }
+
+    /**
+     * Transforms relative patterns to absolute paths, one for each given search path.
+     * The resulting paths are not validated in the file system as the pattern keeps glob information.
+     *
+     * @returns The resulting list may be larger than the received patterns as a relative pattern may
+     * resolve to multiple absolute patterns upto the number of search paths.
+     */
+    protected replaceRelativeToAbsolute(roots: string[], patterns: string[] = []): string[] {
+        const expandedPatterns = new Set<string>();
+        for (const pattern of patterns) {
+            if (this.isPatternRelative(pattern)) {
+                // create new patterns using the absolute form for each root
+                for (const root of roots) {
+                    expandedPatterns.add(path.resolve(root, pattern));
+                }
+            } else {
+                expandedPatterns.add(pattern);
+            }
+        }
+        return Array.from(expandedPatterns);
+    }
+
+    /**
+     * Tests if the pattern is relative and should/can be made absolute.
+     */
+    protected isPatternRelative(pattern: string): boolean {
+        return pattern.replace(/\\/g, '/').startsWith('./');
+    }
+
+    /**
+     * By default, sets the search directories for the string WHAT to the provided ROOTURIS directories
+     * and returns the assigned search id.
+     *
+     * The include / exclude (options in SearchInWorkspaceOptions) are lists of patterns for files to
+     * include / exclude during search (glob characters are allowed).
+     *
+     * include patterns successfully recognized as absolute paths will override the default search and set
+     * the search directories to the ones provided as includes.
+     * Relative paths are allowed, the application will attempt to translate them to valid absolute paths
+     * based on the applicable search directories.
+     */
+    async search(what: string, rootUris: string[], options: SearchInWorkspaceOptions = {}): Promise<number> {
         // Start the rg process.  Use --vimgrep to get one result per
         // line, --color=always to get color control characters that
         // we'll use to parse the lines.
         const searchId = this.nextSearchId++;
-        const rgArgs = this.getArgs(opts);
-        // if we use matchWholeWord we use regExp internally,
-        // so, we need to escape regexp characters if we actually not set regexp true in UI.
-        if (opts && opts.matchWholeWord && !opts.useRegExp) {
+        const rootPaths = rootUris.map(root => FileUri.fsPath(root));
+        // If there are absolute paths in `include` we will remove them and use
+        // those as paths to search from.
+        const searchPaths = this.extractSearchPathsFromIncludes(rootPaths, options);
+        options.include = this.replaceRelativeToAbsolute(searchPaths, options.include);
+        options.exclude = this.replaceRelativeToAbsolute(searchPaths, options.exclude);
+        const rgArgs = this.getArgs(options);
+        // If we use matchWholeWord we use regExp internally, so we need
+        // to escape regexp characters if we actually not set regexp true in UI.
+        if (options?.matchWholeWord && !options.useRegExp) {
             what = what.replace(/[\-\\\{\}\*\+\?\|\^\$\.\[\]\(\)\#]/g, '\\$&');
             if (!/\B/.test(what.charAt(0))) {
                 what = '\\b' + what;
@@ -146,7 +228,7 @@ export class RipgrepSearchInWorkspaceServer implements SearchInWorkspaceServer {
             }
         }
 
-        const args = [...rgArgs, what].concat(rootUris.map(root => FileUri.fsPath(root)));
+        const args = [...rgArgs, what, ...searchPaths];
         const processOptions: RawProcessOptions = {
             command: this.rgPath,
             args
@@ -186,7 +268,7 @@ export class RipgrepSearchInWorkspaceServer implements SearchInWorkspaceServer {
             // It's not necessary to return early here (the check
             // for maxResults below would avoid sending extra
             // results), but it avoids doing unnecessary work.
-            if (opts && opts.maxResults && numResults >= opts.maxResults) {
+            if (options?.maxResults && numResults >= options.maxResults) {
                 return;
             }
 
@@ -262,7 +344,7 @@ export class RipgrepSearchInWorkspaceServer implements SearchInWorkspaceServer {
                         numResults++;
 
                         // Did we reach the maximum number of results?
-                        if (opts && opts.maxResults && numResults >= opts.maxResults) {
+                        if (options?.maxResults && numResults >= options.maxResults) {
                             rgProcess.kill();
                             if (currentSearchResult && this.client) {
                                 this.client.onResult(searchId, currentSearchResult);
@@ -280,14 +362,73 @@ export class RipgrepSearchInWorkspaceServer implements SearchInWorkspaceServer {
             // If we reached maxResults, we should have already
             // wrapped up the search.  Returning early avoids
             // logging a warning message in wrapUpSearch.
-            if (opts && opts.maxResults && numResults >= opts.maxResults) {
+            if (options?.maxResults && numResults >= options.maxResults) {
                 return;
             }
 
             this.wrapUpSearch(searchId);
         });
 
-        return Promise.resolve(searchId);
+        return searchId;
+    }
+
+    /**
+     * The default search paths are set to be the root paths associated to a workspace
+     * however the search scope can be further refined with the include paths available in the search options.
+     * This method will replace the searching paths to the ones specified in the 'include' options but as long
+     * as the 'include' paths can be successfully validated as existing.
+     *
+     * Therefore the returned array of paths can be either the workspace root paths or a set of validated paths
+     * derived from the include options which can be used to perform the search.
+     *
+     * Any pattern that resulted in a valid search path will be removed from the 'include' list as it is
+     * provided as an equivalent search path instead.
+     */
+    protected extractSearchPathsFromIncludes(rootPaths: string[], options: SearchInWorkspaceOptions): string[] {
+        if (!options.include) {
+            return rootPaths;
+        }
+        const resolvedPaths = new Set<string>();
+        options.include = options.include.filter(pattern => {
+            let keep = true;
+            for (const root of rootPaths) {
+                const absolutePath = this.getAbsolutePathFromPattern(root, pattern);
+                // undefined means the pattern cannot be converted into an absolute path
+                if (absolutePath) {
+                    resolvedPaths.add(absolutePath);
+                    keep = false;
+                }
+            }
+            return keep;
+        });
+        return resolvedPaths.size > 0
+            ? Array.from(resolvedPaths)
+            : rootPaths;
+    }
+
+    /**
+     * Transform include/exclude option patterns from relative patterns to absolute patterns.
+     * E.g. './abc/foo.*' to '${root}/abc/foo.*', the transformation does not validate the
+     * pattern against the file system as glob suffixes remain.
+     *
+     * @returns undefined if the pattern cannot be converted into an absolute path.
+     */
+    protected getAbsolutePathFromPattern(root: string, pattern: string): string | undefined {
+        pattern = pattern.replace(/\\/g, '/');
+        // The pattern is not referring to a single file or folder, i.e. not to be converted
+        if (!path.isAbsolute(pattern) && !pattern.startsWith('./')) {
+            return undefined;
+        }
+        // remove the `/**` suffix if present
+        if (pattern.endsWith('/**')) {
+            pattern = pattern.substr(0, pattern.length - 3);
+        }
+        // if `pattern` is absolute then `root` will be ignored by `path.resolve()`
+        const targetPath = path.resolve(root, pattern);
+        if (fs.existsSync(targetPath)) {
+            return targetPath;
+        }
+        return undefined;
     }
 
     /**


### PR DESCRIPTION
The following descriptions apply to the user input for the fields
'Files to include' and 'Files to exclude' for the 'Search in
workspace' feature.

Enhancements:
* Handle provided relative paths e.g. ./README.md, README.md to only
  apply the specified file.
* Includes are limited to specific folder e.g. './test' should
  not include './dir/path/test'.
* Input strings (i.e. not resolving to relative paths) are converted
  to two globs in order to include results of a resulting file and
  include files under a resulting folder i.e. resolved globs are
  **`**/string`** and **`**/string/*`**.
  E.g. input file '.snaphot' shall include a file '.snapshot' or if
  it's a folder it should apply to all the files underneath it.
* 'Files to include' can reference folders outside the workspace

Fixes: #8469

**The search strategy offered by the search in workspace server
(RipgrepSearchInWorkspaceServer.search) is changed as follows:**

By default, sets the search directories for the string WHAT to the provided ROOTURIS directories
and returns the assigned search id.

The include / exclude (options in SearchInWorkspaceOptions) are lists of patterns for files to
include / exclude during search (glob characters are allowed).

include patterns successfully recognized as absolute paths will override the default search and set
the search directories to the ones provided as includes.
Relative paths are allowed, the application will attempt to translate them to valid absolute paths
based on the applicable search directories.

Signed-off-by: Alvaro Sanchez-Leon <alvaro.sanchez-leon@ericsson.com>

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->
For strings provided for files to include / exclude
* Checks if the 'include' strings provided are valid paths to the available root folders and if so convert them to glob patterns
* If the include strings are valid paths, replace the root paths with the resulting paths to be consumed by the 'ripgrep' executable.
* Consider each string not resolving to sub-folders as a pattern to either a file or folder, therefore generating two glob entries for each.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
4 new unit test cases provided

Manual testing can be performed as follows:

Using theia repo as an example directory structure:

1. Search to a relative file path of workspace root(s)
    - Search pattern: cloud  (produces a handful of matches)
    - Enter 'Files to Include' text to: ./README.md  (verify that only one file is considered)
2. 'Files to include' can refer to files
    - Search pattern: example
    - Enter 'Files to include' to: `.eslintcache` (verify that multiple matches are reported)
3. 'Files to include' can refer to folders
    - Search pattern: example
    - Enter 'Files to include' to: test (verify that multiple matches are reported)
4. Searching limited to a given subfolder
    -  Search pattern: example
    - Enter 'Files to include' to: **/doc/* (note that matches in two different folders are found i.e. 'doc' and 'packages/plugin-ext/doc'
    - Replace 'Files to include' to doc (note that this now resolves matches for a single folder i.e. 'doc')
5. From the explorer view select a file or folder and from the context menu select 'Find in folder', press enter, and verify the results are as expected.
6. Using the 'Files to include' box, enter absolute paths to external folders, validate expected results.

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

