### PR TITLE
Replace chevron icon with codicon

### DIFF
--- a/packages/core/src/browser/style/tree.css
+++ b/packages/core/src/browser/style/tree.css
@@ -70,8 +70,6 @@
     padding-right: calc(var(--theia-ui-padding)/2);
     min-width: var(--theia-icon-size);
     min-height: var(--theia-icon-size);
-    background-size: var(--theia-icon-size);
-    background: var(--theia-icon-chevron-right) center center no-repeat;
 }
 
 .theia-ExpansionToggle.theia-mod-busy {
@@ -83,8 +81,8 @@
     cursor: pointer;
 }
 
-.theia-ExpansionToggle:not(.theia-mod-busy):not(.theia-mod-collapsed) {
-    transform: rotate(90deg);
+.theia-ExpansionToggle.theia-mod-collapsed:not(.theia-mod-busy) {
+    transform: rotate(-90deg);
 }
 
 .theia-Tree:focus .theia-TreeNode.theia-mod-selected,

--- a/packages/core/src/browser/tree/tree-widget.tsx
+++ b/packages/core/src/browser/tree/tree-widget.tsx
@@ -20,7 +20,7 @@ import { Disposable, MenuPath, SelectionService } from '../../common';
 import { Key, KeyCode, KeyModifier } from '../keyboard/keys';
 import { ContextMenuRenderer } from '../context-menu-renderer';
 import { StatefulWidget } from '../shell';
-import { EXPANSION_TOGGLE_CLASS, SELECTED_CLASS, COLLAPSED_CLASS, FOCUS_CLASS, Widget, BUSY_CLASS } from '../widgets';
+import { EXPANSION_TOGGLE_CLASS, SELECTED_CLASS, COLLAPSED_CLASS, FOCUS_CLASS, BUSY_CLASS, CODICON_TREE_ITEM_CLASSES, Widget } from '../widgets';
 import { TreeNode, CompositeTreeNode } from './tree';
 import { TreeModel } from './tree-model';
 import { ExpandableTreeNode } from './tree-expansion';
@@ -565,6 +565,8 @@ export class TreeWidget extends ReactWidget implements StatefulWidget {
         }
         if (node.busy) {
             classes.push(BUSY_CLASS);
+        } else {
+            classes.push(...CODICON_TREE_ITEM_CLASSES);
         }
         const className = classes.join(' ');
         return <div

--- a/packages/core/src/browser/view-container.ts
+++ b/packages/core/src/browser/view-container.ts
@@ -17,8 +17,8 @@
 import { interfaces, injectable, inject, postConstruct } from 'inversify';
 import { IIterator, toArray, find, some, every, map } from '@phosphor/algorithm';
 import {
-    Widget, EXPANSION_TOGGLE_CLASS, COLLAPSED_CLASS, MessageLoop, Message, SplitPanel, BaseWidget,
-    addEventListener, SplitLayout, LayoutItem, PanelLayout, addKeyListener, waitForRevealed
+    Widget, EXPANSION_TOGGLE_CLASS, COLLAPSED_CLASS, CODICON_TREE_ITEM_CLASSES, MessageLoop, Message, SplitPanel,
+    BaseWidget, addEventListener, SplitLayout, LayoutItem, PanelLayout, addKeyListener, waitForRevealed
 } from './widgets';
 import { Event, Emitter } from '../common/event';
 import { Disposable, DisposableCollection } from '../common/disposable';
@@ -845,7 +845,7 @@ export class ViewContainerPart extends BaseWidget {
         disposable.push(addKeyListener(header, Key.ENTER, () => this.collapsed = !this.collapsed));
 
         const toggleIcon = document.createElement('span');
-        toggleIcon.classList.add(EXPANSION_TOGGLE_CLASS);
+        toggleIcon.classList.add(EXPANSION_TOGGLE_CLASS, ...CODICON_TREE_ITEM_CLASSES);
         if (this.collapsed) {
             toggleIcon.classList.add(COLLAPSED_CLASS);
         }

--- a/packages/core/src/browser/widgets/widget.ts
+++ b/packages/core/src/browser/widgets/widget.ts
@@ -32,6 +32,7 @@ export * from '@phosphor/messaging';
 
 export const DISABLED_CLASS = 'theia-mod-disabled';
 export const EXPANSION_TOGGLE_CLASS = 'theia-ExpansionToggle';
+export const CODICON_TREE_ITEM_CLASSES = ['codicon', 'codicon-tree-item-expanded'];
 export const COLLAPSED_CLASS = 'theia-mod-collapsed';
 export const BUSY_CLASS = 'theia-mod-busy';
 export const SELECTED_CLASS = 'theia-mod-selected';


### PR DESCRIPTION
#### What it does
Closes #9744

Replaces the chevron svg with a codicon. 

#### How to test
1. Assert that the chevron still behaves as expected.
2. Switch to a light theme.
3. Observe that the chevron is colored correctly.

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

