### PR TITLE
Fix import of is-electron (#9729)

### DIFF
--- a/packages/plugin-ext/src/plugin/node/debug/plugin-debug-adapter-starter.ts
+++ b/packages/plugin-ext/src/plugin/node/debug/plugin-debug-adapter-starter.ts
@@ -18,7 +18,7 @@ import * as net from 'net';
 import * as theia from '@theia/plugin';
 import { CommunicationProvider } from '@theia/debug/lib/common/debug-model';
 import { ChildProcess, spawn, fork, ForkOptions } from 'child_process';
-import isElectron from 'is-electron';
+const isElectron = require('is-electron');
 
 /**
  * Starts debug adapter process.


### PR DESCRIPTION
Fix #9729

Signed-off-by: Philip Langer <planger@eclipsesource.com>

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

This change replaces the import `is-electron` with a `require` to workaround the error
```
root ERROR Error starting the debug session TypeError: is_electron_1.default is not a function
    at Object.startDebugAdapter (/home/philip/Git/OpenSource/Theia/theia/packages/plugin-ext/lib/plugin/node/debug/plugin-debug-adapter-starter.js:44:48)
    at DebugExtImpl.<anonymous> (/home/philip/Git/OpenSource/Theia/theia/packages/plugin-ext/lib/plugin/node/debug/debug.js:725:82)
    at step (/home/philip/Git/OpenSource/Theia/theia/packages/plugin-ext/lib/plugin/node/debug/debug.js:33:23)
    at Object.next (/home/philip/Git/OpenSource/Theia/theia/packages/plugin-ext/lib/plugin/node/debug/debug.js:14:53)
    at fulfilled (/home/philip/Git/OpenSource/Theia/theia/packages/plugin-ext/lib/plugin/node/debug/debug.js:5:58)
    at processTicksAndRejections (internal/process/task_queues.js:97:5)
```

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

Please follow the steps to reproduce documented in https://github.com/eclipse-theia/theia/issues/9729 and check the console that the error above doesn't occur.

#### Review checklist

- [X] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

