### PR TITLE
monaco: fix monaco peek styling

### DIFF
--- a/packages/monaco/src/browser/style/index.css
+++ b/packages/monaco/src/browser/style/index.css
@@ -180,5 +180,13 @@
 }
 
 .monaco-list:not(.drop-target) .monaco-list-row:hover:not(.selected):not(.focused) {
-  background: var(--theia-list-hoverBackground); 
+  background: var(--theia-list-hoverBackground);
+}
+
+.monaco-editor .peekview-widget .head .peekview-title {
+  font-family: var(--theia-ui-font-family);
+}
+
+.monaco-editor .peekview-widget .referenceMatch {
+  font-family: var(--theia-ui-font-family);
 }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

Fixes: https://github.com/eclipse-theia/theia/issues/9458.

The pull-request updates the monaco peekview-widget `fontFamily` styling.
The title and references are now aligned with the styling of vscode.

![peek-styling](https://user-images.githubusercontent.com/40359487/125460532-0d4f04ef-4e2e-43de-ad55-660d302e4f65.png)

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

1. start the application with `theia` as a workspace folder
2. open a typescript file (wait for language-server to initialize)
3. use the context-menu item - `peek` > `peek type definition`
4. the styling for the filename, and result (tree or flat list) should be displayed correctly

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

Signed-off-by: vince-fugnitto <vincent.fugnitto@ericsson.com>
