### PR TITLE
No dialog if multiple editors

### DIFF
--- a/packages/editor/src/browser/editor-frontend-module.ts
+++ b/packages/editor/src/browser/editor-frontend-module.ts
@@ -34,6 +34,8 @@ import { NavigationLocationService } from './navigation/navigation-location-serv
 import { NavigationLocationSimilarity } from './navigation/navigation-location-similarity';
 import { EditorVariableContribution } from './editor-variable-contribution';
 import { EditorQuickOpenService } from './editor-quick-open-service';
+import { EditorWidgetFactoryFunction, EditorWidget } from './editor-widget';
+import { TextEditor } from './editor';
 
 export default new ContainerModule(bind => {
     bindEditorPreferences(bind);
@@ -77,4 +79,10 @@ export default new ContainerModule(bind => {
     bind(ActiveEditorAccess).toSelf().inSingletonScope();
     bind(EditorAccess).to(CurrentEditorAccess).inSingletonScope().whenTargetNamed(EditorAccess.CURRENT);
     bind(EditorAccess).to(ActiveEditorAccess).inSingletonScope().whenTargetNamed(EditorAccess.ACTIVE);
+
+    bind(EditorWidgetFactoryFunction).toFactory(({ container }) => editor => {
+        const child = container.createChild();
+        child.bind(TextEditor).toConstantValue(editor);
+        return child.resolve(EditorWidget);
+    });
 });

--- a/packages/editor/src/browser/editor-widget-factory.ts
+++ b/packages/editor/src/browser/editor-widget-factory.ts
@@ -18,7 +18,7 @@ import { injectable, inject, } from '@theia/core/shared/inversify';
 import URI from '@theia/core/lib/common/uri';
 import { SelectionService } from '@theia/core/lib/common';
 import { NavigatableWidgetOptions, WidgetFactory, LabelProvider } from '@theia/core/lib/browser';
-import { EditorWidget } from './editor-widget';
+import { EditorWidget, EditorWidgetFactoryFunction } from './editor-widget';
 import { TextEditorProvider } from './editor';
 
 @injectable()
@@ -43,6 +43,9 @@ export class EditorWidgetFactory implements WidgetFactory {
     @inject(SelectionService)
     protected readonly selectionService: SelectionService;
 
+    @inject(EditorWidgetFactoryFunction)
+    protected readonly editorFactory: EditorWidgetFactoryFunction;
+
     createWidget(options: NavigatableWidgetOptions): Promise<EditorWidget> {
         const uri = new URI(options.uri);
         return this.createEditor(uri, options);
@@ -50,7 +53,7 @@ export class EditorWidgetFactory implements WidgetFactory {
 
     protected async createEditor(uri: URI, options?: NavigatableWidgetOptions): Promise<EditorWidget> {
         const textEditor = await this.editorProvider(uri);
-        const newEditor = new EditorWidget(textEditor, this.selectionService);
+        const newEditor = this.editorFactory(textEditor);
 
         this.setLabels(newEditor, uri);
         const labelListener = this.labelProvider.onDidChange(event => {

--- a/packages/editor/src/browser/editor.ts
+++ b/packages/editor/src/browser/editor.ts
@@ -195,6 +195,7 @@ export interface FindMatch {
     readonly range: Range;
 }
 
+export const TextEditor = Symbol('TextEditor');
 export interface TextEditor extends Disposable, TextEditorSelection, Navigatable {
     readonly node: HTMLElement;
 

--- a/packages/output/src/browser/output-widget.ts
+++ b/packages/output/src/browser/output-widget.ts
@@ -18,7 +18,7 @@ import '../../src/browser/style/output.css';
 import { inject, injectable, postConstruct } from '@theia/core/shared/inversify';
 import { toArray } from '@theia/core/shared/@phosphor/algorithm';
 import { IDragEvent } from '@theia/core/shared/@phosphor/dragdrop';
-import { EditorWidget } from '@theia/editor/lib/browser';
+import { EditorWidget, EditorWidgetFactoryFunction } from '@theia/editor/lib/browser';
 import { MonacoEditor } from '@theia/monaco/lib/browser/monaco-editor';
 import { SelectionService } from '@theia/core/lib/common/selection-service';
 import { MonacoEditorProvider } from '@theia/monaco/lib/browser/monaco-editor-provider';
@@ -38,6 +38,9 @@ export class OutputWidget extends BaseWidget implements StatefulWidget {
 
     @inject(MonacoEditorProvider)
     protected readonly editorProvider: MonacoEditorProvider;
+
+    @inject(EditorWidgetFactoryFunction)
+    protected readonly editorFactory: EditorWidgetFactoryFunction;
 
     @inject(OutputChannelManager)
     protected readonly outputChannelManager: OutputChannelManager;
@@ -211,7 +214,7 @@ export class OutputWidget extends BaseWidget implements StatefulWidget {
         }
         const { name } = this.selectedChannel;
         const editor = await this.editorProvider.get(OutputUri.create(name));
-        return new EditorWidget(editor, this.selectionService);
+        return this.editorFactory(editor);
     }
 
     private get editorWidget(): EditorWidget | undefined {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

Fixes #9474 by modifying the functions created by `Saveable.apply` and the interface for `SaveableWidget`. `Saveable.apply` now allows for partial implementations of the `SaveableWidget` interface and will use existing implementations, and the `SaveableWidget` interface now includes a `isSafeToClose` method that widgets can implement if they understand conditions under which it is safe to close without opening a dialog.

This PR also makes the `EditorWidget` `@injectable` and introduces a binding for an `EditorWidgetFactoryFunction`. I believe this his been implemented in a way that should _not_ break existing calls to the constructor.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
1. Open two editors for the same file.
2. Dirty the file.
3. Close one editor.
4. Observe that no dialog is shown asking whether you would like to save.
5. Close the other editor.
6. Observe that a dialog is shown asking whether you would like to save.

#### Review checklist

- [ ] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

Signed-off-by: Colin Grant <colin.grant@ericsson.com>