### PR TITLE
Keep separate commits for PR fixups

### DIFF
--- a/doc/pull-requests.md
+++ b/doc/pull-requests.md
@@ -45,6 +45,9 @@ Contributors guide: https://github.com/eclipse-theia/theia/blob/master/CONTRIBUT
   - A request on the design review should be an explicit comment.
   - Such PR should be marked as a draft or with the WIP prefix.
 
+<a name="fixups"></a>
+- [3.](#fixups) Changes done _after_ the PR has been opened should be kept in separate commits while the review process is not finished. This allows reviewers to re-review only the updated parts of the PR and to determine what needs to be tested again. The "fixup" commits must be squashed before merging in order to keep a clean history. 
+
 ## Requesting a Review
 
 <a name="review-reqs"></a>
@@ -81,7 +84,6 @@ Contributors guide: https://github.com/eclipse-theia/theia/blob/master/CONTRIBUT
 <a name="checklist-commit-history"></a>
 - [10.](#checklist-commit-history) Commit history is rebased on master and contains only meaningful commits and changes (less are usually better).
   - For example, use `git pull -r` or `git fetch && git rebase` to pick up changes from the master.
-  - When addressing change requests on a PR, the PR author should provide those changes in separate commits while the review process is not finished. This allows reviewers to re-review only the updated parts of the PR and to determine what needs to be tested again. The "fixup" commits must be squashed before merging in order to keep a clean history. 
 
 ## Reviewing
 

--- a/doc/pull-requests.md
+++ b/doc/pull-requests.md
@@ -81,6 +81,7 @@ Contributors guide: https://github.com/eclipse-theia/theia/blob/master/CONTRIBUT
 <a name="checklist-commit-history"></a>
 - [10.](#checklist-commit-history) Commit history is rebased on master and contains only meaningful commits and changes (less are usually better).
   - For example, use `git pull -r` or `git fetch && git rebase` to pick up changes from the master.
+  - When addressing change requests on a PR, the PR author should provide those changes in separate commits while the review process is not finished. This allows reviewers to re-review only the updated parts of the PR and to determine what needs to be tested again. The "fixup" commits must be squashed before merging in order to keep a clean history. 
 
 ## Reviewing
 


### PR DESCRIPTION
Just added new instructions for PR's. Please let me know if it's unclear or if you disagree.