### PR TITLE
9468-showOpenDialog-filter-not-applied-by-default:

### DIFF
--- a/packages/filesystem/src/browser/file-dialog/file-dialog-tree-filters-renderer.tsx
+++ b/packages/filesystem/src/browser/file-dialog/file-dialog-tree-filters-renderer.tsx
@@ -36,14 +36,14 @@ export class FileDialogTreeFilters {
 
 export class FileDialogTreeFiltersRenderer extends ReactRenderer {
 
-    readonly appliedFilters: FileDialogTreeFilters;
+    appliedFilters: FileDialogTreeFilters;
 
     constructor(
         readonly suppliedFilters: FileDialogTreeFilters,
         readonly fileDialogTree: FileDialogTree
     ) {
         super();
-        this.appliedFilters = { 'All Files': [], ...suppliedFilters, };
+        this.applyFilters();
     }
 
     protected readonly handleFilterChanged = (e: React.ChangeEvent<HTMLSelectElement>) => this.onFilterChanged(e);
@@ -73,6 +73,15 @@ export class FileDialogTreeFiltersRenderer extends ReactRenderer {
         e.stopPropagation();
     }
 
+    protected applyFilters(): void {
+        if (this.suppliedFilters && Object.entries(this.suppliedFilters).length > 0) {
+            this.appliedFilters = this.suppliedFilters;
+            this.fileDialogTree.setFilter(Object.entries(this.suppliedFilters)[0][1]);
+        } else {
+            this.appliedFilters = { 'All Files': [] };
+        }
+    }
+
     get locationList(): HTMLSelectElement | undefined {
         const locationList = this.host.getElementsByClassName(FILE_TREE_FILTERS_LIST_CLASS)[0];
         if (locationList instanceof HTMLSelectElement) {
@@ -80,5 +89,4 @@ export class FileDialogTreeFiltersRenderer extends ReactRenderer {
         }
         return undefined;
     }
-
 }

--- a/packages/filesystem/src/electron-browser/file-dialog/electron-file-dialog-service.ts
+++ b/packages/filesystem/src/electron-browser/file-dialog/electron-file-dialog-service.ts
@@ -93,9 +93,11 @@ export class ElectronFileDialogService extends DefaultFileDialogService {
     protected toDialogOptions(uri: URI, props: SaveFileDialogProps | OpenFileDialogProps, dialogTitle: string): electron.FileDialogProps {
         const title = props.title || dialogTitle;
         const defaultPath = FileUri.fsPath(uri);
-        const filters: FileFilter[] = [{ name: 'All Files', extensions: ['*'] }];
+        const filters: FileFilter[] = [];
         if (props.filters) {
             filters.push(...Object.keys(props.filters).map(key => ({ name: key, extensions: props.filters![key] })));
+        } else {
+            filters.push({ name: 'All Files', extensions: ['*'] });
         }
         return { title, defaultPath, filters };
     }


### PR DESCRIPTION
1. When "filters" is not supplied to dialog - "All files" filter is set.
2. When "filters" is supplied to dialog - only supplied "filters" are updated in file filter dropdown (without all files) and first filter is selected and invoked.

Signed-off-by: Dan Arad <dan.arad@sap.com>

#### What it does

Fixes: #9468 
Fixes: #9242

#### How to test
see explanation in #9468

#### Review checklist

- [X] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

