### PR TITLE
`CodeAction` and `CodeActionProviderMetaData` fields added

### DIFF
--- a/packages/plugin-ext/src/common/plugin-api-rpc-model.ts
+++ b/packages/plugin-ext/src/common/plugin-api-rpc-model.ts
@@ -343,6 +343,8 @@ export interface CodeAction {
     edit?: WorkspaceEdit;
     diagnostics?: MarkerData[];
     kind?: string;
+    disabled?: { reason: string };
+    isPreferred?: boolean;
 }
 
 export interface CodeActionContext {

--- a/packages/plugin-ext/src/main/browser/languages-main.ts
+++ b/packages/plugin-ext/src/main/browser/languages-main.ts
@@ -1013,6 +1013,7 @@ function toMonacoAction(action: CodeAction): monaco.languages.CodeAction {
     return {
         ...action,
         diagnostics: action.diagnostics ? action.diagnostics.map(m => toMonacoMarkerData(m)) : undefined,
+        disabled: action.disabled?.reason,
         edit: action.edit ? toMonacoWorkspaceEdit(action.edit) : undefined
     };
 }

--- a/packages/plugin-ext/src/plugin/languages/code-action.ts
+++ b/packages/plugin-ext/src/plugin/languages/code-action.ts
@@ -92,7 +92,9 @@ export class CodeActionAdapter {
                     command: this.commands.converter.toSafeCommand(candidate.command, toDispose),
                     diagnostics: candidate.diagnostics && candidate.diagnostics.map(Converter.convertDiagnosticToMarkerData),
                     edit: candidate.edit && Converter.fromWorkspaceEdit(candidate.edit),
-                    kind: candidate.kind && candidate.kind.value
+                    kind: candidate.kind && candidate.kind.value,
+                    disabled: candidate.disabled,
+                    isPreferred: candidate.isPreferred
                 });
             }
         }

--- a/packages/plugin-ext/src/plugin/types-impl.ts
+++ b/packages/plugin-ext/src/plugin/types-impl.ts
@@ -1216,6 +1216,10 @@ export class CodeAction {
 
     kind?: CodeActionKind;
 
+    disabled?: { reason: string };
+
+    isPreferred?: boolean;
+
     constructor(title: string, kind?: CodeActionKind) {
         this.title = title;
         this.kind = kind;

--- a/packages/plugin/src/theia.d.ts
+++ b/packages/plugin/src/theia.d.ts
@@ -7523,6 +7523,16 @@ declare module '@theia/plugin' {
         kind?: CodeActionKind;
 
         /**
+         * Marks that the code action cannot currently be applied.
+         */
+        disabled?: { reason: string };
+
+        /**
+         * Marks this as a preferred action.
+         */
+        isPreferred?: boolean;
+
+        /**
          * Creates a new code action.
          *
          * A code action must have at least a [title](#CodeAction.title) and [edits](#CodeAction.edit)
@@ -7571,6 +7581,13 @@ declare module '@theia/plugin' {
          * may list our every specific kind they provide, such as `CodeActionKind.Refactor.Extract.append('function`)`
          */
         readonly providedCodeActionKinds?: ReadonlyArray<CodeActionKind>;
+
+        /**
+         * Documentation from the provider is shown in the code actions menu
+         *
+         * At most one documentation entry will be shown per provider.
+         */
+        documentation?: ReadonlyArray<{ command: Command, kind: CodeActionKind }>
     }
 
     /**


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

Fixes #9989

- added support for the `disabled` and `isPreferred` fields to the `CodeAction` interface
- added support for the `documentation` field to `CodeActionProviderMetaData` interface


#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

1. include the [vscode-code-action-test](https://github.com/vince-fugnitto/vscode-code-action-test/releases/download/0.0.1/code-actions-sample-0.0.2.vsix) test plugin
2. start the application and open a markdown file
3. type `:)` in the file
4. the quick-fix should display entries - the cat emoji entry is explicitly hidden (will be present on master)
   - [reference](https://github.com/vince-fugnitto/vscode-code-action-test/blob/54dd7898b5f0834eb70bca56c6a267b67a71d2a9/src/extension.ts#L48)

#### Review checklist

- [X] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
