### PR TITLE
menus: make menus that reference unregistered commands more robust

### DIFF
--- a/examples/api-samples/src/browser/menu/sample-menu-contribution.ts
+++ b/examples/api-samples/src/browser/menu/sample-menu-contribution.ts
@@ -70,6 +70,12 @@ export class SampleMenuContribution implements MenuContribution {
         });
         const placeholder = new PlaceholderMenuNode([...subSubMenuPath, 'placeholder'].join('-'), 'Placeholder', { order: '0' });
         menus.registerMenuNode(subSubMenuPath, placeholder);
+
+        /**
+         * Register an action menu with an invalid command (un-registered and without a label) in order
+         * to determine that menus and the layout does not break on startup.
+         */
+        menus.registerMenuAction(subMenuPath, { commandId: 'invalid-command' });
     }
 
 }

--- a/examples/api-tests/src/menus.spec.js
+++ b/examples/api-tests/src/menus.spec.js
@@ -169,4 +169,8 @@ describe('Menus', function () {
         assert.isTrue(access2.disposed);
     });
 
+    it('should not fail to register a menu with an invalid command', () => {
+        assert.doesNotThrow(() => menus.registerMenuAction(['test-menu-path'], { commandId: 'invalid-command', label: 'invalid command' }), 'should not throw.');
+    });
+
 });

--- a/packages/core/src/common/menu.ts
+++ b/packages/core/src/common/menu.ts
@@ -429,7 +429,8 @@ export class ActionMenuNode implements MenuNode {
         }
         const cmd = this.commands.getCommand(this.action.commandId);
         if (!cmd) {
-            throw new Error(`A command with id '${this.action.commandId}' does not exist.`);
+            console.debug(`No label for action menu node: No command "${this.action.commandId}" exists.`);
+            return '';
         }
         return cmd.label || cmd.id;
     }

--- a/packages/core/src/electron-browser/menu/electron-main-menu-factory.ts
+++ b/packages/core/src/electron-browser/menu/electron-main-menu-factory.ts
@@ -155,7 +155,8 @@ export class ElectronMainMenuFactory {
 
                 // That is only a sanity check at application startup.
                 if (!this.commandRegistry.getCommand(commandId)) {
-                    throw new Error(`Unknown command with ID: ${commandId}.`);
+                    console.debug(`Skipping menu item with missing command: "${commandId}".`);
+                    continue;
                 }
 
                 if (!this.commandRegistry.isVisible(commandId, ...args)


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

<!--
Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

Fixes: https://github.com/eclipse-theia/theia/issues/9870

The pull-request updates the registration of menus that reference invalid or missing commands to be more robust.
Rather than fail the layout, or the start of the application, the menus items will be omitted with an error log for extenders to handle.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

1. start the application, and confirm it starts correctly
2. the menus should be present - there should be error logs in the console regarding missing commands
3. repeat the steps for the browser or electron target respectfully.

https://user-images.githubusercontent.com/40359487/129045597-adcc19b1-699e-4e36-845e-6d2b525d50ca.mp4

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

