### PR TITLE
fix file tree scroll bug

### DIFF
--- a/packages/core/src/browser/tree/tree-widget.tsx
+++ b/packages/core/src/browser/tree/tree-widget.tsx
@@ -1414,10 +1414,6 @@ export namespace TreeWidget {
                 scrollToIndex={scrollToRow}
                 onScroll={handleScroll}
                 tabIndex={-1}
-                style={{
-                    overflowY: 'visible',
-                    overflowX: 'visible'
-                }}
             />;
         }
         protected renderTreeRow: ListRowRenderer = ({ key, index, style, parent }) => {


### PR DESCRIPTION
Signed-off-by: shuyaqian 717749594@qq.com

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->
fix [#9407](https://github.com/eclipse-theia/theia/issues/9407)

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
1. click 'open workspace' menu
2. scroll
3. other tree widgets still scroll fine with `overflow: auto`

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

