### PR TITLE
Consider taskConfig.type when running tasks.

### DIFF
--- a/packages/task/src/browser/process/process-task-resolver.ts
+++ b/packages/task/src/browser/process/process-task-resolver.ts
@@ -42,7 +42,8 @@ export class ProcessTaskResolver implements TaskResolver {
      * sane default values. Also, resolve all known variables, e.g. `${workspaceFolder}`.
      */
     async resolveTask(taskConfig: TaskConfiguration): Promise<TaskConfiguration> {
-        if (taskConfig.taskType !== 'process' && taskConfig.taskType !== 'shell') {
+        const type = taskConfig.taskType || taskConfig.type;
+        if (type !== 'process' && type !== 'shell') {
             throw new Error('Unsupported task configuration type.');
         }
         const context = typeof taskConfig._scope === 'string' ? new URI(taskConfig._scope) : undefined;

--- a/packages/task/src/node/process/process-task-runner.ts
+++ b/packages/task/src/node/process/process-task-runner.ts
@@ -141,7 +141,7 @@ export class ProcessTaskRunner implements TaskRunner {
          */
         let commandLine: string | undefined;
 
-        if (taskConfig.type === 'shell') {
+        if ((taskConfig.taskType || taskConfig.type) === 'shell') {
             // When running a shell task, we have to spawn a shell process somehow,
             // and tell it to run the command the user wants to run inside of it.
             //


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
Fix for "Cannot execute npm Task" #9335

This change looks at task.type as well as task.taskType when executing tasks.

#### How to test
Run the scenario from the linked issue and also execute tasks from tasks.json

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

