### PR TITLE
[search-in-workspace] Show diff editor only when replacement term is provided

### DIFF
--- a/packages/search-in-workspace/src/browser/search-in-workspace-result-tree-widget.tsx
+++ b/packages/search-in-workspace/src/browser/search-in-workspace-result-tree-widget.tsx
@@ -222,6 +222,10 @@ export class SearchInWorkspaceResultTreeWidget extends TreeWidget {
         this.update();
     }
 
+    get isReplacing(): boolean {
+        return this._replaceTerm !== '' && this._showReplaceButtons;
+    }
+
     get onChange(): Event<Map<string, SearchInWorkspaceRootFolderNode>> {
         return this.changeEmitter.event;
     }
@@ -938,8 +942,8 @@ export class SearchInWorkspaceResultTreeWidget extends TreeWidget {
     }
 
     protected renderMatchLinePart(node: SearchInWorkspaceResultLineNode): React.ReactNode {
-        const replaceTerm = this._replaceTerm !== '' && this._showReplaceButtons ? <span className='replace-term'>{this._replaceTerm}</span> : '';
-        const className = `match${this._showReplaceButtons ? ' strike-through' : ''}`;
+        const replaceTerm = this.isReplacing ? <span className='replace-term'>{this._replaceTerm}</span> : '';
+        const className = `match${this.isReplacing ? ' strike-through' : ''}`;
         const match = typeof node.lineText === 'string' ?
             node.lineText.substr(node.character - 1, node.length)
             : node.lineText.text.substr(node.lineText.character - 1, node.length);
@@ -963,7 +967,7 @@ export class SearchInWorkspaceResultTreeWidget extends TreeWidget {
     protected async doOpen(node: SearchInWorkspaceResultLineNode, preview: boolean = false): Promise<EditorWidget> {
         let fileUri: URI;
         const resultNode = node.parent;
-        if (resultNode && this._showReplaceButtons && preview) {
+        if (resultNode && this.isReplacing && preview) {
             const leftUri = new URI(node.fileUri);
             const rightUri = await this.createReplacePreview(resultNode);
             fileUri = DiffUris.encode(leftUri, rightUri);


### PR DESCRIPTION
Signed-off-by: Gabriel Bodeen <gabriel.bodeen@ericsson.com>

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->
Aligns Theia's search-in-workspace replacement behavior more closely with VS Code's. The latter switches from search mode to search-and-replace mode only when the replacement field is visible and nonempty; currently Theia goes into search-and-replace mode whether the replacement field is filled or not. This behavior was reported by some of our users as confusing.

I'll note that there is one potential advantage to Theia's current behavior, which is making it obvious that the search-and-replace mode has the ability to easily search a term and replace it with nothing (i.e. just remove it). It can still do that in this branch via the replace-all button, but this option is no longer obvious. I think it's an acceptable cost.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

This branch:
1. Open the search-in-workspace widget. Enter search text. Observe the styling.
2. Toggle to show the replace field & buttons. Observe the styling has not changed. If you click one of the lines, it will open a normal editor.
3. Enter a replacement term. Observe the styling changes and now displays the search and replace terms. If you click one of the lines, it will open a diff editor.

![image](https://user-images.githubusercontent.com/20653241/119527619-1dc8ee80-bd46-11eb-8719-63eba69340bc.png)
![image](https://user-images.githubusercontent.com/20653241/119530645-d2fca600-bd48-11eb-8e93-b2b1a2e6be75.png)

Current master:
1. Open the search-in-workspace widget. Enter search text. Observe the styling. If you click one of the lines, it will open a normal editor.
2. Toggle to show the replace field & buttons. Observe the styling changes and now displays the search and replace terms. If you click one of the lines, it will open a diff editor.

#### Review checklist

- [X] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

