### PR TITLE
Explicitly mark UnsafeWidgetUtilities

### DIFF
--- a/packages/core/src/browser/shell/theia-dock-panel.ts
+++ b/packages/core/src/browser/shell/theia-dock-panel.ts
@@ -18,7 +18,7 @@ import { find, toArray, ArrayExt } from '@phosphor/algorithm';
 import { TabBar, Widget, DockPanel, Title, DockLayout } from '@phosphor/widgets';
 import { Signal } from '@phosphor/signaling';
 import { Disposable, DisposableCollection } from '../../common/disposable';
-import { MessageLoop } from '../widgets';
+import { UnsafeWidgetUtilities } from '../widgets';
 import { CorePreferences } from '../core-preferences';
 import { inject } from 'inversify';
 import { Emitter, environment } from '../../common';
@@ -175,9 +175,7 @@ export class TheiaDockPanel extends DockPanel {
             return;
         }
         if (this.isAttached) {
-            MessageLoop.sendMessage(this, Widget.Msg.BeforeDetach);
-            this.node.remove();
-            MessageLoop.sendMessage(this, Widget.Msg.AfterDetach);
+            UnsafeWidgetUtilities.detach(this);
         }
         maximizedElement.style.display = 'block';
         this.addClass(MAXIMIZED_CLASS);
@@ -185,9 +183,7 @@ export class TheiaDockPanel extends DockPanel {
         if (!this.isElectron() && preference === 'visible') {
             this.addClass(VISIBLE_MENU_MAXIMIZED_CLASS);
         }
-        MessageLoop.sendMessage(this, Widget.Msg.BeforeAttach);
-        maximizedElement.appendChild(this.node);
-        MessageLoop.sendMessage(this, Widget.Msg.AfterAttach);
+        UnsafeWidgetUtilities.attach(this, maximizedElement);
         this.fit();
         this.onDidToggleMaximizedEmitter.fire(this);
         this.toDisposeOnToggleMaximized.push(Disposable.create(() => {
@@ -198,13 +194,9 @@ export class TheiaDockPanel extends DockPanel {
                 this.removeClass(VISIBLE_MENU_MAXIMIZED_CLASS);
             }
             if (this.isAttached) {
-                MessageLoop.sendMessage(this, Widget.Msg.BeforeDetach);
-                this.node.remove();
-                MessageLoop.sendMessage(this, Widget.Msg.AfterDetach);
+                UnsafeWidgetUtilities.detach(this);
             }
-            MessageLoop.sendMessage(this, Widget.Msg.BeforeAttach);
-            areaContainer.appendChild(this.node);
-            MessageLoop.sendMessage(this, Widget.Msg.AfterAttach);
+            UnsafeWidgetUtilities.attach(this, areaContainer);
             this.fit();
         }));
 

--- a/packages/core/src/browser/tree/tree-widget.tsx
+++ b/packages/core/src/browser/tree/tree-widget.tsx
@@ -20,7 +20,7 @@ import { Disposable, MenuPath, SelectionService } from '../../common';
 import { Key, KeyCode, KeyModifier } from '../keyboard/keys';
 import { ContextMenuRenderer } from '../context-menu-renderer';
 import { StatefulWidget } from '../shell';
-import { EXPANSION_TOGGLE_CLASS, SELECTED_CLASS, COLLAPSED_CLASS, FOCUS_CLASS, BUSY_CLASS, CODICON_TREE_ITEM_CLASSES, Widget } from '../widgets';
+import { EXPANSION_TOGGLE_CLASS, SELECTED_CLASS, COLLAPSED_CLASS, FOCUS_CLASS, BUSY_CLASS, CODICON_TREE_ITEM_CLASSES, Widget, UnsafeWidgetUtilities } from '../widgets';
 import { TreeNode, CompositeTreeNode } from './tree';
 import { TreeModel } from './tree-model';
 import { ExpandableTreeNode } from './tree-expansion';
@@ -1051,7 +1051,7 @@ export class TreeWidget extends ReactWidget implements StatefulWidget {
             if (this.searchBox.isAttached) {
                 Widget.detach(this.searchBox);
             }
-            Widget.attach(this.searchBox, this.node.parentElement!);
+            UnsafeWidgetUtilities.attach(this.searchBox, this.node.parentElement!);
             this.addKeyListener(this.node, this.searchBox.keyCodePredicate.bind(this.searchBox), this.searchBox.handle.bind(this.searchBox));
             this.toDisposeOnDetach.push(Disposable.create(() => {
                 Widget.detach(this.searchBox);


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

<!--
Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

Fixes https://github.com/eclipse-theia/theia/issues/9960 by working around it.

This PR creates a new namespace for non-error-checked versions of Phosphor
utilities, replaces existing code blocks, and applies the new
utilities to cases that were throwing errors.

As the name implies, these utilities are unsafe because they
violate the expectations of Phosphor widgets. We should investigate
why we ever wrote code to do this in the first place, and fix it
if possible.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

1. Start the application.
2. Open the console.
3. Observe no errors about attachment or detachment.
4. Hover over `ViewContainerParts` with toolbars.
5. The toolbars should work.
6. Use the tree search in the Navigator Widget
7. You should see the search bar, in addition to highlights for the results.
8. Dragging and dropping from the navigator tree into the main area should work.
> The listener is set up `onAfterAttach`, so previously when an error was thrown, the listener might not be set up correctly.

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

Signed-off-by: Colin Grant <colin.grant@ericsson.com>