### PR TITLE
upgrade to `inversify@^5.1.1`

### DIFF
--- a/doc/Migration.md
+++ b/doc/Migration.md
@@ -25,8 +25,10 @@ Please see the latest version (`master`) for the most up-to-date information.
             }
         }
     });
-    ```  
+    ```
   - Replace the targets with the ones that are needed for your use case
+  - Make sure to use `inversify@5.1.1`. Theia requires `inversify@^5.0.1` which means that `5.1.1` is compatible,
+    but your lockfile might reference an older version.
 
 ### v1.16.0
 
@@ -46,7 +48,7 @@ Please see the latest version (`master`) for the most up-to-date information.
   - Arch Linux: `sudo pacman -S libsecret`
   - Alpine: `apk add libsecret-dev`
 - It is possible that a `yarn resolution` is necessary for `keytar` to work on older distributions (the fix was added in `1.16.0` by downgrading the dependency version):
-  
+
   ```json
   "resolutions": {
     "**/keytar": "7.6.0",
@@ -73,4 +75,3 @@ Please see the latest version (`master`) for the most up-to-date information.
     "**/webpack": "5.46.0",
   }
   ```
-

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -85,7 +85,7 @@ export class SomeClass {
  - [`express@^4.16.3`](https://www.npmjs.com/package/express)
  - [`fs-extra@^4.0.2`](https://www.npmjs.com/package/fs-extra)
  - [`fuzzy@^0.1.3`](https://www.npmjs.com/package/fuzzy)
- - [`inversify@^5.0.1`](https://www.npmjs.com/package/inversify)
+ - [`inversify@^5.1.1`](https://www.npmjs.com/package/inversify)
  - [`lodash.debounce@^4.0.8`](https://www.npmjs.com/package/lodash.debounce)
  - [`lodash.throttle@^4.1.1`](https://www.npmjs.com/package/lodash.throttle)
  - [`nsfw@^2.1.2`](https://www.npmjs.com/package/nsfw)

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -45,7 +45,7 @@
     "fs-extra": "^4.0.2",
     "fuzzy": "^0.1.3",
     "iconv-lite": "^0.6.0",
-    "inversify": "^5.0.1",
+    "inversify": "^5.1.1",
     "jschardet": "^2.1.1",
     "keytar": "7.2.0",
     "lodash.debounce": "^4.0.8",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5800,7 +5800,7 @@ interpret@^2.2.0:
   resolved "https://registry.yarnpkg.com/interpret/-/interpret-2.2.0.tgz#1a78a0b5965c40a5416d007ad6f50ad27c417df9"
   integrity sha512-Ju0Bz/cEia55xDwUWEa8+olFpCiQoypjnQySseKtmjNrnps3P+xfpUmGr90T7yjlVJmOtybRvPXhKMbHr+fWnw==
 
-inversify@^5.0.1:
+inversify@^5.1.1:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/inversify/-/inversify-5.1.1.tgz#6fbd668c591337404e005a1946bfe0d802c08730"
   integrity sha512-j8grHGDzv1v+8T1sAQ+3boTCntFPfvxLCkNcxB1J8qA0lUN+fAlSyYd+RXKvaPRL4AGyPxViutBEJHNXOyUdFQ==


### PR DESCRIPTION
Since we changed our TypeScript compilation target from ES5 to ES2017
there is a bug with `inversify` prior to version `5.1.1` leading to
the frontend application not starting.

We expected issues with `inversify` when targeting ES2017 but couldn't
find it in the end. This is because we are pulling a version of
`inversify` that did not cause the problem.

This commit updates the `inversify` range to pull a working version.

#### How to test

If you want to reproduce the issue you can add a resolution field such as `"**/inversify": "5.0.1"` and run `yarn`.

Using `inversify@5.0.1` will cause the frontend to crash on startup.

The problem is fixed when using `inversify@5.1.1`.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
