### PR TITLE
preferences: Fix search term on open via menu

### DIFF
--- a/packages/preferences/src/browser/preferences-contribution.ts
+++ b/packages/preferences/src/browser/preferences-contribution.ts
@@ -67,7 +67,7 @@ export class PreferencesContribution extends AbstractViewContribution<Preference
         commands.registerCommand(CommonCommands.OPEN_PREFERENCES, {
             execute: async (query?: string) => {
                 const widget = await this.openView({ activate: true });
-                if (query) {
+                if (typeof query === 'string') {
                     widget.setSearchTerm(query);
                 }
             },


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

<!--
Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
Closes #9931 

Fixes the issue by simply checking for the string type before passing the argument into the search term.

#### How to test

1. Open the preferences menu via the settings menu in the bottom left.
2. Observe an empty search bar

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

