### PR TITLE
workspace: add command mapping to plugin-system

### DIFF
--- a/packages/plugin-ext-vscode/src/browser/plugin-vscode-commands-contribution.ts
+++ b/packages/plugin-ext-vscode/src/browser/plugin-vscode-commands-contribution.ts
@@ -240,6 +240,9 @@ export class PluginVscodeCommandsContribution implements CommandContribution {
         commands.registerCommand({ id: 'workbench.action.openSettings' }, {
             execute: (query?: string) => commands.executeCommand(CommonCommands.OPEN_PREFERENCES.id, query)
         });
+        commands.registerCommand({ id: 'workbench.action.openWorkspaceConfigFile' }, {
+            execute: () => commands.executeCommand(WorkspaceCommands.OPEN_WORKSPACE_FILE.id)
+        });
         commands.registerCommand({ id: 'workbench.files.action.refreshFilesExplorer' }, {
             execute: () => commands.executeCommand(FileNavigatorCommands.REFRESH_NAVIGATOR.id)
         });


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
Handling Issue #9840
With the aid of @vince-fugnitto, Added the command `workspace:openConfigFile` mapping in the plugin system to be able to be executed by vscode plugins.
(vscode command id) `workbench.action.openWorkspaceConfigFile`

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

To test functionality, from @vince-fugnitto ,
> @dineshUmasankar to test it is quite simple, I created a plugin to test which you can use since you were having difficulty:
> 
> * https://github.com/vince-fugnitto/vscode-open-config-file/releases/download/v0.0.1/vscode-open-config-file-0.0.1.vsix
> 
> The plugin simply [executes the command](https://github.com/vince-fugnitto/vscode-open-config-file/blob/fe083b5a8abf0084dea014a338ac6bc0023a5d88/src/extension.ts#L5):
> 
> ```ts
> export function activate(context: vscode.ExtensionContext) {
>     let disposable = vscode.commands.registerCommand('vscode-open-config-file.test', () => {
>         vscode.commands.executeCommand('workbench.action.openWorkspaceConfigFile');
>     });
> 
>     context.subscriptions.push(disposable);
> }
> ```
> 
> The command `workbench.action.openWorkspaceConfigFile` is available when we start the application, and we have a multi-root workspace opened (a workspace with more than one root folder, and described as a workspace file). In vscode this plugin will successfully work, but in the theia framework we need to make sure to add the proper mapping so that it is available by the plugin.
> 
> _Error_ (theia):
> 
> ```
> Error: Command with id 'workbench.action.openWorkspaceConfigFile' is not registered.
> ```
> 
> To test the feature you would do the following:
> 
> 1. add the test plugin to the `plugins/` folder
> 2. start the application
> 3. open a workspace
> 4. use the command `add folder to workspace` (to add a secondary root and create a multi-root workspace)
> 5. use the command `test: open config file` (the configuration file should open)
> 
> I confirmed it works locally with the plugin and the mapping updates:
> 
> <img alt="Screen Shot 2021-08-31 at 9 50 08 PM" width="1084" src="https://user-images.githubusercontent.com/40359487/131598658-4a5e4549-89bb-4485-9a05-25141d8b02a4.png">


#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
