### PR TITLE
Don't send widgets on `.focus` command

### DIFF
--- a/packages/plugin-ext/src/main/browser/view/plugin-view-registry.ts
+++ b/packages/plugin-ext/src/main/browser/view/plugin-view-registry.ts
@@ -309,7 +309,7 @@ export class PluginViewRegistry implements FrontendApplicationContribution {
             open: () => this.openView(view.id, { activate: true })
         }));
         toDispose.push(this.commands.registerCommand({ id: `${view.id}.focus` }, {
-            execute: () => this.openView(view.id, { activate: true })
+            execute: async () => { await this.openView(view.id, { activate: true }); }
         }));
         return toDispose;
     }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

Fixes #9353 by adjusting the command registration not to return a promise of the widget. Instead it returns a void promise.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

1. Start the application, and open a TS/JS file.
2. Open the devTools.
3. Trigger the command Find All References on a symbol.
4. Observe that no error is logged.

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

Signed-off-by: Colin Grant <colin.grant@ericsson.com>