### PR TITLE
monaco: restore `drop-shadow` for quick-input

### DIFF
--- a/packages/monaco/src/browser/style/index.css
+++ b/packages/monaco/src/browser/style/index.css
@@ -105,6 +105,7 @@
   margin-left: -300px !important;
   background-color: var(--theia-quickInput-background) !important;
   color: var(--theia-foreground) !important;
+  box-shadow: rgb(0 0 0 / 36%) 0px 0px 8px 2px;
 }
 
 .monaco-icon-label,


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

<!--
Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

The commit updates the styling of the `quick-input` to restore the drop-shadow which was previously present (and present in vscode) following the monaco upgrade. The drop-shadow helps to display the overlay especially when there is content behind such as an editor, and it aligns with our previous styling and that of vscode.

_before_:

https://user-images.githubusercontent.com/40359487/130246268-7b459a65-36ff-428a-92c7-36f80e835ee8.mov

_after_:

https://user-images.githubusercontent.com/40359487/130246303-c4ad9f0a-8958-4663-a365-3a617e14be2c.mov


#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

1. start the application, and trigger a `quick-input` (ex: <kbd>F1</kbd>)
2. confirm that the quick-input has a drop-shadow applied, similarly to vscode and that master did not
3. confirm the same for quick-pick (ex: `run task...`)

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

Signed-off-by: vince-fugnitto <vincent.fugnitto@ericsson.com>
