### PR TITLE
Bumped `deepmerge` to `4.2.2`.

### DIFF
--- a/dev-packages/application-package/package.json
+++ b/dev-packages/application-package/package.json
@@ -28,12 +28,13 @@
     "test": "theiaext test"
   },
   "dependencies": {
+    "@types/deepmerge": "^2.2.0",
     "@types/fs-extra": "^4.0.2",
     "@types/request": "^2.0.3",
     "@types/semver": "^5.4.0",
     "@types/write-json-file": "^2.2.1",
     "changes-stream": "^2.2.0",
-    "deepmerge": "2.0.1",
+    "deepmerge": "^4.2.2",
     "fs-extra": "^4.0.2",
     "is-electron": "^2.1.0",
     "request": "^2.82.0",

--- a/dev-packages/application-package/src/application-package.ts
+++ b/dev-packages/application-package/src/application-package.ts
@@ -20,7 +20,7 @@ import { NpmRegistry, NodePackage, PublishedNodePackage, sortByKey } from './npm
 import { Extension, ExtensionPackage, RawExtensionPackage } from './extension-package';
 import { ExtensionPackageCollector } from './extension-package-collector';
 import { ApplicationProps } from './application-props';
-const merge = require('deepmerge');
+import * as deepmerge from 'deepmerge';
 
 // tslint:disable:no-implicit-dependencies
 
@@ -88,7 +88,7 @@ export class ApplicationPackage {
             theia.target = defaultTarget;
         }
 
-        return this._props = merge(ApplicationProps.DEFAULT, theia);
+        return this._props = deepmerge(ApplicationProps.DEFAULT, theia);
     }
 
     protected _pck: NodePackage | undefined;

--- a/packages/monaco/package.json
+++ b/packages/monaco/package.json
@@ -10,7 +10,6 @@
     "@theia/monaco-editor-core": "^0.20.0",
     "@theia/outline-view": "1.12.0",
     "@theia/workspace": "1.12.0",
-    "deepmerge": "2.0.1",
     "fast-plist": "^0.1.2",
     "idb": "^4.0.5",
     "jsonc-parser": "^2.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1201,6 +1201,13 @@
   dependencies:
     "@types/node" "*"
 
+"@types/deepmerge@^2.2.0":
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/@types/deepmerge/-/deepmerge-2.2.0.tgz#6f63896c217f3164782f52d858d9f3a927139f64"
+  integrity sha512-FEQYDHh6+Q+QXKSrIY46m+/lAmAj/bk4KpLaam+hArmzaVpMBHLcfwOH2Q2UOkWM7XsdY9PmZpGyPAjh/JRGhQ==
+  dependencies:
+    deepmerge "*"
+
 "@types/diff@^3.2.2":
   version "3.5.3"
   resolved "https://registry.yarnpkg.com/@types/diff/-/diff-3.5.3.tgz#7c6c3721ba454d838790100faf7957116ee7deab"
@@ -5035,10 +5042,10 @@ deep-is@^0.1.3, deep-is@~0.1.3:
   resolved "https://registry.yarnpkg.com/deep-is/-/deep-is-0.1.3.tgz#b369d6fb5dbc13eecf524f91b070feedc357cf34"
   integrity sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=
 
-deepmerge@2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/deepmerge/-/deepmerge-2.0.1.tgz#25c1c24f110fb914f80001b925264dd77f3f4312"
-  integrity sha512-VIPwiMJqJ13ZQfaCsIFnp5Me9tnjURiaIFxfz7EH0Ci0dTSQpZtSLrqOicXqEd/z2r+z+Klk9GzmnRsgpgbOsQ==
+deepmerge@*, deepmerge@^4.2.2:
+  version "4.2.2"
+  resolved "https://registry.yarnpkg.com/deepmerge/-/deepmerge-4.2.2.tgz#44d2ea3679b8f4d4ffba33f03d865fc1e7bf4955"
+  integrity sha512-FJ3UgI4gIl+PHZm53knsuSFpE+nESMr7M4v9QcgB7S63Kj/6WqMiFQJpBBYz1Pt+66bZpP3Q7Lye0Oo9MPKEdg==
 
 default-require-extensions@^3.0.0:
   version "3.0.0"


### PR DESCRIPTION
 - Removed the obsolete dependency from `@theia/monaco.`
 - Switched from `require` to ES `import`.

Signed-off-by: Akos Kitta <kittaakos@typefox.io>

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

 - Updates the `deepmerge` version,
 - Switches from `require` to ES `import`, and
 - Removes the obsolete `deepmerge` from `@theia/monaco`.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

 - Run `yarn why deepmerge`.

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

