### PR TITLE
Add utility to handle profusion of clicks

### DIFF
--- a/packages/core/src/browser/core-preferences.ts
+++ b/packages/core/src/browser/core-preferences.ts
@@ -97,11 +97,19 @@ export const corePreferenceSchema: PreferenceSchema = {
             default: 'code',
             description: 'Whether to interpret keypresses by the `code` of the physical key, or by the `keyCode` provided by the OS.'
         },
+        'application.clickTime': {
+            type: 'number',
+            minimum: 0,
+            default: 500, // This is Windows' default.
+            description: 'The number of milliseconds within which a second click should trigger a double-click action'
+        }
     }
 };
 
 export interface CoreConfiguration {
     'application.confirmExit': 'never' | 'ifRequired' | 'always';
+    'application.clickTime': number;
+    'files.encoding': string
     'keyboard.dispatch': 'code' | 'keyCode';
     'workbench.list.openMode': 'singleClick' | 'doubleClick';
     'workbench.commandPalette.history': number;
@@ -110,7 +118,6 @@ export interface CoreConfiguration {
     'workbench.colorTheme': string;
     'workbench.iconTheme': string | null;
     'workbench.silentNotifications': boolean;
-    'files.encoding': string
     'workbench.tree.renderIndentGuides': 'onHover' | 'none' | 'always';
 }
 

--- a/packages/core/src/browser/frontend-application-module.ts
+++ b/packages/core/src/browser/frontend-application-module.ts
@@ -104,6 +104,7 @@ import {
 } from './quick-input';
 import { QuickAccessContribution } from './quick-input/quick-access';
 import { QuickCommandService } from './quick-input/quick-command-service';
+import { ClickEventHandler, ClickEventHandlerFactory, ClickEventHandlerOptions } from './widgets/event-utils';
 
 export { bindResourceProvider, bindMessageService, bindPreferenceService };
 
@@ -353,4 +354,11 @@ export const frontendApplicationModule = new ContainerModule((bind, unbind, isBo
     bind(CredentialsService).to(CredentialsServiceImpl);
 
     bind(ContributionFilterRegistry).to(ContributionFilterRegistryImpl).inSingletonScope();
+
+    bind(ClickEventHandler).toSelf();
+    bind(ClickEventHandlerFactory).toFactory(({ container }) => (options: ClickEventHandlerOptions) => {
+        const child = container.createChild();
+        child.bind(ClickEventHandlerOptions).toConstantValue(options);
+        return child.get(ClickEventHandler);
+    });
 });

--- a/packages/core/src/browser/tree/tree-widget.tsx
+++ b/packages/core/src/browser/tree/tree-widget.tsx
@@ -891,7 +891,7 @@ export class TreeWidget extends ReactWidget implements StatefulWidget {
             event => this.handleClickEvent(node, event),
             event => this.handleDblClickEvent(node, event),
             // This component can't use invokeSingle because running the handler causes the tree to refresh, replacing the listener and its closure
-            { timeout: 250, invokeSingle: false }
+            { timeout: 250, invokeImmediately: false }
         );
         return {
             className,

--- a/packages/core/src/browser/tree/tree-widget.tsx
+++ b/packages/core/src/browser/tree/tree-widget.tsx
@@ -39,6 +39,7 @@ import { TreeWidgetSelection } from './tree-widget-selection';
 import { MaybePromise } from '../../common/types';
 import { LabelProvider } from '../label-provider';
 import { CorePreferences } from '../core-preferences';
+import { createClickEventHandler } from '../widgets/event-utils';
 
 const debounce = require('lodash.debounce');
 
@@ -886,11 +887,17 @@ export class TreeWidget extends ReactWidget implements StatefulWidget {
     protected createNodeAttributes(node: TreeNode, props: NodeProps): React.Attributes & React.HTMLAttributes<HTMLElement> {
         const className = this.createNodeClassNames(node, props).join(' ');
         const style = this.createNodeStyle(node, props);
+        const clickListener = createClickEventHandler<React.MouseEvent<HTMLElement>>(
+            event => this.handleClickEvent(node, event),
+            event => this.handleDblClickEvent(node, event),
+            // This component can't use invokeSingle because running the handler causes the tree to refresh, replacing the listener and its closure
+            { timeout: 250, invokeSingle: false }
+        );
         return {
             className,
             style,
-            onClick: event => this.handleClickEvent(node, event),
-            onDoubleClick: event => this.handleDblClickEvent(node, event),
+            onClick: clickListener,
+            onDoubleClick: clickListener,
             onContextMenu: event => this.handleContextMenuEvent(node, event)
         };
     }

--- a/packages/core/src/browser/widgets/event-utils.ts
+++ b/packages/core/src/browser/widgets/event-utils.ts
@@ -1,0 +1,70 @@
+/********************************************************************************
+ * Copyright (C) 2021 Ericsson and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+export interface Handler<T> { (stimulus: T): unknown; }
+export const isReactEvent = (event?: object): event is { persist(): unknown } => !!event && 'persist' in event;
+export interface MinimalEvent {
+    type: string;
+    __superseded?: boolean;
+}
+export interface ClickHandlerOptions {
+    /**
+     * Time in milliseconds to wait for a second click.
+     */
+    timeout: number;
+    /**
+     * If true, the single-click handler will be invoked immediately on the first click.
+     */
+    invokeSingle?: boolean;
+}
+
+/**
+ * @returns a single handler that should be applied to be both 'click' and 'dblclick' events for a given element.
+ * If the user clicks once in the interval specified, the single-click handler will be invoked.
+ * If the user clicks twice in the interval, *only* the double-click handler will be invoked.
+ */
+export function createClickEventHandler<T extends MinimalEvent>(
+    singleClickHandler: Handler<T>,
+    doubleClickHandler: Handler<T>,
+    options: ClickHandlerOptions,
+): Handler<T> {
+    const { timeout, invokeSingle } = options;
+    let deferredEvent: T | undefined;
+    return async (event: T): Promise<void> => {
+        if (!deferredEvent && event.type === 'click') {
+            deferredEvent = event;
+            if (isReactEvent(event)) {
+                event.persist();
+            }
+            if (invokeSingle) {
+                singleClickHandler(event);
+            }
+            await new Promise(resolve => setTimeout(resolve, timeout));
+            if (!event.__superseded) { // No double click has cleaned up the old deferred event.
+                deferredEvent = undefined;
+                if (!invokeSingle) { // We haven't run it yet.
+                    singleClickHandler(event);
+                }
+            }
+        } else if (event.type === 'dblclick') {
+            if (deferredEvent) {
+                deferredEvent.__superseded = true;
+                deferredEvent = undefined;
+            }
+            doubleClickHandler(event);
+        }
+    };
+}


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->
This is my proposal for a way to handle the problem of double clicks triggering single-click handlers (twice). It's a bit of a sketch. A fuller implementation might:
[ ] - Hook the delay up to a preference so that the user could configure it. (This would be fairly straightforward)
[ ] - Abstract over more event types than click and double click, if there are others that suffer similar problems (maybe key chords?).

Other thoughts have been expressed and proposals made in #9546, #8735, #8168. This approach has at least these advantages:
 - It's generalizable - anywhere anyone faces this problem (React or regular DOM), they could use this utility 
 - Its configurable - you have some options about whether and when to trigger the single-click handler relative to user action and the double-click handler.

One drawback, noted in the code, is that the `TreeWidget`, where most of the complaints have focused, can't use this code to invoke the single-click handler immediately and then double-click handler once, because invoking the single-click handler triggers a full rerender of the tree, attaching a new listener to the DOM node and so obviating the state stored in the closure around the handler. I've added (in my second commit) an option to call the single-click handler and *then* the double-click handler, if that's desirable.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

1. Open a tree widget of your choice.
2. Interact with nodes via a single click
3. After ca. 250 milliseconds, you should get what you expect from a single click.
4. Interact with nodes via double click faster than 250 ms
5. You should get what you expect from a double click, but not what you expect from a single click
6. Triple clicking in under 250ms should give you double-click + single click.

#### Review checklist

- [ ] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

Signed-off-by: Colin Grant <colin.grant@ericsson.com>