### PR TITLE
Fix #9761: Hosted plugin can't be stop or restart

### DIFF
--- a/packages/plugin-dev/src/browser/hosted-plugin-controller.ts
+++ b/packages/plugin-dev/src/browser/hosted-plugin-controller.ts
@@ -15,7 +15,6 @@
  ********************************************************************************/
 
 import { injectable, inject } from '@theia/core/shared/inversify';
-import { setTimeout } from 'timers';
 import { StatusBar } from '@theia/core/lib/browser/status-bar/status-bar';
 import { StatusBarAlignment, StatusBarEntry, FrontendApplicationContribution, PreferenceServiceImpl, PreferenceChange } from '@theia/core/lib/browser';
 import { MessageService } from '@theia/core/lib/common';


### PR DESCRIPTION
Signed-off-by: Esther Perelman <esther.perelman@sap.com>

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
Fix #9761 **by removing a problematic import...**

#### How to test

1. Unzip [test-extension.zip](https://github.com/eclipse-theia/theia/files/6885925/err-test.zip)
2. Run inside: `yarn` & `yarn run compile` 
3. Open Theia
4. Run `ctrl+shift+p` -> `Hosted Plugin: Start Instance`
5. Select the downloaded extension
6. Stop or Restart (by pressing on the left bottom bar or `ctrl+shift+p` -> `Hosted Plugin: Stop/Restart Instance`
7. See no error

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

