### PR TITLE
Tests: update file-search tests

### DIFF
--- a/examples/api-tests/src/file-search.spec.js
+++ b/examples/api-tests/src/file-search.spec.js
@@ -21,6 +21,7 @@ describe('file-search', function () {
 
     const Uri = require('@theia/core/lib/common/uri');
     const { QuickFileOpenService } = require('@theia/file-search/lib/browser/quick-file-open');
+    const { CancellationTokenSource } = require('@theia/core/lib/common/cancellation');
 
     /** @type {import('inversify').Container} */
     const container = window['theia'].container;
@@ -56,6 +57,60 @@ describe('file-search', function () {
                 assert.equal(quickFileOpenService['compareItems'](a, b, 'resource'), 1, 'a should be before b');
                 assert.equal(quickFileOpenService['compareItems'](b, a, 'resource'), -1, 'a should be before b');
                 assert.equal(quickFileOpenService['compareItems'](a, a, 'resource'), 0, 'items should be equal');
+            });
+
+        });
+
+        describe('#filterAndRange', () => {
+
+            it('should return the default when not searching', () => {
+                const filterAndRange = quickFileOpenService['filterAndRange'];
+                assert.equal(filterAndRange, quickFileOpenService['filterAndRangeDefault']);
+            });
+
+            it('should update when searching', () => {
+                quickFileOpenService['getPicks']('a:2:1', new CancellationTokenSource().token); // perform a mock search.
+                const filterAndRange = quickFileOpenService['filterAndRange'];
+                assert.equal(filterAndRange.filter, 'a');
+                assert.deepEqual(filterAndRange.range, { start: { line: 1, character: 0 }, end: { line: 1, character: 0 } });
+            });
+
+        });
+
+        describe('#splitFilterAndRange', () => {
+
+            const expression1 = 'a:2:1';
+            const expression2 = 'a:2,1';
+            const expression3 = 'a:2#2';
+            const expression4 = 'a#2:2';
+            const expression5 = 'a#2,1';
+            const expression6 = 'a#2#2';
+            const expression7 = 'a:2';
+            const expression8 = 'a#2';
+
+            it('should split the filter correctly for different combinations', () => {
+                assert.equal((quickFileOpenService['splitFilterAndRange'](expression1).filter), 'a');
+                assert.equal((quickFileOpenService['splitFilterAndRange'](expression2).filter), 'a');
+                assert.equal((quickFileOpenService['splitFilterAndRange'](expression3).filter), 'a');
+                assert.equal((quickFileOpenService['splitFilterAndRange'](expression4).filter), 'a');
+                assert.equal((quickFileOpenService['splitFilterAndRange'](expression5).filter), 'a');
+                assert.equal((quickFileOpenService['splitFilterAndRange'](expression6).filter), 'a');
+                assert.equal((quickFileOpenService['splitFilterAndRange'](expression7).filter), 'a');
+                assert.equal((quickFileOpenService['splitFilterAndRange'](expression8).filter), 'a');
+            });
+
+            it('should split the range correctly for different combinations', () => {
+                const rangeTest1 = { start: { line: 1, character: 0 }, end: { line: 1, character: 0 } };
+                const rangeTest2 = { start: { line: 1, character: 1 }, end: { line: 1, character: 1 } };
+
+                assert.deepEqual(quickFileOpenService['splitFilterAndRange'](expression1).range, rangeTest1);
+                assert.deepEqual(quickFileOpenService['splitFilterAndRange'](expression2).range, rangeTest1);
+                assert.deepEqual(quickFileOpenService['splitFilterAndRange'](expression3).range, rangeTest2);
+                assert.deepEqual(quickFileOpenService['splitFilterAndRange'](expression4).range, rangeTest2);
+                assert.deepEqual(quickFileOpenService['splitFilterAndRange'](expression5).range, rangeTest1);
+                assert.deepEqual(quickFileOpenService['splitFilterAndRange'](expression6).range, rangeTest2);
+                assert.deepEqual(quickFileOpenService['splitFilterAndRange'](expression7).range, rangeTest1);
+                assert.deepEqual(quickFileOpenService['splitFilterAndRange'](expression8).range, rangeTest1);
             });
 
         });


### PR DESCRIPTION

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

The commit updates the `file-search` api-tests (integration) by testing the following:

- verify `fileAndRange` property by default, and once a search is performed.
- verify that `splitFilterAndRange` successfully handles different input value combinations.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

The CI should be green and the new tests should be executed.
You can also manually run the tests with `yarn test` in the `examples/browser` directory.

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

