### PR TITLE
Implement extensionsUri field

### DIFF
--- a/packages/plugin-ext-vscode/src/node/plugin-vscode-init.ts
+++ b/packages/plugin-ext-vscode/src/node/plugin-vscode-init.ts
@@ -103,6 +103,10 @@ function asExtension(plugin: any | undefined): any | undefined {
     if (plugin.pluginPath) {
         plugin.extensionPath = plugin.pluginPath;
     }
+
+    if (plugin.pluginUri) {
+        plugin.extensionUri = plugin.pluginUri;
+    }
     // stub as a local VS Code extension (not running on a remote workspace)
     plugin.extensionKind = ExtensionKind.UI;
     return plugin;

--- a/packages/plugin-ext/src/common/plugin-api-rpc.ts
+++ b/packages/plugin-ext/src/common/plugin-api-rpc.ts
@@ -103,6 +103,7 @@ export interface PreferenceData {
 export interface Plugin {
     pluginPath: string | undefined;
     pluginFolder: string;
+    pluginUri: string;
     model: PluginModel;
     rawModel: PluginPackage;
     lifecycle: PluginLifecycle;
@@ -177,6 +178,7 @@ export const emptyPlugin: Plugin = {
     },
     pluginPath: 'empty',
     pluginFolder: 'empty',
+    pluginUri: 'empty',
     rawModel: {
         name: 'emptyPlugin',
         publisher: 'Theia',

--- a/packages/plugin-ext/src/hosted/browser/worker/worker-main.ts
+++ b/packages/plugin-ext/src/hosted/browser/worker/worker-main.ts
@@ -111,6 +111,7 @@ const pluginManager = new PluginManagerExtImpl({
                 const plugin: Plugin = {
                     pluginPath: pluginModel.entryPoint.frontend!,
                     pluginFolder: pluginModel.packagePath,
+                    pluginUri: pluginModel.packageUri,
                     model: pluginModel,
                     lifecycle: pluginLifecycle,
                     rawModel
@@ -125,6 +126,7 @@ const pluginManager = new PluginManagerExtImpl({
                     plugin: {
                         pluginPath: pluginModel.entryPoint.backend,
                         pluginFolder: pluginModel.packagePath,
+                        pluginUri: pluginModel.packageUri,
                         model: pluginModel,
                         lifecycle: pluginLifecycle,
                         get rawModel(): never {

--- a/packages/plugin-ext/src/hosted/node/plugin-host-rpc.ts
+++ b/packages/plugin-ext/src/hosted/node/plugin-host-rpc.ts
@@ -158,6 +158,7 @@ export class PluginHostRPC {
                             foreign.push({
                                 pluginPath: pluginModel.entryPoint.frontend!,
                                 pluginFolder: pluginModel.packagePath,
+                                pluginUri: pluginModel.packageUri,
                                 model: pluginModel,
                                 lifecycle: pluginLifecycle,
                                 rawModel
@@ -172,6 +173,7 @@ export class PluginHostRPC {
                             const plugin: Plugin = {
                                 pluginPath: pluginModel.entryPoint.backend!,
                                 pluginFolder: pluginModel.packagePath,
+                                pluginUri: pluginModel.packageUri,
                                 model: pluginModel,
                                 lifecycle: pluginLifecycle,
                                 rawModel

--- a/packages/plugin-ext/src/plugin/plugin-context.ts
+++ b/packages/plugin-ext/src/plugin/plugin-context.ts
@@ -959,14 +959,14 @@ export function createAPIFactory(
 class Plugin<T> implements theia.Plugin<T> {
     id: string;
     pluginPath: string;
-    pluginUri: URI;
+    pluginUri: theia.Uri;
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     packageJSON: any;
     pluginType: theia.PluginType;
     constructor(private readonly pluginManager: PluginManager, plugin: InternalPlugin) {
         this.id = plugin.model.id;
         this.pluginPath = plugin.pluginFolder;
-        this.pluginUri = URI.file(plugin.pluginFolder);
+        this.pluginUri = URI.parse(plugin.pluginUri);
         this.packageJSON = plugin.rawModel;
         this.pluginType = plugin.model.entryPoint.frontend ? 'frontend' : 'backend';
     }

--- a/packages/plugin/src/theia.d.ts
+++ b/packages/plugin/src/theia.d.ts
@@ -82,6 +82,11 @@ declare module '@theia/plugin' {
         readonly pluginPath: string;
 
         /**
+         * The uri of the directory containing this plug-in.
+         */
+        readonly pluginUri: Uri;
+
+        /**
          * `true` if the plug-in has been activated.
          */
         readonly isActive: boolean;


### PR DESCRIPTION
Signed-off-by: tsmaeder <tmader@redhat.com>

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
Adds support for the "extensionUri" field from the vscode API, see #9427 

#### How to test
The json built-in extension (1.50.1) throws an exception upon activation (see https://github.com/eclipse/che/issues/19485). Make sure this exception does not happen when activating the extension.

In order to get the newer version of the extension, rebuild theia with the version of the json plugin corrected in `theia/package.json`. You'll have to remove the vscode-builtin-json-language-features folder from the plugins folder firt.

#### Review checklist

- [ ] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

