### PR TITLE
Fix applying variable updates provided by plugins

### DIFF
--- a/packages/terminal/src/node/shell-process.spec.ts
+++ b/packages/terminal/src/node/shell-process.spec.ts
@@ -1,0 +1,68 @@
+/********************************************************************************
+ * Copyright (C) 2021 Ericsson and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import * as chai from 'chai';
+import { mergeProcessEnv } from './shell-process';
+
+const expect = chai.expect;
+
+describe('ShellProcess', function (): void {
+
+    describe('#mergeProcessEnv', function (): void {
+
+        this.timeout(5000);
+        const PATH = 'PATH';
+
+        it('should validate the presence of a known process variable', async function (): Promise<void> {
+            const mergedEnv = mergeProcessEnv();
+            expect(mergedEnv[PATH]).length.greaterThan(0);
+        });
+
+        it('should be possible to remove a known process variable', async function (): Promise<void> {
+            // eslint-disable-next-line no-null/no-null
+            const customizedEnv = { [PATH]: null };
+            const mergedEnv = mergeProcessEnv(customizedEnv);
+            expect(mergedEnv[PATH]).to.equal(undefined);
+        });
+
+        it('should be possible to override the value of a known process variable', async function (): Promise<void> {
+            const expectedValue = '/path/to/one';
+            const customizedEnv = { [PATH]: expectedValue };
+
+            const mergedEnv = mergeProcessEnv(customizedEnv);
+            expect(mergedEnv[PATH]).equals(expectedValue);
+        });
+
+        it('should not produce a different result when merging a previous result', async function (): Promise<void> {
+            const variableName = 'NEW_VARIABLE';
+            const expectedValue = 'true';
+            const customizedEnv = { [variableName]: expectedValue };
+
+            const mergedEnv = mergeProcessEnv(customizedEnv);
+            expect(mergedEnv[variableName]).equals(expectedValue);
+        });
+
+        it('should not produce a different result when performing multiple merges', async function (): Promise<void> {
+            const variableName = 'NEW_VARIABLE';
+            const expectedValue = 'true';
+            const customizedEnv = { [variableName]: expectedValue };
+
+            const mergedEnv = mergeProcessEnv(customizedEnv);
+            const mergedSecondPass = mergeProcessEnv(mergedEnv);
+            expect(mergedEnv).to.deep.equal(mergedSecondPass);
+        });
+    });
+});

--- a/packages/terminal/src/node/shell-process.ts
+++ b/packages/terminal/src/node/shell-process.ts
@@ -39,23 +39,6 @@ export interface ShellProcessOptions {
     isPseudo?: boolean,
 }
 
-function setUpEnvVariables(customEnv?: { [key: string]: string | null }): { [key: string]: string } {
-    const processEnv: { [key: string]: string } = {};
-
-    const prEnv: NodeJS.ProcessEnv = process.env;
-    Object.keys(prEnv).forEach((key: string) => {
-        processEnv[key] = prEnv[key] || '';
-    });
-
-    if (customEnv) {
-        for (const envName of Object.keys(customEnv)) {
-            processEnv[envName] = customEnv[envName] || '';
-        }
-    }
-
-    return processEnv;
-}
-
 function getRootPath(rootURI?: string): string {
     if (rootURI) {
         const uri = new URI(rootURI);
@@ -85,7 +68,7 @@ export class ShellProcess extends TerminalProcess {
                 cols: options.cols || ShellProcess.defaultCols,
                 rows: options.rows || ShellProcess.defaultRows,
                 cwd: getRootPath(options.rootURI),
-                env: setUpEnvVariables(options.env),
+                env: mergeProcessEnv(options.env),
             },
             isPseudo: options.isPseudo,
         }, processManager, ringBuffer, logger);
@@ -118,4 +101,25 @@ export class ShellProcess extends TerminalProcess {
             return [];
         }
     }
+}
+
+/**
+ * Merges a given record of environment variables with the process environment variables.
+ * Empty string values will not be included in the final env.
+ * @param env desired environment to merge with `process.env`.
+ *
+ * @returns a merged record of valid environment variables.
+ */
+ export function mergeProcessEnv(env: Record<string, string | null> = {}): Record<string, string> {
+    // eslint-disable-next-line no-null/no-null
+    const mergedEnv: Record<string, string> = Object.create(null);
+    for (const [key, value] of Object.entries(process.env)) {
+        // Ignore keys from `process.env` that are overridden in `env`. Accept only non-empty strings.
+        if (!(key in env) && value) { mergedEnv[key] = value; }
+    }
+    for (const [key, value] of Object.entries(env)) {
+        // Accept only non-empty strings from the `env` object.
+        if (value) { mergedEnv[key] = value; }
+    }
+    return mergedEnv;
 }


### PR DESCRIPTION
Process environment variables need to be merged with terminal options
before applying updates requested by plugins, otherwise the
environment variables may get corrupted.

Fixes: #9392
Fixes: theia-ide/theia-apps#437

Signed-off-by: Alvaro Sanchez-Leon <alvaro.sanchez-leon@ericsson.com>

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->
Environment variable customization entries provided by plugins were applied before resolving the set of process environment variables, so prepend, append and replace actions were taken on empty variables, causing corruptions as reported in the referenced issues.

The fix moves the resolution of applicable parent process environment variables and merges them with the terminal options environment variables before applying the requested customization entries by plugins. 

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

The issue: #9392' has a nice explanation on how to reproduce the issues and provides a plugin that can be used to exercise variable updates (prepend, append and replace).

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

