### PR TITLE
monaco: adjust `find-widget` font-family

### DIFF
--- a/packages/monaco/src/browser/style/index.css
+++ b/packages/monaco/src/browser/style/index.css
@@ -198,3 +198,8 @@
 .monaco-editor .peekview-widget .referenceMatch {
   font-family: var(--theia-ui-font-family);
 }
+
+.monaco-editor .find-widget .monaco-findInput .input,
+.monaco-editor .find-widget .matchesCount {
+  font-family: var(--theia-ui-font-family);
+}


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

<!--
Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

The commit updates the font-family for both the input and result label in the `find-widget` (embedded file-search) in the monaco editor. The change updates the font-family like the rest of the application for consistency (and aligns with vscode) rather than using the default monospaced font.

_before_:

![file-search-before](https://user-images.githubusercontent.com/40359487/130242501-bd63d8ca-a264-40bd-a408-02d60b34f06f.png)

_after_:

![file-search-after](https://user-images.githubusercontent.com/40359487/130242519-f0af3c9a-1203-4c81-961b-0260ad027ab5.png)

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

1. start the application, and open an editor
2. execute the embedded file-search (<kbd>ctrl</kbd>+<kbd>f</kbd> when the editor has focus)
3. confirm both the input and label has the proper font
4. perform some search and confirm it is still correct

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

Signed-off-by: vince-fugnitto <vincent.fugnitto@ericsson.com>
