### PR TITLE
Electron: Add 'Toggle Full Screen' Command

### DIFF
--- a/packages/core/src/electron-browser/menu/electron-menu-contribution.ts
+++ b/packages/core/src/electron-browser/menu/electron-menu-contribution.ts
@@ -51,6 +51,11 @@ export namespace ElectronCommands {
         id: 'close.window',
         label: 'Close Window'
     };
+    export const TOGGLE_FULL_SCREEN: Command = {
+        id: 'workbench.action.toggleFullScreen',
+        category: 'View',
+        label: 'Toggle Full Screen'
+    };
 }
 
 export namespace ElectronMenus {
@@ -182,6 +187,11 @@ export class ElectronMenuContribution implements FrontendApplicationContribution
         registry.registerCommand(ElectronCommands.RESET_ZOOM, {
             execute: () => this.preferenceService.set('window.zoomLevel', ZoomLevel.DEFAULT, PreferenceScope.User)
         });
+        registry.registerCommand(ElectronCommands.TOGGLE_FULL_SCREEN, {
+            isEnabled: () => currentWindow.isFullScreenable(),
+            isVisible: () => currentWindow.isFullScreenable(),
+            execute: () => currentWindow.setFullScreen(!currentWindow.isFullScreen())
+        });
     }
 
     registerKeybindings(registry: KeybindingRegistry): void {
@@ -209,6 +219,10 @@ export class ElectronMenuContribution implements FrontendApplicationContribution
             {
                 command: ElectronCommands.CLOSE_WINDOW.id,
                 keybinding: (isOSX ? 'cmd+shift+w' : (isWindows ? 'ctrl+w' : /* Linux */ 'ctrl+q'))
+            },
+            {
+                command: ElectronCommands.TOGGLE_FULL_SCREEN.id,
+                keybinding: isOSX ? 'ctrl+ctrlcmd+f' : 'f11'
             }
         );
     }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

- Enables full screen toggling of Electron window.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

- Search for `Toggle Full Screen` in the command palette and execute.
- Or, use `f11` keybinding on Windows.
- Or, use `ctrl+ctrlcmd+f` keybinding on MacOS.

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

Signed-off-by: seantan22 <sean.a.tan@ericsson.com>