### PR TITLE
fix(scm): add onDidChangeCommitTemplate event

### DIFF
--- a/packages/git/src/browser/git-scm-provider.ts
+++ b/packages/git/src/browser/git-scm-provider.ts
@@ -50,11 +50,15 @@ export class GitScmProvider implements ScmProvider {
         this.onDidChangeEmitter.fire(undefined);
     }
 
+    private readonly onDidChangeCommitTemplateEmitter = new Emitter<string>();
+    readonly onDidChangeCommitTemplate = this.onDidChangeCommitTemplateEmitter.event;
+
     private readonly onDidChangeStatusBarCommandsEmitter = new Emitter<ScmCommand[] | undefined>();
     readonly onDidChangeStatusBarCommands = this.onDidChangeStatusBarCommandsEmitter.event;
 
     private readonly toDispose = new DisposableCollection(
         this.onDidChangeEmitter,
+        this.onDidChangeCommitTemplateEmitter,
         this.onDidChangeStatusBarCommandsEmitter
     );
 

--- a/packages/scm/src/browser/scm-commit-widget.tsx
+++ b/packages/scm/src/browser/scm-commit-widget.tsx
@@ -71,6 +71,9 @@ export class ScmCommitWidget extends ReactWidget implements StatefulWidget {
             this.toDisposeOnRepositoryChange.push(repository.provider.onDidChange(async () => {
                 this.update();
             }));
+            this.toDisposeOnRepositoryChange.push(repository.provider.onDidChangeCommitTemplate(e => {
+                this.setInputValue(e);
+            }));
         }
     }
 

--- a/packages/scm/src/browser/scm-provider.ts
+++ b/packages/scm/src/browser/scm-provider.ts
@@ -32,6 +32,8 @@ export interface ScmProvider extends Disposable {
     readonly statusBarCommands?: ScmCommand[];
     readonly onDidChangeStatusBarCommands?: Event<ScmCommand[] | undefined>;
 
+    readonly onDidChangeCommitTemplate: Event<string>;
+
     readonly amendSupport?: ScmAmendSupport;
 }
 


### PR DESCRIPTION
Signed-off-by: zwingz <zhengzwing@gmail.com>


#### What it does

add `onDidChangeCommitTemplate` event to `SCM` extensions

theia missing the event `onDidChangeCommitTemplate`
ref [vscode](https://github.com/microsoft/vscode/blob/main/src/vs/workbench/contrib/scm/browser/scmViewPane.ts#L1600)

#### How to test

- remove `example/browser` dependencies `@theia/git`
- add `vscode-git@1.49.3` to `theiaPlugins`
- start example browser
- merge two conflicting branches
```bash
mkdir test-merge-conflict
cd test-merge-conflict
echo 'master' > a.txt
git add . && git commit -m 'from master'
git checkout -b conflict-1
echo 'conflict-1' > a.txt
git add . && git commit -m 'from conflict-1'
git checkout master
echo 'master modified` > a.txt
git add . && git commit -m 'from master 2`
git merge conflit
```

Note the SCM input, should be with value `Merge branch 'conflict'`
![image](https://user-images.githubusercontent.com/13031838/127317461-da59f892-a2bd-4e2d-b5e9-c76b254d5a3c.png)

