### PR TITLE
fix #9962: set session at the first place when construct `ConsoleWidget`

### DIFF
--- a/packages/console/src/browser/console-widget.ts
+++ b/packages/console/src/browser/console-widget.ts
@@ -113,6 +113,7 @@ export class ConsoleWidget extends BaseWidget implements StatefulWidget {
             }
         }));
 
+        this.session = this.sessionManager.selectedSession;
         this.toDispose.push(this.sessionManager.onDidChangeSelectedSession(session => {
             // Don't delete the last session by overriding it with 'undefined'
             if (session) {


### PR DESCRIPTION
Signed-off-by: FinnChen <chenfengole@gmail.com>

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

<!--
Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->
set session at the first place when construct `ConsoleWidget`

fix #9962

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
1. keep debug console closed
2. clear all data in local storage
3. launch a debug session
4. verify the debug console widget is open and print debug log in it

#### Review checklist

- [ ] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

