### PR TITLE
mini-browser: fix source and preview

### DIFF
--- a/packages/preview/src/browser/preview-contribution.ts
+++ b/packages/preview/src/browser/preview-contribution.ts
@@ -266,7 +266,7 @@ export class PreviewContribution extends NavigatableWidgetOpenHandler<PreviewWid
     protected async openSource(ref?: Widget): Promise<EditorWidget | undefined> {
         if (ref instanceof PreviewWidget) {
             return this.editorManager.open(ref.uri, {
-                widgetOptions: { ref, mode: 'open-to-left' }
+                widgetOptions: { ref, mode: 'tab-after' }
             });
         }
     }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

Fixes: https://github.com/eclipse-theia/theia/issues/5110
Fixes: https://github.com/eclipse-theia/theia/issues/5223

Closes: https://github.com/eclipse-theia/theia/pull/5206

The change fixes the **source** and **preview** commands from the `mini-browser` to use the proper opener.
The change allows us to now successfully open the source of a preview, and vice-versa which was previously not possible (master).

The commit also aligns the behavior when opening the **sources** from a **preview** to open as tab-right instead of in a new editor group similarly to the behavior present in vscode. 

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

1. start the application with a workspace (use a workspace that contains images (.png, .svg, .jpg), and html files).
2. double-click a file the mini-browser supports (ex: .svg).
3. confirm the file is opened as preview (rendered content)
4. confirm the same use-case when opening from the quick-file-open
5. confirm that the `open source` toolbar item successfully opens the file's sources (a dialog might appear)
6. close the preview (rendered content)
7. confirm the `open preview` toolbar item opens the file's preview

https://user-images.githubusercontent.com/40359487/132010432-8fcfc51d-7f13-4b6e-b381-a988ae6b4648.mp4

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

Signed-off-by: vince-fugnitto <vincent.fugnitto@ericsson.com>
Co-authored-by: fangx <naxin.fang@ericsson.com>