### PR TITLE
vsx: fix search input behavior

### DIFF
--- a/packages/vsx-registry/src/browser/vsx-extensions-search-bar.tsx
+++ b/packages/vsx-registry/src/browser/vsx-extensions-search-bar.tsx
@@ -29,7 +29,7 @@ export class VSXExtensionsSearchBar extends ReactWidget {
     protected init(): void {
         this.id = 'vsx-extensions-search-bar';
         this.addClass('theia-vsx-extensions-search-bar');
-        this.model.onDidChangeQuery(() => this.update());
+        this.model.onDidChangeQuery((query: string) => this.updateSearchTerm(query));
     }
 
     protected input: HTMLInputElement | undefined;
@@ -37,7 +37,7 @@ export class VSXExtensionsSearchBar extends ReactWidget {
     protected render(): React.ReactNode {
         return <input type='text'
             ref={input => this.input = input || undefined}
-            value={this.model.query}
+            defaultValue={this.model.query}
             className='theia-input'
             placeholder='Search Extensions in Open VSX Registry'
             onChange={this.updateQuery}>
@@ -45,6 +45,12 @@ export class VSXExtensionsSearchBar extends ReactWidget {
     }
 
     protected updateQuery = (e: React.ChangeEvent<HTMLInputElement>) => this.model.query = e.target.value;
+
+    protected updateSearchTerm(term: string): void {
+        if (this.input) {
+            this.input.value = term;
+        }
+    }
 
     protected onActivateRequest(msg: Message): void {
         super.onActivateRequest(msg);


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

Fixes: #9771 

The commit fixes the search input behavior which would always move the cursor to the end of the input when inputting characters, even those in between. The issue was the mismatch of react controlled and uncontrolled input, which would mean keeping a state about the cursor during updates.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

1. start the application, and open the `extensions-view`
2. perform a regular search - should work correctly
3. add characters in the middle of the search term - should work correctly
4. click the `clear-all` toolbar item - should clear the search input
5. search for `@builtin` - the results should show installed builtins

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

Signed-off-by: vince-fugnitto <vincent.fugnitto@ericsson.com>