### PR TITLE
plugin: add `showDeprecated` support

### DIFF
--- a/packages/monaco/src/browser/protocol-to-monaco-converter.ts
+++ b/packages/monaco/src/browser/protocol-to-monaco-converter.ts
@@ -131,7 +131,8 @@ export class ProtocolToMonacoConverter {
             startColumn: diagnostic.range.start.character + 1,
             endLineNumber: diagnostic.range.end.line + 1,
             endColumn: diagnostic.range.end.character + 1,
-            relatedInformation: this.asRelatedInformations(diagnostic.relatedInformation)
+            relatedInformation: this.asRelatedInformations(diagnostic.relatedInformation),
+            tags: diagnostic.tags
         };
     }
 

--- a/packages/plugin-ext/src/common/plugin-api-rpc-model.ts
+++ b/packages/plugin-ext/src/common/plugin-api-rpc-model.ts
@@ -219,6 +219,7 @@ export enum MarkerSeverity {
 
 export enum MarkerTag {
     Unnecessary = 1,
+    Deprecated = 2,
 }
 
 export interface ParameterInformation {

--- a/packages/plugin-ext/src/main/browser/languages-main.ts
+++ b/packages/plugin-ext/src/main/browser/languages-main.ts
@@ -57,6 +57,7 @@ import { ObjectIdentifier } from '../../common/object-identifier';
 import { mixin } from '../../common/types';
 import { relative } from '../../common/paths-util';
 import { decodeSemanticTokensDto } from '../../common/semantic-tokens-dto';
+import { DiagnosticTag } from '@theia/core/shared/vscode-languageserver-protocol';
 
 @injectable()
 export class LanguagesMainImpl implements LanguagesMain, Disposable {
@@ -919,6 +920,10 @@ function reviveMarker(marker: MarkerData): vst.Diagnostic {
         monacoMarker.relatedInformation = marker.relatedInformation.map(reviveRelated);
     }
 
+    if (marker.tags) {
+        monacoMarker.tags = marker.tags.map(reviveTag);
+    }
+
     return monacoMarker;
 }
 
@@ -953,6 +958,13 @@ function reviveRelated(related: RelatedInformation): vst.DiagnosticRelatedInform
             range: reviveRange(related.startLineNumber, related.startColumn, related.endLineNumber, related.endColumn)
         }
     };
+}
+
+function reviveTag(tag: DiagnosticTag): vst.DiagnosticTag {
+    switch (tag) {
+        case 1: return DiagnosticTag.Unnecessary;
+        case 2: return DiagnosticTag.Deprecated;
+    }
 }
 
 function reviveRegExp(regExp?: SerializedRegExp): RegExp | undefined {

--- a/packages/plugin-ext/src/plugin/type-converters.ts
+++ b/packages/plugin-ext/src/plugin/type-converters.ts
@@ -376,7 +376,12 @@ function convertTags(tags: types.DiagnosticTag[] | undefined): types.MarkerTag[]
     const markerTags: types.MarkerTag[] = [];
     for (const tag of tags) {
         switch (tag) {
-            case types.DiagnosticTag.Unnecessary: markerTags.push(types.MarkerTag.Unnecessary);
+            case types.DiagnosticTag.Unnecessary:
+                markerTags.push(types.MarkerTag.Unnecessary);
+                break;
+            case types.DiagnosticTag.Deprecated:
+                markerTags.push(types.MarkerTag.Deprecated);
+                break;
         }
     }
     return markerTags;

--- a/packages/plugin-ext/src/plugin/types-impl.ts
+++ b/packages/plugin-ext/src/plugin/types-impl.ts
@@ -944,6 +944,7 @@ export class Location {
 
 export enum DiagnosticTag {
     Unnecessary = 1,
+    Deprecated = 2,
 }
 
 export enum CompletionItemTag {
@@ -975,6 +976,7 @@ export enum MarkerSeverity {
 
 export enum MarkerTag {
     Unnecessary = 1,
+    Deprecated = 2,
 }
 
 export class ParameterInformation {

--- a/packages/plugin/src/theia.d.ts
+++ b/packages/plugin/src/theia.d.ts
@@ -7332,6 +7332,12 @@ declare module '@theia/plugin' {
          * instead of fading it out.
          */
         Unnecessary = 1,
+        /**
+         * Deprecated or obsolete code.
+         *
+         * Diagnostics with this tag are rendered with a strike through.
+         */
+        Deprecated = 2,
     }
 
     /**


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

Fixes: #8557 

The pull-request adds support for the `editor.showDeprecated` preference which styles deprecated code in editors with a `strike-through`. The diagnostic is contributed by language-servers:

![image](https://user-images.githubusercontent.com/40359487/125096873-8b856b80-e0a3-11eb-8bf8-310140477296.png)

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

1. update the [vscode-builtin-typescript-language-features](https://open-vsx.org/api/vscode/typescript-language-features/1.57.1/file/vscode.typescript-language-features-1.57.1.vsix) extension to `1.57.1` in the `package.json`.
2. start the application with the changes, and use `theia` as a workspace folder.
3. open `keymaps-service.ts` and navigate to line `140`
4. uses of `context` (deprecated) should have the deprecated strike-through.

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

Signed-off-by: vince-fugnitto <vincent.fugnitto@ericsson.com>
