### PR TITLE
Parse command line for shell execution

### DIFF
--- a/packages/plugin-ext/src/plugin/type-converters.ts
+++ b/packages/plugin-ext/src/plugin/type-converters.ts
@@ -857,7 +857,14 @@ export function fromShellExecution(execution: theia.ShellExecution, taskDto: Tas
 
     const commandLine = execution.commandLine;
     if (commandLine) {
-        taskDto.command = commandLine;
+        const args = commandLine.split(' ');
+        const taskCommand = args.shift();
+
+        if (taskCommand) {
+            taskDto.command = taskCommand;
+        }
+
+        taskDto.args = args;
         return taskDto;
     }
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
This PR restores some old code that parses the command line when a `ProcessExecution` in a task has the `commandLine` field set (instead of `command` and `args`).
Fixes "Cannot execute npm Task" #9335

#### How to test
Follow the failing script in the Issue.  Note that on Windows, execution of the commands does not work, but that seems to be a different problem (I suspect that the executable is not found when executing a process directly instead of going through `cmd.exe /K <command>`).

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

