### PR TITLE
VSX: Add 'Install Another Version...' Command

### DIFF
--- a/dev-packages/ovsx-client/src/ovsx-client.ts
+++ b/dev-packages/ovsx-client/src/ovsx-client.ts
@@ -70,8 +70,9 @@ export class OVSXClient {
         return new URL(`${url}${searchUri}`, this.options!.apiUrl).toString();
     }
 
-    async getExtension(id: string): Promise<VSXExtensionRaw> {
+    async getExtension(id: string, queryParam?: VSXQueryParam): Promise<VSXExtensionRaw> {
         const param: VSXQueryParam = {
+            ...queryParam,
             extensionId: id
         };
         const apiUri = this.buildQueryUri(param);

--- a/packages/plugin-ext/src/common/plugin-protocol.ts
+++ b/packages/plugin-ext/src/common/plugin-protocol.ts
@@ -339,7 +339,7 @@ export interface PluginDeployerResolver {
 
     accept(pluginSourceId: string): boolean;
 
-    resolve(pluginResolverContext: PluginDeployerResolverContext): Promise<void>;
+    resolve(pluginResolverContext: PluginDeployerResolverContext, options?: PluginDeployOptions): Promise<void>;
 
 }
 
@@ -862,6 +862,10 @@ export interface WorkspaceStorageKind {
 export type GlobalStorageKind = undefined;
 export type PluginStorageKind = GlobalStorageKind | WorkspaceStorageKind;
 
+export interface PluginDeployOptions {
+    version: string;
+}
+
 /**
  * The JSON-RPC workspace interface.
  */
@@ -874,7 +878,7 @@ export interface PluginServer {
      *
      * @param type whether a plugin is installed by a system or a user, defaults to a user
      */
-    deploy(pluginEntry: string, type?: PluginType): Promise<void>;
+    deploy(pluginEntry: string, type?: PluginType, options?: PluginDeployOptions): Promise<void>;
 
     undeploy(pluginId: string): Promise<void>;
 

--- a/packages/plugin-ext/src/main/node/plugin-server-handler.ts
+++ b/packages/plugin-ext/src/main/node/plugin-server-handler.ts
@@ -18,7 +18,7 @@ import { injectable, inject } from '@theia/core/shared/inversify';
 import { CancellationToken } from '@theia/core/lib/common/cancellation';
 import { PluginDeployerImpl } from './plugin-deployer-impl';
 import { PluginsKeyValueStorage } from './plugins-key-value-storage';
-import { PluginServer, PluginDeployer, PluginStorageKind, PluginType } from '../../common/plugin-protocol';
+import { PluginServer, PluginDeployer, PluginStorageKind, PluginType, PluginDeployOptions } from '../../common/plugin-protocol';
 import { KeysToAnyValues, KeysToKeysToAnyValue } from '../../common/types';
 
 @injectable()
@@ -30,12 +30,12 @@ export class PluginServerHandler implements PluginServer {
     @inject(PluginsKeyValueStorage)
     protected readonly pluginsKeyValueStorage: PluginsKeyValueStorage;
 
-    deploy(pluginEntry: string, arg2?: PluginType | CancellationToken): Promise<void> {
+    deploy(pluginEntry: string, arg2?: PluginType | CancellationToken, options?: PluginDeployOptions): Promise<void> {
         const type = typeof arg2 === 'number' ? arg2 as PluginType : undefined;
-        return this.doDeploy(pluginEntry, type);
+        return this.doDeploy(pluginEntry, type, options);
     }
-    protected doDeploy(pluginEntry: string, type: PluginType = PluginType.User): Promise<void> {
-        return this.pluginDeployer.deploy(pluginEntry, type);
+    protected doDeploy(pluginEntry: string, type: PluginType = PluginType.User, options?: PluginDeployOptions): Promise<void> {
+        return this.pluginDeployer.deploy(pluginEntry, type, options);
     }
 
     undeploy(pluginId: string): Promise<void> {

--- a/packages/vsx-registry/package.json
+++ b/packages/vsx-registry/package.json
@@ -15,6 +15,7 @@
     "@types/showdown": "^1.7.1",
     "bent": "^7.1.0",
     "markdown-it": "^8.4.0",
+    "moment": "2.24.0",
     "p-debounce": "^2.1.0",
     "requestretry": "^3.1.0",
     "semver": "^5.4.1",

--- a/packages/vsx-registry/src/browser/vsx-extension-commands.ts
+++ b/packages/vsx-registry/src/browser/vsx-extension-commands.ts
@@ -36,6 +36,9 @@ export namespace VSXExtensionsCommands {
         label: nls.localize('theia/vsx-registry/installFromVSIX', 'Install from VSIX') + '...',
         dialogLabel: nls.localize('theia/vsx-registry/installFromVSIX', 'Install from VSIX')
     };
+    export const INSTALL_ANOTHER_VERSION: Command = {
+        id: 'vsxExtensions.installAnotherVersion'
+    }
     export const COPY: Command = {
         id: 'vsxExtensions.copy'
     };

--- a/packages/vsx-registry/src/browser/vsx-extension-commands.ts
+++ b/packages/vsx-registry/src/browser/vsx-extension-commands.ts
@@ -33,12 +33,12 @@ export namespace VSXExtensionsCommands {
         category: nls.localizeByDefault(EXTENSIONS_CATEGORY),
         originalCategory: EXTENSIONS_CATEGORY,
         originalLabel: 'Install from VSIX...',
-        label: nls.localize('theia/vsx-registry/installFromVSIX', 'Install from VSIX') + '...',
-        dialogLabel: nls.localize('theia/vsx-registry/installFromVSIX', 'Install from VSIX')
+        label: nls.localizeByDefault('Install from VSIX...'),
+        dialogLabel: nls.localizeByDefault('Install from VSIX')
     };
     export const INSTALL_ANOTHER_VERSION: Command = {
         id: 'vsxExtensions.installAnotherVersion'
-    }
+    };
     export const COPY: Command = {
         id: 'vsxExtensions.copy'
     };

--- a/packages/vsx-registry/src/browser/vsx-extension.tsx
+++ b/packages/vsx-registry/src/browser/vsx-extension.tsx
@@ -89,6 +89,15 @@ export type VSXExtensionFactory = (options: VSXExtensionOptions) => VSXExtension
 
 @injectable()
 export class VSXExtension implements VSXExtensionData, TreeElement {
+    /**
+     * Ensure the version string begins with `'v'`.
+     */
+    static formatVersion(version: string | undefined): string | undefined {
+        if (version && !version.startsWith('v')) {
+            return `v${version}`;
+        }
+        return version;
+    }
 
     @inject(VSXExtensionOptions)
     protected readonly options: VSXExtensionOptions;
@@ -191,14 +200,7 @@ export class VSXExtension implements VSXExtensionData, TreeElement {
     }
 
     get version(): string | undefined {
-        let version = this.getData('version');
-
-        // Ensure version begins with a 'v'
-        if (version && !version.startsWith('v')) {
-            version = `v${version}`;
-        }
-
-        return version;
+        return this.getData('version');
     }
 
     get averageRating(): number | undefined {
@@ -264,7 +266,7 @@ export class VSXExtension implements VSXExtensionData, TreeElement {
     }
 
     get tooltip(): string {
-        let md = `__${this.displayName}__ ${this.version}\n\n${this.description}\n_____\n\nPublisher: ${this.publisher}`;
+        let md = `__${this.displayName}__ ${VSXExtension.formatVersion(this.version)}\n\n${this.description}\n_____\n\nPublisher: ${this.publisher}`;
 
         if (this.license) {
             md += `  \rLicense: ${this.license}`;
@@ -427,7 +429,7 @@ export class VSXExtensionComponent extends AbstractVSXExtensionComponent {
             <div className='theia-vsx-extension-content'>
                 <div className='title'>
                     <div className='noWrapInfo'>
-                        <span className='name'>{displayName}</span> <span className='version'>{version}</span>
+                        <span className='name'>{displayName}</span> <span className='version'>{VSXExtension.formatVersion(version)}</span>
                     </div>
                     <div className='stat'>
                         {!!downloadCount && <span className='download-count'><i className={codicon('cloud-download')} />{downloadCompactFormatter.format(downloadCount)}</span>}
@@ -484,7 +486,7 @@ export class VSXExtensionEditorComponent extends AbstractVSXExtensionComponent {
                         {averageRating !== undefined && <span className='average-rating' onClick={this.openAverageRating}>{this.renderStars()}</span>}
                         {repository && <span className='repository' onClick={this.openRepository}>Repository</span>}
                         {license && <span className='license' onClick={this.openLicense}>{license}</span>}
-                        {version && <span className='version'>{version}</span>}
+                        {version && <span className='version'>{VSXExtension.formatVersion(version)}</span>}
                     </div>
                     <div className='description noWrapInfo'>{description}</div>
                     {this.renderAction()}

--- a/packages/vsx-registry/src/browser/vsx-extension.tsx
+++ b/packages/vsx-registry/src/browser/vsx-extension.tsx
@@ -22,20 +22,21 @@ import URI from '@theia/core/lib/common/uri';
 import { TreeElement } from '@theia/core/lib/browser/source-tree';
 import { OpenerService, open, OpenerOptions } from '@theia/core/lib/browser/opener-service';
 import { HostedPluginSupport } from '@theia/plugin-ext/lib/hosted/browser/hosted-plugin';
-import { PluginServer, DeployedPlugin, PluginType } from '@theia/plugin-ext/lib/common/plugin-protocol';
+import { PluginServer, DeployedPlugin, PluginType, PluginDeployOptions } from '@theia/plugin-ext/lib/common/plugin-protocol';
 import { VSXExtensionUri } from '../common/vsx-extension-uri';
 import { ProgressService } from '@theia/core/lib/common/progress-service';
 import { Endpoint } from '@theia/core/lib/browser/endpoint';
 import { VSXEnvironment } from '../common/vsx-environment';
 import { VSXExtensionsSearchModel } from './vsx-extensions-search-model';
-import { MenuPath } from '@theia/core/lib/common';
+import { MenuPath, CommandRegistry } from '@theia/core/lib/common';
 import { codicon, ContextMenuRenderer, TooltipService } from '@theia/core/lib/browser';
 import { VSXExtensionNamespaceAccess, VSXUser } from '@theia/ovsx-client/lib/ovsx-types';
 
 export const EXTENSIONS_CONTEXT_MENU: MenuPath = ['extensions_context_menu'];
 
 export namespace VSXExtensionsContextMenu {
-    export const COPY = [...EXTENSIONS_CONTEXT_MENU, '1_copy'];
+    export const INSTALL = [...EXTENSIONS_CONTEXT_MENU, '1_install'];
+    export const COPY = [...EXTENSIONS_CONTEXT_MENU, '2_copy'];
 }
 
 @injectable()
@@ -115,6 +116,9 @@ export class VSXExtension implements VSXExtensionData, TreeElement {
 
     @inject(TooltipService)
     readonly tooltipService: TooltipService;
+
+    @inject(CommandRegistry)
+    readonly commandRegistry: CommandRegistry;
 
     protected readonly data: Partial<VSXExtensionData> = {};
 
@@ -282,11 +286,11 @@ export class VSXExtension implements VSXExtensionData, TreeElement {
         return !!this._busy;
     }
 
-    async install(): Promise<void> {
+    async install(options?: PluginDeployOptions): Promise<void> {
         this._busy++;
         try {
             await this.progressService.withProgress(`"Installing '${this.id}' extension...`, 'extensions', () =>
-                this.pluginServer.deploy(this.uri.toString())
+                this.pluginServer.deploy(this.uri.toString(), undefined, options)
             );
         } finally {
             this._busy--;

--- a/packages/vsx-registry/src/browser/vsx-extensions-model.ts
+++ b/packages/vsx-registry/src/browser/vsx-extensions-model.ts
@@ -199,16 +199,19 @@ export class VSXExtensionsModel {
             const currInstalled = new Set<string>();
             const refreshing = [];
             for (const plugin of plugins) {
+                const version = plugin.model.version;
                 if (plugin.model.engine.type === 'vscode') {
                     const id = plugin.model.id;
                     this._installed.delete(id);
                     const extension = this.setExtension(id);
                     currInstalled.add(extension.id);
-                    refreshing.push(this.refresh(id));
+                    refreshing.push(this.refresh(id, version));
                 }
             }
             for (const id of this._installed) {
-                refreshing.push(this.refresh(id));
+                const extension = this.getExtension(id);
+                if (!extension) continue;
+                refreshing.push(this.refresh(id, extension.version));
             }
             Promise.all(refreshing);
             const installed = new Set([...prevInstalled, ...currInstalled]);
@@ -287,14 +290,16 @@ export class VSXExtensionsModel {
         return DOMPurify.sanitize(readmeHtml);
     }
 
-    protected async refresh(id: string): Promise<VSXExtension | undefined> {
+    protected async refresh(id: string, version?: string): Promise<VSXExtension | undefined> {
         try {
             let extension = this.getExtension(id);
             if (!this.shouldRefresh(extension)) {
                 return extension;
             }
+
             const client = await this.clientProvider();
-            const data = await client.getLatestCompatibleExtensionVersion(id);
+            const data = version !== undefined ? await client.getExtension(id, { extensionVersion: version }) : await client.getLatestCompatibleExtensionVersion(id);
+
             if (!data) {
                 return;
             }

--- a/packages/vsx-registry/src/browser/vsx-extensions-model.ts
+++ b/packages/vsx-registry/src/browser/vsx-extensions-model.ts
@@ -210,7 +210,7 @@ export class VSXExtensionsModel {
             }
             for (const id of this._installed) {
                 const extension = this.getExtension(id);
-                if (!extension) continue;
+                if (!extension) {continue; }
                 refreshing.push(this.refresh(id, extension.version));
             }
             Promise.all(refreshing);

--- a/packages/vsx-registry/src/node/vsx-extension-resolver.ts
+++ b/packages/vsx-registry/src/node/vsx-extension-resolver.ts
@@ -49,30 +49,22 @@ export class VSXExtensionResolver implements PluginDeployerResolver {
         if (!id) {
             return;
         }
-        let extensionVersion: string | undefined;
         let extension: VSXExtensionRaw | undefined;
         const client = await this.clientProvider();
         if (options) {
-            extensionVersion = options.version;
-            console.log(`[${id}]: trying to resolve version ${extensionVersion}...`);
-            extension = await client.getExtension(id, { extensionVersion: extensionVersion });
-            if (!extension) {
-                return;
-            }
-            if (extension.error) {
-                throw new Error(extension.error);
-            }
+            console.log(`[${id}]: trying to resolve version ${options.version}...`);
+            extension = await client.getExtension(id, { extensionVersion: options.version });
         } else {
             console.log(`[${id}]: trying to resolve latest version...`);
             extension = await client.getLatestCompatibleExtensionVersion(id);
-            if (!extension) {
-                return;
-            }
-            if (extension.error) {
-                throw new Error(extension.error);
-            }
-            extensionVersion = extension.version;
         }
+        if (!extension) {
+            return;
+        }
+        if (extension.error) {
+            throw new Error(extension.error);
+        }
+        const extensionVersion = extension.version;
         const resolvedId = id + '-' + extensionVersion;
         const downloadUrl = extension.files.download;
         console.log(`[${id}]: resolved to '${resolvedId}'`);


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

- Supports the ability to install any compatible version of an user-installed extension, provided that the extension is available in the Open VSX Registry.

https://user-images.githubusercontent.com/46289281/114419822-c3067980-9b81-11eb-9155-6556d10b7919.mp4

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

1. Open the extensions view and locate the `Installed` view of all user-installed extensions.
2. Pick an extension --> Click the `manage` gear icon --> Click `Install Another Version...` command. Note that the command is disabled for any extension not available in the Open VSX Registry.
3. Select a compatible version to install from the Quick Pick dropdown.
4. Observe that the previous version is uninstalled and replaced with the newly selected version.

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

Signed-off-by: seantan22 <sean.a.tan@ericsson.com>