### PR TITLE
cli: fix help message

### DIFF
--- a/dev-packages/application-manager/src/application-package-manager.ts
+++ b/dev-packages/application-manager/src/application-package-manager.ts
@@ -25,7 +25,6 @@ import yargs = require('yargs');
 
 export class ApplicationPackageManager {
 
-    // eslint-disable-next-line @typescript-eslint/tslint/config
     static defineGeneratorOptions<T>(cli: yargs.Argv<T>): yargs.Argv<T & {
         mode: 'development' | 'production'
         splitFrontend?: boolean

--- a/dev-packages/application-manager/src/application-package-manager.ts
+++ b/dev-packages/application-manager/src/application-package-manager.ts
@@ -20,25 +20,38 @@ import * as cp from 'child_process';
 import { ApplicationPackage, ApplicationPackageOptions } from '@theia/application-package';
 import { WebpackGenerator, FrontendGenerator, BackendGenerator } from './generator';
 import { ApplicationProcess } from './application-process';
+import { GeneratorOptions } from './generator/abstract-generator';
+import yargs = require('yargs');
 
 export class ApplicationPackageManager {
+
+    // eslint-disable-next-line @typescript-eslint/tslint/config
+    static defineGeneratorOptions<T>(cli: yargs.Argv<T>): yargs.Argv<T & {
+        'mode': 'development' | 'production'
+        'split-frontend'?: boolean
+    }> {
+        return cli
+            .option('mode', {
+                description: 'Generation mode to use',
+                choices: ['development', 'production'],
+                default: 'production' as const,
+            })
+            .option('split-frontend', {
+                description: 'Split frontend modules into separate chunks. By default enabled in the `development` mode and disabled in the `production` mode.',
+                type: 'boolean'
+            });
+    }
 
     readonly pck: ApplicationPackage;
     /** application process */
     readonly process: ApplicationProcess;
     /** manager process */
     protected readonly __process: ApplicationProcess;
-    protected readonly webpack: WebpackGenerator;
-    protected readonly backend: BackendGenerator;
-    protected readonly frontend: FrontendGenerator;
 
     constructor(options: ApplicationPackageOptions) {
         this.pck = new ApplicationPackage(options);
         this.process = new ApplicationProcess(this.pck, options.projectPath);
         this.__process = new ApplicationProcess(this.pck, path.join(__dirname, '..'));
-        this.webpack = new WebpackGenerator(this.pck);
-        this.backend = new BackendGenerator(this.pck);
-        this.frontend = new FrontendGenerator(this.pck);
     }
 
     protected async remove(fsPath: string): Promise<void> {
@@ -48,15 +61,19 @@ export class ApplicationPackageManager {
     }
 
     async clean(): Promise<void> {
-        await this.remove(this.pck.lib());
-        await this.remove(this.pck.srcGen());
-        await this.remove(this.webpack.genConfigPath);
+        await Promise.all([
+            this.remove(this.pck.lib()),
+            this.remove(this.pck.srcGen()),
+            this.remove(new WebpackGenerator(this.pck).genConfigPath)
+        ]);
     }
 
-    async generate(): Promise<void> {
-        await this.webpack.generate();
-        await this.backend.generate();
-        await this.frontend.generate();
+    async generate(options: GeneratorOptions = {}): Promise<void> {
+        await Promise.all([
+            new WebpackGenerator(this.pck, options).generate(),
+            new BackendGenerator(this.pck, options).generate(),
+            new FrontendGenerator(this.pck, options).generate(),
+        ]);
     }
 
     async copy(): Promise<void> {
@@ -64,8 +81,8 @@ export class ApplicationPackageManager {
         await fs.copy(this.pck.frontend('index.html'), this.pck.lib('index.html'));
     }
 
-    async build(args: string[] = []): Promise<void> {
-        await this.generate();
+    async build(args: string[] = [], options: GeneratorOptions = {}): Promise<void> {
+        await this.generate(options);
         await this.copy();
         return this.__process.run('webpack', args);
     }

--- a/dev-packages/application-manager/src/application-package-manager.ts
+++ b/dev-packages/application-manager/src/application-package-manager.ts
@@ -27,8 +27,8 @@ export class ApplicationPackageManager {
 
     // eslint-disable-next-line @typescript-eslint/tslint/config
     static defineGeneratorOptions<T>(cli: yargs.Argv<T>): yargs.Argv<T & {
-        'mode': 'development' | 'production'
-        'split-frontend'?: boolean
+        mode: 'development' | 'production'
+        splitFrontend?: boolean
     }> {
         return cli
             .option('mode', {

--- a/dev-packages/application-manager/src/generator/abstract-generator.ts
+++ b/dev-packages/application-manager/src/generator/abstract-generator.ts
@@ -16,29 +16,22 @@
 
 import * as os from 'os';
 import * as fs from 'fs-extra';
-import * as yargs from 'yargs';
 import { ApplicationPackage } from '@theia/application-package';
 
-const argv = yargs.option('mode', {
-    description: 'Mode to use',
-    choices: ['development', 'production'],
-    default: 'production' as 'development' | 'production',
-}).option('split-frontend', {
-    description: 'Split frontend modules into separate chunks. By default enabled in the dev mode and disabled in the prod mode.',
-    type: 'boolean',
-}).option('app-target', {
-    description: 'The target application type. Overrides ["theia.target"] in the application\'s package.json.',
-    choices: ['browser', 'electron'],
-}).argv;
-const splitFrontend: boolean = argv['split-frontend'] ?? argv.mode === 'development';
+export interface GeneratorOptions {
+    mode?: 'development' | 'production'
+    splitFrontend?: boolean
+}
 
 export abstract class AbstractGenerator {
 
     constructor(
-        protected readonly pck: ApplicationPackage
+        protected readonly pck: ApplicationPackage,
+        protected options: GeneratorOptions = {}
     ) { }
 
     protected compileFrontendModuleImports(modules: Map<string, string>): string {
+        const splitFrontend = this.options.splitFrontend ?? this.options.mode !== 'production';
         return this.compileModuleImports(modules, splitFrontend ? 'import' : 'require');
     }
 

--- a/dev-packages/application-manager/src/generator/frontend-generator.ts
+++ b/dev-packages/application-manager/src/generator/frontend-generator.ts
@@ -16,12 +16,12 @@
 
 /* eslint-disable @typescript-eslint/indent */
 
-import { AbstractGenerator } from './abstract-generator';
+import { AbstractGenerator, GeneratorOptions } from './abstract-generator';
 import { existsSync, readFileSync } from 'fs';
 
 export class FrontendGenerator extends AbstractGenerator {
 
-    async generate(): Promise<void> {
+    async generate(options: GeneratorOptions = {}): Promise<void> {
         const frontendModules = this.pck.targetFrontendModules;
         await this.write(this.pck.frontend('index.html'), this.compileIndexHtml(frontendModules));
         await this.write(this.pck.frontend('index.js'), this.compileIndexJs(frontendModules));

--- a/dev-packages/cli/src/test-page.ts
+++ b/dev-packages/cli/src/test-page.ts
@@ -49,7 +49,7 @@ export default async function newTestPage(options: TestPageOptions): Promise<pup
     };
 
     // quick check whether test files exist
-    collectFiles(fileOptions);
+    const files = collectFiles(fileOptions);
 
     const page = await newPage();
     page.on('dialog', dialog => dialog.dismiss());
@@ -121,7 +121,6 @@ export default async function newTestPage(options: TestPageOptions): Promise<pup
             await onWillRun();
         }
 
-        const files = collectFiles(fileOptions);
         for (const file of files) {
             await page.addScriptTag({ path: file });
         }

--- a/dev-packages/cli/src/theia.ts
+++ b/dev-packages/cli/src/theia.ts
@@ -37,6 +37,8 @@ process.on('uncaughtException', error => {
 });
 theiaCli();
 
+function toStringArray(argv: (string | number)[]): string[];
+function toStringArray(argv?: (string | number)[]): string[] | undefined;
 function toStringArray(argv?: (string | number)[]): string[] | undefined {
     return argv === undefined
         ? undefined
@@ -114,13 +116,13 @@ function theiaCli(): void {
         .command<{
             mode: 'development' | 'production',
             splitFrontend?: boolean
-            webpackArgs?: string[]
+            webpackArgs?: (string | number)[]
         }>({
             command: 'build [webpack-args...]',
             describe: `Generate and bundle the ${target} frontend using webpack`,
             builder: cli => ApplicationPackageManager.defineGeneratorOptions(cli),
-            handler: async ({ mode, splitFrontend, webpackArgs }) => {
-                await manager.build(toStringArray(webpackArgs), { mode, splitFrontend });
+            handler: async ({ mode, splitFrontend, webpackArgs = [] }) => {
+                await manager.build(['--mode', mode, ...toStringArray(webpackArgs)], { mode, splitFrontend });
             }
         })
         .command(rebuildCommand('rebuild', target))
@@ -230,6 +232,7 @@ function theiaCli(): void {
                 }
             },
             handler: async ({ testInspect, testExtension, testFile, testIgnore, testRecursive, testSort, testSpec, testCoverage, theiaArgs }) => {
+                console.log('THEIA ARGS', theiaArgs);
                 if (!process.env.THEIA_CONFIG_DIR) {
                     process.env.THEIA_CONFIG_DIR = temp.track().mkdirSync('theia-test-config-dir');
                 }

--- a/dev-packages/cli/src/theia.ts
+++ b/dev-packages/cli/src/theia.ts
@@ -78,7 +78,7 @@ function theiaCli(): void {
     const { appTarget } = defineCommonOptions(yargsFactory()).help(false).parse();
     const manager = new ApplicationPackageManager({ projectPath, appTarget });
     const { target } = manager.pck;
-    const parser = defineCommonOptions(yargs)
+    defineCommonOptions(yargs)
         .command<{
             theiaArgs?: (string | number)[]
         }>({
@@ -279,6 +279,6 @@ function theiaCli(): void {
             'unknown-options-as-args': true,
         })
         .strictCommands()
-        .demandCommand(1, 'Please run a command');
-    parser.parse();
+        .demandCommand(1, 'Please run a command')
+        .parse();
 }


### PR DESCRIPTION
The CLI parsing logic is broken in `@theia/cli`. The help doesn't show
the right information.

The issue comes from using `yargs` at the script level in some places,
leading to corrupt global `yargs` state.

This commit refactors code around so that `--help` works as expected.

Fixes https://github.com/eclipse-theia/theia/issues/1902

#### How to test

- Run `yarn`
- Run `cd examples\browser`
- `yarn theia --help` or `npx theia --help` should display a lot of commands, not just a few parameters.
- `yarn theia <command> --help` should display help for that command.
- `yarn theia patate` should fail with "unknown command" (code 1).

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)