### PR TITLE
Implement internationalization support

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -116,6 +116,10 @@
   },
   "theiaExtensions": [
     {
+      "frontend": "lib/browser/i18n/i18n-frontend-module",
+      "backend": "lib/node/i18n/i18n-backend-module"
+    },
+    {
       "frontend": "lib/browser/menu/browser-menu-module",
       "frontendElectron": "lib/electron-browser/menu/electron-menu-module"
     },

--- a/packages/core/src/browser/i18n/i18n-frontend-module.ts
+++ b/packages/core/src/browser/i18n/i18n-frontend-module.ts
@@ -1,0 +1,25 @@
+/********************************************************************************
+ * Copyright (C) 2021 Ericsson and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import { ContainerModule } from 'inversify';
+import { AsyncLocalizationProvider, localizationPath } from '../../common/i18n/localization';
+import { WebSocketConnectionProvider } from '../messaging/ws-connection-provider';
+
+export default new ContainerModule(bind => {
+    bind(AsyncLocalizationProvider).toDynamicValue(
+        ctx => ctx.container.get(WebSocketConnectionProvider).createProxy(localizationPath)
+    ).inSingletonScope();
+});

--- a/packages/core/src/browser/nls.ts
+++ b/packages/core/src/browser/nls.ts
@@ -1,0 +1,65 @@
+/********************************************************************************
+ * Copyright (C) 2021 TypeFox and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import { Localization } from '../common/i18n/localization';
+import { Endpoint } from './endpoint';
+
+let localization: Localization | undefined;
+
+function format(message: string, args: string[]): string {
+    let result = message;
+    if (args.length > 0) {
+        result = message.replace(/\{(\d+)\}/g, (match, rest) => {
+            const index = rest[0];
+            const arg = args[index];
+            let replacement = match;
+            if (typeof arg === 'string') {
+                replacement = arg;
+            } else if (typeof arg === 'number' || typeof arg === 'boolean' || !arg) {
+                replacement = String(arg);
+            }
+            return replacement;
+        });
+    }
+    return result;
+}
+
+export namespace nls {
+
+    export const localeId = 'localeId';
+
+    export const locale = typeof window === 'object' && window && window.localStorage.getItem('localeId') || undefined;
+
+    export function localize(key: string, defaultValue: string, ...args: string[]): string {
+        let value = defaultValue;
+        if (localization) {
+            const translation = localization.translations[key];
+            if (translation) {
+                // vscode's localizations often contain additional '&&' symbols, which we simply ignore
+                value = translation.replace(/&&/g, '');
+            }
+        }
+        return format(value, args);
+    }
+}
+
+export async function loadTranslations(): Promise<void> {
+    if (nls.locale) {
+        const endpoint = new Endpoint({ path: '/i18n/' + nls.locale }).getRestUrl().toString();
+        const response = await fetch(endpoint);
+        localization = await response.json();
+    }
+}

--- a/packages/core/src/browser/quick-input/quick-command-service.ts
+++ b/packages/core/src/browser/quick-input/quick-command-service.ts
@@ -102,8 +102,16 @@ export class QuickCommandService implements QuickAccessContribution, QuickAccess
         const iconClasses = this.getItemIconClasses(command);
         const activeElement = window.document.activeElement as HTMLElement;
 
+        const originalLabel = command.originalLabel || command.label!;
+        const originalCategory = command.originalCategory || command.category;
+        let detail: string | undefined = originalCategory ? `${originalCategory}: ${originalLabel}` : originalLabel;
+        if (label === detail) {
+            detail = undefined;
+        }
+
         return {
             label,
+            detail,
             iconClasses,
             alwaysShow: !!this.commandRegistry.getActiveHandler(command.id),
             keySequence: this.getKeybinding(command),

--- a/packages/core/src/common/command.ts
+++ b/packages/core/src/common/command.ts
@@ -18,6 +18,7 @@ import { injectable, inject, named } from 'inversify';
 import { Event, Emitter, WaitUntilEvent } from './event';
 import { Disposable, DisposableCollection } from './disposable';
 import { ContributionProvider } from './contribution-provider';
+import { nls } from '../browser/nls';
 
 /**
  * A command is a unique identifier of a function
@@ -33,6 +34,7 @@ export interface Command {
      * A label of this command.
      */
     label?: string;
+    originalLabel?: string;
     /**
      * An icon class of this command.
      */
@@ -41,6 +43,7 @@ export interface Command {
      * A category of this command.
      */
     category?: string;
+    originalCategory?: string;
 }
 
 export namespace Command {
@@ -48,6 +51,17 @@ export namespace Command {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     export function is(arg: Command | any): arg is Command {
         return !!arg && arg === Object(arg) && 'id' in arg;
+    }
+
+    /** Utility function to easily translate commands */
+    export function toLocalizedCommand(command: Command, nlsLabelKey: string = command.id, nlsCategoryKey?: string): Command {
+        return {
+            ...command,
+            label: command.label && nls.localize(nlsLabelKey, command.label),
+            originalLabel: command.label,
+            category: nlsCategoryKey && command.category && nls.localize(nlsCategoryKey, command.category) || command.category,
+            originalCategory: command.category,
+        };
     }
 
     /** Comparator function for when sorting commands */

--- a/packages/core/src/common/i18n/localization.ts
+++ b/packages/core/src/common/i18n/localization.ts
@@ -1,0 +1,33 @@
+/********************************************************************************
+ * Copyright (C) 2021 TypeFox and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+export const localizationPath = '/services/i18n';
+
+export const AsyncLocalizationProvider = Symbol('AsyncLocalizationProvider');
+export interface AsyncLocalizationProvider {
+    getCurrentLanguage(): Promise<string>
+    setCurrentLanguage(languageId: string): Promise<void>
+    getAvailableLanguages(): Promise<string[]>
+    loadLocalization(languageId: string): Promise<Localization>
+}
+
+export interface Localization {
+    languageId: string;
+    languageName?: string;
+    languagePack?: boolean;
+    localizedLanguageName?: string;
+    translations: { [key: string]: string };
+}

--- a/packages/core/src/node/i18n/i18n-backend-module.ts
+++ b/packages/core/src/node/i18n/i18n-backend-module.ts
@@ -1,0 +1,36 @@
+/********************************************************************************
+ * Copyright (C) 2021 Ericsson and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import { ContainerModule } from 'inversify';
+import { localizationPath } from '../../common/i18n/localization';
+import { LocalizationProvider } from './localization-provider';
+import { ConnectionHandler, JsonRpcConnectionHandler, bindContributionProvider } from '../../common';
+import { LocalizationRegistry, LocalizationContribution, TheiaLocalizationContribution } from './localization-contribution';
+import { LocalizationBackendContribution } from './localization-backend-contribution';
+import { BackendApplicationContribution } from '../backend-application';
+
+export default new ContainerModule(bind => {
+    bind(LocalizationProvider).toSelf().inSingletonScope();
+    bind(ConnectionHandler).toDynamicValue(ctx =>
+        new JsonRpcConnectionHandler(localizationPath, () => ctx.container.get(LocalizationProvider))
+    ).inSingletonScope();
+    bind(LocalizationRegistry).toSelf().inSingletonScope();
+    bindContributionProvider(bind, LocalizationContribution);
+    bind(TheiaLocalizationContribution).toSelf().inSingletonScope();
+    bind(LocalizationContribution).toService(TheiaLocalizationContribution);
+    bind(LocalizationBackendContribution).toSelf().inSingletonScope();
+    bind(BackendApplicationContribution).toService(LocalizationBackendContribution);
+});

--- a/packages/core/src/node/i18n/localization-backend-contribution.ts
+++ b/packages/core/src/node/i18n/localization-backend-contribution.ts
@@ -1,0 +1,45 @@
+/********************************************************************************
+ * Copyright (C) 2021 TypeFox and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import * as express from 'express';
+import { inject, injectable } from 'inversify';
+import { BackendApplicationContribution } from '../backend-application';
+import { LocalizationRegistry } from './localization-contribution';
+import { LocalizationProvider } from './localization-provider';
+
+@injectable()
+export class LocalizationBackendContribution implements BackendApplicationContribution {
+
+    @inject(LocalizationRegistry)
+    protected readonly localizationRegistry: LocalizationRegistry;
+
+    @inject(LocalizationProvider)
+    protected readonly localizationProvider: LocalizationProvider;
+
+    async initialize(): Promise<void> {
+        await this.localizationRegistry.initialize();
+    }
+
+    configure(app: express.Application): void {
+        app.get('/i18n/:locale', (req, res) => {
+            let locale = req.params.locale;
+            locale = this.localizationProvider.getAvailableLanguages().includes(locale) && locale || 'en';
+            this.localizationProvider.setCurrentLanguage(locale);
+            res.send(this.localizationProvider.loadLocalization(locale));
+        });
+    }
+
+}

--- a/packages/core/src/node/i18n/localization-contribution.ts
+++ b/packages/core/src/node/i18n/localization-contribution.ts
@@ -1,0 +1,107 @@
+/********************************************************************************
+ * Copyright (C) 2021 TypeFox and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import * as fs from 'fs-extra';
+import { inject, injectable, named } from 'inversify';
+import { ContributionProvider } from '../../common';
+import { Localization } from '../../common/i18n/localization';
+import { LocalizationProvider } from './localization-provider';
+
+export const LocalizationContribution = Symbol('LocalizationContribution');
+
+export interface LocalizationContribution {
+    registerLocalizations(registry: LocalizationRegistry): Promise<void>;
+}
+
+@injectable()
+export class LocalizationRegistry {
+
+    @inject(LocalizationProvider)
+    protected readonly localizationProvider: LocalizationProvider;
+
+    @inject(ContributionProvider) @named(LocalizationContribution)
+    protected readonly contributions: ContributionProvider<LocalizationContribution>;
+
+    async initialize(): Promise<void> {
+        await Promise.all(this.contributions.getContributions().map(
+            contribution => contribution.registerLocalizations(this)
+        ));
+    }
+
+    registerLocalization(localization: Localization): void {
+        this.localizationProvider.addLocalizations(localization);
+    }
+
+    registerLocalizationFromRequire(locale: string, required: unknown): void {
+        const translations = this.flattenTranslations(required);
+        const localization: Localization = {
+            languageId: locale,
+            translations
+        };
+        this.registerLocalization(localization);
+    }
+
+    async registerLocalizationFromFile(localizationPath: string, locale?: string): Promise<void> {
+        if (!locale) {
+            locale = this.identifyLocale(localizationPath);
+        }
+        if (!locale) {
+            throw new Error('Could not determine locale from path.');
+        }
+        const translationJson = await fs.readJson(localizationPath);
+        const translations = this.flattenTranslations(translationJson);
+        const localization: Localization = {
+            languageId: locale,
+            translations
+        };
+        this.registerLocalization(localization);
+    }
+
+    protected flattenTranslations(localization: unknown): Record<string, string> {
+        if (typeof localization === 'object' && localization) {
+            const record: Record<string, string> = {};
+            for (const [key, value] of Object.entries(localization)) {
+                if (typeof value === 'string') {
+                    record[key] = value;
+                } else if (value && typeof value === 'object') {
+                    const flattened = this.flattenTranslations(value);
+                    for (const [flatKey, flatValue] of Object.entries(flattened)) {
+                        record[`${key}/${flatKey}`] = flatValue;
+                    }
+                }
+            }
+            return record;
+        } else {
+            return {};
+        }
+    }
+
+    protected identifyLocale(localizationPath: string): string | undefined {
+        const regex = /nls\.(\w+)\.json$/i;
+        const match = regex.exec(localizationPath);
+        if (match) {
+            return match[1];
+        }
+        return undefined;
+    }
+}
+
+@injectable()
+export class TheiaLocalizationContribution implements LocalizationContribution {
+    async registerLocalizations(registry: LocalizationRegistry): Promise<void> {
+        registry.registerLocalizationFromRequire('de', require('../../../i18n/nls.de.json'));
+    }
+}

--- a/packages/core/src/node/i18n/localization-provider.ts
+++ b/packages/core/src/node/i18n/localization-provider.ts
@@ -1,0 +1,68 @@
+/********************************************************************************
+ * Copyright (C) 2021 TypeFox and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import { injectable } from 'inversify';
+import { Localization } from '../../common/i18n/localization';
+
+@injectable()
+export class LocalizationProvider {
+
+    protected localizations = new Map<string, Localization>();
+    protected currentLanguage = 'en';
+
+    addLocalizations(...localizations: Localization[]): void {
+        for (const localization of localizations) {
+            let merged = this.localizations.get(localization.languageId);
+            if (!merged) {
+                this.localizations.set(localization.languageId, merged = {
+                    languageId: localization.languageId,
+                    languageName: localization.languageName,
+                    localizedLanguageName: localization.localizedLanguageName,
+                    translations: {}
+                });
+            }
+            merged.languagePack = merged.languagePack || localization.languagePack;
+            Object.assign(merged.translations, localization.translations);
+        }
+    }
+
+    setCurrentLanguage(languageId: string): void {
+        this.currentLanguage = languageId;
+    }
+
+    getCurrentLanguage(): string {
+        return this.currentLanguage;
+    }
+
+    getAvailableLanguages(all?: boolean): string[] {
+        const languageIds: string[] = [];
+        for (const localization of this.localizations.values()) {
+            if (all || localization.languagePack) {
+                languageIds.push(localization.languageId);
+            }
+        }
+        return languageIds.sort((a, b) => a.localeCompare(b));
+    }
+
+    loadLocalization(languageId: string): Localization {
+        return this.localizations.get(languageId) ||
+        {
+            languageId,
+            translations: {}
+        };
+    }
+
+}

--- a/packages/debug/src/browser/debug-frontend-application-contribution.ts
+++ b/packages/debug/src/browser/debug-frontend-application-contribution.ts
@@ -65,7 +65,7 @@ export namespace DebugMenus {
 
 export namespace DebugCommands {
 
-    const DEBUG_CATEGORY = 'Debug';
+    export const DEBUG_CATEGORY = 'Debug';
 
     export const START: Command = {
         id: 'workbench.action.debug.start',
@@ -482,9 +482,11 @@ export class DebugFrontendApplicationContribution extends AbstractViewContributi
         super.registerMenus(menus);
         const registerMenuActions = (menuPath: string[], ...commands: Command[]) => {
             for (const [index, command] of commands.entries()) {
+                const label = command.label;
+                const debug = `${DebugCommands.DEBUG_CATEGORY}:`;
                 menus.registerMenuAction(menuPath, {
                     commandId: command.id,
-                    label: command.label && command.label.startsWith('Debug: ') && command.label.slice('Debug: '.length) || command.label,
+                    label: label && label.startsWith(debug) && label.slice(debug.length).trimStart() || label,
                     icon: command.iconClass,
                     order: String.fromCharCode('a'.charCodeAt(0) + index)
                 });

--- a/packages/monaco/src/browser/monaco-loader.ts
+++ b/packages/monaco/src/browser/monaco-loader.ts
@@ -16,13 +16,19 @@
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
+import { nls } from '@theia/core/lib/browser/nls';
+
 export function loadVsRequire(context: any): Promise<any> {
     // Monaco uses a custom amd loader that over-rides node's require.
     // Keep a reference to an original require so we can restore it after executing the amd loader file.
     const originalRequire = context.require;
-
-    return new Promise<any>(resolve =>
-        window.addEventListener('load', () => {
+    return new Promise(resolve => {
+        if (document.readyState === 'loading') {
+            window.addEventListener('load', attachVsLoader, { once: true });
+        } else {
+            attachVsLoader();
+        }
+        function attachVsLoader(): void {
             const vsLoader = document.createElement('script');
             vsLoader.type = 'text/javascript';
             vsLoader.src = './vs/loader.js';
@@ -36,12 +42,21 @@ export function loadVsRequire(context: any): Promise<any> {
                 resolve(amdRequire);
             });
             document.body.appendChild(vsLoader);
-        }, { once: true })
-    );
+        };
+    });
 }
 
 export function loadMonaco(vsRequire: any): Promise<void> {
     return new Promise<void>(resolve => {
+        if (nls.locale && ['de', 'es', 'fr', 'it', 'ja', 'ko', 'ru', 'zh-cn', 'zh-tw'].includes(nls.locale)) {
+            vsRequire.config({
+                'vs/nls': {
+                    availableLanguages: {
+                        '*': nls.locale
+                    }
+                }
+            });
+        }
         vsRequire(['vs/editor/editor.main'], () => {
             vsRequire([
                 'vs/platform/commands/common/commands',

--- a/packages/plugin-ext-vscode/src/node/plugin-vscode-init.ts
+++ b/packages/plugin-ext-vscode/src/node/plugin-vscode-init.ts
@@ -20,8 +20,6 @@ import * as theia from '@theia/plugin';
 import { BackendInitializationFn, PluginAPIFactory, Plugin, emptyPlugin } from '@theia/plugin-ext';
 import { VSCODE_DEFAULT_API_VERSION } from '../common/plugin-vscode-types';
 
-/** Set up en as a default locale for VS Code extensions using vscode-nls */
-process.env['VSCODE_NLS_CONFIG'] = JSON.stringify({ locale: 'en', availableLanguages: {} });
 process.env['VSCODE_PID'] = process.env['THEIA_PARENT_PID'];
 
 const pluginsApiImpl = new Map<string, typeof theia>();

--- a/packages/plugin-ext/src/common/plugin-protocol.ts
+++ b/packages/plugin-ext/src/common/plugin-protocol.ts
@@ -89,6 +89,20 @@ export interface PluginPackageContribution {
     problemPatterns?: PluginProblemPatternContribution[];
     jsonValidation?: PluginJsonValidationContribution[];
     resourceLabelFormatters?: ResourceLabelFormatter[];
+    localizations?: PluginPackageLocalization[];
+}
+
+export interface PluginPackageLocalization {
+    languageId: string;
+    languageName?: string;
+    localizedLanguageName?: string;
+    translations: PluginPackageTranslation[];
+    minimalTranslations?: { [key: string]: string };
+}
+
+export interface PluginPackageTranslation {
+    id: string;
+    path: string;
 }
 
 export interface PluginPackageCustomEditor {
@@ -129,6 +143,7 @@ export interface PluginPackageViewWelcome {
 export interface PluginPackageCommand {
     command: string;
     title: string;
+    original?: string;
     category?: string;
     icon?: string | { light: string; dark: string; };
     enablement?: string;
@@ -513,7 +528,7 @@ export interface PluginContribution {
     viewsContainers?: { [location: string]: ViewContainer[] };
     views?: { [location: string]: View[] };
     viewsWelcome?: ViewWelcome[];
-    commands?: PluginCommand[]
+    commands?: PluginCommand[];
     menus?: { [location: string]: Menu[] };
     submenus?: Submenu[];
     keybindings?: Keybinding[];
@@ -526,6 +541,21 @@ export interface PluginContribution {
     problemMatchers?: ProblemMatcherContribution[];
     problemPatterns?: ProblemPatternContribution[];
     resourceLabelFormatters?: ResourceLabelFormatter[];
+    localizations?: Localization[];
+}
+
+export interface Localization {
+    languageId: string;
+    languageName?: string;
+    localizedLanguageName?: string;
+    translations: Translation[];
+    minimalTranslations?: { [key: string]: string };
+}
+
+export interface Translation {
+    id: string;
+    version: string;
+    contents: { [scope: string]: { [key: string]: string } }
 }
 
 export interface SnippetContribution {
@@ -674,6 +704,7 @@ export interface ViewWelcome {
 export interface PluginCommand {
     command: string;
     title: string;
+    originalTitle?: string;
     category?: string;
     iconUrl?: IconUrl;
     themeIcon?: string;

--- a/packages/plugin-ext/src/hosted/node/hosted-plugin-deployer-handler.ts
+++ b/packages/plugin-ext/src/hosted/node/hosted-plugin-deployer-handler.ts
@@ -17,9 +17,11 @@
 import * as fs from '@theia/core/shared/fs-extra';
 import { injectable, inject } from '@theia/core/shared/inversify';
 import { ILogger } from '@theia/core';
-import { PluginDeployerHandler, PluginDeployerEntry, PluginEntryPoint, DeployedPlugin, PluginDependencies } from '../../common/plugin-protocol';
+import { PluginDeployerHandler, PluginDeployerEntry, PluginEntryPoint, DeployedPlugin, PluginDependencies, Localization } from '../../common/plugin-protocol';
 import { HostedPluginReader } from './plugin-reader';
 import { Deferred } from '@theia/core/lib/common/promise-util';
+import { LocalizationProvider } from '@theia/core/lib/node/i18n/localization-provider';
+import { Localization as TheiaLocalization } from '@theia/core/lib/common/i18n/localization';
 
 @injectable()
 export class HostedPluginDeployerHandler implements PluginDeployerHandler {
@@ -29,6 +31,9 @@ export class HostedPluginDeployerHandler implements PluginDeployerHandler {
 
     @inject(HostedPluginReader)
     private readonly reader: HostedPluginReader;
+
+    @inject(LocalizationProvider)
+    private readonly localizationProvider: LocalizationProvider;
 
     private readonly deployedLocations = new Map<string, Set<string>>();
 
@@ -129,6 +134,9 @@ export class HostedPluginDeployerHandler implements PluginDeployerHandler {
             const { type } = entry;
             const deployed: DeployedPlugin = { metadata, type };
             deployed.contributes = this.reader.readContribution(manifest);
+            if (deployed.contributes?.localizations) {
+                this.localizationProvider.addLocalizations(...buildTheiaLocalizations(deployed.contributes.localizations));
+            }
             deployedPlugins.set(metadata.model.id, deployed);
             this.logger.info(`Deploying ${entryPoint} plugin "${metadata.model.name}@${metadata.model.version}" from "${metadata.model.entryPoint[entryPoint] || pluginPath}"`);
         } catch (e) {
@@ -153,5 +161,35 @@ export class HostedPluginDeployerHandler implements PluginDeployerHandler {
         }
         return true;
     }
+}
 
+function buildTheiaLocalizations(localizations: Localization[]): TheiaLocalization[] {
+    const theiaLocalizations: TheiaLocalization[] = [];
+    for (const localization of localizations) {
+        const theiaLocalization: TheiaLocalization = {
+            languageId: localization.languageId,
+            languageName: localization.languageName,
+            localizedLanguageName: localization.localizedLanguageName,
+            languagePack: true,
+            translations: {}
+        };
+        for (const translation of localization.translations) {
+            for (const [scope, value] of Object.entries(translation.contents)) {
+                for (const [key, item] of Object.entries(value)) {
+                    const translationKey = buildTheiaTranslationKey(translation.id, scope, key);
+                    theiaLocalization.translations[translationKey] = item;
+                }
+            }
+        }
+        theiaLocalizations.push(theiaLocalization);
+    }
+    return theiaLocalizations;
+}
+
+function buildTheiaTranslationKey(pluginId: string, scope: string, key: string): string {
+    const scopeSlashIndex = scope.lastIndexOf('/');
+    if (scopeSlashIndex >= 0) {
+        scope = scope.substring(scopeSlashIndex + 1);
+    }
+    return `${pluginId}/${scope}/${key}`;
 }

--- a/packages/plugin-ext/src/hosted/node/hosted-plugin-process.ts
+++ b/packages/plugin-ext/src/hosted/node/hosted-plugin-process.ts
@@ -23,6 +23,7 @@ import { MessageType } from '../../common/rpc-protocol';
 import { HostedPluginCliContribution } from './hosted-plugin-cli-contribution';
 import * as psTree from 'ps-tree';
 import { Deferred } from '@theia/core/lib/common/promise-util';
+import { LocalizationProvider } from '@theia/core/lib/node/i18n/localization-provider';
 
 export interface IPCConnectionOptions {
     readonly serverName: string;
@@ -54,6 +55,9 @@ export class HostedPluginProcess implements ServerPluginRunner {
 
     @inject(MessageService)
     protected readonly messageService: MessageService;
+
+    @inject(LocalizationProvider)
+    protected readonly localizationProvider: LocalizationProvider;
 
     private childProcess: cp.ChildProcess | undefined;
     private client: HostedPluginClient;
@@ -169,6 +173,9 @@ export class HostedPluginProcess implements ServerPluginRunner {
                 delete env[key];
             }
         }
+        const availableLanguages = ['en', ...this.localizationProvider.getAvailableLanguages()];
+        const locale = this.localizationProvider.getCurrentLanguage();
+        env['VSCODE_NLS_CONFIG'] = JSON.stringify({ locale, availableLanguages });
         // apply external env variables
         this.pluginHostEnvironmentVariables.getContributions().forEach(envVar => envVar.process(env));
         if (this.cli.extensionTestsPath) {

--- a/packages/plugin-ext/src/hosted/node/plugin-manifest-loader.ts
+++ b/packages/plugin-ext/src/hosted/node/plugin-manifest-loader.ts
@@ -21,10 +21,10 @@ import * as fs from '@theia/core/shared/fs-extra';
 
 const NLS_REGEX = /^%([\w\d.-]+)%$/i;
 
-export async function loadManifest(pluginPath: string): Promise<any> {
+export async function loadManifest(pluginPath: string, locale?: string): Promise<any> {
     const [manifest, translations] = await Promise.all([
         fs.readJson(path.join(pluginPath, 'package.json')),
-        loadTranslations(pluginPath)
+        loadTranslations(pluginPath, locale)
     ]);
     // translate vscode builtins, as they are published with a prefix. See https://github.com/theia-ide/vscode-builtin-extensions/blob/master/src/republish.js#L50
     const built_prefix = '@theia/vscode-builtin-';
@@ -36,9 +36,14 @@ export async function loadManifest(pluginPath: string): Promise<any> {
         manifest;
 }
 
-async function loadTranslations(pluginPath: string): Promise<any> {
+async function loadTranslations(pluginPath: string, locale?: string): Promise<any> {
     try {
-        return await fs.readJson(path.join(pluginPath, 'package.nls.json'));
+        const localizedPluginPath = path.join(pluginPath, `package.nls.${locale}.json`);
+        if (await fs.pathExists(localizedPluginPath)) {
+            return await fs.readJson(localizedPluginPath);
+        } else {
+            return await fs.readJson(path.join(pluginPath, 'package.nls.json'));
+        }
     } catch (e) {
         if (e.code !== 'ENOENT') {
             throw e;

--- a/packages/plugin-ext/src/hosted/node/plugin-service.ts
+++ b/packages/plugin-ext/src/hosted/node/plugin-service.ts
@@ -21,6 +21,8 @@ import { ContributionProvider } from '@theia/core';
 import { ExtPluginApiProvider, ExtPluginApi } from '../../common/plugin-ext-api-contribution';
 import { HostedPluginDeployerHandler } from './hosted-plugin-deployer-handler';
 import { PluginDeployerImpl } from '../../main/node/plugin-deployer-impl';
+import { LocalizationProvider } from '@theia/core/lib/node/i18n/localization-provider';
+import { loadManifest } from './plugin-manifest-loader';
 
 @injectable()
 export class HostedPluginServerImpl implements HostedPluginServer {
@@ -32,6 +34,9 @@ export class HostedPluginServerImpl implements HostedPluginServer {
 
     @inject(PluginDeployer)
     protected readonly pluginDeployer: PluginDeployerImpl;
+
+    @inject(LocalizationProvider)
+    protected readonly localizationProvider: LocalizationProvider;
 
     @inject(ContributionProvider)
     @named(Symbol.for(ExtPluginApiProvider))
@@ -85,6 +90,7 @@ export class HostedPluginServerImpl implements HostedPluginServer {
         if (!pluginIds.length) {
             return [];
         }
+        const locale = this.localizationProvider.getCurrentLanguage();
         const plugins = [];
         let extraDeployedPlugins: Map<string, DeployedPlugin> | undefined;
         for (const pluginId of pluginIds) {
@@ -99,7 +105,7 @@ export class HostedPluginServerImpl implements HostedPluginServer {
                 plugin = extraDeployedPlugins.get(pluginId);
             }
             if (plugin) {
-                plugins.push(plugin);
+                plugins.push(await this.localizePlugin(plugin, locale));
             }
         }
         return plugins;
@@ -112,5 +118,35 @@ export class HostedPluginServerImpl implements HostedPluginServer {
 
     getExtPluginAPI(): Promise<ExtPluginApi[]> {
         return Promise.resolve(this.extPluginAPIContributions.getContributions().map(p => p.provideApi()));
+    }
+
+    protected async localizePlugin(plugin: DeployedPlugin, locale: string): Promise<DeployedPlugin> {
+        const packagePath = plugin.metadata.model.packagePath;
+        const translatedManifest = await loadManifest(packagePath, locale);
+        this.mergeContributes(plugin.contributes, translatedManifest.contributes);
+        return plugin;
+    }
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    protected mergeContributes(main: any, other: any): void {
+        if (main && other) {
+            if (Array.isArray(main) && Array.isArray(other)) {
+                for (let i = 0; i < main.length && i < other.length; i++) {
+                    if (typeof main[i] === 'object' && typeof other[i] === 'object') {
+                        this.mergeContributes(main[i], other[i]);
+                    }
+                }
+            } else {
+                for (const [key, value] of Object.entries(main)) {
+                    if (key in other) {
+                        if (typeof value === 'string') {
+                            main[key] = other[key];
+                        } else if (typeof value === 'object' && typeof other[key] === 'object') {
+                            this.mergeContributes(main[key], other[key]);
+                        }
+                    }
+                }
+            }
+        }
     }
 }

--- a/packages/plugin-ext/src/main/browser/plugin-contribution-handler.ts
+++ b/packages/plugin-ext/src/main/browser/plugin-contribution-handler.ts
@@ -357,7 +357,7 @@ export class PluginContributionHandler {
             return Disposable.NULL;
         }
         const toDispose = new DisposableCollection();
-        for (const { iconUrl, themeIcon, command, category, title } of contribution.commands) {
+        for (const { iconUrl, themeIcon, command, category, title, originalTitle } of contribution.commands) {
             const reference = iconUrl && this.style.toIconClass(iconUrl);
             const icon = themeIcon && monaco.theme.ThemeIcon.fromString(themeIcon);
             let iconClass;
@@ -367,7 +367,7 @@ export class PluginContributionHandler {
             } else if (icon) {
                 iconClass = monaco.theme.ThemeIcon.asClassName(icon);
             }
-            toDispose.push(this.registerCommand({ id: command, category, label: title, iconClass }));
+            toDispose.push(this.registerCommand({ id: command, category, label: title, originalLabel: originalTitle, iconClass }));
         }
         return toDispose;
     }


### PR DESCRIPTION
#### What it does

Closes #1327

Adds internationalization support for Theia. The following features are supported:

- [x] Support for [vscode language packs](https://code.visualstudio.com/docs/getstarted/locales) to localize Theia itself.
- [x] Support for localized vscode extensions (both `package.json` and runtime translations via `nls.localize()`)
- [x] Support for custom Theia localizations through a `LocalizationContribution` interface.
- [x] Support for localization of the monaco editor (search widget, context menu and so on).
- [x] Showing the original text under the localized value (for commands).

Things that are out of scope for this PR (and will probably be addressed in another PR):

- Support for vscode language packs to localize other vscode extensions (like the builtins)

#### How it works

1. The `core/browser` package contains a `nls` namespace with a `localize` function similiar to vscode. It accepts a translation key, a default value (usually the original english value) and additional args. The translations are loaded before any other imports so that they are available during load-time of any other code.
2. The backend application loads vscode language packs and Theia's `LocalizationContribution`s and places them in a `LocalizationProvider`. Additionally, the backend exposes a `/i18n/<locale>` HTTP endpoint to retrieve localizations for any locale.
3. The vscode plugin host starts the vscode extension process with the locale that is currently used by the user. This allows vscode extensions to translate themselves.
4. The `monaco-loader.ts` uses the frontend locale as well to configure monaco to use the currently active language.

#### How to test

0. Test that the `Configure display language` command can be invoked but only displays `en` (even though german translations exist in the backend, but no language pack is installed)
1. Download & install the german language pack (v1.50, search for `german` in the Theia extension menu)
2. Download & install [the i18n sample extension in german](https://github.com/eclipse-theia/theia/files/6658579/i18n-sample-0.1.0.zip)
3. Execute the `Hello` and `Bye` command contributed by the i18n sample extension. Those will simply show `Hello` and `Bye` respectively in a notification.
4. Execute the `Configure Display Language` command and choose the german locale `de`.
5. The application will be reloaded (you will maybe have to reload it yourself) and partially translated into german. You will see this in the main menu as well as the workspace and some common commands. *(Test for vscode localization packs)*
6. Execute the `Hallo` (Hello) and `Auf Wiedersehen` (Bye) command, which will now display german text as a notification. *(Test for vscode extensions to correctly localize themselves and for Theia to read the translated `package.json` correctly)*
7. In the context menu of the file explorer, you will see that the `Download` menu item has been replaced with `Herunterladen`. This was done with a german `LocalizationContribution`.
8. (optionally) Replace the `editor.main.nls.de.js` in the `examples/browser/lib/vs/editor` source directory with [this file](https://github.com/eclipse-theia/theia/files/6577192/editor.main.nls.de.zip). Run `gzip -k editor.main.nls.de.js` in that directory. Reloading the Theia application and using `de` locale will now show german translation in the monaco search widget (`Ctrl+F`) as well as in the context menu. *This is a workaround, see below for more information.*

#### Open Issues

* Do we need internationalization support for numbers and dates? - _Will be addressed in a separate PR, if at all_
* How about right to left languages?
* The `@theia/monaco-editor-core` package contains only english translations. Is this done on purpose? Replacing the `nls.*.json` files with the correct translations will translate monaco correctly.
* The translations for the monaco editor rely on the order of certain language pack versions. This isn't an issue for the default languages (like `de`, `it`, `fr`...), but makes it virtually impossible for vscode language packs to actually contribute to monaco's translation process.
* Language Packs can't be uninstalled without restarting the server (all localizations are held in memory after startup), as we don't know which translations are contributed by vscode language packs and which by Theia extensions **yet**.
* Currently the `LocalizationProvider` holds a single active language for the whole application. Is there a way to hold a value for every user?
* How do we handle translations contributed by Theia extensions without having a language pack installed? Selecting the german locale e.g. will just translate Theia's own commands, not the rest.
* Theia's quick-input-bar doesn't filter by the details of the item, unlike vscode. This makes finding commands quite difficult after switching the locale.

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

