### PR TITLE
Add vscode API `DebugSessionOptions`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 <a name="breaking_changes_1.16.0">[Breaking Changes:](#breaking_changes_1.16.0)</a>
 
+- [debug] `DebugSession` and `PluginDebugSession` constructors accept a `parentSession` of type `DebugSession | undefined` as their 3rd parameter, offsetting every subsequent parameter by one. [#9613](https://github.com/eclipse-theia/theia/pull/9613)
 - [monaco] upgraded to monaco 0.23.0 including replacement of `quickOpen` API (0.20.x) with `quickInput` API (0.23.x) [#9154](https://github.com/eclipse-theia/theia/pull/9154)
 - [call-hierarchy] `CurrentEditorAccess` is deprecated. Use the version implemented in the `editor` package instead. The services in `call-hierarchy` that previously used the local `CurrentEditorAccess` no longer do. [#9681](https://github.com/eclipse-theia/theia/pull/9681)
 - [workspace] `WorkspaceCommandContribution.addFolderToWorkspace` no longer accepts `undefined`. `WorkspaceService.addRoot` now accepts a URI or a URI[]. [#9684](https://github.com/eclipse-theia/theia/pull/9684)

--- a/packages/console/src/browser/console-session-manager.ts
+++ b/packages/console/src/browser/console-session-manager.ts
@@ -1,0 +1,119 @@
+/********************************************************************************
+ * Copyright (C) 2021 TypeFox and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import { injectable } from '@theia/core/shared/inversify';
+import { Emitter, Event, Disposable, DisposableCollection } from '@theia/core';
+import { ConsoleSession } from './console-session';
+import { Severity } from '@theia/core/lib/common/severity';
+
+@injectable()
+export class ConsoleSessionManager implements Disposable {
+
+    protected readonly sessions = new Map<string, ConsoleSession>();
+    protected _selectedSession: ConsoleSession | undefined;
+    protected _severity: Severity | undefined;
+
+    protected readonly sessionAddedEmitter = new Emitter<ConsoleSession>();
+    protected readonly sessionDeletedEmitter = new Emitter<ConsoleSession>();
+    protected readonly sessionWasShownEmitter = new Emitter<ConsoleSession>();
+    protected readonly sessionWasHiddenEmitter = new Emitter<ConsoleSession>();
+    protected readonly selectedSessionChangedEmitter = new Emitter<ConsoleSession | undefined>();
+    protected readonly severityChangedEmitter = new Emitter<void>();
+
+    get onDidAddSession(): Event<ConsoleSession> {
+        return this.sessionAddedEmitter.event;
+    }
+    get onDidDeleteSession(): Event<ConsoleSession> {
+        return this.sessionDeletedEmitter.event;
+    }
+    get onDidShowSession(): Event<ConsoleSession> {
+        return this.sessionWasShownEmitter.event;
+    }
+    get onDidHideSession(): Event<ConsoleSession> {
+        return this.sessionWasHiddenEmitter.event;
+    }
+    get onDidChangeSelectedSession(): Event<ConsoleSession | undefined> {
+        return this.selectedSessionChangedEmitter.event;
+    }
+    get onDidChangeSeverity(): Event<void> {
+        return this.severityChangedEmitter.event;
+    }
+
+    protected readonly toDispose = new DisposableCollection();
+    protected readonly toDisposeOnSessionDeletion = new Map<string, Disposable>();
+
+    dispose(): void {
+        this.toDispose.dispose();
+    }
+
+    get severity(): Severity | undefined {
+        return this._severity;
+    }
+
+    set severity(value: Severity | undefined) {
+        value = value || Severity.Ignore;
+        this._severity = value;
+        for (const session of this.sessions.values()) {
+            session.severity = value;
+        }
+        this.severityChangedEmitter.fire(undefined);
+    }
+
+    get all(): ConsoleSession[] {
+        return Array.from(this.sessions.values());
+    }
+
+    get selectedSession(): ConsoleSession | undefined {
+        return this._selectedSession;
+    }
+
+    set selectedSession(session: ConsoleSession | undefined) {
+        const oldSession = this.selectedSession;
+        this._selectedSession = session;
+        this.selectedSessionChangedEmitter.fire(session);
+        if (oldSession !== session) {
+            if (oldSession) {
+                this.sessionWasHiddenEmitter.fire(oldSession);
+            }
+            if (session) {
+                this.sessionWasShownEmitter.fire(session);
+            }
+        }
+    }
+
+    get(id: string): ConsoleSession | undefined {
+        return this.sessions.get(id);
+    }
+
+    add(session: ConsoleSession): void {
+        this.sessions.set(session.id, session);
+        this.sessionAddedEmitter.fire(session);
+        if (this.sessions.size === 1) {
+            this.selectedSession = session;
+        }
+    }
+
+    delete(id: string): void {
+        const session = this.sessions.get(id);
+        if (this.sessions.delete(id) && session) {
+            this.sessionDeletedEmitter.fire(session);
+            if (this.sessions.size === 0) {
+                this.selectedSessionChangedEmitter.fire(undefined);
+            }
+        }
+    }
+
+}

--- a/packages/console/src/browser/console-session.ts
+++ b/packages/console/src/browser/console-session.ts
@@ -39,6 +39,7 @@ export abstract class ConsoleSession extends TreeSource {
     protected selectedSeverity?: Severity;
     protected readonly selectionEmitter: Emitter<void> = new Emitter<void>();
     readonly onSelectionChange = this.selectionEmitter.event;
+    id: string;
 
     get severity(): Severity | undefined {
         return this.selectedSeverity;

--- a/packages/console/src/browser/console-widget.ts
+++ b/packages/console/src/browser/console-widget.ts
@@ -25,6 +25,7 @@ import { MonacoEditorProvider } from '@theia/monaco/lib/browser/monaco-editor-pr
 import { ConsoleHistory } from './console-history';
 import { ConsoleContentWidget } from './console-content-widget';
 import { ConsoleSession } from './console-session';
+import { ConsoleSessionManager } from './console-session-manager';
 
 export const ConsoleOptions = Symbol('ConsoleWidgetOptions');
 export interface ConsoleOptions {
@@ -67,6 +68,9 @@ export class ConsoleWidget extends BaseWidget implements StatefulWidget {
     @inject(ConsoleHistory)
     protected readonly history: ConsoleHistory;
 
+    @inject(ConsoleSessionManager)
+    protected readonly sessionManager: ConsoleSessionManager;
+
     @inject(MonacoEditorProvider)
     protected readonly editorProvider: MonacoEditorProvider;
 
@@ -106,6 +110,13 @@ export class ConsoleWidget extends BaseWidget implements StatefulWidget {
         this.toDispose.push(input.getControl().onDidChangeConfiguration(event => {
             if (event.hasChanged(monaco.editor.EditorOption.fontInfo)) {
                 this.updateFont();
+            }
+        }));
+
+        this.toDispose.push(this.sessionManager.onDidChangeSelectedSession(session => {
+            // Don't delete the last session by overriding it with 'undefined'
+            if (session) {
+                this.session = session;
             }
         }));
 

--- a/packages/core/src/browser/style/index.css
+++ b/packages/core/src/browser/style/index.css
@@ -205,6 +205,7 @@ button.secondary[disabled], .theia-button.secondary[disabled] {
     border: 1px solid var(--theia-dropdown-border);
     background: var(--theia-dropdown-background);
     outline: none;
+    margin-left: var(--theia-ui-padding);
 }
 
 .theia-select option {

--- a/packages/debug/src/browser/debug-session-contribution.ts
+++ b/packages/debug/src/browser/debug-session-contribution.ts
@@ -90,7 +90,7 @@ export const DebugSessionFactory = Symbol('DebugSessionFactory');
  * The [debug session](#DebugSession) factory.
  */
 export interface DebugSessionFactory {
-    get(sessionId: string, options: DebugSessionOptions): DebugSession;
+    get(sessionId: string, options: DebugSessionOptions, parentSession?: DebugSession): DebugSession;
 }
 
 @injectable()
@@ -116,7 +116,7 @@ export class DefaultDebugSessionFactory implements DebugSessionFactory {
     @inject(ContributionProvider) @named(DebugContribution)
     protected readonly debugContributionProvider: ContributionProvider<DebugContribution>;
 
-    get(sessionId: string, options: DebugSessionOptions): DebugSession {
+    get(sessionId: string, options: DebugSessionOptions, parentSession?: DebugSession): DebugSession {
         const connection = new DebugSessionConnection(
             sessionId,
             () => new Promise<IWebSocket>(resolve =>
@@ -128,6 +128,7 @@ export class DefaultDebugSessionFactory implements DebugSessionFactory {
         return new DebugSession(
             sessionId,
             options,
+            parentSession,
             connection,
             this.terminalService,
             this.editorManager,

--- a/packages/debug/src/browser/debug-session-manager.ts
+++ b/packages/debug/src/browser/debug-session-manager.ts
@@ -254,9 +254,10 @@ export class DebugSessionManager {
     }
 
     protected async doStart(sessionId: string, options: DebugSessionOptions): Promise<DebugSession> {
+        const parentSession = options.configuration.parentSession && this._sessions.get(options.configuration.parentSession.id);
         const contrib = this.sessionContributionRegistry.get(options.configuration.type);
         const sessionFactory = contrib ? contrib.debugSessionFactory() : this.debugSessionFactory;
-        const session = sessionFactory.get(sessionId, options);
+        const session = sessionFactory.get(sessionId, options, parentSession);
         this._sessions.set(sessionId, session);
 
         this.debugTypeKey.set(session.configuration.type);

--- a/packages/debug/src/browser/view/debug-threads-source.tsx
+++ b/packages/debug/src/browser/view/debug-threads-source.tsx
@@ -40,11 +40,15 @@ export class DebugThreadsSource extends TreeSource {
         return this.model.sessionCount > 1;
     }
 
-    getElements(): IterableIterator<TreeElement> {
+    *getElements(): IterableIterator<TreeElement> {
         if (this.model.sessionCount === 1 && this.model.session && this.model.session.threadCount) {
-            return this.model.session.threads;
+            return yield* this.model.session.threads;
         }
-        return this.model.sessions;
+        for (const session of this.model.sessions) {
+            if (!session.parentSession) {
+                yield session;
+            }
+        }
     }
 
 }

--- a/packages/debug/src/common/debug-configuration.ts
+++ b/packages/debug/src/common/debug-configuration.ts
@@ -37,6 +37,12 @@ export interface DebugConfiguration {
      */
     [key: string]: any;
 
+    parentSession?: { id: string };
+
+    consoleMode?: DebugConsoleMode;
+
+    compact?: boolean;
+
     /**
      * The request type of the debug adapter session.
      */
@@ -73,4 +79,16 @@ export namespace DebugConfiguration {
     export function is(arg: DebugConfiguration | any): arg is DebugConfiguration {
         return !!arg && typeof arg === 'object' && 'type' in arg && 'name' in arg && 'request' in arg;
     }
+}
+
+export interface DebugSessionOptions {
+    parentSession?: { id: string };
+    consoleMode?: DebugConsoleMode;
+    noDebug?: boolean;
+    compact?: boolean;
+}
+
+export enum DebugConsoleMode {
+    Separate = 0,
+    MergeWithParent = 1
 }

--- a/packages/debug/src/common/debug-model.ts
+++ b/packages/debug/src/common/debug-model.ts
@@ -41,6 +41,7 @@ export const DebugAdapterSession = Symbol('DebugAdapterSession');
  */
 export interface DebugAdapterSession {
     id: string;
+    parentSession?: DebugAdapterSession;
     start(channel: WebSocketChannel): Promise<void>
     stop(): Promise<void>
 }

--- a/packages/debug/src/node/debug-adapter-session-manager.ts
+++ b/packages/debug/src/node/debug-adapter-session-manager.ts
@@ -67,6 +67,14 @@ export class DebugAdapterSessionManager implements MessagingService.Contribution
         const sessionFactory = registry.debugAdapterSessionFactory(config.type) || this.debugAdapterSessionFactory;
         const session = sessionFactory.get(sessionId, communicationProvider);
         this.sessions.set(sessionId, session);
+
+        if (config.parentSession) {
+            const parentSession = this.sessions.get(config.parentSession.id);
+            if (parentSession) {
+                session.parentSession = parentSession;
+            }
+        }
+
         return session;
     }
 

--- a/packages/plugin-ext/compile.tsconfig.json
+++ b/packages/plugin-ext/compile.tsconfig.json
@@ -21,6 +21,9 @@
       "path": "../callhierarchy/compile.tsconfig.json"
     },
     {
+      "path": "../console/compile.tsconfig.json"
+    },
+    {
       "path": "../core/compile.tsconfig.json"
     },
     {

--- a/packages/plugin-ext/package.json
+++ b/packages/plugin-ext/package.json
@@ -8,6 +8,7 @@
     "@theia/bulk-edit": "1.15.0",
     "@theia/callhierarchy": "1.15.0",
     "@theia/core": "1.15.0",
+    "@theia/console": "1.15.0",
     "@theia/debug": "1.15.0",
     "@theia/editor": "1.15.0",
     "@theia/file-search": "1.15.0",

--- a/packages/plugin-ext/src/common/plugin-api-rpc.ts
+++ b/packages/plugin-ext/src/common/plugin-api-rpc.ts
@@ -1616,7 +1616,7 @@ export interface DebugMain {
     $unregisterDebuggerConfiguration(debugType: string): Promise<void>;
     $addBreakpoints(breakpoints: Breakpoint[]): Promise<void>;
     $removeBreakpoints(breakpoints: string[]): Promise<void>;
-    $startDebugging(folder: theia.WorkspaceFolder | undefined, nameOrConfiguration: string | theia.DebugConfiguration): Promise<boolean>;
+    $startDebugging(folder: theia.WorkspaceFolder | undefined, nameOrConfiguration: string | theia.DebugConfiguration, options: theia.DebugSessionOptions): Promise<boolean>;
     $customRequest(sessionId: string, command: string, args?: any): Promise<DebugProtocol.Response>;
 }
 

--- a/packages/plugin-ext/src/main/browser/debug/plugin-debug-session-factory.ts
+++ b/packages/plugin-ext/src/main/browser/debug/plugin-debug-session-factory.ts
@@ -36,6 +36,7 @@ export class PluginDebugSession extends DebugSession {
     constructor(
         readonly id: string,
         readonly options: DebugSessionOptions,
+        readonly parentSession: DebugSession | undefined,
         protected readonly connection: DebugSessionConnection,
         protected readonly terminalServer: TerminalService,
         protected readonly editorManager: EditorManager,
@@ -45,7 +46,7 @@ export class PluginDebugSession extends DebugSession {
         protected readonly fileService: FileService,
         protected readonly terminalOptionsExt: TerminalOptionsExt | undefined,
         protected readonly debugContributionProvider: ContributionProvider<DebugContribution>) {
-        super(id, options, connection, terminalServer, editorManager, breakpoints, labelProvider, messages, fileService, debugContributionProvider);
+        super(id, options, parentSession, connection, terminalServer, editorManager, breakpoints, labelProvider, messages, fileService, debugContributionProvider);
     }
 
     protected async doCreateTerminal(terminalWidgetOptions: TerminalWidgetOptions): Promise<TerminalWidget> {
@@ -75,7 +76,7 @@ export class PluginDebugSessionFactory extends DefaultDebugSessionFactory {
         super();
     }
 
-    get(sessionId: string, options: DebugSessionOptions): DebugSession {
+    get(sessionId: string, options: DebugSessionOptions, parentSession?: DebugSession): DebugSession {
         const connection = new DebugSessionConnection(
             sessionId,
             this.connectionFactory,
@@ -84,6 +85,7 @@ export class PluginDebugSessionFactory extends DefaultDebugSessionFactory {
         return new PluginDebugSession(
             sessionId,
             options,
+            parentSession,
             connection,
             this.terminalService,
             this.editorManager,

--- a/packages/plugin-ext/src/plugin/node/debug/debug.ts
+++ b/packages/plugin-ext/src/plugin/node/debug/debug.ts
@@ -159,8 +159,8 @@ export class DebugExtImpl implements DebugExt {
         }
     }
 
-    startDebugging(folder: theia.WorkspaceFolder | undefined, nameOrConfiguration: string | theia.DebugConfiguration): PromiseLike<boolean> {
-        return this.proxy.$startDebugging(folder, nameOrConfiguration);
+    startDebugging(folder: theia.WorkspaceFolder | undefined, nameOrConfiguration: string | theia.DebugConfiguration, options: theia.DebugSessionOptions): PromiseLike<boolean> {
+        return this.proxy.$startDebugging(folder, nameOrConfiguration, options);
     }
 
     registerDebugAdapterDescriptorFactory(debugType: string, factory: theia.DebugAdapterDescriptorFactory): Disposable {

--- a/packages/plugin-ext/src/plugin/plugin-context.ts
+++ b/packages/plugin-ext/src/plugin/plugin-context.ts
@@ -773,8 +773,9 @@ export function createAPIFactory(
             registerDebugAdapterTrackerFactory(debugType: string, factory: theia.DebugAdapterTrackerFactory): Disposable {
                 return debugExt.registerDebugAdapterTrackerFactory(debugType, factory);
             },
-            startDebugging(folder: theia.WorkspaceFolder | undefined, nameOrConfiguration: string | theia.DebugConfiguration): Thenable<boolean> {
-                return debugExt.startDebugging(folder, nameOrConfiguration);
+            startDebugging(folder: theia.WorkspaceFolder | undefined, nameOrConfiguration: string | theia.DebugConfiguration, options: theia.DebugSessionOptions):
+                Thenable<boolean> {
+                return debugExt.startDebugging(folder, nameOrConfiguration, options);
             },
             addBreakpoints(breakpoints: theia.Breakpoint[]): void {
                 debugExt.addBreakpoints(breakpoints);

--- a/packages/plugin/src/theia.d.ts
+++ b/packages/plugin/src/theia.d.ts
@@ -9188,6 +9188,38 @@ declare module '@theia/plugin' {
     }
 
     /**
+     * Options for starting a debug session.
+     */
+    export interface DebugSessionOptions {
+
+        /**
+         * When specified the newly created debug session is registered as a "child" session of this
+         * "parent" debug session.
+         */
+        parentSession?: DebugSession;
+
+        /**
+         * Controls whether this session should have a separate debug console or share it
+         * with the parent session. Has no effect for sessions which do not have a parent session.
+         * Defaults to Separate.
+         */
+        consoleMode?: DebugConsoleMode;
+
+        /**
+         * Controls whether this session should run without debugging, thus ignoring breakpoints.
+         * When this property is not specified, the value from the parent session (if there is one) is used.
+         */
+        noDebug?: boolean;
+
+        /**
+         * Controls if the debug session's parent session is shown in the CALL STACK view even if it has only a single child.
+         * By default, the debug session will never hide its parent.
+         * If compact is true, debug sessions with a single child are hidden in the CALL STACK view to make the tree more compact.
+         */
+        compact?: boolean;
+    }
+
+    /**
      * A debug configuration provider allows to add the initial debug configurations to a newly created launch.json
      * and to resolve a launch configuration before it is used to start a new debug session.
      * A debug configuration provider is registered via #debug.registerDebugConfigurationProvider.
@@ -9556,7 +9588,7 @@ declare module '@theia/plugin' {
          * @param nameOrConfiguration Either the name of a debug or compound configuration or a [DebugConfiguration](#DebugConfiguration) object.
          * @return A thenable that resolves when debugging could be successfully started.
          */
-        export function startDebugging(folder: WorkspaceFolder | undefined, nameOrConfiguration: string | DebugConfiguration): PromiseLike<boolean>;
+        export function startDebugging(folder: WorkspaceFolder | undefined, nameOrConfiguration: string | DebugConfiguration, options: DebugSessionOptions): PromiseLike<boolean>;
 
         /**
          * Add breakpoints.


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
Closes #8518 

Adds the `vscode.debug.DebugSessionOptions` API to Theia. This enables the following features:

- Show child debug sessions as a tree under the parent sessions (Theia used to show them as siblings)
    - The new `compact` property will simplify the label and tree structure if possible
- Different debug sessions no longer share the same `DebugConsoleSession` and therefore are displayed independently
    - Child debug sessions with the `consoleMode` property set to `MergeWithParent` will continue to share their console session with each other.
    - You can switch between console sessions with a selector, assuming more than one session is currently running.

The changes to `DebugConsoleSession` are slightly breaking. While it's still possible to simply inject the `DebugConsoleSession` directly, its tight coupling to `DebugSession` makes that impractical. Instead of injecting the `DebugConsoleSession` directly, a `DebugConsoleSessionFactory` allows to create a `DebugConsoleSession` with a provided `DebugSession`.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

1. Clone [this test repo](https://github.com/msujew/debug-session-options-example) into Theia and make sure the `vscode-js-debug` extension is installed in Theia.
2. Start a debugging session with the contained `Launch Program` configuration.
3. Child processes will now be shown as a tree in the threads view.
4. Start a second debugging session with the same configuration
5. Another tree will appear in the threads view and you can switch between the different debug consoles.
6. You can add `configuration.consoleMode = undefined;` and/or `configuration.compact = undefined;` after [this line](https://github.com/msujew/theia/blob/e26d3bff923e51f013aece29ed7a9db8eb27efce/packages/plugin-ext/src/main/browser/debug/debug-main.ts#L273), and restart the server to test how these properties influence the debug console/view.

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

