### PR TITLE
Modify closeOnFileDelete default to agree with VSCode

### DIFF
--- a/packages/core/src/browser/core-preferences.ts
+++ b/packages/core/src/browser/core-preferences.ts
@@ -40,7 +40,7 @@ export const corePreferenceSchema: PreferenceSchema = {
             'type': 'boolean',
             // eslint-disable-next-line max-len
             'description': 'Controls whether editors showing a file that was opened during the session should close automatically when getting deleted or renamed by some other process. Disabling this will keep the editor open  on such an event. Note that deleting from within the application will always close the editor and that dirty files will never close to preserve your data.',
-            'default': true
+            'default': false
         },
         'application.confirmExit': {
             type: 'string',


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->
Modifies the default value of `workbench.editor.closeOnFileDelete` to agree with VSCode. We have it set to `true`, they have it set to `false`. `false` is a better default, I think - closing fewer editors automatically is safer.

https://github.com/microsoft/vscode/blob/40b2219e394fd4721934b4007ae0b2890b6b086a/src/vs/workbench/browser/workbench.contribution.ts#L163-L167

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
1. Open a workspace with no modifications to the `workbench.editor.closeOnFileDelete` preference.
2. Check the preferences UI and observe that the preference is set to false, and that setting it to true gives you a blue modified border.
3. Open a file, then delete it, and observe that the editor doesn't close, but does mark itself as `(deleted)`.

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

Signed-off-by: Colin Grant <colin.grant@ericsson.com>