### PR TITLE
WorkspacePreferenceProvider waits for WorkspaceService to be ready

### DIFF
--- a/packages/workspace/src/browser/workspace-service.ts
+++ b/packages/workspace/src/browser/workspace-service.ts
@@ -83,6 +83,11 @@ export class WorkspaceService implements FrontendApplicationContribution {
 
     protected applicationName: string;
 
+    protected _ready = new Deferred<void>();
+    get ready(): Promise<void> {
+        return this._ready.promise;
+    }
+
     @postConstruct()
     protected async init(): Promise<void> {
         this.applicationName = FrontendApplicationConfigProvider.get().applicationName;
@@ -105,6 +110,7 @@ export class WorkspaceService implements FrontendApplicationContribution {
                 this.refreshRootWatchers();
             }
         });
+        this._ready.resolve();
     }
 
     /**
@@ -193,6 +199,7 @@ export class WorkspaceService implements FrontendApplicationContribution {
             const uri = this._workspace.resource;
             if (this._workspace.isFile) {
                 this.toDisposeOnWorkspace.push(this.fileService.watch(uri));
+                this.onWorkspaceLocationChangedEmitter.fire(this._workspace);
             }
             this.setURLFragment(uri.path.toString());
         } else {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->
Fixes #9530 by
 - Adding a `ready` marker to the `WorkspaceService` that resolves when it has completed its `@postConstruct` `init` method.
 - Ensuring that the `WorkspaceService` fires an event when it first determines the location of a workspace file in a multiroot workspace
 - Waiting for the `WorkspaceService` to be ready before declaring the `WorkspacePreferenceProvider` ready
 - Checking for identity of workspace file when creating a new `WorkspaceFilePreferenceProvider` delegate.
 - Not attempting to create a new delegate for the `WorkspacePreferenceProvider` every time the `.delegate` field is accessed.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
1. Start the application without a workspace, in a single-root workspace, and in a multi-root workspace and confirm that no errors are shown.
2. In a single-root and a multi-root workspace, confirm that you can access and set a preference in the Preferences UI.

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

Signed-off-by: Colin Grant <colin.grant@ericsson.com>