### PR TITLE
monaco: properly pass `options` to `input`

### DIFF
--- a/examples/api-samples/src/browser/menu/sample-menu-contribution.ts
+++ b/examples/api-samples/src/browser/menu/sample-menu-contribution.ts
@@ -14,8 +14,12 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
-import { Command, CommandContribution, CommandRegistry, MAIN_MENU_BAR, MenuContribution, MenuModelRegistry, MenuNode, SubMenuOptions } from '@theia/core/lib/common';
-import { injectable, interfaces } from '@theia/core/shared/inversify';
+import { QuickInputService } from '@theia/core/lib/browser';
+import {
+    Command, CommandContribution, CommandRegistry, MAIN_MENU_BAR,
+    MenuContribution, MenuModelRegistry, MenuNode, MessageService, SubMenuOptions
+} from '@theia/core/lib/common';
+import { inject, injectable, interfaces } from '@theia/core/shared/inversify';
 
 const SampleCommand: Command = {
     id: 'sample-command',
@@ -25,9 +29,21 @@ const SampleCommand2: Command = {
     id: 'sample-command2',
     label: 'Sample Command2'
 };
+const SampleQuickInputCommand: Command = {
+    id: 'sample-quick-input-command',
+    category: 'Quick Input',
+    label: 'Test Positive Integer'
+};
 
 @injectable()
 export class SampleCommandContribution implements CommandContribution {
+
+    @inject(QuickInputService)
+    protected readonly quickInputService: QuickInputService;
+
+    @inject(MessageService)
+    protected readonly messageService: MessageService;
+
     registerCommands(commands: CommandRegistry): void {
         commands.registerCommand(SampleCommand, {
             execute: () => {
@@ -37,6 +53,28 @@ export class SampleCommandContribution implements CommandContribution {
         commands.registerCommand(SampleCommand2, {
             execute: () => {
                 alert('This is sample command2!');
+            }
+        });
+        commands.registerCommand(SampleQuickInputCommand, {
+            execute: async () => {
+                const result = await this.quickInputService.input({
+                    placeHolder: 'Please provide a positive integer',
+                    validateInput: async (input: string) => {
+                        const numericValue = Number(input);
+                        if (isNaN(numericValue)) {
+                            return 'Invalid: NaN';
+                        } else if (numericValue % 2 === 1) {
+                            return 'Invalid: Odd Number';
+                        } else if (numericValue < 0) {
+                            return 'Invalid: Negative Number';
+                        } else if (!Number.isInteger(numericValue)) {
+                            return 'Invalid: Only Integers Allowed';
+                        }
+                    }
+                });
+                if (result) {
+                    this.messageService.info(`Positive Integer: ${result}`);
+                }
             }
         });
     }

--- a/packages/monaco/src/browser/monaco-quick-input-service.ts
+++ b/packages/monaco/src/browser/monaco-quick-input-service.ts
@@ -182,8 +182,17 @@ export class MonacoQuickInputService implements QuickInputService {
     }
 
     input(options?: InputOptions, token?: CancellationToken): Promise<string | undefined> {
-        return this.monacoService.input();
+        let inputOptions: monaco.quickInput.IInputOptions | undefined;
+        if (options) {
+            const { validateInput, ...props } = options;
+            inputOptions = { ...props };
+            if (validateInput) {
+                inputOptions.validateInput = async input => validateInput(input);
+            }
+        }
+        return this.monacoService.input(inputOptions, token);
     }
+
     pick<T extends QuickPickItem, O extends PickOptions<T>>(picks: T[] | Promise<T[]>, options?: O, token?: CancellationToken):
         Promise<(O extends { canPickMany: true; } ? T[] : T) | undefined> {
         return this.monacoService.pick(picks, options, token);


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

Fixes: #10094 

The pull-request addresses the issue where the `options` parameter used in `QuickInputService.input` was not being passed properly. This meant that configurations provided by callers were always disregarded.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

1. start the application
2. use <kbd>F1</kbd> to execute `Quick Input: Test Positive Integer`
3. confirm that options such as `placholder` and `validateInput` works correctly (positive integer allowed only)

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

Signed-off-by: vince-fugnitto <vincent.fugnitto@ericsson.com>