### PR TITLE
api-test: remove leftover `.only`

### DIFF
--- a/examples/api-tests/src/saveable.spec.js
+++ b/examples/api-tests/src/saveable.spec.js
@@ -468,7 +468,7 @@ describe('Saveable', function () {
         }
     });
 
-    it.only(`'${closeOnFileDelete}' should close the editor when set to 'true'`, async () => {
+    it(`'${closeOnFileDelete}' should close the editor when set to 'true'`, async () => {
 
         await preferences.set(closeOnFileDelete, true);
         assert.isTrue(preferences.get(closeOnFileDelete));


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

The commit removes a leftover `.only` likely used for test-purposes in the `saveable.spec.js` api-tests.
Only one test was executed: https://github.com/eclipse-theia/theia/runs/2889499092#step:7:501.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

Confirm that CI is green, and the tests are executed.

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

Signed-off-by: vince-fugnitto <vincent.fugnitto@ericsson.com>