### PR TITLE
task: make `TaskDefinition` `required` optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 <a name="breaking_changes_1.18.0">[Breaking Changes:](#breaking_changes_1.18.0)</a>
 
 - [core] added `BreadcrumbsRendererFactory` to constructor arguments of `DockPanelRenderer` and `ToolbarAwareTabBar`. [#9920](https://github.com/eclipse-theia/theia/pull/9920)
+- [task] `TaskDefinition.properties.required` is now optional to align with the specification [#10015](https://github.com/eclipse-theia/theia/pull/10015)
 
 ## v1.17.2 - 9/1/2021
 

--- a/packages/plugin-ext/src/hosted/node/scanners/scanner-theia.ts
+++ b/packages/plugin-ext/src/hosted/node/scanners/scanner-theia.ts
@@ -698,7 +698,7 @@ export class TheiaPluginScanner implements PluginScanner {
             taskType: definitionContribution.type,
             source: pluginName,
             properties: {
-                required: definitionContribution.required,
+                required: definitionContribution.required || [],
                 all: propertyKeys,
                 schema: definitionContribution
             }

--- a/packages/task/src/browser/provided-task-configurations.ts
+++ b/packages/task/src/browser/provided-task-configurations.ts
@@ -101,12 +101,12 @@ export class ProvidedTaskConfigurations {
         let highest = -1;
         const tasks = await this.getTasks(token);
         for (const task of tasks) { // find detected tasks that match the `definition`
-            let score = 0;
-            if (!definition.properties.required.every(requiredProp => customization[requiredProp] !== undefined)) {
+            const required = definition.properties.required || [];
+            if (!required.every(requiredProp => customization[requiredProp] !== undefined)) {
                 continue;
             }
-            score += definition.properties.required.length; // number of required properties
-            const requiredProps = new Set(definition.properties.required);
+            let score = required.length; // number of required properties
+            const requiredProps = new Set(required);
             // number of optional properties
             score += definition.properties.all.filter(p => !requiredProps.has(p) && customization[p] !== undefined).length;
             if (score >= highest) {

--- a/packages/task/src/browser/task-configurations.ts
+++ b/packages/task/src/browser/task-configurations.ts
@@ -249,10 +249,9 @@ export class TaskConfigurations implements Disposable {
         if (hasCustomization) {
             const taskDefinition = this.taskDefinitionRegistry.getDefinition(taskConfig);
             if (taskDefinition) {
-                const cus = customizationByType.filter(customization =>
-                    taskDefinition.properties.required.every(rp => customization[rp] === taskConfig[rp])
-                )[0]; // Only support having one customization per task
-                return cus;
+                const required = taskDefinition.properties.required || [];
+                // Only support having one customization per task.
+                return customizationByType.find(customization => required.every(property => customization[property] === taskConfig[property]));
             }
         }
         return undefined;

--- a/packages/task/src/browser/task-definition-registry.ts
+++ b/packages/task/src/browser/task-definition-registry.ts
@@ -71,12 +71,12 @@ export class TaskDefinitionRegistry {
         let matchedDefinition: TaskDefinition | undefined;
         let highest = -1;
         for (const def of definitions) {
-            let score = 0;
-            if (!def.properties.required.every(requiredProp => taskConfiguration[requiredProp] !== undefined)) {
+            const required = def.properties.required || [];
+            if (!required.every(requiredProp => taskConfiguration[requiredProp] !== undefined)) {
                 continue;
             }
-            score += def.properties.required.length; // number of required properties
-            const requiredProps = new Set(def.properties.required);
+            let score = required.length; // number of required properties
+            const requiredProps = new Set(required);
             // number of optional properties
             score += def.properties.all.filter(p => !requiredProps.has(p) && taskConfiguration[p] !== undefined).length;
             if (score > highest) {

--- a/packages/task/src/browser/task-schema-updater.ts
+++ b/packages/task/src/browser/task-schema-updater.ts
@@ -168,8 +168,9 @@ export class TaskSchemaUpdater implements JsonSchemaContribution {
                 description: 'The task type to customize'
             };
             customizedDetectedTask.properties!.type = taskType;
+            const required = def.properties.required || [];
             def.properties.all.forEach(taskProp => {
-                if (!!def.properties.required.find(requiredProp => requiredProp === taskProp)) { // property is mandatory
+                if (required.find(requiredProp => requiredProp === taskProp)) { // property is mandatory
                     customizedDetectedTask.required!.push(taskProp);
                 }
                 customizedDetectedTask.properties![taskProp] = { ...def.properties.schema.properties![taskProp] };

--- a/packages/task/src/common/task-protocol.ts
+++ b/packages/task/src/common/task-protocol.ts
@@ -274,7 +274,11 @@ export interface TaskDefinition {
     taskType: string;
     source: string;
     properties: {
-        required: string[];
+        /**
+         * Should be treated as an empty array if omitted.
+         * https://json-schema.org/draft/2020-12/json-schema-validation.html#rfc.section.6.5.3
+         */
+        required?: string[];
         all: string[];
         schema: IJSONSchema;
     }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->
Fixes: #10014 

The commit makes `TaskDefinition.properties.required` optional based on the json schema validation definition. Previously, if an extension defines a schema that omits the `required` property the application will throw errors and fail to display the menu. The change treats the missing `required` property as an empty array as per the spec.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

- Follow the steps as described in #10014

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

![image](https://user-images.githubusercontent.com/40359487/131561311-4402d7af-caac-415e-b5e2-1fb0a78bfa18.png)


Signed-off-by: vince-fugnitto <vincent.fugnitto@ericsson.com>