### PR TITLE
Align code-lens css with vscode

### DIFF
--- a/packages/debug/src/browser/debug-frontend-application-contribution.ts
+++ b/packages/debug/src/browser/debug-frontend-application-contribution.ts
@@ -1248,16 +1248,30 @@ export class DebugFrontendApplicationContribution extends AbstractViewContributi
 
     registerColors(colors: ColorRegistry): void {
         colors.register(
-            // Debug colors should be aligned with https://code.visualstudio.com/api/references/theme-color#debug
+            // Debug colors should be aligned with https://code.visualstudio.com/api/references/theme-color#debug-colors
             {
                 id: 'editor.stackFrameHighlightBackground',
-                defaults: { dark: '#ffff0033', light: '#ffff6673', hc: '#fff600' },
-                description: 'Background color for the highlight of line at the top stack frame position.'
-            }, {
-            id: 'editor.focusedStackFrameHighlightBackground',
-            defaults: { dark: '#7abd7a4d', light: '#cee7ce73', hc: '#cee7ce' },
-            description: 'Background color for the highlight of line at focused stack frame position.'
-        },
+                defaults: {
+                    dark: '#ffff0033',
+                    light: '#ffff6673',
+                    hc: '#fff600'
+                }, description: 'Background color for the highlight of line at the top stack frame position.'
+            },
+            {
+                id: 'editor.focusedStackFrameHighlightBackground',
+                defaults: {
+                    dark: '#7abd7a4d',
+                    light: '#cee7ce73',
+                    hc: '#cee7ce'
+                }, description: 'Background color for the highlight of line at focused stack frame position.'
+            },
+            {
+                id: 'debugIcon.startForeground', defaults: {
+                    dark: '#89D185',
+                    light: '#388A34',
+                    hc: '#89D185'
+                }, description: 'Debug toolbar icon for start debugging.'
+            },
             // Status bar colors should be aligned with debugging colors from https://code.visualstudio.com/api/references/theme-color#status-bar-colors
             {
                 id: 'statusBar.debuggingBackground', defaults: {
@@ -1284,13 +1298,18 @@ export class DebugFrontendApplicationContribution extends AbstractViewContributi
             // https://github.com/microsoft/vscode/blob/ff5f581425da6230b6f9216ecf19abf6c9d285a6/src/vs/workbench/contrib/debug/browser/exceptionWidget.ts#L23
             {
                 id: 'debugExceptionWidget.border', defaults: {
-                    dark: '#a31515', light: '#a31515', hc: '#a31515'
+                    dark: '#a31515',
+                    light: '#a31515',
+                    hc: '#a31515'
                 }, description: 'Exception widget border color.',
-            }, {
-            id: 'debugExceptionWidget.background', defaults: {
-                dark: '#420b0d', light: '#f1dfde', hc: '#420b0d'
-            }, description: 'Exception widget background color.'
-        }
+            },
+            {
+                id: 'debugExceptionWidget.background', defaults: {
+                    dark: '#420b0d',
+                    light: '#f1dfde',
+                    hc: '#420b0d'
+                }, description: 'Exception widget background color.'
+            }
         );
     }
 

--- a/packages/monaco/src/browser/style/index.css
+++ b/packages/monaco/src/browser/style/index.css
@@ -71,6 +71,14 @@
   height: var(--theia-scrollbar-width) !important;
 }
 
+.monaco-editor .codicon.codicon-debug-start {
+  color: var(--theia-debugIcon-startForeground) !important;
+}
+
+.monaco-editor .codelens-decoration a {
+  color: inherit !important;
+}
+
 .monaco-editor .reference-zone-widget .ref-tree .referenceMatch .highlight {
   color: unset !important;
 }


### PR DESCRIPTION
#### What it does

Aligns the code-lens css with vscode. Currently code-lenses always look like they're highlighted, because they contain the `a` tag:

![grafik](https://user-images.githubusercontent.com/4377073/126474573-80453044-dba7-4e19-a1e8-6b5d88ce10f4.png)

With this change in place, the code-lenses in Theia will look like this:

https://user-images.githubusercontent.com/4377073/126474427-8b625bd9-309c-44d6-a249-6a66da607ab7.mp4

#### How to test

1. Ensure the `vscode-npm` extension is installed in Theia.
2. Open a `package.json` with the `scripts` property.
3. Observe the color of the start button and the `Debug` text.
4. Hover over the element and observe the change in color.
5. This can also be repeated for the debugger extension for java for example. See the screencap above.

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

