### PR TITLE
Remove important keyword in focus opacity style

### DIFF
--- a/packages/core/src/browser/style/index.css
+++ b/packages/core/src/browser/style/index.css
@@ -146,7 +146,7 @@ blockquote {
     outline-width: 1px;
     outline-style: solid;
     outline-offset: -1px;
-    opacity: 1 !important;
+    opacity: 1;
     outline-color: var(--theia-focusBorder);
 }
 


### PR DESCRIPTION
Signed-off-by: Alexander Kozinko <xcariba@gmail.com>

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->
Allows client to override opacity in focused elements without !important keyword.
I've tried to set existing style to my extension but there is a problem with opacity. There is no way to override it anywhere without marking every opacity change in css. I found [this conversation](https://community.theia-ide.org/t/important-keyword-in-css-for-opacity-in-focus/1786) and fixed it. I've checked existing styling and nothing changed. I also looked in all `:focus` overrides in this repository and found that it has a few overrides with this keyword. I think that it will be better if this base property can be changed without additional marks.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
* Open Preferences, set focus in `Search Settings`, `Editor: Font Size`, `Editor: Render Whitespace` and check that focus is visible. Set focus on `Editor: Insert Spaces` Checkbox using Tab key and check that focus border is visible.
* Open debug view and use Tab to move focus on buttons, tree view headers and configuration selector, check that focus border is visible.
* Open `Find Command` view (Ctrl+Shift+P) and check that focus border is visible.

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

