### PR TITLE
Fix frontend plugin-ext can not load two plugin at the same time

### DIFF
--- a/packages/plugin-ext/src/hosted/browser/hosted-plugin.ts
+++ b/packages/plugin-ext/src/hosted/browser/hosted-plugin.ts
@@ -364,7 +364,7 @@ export class HostedPluginSupport {
             if (contributions.state === PluginContributions.State.LOADED) {
                 contributions.state = PluginContributions.State.STARTING;
                 const host = plugin.model.entryPoint.frontend ? 'frontend' : plugin.host;
-                const dynamicContributions = hostContributions.get(plugin.host) || [];
+                const dynamicContributions = hostContributions.get(host) || [];
                 dynamicContributions.push(contributions);
                 hostContributions.set(host, dynamicContributions);
                 toDisconnect.push(Disposable.create(() => {


### PR DESCRIPTION
#### What it does

Fixes #9901.
Fix frontend plugin-ext can not load two plugin at the same time

#### How to test
1. Use yo generate two frontend hello-world example plugin in the same dir
2. Start theia with --plugins=local-dir:path/to/dir
3. check terminal whether it start two plugin

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

