### PR TITLE
[eclipse-theiaGH-9882] Add missing completion kind for monaco in plugin

### DIFF
--- a/packages/plugin-ext/src/common/plugin-api-rpc-model.ts
+++ b/packages/plugin-ext/src/common/plugin-api-rpc-model.ts
@@ -167,7 +167,9 @@ export enum CompletionItemKind {
     Customcolor = 22,
     Folder = 23,
     TypeParameter = 24,
-    Snippet = 25
+    User = 25,
+    Issue = 26,
+    Snippet = 27
 }
 
 export class IdObject {


### PR DESCRIPTION
#### What it does
This PR:

Add missing CompletionItemKind to packages\plugin-ext\src\common\plugin-api-rpc-model.ts

Closes #9882.

#### How to test
The testing steps are described in https://github.com/eclipse-theia/theia/issues/9882.

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

