### PR TITLE
plugin: fix tree-searching in tree-views

### DIFF
--- a/packages/plugin-ext/src/main/browser/plugin-ext-frontend-module.ts
+++ b/packages/plugin-ext/src/main/browser/plugin-ext-frontend-module.ts
@@ -21,7 +21,7 @@ import '../../../src/main/browser/style/comments.css';
 import { ContainerModule } from '@theia/core/shared/inversify';
 import {
     FrontendApplicationContribution, WidgetFactory, bindViewContribution,
-    ViewContainerIdentifier, ViewContainer, createTreeContainer, TreeImpl, TreeWidget, TreeModelImpl, LabelProviderContribution, TreeProps
+    ViewContainerIdentifier, ViewContainer, createTreeContainer, TreeImpl, TreeWidget, TreeModelImpl, LabelProviderContribution
 } from '@theia/core/lib/browser';
 import { MaybePromise, CommandContribution, ResourceResolver, bindContributionProvider } from '@theia/core/lib/common';
 import { WebSocketConnectionProvider } from '@theia/core/lib/browser/messaging';
@@ -147,10 +147,12 @@ export default new ContainerModule((bind, unbind, isBound, rebind) => {
         createWidget: (identifier: TreeViewWidgetIdentifier) => {
             const child = createTreeContainer(container, {
                 contextMenuPath: VIEW_ITEM_CONTEXT_MENU,
-                search: true,
-                globalSelection: true
+                expandOnlyOnExpansionToggleClick: true,
+                expansionTogglePadding: 22,
+                globalSelection: true,
+                leftPadding: 8,
+                search: true
             });
-            child.rebind(TreeProps).toConstantValue({ leftPadding: 8, expansionTogglePadding: 22, expandOnlyOnExpansionToggleClick: true, });
             child.bind(TreeViewWidgetIdentifier).toConstantValue(identifier);
             child.bind(PluginTree).toSelf();
             child.rebind(TreeImpl).toService(PluginTree);


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

Fixes: https://github.com/eclipse-theia/theia/issues/10095

The pull-request fixes the bogus rebinding of `tree-props` which meant that we are not longer able to `search` as a result.
Instead of rebinding the `props` (losing them), we pass them correctly.

https://user-images.githubusercontent.com/40359487/133282500-13d5b908-a250-4c96-87e4-ab97dfd79101.mp4


#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

1. start the application
2. open the `npm scripts` view
3. start typing and the tree-search should appear

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

Signed-off-by: vince-fugnitto <vincent.fugnitto@ericsson.com>