### PR TITLE
Add SECURITY.md

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,9 +1,13 @@
 ---
-name: Bug Report
+name: Bug Report (except security vulnerabilities)
 about: Create a report to help us improve
 ---
 
 <!-- Please provide a detailed description of the bug. -->
+<!-- Note: This template is not meant for security vulnerabilities disclosure -->
+<!-- Any such issue, created in this repo, will be deleted on sight -->
+<!-- Instead please report vulnerabilities to the Eclipse Foundation's security team -->
+<!-- For more details, please read SECURITY.md in the repository root -->
 ### Bug Description:
 
 <!-- Please provide clear steps to reproduce the bug. -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -5,6 +5,12 @@ the requirements below.
 Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
 -->
 
+<!--
+Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
+other means. See SECURITY.md at the root of this repository, to learn how to report
+vulnerabilities.
+-->
+
 #### What it does
 <!-- Include relevant issues and describe how they are addressed. -->
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,11 @@
+# Eclipse Theia Vulnerability Reporting Policy
+
+If you think or suspect that you have discovered a new security vulnerability
+in this project, please __do not__ disclose it on GitHub, e.g. in an issue, a
+PR, or a discussion. Any such disclosure will be removed/deleted on sight, to
+promote orderly disclosure, as per the Eclipse Foundation Security Policy (1).
+
+Instead, please report any potential vulnerability to the Eclipse Foundation [Security Team](https://www.eclipse.org/security/). Make sure to provide a concise description of the issue, a CWE, and other supporting information.
+
+(1) _Eclipse Foundation Vulnerability Reporting Policy_:
+[https://www.eclipse.org/security/policy.php](https://www.eclipse.org/security/policy.php)


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->
As part of our project's periodic Eclipse Foundation progress review (1),
we are encouraged to add a security policy file, for our project. I went
with the miminal amount of information I thought was needed, not duplicating
info from the EF policy. It should be a good first step, I think.

In addition, I also modified the GitHub bug report issue template and PR
template, to make it clear they're not meant to be used to disclose security
vulnerabilities.

A nice side-effect of adding SECURITY.md is that GitHub automatically adds
an entry in our issue-submission page: "Report a security vulnerability",
that has a button "View Policy" that opens our policy.

There are some more seemingly nice GitHub project security features that
could be enabled for our repo/project (with webmaster's help). We can
consider them separately.

(1): https://gitlab.eclipse.org/eclipsefdn/emo-team/emo/-/issues/64

Fixes #8795


#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
This is a non-functional change for the most part. To see the changes to the GH issue and PR templates "live", I have deployed this PR to the master branch of my fork: 
https://github.com/marcdumais-work/theia/issues/new/choose

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

