### PR TITLE
file-search: fix paths when performing quick-file-open

### DIFF
--- a/packages/file-search/src/browser/quick-file-open.ts
+++ b/packages/file-search/src/browser/quick-file-open.ts
@@ -322,14 +322,21 @@ export class QuickFileOpenService implements QuickAccessProvider {
     }
 
     private getItemDescription(uri: URI): string {
-        let description = this.labelProvider.getLongName(uri.parent);
-        if (this.workspaceService.isMultiRootWorkspaceOpened) {
-            const rootUri = this.workspaceService.getWorkspaceRootUri(uri);
-            if (rootUri) {
-                description = `${this.labelProvider.getLongName(rootUri)} • ${description}`;
-            }
+        const resourcePathLabel = this.labelProvider.getLongName(uri.parent);
+        const rootUri = this.workspaceService.getWorkspaceRootUri(uri);
+
+        // Display the path normally if outside any workspace root.
+        if (!rootUri) {
+            return resourcePathLabel;
         }
-        return description;
+
+        // Compute the multi-root label for the resource.
+        if (this.workspaceService.isMultiRootWorkspaceOpened) {
+            const rootLabel = this.labelProvider.getName(rootUri);
+            return rootUri.path.toString() === uri.parent.path.toString() ? `${rootLabel}` : `${rootLabel} • ${resourcePathLabel}`;
+        } else {
+            return rootUri.toString() === uri.parent.toString() ? '' : resourcePathLabel;
+        }
     }
 
     private getPlaceHolder(): string {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

<!--
Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

Fixes: https://github.com/eclipse-theia/theia/issues/9951

The pull-request addresses issues when performing the `quick-file-open` and a resource's paths are not properly displayed.
The main purpose of the change is to fix the following:
- in both single and multi-root workspaces, resources which are direct children of the workspace root should not have a description (previously displayed the full workspace path)
- in a multi-root workspace, the root name should be displayed following the path (previously displayed the whole root path)

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

- you can verify the use-cases of #9951
- start the application with theia as a workspace, open the quick-file-open
- search for `readme` (the root readme should not have a path)
- confirm other paths are correct
- add a workspace folder (creating a multi-root)
- perform similar searches - confirm that the root name is correct, confirm the paths are correct, especially for resources directly at a root

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

Signed-off-by: vince-fugnitto <vincent.fugnitto@ericsson.com>