### PR TITLE
siw: improve search result message

### DIFF
--- a/packages/search-in-workspace/src/browser/search-in-workspace-widget.tsx
+++ b/packages/search-in-workspace/src/browser/search-in-workspace-widget.tsx
@@ -623,25 +623,40 @@ export class SearchInWorkspaceWidget extends BaseWidget implements StatefulWidge
     }
 
     protected renderSearchInfo(): React.ReactNode {
-        let message = '';
-        if (this.searchTerm) {
-            if (this.searchInWorkspaceOptions.include && this.searchInWorkspaceOptions.include.length > 0 && this.resultNumber === 0) {
-                message = `No results found in '${this.searchInWorkspaceOptions.include}'`;
-            } else if (this.resultNumber === 0) {
-                message = 'No results found.';
+        const message = this.getSearchResultMessage() || '';
+        return <div className='search-info'>{message}</div>;
+    }
+
+    protected getSearchResultMessage(): string | undefined {
+
+        if (!this.searchTerm) {
+            return undefined;
+        }
+
+        if (this.resultNumber === 0) {
+            const isIncludesPresent = this.searchInWorkspaceOptions.include && this.searchInWorkspaceOptions.include.length > 0;
+            const isExcludesPresent = this.searchInWorkspaceOptions.exclude && this.searchInWorkspaceOptions.exclude.length > 0;
+
+            if (isIncludesPresent && isExcludesPresent) {
+                return `No results found in '${this.searchInWorkspaceOptions.include}' excluding '${this.searchInWorkspaceOptions.exclude}'`;
+            } else if (isIncludesPresent) {
+                return `No results found in '${this.searchInWorkspaceOptions.include}'`;
+            } else if (isExcludesPresent) {
+                return `No results found excluding '${this.searchInWorkspaceOptions.exclude}'`;
             } else {
-                if (this.resultNumber === 1 && this.resultTreeWidget.fileNumber === 1) {
-                    message = `${this.resultNumber} result in ${this.resultTreeWidget.fileNumber} file`;
-                } else if (this.resultTreeWidget.fileNumber === 1) {
-                    message = `${this.resultNumber} results in ${this.resultTreeWidget.fileNumber} file`;
-                } else if (this.resultTreeWidget.fileNumber > 0) {
-                    message = `${this.resultNumber} results in ${this.resultTreeWidget.fileNumber} files`;
-                } else {
-                    // if fileNumber === 0, return undefined so that `onUpdateRequest()` would not re-render component
-                    return undefined;
-                }
+                return 'No results found.';
+            }
+        } else {
+            if (this.resultNumber === 1 && this.resultTreeWidget.fileNumber === 1) {
+                return `${this.resultNumber} result in ${this.resultTreeWidget.fileNumber} file`;
+            } else if (this.resultTreeWidget.fileNumber === 1) {
+                return `${this.resultNumber} results in ${this.resultTreeWidget.fileNumber} file`;
+            } else if (this.resultTreeWidget.fileNumber > 0) {
+                return `${this.resultNumber} results in ${this.resultTreeWidget.fileNumber} files`;
+            } else {
+                // if fileNumber === 0, return undefined so that `onUpdateRequest()` would not re-render component
+                return undefined;
             }
         }
-        return <div className='search-info'>{message}</div>;
     }
 }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

The following pull-request updates the `search-in-workspace` result message (which is displayed upon searching) by adding support for additional use-cases and options.

The changes should now support the following messages:
- no results are found when no options are present.
- no results are found when `includes` and `excludes` are present.
- no results are found when `includes` is present.
- no results are found when `excludes` is present.
- results are found (like master) - statistics the search yields.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

For each of the tests, start the application and open the `search-in-workspace` view:

- `No results found` - search for a non-existing term without `includes` or `excludes` set.
- `No results found in {a} excluding {b}` - search for a non-existing term with `includes` and `excludes` present.
- `No results found in {a}` - search for a non-existing term with `includes` present.
- `No results found excluding {a}` - search for a non-existing term with `excludes` present.

The message when results are found should be the same as in `master`.

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

Signed-off-by: vince-fugnitto <vincent.fugnitto@ericsson.com>