### PR TITLE
fix deleting hosted plugin directory when undeploy

### DIFF
--- a/packages/plugin-ext/src/hosted/node/hosted-plugin-deployer-handler.ts
+++ b/packages/plugin-ext/src/hosted/node/hosted-plugin-deployer-handler.ts
@@ -146,7 +146,9 @@ export class HostedPluginDeployerHandler implements PluginDeployerHandler {
         this.deployedLocations.delete(pluginId);
         for (const location of deployedLocations) {
             try {
-                await fs.remove(location);
+                if (location !== process.env.HOSTED_PLUGIN) {
+                    await fs.remove(location);
+                }
             } catch (e) {
                 console.error(`[${pluginId}]: failed to undeploy from "${location}", reason`, e);
             }


### PR DESCRIPTION
Signed-off-by: shuyaqian 717749594@qq.com

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

<!--
Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->
fix [9855](https://github.com/eclipse-theia/theia/issues/9855)

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
1. execute the command `hosted plugin: start instance` to debug plugin 
2. install the debugging plugin package  in development host
3. the debugging plugin directory will be removed 
4. After the fix, the directory will only be refreshed.

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

