### PR TITLE
Bump API version to 1.53.2

### DIFF
--- a/packages/plugin-ext-vscode/src/common/plugin-vscode-types.ts
+++ b/packages/plugin-ext-vscode/src/common/plugin-vscode-types.ts
@@ -14,5 +14,5 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
-export const VSCODE_DEFAULT_API_VERSION = '1.50.0';
+export const VSCODE_DEFAULT_API_VERSION = '1.53.2';
 export const VSX_REGISTRY_URL_DEFAULT = 'https://open-vsx.org';


### PR DESCRIPTION
Signed-off-by: Thomas Mäder <tmader@redhat.com>

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

<!--
Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
Bumps the default vscode API version to 1.53.2. The linked issue proposes 1.52.0, but I believe the the changes between 1.52.0 and 1.53.2 should be binary compatible or already implemented in theia (see `SecretsStorage`). 

https://github.com/eclipse-theia/theia/issues/9193


#### How to test
I tested by starting VS Code Java 0.81

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

