### PR TITLE
Format error logs in debug module [issue 9244] 

### DIFF
--- a/packages/debug/src/browser/console/debug-console-items.tsx
+++ b/packages/debug/src/browser/console/debug-console-items.tsx
@@ -201,7 +201,7 @@ export class DebugVariable extends ExpressionContainer {
             this.elements = undefined;
             this.session['fireDidChange']();
         } catch (error) {
-            console.error(error);
+            console.error('setValue failed:', error);
         }
     }
 

--- a/packages/debug/src/browser/debug-session-manager.ts
+++ b/packages/debug/src/browser/debug-session-manager.ts
@@ -178,7 +178,7 @@ export class DebugSessionManager {
             await this.shell.saveAll();
             return true;
         } catch (error) {
-            console.error(error);
+            console.error('saveAll failed:', error);
             return false;
         }
     }

--- a/packages/debug/src/browser/debug-session.tsx
+++ b/packages/debug/src/browser/debug-session.tsx
@@ -173,7 +173,7 @@ export class DebugSession implements CompositeTreeElement {
                 try {
                     await thread.pause();
                 } catch (e) {
-                    console.error(e);
+                    console.error('pauseAll failed:', e);
                 }
             })());
         }
@@ -187,7 +187,7 @@ export class DebugSession implements CompositeTreeElement {
                 try {
                     await thread.continue();
                 } catch (e) {
-                    console.error(e);
+                    console.error('continueAll failed:', e);
                 }
             })());
         }
@@ -416,7 +416,7 @@ export class DebugSession implements CompositeTreeElement {
                 const threads = response && response.body && response.body.threads || [];
                 this.doUpdateThreads(threads, stoppedDetails);
             } catch (e) {
-                console.error(e);
+                console.error('updateThreads failed:', e);
             }
         });
     }

--- a/packages/debug/src/browser/model/debug-thread.tsx
+++ b/packages/debug/src/browser/model/debug-thread.tsx
@@ -155,7 +155,7 @@ export class DebugThread extends DebugThreadData implements TreeElement {
                 }
                 return this.doUpdateFrames(frames);
             } catch (e) {
-                console.error(e);
+                console.error('fetchFrames failed:', e);
                 return [];
             } finally {
                 if (!cancel.isCancellationRequested) {

--- a/packages/debug/src/node/debug-adapter-contribution-registry.ts
+++ b/packages/debug/src/node/debug-adapter-contribution-registry.ts
@@ -83,7 +83,7 @@ export class DebugAdapterContributionRegistry {
                     const result = await contribution.provideDebugConfigurations(workspaceFolderUri);
                     configurations.push(...result);
                 } catch (e) {
-                    console.error(e);
+                    console.error('provideDebugConfigurations failed:', e);
                 }
             }
         }
@@ -108,7 +108,7 @@ export class DebugAdapterContributionRegistry {
                         return current;
                     }
                 } catch (e) {
-                    console.error(e);
+                    console.error('resolveDebugConfiguration failed:', e);
                 }
             }
         }
@@ -133,7 +133,7 @@ export class DebugAdapterContributionRegistry {
                         return current;
                     }
                 } catch (e) {
-                    console.error(e);
+                    console.error('resolveDebugConfigurationWithSubstitutedVariables failed:', e);
                 }
             }
         }
@@ -152,7 +152,7 @@ export class DebugAdapterContributionRegistry {
                 try {
                     schemas.push(...await contribution.getSchemaAttributes());
                 } catch (e) {
-                    console.error(e);
+                    console.error('getSchemaAttributes failed:', e);
                 }
             }
         }
@@ -165,7 +165,7 @@ export class DebugAdapterContributionRegistry {
                 try {
                     schemas.push(...await contribution.getConfigurationSnippets());
                 } catch (e) {
-                    console.error(e);
+                    console.error('getConfigurationSnippets failed:', e);
                 }
             }
         }

--- a/packages/debug/src/node/debug-service-impl.ts
+++ b/packages/debug/src/node/debug-service-impl.ts
@@ -83,7 +83,7 @@ export class DebugServiceImpl implements DebugService {
                     try {
                         await this.doStop(session);
                     } catch (e) {
-                        console.error(e);
+                        console.error('terminateDebugSession failed:', e);
                     }
                 })());
             }


### PR DESCRIPTION
#### What it does

Fixes: #9244
In case where error is logged as `console.error(error)` it gets stringified to `[object Object]`.
So replaced such occurrences with the format `console.error('<Method> failed:', e)`.
Made changes only for the `debug` module.

#### How to test
I tested by manually throwing the error. 

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

