### PR TITLE
Modify scrollToAlignment of TreeWidget to align vscode

### DIFF
--- a/packages/core/src/browser/tree/tree-model.ts
+++ b/packages/core/src/browser/tree/tree-model.ts
@@ -69,6 +69,11 @@ export interface TreeModel extends Tree, TreeSelectionService, TreeExpansionServ
     readonly onOpenNode: Event<Readonly<TreeNode>>;
 
     /**
+     * Event when a node's sroll alignment shoud be requested.
+     */
+    readonly onScrollToNodeRequested: Event<scrollAlignment>;
+
+    /**
      * Selects the parent node relatively to the selected taking into account node expansion.
      */
     selectParent(): void;
@@ -148,6 +153,7 @@ export class TreeModelImpl implements TreeModel, SelectionProvider<ReadonlyArray
 
     protected readonly onChangedEmitter = new Emitter<void>();
     protected readonly onOpenNodeEmitter = new Emitter<TreeNode>();
+    protected readonly onScrollToNodeRequestEmitter = new Emitter<scrollAlignment>();
     protected readonly toDispose = new DisposableCollection();
 
     @postConstruct()
@@ -201,6 +207,10 @@ export class TreeModelImpl implements TreeModel, SelectionProvider<ReadonlyArray
 
     get onOpenNode(): Event<TreeNode> {
         return this.onOpenNodeEmitter.event;
+    }
+
+    get onScrollToNodeRequested(): Event<scrollAlignment> {
+        return this.onScrollToNodeRequestEmitter.event;
     }
 
     protected fireChanged(): void {
@@ -410,7 +420,8 @@ export class TreeModelImpl implements TreeModel, SelectionProvider<ReadonlyArray
         this.selectionService.addSelection(selectionOrTreeNode);
     }
 
-    selectNode(node: Readonly<SelectableTreeNode>): void {
+    selectNode(node: Readonly<SelectableTreeNode>, selectedByNavigator?: boolean): void {
+        this.onScrollToNodeRequestEmitter.fire(selectedByNavigator ? 'center' : 'auto');
         this.addSelection(node);
     }
 
@@ -443,6 +454,7 @@ export class TreeModelImpl implements TreeModel, SelectionProvider<ReadonlyArray
     }
 
 }
+export type scrollAlignment = 'auto' | 'end' | 'start' | 'center' | undefined;
 export namespace TreeModelImpl {
     export interface State {
         selection: object

--- a/packages/core/src/browser/tree/tree-widget.tsx
+++ b/packages/core/src/browser/tree/tree-widget.tsx
@@ -234,6 +234,7 @@ export class TreeWidget extends ReactWidget implements StatefulWidget {
             this.model,
             this.model.onChanged(() => this.updateRows()),
             this.model.onSelectionChanged(() => this.updateScrollToRow({ resize: false })),
+            this.model.onScrollToNodeRequested(align => this.scrollToAlignment = align),
             this.model.onDidChangeBusy(() => this.update()),
             this.model.onNodeRefreshed(() => this.updateDecorations()),
             this.model.onExpansionChanged(() => this.updateDecorations()),
@@ -320,6 +321,10 @@ export class TreeWidget extends ReactWidget implements StatefulWidget {
      * - Used to forcefully scroll if necessary.
      */
     protected scrollToRow: number | undefined;
+    /**
+     * Controls the alignment scrolled-to-rows.
+     */
+    protected scrollToAlignment: 'auto' | 'end' | 'start' | 'center' | undefined;
     /**
      * Update the `scrollToRow`.
      * @param updateOptions the tree widget force update options.
@@ -462,6 +467,7 @@ export class TreeWidget extends ReactWidget implements StatefulWidget {
                 rows={rows}
                 renderNodeRow={this.renderNodeRow}
                 scrollToRow={this.scrollToRow}
+                scrollToAlignment={this.scrollToAlignment}
                 handleScroll={this.handleScroll}
             />;
         }
@@ -1368,6 +1374,10 @@ export namespace TreeWidget {
          */
         scrollToRow?: number
         /**
+         * Controls the alignment scrolled-to-rows.
+         */
+         scrollToAlignment?: 'auto' | 'end' | 'start' | 'center';
+        /**
          * The list of node rows.
          */
         rows: NodeRow[]
@@ -1380,7 +1390,7 @@ export namespace TreeWidget {
             fixedWidth: true
         });
         render(): React.ReactNode {
-            const { rows, width, height, scrollToRow, handleScroll } = this.props;
+            const { rows, width, height, scrollToRow, handleScroll, scrollToAlignment } = this.props;
             return <List
                 ref={list => this.list = (list || undefined)}
                 width={width}
@@ -1389,6 +1399,7 @@ export namespace TreeWidget {
                 rowHeight={this.cache.rowHeight}
                 rowRenderer={this.renderTreeRow}
                 scrollToIndex={scrollToRow}
+                scrollToAlignment={scrollToAlignment}
                 onScroll={handleScroll}
                 tabIndex={-1}
                 style={{


### PR DESCRIPTION
Signed-off-by: shuyaqian 717749594@qq.com

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->
To fix when switch files in editor , the selected node is not in the center.
theia:
![1](https://bbs-img.huaweicloud.com/blogs/img/1620372083849071651.gif)
vscode:
![2](https://bbs-img.huaweicloud.com/blogs/img/1620372101381039307.gif)

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

