### PR TITLE
PoC - cli: filter Theia extensions

### DIFF
--- a/dev-packages/application-manager/src/generator/abstract-generator.ts
+++ b/dev-packages/application-manager/src/generator/abstract-generator.ts
@@ -54,13 +54,13 @@ export abstract class AbstractGenerator {
         if (modules.size === 0) {
             return '';
         }
-        const lines = Array.from(modules.keys()).map(moduleName => {
-            const invocation = `${fn}('${modules.get(moduleName)}')`;
-            if (fn === 'require') {
-                return `Promise.resolve(${invocation})`;
-            }
-            return invocation;
-        }).map(statement => `    .then(function () { return ${statement}.then(load) })`);
+        const lines = Array.from(modules.values(), modulePath => {
+            const invocation = `${fn}('${modulePath}')`;
+            const promiseStatement = fn === 'require'
+                ? `Promise.resolve(${invocation})`
+                : invocation; // the `import` function already returns a Promise
+            return `    .then(function () { return ${promiseStatement}.then(load); })`;
+        });
         return os.EOL + lines.join(os.EOL);
     }
 

--- a/dev-packages/application-manager/src/generator/backend-generator.ts
+++ b/dev-packages/application-manager/src/generator/backend-generator.ts
@@ -19,7 +19,7 @@ import { AbstractGenerator } from './abstract-generator';
 export class BackendGenerator extends AbstractGenerator {
 
     async generate(): Promise<void> {
-        const backendModules = this.pck.targetBackendModules;
+        const backendModules = this.pck.targetBackendModulesFiltered;
         await this.write(this.pck.backend('server.js'), this.compileServer(backendModules));
         await this.write(this.pck.backend('main.js'), this.compileMain(backendModules));
     }

--- a/dev-packages/application-manager/src/generator/frontend-generator.ts
+++ b/dev-packages/application-manager/src/generator/frontend-generator.ts
@@ -22,11 +22,11 @@ import { existsSync, readFileSync } from 'fs';
 export class FrontendGenerator extends AbstractGenerator {
 
     async generate(): Promise<void> {
-        const frontendModules = this.pck.targetFrontendModules;
+        const frontendModules = this.pck.targetFrontendModulesFiltered;
         await this.write(this.pck.frontend('index.html'), this.compileIndexHtml(frontendModules));
         await this.write(this.pck.frontend('index.js'), this.compileIndexJs(frontendModules));
         if (this.pck.isElectron()) {
-            const electronMainModules = this.pck.targetElectronMainModules;
+            const electronMainModules = this.pck.targetElectronMainModulesFiltered;
             await this.write(this.pck.frontend('electron-main.js'), this.compileElectronMain(electronMainModules));
         }
     }

--- a/dev-packages/application-package/src/application-props.ts
+++ b/dev-packages/application-package/src/application-props.ts
@@ -50,6 +50,11 @@ export interface ApplicationProps extends NpmRegistryProps {
     readonly target: ApplicationProps.Target;
 
     /**
+     * Theia extensions related properties.
+     */
+    readonly extensions: Readonly<ExtensionsConfig>;
+
+    /**
      * Frontend related properties.
      */
     readonly frontend: Readonly<{ config: FrontendApplicationConfig }>;
@@ -75,6 +80,11 @@ export namespace ApplicationProps {
     export const DEFAULT: ApplicationProps = {
         ...NpmRegistryProps.DEFAULT,
         target: 'browser',
+        extensions: {
+            loading: {
+                strategy: 'all'
+            }
+        },
         backend: {
             config: {}
         },
@@ -92,6 +102,41 @@ export namespace ApplicationProps {
         }
     };
 
+}
+
+/**
+ * Configure how Theia handles extensions.
+ */
+export interface ExtensionsConfig {
+
+    /**
+     * Specify which inversify modules to mount in your application.
+     *
+     * Note that the `loadingStrategy` only affects which inversify module will be mounted
+     * to your application, but an ignored extension might still end up in your bundles.
+     */
+    loading: ExtensionLoadingStrategy;
+}
+
+export interface ExtensionLoadingStrategy {
+
+    /**
+     * - `all`: Use all Theia extensions found installed under `node_modules`.
+     * - `explicitDependenciesOnly`: Only use what's defined as your application dependencies.
+     */
+    strategy: 'all' | 'explicitDependenciesOnly';
+
+    /**
+     * List of regexes to filter in Theia extensions, will be matched against the modules file path.
+     *
+     * Note that matched files will be added to what's matched by `explicitDependenciesOnly`.
+     */
+    includes?: string[]
+
+    /**
+     * List of regexes to filter out Theia extensions, will be matched against the modules file path.
+     */
+    excludes?: string[]
 }
 
 /**


### PR DESCRIPTION
Our generators currently collect any Theia extension installed in
node_modules and mount them into your application without leaving you
much of a choice.

An alternative could be to create your own generators, but this is a lot
of maintenance work.

This commit simplifies the process of controlling what ends up in your
applications by adding new loading strategies:

- all: Like before, use everything found in node_modules
- explicitDependenciesOnly: only use what is defined in your
  dependencies

This is configurable from an application package.json through the
theia.extensions.loading.strategy field.

In addition to those strategies, you can also specify an includes list
and an excludes list. Using those, you can define regular expressions to
filter extensions even more precisely. The matching will be done on the
candidate inversify modules path.

When using the `explicitDependenciesOnly` the includes list will be
evaluated as "in addition to explicit dependencies". If you want the
includes list to be absolute again, use the default 'all' strategy so
that only what's defined in includes is included.

Note that preventing an extension from having its inversify modules
loaded won't prevent it from being included in your bundles. Bundling
should also mostly work no matter what you exclude, but if another
extension was relying on a given Symbol it will most likely break at
runtime. In such a case it is your responsability to bind the missing
symbols using a custom Theia extension, specific to your use-cases.

#### How to test

Edit `examples/browser/package.json` to have the following fields:

```jsonc
  "theia": {
    "extensions": {
      "loading": {
        "strategy": "all",
        "includes": [],
        "excludes": [
          "^@theia/typehierarchy"
        ]
      }
    },
    // ...
```

After rebuilding the browser app, inspect the `src-gen/frontend/index.js` and `src-gen/backend/server.js` files and make sure that no modules are matching the `excludes` list.

To test the `explicitDependenciesOnly` you can remove `@theia/terminal` from the browser app dependencies and make sure it doesn't get included in the previously mentioned files, but it should be included when using the `all` strategy.

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)