### PR TITLE
support hiding the status bar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - [task] `TaskDefinition.properties.required` is now optional to align with the specification [#10015](https://github.com/eclipse-theia/theia/pull/10015)
 - [core] `setTopPanelVisibily` renamed to `setTopPanelVisibility` [#10020](https://github.com/eclipse-theia/theia/pull/10020)
 - [application-manager] break `rebuild` API: second argument is now an optional object instead of an optional array.
+- [core] added `PreferenceService` to constructor arguments of `StatusBarImpl`. [#10092](https://github.com/eclipse-theia/theia/pull/10092)
 
 ## v1.17.2 - 9/1/2021
 

--- a/packages/core/src/browser/common-frontend-contribution.ts
+++ b/packages/core/src/browser/common-frontend-contribution.ts
@@ -218,9 +218,9 @@ export namespace CommonCommands {
         label: 'Toggle Bottom Panel'
     };
     export const TOGGLE_STATUS_BAR: Command = {
-        id: 'core.toggle.statusbar',
+        id: 'workbench.action.toggleStatusbarVisibility',
         category: VIEW_CATEGORY,
-        label: 'Toggle Status Bar'
+        label: 'Toggle Status Bar Visibility'
     };
     export const TOGGLE_MAXIMIZED: Command = {
         id: 'core.toggleMaximized',
@@ -534,7 +534,8 @@ export class CommonFrontendContribution implements FrontendApplicationContributi
         });
         registry.registerMenuAction(CommonMenus.VIEW_LAYOUT, {
             commandId: CommonCommands.TOGGLE_STATUS_BAR.id,
-            order: '1'
+            order: '1',
+            label: 'Toggle Status Bar'
         });
         registry.registerMenuAction(CommonMenus.VIEW_LAYOUT, {
             commandId: CommonCommands.COLLAPSE_ALL_PANELS.id,
@@ -962,10 +963,6 @@ export class CommonFrontendContribution implements FrontendApplicationContributi
             {
                 command: CommonCommands.TOGGLE_BOTTOM_PANEL.id,
                 keybinding: 'ctrlcmd+j',
-            },
-            {
-                command: CommonCommands.TOGGLE_STATUS_BAR.id,
-                keybinding: 'ctrlcmd+b',
             },
             {
                 command: CommonCommands.COLLAPSE_ALL_PANELS.id,

--- a/packages/core/src/browser/common-frontend-contribution.ts
+++ b/packages/core/src/browser/common-frontend-contribution.ts
@@ -217,6 +217,11 @@ export namespace CommonCommands {
         category: VIEW_CATEGORY,
         label: 'Toggle Bottom Panel'
     };
+    export const TOGGLE_STATUS_BAR: Command = {
+        id: 'core.toggle.statusbar',
+        category: VIEW_CATEGORY,
+        label: 'Toggle Status Bar'
+    };
     export const TOGGLE_MAXIMIZED: Command = {
         id: 'core.toggleMaximized',
         category: VIEW_CATEGORY,
@@ -528,8 +533,12 @@ export class CommonFrontendContribution implements FrontendApplicationContributi
             order: '0'
         });
         registry.registerMenuAction(CommonMenus.VIEW_LAYOUT, {
-            commandId: CommonCommands.COLLAPSE_ALL_PANELS.id,
+            commandId: CommonCommands.TOGGLE_STATUS_BAR.id,
             order: '1'
+        });
+        registry.registerMenuAction(CommonMenus.VIEW_LAYOUT, {
+            commandId: CommonCommands.COLLAPSE_ALL_PANELS.id,
+            order: '2'
         });
 
         registry.registerMenuAction(SHELL_TABBAR_CONTEXT_MENU, {
@@ -771,6 +780,9 @@ export class CommonFrontendContribution implements FrontendApplicationContributi
                 }
             }
         });
+        commandRegistry.registerCommand(CommonCommands.TOGGLE_STATUS_BAR, {
+            execute: () => this.preferenceService.updateValue('workbench.statusBar.visible', !this.preferences['workbench.statusBar.visible'])
+        });
         commandRegistry.registerCommand(CommonCommands.TOGGLE_MAXIMIZED, {
             isEnabled: (event?: Event) => this.canToggleMaximized(event),
             isVisible: (event?: Event) => this.canToggleMaximized(event),
@@ -950,6 +962,10 @@ export class CommonFrontendContribution implements FrontendApplicationContributi
             {
                 command: CommonCommands.TOGGLE_BOTTOM_PANEL.id,
                 keybinding: 'ctrlcmd+j',
+            },
+            {
+                command: CommonCommands.TOGGLE_STATUS_BAR.id,
+                keybinding: 'ctrlcmd+b',
             },
             {
                 command: CommonCommands.COLLAPSE_ALL_PANELS.id,

--- a/packages/core/src/browser/core-preferences.ts
+++ b/packages/core/src/browser/core-preferences.ts
@@ -113,6 +113,11 @@ export const corePreferenceSchema: PreferenceSchema = {
             default: false,
             description: 'Controls whether to suppress notification popups.'
         },
+        'workbench.statusBar.visible': {
+            type: 'boolean',
+            default: true,
+            description: 'Controls the visibility of the status bar at the bottom of the workbench.'
+        },
         'workbench.tree.renderIndentGuides': {
             type: 'string',
             enum: ['onHover', 'none', 'always'],
@@ -135,6 +140,7 @@ export interface CoreConfiguration {
     'workbench.colorTheme': string;
     'workbench.iconTheme': string | null;
     'workbench.silentNotifications': boolean;
+    'workbench.statusBar.visible': boolean;
     'workbench.tree.renderIndentGuides': 'onHover' | 'none' | 'always';
 }
 

--- a/packages/core/src/browser/keybinding.spec.ts
+++ b/packages/core/src/browser/keybinding.spec.ts
@@ -36,7 +36,9 @@ import * as os from '../common/os';
 import * as chai from 'chai';
 import * as sinon from 'sinon';
 import { Emitter, Event } from '../common/event';
-import { PreferenceService } from './preferences';
+import { bindPreferenceService } from './frontend-application-bindings';
+import { FrontendApplicationConfigProvider } from './frontend-application-config-provider';
+import { ApplicationProps } from '@theia/application-package/lib/';
 
 disableJSDOM();
 
@@ -88,7 +90,7 @@ before(async () => {
         bind(ContextKeyService).toSelf().inSingletonScope();
         bind(FrontendApplicationStateService).toSelf().inSingletonScope();
         bind(CorePreferences).toConstantValue(<CorePreferences>{});
-        bind(PreferenceService).toSelf().inSingletonScope();
+        bindPreferenceService(bind);
     });
 
     testContainer.load(module);
@@ -104,6 +106,10 @@ describe('keybindings', () => {
 
     before(() => {
         disableJSDOM = enableJSDOM();
+        FrontendApplicationConfigProvider.set({
+            ...ApplicationProps.DEFAULT.frontend.config,
+            'applicationName': 'test'
+        });
     });
 
     after(() => {
@@ -539,4 +545,3 @@ function isKeyBindingRegistered(keybinding: Keybinding): boolean {
     );
     return keyBindingFound;
 }
-

--- a/packages/core/src/browser/keybinding.spec.ts
+++ b/packages/core/src/browser/keybinding.spec.ts
@@ -36,6 +36,7 @@ import * as os from '../common/os';
 import * as chai from 'chai';
 import * as sinon from 'sinon';
 import { Emitter, Event } from '../common/event';
+import { PreferenceService } from './preferences';
 
 disableJSDOM();
 
@@ -87,6 +88,7 @@ before(async () => {
         bind(ContextKeyService).toSelf().inSingletonScope();
         bind(FrontendApplicationStateService).toSelf().inSingletonScope();
         bind(CorePreferences).toConstantValue(<CorePreferences>{});
+        bind(PreferenceService).toSelf().inSingletonScope();
     });
 
     testContainer.load(module);

--- a/packages/core/src/browser/status-bar/status-bar.tsx
+++ b/packages/core/src/browser/status-bar/status-bar.tsx
@@ -86,7 +86,7 @@ export class StatusBarImpl extends ReactWidget implements StatusBar {
         delete this.scrollOptions;
         this.id = 'theia-statusBar';
         this.addClass('noselect');
-        // Don't show the status bar until get `workbench.statusBar.visible` preference with `true` value.
+        // Hide the status bar until the `workbench.statusBar.visible` preference returns with a `true` value.
         this.hide();
         this.preferences.ready.then(() => {
             const preferenceValue = this.preferences.get<boolean>('workbench.statusBar.visible', true);

--- a/packages/core/src/browser/status-bar/status-bar.tsx
+++ b/packages/core/src/browser/status-bar/status-bar.tsx
@@ -21,6 +21,7 @@ import { CommandService } from '../../common';
 import { ReactWidget } from '../widgets/react-widget';
 import { FrontendApplicationStateService } from '../frontend-application-state';
 import { LabelParser, LabelIcon } from '../label-parser';
+import { PreferenceService } from '../preferences';
 
 export interface StatusBarEntry {
     /**
@@ -78,12 +79,26 @@ export class StatusBarImpl extends ReactWidget implements StatusBar {
     constructor(
         @inject(CommandService) protected readonly commands: CommandService,
         @inject(LabelParser) protected readonly entryService: LabelParser,
-        @inject(FrontendApplicationStateService) protected readonly applicationStateService: FrontendApplicationStateService
+        @inject(FrontendApplicationStateService) protected readonly applicationStateService: FrontendApplicationStateService,
+        @inject(PreferenceService) protected readonly preferences: PreferenceService,
     ) {
         super();
         delete this.scrollOptions;
         this.id = 'theia-statusBar';
         this.addClass('noselect');
+        // Don't show the status bar until get `workbench.statusBar.visible` preference with `true` value.
+        this.hide();
+        this.preferences.ready.then(() => {
+            const preferenceValue = this.preferences.get<boolean>('workbench.statusBar.visible', true);
+            this.setHidden(!preferenceValue);
+        });
+        this.toDispose.push(
+            this.preferences.onPreferenceChanged(preference => {
+                if (preference.preferenceName === 'workbench.statusBar.visible') {
+                    this.setHidden(!preference.newValue);
+                }
+            })
+        );
     }
 
     protected get ready(): Promise<void> {


### PR DESCRIPTION
Signed-off-by: Esther Perelman <esther.perelman@sap.com>

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
This PR supports hiding the status bar (blue bar on the bottom) in 3 ways:
1. By selecting the `Toggle status Bar` command from the `view` menu: 
![image](https://user-images.githubusercontent.com/71729183/133214868-9dd52652-2601-4643-986e-6cd58c7a2dfc.png)

2. By using the key binding: `ctrlcmd+b`.
3. By updating the `workbench.statusBar.visible` setting in the preferences file.
![image](https://user-images.githubusercontent.com/71729183/133215056-bbb3b524-8dc2-4fb3-8645-b668a5014071.png)

#### How to test

- Validate that the status bar appears for the first time,
- Play around with the 3 ways mentions above...

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
