### PR TITLE
monaco: fix focused quick-input

### DIFF
--- a/packages/core/src/browser/common-frontend-contribution.ts
+++ b/packages/core/src/browser/common-frontend-contribution.ts
@@ -1225,6 +1225,8 @@ export class CommonFrontendContribution implements FrontendApplicationContributi
             { id: 'list.hoverBackground', defaults: { dark: '#2A2D2E', light: '#F0F0F0' }, description: 'List/Tree background when hovering over items using the mouse.' },
             { id: 'list.hoverForeground', description: 'List/Tree foreground when hovering over items using the mouse.' },
             { id: 'list.filterMatchBackground', defaults: { dark: 'editor.findMatchHighlightBackground', light: 'editor.findMatchHighlightBackground' }, description: 'Background color of the filtered match.' },
+            { id: 'list.highlightForeground', defaults: { dark: '#18A3FF', light: '#0066BF', hc: 'focusBorder' }, description: 'List/Tree foreground color of the match highlights when searching inside the list/tree.' },
+            { id: 'list.focusHighlightForeground', defaults: { dark: 'list.highlightForeground', light: 'list.activeSelectionForeground', hc: 'list.highlightForeground' }, description: 'List/Tree foreground color of the match highlights on actively focused items when searching inside the list/tree.' },
             { id: 'tree.inactiveIndentGuidesStroke', defaults: { dark: Color.transparent('tree.indentGuidesStroke', 0.4), light: Color.transparent('tree.indentGuidesStroke', 0.4), hc: Color.transparent('tree.indentGuidesStroke', 0.4) }, description: 'Tree stroke color for the inactive indentation guides.' },
 
             // Editor Group & Tabs colors should be aligned with https://code.visualstudio.com/api/references/theme-color#editor-groups-tabs
@@ -1467,6 +1469,27 @@ export class CommonFrontendContribution implements FrontendApplicationContributi
                     light: 'sideBar.foreground',
                     hc: 'sideBar.foreground'
                 }, description: 'Quick Input foreground color. The Quick Input widget is the container for views like the color theme picker.'
+            },
+            {
+                id: 'quickInput.list.focusBackground', defaults: {
+                    dark: undefined,
+                    light: undefined,
+                    hc: undefined
+                }, description: 'quickInput.list.focusBackground deprecation. Please use quickInputList.focusBackground instead'
+            },
+            {
+                id: 'quickInputList.focusForeground', defaults: {
+                    dark: 'list.activeSelectionForeground',
+                    light: 'list.activeSelectionForeground',
+                    hc: 'list.activeSelectionForeground'
+                }, description: 'Quick picker foreground color for the focused item'
+            },
+            {
+                id: 'quickInputList.focusBackground', defaults: {
+                    dark: 'list.activeSelectionBackground',
+                    light: 'list.activeSelectionBackground',
+                    hc: undefined
+                }, description: 'Quick picker background color for the focused item.'
             },
 
             // Panel colors should be aligned with https://code.visualstudio.com/api/references/theme-color#panel-colors

--- a/packages/monaco/src/browser/style/index.css
+++ b/packages/monaco/src/browser/style/index.css
@@ -140,7 +140,24 @@
 }
 
 .quick-input-list .monaco-list-row.focused {
-  background-color: var(--theia-quickInput-list-focusBackground) !important;
+  background-color: var(--theia-quickInputList-focusBackground) !important;
+}
+
+.quick-input-list .monaco-keybinding > .monaco-keybinding-key {
+  color: inherit !important;
+}
+
+.quick-input-list .monaco-list-row.focused,
+.quick-input-list .monaco-list-row.focused .monaco-highlighted-label,
+.quick-input-list .monaco-list-row.focused .monaco-highlighted-label .codicon,
+.quick-input-list .monaco-list-row.focused .quick-input-list-entry .quick-input-list-separator,
+.quick-input-list .monaco-list-row.focused .monaco-highlighted-label .monaco-keybinding .monaco-keybinding-key,
+.quick-input-list .monaco-list-row.focused .monaco-highlighted-label .monaco-keybinding .monaco-keybinding-key-separator {
+  color: var(--theia-quickInputList-focusForeground) !important;
+}
+
+.quick-input-list .monaco-list-row.focused .monaco-highlighted-label .highlight {
+  color: var(--theia-list-focusHighlightForeground) !important;
 }
 
 .monaco-list-rows


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

The commit fixes the monaco `quick-input` styling for entries which are focused by end-users.
The change includes additional vscode colors (registered to the `ColorRegistry`) and applies them to the focused elements.

The changes should:
- properly apply the focused background color similarly to vscode.
- properly style foreground elements for focused entries including label, keybindings, separators.
- properly style fuzzy results (highlights) when entries are focused so they do not clash with the focused background.

https://user-images.githubusercontent.com/40359487/132726065-59144179-438d-4a3b-958d-bec1e600beef.mp4

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

1. start the application and use multiple themes (light and dark).
2. confirm that selected entries (through up and down arrow) are properly styled.
3. confirm that labels, keybindings and separators are displayed properly when focused and otherwise.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

Signed-off-by: vince-fugnitto <vincent.fugnitto@ericsson.com>