### PR TITLE
filesystem: improve MAX_FILE_SIZE_MB definition

### DIFF
--- a/packages/filesystem/src/browser/filesystem-preferences.ts
+++ b/packages/filesystem/src/browser/filesystem-preferences.ts
@@ -23,13 +23,16 @@ import {
     PreferenceContribution
 } from '@theia/core/lib/browser/preferences';
 import { SUPPORTED_ENCODINGS } from '@theia/core/lib/browser/supported-encodings';
-import { environment } from '@theia/core/shared/@theia/application-package/lib/environment';
 
 // See https://github.com/Microsoft/vscode/issues/30180
 export const WIN32_MAX_FILE_SIZE_MB = 300; // 300 MB
 export const GENERAL_MAX_FILE_SIZE_MB = 16 * 1024; // 16 GB
 
-export const MAX_FILE_SIZE_MB = environment.electron.is() ? process.arch === 'ia32' ? WIN32_MAX_FILE_SIZE_MB : GENERAL_MAX_FILE_SIZE_MB : 32;
+export const MAX_FILE_SIZE_MB = typeof process === 'object'
+    ? process.arch === 'ia32'
+        ? WIN32_MAX_FILE_SIZE_MB
+        : GENERAL_MAX_FILE_SIZE_MB
+    : 32;
 
 export const filesystemPreferenceSchema: PreferenceSchema = {
     type: 'object',


### PR DESCRIPTION
#### What it does

Fixes: https://github.com/eclipse-theia/theia/issues/9815
Closes: https://github.com/eclipse-theia/theia/pull/9818

Depending how you configure your Electron `BrowserWindow`, `environment.electron.is()` can return `true` but `process` would still be `undefined`. Instead we should check for `process` to be defined.

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
