### PR TITLE
Enables opening read-only files in electron.

### DIFF
--- a/packages/filesystem/src/electron-browser/file-dialog/electron-file-dialog-service.ts
+++ b/packages/filesystem/src/electron-browser/file-dialog/electron-file-dialog-service.ts
@@ -53,7 +53,7 @@ export class ElectronFileDialogService extends DefaultFileDialogService {
             }
 
             const uris = filePaths.map(path => FileUri.create(path));
-            const canAccess = await this.canReadWrite(uris);
+            const canAccess = await this.canRead(uris);
             const result = canAccess ? uris.length === 1 ? uris[0] : uris : undefined;
             return result;
         }
@@ -74,8 +74,8 @@ export class ElectronFileDialogService extends DefaultFileDialogService {
                 return uri;
             }
 
-            const canAccess = await this.canReadWrite(uri);
-            return canAccess ? uri : undefined;
+            const canWrite = await this.canReadWrite(uri);
+            return canWrite ? uri : undefined;
         }
         return undefined;
     }
@@ -84,6 +84,16 @@ export class ElectronFileDialogService extends DefaultFileDialogService {
         for (const uri of Array.isArray(uris) ? uris : [uris]) {
             if (!(await this.fileService.access(uri, FileAccess.Constants.R_OK | FileAccess.Constants.W_OK))) {
                 this.messageService.error(`Cannot access resource at ${uri.path}.`);
+                return false;
+            }
+        }
+        return true;
+    }
+
+    protected async canRead(uris: MaybeArray<URI>): Promise<boolean> {
+        for (const uri of Array.isArray(uris) ? uris : [uris]) {
+            if (!(await this.fileService.access(uri, FileAccess.Constants.R_OK))) {
+                this.messageService.error(`Cannot read resource at ${uri.path}.`);
                 return false;
             }
         }


### PR DESCRIPTION
Signed-off-by: Kejsi Take <kejsitake@hotmail.com>

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

Addresses issue #9860
Makes sure that a user can open a new file in the ElectronFileDialog when it has Read permissions (and not Write).


#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

- Adds a new canRead() method to check if the user has read permissions to the file.
- Calls the method from .showOpenDialog() 

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
After making the above-mentioned changes, I ran the Electron example and verified that I could open a file that had only read permissions.

#### Review checklist

- [ X] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)


