### PR TITLE
Handle pref display without plugins

### DIFF
--- a/packages/preferences/src/browser/util/preference-tree-generator.ts
+++ b/packages/preferences/src/browser/util/preference-tree-generator.ts
@@ -30,8 +30,10 @@ export class PreferenceTreeGenerator {
     readonly onSchemaChanged = this.onSchemaChangedEmitter.event;
 
     @postConstruct()
-    protected init(): void {
+    protected async init(): Promise<void> {
+        await this.schemaProvider.ready;
         this.schemaProvider.onDidPreferenceSchemaChanged(() => this.handleChangedSchema());
+        this.handleChangedSchema();
     }
 
     generateTree = (): CompositeTreeNode => {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

A [bug](https://community.theia-ide.org/t/what-causes-the-preferences-view-to-display-that-search-query-has-returned-no-results/1642) was discovered by a user of the Yo Theia Extension Generator in which the preference widget was not displaying preferences unless an extension with plugin support was included in the dependencies.

The basic problem was that the `PreferenceTreeGenerator` was waiting for an event from the `PreferenceSchemaProvider` before initializing its tree.

https://github.com/eclipse-theia/theia/blob/a8dec8d798342631f2ab3a84bec4b8fdc4621d61/packages/preferences/src/browser/util/preference-tree-generator.ts#L32-L35

That event is only fired when plugins call the `setSchema` method:

https://github.com/eclipse-theia/theia/blob/a8dec8d798342631f2ab3a84bec4b8fdc4621d61/packages/core/src/browser/preferences/preference-contribution.ts#L308-L323

Internal preference contributions only call `doSetSchema`, which does not fire any events. I believe this behavior is correct: the schema hasn't changed, but only been initialized.

https://github.com/eclipse-theia/theia/blob/a8dec8d798342631f2ab3a84bec4b8fdc4621d61/packages/core/src/browser/preferences/preference-contribution.ts#L126-L128

This PR modifies the behavior of the `PreferenceTreeGenerator` to generate a tree when the `PreferenceSchemaProvider` is `ready` (after all internal preference contributions have been processed) without waiting for an `onSchemaChanged` event.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

1. Modify the electron or browser `package.json` to have only these Theia packages as dependencies:
```
  "dependencies": {
    "@theia/core": "1.12.0",
    "@theia/editor": "1.12.0",
    "@theia/electron": "1.12.0",
    "@theia/filesystem": "1.12.0",
    "@theia/markers": "1.12.0",
    "@theia/messages": "1.12.0",
    "@theia/monaco": "1.12.0",
    "@theia/navigator": "1.12.0",
    "@theia/preferences": "1.12.0",
    "@theia/process": "1.12.0",
    "@theia/terminal": "1.12.0",
    "@theia/workspace": "1.12.0",
  },
```
2. Build and start the application, and open the preferences view (<kbd>ctrl</kbd> + <kbd>,</kbd>)
3. Observe that the preferences are populated.

![image](https://user-images.githubusercontent.com/62660806/116104706-45a93180-a676-11eb-819d-f634cfadef20.png)

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

Signed-off-by: Colin Grant <colin.grant@ericsson.com>