### PR TITLE
cli: better error handling

### DIFF
--- a/dev-packages/cli/src/theia.ts
+++ b/dev-packages/cli/src/theia.ts
@@ -280,5 +280,16 @@ function theiaCli(): void {
         })
         .strictCommands()
         .demandCommand(1, 'Please run a command')
+        .fail((msg, err, cli) => {
+            process.exitCode = 1;
+            if (err) {
+                // One of the handlers threw an error:
+                console.error(err);
+            } else {
+                // Yargs detected a problem with commands and/or arguments while parsing:
+                cli.showHelp();
+                console.error(msg);
+            }
+        })
         .parse();
 }


### PR DESCRIPTION
`yargs` displays the full help by default when an error occurs within a
handler. This somewhat buries the actual error.

Add custom failure handling logic to either:
- Display `yargs` help on parse error.
- Display the error thrown from command handlers.

#### How to test

- Running `yarn --cwd examples/browser theia test --app-target=aaa` should display a cli error like "invalid argument"
- Add a line like `throw new Error('patate')` in `theia.ts` line 252 then run `yarn build`.
- Running `yarn --cwd examples/browser theia test` should only display the added error, not the full cli help.

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)