### PR TITLE
Align addOrReattachWidget behavior with VSCode

### DIFF
--- a/packages/plugin-ext/src/main/browser/webviews-main.ts
+++ b/packages/plugin-ext/src/main/browser/webviews-main.ts
@@ -30,7 +30,7 @@ import { Mutable } from '@theia/core/lib/common/types';
 import { HostedPluginSupport } from '../../hosted/browser/hosted-plugin';
 import { IconUrl } from '../../common/plugin-protocol';
 import { CustomEditorWidget } from './custom-editors/custom-editor-widget';
-import { WebviewPanelTargetArea } from '../../plugin/types-impl';
+import { ViewColumn, WebviewPanelTargetArea } from '../../plugin/types-impl';
 
 export class WebviewsMainImpl implements WebviewsMain, Disposable {
 
@@ -93,14 +93,9 @@ export class WebviewsMainImpl implements WebviewsMain, Disposable {
         const area = showOptions.area ? showOptions.area : WebviewPanelTargetArea.Main;
         const widgetOptions: ApplicationShell.WidgetOptions = { area };
         let mode = 'open-to-right';
-        // -2 corresponds to vscode.ViewColumn.Beside opening option
-        const canOpenBeside = showOptions.viewColumn === -2 && (area === WebviewPanelTargetArea.Main || area === WebviewPanelTargetArea.Bottom);
+        const canOpenBeside = showOptions.viewColumn === ViewColumn.Beside && (area === WebviewPanelTargetArea.Main || area === WebviewPanelTargetArea.Bottom);
         if (canOpenBeside) {
-            let activeOrRightmostTabbar = this.shell.getTabBarFor(area);
-            if (!activeOrRightmostTabbar) {
-                const areaTabBars = area === WebviewPanelTargetArea.Main ? this.shell.mainAreaTabBars : this.shell.bottomAreaTabBars;
-                activeOrRightmostTabbar = areaTabBars[areaTabBars.length - 1];
-            }
+            const activeOrRightmostTabbar = this.shell.getTabBarFor(area);
             const ref = activeOrRightmostTabbar?.currentTitle?.owner;
             if (ref) {
                 Object.assign(widgetOptions, { ref, mode });


### PR DESCRIPTION
Signed-off-by: Kenneth Marut <kenneth.marut@ericsson.com>

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->
Fixes #9617 by aligning webview placement during creation with VSCode. It determines if the webview should be open in a new split panel, or appended to a previously created panel by adding the appropriate checks to align with VSCode's behavior. It also ensures that split pane webviews follow the same rules for 'bottom' panel (which is specific to Theia).

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
1. Build this branch, clone this example [extension](https://github.com/kenneth-marut-work/vscode-webview-sample/tree/webview-main-bottom-example), and copy `cat-coding-0.0.1.vsix` into your `theia/plugins` directory.
1. Start Theia, close all editors and tabs, then run the command `Start Cat Coding session from the Main Panel` using the keyboard shortcut `ctrl+shift+p`
    - [ ] observe that a new webview opens
1. Without clicking anywhere, run the command again
    - [ ] observe another webview opens in a split view
1. Close one of the two editors so that you are left with a single 'Cat Coding' editor
1. Click somewhere in the file navigator (to apply focus to the navigator widget), then run the command again using `ctrl+shift+p`
    - [ ] Observe another window opens in split view again, this is correct.

- Also try using the command `Start Cat Coding session from the Bottom Panel` to verify the behavior is identical for Webviews added to the bottom panel.


The correct general behavior for `vscode.ViewColumn.Besides` should be as follows:
- If no editors are open, a webview should be placed in the main area tabbar
- If one editor is open, the new webview should open *to the right* as a split view
- If multiple split views are open:
  - If an editor tab is *active*, the webview should open in the panel *to the right* of the active tab
     - If there is already a panel to the right, the webview is added to that tabbar
     - If there is no panel to the right, a new panel is created
  - If an editor is *not active* (or any other widget is active, i.e. the navigator), the webview should open in a *new split panel* all the way to the right

 
**Note: don't open up *too* many coding cats, you'll start to get some slow downs and a lot of toast spam 🙂**

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

