### PR TITLE
Add deprecated fields to LanguageConfiguration

### DIFF
--- a/packages/plugin/src/theia.d.ts
+++ b/packages/plugin/src/theia.d.ts
@@ -6266,6 +6266,14 @@ declare module '@theia/plugin' {
      */
     export interface LanguageConfiguration {
         /**
+         * @deprecated Use the autoClosingPairs property in the language configuration file instead.
+         */
+        __characterPairSupport?: { autoClosingPairs: { close: String, notIn: String[], open: String }[] }
+        /**
+         * @deprecated Do not use. Will be replaced by a better API soon.
+         */
+        __electricCharacterSupport?: { brackets: any, docComment: { close: String, lineStart: String, open: String, scope: String } }
+        /**
          * The language's comment settings.
          */
         comments?: CommentRule;


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->
Handling issue: #10031 

There are two deprecate fields __electricCharacterSupport and __characterPairSupport in LanguageConfiguration.
I added these declarations into [theia.d.ts](https://github.com/eclipse-theia/theia/blob/master/packages/plugin/src/theia.d.ts#L6267) and ensured they were marked with deprecation annotations.

As #10031 stated, I only added declarations for support but did not pursue implementation.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

I require help with testing the existence of fields within interfaces. Would I write up a test inside of the respective `package.spec.ts`?

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
