### PR TITLE
preferences: make schemas extensible

### DIFF
--- a/packages/core/src/browser/core-preferences.ts
+++ b/packages/core/src/browser/core-preferences.ts
@@ -114,17 +114,20 @@ export interface CoreConfiguration {
     'workbench.tree.renderIndentGuides': 'onHover' | 'none' | 'always';
 }
 
+export const CorePreferenceContribution = Symbol('CorePreferenceContribution');
 export const CorePreferences = Symbol('CorePreferences');
 export type CorePreferences = PreferenceProxy<CoreConfiguration>;
 
-export function createCorePreferences(preferences: PreferenceService): CorePreferences {
-    return createPreferenceProxy(preferences, corePreferenceSchema);
+export function createCorePreferences(preferences: PreferenceService, schema: PreferenceSchema = corePreferenceSchema): CorePreferences {
+    return createPreferenceProxy(preferences, schema);
 }
 
 export function bindCorePreferences(bind: interfaces.Bind): void {
     bind(CorePreferences).toDynamicValue(ctx => {
         const preferences = ctx.container.get<PreferenceService>(PreferenceService);
-        return createCorePreferences(preferences);
+        const contribution = ctx.container.get<PreferenceContribution>(CorePreferenceContribution);
+        return createCorePreferences(preferences, contribution.schema);
     }).inSingletonScope();
-    bind(PreferenceContribution).toConstantValue({ schema: corePreferenceSchema });
+    bind(CorePreferenceContribution).toConstantValue({ schema: corePreferenceSchema });
+    bind(PreferenceContribution).toService(CorePreferenceContribution);
 }

--- a/packages/core/src/electron-browser/window/electron-window-preferences.ts
+++ b/packages/core/src/electron-browser/window/electron-window-preferences.ts
@@ -45,18 +45,20 @@ export class ElectronWindowConfiguration {
     'window.zoomLevel': number;
 }
 
+export const ElectronWindowPreferenceContribution = Symbol('ElectronWindowPreferenceContribution');
 export const ElectronWindowPreferences = Symbol('ElectronWindowPreferences');
 export type ElectronWindowPreferences = PreferenceProxy<ElectronWindowConfiguration>;
 
-export function createElectronWindowPreferences(preferences: PreferenceService): ElectronWindowPreferences {
-    return createPreferenceProxy(preferences, electronWindowPreferencesSchema);
+export function createElectronWindowPreferences(preferences: PreferenceService, schema: PreferenceSchema = electronWindowPreferencesSchema): ElectronWindowPreferences {
+    return createPreferenceProxy(preferences, schema);
 }
 
 export function bindWindowPreferences(bind: interfaces.Bind): void {
     bind(ElectronWindowPreferences).toDynamicValue(ctx => {
         const preferences = ctx.container.get<PreferenceService>(PreferenceService);
-        return createElectronWindowPreferences(preferences);
+        const contribution = ctx.container.get<PreferenceContribution>(ElectronWindowPreferenceContribution);
+        return createElectronWindowPreferences(preferences, contribution.schema);
     }).inSingletonScope();
-
-    bind(PreferenceContribution).toConstantValue({ schema: electronWindowPreferencesSchema });
+    bind(ElectronWindowPreferenceContribution).toConstantValue({ schema: electronWindowPreferencesSchema });
+    bind(PreferenceContribution).toService(ElectronWindowPreferenceContribution);
 }

--- a/packages/debug/src/browser/debug-preferences.ts
+++ b/packages/debug/src/browser/debug-preferences.ts
@@ -62,18 +62,20 @@ export class DebugConfiguration {
     'debug.showInStatusBar': 'never' | 'always' | 'onFirstSessionStart';
 }
 
+export const DebugPreferenceContribution = Symbol('DebugPreferenceContribution');
 export const DebugPreferences = Symbol('DebugPreferences');
 export type DebugPreferences = PreferenceProxy<DebugConfiguration>;
 
-export function createDebugPreferences(preferences: PreferenceService): DebugPreferences {
-    return createPreferenceProxy(preferences, debugPreferencesSchema);
+export function createDebugPreferences(preferences: PreferenceService, schema: PreferenceSchema = debugPreferencesSchema): DebugPreferences {
+    return createPreferenceProxy(preferences, schema);
 }
 
 export function bindDebugPreferences(bind: interfaces.Bind): void {
     bind(DebugPreferences).toDynamicValue(ctx => {
         const preferences = ctx.container.get<PreferenceService>(PreferenceService);
-        return createDebugPreferences(preferences);
+        const contribution = ctx.container.get<PreferenceContribution>(DebugPreferenceContribution);
+        return createDebugPreferences(preferences, contribution.schema);
     }).inSingletonScope();
-
-    bind(PreferenceContribution).toConstantValue({ schema: debugPreferencesSchema });
+    bind(DebugPreferenceContribution).toConstantValue({ schema: debugPreferencesSchema });
+    bind(PreferenceContribution).toService(DebugPreferenceContribution);
 }

--- a/packages/editor-preview/src/browser/editor-preview-preferences.ts
+++ b/packages/editor-preview/src/browser/editor-preview-preferences.ts
@@ -32,17 +32,20 @@ export interface EditorPreviewConfiguration {
     'editor.enablePreview': boolean;
 }
 
+export const EditorPreviewPreferenceContribution = Symbol('EditorPreviewPreferenceContribution');
 export const EditorPreviewPreferences = Symbol('EditorPreviewPreferences');
 export type EditorPreviewPreferences = PreferenceProxy<EditorPreviewConfiguration>;
 
-export function createEditorPreviewPreferences(preferences: PreferenceService): EditorPreviewPreferences {
-    return createPreferenceProxy(preferences, EditorPreviewConfigSchema);
+export function createEditorPreviewPreferences(preferences: PreferenceService, schema: PreferenceSchema = EditorPreviewConfigSchema): EditorPreviewPreferences {
+    return createPreferenceProxy(preferences, schema);
 }
 
 export function bindEditorPreviewPreferences(bind: interfaces.Bind): void {
     bind(EditorPreviewPreferences).toDynamicValue(ctx => {
         const preferences = ctx.container.get<PreferenceService>(PreferenceService);
-        return createEditorPreviewPreferences(preferences);
+        const contribution = ctx.container.get<PreferenceContribution>(EditorPreviewPreferenceContribution);
+        return createEditorPreviewPreferences(preferences, contribution.schema);
     }).inSingletonScope();
-    bind(PreferenceContribution).toConstantValue({ schema: EditorPreviewConfigSchema });
+    bind(EditorPreviewPreferenceContribution).toConstantValue({ schema: EditorPreviewConfigSchema });
+    bind(PreferenceContribution).toService(EditorPreviewPreferenceContribution);
 }

--- a/packages/editor/src/browser/editor-preferences.ts
+++ b/packages/editor/src/browser/editor-preferences.ts
@@ -1566,18 +1566,20 @@ export type EndOfLinePreference = '\n' | '\r\n' | 'auto';
 
 export type EditorPreferenceChange = PreferenceChangeEvent<EditorConfiguration>;
 
+export const EditorPreferenceContribution = Symbol('EditorPreferenceContribution');
 export const EditorPreferences = Symbol('EditorPreferences');
 export type EditorPreferences = PreferenceProxy<EditorConfiguration>;
 
-export function createEditorPreferences(preferences: PreferenceService): EditorPreferences {
-    return createPreferenceProxy(preferences, editorPreferenceSchema);
+export function createEditorPreferences(preferences: PreferenceService, schema: PreferenceSchema = editorPreferenceSchema): EditorPreferences {
+    return createPreferenceProxy(preferences, schema);
 }
 
 export function bindEditorPreferences(bind: interfaces.Bind): void {
     bind(EditorPreferences).toDynamicValue(ctx => {
         const preferences = ctx.container.get<PreferenceService>(PreferenceService);
-        return createEditorPreferences(preferences);
+        const contribution = ctx.container.get<PreferenceContribution>(EditorPreferenceContribution);
+        return createEditorPreferences(preferences, contribution.schema);
     }).inSingletonScope();
-
-    bind(PreferenceContribution).toConstantValue({ schema: editorPreferenceSchema });
+    bind(EditorPreferenceContribution).toConstantValue({ schema: editorPreferenceSchema });
+    bind(PreferenceContribution).toService(EditorPreferenceContribution);
 }

--- a/packages/filesystem/src/browser/filesystem-preferences.ts
+++ b/packages/filesystem/src/browser/filesystem-preferences.ts
@@ -100,18 +100,20 @@ export interface FileSystemConfiguration {
     'files.trimTrailingWhitespace': boolean;
 }
 
+export const FileSystemPreferenceContribution = Symbol('FilesystemPreferenceContribution');
 export const FileSystemPreferences = Symbol('FileSystemPreferences');
 export type FileSystemPreferences = PreferenceProxy<FileSystemConfiguration>;
 
-export function createFileSystemPreferences(preferences: PreferenceService): FileSystemPreferences {
-    return createPreferenceProxy(preferences, filesystemPreferenceSchema);
+export function createFileSystemPreferences(preferences: PreferenceService, schema: PreferenceSchema = filesystemPreferenceSchema): FileSystemPreferences {
+    return createPreferenceProxy(preferences, schema);
 }
 
 export function bindFileSystemPreferences(bind: interfaces.Bind): void {
     bind(FileSystemPreferences).toDynamicValue(ctx => {
         const preferences = ctx.container.get<PreferenceService>(PreferenceService);
-        return createFileSystemPreferences(preferences);
+        const contribution = ctx.container.get<PreferenceContribution>(FileSystemPreferenceContribution);
+        return createFileSystemPreferences(preferences, contribution.schema);
     }).inSingletonScope();
-
-    bind(PreferenceContribution).toConstantValue({ schema: filesystemPreferenceSchema });
+    bind(FileSystemPreferenceContribution).toConstantValue({ schema: filesystemPreferenceSchema });
+    bind(PreferenceContribution).toService(FileSystemPreferenceContribution);
 }

--- a/packages/git/src/browser/git-preferences.ts
+++ b/packages/git/src/browser/git-preferences.ts
@@ -56,17 +56,20 @@ export interface GitConfiguration {
     'git.alwaysSignOff': boolean
 }
 
+export const GitPreferenceContribution = Symbol('GitPreferenceContribution');
 export const GitPreferences = Symbol('GitPreferences');
 export type GitPreferences = PreferenceProxy<GitConfiguration>;
 
-export function createGitPreferences(preferences: PreferenceService): GitPreferences {
-    return createPreferenceProxy(preferences, GitConfigSchema);
+export function createGitPreferences(preferences: PreferenceService, schema: PreferenceSchema = GitConfigSchema): GitPreferences {
+    return createPreferenceProxy(preferences, schema);
 }
 
 export function bindGitPreferences(bind: interfaces.Bind): void {
     bind(GitPreferences).toDynamicValue(ctx => {
         const preferences = ctx.container.get<PreferenceService>(PreferenceService);
-        return createGitPreferences(preferences);
-    });
-    bind(PreferenceContribution).toConstantValue({ schema: GitConfigSchema });
+        const contribution = ctx.container.get<PreferenceContribution>(GitPreferenceContribution);
+        return createGitPreferences(preferences, contribution.schema);
+    }).inSingletonScope();
+    bind(GitPreferenceContribution).toConstantValue({ schema: GitConfigSchema });
+    bind(PreferenceContribution).toService(GitPreferenceContribution);
 }

--- a/packages/markers/src/browser/problem/problem-preferences.ts
+++ b/packages/markers/src/browser/problem/problem-preferences.ts
@@ -44,16 +44,20 @@ export interface ProblemConfiguration {
     'problems.autoReveal': boolean
 }
 
+export const ProblemPreferenceContribution = Symbol('ProblemPreferenceContribution');
 export const ProblemPreferences = Symbol('ProblemPreferences');
 export type ProblemPreferences = PreferenceProxy<ProblemConfiguration>;
 
-export const createProblemPreferences = (preferences: PreferenceService): ProblemPreferences =>
-    createPreferenceProxy(preferences, ProblemConfigSchema);
+export function createProblemPreferences(preferences: PreferenceService, schema: PreferenceSchema = ProblemConfigSchema): ProblemPreferences {
+    return createPreferenceProxy(preferences, schema);
+}
 
 export const bindProblemPreferences = (bind: interfaces.Bind): void => {
     bind(ProblemPreferences).toDynamicValue(ctx => {
         const preferences = ctx.container.get<PreferenceService>(PreferenceService);
-        return createProblemPreferences(preferences);
-    });
-    bind(PreferenceContribution).toConstantValue({ schema: ProblemConfigSchema });
+        const contribution = ctx.container.get<PreferenceContribution>(ProblemPreferenceContribution);
+        return createProblemPreferences(preferences, contribution.schema);
+    }).inSingletonScope();
+    bind(ProblemPreferenceContribution).toConstantValue({ schema: ProblemConfigSchema });
+    bind(PreferenceContribution).toService(ProblemPreferenceContribution);
 };

--- a/packages/messages/src/browser/notification-preferences.ts
+++ b/packages/messages/src/browser/notification-preferences.ts
@@ -38,18 +38,20 @@ export interface NotificationConfiguration {
     'notification.timeout': number
 }
 
+export const NotificationPreferenceContribution = Symbol('NotificationPreferenceContribution');
 export const NotificationPreferences = Symbol('NotificationPreferences');
 export type NotificationPreferences = PreferenceProxy<NotificationConfiguration>;
 
-export function createNotificationPreferences(preferences: PreferenceService): NotificationPreferences {
-    return createPreferenceProxy(preferences, NotificationConfigSchema);
+export function createNotificationPreferences(preferences: PreferenceService, schema: PreferenceSchema = NotificationConfigSchema): NotificationPreferences {
+    return createPreferenceProxy(preferences, schema);
 }
 
 export function bindNotificationPreferences(bind: interfaces.Bind): void {
     bind(NotificationPreferences).toDynamicValue(ctx => {
         const preferences = ctx.container.get<PreferenceService>(PreferenceService);
-        return createNotificationPreferences(preferences);
-    });
-
-    bind(PreferenceContribution).toConstantValue({ schema: NotificationConfigSchema });
+        const contribution = ctx.container.get<PreferenceContribution>(NotificationPreferenceContribution);
+        return createNotificationPreferences(preferences, contribution.schema);
+    }).inSingletonScope();
+    bind(NotificationPreferenceContribution).toConstantValue({ schema: NotificationConfigSchema });
+    bind(PreferenceContribution).toService(NotificationPreferenceContribution);
 }

--- a/packages/navigator/src/browser/navigator-preferences.ts
+++ b/packages/navigator/src/browser/navigator-preferences.ts
@@ -32,17 +32,20 @@ export interface FileNavigatorConfiguration {
     'explorer.autoReveal': boolean;
 }
 
+export const FileNavigatorPreferenceContribution = Symbol('FileNavigatorPreferenceContribution');
 export const FileNavigatorPreferences = Symbol('NavigatorPreferences');
 export type FileNavigatorPreferences = PreferenceProxy<FileNavigatorConfiguration>;
 
-export function createNavigatorPreferences(preferences: PreferenceService): FileNavigatorPreferences {
-    return createPreferenceProxy(preferences, FileNavigatorConfigSchema);
+export function createNavigatorPreferences(preferences: PreferenceService, schema: PreferenceSchema = FileNavigatorConfigSchema): FileNavigatorPreferences {
+    return createPreferenceProxy(preferences, schema);
 }
 
 export function bindFileNavigatorPreferences(bind: interfaces.Bind): void {
     bind(FileNavigatorPreferences).toDynamicValue(ctx => {
         const preferences = ctx.container.get<PreferenceService>(PreferenceService);
-        return createNavigatorPreferences(preferences);
-    });
-    bind(PreferenceContribution).toConstantValue({ schema: FileNavigatorConfigSchema });
+        const contribution = ctx.container.get<PreferenceContribution>(FileNavigatorPreferenceContribution);
+        return createNavigatorPreferences(preferences, contribution.schema);
+    }).inSingletonScope();
+    bind(FileNavigatorPreferenceContribution).toConstantValue({ schema: FileNavigatorConfigSchema });
+    bind(PreferenceContribution).toService(FileNavigatorPreferenceContribution);
 }

--- a/packages/output/src/common/output-preferences.ts
+++ b/packages/output/src/common/output-preferences.ts
@@ -38,18 +38,20 @@ export interface OutputConfiguration {
     'output.maxChannelHistory': number
 }
 
+export const OutputPreferenceContribution = Symbol('OutputPreferenceContribution');
 export const OutputPreferences = Symbol('OutputPreferences');
 export type OutputPreferences = PreferenceProxy<OutputConfiguration>;
 
-export function createOutputPreferences(preferences: PreferenceService): OutputPreferences {
-    return createPreferenceProxy(preferences, OutputConfigSchema);
+export function createOutputPreferences(preferences: PreferenceService, schema: PreferenceSchema = OutputConfigSchema): OutputPreferences {
+    return createPreferenceProxy(preferences, schema);
 }
 
 export function bindOutputPreferences(bind: interfaces.Bind): void {
     bind(OutputPreferences).toDynamicValue(ctx => {
         const preferences = ctx.container.get<PreferenceService>(PreferenceService);
-        return createOutputPreferences(preferences);
-    });
-
-    bind(PreferenceContribution).toConstantValue({ schema: OutputConfigSchema });
+        const contribution = ctx.container.get<PreferenceContribution>(OutputPreferenceContribution);
+        return createOutputPreferences(preferences, contribution.schema);
+    }).inSingletonScope();
+    bind(OutputPreferenceContribution).toConstantValue({ schema: OutputConfigSchema });
+    bind(PreferenceContribution).toService(OutputPreferenceContribution);
 }

--- a/packages/plugin-dev/src/browser/hosted-plugin-preferences.ts
+++ b/packages/plugin-dev/src/browser/hosted-plugin-preferences.ts
@@ -48,17 +48,20 @@ export interface HostedPluginConfiguration {
     'hosted-plugin.launchOutFiles': string[];
 }
 
+export const HostedPluginPreferenceContribution = Symbol('HostedPluginPreferenceContribution');
 export const HostedPluginPreferences = Symbol('HostedPluginPreferences');
 export type HostedPluginPreferences = PreferenceProxy<HostedPluginConfiguration>;
 
-export function createNavigatorPreferences(preferences: PreferenceService): HostedPluginPreferences {
-    return createPreferenceProxy(preferences, HostedPluginConfigSchema);
+export function createNavigatorPreferences(preferences: PreferenceService, schema: PreferenceSchema = HostedPluginConfigSchema): HostedPluginPreferences {
+    return createPreferenceProxy(preferences, schema);
 }
 
 export function bindHostedPluginPreferences(bind: interfaces.Bind): void {
     bind(HostedPluginPreferences).toDynamicValue(ctx => {
         const preferences = ctx.container.get<PreferenceService>(PreferenceService);
-        return createNavigatorPreferences(preferences);
-    });
-    bind(PreferenceContribution).toConstantValue({ schema: HostedPluginConfigSchema });
+        const contribution = ctx.container.get<PreferenceContribution>(HostedPluginPreferenceContribution);
+        return createNavigatorPreferences(preferences, contribution.schema);
+    }).inSingletonScope();
+    bind(HostedPluginPreferenceContribution).toConstantValue({ schema: HostedPluginConfigSchema });
+    bind(PreferenceContribution).toService(HostedPluginPreferenceContribution);
 }

--- a/packages/plugin-ext/src/main/browser/webview/webview-preferences.ts
+++ b/packages/plugin-ext/src/main/browser/webview/webview-preferences.ts
@@ -52,17 +52,20 @@ export interface WebviewConfiguration {
     'webview.warnIfUnsecure'?: boolean
 }
 
+export const WebviewPreferenceContribution = Symbol('WebviewPreferenceContribution');
 export const WebviewPreferences = Symbol('WebviewPreferences');
 export type WebviewPreferences = PreferenceProxy<WebviewConfiguration>;
 
-export function createWebviewPreferences(preferences: PreferenceService): WebviewPreferences {
-    return createPreferenceProxy(preferences, WebviewConfigSchema);
+export function createWebviewPreferences(preferences: PreferenceService, schema: PreferenceSchema = WebviewConfigSchema): WebviewPreferences {
+    return createPreferenceProxy(preferences, schema);
 }
 
 export function bindWebviewPreferences(bind: interfaces.Bind): void {
     bind(WebviewPreferences).toDynamicValue(ctx => {
         const preferences = ctx.container.get<PreferenceService>(PreferenceService);
-        return createWebviewPreferences(preferences);
-    });
-    bind(PreferenceContribution).toConstantValue({ schema: WebviewConfigSchema });
+        const contribution = ctx.container.get<PreferenceContribution>(WebviewPreferenceContribution);
+        return createWebviewPreferences(preferences, contribution.schema);
+    }).inSingletonScope();
+    bind(WebviewPreferenceContribution).toConstantValue({ schema: WebviewConfigSchema });
+    bind(PreferenceContribution).toService(WebviewPreferenceContribution);
 }

--- a/packages/preview/src/browser/preview-preferences.ts
+++ b/packages/preview/src/browser/preview-preferences.ts
@@ -38,19 +38,20 @@ export interface PreviewConfiguration {
     'preview.openByDefault': boolean;
 }
 
+export const PreviewPreferenceContribution = Symbol('PreviewPreferenceContribution');
 export const PreviewPreferences = Symbol('PreviewPreferences');
 export type PreviewPreferences = PreferenceProxy<PreviewConfiguration>;
 
-export function createPreviewPreferences(
-    preferences: PreferenceService
-): PreviewPreferences {
-    return createPreferenceProxy(preferences, PreviewConfigSchema);
+export function createPreviewPreferences(preferences: PreferenceService, schema: PreferenceSchema = PreviewConfigSchema): PreviewPreferences {
+    return createPreferenceProxy(preferences, schema);
 }
 
 export function bindPreviewPreferences(bind: interfaces.Bind): void {
     bind(PreviewPreferences).toDynamicValue(ctx => {
         const preferences = ctx.container.get<PreferenceService>(PreferenceService);
-        return createPreviewPreferences(preferences);
-    });
-    bind(PreferenceContribution).toConstantValue({ schema: PreviewConfigSchema });
+        const contribution = ctx.container.get<PreferenceContribution>(PreviewPreferenceContribution);
+        return createPreviewPreferences(preferences, contribution.schema);
+    }).inSingletonScope();
+    bind(PreviewPreferenceContribution).toConstantValue({ schema: PreviewConfigSchema });
+    bind(PreferenceContribution).toService(PreviewPreferenceContribution);
 }

--- a/packages/scm/src/browser/scm-preferences.ts
+++ b/packages/scm/src/browser/scm-preferences.ts
@@ -43,18 +43,20 @@ export interface ScmConfiguration {
     'scm.defaultViewMode': 'tree' | 'list'
 }
 
+export const ScmPreferenceContribution = Symbol('ScmPreferenceContribution');
 export const ScmPreferences = Symbol('ScmPreferences');
 export type ScmPreferences = PreferenceProxy<ScmConfiguration>;
 
-export function createScmPreferences(preferences: PreferenceService): ScmPreferences {
-    return createPreferenceProxy(preferences, scmPreferenceSchema);
+export function createScmPreferences(preferences: PreferenceService, schema: PreferenceSchema = scmPreferenceSchema): ScmPreferences {
+    return createPreferenceProxy(preferences, schema);
 }
 
 export function bindScmPreferences(bind: interfaces.Bind): void {
     bind(ScmPreferences).toDynamicValue((ctx: interfaces.Context) => {
         const preferences = ctx.container.get<PreferenceService>(PreferenceService);
-        return createScmPreferences(preferences);
+        const contribution = ctx.container.get<PreferenceContribution>(ScmPreferenceContribution);
+        return createScmPreferences(preferences, contribution.schema);
     }).inSingletonScope();
-
-    bind(PreferenceContribution).toConstantValue({ schema: scmPreferenceSchema });
+    bind(ScmPreferenceContribution).toConstantValue({ schema: scmPreferenceSchema });
+    bind(PreferenceContribution).toService(ScmPreferenceContribution);
 }

--- a/packages/search-in-workspace/src/browser/search-in-workspace-preferences.ts
+++ b/packages/search-in-workspace/src/browser/search-in-workspace-preferences.ts
@@ -64,17 +64,20 @@ export class SearchInWorkspaceConfiguration {
     'search.smartCase': boolean;
 }
 
+export const SearchInWorkspacePreferenceContribution = Symbol('SearchInWorkspacePreferenceContribution');
 export const SearchInWorkspacePreferences = Symbol('SearchInWorkspacePreferences');
 export type SearchInWorkspacePreferences = PreferenceProxy<SearchInWorkspaceConfiguration>;
 
-export function createSearchInWorkspacePreferences(preferences: PreferenceService): SearchInWorkspacePreferences {
-    return createPreferenceProxy(preferences, searchInWorkspacePreferencesSchema);
+export function createSearchInWorkspacePreferences(preferences: PreferenceService, schema: PreferenceSchema = searchInWorkspacePreferencesSchema): SearchInWorkspacePreferences {
+    return createPreferenceProxy(preferences, schema);
 }
 
 export function bindSearchInWorkspacePreferences(bind: interfaces.Bind): void {
     bind(SearchInWorkspacePreferences).toDynamicValue(ctx => {
         const preferences = ctx.container.get<PreferenceService>(PreferenceService);
-        return createSearchInWorkspacePreferences(preferences);
+        const contribution = ctx.container.get<PreferenceContribution>(SearchInWorkspacePreferenceContribution);
+        return createSearchInWorkspacePreferences(preferences, contribution.schema);
     }).inSingletonScope();
-    bind(PreferenceContribution).toConstantValue({ schema: searchInWorkspacePreferencesSchema });
+    bind(SearchInWorkspacePreferenceContribution).toConstantValue({ schema: searchInWorkspacePreferencesSchema });
+    bind(PreferenceContribution).toService(SearchInWorkspacePreferenceContribution);
 }

--- a/packages/terminal/src/browser/terminal-preferences.ts
+++ b/packages/terminal/src/browser/terminal-preferences.ts
@@ -185,17 +185,20 @@ export function isTerminalRendererType(arg: any): arg is TerminalRendererType {
     return typeof arg === 'string' && (arg === 'canvas' || arg === 'dom');
 }
 
+export const TerminalPreferenceContribution = Symbol('TerminalPreferenceContribution');
 export const TerminalPreferences = Symbol('TerminalPreferences');
 export type TerminalPreferences = PreferenceProxy<TerminalConfiguration>;
 
-export function createTerminalPreferences(preferences: PreferenceService): TerminalPreferences {
-    return createPreferenceProxy(preferences, TerminalConfigSchema);
+export function createTerminalPreferences(preferences: PreferenceService, schema: PreferenceSchema = TerminalConfigSchema): TerminalPreferences {
+    return createPreferenceProxy(preferences, schema);
 }
 
 export function bindTerminalPreferences(bind: interfaces.Bind): void {
     bind(TerminalPreferences).toDynamicValue(ctx => {
         const preferences = ctx.container.get<PreferenceService>(PreferenceService);
-        return createTerminalPreferences(preferences);
-    });
-    bind(PreferenceContribution).toConstantValue({ schema: TerminalConfigSchema });
+        const contribution = ctx.container.get<PreferenceContribution>(TerminalPreferenceContribution);
+        return createTerminalPreferences(preferences, contribution.schema);
+    }).inSingletonScope();
+    bind(TerminalPreferenceContribution).toConstantValue({ schema: TerminalConfigSchema });
+    bind(PreferenceContribution).toService(TerminalPreferenceContribution);
 }

--- a/packages/workspace/src/browser/workspace-preferences.ts
+++ b/packages/workspace/src/browser/workspace-preferences.ts
@@ -44,18 +44,20 @@ export interface WorkspaceConfiguration {
     'workspace.supportMultiRootWorkspace': boolean
 }
 
+export const WorkspacePreferenceContribution = Symbol('WorkspacePreferenceContribution');
 export const WorkspacePreferences = Symbol('WorkspacePreferences');
 export type WorkspacePreferences = PreferenceProxy<WorkspaceConfiguration>;
 
-export function createWorkspacePreferences(preferences: PreferenceService): WorkspacePreferences {
-    return createPreferenceProxy(preferences, workspacePreferenceSchema);
+export function createWorkspacePreferences(preferences: PreferenceService, schema: PreferenceSchema = workspacePreferenceSchema): WorkspacePreferences {
+    return createPreferenceProxy(preferences, schema);
 }
 
 export function bindWorkspacePreferences(bind: interfaces.Bind): void {
     bind(WorkspacePreferences).toDynamicValue(ctx => {
         const preferences = ctx.container.get<PreferenceService>(PreferenceService);
-        return createWorkspacePreferences(preferences);
+        const contribution = ctx.container.get<PreferenceContribution>(WorkspacePreferenceContribution);
+        return createWorkspacePreferences(preferences, contribution.schema);
     }).inSingletonScope();
-
-    bind(PreferenceContribution).toConstantValue({ schema: workspacePreferenceSchema });
+    bind(WorkspacePreferenceContribution).toConstantValue({ schema: workspacePreferenceSchema });
+    bind(PreferenceContribution).toService(WorkspacePreferenceContribution);
 }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

<!--
Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

The pull-request introduces a new a new abstract class `PreferencesSchemaProvider` which is used to provide preference schema definitions. The class is ultimately used to bind preference schemas in an extensible way instead of to constant values.

This allows extenders to easily modify preference schemas as illustrated in the commit https://github.com/eclipse-theia/theia/commit/c5a7d712d21a7f89eb03c03244ac1b91f38d02a6.


#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

1. ensure that the application successfully builds and starts.
2. start the application, and navigate to the preferences-view - preferences should be correctly listed.
3. search for `workspace.preserveWindow`, the preference definition should not be listed as it was removed in https://github.com/eclipse-theia/theia/commit/c5a7d712d21a7f89eb03c03244ac1b91f38d02a6 for test purposes.

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

