### PR TITLE
Use more unique ID for non-command toolbar items

### DIFF
--- a/packages/core/src/browser/view-container.ts
+++ b/packages/core/src/browser/view-container.ts
@@ -207,6 +207,7 @@ export class ViewContainer extends BaseWidget implements StatefulWidget, Applica
                 } else {
                     this.toDisposeOnUpdateTitle.push(this.toolbarRegistry.registerItem({
                         ...partItem,
+                        id,
                         isVisible: widget => widget.id === this.id && (!partItem.isVisible || partItem.isVisible(part.wrapped))
                     }));
                 }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

Fixes #9585 by using an ID that includes the widget id when registering a view-container-part-specific toolbar item.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

1. Register a toolbar item like this one:
```typescript
        toolbar.registerItem({
            id: 'certainly-unique-toolbar-ID',
            render: () => (<div onClick={()=> console.log('Clicked a toolbar item.')}>A</div>),
        });
```
2. Build the application 
3. Observe that your toolbar item appears *everywhere*, but nothing is broken.

Mostly this PR just applies the same logic to command and non-command toolbar items.

https://github.com/eclipse-theia/theia/blob/739a40d20044b2643ca881c1ee0116d15b69e997/packages/core/src/browser/view-container.ts#L206-L211

Note that the `registerToolbarItem` call before the `else` uses the local variable `id` to override the `id` field of the toolbar item (`...partItem`), but the call after the `else` doesn't. With this change, it now does.

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

Signed-off-by: Colin Grant <colin.grant@ericsson.com>