### PR TITLE
Remove 'All Files' filter if OpenFileDialogProps filters are configured

### DIFF
--- a/packages/filesystem/src/electron-browser/file-dialog/electron-file-dialog-service.ts
+++ b/packages/filesystem/src/electron-browser/file-dialog/electron-file-dialog-service.ts
@@ -93,9 +93,11 @@ export class ElectronFileDialogService extends DefaultFileDialogService {
     protected toDialogOptions(uri: URI, props: SaveFileDialogProps | OpenFileDialogProps, dialogTitle: string): electron.FileDialogProps {
         const title = props.title || dialogTitle;
         const defaultPath = FileUri.fsPath(uri);
-        const filters: FileFilter[] = [{ name: 'All Files', extensions: ['*'] }];
+        const filters: FileFilter[] = [];
         if (props.filters) {
             filters.push(...Object.keys(props.filters).map(key => ({ name: key, extensions: props.filters![key] })));
+        } else {
+            filters.push({ name: 'All Files', extensions: ['*'] });
         }
         return { title, defaultPath, filters };
     }


### PR DESCRIPTION
#### What it does

Fixes #9242 

#### How to test

1. Visit open-vsx.org and download an extension as a `.vsix` file.
2. Open the `extensions` view.
3. Select the `_more_` menu item in the toolbar and execute the `Install from VSIX...` command.
4. In the file dialog, confirm that the file extension filter only has one option of `VSIX Extensions (*.vsix)`.

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

Signed-off-by: Scott Axcell <saxcell@xilinx.com>