### PR TITLE
Check widget is dirty before saving

### DIFF
--- a/packages/core/src/browser/shell/application-shell.ts
+++ b/packages/core/src/browser/shell/application-shell.ts
@@ -1746,7 +1746,11 @@ export class ApplicationShell extends Widget {
      * Save all dirty widgets.
      */
     async saveAll(options?: SaveOptions): Promise<void> {
-        await Promise.all(this.tracker.widgets.map(widget => Saveable.save(widget, options)));
+        await Promise.all(this.tracker.widgets.map(widget => {
+            if (Saveable.isDirty(widget)) {
+                Saveable.save(widget, options);
+            }
+        }));
     }
 
     /**


### PR DESCRIPTION
Signed-off-by: thegecko <rob.moran@arm.com>

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

This PR adds a check to only save open files if they are dirty (as the function describes it should). Without this, all open files were forced to be saved, causing filewatchers to incorrectly fire updates.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

Check modified dates on files which are open when a debug session is launched. They should only update if the file was changed.

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

