### PR TITLE
Convert iconPath to URL

### DIFF
--- a/packages/plugin-ext/src/main/browser/webview/webview.ts
+++ b/packages/plugin-ext/src/main/browser/webview/webview.ts
@@ -383,12 +383,16 @@ export class WebviewWidget extends BaseWidget implements StatefulWidget {
             const iconClass = `webview-${this.identifier.id}-file-icon`;
             this.toDisposeOnIcon.push(this.sharedStyle.insertRule(
                 `.theia-webview-icon.${iconClass}::before`,
-                theme => `background-image: url(${theme.type === 'light' ? lightIconUrl : darkIconUrl});`
+                theme => `background-image: url(${this.toEndpoint(theme.type === 'light' ? lightIconUrl : darkIconUrl)});`
             ));
             this.title.iconClass = `theia-webview-icon ${iconClass}`;
         } else {
             this.title.iconClass = '';
         }
+    }
+
+    protected toEndpoint(pathname: string): string {
+        return new Endpoint({ path: pathname }).getRestUrl().toString();
     }
 
     setHTML(value: string): void {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

Fixes #9553 by converting the path used for the icon to an endpoint targeting the backend plugin server.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
1. Install a plugin that has webviews that include icons. (e.g. Gitlens)
2. Open a webview with an icon (e.g. run command `Gitlens: Open Settings`)
3. Observe that the icon for the webview is displayed correctly.

![image](https://user-images.githubusercontent.com/62660806/122472569-614dfb80-cf86-11eb-92ec-ea9f7a26c226.png)

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

