### PR TITLE
Downgrade keytar dependency for broader compatibility

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -46,7 +46,7 @@
     "iconv-lite": "^0.6.0",
     "inversify": "^5.0.1",
     "jschardet": "^2.1.1",
-    "keytar": "7.7.0",
+    "keytar": "7.2.0",
     "lodash.debounce": "^4.0.8",
     "lodash.throttle": "^4.1.1",
     "nsfw": "^2.1.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6359,10 +6359,10 @@ jxLoader@*:
     promised-io "*"
     walker "1.x"
 
-keytar@7.7.0:
-  version "7.7.0"
-  resolved "https://registry.yarnpkg.com/keytar/-/keytar-7.7.0.tgz#3002b106c01631aa79b1aa9ee0493b94179bbbd2"
-  integrity sha512-YEY9HWqThQc5q5xbXbRwsZTh2PJ36OSYRjSv3NN2xf5s5dpLTjEZnC2YikR29OaVybf9nQ0dJ/80i40RS97t/A==
+keytar@7.2.0:
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/keytar/-/keytar-7.2.0.tgz#4db2bec4f9700743ffd9eda22eebb658965c8440"
+  integrity sha512-ECSaWvoLKI5SI0pGpZQeUV1/lpBYfkaxvoSp3zkiPOz05VavwSfLi8DdEaa9N2ekQZv3Chy+o7aP6n9mairBgw==
   dependencies:
     node-addon-api "^3.0.0"
     prebuild-install "^6.0.0"


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

Fixes #9640 by downgradiing `keytar` to the version currently used by VSCode.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

Follow steps in #9463:
1. Clone, compile and start the sample project: https://github.com/vinokurig/secrets-test.
2. Run `Get Password` command and see a notification with empty (undefined) password.
3. Run `Set Password` command and see a notification about password change.
4. Run `Get Password` command and see a notification with the updated password.
5. Run `Delete Password` command and see a notification about password change.
6. Run `Get Password` command and see a notification with empty (undefined) password.

Now do it on RHEL/CentOS7 and see that you don't get any runtime failures.

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

Signed-off-by: Colin Grant <colin.grant@ericsson.com>