### PR TITLE
plugin: align `provideTasks` with vscode

### DIFF
--- a/packages/plugin-ext/src/common/plugin-api-rpc.ts
+++ b/packages/plugin-ext/src/common/plugin-api-rpc.ts
@@ -1773,7 +1773,7 @@ export const MAIN_RPC_CONTEXT = {
 };
 
 export interface TasksExt {
-    $provideTasks(handle: number, token?: CancellationToken): Promise<TaskDto[] | undefined>;
+    $provideTasks(handle: number): Promise<TaskDto[] | undefined>;
     $resolveTask(handle: number, task: TaskDto, token?: CancellationToken): Promise<TaskDto | undefined>;
     $onDidStartTask(execution: TaskExecutionDto, terminalId: number): void;
     $onDidEndTask(id: number): void;

--- a/packages/plugin-ext/src/plugin/tasks/tasks.ts
+++ b/packages/plugin-ext/src/plugin/tasks/tasks.ts
@@ -29,6 +29,7 @@ import { TaskProviderAdapter } from './task-provider';
 import { Emitter, Event } from '@theia/core/lib/common/event';
 import { TerminalServiceExtImpl } from '../terminal-ext';
 import { UUID } from '@theia/core/shared/@phosphor/coreutils';
+import { CancellationToken } from '@theia/core/lib/common/cancellation';
 
 type ExecutionCallback = (resolvedDefinition: theia.TaskDefinition) => Thenable<theia.Pseudoterminal>;
 export class TasksExtImpl implements TasksExt {
@@ -164,10 +165,10 @@ export class TasksExtImpl implements TasksExt {
         throw new Error('Task was not successfully transformed into a task config');
     }
 
-    $provideTasks(handle: number, token: theia.CancellationToken): Promise<TaskDto[] | undefined> {
+    $provideTasks(handle: number): Promise<TaskDto[] | undefined> {
         const adapter = this.adaptersMap.get(handle);
         if (adapter) {
-            return adapter.provideTasks(token).then(tasks => {
+            return adapter.provideTasks(CancellationToken.None).then(tasks => {
                 if (tasks) {
                     for (const task of tasks) {
                         if (task.taskType === 'customExecution') {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

Fixes: https://github.com/eclipse-theia/theia/issues/8662.

The pull-request updates `$provideTasks` (ext-side) with the expectations of vscode and uses the `CancellationToken.None` when calling `provideTasks` from the task provider adapter.

- [vscode $provideTasks](https://github.com/microsoft/vscode/blob/622cb03f7e070a9670c94bae1a45d78d7181fbd4/src/vs/workbench/api/common/extHostTask.ts#L535)
- [vscode $provideTasks CancellationToken.None](https://github.com/microsoft/vscode/blob/622cb03f7e070a9670c94bae1a45d78d7181fbd4/src/vs/workbench/api/common/extHostTask.ts#L550-L552)
- [protocol](https://github.com/microsoft/vscode/blob/622cb03f7e070a9670c94bae1a45d78d7181fbd4/src/vs/workbench/api/common/extHost.protocol.ts#L1611)

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

1. update `vscode.typescript-language-features` plugin to `1.50.0`: 
    - https://open-vsx.org/extension/vscode/typescript/1.50.0
2. start the application with a typescript project (ex: theia).
3. open the `npm scripts` view in the explorer, the view should be populated.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

#### Additional Information

Prerequisite for https://github.com/eclipse-theia/theia/pull/10049.

Signed-off-by: vince-fugnitto <vincent.fugnitto@ericsson.com>