### PR TITLE
application-package: require deepmerge cjs

### DIFF
--- a/dev-packages/application-package/src/application-package.ts
+++ b/dev-packages/application-package/src/application-package.ts
@@ -20,7 +20,7 @@ import { NpmRegistry, NodePackage, PublishedNodePackage, sortByKey } from './npm
 import { Extension, ExtensionPackage, RawExtensionPackage } from './extension-package';
 import { ExtensionPackageCollector } from './extension-package-collector';
 import { ApplicationProps } from './application-props';
-const merge = require('deepmerge');
+const merge = require('deepmerge/dist/cjs');
 
 // tslint:disable:no-implicit-dependencies
 

--- a/dev-packages/application-package/src/application-props.ts
+++ b/dev-packages/application-package/src/application-props.ts
@@ -16,9 +16,8 @@
 
 import type { BrowserWindowConstructorOptions } from 'electron';
 
-/** deepmerge/dist/umd */
-const merge = require('deepmerge/dist/umd');
-export { merge };
+/** `deepmerge/dist/cjs` */
+export const merge = require('deepmerge/dist/cjs');
 
 export type RequiredRecursive<T> = {
     [K in keyof T]-?: T[K] extends object ? RequiredRecursive<T[K]> : T[K]


### PR DESCRIPTION
The line `const merge = require('deepmerge')` actually implies we want
the CJS version of deepmerge. It makes it easier to bundle using
Webpack.

#### How to test

N/A

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)