### PR TITLE
Revert task types updates

### DIFF
--- a/packages/plugin-ext/src/plugin/tasks/tasks.ts
+++ b/packages/plugin-ext/src/plugin/tasks/tasks.ts
@@ -158,7 +158,7 @@ export class TasksExtImpl implements TasksExt {
             // If this task is a custom execution, then we need to save it away
             // in the provided custom execution map that is cleaned up after the
             // task is executed.
-            if (CustomExecution.is(task.execution!)) {
+            if (taskDto.type === 'customExecution') {
                 this.addCustomExecution(taskDto, false);
             }
             const executionDto = await this.proxy.$executeTask(taskDto);
@@ -177,7 +177,7 @@ export class TasksExtImpl implements TasksExt {
             return adapter.provideTasks(token).then(tasks => {
                 if (tasks) {
                     for (const task of tasks) {
-                        if (task.type === 'customExecution' || task.taskType === 'customExecution') {
+                        if (task.type === 'customExecution') {
                             this.addCustomExecution(task, true);
                         }
                     }

--- a/packages/plugin-ext/src/plugin/type-converters.ts
+++ b/packages/plugin-ext/src/plugin/type-converters.ts
@@ -750,15 +750,15 @@ export function fromTask(task: theia.Task): TaskDto | undefined {
         return taskDto;
     }
 
-    if (taskDefinition.taskType === 'shell' || types.ShellExecution.is(execution)) {
+    if (taskDefinition.type === 'shell' || types.ShellExecution.is(execution)) {
         return fromShellExecution(<theia.ShellExecution>execution, taskDto);
     }
 
-    if (taskDefinition.taskType === 'process' || types.ProcessExecution.is(execution)) {
+    if (taskDefinition.type === 'process' || types.ProcessExecution.is(execution)) {
         return fromProcessExecution(<theia.ProcessExecution>execution, taskDto);
     }
 
-    if (taskDefinition.taskType === 'customExecution' || types.CustomExecution.is(execution)) {
+    if (taskDefinition.type === 'customExecution' || types.CustomExecution.is(execution)) {
         return fromCustomExecution(<theia.CustomExecution>execution, taskDto);
     }
 
@@ -770,7 +770,7 @@ export function toTask(taskDto: TaskDto): theia.Task {
         throw new Error('Task should be provided for converting');
     }
 
-    const { type, taskType, label, source, scope, problemMatcher, detail, command, args, options, group, presentation, ...properties } = taskDto;
+    const { type, label, source, scope, problemMatcher, detail, command, args, options, group, presentation, ...properties } = taskDto;
     const result = {} as theia.Task;
     result.name = label;
     result.source = source;
@@ -788,8 +788,9 @@ export function toTask(taskDto: TaskDto): theia.Task {
         result.scope = scope;
     }
 
+    const taskType = type;
     const taskDefinition: theia.TaskDefinition = {
-        type: type
+        type: taskType
     };
 
     result.definition = taskDefinition;

--- a/packages/plugin-ext/src/plugin/types-impl.ts
+++ b/packages/plugin-ext/src/plugin/types-impl.ts
@@ -1911,18 +1911,21 @@ export class Task {
     private updateDefinitionBasedOnExecution(): void {
         if (this.taskExecution instanceof ProcessExecution) {
             Object.assign(this.taskDefinition, {
+                type: 'process',
                 id: this.taskExecution.computeId(),
-                taskType: 'process'
+                taskType: this.taskDefinition!.type
             });
         } else if (this.taskExecution instanceof ShellExecution) {
             Object.assign(this.taskDefinition, {
+                type: 'shell',
                 id: this.taskExecution.computeId(),
-                taskType: 'shell'
+                taskType: this.taskDefinition!.type
             });
         } else if (this.taskExecution instanceof CustomExecution) {
             Object.assign(this.taskDefinition, {
-                id: this.taskDefinition.id ? this.taskDefinition.id : this.taskExecution.computeId(),
-                taskType: 'customExecution'
+                type: 'customExecution',
+                id: this.taskExecution.computeId(),
+                taskType: this.taskDefinition!.type
             });
         } else {
             Object.assign(this.taskDefinition, {

--- a/packages/task/src/browser/process/process-task-resolver.ts
+++ b/packages/task/src/browser/process/process-task-resolver.ts
@@ -42,7 +42,7 @@ export class ProcessTaskResolver implements TaskResolver {
      * sane default values. Also, resolve all known variables, e.g. `${workspaceFolder}`.
      */
     async resolveTask(taskConfig: TaskConfiguration): Promise<TaskConfiguration> {
-        if (taskConfig.taskType !== 'process' && taskConfig.taskType !== 'shell') {
+        if (taskConfig.type !== 'process' && taskConfig.type !== 'shell') {
             throw new Error('Unsupported task configuration type.');
         }
         const context = typeof taskConfig._scope === 'string' ? new URI(taskConfig._scope) : undefined;

--- a/packages/task/src/browser/process/process-task-resolver.ts
+++ b/packages/task/src/browser/process/process-task-resolver.ts
@@ -42,8 +42,7 @@ export class ProcessTaskResolver implements TaskResolver {
      * sane default values. Also, resolve all known variables, e.g. `${workspaceFolder}`.
      */
     async resolveTask(taskConfig: TaskConfiguration): Promise<TaskConfiguration> {
-        const type = taskConfig.taskType || taskConfig.type;
-        if (type !== 'process' && type !== 'shell') {
+        if (taskConfig.taskType !== 'process' && taskConfig.taskType !== 'shell') {
             throw new Error('Unsupported task configuration type.');
         }
         const context = typeof taskConfig._scope === 'string' ? new URI(taskConfig._scope) : undefined;

--- a/packages/task/src/node/process/process-task-runner.ts
+++ b/packages/task/src/node/process/process-task-runner.ts
@@ -141,7 +141,7 @@ export class ProcessTaskRunner implements TaskRunner {
          */
         let commandLine: string | undefined;
 
-        if ((taskConfig.taskType || taskConfig.type) === 'shell') {
+        if (taskConfig.type === 'shell') {
             // When running a shell task, we have to spawn a shell process somehow,
             // and tell it to run the command the user wants to run inside of it.
             //

--- a/packages/task/src/node/task-runner.ts
+++ b/packages/task/src/node/task-runner.ts
@@ -84,20 +84,14 @@ export class TaskRunnerRegistry {
     }
 
     /**
-     * Looks for a registered {@link TaskRunner} for each of the task types in sequence and returns the first that is found
-     * If no task runner is registered for any of the types, the default runner is returned.
-     * @param types the task types.
+     * Retrieves the {@link TaskRunner} registered for the specified Task type.
+     * @param type the task type.
      *
-     * @returns the registered {@link TaskRunner} or a default runner if none is registered for the specified types.
+     * @returns the registered {@link TaskRunner} or a default runner if none is registered for the specified type.
      */
-    getRunner(...types: string[]): TaskRunner {
-        for (const type of types) {
-            const runner = this.runners.get(type);
-            if (runner) {
-                return runner;
-            }
-        }
-        return this.defaultRunner;
+    getRunner(type: string): TaskRunner {
+        const runner = this.runners.get(type);
+        return runner ? runner : this.defaultRunner;
     }
 
     /**

--- a/packages/task/src/node/task-server.ts
+++ b/packages/task/src/node/task-server.ts
@@ -90,7 +90,7 @@ export class TaskServerImpl implements TaskServer, Disposable {
     }
 
     async run(taskConfiguration: TaskConfiguration, ctx?: string, option?: RunTaskOption): Promise<TaskInfo> {
-        const runner = this.runnerRegistry.getRunner(taskConfiguration.taskType);
+        const runner = this.runnerRegistry.getRunner(taskConfiguration.type);
         const task = await runner.run(taskConfiguration, ctx);
 
         if (!this.toDispose.has(task.id)) {

--- a/packages/task/src/node/task-server.ts
+++ b/packages/task/src/node/task-server.ts
@@ -90,7 +90,7 @@ export class TaskServerImpl implements TaskServer, Disposable {
     }
 
     async run(taskConfiguration: TaskConfiguration, ctx?: string, option?: RunTaskOption): Promise<TaskInfo> {
-        const runner = this.runnerRegistry.getRunner(taskConfiguration.type, taskConfiguration.taskType);
+        const runner = this.runnerRegistry.getRunner(taskConfiguration.taskType);
         const task = await runner.run(taskConfiguration, ctx);
 
         if (!this.toDispose.has(task.id)) {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->
Reverts commits affecting the use of task type

The PR #9189 merged 5 commits to support the Tasks customExecution API,
one of the commits ("Fixed task type is modified")  impacted how the task type is used in multiple areas of the task
system, impacting the functionality to configure tasks, running tasks, etc.

There are a couple of other commits trying to fix the broken scenarios which cascaded to other problems.
This PR brings back the functionality before the commit mentioned above.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

* Plugin provided tasks shall work (shell, process and even customExecution).
* Global tasks, and manually provisioned task shall work

NOTE: Gradle tasks are not expected to be visible in the task view since that's the scenario which was addressed by the
reverted commit (a proper solution shall be discussed).

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
