### PR TITLE
Fix enable/disable of verified breakpoints if moved

### DIFF
--- a/packages/debug/src/browser/model/debug-source-breakpoint.tsx
+++ b/packages/debug/src/browser/model/debug-source-breakpoint.tsx
@@ -50,7 +50,8 @@ export class DebugSourceBreakpoint extends DebugBreakpoint<SourceBreakpoint> imp
         const { uri, raw } = this;
         let shouldUpdate = false;
         let breakpoints = raw && this.doRemove(this.origins.filter(origin => !(origin.raw.line === raw.line && origin.raw.column === raw.column)));
-        if (breakpoints) {
+        // Check for breakpoints array with at least one entry
+        if (breakpoints && breakpoints.length) {
             shouldUpdate = true;
         } else {
             breakpoints = this.breakpoints.getBreakpoints(uri);


### PR DESCRIPTION
Signed-off-by: thegecko <rob.moran@arm.com>

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

This PR fixes the issue of not being able to enable/disable verified breakpoints if they have moved their location.

This is as mentioned in: https://github.com/eclipse-theia/theia/issues/8222#issuecomment-830565878

@marechal-p this may also fix the issue you've seen in #8222 , but I've been unable to verify that.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

- Set a breakpoint on a non-code line (e.g. on a line with a comment) before or during a debug session
- Once verified, it should move to a different line
- Notice that disabling the breakpoint in its new position removes it. This PR fixes that.

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

