### PR TITLE
Preferences: Render node only if present in schema

### DIFF
--- a/packages/preferences/src/browser/views/preference-editor-widget.tsx
+++ b/packages/preferences/src/browser/views/preference-editor-widget.tsx
@@ -185,8 +185,12 @@ export class PreferencesEditorWidget extends ReactWidget implements StatefulWidg
 
     protected renderSingleEntry(node: TreeNode): React.ReactNode {
         const values = this.preferenceValueRetrievalService.inspect<PreferenceItem>(node.id, this.model.currentScope.uri);
-        const preferenceNodeWithValueInAllScopes = { ...node, preference: { data: this.model.propertyList[node.id], values } };
-        return this.singlePreferenceFactory.render(preferenceNodeWithValueInAllScopes);
+        const data = this.model.propertyList[node.id];
+        if (data && values) {
+            const preferenceNodeWithValueInAllScopes = { ...node, preference: { data, values } };
+            return this.singlePreferenceFactory.render(preferenceNodeWithValueInAllScopes);
+        }
+        return undefined;
     }
 
     protected renderCategoryHeader({ node, visibleChildren }: PreferenceTreeNodeRow): React.ReactNode {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

Fixes #9241 by not attempting to render a node in the `PreferencesEditorWidget` if we can't retrieve any information about that preference from the `PreferenceService`.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
1. Install the plugins described #9241.
2. Uninstall them using the Extensions widget.
3. You should see no errors in the console about attempts to access fields on an undefined variable.

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

