### PR TITLE
[search-in-workspace] Add history to input fields

### DIFF
--- a/packages/search-in-workspace/src/browser/components/search-in-workspace-input.tsx
+++ b/packages/search-in-workspace/src/browser/components/search-in-workspace-input.tsx
@@ -1,0 +1,141 @@
+/********************************************************************************
+ * Copyright (C) 2021 Ericsson and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import * as React from '@theia/core/shared/react';
+import { Key, KeyCode } from '@theia/core/lib/browser';
+import debounce = require('@theia/core/shared/lodash.debounce');
+
+interface HistoryState {
+    history: string[];
+    index: number;
+};
+type InputAttributes = React.InputHTMLAttributes<HTMLInputElement>;
+
+export class SearchInWorkspaceInput extends React.Component<InputAttributes, HistoryState> {
+    static LIMIT = 100;
+
+    private input = React.createRef<HTMLInputElement>();
+
+    constructor(props: InputAttributes) {
+        super(props);
+        this.state = {
+            history: [],
+            index: 0,
+        };
+    }
+
+    setHistory(history: string[]): void {
+        this.setState(prevState => ({
+            ...prevState,
+            history,
+        }));
+    }
+
+    setIndex(index: number): void {
+        const { history } = this.state;
+        this.value = history[index];
+        this.setState(prevState => ({
+            ...prevState,
+            index,
+        }));
+    }
+
+    get value(): string {
+        return this.input.current?.value ?? '';
+    }
+
+    set value(value: string) {
+        if (this.input.current) {
+            this.input.current.value = value;
+        }
+    }
+
+    /**
+     * Handle history navigation without overriding the parent's onKeyDown handler, if any.
+     */
+    protected readonly onKeyDown = (e: React.KeyboardEvent<HTMLInputElement>): void => {
+        if (Key.ARROW_UP.keyCode === KeyCode.createKeyCode(e.nativeEvent).key?.keyCode) {
+            e.preventDefault();
+            this.previousValue();
+        } else if (Key.ARROW_DOWN.keyCode === KeyCode.createKeyCode(e.nativeEvent).key?.keyCode) {
+            e.preventDefault();
+            this.nextValue();
+        }
+        this.props.onKeyDown?.(e);
+    };
+
+    /**
+     * Switch the input's text to the previous value, if any.
+     */
+    previousValue(): void {
+        const { history, index } = this.state;
+        if (!this.value) {
+            this.value = history[index];
+        } else if (index > 0 && index < history.length) {
+            this.setIndex(index - 1);
+        }
+    }
+
+    /**
+     * Switch the input's text to the next value, if any.
+     */
+    nextValue(): void {
+        const { history, index } = this.state;
+        if (index === history.length - 1) {
+            this.value = '';
+        } else if (!this.value) {
+            this.value = history[index];
+        } else if (index >= 0 && index < history.length - 1) {
+            this.setIndex(index + 1);
+        }
+    }
+
+    /**
+     * Handle history collection without overriding the parent's onChange handler, if any.
+     */
+    protected readonly onChange = (e: React.ChangeEvent<HTMLInputElement>): void => {
+        this.addToHistory();
+        this.props.onChange?.(e);
+    };
+
+    /**
+     * Add a nonempty current value to the history, if not already present. (Debounced, 1 second delay.)
+     */
+    readonly addToHistory = debounce(this.doAddToHistory, 1000);
+
+    private doAddToHistory(): void {
+        if (!this.value) {
+            return;
+        }
+        const history = this.state.history
+            .filter(term => term !== this.value)
+            .concat(this.value)
+            .slice(-SearchInWorkspaceInput.LIMIT);
+        this.setHistory(history);
+        this.setIndex(history.length - 1);
+    }
+
+    render(): React.ReactNode {
+        return (
+            <input
+                {...this.props}
+                onKeyDown={this.onKeyDown}
+                onChange={this.onChange}
+                ref={this.input}
+            />
+        );
+    }
+}


### PR DESCRIPTION
Signed-off-by: Gabriel Bodeen <gabriel.bodeen@ericsson.com>

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->
Fixes https://github.com/eclipse-theia/theia/issues/8959.

Some debatable choices:
* VS Code's way of handling histories on input fields involves a pretty significant class hierarchy and detailed API. I don't believe that level of refactoring is justified here yet.
* SIW uses uncontrolled input fields and direct manipulation of the element value, so this component cooperates with that in a way that is somewhat unidiomatic React. As a result this component may not be easily reusable elsewhere. The alternative would be a significant refactor.
* Setting the history is debounced with 1 full second delay on the theory that we should only keep entries when the user waited long enough to look down at the list of results.

Mostly these choices were driven by KISS.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

1. Use the search-in-workspace widget. Search for several different things. All previous behavior should still work, except as regards the up and down arrow keys.
2. The up key now switches the text value of the input field to the previous value, if any. The down key now switches the text value to the next value, if any. The results tree should update. This should work for both the search input and the replace input.

![history](https://user-images.githubusercontent.com/20653241/119879443-df236780-bef0-11eb-82ee-2e86d9531afb.gif)

#### Review checklist

- [X] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

