### PR TITLE
getting-started: fix opening of external links

### DIFF
--- a/packages/getting-started/src/browser/getting-started-widget.tsx
+++ b/packages/getting-started/src/browser/getting-started-widget.tsx
@@ -25,6 +25,7 @@ import { CommonCommands, LabelProvider, Key, KeyCode } from '@theia/core/lib/bro
 import { ApplicationInfo, ApplicationServer } from '@theia/core/lib/common/application-protocol';
 import { FrontendApplicationConfigProvider } from '@theia/core/lib/browser/frontend-application-config-provider';
 import { EnvVariablesServer } from '@theia/core/lib/common/env-variables';
+import { WindowService } from '@theia/core/lib/browser/window/window-service';
 
 /**
  * Default implementation of the `GettingStartedWidget`.
@@ -88,6 +89,9 @@ export class GettingStartedWidget extends ReactWidget {
 
     @inject(LabelProvider)
     protected readonly labelProvider: LabelProvider;
+
+    @inject(WindowService)
+    protected readonly windowService: WindowService;
 
     @inject(WorkspaceService)
     protected readonly workspaceService: WorkspaceService;
@@ -286,13 +290,31 @@ export class GettingStartedWidget extends ReactWidget {
                 Help
             </h3>
             <div className='gs-action-container'>
-                <a href={this.documentationUrl} target='_blank'>Documentation</a>
+                <a
+                    role={'button'}
+                    tabIndex={0}
+                    onClick={() => this.doOpenExternalLink(this.documentationUrl)}
+                    onKeyDown={(e: React.KeyboardEvent) => this.doOpenExternalLinkEnter(e, this.documentationUrl)}>
+                    Documentation
+                </a>
             </div>
             <div className='gs-action-container'>
-                <a href={this.extensionUrl} target='_blank'>Building a New Extension</a>
+                <a
+                    role={'button'}
+                    tabIndex={0}
+                    onClick={() => this.doOpenExternalLink(this.extensionUrl)}
+                    onKeyDown={(e: React.KeyboardEvent) => this.doOpenExternalLinkEnter(e, this.extensionUrl)}>
+                    Building a New Extension
+                </a>
             </div>
             <div className='gs-action-container'>
-                <a href={this.pluginUrl} target='_blank'>Building a New Plugin</a>
+                <a
+                    role={'button'}
+                    tabIndex={0}
+                    onClick={() => this.doOpenExternalLink(this.pluginUrl)}
+                    onKeyDown={(e: React.KeyboardEvent) => this.doOpenExternalLinkEnter(e, this.pluginUrl)}>
+                    Building a New Plugin
+                </a>
             </div>
         </div>;
     }
@@ -406,6 +428,17 @@ export class GettingStartedWidget extends ReactWidget {
     protected openEnter = (e: React.KeyboardEvent, uri: URI) => {
         if (this.isEnterKey(e)) {
             this.open(uri);
+        }
+    };
+
+    /**
+     * Open a link in an external window.
+     * @param url the link.
+     */
+    protected doOpenExternalLink = (url: string) => this.windowService.openNewWindow(url, { external: true });
+    protected doOpenExternalLinkEnter = (e: React.KeyboardEvent, url: string) => {
+        if (this.isEnterKey(e)) {
+            this.doOpenExternalLink(url);
         }
     };
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

The following pull-request refactors the `getting-started` widget to make use of the `WindowService` when opening links in external windows since it is properly implemented by both the **browser** and **electron** targets.

On `master`, the electron target incorrectly opens the links in an electron window:

<div align='center'>

<img width="1370" alt="Screen Shot 2021-04-21 at 1 57 33 PM" src="https://user-images.githubusercontent.com/40359487/115602705-38bec380-a2ad-11eb-996f-e4c1a8334127.png">

</div>

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

- verify the changes in both the **browser** and **electron** targets
  - open the `getting-started` view
  - confirm that the three external links work correctly and open in an external browser window
    - confirm the links are openable with the cursor
    - confirm the links are openable with <kbd>tab</kbd>+<kbd>enter</kbd>  

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

Signed-off-by: vince-fugnitto <vincent.fugnitto@ericsson.com>

