### PR TITLE
Support multiselection in 'Add Folder to Workspace...' dialog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Change Log
 
+## v1.16.0 - 7/29/2021
+
+[1.16.0 Milestone](https://github.com/eclipse-theia/theia/milestone/22)
+
+ - [workspace] added support for multiple selections in 'Add folder to workspace' dialog. [#9684](https://github.com/eclipse-theia/theia/pull/9684)
+
+<a name="breaking_changes_1.16.0">[Breaking Changes:](#breaking_changes_1.16.0)</a>
+
+- [workspace] `WorkspaceCommandContribution.addFolderToWorkspace` no longer accepts `undefined`. `WorkspaceService.addRoot` now accepts a URI or a URI[]. [#9684](https://github.com/eclipse-theia/theia/pull/9684)
+
 ## v1.15.0 - 6/30/2021
 
 [1.15.0 Milestone](https://github.com/eclipse-theia/theia/milestone/21)

--- a/packages/workspace/src/browser/workspace-service.ts
+++ b/packages/workspace/src/browser/workspace-service.ts
@@ -366,11 +366,12 @@ export class WorkspaceService implements FrontendApplicationContribution {
     }
 
     /**
-     * Adds a root folder to the workspace
-     * @param uri URI of the root folder being added
+     * Adds root folder(s) to the workspace
+     * @param uris URI or URIs of the root folder(s) to add
      */
-    async addRoot(uri: URI): Promise<void> {
-        await this.spliceRoots(this._roots.length, 0, uri);
+    async addRoot(uris: URI[] | URI): Promise<void> {
+        const toAdd = Array.isArray(uris) ? uris : [uris];
+        await this.spliceRoots(this._roots.length, 0, ...toAdd);
     }
 
     /**
@@ -388,6 +389,7 @@ export class WorkspaceService implements FrontendApplicationContribution {
                     workspaceData
                 )
             );
+            await this.updateWorkspace();
         }
     }
 
@@ -416,6 +418,7 @@ export class WorkspaceService implements FrontendApplicationContribution {
         const currentData = await this.getWorkspaceDataFromFile();
         const newData = WorkspaceData.buildWorkspaceData(roots, currentData);
         await this.writeWorkspaceFile(this._workspace, newData);
+        await this.updateWorkspace();
         return toRemove.map(root => new URI(root));
     }
 


### PR DESCRIPTION
Signed-off-by: Colin Grant <colin.grant@ericsson.com>

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

Fixes #9665 by allowing multiple selection in the workspace dialog and ensuring that the public methods 'addRoot' and 'removeRoots' (and new method `addRoots`) don't return before the `._roots` field of the `WorkspaceService` has been updated. Previously, changes to the workspace would emit an event that would trigger an `updateWorkspace` cycle, but since that method is also asynchronous, it was guaranteed not to have finished its work in the tick after `addRoot` and `removeRoots` resolved, meaning that even `await`ing those methods didn't guarantee that the `WorkspaceService` was ready for another call.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
1. Open a workspace.
2. Use the 'Add folder to workspace' command (available in the `...` context menu in the explorer).
3. Select several folders.
4. Observe that your workspace updates correctly to include all of the folders added.

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

