### PR TITLE
Add Open Folder Preferences command

### DIFF
--- a/packages/preferences/src/browser/util/preference-scope-command-manager.ts
+++ b/packages/preferences/src/browser/util/preference-scope-command-manager.ts
@@ -18,10 +18,16 @@ import { injectable, inject } from '@theia/core/shared/inversify';
 import { PreferenceScope, LabelProvider } from '@theia/core/lib/browser';
 import { FileStat } from '@theia/filesystem/lib/common/files';
 import { CommandRegistry, MenuModelRegistry, Command } from '@theia/core/lib/common';
-import { Preference } from './preference-types';
+import { Preference, PreferenceMenus } from './preference-types';
 
-export const FOLDER_SCOPE_MENU_PATH = ['preferences:scope.menu'];
+/**
+ * @deprecated since 1.17.0 moved to PreferenceMenus namespace.
+ */
+export const FOLDER_SCOPE_MENU_PATH = PreferenceMenus.FOLDER_SCOPE_MENU_PATH;
 
+/**
+ * @deprecated since 1.17.0. This work is now done in the PreferenceScopeTabbarWidget.
+ */
 @injectable()
 export class PreferenceScopeCommandManager {
     @inject(CommandRegistry) protected readonly commandRegistry: CommandRegistry;

--- a/packages/preferences/src/browser/util/preference-types.ts
+++ b/packages/preferences/src/browser/util/preference-types.ts
@@ -97,6 +97,9 @@ export namespace Preference {
         activeScopeIsFolder: false
     };
 
+    /**
+     * @deprecated since 1.15.0 this type is no longer used.
+     */
     export interface ContextMenuCallbacks {
         resetCallback(): void;
         copyIDCallback(): void;
@@ -135,6 +138,12 @@ export namespace PreferencesCommands {
         label: 'Open Workspace Preferences',
     };
 
+    export const OPEN_FOLDER_PREFERENCES: Command = {
+        id: 'workbench.action.openFolderSettings',
+        category: 'Preferences',
+        label: 'Open Folder Preferences'
+    };
+
     export const OPEN_USER_PREFERENCES_JSON: Command = {
         id: 'workbench.action.openSettingsJson',
         category: 'Preferences',
@@ -157,4 +166,5 @@ export namespace PreferencesCommands {
 export namespace PreferenceMenus {
     export const PREFERENCE_EDITOR_CONTEXT_MENU: MenuPath = ['preferences:editor.contextMenu'];
     export const PREFERENCE_EDITOR_COPY_ACTIONS: MenuPath = [...PREFERENCE_EDITOR_CONTEXT_MENU, 'preferences:editor.contextMenu.copy'];
+    export const FOLDER_SCOPE_MENU_PATH = ['preferences:scope.menu'];
 }

--- a/packages/preferences/src/browser/views/preference-scope-tabbar-widget.tsx
+++ b/packages/preferences/src/browser/views/preference-scope-tabbar-widget.tsx
@@ -96,7 +96,7 @@ export class PreferencesScopeTabBar extends TabBar<Widget> implements StatefulWi
         });
         this.toDispose.pushAll([
             this.workspaceService.onWorkspaceChanged(newRoots => this.doUpdateDisplay(newRoots)),
-            this.workspaceService.onWorkspaceLocationChanged(() => this.updateWorkspaceTab())
+            this.workspaceService.onWorkspaceLocationChanged(() => this.doUpdateDisplay(this.workspaceService.tryGetRoots())),
         ]);
         const tabUnderline = document.createElement('div');
         tabUnderline.className = TABBAR_UNDERLINE_CLASSNAME;

--- a/packages/preferences/src/browser/views/preference-widget.tsx
+++ b/packages/preferences/src/browser/views/preference-widget.tsx
@@ -21,6 +21,7 @@ import { PreferencesTreeWidget } from './preference-tree-widget';
 import { PreferencesSearchbarState, PreferencesSearchbarWidget } from './preference-searchbar-widget';
 import { PreferencesScopeTabBar, PreferencesScopeTabBarState } from './preference-scope-tabbar-widget';
 import { Preference } from '../util/preference-types';
+import URI from '@theia/core/lib/common/uri';
 
 interface PreferencesWidgetState {
     scopeTabBarState: PreferencesScopeTabBarState,
@@ -52,7 +53,7 @@ export class PreferencesWidget extends Panel implements StatefulWidget {
         this.searchbarWidget.updateSearchTerm(query);
     }
 
-    setScope(scope: PreferenceScope.User | PreferenceScope.Workspace): void {
+    setScope(scope: PreferenceScope.User | PreferenceScope.Workspace | URI): void {
         this.tabBarWidget.setScope(scope);
     }
 

--- a/packages/preferences/src/browser/workspace-preference-provider.ts
+++ b/packages/preferences/src/browser/workspace-preference-provider.ts
@@ -46,14 +46,16 @@ export class WorkspacePreferenceProvider extends PreferenceProvider {
                 this._ready.resolve();
             }
         });
-        this.toDispose.push(this.toDisposeOnEnsureDelegateUpToDate);
         this.workspaceService.onWorkspaceLocationChanged(() => this.ensureDelegateUpToDate());
         this.workspaceService.onWorkspaceChanged(() => this.ensureDelegateUpToDate());
     }
 
     getConfigUri(resourceUri: string | undefined = this.ensureResourceUri(), sectionName?: string): URI | undefined {
-        const delegate = this.delegate;
-        return delegate && delegate.getConfigUri(resourceUri, sectionName);
+        return this.delegate?.getConfigUri(resourceUri, sectionName);
+    }
+
+    getContainingConfigUri(resourceUri: string | undefined = this.ensureResourceUri(), sectionName?: string): URI | undefined {
+        return this.delegate?.getContainingConfigUri?.(resourceUri, sectionName);
     }
 
     protected _delegate: PreferenceProvider | undefined;
@@ -65,6 +67,7 @@ export class WorkspacePreferenceProvider extends PreferenceProvider {
         const delegate = this.createDelegate();
         if (this._delegate !== delegate) {
             this.toDisposeOnEnsureDelegateUpToDate.dispose();
+            this.toDispose.push(this.toDisposeOnEnsureDelegateUpToDate);
 
             this._delegate = delegate;
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

<!--
Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

This PR adds a command to open the preferences UI for a given folder scope.

It also refactors the handling of the context menu for folder scopes in the preferences UI to obviate the `PreferenceScopeCommandManager`, which this PR marks as deprecated.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

1. Open no workspace or a single-root, unsaved workspace.
2. You should not see the new command.
3. Open a single-root, saved workspace.
4. You should see the new command in the command palette labeled `Preferences: Open Folder Preferences`
5. Running the command should open the Preferences UI and set the scope to the sole folder in the workspace. (@vince-fugnitto, same re: your JSON command.)
6. Open a multi-root workspace.
7. You should see the command.
8. Running the command should open a quick pick, and selecting a folder should open the Preferences UI with the scope set to that folder.

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

Signed-off-by: Colin Grant <colin.grant@ericsson.com>