### PR TITLE
Align collapsable item behaviour with VSCode

### DIFF
--- a/packages/plugin-ext/src/main/browser/plugin-ext-frontend-module.ts
+++ b/packages/plugin-ext/src/main/browser/plugin-ext-frontend-module.ts
@@ -21,7 +21,7 @@ import '../../../src/main/browser/style/comments.css';
 import { ContainerModule } from '@theia/core/shared/inversify';
 import {
     FrontendApplicationContribution, WidgetFactory, bindViewContribution,
-    ViewContainerIdentifier, ViewContainer, createTreeContainer, TreeImpl, TreeWidget, TreeModelImpl, LabelProviderContribution
+    ViewContainerIdentifier, ViewContainer, createTreeContainer, TreeImpl, TreeWidget, TreeModelImpl, LabelProviderContribution, TreeProps
 } from '@theia/core/lib/browser';
 import { MaybePromise, CommandContribution, ResourceResolver, bindContributionProvider } from '@theia/core/lib/common';
 import { WebSocketConnectionProvider } from '@theia/core/lib/browser/messaging';
@@ -149,6 +149,7 @@ export default new ContainerModule((bind, unbind, isBound, rebind) => {
                 contextMenuPath: VIEW_ITEM_CONTEXT_MENU,
                 globalSelection: true
             });
+            child.rebind(TreeProps).toConstantValue({ leftPadding: 8, expansionTogglePadding: 22, expandOnlyOnExpansionToggleClick: true, });
             child.bind(TreeViewWidgetIdentifier).toConstantValue(identifier);
             child.bind(PluginTree).toSelf();
             child.rebind(TreeImpl).toService(PluginTree);


### PR DESCRIPTION
Signed-off-by: Alexander Kozinko <xcariba@gmail.com>

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
It aligns tree view behavior with VSCode (now Theia does not ignore commands on expandable items and fixes #6359):
1. If TreeViewItem is collapsable and has command - do not ignore it.
2. If user clicks on collapse/expand icon - do not execute command.
3. If user clicks on expendable item that has no command - toggle expansion.
4. If user clicks on expendable item that has command - execute command.

Also I changed item padding properties so that expandable and regular items are aligned (as in VSCode)

#### How to test
1. Install extension [vscode-theia-test-extension-0.0.1.vsix](https://github.com/xcariba/vscode-theia-test-extension/raw/main/vscode-theia-test-extension-0.0.1.vsix)
2. Open Test Tree View
3. Click on `Collapsable Item Without Command` expansion icon - it will toggle state
4. Click on `Collapsable Item Without Command` item - it will toggle state
5. Click on `Collapsable Item With Command` expansion icon - it will toggle state
6. Click on `Collapsable Item With Command` item - it will execute command (it will show Hello message)
7. Double click on `Collapsable Item With Command` item - it will execute command (it will show Hello message) and toggle state

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

