### PR TITLE
Replaced all unnecessary 'private' modifiers with 'protected' in Work…

### DIFF
--- a/packages/workspace/src/browser/workspace-service.ts
+++ b/packages/workspace/src/browser/workspace-service.ts
@@ -40,10 +40,10 @@ import { IJSONSchema } from '@theia/core/lib/common/json-schema';
 @injectable()
 export class WorkspaceService implements FrontendApplicationContribution {
 
-    private _workspace: FileStat | undefined;
+    protected _workspace: FileStat | undefined;
 
-    private _roots: FileStat[] = [];
-    private deferredRoots = new Deferred<FileStat[]>();
+    protected _roots: FileStat[] = [];
+    protected deferredRoots = new Deferred<FileStat[]>();
 
     @inject(FileService)
     protected readonly fileService: FileService;
@@ -423,7 +423,7 @@ export class WorkspaceService implements FrontendApplicationContribution {
         return getTemporaryWorkspaceFileUri(this.envVariableServer);
     }
 
-    private async writeWorkspaceFile(workspaceFile: FileStat | undefined, workspaceData: WorkspaceData): Promise<FileStat | undefined> {
+    protected async writeWorkspaceFile(workspaceFile: FileStat | undefined, workspaceData: WorkspaceData): Promise<FileStat | undefined> {
         if (workspaceFile) {
             const data = JSON.stringify(WorkspaceData.transformToRelative(workspaceData, workspaceFile));
             const edits = jsoncparser.format(data, undefined, { tabSize: 3, insertSpaces: true, eol: '' });


### PR DESCRIPTION
#### What it does

Fixes: #9591

Removes the optional use of 'private' modifiers in Workspace Service to make it easier to write code for child classes in the future.

#### How to test
1. This is more of a code refactor, so you can just run the application and try to use the features associated with the Workspace Service (For example, open a new workspace and check if there are any errors in the logs related to new changes)

#### Review checklist

- [ ] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

Signed-off-by: Timur Zhigmytov timur.zhigmytov@mediamonks.com
