### PR TITLE
Delegate `ViewContainer` toolbar checks to child widgets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Change Log
 
+## v1.17.0 - unreleased
+
+[1.17.0 Milestone](https://github.com/eclipse-theia/theia/milestone/23)
+
+- [core] modified handling of toolbar items for `ViewContainer`s to handle `onDidChange` correctly. [#9798](https://github.com/eclipse-theia/theia/pull/9798)
+
+<a name="breaking_changes_1.17.0">[Breaking Changes:](#breaking_changes_1.17.0)</a>
+
+- [core] registering toolbar items for commands that explicitly target a `ViewContainer` rather than a child widget may not behave as expected. Such registrations should be made in the `ViewContainer` by overriding the `updateToolbarItems` method and using the `registerToolbarItem` utility. See the modifications to the `scm` and `vsx-registry` packages in the PR for examples. [#9798](https://github.com/eclipse-theia/theia/pull/9798)
+- [vsx-registry] `VSXExtensionsContribution` no longer implements `TabBarToolbarContribution` and is not bound as such. Extensions of the class that expect such behavior should reimplement it with caution. See caveats in PR. [#9798](https://github.com/eclipse-theia/theia/pull/9798)
+
 ## v1.16.0 - 7/29/2021
 
 [1.16.0 Milestone](https://github.com/eclipse-theia/theia/milestone/22)

--- a/packages/core/src/browser/shell/side-panel-toolbar.ts
+++ b/packages/core/src/browser/shell/side-panel-toolbar.ts
@@ -76,10 +76,8 @@ export class SidePanelToolbar extends BaseWidget {
         if (!this.toolbar) {
             return;
         }
-        const current = this._toolbarTitle;
-        const widget = current && current.owner || undefined;
-        const items = widget ? this.tabBarToolbarRegistry.visibleItems(widget) : [];
-        this.toolbar.updateItems(items, widget);
+        const widget = this._toolbarTitle?.owner ?? undefined;
+        this.toolbar.updateTarget(widget);
     }
 
     protected init(): void {

--- a/packages/core/src/browser/shell/tab-bar-toolbar.tsx
+++ b/packages/core/src/browser/shell/tab-bar-toolbar.tsx
@@ -29,222 +29,6 @@ import { ContextMenuRenderer, Anchor } from '../context-menu-renderer';
 import { MenuModelRegistry } from '../../common/menu';
 
 /**
- * Factory for instantiating tab-bar toolbars.
- */
-export const TabBarToolbarFactory = Symbol('TabBarToolbarFactory');
-export interface TabBarToolbarFactory {
-    (): TabBarToolbar;
-}
-
-/**
- * Tab-bar toolbar widget representing the active [tab-bar toolbar items](TabBarToolbarItem).
- */
-@injectable()
-export class TabBarToolbar extends ReactWidget {
-
-    protected current: Widget | undefined;
-    protected inline = new Map<string, TabBarToolbarItem | ReactTabBarToolbarItem>();
-    protected more = new Map<string, TabBarToolbarItem>();
-
-    @inject(CommandRegistry)
-    protected readonly commands: CommandRegistry;
-
-    @inject(LabelParser)
-    protected readonly labelParser: LabelParser;
-
-    @inject(MenuModelRegistry)
-    protected readonly menus: MenuModelRegistry;
-
-    @inject(ContextMenuRenderer)
-    protected readonly contextMenuRenderer: ContextMenuRenderer;
-
-    constructor() {
-        super();
-        this.addClass(TabBarToolbar.Styles.TAB_BAR_TOOLBAR);
-        this.hide();
-    }
-
-    updateItems(items: Array<TabBarToolbarItem | ReactTabBarToolbarItem>, current: Widget | undefined): void {
-        this.inline.clear();
-        this.more.clear();
-        for (const item of items.sort(TabBarToolbarItem.PRIORITY_COMPARATOR).reverse()) {
-            if ('render' in item || item.group === undefined || item.group === 'navigation') {
-                this.inline.set(item.id, item);
-            } else {
-                this.more.set(item.id, item);
-            }
-        }
-        this.setCurrent(current);
-        if (!items.length) {
-            this.hide();
-        }
-        this.onRender.push(Disposable.create(() => {
-            if (items.length) {
-                this.show();
-            }
-        }));
-        this.update();
-    }
-
-    protected readonly toDisposeOnSetCurrent = new DisposableCollection();
-    protected setCurrent(current: Widget | undefined): void {
-        this.toDisposeOnSetCurrent.dispose();
-        this.toDispose.push(this.toDisposeOnSetCurrent);
-        this.current = current;
-        if (current) {
-            const resetCurrent = () => {
-                this.setCurrent(undefined);
-                this.update();
-            };
-            current.disposed.connect(resetCurrent);
-            this.toDisposeOnSetCurrent.push(Disposable.create(() =>
-                current.disposed.disconnect(resetCurrent)
-            ));
-        }
-    }
-
-    protected render(): React.ReactNode {
-        return <React.Fragment>
-            {this.renderMore()}
-            {[...this.inline.values()].map(item => TabBarToolbarItem.is(item) ? this.renderItem(item) : item.render(this.current))}
-        </React.Fragment>;
-    }
-
-    protected renderItem(item: TabBarToolbarItem): React.ReactNode {
-        let innerText = '';
-        const classNames = [];
-        if (item.text) {
-            for (const labelPart of this.labelParser.parse(item.text)) {
-                if (typeof labelPart !== 'string' && LabelIcon.is(labelPart)) {
-                    const className = `fa fa-${labelPart.name}${labelPart.animation ? ' fa-' + labelPart.animation : ''}`;
-                    classNames.push(...className.split(' '));
-                } else {
-                    innerText = labelPart;
-                }
-            }
-        }
-        const command = this.commands.getCommand(item.command);
-        const iconClass = (typeof item.icon === 'function' && item.icon()) || item.icon || (command && command.iconClass);
-        if (iconClass) {
-            classNames.push(iconClass);
-        }
-        const tooltip = item.tooltip || (command && command.label);
-        const toolbarItemClassNames = this.getToolbarItemClassNames(command?.id);
-        return <div key={item.id}
-            className={toolbarItemClassNames}
-            onMouseDown={this.onMouseDownEvent}
-            onMouseUp={this.onMouseUpEvent}
-            onMouseOut={this.onMouseUpEvent} >
-            <div id={item.id} className={classNames.join(' ')}
-                onClick={this.executeCommand}
-                title={tooltip}>{innerText}
-            </div>
-        </div>;
-    }
-
-    protected getToolbarItemClassNames(commandId: string | undefined): string {
-        const classNames = [TabBarToolbar.Styles.TAB_BAR_TOOLBAR_ITEM];
-        if (commandId) {
-            if (this.commandIsEnabled(commandId)) {
-                classNames.push('enabled');
-            }
-            if (this.commandIsToggled(commandId)) {
-                classNames.push('toggled');
-            }
-        }
-        return classNames.join(' ');
-    }
-
-    protected renderMore(): React.ReactNode {
-        return !!this.more.size && <div key='__more__' className={TabBarToolbar.Styles.TAB_BAR_TOOLBAR_ITEM + ' enabled'}>
-            <div id='__more__' className='fa fa-ellipsis-h' onClick={this.showMoreContextMenu} title='More Actions...' />
-        </div>;
-    }
-
-    protected showMoreContextMenu = (event: React.MouseEvent) => {
-        event.stopPropagation();
-        event.preventDefault();
-
-        this.renderMoreContextMenu(event.nativeEvent);
-    };
-
-    /* eslint-disable-next-line @typescript-eslint/no-explicit-any */
-    renderMoreContextMenu(anchor: Anchor): any {
-        const menuPath = ['TAB_BAR_TOOLBAR_CONTEXT_MENU'];
-        const toDisposeOnHide = new DisposableCollection();
-        for (const [, item] of this.more) {
-            // Register a submenu for the item, if the group is in format `<submenu group>/<submenu name>/.../<item group>`
-            if (item.group!.indexOf('/') !== -1) {
-                const split = item.group!.split('/');
-                const paths: string[] = [];
-                for (let i = 0; i < split.length - 1; i += 2) {
-                    paths.push(split[i], split[i + 1]);
-                    // TODO order is missing, items sorting will be alphabetic
-                    toDisposeOnHide.push(this.menus.registerSubmenu([...menuPath, ...paths], split[i + 1]));
-                }
-            }
-            // TODO order is missing, items sorting will be alphabetic
-            toDisposeOnHide.push(this.menus.registerMenuAction([...menuPath, ...item.group!.split('/')], {
-                label: item.tooltip,
-                commandId: item.id,
-                when: item.when
-            }));
-        }
-        return this.contextMenuRenderer.render({
-            menuPath,
-            args: [this.current],
-            anchor,
-            onHide: () => toDisposeOnHide.dispose()
-        });
-    }
-
-    shouldHandleMouseEvent(event: MouseEvent): boolean {
-        return event.target instanceof Element && this.node.contains(event.target);
-    }
-
-    protected commandIsEnabled(command: string): boolean {
-        return this.commands.isEnabled(command, this.current);
-    }
-
-    protected commandIsToggled(command: string): boolean {
-        return this.commands.isToggled(command, this.current);
-    }
-
-    protected executeCommand = (e: React.MouseEvent<HTMLElement>) => {
-        e.preventDefault();
-        e.stopPropagation();
-
-        const item = this.inline.get(e.currentTarget.id);
-        if (TabBarToolbarItem.is(item)) {
-            this.commands.executeCommand(item.command, this.current);
-        }
-        this.update();
-    };
-
-    protected onMouseDownEvent = (e: React.MouseEvent<HTMLElement>) => {
-        if (e.button === 0) {
-            e.currentTarget.classList.add('active');
-        }
-    };
-
-    protected onMouseUpEvent = (e: React.MouseEvent<HTMLElement>) => {
-        e.currentTarget.classList.remove('active');
-    };
-
-}
-
-export namespace TabBarToolbar {
-
-    export namespace Styles {
-
-        export const TAB_BAR_TOOLBAR = 'p-TabBar-toolbar';
-        export const TAB_BAR_TOOLBAR_ITEM = 'item';
-
-    }
-
-}
-
-/**
  * Clients should implement this interface if they want to contribute to the tab-bar toolbar.
  */
 export const TabBarToolbarContribution = Symbol('TabBarToolbarContribution');
@@ -257,6 +41,20 @@ export interface TabBarToolbarContribution {
      * @param registry the tabbar toolbar registry.
      */
     registerToolbarItems(registry: TabBarToolbarRegistry): void;
+}
+
+export interface TabBarDelegator extends Widget {
+    getTabBarDelegate(): Widget | undefined;
+}
+
+export namespace TabBarDelegator {
+    export const is = (candidate?: Widget): candidate is TabBarDelegator => {
+        if (candidate) {
+            const asDelegator = candidate as TabBarDelegator;
+            return typeof asDelegator.getTabBarDelegate === 'function';
+        }
+        return false;
+    };
 }
 
 /**
@@ -462,6 +260,231 @@ export class TabBarToolbarRegistry implements FrontendApplicationContribution {
         if (this.items.delete(id)) {
             this.fireOnDidChange();
         }
+    }
+
+}
+
+/**
+ * Factory for instantiating tab-bar toolbars.
+ */
+export const TabBarToolbarFactory = Symbol('TabBarToolbarFactory');
+export interface TabBarToolbarFactory {
+    (): TabBarToolbar;
+}
+
+/**
+ * Tab-bar toolbar widget representing the active [tab-bar toolbar items](TabBarToolbarItem).
+ */
+@injectable()
+export class TabBarToolbar extends ReactWidget {
+
+    protected current: Widget | undefined;
+    protected inline = new Map<string, TabBarToolbarItem | ReactTabBarToolbarItem>();
+    protected more = new Map<string, TabBarToolbarItem>();
+
+    @inject(CommandRegistry)
+    protected readonly commands: CommandRegistry;
+
+    @inject(LabelParser)
+    protected readonly labelParser: LabelParser;
+
+    @inject(MenuModelRegistry)
+    protected readonly menus: MenuModelRegistry;
+
+    @inject(ContextMenuRenderer)
+    protected readonly contextMenuRenderer: ContextMenuRenderer;
+
+    @inject(TabBarToolbarRegistry)
+    protected readonly toolbarRegistry: TabBarToolbarRegistry;
+
+    constructor() {
+        super();
+        this.addClass(TabBarToolbar.Styles.TAB_BAR_TOOLBAR);
+        this.hide();
+    }
+
+    updateItems(items: Array<TabBarToolbarItem | ReactTabBarToolbarItem>, current: Widget | undefined): void {
+        this.inline.clear();
+        this.more.clear();
+        for (const item of items.sort(TabBarToolbarItem.PRIORITY_COMPARATOR).reverse()) {
+            if ('render' in item || item.group === undefined || item.group === 'navigation') {
+                this.inline.set(item.id, item);
+            } else {
+                this.more.set(item.id, item);
+            }
+        }
+        this.setCurrent(current);
+        if (!items.length) {
+            this.hide();
+        }
+        this.onRender.push(Disposable.create(() => {
+            if (items.length) {
+                this.show();
+            }
+        }));
+        this.update();
+    }
+
+    updateTarget(current?: Widget): void {
+        const operativeWidget = TabBarDelegator.is(current) ? current.getTabBarDelegate() : current;
+        const items = operativeWidget ? this.toolbarRegistry.visibleItems(operativeWidget) : [];
+        this.updateItems(items, operativeWidget);
+    }
+
+    protected readonly toDisposeOnSetCurrent = new DisposableCollection();
+    protected setCurrent(current: Widget | undefined): void {
+        this.toDisposeOnSetCurrent.dispose();
+        this.toDispose.push(this.toDisposeOnSetCurrent);
+        this.current = current;
+        if (current) {
+            const resetCurrent = () => {
+                this.setCurrent(undefined);
+                this.update();
+            };
+            current.disposed.connect(resetCurrent);
+            this.toDisposeOnSetCurrent.push(Disposable.create(() =>
+                current.disposed.disconnect(resetCurrent)
+            ));
+        }
+    }
+
+    protected render(): React.ReactNode {
+        return <React.Fragment>
+            {this.renderMore()}
+            {[...this.inline.values()].map(item => TabBarToolbarItem.is(item) ? this.renderItem(item) : item.render(this.current))}
+        </React.Fragment>;
+    }
+
+    protected renderItem(item: TabBarToolbarItem): React.ReactNode {
+        let innerText = '';
+        const classNames = [];
+        if (item.text) {
+            for (const labelPart of this.labelParser.parse(item.text)) {
+                if (typeof labelPart !== 'string' && LabelIcon.is(labelPart)) {
+                    const className = `fa fa-${labelPart.name}${labelPart.animation ? ' fa-' + labelPart.animation : ''}`;
+                    classNames.push(...className.split(' '));
+                } else {
+                    innerText = labelPart;
+                }
+            }
+        }
+        const command = this.commands.getCommand(item.command);
+        const iconClass = (typeof item.icon === 'function' && item.icon()) || item.icon || (command && command.iconClass);
+        if (iconClass) {
+            classNames.push(iconClass);
+        }
+        const tooltip = item.tooltip || (command && command.label);
+        const toolbarItemClassNames = this.getToolbarItemClassNames(command?.id);
+        return <div key={item.id}
+            className={toolbarItemClassNames}
+            onMouseDown={this.onMouseDownEvent}
+            onMouseUp={this.onMouseUpEvent}
+            onMouseOut={this.onMouseUpEvent} >
+            <div id={item.id} className={classNames.join(' ')}
+                onClick={this.executeCommand}
+                title={tooltip}>{innerText}
+            </div>
+        </div>;
+    }
+
+    protected getToolbarItemClassNames(commandId: string | undefined): string {
+        const classNames = [TabBarToolbar.Styles.TAB_BAR_TOOLBAR_ITEM];
+        if (commandId) {
+            if (this.commandIsEnabled(commandId)) {
+                classNames.push('enabled');
+            }
+            if (this.commandIsToggled(commandId)) {
+                classNames.push('toggled');
+            }
+        }
+        return classNames.join(' ');
+    }
+
+    protected renderMore(): React.ReactNode {
+        return !!this.more.size && <div key='__more__' className={TabBarToolbar.Styles.TAB_BAR_TOOLBAR_ITEM + ' enabled'}>
+            <div id='__more__' className='fa fa-ellipsis-h' onClick={this.showMoreContextMenu} title='More Actions...' />
+        </div>;
+    }
+
+    protected showMoreContextMenu = (event: React.MouseEvent) => {
+        event.stopPropagation();
+        event.preventDefault();
+
+        this.renderMoreContextMenu(event.nativeEvent);
+    };
+
+    /* eslint-disable-next-line @typescript-eslint/no-explicit-any */
+    renderMoreContextMenu(anchor: Anchor): any {
+        const menuPath = ['TAB_BAR_TOOLBAR_CONTEXT_MENU'];
+        const toDisposeOnHide = new DisposableCollection();
+        for (const item of this.more.values()) {
+            // Register a submenu for the item, if the group is in format `<submenu group>/<submenu name>/.../<item group>`
+            if (item.group?.includes('/')) {
+                const split = item.group.split('/');
+                const paths: string[] = [];
+                for (let i = 0; i < split.length - 1; i += 2) {
+                    paths.push(split[i], split[i + 1]);
+                    // TODO order is missing, items sorting will be alphabetic
+                    toDisposeOnHide.push(this.menus.registerSubmenu([...menuPath, ...paths], split[i + 1]));
+                }
+            }
+            // TODO order is missing, items sorting will be alphabetic
+            toDisposeOnHide.push(this.menus.registerMenuAction([...menuPath, ...item.group!.split('/')], {
+                label: item.tooltip,
+                commandId: item.command,
+                when: item.when
+            }));
+        }
+        return this.contextMenuRenderer.render({
+            menuPath,
+            args: [this.current],
+            anchor,
+            onHide: () => toDisposeOnHide.dispose()
+        });
+    }
+
+    shouldHandleMouseEvent(event: MouseEvent): boolean {
+        return event.target instanceof Element && this.node.contains(event.target);
+    }
+
+    protected commandIsEnabled(command: string): boolean {
+        return this.commands.isEnabled(command, this.current);
+    }
+
+    protected commandIsToggled(command: string): boolean {
+        return this.commands.isToggled(command, this.current);
+    }
+
+    protected executeCommand = (e: React.MouseEvent<HTMLElement>) => {
+        e.preventDefault();
+        e.stopPropagation();
+
+        const item = this.inline.get(e.currentTarget.id);
+        if (TabBarToolbarItem.is(item)) {
+            this.commands.executeCommand(item.command, this.current);
+        }
+        this.update();
+    };
+
+    protected onMouseDownEvent = (e: React.MouseEvent<HTMLElement>) => {
+        if (e.button === 0) {
+            e.currentTarget.classList.add('active');
+        }
+    };
+
+    protected onMouseUpEvent = (e: React.MouseEvent<HTMLElement>) => {
+        e.currentTarget.classList.remove('active');
+    };
+
+}
+
+export namespace TabBarToolbar {
+
+    export namespace Styles {
+
+        export const TAB_BAR_TOOLBAR = 'p-TabBar-toolbar';
+        export const TAB_BAR_TOOLBAR_ITEM = 'item';
+
     }
 
 }

--- a/packages/core/src/browser/shell/tab-bars.ts
+++ b/packages/core/src/browser/shell/tab-bars.ts
@@ -638,10 +638,8 @@ export class ToolbarAwareTabBar extends ScrollableTabBar {
         if (!this.toolbar) {
             return;
         }
-        const current = this.currentTitle;
-        const widget = current && current.owner || undefined;
-        const items = widget ? this.tabBarToolbarRegistry.visibleItems(widget) : [];
-        this.toolbar.updateItems(items, widget);
+        const widget = this.currentTitle?.owner ?? undefined;
+        this.toolbar.updateTarget(widget);
     }
 
     handleEvent(event: Event): void {

--- a/packages/navigator/src/browser/navigator-widget.tsx
+++ b/packages/navigator/src/browser/navigator-widget.tsx
@@ -62,6 +62,10 @@ export class FileNavigatorWidget extends FileTreeWidget {
     @postConstruct()
     protected init(): void {
         super.init();
+        // This ensures that the context menu command to hide this widget receives the label 'Folders'
+        // regardless of the name of workspace. See ViewContainer.updateToolbarItems.
+        const dataset = { ...this.title.dataset, visibilityCommandLabel: 'Folders' };
+        this.title.dataset = dataset;
         this.updateSelectionContextKeys();
         this.toDispose.pushAll([
             this.model.onSelectionChanged(() =>

--- a/packages/vsx-registry/src/browser/vsx-extension-commands.ts
+++ b/packages/vsx-registry/src/browser/vsx-extension-commands.ts
@@ -1,0 +1,56 @@
+/********************************************************************************
+ * Copyright (C) 2021 Ericsson and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import { Command } from '@theia/core/lib/common';
+
+export namespace VSXExtensionsCommands {
+
+    const EXTENSIONS_CATEGORY = 'Extensions';
+
+    export const CLEAR_ALL: Command = {
+        id: 'vsxExtensions.clearAll',
+        category: EXTENSIONS_CATEGORY,
+        label: 'Clear Search Results',
+        iconClass: 'clear-all'
+    };
+    export const INSTALL_FROM_VSIX: Command & { dialogLabel: string } = {
+        id: 'vsxExtensions.installFromVSIX',
+        category: EXTENSIONS_CATEGORY,
+        label: 'Install from VSIX...',
+        dialogLabel: 'Install from VSIX'
+    };
+    export const COPY: Command = {
+        id: 'vsxExtensions.copy'
+    };
+    export const COPY_EXTENSION_ID: Command = {
+        id: 'vsxExtensions.copyExtensionId'
+    };
+    export const SHOW_BUILTINS: Command = {
+        id: 'vsxExtension.showBuiltins',
+        label: 'Show Built-in Extensions',
+        category: EXTENSIONS_CATEGORY,
+    };
+    export const SHOW_INSTALLED: Command = {
+        id: 'vsxExtension.showInstalled',
+        label: 'Show Installed Extensions',
+        category: EXTENSIONS_CATEGORY,
+    };
+    export const SHOW_RECOMMENDATIONS: Command = {
+        id: 'vsxExtension.showRecommendations',
+        label: 'Show Recommended Extensions',
+        category: EXTENSIONS_CATEGORY,
+    };
+}

--- a/packages/vsx-registry/src/browser/vsx-extensions-view-container.ts
+++ b/packages/vsx-registry/src/browser/vsx-extensions-view-container.ts
@@ -21,6 +21,7 @@ import { VSXExtensionsModel } from './vsx-extensions-model';
 import { VSXSearchMode } from './vsx-extensions-search-model';
 import { generateExtensionWidgetId } from './vsx-extensions-widget';
 import { VSXExtensionsSourceOptions } from './vsx-extensions-source';
+import { VSXExtensionsCommands } from './vsx-extension-commands';
 
 @injectable()
 export class VSXExtensionsViewContainer extends ViewContainer {
@@ -155,6 +156,15 @@ export class VSXExtensionsViewContainer extends ViewContainer {
         this.model.search.query = state.query;
     }
 
+    protected updateToolbarItems(allParts: ViewContainerPart[]): void {
+        super.updateToolbarItems(allParts);
+        this.registerToolbarItem(VSXExtensionsCommands.INSTALL_FROM_VSIX.id, { tooltip: VSXExtensionsCommands.INSTALL_FROM_VSIX.label, group: 'other_1' });
+        this.registerToolbarItem(VSXExtensionsCommands.CLEAR_ALL.id, { tooltip: VSXExtensionsCommands.CLEAR_ALL.label, priority: 1, onDidChange: this.model.onDidChange });
+    }
+
+    protected getToggleVisibilityGroupLabel(): string {
+        return 'a/Views';
+    }
 }
 export namespace VSXExtensionsViewContainer {
     export interface State {

--- a/packages/vsx-registry/src/browser/vsx-registry-frontend-module.ts
+++ b/packages/vsx-registry/src/browser/vsx-registry-frontend-module.ts
@@ -24,7 +24,6 @@ import { VSXExtensionsSearchBar } from './vsx-extensions-search-bar';
 import { VSXExtensionsModel } from './vsx-extensions-model';
 import { ColorContribution } from '@theia/core/lib/browser/color-application-contribution';
 import { VSXExtensionsWidget, VSXExtensionsWidgetOptions } from './vsx-extensions-widget';
-import { TabBarToolbarContribution } from '@theia/core/lib/browser/shell/tab-bar-toolbar';
 import { VSXExtensionFactory, VSXExtension, VSXExtensionOptions } from './vsx-extension';
 import { VSXExtensionEditor } from './vsx-extension-editor';
 import { VSXExtensionEditorManager } from './vsx-extension-editor-manager';
@@ -105,7 +104,6 @@ export default new ContainerModule((bind, unbind) => {
     bindViewContribution(bind, VSXExtensionsContribution);
     bind(FrontendApplicationContribution).toService(VSXExtensionsContribution);
     bind(ColorContribution).toService(VSXExtensionsContribution);
-    bind(TabBarToolbarContribution).toService(VSXExtensionsContribution);
 
     bindExtensionPreferences(bind);
     bindPreferenceProviderOverrides(bind, unbind);


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->
Fixes #8970 by changing the way toolbar item visibility is handled for `ViewContainers`. Instead of registering temporary toolbar items that refer to itself, a `ViewContainer` now implements the interface `TabBarDelegator`, which allows the `TabBarToolbar` system to access the child rather than the `ViewContainer`.

Paired with #8967 (and possible #9080), it should fix most of our toolbar update issues.

I've done it as two commits because giving the `TabBarToolbar` access to the `TabBarToolbarRegistry` required shifting the order in which the two things were declared in the file. The first commit contains no meaningful changes, and I didn't want to obscure the changes in the second commit by including the cut-paste as part of it.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
1. Check that the existing toolbar items for the `scm` package behave as expected (list vs. tree toggle, collapse all). They have been adjusted to refer to the `ScmWidget` directly rather than checking the `ScmViewContainer` to find the right widget - that was a workaround to avoid #8970.
2. Check existing items for the Extensions view. They have been adjusted to be registered inside the `ViewContainer` rather than in the contribution.
3. Check that for any `ViewContainer` with multiple children, a `...` item exists that reveals a context menu that can hide and unhide children. In the Extensions view, they should appear under a `Views` submenu.
4. Check that hiding and revealing children (e.g. in the `navigator` if the NPM view is available), using that menu or the `ViewContainer`'s context menu, puts the correct items in the top bar
  - When a single child is visible, its toolbar items should populate the `ViewContainer`'s toolbar.
  - When multiple children are visible, only the `...` should be visible.


> NB: It was formerly possible to register toolbar items whose visibility depended on a check for the `ViewContainer` rather than a child widget, as was done in the `scm` package. Such checks don't appear to be possible in VSCode - toolbar items are always associated with a particular child - and they will no longer behave as expected if this PR is accepted.

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

