### PR TITLE
fix updating items in the quick-pick menu

### DIFF
--- a/packages/core/src/browser/quick-input/quick-input-service.ts
+++ b/packages/core/src/browser/quick-input/quick-input-service.ts
@@ -206,6 +206,7 @@ export interface QuickInputService {
         Promise<(O extends { canPickMany: true } ? T[] : T) | undefined>;
     showQuickPick<T extends QuickPickItem>(items: Array<T>, options?: QuickPickOptions<T>): Promise<T>;
     hide(): void;
+    getCurrentInput(): QuickInput | undefined;
 }
 
 /**

--- a/packages/core/src/browser/quick-input/quick-input-service.ts
+++ b/packages/core/src/browser/quick-input/quick-input-service.ts
@@ -206,7 +206,10 @@ export interface QuickInputService {
         Promise<(O extends { canPickMany: true } ? T[] : T) | undefined>;
     showQuickPick<T extends QuickPickItem>(items: Array<T>, options?: QuickPickOptions<T>): Promise<T>;
     hide(): void;
-    getCurrentInput(): QuickInput | undefined;
+    /**
+     * Provides raw access to the quick pick controller.
+     */
+    createQuickPick<T extends QuickPickItem>(): QuickPick<T>;
 }
 
 /**

--- a/packages/monaco/src/browser/monaco-quick-input-service.ts
+++ b/packages/monaco/src/browser/monaco-quick-input-service.ts
@@ -16,8 +16,19 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
 import {
-    InputBox, InputOptions, KeybindingRegistry, PickOptions,
-    QuickInputButton, QuickInputService, QuickPick, QuickPickItem, QuickPickItemButtonEvent, QuickPickItemHighlights, QuickPickOptions, QuickPickSeparator
+    InputBox,
+    InputOptions,
+    KeybindingRegistry,
+    PickOptions,
+    QuickInput,
+    QuickInputButton,
+    QuickInputService,
+    QuickPick,
+    QuickPickItem,
+    QuickPickItemButtonEvent,
+    QuickPickItemHighlights,
+    QuickPickOptions,
+    QuickPickSeparator
 } from '@theia/core/lib/browser';
 import { CancellationToken, Event } from '@theia/core/lib/common';
 import { injectable, inject } from '@theia/core/shared/inversify';
@@ -162,6 +173,7 @@ export class MonacoQuickInputImplementation implements monaco.quickInput.IQuickI
 export class MonacoQuickInputService implements QuickInputService {
     @inject(MonacoQuickInputImplementation)
     private monacoService: MonacoQuickInputImplementation;
+    private quickInput: QuickInput;
 
     @inject(KeybindingRegistry)
     protected readonly keybindingRegistry: KeybindingRegistry;
@@ -190,9 +202,10 @@ export class MonacoQuickInputService implements QuickInputService {
     }
 
     showQuickPick<T extends QuickPickItem>(items: T[], options?: QuickPickOptions<T>): Promise<T> {
+        const quickPick = this.monacoService.createQuickPick<MonacoQuickPickItem<T>>();
+        const wrapped = this.wrapQuickPick(quickPick);
+        this.quickInput = wrapped;
         return new Promise<T>((resolve, reject) => {
-            const quickPick = this.monacoService.createQuickPick<MonacoQuickPickItem<T>>();
-            const wrapped = this.wrapQuickPick(quickPick);
 
             if (options) {
                 wrapped.canSelectMany = !!options.canSelectMany;
@@ -271,6 +284,10 @@ export class MonacoQuickInputService implements QuickInputService {
 
     hide(): void {
         return this.monacoService.hide();
+    }
+
+    getCurrentInput(): QuickInput | undefined {
+        return this.quickInput;
     }
 }
 

--- a/packages/monaco/src/browser/monaco-quick-input-service.ts
+++ b/packages/monaco/src/browser/monaco-quick-input-service.ts
@@ -16,19 +16,8 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
 import {
-    InputBox,
-    InputOptions,
-    KeybindingRegistry,
-    PickOptions,
-    QuickInput,
-    QuickInputButton,
-    QuickInputService,
-    QuickPick,
-    QuickPickItem,
-    QuickPickItemButtonEvent,
-    QuickPickItemHighlights,
-    QuickPickOptions,
-    QuickPickSeparator
+    InputBox, InputOptions, KeybindingRegistry, PickOptions,
+    QuickInputButton, QuickInputService, QuickPick, QuickPickItem, QuickPickItemButtonEvent, QuickPickItemHighlights, QuickPickOptions, QuickPickSeparator
 } from '@theia/core/lib/browser';
 import { CancellationToken, Event } from '@theia/core/lib/common';
 import { injectable, inject } from '@theia/core/shared/inversify';
@@ -173,7 +162,6 @@ export class MonacoQuickInputImplementation implements monaco.quickInput.IQuickI
 export class MonacoQuickInputService implements QuickInputService {
     @inject(MonacoQuickInputImplementation)
     private monacoService: MonacoQuickInputImplementation;
-    private quickInput: QuickInput;
 
     @inject(KeybindingRegistry)
     protected readonly keybindingRegistry: KeybindingRegistry;
@@ -202,10 +190,9 @@ export class MonacoQuickInputService implements QuickInputService {
     }
 
     showQuickPick<T extends QuickPickItem>(items: T[], options?: QuickPickOptions<T>): Promise<T> {
-        const quickPick = this.monacoService.createQuickPick<MonacoQuickPickItem<T>>();
-        const wrapped = this.wrapQuickPick(quickPick);
-        this.quickInput = wrapped;
         return new Promise<T>((resolve, reject) => {
+            const quickPick = this.monacoService.createQuickPick<MonacoQuickPickItem<T>>();
+            const wrapped = this.wrapQuickPick(quickPick);
 
             if (options) {
                 wrapped.canSelectMany = !!options.canSelectMany;
@@ -274,6 +261,12 @@ export class MonacoQuickInputService implements QuickInputService {
             return item;
         });
     }
+
+    createQuickPick<T extends QuickPickItem>(): QuickPick<T> {
+        const quickPick = this.monacoService.createQuickPick<MonacoQuickPickItem<T>>();
+        return this.wrapQuickPick(quickPick);
+    }
+
     wrapQuickPick<T extends QuickPickItem>(wrapped: monaco.quickInput.IQuickPick<MonacoQuickPickItem<T>>): QuickPick<T> {
         return new MonacoQuickPick(wrapped, this.keybindingRegistry);
     }
@@ -284,10 +277,6 @@ export class MonacoQuickInputService implements QuickInputService {
 
     hide(): void {
         return this.monacoService.hide();
-    }
-
-    getCurrentInput(): QuickInput | undefined {
-        return this.quickInput;
     }
 }
 

--- a/packages/plugin-ext/src/common/plugin-api-rpc.ts
+++ b/packages/plugin-ext/src/common/plugin-api-rpc.ts
@@ -609,7 +609,6 @@ export interface QuickOpenMain {
 
     $hide(): void;
     $showInputBox(options: TransferInputBox, validateInput: boolean): Promise<string | undefined>;
-    $showCustomQuickPick<T extends theia.QuickPickItem>(options: TransferQuickPick<T>): void;
 }
 
 export interface WorkspaceMain {

--- a/packages/plugin-ext/src/main/browser/quick-open-main.ts
+++ b/packages/plugin-ext/src/main/browser/quick-open-main.ts
@@ -15,7 +15,7 @@
  ********************************************************************************/
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
-import { InputBoxOptions, QuickPickItem as QuickPickItemExt } from '@theia/plugin';
+import { InputBoxOptions } from '@theia/plugin';
 import { interfaces } from '@theia/core/shared/inversify';
 import { RPCProtocol } from '../../common/rpc-protocol';
 import {
@@ -23,15 +23,17 @@ import {
     QuickOpenMain,
     MAIN_RPC_CONTEXT,
     TransferInputBox,
-    TransferQuickPick,
     TransferQuickPickItems,
     TransferQuickInput,
     TransferQuickInputButton
 } from '../../common/plugin-api-rpc';
 import {
-    InputOptions, PickOptions, QuickInputButton, QuickInputService, QuickPickItem, QuickPickValue
+    InputOptions,
+    PickOptions,
+    QuickInputButton,
+    QuickInputButtonHandle,
+    QuickInputService
 } from '@theia/core/lib/browser';
-import { QuickPickService } from '@theia/core/lib/common/quick-pick-service';
 import { DisposableCollection, Disposable } from '@theia/core/lib/common/disposable';
 import { CancellationToken } from '@theia/core/lib/common/cancellation';
 import { MonacoQuickInputService } from '@theia/monaco/lib/browser/monaco-quick-input-service';
@@ -47,7 +49,6 @@ export interface QuickInputSession {
 export class QuickOpenMainImpl implements QuickOpenMain, Disposable {
 
     private quickInputService: QuickInputService;
-    private quickPickService: QuickPickService;
     private proxy: QuickOpenExt;
     private delegate: MonacoQuickInputService;
     private readonly items: Record<number, {
@@ -61,7 +62,6 @@ export class QuickOpenMainImpl implements QuickOpenMain, Disposable {
         this.proxy = rpc.getProxy(MAIN_RPC_CONTEXT.QUICK_OPEN_EXT);
         this.delegate = container.get(MonacoQuickInputService);
         this.quickInputService = container.get(QuickInputService);
-        this.quickPickService = container.get(QuickPickService);
     }
 
     dispose(): void {
@@ -196,52 +196,53 @@ export class QuickOpenMainImpl implements QuickOpenMain, Disposable {
 
     $createOrUpdate<T extends theia.QuickPickItem>(params: TransferQuickInput<T>): Promise<void> {
         const sessionId = params.id;
-        const session = this.sessions.get(sessionId);
-        // if (!session) {
-        //     if (params.type === 'quickPick') {
-        //         const quickPick = this.quickInputService.createQuickPick();
-        //         quickPick.onDidAccept(() => {
-        //             this.proxy.$acceptOnDidAccept(sessionId);
-        //         });
-        //         quickPick.onDidChangeActive((items: Array<monaco.quickInput.IQuickPickItem>) => {
-        //             this.proxy.$onDidChangeActive(sessionId, items.map(item => (item as TransferQuickPickItems).handle));
-        //         });
-        //         quickPick.onDidChangeSelection((items: Array<monaco.quickInput.IQuickPickItem>) => {
-        //             this.proxy.$onDidChangeSelection(sessionId, items.map(item => (item as TransferQuickPickItems).handle));
-        //         });
-        //         quickPick.onDidTriggerButton((button: QuickInputButtonHandle) => {
-        //             this.proxy.$acceptOnDidTriggerButton(sessionId, button);
-        //         });
-        //         quickPick.onDidChangeValue((value: string) => {
-        //             this.proxy.$acceptDidChangeValue(sessionId, value);
-        //         });
-        //         quickPick.onDidHide(() => {
-        //             this.proxy.$acceptOnDidHide(sessionId);
-        //         });
-        //         session = {
-        //             input: quickPick,
-        //             handlesToItems: new Map()
-        //         };
-        //     } else {
-        //         const inputBox = this.quickInputService.createInputBox();
-        //         inputBox.onDidAccept(() => {
-        //             this.proxy.$acceptOnDidAccept(sessionId);
-        //         });
-        //         inputBox.onDidTriggerButton((button: QuickInputButtonHandle) => {
-        //             this.proxy.$acceptOnDidTriggerButton(sessionId, button);
-        //         });
-        //         inputBox.onDidChangeValue((value: string) => {
-        //             this.proxy.$acceptDidChangeValue(sessionId, value);
-        //         });
-        //         inputBox.onDidHide(() => {
-        //             this.proxy.$acceptOnDidHide(sessionId);
-        //         });
-        //         session = {
-        //             input: inputBox,
-        //             handlesToItems: new Map()
-        //         };
-        //     }
-        // }
+        let session = this.sessions.get(sessionId);
+        if (!session) {
+            if (params.type === 'quickPick') {
+                const quickPick = this.quickInputService.createQuickPick();
+                quickPick.onDidAccept(() => {
+                    this.proxy.$acceptOnDidAccept(sessionId);
+                });
+                quickPick.onDidChangeActive((items: Array<monaco.quickInput.IQuickPickItem>) => {
+                    this.proxy.$onDidChangeActive(sessionId, items.map(item => (item as TransferQuickPickItems).handle));
+                });
+                quickPick.onDidChangeSelection((items: Array<monaco.quickInput.IQuickPickItem>) => {
+                    this.proxy.$onDidChangeSelection(sessionId, items.map(item => (item as TransferQuickPickItems).handle));
+                });
+                quickPick.onDidTriggerButton((button: QuickInputButtonHandle) => {
+                    this.proxy.$acceptOnDidTriggerButton(sessionId, button);
+                });
+                quickPick.onDidChangeValue((value: string) => {
+                    this.proxy.$acceptDidChangeValue(sessionId, value);
+                });
+                quickPick.onDidHide(() => {
+                    this.proxy.$acceptOnDidHide(sessionId);
+                });
+                session = {
+                    input: quickPick,
+                    handlesToItems: new Map()
+                };
+            } else {
+                const inputBox = this.quickInputService.createInputBox();
+                inputBox.onDidAccept(() => {
+                    this.proxy.$acceptOnDidAccept(sessionId);
+                });
+                inputBox.onDidTriggerButton((button: QuickInputButtonHandle) => {
+                    this.proxy.$acceptOnDidTriggerButton(sessionId, button);
+                });
+                inputBox.onDidChangeValue((value: string) => {
+                    this.proxy.$acceptDidChangeValue(sessionId, value);
+                });
+                inputBox.onDidHide(() => {
+                    this.proxy.$acceptOnDidHide(sessionId);
+                });
+                session = {
+                    input: inputBox,
+                    handlesToItems: new Map()
+                };
+            }
+            this.sessions.set(sessionId, session);
+        }
         if (session) {
             const { input, handlesToItems } = session;
             for (const param in params) {
@@ -297,51 +298,6 @@ export class QuickOpenMainImpl implements QuickOpenMain, Disposable {
         return Promise.resolve(undefined);
     }
 
-    async $showCustomQuickPick<T extends QuickPickItemExt>(options: TransferQuickPick<T>): Promise<void> {
-        const sessionId = options.id;
-        const toDispose = new DisposableCollection();
-
-        toDispose.push(this.quickPickService.onDidAccept(() => {
-            this.proxy.$acceptOnDidAccept(sessionId);
-        }));
-        toDispose.push(this.quickPickService.onDidChangeActive((e: { quickPick: any, activeItems: Array<QuickPickValue<number>> }) => {
-            this.proxy.$onDidChangeActive(sessionId, e.activeItems.map(item => item.value!));
-        }));
-        toDispose.push(this.quickPickService.onDidChangeSelection((e: { quickPick: any, selectedItems: Array<QuickPickValue<number>> }) => {
-            this.proxy.$onDidChangeSelection(sessionId, e.selectedItems.map(item => item.value!));
-        }));
-        toDispose.push(this.quickPickService.onDidChangeValue((e: { quickPick: any, filter: string }) => {
-            this.proxy.$acceptDidChangeValue(sessionId, e.filter);
-        }));
-        toDispose.push(this.quickPickService.onDidTriggerButton(button => {
-            this.proxy.$acceptOnDidTriggerButton(sessionId, button);
-        }));
-        toDispose.push(this.quickPickService.onDidHide(() => {
-            this.proxy.$acceptOnDidHide(sessionId);
-            if (!toDispose.disposed) {
-                toDispose.dispose();
-            }
-        }));
-        this.toDispose.push(toDispose);
-
-        this.quickPickService.show(this.convertToQuickPickItem(options.items), {
-            buttons: options.buttons ? this.convertToQuickInputButtons(options.buttons) : [],
-            placeholder: options.placeholder,
-            matchOnDescription: options.matchOnDescription,
-            step: options.step,
-            title: options.title,
-            totalSteps: options.totalSteps,
-            ignoreFocusOut: options.ignoreFocusOut,
-            value: options.value,
-            matchOnLabel: true,
-            runIfSingle: false,
-        });
-        const input = this.quickInputService.getCurrentInput();
-        if (input) {
-            this.sessions.set(sessionId, { input, handlesToItems: new Map() });
-        }
-    }
-
     $hide(): void {
         this.delegate.hide();
     }
@@ -353,21 +309,6 @@ export class QuickOpenMainImpl implements QuickOpenMain, Disposable {
             this.sessions.delete(sessionId);
         }
         return Promise.resolve(undefined);
-    }
-
-    private convertToQuickPickItem(items: TransferQuickPickItems[] | undefined): Array<QuickPickItem> {
-        const convertedItems: QuickPickValue<number>[] = [];
-        if (items) {
-            for (const i of items) {
-                convertedItems.push({
-                    label: i.label,
-                    description: i.description,
-                    detail: i.detail,
-                    value: i.handle
-                });
-            }
-        }
-        return convertedItems;
     }
 
     private convertToQuickInputButtons(buttons: Array<TransferQuickInputButton>): Array<QuickInputButton> {

--- a/packages/plugin-ext/src/main/browser/quick-open-main.ts
+++ b/packages/plugin-ext/src/main/browser/quick-open-main.ts
@@ -336,6 +336,10 @@ export class QuickOpenMainImpl implements QuickOpenMain, Disposable {
             matchOnLabel: true,
             runIfSingle: false,
         });
+        const input = this.quickInputService.getCurrentInput();
+        if (input) {
+            this.sessions.set(sessionId, { input, handlesToItems: new Map() });
+        }
     }
 
     $hide(): void {

--- a/packages/plugin-ext/src/plugin/quick-open.ts
+++ b/packages/plugin-ext/src/plugin/quick-open.ts
@@ -16,7 +16,7 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import {
     QuickOpenExt, PLUGIN_RPC_CONTEXT as Ext, QuickOpenMain, TransferInputBox, Plugin,
-    Item, TransferQuickInputButton, TransferQuickPickItems, TransferQuickInput, TransferQuickPick
+    Item, TransferQuickInputButton, TransferQuickPickItems, TransferQuickInput
 } from '../common/plugin-api-rpc';
 import * as theia from '@theia/plugin';
 import { QuickPickItem, InputBoxOptions, InputBox, QuickPick, QuickInput } from '@theia/plugin';
@@ -176,10 +176,6 @@ export class QuickOpenExtImpl implements QuickOpenExt {
         const session: any = new InputBoxExt(this, this.proxy, plugin, () => this._sessions.delete(session._id));
         this._sessions.set(session._id, session);
         return session;
-    }
-
-    showCustomQuickPick<T extends QuickPickItem>(options: TransferQuickPick<T>): void {
-        this.proxy.$showCustomQuickPick(options);
     }
 
     hide(): void {
@@ -389,6 +385,7 @@ export class QuickInputExt implements QuickInput {
         this._fireHide();
         this.disposableCollection.dispose();
         this._onDidDispose();
+        this.quickOpenMain.$dispose(this._id);
     }
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -692,25 +689,25 @@ export class QuickPickExt<T extends theia.QuickPickItem> extends QuickInputExt i
         this._onDidChangeSelectionEmitter.fire(items);
     }
 
-    show(): void {
-        super.show();
-        this.quickOpen.showCustomQuickPick({
-            id: this._id,
-            title: this.title,
-            step: this.step,
-            totalSteps: this.totalSteps,
-            enabled: this.enabled,
-            busy: this.busy,
-            ignoreFocusOut: this.ignoreFocusOut,
-            value: this.value,
-            placeholder: this.placeholder,
-            buttons: this.buttons,
-            items: convertToTransferQuickPickItems(this.items),
-            canSelectMany: this.canSelectMany,
-            matchOnDescription: this.matchOnDescription,
-            matchOnDetail: this.matchOnDetail,
-            activeItems: this.activeItems,
-            selectedItems: this.selectedItems
-        });
-    }
+    // show(): void {
+    //     super.show();
+    //     this.quickOpen.showCustomQuickPick({
+    //         id: this._id,
+    //         title: this.title,
+    //         step: this.step,
+    //         totalSteps: this.totalSteps,
+    //         enabled: this.enabled,
+    //         busy: this.busy,
+    //         ignoreFocusOut: this.ignoreFocusOut,
+    //         value: this.value,
+    //         placeholder: this.placeholder,
+    //         buttons: this.buttons,
+    //         items: convertToTransferQuickPickItems(this.items),
+    //         canSelectMany: this.canSelectMany,
+    //         matchOnDescription: this.matchOnDescription,
+    //         matchOnDetail: this.matchOnDetail,
+    //         activeItems: this.activeItems,
+    //         selectedItems: this.selectedItems
+    //     });
+    // }
 }

--- a/packages/plugin-ext/src/plugin/quick-open.ts
+++ b/packages/plugin-ext/src/plugin/quick-open.ts
@@ -616,6 +616,7 @@ export class QuickPickExt<T extends theia.QuickPickItem> extends QuickInputExt i
             this._handlesToItems.set(i, item);
             this._itemsToHandles.set(item, i);
         });
+        items.forEach((item, i) => Object.assign(item, { handle: i }));
         this.update({
             items
         });


### PR DESCRIPTION
Signed-off-by: Igor Vinokur <ivinokur@redhat.com>

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->
Fixes a bug when quick pick items are not updated on the fly.

When a quick open widget is shown, set an instance of the monaco quick-input to the [sessions map](https://github.com/eclipse-theia/theia/blob/master/packages/plugin-ext/src/main/browser/quick-open-main.ts#L195).
When plugin request's a quick-input items update, they are set to the monaco quick-input instance from the map:
https://github.com/eclipse-theia/theia/blob/d3501165bb4e87c3612a1a02c34a1d16ab81802c/packages/plugin-ext/src/main/browser/quick-open-main.ts#L257-L262

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
1. Clone and compile the test plugin: https://github.com/microsoft/vscode-extension-samples/tree/main/quickinput-sample
2. Start hosted plugin
3. Execute the `Quick Input Samples` from the command palette.
4. Choose `quickOpen` and type something to the input box.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
