### PR TITLE
Explicitly sanitize notification content

### DIFF
--- a/packages/messages/package.json
+++ b/packages/messages/package.json
@@ -4,6 +4,8 @@
   "description": "Theia - Messages Extension",
   "dependencies": {
     "@theia/core": "1.13.0",
+    "@types/dompurify": "^2.0.2",
+    "dompurify": "^2.0.11",
     "markdown-it": "^8.4.0",
     "react-perfect-scrollbar": "^1.5.3",
     "ts-md5": "^1.2.2"

--- a/packages/messages/src/browser/notification-component.tsx
+++ b/packages/messages/src/browser/notification-component.tsx
@@ -15,6 +15,7 @@
  ********************************************************************************/
 
 import * as React from '@theia/core/shared/react';
+import * as DOMPurify from 'dompurify';
 import { NotificationManager, Notification } from './notifications-manager';
 
 export interface NotificationComponentProps {
@@ -74,14 +75,17 @@ export class NotificationComponent extends React.Component<NotificationComponent
                 <div className='theia-notification-list-item-content-main'>
                     <div className={`theia-notification-icon theia-notification-icon-${type}`} />
                     <div className='theia-notification-message'>
-                        <span dangerouslySetInnerHTML={{ __html: message }} onClick={this.onMessageClick} />
+                        <span
+                            dangerouslySetInnerHTML={{ __html: DOMPurify.sanitize(message) }} // eslint-disable-line react/no-danger
+                            onClick={this.onMessageClick}
+                        />
                     </div>
                     <ul className='theia-notification-actions'>
                         {expandable && (
                             <li className={collapsed ? 'expand' : 'collapse'} title={collapsed ? 'Expand' : 'Collapse'}
                                 data-message-id={messageId} onClick={this.onToggleExpansion} />
                         )}
-                        { !isProgress && (<li className='clear' title='Clear' data-message-id={messageId} onClick={this.onClear} />)}
+                        {!isProgress && (<li className='clear' title='Clear' data-message-id={messageId} onClick={this.onClear} />)}
                     </ul>
                 </div>
                 {(source || !!actions.length) && (


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

This PR adds explicit local sanitization to the `dangerouslySetInnerHTML` call in the messages package. It's probable that content renderer in that package is properly configured to reject all potentially dangerous HTML, but this makes certain that the markup is sanitized at the point of rendering.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

Signed-off-by: Colin Grant <colin.grant@ericsson.com>