### PR TITLE
5876-align-outline-expansion-with-vscode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 <a name="breaking_changes_1.15.0">[Breaking Changes:](#breaking_changes_1.15.0)</a>
 
 - [editor-preview] `EditorPreviewWidget` now extends `EditorWidget` and `EditorPreviewManager` extends and overrides `EditorManager`. `instanceof` checks can no longer distinguish between preview and non-preview editors; use `.isPreview` field instead. [#9518](https://github.com/eclipse-theia/theia/pull/9517)
+- [core] `outline-view-tree.ts` has been renamed to `outline-view-tree-model.ts` to match class name. [#9583](https://github.com/eclipse-theia/theia/pull/9583)
 
 ## v1.14.0 - 5/27/2021
 

--- a/packages/core/src/browser/tree/tree-widget.tsx
+++ b/packages/core/src/browser/tree/tree-widget.tsx
@@ -537,8 +537,10 @@ export class TreeWidget extends ReactWidget implements StatefulWidget {
         const nodeId = event.currentTarget.getAttribute('data-node-id');
         if (nodeId) {
             const node = this.model.getNode(nodeId);
-            if (this.props.expandOnlyOnExpansionToggleClick) {
-                this.handleExpansionToggleClickEvent(node, event);
+            if (node && this.props.expandOnlyOnExpansionToggleClick) {
+                if (this.isExpandable(node) && !this.hasShiftMask(event) && !this.hasCtrlCmdMask(event)) {
+                    this.model.toggleNodeExpansion(node);
+                }
             } else {
                 this.handleClickEvent(node, event);
             }
@@ -1134,9 +1136,9 @@ export class TreeWidget extends ReactWidget implements StatefulWidget {
      */
     protected handleClickEvent(node: TreeNode | undefined, event: React.MouseEvent<HTMLElement>): void {
         if (node) {
+            const shiftMask = this.hasShiftMask(event);
+            const ctrlCmdMask = this.hasCtrlCmdMask(event);
             if (!!this.props.multiSelect) {
-                const shiftMask = this.hasShiftMask(event);
-                const ctrlCmdMask = this.hasCtrlCmdMask(event);
                 if (SelectableTreeNode.is(node)) {
                     if (shiftMask) {
                         this.model.selectRange(node);
@@ -1146,19 +1148,14 @@ export class TreeWidget extends ReactWidget implements StatefulWidget {
                         this.model.selectNode(node);
                     }
                 }
-                if (!this.props.expandOnlyOnExpansionToggleClick) {
-                    if (this.isExpandable(node) && !shiftMask && !ctrlCmdMask) {
-                        this.model.toggleNodeExpansion(node);
-                    }
-                }
             } else {
                 if (SelectableTreeNode.is(node)) {
                     this.model.selectNode(node);
                 }
-                if (!this.props.expandOnlyOnExpansionToggleClick) {
-                    if (this.isExpandable(node) && !this.hasCtrlCmdMask(event) && !this.hasShiftMask(event)) {
-                        this.model.toggleNodeExpansion(node);
-                    }
+            }
+            if (!this.props.expandOnlyOnExpansionToggleClick) {
+                if (this.isExpandable(node) && !shiftMask && !ctrlCmdMask) {
+                    this.model.toggleNodeExpansion(node);
                 }
             }
             event.stopPropagation();
@@ -1204,28 +1201,6 @@ export class TreeWidget extends ReactWidget implements StatefulWidget {
         }
         event.stopPropagation();
         event.preventDefault();
-    }
-
-    /**
-     * Handle the single-click mouse event on the expansion toggle.
-     * @param node the tree node if available.
-     * @param event the mouse single-click event.
-     */
-    protected handleExpansionToggleClickEvent(node: TreeNode | undefined, event: React.MouseEvent<HTMLElement>): void {
-        if (node) {
-            if (!!this.props.multiSelect) {
-                const shiftMask = this.hasShiftMask(event);
-                const ctrlCmdMask = this.hasCtrlCmdMask(event);
-                if (this.isExpandable(node) && !shiftMask && !ctrlCmdMask) {
-                    this.model.toggleNodeExpansion(node);
-                }
-            } else {
-                if (this.isExpandable(node) && !this.hasCtrlCmdMask(event) && !this.hasShiftMask(event)) {
-                    this.model.toggleNodeExpansion(node);
-                }
-            }
-            event.stopPropagation();
-        }
     }
 
     /**

--- a/packages/outline-view/src/browser/outline-view-frontend-module.ts
+++ b/packages/outline-view/src/browser/outline-view-frontend-module.ts
@@ -34,7 +34,7 @@ import { OutlineViewWidgetFactory, OutlineViewWidget } from './outline-view-widg
 import '../../src/browser/styles/index.css';
 import { bindContributionProvider } from '@theia/core/lib/common/contribution-provider';
 import { OutlineDecoratorService, OutlineTreeDecorator } from './outline-decorator-service';
-import { OutlineViewTreeModel } from './outline-view-tree';
+import { OutlineViewTreeModel } from './outline-view-tree-model';
 
 export default new ContainerModule(bind => {
     bind(OutlineViewWidgetFactory).toFactory(ctx =>
@@ -61,7 +61,7 @@ export default new ContainerModule(bind => {
 function createOutlineViewWidget(parent: interfaces.Container): OutlineViewWidget {
     const child = createTreeContainer(parent);
 
-    child.rebind(TreeProps).toConstantValue({ ...defaultTreeProps, search: true });
+    child.rebind(TreeProps).toConstantValue({ ...defaultTreeProps, expandOnlyOnExpansionToggleClick: true, search: true });
 
     child.unbind(TreeWidget);
     child.bind(OutlineViewWidget).toSelf();

--- a/packages/outline-view/src/browser/outline-view-tree-model.ts
+++ b/packages/outline-view/src/browser/outline-view-tree-model.ts
@@ -15,7 +15,7 @@
  ********************************************************************************/
 
 import { injectable, inject } from '@theia/core/shared/inversify';
-import { CompositeTreeNode, TreeModelImpl, TreeExpansionService, ExpandableTreeNode } from '@theia/core/lib/browser';
+import { CompositeTreeNode, TreeModelImpl, TreeExpansionService, ExpandableTreeNode, TreeNode } from '@theia/core/lib/browser';
 
 @injectable()
 export class OutlineViewTreeModel extends TreeModelImpl {
@@ -38,5 +38,15 @@ export class OutlineViewTreeModel extends TreeModelImpl {
             return this.expansionService.collapseAll(node);
         }
         return false;
+    }
+
+    /**
+     * The default behavior of `doOpenNode` is to toggle the expansion of the node.
+     * Override this behavior in order to prevent expansion, but allow for the
+     * `onOpenNode` event to still fire on a double-click event.
+     * @param node the expandable tree node.
+     */
+    protected doOpenNode(node: TreeNode): void {
+        // no-op
     }
 }

--- a/packages/outline-view/src/browser/outline-view-tree-model.ts
+++ b/packages/outline-view/src/browser/outline-view-tree-model.ts
@@ -41,12 +41,14 @@ export class OutlineViewTreeModel extends TreeModelImpl {
     }
 
     /**
-     * The default behavior of `doOpenNode` is to toggle the expansion of the node.
-     * Override this behavior in order to prevent expansion, but allow for the
-     * `onOpenNode` event to still fire on a double-click event.
-     * @param node the expandable tree node.
+     * The default behavior of `openNode` calls `doOpenNode` which by default
+     * toggles the expansion of the node. Overriding to prevent expansion, but
+     * allow for the `onOpenNode` event to still fire on a double-click event.
      */
-    protected doOpenNode(node: TreeNode): void {
-        // no-op
+    openNode(raw?: TreeNode | undefined): void {
+        const node = raw || this.selectedNodes[0];
+        if (node) {
+            this.onOpenNodeEmitter.fire(node);
+        }
     }
 }

--- a/packages/outline-view/src/browser/outline-view-widget.tsx
+++ b/packages/outline-view/src/browser/outline-view-widget.tsx
@@ -25,7 +25,7 @@ import {
     TreeModel,
     ExpandableTreeNode
 } from '@theia/core/lib/browser';
-import { OutlineViewTreeModel } from './outline-view-tree';
+import { OutlineViewTreeModel } from './outline-view-tree-model';
 import { Message } from '@theia/core/shared/@phosphor/messaging';
 import { Emitter } from '@theia/core';
 import { CompositeTreeNode } from '@theia/core/lib/browser';


### PR DESCRIPTION
#### What it does

Fixes https://github.com/eclipse-theia/theia/issues/5876 by aligning the node expand/collapse behavior of the `outline-view-widget` with VS Code. Previously, the behavior of the `outline-view-widget` matched the default behavior of a `tree-widget`.

The `tree-widget` now has an optional `expandOnlyOnExpansionToggleClick` prop that will separate the expand/collapse and selection behavior on an expandable node. When this prop is true, expand/collapse of a node will only occur when the expansion toggle is selected.

Rename outline-view-tree.ts to outline-view-tree-model.ts to match class name.

#### How to test

1. Open a file that will have expandable nodes in the outline.
2. Open the outline.
3. Expanding and collapsing of an expandable node should only occur when the expansion toggle is clicked and not when any other part of the node is clicked.

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

Signed-off-by: Scott Axcell <scott.axcell@xilinx.com>