### PR TITLE
[task]: Update `TaskConfigurationManager` on Workspace Location Change

### DIFF
--- a/packages/task/src/browser/task-configuration-manager.ts
+++ b/packages/task/src/browser/task-configuration-manager.ts
@@ -97,6 +97,9 @@ export class TaskConfigurationManager {
         this.workspaceService.onWorkspaceChanged(() => {
             this.updateModels();
         });
+        this.workspaceService.onWorkspaceLocationChanged(() => {
+            this.updateModels();
+        });
     }
 
     protected createModels(): void {
@@ -237,6 +240,7 @@ export class TaskConfigurationManager {
                 }));
             }
             this.models.set(TaskScope.Workspace, workspaceModel);
+            this.onDidChangeTaskConfigEmitter.fire({ scope: TaskScope.Workspace, type: FileChangeType.UPDATED });
         }
     }
 }

--- a/packages/task/src/browser/task-configurations.ts
+++ b/packages/task/src/browser/task-configurations.ts
@@ -146,7 +146,7 @@ export class TaskConfigurations implements Disposable {
     }
 
     getRawTaskConfigurations(scope?: TaskConfigurationScope): (TaskCustomization | TaskConfiguration)[] {
-        if (!scope) {
+        if (scope === undefined) {
             const tasks: (TaskCustomization | TaskConfiguration)[] = [];
             for (const configs of this.rawTaskConfigurations.values()) {
                 tasks.push(...configs);

--- a/packages/task/src/browser/task-service.ts
+++ b/packages/task/src/browser/task-service.ts
@@ -841,7 +841,7 @@ export class TaskService implements TaskConfigurationClient {
     }
 
     /**
-     * Runs a task identified by the given identifier, but only if found in the give workspace folder
+     * Runs a task identified by the given identifier, but only if found in the given workspace folder
      *
      * @param token  The cache token for the user interaction in progress
      * @param workspaceFolderUri  The folder to restrict the search to


### PR DESCRIPTION
Signed-off-by: Colin Grant <colin.grant@ericsson.com>

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

Fixes #9329 by adding a listener for `onLocationChanged` to the `TaskConfigurationManager` to ensure that it updates the target of its workspace proxy when a workspace file is created.

In addition, it fires a changed event when the workspace proxy is changed, parallel to the events fired when new folder-scope models are created.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

1. Checkout this PR branch.
2. Cherry pick the commit from [this branch](https://github.com/colin-grant-work/theia/tree/reproduction/bad-workspace-handling) to add a command to log what the configuration service lists in workspace scope. (ctrl+p, search 'Check tasks listed in workspace scope.')
3. Open a single-root, unsaved workspace.
4. If there are no tasks in the root, add one, e.g.
```
{
  "version": "2.0.0",
  "tasks": [
    {"label": "Folder task", "type": "shell", "command": "htop"}
  ]
}
```
5. Run the command to log tasks in workspace scope.
6. See that the tasks in the folder scope are logged (since folder scope = workspace scope)
7. Run `File > Save Workspace as ...` and save the workspace wherever you'd like.
8. Run the command to log tasks in workspace scope.
9. See that the tasks in folder scope are **not** logged, since folder scope != workspace scope after saving the workspace file.

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

