### PR TITLE
Create Websocket lifecycle notification contribution

### DIFF
--- a/packages/core/src/node/messaging/messaging-backend-module.ts
+++ b/packages/core/src/node/messaging/messaging-backend-module.ts
@@ -20,6 +20,7 @@ import { BackendApplicationContribution } from '../backend-application';
 import { MessagingContribution, MessagingContainer } from './messaging-contribution';
 import { ConnectionContainerModule } from './connection-container-module';
 import { MessagingService } from './messaging-service';
+import { MessagingListener, MessagingListenerContribution } from './messaging-listeners';
 
 export const messagingBackendModule = new ContainerModule(bind => {
     bindContributionProvider(bind, ConnectionContainerModule);
@@ -31,4 +32,6 @@ export const messagingBackendModule = new ContainerModule(bind => {
         return child.get(MessagingService.Identifier);
     }).inSingletonScope();
     bind(BackendApplicationContribution).toService(MessagingContribution);
+    bind(MessagingListener).toSelf().inSingletonScope();
+    bindContributionProvider(bind, MessagingListenerContribution);
 });

--- a/packages/core/src/node/messaging/messaging-contribution.ts
+++ b/packages/core/src/node/messaging/messaging-contribution.ts
@@ -32,6 +32,7 @@ import { ConsoleLogger } from './logger';
 import { ConnectionContainerModule } from './connection-container-module';
 import Route = require('route-parser');
 import { WsRequestValidator } from '../ws-request-validators';
+import { MessagingListener } from './messaging-listeners';
 
 export const MessagingContainer = Symbol('MessagingContainer');
 
@@ -49,6 +50,9 @@ export class MessagingContribution implements BackendApplicationContribution, Me
 
     @inject(WsRequestValidator)
     protected readonly wsRequestValidator: WsRequestValidator;
+
+    @inject(MessagingListener)
+    protected readonly messagingListener: MessagingListener;
 
     protected webSocketServer: ws.Server | undefined;
     protected readonly wsHandlers = new MessagingContribution.ConnectionHandlers<ws>();
@@ -122,6 +126,7 @@ export class MessagingContribution implements BackendApplicationContribution, Me
             if (allowed) {
                 this.webSocketServer!.handleUpgrade(request, socket, head, client => {
                     this.webSocketServer!.emit('connection', client, request);
+                    this.messagingListener.onWebSocketUpgrade(request, client);
                 });
             } else {
                 console.error(`refused a websocket connection: ${request.connection.remoteAddress}`);

--- a/packages/core/src/node/messaging/messaging-listeners.ts
+++ b/packages/core/src/node/messaging/messaging-listeners.ts
@@ -1,0 +1,52 @@
+/********************************************************************************
+ * Copyright (C) 2021 MayStreet Inc. and others
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import { inject, injectable, named } from 'inversify';
+import { ContributionProvider, MaybePromise } from '../../common';
+
+import * as http from 'http';
+import * as ws from 'ws';
+
+/**
+ * Bind components to this symbol to subscribe to WebSocket events.
+ */
+export const MessagingListenerContribution = Symbol('MessagingListenerContribution');
+export interface MessagingListenerContribution {
+    /**
+     * Function invoked when a HTTP connection is upgraded to a websocket.
+     *
+     * @param request The HTTP connection upgrade request received by the server.
+     * @param socket The WebSocket that the connection was upgraded to.
+     */
+    onWebSocketUpgrade(request: http.IncomingMessage, socket: ws): MaybePromise<void>;
+}
+
+/**
+ * Handler of Theia messaging system events, dispatching to MessagingListenerContribution instances.
+ */
+@injectable()
+export class MessagingListener {
+
+    @inject(ContributionProvider) @named(MessagingListenerContribution)
+    protected readonly messagingListenerContributions: ContributionProvider<MessagingListenerContribution>;
+
+    /**
+     * Notify all the subscribed `MessagingListenerContribution`s that the Websocket was upgraded.
+     */
+    async onWebSocketUpgrade(request: http.IncomingMessage, socket: ws): Promise<void> {
+        await Promise.all(Array.from(this.messagingListenerContributions.getContributions(), async messagingListener => messagingListener.onWebSocketUpgrade(request, socket)));
+    }
+}


### PR DESCRIPTION

#### What it does
Allows contributions to become invoked when a websocket's lifecycle changes.
Right now, it's just for when a socket is upgraded.

#### How to test
Implement a simple contribution, such as:
```ts
import { injectable } from '@theia/core/shared/inversify';
import { MaybePromise } from '@theia/core/lib/common';
import { WsLifecycleNotificationContribution } from '@theia/core/lib/node/ws-lifecycle-notification';

import * as http from 'http';
import * as ws from 'ws';

@injectable()
export class MessagingBackendContribution implements WsLifecycleNotificationContribution {
  socketUpgraded(request: http.IncomingMessage, socket: ws): MaybePromise<void> {
    console.debug('[MessagingBackendContribution] socket upgraded!', socket);
    socket.terminate();
  }
}
```

Bind it:
```ts
bind(MessagingBackendContribution)
    .toSelf()
    .inSingletonScope();
  bind(WsLifecycleNotificationContribution).toService(MessagingBackendContribution);
```

#### Review checklist

- [X] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

Signed-off-by: Dave Thompson <dwt@outlook.com> / <dthompson@maystreet.com>
