### PR TITLE
Pass `EditorWidgetFactory` options to `TextEditorProvider`

### DIFF
--- a/packages/core/src/browser/navigatable.ts
+++ b/packages/core/src/browser/navigatable.ts
@@ -69,7 +69,6 @@ export namespace NavigatableWidget {
 export interface NavigatableWidgetOptions {
     kind: 'navigatable',
     uri: string,
-    counter?: number,
 }
 export namespace NavigatableWidgetOptions {
     export function is(arg: Object | undefined): arg is NavigatableWidgetOptions {

--- a/packages/editor-preview/src/browser/editor-preview-manager.ts
+++ b/packages/editor-preview/src/browser/editor-preview-manager.ts
@@ -14,12 +14,12 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
-import { EditorManager, EditorOpenerOptions, EditorWidget } from '@theia/editor/lib/browser';
+import { EditorManager, EditorOpenerOptions, EditorWidget, EditorFactoryOptions } from '@theia/editor/lib/browser';
 import { inject, injectable, postConstruct } from '@theia/core/shared/inversify';
 import { EditorPreviewPreferences } from './editor-preview-preferences';
-import { DisposableCollection, MaybePromise } from '@theia/core/lib/common';
+import { DisposableCollection } from '@theia/core/lib/common';
 import URI from '@theia/core/lib/common/uri';
-import { EditorPreviewWidgetFactory, EditorPreviewOptions } from './editor-preview-widget-factory';
+import { EditorPreviewWidgetFactory } from './editor-preview-widget-factory';
 import { EditorPreviewWidget } from './editor-preview-widget';
 import { FrontendApplicationStateService } from '@theia/core/lib/browser/frontend-application-state';
 
@@ -98,20 +98,12 @@ export class EditorPreviewManager extends EditorManager {
         this.toDisposeOnPreviewChange.push(widget.onDidDispose(() => this.toDisposeOnPreviewChange.dispose()));
     }
 
-    protected tryGetPendingWidget(uri: URI, options?: EditorOpenerOptions): MaybePromise<EditorWidget> | undefined {
-        return super.tryGetPendingWidget(uri, { ...options, preview: true }) ?? super.tryGetPendingWidget(uri, { ...options, preview: false });
-    }
-
-    protected async getWidget(uri: URI, options?: EditorOpenerOptions): Promise<EditorWidget | undefined> {
-        return (await super.getWidget(uri, { ...options, preview: true })) ?? super.getWidget(uri, { ...options, preview: false });
-    }
-
     protected async getOrCreateWidget(uri: URI, options?: EditorOpenerOptions): Promise<EditorWidget> {
         return this.tryGetPendingWidget(uri, options) ?? super.getOrCreateWidget(uri, options);
     }
 
-    protected createWidgetOptions(uri: URI, options?: EditorOpenerOptions): EditorPreviewOptions {
-        const navigatableOptions = super.createWidgetOptions(uri, options) as EditorPreviewOptions;
+    protected createWidgetOptions(uri: URI, options?: EditorOpenerOptions): EditorFactoryOptions {
+        const navigatableOptions = super.createWidgetOptions(uri, options);
         navigatableOptions.preview = !!(options?.preview && this.preferences['editor.enablePreview']);
         return navigatableOptions;
     }

--- a/packages/editor-preview/src/browser/editor-preview-widget-factory.ts
+++ b/packages/editor-preview/src/browser/editor-preview-widget-factory.ts
@@ -18,18 +18,19 @@ import URI from '@theia/core/lib/common/uri';
 import { EditorWidgetFactory } from '@theia/editor/lib/browser/editor-widget-factory';
 import { injectable } from '@theia/core/shared/inversify';
 import { EditorPreviewWidget } from './editor-preview-widget';
-import { NavigatableWidgetOptions } from '@theia/core/lib/browser';
+import { EditorFactoryOptions } from '@theia/editor/lib/browser/editor';
 
-export interface EditorPreviewOptions extends NavigatableWidgetOptions {
-    preview?: boolean;
-}
+/**
+ * @deprecated Now identical to EditorFactoryOptions - use that instead.
+ */
+export interface EditorPreviewOptions extends EditorFactoryOptions { }
 
 @injectable()
 export class EditorPreviewWidgetFactory extends EditorWidgetFactory {
     static ID: string = 'editor-preview-widget';
     readonly id = EditorPreviewWidgetFactory.ID;
 
-    async createWidget(options: EditorPreviewOptions): Promise<EditorPreviewWidget> {
+    async createWidget(options: EditorFactoryOptions): Promise<EditorPreviewWidget> {
         const uri = new URI(options.uri);
         const editor = await this.createEditor(uri, options) as EditorPreviewWidget;
         if (options.preview) {
@@ -38,8 +39,8 @@ export class EditorPreviewWidgetFactory extends EditorWidgetFactory {
         return editor;
     }
 
-    protected async constructEditor(uri: URI): Promise<EditorPreviewWidget> {
-        const textEditor = await this.editorProvider(uri);
+    protected async constructEditor(uri: URI, options?: EditorFactoryOptions): Promise<EditorPreviewWidget> {
+        const textEditor = await this.editorProvider(uri, options);
         return new EditorPreviewWidget(textEditor, this.selectionService);
     }
 }

--- a/packages/editor/src/browser/editor-widget-factory.ts
+++ b/packages/editor/src/browser/editor-widget-factory.ts
@@ -17,9 +17,9 @@
 import { injectable, inject, } from '@theia/core/shared/inversify';
 import URI from '@theia/core/lib/common/uri';
 import { SelectionService } from '@theia/core/lib/common';
-import { NavigatableWidgetOptions, WidgetFactory, LabelProvider } from '@theia/core/lib/browser';
+import { WidgetFactory, LabelProvider } from '@theia/core/lib/browser';
 import { EditorWidget } from './editor-widget';
-import { TextEditorProvider } from './editor';
+import { EditorFactoryOptions, TextEditorProvider } from './editor';
 
 @injectable()
 export class EditorWidgetFactory implements WidgetFactory {
@@ -43,12 +43,12 @@ export class EditorWidgetFactory implements WidgetFactory {
     @inject(SelectionService)
     protected readonly selectionService: SelectionService;
 
-    createWidget(options: NavigatableWidgetOptions): Promise<EditorWidget> {
+    createWidget(options: EditorFactoryOptions): Promise<EditorWidget> {
         const uri = new URI(options.uri);
         return this.createEditor(uri, options);
     }
 
-    protected async createEditor(uri: URI, options?: NavigatableWidgetOptions): Promise<EditorWidget> {
+    protected async createEditor(uri: URI, options?: EditorFactoryOptions): Promise<EditorWidget> {
         const newEditor = await this.constructEditor(uri);
 
         this.setLabels(newEditor, uri);
@@ -65,7 +65,7 @@ export class EditorWidgetFactory implements WidgetFactory {
         return newEditor;
     }
 
-    protected async constructEditor(uri: URI): Promise<EditorWidget> {
+    protected async constructEditor(uri: URI, options?: EditorFactoryOptions): Promise<EditorWidget> {
         const textEditor = await this.editorProvider(uri);
         return new EditorWidget(textEditor, this.selectionService);
     }

--- a/packages/editor/src/browser/editor.ts
+++ b/packages/editor/src/browser/editor.ts
@@ -17,8 +17,8 @@
 import { Position, Range, Location } from '@theia/core/shared/vscode-languageserver-types';
 import * as lsp from '@theia/core/shared/vscode-languageserver-types';
 import URI from '@theia/core/lib/common/uri';
-import { Event, Disposable, TextDocumentContentChangeDelta } from '@theia/core/lib/common';
-import { Saveable, Navigatable, Widget } from '@theia/core/lib/browser';
+import { Event, Disposable, TextDocumentContentChangeDelta, RecursivePartial } from '@theia/core/lib/common';
+import { Saveable, Navigatable, Widget, WidgetOpenerOptions, NavigatableWidgetOptions } from '@theia/core/lib/browser';
 import { EditorDecoration } from './decorations';
 import { Reference } from '@theia/core/lib/common';
 
@@ -27,7 +27,15 @@ export {
 };
 
 export const TextEditorProvider = Symbol('TextEditorProvider');
-export type TextEditorProvider = (uri: URI) => Promise<TextEditor>;
+export type TextEditorProvider = (uri: URI, options?: EditorFactoryOptions) => Promise<TextEditor>;
+
+export interface EditorOpenerOptions extends WidgetOpenerOptions {
+    selection?: RecursivePartial<Range>;
+    preview?: boolean;
+    counter?: number
+}
+
+export interface EditorFactoryOptions extends EditorOpenerOptions, NavigatableWidgetOptions { counter: number }
 
 export interface TextEditorDocument extends lsp.TextDocument, Saveable, Disposable {
     getLineContent(lineNumber: number): string;

--- a/packages/monaco/src/browser/monaco-frontend-module.ts
+++ b/packages/monaco/src/browser/monaco-frontend-module.ts
@@ -114,7 +114,7 @@ export default new ContainerModule((bind, unbind, isBound, rebind) => {
     bind(MonacoCommandServiceFactory).toAutoFactory(MonacoCommandService);
 
     bind(TextEditorProvider).toProvider(context =>
-        uri => context.container.get(MonacoEditorProvider).get(uri)
+        (uri, options) => context.container.get(MonacoEditorProvider).get(uri, options)
     );
 
     bind(MonacoDiffNavigatorFactory).toSelf().inSingletonScope();


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

This PR fixes #9746 by giving `DiffEditor`s knowledge of the options used to create them. This allows them to set the correct value for `alwaysRevealFirst` in the options passed to the `DiffNavigator`. It may also make it possible to fix some of the lifecycle difficulties we previously had with `EditorManager.revealSelection` in a manner more consistent with VSCode's / Monaco's approach.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

1. Please follow the steps outlined in #9746.
2. You should observe that, when you open the diff editor for the first time, the correct selection is revealed and the editor does not scroll away to the next change in the file.

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

Signed-off-by: Colin Grant <colin.grant@ericsson.com>