### PR TITLE
Add `@vscode/codicons` dependency to core package

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -32,6 +32,7 @@
     "@types/safer-buffer": "^2.1.0",
     "@types/ws": "^5.1.2",
     "@types/yargs": "^15",
+    "@vscode/codicons": "^0.0.21",
     "ajv": "^6.5.3",
     "body-parser": "^1.17.2",
     "cookie": "^0.4.0",

--- a/packages/core/src/browser/frontend-application-module.ts
+++ b/packages/core/src/browser/frontend-application-module.ts
@@ -18,6 +18,7 @@ import '../../src/browser/style/index.css';
 require('../../src/browser/style/materialcolors.css').use();
 import 'font-awesome/css/font-awesome.min.css';
 import 'file-icons-js/css/style.css';
+import '@vscode/codicons/dist/codicon.css';
 
 import { ContainerModule } from 'inversify';
 import {

--- a/packages/core/src/browser/widgets/widget.ts
+++ b/packages/core/src/browser/widgets/widget.ts
@@ -32,7 +32,7 @@ export * from '@phosphor/messaging';
 
 export const DISABLED_CLASS = 'theia-mod-disabled';
 export const EXPANSION_TOGGLE_CLASS = 'theia-ExpansionToggle';
-export const CODICON_TREE_ITEM_CLASSES = ['codicon', 'codicon-tree-item-expanded'];
+export const CODICON_TREE_ITEM_CLASSES = ['codicon', 'codicon-chevron-down'];
 export const COLLAPSED_CLASS = 'theia-mod-collapsed';
 export const BUSY_CLASS = 'theia-mod-busy';
 export const SELECTED_CLASS = 'theia-mod-selected';

--- a/yarn.lock
+++ b/yarn.lock
@@ -1774,6 +1774,11 @@
     "@typescript-eslint/types" "4.28.5"
     eslint-visitor-keys "^2.0.0"
 
+"@vscode/codicons@^0.0.21":
+  version "0.0.21"
+  resolved "https://registry.yarnpkg.com/@vscode/codicons/-/codicons-0.0.21.tgz#20ef724b141fdddba3ad86e85f34aaad29e4d3a0"
+  integrity sha512-oUfqbWTaEc2NIVLUxOK2Vi8AB/ixFfp52CkmR+pYZcWAr82IVIDDn50pdEDRXfJNIc4giHDSc5F5ZTsVMZK9Sg==
+
 "@webassemblyjs/ast@1.11.1":
   version "1.11.1"
   resolved "https://registry.yarnpkg.com/@webassemblyjs/ast/-/ast-1.11.1.tgz#2bfd767eae1a6996f432ff7e8d7fc75679c0b6a7"


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

<!--
Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

Closes #9826

Adds the [`@vscode/codicons`](https://www.npmjs.com/package/@vscode/codicons) package to the core Theia package. Currently `codicons` are only available once `monaco` has been loaded to the DOM. This loads any `codicons` at startup without the need to include monaco in Theia. I've confirmed that all currently used `codicons` classes are contained in the referenced css file, except for `tree-item-expanded`, which I've replaced with `chevron-down`.

cc @vince-fugnitto does this require a CQ?
<!-- Include relevant issues and describe how they are addressed. -->

#### How to test

1. Confirm that everything works as expected with this change in place.
2. Modify the example packages to remove any references to `monaco` packages. See the following `dependencies` section:

```
"dependencies": {
    "@theia/bulk-edit": "1.16.0",
    "@theia/callhierarchy": "1.16.0",
    "@theia/core": "1.16.0",
    "@theia/file-search": "1.16.0",
    "@theia/filesystem": "1.16.0",
    "@theia/git": "1.16.0",
    "@theia/keymaps": "1.16.0",
    "@theia/messages": "1.16.0",
    "@theia/metrics": "1.16.0",
    "@theia/mini-browser": "1.16.0",
    "@theia/navigator": "1.16.0",
    "@theia/preferences": "1.16.0",
    "@theia/scm": "1.16.0",
    "@theia/scm-extra": "1.16.0",
    "@theia/workspace": "1.16.0"
},
```

3. Compile everything and start the application. Confirm that any codicons are correctly rendered. (e.g. chevrons for tree explorers, settings gear in the bottom left corner)

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

