### PR TITLE
plugin: fix starting hosted-plugins

### DIFF
--- a/packages/plugin-dev/src/browser/hosted-plugin-manager-client.ts
+++ b/packages/plugin-dev/src/browser/hosted-plugin-manager-client.ts
@@ -17,7 +17,7 @@
 import { injectable, inject, postConstruct } from '@theia/core/shared/inversify';
 import URI from '@theia/core/lib/common/uri';
 import { Path } from '@theia/core/lib/common/path';
-import { MessageService, Command, Emitter, Event, UriSelection } from '@theia/core/lib/common';
+import { MessageService, Command, Emitter, Event } from '@theia/core/lib/common';
 import { LabelProvider, isNative, AbstractDialog } from '@theia/core/lib/browser';
 import { WindowService } from '@theia/core/lib/browser/window/window-service';
 import { WorkspaceService } from '@theia/workspace/lib/browser';
@@ -280,10 +280,10 @@ export class HostedPluginManagerClient {
             canSelectMany: false
         }, workspaceFolder);
 
-        if (UriSelection.is(result)) {
-            if (await this.hostedPluginServer.isPluginValid(result.uri.toString())) {
-                this.pluginLocation = result.uri;
-                this.messageService.info('Plugin folder is set to: ' + this.labelProvider.getLongName(result.uri));
+        if (result) {
+            if (await this.hostedPluginServer.isPluginValid(result.toString())) {
+                this.pluginLocation = result;
+                this.messageService.info('Plugin folder is set to: ' + this.labelProvider.getLongName(result));
             } else {
                 this.messageService.error('Specified folder does not contain valid plugin.');
             }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

<!--
Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

Fixes: https://github.com/eclipse-theia/theia/issues/9871

The pull-request fixes an issue where the hosted-plugin mode cannot be started when selecting a resource from the dialog. 
Previously, we relied on a `UriSelection` but we now refactored the dialog to use the service instead which returns us a `Uri` directly. The logic to set the `pluginLocation` was adjusted to support the new type.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

1. clone [theia-hello-world](https://github.com/vince-fugnitto/theia-hello-world) test frontend plugin
2. start the `example-browser` application
3. execute the command `hosted plugin: start instance` (using <kbd>F1</kbd>)
4. in the dialog, choose the `theia-hello-world` project folder
5. the hosted plugin should start

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

Signed-off-by: vince-fugnitto <vincent.fugnitto@ericsson.com>