### PR TITLE
SIW: Support 'search.smartCase'

### DIFF
--- a/packages/search-in-workspace/src/browser/search-in-workspace-preferences.ts
+++ b/packages/search-in-workspace/src/browser/search-in-workspace-preferences.ts
@@ -46,6 +46,11 @@ export const searchInWorkspacePreferencesSchema: PreferenceSchema = {
             description: 'Search the active editor when modified.',
             default: true,
             type: 'boolean',
+        },
+        'search.smartCase': {
+            description: 'Search case-insensitively if the pattern is all lowercase, otherwise, search case-sensitively.',
+            default: false,
+            type: 'boolean',
         }
     }
 };
@@ -56,6 +61,7 @@ export class SearchInWorkspaceConfiguration {
     'search.searchOnType': boolean;
     'search.searchOnTypeDebouncePeriod': number;
     'search.searchOnEditorModification': boolean;
+    'search.smartCase': boolean;
 }
 
 export const SearchInWorkspacePreferences = Symbol('SearchInWorkspacePreferences');


### PR DESCRIPTION
#### What it does
The following commit adds support for the preference 'search.smartCase'.
When the preference is true, search is case-insensitive if the pattern
is all lowercase, otherwise search is case-sensitive.

#### How to test
With `search.smartCase` turned on (default is off).
+ Search for a term (all characters in query are lowercase) in SIW view. (i.e: search for `hello`)
+ Observe that the search is case-insensitive (`Hello`, `HeLlo` , etc are shown up in the result view).
+ Change the search term to a query that contains at least an uppercase letter. (i.e: search for `Hello`).
+ Observe that the search is now case-sensitive (`heLlo`, `hello` are now not showing up).

#### Review checklist
- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

Signed-off-by: Duc Nguyen <duc.a.nguyen@ericsson.com>
