### PR TITLE
ci(compile-references): add error info for configureTypeScriptNavigation

### DIFF
--- a/scripts/compile-references.js
+++ b/scripts/compile-references.js
@@ -267,7 +267,7 @@ function configureTypeScriptNavigation(targetPackage, tsconfigPath) {
         const currentFsPaths = currentPaths[originalImportPath];
 
         if (typeof currentFsPaths === 'undefined' || currentFsPaths.length !== 1 || currentFsPaths[0] !== mappedFsPath) {
-            console.error(`error: ${targetPackage.name} invalid mapped path: ${JSON.stringify({ [originalImportPath]: currentFsPaths })}`);
+            console.error(`error: ${targetPackage.name} invalid mapped path: {"${originalImportPath}": "${currentFsPaths}"}`);
             currentPaths[originalImportPath] = [mappedFsPath];
             needRewrite = true;
         }


### PR DESCRIPTION

#### What it does

add error info in `configureTypeScriptNavigation`. fixed #9666 

#### How to test
- remove a property in `compilerOptions.paths`
- `yarn prepare:references`

![image](https://user-images.githubusercontent.com/13031838/123898301-a9fab100-d997-11eb-9c55-d73c15859e51.png)


#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)



