### PR TITLE
cli: support downloading `.theia` plugins

### DIFF
--- a/dev-packages/cli/src/download-plugins.ts
+++ b/dev-packages/cli/src/download-plugins.ts
@@ -162,6 +162,8 @@ async function downloadPluginAsync(failures: string[], plugin: string, pluginUrl
         fileExt = '.tar.gz';
     } else if (pluginUrl.endsWith('vsix')) {
         fileExt = '.vsix';
+    } else if (pluginUrl.endsWith('theia')) {
+        fileExt = '.theia'; // theia plugins.
     } else {
         failures.push(red(`error: '${plugin}' has an unsupported file type: '${pluginUrl}'`));
         return;
@@ -210,7 +212,7 @@ async function downloadPluginAsync(failures: string[], plugin: string, pluginUrl
         return;
     }
 
-    if (fileExt === '.vsix' && packed === true) {
+    if ((fileExt === '.vsix' || fileExt === '.theia') && packed === true) {
         // Download .vsix without decompressing.
         const file = createWriteStream(targetPath);
         await pipelineAsPromised(response.body, file);


### PR DESCRIPTION



<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

Fixes: https://github.com/eclipse-theia/theia/issues/9264.

The pull-request updates the `download-plugins` script to allow the downloading of `.theia` files (theia-plugins).
Previously, the operation would fail as it was treated as an unsupported file type.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

1. include the following entry under `theiaPlugins`:

```json
"theia-helloworld": "https://github.com/vince-fugnitto/theia-plugin-helloworld/releases/download/0.0.1/hello.theia"
```

2. perform `yarn download:plugins`
3. confirm the download is successful, and the resource is present under the `plugins/` folder
4. start the application
5. execute the command `theia: hello world` and confirm it is successul

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

Signed-off-by: vince-fugnitto <vincent.fugnitto@ericsson.com>
