### PR TITLE
Fixed broken link in README

### DIFF
--- a/packages/keymaps/README.md
+++ b/packages/keymaps/README.md
@@ -37,7 +37,7 @@ You can use `shift`, `ctrl`, `alt`, `meta`, `option` (`alt`), `command` (`meta`)
 
 You can also use the following strings for special keys: `backspace`, `tab`, `enter`, `return`, `capslock`, `esc`, `escape`, `space`, `pageup`, `pagedown`, `end`, `home`, `left`, `up`, `right`, `down`, `ins`, `del` and `plus`.
 
-If unsure you can always look at [keys.ts](https://eclipse-theia.github.io/theia/docs/next/modules/core.key-2.html) to see if a string is supported.
+If unsure you can always look at the framework's [supported keys](https://eclipse-theia.github.io/theia/docs/next/modules/core.key-2.html)
 
 ## Key Sequences
 

--- a/packages/keymaps/README.md
+++ b/packages/keymaps/README.md
@@ -37,7 +37,7 @@ You can use `shift`, `ctrl`, `alt`, `meta`, `option` (`alt`), `command` (`meta`)
 
 You can also use the following strings for special keys: `backspace`, `tab`, `enter`, `return`, `capslock`, `esc`, `escape`, `space`, `pageup`, `pagedown`, `end`, `home`, `left`, `up`, `right`, `down`, `ins`, `del` and `plus`.
 
-If unsure you can always look at [keys.ts](../core/src/common/keys.ts#207) to see if a string is supported.
+If unsure you can always look at [keys.ts](https://eclipse-theia.github.io/theia/docs/next/modules/core.key-2.html) to see if a string is supported.
 
 ## Key Sequences
 


### PR DESCRIPTION
fixed #9927

Signed-off-by: Jonas Helming <jhelming@eclipsesource.com>

#### What it does
Fixed a broken link in the README

#### How to test
Click the link to keys.ts, should lead to the file and the section where the special keys are defined.

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

