### PR TITLE
Activate pinned editor only if already active

### DIFF
--- a/packages/editor-preview/src/browser/editor-preview-manager.spec.ts
+++ b/packages/editor-preview/src/browser/editor-preview-manager.spec.ts
@@ -62,6 +62,7 @@ before(() => {
     // Mock out injected dependencies.
     testContainer.bind(EditorManager).toDynamicValue(ctx => mockEditorManager);
     testContainer.bind(WidgetManager).toDynamicValue(ctx => mockWidgetManager);
+    (<any>mockShell)['tracker'] = { activeWidget: undefined };
     testContainer.bind(ApplicationShell).toConstantValue(mockShell);
     testContainer.bind(PreferenceService).toDynamicValue(ctx => mockPreference);
 

--- a/packages/editor-preview/src/browser/editor-preview-manager.ts
+++ b/packages/editor-preview/src/browser/editor-preview-manager.ts
@@ -82,15 +82,17 @@ export class EditorPreviewManager extends WidgetOpenHandler<EditorPreviewWidget 
         widget.disposed.connect(() => this.currentEditorPreview = Promise.resolve(undefined));
 
         widget.onPinned(({ preview, editorWidget }) => {
-            // TODO(caseyflynn): I don't believe there is ever a case where
-            // this will not hold true.
+            const wasActive = this.shell.activeWidget === preview || this.shell.activeWidget === editorWidget;
+            // TODO(caseyflynn): I don't believe there is ever a case where the parent will not be a DockPanel.
             if (preview.parent && preview.parent instanceof DockPanel) {
                 preview.parent.addWidget(editorWidget, { ref: preview });
             } else {
                 this.shell.addWidget(editorWidget, { area: 'main' });
             }
             preview.dispose();
-            this.shell.activateWidget(editorWidget.id);
+            if (wasActive) {
+                this.shell.activateWidget(editorWidget.id);
+            }
             this.currentEditorPreview = Promise.resolve(undefined);
         });
     }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

Fixes #9268 by preventing a newly pinned editor widget from activating when it was not previously the active widget.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
1. Open preferences UI, search for `editor.enablePreview` and ensure that the preference is set to to `true` (default).
2. Open the file navigator and single-click on a file.
3. Observe that it opens with its title italicized. Leave it in that state!
4. Return to preferences UI and change `editor.enablePreview` to false.
5. Observe that the editor tab changes to Roman type, but is not activated.

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

Signed-off-by: Colin Grant <colin.grant@ericsson.com>