### PR TITLE
console: sanitize html content for ansi-console-item

### DIFF
--- a/packages/console/package.json
+++ b/packages/console/package.json
@@ -5,7 +5,9 @@
   "dependencies": {
     "@theia/core": "1.12.0",
     "@theia/monaco": "1.12.0",
-    "anser": "^2.0.1"
+    "@types/dompurify": "^2.0.2",
+    "anser": "^2.0.1",
+    "dompurify": "^2.0.11"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/console/src/browser/ansi-console-item.tsx
+++ b/packages/console/src/browser/ansi-console-item.tsx
@@ -15,6 +15,7 @@
  ********************************************************************************/
 
 import * as React from '@theia/core/shared/react';
+import * as DOMPurify from 'dompurify';
 import { ConsoleItem } from './console-session';
 import { Severity } from '@theia/core/lib/common/severity';
 import Anser = require('anser');
@@ -38,7 +39,10 @@ export class AnsiConsoleItem implements ConsoleItem {
     }
 
     render(): React.ReactNode {
-        return <div className='theia-console-ansi-console-item' dangerouslySetInnerHTML={{ __html: this.htmlContent }} />;
+        return <div
+            className='theia-console-ansi-console-item'
+            dangerouslySetInnerHTML={{ __html: DOMPurify.sanitize(this.htmlContent) }}
+        />;
     }
 
 }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

Fixes: #8794

The following commit sanitizes the `htmlContent` used by the `ansi-console` to prevent cross-site-scripting (xss).
The commit makes use of `DOMPurify.sanitize` to sanitize the content of the html content.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

Follow the steps provided in the #8794 video.
I confirmed that the dialog appears on _master_ but not the _pull-request_ when sanitization occurs.

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

Signed-off-by: vince-fugnitto <vincent.fugnitto@ericsson.com>