### PR TITLE
Added support for yarn aliases

### DIFF
--- a/dev-packages/application-package/src/application-package.ts
+++ b/dev-packages/application-package/src/application-package.ts
@@ -112,7 +112,7 @@ export class ApplicationPackage {
     get extensionPackages(): ReadonlyArray<ExtensionPackage> {
         if (!this._extensionPackages) {
             const collector = new ExtensionPackageCollector(
-                raw => this.newExtensionPackage(raw),
+                (raw: PublishedNodePackage, alias: string) => this.newExtensionPackage(raw, alias),
                 this.resolveModule
             );
             this._extensionPackages = collector.collect(this.pck);
@@ -128,13 +128,18 @@ export class ApplicationPackage {
         return this.getExtensionPackage(extension) || this.resolveExtensionPackage(extension);
     }
 
+    /**
+     * Resolve an extension name to its associated package
+     * @param extension the name of the extension's package as defined in "dependencies" (might be aliased)
+     * @returns the extension package
+     */
     async resolveExtensionPackage(extension: string): Promise<ExtensionPackage | undefined> {
         const raw = await RawExtensionPackage.view(this.registry, extension);
-        return raw ? this.newExtensionPackage(raw) : undefined;
+        return raw ? this.newExtensionPackage(raw, extension) : undefined;
     }
 
-    protected newExtensionPackage(raw: PublishedNodePackage): ExtensionPackage {
-        return new ExtensionPackage(raw, this.registry);
+    protected newExtensionPackage(raw: PublishedNodePackage, alias: string): ExtensionPackage {
+        return new ExtensionPackage(raw, this.registry, alias);
     }
 
     get frontendModules(): Map<string, string> {

--- a/dev-packages/application-package/src/application-package.ts
+++ b/dev-packages/application-package/src/application-package.ts
@@ -17,7 +17,7 @@
 import * as paths from 'path';
 import { readJsonFile, writeJsonFile } from './json-file';
 import { NpmRegistry, NodePackage, PublishedNodePackage, sortByKey } from './npm-registry';
-import { Extension, ExtensionPackage, RawExtensionPackage } from './extension-package';
+import { Extension, ExtensionPackage, ExtensionPackageOptions, RawExtensionPackage } from './extension-package';
 import { ExtensionPackageCollector } from './extension-package-collector';
 import { ApplicationProps } from './application-props';
 const merge = require('deepmerge/dist/cjs');
@@ -112,7 +112,7 @@ export class ApplicationPackage {
     get extensionPackages(): ReadonlyArray<ExtensionPackage> {
         if (!this._extensionPackages) {
             const collector = new ExtensionPackageCollector(
-                (raw: PublishedNodePackage, alias: string) => this.newExtensionPackage(raw, alias),
+                (raw: PublishedNodePackage, options: ExtensionPackageOptions = {}) => this.newExtensionPackage(raw, options),
                 this.resolveModule
             );
             this._extensionPackages = collector.collect(this.pck);
@@ -135,11 +135,11 @@ export class ApplicationPackage {
      */
     async resolveExtensionPackage(extension: string): Promise<ExtensionPackage | undefined> {
         const raw = await RawExtensionPackage.view(this.registry, extension);
-        return raw ? this.newExtensionPackage(raw, extension) : undefined;
+        return raw ? this.newExtensionPackage(raw, { alias: extension }) : undefined;
     }
 
-    protected newExtensionPackage(raw: PublishedNodePackage, alias: string): ExtensionPackage {
-        return new ExtensionPackage(raw, this.registry, alias);
+    protected newExtensionPackage(raw: PublishedNodePackage, options: ExtensionPackageOptions = {}): ExtensionPackage {
+        return new ExtensionPackage(raw, this.registry, options);
     }
 
     get frontendModules(): Map<string, string> {

--- a/dev-packages/application-package/src/extension-package-collector.ts
+++ b/dev-packages/application-package/src/extension-package-collector.ts
@@ -16,7 +16,7 @@
 
 import { readJsonFile } from './json-file';
 import { NodePackage, PublishedNodePackage } from './npm-registry';
-import { ExtensionPackage, RawExtensionPackage } from './extension-package';
+import { ExtensionPackage, ExtensionPackageOptions, RawExtensionPackage } from './extension-package';
 
 export class ExtensionPackageCollector {
 
@@ -24,7 +24,7 @@ export class ExtensionPackageCollector {
     protected readonly visited = new Map<string, boolean>();
 
     constructor(
-        protected readonly extensionPackageFactory: (raw: PublishedNodePackage, alias: string) => ExtensionPackage,
+        protected readonly extensionPackageFactory: (raw: PublishedNodePackage, options?: ExtensionPackageOptions) => ExtensionPackage,
         protected readonly resolveModule: (modulePath: string) => string
     ) { }
 
@@ -76,7 +76,7 @@ export class ExtensionPackageCollector {
             const transitive = !(name in this.root.dependencies!);
             pck.installed = { packagePath, version, parent, transitive };
             pck.version = versionRange;
-            const extensionPackage = this.extensionPackageFactory(pck, name);
+            const extensionPackage = this.extensionPackageFactory(pck, { alias: name });
             this.collectPackagesWithParent(pck, extensionPackage);
             this.sorted.push(extensionPackage);
         }

--- a/dev-packages/application-package/src/extension-package-collector.ts
+++ b/dev-packages/application-package/src/extension-package-collector.ts
@@ -24,7 +24,7 @@ export class ExtensionPackageCollector {
     protected readonly visited = new Map<string, boolean>();
 
     constructor(
-        protected readonly extensionPackageFactory: (raw: PublishedNodePackage) => ExtensionPackage,
+        protected readonly extensionPackageFactory: (raw: PublishedNodePackage, alias: string) => ExtensionPackage,
         protected readonly resolveModule: (modulePath: string) => string
     ) { }
 
@@ -76,7 +76,7 @@ export class ExtensionPackageCollector {
             const transitive = !(name in this.root.dependencies!);
             pck.installed = { packagePath, version, parent, transitive };
             pck.version = versionRange;
-            const extensionPackage = this.extensionPackageFactory(pck);
+            const extensionPackage = this.extensionPackageFactory(pck, name);
             this.collectPackagesWithParent(pck, extensionPackage);
             this.sorted.push(extensionPackage);
         }

--- a/dev-packages/application-package/src/extension-package.ts
+++ b/dev-packages/application-package/src/extension-package.ts
@@ -30,11 +30,15 @@ export interface Extension {
 export class ExtensionPackage {
     constructor(
         readonly raw: PublishedNodePackage & Partial<RawExtensionPackage>,
-        protected readonly registry: NpmRegistry
+        protected readonly registry: NpmRegistry,
+        protected readonly alias: string,
     ) { }
 
+    /**
+     * The name of the extension's package as defined in "dependencies" (might be aliased)
+     */
     get name(): string {
-        return this.raw.name;
+        return this.alias;
     }
 
     get version(): string {

--- a/dev-packages/application-package/src/extension-package.ts
+++ b/dev-packages/application-package/src/extension-package.ts
@@ -27,18 +27,30 @@ export interface Extension {
     electronMain?: string;
 }
 
+export interface ExtensionPackageOptions {
+    /**
+     * Alias to use in place of the original package's name.
+     */
+    alias?: string
+}
+
 export class ExtensionPackage {
+
+    protected _name: string;
+
     constructor(
         readonly raw: PublishedNodePackage & Partial<RawExtensionPackage>,
         protected readonly registry: NpmRegistry,
-        protected readonly alias: string,
-    ) { }
+        options: ExtensionPackageOptions = {}
+    ) {
+        this._name = options.alias ?? raw.name;
+    }
 
     /**
      * The name of the extension's package as defined in "dependencies" (might be aliased)
      */
     get name(): string {
-        return this.alias;
+        return this._name;
     }
 
     get version(): string {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

<!--
Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->
This PR fixes #9856 . It is done by changing the application package extension to use as a name for the packages (and more specifically theia extensions) the name used in the list of dependencies in `package.json` in place of the package name. In most cases these two names should match, but when yarn aliases are used they differ.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
I've tested this PR by adding a Theia extension using a yarn alias. After that it should be possible to build Theia and import the extension exported objects using its alias. As a comparison, if a yarn alias is used without this PR the building phase of the examples fails.

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

