### PR TITLE
Fix search debounce in search-in-workspace widget

### DIFF
--- a/packages/search-in-workspace/src/browser/search-in-workspace-widget.tsx
+++ b/packages/search-in-workspace/src/browser/search-in-workspace-widget.tsx
@@ -383,12 +383,14 @@ export class SearchInWorkspaceWidget extends BaseWidget implements StatefulWidge
         this.doBlurSearchFieldContainer();
     }
 
+    private _searchTimeout: NodeJS.Timeout;
     protected readonly search = (e: React.KeyboardEvent) => {
         e.persist();
         const searchOnType = this.searchInWorkspacePreferences['search.searchOnType'];
         if (searchOnType) {
-            const delay = searchOnType ? this.searchInWorkspacePreferences['search.searchOnTypeDebouncePeriod'] : 0;
-            setTimeout(() => this.doSearch(e), delay);
+            const delay = this.searchInWorkspacePreferences['search.searchOnTypeDebouncePeriod'] || 0;
+            clearTimeout(this._searchTimeout);
+            this._searchTimeout = setTimeout(() => this.doSearch(e), delay);
         }
     };
 

--- a/packages/search-in-workspace/src/browser/search-in-workspace-widget.tsx
+++ b/packages/search-in-workspace/src/browser/search-in-workspace-widget.tsx
@@ -383,14 +383,14 @@ export class SearchInWorkspaceWidget extends BaseWidget implements StatefulWidge
         this.doBlurSearchFieldContainer();
     }
 
-    private _searchTimeout: NodeJS.Timeout;
+    private _searchTimeout: number;
     protected readonly search = (e: React.KeyboardEvent) => {
         e.persist();
         const searchOnType = this.searchInWorkspacePreferences['search.searchOnType'];
         if (searchOnType) {
             const delay = this.searchInWorkspacePreferences['search.searchOnTypeDebouncePeriod'] || 0;
-            clearTimeout(this._searchTimeout);
-            this._searchTimeout = setTimeout(() => this.doSearch(e), delay);
+            window.clearTimeout(this._searchTimeout);
+            this._searchTimeout = window.setTimeout(() => this.doSearch(e), delay);
         }
     };
 


### PR DESCRIPTION
Signed-off-by: Gabriel Bodeen <gabriel.bodeen@ericsson.com>

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does

The `search` method of `SearchInWorkspaceWidget` references a debounce period but actually searches on every keyup with a delay. This PR adds a `clearTimeout` to debounce as intended.

<!-- Include relevant issues and describe how they are addressed. -->

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

The diff is very simple, but one way to confirm via testing is to add a logging statement to the setTimeout callback. Then you can observe the logs occurring on every keyup on `master` but debounced on this branch.

#### Review checklist

- [X] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

