### PR TITLE
preferences: add `json` commands

### DIFF
--- a/packages/preferences/src/browser/util/preference-types.ts
+++ b/packages/preferences/src/browser/util/preference-types.ts
@@ -134,6 +134,24 @@ export namespace PreferencesCommands {
         category: 'Preferences',
         label: 'Open Workspace Preferences',
     };
+
+    export const OPEN_USER_PREFERENCES_JSON: Command = {
+        id: 'workbench.action.openSettingsJson',
+        category: 'Preferences',
+        label: 'Open Preferences (JSON)'
+    };
+
+    export const OPEN_WORKSPACE_PREFERENCES_JSON: Command = {
+        id: 'workbench.action.openWorkspaceSettingsFile',
+        category: 'Preferences',
+        label: 'Open Workspace Preferences (JSON)',
+    };
+
+    export const OPEN_FOLDER_PREFERENCES_JSON: Command = {
+        id: 'workbench.action.openFolderSettingsFile',
+        category: 'Preferences',
+        label: 'Open Folder Preferences (JSON)',
+    };
 }
 
 export namespace PreferenceMenus {


### PR DESCRIPTION




<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

<!--
Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

The pull-request adds the following commands:
- `open user preferences (json)`
- `open workspace preferences (json)`
- `open folder preferences (json)`

The folder command will prompt users to first select a root before opening.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

1. in a **single-root workspace** execute `open user preferences (json)` - the user `settings.json` should be opened in an editor.
2. in a **single-root workspace** execute `open workspace preferences (json)` - the workspace `settings.json` should be opened in an editor.
3. in a **multi-root workspace** with multiple folders execute `open folder preferences (json)` - the respective `settings.json` should be opened after selecting a root.
4. confirm that `open folder preferences (json)` does not appear in a single-root workspace or a multi-root workspace without any root folders.

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

Signed-off-by: vince-fugnitto <vincent.fugnitto@ericsson.com>
