### PR TITLE
Increase specificity of Output styles

### DIFF
--- a/packages/output/src/browser/style/output.css
+++ b/packages/output/src/browser/style/output.css
@@ -18,10 +18,10 @@
     height: 100%;
 }
 
-.theia-output-error {
+.theia-output .theia-output-error {
     color: var(--theia-errorForeground);
 }
 
-.theia-output-warning {
+.theia-output .theia-output-warning {
     color: var(--theia-editorWarning-foreground);
 }


### PR DESCRIPTION
Signed-off-by: Gabriel Bodeen <gabriel.bodeen@ericsson.com>

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->
Fixes #9110. 

As noted in a comment on the issue, git-bisect shows the regression was introduced in [this commit](https://github.com/eclipse-theia/theia/commit/d797396c5a2adfcd1180fc5d7c3d61909311bf7d), part of [the PR](https://github.com/eclipse-theia/theia/pull/8010) where `@theia/monaco-editor-core` was upgraded from 0.19.0 to 0.20.0.

The cause is that in the upgraded Monaco, [the editor token colors stylesheet is lazy-loaded](https://github.com/microsoft/monaco-editor/issues/1828) and only attached to the DOM after the first editor is attached. So the CSS classes affecting the output are now loaded in the reverse order to what was originally expected.

The [upstream fix ](https://github.com/microsoft/vscode/commit/bee54638b780288361b8d5e92c3e0561a1d8634f) is included as of v0.21.x, so if a PR [such as this one going to 0.23.x](https://github.com/eclipse-theia/theia/issues/8969) is merged it will resolve the problem.

In the meantime, the immediate problem in the Output package can be resolved simply by increasing the specificity of the CSS selector, and it will not need to be reverted after a Monaco upgrade.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

1. `View > Output` in the menus to open the Output widget if it is not visible. In the dropdown output channel list, select `API Sample: my test channel`.
2. On this branch, you'll see:

![image](https://user-images.githubusercontent.com/20653241/118730077-9dae0080-b7fc-11eb-97f6-b1f0bcb0e1e4.png)

3. Versus `master` where you'll currently see:

![image](https://user-images.githubusercontent.com/20653241/118730395-262ca100-b7fd-11eb-9291-da4bb05fe3a0.png)

#### Review checklist

- [X] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

