### PR TITLE
limit use of dynamic require

### DIFF
--- a/configs/errors.eslintrc.json
+++ b/configs/errors.eslintrc.json
@@ -131,17 +131,25 @@
       }
     ],
     "@theia/shared-dependencies": "error",
-    "import/no-extraneous-dependencies": "error"
+    "import/no-extraneous-dependencies": "error",
+    "import/no-dynamic-require": "error"
   },
   "overrides": [
     {
       "files": [
-        "dev-packages",
-        "*.{spec,espec,slow-spec}.{js,ts}"
+        "**/*.{spec,espec,slow-spec}.{js,ts}"
       ],
       "rules": {
         "@theia/shared-dependencies": "off",
         "import/no-extraneous-dependencies": "off"
+      }
+    },
+    {
+      "files": [
+        "**/electron-{node,main}/**"
+      ],
+      "rules": {
+        "import/no-dynamic-require": "off"
       }
     }
   ]

--- a/dev-packages/application-manager/.eslintrc.js
+++ b/dev-packages/application-manager/.eslintrc.js
@@ -6,5 +6,8 @@ module.exports = {
     parserOptions: {
         tsconfigRootDir: __dirname,
         project: 'compile.tsconfig.json'
+    },
+    rules: {
+        'import/no-dynamic-require': 'off'
     }
 };

--- a/dev-packages/application-manager/src/expose-loader.ts
+++ b/dev-packages/application-manager/src/expose-loader.ts
@@ -14,6 +14,7 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
+import fs = require('fs-extra');
 import * as path from 'path';
 // eslint-disable-next-line import/no-extraneous-dependencies
 import type { RawSourceMap } from 'source-map';
@@ -65,7 +66,7 @@ export = function (this: any, source: string, sourceMap?: RawSourceMap): string 
         let dir = this.resourcePath;
         while ((dir = path.dirname(dir)) !== nodeModulesPath) {
             try {
-                const { name } = require(path.join(dir, 'package.json'));
+                const { name } = fs.readJSONSync(path.join(dir, 'package.json'));
                 modulePackage = { name, dir };
                 modulePackages.push(modulePackage);
                 this.callback(undefined, exposeModule(modulePackage, this.resourcePath, source), sourceMap);

--- a/dev-packages/application-package/src/application-package.spec.ts
+++ b/dev-packages/application-package/src/application-package.spec.ts
@@ -54,6 +54,17 @@ describe('application-package', function (): void {
         assert.deepStrictEqual(applicationPackage.target, optTarget);
     });
 
+    it('should return all entry points', function (): void {
+        const applicationPackage = new ApplicationPackage({ projectPath: path.resolve(__dirname, '../../../examples/browser') });
+        assert.deepStrictEqual(applicationPackage.extensionEntryPoints, new Map([
+            ['ipc-bootstrap', '@theia/core/lib/node/messaging/ipc-bootstrap.js'],
+            ['nsfw-watcher', '@theia/filesystem/lib/node/nsfw-watcher/index.js'],
+            ['plugin-host', '@theia/plugin-ext/lib/hosted/node/plugin-host.js'],
+            ['backend-init-theia', '@theia/plugin-ext/lib/hosted/node/scanners/backend-init-theia.js'],
+            ['plugin-vscode-init', '@theia/plugin-ext-vscode/lib/node/plugin-vscode-init.js'],
+        ]));
+    });
+
     function createProjectWithTarget(target: string): string {
         const root = track.mkdirSync('foo-project');
         fs.writeFileSync(path.join(root, 'package.json'), `{"theia": {"target": "${target}"}}`);

--- a/dev-packages/application-package/src/application-package.spec.ts
+++ b/dev-packages/application-package/src/application-package.spec.ts
@@ -57,11 +57,11 @@ describe('application-package', function (): void {
     it('should return all entry points', function (): void {
         const applicationPackage = new ApplicationPackage({ projectPath: path.resolve(__dirname, '../../../examples/browser') });
         assert.deepStrictEqual(applicationPackage.extensionEntryPoints, new Map([
-            ['ipc-bootstrap', '@theia/core/lib/node/messaging/ipc-bootstrap.js'],
-            ['nsfw-watcher', '@theia/filesystem/lib/node/nsfw-watcher/index.js'],
-            ['plugin-host', '@theia/plugin-ext/lib/hosted/node/plugin-host.js'],
-            ['backend-init-theia', '@theia/plugin-ext/lib/hosted/node/scanners/backend-init-theia.js'],
-            ['plugin-vscode-init', '@theia/plugin-ext-vscode/lib/node/plugin-vscode-init.js'],
+            ['@theia/core/ipc-bootstrap', require.resolve('@theia/core/lib/node/messaging/ipc-bootstrap.js')],
+            ['@theia/filesystem/nsfw-watcher', require.resolve('@theia/filesystem/lib/node/nsfw-watcher/index.js')],
+            ['@theia/plugin-ext/plugin-host', require.resolve('@theia/plugin-ext/lib/hosted/node/plugin-host.js')],
+            ['@theia/plugin-ext/backend-init-theia', require.resolve('@theia/plugin-ext/lib/hosted/node/scanners/backend-init-theia.js')],
+            ['@theia/plugin-ext-vscode/plugin-vscode-init', require.resolve('@theia/plugin-ext-vscode/lib/node/plugin-vscode-init.js')],
         ]));
     });
 

--- a/dev-packages/application-package/src/application-package.ts
+++ b/dev-packages/application-package/src/application-package.ts
@@ -122,7 +122,7 @@ export class ApplicationPackage {
     /**
      * All entry points defined by the installed Theia extensions.
      *
-     * Map of entry point name to script import path.
+     * Map of entry point name to script absolute path.
      */
     get extensionEntryPoints(): ReadonlyMap<string, string> {
         if (!this._extensionEntryPoints) {
@@ -131,7 +131,7 @@ export class ApplicationPackage {
                 for (const theiaExtension of extensionPackage.theiaExtensions) {
                     if (typeof theiaExtension.entryPoints === 'object') {
                         for (const [key, value] of Object.entries(theiaExtension.entryPoints)) {
-                            this._extensionEntryPoints.set(key, `${extensionPackage.name}/${value}`);
+                            this._extensionEntryPoints.set(`${extensionPackage.name}/${key}`, require.resolve(`${extensionPackage.name}/${value}`));
                         }
                     }
                 }

--- a/dev-packages/application-package/src/extension-package.ts
+++ b/dev-packages/application-package/src/extension-package.ts
@@ -25,6 +25,10 @@ export interface Extension {
     backend?: string;
     backendElectron?: string;
     electronMain?: string;
+    /**
+     * Map of script name to script relative path
+     */
+    entryPoints?: Record<string, string>;
 }
 
 export class ExtensionPackage {

--- a/dev-packages/application-package/src/extension-package.ts
+++ b/dev-packages/application-package/src/extension-package.ts
@@ -26,7 +26,7 @@ export interface Extension {
     backendElectron?: string;
     electronMain?: string;
     /**
-     * Map of script name to script relative path
+     * Map of entry point id to js script path relative to its package root.
      */
     entryPoints?: Record<string, string>;
 }

--- a/dev-packages/cli/.eslintrc.js
+++ b/dev-packages/cli/.eslintrc.js
@@ -6,5 +6,8 @@ module.exports = {
     parserOptions: {
         tsconfigRootDir: __dirname,
         project: 'compile.tsconfig.json'
+    },
+    rules: {
+        'import/no-dynamic-require': 'off'
     }
 };

--- a/dev-packages/dynamic-require/README.md
+++ b/dev-packages/dynamic-require/README.md
@@ -1,0 +1,29 @@
+<div align='center'>
+
+<br />
+
+<img src='https://raw.githubusercontent.com/eclipse-theia/theia/master/logo/theia.svg?sanitize=true' alt='theia-ext-logo' width='100px' />
+
+<h2>ECLIPSE THEIA - DYNAMIC REQUIRE</h2>
+
+<hr />
+
+</div>
+
+## Description
+
+We need to factorize dynamic require calls for when bundling. This module only re-exports its own `require` function for that purpose.
+
+## Additional Information
+
+- [Theia - GitHub](https://github.com/eclipse-theia/theia)
+- [Theia - Website](https://theia-ide.org/)
+
+## License
+
+- [Eclipse Public License 2.0](http://www.eclipse.org/legal/epl-2.0/)
+- [一 (Secondary) GNU General Public License, version 2 with the GNU Classpath Exception](https://projects.eclipse.org/license/secondary-gpl-2.0-cp)
+
+## Trademark
+"Theia" is a trademark of the Eclipse Foundation
+https://www.eclipse.org/theia

--- a/dev-packages/dynamic-require/index.d.ts
+++ b/dev-packages/dynamic-require/index.d.ts
@@ -1,0 +1,21 @@
+/********************************************************************************
+ * Copyright (C) 2021 Ericsson and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+/**
+ * Throws if you try to require a relative path.
+ */
+const dynamicRequire: NodeRequireFunction;
+export = dynamicRequire;

--- a/dev-packages/dynamic-require/index.js
+++ b/dev-packages/dynamic-require/index.js
@@ -1,0 +1,26 @@
+"use strict";
+/********************************************************************************
+ * Copyright (C) 2021 Ericsson and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+module.exports = function dynamicRequire(id) {
+    if (typeof id !== 'string') {
+        throw new TypeError('module id must be a string');
+    }
+    if (id.startsWith('.')) {
+        throw new Error(`module id cannot be a relative path, id: "${id}"`);
+    }
+    return require(/* webpackIgnore: true */ id);
+}

--- a/dev-packages/dynamic-require/package.json
+++ b/dev-packages/dynamic-require/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "@theia/dynamic-require",
+  "version": "1.14.0",
+  "description": "Theia internal utility to wrap and factorize dynamic require calls on Node",
+  "main": "index.js",
+  "typings": "index.d.ts",
+  "engines": {
+    "node": "*"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "license": "EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/eclipse-theia/theia.git"
+  },
+  "bugs": {
+    "url": "https://github.com/eclipse-theia/theia/issues"
+  },
+  "homepage": "https://github.com/eclipse-theia/theia"
+}

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -18,6 +18,7 @@
     "@phosphor/widgets": "1",
     "@primer/octicons-react": "^9.0.0",
     "@theia/application-package": "1.14.0",
+    "@theia/dynamic-require": "1.14.0",
     "@types/body-parser": "^1.16.4",
     "@types/cookie": "^0.3.3",
     "@types/dompurify": "^2.2.2",
@@ -114,6 +115,11 @@
     ]
   },
   "theiaExtensions": [
+    {
+      "entryPoints": {
+        "ipc-bootstrap": "lib/node/messaging/ipc-bootstrap.js"
+      }
+    },
     {
       "frontend": "lib/browser/menu/browser-menu-module",
       "frontendElectron": "lib/electron-browser/menu/electron-menu-module"

--- a/packages/core/src/browser/keyboard/browser-keyboard-layout-provider.ts
+++ b/packages/core/src/browser/keyboard/browser-keyboard-layout-provider.ts
@@ -401,6 +401,8 @@ function loadLayout(fileName: string): KeyboardLayoutData {
         name: name.replace('_', ' '),
         hardware: hardware as 'pc' | 'mac',
         language,
+        // Webpack knows what to do here and it should bundle all files under `../../../src/common/keyboard/layouts/`
+        // eslint-disable-next-line import/no-dynamic-require
         raw: require('../../../src/common/keyboard/layouts/' + fileName + '.json')
     };
 }

--- a/packages/core/src/node/backend-application-module.ts
+++ b/packages/core/src/node/backend-application-module.ts
@@ -32,6 +32,7 @@ import { QuickPickService, quickPickServicePath } from '../common/quick-pick-ser
 import { WsRequestValidator, WsRequestValidatorContribution } from './ws-request-validators';
 import { KeytarService, keytarServicePath } from '../common/keytar-protocol';
 import { KeytarServiceImpl } from './keytar-server';
+import { EntryPointsRegistry, EntryPointsRegistryImpl } from './entry-point-registry';
 
 decorate(injectable(), ApplicationPackage);
 
@@ -101,4 +102,6 @@ export const backendApplicationModule = new ContainerModule(bind => {
     bind(ConnectionHandler).toDynamicValue(ctx =>
         new JsonRpcConnectionHandler(keytarServicePath, () => ctx.container.get<KeytarService>(KeytarService))
     ).inSingletonScope();
+
+    bind(EntryPointsRegistry).to(EntryPointsRegistryImpl).inSingletonScope();
 });

--- a/packages/core/src/node/backend-application-module.ts
+++ b/packages/core/src/node/backend-application-module.ts
@@ -32,7 +32,7 @@ import { QuickPickService, quickPickServicePath } from '../common/quick-pick-ser
 import { WsRequestValidator, WsRequestValidatorContribution } from './ws-request-validators';
 import { KeytarService, keytarServicePath } from '../common/keytar-protocol';
 import { KeytarServiceImpl } from './keytar-server';
-import { EntryPointsRegistry, EntryPointsRegistryImpl } from './entry-point-registry';
+import { EntryPointsRegistry, EntryPointsRegistryImpl, EntryPoint } from './entry-point';
 
 decorate(injectable(), ApplicationPackage);
 
@@ -104,4 +104,12 @@ export const backendApplicationModule = new ContainerModule(bind => {
     ).inSingletonScope();
 
     bind(EntryPointsRegistry).to(EntryPointsRegistryImpl).inSingletonScope();
+    bind(EntryPoint).toDynamicValue(ctx => {
+        const namedTag = ctx.currentRequest.target.getNamedTag();
+        if (!namedTag) {
+            throw new Error('inversify requests for "EntryPoint" must be named');
+        }
+        const registry: EntryPointsRegistry = ctx.container.get(EntryPointsRegistry);
+        return registry.getEntryPoint(namedTag.value);
+    });
 });

--- a/packages/core/src/node/entry-point-registry.ts
+++ b/packages/core/src/node/entry-point-registry.ts
@@ -1,0 +1,41 @@
+/********************************************************************************
+ * Copyright (C) 2021 Ericsson and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import { injectable, inject } from 'inversify';
+import { ApplicationPackage } from '@theia/application-package';
+
+export const EntryPointsRegistry = Symbol('EntryPointsRegistry');
+export interface EntryPointsRegistry {
+    getEntryPoint(name: string): string
+}
+
+@injectable()
+export class EntryPointsRegistryImpl implements EntryPointsRegistry {
+
+    @inject(ApplicationPackage)
+    protected app: ApplicationPackage;
+
+    /**
+     * Throws if `name` is not found.
+     */
+    getEntryPoint(name: string): string {
+        const entryPoint = this.app.extensionEntryPoints.get(name);
+        if (!entryPoint) {
+            throw new Error(`unknown entry point: "${name}"`);
+        }
+        return entryPoint;
+    }
+}

--- a/packages/core/src/node/entry-point.ts
+++ b/packages/core/src/node/entry-point.ts
@@ -17,6 +17,21 @@
 import { injectable, inject } from 'inversify';
 import { ApplicationPackage } from '@theia/application-package';
 
+/**
+ * You can quickly fetch the path of an entry point by doing a named injection on this symbol.
+ *
+ * Usage example:
+ *
+ * ```ts
+ * \@injectable()
+ * class {
+ *     \@inject(EntryPoint) @named('@theia/core/ipc-bootstrap')
+ *     protected ipcBootstrapPath: string;
+ * }
+ * ```
+ */
+export const EntryPoint = Symbol('EntryPoint');
+
 export const EntryPointsRegistry = Symbol('EntryPointsRegistry');
 export interface EntryPointsRegistry {
     getEntryPoint(name: string): string

--- a/packages/core/src/node/messaging/ipc-bootstrap.ts
+++ b/packages/core/src/node/messaging/ipc-bootstrap.ts
@@ -15,12 +15,14 @@
  ********************************************************************************/
 
 import 'reflect-metadata';
+import dynamicRequire = require('@theia/dynamic-require');
 import { ConsoleLogger } from 'vscode-ws-jsonrpc/lib/logger';
 import { createMessageConnection, IPCMessageReader, IPCMessageWriter, Trace } from 'vscode-ws-jsonrpc';
-import { checkParentAlive, ipcEntryPoint, IPCEntryPoint } from './ipc-protocol';
+import { checkParentAlive, IPCEntryPoint } from './ipc-protocol';
 
 checkParentAlive();
 
+const entryPoint = IPCEntryPoint.getScriptFromEnv();
 const reader = new IPCMessageReader(process);
 const writer = new IPCMessageWriter(process);
 const logger = new ConsoleLogger();
@@ -30,5 +32,4 @@ connection.trace(Trace.Off, {
     log: (message: any, data?: string) => console.log(message, data)
 });
 
-const entryPoint = require(ipcEntryPoint!).default as IPCEntryPoint;
-entryPoint(connection);
+dynamicRequire(entryPoint).default(connection);

--- a/packages/core/src/node/messaging/ipc-connection-provider.ts
+++ b/packages/core/src/node/messaging/ipc-connection-provider.ts
@@ -15,11 +15,11 @@
  ********************************************************************************/
 
 import * as cp from 'child_process';
-import { injectable, inject, postConstruct } from 'inversify';
+import { injectable, inject, named } from 'inversify';
 import { Trace, IPCMessageReader, IPCMessageWriter, createMessageConnection, MessageConnection, Message } from 'vscode-ws-jsonrpc';
 import { ILogger, ConnectionErrorHandler, DisposableCollection, Disposable } from '../../common';
 import { createIpcEnv } from './ipc-protocol';
-import { EntryPointsRegistry } from '../entry-point-registry';
+import { EntryPoint } from '../entry-point';
 
 export interface ResolvedIPCConnectionOptions {
     readonly serverName: string
@@ -37,18 +37,11 @@ export type IPCConnectionOptions = Partial<ResolvedIPCConnectionOptions> & {
 @injectable()
 export class IPCConnectionProvider {
 
+    @inject(EntryPoint) @named('@theia/core/ipc-bootstrap')
     protected ipcBootstrapEntryPoint: string;
 
     @inject(ILogger)
     protected readonly logger: ILogger;
-
-    @inject(EntryPointsRegistry)
-    protected entryPointsRegistry: EntryPointsRegistry;
-
-    @postConstruct()
-    protected postConstruct(): void {
-        this.ipcBootstrapEntryPoint = this.entryPointsRegistry.getEntryPoint('@theia/core/ipc-bootstrap');
-    }
 
     listen(options: IPCConnectionOptions, acceptor: (connection: MessageConnection) => void): Disposable {
         return this.doListen({

--- a/packages/core/src/node/messaging/ipc-protocol.ts
+++ b/packages/core/src/node/messaging/ipc-protocol.ts
@@ -19,8 +19,22 @@ import { MessageConnection } from 'vscode-ws-jsonrpc';
 
 const THEIA_PARENT_PID = 'THEIA_PARENT_PID';
 const THEIA_ENTRY_POINT = 'THEIA_ENTRY_POINT';
+const THEIA_ENV_REGEXP_EXCLUSION = new RegExp('^THEIA_*');
+
+export const ipcEntryPoint: string | undefined = process.env[THEIA_ENTRY_POINT];
 
 export type IPCEntryPoint = (connection: MessageConnection) => void;
+export namespace IPCEntryPoint {
+    /**
+     * Throws if `THEIA_ENTRY_POINT` is undefined or empty.
+     */
+    export function getScriptFromEnv(): string {
+        if (!ipcEntryPoint) {
+            throw new Error(`"${THEIA_ENTRY_POINT}" is missing from the environment`);
+        }
+        return ipcEntryPoint;
+    }
+}
 
 /**
  * Exit the current process if the parent process is not alive.
@@ -43,9 +57,6 @@ export function checkParentAlive(): void {
     }
 }
 
-export const ipcEntryPoint = process.env[THEIA_ENTRY_POINT];
-
-const THEIA_ENV_REGEXP_EXCLUSION = new RegExp('^THEIA_*');
 export function createIpcEnv(options?: {
     entryPoint?: string
     env?: NodeJS.ProcessEnv

--- a/packages/debug/src/node/vscode/vscode-debug-adapter-contribution.ts
+++ b/packages/debug/src/node/vscode/vscode-debug-adapter-contribution.ts
@@ -98,13 +98,11 @@ export abstract class AbstractVSCodeDebugAdapterContribution implements DebugAda
     }
 
     protected async parse(): Promise<VSCodeExtensionPackage> {
-        let text = (await fs.readFile(this.pckPath)).toString();
+        let text: string = await fs.readFile(this.pckPath, 'utf8');
 
         const nlsPath = path.join(this.extensionPath, 'package.nls.json');
-        if (fs.existsSync(nlsPath)) {
-            const nlsMap: {
-                [key: string]: string
-            } = require(nlsPath);
+        if (await fs.pathExists(nlsPath)) {
+            const nlsMap: Record<string, string> = await fs.readJSON(nlsPath);
             for (const key of Object.keys(nlsMap)) {
                 const value = nlsMap[key].replace(/\"/g, '\\"');
                 text = text.split('%' + key + '%').join(value);

--- a/packages/filesystem/package.json
+++ b/packages/filesystem/package.json
@@ -25,7 +25,7 @@
       "frontend": "lib/browser/filesystem-frontend-module",
       "backend": "lib/node/filesystem-backend-module",
       "entryPoints": {
-        "nsfw-watcher": "lib/node/nsfw-watcher/index.js"
+        "ipc-nsfw-watcher": "lib/node/nsfw-watcher/index.js"
       }
     },
     {

--- a/packages/filesystem/package.json
+++ b/packages/filesystem/package.json
@@ -23,7 +23,10 @@
   "theiaExtensions": [
     {
       "frontend": "lib/browser/filesystem-frontend-module",
-      "backend": "lib/node/filesystem-backend-module"
+      "backend": "lib/node/filesystem-backend-module",
+      "entryPoints": {
+        "nsfw-watcher": "lib/node/nsfw-watcher/index.js"
+      }
     },
     {
       "frontend": "lib/browser/download/file-download-frontend-module",

--- a/packages/filesystem/src/node/filesystem-backend-module.ts
+++ b/packages/filesystem/src/node/filesystem-backend-module.ts
@@ -31,7 +31,7 @@ import { EncodingService } from '@theia/core/lib/common/encoding-service';
 import { IPCConnectionProvider } from '@theia/core/lib/node';
 import { JsonRpcProxyFactory, ConnectionErrorHandler } from '@theia/core';
 import { FileSystemWatcherServiceDispatcher } from './filesystem-watcher-dispatcher';
-import { EntryPointsRegistry } from '@theia/core/lib/node/entry-point-registry';
+import { EntryPoint } from '@theia/core/lib/node/entry-point';
 
 export const NSFW_SINGLE_THREADED = process.argv.includes('--no-cluster');
 export const NSFW_WATCHER_VERBOSE = process.argv.includes('--nsfw-watcher-verbose');
@@ -74,12 +74,9 @@ export function bindFileSystemWatcherServer(bind: interfaces.Bind): void {
     bind(FileSystemWatcherServerClient).toSelf();
     bind(FileSystemWatcherServer).toService(FileSystemWatcherServerClient);
 
-    bind<NsfwFileSystemWatcherServiceProcessOptions>(NsfwFileSystemWatcherServiceProcessOptions).toDynamicValue(ctx => {
-        const registry: EntryPointsRegistry = ctx.container.get(EntryPointsRegistry);
-        return {
-            entryPoint: registry.getEntryPoint('@theia/filesystem/ipc-nsfw-watcher'),
-        };
-    }).inSingletonScope();
+    bind<NsfwFileSystemWatcherServiceProcessOptions>(NsfwFileSystemWatcherServiceProcessOptions).toDynamicValue(ctx => ({
+        entryPoint: ctx.container.getNamed(EntryPoint, '@theia/filesystem/ipc-nsfw-watcher'),
+    })).inSingletonScope();
     bind<NsfwFileSystemWatcherServerOptions>(NsfwFileSystemWatcherServerOptions).toDynamicValue(ctx => {
         const logger = ctx.container.get<ILogger>(ILogger);
         const nsfwOptions = ctx.container.get<NsfwOptions>(NsfwOptions);

--- a/packages/filesystem/src/node/filesystem-backend-module.ts
+++ b/packages/filesystem/src/node/filesystem-backend-module.ts
@@ -14,7 +14,6 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
-import * as path from 'path';
 import { ContainerModule, interfaces } from '@theia/core/shared/inversify';
 import { ConnectionHandler, JsonRpcConnectionHandler, ILogger } from '@theia/core/lib/common';
 import { FileSystemWatcherServer, FileSystemWatcherService } from '../common/filesystem-watcher-protocol';
@@ -32,6 +31,7 @@ import { EncodingService } from '@theia/core/lib/common/encoding-service';
 import { IPCConnectionProvider } from '@theia/core/lib/node';
 import { JsonRpcProxyFactory, ConnectionErrorHandler } from '@theia/core';
 import { FileSystemWatcherServiceDispatcher } from './filesystem-watcher-dispatcher';
+import { EntryPointsRegistry } from '@theia/core/lib/node/entry-point-registry';
 
 export const NSFW_SINGLE_THREADED = process.argv.includes('--no-cluster');
 export const NSFW_WATCHER_VERBOSE = process.argv.includes('--nsfw-watcher-verbose');
@@ -74,9 +74,12 @@ export function bindFileSystemWatcherServer(bind: interfaces.Bind): void {
     bind(FileSystemWatcherServerClient).toSelf();
     bind(FileSystemWatcherServer).toService(FileSystemWatcherServerClient);
 
-    bind<NsfwFileSystemWatcherServiceProcessOptions>(NsfwFileSystemWatcherServiceProcessOptions).toConstantValue({
-        entryPoint: path.resolve(__dirname, 'nsfw-watcher'),
-    });
+    bind<NsfwFileSystemWatcherServiceProcessOptions>(NsfwFileSystemWatcherServiceProcessOptions).toDynamicValue(ctx => {
+        const registry: EntryPointsRegistry = ctx.container.get(EntryPointsRegistry);
+        return {
+            entryPoint: registry.getEntryPoint('@theia/filesystem/ipc-nsfw-watcher'),
+        };
+    }).inSingletonScope();
     bind<NsfwFileSystemWatcherServerOptions>(NsfwFileSystemWatcherServerOptions).toDynamicValue(ctx => {
         const logger = ctx.container.get<ILogger>(ILogger);
         const nsfwOptions = ctx.container.get<NsfwOptions>(NsfwOptions);

--- a/packages/git/package.json
+++ b/packages/git/package.json
@@ -28,7 +28,10 @@
   "theiaExtensions": [
     {
       "frontend": "lib/browser/git-frontend-module",
-      "backend": "lib/node/git-backend-module"
+      "backend": "lib/node/git-backend-module",
+      "entryPoints": {
+        "git-locator-host": "lib/node/git-locator/git-locator-host.js"
+      }
     },
     {
       "backend": "lib/node/env/git-env-module",

--- a/packages/git/src/node/git-locator/git-locator-client.ts
+++ b/packages/git/src/node/git-locator/git-locator-client.ts
@@ -14,28 +14,22 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
-import { inject, injectable, postConstruct } from '@theia/core/shared/inversify';
+import { inject, injectable, named } from '@theia/core/shared/inversify';
 import { JsonRpcProxyFactory, DisposableCollection } from '@theia/core';
 import { IPCConnectionProvider } from '@theia/core/lib/node';
 import { GitLocator, GitLocateOptions } from './git-locator-protocol';
-import { EntryPointsRegistry } from '@theia/core/lib/node/entry-point-registry';
+import { EntryPoint } from '@theia/core/lib/node/entry-point';
 
 @injectable()
 export class GitLocatorClient implements GitLocator {
 
-    protected ipcGitLocatorEntryPoint: string;
     protected readonly toDispose = new DisposableCollection();
 
-    @inject(EntryPointsRegistry)
-    protected entryPointRegistry: EntryPointsRegistry;
+    @inject(EntryPoint) @named('@theia/git/git-locator-host')
+    protected ipcGitLocatorEntryPoint: string;
 
     @inject(IPCConnectionProvider)
     protected readonly ipcConnectionProvider: IPCConnectionProvider;
-
-    @postConstruct()
-    protected postConstruct(): void {
-        this.ipcGitLocatorEntryPoint = this.entryPointRegistry.getEntryPoint('@theia/git/git-locator-host');
-    }
 
     dispose(): void {
         this.toDispose.dispose();

--- a/packages/plugin-dev/src/node/hosted-instance-manager.ts
+++ b/packages/plugin-dev/src/node/hosted-instance-manager.ts
@@ -16,7 +16,7 @@
 
 import { inject, injectable, named } from '@theia/core/shared/inversify';
 import * as cp from 'child_process';
-import * as fs from 'fs';
+import * as fs from '@theia/core/shared/fs-extra';
 import * as net from 'net';
 import * as path from 'path';
 import * as request from 'request';
@@ -229,9 +229,10 @@ export abstract class AbstractHostedInstanceManager implements HostedInstanceMan
     isPluginValid(uri: URI): boolean {
         const pckPath = path.join(FileUri.fsPath(uri), 'package.json');
         if (fs.existsSync(pckPath)) {
-            const pck = require(pckPath);
+            const pck = fs.readJSONSync(pckPath);
             try {
-                return !!this.metadata.getScanner(pck);
+                this.metadata.getScanner(pck);
+                return true;
             } catch (e) {
                 console.error(e);
                 return false;

--- a/packages/plugin-dev/src/node/hosted-plugins-manager.ts
+++ b/packages/plugin-dev/src/node/hosted-plugins-manager.ts
@@ -17,7 +17,7 @@
 import { inject, injectable } from '@theia/core/shared/inversify';
 import * as cp from 'child_process';
 import * as processTree from 'ps-tree';
-import * as fs from 'fs';
+import * as fs from '@theia/core/shared/fs-extra';
 import * as path from 'path';
 import { FileUri } from '@theia/core/lib/node';
 import { HostedPluginSupport } from '@theia/plugin-ext/lib/hosted/node/hosted-plugin';
@@ -134,7 +134,7 @@ export class HostedPluginsManagerImpl implements HostedPluginsManager {
     protected checkWatchScript(pluginPath: string): boolean {
         const pluginPackageJsonPath = path.join(pluginPath, 'package.json');
         if (fs.existsSync(pluginPackageJsonPath)) {
-            const packageJson = require(pluginPackageJsonPath);
+            const packageJson = fs.readJSONSync(pluginPackageJsonPath);
             const scripts = packageJson['scripts'];
             if (scripts && scripts['watch']) {
                 return true;

--- a/packages/plugin-ext-vscode/package.json
+++ b/packages/plugin-ext-vscode/package.json
@@ -23,7 +23,10 @@
   "theiaExtensions": [
     {
       "backend": "lib/node/plugin-vscode-backend-module",
-      "frontend": "lib/browser/plugin-vscode-frontend-module"
+      "frontend": "lib/browser/plugin-vscode-frontend-module",
+      "entryPoints": {
+        "plugin-vscode-init": "lib/node/plugin-vscode-init.js"
+      }
     }
   ],
   "keywords": [

--- a/packages/plugin-ext-vscode/src/node/plugin-vscode-directory-handler.ts
+++ b/packages/plugin-ext-vscode/src/node/plugin-vscode-directory-handler.ts
@@ -14,7 +14,7 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
-import * as fs from 'fs';
+import * as fs from '@theia/core/shared/fs-extra';
 import * as path from 'path';
 import { injectable } from '@theia/core/shared/inversify';
 import { RecursivePartial } from '@theia/core';
@@ -76,7 +76,7 @@ export class PluginVsCodeDirectoryHandler implements PluginDeployerDirectoryHand
 
     protected requirePackage(pluginPath: string): PluginPackage | undefined {
         try {
-            return require(path.join(pluginPath, 'package.json'));
+            return fs.readJSONSync(path.join(pluginPath, 'package.json'));
         } catch {
             return undefined;
         }

--- a/packages/plugin-ext-vscode/src/node/scanner-vscode.ts
+++ b/packages/plugin-ext-vscode/src/node/scanner-vscode.ts
@@ -14,14 +14,22 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
-import { injectable } from '@theia/core/shared/inversify';
+import { injectable, postConstruct } from '@theia/core/shared/inversify';
 import { PluginScanner, PluginEngine, PluginPackage, PluginModel, PluginLifecycle } from '@theia/plugin-ext';
 import { TheiaPluginScanner } from '@theia/plugin-ext/lib/hosted/node/scanners/scanner-theia';
 
 @injectable()
 export class VsCodePluginScanner extends TheiaPluginScanner implements PluginScanner {
+
+    protected pluginVscodeInitEntryPoint: string;
+
     private readonly VSCODE_TYPE: PluginEngine = 'vscode';
     private readonly VSCODE_PREFIX: string = 'vscode:extension/';
+
+    @postConstruct()
+    protected postConstruct(): void {
+        this.pluginVscodeInitEntryPoint = this.entryPointRegistry.getEntryPoint('@theia/plugin-ext-vscode/plugin-vscode-init');
+    }
 
     get apiType(): PluginEngine {
         return this.VSCODE_TYPE;
@@ -79,7 +87,7 @@ export class VsCodePluginScanner extends TheiaPluginScanner implements PluginSca
             startMethod: 'activate',
             stopMethod: 'deactivate',
 
-            backendInitPath: __dirname + '/plugin-vscode-init.js'
+            backendInitPath: this.pluginVscodeInitEntryPoint,
         };
     }
 

--- a/packages/plugin-ext-vscode/src/node/scanner-vscode.ts
+++ b/packages/plugin-ext-vscode/src/node/scanner-vscode.ts
@@ -14,22 +14,19 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
-import { injectable, postConstruct } from '@theia/core/shared/inversify';
+import { injectable, inject, named } from '@theia/core/shared/inversify';
 import { PluginScanner, PluginEngine, PluginPackage, PluginModel, PluginLifecycle } from '@theia/plugin-ext';
 import { TheiaPluginScanner } from '@theia/plugin-ext/lib/hosted/node/scanners/scanner-theia';
+import { EntryPoint } from '@theia/core/lib/node/entry-point';
 
 @injectable()
 export class VsCodePluginScanner extends TheiaPluginScanner implements PluginScanner {
 
-    protected pluginVscodeInitEntryPoint: string;
-
     private readonly VSCODE_TYPE: PluginEngine = 'vscode';
     private readonly VSCODE_PREFIX: string = 'vscode:extension/';
 
-    @postConstruct()
-    protected postConstruct(): void {
-        this.pluginVscodeInitEntryPoint = this.entryPointRegistry.getEntryPoint('@theia/plugin-ext-vscode/plugin-vscode-init');
-    }
+    @inject(EntryPoint) @named('@theia/plugin-ext-vscode/plugin-vscode-init')
+    protected pluginVscodeInitEntryPoint: string;
 
     get apiType(): PluginEngine {
         return this.VSCODE_TYPE;

--- a/packages/plugin-ext/package.json
+++ b/packages/plugin-ext/package.json
@@ -9,6 +9,7 @@
     "@theia/callhierarchy": "1.14.0",
     "@theia/core": "1.14.0",
     "@theia/debug": "1.14.0",
+    "@theia/dynamic-require": "1.14.0",
     "@theia/editor": "1.14.0",
     "@theia/file-search": "1.14.0",
     "@theia/filesystem": "1.14.0",
@@ -48,7 +49,11 @@
     {
       "backend": "lib/plugin-ext-backend-module",
       "backendElectron": "lib/plugin-ext-backend-electron-module",
-      "frontend": "lib/plugin-ext-frontend-module"
+      "frontend": "lib/plugin-ext-frontend-module",
+      "entryPoints": {
+        "plugin-host": "lib/hosted/node/plugin-host.js",
+        "backend-init-theia": "lib/hosted/node/scanners/backend-init-theia.js"
+      }
     },
     {
       "frontendElectron": "lib/plugin-ext-frontend-electron-module"

--- a/packages/plugin-ext/src/hosted/node/metadata-scanner.ts
+++ b/packages/plugin-ext/src/hosted/node/metadata-scanner.ts
@@ -40,24 +40,23 @@ export class MetadataScanner {
     /**
      * Returns the first suitable scanner.
      *
+     * Throws if no scanner was found.
+     *
      * @param {PluginPackage} plugin
      * @returns {PluginScanner}
      */
     getScanner(plugin: PluginPackage): PluginScanner {
-        let scanner;
+        let scanner: PluginScanner | undefined;
         if (plugin && plugin.engines) {
             const scanners = Object.keys(plugin.engines)
-                .filter((engineName: string) => this.scanners.has(engineName))
-                .map((engineName: string) => this.scanners.get(engineName));
-
+                .filter(engineName => this.scanners.has(engineName))
+                .map(engineName => this.scanners.get(engineName)!);
             // get the first suitable scanner from the list
             scanner = scanners[0];
         }
-
         if (!scanner) {
             throw new Error('There is no suitable scanner found for ' + plugin.name);
         }
-
         return scanner;
     }
 }

--- a/packages/plugin-ext/src/hosted/node/plugin-ext-hosted-backend-module.ts
+++ b/packages/plugin-ext/src/hosted/node/plugin-ext-hosted-backend-module.ts
@@ -32,7 +32,7 @@ import { HostedPluginCliContribution } from './hosted-plugin-cli-contribution';
 import { HostedPluginDeployerHandler } from './hosted-plugin-deployer-handler';
 import { PluginUriFactory } from './scanners/plugin-uri-factory';
 import { FilePluginUriFactory } from './scanners/file-plugin-uri-factory';
-import { EntryPointsRegistry } from '@theia/core/lib/node/entry-point-registry';
+import { EntryPoint } from '@theia/core/lib/node/entry-point';
 
 const commonHostedConnectionModule = ConnectionContainerModule.create(({ bind, bindBackendService }) => {
     bind(HostedPluginProcess).toSelf().inSingletonScope();
@@ -62,12 +62,9 @@ export function bindCommonHostedBackend(bind: interfaces.Bind): void {
     bind(PluginDeployerHandler).toService(HostedPluginDeployerHandler);
 
     bind(GrammarsReader).toSelf().inSingletonScope();
-    bind(HostedPluginProcessConfiguration).toDynamicValue(ctx => {
-        const registry: EntryPointsRegistry = ctx.container.get(EntryPointsRegistry);
-        return {
-            path: registry.getEntryPoint('@theia/plugin-ext/plugin-host'),
-        };
-    }).inSingletonScope();
+    bind(HostedPluginProcessConfiguration).toDynamicValue(ctx => ({
+        path: ctx.container.getNamed(EntryPoint, '@theia/plugin-ext/plugin-host'),
+    })).inSingletonScope();
 
     bind(ConnectionContainerModule).toConstantValue(commonHostedConnectionModule);
     bind(PluginUriFactory).to(FilePluginUriFactory).inSingletonScope();

--- a/packages/plugin-ext/src/hosted/node/plugin-host-rpc.ts
+++ b/packages/plugin-ext/src/hosted/node/plugin-host-rpc.ts
@@ -14,6 +14,7 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
+import dynamicRequire = require('@theia/dynamic-require');
 import { PluginManagerExtImpl } from '../../plugin/plugin-manager';
 import { MAIN_RPC_CONTEXT, Plugin, PluginAPIFactory } from '../../common/plugin-api-rpc';
 import { PluginMetadata } from '../../common/plugin-protocol';
@@ -85,12 +86,11 @@ export class PluginHostRPC {
         await this.pluginManager.terminate();
     }
 
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    initContext(contextPath: string, plugin: Plugin): any {
+    initContext(contextPath: string, plugin: Plugin): void {
         const { name, version } = plugin.rawModel;
         console.log('PLUGIN_HOST(' + process.pid + '): initializing(' + name + '@' + version + ' with ' + contextPath + ')');
         try {
-            const backendInit = require(contextPath);
+            const backendInit = dynamicRequire(contextPath);
             backendInit.doInitialization(this.apiFactory, plugin);
         } catch (e) {
             console.error(e);
@@ -144,7 +144,7 @@ export class PluginHostRPC {
 
                 });
                 if (plugin.pluginPath) {
-                    return require(plugin.pluginPath);
+                    return dynamicRequire(plugin.pluginPath);
                 }
             },
             async init(raw: PluginMetadata[]): Promise<[Plugin[], Plugin[]]> {
@@ -197,7 +197,7 @@ export class PluginHostRPC {
                 for (const api of extApi) {
                     if (api.backendInitPath) {
                         try {
-                            const extApiInit = require(api.backendInitPath);
+                            const extApiInit = dynamicRequire(api.backendInitPath);
                             extApiInit.provideApi(rpc, pluginManager);
                         } catch (e) {
                             console.error(e);
@@ -211,7 +211,7 @@ export class PluginHostRPC {
                 let testRunner: any;
                 let requireError: Error | undefined;
                 try {
-                    testRunner = require(extensionTestsPath);
+                    testRunner = dynamicRequire(extensionTestsPath);
                 } catch (error) {
                     requireError = error;
                 }

--- a/packages/plugin-ext/src/hosted/node/plugin-host.ts
+++ b/packages/plugin-ext/src/hosted/node/plugin-host.ts
@@ -83,9 +83,9 @@ const rpc = new RPCProtocolImpl({
         }
     }
 },
-{
-    reviver: reviver
-});
+    {
+        reviver: reviver
+    });
 
 process.on('message', async (message: string) => {
     if (terminating) {

--- a/packages/plugin-ext/src/hosted/node/scanners/grammars-reader.ts
+++ b/packages/plugin-ext/src/hosted/node/scanners/grammars-reader.ts
@@ -17,7 +17,8 @@
 import { injectable } from '@theia/core/shared/inversify';
 import { PluginPackageGrammarsContribution, GrammarsContribution } from '../../../common';
 import * as path from 'path';
-import * as fs from 'fs';
+import * as fs from '@theia/core/shared/fs-extra';
+
 @injectable()
 export class GrammarsReader {
 
@@ -37,7 +38,7 @@ export class GrammarsReader {
         // TODO: validate inputs
         let grammar: string | object;
         if (rawGrammar.path.endsWith('json')) {
-            grammar = require(path.resolve(pluginPath, rawGrammar.path));
+            grammar = fs.readJSONSync(path.resolve(pluginPath, rawGrammar.path));
         } else {
             grammar = fs.readFileSync(path.resolve(pluginPath, rawGrammar.path), 'utf8');
         }

--- a/packages/plugin-ext/src/hosted/node/scanners/scanner-theia.ts
+++ b/packages/plugin-ext/src/hosted/node/scanners/scanner-theia.ts
@@ -14,7 +14,7 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
-import { inject, injectable, postConstruct } from '@theia/core/shared/inversify';
+import { inject, injectable, named } from '@theia/core/shared/inversify';
 import {
     AutoClosingPair,
     AutoClosingPairConditional,
@@ -72,7 +72,7 @@ import {
 import { ColorDefinition } from '@theia/core/lib/browser/color-registry';
 import { ResourceLabelFormatter } from '@theia/core/lib/common/label-protocol';
 import { PluginUriFactory } from './plugin-uri-factory';
-import { EntryPointsRegistry } from '@theia/core/lib/node/entry-point-registry';
+import { EntryPoint } from '@theia/core/lib/node/entry-point';
 
 namespace nls {
     export function localize(key: string, _default: string): string {
@@ -91,7 +91,6 @@ const colorIdPattern = '^\\w+[.\\w+]*$';
 @injectable()
 export class TheiaPluginScanner implements PluginScanner {
 
-    protected backendInitTheiaEntryPoint: string;
     private readonly _apiType: PluginEngine = 'theiaPlugin';
 
     @inject(GrammarsReader)
@@ -100,13 +99,8 @@ export class TheiaPluginScanner implements PluginScanner {
     @inject(PluginUriFactory)
     protected readonly pluginUriFactory: PluginUriFactory;
 
-    @inject(EntryPointsRegistry)
-    protected entryPointRegistry: EntryPointsRegistry;
-
-    @postConstruct()
-    protected postConstruct(): void {
-        this.backendInitTheiaEntryPoint = this.entryPointRegistry.getEntryPoint('@theia/plugin-ext/backend-init-theia');
-    }
+    @inject(EntryPoint) @named('@theia/plugin-ext/backend-init-theia')
+    protected backendInitTheiaEntryPoint: string;
 
     get apiType(): PluginEngine {
         return this._apiType;

--- a/packages/plugin-ext/src/hosted/node/scanners/scanner-theia.ts
+++ b/packages/plugin-ext/src/hosted/node/scanners/scanner-theia.ts
@@ -14,7 +14,7 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
-import { inject, injectable } from '@theia/core/shared/inversify';
+import { inject, injectable, postConstruct } from '@theia/core/shared/inversify';
 import {
     AutoClosingPair,
     AutoClosingPairConditional,
@@ -72,6 +72,7 @@ import {
 import { ColorDefinition } from '@theia/core/lib/browser/color-registry';
 import { ResourceLabelFormatter } from '@theia/core/lib/common/label-protocol';
 import { PluginUriFactory } from './plugin-uri-factory';
+import { EntryPointsRegistry } from '@theia/core/lib/node/entry-point-registry';
 
 namespace nls {
     export function localize(key: string, _default: string): string {
@@ -90,6 +91,7 @@ const colorIdPattern = '^\\w+[.\\w+]*$';
 @injectable()
 export class TheiaPluginScanner implements PluginScanner {
 
+    protected backendInitTheiaEntryPoint: string;
     private readonly _apiType: PluginEngine = 'theiaPlugin';
 
     @inject(GrammarsReader)
@@ -97,6 +99,14 @@ export class TheiaPluginScanner implements PluginScanner {
 
     @inject(PluginUriFactory)
     protected readonly pluginUriFactory: PluginUriFactory;
+
+    @inject(EntryPointsRegistry)
+    protected entryPointRegistry: EntryPointsRegistry;
+
+    @postConstruct()
+    protected postConstruct(): void {
+        this.backendInitTheiaEntryPoint = this.entryPointRegistry.getEntryPoint('@theia/plugin-ext/backend-init-theia');
+    }
 
     get apiType(): PluginEngine {
         return this._apiType;
@@ -131,7 +141,7 @@ export class TheiaPluginScanner implements PluginScanner {
             stopMethod: 'stop',
             frontendModuleName: buildFrontendModuleName(plugin),
 
-            backendInitPath: __dirname + '/backend-init-theia.js'
+            backendInitPath: this.backendInitTheiaEntryPoint,
         };
     }
 

--- a/packages/plugin-ext/src/main/node/handlers/plugin-theia-directory-handler.ts
+++ b/packages/plugin-ext/src/main/node/handlers/plugin-theia-directory-handler.ts
@@ -20,7 +20,7 @@ import {
     PluginDeployerEntryType
 } from '../../../common/plugin-protocol';
 import { injectable } from '@theia/core/shared/inversify';
-import * as fs from 'fs';
+import * as fs from '@theia/core/shared/fs-extra';
 import * as path from 'path';
 
 @injectable()
@@ -44,7 +44,7 @@ export class PluginTheiaDirectoryHandler implements PluginDeployerDirectoryHandl
 
         let packageJson: PluginPackage = resolvedPlugin.getValue('package.json');
         if (!packageJson) {
-            packageJson = require(packageJsonPath);
+            packageJson = fs.readJSONSync(packageJsonPath);
             resolvedPlugin.storeValue('package.json', packageJson);
         }
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -183,6 +183,9 @@
       ],
       "@theia/ovsx-client/lib/*": [
         "dev-packages/ovsx-client/src/*"
+      ],
+      "@theia/dynamic-require/*": [
+        "dev-packages/dynamic-require/*"
       ]
     }
   }


### PR DESCRIPTION
Using Node's builtin require function to dynamically import scripts
makes bundling Node apps difficult when using tools like Webpack.

Add a new package `@theia/dynamic-require`: This is a minimal package
that re-export a function wrapping Node's require. The purpose of this
is to factorize dynamic requires into a single package to make bundling
easier.

Remove as many occurences of Node require and replace the few required
ones with `@theia/dynamic-require`.

Add a new eslint rule `import/no-dynamic-require` to help detect places
that would benefit from `@theia/dynamic-require`.

Add `entryPoints` declarations to Theia extensions.

Add `extensionEntryPoints` property to `ApplicationPackage` that lists
all declared entry points.

Closes https://github.com/eclipse-theia/theia/issues/9434
Closes https://github.com/eclipse-theia/theia/issues/9432

#### How to test

Everything should work as before, this is a refactoring.

As long as the new test in `dev-packages/application-package` passes it means the added API works as well.

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)