### PR TITLE
siw: add `expand-all` toolbar item

### DIFF
--- a/packages/search-in-workspace/src/browser/search-in-workspace-frontend-contribution.ts
+++ b/packages/search-in-workspace/src/browser/search-in-workspace-frontend-contribution.ts
@@ -49,25 +49,31 @@ export namespace SearchInWorkspaceCommands {
         id: 'search-in-workspace.refresh',
         category: SEARCH_CATEGORY,
         label: 'Refresh',
-        iconClass: 'refresh'
+        iconClass: 'codicon codicon-refresh'
     };
     export const CANCEL_SEARCH: Command = {
         id: 'search-in-workspace.cancel',
         category: SEARCH_CATEGORY,
         label: 'Cancel Search',
-        iconClass: 'cancel'
+        iconClass: 'codicon codicon-search-stop'
     };
     export const COLLAPSE_ALL: Command = {
         id: 'search-in-workspace.collapse-all',
         category: SEARCH_CATEGORY,
         label: 'Collapse All',
-        iconClass: 'theia-collapse-all-icon'
+        iconClass: 'codicon codicon-collapse-all'
+    };
+    export const EXPAND_ALL: Command = {
+        id: 'search-in-workspace.expand-all',
+        category: SEARCH_CATEGORY,
+        label: 'Expand All',
+        iconClass: 'codicon codicon-expand-all'
     };
     export const CLEAR_ALL: Command = {
         id: 'search-in-workspace.clear-all',
         category: SEARCH_CATEGORY,
         label: 'Clear Search Results',
-        iconClass: 'clear-all'
+        iconClass: 'codicon codicon-clear-all'
     };
 }
 
@@ -148,7 +154,12 @@ export class SearchInWorkspaceFrontendContribution extends AbstractViewContribut
         commands.registerCommand(SearchInWorkspaceCommands.COLLAPSE_ALL, {
             execute: w => this.withWidget(w, widget => widget.collapseAll()),
             isEnabled: w => this.withWidget(w, widget => widget.hasResultList()),
-            isVisible: w => this.withWidget(w, () => true)
+            isVisible: w => this.withWidget(w, widget => !widget.areResultsCollapsed())
+        });
+        commands.registerCommand(SearchInWorkspaceCommands.EXPAND_ALL, {
+            execute: w => this.withWidget(w, widget => widget.expandAll()),
+            isEnabled: w => this.withWidget(w, widget => widget.hasResultList()),
+            isVisible: w => this.withWidget(w, widget => widget.areResultsCollapsed())
         });
         commands.registerCommand(SearchInWorkspaceCommands.CLEAR_ALL, {
             execute: w => this.withWidget(w, widget => widget.clear()),
@@ -233,6 +244,13 @@ export class SearchInWorkspaceFrontendContribution extends AbstractViewContribut
             id: SearchInWorkspaceCommands.COLLAPSE_ALL.id,
             command: SearchInWorkspaceCommands.COLLAPSE_ALL.id,
             tooltip: SearchInWorkspaceCommands.COLLAPSE_ALL.label,
+            priority: 3,
+            onDidChange
+        });
+        toolbarRegistry.registerItem({
+            id: SearchInWorkspaceCommands.EXPAND_ALL.id,
+            command: SearchInWorkspaceCommands.EXPAND_ALL.id,
+            tooltip: SearchInWorkspaceCommands.EXPAND_ALL.label,
             priority: 3,
             onDidChange
         });

--- a/packages/search-in-workspace/src/browser/search-in-workspace-result-tree-widget.tsx
+++ b/packages/search-in-workspace/src/browser/search-in-workspace-result-tree-widget.tsx
@@ -128,6 +128,10 @@ export class SearchInWorkspaceResultTreeWidget extends TreeWidget {
     cancelIndicator?: CancellationTokenSource;
 
     protected changeEmitter = new Emitter<Map<string, SearchInWorkspaceRootFolderNode>>();
+
+    protected onExpansionChangedEmitter = new Emitter();
+    readonly onExpansionChanged: Event<void> = this.onExpansionChangedEmitter.event;
+
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     protected focusInputEmitter = new Emitter<any>();
 
@@ -202,6 +206,10 @@ export class SearchInWorkspaceResultTreeWidget extends TreeWidget {
                 this.model.refresh();
             }
         }));
+
+        this.toDispose.push(this.model.onExpansionChanged(() => {
+            this.onExpansionChangedEmitter.fire(undefined);
+        }));
     }
 
     get fileNumber(): number {
@@ -235,12 +243,36 @@ export class SearchInWorkspaceResultTreeWidget extends TreeWidget {
     }
 
     collapseAll(): void {
-        this.resultTree.forEach(rootFolderNode => {
-            rootFolderNode.children.forEach(fileNode => this.expansionService.collapseNode(fileNode));
+        for (const rootFolderNode of this.resultTree.values()) {
+            for (const fileNode of rootFolderNode.children) {
+                this.expansionService.collapseNode(fileNode);
+            }
             if (rootFolderNode.visible) {
                 this.expansionService.collapseNode(rootFolderNode);
             }
-        });
+        }
+    }
+
+    expandAll(): void {
+        for (const rootFolderNode of this.resultTree.values()) {
+            for (const fileNode of rootFolderNode.children) {
+                this.expansionService.expandNode(fileNode);
+            }
+            if (rootFolderNode.visible) {
+                this.expansionService.expandNode(rootFolderNode);
+            }
+        }
+    }
+
+    areResultsCollapsed(): boolean {
+        for (const rootFolderNode of this.resultTree.values()) {
+            for (const fileNode of rootFolderNode.children) {
+                if (!ExpandableTreeNode.isCollapsed(fileNode)) {
+                    return false;
+                }
+            }
+        }
+        return true;
     }
 
     /**

--- a/packages/search-in-workspace/src/browser/search-in-workspace-widget.tsx
+++ b/packages/search-in-workspace/src/browser/search-in-workspace-widget.tsx
@@ -157,6 +157,9 @@ export class SearchInWorkspaceWidget extends BaseWidget implements StatefulWidge
         }));
 
         this.toDispose.push(this.resultTreeWidget);
+        this.toDispose.push(this.resultTreeWidget.onExpansionChanged(() => {
+            this.onDidUpdateEmitter.fire();
+        }));
 
         this.toDispose.push(this.progressBarFactory({ container: this.node, insertMode: 'prepend', locationId: 'search' }));
     }
@@ -236,6 +239,15 @@ export class SearchInWorkspaceWidget extends BaseWidget implements StatefulWidge
     collapseAll(): void {
         this.resultTreeWidget.collapseAll();
         this.update();
+    }
+
+    expandAll(): void {
+        this.resultTreeWidget.expandAll();
+        this.update();
+    }
+
+    areResultsCollapsed(): boolean {
+        return this.resultTreeWidget.areResultsCollapsed();
     }
 
     clear(): void {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

Fixes: #7714

The pull-request introduces the `expand-all` toolbar item to the `search-in-workspace` (siw) widget to expand the result tree when it is collapsed. The toolbar toggles between the `collapse-all` and `expand-all` items based on the state of the result tree:

https://user-images.githubusercontent.com/40359487/125858322-6d6ab195-ba8b-42d9-9c74-8ee1fd7a56b8.mov

The `search-in-workspace` toolbar items are also updated to their `codicon` counterparts.

![image](https://user-images.githubusercontent.com/40359487/125968518-e071ca31-0839-44b3-a662-5e2d4a03ceb9.png)

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

1. start the application, open the `search-in-workspace` widget and perform a search with multiple results
2. perform `collapse-all` - confirm the toolbar toggles to `expand-all` and the tree is collapsed
3. perform `expand-all` - confirm the toolbar toggles to `collapse-all` and the tree is expanded
4. repeat the steps in a multi-root workspace

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

Signed-off-by: vince-fugnitto <vincent.fugnitto@ericsson.com>

