### PR TITLE
Remove colons after empty strings in diff labels

### DIFF
--- a/packages/core/src/browser/diff-uris.ts
+++ b/packages/core/src/browser/diff-uris.ts
@@ -81,10 +81,11 @@ export class DiffUriLabelProviderContribution implements LabelProviderContributi
         const [left, right] = DiffUris.decode(uri);
 
         if (left.path.toString() === right.path.toString() && left.query && right.query) {
-            return `${left.displayName}: ${left.query} ⟷ ${right.query}`;
+            const prefix = left.displayName ? `${left.displayName}: ` : '';
+            return `${prefix}${left.query} ⟷ ${right.query}`;
         } else {
             let title;
-            if (left.path.toString() !== right.path.toString() && left.displayName !== uri.displayName) {
+            if (uri.displayName && left.path.toString() !== right.path.toString() && left.displayName !== uri.displayName) {
                 title = `${uri.displayName}: `;
             } else {
                 title = '';


### PR DESCRIPTION
Signed-off-by: Colin Grant <colin.grant@ericsson.com>

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

In the screenshots for #9765, it is clear that diff widgets can wind up with rather odd initial `:` characters. This is due to faulty logic in the label provider for `DiffUri`s, which doesn't check whether a `.displayName` is available before creating certain prefixes that use it.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
1. Open two or more editors.
2. Use the Open Editors widget context menu to select one for comparison and compare another with that selection.
3. Observe that the title of the diff widget that appears does not contain a leading `:` character unless that colon is preceded by actual text.

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

