### PR TITLE
Preferences: Additional `Open Preferences` Commands

### DIFF
--- a/packages/plugin-ext-vscode/src/browser/plugin-vscode-commands-contribution.ts
+++ b/packages/plugin-ext-vscode/src/browser/plugin-vscode-commands-contribution.ts
@@ -238,7 +238,7 @@ export class PluginVscodeCommandsContribution implements CommandContribution {
             execute: (prefix?: unknown) => this.quickInput.open(typeof prefix === 'string' ? prefix : '')
         });
         commands.registerCommand({ id: 'workbench.action.openSettings' }, {
-            execute: () => commands.executeCommand(CommonCommands.OPEN_PREFERENCES.id)
+            execute: (query?: string) => commands.executeCommand(CommonCommands.OPEN_PREFERENCES.id, query)
         });
         commands.registerCommand({ id: 'workbench.files.action.refreshFilesExplorer' }, {
             execute: () => commands.executeCommand(FileNavigatorCommands.REFRESH_NAVIGATOR.id)

--- a/packages/preferences/src/browser/util/preference-types.ts
+++ b/packages/preferences/src/browser/util/preference-types.ts
@@ -122,6 +122,18 @@ export namespace PreferencesCommands {
         id: 'preferences:copyJson.value',
         label: 'Copy Setting as JSON',
     };
+
+    export const OPEN_USER_PREFERENCES: Command = {
+        id: 'workbench.action.openGlobalSettings',
+        category: 'Preferences',
+        label: 'Open User Preferences',
+    };
+
+    export const OPEN_WORKSPACE_PREFERENCES: Command = {
+        id: 'workbench.action.openWorkspaceSettings',
+        category: 'Preferences',
+        label: 'Open Workspace Preferences',
+    };
 }
 
 export namespace PreferenceMenus {

--- a/packages/preferences/src/browser/views/preference-widget.tsx
+++ b/packages/preferences/src/browser/views/preference-widget.tsx
@@ -15,7 +15,7 @@
  ********************************************************************************/
 
 import { postConstruct, injectable, inject } from '@theia/core/shared/inversify';
-import { Panel, Widget, Message, StatefulWidget } from '@theia/core/lib/browser';
+import { Panel, Widget, Message, StatefulWidget, PreferenceScope } from '@theia/core/lib/browser';
 import { PreferencesEditorState, PreferencesEditorWidget } from './preference-editor-widget';
 import { PreferencesTreeWidget } from './preference-tree-widget';
 import { PreferencesSearchbarState, PreferencesSearchbarWidget } from './preference-searchbar-widget';
@@ -46,6 +46,14 @@ export class PreferencesWidget extends Panel implements StatefulWidget {
 
     get currentScope(): Preference.SelectedScopeDetails {
         return this.tabBarWidget.currentScope;
+    }
+
+    setSearchTerm(query: string): void {
+        this.searchbarWidget.updateSearchTerm(query);
+    }
+
+    setScope(scope: PreferenceScope.User | PreferenceScope.Workspace): void {
+        this.tabBarWidget.setScope(scope);
     }
 
     protected onResize(msg: Widget.ResizeMessage): void {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

> This is a rebased and modified version of #9410.

Fixes #7328

- Adds `Preferences: Open User Preferences` command, which opens the _preferences-view_ with `User` scope.
- Adds `Preferences: Open Workspace Preferences` command, which opens the _preferences-view_ with `Workspace` scope.
- Modifies `Settings: Open Preferences` command to be able to accept an optional `query` parameter. Pre-populates the search with this query upon opening the _preferences-view_.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

1. Open the command palette and search `Preferences: Open User Preferences` or `Preferences: Open Workspace Preferences`.
2. Execute either command and confirm that the _preferences-view_ is opened with the correct scope.
3. Use the .vsix provided [here](https://github.com/eclipse-theia/theia/issues/7328#issuecomment-632400156), to pass queries to the `Settings: Open Preferences` command. Observe that the _preferences-view_ opens with the correct search results displayed.

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

Signed-off-by: seantan22 <sean.a.tan@ericsson.com>
Signed-off-by: Colin Grant <colin.grant@ericsson.com>
