### PR TITLE
Use supplied filter by default

### DIFF
--- a/packages/filesystem/src/browser/file-dialog/file-dialog-tree-filters-renderer.tsx
+++ b/packages/filesystem/src/browser/file-dialog/file-dialog-tree-filters-renderer.tsx
@@ -59,7 +59,7 @@ export class FileDialogTreeFiltersRenderer extends ReactRenderer {
         super();
         this.suppliedFilters = options.suppliedFilters;
         this.fileDialogTree = options.fileDialogTree;
-        this.appliedFilters = { 'All Files': [], ...this.suppliedFilters, };
+        this.appliedFilters = { ...this.suppliedFilters, 'All Files': [], };
     }
 
     protected readonly handleFilterChanged = (e: React.ChangeEvent<HTMLSelectElement>) => this.onFilterChanged(e);

--- a/packages/filesystem/src/electron-browser/file-dialog/electron-file-dialog-service.ts
+++ b/packages/filesystem/src/electron-browser/file-dialog/electron-file-dialog-service.ts
@@ -95,7 +95,7 @@ export class ElectronFileDialogService extends DefaultFileDialogService {
         const defaultPath = FileUri.fsPath(uri);
         const filters: FileFilter[] = [{ name: 'All Files', extensions: ['*'] }];
         if (props.filters) {
-            filters.push(...Object.keys(props.filters).map(key => ({ name: key, extensions: props.filters![key] })));
+            filters.unshift(...Object.keys(props.filters).map(key => ({ name: key, extensions: props.filters![key] })));
         }
         return { title, defaultPath, filters };
     }


### PR DESCRIPTION
Signed-off-by: Gabriel Bodeen <gabriel.bodeen@ericsson.com>

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

Fixes: #9468
Fixes: #9242

This is a simple alternative to https://github.com/eclipse-theia/theia/pull/9502. I prefer it because:
* Navigating some large file structures is much easier when all files are visible, so I want the "All Files" option to be available in such cases.
* Sometimes I have a misnamed file and I want to be able to tell the dialog I know better than its extension filter.

For the browser version, it makes use of the ordering of `Object.keys()` in ES2015+, which is:
1. number-like keys in numerical order
2. other string keys in insertion order (this is the only one that should be relevant)
3. symbol keys in insertion order

The electron version uses an array.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

From issue #9468:

1. Unzip this plugin (vsix file) into your plugins folder: https://github.com/eclipse-theia/theia/files/6464691/helloworld-0.0.12.zip
2. Launch Theia, use the palette to run the `Hello World` command.
3. In both browser and electron, the default file filter should be `test` (for .txt files), with `All Files` the next option in the dropdown.

#### Review checklist

- [X] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

