### PR TITLE
editor: add 'revert and close editor' command

### DIFF
--- a/packages/editor/src/browser/editor-command.ts
+++ b/packages/editor/src/browser/editor-command.ts
@@ -69,6 +69,11 @@ export namespace EditorCommands {
         category: EDITOR_CATEGORY,
         label: 'Change File Encoding'
     };
+    export const REVERT_AND_CLOSE: Command = {
+        id: 'workbench.action.revertAndCloseActiveEditor',
+        category: 'View',
+        label: 'Revert and Close Editor'
+    };
 
     /**
      * Command for going back to the last editor navigation location.
@@ -229,6 +234,7 @@ export class EditorCommandContribution implements CommandContribution {
         registry.registerCommand(EditorCommands.CONFIG_EOL);
         registry.registerCommand(EditorCommands.INDENT_USING_SPACES);
         registry.registerCommand(EditorCommands.INDENT_USING_TABS);
+        registry.registerCommand(EditorCommands.REVERT_AND_CLOSE);
         registry.registerCommand(EditorCommands.CHANGE_LANGUAGE, {
             isEnabled: () => this.canConfigureLanguage(),
             isVisible: () => this.canConfigureLanguage(),

--- a/packages/monaco/src/browser/monaco-command.ts
+++ b/packages/monaco/src/browser/monaco-command.ts
@@ -17,8 +17,8 @@
 import { injectable, inject, optional } from '@theia/core/shared/inversify';
 import { Position, Location } from '@theia/core/shared/vscode-languageserver-types';
 import { CommandContribution, CommandRegistry, CommandHandler } from '@theia/core/lib/common/command';
-import { CommonCommands, QuickInputService } from '@theia/core/lib/browser';
-import { EditorCommands } from '@theia/editor/lib/browser';
+import { CommonCommands, QuickInputService, ApplicationShell } from '@theia/core/lib/browser';
+import { EditorCommands, EditorManager } from '@theia/editor/lib/browser';
 import { MonacoEditor } from './monaco-editor';
 import { MonacoCommandRegistry, MonacoEditorCommandHandler } from './monaco-command-registry';
 import { MonacoEditorService } from './monaco-editor-service';
@@ -68,6 +68,12 @@ export class MonacoEditorCommandHandlers implements CommandContribution {
 
     @inject(monaco.contextKeyService.ContextKeyService)
     protected readonly contextKeyService: monaco.contextKeyService.ContextKeyService;
+
+    @inject(ApplicationShell)
+    protected readonly shell: ApplicationShell;
+
+    @inject(EditorManager)
+    protected editorManager: EditorManager;
 
     registerCommands(): void {
         this.registerMonacoCommands();
@@ -185,6 +191,7 @@ export class MonacoEditorCommandHandlers implements CommandContribution {
         this.monacoCommandRegistry.registerHandler(EditorCommands.CONFIG_EOL.id, this.newConfigEolHandler());
         this.monacoCommandRegistry.registerHandler(EditorCommands.INDENT_USING_SPACES.id, this.newConfigTabSizeHandler(true));
         this.monacoCommandRegistry.registerHandler(EditorCommands.INDENT_USING_TABS.id, this.newConfigTabSizeHandler(false));
+        this.monacoCommandRegistry.registerHandler(EditorCommands.REVERT_AND_CLOSE.id, this.newRevertAndCloseActiveEditorHandler());
     }
 
     protected newShowReferenceHandler(): MonacoEditorCommandHandler {
@@ -222,10 +229,11 @@ export class MonacoEditorCommandHandlers implements CommandContribution {
 
     protected configureEol(editor: MonacoEditor): void {
         const items = ['LF', 'CRLF'].map(lineEnding =>
-        ({
-            label: lineEnding,
-            execute: () => this.setEol(editor, lineEnding)
-        }));
+            ({
+                label: lineEnding,
+                execute: () => this.setEol(editor, lineEnding)
+            })
+        );
         this.quickInputService?.showQuickPick(items, { placeholder: 'Select End of Line Sequence' });
     }
 
@@ -251,15 +259,37 @@ export class MonacoEditorCommandHandlers implements CommandContribution {
             const { tabSize } = model.getOptions();
             const sizes = Array.from(Array(8), (_, x) => x + 1);
             const tabSizeOptions = sizes.map(size =>
-            ({
-                label: size === tabSize ? `${size}   Configured Tab Size` : size.toString(),
-                // eslint-disable-next-line @typescript-eslint/no-explicit-any
-                execute: (quickPick: any, lookFor: string) => model.updateOptions({
-                    tabSize: size || tabSize,
-                    insertSpaces: useSpaces
+                ({
+                    label: size === tabSize ? `${size}   Configured Tab Size` : size.toString(),
+                    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                    execute: (quickPick: any, lookFor: string) => model.updateOptions({
+                        tabSize: size || tabSize,
+                        insertSpaces: useSpaces
+                    })
                 })
-            }));
+            );
             this.quickInputService?.showQuickPick(tabSizeOptions, { placeholder: 'Select Tab Size for Current File' });
+        }
+    }
+
+    protected newRevertAndCloseActiveEditorHandler(): MonacoEditorCommandHandler {
+        return {
+            execute: async () => this.revertAndCloseActiveEditor()
+        };
+    }
+
+    protected async revertAndCloseActiveEditor(): Promise<void> {
+        const editor = this.editorManager.currentEditor;
+        if (editor) {
+            const monacoEditor = MonacoEditor.getCurrent(this.editorManager);
+            if (monacoEditor) {
+                try {
+                    await monacoEditor.document.revert();
+                    editor.close();
+                } catch (error) {
+                    await this.shell.closeWidget(editor.id, { save: false });
+                }
+            }
         }
     }
 }

--- a/packages/plugin-ext-vscode/src/browser/plugin-vscode-commands-contribution.ts
+++ b/packages/plugin-ext-vscode/src/browser/plugin-vscode-commands-contribution.ts
@@ -54,7 +54,6 @@ import { inject, injectable, optional } from '@theia/core/shared/inversify';
 import { Position } from '@theia/plugin-ext/lib/common/plugin-api-rpc';
 import { URI } from '@theia/core/shared/vscode-uri';
 import { PluginServer } from '@theia/plugin-ext/lib/common/plugin-protocol';
-import { MonacoEditor } from '@theia/monaco/lib/browser/monaco-editor';
 import { TerminalFrontendContribution } from '@theia/terminal/lib/browser/terminal-frontend-contribution';
 import { QuickOpenWorkspace } from '@theia/workspace/lib/browser/quick-open-workspace';
 import { TerminalService } from '@theia/terminal/lib/browser/base/terminal-service';
@@ -396,23 +395,6 @@ export class PluginVscodeCommandsContribution implements CommandContribution {
         commands.registerCommand({ id: 'workbench.action.reloadWindow' }, {
             execute: () => {
                 window.location.reload();
-            }
-        });
-
-        commands.registerCommand({ id: 'workbench.action.revertAndCloseActiveEditor' }, {
-            execute: async () => {
-                const editor = this.editorManager.currentEditor;
-                if (editor) {
-                    const monacoEditor = MonacoEditor.getCurrent(this.editorManager);
-                    if (monacoEditor) {
-                        try {
-                            await monacoEditor.document.revert();
-                            editor.close();
-                        } catch (error) {
-                            await this.shell.closeWidget(editor.id, { save: false });
-                        }
-                    }
-                }
             }
         });
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

Fixes:  #7575.

The command `'workbench.action.revertAndCloseActiveEditor'` was added as part of https://github.com/eclipse-theia/theia/pull/7702 but was only available to the plugin-system unlike vscode. The changes update the functionality to allow users to execute the command from the application, while it also working from a vscode plugin.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

1. include the [vscode-revert-and-close](https://github.com/vince-fugnitto/vscode-revert-and-close/releases/download/0.0.1/revert-and-close-0.0.1.vsix) test plugin
2. start the application, ensure that `autoSave` is off (to properly test `revert`)
3. open an editor, and make dirty changes
4. execute the application command `View: Revert and Close Editor` - should successfully revert the changes and close the editor
5. open an editor, and make dirty changes
6. execute the plugin command `Test: Revert and Close Editor` - should successfully revert the changes and close the editor

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

Signed-off-by: vince-fugnitto <vincent.fugnitto@ericsson.com>
