### PR TITLE
editor: support additional prefix quick-open menus

### DIFF
--- a/packages/editor/src/browser/editor-frontend-module.ts
+++ b/packages/editor/src/browser/editor-frontend-module.ts
@@ -34,6 +34,7 @@ import { NavigationLocationService } from './navigation/navigation-location-serv
 import { NavigationLocationSimilarity } from './navigation/navigation-location-similarity';
 import { EditorVariableContribution } from './editor-variable-contribution';
 import { EditorQuickOpenService } from './editor-quick-open-service';
+import { EditorGotoSymbolQuickOpenService, EditorGotoSymbolQuickOpenContribution } from './editor-goto-symbol-quick-open-service';
 
 export default new ContainerModule(bind => {
     bindEditorPreferences(bind);
@@ -77,4 +78,10 @@ export default new ContainerModule(bind => {
     bind(ActiveEditorAccess).toSelf().inSingletonScope();
     bind(EditorAccess).to(CurrentEditorAccess).inSingletonScope().whenTargetNamed(EditorAccess.CURRENT);
     bind(EditorAccess).to(ActiveEditorAccess).inSingletonScope().whenTargetNamed(EditorAccess.ACTIVE);
+
+    bind(EditorGotoSymbolQuickOpenService).toSelf().inSingletonScope();
+    bind(EditorGotoSymbolQuickOpenContribution).toSelf().inSingletonScope();
+    for (const identifier of [CommandContribution, QuickOpenContribution]) {
+        bind(identifier).toService(EditorGotoSymbolQuickOpenContribution);
+    }
 });

--- a/packages/editor/src/browser/editor-frontend-module.ts
+++ b/packages/editor/src/browser/editor-frontend-module.ts
@@ -35,6 +35,7 @@ import { NavigationLocationSimilarity } from './navigation/navigation-location-s
 import { EditorVariableContribution } from './editor-variable-contribution';
 import { EditorQuickOpenService } from './editor-quick-open-service';
 import { EditorGotoSymbolQuickOpenService, EditorGotoSymbolQuickOpenContribution } from './editor-goto-symbol-quick-open-service';
+import { EditorGotoLineQuickOpenService, EditorGotoLineQuickOpenContribution } from './editor-goto-line-quick-open-service';
 
 export default new ContainerModule(bind => {
     bindEditorPreferences(bind);
@@ -79,9 +80,13 @@ export default new ContainerModule(bind => {
     bind(EditorAccess).to(CurrentEditorAccess).inSingletonScope().whenTargetNamed(EditorAccess.CURRENT);
     bind(EditorAccess).to(ActiveEditorAccess).inSingletonScope().whenTargetNamed(EditorAccess.ACTIVE);
 
+    bind(EditorGotoLineQuickOpenService).toSelf().inSingletonScope();
     bind(EditorGotoSymbolQuickOpenService).toSelf().inSingletonScope();
+
+    bind(EditorGotoLineQuickOpenContribution).toSelf().inSingletonScope();
     bind(EditorGotoSymbolQuickOpenContribution).toSelf().inSingletonScope();
     for (const identifier of [CommandContribution, QuickOpenContribution]) {
+        bind(identifier).toService(EditorGotoLineQuickOpenContribution);
         bind(identifier).toService(EditorGotoSymbolQuickOpenContribution);
     }
 });

--- a/packages/editor/src/browser/editor-goto-line-quick-open-service.ts
+++ b/packages/editor/src/browser/editor-goto-line-quick-open-service.ts
@@ -1,0 +1,77 @@
+/********************************************************************************
+ * Copyright (C) 2021 Ericsson and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import { inject, injectable } from '@theia/core/shared/inversify';
+import { CommandService } from '@theia/core/lib/common';
+import { QuickOpenModel } from '@theia/core/lib/common/quick-open-model';
+import { CommandContribution, CommandRegistry } from '@theia/core/lib/common/command';
+import {
+    PrefixQuickOpenService,
+    QuickOpenContribution,
+    QuickOpenGroupItem,
+    QuickOpenHandler,
+    QuickOpenHandlerRegistry,
+    QuickOpenOptions
+} from '@theia/core/lib/browser';
+
+@injectable()
+export class EditorGotoLineQuickOpenService implements QuickOpenModel, QuickOpenHandler {
+
+    @inject(PrefixQuickOpenService)
+    protected prefixQuickOpenService: PrefixQuickOpenService;
+
+    @inject(CommandService)
+    protected readonly commandService: CommandService;
+
+    readonly prefix = ':';
+    readonly description = 'Go to Line';
+
+    getModel(): QuickOpenModel {
+        return this;
+    }
+
+    getOptions(): QuickOpenOptions {
+        return {};
+    }
+
+    open(): void {
+        this.prefixQuickOpenService.open(this.prefix);
+    }
+
+    async onType(lookFor: string, acceptor: (items: QuickOpenGroupItem[]) => void): Promise<void> {
+        // Execute the builtin `gotoLine` command.
+        this.commandService.executeCommand('editor.action.gotoLine');
+        acceptor([]);
+    }
+}
+
+@injectable()
+export class EditorGotoLineQuickOpenContribution implements CommandContribution, QuickOpenContribution {
+
+    @inject(EditorGotoLineQuickOpenService)
+    protected readonly gettingStartedQuickOpenService: EditorGotoLineQuickOpenService;
+
+    registerQuickOpenHandlers(handlers: QuickOpenHandlerRegistry): void {
+        handlers.registerHandler(this.gettingStartedQuickOpenService);
+    }
+
+    registerCommands(commands: CommandRegistry): void {
+        commands.registerCommand({ id: 'editor.goto.line' }, {
+            execute: () => this.gettingStartedQuickOpenService.open()
+        });
+    }
+
+}

--- a/packages/editor/src/browser/editor-goto-symbol-quick-open-service.ts
+++ b/packages/editor/src/browser/editor-goto-symbol-quick-open-service.ts
@@ -1,0 +1,77 @@
+/********************************************************************************
+ * Copyright (C) 2021 Ericsson and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import { inject, injectable } from '@theia/core/shared/inversify';
+import { CommandService } from '@theia/core/lib/common';
+import { QuickOpenModel } from '@theia/core/lib/common/quick-open-model';
+import { CommandContribution, CommandRegistry } from '@theia/core/lib/common/command';
+import {
+    PrefixQuickOpenService,
+    QuickOpenContribution,
+    QuickOpenGroupItem,
+    QuickOpenHandler,
+    QuickOpenHandlerRegistry,
+    QuickOpenOptions
+} from '@theia/core/lib/browser';
+
+@injectable()
+export class EditorGotoSymbolQuickOpenService implements QuickOpenModel, QuickOpenHandler {
+
+    @inject(PrefixQuickOpenService)
+    protected prefixQuickOpenService: PrefixQuickOpenService;
+
+    @inject(CommandService)
+    protected readonly commandService: CommandService;
+
+    readonly prefix = '@';
+    readonly description = 'Go to Symbol';
+
+    getModel(): QuickOpenModel {
+        return this;
+    }
+
+    getOptions(): QuickOpenOptions {
+        return {};
+    }
+
+    open(): void {
+        this.prefixQuickOpenService.open(this.prefix);
+    }
+
+    async onType(lookFor: string, acceptor: (items: QuickOpenGroupItem[]) => void): Promise<void> {
+        // Execute the builtin `quickOutline` command.
+        this.commandService.executeCommand('editor.action.quickOutline');
+        acceptor([]);
+    }
+}
+
+@injectable()
+export class EditorGotoSymbolQuickOpenContribution implements CommandContribution, QuickOpenContribution {
+
+    @inject(EditorGotoSymbolQuickOpenService)
+    protected readonly gettingStartedQuickOpenService: EditorGotoSymbolQuickOpenService;
+
+    registerQuickOpenHandlers(handlers: QuickOpenHandlerRegistry): void {
+        handlers.registerHandler(this.gettingStartedQuickOpenService);
+    }
+
+    registerCommands(commands: CommandRegistry): void {
+        commands.registerCommand({ id: 'editor.goto.symbol' }, {
+            execute: () => this.gettingStartedQuickOpenService.open()
+        });
+    }
+
+}


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

##### What it does
<!-- Include relevant issues and describe how they are addressed. -->

Fixes: https://github.com/eclipse-theia/theia/issues/2670

The following pull-request adds support for additional `prefix` quick-open menus:
- **go to symbol**: add support for the `@` prefix quick-open which displays outline information for the given file.
- **go to line**: add support for the `:` prefix quick-open which allows end-users to go to line in the given file.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

TBD.

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

