### PR TITLE
[Debug] Fixed issue on readonly variables

### DIFF
--- a/packages/debug/src/browser/console/debug-console-items.tsx
+++ b/packages/debug/src/browser/console/debug-console-items.tsx
@@ -232,6 +232,9 @@ export class DebugVariable extends ExpressionContainer {
     protected setNameRef = (nameRef: HTMLSpanElement | null) => this.nameRef = nameRef || undefined;
 
     async open(): Promise<void> {
+        if (!this.supportSetVariable) {
+            return;
+        }
         const input = new SingleTextInputDialog({
             title: `Set ${this.name} Value`,
             initialValue: this.value


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

This fixes #9615.
The dialog to edit a variable is not opened if a variable is not editable.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
1. Disable the set `supportsSetVariable` capability of the debug session
2. Start a debug session
3. Double click on a variable. It's now not possible anymore to edit the variable.

#### Review checklist

- [X] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

