### PR TITLE
Don't modify settings.json when adding debug configurations

### DIFF
--- a/packages/debug/src/browser/debug-configuration-manager.ts
+++ b/packages/debug/src/browser/debug-configuration-manager.ts
@@ -265,7 +265,11 @@ export class DebugConfigurationManager {
         if (!uri) { // Since we are requesting information about a known workspace folder, this should never happen.
             throw new Error('PreferenceService.getConfigUri has returned undefined when a URI was expected.');
         }
-        await this.ensureContent(uri, model);
+        const settingsUri = this.preferences.getConfigUri(PreferenceScope.Folder, model.workspaceFolderUri);
+        // Users may have placed their debug configurations in a `settings.json`, in which case we shouldn't modify the file.
+        if (settingsUri && !uri.isEqual(settingsUri)) {
+            await this.ensureContent(uri, model);
+        }
         return uri;
     }
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

Fixes #9712 by checking whether the file found is a default config file (`settings.json`) before modifying it when adding debug configurations.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
1. In an otherwise empty folder, create a `.theia` folder and populate it with a `settings.json` that includes a `"launch" field. Something like this:
```
{
  "launch": {
    // Use IntelliSense to learn about possible attributes.
    // Hover to view descriptions of existing attributes.
    "version": "0.2.0",
    "configurations": []
  },
  "editor.fontSize": 20
}
```
2. Open that folder in Theia.
3. Open the debug view, open the dropdown and select 'Add configurations'
4. It should open your `settings.json` and put you in the middle of the array, but it should _not_ remove your "editor.fontSize" setting.

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

Signed-off-by: Colin Grant <colin.grant@ericsson.com>