### PR TITLE
vsx: update compatibility check for builtins

### DIFF
--- a/packages/vsx-registry/src/browser/vsx-extensions-model.ts
+++ b/packages/vsx-registry/src/browser/vsx-extensions-model.ts
@@ -139,7 +139,7 @@ export class VSXExtensionsModel {
             const searchResult = new Set<string>();
             for (const data of result.extensions) {
                 const id = data.namespace.toLowerCase() + '.' + data.name.toLowerCase();
-                const extension = this.api.getLatestCompatibleVersion(data.allVersions);
+                const extension = this.api.getLatestCompatibleVersion(data);
                 if (!extension) {
                     continue;
                 }

--- a/packages/vsx-registry/src/common/vsx-registry-api.spec.ts
+++ b/packages/vsx-registry/src/common/vsx-registry-api.spec.ts
@@ -155,4 +155,14 @@ describe('VSX Registry API', () => {
 
     });
 
+    describe.only('#isVersionLTE', () => {
+
+        it('should determine if v1 is less than or equal to v2', () => {
+            expect(api['isVersionLTE']('1.40.0', '1.50.0')).equal(true, 'should be satisfied since v1 is less than v2');
+            expect(api['isVersionLTE']('1.50.0', '1.50.0')).equal(true, 'should be satisfied since v1 and v2 are equal');
+            expect(api['isVersionLTE']('2.0.2', '2.0.1')).equal(false, 'should not be satisfied since v1 is greater than v2');
+        });
+
+    });
+
 });

--- a/packages/vsx-registry/src/common/vsx-registry-types.ts
+++ b/packages/vsx-registry/src/common/vsx-registry-types.ts
@@ -143,3 +143,18 @@ export interface VSXExtensionRaw {
     readonly qna?: string;
     readonly engines?: { [engine: string]: string };
 }
+
+/**
+ * Builtin namespaces maintained by the framework.
+ */
+export namespace VSXBuiltinNamespaces {
+    /**
+     * Namespace for individual vscode builtin extensions.
+     */
+    export const VSCODE = 'vscode';
+    /**
+     * Namespace for vscode builtin extension packs.
+     * - corresponds to: https://github.com/eclipse-theia/vscode-builtin-extensions/blob/af9cfeb2ea23e1668a8340c1c2fb5afd56be07d7/src/create-extension-pack.js#L45
+     */
+    export const THEIA = 'eclipse-theia';
+}


### PR DESCRIPTION
#### Problem

The framework requires special logic when handling `builtin` extensions which are maintained by the project:
- `vscode-builtin-extension`: builtin extensions which are bundled with vscode
- `vscode-builtin-extension-packs`: builtin extension pack containing bundled vscode extensions referenced by id.

The issue is that these such extensions do not necessarily maintain their `engines.vscode` field so instead we should be smarter and fetch compatible versions of these extensions by their actual `version` (which corresponds to the actual vscode version). This way, we are more likely to fetch a valid version of an extension which satisfies our API level.

#### What it does

The changes include updating the logic to determine compatible versions of extensions:
- `project maintained builtins` (vscode): we check compatibility based on `version`.
- `builtin` (non-vscode bundled extensions): we check compatibility based on `engines.vscode` version.
- other extensions: we check compatibility based on `engines.vscode` version.

The changes determine builtin compatibility by using `semver.lte` (less than or equal) in order to get a version which matches the API version, or a previous version to ensure that extensions are compatible.

The changes also include the `VSXBuiltinNamespaces` namespace which contains information on reserved builtin namespaces:
- `vscode`: reserved for individual vscode builtin extensions.
- `eclipse-theia`: reserved for builtin extension-packs of individual vscode builtin extensions.

#### How to test

1. remove the plugins folder and temp files (ex: `rm -rf plugins/`, `rm -rf /tmp/vscode-unpacked`, `rm -rf ~/theia/extensions`).
2. start the application.
3. search for vscode builtin extensions (ex: `json-language-features` - the extension should be at `1.50.0` (current API level).
4. searching other extensions should behave like today.
5. installing extensions should work correctly.
6. repeat step 1 - ensure that no builtins are present.
7. add the following [extension-pack](https://open-vsx.org/api/eclipse-theia/builtin-extension-pack/1.50.0/file/eclipse-theia.builtin-extension-pack-1.50.0.vsix).
8. ensure that extensions in the pack are resolved to version `1.50.0` if it exists, else a previous version if it exists.

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

Signed-off-by: vince-fugnitto <vincent.fugnitto@ericsson.com>