### PR TITLE
Use Monaco when creating files in `DebugConfigurationManager`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Change Log
 
+## v1.14.0 - unreleased
+
+[1.14.0 Milestone](https://github.com/eclipse-theia/theia/milestone/20)
+
+- [debug] Fix behavior of `Add Configurations` command when empty `launch.json` present. [#9467](https://github.com/eclipse-theia/theia/pull/9467)
+
+<a name="breaking_changes_1.14.0">[Breaking Changes:](#breaking_changes_1.14.0)</a>
+
+- [debug] `DebugConfigurationManager` no longer `@injects()` the `FileService` and now uses `MonacoTextModelService` instead. [#9467](https://github.com/eclipse-theia/theia/pull/9467)
+
 ## v1.13.0 - 4/29/2021
 
 [1.13.0 Milestone](https://github.com/eclipse-theia/theia/milestone/19)


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

This PR fixes #9310 by using Monaco to manipulate the file contents rather than having the `FileService` make the change on the backend only.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

1. Open a workspace with no `launch.json` files.
2. Create an empty `launch.json` file in some root and have it open.
3. Open the debug widget.
4. Open the dropdown to select configurations and select `Add Configuration`.
5. The file you created should be populated with the default content of a `launch.json` file.
6. Save the file.
7. You should see no error message.
8. It should work regardless of whether the file you create is in a `.vscode` or `.theia` folder.
> The behavior may differ depending on whether you've previously had a `launch.json` in the other folder during the same session.

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

Signed-off-by: Colin Grant <colin.grant@ericsson.com>