### PR TITLE
Use CSS to control ViewContainerPart toolbar visibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - [core] registering toolbar items for commands that explicitly target a `ViewContainer` rather than a child widget may not behave as expected. Such registrations should be made in the `ViewContainer` by overriding the `updateToolbarItems` method and using the `registerToolbarItem` utility. See the modifications to the `scm` and `vsx-registry` packages in the PR for examples. [#9798](https://github.com/eclipse-theia/theia/pull/9798)
 - [vsx-registry] `VSXExtensionsContribution` no longer implements `TabBarToolbarContribution` and is not bound as such. Extensions of the class that expect such behavior should reimplement it with caution. See caveats in PR. [#9798](https://github.com/eclipse-theia/theia/pull/9798)
 - [core] `handleExpansionToggleDblClickEvent` in `TreeWidget` can no longer be overridden. Instead, `doHandleExpansionToggleDblClickEvent` can be overridden. [#9877](https://github.com/eclipse-theia/theia/pull/9877)
+- [core] `ViewContainerPart` methods and properties related to hiding and showing toolbar removed: `toHideToolbar`, `hideToolbar`, `showToolbar`, `toolbarHidden`. `ViewContainerPart` toolbars are now hidden or shown using CSS properties. [#9935](https://github.com/eclipse-theia/theia/pull/9935)
 
 ## v1.16.0 - 7/29/2021
 

--- a/packages/core/src/browser/shell/tab-bar-toolbar.tsx
+++ b/packages/core/src/browser/shell/tab-bar-toolbar.tsx
@@ -417,6 +417,8 @@ export class TabBarToolbar extends ReactWidget {
     renderMoreContextMenu(anchor: Anchor): any {
         const menuPath = ['TAB_BAR_TOOLBAR_CONTEXT_MENU'];
         const toDisposeOnHide = new DisposableCollection();
+        this.addClass('menu-open');
+        toDisposeOnHide.push(Disposable.create(() => this.removeClass('menu-open')));
         for (const item of this.more.values()) {
             // Register a submenu for the item, if the group is in format `<submenu group>/<submenu name>/.../<item group>`
             if (item.group?.includes('/')) {

--- a/packages/core/src/browser/style/view-container.css
+++ b/packages/core/src/browser/style/view-container.css
@@ -128,3 +128,13 @@
     background-size: var(--theia-icon-size);
     line-height: var(--theia-icon-size);
 }
+
+.theia-view-container-part-title {
+    display: none;
+}
+
+.theia-view-container-part-title.menu-open,
+.p-Widget.part:not(.collapsed):hover .header .theia-view-container-part-title,
+.p-Widget.part:not(.collapsed):focus-within .header .theia-view-container-part-title {
+    display: flex;
+}


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

<!--
Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

> This PR supersedes #8967, as it contains alternative logic for updating the toolbar.

At the moment, we have quite an elaborate routine for managing the visibility of the toolbars on `ViewContainerPart`s. The results differ from VSCode in a couple of ways:
 - The toolbar disappears if a context-menu is opened using the `...` more icon.
 - The toolbar isn't always visible if the widget is focused.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

1. Test different states of widget focus and hovering.
   - The toolbar should never be visible if the `ViewContainerPart` is collapsed
   - The toolbar should be visible if the widget is focused
   - The toolbar should be visible if you hover over the widget
   - The toolbar should be visible if a context menu is opened from the toolbar

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

Signed-off-by: Colin Grant <colin.grant@ericsson.com>