### PR TITLE
plugin: add support for `refreshFilesExplorer`

### DIFF
--- a/packages/plugin-ext-vscode/src/browser/plugin-vscode-commands-contribution.ts
+++ b/packages/plugin-ext-vscode/src/browser/plugin-vscode-commands-contribution.ts
@@ -226,6 +226,9 @@ export class PluginVscodeCommandsContribution implements CommandContribution {
         commands.registerCommand({ id: 'workbench.action.openSettings' }, {
             execute: () => commands.executeCommand(CommonCommands.OPEN_PREFERENCES.id)
         });
+        commands.registerCommand({ id: 'workbench.files.action.refreshFilesExplorer' }, {
+            execute: () => commands.executeCommand(FileNavigatorCommands.REFRESH_NAVIGATOR.id)
+        });
         commands.registerCommand({ id: VscodeCommands.INSTALL_FROM_VSIX.id }, {
             execute: async (vsixUriOrExtensionId: TheiaURI | UriComponents | string) => {
                 if (typeof vsixUriOrExtensionId === 'string') {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

Fixes: https://github.com/eclipse-theia/theia/issues/5885.

The commit adds support for the `workbench.files.action.refreshFilesExplorer` command on the plugin side
which delegates to the `REFRESH_NAVIGATOR` command.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

1. add [vscode-refresh-explorer](https://github.com/vince-fugnitto/vscode-refresh-explorer/releases/download/0.0.1/vscode-refresh-explorer-0.0.1.vsix) test plugin.
2. on master the execution of the `test: refresh explorer` command will throw an error on the backend.

```
root ERROR [hosted-plugin: 21091] With stack trace: Error: Command with id 'workbench.files.action.refreshFilesExplorer' is not registered.
    at CommandRegistryMainImpl.<anonymous> (file:///home/evinfug/workspaces/theia/examples/electron/lib/packages_plugin-ext_lib_hosted_browser_hosted-plugin_js.bundle.js:3228:35)
    at step (file:///home/evinfug/workspaces/theia/examples/electron/lib/packages_plugin-ext_lib_hosted_browser_hosted-plugin_js.bundle.js:3138:23)
    at Object.next (file:///home/evinfug/workspaces/theia/examples/electron/lib/packages_plugin-ext_lib_hosted_browser_hosted-plugin_js.bundle.js:3119:53)
    at file:///home/evinfug/workspaces/theia/examples/electron/lib/packages_plugin-ext_lib_hosted_browser_hosted-plugin_js.bundle.js:3113:71
    at new Promise (<anonymous>)
```

3. on the pull-request the execution of the `test: refresh explorer` command will successfully execute.

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

Signed-off-by: vince-fugnitto <vincent.fugnitto@ericsson.com>