### PR TITLE
Activate Preferences Widget When Opened by Command

### DIFF
--- a/packages/preferences/src/browser/preferences-contribution.ts
+++ b/packages/preferences/src/browser/preferences-contribution.ts
@@ -59,7 +59,7 @@ export class PreferencesContribution extends AbstractViewContribution<Preference
 
     registerCommands(commands: CommandRegistry): void {
         commands.registerCommand(CommonCommands.OPEN_PREFERENCES, {
-            execute: () => this.openView({ reveal: true }),
+            execute: () => this.openView({ activate: true }),
         });
         commands.registerCommand(PreferencesCommands.OPEN_PREFERENCES_JSON_TOOLBAR, {
             isEnabled: () => true,


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

Fixes #9354 by activating the preferences widget when it is opened on command.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

1. Use the keyboard shortcut (<kbd>ctrl</kbd> + <kbd>,</kbd>) to open the preferences widget.
2. Observe that the searchbar is focused.

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

Signed-off-by: Colin Grant <colin.grant@ericsson.com>