### PR TITLE
monaco: fix quick-command separator

### DIFF
--- a/packages/monaco/src/browser/monaco-quick-command-service.ts
+++ b/packages/monaco/src/browser/monaco-quick-command-service.ts
@@ -58,7 +58,10 @@ export class MonacoQuickCommandService extends QuickCommandService implements mo
         }
 
         if (otherItems.length > 0) {
-            items.push({ type: 'separator', label: 'other commands' }, ...otherItems);
+            if (recentItems.length > 0) {
+                items.push({ type: 'separator', label: 'other commands' });
+            }
+            items.push(...otherItems);
         }
         return items;
     }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

The following commit fixes the `other commands` separator which should be present only when there are recently used commands.

https://user-images.githubusercontent.com/40359487/127211089-3f228279-f180-4c91-8911-5fb7076c3093.mp4


#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

1. start the application.
2. trigger the quick-command palette (<kbd>F1</kbd>).
3. ensure that the list of `recently used` commands are separated from `other commands`.
4. execute commands to add them to the `recently used` list.

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

Signed-off-by: vince-fugnitto <vincent.fugnitto@ericsson.com>