### PR TITLE
Make preference widget initialization independent of event timing

### DIFF
--- a/packages/preferences/src/browser/util/preference-tree-generator.ts
+++ b/packages/preferences/src/browser/util/preference-tree-generator.ts
@@ -28,6 +28,8 @@ export class PreferenceTreeGenerator {
     @inject(PreferenceSchemaProvider) protected readonly schemaProvider: PreferenceSchemaProvider;
     @inject(PreferenceConfigurations) protected readonly preferenceConfigs: PreferenceConfigurations;
 
+    protected _root: CompositeTreeNode;
+
     protected readonly onSchemaChangedEmitter = new Emitter<CompositeTreeNode>();
     readonly onSchemaChanged = this.onSchemaChangedEmitter.event;
     protected readonly commonlyUsedPreferences = [
@@ -64,6 +66,10 @@ export class PreferenceTreeGenerator {
         ['workspace', 'application'],
     ]);
     protected readonly defaultTopLevelCategory = 'extensions';
+
+    get root(): CompositeTreeNode {
+        return this._root ?? this.generateTree();
+    }
 
     @postConstruct()
     protected async init(): Promise<void> {
@@ -115,6 +121,7 @@ export class PreferenceTreeGenerator {
             }
         }
 
+        this._root = root;
         return root;
     };
 

--- a/packages/preferences/src/browser/views/preference-editor-widget.ts
+++ b/packages/preferences/src/browser/views/preference-editor-widget.ts
@@ -66,16 +66,18 @@ export class PreferencesEditorWidget extends BaseWidget implements StatefulWidge
     @inject(PreferencesScopeTabBar) protected readonly tabbar: PreferencesScopeTabBar;
 
     @postConstruct()
-    protected init(): void {
+    protected async init(): Promise<void> {
         this.id = PreferencesEditorWidget.ID;
         this.title.label = PreferencesEditorWidget.LABEL;
         this.addClass('settings-main');
         this.toDispose.pushAll([
             this.preferenceService.onPreferencesChanged(e => this.handlePreferenceChanges(e)),
-            this.model.onFilterChanged(e => this.handleFilterChange(e)),
+            this.model.onFilterChanged(e => this.handleDisplayChange(e)),
             this.model.onSelectionChanged(e => this.handleSelectionChange(e)),
         ]);
         this.createContainers();
+        await this.preferenceService.ready;
+        this.handleDisplayChange({ source: PreferenceFilterChangeSource.Schema });
     }
 
     protected createContainers(): void {
@@ -90,7 +92,7 @@ export class PreferencesEditorWidget extends BaseWidget implements StatefulWidge
         this.node.appendChild(noLeavesMessage);
     }
 
-    protected handleFilterChange(e: PreferenceFilterChangeEvent): void {
+    protected handleDisplayChange(e: PreferenceFilterChangeEvent): void {
         const { isFiltered } = this.model;
         const currentFirstVisible = this.firstVisibleChildID;
         const leavesAreVisible = this.areLeavesVisible();


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

Fixes the issue reported [here](https://github.com/eclipse-theia/theia/pull/9403#issuecomment-860258150) regarding failure of preferences display when plugins are missing. By extending [this fix](https://github.com/eclipse-theia/theia/pull/9403) to the `PreferenceTreeModel` and `PreferenceEditorWidget` and adding code in their `init()` routines that establishes a good initial state regardless of the timing of events.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
1. Pull the [`demo/bad-preference-loading`](https://github.com/colin-grant-work/theia/tree/demo/bad-preference-loading) branch here.
2. Build it and verify that the preferences display correctly.
3. Rebase or reset away the last commit (equivalent to this PR) if you want to confirm the presence of the bug.

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

Signed-off-by: Colin Grant <colin.grant@ericsson.com>