### PR TITLE
Don't re-open hidden tree-view after reload

### DIFF
--- a/packages/plugin-ext/src/main/browser/view/plugin-view-widget.ts
+++ b/packages/plugin-ext/src/main/browser/view/plugin-view-widget.ts
@@ -70,13 +70,15 @@ export class PluginViewWidget extends Panel implements StatefulWidget {
         return {
             label: this.title.label,
             message: this.message,
-            widgets: this.widgets
+            widgets: this.widgets,
+            suppressUpdateViewVisibility: this._suppressUpdateViewVisibility
         };
     }
 
     restoreState(state: PluginViewWidget.State): void {
         this.title.label = state.label;
         this.message = state.message;
+        this.suppressUpdateViewVisibility = state.suppressUpdateViewVisibility;
         for (const widget of state.widgets) {
             this.addWidget(widget);
         }
@@ -131,8 +133,9 @@ export class PluginViewWidget extends Panel implements StatefulWidget {
 }
 export namespace PluginViewWidget {
     export interface State {
-        label: string
-        message?: string;
-        widgets: ReadonlyArray<Widget>
+        label: string,
+        message?: string,
+        widgets: ReadonlyArray<Widget>,
+        suppressUpdateViewVisibility: boolean
     }
 }


### PR DESCRIPTION
The PluginViewWidget has a property to suppress visibility updates
from a `when` clause in the case a user specifically requests to hide
it. However when the browser got reloaded, the flag was reset to
default and did not keep the hide request from the user.

This change preserves the flag mentioned above in the PluginViewWidget
state, this state is preserved and then available for use in
`restoreState` where the flag is now updated to the state before the 
browser reloads.

Fixes: #7037 
Signed-off-by: Alvaro Sanchez-Leon <alvaro.sanchez-leon@ericsson.com>

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->
This change preserves the suppress updates flag mentioned above in the PluginViewWidget
state, and then restores it at reload.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
1. Have an extension that contributes a tree-view to the `Explorer` and gets activated by a `when` clause statement e.g [vscode example](https://github.com/microsoft/vscode-extension-samples/tree/main/tree-view-sample), specifically the 'JSON OUTLINE VIEW', you can also reproduce the problem via the NPM extension.
2. Using the master branch, Follow the steps as shown in the following '.gif' to reproduce the problem
![tree-view-reload-not-keeping-hidden](https://user-images.githubusercontent.com/76971376/120363073-bc6ec580-c2d9-11eb-9bf9-4153af3e3055.gif)
3. Apply the fix in this PR and verify that the views can now remain hidden after a browser reload.
4. Verify that views are visible (as per the `when clause`) when opening new work spaces.
5. Make sure the views can be manually re-opened and that the visibility remains after a browser reload
6. Make sure the default behavior returns after the user executes the command `reset workbench layout`.

![npm_hide_reset](https://user-images.githubusercontent.com/76971376/120525564-3cfaf800-c3a6-11eb-8521-a1adb6fda9bf.gif)


#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

