### PR TITLE
Use task.type first to look up task runner

### DIFF
--- a/packages/task/src/node/task-runner.ts
+++ b/packages/task/src/node/task-runner.ts
@@ -84,14 +84,20 @@ export class TaskRunnerRegistry {
     }
 
     /**
-     * Retrieves the {@link TaskRunner} registered for the specified Task type.
-     * @param type the task type.
+     * Looks for a registered {@link TaskRunner} for each of the task types in sequence and returns the first that is found
+     * If no task runner is registered for any of the types, the default runner is returned.
+     * @param types the task types.
      *
-     * @returns the registered {@link TaskRunner} or a default runner if none is registered for the specified type.
+     * @returns the registered {@link TaskRunner} or a default runner if none is registered for the specified types.
      */
-    getRunner(type: string): TaskRunner {
-        const runner = this.runners.get(type);
-        return runner ? runner : this.defaultRunner;
+    getRunner(...types: string[]): TaskRunner {
+        for (const type of types) {
+            const runner = this.runners.get(type);
+            if (runner) {
+                return runner;
+            }
+        }
+        return this.defaultRunner;
     }
 
     /**

--- a/packages/task/src/node/task-server.ts
+++ b/packages/task/src/node/task-server.ts
@@ -90,7 +90,7 @@ export class TaskServerImpl implements TaskServer, Disposable {
     }
 
     async run(taskConfiguration: TaskConfiguration, ctx?: string, option?: RunTaskOption): Promise<TaskInfo> {
-        const runner = this.runnerRegistry.getRunner(taskConfiguration.taskType);
+        const runner = this.runnerRegistry.getRunner(taskConfiguration.type, taskConfiguration.taskType);
         const task = await runner.run(taskConfiguration, ctx);
 
         if (!this.toDispose.has(task.id)) {


### PR DESCRIPTION
#### What it does
Fixes TaskRunner Registration is broken #9334.  

#### How to test
Verify both detected tasks (I used the `npm` style tasks) and tasks added manually (from tasks.json) can be executed. In order to verify the fix works for Che, I have compiled github.com/eclipse-che/che-theia master against Theia master. 
It seems a bit of overkill to create a Theia-only reproducer for what seems a relatively safe and trivial fix.

Testing with contributed tasks is a bit difficult right now because of https://github.com/eclipse-theia/theia/issues/9335

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

