### PR TITLE
8691 support in operator for when clauses

### DIFF
--- a/packages/core/src/browser/context-key-service.ts
+++ b/packages/core/src/browser/context-key-service.ts
@@ -58,7 +58,7 @@ export class ContextKeyService {
     /**
      * It should be implemented by an extension, e.g. by the monaco extension.
      */
-    parseKeys(expression: string): Set<string> {
+    parseKeys(expression: string): Set<string> | undefined {
         return new Set<string>();
     }
 

--- a/packages/monaco/src/browser/monaco-context-key-service.ts
+++ b/packages/monaco/src/browser/monaco-context-key-service.ts
@@ -48,18 +48,21 @@ export class MonacoContextKeyService extends ContextKeyService {
         return monaco.keybindings.KeybindingResolver.contextMatchesRules(keyContext, parsed);
     }
 
-    protected readonly expressions = new Map<string, monaco.contextkey.ContextKeyExpr>();
-    protected parse(when: string): monaco.contextkey.ContextKeyExpr {
+    protected readonly expressions = new Map<string, monaco.contextkey.ContextKeyExpression>();
+    protected parse(when: string): monaco.contextkey.ContextKeyExpression | undefined {
         let expression = this.expressions.get(when);
         if (!expression) {
             expression = monaco.contextkey.ContextKeyExpr.deserialize(when);
-            this.expressions.set(when, expression);
+            if (expression) {
+                this.expressions.set(when, expression);
+            }
         }
         return expression;
     }
 
-    parseKeys(expression: string): Set<string> {
-        return new Set<string>(monaco.contextkey.ContextKeyExpr.deserialize(expression).keys());
+    parseKeys(expression: string): Set<string> | undefined {
+        const expr = monaco.contextkey.ContextKeyExpr.deserialize(expression);
+        return expr ? new Set<string>(expr.keys()) : expr;
     }
 
 }

--- a/packages/monaco/src/typings/monaco/index.d.ts
+++ b/packages/monaco/src/typings/monaco/index.d.ts
@@ -538,14 +538,14 @@ declare module monaco.actions {
         title: string | ILocalizedString;
         category?: string | ILocalizedString;
         icon?: { dark?: monaco.Uri; light?: monaco.Uri; } | monaco.theme.ThemeIcon;
-        precondition?: monaco.contextkey.ContextKeyExpr;
-        toggled?: monaco.contextkey.ContextKeyExpr;
+        precondition?: monaco.contextkey.ContextKeyExpression;
+        toggled?: monaco.contextkey.ContextKeyExpression;
     }
 
     // https://github.com/theia-ide/vscode/blob/standalone/0.23.x/src/vs/platform/actions/common/actions.ts#L53
     export interface IMenuItem {
         command: ICommandAction;
-        when?: monaco.contextkey.ContextKeyExpr;
+        when?: monaco.contextkey.ContextKeyExpression;
         group?: 'navigation' | string;
         order?: number;
         alt?: ICommandAction;
@@ -555,7 +555,7 @@ declare module monaco.actions {
     export interface ISubmenuItem {
         title: string | ILocalizedString;
         submenu: number; // enum MenuId
-        when?: monaco.contextkey.ContextKeyExpr;
+        when?: monaco.contextkey.ContextKeyExpression;
         group?: 'navigation' | string;
         order?: number;
     }
@@ -700,7 +700,7 @@ declare module monaco.keybindings {
 
     // https://github.com/theia-ide/vscode/blob/standalone/0.23.x/src/vs/platform/keybinding/common/keybindingResolver.ts#L19
     export class KeybindingResolver {
-        static contextMatchesRules(context: monaco.contextKeyService.IContext, rules: monaco.contextkey.ContextKeyExpr | null | undefined): boolean;
+        static contextMatchesRules(context: monaco.contextKeyService.IContext, rules: monaco.contextkey.ContextKeyExpression | null | undefined): boolean;
     }
 
     // https://github.com/theia-ide/vscode/blob/standalone/0.23.x/src/vs/base/common/keyCodes.ts#L443
@@ -727,7 +727,7 @@ declare module monaco.keybindings {
     export interface IKeybindingItem {
         keybinding: Keybinding;
         command: string;
-        when?: monaco.contextkey.ContextKeyExpr;
+        when?: monaco.contextkey.ContextKeyExpression;
     }
 
     // https://github.com/theia-ide/vscode/blob/standalone/0.23.x/src/vs/platform/keybinding/common/keybindingsRegistry.ts#L73
@@ -2174,7 +2174,7 @@ declare module monaco.contextKeyService {
         bufferChangeEvents(callback: Function): void;
 
         createKey<T>(key: string, defaultValue: T | undefined): IContextKey<T>;
-        contextMatchesRules(rules: monaco.contextkey.ContextKeyExpr | undefined): boolean;
+        contextMatchesRules(rules: monaco.contextkey.ContextKeyExpression | undefined): boolean;
         getContextKeyValue<T>(key: string): T | undefined;
 
         createScoped(target?: HTMLElement): IContextKeyService;
@@ -2201,7 +2201,7 @@ declare module monaco.contextKeyService {
         bufferChangeEvents(callback: Function): void;
 
         createKey<T>(key: string, defaultValue: T | undefined): IContextKey<T>;
-        contextMatchesRules(rules: monaco.contextkey.ContextKeyExpr | undefined): boolean;
+        contextMatchesRules(rules: monaco.contextkey.ContextKeyExpression | undefined): boolean;
         getContextKeyValue<T>(key: string): T | undefined;
 
         createScoped(target?: HTMLElement): IContextKeyService;
@@ -2213,6 +2213,77 @@ declare module monaco.contextKeyService {
 }
 
 declare module monaco.contextkey {
+    export const enum ContextKeyExprType {
+        False = 0,
+        True = 1,
+        Defined = 2,
+        Not = 3,
+        Equals = 4,
+        NotEquals = 5,
+        And = 6,
+        Regex = 7,
+        NotRegex = 8,
+        Or = 9,
+        In = 10,
+        NotIn = 11,
+        Greater = 12,
+        GreaterEquals = 13,
+        Smaller = 14,
+        SmallerEquals = 15,
+    }
+
+    export class ContextKeyFalseExpr extends ContextKeyExpr { }
+    export class ContextKeyTrueExpr extends ContextKeyExpr { }
+    export class ContextKeyDefinedExpr extends ContextKeyExpr {
+        static create(key: string): ContextKeyExpression;
+    }
+    export class ContextKeyNotExpr extends ContextKeyExpr {
+        static create(key: string): ContextKeyExpression;
+    }
+    export class ContextKeyEqualsExpr extends ContextKeyExpr {
+        static create(key: string, value: any): ContextKeyExpression;
+    }
+    export class ContextKeyNotEqualsExpr extends ContextKeyExpr {
+        static create(key: string, value: any): ContextKeyExpression
+    }
+    export class ContextKeyRegexExpr extends ContextKeyExpr {
+        static create(key: string, regexp: RegExp | null): ContextKeyRegexExpr;
+    }
+    export class ContextKeyNotRegexExpr extends ContextKeyExpr {
+        static create(actual: ContextKeyRegexExpr): ContextKeyExpression;
+    }
+    export class ContextKeyAndExpr extends ContextKeyExpr {
+        static create(_expr: ReadonlyArray<ContextKeyExpression | null | undefined>): ContextKeyExpression | undefined;
+    }
+    export class ContextKeyOrExpr extends ContextKeyExpr {
+        static create(_expr: ReadonlyArray<ContextKeyExpression | null | undefined>): ContextKeyExpression | undefined;
+    }
+    export class ContextKeyInExpr extends ContextKeyExpr {
+        static create(key: string, valueKey: string): ContextKeyInExpr
+    }
+    export class ContextKeyNotInExpr extends ContextKeyExpr {
+        static create(actual: ContextKeyInExpr): ContextKeyNotInExpr;
+    }
+    export class ContextKeyGreaterExpr extends ContextKeyExpr {
+        static create(key: string, value: any): ContextKeyExpression;
+    }
+    export class ContextKeyGreaterEqualsExpr extends ContextKeyExpr {
+        static create(key: string, value: any): ContextKeyExpression
+    }
+    export class ContextKeySmallerExpr extends ContextKeyExpr {
+        static create(key: string, value: any): ContextKeyExpression
+    }
+    export class ContextKeySmallerEqualsExpr extends ContextKeyExpr {
+        static create(key: string, value: any): ContextKeyExpression
+    }
+
+    export type ContextKeyExpression = (
+        ContextKeyFalseExpr | ContextKeyTrueExpr | ContextKeyDefinedExpr | ContextKeyNotExpr
+        | ContextKeyEqualsExpr | ContextKeyNotEqualsExpr | ContextKeyRegexExpr
+        | ContextKeyNotRegexExpr | ContextKeyAndExpr | ContextKeyOrExpr | ContextKeyInExpr
+        | ContextKeyNotInExpr | ContextKeyGreaterExpr | ContextKeyGreaterEqualsExpr
+        | ContextKeySmallerExpr | ContextKeySmallerEqualsExpr
+    );
 
     // https://github.com/theia-ide/vscode/blob/standalone/0.23.x/src/vs/platform/contextkey/common/contextkey.ts#L1327
     export const IContextKeyService: any;
@@ -2220,7 +2291,7 @@ declare module monaco.contextkey {
     // https://github.com/theia-ide/vscode/blob/standalone/0.23.x/src/vs/platform/contextkey/common/contextkey.ts#L79
     export class ContextKeyExpr {
         keys(): string[];
-        static deserialize(when: string): ContextKeyExpr;
+        static deserialize(serialized: string | null | undefined, strict: boolean = false): ContextKeyExpression | undefined;
         serialize(): string;
     }
 }

--- a/packages/plugin-ext/src/main/browser/comments/comments-context-key-service.ts
+++ b/packages/plugin-ext/src/main/browser/comments/comments-context-key-service.ts
@@ -56,7 +56,7 @@ export class CommentsContextKeyService {
     }
 
     setExpression(expression: string): void {
-        this.contextKeyService.parseKeys(expression).forEach(key => {
+        this.contextKeyService.parseKeys(expression)?.forEach(key => {
             this.contextKeys.add(key);
         });
     }

--- a/packages/plugin-ext/src/main/browser/view/plugin-view-registry.ts
+++ b/packages/plugin-ext/src/main/browser/view/plugin-view-registry.ts
@@ -91,7 +91,7 @@ export class PluginViewRegistry implements FrontendApplicationContribution {
     private readonly viewsWelcome = new Map<string, ViewWelcome[]>();
     private readonly viewContainers = new Map<string, [string, ViewContainerTitleOptions]>();
     private readonly containerViews = new Map<string, string[]>();
-    private readonly viewClauseContexts = new Map<string, Set<string>>();
+    private readonly viewClauseContexts = new Map<string, Set<string> | undefined>();
 
     private readonly viewDataProviders = new Map<string, ViewDataProvider>();
     private readonly viewDataState = new Map<string, object>();
@@ -300,8 +300,11 @@ export class PluginViewRegistry implements FrontendApplicationContribution {
         }));
 
         if (view.when && view.when !== 'false' && view.when !== 'true') {
-            this.viewClauseContexts.set(view.id, this.contextKeyService.parseKeys(view.when));
-            toDispose.push(Disposable.create(() => this.viewClauseContexts.delete(view.id)));
+            const keys = this.contextKeyService.parseKeys(view.when);
+            if (keys) {
+                this.viewClauseContexts.set(view.id, keys);
+                toDispose.push(Disposable.create(() => this.viewClauseContexts.delete(view.id)));
+            }
         }
         toDispose.push(this.quickView?.registerItem({
             label: view.name,


### PR DESCRIPTION
#### What it does
Fixes #8691 

#### How to test
**_Note: This PR is dependent on merging of #9154 as it requires latest monaco typings._**

1. Open a project - i.e. "helloworld sample" from "vscode-extension-samples"
2. Update `extension.ts` to setContext i.e.:
![image](https://user-images.githubusercontent.com/71069170/118639031-24081980-b7e0-11eb-970c-e8fe2d60e276.png)

3. Add to sample `package.json` - menus dependent on context key:
![image](https://user-images.githubusercontent.com/71069170/118639197-4d28aa00-b7e0-11eb-87fa-5a960b0a7c97.png)

4. Run as hosted plugin
5. Run command "extension.helloWorld" from command palette
6. Right click on "src" folder and see that "Hello World" command is added to opened context menu:
![image](https://user-images.githubusercontent.com/71069170/118639451-9973ea00-b7e0-11eb-8df5-df8dfcfd9e36.png)
7. Right-clicking on file and not folder - doesn't display "Hello World" command in context menu:
![image](https://user-images.githubusercontent.com/71069170/118639557-b7d9e580-b7e0-11eb-9934-0966875f6996.png)


#### Review checklist

- [X] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

