### PR TITLE
Align the menu separator with vscode

### DIFF
--- a/packages/core/src/browser/style/menus.css
+++ b/packages/core/src/browser/style/menus.css
@@ -160,13 +160,14 @@
 
 .p-Menu-itemSubmenuIcon {
   width: var(--theia-icon-size);
-  padding: 0px 4px 0px 0px;
+  padding: 0px 10px 0px 0px;
 }
 
 
 .p-Menu-item[data-type='separator'] > div {
   padding: 0;
   height: 9px;
+  opacity: 0.36;
 }
 
 
@@ -176,6 +177,14 @@
   position: relative;
   top: 4px;
   border-top: var(--theia-border-width) solid var(--theia-menu-separatorBackground);
+}
+
+.p-Menu-item[data-type='separator'] > div.p-Menu-itemIcon::after {
+  margin-left: 12px;
+}
+
+.p-Menu-item[data-type='separator'] > div.p-Menu-itemSubmenuIcon::after {
+  margin-right: 12px;
 }
 
 .p-Menu-itemIcon::before,


### PR DESCRIPTION
#### What it does

Aligns the menu separator with vscode. Includes a lower opacity and margins on the left and right side of the separators. See [vscode's menu](https://user-images.githubusercontent.com/4377073/132839616-4bd238d8-65e6-49b8-9a16-6c507d214c4e.png) and [Theia's new menu](https://user-images.githubusercontent.com/4377073/132839586-0af3c7e3-cd48-487c-b7e8-1e811ad68438.png).

#### How to test

1. Open entries of different menus (main menu, context menu)
2. Compare the changes to vscode
3. Use different themes and assert that the separators behave as expected

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
