### PR TITLE
fix: trying to access undefined process variable

### DIFF
--- a/packages/filesystem/src/browser/filesystem-preferences.ts
+++ b/packages/filesystem/src/browser/filesystem-preferences.ts
@@ -29,7 +29,7 @@ import { environment } from '@theia/core/shared/@theia/application-package/lib/e
 export const WIN32_MAX_FILE_SIZE_MB = 300; // 300 MB
 export const GENERAL_MAX_FILE_SIZE_MB = 16 * 1024; // 16 GB
 
-export const MAX_FILE_SIZE_MB = environment.electron.is() ? process.arch === 'ia32' ? WIN32_MAX_FILE_SIZE_MB : GENERAL_MAX_FILE_SIZE_MB : 32;
+export const MAX_FILE_SIZE_MB = environment.electron.is() && 'process' in window ? process.arch === 'ia32' ? WIN32_MAX_FILE_SIZE_MB : GENERAL_MAX_FILE_SIZE_MB : 32;
 
 export const filesystemPreferenceSchema: PreferenceSchema = {
     'type': 'object',


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

<!--
Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->
This makes sure that the `filesystem` package accesses the `process` variable only when it exists.
See #9815 #9751 for more info
#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
In our use case, we simply access the browser IDE from a Cypress test that's running on Electron.
The `filesystem` will throw an exception during its initialization, and the frontend will fail to load.
This PR fixes that.

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

