### PR TITLE
Remove duplicated Keybinding interface

### DIFF
--- a/packages/plugin-ext/src/common/plugin-protocol.ts
+++ b/packages/plugin-ext/src/common/plugin-protocol.ts
@@ -709,18 +709,6 @@ export interface Keybinding {
 }
 
 /**
- * Keybinding contribution
- */
-export interface Keybinding {
-    keybinding?: string;
-    command: string;
-    when?: string;
-    mac?: string;
-    linux?: string;
-    win?: string;
-}
-
-/**
  * This interface describes a plugin lifecycle object.
  */
 export interface PluginLifecycle {


### PR DESCRIPTION
Signed-off-by: Roman Nikitenko <rnikiten@redhat.com>

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

Remove duplicated interface, please see [here](https://github.com/eclipse-theia/theia/blob/199fb89c159904f2fc8f8dcc16997b58b37eb12a/packages/plugin-ext/src/common/plugin-protocol.ts#L702-L721)
The interface was provided within https://github.com/eclipse-theia/theia/pull/8870

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
It's code clean up, I don't bring a new functionality. 

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

