### PR TITLE
Check visible leaves for all change types

### DIFF
--- a/packages/preferences/src/browser/preference-tree-model.ts
+++ b/packages/preferences/src/browser/preference-tree-model.ts
@@ -100,6 +100,9 @@ export class PreferenceTreeModel extends TreeModelImpl {
         this.toDispose.pushAll([
             this.treeGenerator.onSchemaChanged(newTree => {
                 this.root = newTree;
+                if (this.isFiltered) {
+                    this.expandAll();
+                }
                 this.updateFilteredRows(PreferenceFilterChangeSource.Schema);
             }),
             this.scopeTracker.onScopeChanged(scopeDetails => {
@@ -110,10 +113,12 @@ export class PreferenceTreeModel extends TreeModelImpl {
                 this.lastSearchedLiteral = newSearchTerm;
                 this.lastSearchedFuzzy = newSearchTerm.replace(/\s/g, '');
                 this._isFiltered = newSearchTerm.length > 2;
-                this.updateFilteredRows(PreferenceFilterChangeSource.Search);
                 if (this.isFiltered) {
                     this.expandAll();
+                } else if (CompositeTreeNode.is(this.root)) {
+                    this.collapseAll(this.root);
                 }
+                this.updateFilteredRows(PreferenceFilterChangeSource.Search);
             }),
             this.onFilterChanged(() => {
                 this.filterInput.updateResultsCount(this._totalVisibleLeaves);

--- a/packages/preferences/src/browser/views/preference-editor-widget.ts
+++ b/packages/preferences/src/browser/views/preference-editor-widget.ts
@@ -93,8 +93,9 @@ export class PreferencesEditorWidget extends BaseWidget implements StatefulWidge
     protected handleFilterChange(e: PreferenceFilterChangeEvent): void {
         const { isFiltered } = this.model;
         const currentFirstVisible = this.firstVisibleChildID;
+        const leavesAreVisible = this.areLeavesVisible();
         if (e.source === PreferenceFilterChangeSource.Search) {
-            this.handleSearchChange(isFiltered);
+            this.handleSearchChange(isFiltered, leavesAreVisible);
         } else if (e.source === PreferenceFilterChangeSource.Scope) {
             this.handleScopeChange(isFiltered);
         } else if (e.source === PreferenceFilterChangeSource.Schema) {
@@ -146,11 +147,8 @@ export class PreferencesEditorWidget extends BaseWidget implements StatefulWidge
         }
     }
 
-    protected handleSearchChange(isFiltered: boolean): void {
-        const noLeavesVisible = this.model.totalVisibleLeaves === 0;
-        this.node.classList.toggle('no-results', noLeavesVisible);
-        this.scrollContainer.classList.toggle('hidden', noLeavesVisible);
-        if (!noLeavesVisible) {
+    protected handleSearchChange(isFiltered: boolean, leavesAreVisible: boolean): void {
+        if (leavesAreVisible) {
             for (const [, renderer] of this.allRenderers()) {
                 const isHidden = this.hideIfFailsFilters(renderer, isFiltered);
                 if (!isHidden) {
@@ -158,6 +156,13 @@ export class PreferencesEditorWidget extends BaseWidget implements StatefulWidge
                 }
             }
         }
+    }
+
+    protected areLeavesVisible(): boolean {
+        const leavesAreVisible = this.model.totalVisibleLeaves > 0;
+        this.node.classList.toggle('no-results', !leavesAreVisible);
+        this.scrollContainer.classList.toggle('hidden', !leavesAreVisible);
+        return leavesAreVisible;
     }
 
     protected *allRenderers(): IterableIterator<[string, GeneralPreferenceNodeRenderer, Map<string, GeneralPreferenceNodeRenderer>]> {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

This PR fixes an unreported bug in the preference editor widget regarding reloading when a query is active.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
1. Open the Preferences UI
2. Search for some term that shows some result (e.g. `javascript`)
3. Refresh the application
4. The following should be the case:
    [ ] You should see the same results as before
    [ ] All expansible tree nodes should be expanded
5. Delete the search term
6. You should return to the default display (all collapsed nodes)

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

Signed-off-by: Colin Grant <colin.grant@ericsson.com>