### PR TITLE
fix scrollToAlignment of TreeWidget to align vscode

### DIFF
--- a/packages/core/src/browser/shell/application-shell.ts
+++ b/packages/core/src/browser/shell/application-shell.ts
@@ -80,6 +80,9 @@ export class DockPanelRenderer implements DockLayout.IRenderer {
 
     readonly tabBarClasses: string[] = [];
 
+    protected readonly onTabActivateRequestedEmitter = new Emitter<void>();
+    readonly onTabActivateRequested = this.onTabActivateRequestedEmitter.event;
+
     constructor(
         @inject(TabBarRendererFactory) protected readonly tabBarRendererFactory: () => TabBarRenderer,
         @inject(TabBarToolbarRegistry) protected readonly tabBarToolbarRegistry: TabBarToolbarRegistry,
@@ -106,6 +109,7 @@ export class DockPanelRenderer implements DockLayout.IRenderer {
         tabBar.disposed.connect(() => renderer.dispose());
         renderer.contextMenuPath = SHELL_TABBAR_CONTEXT_MENU;
         tabBar.currentChanged.connect(this.onCurrentTabChanged, this);
+        tabBar.tabActivateRequested.connect(() => this.onTabActivateRequestedEmitter.fire());
         return tabBar;
     }
 
@@ -204,6 +208,9 @@ export class ApplicationShell extends Widget {
 
     protected readonly onDidChangeCurrentWidgetEmitter = new Emitter<FocusTracker.IChangedArgs<Widget>>();
     readonly onDidChangeCurrentWidget = this.onDidChangeCurrentWidgetEmitter.event;
+
+    protected readonly onTabActivateInMainPanelEmitter = new Emitter<void>();
+    readonly onTabActivateInMainPanel = this.onTabActivateInMainPanelEmitter.event;
 
     /**
      * Construct a new application shell.
@@ -471,6 +478,7 @@ export class ApplicationShell extends Widget {
         const renderer = this.dockPanelRendererFactory();
         renderer.tabBarClasses.push(MAIN_BOTTOM_AREA_CLASS);
         renderer.tabBarClasses.push(MAIN_AREA_CLASS);
+        renderer.onTabActivateRequested(() => this.onTabActivateInMainPanelEmitter.fire());
         const dockPanel = new TheiaDockPanel({
             mode: 'multiple-document',
             renderer,

--- a/packages/core/src/browser/tree/tree-widget.tsx
+++ b/packages/core/src/browser/tree/tree-widget.tsx
@@ -1413,6 +1413,10 @@ export namespace TreeWidget {
          */
         scrollToRow?: number
         /**
+         * Controls the alignment scrolled-to-rows.
+         */
+        scrollToAlignment?: 'auto' | 'end' | 'start' | 'center';
+        /**
          * The list of node rows.
          */
         rows: NodeRow[]
@@ -1425,7 +1429,7 @@ export namespace TreeWidget {
             fixedWidth: true
         });
         render(): React.ReactNode {
-            const { rows, width, height, scrollToRow, handleScroll } = this.props;
+            const { rows, width, height, scrollToRow, handleScroll, scrollToAlignment } = this.props;
             return <List
                 ref={list => this.list = (list || undefined)}
                 width={width}
@@ -1434,6 +1438,7 @@ export namespace TreeWidget {
                 rowHeight={this.cache.rowHeight}
                 rowRenderer={this.renderTreeRow}
                 scrollToIndex={scrollToRow}
+                scrollToAlignment={scrollToAlignment}
                 onScroll={handleScroll}
                 tabIndex={-1}
             />;


### PR DESCRIPTION
Signed-off-by: shuyaqian 717749594@qq.com

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->
To fix when switch files in editor , the selected node is not in the center.
theia:
![1](https://bbs-img.huaweicloud.com/blogs/img/1620372083849071651.gif)
vscode:
![2](https://bbs-img.huaweicloud.com/blogs/img/1620372101381039307.gif)

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

