### PR TITLE
scm: add `title` for resources

### DIFF
--- a/packages/scm/src/browser/scm-tree-widget.tsx
+++ b/packages/scm/src/browser/scm-tree-widget.tsx
@@ -529,12 +529,17 @@ export class ScmResourceComponent extends ScmElement<ScmResourceComponent.Props>
         const tooltip = decoration && decoration.tooltip || '';
         const relativePath = parentPath.relative(resourceUri.parent);
         const path = relativePath ? relativePath.toString() : labelProvider.getLongName(resourceUri.parent);
+        const title = tooltip.length !== 0
+            ? `${resourceUri.path.toString()} • ${tooltip}`
+            : resourceUri.path.toString();
+
         return <div key={sourceUri}
             className={`scmItem ${TREE_NODE_SEGMENT_CLASS} ${TREE_NODE_SEGMENT_GROW_CLASS}`}
             onContextMenu={this.renderContextMenu}
             onMouseEnter={this.showHover}
             onMouseLeave={this.hideHover}
             ref={this.detectHover}
+            title={title}
             onClick={this.handleClick}
             onDoubleClick={this.handleDoubleClick} >
             <span className={icon + ' file-icon'} />
@@ -682,9 +687,11 @@ export class ScmResourceFolderElement extends ScmElement<ScmResourceFolderElemen
         const { model, treeNode, sourceUri, labelProvider, commands, menus, contextKeys, caption } = this.props;
         const sourceFileStat: FileStat = { uri: sourceUri, isDirectory: true, lastModification: 0 };
         const icon = labelProvider.getIcon(sourceFileStat);
+        const title = new URI(sourceUri).path.toString();
 
         return <div key={sourceUri}
             className={`scmItem  ${TREE_NODE_SEGMENT_CLASS} ${TREE_NODE_SEGMENT_GROW_CLASS} ${ScmTreeWidget.Styles.NO_SELECT}`}
+            title={title}
             onContextMenu={this.renderContextMenu}
             onMouseEnter={this.showHover}
             onMouseLeave={this.hideHover}


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

Fixes: https://github.com/eclipse-theia/theia/issues/9020.

The commit updates the `scm` view to add `tooltips` or `titles` to the elements in the view so end-users can see the full path of resources and folders.

https://user-images.githubusercontent.com/40359487/125822026-004c43ee-e9e1-4ae0-827e-6d52d029806e.mp4

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

1. start the application with a workspace folder under git version control (ex: theia)
2. perform changes to the workspace (at the root, nested folders, etc.)
3. open the `scm` view
4. verify that changes in the view display the path when hovering over the entries - confirm with tree and list modes

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

Signed-off-by: vince-fugnitto <vincent.fugnitto@ericsson.com>