### PR TITLE
terminal: remove process.env from browser

### DIFF
--- a/packages/terminal/src/browser/terminal-preferences.ts
+++ b/packages/terminal/src/browser/terminal-preferences.ts
@@ -115,14 +115,14 @@ export const TerminalConfigSchema: PreferenceSchema = {
         },
         'terminal.integrated.shell.osx': {
             type: ['string', 'null'],
-            description: `The path of the shell that the terminal uses on macOS (default: ${process.env.SHELL || '/bin/bash'}).`,
-            markdownDescription: `The path of the shell that the terminal uses on macOS (default: ${process.env.SHELL || '/bin/bash'}).`,
+            description: 'The path of the shell that the terminal uses on macOS (default: \'/bin/bash\'}).',
+            markdownDescription: 'The path of the shell that the terminal uses on macOS (default: \'/bin/bash\'}).',
             default: undefined
         },
         'terminal.integrated.shell.linux': {
             type: ['string', 'null'],
-            description: `The path of the shell that the terminal uses on Linux (default: ${process.env.SHELL || '/bin/bash'}).`,
-            markdownDescription: `The path of the shell that the terminal uses on Linux (default: ${process.env.SHELL || '/bin/bash'}).`,
+            description: 'The path of the shell that the terminal uses on Linux (default: \'/bin/bash\'}).',
+            markdownDescription: 'The path of the shell that the terminal uses on Linux (default: \'/bin/bash\'}).',
             default: undefined
         },
         'terminal.integrated.shellArgs.windows': {


### PR DESCRIPTION
process.env is not available when in a browser environment. Webpack most
likely included a shim for it.

#### How to test

We should get the same default values on both master and this PR for the following preferences, and it should be independent from your `SHELL` environment variable.

- `terminal.integrated.shell.windows` defaults to `C:\\Windows\\System32\\cmd.exe`
- `terminal.integrated.shell.osx` defaults to `/bin/bash`
- `terminal.integrated.shell.linux` defaults to `/bin/bash`

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)