### PR TITLE
Modify next-node selection logic for PreferenceTreeModel

### DIFF
--- a/packages/core/src/browser/tree/tree-model.ts
+++ b/packages/core/src/browser/tree/tree-model.ts
@@ -306,7 +306,7 @@ export class TreeModelImpl implements TreeModel, SelectionProvider<ReadonlyArray
         // Skip the first item. // TODO: clean this up, and skip the first item in a different way without loading everything.
         iterator.next();
         let result = iterator.next();
-        while (!result.done && !SelectableTreeNode.isVisible(result.value)) {
+        while (!result.done && !this.isVisibleSelectableNode(result.value)) {
             result = iterator.next();
         }
         const node = result.value;
@@ -314,6 +314,10 @@ export class TreeModelImpl implements TreeModel, SelectionProvider<ReadonlyArray
             return node;
         }
         return undefined;
+    }
+
+    protected isVisibleSelectableNode(node: TreeNode): node is SelectableTreeNode {
+        return SelectableTreeNode.isVisible(node);
     }
 
     protected createBackwardIterator(node: TreeNode | undefined): TreeIterator | undefined {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->
Fixes #9655 by changing the logic for choosing the 'next selectable node' in preferences tree. For extensibility, I've made that check a protected method in the base `TreeModel` class and overridden it in the `PreferenceTreeModel`

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
1. Open the Preferences widget.
2. Search for "selection", or other text of your choosing.
3. Click on "Text Editor".
4. Press the down arrow and notice that it takes 1x before selecting "Find", and then another 1x before selecting "Suggest".
5. Perform the same test on an unfiltered tree and see that each keyboard press moves you 1 item.

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

Signed-off-by: Colin Grant <colin.grant@ericsson.com>