### PR TITLE
Fix Cannot Read property 'cwd' of undefined

### DIFF
--- a/packages/task/src/browser/task-terminal-widget-manager.ts
+++ b/packages/task/src/browser/task-terminal-widget-manager.ts
@@ -196,7 +196,8 @@ export class TaskTerminalWidgetManager {
         }
 
         // we are unable to find a terminal widget to run the task, or `taskPresentation === 'new'`
-        const lastCwd = new URI(taskConfig?.options.cwd);
+        const lastCwd = taskConfig?.options?.cwd ? new URI(taskConfig.options.cwd) : new URI();
+
         if (!reusableTerminalWidget) {
             const widget = await this.newTaskTerminal(factoryOptions);
             widget.lastCwd = lastCwd;

--- a/packages/terminal/src/browser/base/terminal-widget.ts
+++ b/packages/terminal/src/browser/base/terminal-widget.ts
@@ -46,7 +46,7 @@ export abstract class TerminalWidget extends BaseWidget {
     abstract readonly dimensions: TerminalDimensions;
 
     /** The last CWD assigned to the terminal, useful when attempting getCwdURI on a task terminal fails */
-    lastCwd: URI | undefined;
+    lastCwd: URI;
 
     /**
      * Start terminal and return terminal id.

--- a/packages/terminal/src/browser/terminal-widget-impl.ts
+++ b/packages/terminal/src/browser/terminal-widget-impl.ts
@@ -61,7 +61,7 @@ export class TerminalWidgetImpl extends TerminalWidget implements StatefulWidget
     protected hoverMessage: HTMLDivElement;
     protected lastTouchEnd: TouchEvent | undefined;
     protected isAttachedCloseListener: boolean = false;
-    lastCwd: URI;
+    lastCwd = new URI();
 
     @inject(WorkspaceService) protected readonly workspaceService: WorkspaceService;
     @inject(WebSocketConnectionProvider) protected readonly webSocketConnectionProvider: WebSocketConnectionProvider;


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->
Fixes #9743 by improving check for `taskConfig.options.cwd` from #9695. Also ensures that `lastCwd` field on terminal-widget is never `undefined` as to ensure `get cwd()` will always return a `URI` (whether it is empty or not, these adjustments were made as TypeScript had brought them to my attention after adjusting the `taskConfig.options.cwd` check)

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
- Pull this branch and build
- Clone this vscode-extension-samples repo, and build the `task-provider-example`
- Copy the `.vsix` file into your theia plugins directory
- Open the command palette: `Tasks: run Task -> custombuildscript: 32 watch incremental`
- Observe that the task runs with no toast of "Cannot Read Property 'cwd' of undefined"

#### Review checklist

- [ ] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

