### PR TITLE
Fix breakpoint expression resizing

### DIFF
--- a/packages/debug/src/browser/editor/debug-breakpoint-widget.tsx
+++ b/packages/debug/src/browser/editor/debug-breakpoint-widget.tsx
@@ -25,6 +25,7 @@ import { MonacoEditorZoneWidget } from '@theia/monaco/lib/browser/monaco-editor-
 import { MonacoEditor } from '@theia/monaco/lib/browser/monaco-editor';
 import { DebugEditor } from './debug-editor';
 import { DebugSourceBreakpoint } from '../model/debug-source-breakpoint';
+import { Dimension } from '@theia/editor/lib/browser';
 
 export type ShowDebugBreakpointOptions = DebugSourceBreakpoint | {
     position: monaco.Position,
@@ -68,6 +69,16 @@ export class DebugBreakpointWidget implements Disposable {
     protected _input: MonacoEditor | undefined;
     get input(): MonacoEditor | undefined {
         return this._input;
+    }
+    // eslint-disable-next-line no-null/no-null
+    set inputSize(dimension: Dimension | null) {
+        if (this._input) {
+            if (dimension) {
+                this._input.setSize(dimension);
+            } else {
+                this._input.resizeToFit();
+            }
+        }
     }
 
     @postConstruct()

--- a/packages/debug/src/browser/editor/debug-editor-model.ts
+++ b/packages/debug/src/browser/editor/debug-editor-model.ts
@@ -105,6 +105,7 @@ export class DebugEditorModel implements Disposable {
             this.editor.getControl().onKeyDown(() => this.hover.hide({ immediate: false })),
             this.editor.getControl().onDidChangeModelContent(() => this.update()),
             this.editor.getControl().getModel()!.onDidChangeDecorations(() => this.updateBreakpoints()),
+            this.editor.onDidResize(e => this.breakpointWidget.inputSize = e),
             this.sessions.onDidChange(() => this.update()),
             this.toDisposeOnUpdate
         ]);

--- a/packages/monaco/src/browser/monaco-editor.ts
+++ b/packages/monaco/src/browser/monaco-editor.ts
@@ -84,6 +84,9 @@ export class MonacoEditor extends MonacoEditorServices implements TextEditor {
     readonly onLanguageChanged = this.onLanguageChangedEmitter.event;
     protected readonly onScrollChangedEmitter = new Emitter<void>();
     readonly onEncodingChanged = this.document.onDidChangeEncoding;
+    // eslint-disable-next-line no-null/no-null
+    protected readonly onResizeEmitter = new Emitter<Dimension | null>();
+    readonly onDidResize = this.onResizeEmitter.event;
 
     readonly documents = new Set<MonacoEditorModel>();
 
@@ -340,10 +343,13 @@ export class MonacoEditor extends MonacoEditorServices implements TextEditor {
 
     resizeToFit(): void {
         this.autoresize();
+        // eslint-disable-next-line no-null/no-null
+        this.onResizeEmitter.fire(null);
     }
 
     setSize(dimension: Dimension): void {
         this.resize(dimension);
+        this.onResizeEmitter.fire(dimension);
     }
 
     protected autoresize(): void {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->
Fixes #9526 by adding a resize handler to the debug-breakpoint-widget's input editor. It also adds a resize emitter on the MonacoEditor so that resize events from a parent Widget can be forwarded when necessary.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
Follow the steps outlined in #9526, and observe that the expression input field *does* resize when the the window is maximized

![good-resizing](https://user-images.githubusercontent.com/62660714/119889097-c8ced900-befb-11eb-800c-9f0eee1b11ef.gif)


#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

