### PR TITLE
add-resource-dir-name-and-resource-path:

### DIFF
--- a/packages/core/src/browser/resource-context-key.ts
+++ b/packages/core/src/browser/resource-context-key.ts
@@ -34,6 +34,8 @@ export class ResourceContextKey {
     protected resourceFileName: ContextKey<string>;
     protected resourceExtname: ContextKey<string>;
     protected resourceLangId: ContextKey<string>;
+    protected resourceDirName: ContextKey<string>;
+    protected resourcePath: ContextKey<string>;
 
     @postConstruct()
     protected init(): void {
@@ -42,6 +44,8 @@ export class ResourceContextKey {
         this.resourceFileName = this.contextKeyService.createKey<string>('resourceFilename', undefined);
         this.resourceExtname = this.contextKeyService.createKey<string>('resourceExtname', undefined);
         this.resourceLangId = this.contextKeyService.createKey<string>('resourceLangId', undefined);
+        this.resourceDirName = this.contextKeyService.createKey<string>('resourceDirName', undefined);
+        this.resourcePath = this.contextKeyService.createKey<string>('resourcePath', undefined);
     }
 
     get(): URI | undefined {
@@ -55,6 +59,8 @@ export class ResourceContextKey {
         this.resourceFileName.set(resourceUri && resourceUri.path.base);
         this.resourceExtname.set(resourceUri && resourceUri.path.ext);
         this.resourceLangId.set(resourceUri && this.getLanguageId(resourceUri));
+        this.resourceDirName.set(resourceUri && Uri.parse(resourceUri.path.dir.toString()).fsPath);
+        this.resourcePath.set(resourceUri && resourceUri['codeUri'].fsPath);
     }
 
     protected getLanguageId(uri: URI | undefined): string | undefined {
@@ -67,5 +73,4 @@ export class ResourceContextKey {
         }
         return undefined;
     }
-
 }


### PR DESCRIPTION


Signed-off-by: Dan Arad <dan.arad@sap.com>

#### What it does
1. add resourceDirName and resourcePath to contextkeys (see https://code.visualstudio.com/updates/v1_50#_added-new-resource-explorerrelated-context-keys)

#### How to test
1. Either debug resource-context-key.ts in Theia when opening a resource
![image](https://user-images.githubusercontent.com/71069170/118950630-0a430f80-b963-11eb-988b-e113d606db9d.png)

2. Retrieve context or contextkeyvalues
![image](https://user-images.githubusercontent.com/71069170/118950440-dff15200-b962-11eb-8bea-4d0529c41a43.png)


#### Review checklist

- [X] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

