### PR TITLE
fix electron frontend debug configuration

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -151,7 +151,10 @@
       "type": "chrome",
       "request": "attach",
       "name": "Attach to Electron Frontend",
-      "port": 9222
+      "port": 9222,
+      "sourceMapPathOverrides": {
+        "webpack://@theia/example-electron/*": "${workspaceFolder}/examples/electron/*"
+      }
     },
     {
       "name": "Launch VS Code Tests",


### PR DESCRIPTION
For some reason TS files are loaded as
`webpack://@theia/example-electron/*` in Electron's Chrome DevTools, and
it confused VS Code's JS debugger.

Add a `sourceMapPathOverride` to point the debugger to the right place
on disk.

Closes https://github.com/eclipse-theia/theia/pull/9827

#### How to test

- Build the Electron example application.
- Place breakpoints in frontend code.
- Run the `Launch Electron Backend & Frontend` debug configuration.
- Breakpoints should be attached and hit.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)