### PR TITLE
Don't require `defaultTheme`, `defaultIconTheme` and `applicationName` in `FrontendApplicationConfig`

### DIFF
--- a/dev-packages/application-package/src/application-props.ts
+++ b/dev-packages/application-package/src/application-props.ts
@@ -37,6 +37,60 @@ export namespace NpmRegistryProps {
 }
 
 /**
+ * Representation of all backend and frontend related Theia extension and application properties.
+ */
+export interface ApplicationProps extends NpmRegistryProps {
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    readonly [key: string]: any;
+
+    /**
+     * Whether the extension targets the browser or electron. Defaults to `browser`.
+     */
+    readonly target: ApplicationProps.Target;
+
+    /**
+     * Frontend related properties.
+     */
+    readonly frontend: Readonly<{ config: FrontendApplicationConfig & typeof FrontendApplicationConfig.DEFAULT }>;
+
+    /**
+     * Backend specific properties.
+     */
+    readonly backend: Readonly<{ config: BackendApplicationConfig }>;
+
+    /**
+     * Generator specific properties.
+     */
+    readonly generator: Readonly<{ config: GeneratorConfig }>;
+}
+export namespace ApplicationProps {
+    export enum ApplicationTarget {
+        browser = 'browser',
+        electron = 'electron'
+    };
+
+    export type Target = keyof typeof ApplicationTarget;
+
+    export const DEFAULT: ApplicationProps = {
+        ...NpmRegistryProps.DEFAULT,
+        target: 'browser',
+        backend: {
+            config: {}
+        },
+        frontend: {
+            config: FrontendApplicationConfig.DEFAULT,
+        },
+        generator: {
+            config: {
+                preloadTemplate: ''
+            }
+        }
+    };
+
+}
+
+/**
  * Base configuration for the Theia application.
  */
 export interface ApplicationConfig {
@@ -78,61 +132,6 @@ export namespace FrontendApplicationConfig {
         defaultTheme: 'dark',
         defaultIconTheme: 'none'
     };
-}
-
-/**
- * Representation of all backend and frontend related Theia extension and application properties.
- */
-export interface ApplicationProps extends NpmRegistryProps {
-
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    readonly [key: string]: any;
-
-    /**
-     * Whether the extension targets the browser or electron. Defaults to `browser`.
-     */
-    readonly target: ApplicationProps.Target;
-
-    /**
-     * Frontend related properties.
-     */
-    readonly frontend: Readonly<{ config: FrontendApplicationConfig & typeof FrontendApplicationConfig.DEFAULT }>;
-
-    /**
-     * Backend specific properties.
-     */
-    readonly backend: Readonly<{ config: BackendApplicationConfig }>;
-
-    /**
-     * Generator specific properties.
-     */
-    readonly generator: Readonly<{ config: GeneratorConfig }>;
-}
-
-export namespace ApplicationProps {
-    export enum ApplicationTarget {
-        browser = 'browser',
-        electron = 'electron'
-    };
-
-    export type Target = keyof typeof ApplicationTarget;
-
-    export const DEFAULT: ApplicationProps = {
-        ...NpmRegistryProps.DEFAULT,
-        target: 'browser',
-        backend: {
-            config: {}
-        },
-        frontend: {
-            config: FrontendApplicationConfig.DEFAULT,
-        },
-        generator: {
-            config: {
-                preloadTemplate: ''
-            }
-        }
-    };
-
 }
 
 export interface ElectronFrontendApplicationConfig {

--- a/dev-packages/application-package/src/application-props.ts
+++ b/dev-packages/application-package/src/application-props.ts
@@ -37,64 +37,6 @@ export namespace NpmRegistryProps {
 }
 
 /**
- * Representation of all backend and frontend related Theia extension and application properties.
- */
-export interface ApplicationProps extends NpmRegistryProps {
-
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    readonly [key: string]: any;
-
-    /**
-     * Whether the extension targets the browser or electron. Defaults to `browser`.
-     */
-    readonly target: ApplicationProps.Target;
-
-    /**
-     * Frontend related properties.
-     */
-    readonly frontend: Readonly<{ config: FrontendApplicationConfig }>;
-
-    /**
-     * Backend specific properties.
-     */
-    readonly backend: Readonly<{ config: BackendApplicationConfig }>;
-
-    /**
-     * Generator specific properties.
-     */
-    readonly generator: Readonly<{ config: GeneratorConfig }>;
-}
-export namespace ApplicationProps {
-    export enum ApplicationTarget {
-        browser = 'browser',
-        electron = 'electron'
-    };
-
-    export type Target = keyof typeof ApplicationTarget;
-
-    export const DEFAULT: ApplicationProps = {
-        ...NpmRegistryProps.DEFAULT,
-        target: 'browser',
-        backend: {
-            config: {}
-        },
-        frontend: {
-            config: {
-                applicationName: 'Eclipse Theia',
-                defaultTheme: 'dark',
-                defaultIconTheme: 'none'
-            }
-        },
-        generator: {
-            config: {
-                preloadTemplate: ''
-            }
-        }
-    };
-
-}
-
-/**
  * Base configuration for the Theia application.
  */
 export interface ApplicationConfig {
@@ -126,6 +68,71 @@ export interface FrontendApplicationConfig extends ApplicationConfig {
      * Electron specific configuration.
      */
     readonly electron?: Readonly<ElectronFrontendApplicationConfig>;
+}
+
+type PickRequired<T, K extends keyof T> = Omit<T, K> & Required<Pick<T, K>>;
+
+export namespace FrontendApplicationConfig {
+    export const DEFAULT: PickRequired<FrontendApplicationConfig, 'applicationName' | 'defaultTheme' | 'defaultIconTheme'> = {
+        applicationName: 'Eclipse Theia',
+        defaultTheme: 'dark',
+        defaultIconTheme: 'none'
+    };
+}
+
+/**
+ * Representation of all backend and frontend related Theia extension and application properties.
+ */
+export interface ApplicationProps extends NpmRegistryProps {
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    readonly [key: string]: any;
+
+    /**
+     * Whether the extension targets the browser or electron. Defaults to `browser`.
+     */
+    readonly target: ApplicationProps.Target;
+
+    /**
+     * Frontend related properties.
+     */
+    readonly frontend: Readonly<{ config: FrontendApplicationConfig & typeof FrontendApplicationConfig.DEFAULT }>;
+
+    /**
+     * Backend specific properties.
+     */
+    readonly backend: Readonly<{ config: BackendApplicationConfig }>;
+
+    /**
+     * Generator specific properties.
+     */
+    readonly generator: Readonly<{ config: GeneratorConfig }>;
+}
+
+export namespace ApplicationProps {
+    export enum ApplicationTarget {
+        browser = 'browser',
+        electron = 'electron'
+    };
+
+    export type Target = keyof typeof ApplicationTarget;
+
+    export const DEFAULT: ApplicationProps = {
+        ...NpmRegistryProps.DEFAULT,
+        target: 'browser',
+        backend: {
+            config: {}
+        },
+        frontend: {
+            config: FrontendApplicationConfig.DEFAULT,
+        },
+        generator: {
+            config: {
+                preloadTemplate: ''
+            }
+        }
+    };
+
 }
 
 export interface ElectronFrontendApplicationConfig {

--- a/dev-packages/application-package/src/application-props.ts
+++ b/dev-packages/application-package/src/application-props.ts
@@ -110,17 +110,17 @@ export interface FrontendApplicationConfig extends ApplicationConfig {
     /**
      * The default theme for the application. If not given, defaults to `dark`. If invalid theme is given, also defaults to `dark`.
      */
-    readonly defaultTheme: string;
+    readonly defaultTheme?: string;
 
     /**
      * The default icon theme for the application. If not given, defaults to `none`. If invalid theme is given, also defaults to `none`.
      */
-    readonly defaultIconTheme: string;
+    readonly defaultIconTheme?: string;
 
     /**
      * The name of the application. `Eclipse Theia` by default.
      */
-    readonly applicationName: string;
+    readonly applicationName?: string;
 
     /**
      * Electron specific configuration.

--- a/packages/core/src/browser/frontend-application-config-provider.ts
+++ b/packages/core/src/browser/frontend-application-config-provider.ts
@@ -20,12 +20,12 @@ export class FrontendApplicationConfigProvider {
 
     private static KEY = Symbol('FrontendApplicationConfigProvider');
 
-    static get(): FrontendApplicationConfig {
+    static get(): FrontendApplicationConfig & typeof FrontendApplicationConfig.DEFAULT {
         const config = FrontendApplicationConfigProvider.doGet();
         if (config === undefined) {
             throw new Error('The configuration is not set. Did you call FrontendApplicationConfigProvider#set?');
         }
-        return config;
+        return Object.assign({ ...FrontendApplicationConfig.DEFAULT }, config);
     }
 
     static set(config: FrontendApplicationConfig): void {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
Remove the requirement for properties `defaultTheme`, `defaultIconTheme` and `applicationName` in `FrontendApplicationConfig` class.

#### How to test
Using `FrontendApplicationConfigProvider.set` we were required to set a value for the edited properties even though they have default values.

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

