### PR TITLE
vsx-registry: add support for additional queries

### DIFF
--- a/packages/vsx-registry/src/browser/vsx-extensions-contribution.ts
+++ b/packages/vsx-registry/src/browser/vsx-extensions-contribution.ts
@@ -31,7 +31,7 @@ import { LabelProvider, PreferenceService } from '@theia/core/lib/browser';
 import { VscodeCommands } from '@theia/plugin-ext-vscode/lib/browser/plugin-vscode-commands-contribution';
 import { VSXExtensionsContextMenu, VSXExtension } from './vsx-extension';
 import { ClipboardService } from '@theia/core/lib/browser/clipboard-service';
-import { RECOMMENDED_QUERY } from './vsx-extensions-search-model';
+import { BUILTIN_QUERY, INSTALLED_QUERY, RECOMMENDED_QUERY } from './vsx-extensions-search-model';
 import { IGNORE_RECOMMENDATIONS_ID } from './recommended-extensions/recommended-extensions-preference-contribution';
 
 export namespace VSXExtensionsCommands {
@@ -55,6 +55,16 @@ export namespace VSXExtensionsCommands {
     };
     export const COPY_EXTENSION_ID: Command = {
         id: 'vsxExtensions.copyExtensionId'
+    };
+    export const SHOW_BUILTINS: Command = {
+        id: 'vsxExtension.showBuiltins',
+        label: 'Show Built-in Extensions',
+        category: EXTENSIONS_CATEGORY,
+    };
+    export const SHOW_INSTALLED: Command = {
+        id: 'vsxExtension.showInstalled',
+        label: 'Show Installed Extensions',
+        category: EXTENSIONS_CATEGORY,
     };
     export const SHOW_RECOMMENDATIONS: Command = {
         id: 'vsxExtension.showRecommendations',
@@ -119,6 +129,14 @@ export class VSXExtensionsContribution extends AbstractViewContribution<VSXExten
 
         commands.registerCommand(VSXExtensionsCommands.COPY_EXTENSION_ID, {
             execute: (extension: VSXExtension) => this.copyExtensionId(extension)
+        });
+
+        commands.registerCommand(VSXExtensionsCommands.SHOW_BUILTINS, {
+            execute: () => this.showBuiltinExtensions()
+        });
+
+        commands.registerCommand(VSXExtensionsCommands.SHOW_INSTALLED, {
+            execute: () => this.showInstalledExtensions()
         });
 
         commands.registerCommand(VSXExtensionsCommands.SHOW_RECOMMENDATIONS, {
@@ -261,6 +279,16 @@ export class VSXExtensionsContribution extends AbstractViewContribution<VSXExten
                 }
             }
         }
+    }
+
+    protected async showBuiltinExtensions(): Promise<void> {
+        await this.openView({ activate: true });
+        this.model.search.query = BUILTIN_QUERY;
+    }
+
+    protected async showInstalledExtensions(): Promise<void> {
+        await this.openView({ activate: true });
+        this.model.search.query = INSTALLED_QUERY;
     }
 
     protected async showRecommendedExtensions(): Promise<void> {

--- a/packages/vsx-registry/src/browser/vsx-extensions-search-model.ts
+++ b/packages/vsx-registry/src/browser/vsx-extensions-search-model.ts
@@ -21,9 +21,13 @@ export enum VSXSearchMode {
     Initial,
     None,
     Search,
+    Installed,
+    Builtin,
     Recommended,
 }
 
+export const BUILTIN_QUERY = '@builtin';
+export const INSTALLED_QUERY = '@installed';
 export const RECOMMENDED_QUERY = '@recommended';
 
 @injectable()
@@ -32,7 +36,9 @@ export class VSXExtensionsSearchModel {
     protected readonly onDidChangeQueryEmitter = new Emitter<string>();
     readonly onDidChangeQuery = this.onDidChangeQueryEmitter.event;
     protected readonly specialQueries = new Map<string, VSXSearchMode>([
-        [RECOMMENDED_QUERY, VSXSearchMode.Recommended]
+        [BUILTIN_QUERY, VSXSearchMode.Builtin],
+        [INSTALLED_QUERY, VSXSearchMode.Installed],
+        [RECOMMENDED_QUERY, VSXSearchMode.Recommended],
     ]);
 
     protected _query = '';

--- a/packages/vsx-registry/src/browser/vsx-extensions-view-container.ts
+++ b/packages/vsx-registry/src/browser/vsx-extensions-view-container.ts
@@ -117,6 +117,10 @@ export class VSXExtensionsViewContainer extends ViewContainer {
 
     protected getWidgetsForMode(): string[] {
         switch (this.currentMode) {
+            case VSXSearchMode.Builtin:
+                return [generateExtensionWidgetId(VSXExtensionsSourceOptions.BUILT_IN)];
+            case VSXSearchMode.Installed:
+                return [generateExtensionWidgetId(VSXExtensionsSourceOptions.INSTALLED)];
             case VSXSearchMode.Recommended:
                 return [generateExtensionWidgetId(VSXExtensionsSourceOptions.RECOMMENDED)];
             case VSXSearchMode.Search:


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

The pull-request adds support for additional special queries for the `extensions-view`.
The special queries are the following:
- `@builtin`: displays the `builtin` tree-view part with all builtin extensions.
- `@installed`: displays the `installed` tree-view part with all installed extensions.

The change also includes the following commands:
- `Extensions: Show Built-in Extensions`: triggers the `@builtin` query.
- `Extensions: Show Installed Extensions`: triggers the `@installed` query.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

1. start the application, open the extensions-view and install at least one extension
2. execute the command `Extensions: Show Built-in Extensions` and ensure the query is satisfied displaying all builtin extensions.
3. execute the command `Extensions: Show Installed Extensions` and ensure the query is satisfied displaying all installed extensions.

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

Signed-off-by: vince-fugnitto <vincent.fugnitto@ericsson.com>
