### PR TITLE
ovsx-client: add special handling for external vscode builtins

### DIFF
--- a/dev-packages/ovsx-client/src/ovsx-client.spec.ts
+++ b/dev-packages/ovsx-client/src/ovsx-client.spec.ts
@@ -15,8 +15,8 @@
  ********************************************************************************/
 
 import * as chai from 'chai';
-import { OVSXClient } from './ovsx-client';
-import { VSXSearchParam } from './ovsx-types';
+import { VSCODE_EXTERNAL_BUILTINS, OVSXClient } from './ovsx-client';
+import { VSXBuiltinNamespaces, VSXSearchParam } from './ovsx-types';
 
 const expect = chai.expect;
 
@@ -105,6 +105,33 @@ describe('OVSX Client', () => {
             expect(client['isVersionLTE']('1.40.0', '1.50.0')).equal(true, 'should be satisfied since v1 is less than v2');
             expect(client['isVersionLTE']('1.50.0', '1.50.0')).equal(true, 'should be satisfied since v1 and v2 are equal');
             expect(client['isVersionLTE']('2.0.2', '2.0.1')).equal(false, 'should not be satisfied since v1 is greater than v2');
+        });
+
+    });
+
+    describe('#isReservedBuiltin', () => {
+
+        it('should be `true` for the `eclipse-theia` namespace', () => {
+            expect(client['isBuiltinExtension'](`${VSXBuiltinNamespaces.THEIA}.java`)).equal(true);
+            expect(client['isBuiltinExtension'](`${VSXBuiltinNamespaces.THEIA}.python`)).equal(true);
+            expect(client['isBuiltinExtension'](`${VSXBuiltinNamespaces.THEIA}.typescript`)).equal(true);
+        });
+
+        it('should be `true` for the `vscode` namespace', () => {
+            expect(client['isBuiltinExtension'](`${VSXBuiltinNamespaces.VSCODE}.java`)).equal(true);
+            expect(client['isBuiltinExtension'](`${VSXBuiltinNamespaces.VSCODE}.python`)).equal(true);
+            expect(client['isBuiltinExtension'](`${VSXBuiltinNamespaces.VSCODE}.typescript`)).equal(true);
+        });
+
+        it('should be `true` for external builtin extensions', () => {
+            for (const id of VSCODE_EXTERNAL_BUILTINS) {
+                expect(client['isBuiltinExtension'](id)).equal(true);
+            }
+        });
+
+        it('should return `false` for non-builtin extensions', () => {
+            expect(client['isBuiltinExtension']('foo.bar')).equal(false);
+            expect(client['isBuiltinExtension']('bar.foo')).equal(false);
         });
 
     });


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

The pull-request adds additional logic to `@theia/ovsx-client` in order to handle `ms-vscode` builtin extensions which are included with vscode at build time (referenced in [vscode/product.json](https://github.com/microsoft/vscode/blob/1.57.0/product.json#L34-L126).  For such extensions, we want to handle them as specifically as regular vscode builtins meaning they should be resolved at their compatible versions. Since `ms-vscode` is not a reserved namespace (other extensions may use the namespace) we need to maintain a list of extensions we need to handle specifically.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

1. ensure a clean working state by removing the `plugins` folder and tmp files:
    - `rm -rf plugins/`
    - `rm -rf /tmp/vscode-unpacked`
    - `rm -rf ~/.theia/extensions`
2. remove builtin `ms-vscode` extensions from the [root package.json](https://github.com/eclipse-theia/theia/blob/c92e822830e356c77d3186fda73b47f91da272e9/package.json#L85):
    - `vscode-builtin-js-debug`
    - `vscode-builtin-node-debug`
    - `vscode-builtin-node-debug2`
    - `vscode-references-view`
3. start the application, and open the `extensions-view`
4. confirm that searching, opening extensions's readme, installing extensions work correctly
5. search for `js-debug` - extension should be at version `1.50.0` (current api version)
6. search for `js-debug-companion` - extension version should be latest compatible api version
7. repeat step 1 - ensure that no builtins are present
8. download the `ms-vscode` extension pack (change from `.zip` to `.vsix`) - ([pack](https://github.com/eclipse-theia/theia/files/6658996/ms-vscode.zip)
9. install the `.vsix` from the `install from vsix` command
10. ensure that extensions in the pack are resolve to version `1.50.0` it if exists, else the latest compatible version.

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

Signed-off-by: vince-fugnitto <vincent.fugnitto@ericsson.com>
Co-authored-by: Alvaro Sanchez-Leon <alvaro.sanchez-leon@ericsson.com>