### PR TITLE
Implement missing functionality for call hierarchy API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 <a name="breaking_changes_1.16.0">[Breaking Changes:](#breaking_changes_1.16.0)</a>
 
 - [monaco] upgraded to monaco 0.23.0 including replacement of `quickOpen` API (0.20.x) with `quickInput` API (0.23.x) [#9154](https://github.com/eclipse-theia/theia/pull/9154)
+- [call-hierarchy] `CurrentEditorAccess` is deprecated. Use the version implemented in the `editor` package instead. The services in `call-hierarchy` that previously used the local `CurrentEditorAccess` no longer do. [#9681](https://github.com/eclipse-theia/theia/pull/9681)
 - [workspace] `WorkspaceCommandContribution.addFolderToWorkspace` no longer accepts `undefined`. `WorkspaceService.addRoot` now accepts a URI or a URI[]. [#9684](https://github.com/eclipse-theia/theia/pull/9684)
 
 ## v1.15.0 - 6/30/2021

--- a/packages/callhierarchy/src/browser/callhierarchy-contribution.ts
+++ b/packages/callhierarchy/src/browser/callhierarchy-contribution.ts
@@ -17,10 +17,9 @@
 import { injectable, inject } from '@theia/core/shared/inversify';
 import { MenuModelRegistry, Command, CommandRegistry } from '@theia/core/lib/common';
 import { AbstractViewContribution, OpenViewArguments, KeybindingRegistry } from '@theia/core/lib/browser';
-import { EDITOR_CONTEXT_MENU } from '@theia/editor/lib/browser';
+import { EDITOR_CONTEXT_MENU, CurrentEditorAccess } from '@theia/editor/lib/browser';
 import { CallHierarchyTreeWidget } from './callhierarchy-tree/callhierarchy-tree-widget';
 import { CALLHIERARCHY_ID } from './callhierarchy';
-import { CurrentEditorAccess } from './current-editor-access';
 import { CallHierarchyServiceProvider } from './callhierarchy-service';
 import URI from '@theia/core/lib/common/uri';
 
@@ -52,15 +51,13 @@ export class CallHierarchyContribution extends AbstractViewContribution<CallHier
     }
 
     protected isCallHierarchyAvailable(): boolean {
-        const selection = this.editorAccess.getSelection();
-        const languageId = this.editorAccess.getLanguageId();
+        const { selection, languageId } = this.editorAccess;
         return !!selection && !!languageId && !!this.callHierarchyServiceProvider.get(languageId, new URI(selection.uri));
     }
 
     async openView(args?: Partial<OpenViewArguments>): Promise<CallHierarchyTreeWidget> {
         const widget = await super.openView(args);
-        const selection = this.editorAccess.getSelection();
-        const languageId = this.editorAccess.getLanguageId();
+        const { selection, languageId } = this.editorAccess;
         widget.initializeModel(selection, languageId);
         return widget;
     }

--- a/packages/callhierarchy/src/browser/callhierarchy-frontend-module.ts
+++ b/packages/callhierarchy/src/browser/callhierarchy-frontend-module.ts
@@ -21,7 +21,6 @@ import { WidgetFactory, bindViewContribution } from '@theia/core/lib/browser';
 import { CALLHIERARCHY_ID } from './callhierarchy';
 import { createHierarchyTreeWidget } from './callhierarchy-tree';
 import { CurrentEditorAccess } from './current-editor-access';
-
 import { ContainerModule } from '@theia/core/shared/inversify';
 
 import '../../src/browser/style/index.css';

--- a/packages/callhierarchy/src/browser/current-editor-access.ts
+++ b/packages/callhierarchy/src/browser/current-editor-access.ts
@@ -18,6 +18,9 @@ import { injectable, inject } from '@theia/core/shared/inversify';
 import { EditorManager, TextEditor } from '@theia/editor/lib/browser';
 import { Location } from '@theia/core/shared/vscode-languageserver-types';
 
+/**
+ * @deprecated since 1.15.0. Import from `@theia/editor` instead.
+ */
 @injectable()
 export class CurrentEditorAccess {
 

--- a/packages/plugin-ext-vscode/compile.tsconfig.json
+++ b/packages/plugin-ext-vscode/compile.tsconfig.json
@@ -43,6 +43,9 @@
     },
     {
       "path": "../terminal/compile.tsconfig.json"
+    },
+    {
+      "path": "../callhierarchy/compile.tsconfig.json"
     }
   ]
 }

--- a/packages/plugin-ext-vscode/package.json
+++ b/packages/plugin-ext-vscode/package.json
@@ -3,6 +3,7 @@
   "version": "1.15.0",
   "description": "Theia - Plugin Extension for VsCode",
   "dependencies": {
+    "@theia/callhierarchy": "1.15.0",
     "@theia/core": "1.15.0",
     "@theia/editor": "1.15.0",
     "@theia/filesystem": "1.15.0",

--- a/packages/plugin-ext/src/common/plugin-api-rpc.ts
+++ b/packages/plugin-ext/src/common/plugin-api-rpc.ts
@@ -1459,6 +1459,7 @@ export interface LanguagesExt {
     $provideDocumentRangeSemanticTokens(handle: number, resource: UriComponents, range: Range, token: CancellationToken): Promise<BinaryBuffer | null>;
     $provideRootDefinition(handle: number, resource: UriComponents, location: Position, token: CancellationToken): Promise<CallHierarchyDefinition | undefined>;
     $provideCallers(handle: number, definition: CallHierarchyDefinition, token: CancellationToken): Promise<CallHierarchyReference[] | undefined>;
+    $provideCallees(handle: number, definition: CallHierarchyDefinition, token: CancellationToken): Promise<CallHierarchyReference[] | undefined>;
 }
 
 export const LanguagesMainFactory = Symbol('LanguagesMainFactory');

--- a/packages/plugin-ext/src/main/browser/command-registry-main.ts
+++ b/packages/plugin-ext/src/main/browser/command-registry-main.ts
@@ -77,7 +77,7 @@ export class CommandRegistryMainImpl implements CommandRegistryMain, Disposable 
             throw new Error(`Command with id '${id}' is not registered.`);
         }
         try {
-            return await this.delegate.executeCommand(id, ...args);
+            return await this.delegate.executeCommand<T>(id, ...args);
         } catch (e) {
             // Command handler may be not active at the moment so the error must be caught. See https://github.com/eclipse-theia/theia/pull/6687#discussion_r354810079
             if ('code' in e && e['code'] === 'NO_ACTIVE_HANDLER') {

--- a/packages/plugin-ext/src/main/browser/languages-main.ts
+++ b/packages/plugin-ext/src/main/browser/languages-main.ts
@@ -50,8 +50,8 @@ import * as theia from '@theia/plugin';
 import { UriComponents } from '../../common/uri-components';
 import { CancellationToken } from '@theia/core/lib/common';
 import { LanguageSelector, RelativePattern } from '@theia/callhierarchy/lib/common/language-selector';
-import { CallHierarchyService, CallHierarchyServiceProvider, Caller, Definition } from '@theia/callhierarchy/lib/browser';
-import { toDefinition, toUriComponents, fromDefinition, fromPosition, toCaller } from './callhierarchy/callhierarchy-type-converters';
+import { CallHierarchyService, CallHierarchyServiceProvider, Definition } from '@theia/callhierarchy/lib/browser';
+import { toDefinition, toUriComponents, fromDefinition, fromPosition, toCaller, toCallee } from './callhierarchy/callhierarchy-type-converters';
 import { Position, DocumentUri } from '@theia/core/shared/vscode-languageserver-types';
 import { ObjectIdentifier } from '../../common/object-identifier';
 import { mixin } from '../../common/types';
@@ -782,15 +782,23 @@ export class LanguagesMainImpl implements LanguagesMain, Disposable {
                     }
 
                     if (Array.isArray(result)) {
-                        const callers: Caller[] = [];
-                        for (const item of result) {
-                            callers.push(toCaller(item));
-                        }
-                        return callers;
+                        return result.map(toCaller);
                     }
 
                     return undefined!;
-                })
+                }),
+
+            getCallees: (definition: Definition, cancellationToken: CancellationToken) => this.proxy.$provideCallees(handle, fromDefinition(definition), cancellationToken)
+                .then(result => {
+                    if (!result) {
+                        return undefined;
+                    }
+                    if (Array.isArray(result)) {
+                        return result.map(toCallee);
+                    }
+
+                    return undefined;
+                }),
         };
     }
 

--- a/packages/plugin-ext/src/main/browser/view/tree-view-widget.tsx
+++ b/packages/plugin-ext/src/main/browser/view/tree-view-widget.tsx
@@ -154,7 +154,8 @@ export class PluginTree extends TreeImpl {
             themeIconId,
             resourceUri,
             tooltip: item.tooltip,
-            contextValue: item.contextValue
+            contextValue: item.contextValue,
+            command: item.command,
         };
         const node = this.getNode(item.id);
         if (item.collapsibleState !== undefined && item.collapsibleState !== TreeViewItemCollapsibleState.None) {
@@ -179,7 +180,7 @@ export class PluginTree extends TreeImpl {
             parent,
             visible: true,
             selected: false,
-            command: item.command
+            command: item.command,
         }, update);
     }
 

--- a/packages/plugin-ext/src/plugin/documents.ts
+++ b/packages/plugin-ext/src/plugin/documents.ts
@@ -255,10 +255,10 @@ export class DocumentsExtImpl implements DocumentsExt {
             if (options.selection) {
                 const { start, end } = options.selection;
                 selection = {
-                    startLineNumber: start.line,
-                    startColumn: start.character,
-                    endLineNumber: end.line,
-                    endColumn: end.character
+                    startLineNumber: start.line + 1,
+                    startColumn: start.character + 1,
+                    endLineNumber: end.line + 1,
+                    endColumn: end.character + 1
                 };
             }
             documentOptions = {

--- a/packages/plugin-ext/src/plugin/known-commands.ts
+++ b/packages/plugin-ext/src/plugin/known-commands.ts
@@ -17,13 +17,13 @@
 import { Range as R, Position as P, Location as L } from '@theia/core/shared/vscode-languageserver-types';
 import * as theia from '@theia/plugin';
 import { cloneAndChange } from '../common/objects';
-import { Position, Range, Location, CallHierarchyItem, URI } from './types-impl';
+import { Position, Range, Location, CallHierarchyItem, URI, TextDocumentShowOptions } from './types-impl';
 import {
     fromPosition, fromRange, fromLocation,
     isModelLocation, toLocation,
     isModelCallHierarchyItem, fromCallHierarchyItem, toCallHierarchyItem,
     isModelCallHierarchyIncomingCall, toCallHierarchyIncomingCall,
-    isModelCallHierarchyOutgoingCall, toCallHierarchyOutgoingCall
+    isModelCallHierarchyOutgoingCall, toCallHierarchyOutgoingCall, fromTextDocumentShowOptions
 } from './type-converters';
 
 // Here is a mapping of VSCode commands to monaco commands with their conversions
@@ -294,6 +294,8 @@ export namespace KnownCommands {
     mappings['vscode.prepareCallHierarchy'] = ['vscode.prepareCallHierarchy', CONVERT_VSCODE_TO_MONACO, CONVERT_MONACO_TO_VSCODE];
     mappings['vscode.provideIncomingCalls'] = ['vscode.provideIncomingCalls', CONVERT_VSCODE_TO_MONACO, CONVERT_MONACO_TO_VSCODE];
     mappings['vscode.provideOutgoingCalls'] = ['vscode.provideOutgoingCalls', CONVERT_VSCODE_TO_MONACO, CONVERT_MONACO_TO_VSCODE];
+    mappings['vscode.open'] = ['vscode.open', CONVERT_VSCODE_TO_MONACO];
+    mappings['vscode.diff'] = ['vscode.diff', CONVERT_VSCODE_TO_MONACO];
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     export function map<T>(id: string, args: any[] | undefined, toDo: (mappedId: string, mappedArgs: any[] | undefined, mappedResult: ConversionFunction | undefined) => T): T {
@@ -346,6 +348,12 @@ export namespace KnownCommands {
     function vscodeToMonacoArgsConverter(args: any[]) {
         // tslint:disable-next-line:typedef
         return cloneAndChange(args, function (value) {
+            if (CallHierarchyItem.isCallHierarchyItem(value)) {
+                return fromCallHierarchyItem(value);
+            }
+            if (TextDocumentShowOptions.isTextDocumentShowOptions(value)) {
+                return fromTextDocumentShowOptions(value);
+            }
             if (Position.isPosition(value)) {
                 return fromPosition(value);
             }
@@ -354,9 +362,6 @@ export namespace KnownCommands {
             }
             if (Location.isLocation(value)) {
                 return fromLocation(value);
-            }
-            if (CallHierarchyItem.isCallHierarchyItem(value)) {
-                return fromCallHierarchyItem(value);
             }
             if (!Array.isArray(value)) {
                 return value;
@@ -368,9 +373,6 @@ export namespace KnownCommands {
     function monacoToVscodeArgsConverter(args: any[]) {
         // tslint:disable-next-line:typedef
         return cloneAndChange(args, function (value) {
-            if (isModelLocation(value)) {
-                return toLocation(value);
-            }
             if (isModelCallHierarchyItem(value)) {
                 return toCallHierarchyItem(value);
             }
@@ -379,6 +381,9 @@ export namespace KnownCommands {
             }
             if (isModelCallHierarchyOutgoingCall(value)) {
                 return toCallHierarchyOutgoingCall(value);
+            }
+            if (isModelLocation(value)) {
+                return toLocation(value);
             }
             if (!Array.isArray(value)) {
                 return value;

--- a/packages/plugin-ext/src/plugin/languages.ts
+++ b/packages/plugin-ext/src/plugin/languages.ts
@@ -91,7 +91,6 @@ import { CallHierarchyAdapter } from './languages/call-hierarchy';
 import { BinaryBuffer } from '@theia/core/lib/common/buffer';
 import { DocumentSemanticTokensAdapter, DocumentRangeSemanticTokensAdapter } from './languages/semantic-highlighting';
 
-/* eslint-disable @typescript-eslint/indent */
 type Adapter = CompletionAdapter |
     SignatureHelpAdapter |
     HoverAdapter |
@@ -116,7 +115,6 @@ type Adapter = CompletionAdapter |
     CallHierarchyAdapter |
     DocumentRangeSemanticTokensAdapter |
     DocumentSemanticTokensAdapter;
-/* eslint-enable @typescript-eslint/indent */
 
 export class LanguagesExtImpl implements LanguagesExt {
 
@@ -200,7 +198,7 @@ export class LanguagesExtImpl implements LanguagesExt {
             return fallbackValue;
         }
         if (adapter instanceof ctor) {
-            return callback(<A>adapter);
+            return callback(adapter);
         }
         throw new Error('no adapter found');
     }
@@ -591,6 +589,10 @@ export class LanguagesExtImpl implements LanguagesExt {
     $provideCallers(handle: number, definition: CallHierarchyDefinition, token: theia.CancellationToken): Promise<CallHierarchyReference[] | undefined> {
         return this.withAdapter(handle, CallHierarchyAdapter, adapter => adapter.provideCallers(definition, token), undefined);
     }
+
+    $provideCallees(handle: number, definition: CallHierarchyDefinition, token: theia.CancellationToken): Promise<CallHierarchyReference[] | undefined> {
+        return this.withAdapter(handle, CallHierarchyAdapter, adapter => adapter.provideCallees(definition, token), undefined);
+    }
     // ### Call Hierarchy Provider end
 
     // #region semantic coloring
@@ -640,11 +642,11 @@ function serializeEnterRules(rules?: theia.OnEnterRule[]): SerializedOnEnterRule
     }
 
     return rules.map(r =>
-        ({
-            action: r.action,
-            beforeText: serializeRegExp(r.beforeText),
-            afterText: serializeRegExp(r.afterText)
-        } as SerializedOnEnterRule));
+    ({
+        action: r.action,
+        beforeText: serializeRegExp(r.beforeText),
+        afterText: serializeRegExp(r.afterText)
+    } as SerializedOnEnterRule));
 }
 
 function serializeRegExp(regexp?: RegExp): SerializedRegExp | undefined {

--- a/packages/plugin-ext/src/plugin/types-impl.ts
+++ b/packages/plugin-ext/src/plugin/types-impl.ts
@@ -568,6 +568,22 @@ export class Selection extends Range {
     }
 }
 
+export namespace TextDocumentShowOptions {
+    /**
+     * @param candidate
+     * @returns `true` if `candidate` is an instance of options that includes a selection.
+     * This function should be used to determine whether TextDocumentOptions passed into commands by plugins
+     * need to be translated to TextDocumentShowOptions in the style of the RPC model. Selection is the only field that requires translation.
+     */
+    export function isTextDocumentShowOptions(candidate: unknown): candidate is theia.TextDocumentShowOptions {
+        if (!candidate) {
+            return false;
+        }
+        const options = candidate as theia.TextDocumentShowOptions;
+        return Range.isRange(options.selection);
+    }
+}
+
 export enum EndOfLine {
     LF = 1,
     CRLF = 2

--- a/packages/timeline/src/browser/timeline-widget.tsx
+++ b/packages/timeline/src/browser/timeline-widget.tsx
@@ -68,14 +68,14 @@ export class TimelineWidget extends BaseWidget {
 
         this.refresh();
         this.toDispose.push(this.timelineService.onDidChangeTimeline(event => {
-                const currentWidgetUri = this.getCurrentWidgetUri();
-                if (currentWidgetUri ) {
-                    this.loadTimeline(currentWidgetUri, event.reset);
-                }
-            })
+            const currentWidgetUri = this.getCurrentWidgetUri();
+            if (currentWidgetUri) {
+                this.loadTimeline(currentWidgetUri, event.reset);
+            }
+        })
         );
         this.toDispose.push(this.selectionService.onSelectionChanged(selection => {
-            if (Array.isArray(selection) && 'uri' in selection[0]) {
+            if (Array.isArray(selection) && !!selection[0] && 'uri' in selection[0]) {
                 this.refresh(selection[0].uri);
             }
         }));
@@ -155,7 +155,7 @@ export class TimelineWidget extends BaseWidget {
                 }
             });
         }
-        return  NavigatableWidget.is(current) ? current.getResourceUri() : undefined;
+        return NavigatableWidget.is(current) ? current.getResourceUri() : undefined;
     }
 
     protected get containerLayout(): PanelLayout | undefined {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

Fixes #9612 by implementing the commands used by the vscode-references-view plugin to retrieve call hierarchy information.
It also:
 - Deprecates the `CurrentEditorAccess` class in the `call-hierarchy` package in favor of the one implemented in the `editor` package.
 - Fixes a bunch of off-by-one translation errors between RPC Model Ranges and VSCode Ranges. That is an absolute mess that deserves separate treatment. The translation is implemented separately at least 5 times.
    - Fixes #7065
    - Fixes #8333
 - Adds a check to Timeline module to ensure that a selection exists to avoid an error log that appeared in the original issue report but wasn't actually the cause of the failure of the call hierarchy code.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
1. You should be able to use the `Calls: Show Call Hierarchy Command`
2. You should be able to get both incoming (default) and outgoing calls.
3. When you click on a node, it should reveal the location of that function. Confirm that your cursor is at the beginning of the function.

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

Signed-off-by: Colin Grant <colin.grant@ericsson.com>