### PR TITLE
vsx: add `changelog` support

### DIFF
--- a/dev-packages/ovsx-client/src/ovsx-types.ts
+++ b/dev-packages/ovsx-client/src/ovsx-types.ts
@@ -77,6 +77,7 @@ export interface VSXSearchEntry {
     readonly files: {
         download: string
         readme?: string
+        changelog?: string
         license?: string
         icon?: string
     }
@@ -104,6 +105,7 @@ export interface VSXUser {
 export interface VSXExtensionRawFiles {
     download: string
     readme?: string
+    changelog?: string
     license?: string
     icon?: string
 }

--- a/packages/plugin-ext/src/common/plugin-protocol.ts
+++ b/packages/plugin-ext/src/common/plugin-protocol.ts
@@ -492,6 +492,7 @@ export interface PluginModel {
     packagePath: string;
     iconUrl?: string;
     readmeUrl?: string;
+    changelogUrl?: string;
     licenseUrl?: string;
 }
 

--- a/packages/vsx-registry/src/browser/style/index.css
+++ b/packages/vsx-registry/src/browser/style/index.css
@@ -308,6 +308,21 @@
     vertical-align: middle;
 }
 
+.theia-vsx-extension-editor .extension-tabs {
+    padding-top: calc(var(--theia-ui-padding) * 5);
+}
+
+.theia-vsx-extension-editor .extension-tabs .extension-tab {
+    cursor: pointer;
+    font-size: var(--theia-ui-font-size2);
+    font-weight: 600;
+    padding-right: calc(var(--theia-ui-padding) * 2);
+}
+
+.theia-vsx-extension-editor .extension-tabs .extension-tab.extension-tab-selected {
+    text-decoration: underline !important;
+}
+
 /** Theming */
 
 .theia-vsx-extension-editor .action.prominent,

--- a/packages/vsx-registry/src/browser/vsx-extensions-model.ts
+++ b/packages/vsx-registry/src/browser/vsx-extensions-model.ts
@@ -183,6 +183,7 @@ export class VSXExtensionsModel {
                     downloadUrl: data.files.download,
                     iconUrl: data.files.icon,
                     readmeUrl: data.files.readme,
+                    changelogUrl: data.files.changelog,
                     licenseUrl: data.files.license,
                     version: extension.version
                 }));
@@ -261,7 +262,7 @@ export class VSXExtensionsModel {
             if (extension.readmeUrl) {
                 try {
                     const rawReadme = await this.client.fetchText(extension.readmeUrl);
-                    const readme = this.compileReadme(rawReadme);
+                    const readme = this.compileMarkdown(rawReadme);
                     extension.update({ readme });
                 } catch (e) {
                     if (!VSXResponseError.is(e) || e.statusCode !== 404) {
@@ -269,11 +270,22 @@ export class VSXExtensionsModel {
                     }
                 }
             }
+            if (extension.changelogUrl) {
+                try {
+                    const rawChangelog = await this.client.fetchText(extension.changelogUrl);
+                    const changelog = this.compileMarkdown(rawChangelog);
+                    extension.update({ changelog });
+                } catch (e) {
+                    if (!VSXResponseError.is(e) || e.statusCode !== 404) {
+                        console.error(`[${id}]: failed to compile changelog, reason:`, e);
+                    }
+                }
+            }
             return extension;
         });
     }
 
-    protected compileReadme(readmeMarkdown: string): string {
+    protected compileMarkdown(readmeMarkdown: string): string {
         const markdownConverter = new showdown.Converter({
             noHeaderId: true,
             strikethrough: true,
@@ -305,6 +317,7 @@ export class VSXExtensionsModel {
                 downloadUrl: data.files.download,
                 iconUrl: data.files.icon,
                 readmeUrl: data.files.readme,
+                changelogUrl: data.files.changelog,
                 licenseUrl: data.files.license,
                 version: data.version
             }));


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

The pull-request adds support for viewing an extension's `changelog` as part of the `extensions-view` editor when it is available. 


https://user-images.githubusercontent.com/40359487/126819557-0ccb0c4b-74c5-43fa-8478-6f0e87934762.mov

A couple of improvements are still necessary to make the changes nicer and have a proper behavior.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

TBD.

#### Review checklist

- [ ] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

Signed-off-by: vince-fugnitto <vincent.fugnitto@ericsson.com>

