### PR TITLE
[vscode] Read args from keybindings #9126

### DIFF
--- a/packages/plugin-ext/src/common/plugin-protocol.ts
+++ b/packages/plugin-ext/src/common/plugin-protocol.ts
@@ -154,6 +154,8 @@ export interface PluginPackageKeybinding {
     mac?: string;
     linux?: string;
     win?: string;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    args?: any;
 }
 
 export interface PluginPackageGrammarsContribution {
@@ -706,6 +708,8 @@ export interface Keybinding {
     mac?: string;
     linux?: string;
     win?: string;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    args?: any;
 }
 
 /**

--- a/packages/plugin-ext/src/hosted/node/scanners/scanner-theia.ts
+++ b/packages/plugin-ext/src/hosted/node/scanners/scanner-theia.ts
@@ -492,7 +492,8 @@ export class TheiaPluginScanner implements PluginScanner {
             when: rawKeybinding.when,
             mac: rawKeybinding.mac,
             linux: rawKeybinding.linux,
-            win: rawKeybinding.win
+            win: rawKeybinding.win,
+            args: rawKeybinding.args
         };
     }
 

--- a/packages/plugin-ext/src/main/browser/keybindings/keybindings-contribution-handler.ts
+++ b/packages/plugin-ext/src/main/browser/keybindings/keybindings-contribution-handler.ts
@@ -47,8 +47,8 @@ export class KeybindingsContributionPointHandler {
         if (!keybinding) {
             return undefined;
         }
-        const { command, when } = pluginKeybinding;
-        return { keybinding, command, when };
+        const { command, when, args } = pluginKeybinding;
+        return { keybinding, command, when, args };
     }
 
     protected toOSKeybinding(pluginKeybinding: PluginKeybinding): string | undefined {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
Reads and stores args from keybindings field from package.json

#### How to test
Initialize a vscode extension following https://code.visualstudio.com/api/get-started/your-first-extension
Add a shortcut in extension's package.json:
```
	 "contributes": {
		"keybindings": [
			{
				"command": "type",
				"args": {
                                	 "text": "test"
                                },
				"key": "alt+7",
                                "when": "editorTextFocus"
			}
		]
	}
```
Install extension.
Open text editor on any file, be shure that cursor is located somewhere in file and fire alt+7 in text editor.
It should insert "test" text on selection.

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

