### PR TITLE
Open last seen editor, not last created

### DIFF
--- a/packages/editor/src/browser/editor-manager.ts
+++ b/packages/editor/src/browser/editor-manager.ts
@@ -64,8 +64,6 @@ export class EditorManager extends NavigatableWidgetOpenHandler<EditorWidget> {
             widget.onDidChangeVisibility(() => {
                 if (widget.isVisible) {
                     this.addRecentlyVisible(widget);
-                } else {
-                    this.removeRecentlyVisible(widget);
                 }
                 this.updateCurrentEditor();
             });
@@ -143,7 +141,12 @@ export class EditorManager extends NavigatableWidgetOpenHandler<EditorWidget> {
     }
     protected updateActiveEditor(): void {
         const widget = this.shell.activeWidget;
-        this.setActiveEditor(widget instanceof EditorWidget ? widget : undefined);
+        if (widget instanceof EditorWidget) {
+            this.addRecentlyVisible(widget);
+            this.setActiveEditor(widget);
+        } else {
+            this.setActiveEditor(undefined);
+        }
     }
 
     protected _currentEditor: EditorWidget | undefined;
@@ -278,7 +281,9 @@ export class EditorManager extends NavigatableWidgetOpenHandler<EditorWidget> {
     }
 
     protected getCounterForUri(uri: URI): number | undefined {
-        return this.editorCounters.get(uri.toString());
+        const idWithoutCounter = EditorWidgetFactory.createID(uri);
+        const counterOfMostRecentlyVisibleEditor = this.recentlyVisibleIds.find(id => id.startsWith(idWithoutCounter))?.slice(idWithoutCounter.length + 1);
+        return counterOfMostRecentlyVisibleEditor === undefined ? undefined : parseInt(counterOfMostRecentlyVisibleEditor);
     }
 
     protected getOrCreateCounterForUri(uri: URI): number {

--- a/packages/editor/src/browser/editor-widget-factory.ts
+++ b/packages/editor/src/browser/editor-widget-factory.ts
@@ -24,6 +24,12 @@ import { TextEditorProvider } from './editor';
 @injectable()
 export class EditorWidgetFactory implements WidgetFactory {
 
+    static createID(uri: URI, counter?: number): string {
+        return EditorWidgetFactory.ID
+            + `:${uri.toString()}`
+            + (counter !== undefined ? `:${counter}` : '');
+    }
+
     static ID = 'code-editor-opener';
 
     readonly id = EditorWidgetFactory.ID;
@@ -54,10 +60,8 @@ export class EditorWidgetFactory implements WidgetFactory {
         });
         newEditor.onDispose(() => labelListener.dispose());
 
-        newEditor.id = this.id + ':' + uri.toString();
-        if (options?.counter !== undefined) {
-            newEditor.id += `:${options.counter}`;
-        }
+        newEditor.id = EditorWidgetFactory.createID(uri, options?.counter);
+
         newEditor.title.closable = true;
         return newEditor;
     }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->
Fixes #9475 by changing the method by which the counter is found in `EditorWidgetManager.getCounterForUri`. Formerly, the largest existing counter was returned (most-recently opened editor), now the first entry for the widget in the array of `recentlyVisibleIds` is returned, instead.

This also required some modification of the logic for handling the `recentlyVisibleIds`. Previously, a widget would be removed as soon as it was no longer visible. Now the widget is removed only if it is disposed of. In addition, widgets are moved to the front of the line on activation, not only `onVisibilityChanged`.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
1. Open a file (henceforth 'File A') in a full editor (not editor preview).
2. Then open another copy of the file to the side (<kbd>ctrl + \\</kbd>) or through the command palette.
3. Open two new editors and put them in the tabbars with the existing editor widgets so that neither of the editors for File A is visible.
4. Click on the file node for File A in the navigator.
5. Whichever copy of File A was last visible / active should be revealed.
6. Try activating / hiding the editors for File A in different orders, and check that (5) still holds.

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

Signed-off-by: Colin Grant <colin.grant@ericsson.com>