### PR TITLE
electron: restore previous workspace

### DIFF
--- a/packages/core/src/electron-main/electron-main-application.ts
+++ b/packages/core/src/electron-main/electron-main-application.ts
@@ -290,21 +290,19 @@ export class ElectronMainApplication {
     }
 
     protected async handleMainCommand(params: ElectronMainExecutionParams, options: ElectronMainCommandOptions): Promise<void> {
-        if (options.file === undefined) {
+        const file = options.file || '';
+        let workspacePath: string | undefined;
+        try {
+            workspacePath = await fs.realpath(path.resolve(params.cwd, file));
+        } catch {
+            console.error(`Could not resolve the workspace path. "${file}" is not a valid 'file' option. Falling back to the default workspace location.`);
+        }
+        if (workspacePath === undefined) {
             await this.openDefaultWindow();
         } else {
-            let workspacePath: string | undefined;
-            try {
-                workspacePath = await fs.realpath(path.resolve(params.cwd, options.file));
-            } catch {
-                console.error(`Could not resolve the workspace path. "${options.file}" is not a valid 'file' option. Falling back to the default workspace location.`);
-            }
-            if (workspacePath === undefined) {
-                await this.openDefaultWindow();
-            } else {
-                await this.openWindowWithWorkspace(workspacePath);
-            }
+            await this.openWindowWithWorkspace(workspacePath);
         }
+
     }
 
     protected async createWindowUri(): Promise<URI> {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

Fixes: #9990.
Closes: #9993

The commit fixes logic when determining whether to open a default window or existing workspace on electron startup. The update now correctly restores the workspace which would previously never restore properly. As a consequence, the fix also resolves the window-state not being properly restored.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

_Workspace Restoration_:

1. start the `example-electron` application, and select a workspace folder.
2. close the application.
3. the application should re-open with the previous workspace folder (master would reload to the default window).
4. execute the command `new window` - a new window should open with no workspace present.
5. start the application and specify a workspace folder (ex: `(cd examples/electron/ && yarn start ~/workspaces/theia)`) - the application should start and open with the specified workspace.

_Test Size + Position_:

1. start the `example-electron` application
2. resize the window, move the position
3. close the application, and re-open
4. confirm the window size and position is restored
5. opening new folders (which spawns new windows) should not overlap eachother

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

Signed-off-by: vince-fugnitto <vincent.fugnitto@ericsson.com>
