### PR TITLE
api-tests: remove `.only`

### DIFF
--- a/packages/workspace/src/browser/workspace-commands.spec.ts
+++ b/packages/workspace/src/browser/workspace-commands.spec.ts
@@ -42,7 +42,7 @@ import { ApplicationServer } from '@theia/core/lib/common/application-protocol';
 
 disableJSDOM();
 
-describe.only('workspace-commands', () => {
+describe('workspace-commands', () => {
 
     let commands: WorkspaceCommandContribution;
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

<!--
Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

Fixes an issue caused by https://github.com/eclipse-theia/theia/pull/9709, by removing the leftover `.only` from the api test-suite which resulted in only the `workspace-commands` being tested.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

- all of `api-tests` should now execute.

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

Signed-off-by: vince-fugnitto <vincent.fugnitto@ericsson.com>
