### PR TITLE
3632-plugin-installation-progress-indication

### DIFF
--- a/packages/plugin-ext/src/common/plugin-protocol.ts
+++ b/packages/plugin-ext/src/common/plugin-protocol.ts
@@ -819,8 +819,8 @@ export interface PluginDependencies {
 
 export const PluginDeployerHandler = Symbol('PluginDeployerHandler');
 export interface PluginDeployerHandler {
-    deployFrontendPlugins(frontendPlugins: PluginDeployerEntry[]): Promise<void>;
-    deployBackendPlugins(backendPlugins: PluginDeployerEntry[]): Promise<void>;
+    deployFrontendPlugins(frontendPlugins: PluginDeployerEntry[]): Promise<string[]>;
+    deployBackendPlugins(backendPlugins: PluginDeployerEntry[]): Promise<string[]>;
 
     undeployPlugin(pluginId: string): Promise<boolean>;
 
@@ -874,13 +874,18 @@ export interface PluginServer {
      *
      * @param type whether a plugin is installed by a system or a user, defaults to a user
      */
-    deploy(pluginEntry: string, type?: PluginType): Promise<void>;
+    deploy(pluginEntry: string, type?: PluginType): Promise<DeployResult>;
 
     undeploy(pluginId: string): Promise<void>;
 
     setStorageValue(key: string, value: KeysToAnyValues, kind: PluginStorageKind): Promise<boolean>;
     getStorageValue(key: string, kind: PluginStorageKind): Promise<KeysToAnyValues>;
     getAllStorageValues(kind: PluginStorageKind): Promise<KeysToKeysToAnyValue>;
+}
+
+export interface DeployResult {
+    deployedPluginIds: string[];
+    unresolvedPluginIds: string[];
 }
 
 export const ServerPluginRunner = Symbol('ServerPluginRunner');

--- a/packages/plugin-ext/src/hosted/node/hosted-plugin-deployer-handler.ts
+++ b/packages/plugin-ext/src/hosted/node/hosted-plugin-deployer-handler.ts
@@ -92,33 +92,38 @@ export class HostedPluginDeployerHandler implements PluginDeployerHandler {
         }
     }
 
-    async deployFrontendPlugins(frontendPlugins: PluginDeployerEntry[]): Promise<void> {
+    async deployFrontendPlugins(frontendPlugins: PluginDeployerEntry[]): Promise<string[]> {
+        const deployedPluginIds: string[] = [];
         for (const plugin of frontendPlugins) {
-            await this.deployPlugin(plugin, 'frontend');
+            deployedPluginIds.push(...await this.deployPlugin(plugin, 'frontend'));
         }
         // resolve on first deploy
         this.frontendPluginsMetadataDeferred.resolve(undefined);
+        return deployedPluginIds;
     }
 
-    async deployBackendPlugins(backendPlugins: PluginDeployerEntry[]): Promise<void> {
+    async deployBackendPlugins(backendPlugins: PluginDeployerEntry[]): Promise<string[]> {
+        const deployedPluginIds: string[] = [];
         for (const plugin of backendPlugins) {
-            await this.deployPlugin(plugin, 'backend');
+            deployedPluginIds.push(...await this.deployPlugin(plugin, 'backend'));
         }
         // rebuild translation config after deployment
         this.localizationService.buildTranslationConfig([...this.deployedBackendPlugins.values()]);
         // resolve on first deploy
         this.backendPluginsMetadataDeferred.resolve(undefined);
+        return deployedPluginIds;
     }
 
     /**
      * @throws never! in order to isolate plugin deployment
      */
-    protected async deployPlugin(entry: PluginDeployerEntry, entryPoint: keyof PluginEntryPoint): Promise<void> {
+    protected async deployPlugin(entry: PluginDeployerEntry, entryPoint: keyof PluginEntryPoint): Promise<string[]> {
+        const deployedPluginIds: string[] = [];
         const pluginPath = entry.path();
         try {
             const manifest = await this.reader.readPackage(pluginPath);
             if (!manifest) {
-                return;
+                return [];
             }
 
             const metadata = this.reader.readMetadata(manifest);
@@ -129,7 +134,7 @@ export class HostedPluginDeployerHandler implements PluginDeployerHandler {
 
             const deployedPlugins = entryPoint === 'backend' ? this.deployedBackendPlugins : this.deployedFrontendPlugins;
             if (deployedPlugins.has(metadata.model.id)) {
-                return;
+                return [];
             }
 
             const { type } = entry;
@@ -137,10 +142,12 @@ export class HostedPluginDeployerHandler implements PluginDeployerHandler {
             deployed.contributes = this.reader.readContribution(manifest);
             this.localizationService.deployLocalizations(deployed);
             deployedPlugins.set(metadata.model.id, deployed);
+            deployedPluginIds.push(metadata.model.id);
             this.logger.info(`Deploying ${entryPoint} plugin "${metadata.model.name}@${metadata.model.version}" from "${metadata.model.entryPoint[entryPoint] || pluginPath}"`);
         } catch (e) {
             console.error(`Failed to deploy ${entryPoint} plugin from '${pluginPath}' path`, e);
         }
+        return deployedPluginIds;
     }
 
     async undeployPlugin(pluginId: string): Promise<boolean> {

--- a/packages/plugin-ext/src/main/browser/plugin-frontend-contribution.ts
+++ b/packages/plugin-ext/src/main/browser/plugin-frontend-contribution.ts
@@ -31,7 +31,7 @@ export class PluginApiFrontendContribution implements CommandContribution {
 
     registerCommands(commands: CommandRegistry): void {
 
-        commands.registerCommand(PluginExtDeployCommandService.COMMAND, {
+        commands.registerCommand(PluginExtDeployCommandService.DEPLOY_PLUGIN_BY_ID_COMMAND, {
             execute: () => this.pluginExtDeployCommandService.deploy()
         });
 
@@ -40,5 +40,4 @@ export class PluginApiFrontendContribution implements CommandContribution {
             isVisible: () => false
         });
     }
-
 }

--- a/packages/plugin-ext/src/main/node/plugin-server-handler.ts
+++ b/packages/plugin-ext/src/main/node/plugin-server-handler.ts
@@ -18,7 +18,7 @@ import { injectable, inject } from '@theia/core/shared/inversify';
 import { CancellationToken } from '@theia/core/lib/common/cancellation';
 import { PluginDeployerImpl } from './plugin-deployer-impl';
 import { PluginsKeyValueStorage } from './plugins-key-value-storage';
-import { PluginServer, PluginDeployer, PluginStorageKind, PluginType } from '../../common/plugin-protocol';
+import { PluginServer, PluginDeployer, PluginStorageKind, PluginType, DeployResult } from '../../common/plugin-protocol';
 import { KeysToAnyValues, KeysToKeysToAnyValue } from '../../common/types';
 
 @injectable()
@@ -30,11 +30,11 @@ export class PluginServerHandler implements PluginServer {
     @inject(PluginsKeyValueStorage)
     protected readonly pluginsKeyValueStorage: PluginsKeyValueStorage;
 
-    deploy(pluginEntry: string, arg2?: PluginType | CancellationToken): Promise<void> {
+    deploy(pluginEntry: string, arg2?: PluginType | CancellationToken): Promise<DeployResult> {
         const type = typeof arg2 === 'number' ? arg2 as PluginType : undefined;
         return this.doDeploy(pluginEntry, type);
     }
-    protected doDeploy(pluginEntry: string, type: PluginType = PluginType.User): Promise<void> {
+    protected doDeploy(pluginEntry: string, type: PluginType = PluginType.User): Promise<DeployResult> {
         return this.pluginDeployer.deploy(pluginEntry, type);
     }
 


### PR DESCRIPTION
Added progress notification when deploying plugin by id and notification if deployed successfully or not

Signed-off-by: Dan Arad <dan.arad@sap.com>

#### What it does
Fixes: #3632

#### How to test
1. deploy valid plugin-id: should result is deployed successfully message - i.e.:
start deploy:
![image](https://user-images.githubusercontent.com/71069170/119344233-1818cd80-bca0-11eb-9e20-d63358903778.png)
deploy result:
![image](https://user-images.githubusercontent.com/71069170/119347198-ddb12f80-bca3-11eb-8377-5d3e9bf2335a.png)
(this notification of deploy result is closed after 5 secs automatically)

2. deploy invalid plugin-id:  should result if deploy failure message - i.e.:
start deploy:
![image](https://user-images.githubusercontent.com/71069170/119343923-b8babd80-bc9f-11eb-9255-1a1cc45cc4c2.png)
deploy result:
![image](https://user-images.githubusercontent.com/71069170/119344020-d6882280-bc9f-11eb-95c9-d075927de872.png)
(this notification of deploy result is closed after 5 secs automatically)

#### Review checklist

- [X] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

