### PR TITLE
electron: restore previous workspace

### DIFF
--- a/packages/core/src/browser/window/window-service.ts
+++ b/packages/core/src/browser/window/window-service.ts
@@ -26,9 +26,9 @@ export interface NewWindowOptions {
 export const WindowService = Symbol('WindowService');
 
 /**
- *  The window hash value that is used to spawn a new default window.
+ * The window hash value that is used to spawn a new default window.
  */
-export const DEFAULT_WINDOW_HASH: string = '#!empty';
+export const DEFAULT_WINDOW_HASH: string = '!empty';
 
 export interface WindowService {
 

--- a/packages/core/src/electron-main/electron-main-application.ts
+++ b/packages/core/src/electron-main/electron-main-application.ts
@@ -290,7 +290,9 @@ export class ElectronMainApplication {
     }
 
     protected async handleMainCommand(params: ElectronMainExecutionParams, options: ElectronMainCommandOptions): Promise<void> {
-        if (options.file === undefined) {
+        if (params.secondInstance === false) {
+            await this.openWindowWithWorkspace(''); // restore previous workspace.
+        } else if (options.file === undefined) {
             await this.openDefaultWindow();
         } else {
             let workspacePath: string | undefined;

--- a/packages/workspace/src/browser/workspace-service.ts
+++ b/packages/workspace/src/browser/workspace-service.ts
@@ -130,7 +130,8 @@ export class WorkspaceService implements FrontendApplicationContribution {
     protected async doGetDefaultWorkspaceUri(): Promise<string | undefined> {
 
         // If an empty window is explicitly requested do not restore a previous workspace.
-        if (window.location.hash === DEFAULT_WINDOW_HASH) {
+        // Note: `window.location.hash` includes leading "#" if non-empty.
+        if (window.location.hash === `#${DEFAULT_WINDOW_HASH}`) {
             window.location.hash = '';
             return undefined;
         }
@@ -213,6 +214,7 @@ export class WorkspaceService implements FrontendApplicationContribution {
             this.setURLFragment('');
         }
         this.updateTitle();
+        await this.server.setMostRecentlyUsedWorkspace(this._workspace ? this._workspace.resource.toString() : '');
         await this.updateWorkspace();
     }
 

--- a/packages/workspace/src/node/default-workspace-server.ts
+++ b/packages/workspace/src/node/default-workspace-server.ts
@@ -92,20 +92,9 @@ export class DefaultWorkspaceServer implements WorkspaceServer {
 
     async setMostRecentlyUsedWorkspace(uri: string): Promise<void> {
         this.root = new Deferred();
-        const listUri: string[] = [];
-        const oldListUri = await this.getRecentWorkspaces();
-        listUri.push(uri);
-        if (oldListUri) {
-            oldListUri.forEach(element => {
-                if (element !== uri && element.length > 0) {
-                    listUri.push(element);
-                }
-            });
-        }
         this.root.resolve(uri);
-        this.writeToUserHome({
-            recentRoots: listUri
-        });
+        const recentRoots = Array.from(new Set([uri, ...await this.getRecentWorkspaces()]));
+        this.writeToUserHome({ recentRoots });
     }
 
     async getRecentWorkspaces(): Promise<string[]> {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

Fixes: #9990.
Fixes: #9997.
Closes: #9993

The commit fixes logic when determining whether to open a default window or existing workspace on electron startup. The update now correctly restores the workspace which would previously never restore properly. As a consequence, the fix also resolves the window-state not being properly restored.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

_Workspace Restoration_:

1. start the `example-electron` application, and select a workspace folder.
2. close the application.
3. the application should re-open with the previous workspace folder (master would reload to the default window).
4. execute the command `new window` - a new window should open with no workspace present.
5. start the application and specify a workspace folder (ex: `(cd examples/electron/ && yarn start ~/workspaces/theia)`) - the application should start and open with the specified workspace.

_Test Size + Position_:

1. start the `example-electron` application
2. resize the window, move the position
3. close the application, and re-open
4. confirm the window size and position is restored
5. opening new folders (which spawns new windows) should not overlap eachother

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

Signed-off-by: vince-fugnitto <vincent.fugnitto@ericsson.com>
