### PR TITLE
fix: Avoid redirect loop for Webviews

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## v1.18.0 - 9/30/2021
 
 - [core, outline-view, file-system, workspace] added breadcrumbs contribution points and renderers to `core` and contributions to other packages. [#9920](https://github.com/eclipse-theia/theia/pull/9920)
+- [plugin] Avoid infinite redirect loop for webview [#5007](https://github.com/eclipse-theia/theia/issues/5007)
 
 <a name="breaking_changes_1.18.0">[Breaking Changes:](#breaking_changes_1.18.0)</a>
 

--- a/packages/plugin-ext/src/main/browser/webview/pre/service-worker.js
+++ b/packages/plugin-ext/src/main/browser/webview/pre/service-worker.js
@@ -248,7 +248,7 @@ async function processLocalhostRequest(event, requestUrl) {
     const origin = requestUrl.origin;
 
     const resolveRedirect = redirectOrigin => {
-        if (!redirectOrigin) {
+        if (!redirectOrigin || requestUrl.origin === redirectOrigin) {
             return fetch(event.request);
         }
         const location = event.request.url.replace(new RegExp(`^${requestUrl.origin}(/|$)`), `${redirectOrigin}$1`);


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

fix (at least a part of) #5007

When the "from" and the "to" location are the same, a redirect should
not be triggered otherwise it will loop and end with a
net::ERR_TOO_MANY_REDIRECTS error

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

- install VS Code AtlasMap 0.0.7
- Launch command "Open AtlasMap" from command palette

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
