### PR TITLE
Track index in Pref Tree to facilitate automatic scrolling

### DIFF
--- a/packages/preferences/src/browser/views/preference-tree-widget.tsx
+++ b/packages/preferences/src/browser/views/preference-tree-widget.tsx
@@ -54,9 +54,10 @@ export class PreferencesTreeWidget extends TreeWidget {
 
     doUpdateRows(): void {
         this.rows = new Map();
+        let index = 0;
         for (const [id, nodeRow] of this.model.currentRows.entries()) {
             if (nodeRow.visibleChildren > 0 && (ExpandableTreeNode.is(nodeRow.node) || ExpandableTreeNode.isExpanded(nodeRow.node.parent))) {
-                this.rows.set(id, nodeRow);
+                this.rows.set(id, { ...nodeRow, index: index++ });
             }
         }
         this.updateScrollToRow();


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

Fixes #9532 by tracking the index in the tree rather than using the index from the model. Previously, the index used for automatic scrolling didn't match any node in the TreeWidget's display.

Some additional cleanup of the filtering process is possible, but I prefer to defer that to a separate PR after #9439 is merged.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
1. Expand nodes in the Preference UI tree so that the next expansion could push the node up out of view. (see GIF in #9532).
2. Expand a node.
3. Observe that it is *not* pushed out of view.


#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

