### PR TITLE
Fix TaskDto conversion in $fetchTasks

### DIFF
--- a/packages/plugin-ext/src/main/browser/tasks-main.ts
+++ b/packages/plugin-ext/src/main/browser/tasks-main.ts
@@ -137,14 +137,7 @@ export class TasksMainImpl implements TasksMain, Disposable {
         for (const tasks of [configured, provided]) {
             for (const task of tasks) {
                 if (!taskType || (!!this.taskDefinitionRegistry.getDefinition(task) ? task._source === taskType : task.type === taskType)) {
-                    const { type, label, _scope, _source, ...properties } = task;
-                    const dto: TaskDto = { type, label, scope: _scope, source: _source };
-                    for (const key in properties) {
-                        if (properties.hasOwnProperty(key)) {
-                            dto[key] = properties[key];
-                        }
-                    }
-                    result.push(dto);
+                    result.push(this.fromTaskConfiguration(task));
                 }
             }
         }


### PR DESCRIPTION
Signed-off-by: Thomas Mäder <tmader@redhat.com>

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
Use the common conversion method on the main side when fetching tasks from a plugin. Fixes https://github.com/eclipse-theia/theia/issues/9605

#### How to test
Instructions for reproducing the issue are in the linked issue above: make sure the behaviour is correct with the fix present.

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

