### PR TITLE
5007 allow downloads in webview

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## v1.18.0 - 9/30/2021
 
 - [core, outline-view, file-system, workspace] added breadcrumbs contribution points and renderers to `core` and contributions to other packages. [#9920](https://github.com/eclipse-theia/theia/pull/9920)
+- [plugin] Avoid infinite redirect loop for webview [#5007](https://github.com/eclipse-theia/theia/issues/5007)
 
 <a name="breaking_changes_1.18.0">[Breaking Changes:](#breaking_changes_1.18.0)</a>
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - [core, outline-view, file-system, workspace] added breadcrumbs contribution points and renderers to `core` and contributions to other packages. [#9920](https://github.com/eclipse-theia/theia/pull/9920)
 - [plugin] Avoid infinite redirect loop for webview [#5007](https://github.com/eclipse-theia/theia/issues/5007)
+- [plugin] Allow downloads for webview [#5007](https://github.com/eclipse-theia/theia/issues/5007)
 
 <a name="breaking_changes_1.18.0">[Breaking Changes:](#breaking_changes_1.18.0)</a>
 

--- a/packages/plugin-ext/src/main/browser/webview/pre/main.js
+++ b/packages/plugin-ext/src/main/browser/webview/pre/main.js
@@ -477,7 +477,7 @@
                 const newFrame = document.createElement('iframe');
                 newFrame.setAttribute('id', 'pending-frame');
                 newFrame.setAttribute('frameborder', '0');
-                newFrame.setAttribute('sandbox', options.allowScripts ? 'allow-scripts allow-forms allow-same-origin' : 'allow-same-origin');
+                newFrame.setAttribute('sandbox', options.allowScripts ? 'allow-scripts allow-forms allow-same-origin allow-downloads' : 'allow-same-origin');
                 if (host.fakeLoad) {
                     // We should just be able to use srcdoc, but I wasn't
                     // seeing the service worker applying properly.

--- a/packages/plugin-ext/src/main/browser/webview/pre/service-worker.js
+++ b/packages/plugin-ext/src/main/browser/webview/pre/service-worker.js
@@ -248,7 +248,7 @@ async function processLocalhostRequest(event, requestUrl) {
     const origin = requestUrl.origin;
 
     const resolveRedirect = redirectOrigin => {
-        if (!redirectOrigin) {
+        if (!redirectOrigin || requestUrl.origin === redirectOrigin) {
             return fetch(event.request);
         }
         const location = event.request.url.replace(new RegExp(`^${requestUrl.origin}(/|$)`), `${redirectOrigin}$1`);

--- a/packages/plugin-ext/src/main/browser/webview/webview.ts
+++ b/packages/plugin-ext/src/main/browser/webview/webview.ts
@@ -249,7 +249,7 @@ export class WebviewWidget extends BaseWidget implements StatefulWidget {
 
         const element = document.createElement('iframe');
         element.className = 'webview';
-        element.sandbox.add('allow-scripts', 'allow-forms', 'allow-same-origin');
+        element.sandbox.add('allow-scripts', 'allow-forms', 'allow-same-origin', 'allow-downloads');
         element.setAttribute('src', `${this.externalEndpoint}/index.html?id=${this.identifier.id}`);
         element.style.border = 'none';
         element.style.width = '100%';


### PR DESCRIPTION
#### What it does

Allow downloads of resources provided by the application displayed in the webview.

relates to #5007

based on https://github.com/eclipse-theia/theia/pull/10063

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

- Install VS Code AtlasMap
- Call command `Open AtlasMap`
- Import an *.adm file (for instance https://github.com/atlasmap/atlasmap/raw/atlasmap-2.2.3/standalone/src/test/resources/json-schema-source-to-xml-schema-target.adm )
- Click on Top left AtlasMap dropdown, then `Export the current mappings adn support files into a catalog`
- Click confirm
![DemoAtlasMapTheiaExport](https://user-images.githubusercontent.com/1105127/132510413-df1f7b6e-9095-4616-af74-4bff01ac8ce9.gif)



#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
