### PR TITLE
core: fix `quick-commands` to properly display recently used commands

### DIFF
--- a/packages/core/src/browser/quick-input/quick-command-frontend-contribution.ts
+++ b/packages/core/src/browser/quick-input/quick-command-frontend-contribution.ts
@@ -32,7 +32,6 @@ export class QuickCommandFrontendContribution implements CommandContribution, Ke
     registerCommands(commands: CommandRegistry): void {
         commands.registerCommand(quickCommand, {
             execute: () => {
-                this.quickCommandService?.reset();
                 this.quickInputService?.open('>');
             }
         });

--- a/packages/core/src/browser/quick-input/quick-command-service.ts
+++ b/packages/core/src/browser/quick-input/quick-command-service.ts
@@ -78,9 +78,9 @@ export class QuickCommandService implements QuickAccessContribution, QuickAccess
 
     getPicks(filter: string, token: CancellationToken): QuickPicks {
         const items: QuickPicks = [];
-        if (this.recentItems.length === 0 && this.otherItems.length === 0) {
-            this.reset();
-        }
+
+        // Update the list of commands by fetching them from the registry.
+        this.reset();
         const recentItems = filterItems(this.recentItems.slice(), filter);
         const otherItems = filterItems(this.otherItems.slice(), filter);
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

<!--
Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

Fixes: #9919 

The commit fixes the `quick-command` behavior which would not display the list of recently used commands properly when users would use the `quick-command` + type the prefix value, instead of triggering the command directly. The change refactors the code to perform the `reset` when we trigger the picks so we pick up the latest commands available.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

1. execute commands in order to add them to recently used list.
2. using either paths to trigger the `quick-command-service` should work and properly display recent commands:
    - <kbd>F1</kbd> directly.
    - <kbd>ctrlcmd</kbd>+<kbd>p</kbd> then typing `>` to trigger the prefixed `quick-commands`.

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

Signed-off-by: vince-fugnitto <vincent.fugnitto@ericsson.com>
