### PR TITLE
[api-samples] Use dynamic label api-sample only when activated

### DIFF
--- a/examples/api-samples/src/browser/label/sample-dynamic-label-provider-contribution.ts
+++ b/examples/api-samples/src/browser/label/sample-dynamic-label-provider-contribution.ts
@@ -37,7 +37,7 @@ export class SampleDynamicLabelProviderContribution extends DefaultUriLabelProvi
     }
 
     canHandle(element: object): number {
-        if (element.toString().includes('test')) {
+        if (this.isActive && element.toString().includes('test')) {
             return 30;
         }
         return 0;


### PR DESCRIPTION
Signed-off-by: Gabriel Bodeen <gabriel.bodeen@ericsson.com>

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->
Fixes https://github.com/eclipse-theia/theia/issues/6796. As the comment on the issue says, the problem is caused by the dynamic label example in the api-samples package, so it should only happen in the Theia repo and not products built using Theia. Nevertheless it's undesirable behavior.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

1. Open the search-in-workspace widget & enter search text as well as replacement text. Click one of the elements in the tree to open the diff editor. The editor tab title should be visible.
   * The api sample checks for the presence of the word "test" in the URI, which for a diff editor includes the whole contents of the file after replacement. So for testing this way to work, you must open a diff editor to a file that has the word "test" (case sensitive) in it somewhere, but be sure you don't strip out that word from the diff using the search-and-replace.
2. Use the command palette to activate `Examples: Toggle Dynamically-Changing Labels`. The editor tab title should be replaced with periodically updating numbers. Run the command again, and the original tab title will be restored.

![dynamic-label](https://user-images.githubusercontent.com/20653241/119550271-d8182000-bd5d-11eb-8272-8683fa602b0e.gif)

#### Review checklist

- [X] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

