### PR TITLE
electron: fix re-opening of electron window

### DIFF
--- a/packages/core/src/electron-main/electron-main-application.ts
+++ b/packages/core/src/electron-main/electron-main-application.ts
@@ -218,7 +218,7 @@ export class ElectronMainApplication {
      */
     async createWindow(asyncOptions: MaybePromise<TheiaBrowserWindowOptions> = this.getDefaultTheiaWindowOptions()): Promise<BrowserWindow> {
         let options = await asyncOptions;
-        options = this.avoidOverlap(options);
+        options = await this.avoidOverlap(options);
         const electronWindow = new BrowserWindow(options);
         electronWindow.setMenuBarVisibility(false);
         this.attachReadyToShow(electronWindow);
@@ -236,7 +236,7 @@ export class ElectronMainApplication {
         };
     }
 
-    protected avoidOverlap(options: TheiaBrowserWindowOptions): TheiaBrowserWindowOptions {
+    protected async avoidOverlap(options: TheiaBrowserWindowOptions): Promise<TheiaBrowserWindowOptions> {
         const existingWindowsBounds = BrowserWindow.getAllWindows().map(window => window.getBounds());
         if (existingWindowsBounds.length > 0) {
             while (existingWindowsBounds.some(window => window.x === options.x || window.y === options.y)) {
@@ -248,6 +248,8 @@ export class ElectronMainApplication {
                 options.y = options.y! + 30;
 
             }
+        } else {
+            options = await this.getLastWindowOptions();
         }
         return options;
     }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

Fixes: #9990.

The commit restores the previous window state (position and size) when re-opening an electron window, and also preserves the fix that avoids the electron window overlap. The idea is to use the previous `windowstate` when opening the window when a single window is found.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

1. start the example-electron application.
2. resize the window, and move the window position.
3. close the window, and re-open it - the size and position should be restored.
4. open a new window (or folder) - there should be a proper overlap (not exactly on top of the other window(s)).

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

Signed-off-by: vince-fugnitto <vincent.fugnitto@ericsson.com>