### PR TITLE
Update DebugRequestTypes to reflect DAP changes

### DIFF
--- a/packages/debug/src/browser/debug-session-connection.ts
+++ b/packages/debug/src/browser/debug-session-connection.ts
@@ -31,9 +31,13 @@ export type DebugRequestHandler = (request: DebugProtocol.Request) => MaybePromi
 
 export interface DebugRequestTypes {
     'attach': [DebugProtocol.AttachRequestArguments, DebugProtocol.AttachResponse]
+    'breakpointLocations': [DebugProtocol.BreakpointLocationsArguments, DebugProtocol.BreakpointLocationsResponse]
+    'cancel': [DebugProtocol.CancelArguments, DebugProtocol.CancelResponse]
     'completions': [DebugProtocol.CompletionsArguments, DebugProtocol.CompletionsResponse]
     'configurationDone': [DebugProtocol.ConfigurationDoneArguments, DebugProtocol.ConfigurationDoneResponse]
     'continue': [DebugProtocol.ContinueArguments, DebugProtocol.ContinueResponse]
+    'dataBreakpointInfo': [DebugProtocol.DataBreakpointInfoArguments, DebugProtocol.DataBreakpointInfoResponse]
+    'disassemble': [DebugProtocol.DisassembleArguments, DebugProtocol.DisassembleResponse]
     'disconnect': [DebugProtocol.DisconnectArguments, DebugProtocol.DisconnectResponse]
     'evaluate': [DebugProtocol.EvaluateArguments, DebugProtocol.EvaluateResponse]
     'exceptionInfo': [DebugProtocol.ExceptionInfoArguments, DebugProtocol.ExceptionInfoResponse]
@@ -45,14 +49,17 @@ export interface DebugRequestTypes {
     'modules': [DebugProtocol.ModulesArguments, DebugProtocol.ModulesResponse]
     'next': [DebugProtocol.NextArguments, DebugProtocol.NextResponse]
     'pause': [DebugProtocol.PauseArguments, DebugProtocol.PauseResponse]
+    'readMemory': [DebugProtocol.ReadMemoryArguments, DebugProtocol.ReadMemoryResponse]
     'restart': [DebugProtocol.RestartArguments, DebugProtocol.RestartResponse]
     'restartFrame': [DebugProtocol.RestartFrameArguments, DebugProtocol.RestartFrameResponse]
     'reverseContinue': [DebugProtocol.ReverseContinueArguments, DebugProtocol.ReverseContinueResponse]
     'scopes': [DebugProtocol.ScopesArguments, DebugProtocol.ScopesResponse]
     'setBreakpoints': [DebugProtocol.SetBreakpointsArguments, DebugProtocol.SetBreakpointsResponse]
+    'setDataBreakpoints': [DebugProtocol.SetDataBreakpointsArguments, DebugProtocol.SetDataBreakpointsResponse]
     'setExceptionBreakpoints': [DebugProtocol.SetExceptionBreakpointsArguments, DebugProtocol.SetExceptionBreakpointsResponse]
     'setExpression': [DebugProtocol.SetExpressionArguments, DebugProtocol.SetExpressionResponse]
     'setFunctionBreakpoints': [DebugProtocol.SetFunctionBreakpointsArguments, DebugProtocol.SetFunctionBreakpointsResponse]
+    'setInstructionBreakpoints': [DebugProtocol.SetInstructionBreakpointsArguments, DebugProtocol.SetInstructionBreakpointsResponse]
     'setVariable': [DebugProtocol.SetVariableArguments, DebugProtocol.SetVariableResponse]
     'source': [DebugProtocol.SourceArguments, DebugProtocol.SourceResponse]
     'stackTrace': [DebugProtocol.StackTraceArguments, DebugProtocol.StackTraceResponse]
@@ -64,6 +71,7 @@ export interface DebugRequestTypes {
     'terminateThreads': [DebugProtocol.TerminateThreadsArguments, DebugProtocol.TerminateThreadsResponse]
     'threads': [{}, DebugProtocol.ThreadsResponse]
     'variables': [DebugProtocol.VariablesArguments, DebugProtocol.VariablesResponse]
+    'writeMemory': [DebugProtocol.WriteMemoryArguments, DebugProtocol.WriteMemoryResponse]
 }
 
 export interface DebugEventTypes {
@@ -72,10 +80,14 @@ export interface DebugEventTypes {
     'continued': DebugProtocol.ContinuedEvent
     'exited': DebugExitEvent
     'initialized': DebugProtocol.InitializedEvent
+    'invalidated': DebugProtocol.InvalidatedEvent
     'loadedSource': DebugProtocol.LoadedSourceEvent
     'module': DebugProtocol.ModuleEvent
     'output': DebugProtocol.OutputEvent
     'process': DebugProtocol.ProcessEvent
+    'progressEnd': DebugProtocol.ProgressEndEvent
+    'progressStart': DebugProtocol.ProgressStartEvent
+    'progressUpdate': DebugProtocol.ProgressUpdateEvent
     'stopped': DebugProtocol.StoppedEvent
     'terminated': DebugProtocol.TerminatedEvent
     'thread': DebugProtocol.ThreadEvent
@@ -86,10 +98,14 @@ const standardDebugEvents = new Set<string>([
     'continued',
     'exited',
     'initialized',
+    'invalidated',
     'loadedSource',
     'module',
     'output',
     'process',
+    'progressEnd',
+    'progressStart',
+    'progressUpdate',
     'stopped',
     'terminated',
     'thread'


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

<!--
Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

This PR updates the Theia types used to reflect Debug Adapter Protocol types. There have been some updates around which UI may need to be built, but in the meantime, this at least allows adopters / extension writers to write code for the new requests and events without running afoul of our type declarations. At the moment something like `session.sendRequest('readMemory', ...)` is treated as an error because we just haven't declared that possibility.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

If it builds, then we're referring to real things in the DAP.

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

Signed-off-by: Colin Grant <colin.grant@ericsson.com>