### PR TITLE
vsx: remove leftover '.only'

### DIFF
--- a/packages/vsx-registry/src/common/vsx-registry-api.spec.ts
+++ b/packages/vsx-registry/src/common/vsx-registry-api.spec.ts
@@ -155,7 +155,7 @@ describe('VSX Registry API', () => {
 
     });
 
-    describe.only('#isVersionLTE', () => {
+    describe('#isVersionLTE', () => {
 
         it('should determine if v1 is less than or equal to v2', () => {
             expect(api['isVersionLTE']('1.40.0', '1.50.0')).equal(true, 'should be satisfied since v1 is less than v2');


### PR DESCRIPTION
**The commit removes the leftover '.only' from the 'vsx-registry' api test-case**

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->
-It removes the leftover '.only' from the 'vsx-registry' api test-case

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
-Make sure that all the vsx-registry tests can be all executed without problems

#### Review checklist

- [ ] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

