### PR TITLE
Replace `instanceof ThemeIcon` with an `is` method

### DIFF
--- a/packages/plugin-ext/src/plugin/quick-open.ts
+++ b/packages/plugin-ext/src/plugin/quick-open.ts
@@ -41,7 +41,7 @@ export function isPromiseCanceledError(error: any): boolean {
 }
 
 export function getIconUris(iconPath: theia.QuickInputButton['iconPath']): { dark: URI, light: URI } | { id: string } {
-    if (iconPath instanceof ThemeIcon) {
+    if (ThemeIcon.is(iconPath)) {
         return { id: iconPath.id };
     }
     const dark = getDarkIconUri(iconPath as URI | { light: URI; dark: URI; });
@@ -439,7 +439,7 @@ export class QuickInputExt implements QuickInput {
             const relativePath = path.relative(packagePath, normalizedPath);
             return PluginPackage.toPluginUrl(this.plugin.rawModel, relativePath);
         };
-        if ('id' in iconPath || iconPath instanceof ThemeIcon) {
+        if (ThemeIcon.is(iconPath)) {
             return iconPath;
         } else if (typeof iconPath === 'string' || iconPath instanceof monaco.Uri) {
             return URI.parse(toUrl(iconPath));

--- a/packages/plugin-ext/src/plugin/tree/tree-views.ts
+++ b/packages/plugin-ext/src/plugin/tree/tree-views.ts
@@ -369,7 +369,7 @@ class TreeViewExtImpl<T> implements Disposable {
                 const { iconPath } = treeItem;
                 if (typeof iconPath === 'string' && iconPath.indexOf('fa-') !== -1) {
                     icon = iconPath;
-                } else if (iconPath instanceof ThemeIcon) {
+                } else if (ThemeIcon.is(iconPath)) {
                     themeIconId = iconPath.id;
                 } else {
                     iconUrl = PluginIconPath.toUrl(<PluginIconPath | undefined>iconPath, this.plugin);

--- a/packages/plugin-ext/src/plugin/types-impl.ts
+++ b/packages/plugin-ext/src/plugin/types-impl.ts
@@ -702,6 +702,12 @@ export class ThemeIcon {
 
 }
 
+export namespace ThemeIcon {
+    export function is(item: unknown): item is ThemeIcon {
+        return typeof item === 'object' && !!item && 'id' in item;
+    }
+}
+
 export enum TextEditorRevealType {
     Default = 0,
     InCenter = 1,


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
Closes #10010 

Replaces the `instanceof` calls for `ThemeIcons` with an `is` method. If anyone knows a better way of fixing this, please comment.

Also, there are a few other `instanceof` calls combined with `es5Compatibility` annotations, but they seem to work, as far as I can tell.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->


1. Install the npm extension (built-in)
2. Open the npm view
3. Notice the missing icon on `master` and existing icon on this PR.


#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
