### PR TITLE
register vscode.openWith api

### DIFF
--- a/packages/plugin-ext-vscode/src/browser/plugin-vscode-commands-contribution.ts
+++ b/packages/plugin-ext-vscode/src/browser/plugin-vscode-commands-contribution.ts
@@ -76,6 +76,7 @@ import {
     fromDefinition,
     toDefinition
 } from '@theia/plugin-ext/lib/main/browser/callhierarchy/callhierarchy-type-converters';
+import { CustomEditorOpener } from '@theia/plugin-ext/lib/main/browser/custom-editors/custom-editor-opener';
 
 export namespace VscodeCommands {
     export const OPEN: Command = {
@@ -203,7 +204,10 @@ export class PluginVscodeCommandsContribution implements CommandContribution {
                     return commands.executeCommand(VscodeCommands.OPEN.id, resource, columnOrOptions);
                 }
 
-                const result = await this.openWith(VscodeCommands.OPEN_WITH.id, resource, columnOrOptions, `custom-editor-${viewType}`);
+                let result = await this.openWith(VscodeCommands.OPEN_WITH.id, resource, columnOrOptions, viewType);
+                if (!result) {
+                    result = await this.openWith(VscodeCommands.OPEN_WITH.id, resource, columnOrOptions, CustomEditorOpener.toCustomEditorId(viewType));
+                }
 
                 if (!result) {
                     throw new Error(`Could not find an editor for '${viewType}'`);

--- a/packages/plugin-ext/src/main/browser/custom-editors/custom-editor-opener.tsx
+++ b/packages/plugin-ext/src/main/browser/custom-editors/custom-editor-opener.tsx
@@ -37,8 +37,12 @@ export class CustomEditorOpener implements OpenHandler {
         @inject(ApplicationShell) protected readonly shell: ApplicationShell,
         @inject(WidgetManager) protected readonly widgetManager: WidgetManager
     ) {
-        this.id = `custom-editor-${this.editor.viewType}`;
+        this.id = CustomEditorOpener.toCustomEditorId(this.editor.viewType);
         this.label = this.editor.displayName;
+    }
+
+    static toCustomEditorId(editorViewType: string): string {
+        return `custom-editor-${editorViewType}`;
     }
 
     canHandle(uri: URI): number {


### PR DESCRIPTION
register vscode.openWith api

#### What it does
Fixes #9865

Register vscode.openWith api

VSCode provides both 'open' and 'openWith' commands.
However, theia does not provide the 'openWith' command.
The 'open' command is a command that automatically finds and opens an editor that matches the 'resource' parameter.
'openWith' allows us to directly designate the editor we want and open it.


#### How to test

You can create a VSCode plugin and test it using the following code.

```ts
vscode.window.registerCustomEditorProvider('UserDefinedTyp_1', new CustomEditorProvider() ... );
```
.
.
.

```ts
vscode.commands.executeCommand('vscode.openWith', vscode.Uri.file(...), 'UserDefinedType_1');
```

Here is the code for testing.

**Sample plug-ins code for test**

```ts
import * as vscode from 'vscode';

class MyEditorProvider implements vscode.CustomTextEditorProvider {
	public static readonly viewTypeId = 'UserDef.MyCustomEditor';

	public static register(context: vscode.ExtensionContext): vscode.Disposable {
		const provider = new MyEditorProvider(context);
		return vscode.window.registerCustomEditorProvider(MyEditorProvider.viewTypeId, provider);
	}

	constructor(private readonly context: vscode.ExtensionContext) { }

	resolveCustomTextEditor(document: vscode.TextDocument, webviewPanel: vscode.WebviewPanel, token: vscode.CancellationToken): Thenable<void> | void {
		webviewPanel.webview.html = this.getHtmlForWebview(webviewPanel.webview, document.getText());
	}

	private getHtmlForWebview(webview: vscode.Webview, content: string): string {
		return /* html */`
			<!DOCTYPE html>
			<html lang="en">
			<body>
			<h1>Test View</h1>
			<br/>
			<pre>${content}</pre>
			</body>
			</html>`;
	}
}

export function activate(context: vscode.ExtensionContext) {
	// Register our custom editor providers
	MyEditorProvider.register(context);
	
	vscode.commands.registerCommand('user-command.openWith-test', () => {
		try {
			vscode.commands.executeCommand('vscode.openWith', vscode.Uri.file('/tmp/data/test.data'), MyEditorProvider.viewTypeId);
		} catch (e) {
			vscode.window.showErrorMessage(e);
		}
	});
}
```

> **NOTE** : Before testing, you need to create a random text file and place it in /tmp/data/test.data
> ```bash
> echo "Test Open With" > /tmp/data/test.data
> ```

#### Review checklist
- [ ] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

