### PR TITLE
core: implement `fuzzy` searching and highlights

### DIFF
--- a/packages/core/src/browser/quick-input/quick-input-service.spec.ts
+++ b/packages/core/src/browser/quick-input/quick-input-service.spec.ts
@@ -1,0 +1,176 @@
+/********************************************************************************
+ * Copyright (C) 2021 Ericsson and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import * as chai from 'chai';
+import { filterItems, findMatches, QuickPickItem } from './quick-input-service';
+
+const expect = chai.expect;
+
+describe('quick-input-service', () => {
+
+    describe('#findMatches', () => {
+
+        it('should return the proper highlights when matches are found', () => {
+            expect(findMatches('abc', 'a')).deep.equal([{ start: 0, end: 1 }]);
+            expect(findMatches('abc', 'ab')).deep.equal([{ start: 0, end: 1 }, { start: 1, end: 2 }]);
+            expect(findMatches('abc', 'ac')).deep.equal([{ start: 0, end: 1 }, { start: 2, end: 3 }]);
+            expect(findMatches('abc', 'abc')).deep.equal([{ start: 0, end: 1 }, { start: 1, end: 2 }, { start: 2, end: 3 }]);
+        });
+
+        it('should fail when out of order', () => {
+            expect(findMatches('abc', 'ba')).equal(undefined);
+        });
+
+        it('should return `undefined` when no matches are found', () => {
+            expect(findMatches('abc', 'f')).equal(undefined);
+        });
+
+        it('should return `undefined` when no filter is present', () => {
+            expect(findMatches('abc', '')).equal(undefined);
+        });
+
+    });
+
+    describe('#filterItems', () => {
+
+        let items: QuickPickItem[] = [];
+
+        beforeEach(() => {
+            items = [
+                { label: 'a' },
+                { label: 'abc', description: 'v' },
+                { label: 'def', description: 'd', detail: 'y' },
+                { label: 'z', description: 'z', detail: 'z' }
+            ];
+        });
+
+        it('should return the full list when no filter is present', () => {
+            const result = filterItems(items, '');
+            expect(result).deep.equal(items);
+        });
+
+        it('should filter items based on the label', () => {
+            const expectation: QuickPickItem = {
+                label: 'abc',
+                highlights: {
+                    label: [
+                        { start: 0, end: 1 },
+                        { start: 1, end: 2 },
+                        { start: 2, end: 3 }
+                    ]
+                }
+            };
+            const result = filterItems(items, 'abc');
+            expect(result).length(1);
+            expect(result[0].label).equal(expectation.label);
+            expect(result[0].highlights?.label).deep.equal(expectation.highlights?.label);
+        });
+
+        it('should filter items based on `description` if `label` does not match', () => {
+            const expectation: QuickPickItem = {
+                label: 'abc',
+                description: 'v',
+                highlights: {
+                    description: [
+                        { start: 0, end: 1 }
+                    ]
+                }
+            };
+            const result = filterItems(items, 'v');
+            expect(result).length(1);
+            expect(result[0].label).equal(expectation.label);
+            expect(result[0].description).equal(expectation.description);
+            expect(result[0].highlights?.label).equal(undefined);
+            expect(result[0].highlights?.description).deep.equal(expectation.highlights?.description);
+        });
+
+        it('should filter items based on `detail` if `label` and `description` does not match', () => {
+            const expectation: QuickPickItem = {
+                label: 'def',
+                description: 'd',
+                detail: 'y',
+                highlights: {
+                    detail: [
+                        { start: 0, end: 1 }
+                    ]
+                }
+            };
+            const result = filterItems(items, 'y');
+            expect(result).length(1);
+            expect(result[0].label).equal(expectation.label);
+            expect(result[0].description).equal(expectation.description);
+            expect(result[0].detail).equal(expectation.detail);
+            expect(result[0].highlights?.label).equal(undefined);
+            expect(result[0].highlights?.description).equal(undefined);
+            expect(result[0].highlights?.detail).deep.equal(expectation.highlights?.detail);
+        });
+
+        it('should return multiple highlights if it matches multiple properties', () => {
+            const expectation: QuickPickItem = {
+                label: 'z',
+                description: 'z',
+                detail: 'z',
+                highlights: {
+                    label: [
+                        { start: 0, end: 1 }
+                    ],
+                    description: [
+                        { start: 0, end: 1 }
+                    ],
+                    detail: [
+                        { start: 0, end: 1 }
+                    ]
+                }
+            };
+            const result = filterItems(items, 'z');
+            expect(result).length(1);
+
+            expect(result[0].label).equal(expectation.label);
+            expect(result[0].description).equal(expectation.description);
+            expect(result[0].detail).equal(expectation.detail);
+
+            expect(result[0].highlights?.label).deep.equal(expectation.highlights?.label);
+            expect(result[0].highlights?.description).deep.equal(expectation.highlights?.description);
+            expect(result[0].highlights?.detail).deep.equal(expectation.highlights?.detail);
+        });
+
+        it('should reset highlights upon subsequent searches', () => {
+            const expectation: QuickPickItem = {
+                label: 'abc',
+                highlights: {
+                    label: [
+                        { start: 0, end: 1 },
+                        { start: 1, end: 2 },
+                        { start: 2, end: 3 }
+                    ]
+                }
+            };
+            let result = filterItems(items, 'abc');
+            expect(result).length(1);
+            expect(result[0].label).equal(expectation.label);
+            expect(result[0].highlights?.label).deep.equal(expectation.highlights?.label);
+
+            result = filterItems(items, '');
+            expect(result[0].highlights?.label).equal(undefined);
+        });
+
+        it('should return an empty list when no matches are found', () => {
+            expect(filterItems(items, 'yyy')).deep.equal([]);
+        });
+
+    });
+
+});


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

<!--
Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

Fixes: https://github.com/eclipse-theia/theia/issues/9851

The pull-request includes updates to the following methods to make them support `fuzzy` searching and highlighting:
- `QuickInputService.filterItems`
- `QuickInputService.findMatches`

Previously, both methods only ever supported strict `substring` searches and highlights which resulted in many items not being displayed properly after https://github.com/eclipse-theia/theia/pull/9702. The change now makes both methods `fuzzy` aware, and will match items on all their properties which are present in the UI (`label`, `description`, `detail`). The `findMatches` method is also enhanced to properly compute highlights, even when we match `fuzzy`-ingly. 

The pull-request also introduces appropriate unit-tests in order to properly test both methods under various conditions and use-cases.

https://user-images.githubusercontent.com/40359487/129908954-fe9286e3-57e4-4b20-b541-cda1affb6c5a.mov

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

- the new test-cases should successfully pass.
- it should now be possible to use the `quick-command` palette (<kbd>F1</kbd>) and perform searches will result in fuzzy matches, and it will display more results than `master`.

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

Signed-off-by: vince-fugnitto <vincent.fugnitto@ericsson.com>