### PR TITLE
Clean up handling of 'taskType' field

### DIFF
--- a/packages/plugin-ext/src/common/plugin-api-rpc.ts
+++ b/packages/plugin-ext/src/common/plugin-api-rpc.ts
@@ -1354,6 +1354,8 @@ export interface CommandProperties {
 
 export interface TaskDto {
     type: string;
+    taskType?: 'shell' | 'process' | 'customExecution'; // the task execution type
+    executionId?: string,
     label: string;
     source?: string;
     scope: string | number;

--- a/packages/plugin-ext/src/main/browser/tasks-main.ts
+++ b/packages/plugin-ext/src/main/browser/tasks-main.ts
@@ -109,7 +109,7 @@ export class TasksMainImpl implements TasksMain, Disposable {
 
         const toDispose = new DisposableCollection(
             this.taskProviderRegistry.register(type, taskProvider, handle),
-            this.taskResolverRegistry.register(type, taskResolver),
+            this.taskResolverRegistry.registerTaskResolver(type, taskResolver),
             Disposable.create(() => this.taskProviders.delete(handle))
         );
         this.taskProviders.set(handle, toDispose);

--- a/packages/plugin-ext/src/plugin/type-converters.spec.ts
+++ b/packages/plugin-ext/src/plugin/type-converters.spec.ts
@@ -187,6 +187,7 @@ describe('Type converters:', () => {
 
         const shellTaskDto: TaskDto = {
             type: shellType,
+            taskType: shellType,
             label,
             source,
             scope: 1,
@@ -203,6 +204,7 @@ describe('Type converters:', () => {
 
         const shellTaskDtoWithCommandLine: TaskDto = {
             type: shellType,
+            taskType: shellType,
             label,
             source,
             scope: 2,

--- a/packages/plugin-ext/src/plugin/type-converters.ts
+++ b/packages/plugin-ext/src/plugin/type-converters.ts
@@ -750,16 +750,16 @@ export function fromTask(task: theia.Task): TaskDto | undefined {
         return taskDto;
     }
 
-    if (taskDefinition.taskType === 'shell' || types.ShellExecution.is(execution)) {
-        return fromShellExecution(<theia.ShellExecution>execution, taskDto);
+    if (types.ShellExecution.is(execution)) {
+        return fromShellExecution(execution, taskDto);
     }
 
-    if (taskDefinition.taskType === 'process' || types.ProcessExecution.is(execution)) {
-        return fromProcessExecution(<theia.ProcessExecution>execution, taskDto);
+    if (types.ProcessExecution.is(execution)) {
+        return fromProcessExecution(execution, taskDto);
     }
 
-    if (taskDefinition.taskType === 'customExecution' || types.CustomExecution.is(execution)) {
-        return fromCustomExecution(<theia.CustomExecution>execution, taskDto);
+    if (types.CustomExecution.is(execution)) {
+        return fromCustomExecution(execution, taskDto);
     }
 
     return taskDto;
@@ -839,6 +839,7 @@ export function toTask(taskDto: TaskDto): theia.Task {
 }
 
 export function fromProcessExecution(execution: theia.ProcessExecution, taskDto: TaskDto): TaskDto {
+    taskDto.taskType = 'process';
     taskDto.command = execution.process;
     taskDto.args = execution.args;
 
@@ -850,6 +851,7 @@ export function fromProcessExecution(execution: theia.ProcessExecution, taskDto:
 }
 
 export function fromShellExecution(execution: theia.ShellExecution, taskDto: TaskDto): TaskDto {
+    taskDto.taskType = 'shell';
     const options = execution.options;
     if (options) {
         taskDto.options = getShellExecutionOptions(options);
@@ -872,6 +874,7 @@ export function fromShellExecution(execution: theia.ShellExecution, taskDto: Tas
 }
 
 export function fromCustomExecution(execution: theia.CustomExecution, taskDto: TaskDto): TaskDto {
+    taskDto.taskType = 'customExecution';
     const callback = execution.callback;
     if (callback) {
         taskDto.callback = callback;

--- a/packages/plugin-ext/src/plugin/types-impl.ts
+++ b/packages/plugin-ext/src/plugin/types-impl.ts
@@ -1466,14 +1466,6 @@ export enum ProgressLocation {
     Notification = 15
 }
 
-function computeTaskExecutionId(values: string[]): string {
-    let id: string = '';
-    for (let i = 0; i < values.length; i++) {
-        id += values[i].replace(/,/g, ',,') + ',';
-    }
-    return id;
-}
-
 export class ProcessExecution {
     private executionProcess: string;
     private arguments: string[];
@@ -1529,21 +1521,7 @@ export class ProcessExecution {
         this.executionOptions = value;
     }
 
-    public computeId(): string {
-        const props: string[] = [];
-        props.push('process');
-        if (this.executionProcess !== undefined) {
-            props.push(this.executionProcess);
-        }
-        if (this.arguments && this.arguments.length > 0) {
-            for (const arg of this.arguments) {
-                props.push(arg);
-            }
-        }
-        return computeTaskExecutionId(props);
-    }
-
-    public static is(value: theia.ShellExecution | theia.ProcessExecution | theia.CustomExecution): boolean {
+    public static is(value: theia.ShellExecution | theia.ProcessExecution | theia.CustomExecution): value is ProcessExecution {
         const candidate = value as ProcessExecution;
         return candidate && !!candidate.process;
     }
@@ -1634,24 +1612,7 @@ export class ShellExecution {
         this.shellOptions = value;
     }
 
-    public computeId(): string {
-        const props: string[] = [];
-        props.push('shell');
-        if (this.shellCommandLine !== undefined) {
-            props.push(this.shellCommandLine);
-        }
-        if (this.shellCommand !== undefined) {
-            props.push(typeof this.shellCommand === 'string' ? this.shellCommand : this.shellCommand.value);
-        }
-        if (this.arguments && this.arguments.length > 0) {
-            for (const arg of this.arguments) {
-                props.push(typeof arg === 'string' ? arg : arg.value);
-            }
-        }
-        return computeTaskExecutionId(props);
-    }
-
-    public static is(value: theia.ShellExecution | theia.ProcessExecution | theia.CustomExecution): boolean {
+    public static is(value: theia.ShellExecution | theia.ProcessExecution | theia.CustomExecution): value is ShellExecution {
         const candidate = value as ShellExecution;
         return candidate && (!!candidate.commandLine || !!candidate.command);
     }
@@ -1662,9 +1623,6 @@ export class CustomExecution {
     constructor(callback: (resolvedDefintion: theia.TaskDefinition) => Thenable<theia.Pseudoterminal>) {
         this._callback = callback;
     }
-    public computeId(): string {
-        return 'customExecution' + UUID.uuid4();
-    }
 
     public set callback(value: (resolvedDefintion: theia.TaskDefinition) => Thenable<theia.Pseudoterminal>) {
         this._callback = value;
@@ -1674,7 +1632,7 @@ export class CustomExecution {
         return this._callback;
     }
 
-    public static is(value: theia.ShellExecution | theia.ProcessExecution | theia.CustomExecution): boolean {
+    public static is(value: theia.ShellExecution | theia.ProcessExecution | theia.CustomExecution): value is CustomExecution {
         const candidate = value as CustomExecution;
         return candidate && (!!candidate._callback);
     }
@@ -1842,7 +1800,6 @@ export class Task {
             value = undefined;
         }
         this.taskExecution = value;
-        this.updateDefinitionBasedOnExecution();
     }
 
     get problemMatchers(): string[] {
@@ -1906,31 +1863,6 @@ export class Task {
             value = Object.create(null);
         }
         this.taskPresentationOptions = value;
-    }
-
-    private updateDefinitionBasedOnExecution(): void {
-        if (this.taskExecution instanceof ProcessExecution) {
-            Object.assign(this.taskDefinition, {
-                id: this.taskExecution.computeId(),
-                taskType: 'process'
-            });
-        } else if (this.taskExecution instanceof ShellExecution) {
-            Object.assign(this.taskDefinition, {
-                id: this.taskExecution.computeId(),
-                taskType: 'shell'
-            });
-        } else if (this.taskExecution instanceof CustomExecution) {
-            Object.assign(this.taskDefinition, {
-                id: this.taskDefinition.id ? this.taskDefinition.id : this.taskExecution.computeId(),
-                taskType: 'customExecution'
-            });
-        } else {
-            Object.assign(this.taskDefinition, {
-                type: '$empty',
-                id: UUID.uuid4(),
-                taskType: this.taskDefinition!.type
-            });
-        }
     }
 }
 

--- a/packages/task/src/browser/process/process-task-contribution.ts
+++ b/packages/task/src/browser/process/process-task-contribution.ts
@@ -25,7 +25,7 @@ export class ProcessTaskContribution implements TaskContribution {
     protected readonly processTaskResolver: ProcessTaskResolver;
 
     registerResolvers(resolvers: TaskResolverRegistry): void {
-        resolvers.register('process', this.processTaskResolver);
-        resolvers.register('shell', this.processTaskResolver);
+        resolvers.registerExecutionResolver('process', this.processTaskResolver);
+        resolvers.registerExecutionResolver('shell', this.processTaskResolver);
     }
 }

--- a/packages/task/src/browser/task-configurations.ts
+++ b/packages/task/src/browser/task-configurations.ts
@@ -244,7 +244,7 @@ export class TaskConfigurations implements Disposable {
             return undefined;
         }
 
-        const customizationByType = this.getTaskCustomizations(taskConfig.taskType || taskConfig.type, taskConfig._scope) || [];
+        const customizationByType = this.getTaskCustomizations(taskConfig.type, taskConfig._scope) || [];
         const hasCustomization = customizationByType.length > 0;
         if (hasCustomization) {
             const taskDefinition = this.taskDefinitionRegistry.getDefinition(taskConfig);
@@ -329,7 +329,7 @@ export class TaskConfigurations implements Disposable {
             console.error('Detected / Contributed tasks should have a task definition.');
             return;
         }
-        const customization: TaskCustomization = { type: task.taskType || task.type };
+        const customization: TaskCustomization = { type: task.type };
         definition.properties.all.forEach(p => {
             if (task[p] !== undefined) {
                 customization[p] = task[p];
@@ -457,7 +457,7 @@ export class TaskConfigurations implements Disposable {
             const jsonTasks = this.taskConfigurationManager.getTasks(scope);
             if (jsonTasks) {
                 const ind = jsonTasks.findIndex((t: TaskCustomization | TaskConfiguration) => {
-                    if (t.type !== (task.taskType || task.type)) {
+                    if (t.type !== (task.type)) {
                         return false;
                     }
                     const def = this.taskDefinitionRegistry.getDefinition(t);
@@ -503,9 +503,6 @@ export class TaskConfigurations implements Disposable {
     }
 
     private getTaskDefinition(task: TaskCustomization): TaskDefinition | undefined {
-        return this.taskDefinitionRegistry.getDefinition({
-            ...task,
-            type: typeof task.taskType === 'string' ? task.taskType : task.type
-        });
+        return this.taskDefinitionRegistry.getDefinition(task);
     }
 }

--- a/packages/task/src/browser/task-definition-registry.ts
+++ b/packages/task/src/browser/task-definition-registry.ts
@@ -66,7 +66,7 @@ export class TaskDefinitionRegistry {
      * @return the task definition for the task configuration. If the task definition is not found, `undefined` is returned.
      */
     getDefinition(taskConfiguration: TaskConfiguration | TaskCustomization): TaskDefinition | undefined {
-        const definitions = this.getDefinitions(taskConfiguration.taskType || taskConfiguration.type);
+        const definitions = this.getDefinitions(taskConfiguration.type);
         let matchedDefinition: TaskDefinition | undefined;
         let highest = -1;
         for (const def of definitions) {
@@ -107,8 +107,8 @@ export class TaskDefinitionRegistry {
     }
 
     compareTasks(one: TaskConfiguration | TaskCustomization, other: TaskConfiguration | TaskCustomization): boolean {
-        const oneType = one.taskType || one.type;
-        const otherType = other.taskType || other.type;
+        const oneType = one.type;
+        const otherType = other.type;
         if (oneType !== otherType) {
             return false;
         }

--- a/packages/task/src/node/process/process-task-runner.ts
+++ b/packages/task/src/node/process/process-task-runner.ts
@@ -83,7 +83,7 @@ export class ProcessTaskRunner implements TaskRunner {
                 });
             });
 
-            const processType = taskConfig.type as 'process' | 'shell';
+            const processType = (taskConfig.taskType || taskConfig.type) as 'process' | 'shell';
             return this.taskFactory({
                 label: taskConfig.label,
                 process: terminal,


### PR DESCRIPTION
Signed-off-by: Thomas Mäder <tmader@redhat.com>

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
This PR cleans up a couple of the issues introduced by Implement CustomExecution extension API https://github.com/eclipse-theia/theia/pull/9189 while retaining the custom execution API.

The approach is to strictly use the "taskType" field in a task configuration to mean the "task execution type". The magic in types-impl.ts (`Task#updateTypeBasedOnExecution`) has been removed and the translation of `Task.execution` into `TaskDTO.taskType` and vice-versa has been moved to the type converter.

I have removed a couple of instances where `taskType` was used erroneously when the declared type was meant and not the execution type.

I have removed some filtering of dependent tasks based on "source".  It did not work (configured tasks have the folder they are in as "source") and I don't think the `source` field should be considered part of the task identity.

I have also removed the "garbage collection" of callback functions for custom executions. There is no explicit lifecycle for those callback functions that I could find in the VS Code API. I believe there are supposed to be only a fixed, small number of callback functions. So I'm retaining these functions based on identity. We could clean up the callbacks whenever we call `provideTasks` and after call to the `executeTask` API, but I don't think it is necessary. Convince me otherwise :-)

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
Make sure non-contributed tasks still work, aka `process` and `shell` tasks.

Make sure we can run and configure both custom execution tasks (see gradle tasks: https://github.com/eclipse-theia/theia/issues/8767) and the shell tasks contributed by @vince-fugnitto's test plugin (see https://github.com/eclipse-theia/theia/issues/9366)

Make sure we can run dependent tasks based on label as well as based on structured task identifier.

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

