### PR TITLE
Allow multiple editors for same file

### DIFF
--- a/packages/core/src/browser/navigatable.ts
+++ b/packages/core/src/browser/navigatable.ts
@@ -68,7 +68,8 @@ export namespace NavigatableWidget {
 
 export interface NavigatableWidgetOptions {
     kind: 'navigatable',
-    uri: string
+    uri: string,
+    counter?: number,
 }
 export namespace NavigatableWidgetOptions {
     export function is(arg: Object | undefined): arg is NavigatableWidgetOptions {

--- a/packages/core/src/browser/widget-open-handler.ts
+++ b/packages/core/src/browser/widget-open-handler.ts
@@ -138,12 +138,12 @@ export abstract class WidgetOpenHandler<W extends BaseWidget> implements OpenHan
 
     protected getWidget(uri: URI, options?: WidgetOpenerOptions): Promise<W | undefined> {
         const widgetOptions = this.createWidgetOptions(uri, options);
-        return this.widgetManager.getWidget(this.id, widgetOptions) as Promise<W | undefined>;
+        return this.widgetManager.getWidget<W>(this.id, widgetOptions);
     }
 
     protected getOrCreateWidget(uri: URI, options?: WidgetOpenerOptions): Promise<W> {
         const widgetOptions = this.createWidgetOptions(uri, options);
-        return this.widgetManager.getOrCreateWidget(this.id, widgetOptions) as Promise<W>;
+        return this.widgetManager.getOrCreateWidget<W>(this.id, widgetOptions);
     }
 
     protected abstract createWidgetOptions(uri: URI, options?: WidgetOpenerOptions): Object;

--- a/packages/editor/src/browser/editor-command.ts
+++ b/packages/editor/src/browser/editor-command.ts
@@ -28,6 +28,7 @@ import { SUPPORTED_ENCODINGS } from '@theia/core/lib/browser/supported-encodings
 export namespace EditorCommands {
 
     const EDITOR_CATEGORY = 'Editor';
+    const VIEW_CATEGORY = 'View';
 
     /**
      * Show editor references
@@ -106,7 +107,7 @@ export namespace EditorCommands {
      */
     export const SHOW_ALL_OPENED_EDITORS: Command = {
         id: 'workbench.action.showAllEditors',
-        category: 'View',
+        category: VIEW_CATEGORY,
         label: 'Show All Opened Editors'
     };
     /**
@@ -114,7 +115,7 @@ export namespace EditorCommands {
      */
     export const TOGGLE_MINIMAP: Command = {
         id: 'editor.action.toggleMinimap',
-        category: 'View',
+        category: VIEW_CATEGORY,
         label: 'Toggle Minimap'
     };
     /**
@@ -122,7 +123,7 @@ export namespace EditorCommands {
      */
     export const TOGGLE_RENDER_WHITESPACE: Command = {
         id: 'editor.action.toggleRenderWhitespace',
-        category: 'View',
+        category: VIEW_CATEGORY,
         label: 'Toggle Render Whitespace'
     };
     /**
@@ -130,7 +131,7 @@ export namespace EditorCommands {
      */
     export const TOGGLE_WORD_WRAP: Command = {
         id: 'editor.action.toggleWordWrap',
-        category: 'View',
+        category: VIEW_CATEGORY,
         label: 'Toggle Word Wrap'
     };
     /**
@@ -138,8 +139,47 @@ export namespace EditorCommands {
      */
     export const REOPEN_CLOSED_EDITOR: Command = {
         id: 'workbench.action.reopenClosedEditor',
-        category: 'View',
+        category: VIEW_CATEGORY,
         label: 'Reopen Closed Editor'
+    };
+    /**
+     * Opens a second instance of the current editor, splitting the view in the direction specified.
+     */
+    export const SPLIT_EDITOR_RIGHT: Command = {
+        id: 'workbench.action.splitEditorRight',
+        category: VIEW_CATEGORY,
+        label: 'Split Editor Right'
+    };
+    export const SPLIT_EDITOR_DOWN: Command = {
+        id: 'workbench.action.splitEditorDown',
+        category: VIEW_CATEGORY,
+        label: 'Split Editor Down'
+    };
+    export const SPLIT_EDITOR_UP: Command = {
+        id: 'workbench.action.splitEditorUp',
+        category: VIEW_CATEGORY,
+        label: 'Split Editor Up'
+    };
+    export const SPLIT_EDITOR_LEFT: Command = {
+        id: 'workbench.action.splitEditorLeft',
+        category: VIEW_CATEGORY,
+        label: 'Split Editor Left'
+    };
+    /**
+     * Default horizontal split: right.
+     */
+    export const SPLIT_EDITOR_HORIZONTAL: Command = {
+        id: 'workbench.action.splitEditor',
+        category: VIEW_CATEGORY,
+        label: 'Split Editor'
+    };
+    /**
+     * Default vertical split: down.
+     */
+    export const SPLIT_EDITOR_VERTICAL: Command = {
+        id: 'workbench.action.splitEditorOrthogonal',
+        category: VIEW_CATEGORY,
+        label: 'Split Editor Orthogonal'
     };
 }
 

--- a/packages/editor/src/browser/editor-contribution.ts
+++ b/packages/editor/src/browser/editor-contribution.ts
@@ -18,9 +18,9 @@ import { EditorManager } from './editor-manager';
 import { TextEditor } from './editor';
 import { injectable, inject } from '@theia/core/shared/inversify';
 import { StatusBarAlignment, StatusBar } from '@theia/core/lib/browser/status-bar/status-bar';
-import { FrontendApplicationContribution, DiffUris } from '@theia/core/lib/browser';
+import { FrontendApplicationContribution, DiffUris, DockLayout } from '@theia/core/lib/browser';
 import { ContextKeyService } from '@theia/core/lib/browser/context-key-service';
-import { DisposableCollection } from '@theia/core';
+import { CommandHandler, DisposableCollection } from '@theia/core';
 import { EditorCommands } from './editor-command';
 import { EditorQuickOpenService } from './editor-quick-open-service';
 import { CommandRegistry, CommandContribution } from '@theia/core/lib/common';
@@ -133,12 +133,39 @@ export class EditorContribution implements FrontendApplicationContribution, Comm
         commands.registerCommand(EditorCommands.SHOW_ALL_OPENED_EDITORS, {
             execute: () => this.editorQuickOpenService.open()
         });
+        const splitHandlerFactory = (splitMode: DockLayout.InsertMode): CommandHandler => ({
+            isEnabled: () => !!this.editorManager.currentEditor,
+            isVisible: () => !!this.editorManager.currentEditor,
+            execute: async () => {
+                const { currentEditor } = this.editorManager;
+                if (currentEditor) {
+                    const selection = currentEditor.editor.selection;
+                    const newEditor = await this.editorManager.openToSide(currentEditor.editor.uri, { selection, widgetOptions: { mode: splitMode } });
+                    const oldEditorState = currentEditor.editor.storeViewState();
+                    newEditor.editor.restoreViewState(oldEditorState);
+                }
+            }
+        });
+        commands.registerCommand(EditorCommands.SPLIT_EDITOR_HORIZONTAL, splitHandlerFactory('split-right'));
+        commands.registerCommand(EditorCommands.SPLIT_EDITOR_VERTICAL, splitHandlerFactory('split-bottom'));
+        commands.registerCommand(EditorCommands.SPLIT_EDITOR_RIGHT, splitHandlerFactory('split-right'));
+        commands.registerCommand(EditorCommands.SPLIT_EDITOR_DOWN, splitHandlerFactory('split-bottom'));
+        commands.registerCommand(EditorCommands.SPLIT_EDITOR_UP, splitHandlerFactory('split-top'));
+        commands.registerCommand(EditorCommands.SPLIT_EDITOR_LEFT, splitHandlerFactory('split-left'));
     }
 
     registerKeybindings(keybindings: KeybindingRegistry): void {
         keybindings.registerKeybinding({
             command: EditorCommands.SHOW_ALL_OPENED_EDITORS.id,
             keybinding: 'ctrlcmd+k ctrlcmd+p'
+        });
+        keybindings.registerKeybinding({
+            command: EditorCommands.SPLIT_EDITOR_HORIZONTAL.id,
+            keybinding: 'ctrlcmd+\\',
+        });
+        keybindings.registerKeybinding({
+            command: EditorCommands.SPLIT_EDITOR_VERTICAL.id,
+            keybinding: 'ctrlcmd+k ctrlcmd+\\',
         });
     }
 

--- a/packages/editor/src/browser/editor-widget-factory.ts
+++ b/packages/editor/src/browser/editor-widget-factory.ts
@@ -39,10 +39,10 @@ export class EditorWidgetFactory implements WidgetFactory {
 
     createWidget(options: NavigatableWidgetOptions): Promise<EditorWidget> {
         const uri = new URI(options.uri);
-        return this.createEditor(uri);
+        return this.createEditor(uri, options);
     }
 
-    protected async createEditor(uri: URI): Promise<EditorWidget> {
+    protected async createEditor(uri: URI, options?: NavigatableWidgetOptions): Promise<EditorWidget> {
         const textEditor = await this.editorProvider(uri);
         const newEditor = new EditorWidget(textEditor, this.selectionService);
 
@@ -55,6 +55,9 @@ export class EditorWidgetFactory implements WidgetFactory {
         newEditor.onDispose(() => labelListener.dispose());
 
         newEditor.id = this.id + ':' + uri.toString();
+        if (options?.counter !== undefined) {
+            newEditor.id += `:${options.counter}`;
+        }
         newEditor.title.closable = true;
         return newEditor;
     }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

This PR fixes #3857 by allowing multiple editors to be opened for the same URI.

The basic principle is that all widget creation calls that go through the `EditorManager` add a `counter` field to the widget options so that the widget manager creates separate widgets for separate counter entries. The `get` calls use an existing counter value; `getOrCreate` an old if available, a new if necessary; and `openToSide` always creates a new value to ensure that a new widget is created.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

1. I've added a set of commands to split the view in various directions. Open an editor and run them. Each new editor should look like its parent: same visible range and selection.

![image](https://user-images.githubusercontent.com/62660806/115090315-207c2c80-9eda-11eb-99cf-987bdfceef74.png)

 - [ ] In VSCode only one copy of an editor widget can exist on the same tabbar. If you create a new instance to the side and then move it to its parent's tabbar, one of them will be closed. I haven't tried to replicate that functionality here, but if it seems desirable, I can.
#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

Signed-off-by: Colin Grant <colin.grant@ericsson.com>