### PR TITLE
Translate Theia using language packs

### DIFF
--- a/packages/callhierarchy/src/browser/callhierarchy-contribution.ts
+++ b/packages/callhierarchy/src/browser/callhierarchy-contribution.ts
@@ -27,10 +27,10 @@ export const CALL_HIERARCHY_TOGGLE_COMMAND_ID = 'callhierarchy:toggle';
 export const CALL_HIERARCHY_LABEL = 'Call Hierarchy';
 
 export namespace CallHierarchyCommands {
-    export const OPEN: Command = {
+    export const OPEN = Command.toLocalizedCommand({
         id: 'callhierarchy:open',
         label: 'Open Call Hierarchy'
-    };
+    }, 'theia/callhierarchy/open');
 }
 
 @injectable()

--- a/packages/console/src/browser/console-contribution.ts
+++ b/packages/console/src/browser/console-contribution.ts
@@ -21,6 +21,7 @@ import { ConsoleManager } from './console-manager';
 import { ConsoleKeybindingContexts } from './console-keybinding-contexts';
 import { ConsoleWidget } from './console-widget';
 import { ConsoleContentWidget } from './console-content-widget';
+import { nls } from '@theia/core/lib/browser/nls';
 
 export namespace ConsoleCommands {
     export const SELECT_ALL: Command = {
@@ -91,22 +92,22 @@ export class ConsoleContribution implements FrontendApplicationContribution, Com
     registerMenus(menus: MenuModelRegistry): void {
         menus.registerMenuAction(ConsoleContextMenu.CLIPBOARD, {
             commandId: CommonCommands.COPY.id,
-            label: 'Copy',
+            label: CommonCommands.COPY.label,
             order: 'a1',
         });
         menus.registerMenuAction(ConsoleContextMenu.CLIPBOARD, {
             commandId: ConsoleCommands.SELECT_ALL.id,
-            label: 'Select All',
+            label: CommonCommands.SELECT_ALL.label,
             order: 'a2'
         });
         menus.registerMenuAction(ConsoleContextMenu.CLIPBOARD, {
             commandId: ConsoleCommands.COLLAPSE_ALL.id,
-            label: 'Collapse All',
+            label: nls.localize('vscode/repl/collapse', 'Collapse All'),
             order: 'a3'
         });
         menus.registerMenuAction(ConsoleContextMenu.CLEAR, {
             commandId: ConsoleCommands.CLEAR.id,
-            label: 'Clear Console'
+            label: nls.localize('vscode/repl/clearRepl', 'Clear Console')
         });
     }
 

--- a/packages/core/data/i18n/nls.json
+++ b/packages/core/data/i18n/nls.json
@@ -1,0 +1,142 @@
+{
+  "theia": {
+    "core": {
+      "common": {
+        "showNextTabInGroup": "Switch to Next Tab in Group",
+        "showPreviousTabInGroup": "Switch to Previous Tab in Group",
+        "showNextTabGroup": "Switch to Next Tab Group",
+        "showPreviousTabGroup": "Switch to Previous Tab Group",
+        "closeTab": "Close Tab",
+        "closeOthers": "Close Other Tabs",
+        "closeRight": "Close Tabs to the Right",
+        "closeAll": "Close All Tabs",
+        "closeTabMain": "Close Tab in Main Area",
+        "closeOtherTabMain": "Close Other Tabs in Main Area",
+        "closeAllTabMain": "Close All Tabs in Main Area",
+        "collapseTab": "Collapse Side Panel",
+        "collapseAllTabs": "Collapse All Side Panels",
+        "collapseBottomPanel": "Toggle Bottom Panel",
+        "toggleMaximized": "Toggle Maximized"
+      },
+      "keyboard": {
+        "choose": "Choose Keyboard Layout",
+        "chooseLayout": "Choose a keyboard layout",
+        "current": "(current: {0})",
+        "currentLayout": " - current layout",
+        "tryDetect": "Try to detect the keyboard layout from browser information and pressed keys.",
+        "mac": "Mac Keyboards",
+        "pc": "PC Keyboards"
+      }
+    },
+    "debug": {
+      "continueAll": "Continue All",
+      "pauseAll": "Pause All",
+      "copyExpressionValue": "Copy Expression Value",
+      "reveal": "Reveal",
+      "openLeft": "Open Left",
+      "openRight": "Open Right",
+      "openBottom": "Open Bottom",
+      "threads": "Threads"
+    },
+    "editor": {
+      "showAllEditors": "Show All Opened Editors",
+      "reopenDirty": "The file is dirty. Please save it first before reopening it with another encoding."
+    },
+    "external-terminal": {
+      "cwd": "Select current working directory for new external terminal"
+    },
+    "filesystem": {
+      "uploadFiles": "Upload Files...",
+      "copyDownloadLink": "Copy Download Link"
+    },
+    "getting-started": {
+      "newExtension": "Building a New Extension",
+      "newPlugin": "Building a New Plugin"
+    },
+    "git": {
+      "toggleBlameAnnotations": "Toggle Blame Annotations",
+      "addSignedOff": "Add Signed-off-by",
+      "noPreviousCommit": "No previous commit to amend",
+      "added": "Added",
+      "unstaged": "Unstaged",
+      "renamed": "Renamed",
+      "copied": "Copied",
+      "conflicted": "Conflicted"
+    },
+    "markers": {
+      "clearAll": "Clear All"
+    },
+    "mini-browser": {
+      "typeUrl": "Type a URL"
+    },
+    "navigator": {
+      "reveal": "Reveal in Explorer",
+      "toggleHiddenFiles": "Toggle Hidden Files",
+      "autoReveal": "Auto Reveal",
+      "refresh": "Refresh in Explorer"
+    },
+    "output": {
+      "clearOutputChannel": "Clear Output Channel...",
+      "showOutputChannel": "Show Output Channel...",
+      "hideOutputChannel": "Hide Output Channel...",
+      "closeOutputChannel": "Close Output Channel...",
+      "outputChannels": "Output Channels",
+      "hiddenChannels": "Hidden Channels"
+    },
+    "preview": {
+      "openPreviewSide": "Open Preview to the Side",
+      "openSource": "Open Source"
+    },
+    "property-view": {
+      "properties": "Properties",
+      "directory": "Directory",
+      "file": "File",
+      "symbolicLink": "Symbolic link",
+      "location": "Location",
+      "name": "Name",
+      "path": "Path",
+      "lastModified": "Last modified",
+      "created": "Created",
+      "size": "Size"
+    },
+    "scm": {
+      "amendHeadCommit": "HEAD Commit",
+      "amendLastCommit": "Amend last commit",
+      "amend": "Amend",
+      "unamendCommit": "Unamend commit",
+      "unamend": "Unamend",
+      "history": "History",
+      "changeRepository": "Change Repository..."
+    },
+    "siw": {
+      "includeIgnoredFiles": "Include Ignored Files",
+      "noFolderSpecified": "You have not opened or specified a folder. Only open files are currently searched.",
+      "resultSubset": "This is only a subset of all results. Use a more specific search term to narrow down the result list."
+    },
+    "task": {
+      "attachTask": "Attach Task...",
+      "openUserTasks": "Open User Tasks",
+      "clearHistory": "Clear History"
+    },
+    "typehierarchy": {
+      "typeHierarchy": "Type Hierarchy",
+      "subtypeHierarchy": "Subtype Hierarchy",
+      "supertypeHierarchy": "Supertype Hierarchy"
+    },
+    "vsx-registry": {
+      "installFromVSIX": "Install from VSIX",
+      "openVSX": "Open VSX Registry"
+    },
+    "workspace": {
+      "openRecentWorkspace": "Open Recent Workspace...",
+      "duplicate": "Duplicate",
+      "workspaceFolderAddedTitle": "Folder added to Workspace",
+      "workspaceFolderAdded": "A workspace with multiple roots was created. Do you want to save your workspace configuration as a file?",
+      "noErasure": "Note: Nothing will be erased from disk"
+    },
+    "webview": {
+      "goToReadme": "Go To README",
+      "messageWarning": "The {0} endpoint's host pattern has been changed to `{1}`; changing the pattern can lead to security vulnerabilities. See `{2}` for more information."
+    }
+  }
+}

--- a/packages/core/src/browser/about-dialog.tsx
+++ b/packages/core/src/browser/about-dialog.tsx
@@ -16,7 +16,7 @@
 
 import * as React from 'react';
 import { inject, injectable, postConstruct } from 'inversify';
-import { DialogProps } from './dialogs';
+import { Dialog, DialogProps } from './dialogs';
 import { ReactDialog } from './dialogs/react-dialog';
 import { ApplicationServer, ApplicationInfo, ExtensionInfo } from '../common/application-protocol';
 import { Message } from './widgets/widget';
@@ -44,7 +44,7 @@ export class AboutDialog extends ReactDialog<void> {
         super({
             title: FrontendApplicationConfigProvider.get().applicationName,
         });
-        this.appendAcceptButton('Ok');
+        this.appendAcceptButton(Dialog.OK);
     }
 
     @postConstruct()

--- a/packages/core/src/browser/common-frontend-contribution.ts
+++ b/packages/core/src/browser/common-frontend-contribution.ts
@@ -90,187 +90,191 @@ export namespace CommonMenus {
 
 export namespace CommonCommands {
 
-    const FILE_CATEGORY = 'File';
-    const VIEW_CATEGORY = 'View';
+    export const FILE_CATEGORY_KEY = 'vscode/menubarControl/mFile';
+    export const VIEW_CATEGORY_KEY = 'vscode/menubarControl/mView';
+    export const PREFERENCES_CATEGORY_KEY = 'vscode/actions/preferences';
+    export const FILE_CATEGORY = 'File';
+    export const VIEW_CATEGORY = 'View';
+    export const PREFERENCES_CATEGORY = 'Preferences';
 
     export const OPEN: Command = {
         id: 'core.open',
     };
 
-    export const CUT: Command = {
+    export const CUT = Command.toLocalizedCommand({
         id: 'core.cut',
         label: 'Cut'
-    };
-    export const COPY: Command = {
+    }, 'vscode/fileActions.contribution/cut');
+    export const COPY = Command.toLocalizedCommand({
         id: 'core.copy',
         label: 'Copy'
-    };
-    export const PASTE: Command = {
+    }, 'vscode/fileActions/copyFile');
+    export const PASTE = Command.toLocalizedCommand({
         id: 'core.paste',
         label: 'Paste'
-    };
+    }, 'vscode/fileActions/pasteFile');
 
-    export const COPY_PATH: Command = {
+    export const COPY_PATH = Command.toLocalizedCommand({
         id: 'core.copy.path',
         label: 'Copy Path'
-    };
+    }, 'vscode/fileActions.contribution/copyPath');
 
-    export const UNDO: Command = {
+    export const UNDO = Command.toLocalizedCommand({
         id: 'core.undo',
         label: 'Undo'
-    };
-    export const REDO: Command = {
+    }, 'vscode/textInputActions/undo');
+    export const REDO = Command.toLocalizedCommand({
         id: 'core.redo',
         label: 'Redo'
-    };
-    export const SELECT_ALL: Command = {
+    }, 'vscode/textInputActions/redo');
+    export const SELECT_ALL = Command.toLocalizedCommand({
         id: 'core.selectAll',
         label: 'Select All'
-    };
+    }, 'vscode/textInputActions/selectAll');
 
-    export const FIND: Command = {
+    export const FIND = Command.toLocalizedCommand({
         id: 'core.find',
         label: 'Find'
-    };
-    export const REPLACE: Command = {
+    }, 'vscode/simpleFindReplaceWidget/label.find');
+    export const REPLACE = Command.toLocalizedCommand({
         id: 'core.replace',
         label: 'Replace'
-    };
+    }, 'vscode/simpleFindReplaceWidget/label.replace');
 
-    export const NEXT_TAB: Command = {
+    export const NEXT_TAB = Command.toLocalizedCommand({
         id: 'core.nextTab',
         category: VIEW_CATEGORY,
         label: 'Switch to Next Tab'
-    };
-    export const PREVIOUS_TAB: Command = {
+    }, 'vscode/menubar/mShowNextTab', VIEW_CATEGORY_KEY);
+    export const PREVIOUS_TAB = Command.toLocalizedCommand({
         id: 'core.previousTab',
         category: VIEW_CATEGORY,
         label: 'Switch to Previous Tab'
-    };
-    export const NEXT_TAB_IN_GROUP: Command = {
+    }, 'vscode/menubar/mShowPreviousTab', VIEW_CATEGORY_KEY);
+    export const NEXT_TAB_IN_GROUP = Command.toLocalizedCommand({
         id: 'core.nextTabInGroup',
         category: VIEW_CATEGORY,
         label: 'Switch to Next Tab in Group'
-    };
-    export const PREVIOUS_TAB_IN_GROUP: Command = {
+    }, 'theia/core/common/showNextTabInGroup', VIEW_CATEGORY_KEY);
+    export const PREVIOUS_TAB_IN_GROUP = Command.toLocalizedCommand({
         id: 'core.previousTabInGroup',
         category: VIEW_CATEGORY,
         label: 'Switch to Previous Tab in Group'
-    };
-    export const NEXT_TAB_GROUP: Command = {
+    }, 'theia/core/common/showPreviousTabInGroup', VIEW_CATEGORY_KEY);
+    export const NEXT_TAB_GROUP = Command.toLocalizedCommand({
         id: 'core.nextTabGroup',
         category: VIEW_CATEGORY,
         label: 'Switch to Next Tab Group'
-    };
-    export const PREVIOUS_TAB_GROUP: Command = {
+    }, 'theia/core/common/showNextTabGroup', VIEW_CATEGORY_KEY);
+    export const PREVIOUS_TAB_GROUP = Command.toLocalizedCommand({
         id: 'core.previousTabBar',
         category: VIEW_CATEGORY,
         label: 'Switch to Previous Tab Group'
-    };
-    export const CLOSE_TAB: Command = {
+    }, 'theia/core/common/showPreviousTabGroup', VIEW_CATEGORY_KEY);
+    export const CLOSE_TAB = Command.toLocalizedCommand({
         id: 'core.close.tab',
         category: VIEW_CATEGORY,
         label: 'Close Tab'
-    };
-    export const CLOSE_OTHER_TABS: Command = {
+    }, 'theia/core/common/closeTab', VIEW_CATEGORY_KEY);
+    export const CLOSE_OTHER_TABS = Command.toLocalizedCommand({
         id: 'core.close.other.tabs',
         category: VIEW_CATEGORY,
         label: 'Close Other Tabs'
-    };
-    export const CLOSE_RIGHT_TABS: Command = {
+    }, 'theia/core/common/closeOthers', VIEW_CATEGORY_KEY);
+    export const CLOSE_RIGHT_TABS = Command.toLocalizedCommand({
         id: 'core.close.right.tabs',
         category: VIEW_CATEGORY,
         label: 'Close Tabs to the Right'
-    };
-    export const CLOSE_ALL_TABS: Command = {
+    }, 'theia/core/common/closeRight', VIEW_CATEGORY_KEY);
+    export const CLOSE_ALL_TABS = Command.toLocalizedCommand({
         id: 'core.close.all.tabs',
         category: VIEW_CATEGORY,
         label: 'Close All Tabs'
-    };
-    export const CLOSE_MAIN_TAB: Command = {
+    }, 'theia/core/common/closeAll', VIEW_CATEGORY_KEY);
+    export const CLOSE_MAIN_TAB = Command.toLocalizedCommand({
         id: 'core.close.main.tab',
         category: VIEW_CATEGORY,
         label: 'Close Tab in Main Area'
-    };
-    export const CLOSE_OTHER_MAIN_TABS: Command = {
+    }, 'theia/core/common/closeTabMain', VIEW_CATEGORY_KEY);
+    export const CLOSE_OTHER_MAIN_TABS = Command.toLocalizedCommand({
         id: 'core.close.other.main.tabs',
         category: VIEW_CATEGORY,
         label: 'Close Other Tabs in Main Area'
-    };
-    export const CLOSE_ALL_MAIN_TABS: Command = {
+    }, 'theia/core/common/closeOtherTabMain', VIEW_CATEGORY_KEY);
+    export const CLOSE_ALL_MAIN_TABS = Command.toLocalizedCommand({
         id: 'core.close.all.main.tabs',
         category: VIEW_CATEGORY,
         label: 'Close All Tabs in Main Area'
-    };
-    export const COLLAPSE_PANEL: Command = {
+    }, 'theia/core/common/closeAllTabMain', VIEW_CATEGORY_KEY);
+    export const COLLAPSE_PANEL = Command.toLocalizedCommand({
         id: 'core.collapse.tab',
         category: VIEW_CATEGORY,
         label: 'Collapse Side Panel'
-    };
-    export const COLLAPSE_ALL_PANELS: Command = {
+    }, 'theia/core/common/collapseTab', VIEW_CATEGORY_KEY);
+    export const COLLAPSE_ALL_PANELS = Command.toLocalizedCommand({
         id: 'core.collapse.all.tabs',
         category: VIEW_CATEGORY,
         label: 'Collapse All Side Panels'
-    };
-    export const TOGGLE_BOTTOM_PANEL: Command = {
+    }, 'theia/core/common/collapseAllTabs', VIEW_CATEGORY_KEY);
+    export const TOGGLE_BOTTOM_PANEL = Command.toLocalizedCommand({
         id: 'core.toggle.bottom.panel',
         category: VIEW_CATEGORY,
         label: 'Toggle Bottom Panel'
-    };
-    export const TOGGLE_MAXIMIZED: Command = {
+    }, 'theia/core/common/collapseBottomPanel', VIEW_CATEGORY_KEY);
+    export const TOGGLE_MAXIMIZED = Command.toLocalizedCommand({
         id: 'core.toggleMaximized',
         category: VIEW_CATEGORY,
         label: 'Toggle Maximized'
-    };
-    export const OPEN_VIEW: Command = {
+    }, 'theia/core/common/toggleMaximized', VIEW_CATEGORY_KEY);
+    export const OPEN_VIEW = Command.toLocalizedCommand({
         id: 'core.openView',
         category: VIEW_CATEGORY,
         label: 'Open View...'
-    };
+    }, 'vscode/quickAccess.contribution/miOpenView', VIEW_CATEGORY_KEY);
 
-    export const SAVE: Command = {
+    export const SAVE = Command.toLocalizedCommand({
         id: 'core.save',
         category: FILE_CATEGORY,
         label: 'Save',
-    };
-    export const SAVE_WITHOUT_FORMATTING: Command = {
+    }, 'vscode/fileCommands/save', FILE_CATEGORY_KEY);
+    export const SAVE_WITHOUT_FORMATTING = Command.toLocalizedCommand({
         id: 'core.saveWithoutFormatting',
         category: FILE_CATEGORY,
         label: 'Save without Formatting',
-    };
-    export const SAVE_ALL: Command = {
+    }, 'vscode/fileCommands/saveWithoutFormatting', FILE_CATEGORY_KEY);
+    export const SAVE_ALL = Command.toLocalizedCommand({
         id: 'core.saveAll',
         category: FILE_CATEGORY,
         label: 'Save All',
-    };
+    }, 'vscode/fileCommands/saveAll', FILE_CATEGORY_KEY);
 
-    export const AUTO_SAVE: Command = {
+    export const AUTO_SAVE = Command.toLocalizedCommand({
         id: 'textEditor.commands.autosave',
         category: FILE_CATEGORY,
         label: 'Auto Save',
-    };
+    }, 'vscode/fileActions.contribution/miAutoSave', FILE_CATEGORY_KEY);
 
-    export const ABOUT_COMMAND: Command = {
+    export const ABOUT_COMMAND = Command.toLocalizedCommand({
         id: 'core.about',
         label: 'About'
-    };
+    }, 'vscode/windowActions/about');
 
-    export const OPEN_PREFERENCES: Command = {
+    export const OPEN_PREFERENCES = Command.toLocalizedCommand({
         id: 'preferences:open',
-        category: 'Settings',
+        category: PREFERENCES_CATEGORY,
         label: 'Open Preferences',
-    };
+    }, 'vscode/preferences.contribution/preferences', PREFERENCES_CATEGORY_KEY);
 
-    export const SELECT_COLOR_THEME: Command = {
+    export const SELECT_COLOR_THEME = Command.toLocalizedCommand({
         id: 'workbench.action.selectTheme',
         label: 'Color Theme',
-        category: 'Preferences'
-    };
-    export const SELECT_ICON_THEME: Command = {
+        category: PREFERENCES_CATEGORY
+    }, 'vscode/themes.contribution/selectTheme.label', PREFERENCES_CATEGORY_KEY);
+    export const SELECT_ICON_THEME = Command.toLocalizedCommand({
         id: 'workbench.action.selectIconTheme',
         label: 'File Icon Theme',
-        category: 'Preferences'
-    };
+        category: PREFERENCES_CATEGORY
+    }, 'vscode/themes.contribution/selectIconTheme.label', PREFERENCES_CATEGORY_KEY);
 
     export const CONFIGURE_DISPLAY_LANGUAGE = Command.toLocalizedCommand({
         id: 'workbench.action.configureLanguage',
@@ -365,14 +369,14 @@ export class CommonFrontendContribution implements FrontendApplicationContributi
         app.shell.leftPanelHandler.addBottomMenu({
             id: 'settings-menu',
             iconClass: 'codicon codicon-settings-gear',
-            title: 'Settings',
+            title: nls.localize(CommonCommands.PREFERENCES_CATEGORY_KEY, CommonCommands.PREFERENCES_CATEGORY),
             menuPath: SETTINGS_MENU,
             order: 0,
         });
         const accountsMenu = {
             id: 'accounts-menu',
             iconClass: 'codicon codicon-person',
-            title: 'Accounts',
+            title: nls.localize('vscode/activitybarPart/accounts', 'Accounts'),
             menuPath: ACCOUNTS_MENU,
             order: 1,
         };
@@ -437,7 +441,7 @@ export class CommonFrontendContribution implements FrontendApplicationContributi
                     this.shell.leftPanelHandler.addTopMenu({
                         id: mainMenuId,
                         iconClass: 'codicon codicon-menu',
-                        title: 'Application Menu',
+                        title: nls.localize('vscode/menubar/mAppMenu', 'Application Menu'),
                         menuPath: ['menubar'],
                         order: 0,
                     });
@@ -470,10 +474,10 @@ export class CommonFrontendContribution implements FrontendApplicationContributi
     }
 
     registerMenus(registry: MenuModelRegistry): void {
-        registry.registerSubmenu(CommonMenus.FILE, 'File');
-        registry.registerSubmenu(CommonMenus.EDIT, 'Edit');
-        registry.registerSubmenu(CommonMenus.VIEW, 'View');
-        registry.registerSubmenu(CommonMenus.HELP, 'Help');
+        registry.registerSubmenu(CommonMenus.FILE, nls.localize('vscode/menubarControl/mFile', 'File'));
+        registry.registerSubmenu(CommonMenus.EDIT, nls.localize('vscode/menubarControl/mEdit', 'Edit'));
+        registry.registerSubmenu(CommonMenus.VIEW, nls.localize('vscode/menubarControl/mView', 'View'));
+        registry.registerSubmenu(CommonMenus.HELP, nls.localize('vscode/menubarControl/mHelp', 'Help'));
 
         registry.registerMenuAction(CommonMenus.FILE_SAVE, {
             commandId: CommonCommands.SAVE.id
@@ -486,7 +490,7 @@ export class CommonFrontendContribution implements FrontendApplicationContributi
             commandId: CommonCommands.AUTO_SAVE.id
         });
 
-        registry.registerSubmenu(CommonMenus.FILE_SETTINGS_SUBMENU, 'Settings');
+        registry.registerSubmenu(CommonMenus.FILE_SETTINGS_SUBMENU, nls.localize(CommonCommands.PREFERENCES_CATEGORY_KEY, CommonCommands.PREFERENCES_CATEGORY));
 
         registry.registerMenuAction(CommonMenus.EDIT_UNDO, {
             commandId: CommonCommands.UNDO.id,
@@ -534,37 +538,37 @@ export class CommonFrontendContribution implements FrontendApplicationContributi
 
         registry.registerMenuAction(SHELL_TABBAR_CONTEXT_MENU, {
             commandId: CommonCommands.CLOSE_TAB.id,
-            label: 'Close',
+            label: nls.localize('vscode/editor.contribution/close', 'Close'),
             order: '0'
         });
         registry.registerMenuAction(SHELL_TABBAR_CONTEXT_MENU, {
             commandId: CommonCommands.CLOSE_OTHER_TABS.id,
-            label: 'Close Others',
+            label: nls.localize('vscode/editor.contribution/closeOthers', 'Close Others'),
             order: '1'
         });
         registry.registerMenuAction(SHELL_TABBAR_CONTEXT_MENU, {
             commandId: CommonCommands.CLOSE_RIGHT_TABS.id,
-            label: 'Close to the Right',
+            label: nls.localize('vscode/editor.contribution/closeRight', 'Close to the Right'),
             order: '2'
         });
         registry.registerMenuAction(SHELL_TABBAR_CONTEXT_MENU, {
             commandId: CommonCommands.CLOSE_ALL_TABS.id,
-            label: 'Close All',
+            label: nls.localize('vscode/editor.contribution/closeAll', 'Close All'),
             order: '3'
         });
         registry.registerMenuAction(SHELL_TABBAR_CONTEXT_MENU, {
             commandId: CommonCommands.COLLAPSE_PANEL.id,
-            label: 'Collapse',
+            label: CommonCommands.COLLAPSE_PANEL.label,
             order: '4'
         });
         registry.registerMenuAction(SHELL_TABBAR_CONTEXT_MENU, {
             commandId: CommonCommands.TOGGLE_MAXIMIZED.id,
-            label: 'Toggle Maximized',
+            label: CommonCommands.TOGGLE_MAXIMIZED.label,
             order: '5'
         });
         registry.registerMenuAction(CommonMenus.HELP, {
             commandId: CommonCommands.ABOUT_COMMAND.id,
-            label: 'About',
+            label: CommonCommands.ABOUT_COMMAND.label,
             order: '9'
         });
 
@@ -1059,7 +1063,7 @@ export class CommonFrontendContribution implements FrontendApplicationContributi
 
         this.quickInputService?.showQuickPick(items,
             {
-                placeholder: 'Select File Icon Theme',
+                placeholder: nls.localize('vscode/extensionsActions/select file icon theme', 'Select File Icon Theme'),
                 activeItem: items.find(item => item.id === resetTo),
                 onDidChangeSelection: (quickPick: QuickPick<QuickPickItem>, selectedItems: Array<QuickPickItem>) => {
                     resetTo = undefined;
@@ -1098,7 +1102,7 @@ export class CommonFrontendContribution implements FrontendApplicationContributi
         const items = [...itemsByTheme.light, ...itemsByTheme.dark, ...itemsByTheme.hc];
         this.quickInputService?.showQuickPick(items,
             {
-                placeholder: 'Select Color Theme (Up/Down Keys to Preview)',
+                placeholder: nls.localize('vscode/extensionActions/select color theme', 'Select Color Theme (Up/Down Keys to Preview)'),
                 activeItem: items.find((item: QuickPickItem) => item.id === resetTo),
                 // eslint-disable-next-line @typescript-eslint/no-explicit-any
                 onDidChangeSelection: (quickPick: any, selectedItems: Array<QuickPickItem>) => {

--- a/packages/core/src/browser/dialogs.ts
+++ b/packages/core/src/browser/dialogs.ts
@@ -19,6 +19,7 @@ import { Disposable, MaybePromise, CancellationTokenSource } from '../common';
 import { Key } from './keyboard/keys';
 import { Widget, BaseWidget, Message, addKeyListener, codiconArray } from './widgets';
 import { FrontendApplicationContribution } from './frontend-application';
+import { nls } from './nls';
 
 @injectable()
 export class DialogProps {
@@ -64,6 +65,13 @@ export namespace DialogError {
         }
         return error.message;
     }
+}
+
+export namespace Dialog {
+    export const YES = nls.localize('vscode/extensionsUtils/yes', 'Yes');
+    export const NO = nls.localize('vscode/extensionsUtils/no', 'No');
+    export const OK = nls.localize('vscode/dialog/ok', 'OK');
+    export const CANCEL = nls.localize('vscode/explorerViewer/cancel', 'Cancel');
 }
 
 @injectable()
@@ -191,14 +199,14 @@ export abstract class AbstractDialog<T> extends BaseWidget {
         this.update();
     }
 
-    protected appendCloseButton(text: string = 'Cancel'): HTMLButtonElement {
+    protected appendCloseButton(text: string = Dialog.CANCEL): HTMLButtonElement {
         this.closeButton = this.createButton(text);
         this.controlPanel.appendChild(this.closeButton);
         this.closeButton.classList.add('secondary');
         return this.closeButton;
     }
 
-    protected appendAcceptButton(text: string = 'OK'): HTMLButtonElement {
+    protected appendAcceptButton(text: string = Dialog.OK): HTMLButtonElement {
         this.acceptButton = this.createButton(text);
         this.controlPanel.appendChild(this.acceptButton);
         this.acceptButton.classList.add('main');

--- a/packages/core/src/browser/keyboard/browser-keyboard-frontend-contribution.ts
+++ b/packages/core/src/browser/keyboard/browser-keyboard-frontend-contribution.ts
@@ -19,16 +19,18 @@ import { isOSX } from '../../common/os';
 import { CommandContribution, CommandRegistry, Command } from '../../common/command';
 import { BrowserKeyboardLayoutProvider, KeyboardLayoutData } from './browser-keyboard-layout-provider';
 import { QuickPickValue, QuickInputService, QuickPickItem } from '../quick-input';
+import { nls } from '../nls';
 
 export namespace KeyboardCommands {
 
+    const KEYBOARD_CATEGORY_KEY = 'vscode/settingsLayout/keyboard';
     const KEYBOARD_CATEGORY = 'Keyboard';
 
-    export const CHOOSE_KEYBOARD_LAYOUT: Command = {
+    export const CHOOSE_KEYBOARD_LAYOUT = Command.toLocalizedCommand({
         id: 'core.keyboard.choose',
         category: KEYBOARD_CATEGORY,
         label: 'Choose Keyboard Layout',
-    };
+    }, 'theia/core/keyboard/choose', KEYBOARD_CATEGORY_KEY);
 
 }
 
@@ -50,9 +52,9 @@ export class BrowserKeyboardFrontendContribution implements CommandContribution 
     protected async chooseLayout(): Promise<KeyboardLayoutData | undefined> {
         const current = this.layoutProvider.currentLayoutData;
         const autodetect: QuickPickValue<'autodetect'> = {
-            label: 'Auto-detect',
-            description: this.layoutProvider.currentLayoutSource !== 'user-choice' ? `(current: ${current.name})` : undefined,
-            detail: 'Try to detect the keyboard layout from browser information and pressed keys.',
+            label: nls.localize('vscode/editorStatus/autoDetect', 'Auto-detect'),
+            description: this.layoutProvider.currentLayoutSource !== 'user-choice' ? nls.localize('theia/core/keyboard/current', '(current: {0})', current.name) : undefined,
+            detail: nls.localize('theia/core/keyboard/tryDetect', 'Try to detect the keyboard layout from browser information and pressed keys.'),
             value: 'autodetect'
         };
         const pcLayouts = this.layoutProvider.allLayoutData
@@ -64,20 +66,22 @@ export class BrowserKeyboardFrontendContribution implements CommandContribution 
             .sort((a, b) => compare(a.name, b.name))
             .map(layout => this.toQuickPickValue(layout, current === layout));
         let layouts: Array<QuickPickValue<KeyboardLayoutData | 'autodetect'> | QuickPickItem>;
+        const macKeyboards = nls.localize('theia/core/keyboard/mac', 'Mac Keyboards');
+        const pcKeyboards = nls.localize('theia/core/keyboard/pc', 'PC Keyboards');
         if (isOSX) {
             layouts = [
                 autodetect,
-                { type: 'separator', label: 'Mac Keyboards' }, ...macLayouts,
-                { type: 'separator', label: 'PC Keyboards' }, ...pcLayouts
+                { type: 'separator', label: macKeyboards }, ...macLayouts,
+                { type: 'separator', label: pcKeyboards }, ...pcLayouts
             ];
         } else {
             layouts = [
                 autodetect,
-                { type: 'separator', label: 'PC Keyboards' }, ...pcLayouts,
-                { type: 'separator', label: 'Mac Keyboards' }, ...macLayouts
+                { type: 'separator', label: pcKeyboards }, ...pcLayouts,
+                { type: 'separator', label: macKeyboards }, ...macLayouts
             ];
         }
-        const selectedItem = await this.quickInputService?.showQuickPick(layouts, { placeholder: 'Choose a keyboard layout' });
+        const selectedItem = await this.quickInputService?.showQuickPick(layouts, { placeholder: nls.localize('theia/core/keyboard/chooseLayout', 'Choose a keyboard layout') });
         if (selectedItem && ('value' in selectedItem)) {
             return this.layoutProvider.setLayoutData(selectedItem.value);
         }
@@ -86,7 +90,8 @@ export class BrowserKeyboardFrontendContribution implements CommandContribution 
     protected toQuickPickValue(layout: KeyboardLayoutData, isCurrent: boolean): QuickPickValue<KeyboardLayoutData> {
         return {
             label: layout.name,
-            description: `${layout.hardware === 'mac' ? 'Mac' : 'PC'} (${layout.language})${isCurrent ? ' - current layout' : ''}`,
+            description:
+                `${layout.hardware === 'mac' ? 'Mac' : 'PC'} (${layout.language})${isCurrent ? nls.localize('theia/core/keyboard/currentLayout', ' - current layout') : ''}`,
             value: layout
         };
     }

--- a/packages/core/src/browser/nls.ts
+++ b/packages/core/src/browser/nls.ts
@@ -45,7 +45,7 @@ export namespace nls {
 
     export function localize(key: string, defaultValue: string, ...args: string[]): string {
         let value = defaultValue;
-        if (localization) {
+        if (localization && key) {
             const translation = localization.translations[key];
             if (translation) {
                 // vscode's localizations often contain additional '&&' symbols, which we simply ignore

--- a/packages/core/src/browser/quick-input/quick-command-frontend-contribution.ts
+++ b/packages/core/src/browser/quick-input/quick-command-frontend-contribution.ts
@@ -19,6 +19,7 @@ import { KeybindingRegistry, KeybindingContribution } from '../keybinding';
 import { CommonMenus } from '../common-frontend-contribution';
 import { CLEAR_COMMAND_HISTORY, quickCommand, QuickCommandService } from './quick-command-service';
 import { QuickInputService } from './quick-input-service';
+import { nls } from '../nls';
 
 @injectable()
 export class QuickCommandFrontendContribution implements CommandContribution, KeybindingContribution, MenuContribution {
@@ -43,7 +44,7 @@ export class QuickCommandFrontendContribution implements CommandContribution, Ke
     registerMenus(menus: MenuModelRegistry): void {
         menus.registerMenuAction(CommonMenus.VIEW_PRIMARY, {
             commandId: quickCommand.id,
-            label: 'Find Command...'
+            label: nls.localize('vscode/quickAccess.contribution/commandsQuickAccess', 'Find Command...')
         });
     }
 

--- a/packages/core/src/browser/shell/tab-bar-toolbar.tsx
+++ b/packages/core/src/browser/shell/tab-bar-toolbar.tsx
@@ -27,6 +27,7 @@ import { ContextKeyService } from '../context-key-service';
 import { Event, Emitter } from '../../common/event';
 import { ContextMenuRenderer, Anchor } from '../context-menu-renderer';
 import { MenuModelRegistry } from '../../common/menu';
+import { nls } from '../nls';
 
 /**
  * Clients should implement this interface if they want to contribute to the tab-bar toolbar.
@@ -403,7 +404,8 @@ export class TabBarToolbar extends ReactWidget {
 
     protected renderMore(): React.ReactNode {
         return !!this.more.size && <div key='__more__' className={TabBarToolbar.Styles.TAB_BAR_TOOLBAR_ITEM + ' enabled'}>
-            <div id='__more__' className={codicon('ellipsis', true)} onClick={this.showMoreContextMenu} title='More Actions...' />
+            <div id='__more__' className={codicon('ellipsis', true)} onClick={this.showMoreContextMenu}
+                title={nls.localize('vscode/compositePart/viewsAndMoreActions', 'More Actions...')} />
         </div>;
     }
 

--- a/packages/core/src/browser/window-contribution.ts
+++ b/packages/core/src/browser/window-contribution.ts
@@ -23,10 +23,10 @@ import { CommonMenus } from '../browser/common-frontend-contribution';
 
 export namespace WindowCommands {
 
-    export const NEW_WINDOW: Command = {
+    export const NEW_WINDOW = Command.toLocalizedCommand({
         id: 'workbench.action.newWindow',
         label: 'New Window'
-    };
+    }, 'vscode/windowActions/newWindow');
 }
 
 @injectable()

--- a/packages/core/src/electron-browser/menu/electron-menu-contribution.ts
+++ b/packages/core/src/electron-browser/menu/electron-menu-contribution.ts
@@ -20,42 +20,42 @@ import {
     Command, CommandContribution, CommandRegistry,
     isOSX, isWindows, MenuModelRegistry, MenuContribution, Disposable
 } from '../../common';
-import { ApplicationShell, KeybindingContribution, KeybindingRegistry, PreferenceScope, PreferenceService } from '../../browser';
+import { ApplicationShell, CommonCommands, KeybindingContribution, KeybindingRegistry, PreferenceScope, PreferenceService } from '../../browser';
 import { FrontendApplication, FrontendApplicationContribution, CommonMenus } from '../../browser';
 import { ElectronMainMenuFactory } from './electron-main-menu-factory';
 import { FrontendApplicationStateService, FrontendApplicationState } from '../../browser/frontend-application-state';
 import { ZoomLevel } from '../window/electron-window-preferences';
 
 export namespace ElectronCommands {
-    export const TOGGLE_DEVELOPER_TOOLS: Command = {
+    export const TOGGLE_DEVELOPER_TOOLS = Command.toLocalizedCommand({
         id: 'theia.toggleDevTools',
         label: 'Toggle Developer Tools'
-    };
-    export const RELOAD: Command = {
+    }, 'vscode/developerActions/toggleDevTools');
+    export const RELOAD = Command.toLocalizedCommand({
         id: 'view.reload',
         label: 'Reload Window'
-    };
-    export const ZOOM_IN: Command = {
+    }, 'vscode/windowActions/reloadWindow');
+    export const ZOOM_IN = Command.toLocalizedCommand({
         id: 'view.zoomIn',
         label: 'Zoom In'
-    };
-    export const ZOOM_OUT: Command = {
+    }, 'vscode/windowActions/zoomIn');
+    export const ZOOM_OUT = Command.toLocalizedCommand({
         id: 'view.zoomOut',
         label: 'Zoom Out'
-    };
-    export const RESET_ZOOM: Command = {
+    }, 'vscode/windowActions/zoomOut');
+    export const RESET_ZOOM = Command.toLocalizedCommand({
         id: 'view.resetZoom',
         label: 'Reset Zoom'
-    };
-    export const CLOSE_WINDOW: Command = {
+    }, 'vscode/windowActions/zoomReset');
+    export const CLOSE_WINDOW = Command.toLocalizedCommand({
         id: 'close.window',
         label: 'Close Window'
-    };
-    export const TOGGLE_FULL_SCREEN: Command = {
+    }, 'vscode/windowActions/close');
+    export const TOGGLE_FULL_SCREEN = Command.toLocalizedCommand({
         id: 'workbench.action.toggleFullScreen',
-        category: 'View',
+        category: CommonCommands.VIEW_CATEGORY,
         label: 'Toggle Full Screen'
-    };
+    }, 'vscode/windowActions/toggleFullScreen', CommonCommands.VIEW_CATEGORY_KEY);
 }
 
 export namespace ElectronMenus {

--- a/packages/debug/src/browser/console/debug-console-contribution.tsx
+++ b/packages/debug/src/browser/console/debug-console-contribution.tsx
@@ -18,6 +18,7 @@ import { ConsoleSessionManager } from '@theia/console/lib/browser/console-sessio
 import { ConsoleOptions, ConsoleWidget } from '@theia/console/lib/browser/console-widget';
 import { AbstractViewContribution, bindViewContribution, codicon, Widget, WidgetFactory } from '@theia/core/lib/browser';
 import { ContextKey, ContextKeyService } from '@theia/core/lib/browser/context-key-service';
+import { nls } from '@theia/core/lib/browser/nls';
 import { TabBarToolbarContribution, TabBarToolbarRegistry } from '@theia/core/lib/browser/shell/tab-bar-toolbar';
 import { Command, CommandRegistry } from '@theia/core/lib/common/command';
 import { Severity } from '@theia/core/lib/common/severity';
@@ -32,13 +33,16 @@ export type InDebugReplContextKey = ContextKey<boolean>;
 export const InDebugReplContextKey = Symbol('inDebugReplContextKey');
 
 export namespace DebugConsoleCommands {
-    const DEBUG_CONSOLE_CATEGORY = 'Debug';
-    export const CLEAR: Command = {
+
+    export const DEBUG_CATEGORY_KEY = 'vscode/debugCommands/debug';
+    export const DEBUG_CATEGORY = 'Debug';
+
+    export const CLEAR = Command.toLocalizedCommand({
         id: 'debug.console.clear',
-        category: DEBUG_CONSOLE_CATEGORY,
+        category: DEBUG_CATEGORY,
         label: 'Clear Console',
         iconClass: codicon('clear-all')
-    };
+    }, 'vscode/repl/clearRepl', DEBUG_CATEGORY_KEY);
 }
 
 @injectable()
@@ -124,7 +128,7 @@ export class DebugConsoleContribution extends AbstractViewContribution<ConsoleWi
         toolbarRegistry.registerItem({
             id: DebugConsoleCommands.CLEAR.id,
             command: DebugConsoleCommands.CLEAR.id,
-            tooltip: 'Clear Console',
+            tooltip: DebugConsoleCommands.CLEAR.label,
             priority: 0,
         });
     }
@@ -132,7 +136,7 @@ export class DebugConsoleContribution extends AbstractViewContribution<ConsoleWi
     static options: ConsoleOptions = {
         id: 'debug-console',
         title: {
-            label: 'Debug Console',
+            label: nls.localize('vscode/repl/debugConsole', 'Debug Console'),
             iconClass: codicon('debug-console')
         },
         input: {

--- a/packages/debug/src/browser/debug-frontend-application-contribution.ts
+++ b/packages/debug/src/browser/debug-frontend-application-contribution.ts
@@ -51,6 +51,7 @@ import { ColorContribution } from '@theia/core/lib/browser/color-application-con
 import { ColorRegistry } from '@theia/core/lib/browser/color-registry';
 import { DebugFunctionBreakpoint } from './model/debug-function-breakpoint';
 import { DebugBreakpoint } from './model/debug-breakpoint';
+import { nls } from '@theia/core/lib/browser/nls';
 
 export namespace DebugMenus {
     export const DEBUG = [...MAIN_MENU_BAR, '6_debug'];
@@ -63,214 +64,241 @@ export namespace DebugMenus {
     export const DEBUG_BREAKPOINTS = [...DEBUG, 'f_breakpoints'];
 }
 
+function nlsEditBreakpoint(breakpointKey: string, breakpoint: string): string {
+    return nls.localize('vscode/breakpointEditorContribution/editBreakpoint', 'Edit {0}...', nls.localize(`vscode/breakpointEditorContribution/${breakpointKey}`, breakpoint));
+}
+
+function nlsRemoveBreakpoint(breakpointKey: string, breakpoint: string): string {
+    return nls.localize('vscode/breakpointEditorContribution/removeBreakpoint', 'Remove {0}',
+        nls.localize(`vscode/breakpointEditorContribution/${breakpointKey}`, breakpoint));
+}
+
+function nlsEnableBreakpoint(breakpointKey: string, breakpoint: string): string {
+    return nls.localize('vscode/breakpointEditorContribution/enableBreakpoint', 'Enable {0}',
+        nls.localize(`vscode/breakpointEditorContribution/${breakpointKey}`, breakpoint));
+}
+
+function nlsDisableBreakpoint(breakpointKey: string, breakpoint: string): string {
+    return nls.localize('vscode/breakpointEditorContribution/disableBreakpoint', 'Disable {0}',
+        nls.localize(`vscode/breakpointEditorContribution/${breakpointKey}`, breakpoint));
+}
+
 export namespace DebugCommands {
 
+    export const DEBUG_CATEGORY_KEY = 'vscode/debugCommands/debug';
     export const DEBUG_CATEGORY = 'Debug';
 
-    export const START: Command = {
+    export const START = Command.toLocalizedCommand({
         id: 'workbench.action.debug.start',
         category: DEBUG_CATEGORY,
         label: 'Start Debugging',
         iconClass: codicon('debug-alt')
-    };
-    export const START_NO_DEBUG: Command = {
+    }, 'vscode/debugCommands/startDebug', DEBUG_CATEGORY_KEY);
+    export const START_NO_DEBUG = Command.toLocalizedCommand({
         id: 'workbench.action.debug.run',
         label: 'Debug: Start Without Debugging'
-    };
-    export const STOP: Command = {
+    }, 'vscode/debugCommands/startWithoutDebugging');
+    export const STOP = Command.toLocalizedCommand({
         id: 'workbench.action.debug.stop',
         category: DEBUG_CATEGORY,
-        label: 'Stop Debugging',
+        label: 'Stop',
         iconClass: codicon('debug-stop')
-    };
-    export const RESTART: Command = {
+    }, 'vscode/debugCommands/stop', DEBUG_CATEGORY_KEY);
+    export const RESTART = Command.toLocalizedCommand({
         id: 'workbench.action.debug.restart',
         category: DEBUG_CATEGORY,
-        label: 'Restart Debugging',
-    };
+        label: 'Restart',
+    }, 'vscode/debugCommands/restartDebug', DEBUG_CATEGORY_KEY);
 
-    export const OPEN_CONFIGURATIONS = {
+    export const OPEN_CONFIGURATIONS = Command.toLocalizedCommand({
         id: 'debug.configurations.open',
-        label: 'Debug: Open Configurations'
-    };
-    export const ADD_CONFIGURATION = {
+        category: DEBUG_CATEGORY,
+        label: 'Open Configurations'
+    }, 'vscode/debugViewlet/miOpenConfigurations', DEBUG_CATEGORY_KEY);
+    export const ADD_CONFIGURATION = Command.toLocalizedCommand({
         id: 'debug.configurations.add',
-        label: 'Debug: Add Configuration...'
-    };
+        category: DEBUG_CATEGORY,
+        label: 'Add Configuration...'
+    }, 'vscode/debugActionViewItems/addConfiguration', DEBUG_CATEGORY_KEY);
 
-    export const STEP_OVER: Command = {
+    export const STEP_OVER = Command.toLocalizedCommand({
         id: 'workbench.action.debug.stepOver',
         category: DEBUG_CATEGORY,
         label: 'Step Over',
         iconClass: codicon('debug-step-over')
-    };
-    export const STEP_INTO: Command = {
+    }, 'vscode/debugCommands/stepOverDebug', DEBUG_CATEGORY_KEY);
+    export const STEP_INTO = Command.toLocalizedCommand({
         id: 'workbench.action.debug.stepInto',
         category: DEBUG_CATEGORY,
         label: 'Step Into',
         iconClass: codicon('debug-step-into')
-    };
-    export const STEP_OUT: Command = {
+    }, 'vscode/debugCommands/stepIntoDebug', DEBUG_CATEGORY_KEY);
+    export const STEP_OUT = Command.toLocalizedCommand({
         id: 'workbench.action.debug.stepOut',
         category: DEBUG_CATEGORY,
         label: 'Step Out',
         iconClass: codicon('debug-step-out')
-    };
-    export const CONTINUE: Command = {
+    }, 'vscode/debugCommands/stepOutDebug', DEBUG_CATEGORY_KEY);
+    export const CONTINUE = Command.toLocalizedCommand({
         id: 'workbench.action.debug.continue',
         category: DEBUG_CATEGORY,
         label: 'Continue',
         iconClass: codicon('debug-continue')
-    };
-    export const PAUSE: Command = {
+    }, 'vscode/debugCommands/continueDebug', DEBUG_CATEGORY_KEY);
+    export const PAUSE = Command.toLocalizedCommand({
         id: 'workbench.action.debug.pause',
         category: DEBUG_CATEGORY,
         label: 'Pause',
         iconClass: codicon('debug-pause')
-    };
-    export const CONTINUE_ALL: Command = {
+    }, 'vscode/debugCommands/pauseDebug', DEBUG_CATEGORY_KEY);
+    export const CONTINUE_ALL = Command.toLocalizedCommand({
         id: 'debug.thread.continue.all',
         category: DEBUG_CATEGORY,
         label: 'Continue All',
         iconClass: codicon('debug-continue')
-    };
-    export const PAUSE_ALL: Command = {
+    }, 'theia/debug/continueAll', DEBUG_CATEGORY_KEY);
+    export const PAUSE_ALL = Command.toLocalizedCommand({
         id: 'debug.thread.pause.all',
         category: DEBUG_CATEGORY,
         label: 'Pause All',
         iconClass: codicon('debug-pause')
-    };
+    }, 'theia/debug/pauseAll', DEBUG_CATEGORY_KEY);
 
-    export const TOGGLE_BREAKPOINT: Command = {
+    export const TOGGLE_BREAKPOINT = Command.toLocalizedCommand({
         id: 'editor.debug.action.toggleBreakpoint',
         category: DEBUG_CATEGORY,
         label: 'Toggle Breakpoint',
-    };
-    export const INLINE_BREAKPOINT: Command = {
+    }, 'vscode/debugEditorActions/miToggleBreakpoint', DEBUG_CATEGORY_KEY);
+    export const INLINE_BREAKPOINT = Command.toLocalizedCommand({
         id: 'editor.debug.action.inlineBreakpoint',
         category: DEBUG_CATEGORY,
         label: 'Inline Breakpoint',
-    };
-    export const ADD_CONDITIONAL_BREAKPOINT: Command = {
+    }, 'vscode/debug.contribution/inlineBreakpoint', DEBUG_CATEGORY_KEY);
+    export const ADD_CONDITIONAL_BREAKPOINT = Command.toLocalizedCommand({
         id: 'debug.breakpoint.add.conditional',
         category: DEBUG_CATEGORY,
         label: 'Add Conditional Breakpoint...',
-    };
-    export const ADD_LOGPOINT: Command = {
+    }, 'vscode/breakpointEditorContribution/addConditionalBreakpoint', DEBUG_CATEGORY_KEY);
+    export const ADD_LOGPOINT = Command.toLocalizedCommand({
         id: 'debug.breakpoint.add.logpoint',
         category: DEBUG_CATEGORY,
         label: 'Add Logpoint...',
-    };
-    export const ADD_FUNCTION_BREAKPOINT: Command = {
+    }, 'vscode/breakpointEditorContribution/addLogPoint', DEBUG_CATEGORY_KEY);
+    export const ADD_FUNCTION_BREAKPOINT = Command.toLocalizedCommand({
         id: 'debug.breakpoint.add.function',
         category: DEBUG_CATEGORY,
         label: 'Add Function Breakpoint...',
-    };
-    export const ENABLE_ALL_BREAKPOINTS: Command = {
+    }, 'vscode/breakpointsView/addFunctionBreakpoint', DEBUG_CATEGORY_KEY);
+    export const ENABLE_ALL_BREAKPOINTS = Command.toLocalizedCommand({
         id: 'debug.breakpoint.enableAll',
         category: DEBUG_CATEGORY,
         label: 'Enable All Breakpoints',
-    };
-    export const DISABLE_ALL_BREAKPOINTS: Command = {
+    }, 'vscode/breakpointsView/enableAllBreakpoints', DEBUG_CATEGORY_KEY);
+    export const DISABLE_ALL_BREAKPOINTS = Command.toLocalizedCommand({
         id: 'debug.breakpoint.disableAll',
         category: DEBUG_CATEGORY,
         label: 'Disable All Breakpoints',
-    };
-    export const EDIT_BREAKPOINT: Command = {
+    }, 'vscode/breakpointsView/disableAllBreakpoints', DEBUG_CATEGORY_KEY);
+    export const EDIT_BREAKPOINT = Command.toLocalizedCommand({
         id: 'debug.breakpoint.edit',
         category: DEBUG_CATEGORY,
-        label: 'Edit Breakpoint...',
-    };
-    export const EDIT_LOGPOINT: Command = {
+        originalLabel: 'Edit Breakpoint...',
+        label: nlsEditBreakpoint('breakpoint', 'Breakpoint')
+    }, '', DEBUG_CATEGORY_KEY);
+    export const EDIT_LOGPOINT = Command.toLocalizedCommand({
         id: 'debug.logpoint.edit',
         category: DEBUG_CATEGORY,
-        label: 'Edit Logpoint...',
-    };
-    export const REMOVE_BREAKPOINT: Command = {
+        originalLabel: 'Edit Logpoint...',
+        label: nlsEditBreakpoint('logPoint', 'Logpoint')
+    }, '', DEBUG_CATEGORY_KEY);
+    export const REMOVE_BREAKPOINT = Command.toLocalizedCommand({
         id: 'debug.breakpoint.remove',
         category: DEBUG_CATEGORY,
-        label: 'Remove Breakpoint',
-    };
-    export const REMOVE_LOGPOINT: Command = {
+        originalLabel: 'Remove Breakpoint',
+        label: nlsRemoveBreakpoint('breakpoint', 'Breakpoint')
+    }, '', DEBUG_CATEGORY_KEY);
+    export const REMOVE_LOGPOINT = Command.toLocalizedCommand({
         id: 'debug.logpoint.remove',
         category: DEBUG_CATEGORY,
-        label: 'Remove Logpoint',
-    };
-    export const REMOVE_ALL_BREAKPOINTS: Command = {
+        originalLabel: 'Remove Logpoint',
+        label: nlsRemoveBreakpoint('logPoint', 'Logpoint')
+    }, '', DEBUG_CATEGORY_KEY);
+    export const REMOVE_ALL_BREAKPOINTS = Command.toLocalizedCommand({
         id: 'debug.breakpoint.removeAll',
         category: DEBUG_CATEGORY,
         label: 'Remove All Breakpoints',
-    };
-    export const TOGGLE_BREAKPOINTS_ENABLED: Command = {
+    }, 'vscode/breakpointsView/removeAllBreakpoints', DEBUG_CATEGORY_KEY);
+    export const TOGGLE_BREAKPOINTS_ENABLED = Command.toLocalizedCommand({
         id: 'debug.breakpoint.toggleEnabled'
-    };
-    export const SHOW_HOVER = {
+    });
+    export const SHOW_HOVER = Command.toLocalizedCommand({
         id: 'editor.debug.action.showDebugHover',
-        label: 'Debug: Show Hover'
-    };
+        category: DEBUG_CATEGORY,
+        label: 'Show Hover'
+    }, 'vscode/hover/showHover', DEBUG_CATEGORY_KEY);
 
-    export const RESTART_FRAME: Command = {
+    export const RESTART_FRAME = Command.toLocalizedCommand({
         id: 'debug.frame.restart',
         category: DEBUG_CATEGORY,
         label: 'Restart Frame',
-    };
-    export const COPY_CALL_STACK: Command = {
+    }, 'vscode/debug.contribution/restartFrame', DEBUG_CATEGORY_KEY);
+    export const COPY_CALL_STACK = Command.toLocalizedCommand({
         id: 'debug.callStack.copy',
         category: DEBUG_CATEGORY,
         label: 'Copy Call Stack',
-    };
+    }, 'vscode/debug.contribution/copyStackTrace', DEBUG_CATEGORY_KEY);
 
-    export const SET_VARIABLE_VALUE: Command = {
+    export const SET_VARIABLE_VALUE = Command.toLocalizedCommand({
         id: 'debug.variable.setValue',
         category: DEBUG_CATEGORY,
         label: 'Set Value',
-    };
-    export const COPY_VARIABLE_VALUE: Command = {
+    }, 'vscode/debug.contribution/setValue', DEBUG_CATEGORY_KEY);
+    export const COPY_VARIABLE_VALUE = Command.toLocalizedCommand({
         id: 'debug.variable.copyValue',
         category: DEBUG_CATEGORY,
         label: 'Copy Value',
-    };
-    export const COPY_VARIABLE_AS_EXPRESSION: Command = {
+    }, 'vscode/debug.contribution/copyValue', DEBUG_CATEGORY_KEY);
+    export const COPY_VARIABLE_AS_EXPRESSION = Command.toLocalizedCommand({
         id: 'debug.variable.copyAsExpression',
         category: DEBUG_CATEGORY,
         label: 'Copy As Expression',
-    };
-    export const WATCH_VARIABLE: Command = {
+    }, 'vscode/debug.contribution/copyAsExpression', DEBUG_CATEGORY_KEY);
+    export const WATCH_VARIABLE = Command.toLocalizedCommand({
         id: 'debug.variable.watch',
         category: DEBUG_CATEGORY,
         label: 'Add to Watch',
-    };
+    }, 'vscode/debug.contribution/addToWatchExpressions', DEBUG_CATEGORY_KEY);
 
-    export const ADD_WATCH_EXPRESSION: Command = {
+    export const ADD_WATCH_EXPRESSION = Command.toLocalizedCommand({
         id: 'debug.watch.addExpression',
         category: DEBUG_CATEGORY,
-        label: 'Add Watch Expression'
-    };
-    export const EDIT_WATCH_EXPRESSION: Command = {
+        label: 'Add Expression'
+    }, 'vscode/watchExpressionsView/addWatchExpression', DEBUG_CATEGORY_KEY);
+    export const EDIT_WATCH_EXPRESSION = Command.toLocalizedCommand({
         id: 'debug.watch.editExpression',
         category: DEBUG_CATEGORY,
-        label: 'Edit Watch Expression'
-    };
-    export const COPY_WATCH_EXPRESSION_VALUE: Command = {
+        label: 'Edit Expression'
+    }, 'vscode/debug.contribution/editWatchExpression', DEBUG_CATEGORY_KEY);
+    export const COPY_WATCH_EXPRESSION_VALUE = Command.toLocalizedCommand({
         id: 'debug.watch.copyExpressionValue',
         category: DEBUG_CATEGORY,
-        label: 'Copy Watch Expression Value'
-    };
-    export const REMOVE_WATCH_EXPRESSION: Command = {
+        label: 'Copy Expression Value'
+    }, 'theia/debug/copyExpressionValue', DEBUG_CATEGORY_KEY);
+    export const REMOVE_WATCH_EXPRESSION = Command.toLocalizedCommand({
         id: 'debug.watch.removeExpression',
         category: DEBUG_CATEGORY,
-        label: 'Remove Watch Expression'
-    };
-    export const COLLAPSE_ALL_WATCH_EXPRESSIONS: Command = {
+        label: 'Remove Expression'
+    }, 'vscode/debug.contribution/removeWatchExpression', DEBUG_CATEGORY_KEY);
+    export const COLLAPSE_ALL_WATCH_EXPRESSIONS = Command.toLocalizedCommand({
         id: 'debug.watch.collapseAllExpressions',
         category: DEBUG_CATEGORY,
-        label: 'Collapse All Watch Expressions'
-    };
-    export const REMOVE_ALL_WATCH_EXPRESSIONS: Command = {
+        label: 'Collapse All Expressions'
+    }, 'vscode/watchExpressionsView/collapse', DEBUG_CATEGORY_KEY);
+    export const REMOVE_ALL_WATCH_EXPRESSIONS = Command.toLocalizedCommand({
         id: 'debug.watch.removeAllExpressions',
         category: DEBUG_CATEGORY,
-        label: 'Remove All Watch Expressions'
-    };
+        label: 'Remove All Expressions'
+    }, 'vscode/watchExpressionsView/removeAllWatchExpressions', DEBUG_CATEGORY_KEY);
 }
 export namespace DebugThreadContextCommands {
     export const STEP_OVER = {
@@ -493,7 +521,7 @@ export class DebugFrontendApplicationContribution extends AbstractViewContributi
             }
         };
 
-        menus.registerSubmenu(DebugMenus.DEBUG, 'Run');
+        menus.registerSubmenu(DebugMenus.DEBUG, nls.localize('vscode/debug.contribution/run', 'Run'));
         registerMenuActions(DebugMenus.DEBUG_CONTROLS,
             DebugCommands.START,
             DebugCommands.START_NO_DEBUG,
@@ -518,7 +546,7 @@ export class DebugFrontendApplicationContribution extends AbstractViewContributi
         registerMenuActions(DebugMenus.DEBUG_BREAKPOINT,
             DebugCommands.TOGGLE_BREAKPOINT
         );
-        menus.registerSubmenu(DebugMenus.DEBUG_NEW_BREAKPOINT, 'New Breakpoint');
+        menus.registerSubmenu(DebugMenus.DEBUG_NEW_BREAKPOINT, nls.localize('vscode/debug.contribution/miNewBreakpoint', 'New Breakpoint'));
         registerMenuActions(DebugMenus.DEBUG_NEW_BREAKPOINT,
             DebugCommands.ADD_CONDITIONAL_BREAKPOINT,
             DebugCommands.INLINE_BREAKPOINT,
@@ -541,15 +569,15 @@ export class DebugFrontendApplicationContribution extends AbstractViewContributi
             { ...DebugCommands.CONTINUE_ALL, ...DebugSessionContextCommands.CONTINUE_ALL }
         );
         registerMenuActions(DebugThreadsWidget.TERMINATE_MENU,
-            { ...DebugCommands.RESTART, ...DebugSessionContextCommands.RESTART, label: 'Restart' },
-            { ...DebugCommands.STOP, ...DebugSessionContextCommands.STOP, label: 'Stop' },
-            { ...DebugThreadContextCommands.TERMINATE, label: 'Terminate Thread' }
+            { ...DebugCommands.RESTART, ...DebugSessionContextCommands.RESTART },
+            { ...DebugCommands.STOP, ...DebugSessionContextCommands.STOP },
+            { ...DebugThreadContextCommands.TERMINATE, label: nls.localize('vscode/debug.contribution/terminateThread', 'Terminate Thread') }
         );
         registerMenuActions(DebugThreadsWidget.OPEN_MENU,
-            { ...DebugSessionContextCommands.REVEAL, label: 'Reveal' },
-            { ...DebugSessionContextCommands.OPEN_LEFT, label: 'Open Left' },
-            { ...DebugSessionContextCommands.OPEN_RIGHT, label: 'Open Right' },
-            { ...DebugSessionContextCommands.OPEN_BOTTOM, label: 'Open Bottom' }
+            { ...DebugSessionContextCommands.REVEAL, label: nls.localize('theia/debug/reveal', 'Reveal') },
+            { ...DebugSessionContextCommands.OPEN_LEFT, label: nls.localize('theia/debug/openLeft', 'Open Left') },
+            { ...DebugSessionContextCommands.OPEN_RIGHT, label: nls.localize('theia/debug/openRight', 'Open Right') },
+            { ...DebugSessionContextCommands.OPEN_BOTTOM, label: nls.localize('theia/debug/openBottom', 'Open Bottom') }
         );
 
         registerMenuActions(DebugStackFramesWidget.CONTEXT_MENU,
@@ -567,12 +595,12 @@ export class DebugFrontendApplicationContribution extends AbstractViewContributi
         );
 
         registerMenuActions(DebugWatchWidget.EDIT_MENU,
-            { ...DebugCommands.EDIT_WATCH_EXPRESSION, label: 'Edit Expression' },
-            { ...DebugCommands.COPY_WATCH_EXPRESSION_VALUE, label: 'Copy Value' }
+            DebugCommands.EDIT_WATCH_EXPRESSION,
+            DebugCommands.COPY_WATCH_EXPRESSION_VALUE
         );
         registerMenuActions(DebugWatchWidget.REMOVE_MENU,
-            { ...DebugCommands.REMOVE_WATCH_EXPRESSION, label: 'Remove Expression' },
-            { ...DebugCommands.REMOVE_ALL_WATCH_EXPRESSIONS, label: 'Remove All Expressions' }
+            DebugCommands.REMOVE_WATCH_EXPRESSION,
+            DebugCommands.REMOVE_ALL_WATCH_EXPRESSIONS
         );
 
         registerMenuActions(DebugBreakpointsWidget.EDIT_MENU,
@@ -590,17 +618,17 @@ export class DebugFrontendApplicationContribution extends AbstractViewContributi
         );
 
         registerMenuActions(DebugEditorModel.CONTEXT_MENU,
-            { ...DebugEditorContextCommands.ADD_BREAKPOINT, label: 'Add Breakpoint' },
+            { ...DebugEditorContextCommands.ADD_BREAKPOINT, label: nls.localize('vscode/breakpointEditorContribution/addBreakpoint', 'Add Breakpoint') },
             { ...DebugEditorContextCommands.ADD_CONDITIONAL_BREAKPOINT, label: DebugCommands.ADD_CONDITIONAL_BREAKPOINT.label },
             { ...DebugEditorContextCommands.ADD_LOGPOINT, label: DebugCommands.ADD_LOGPOINT.label },
             { ...DebugEditorContextCommands.REMOVE_BREAKPOINT, label: DebugCommands.REMOVE_BREAKPOINT.label },
             { ...DebugEditorContextCommands.EDIT_BREAKPOINT, label: DebugCommands.EDIT_BREAKPOINT.label },
-            { ...DebugEditorContextCommands.ENABLE_BREAKPOINT, label: 'Enable Breakpoint' },
-            { ...DebugEditorContextCommands.DISABLE_BREAKPOINT, label: 'Disable Breakpoint' },
+            { ...DebugEditorContextCommands.ENABLE_BREAKPOINT, label: nlsEnableBreakpoint('breakpoint', 'Breakpoint') },
+            { ...DebugEditorContextCommands.DISABLE_BREAKPOINT, label: nlsDisableBreakpoint('breakpoint', 'Breakpoint') },
             { ...DebugEditorContextCommands.REMOVE_LOGPOINT, label: DebugCommands.REMOVE_LOGPOINT.label },
             { ...DebugEditorContextCommands.EDIT_LOGPOINT, label: DebugCommands.EDIT_LOGPOINT.label },
-            { ...DebugEditorContextCommands.ENABLE_LOGPOINT, label: 'Enable Logpoint' },
-            { ...DebugEditorContextCommands.DISABLE_LOGPOINT, label: 'Disable Logpoint' }
+            { ...DebugEditorContextCommands.ENABLE_LOGPOINT, label: nlsEnableBreakpoint('logPoint', 'Logpoint') },
+            { ...DebugEditorContextCommands.DISABLE_LOGPOINT, label: nlsDisableBreakpoint('logPoint', 'Logpoint') }
         );
     }
 
@@ -1074,7 +1102,9 @@ export class DebugFrontendApplicationContribution extends AbstractViewContributi
             priority: 1
         };
         const updateToggleBreakpointsEnabled = () => {
-            const tooltip = this.breakpointManager.breakpointsEnabled ? 'Deactivate Breakpoints' : 'Activate Breakpoints';
+            const activateBreakpoints = nls.localize('vscode/breakpointsView/enableAllBreakpoints', 'Enable Breakpoints');
+            const deactivateBreakpoints = nls.localize('vscode/breakpointsView/disableAllBreakpoints', 'Disable Breakpoints');
+            const tooltip = this.breakpointManager.breakpointsEnabled ? deactivateBreakpoints : activateBreakpoints;
             if (toggleBreakpointsEnabled.tooltip !== tooltip) {
                 toggleBreakpointsEnabled.tooltip = tooltip;
                 onDidChangeToggleBreakpointsEnabled.fire(undefined);
@@ -1084,7 +1114,7 @@ export class DebugFrontendApplicationContribution extends AbstractViewContributi
             id: DebugCommands.ADD_FUNCTION_BREAKPOINT.id,
             command: DebugCommands.ADD_FUNCTION_BREAKPOINT.id,
             icon: codicon('add'),
-            tooltip: 'Add Function Breakpoint'
+            tooltip: DebugCommands.ADD_FUNCTION_BREAKPOINT.label
         });
         updateToggleBreakpointsEnabled();
         this.breakpointManager.onDidChangeBreakpoints(updateToggleBreakpointsEnabled);
@@ -1100,20 +1130,20 @@ export class DebugFrontendApplicationContribution extends AbstractViewContributi
             id: DebugCommands.ADD_WATCH_EXPRESSION.id,
             command: DebugCommands.ADD_WATCH_EXPRESSION.id,
             icon: codicon('add'),
-            tooltip: 'Add Expression'
+            tooltip: DebugCommands.ADD_WATCH_EXPRESSION.label
         });
         toolbar.registerItem({
             id: DebugCommands.COLLAPSE_ALL_WATCH_EXPRESSIONS.id,
             command: DebugCommands.COLLAPSE_ALL_WATCH_EXPRESSIONS.id,
             icon: codicon('collapse-all'),
-            tooltip: 'Collapse All',
+            tooltip: DebugCommands.COLLAPSE_ALL_WATCH_EXPRESSIONS.label,
             priority: 1
         });
         toolbar.registerItem({
             id: DebugCommands.REMOVE_ALL_WATCH_EXPRESSIONS.id,
             command: DebugCommands.REMOVE_ALL_WATCH_EXPRESSIONS.id,
             icon: codicon('close-all'),
-            tooltip: 'Remove All Expressions',
+            tooltip: DebugCommands.REMOVE_ALL_WATCH_EXPRESSIONS.label,
             priority: 2
         });
     }

--- a/packages/debug/src/browser/debug-prefix-configuration.ts
+++ b/packages/debug/src/browser/debug-prefix-configuration.ts
@@ -61,11 +61,11 @@ export class DebugPrefixConfiguration implements CommandContribution, CommandHan
 
     readonly statusBarId = 'select-run-debug-statusbar-item';
 
-    private readonly command: Command = {
+    private readonly command = Command.toLocalizedCommand({
         id: 'select.debug.configuration',
-        category: 'Debug',
+        category: DebugCommands.DEBUG_CATEGORY,
         label: 'Select and Start Debugging'
-    };
+    }, 'vscode/debugCommands/selectAndStartDebugging', DebugCommands.DEBUG_CATEGORY_KEY);
 
     @postConstruct()
     protected initialize(): void {

--- a/packages/debug/src/browser/view/debug-breakpoints-source.tsx
+++ b/packages/debug/src/browser/view/debug-breakpoints-source.tsx
@@ -29,12 +29,6 @@ export class DebugBreakpointsSource extends TreeSource {
     @inject(BreakpointManager)
     protected readonly breakpoints: BreakpointManager;
 
-    constructor() {
-        super({
-            placeholder: 'No breakpoints'
-        });
-    }
-
     @postConstruct()
     protected init(): void {
         this.fireDidChange();

--- a/packages/debug/src/browser/view/debug-breakpoints-widget.ts
+++ b/packages/debug/src/browser/view/debug-breakpoints-widget.ts
@@ -21,6 +21,7 @@ import { SourceTreeWidget } from '@theia/core/lib/browser/source-tree';
 import { DebugBreakpointsSource } from './debug-breakpoints-source';
 import { BreakpointManager } from '../breakpoint/breakpoint-manager';
 import { DebugViewModel } from './debug-view-model';
+import { nls } from '@theia/core/lib/browser/nls';
 
 @injectable()
 export class DebugBreakpointsWidget extends SourceTreeWidget {
@@ -57,7 +58,7 @@ export class DebugBreakpointsWidget extends SourceTreeWidget {
     protected init(): void {
         super.init();
         this.id = 'debug:breakpoints:' + this.viewModel.id;
-        this.title.label = 'Breakpoints';
+        this.title.label = nls.localize('vscode/debug.contribution/breakpoints', 'Breakpoints');
         this.toDispose.push(this.breakpointsSource);
         this.source = this.breakpointsSource;
     }

--- a/packages/debug/src/browser/view/debug-configuration-widget.tsx
+++ b/packages/debug/src/browser/view/debug-configuration-widget.tsx
@@ -28,6 +28,7 @@ import { DebugViewModel } from './debug-view-model';
 import { DebugSessionOptions } from '../debug-session-options';
 import { DebugCommands } from '../debug-frontend-application-contribution';
 import { CommandRegistry } from '@theia/core/lib/common';
+import { nls } from '@theia/core/lib/browser/nls';
 
 @injectable()
 export class DebugConfigurationWidget extends ReactWidget {
@@ -79,14 +80,15 @@ export class DebugConfigurationWidget extends ReactWidget {
     render(): React.ReactNode {
         const { options } = this;
         return <React.Fragment>
-            <DebugAction run={this.start} label='Start Debugging' iconClass='debug-start' ref={this.setStepRef} />
+            <DebugAction run={this.start} label={nls.localize('vscode/debugCommands/startDebug', 'Start Debugging')} iconClass='debug-start' ref={this.setStepRef} />
             <select className='theia-select debug-configuration' value={this.currentValue} onChange={this.setCurrentConfiguration}>
-                {options.length ? options : <option value='__NO_CONF__'>No Configurations</option>}
+                {options.length ? options : <option value='__NO_CONF__'>{nls.localize('vscode/debugActionViewItems/noConfigurations', 'No Configurations')}</option>}
                 <option disabled>{'Add Configuration...'.replace(/./g, '-')}</option>
-                <option value='__ADD_CONF__'>Add Configuration...</option>
+                <option value='__ADD_CONF__'>{nls.localize('vscode/debugActionViewItems/addConfiguration', 'Add Configuration...')}</option>
             </select>
-            <DebugAction run={this.openConfiguration} label='Open launch.json' iconClass='settings-gear' />
-            <DebugAction run={this.openConsole} label='Debug Console' iconClass='terminal' />
+            <DebugAction run={this.openConfiguration} label={nls.localize('vscode/debugCommands/openLaunchJson', 'Open "launch.json"', '"launch.json"')}
+                iconClass='settings-gear' />
+            <DebugAction run={this.openConsole} label={nls.localize('vscode/repl/debugConsole', 'Debug Console')} iconClass='terminal' />
         </React.Fragment>;
     }
     protected get currentValue(): string {

--- a/packages/debug/src/browser/view/debug-stack-frames-source.tsx
+++ b/packages/debug/src/browser/view/debug-stack-frames-source.tsx
@@ -27,12 +27,6 @@ export class DebugStackFramesSource extends TreeSource {
     @inject(DebugViewModel)
     protected readonly model: DebugViewModel;
 
-    constructor() {
-        super({
-            placeholder: 'Not paused'
-        });
-    }
-
     @postConstruct()
     protected init(): void {
         this.refresh();

--- a/packages/debug/src/browser/view/debug-stack-frames-widget.ts
+++ b/packages/debug/src/browser/view/debug-stack-frames-widget.ts
@@ -22,6 +22,7 @@ import { DebugStackFramesSource, LoadMoreStackFrames } from './debug-stack-frame
 import { DebugStackFrame } from '../model/debug-stack-frame';
 import { DebugViewModel } from './debug-view-model';
 import { DebugCallStackItemTypeKey } from '../debug-call-stack-item-type-key';
+import { nls } from '@theia/core/lib/browser/nls';
 
 @injectable()
 export class DebugStackFramesWidget extends SourceTreeWidget {
@@ -55,7 +56,7 @@ export class DebugStackFramesWidget extends SourceTreeWidget {
     protected init(): void {
         super.init();
         this.id = 'debug:frames:' + this.viewModel.id;
-        this.title.label = 'Call Stack';
+        this.title.label = nls.localize('vscode/debug.contribution/callStack', 'Call Stack');
         this.toDispose.push(this.frames);
         this.source = this.frames;
 

--- a/packages/debug/src/browser/view/debug-threads-source.tsx
+++ b/packages/debug/src/browser/view/debug-threads-source.tsx
@@ -24,12 +24,6 @@ export class DebugThreadsSource extends TreeSource {
     @inject(DebugViewModel)
     protected readonly model: DebugViewModel;
 
-    constructor() {
-        super({
-            placeholder: 'Not running'
-        });
-    }
-
     @postConstruct()
     protected init(): void {
         this.fireDidChange();

--- a/packages/debug/src/browser/view/debug-threads-widget.ts
+++ b/packages/debug/src/browser/view/debug-threads-widget.ts
@@ -23,6 +23,7 @@ import { DebugSession } from '../debug-session';
 import { DebugThread } from '../model/debug-thread';
 import { DebugViewModel } from '../view/debug-view-model';
 import { DebugCallStackItemTypeKey } from '../debug-call-stack-item-type-key';
+import { nls } from '@theia/core/lib/browser/nls';
 
 @injectable()
 export class DebugThreadsWidget extends SourceTreeWidget {
@@ -59,7 +60,7 @@ export class DebugThreadsWidget extends SourceTreeWidget {
     protected init(): void {
         super.init();
         this.id = 'debug:threads:' + this.viewModel.id;
-        this.title.label = 'Threads';
+        this.title.label = nls.localize('theia/debug/threads', 'Threads');
         this.toDispose.push(this.threads);
         this.source = this.threads;
 

--- a/packages/debug/src/browser/view/debug-toolbar-widget.tsx
+++ b/packages/debug/src/browser/view/debug-toolbar-widget.tsx
@@ -21,6 +21,7 @@ import { ReactWidget } from '@theia/core/lib/browser/widgets';
 import { DebugViewModel } from './debug-view-model';
 import { DebugState } from '../debug-session';
 import { DebugAction } from './debug-action';
+import { nls } from '@theia/core/lib/browser/nls';
 
 @injectable()
 export class DebugToolBar extends ReactWidget {
@@ -58,26 +59,30 @@ export class DebugToolBar extends ReactWidget {
         const { state } = this.model;
         return <React.Fragment>
             {this.renderContinue()}
-            <DebugAction enabled={state === DebugState.Stopped} run={this.stepOver} label='Step Over' iconClass='debug-step-over' ref={this.setStepRef} />
-            <DebugAction enabled={state === DebugState.Stopped} run={this.stepIn} label='Step Into' iconClass='debug-step-into' />
-            <DebugAction enabled={state === DebugState.Stopped} run={this.stepOut} label='Step Out' iconClass='debug-step-out' />
-            <DebugAction enabled={state !== DebugState.Inactive} run={this.restart} label='Restart' iconClass='debug-restart' />
+            <DebugAction enabled={state === DebugState.Stopped} run={this.stepOver} label={nls.localize('vscode/debugCommands/stepOverDebug', 'Step Over')}
+                iconClass='debug-step-over' ref={this.setStepRef} />
+            <DebugAction enabled={state === DebugState.Stopped} run={this.stepIn} label={nls.localize('vscode/debugCommands/stepIntoDebug', 'Step Into')}
+                iconClass='debug-step-into' />
+            <DebugAction enabled={state === DebugState.Stopped} run={this.stepOut} label={nls.localize('vscode/debugCommands/stepOutDebug', 'Step Out')}
+                iconClass='debug-step-out' />
+            <DebugAction enabled={state !== DebugState.Inactive} run={this.restart} label={nls.localize('vscode/debugCommands/restartDebug', 'Restart')}
+                iconClass='debug-restart' />
             {this.renderStart()}
         </React.Fragment>;
     }
     protected renderStart(): React.ReactNode {
         const { state } = this.model;
         if (state === DebugState.Inactive && this.model.sessionCount === 1) {
-            return <DebugAction run={this.start} label='Start' iconClass='debug-start' />;
+            return <DebugAction run={this.start} label={nls.localize('vscode/debugCommands/startDebug', 'Start')} iconClass='debug-start' />;
         }
-        return <DebugAction enabled={state !== DebugState.Inactive} run={this.stop} label='Stop' iconClass='debug-stop' />;
+        return <DebugAction enabled={state !== DebugState.Inactive} run={this.stop} label={nls.localize('vscode/debugCommands/stop', 'Stop')} iconClass='debug-stop' />;
     }
     protected renderContinue(): React.ReactNode {
         const { state } = this.model;
         if (state === DebugState.Stopped) {
-            return <DebugAction run={this.continue} label='Continue' iconClass='debug-continue' />;
+            return <DebugAction run={this.continue} label={nls.localize('vscode/debugCommands/continueDebug', 'Continue')} iconClass='debug-continue' />;
         }
-        return <DebugAction enabled={state === DebugState.Running} run={this.pause} label='Pause' iconClass='debug-pause' />;
+        return <DebugAction enabled={state === DebugState.Running} run={this.pause} label={nls.localize('vscode/debugCommands/pauseDebug', 'Pause')} iconClass='debug-pause' />;
     }
 
     protected start = () => this.model.start();

--- a/packages/debug/src/browser/view/debug-variables-source.ts
+++ b/packages/debug/src/browser/view/debug-variables-source.ts
@@ -26,12 +26,6 @@ export class DebugVariablesSource extends TreeSource {
     @inject(DebugViewModel)
     protected readonly model: DebugViewModel;
 
-    constructor() {
-        super({
-            placeholder: 'Not paused'
-        });
-    }
-
     @postConstruct()
     protected init(): void {
         this.refresh();

--- a/packages/debug/src/browser/view/debug-variables-widget.ts
+++ b/packages/debug/src/browser/view/debug-variables-widget.ts
@@ -19,6 +19,7 @@ import { MenuPath } from '@theia/core/lib/common';
 import { SourceTreeWidget } from '@theia/core/lib/browser/source-tree';
 import { DebugVariablesSource } from './debug-variables-source';
 import { DebugViewModel } from './debug-view-model';
+import { nls } from '@theia/core/lib/browser/nls';
 
 @injectable()
 export class DebugVariablesWidget extends SourceTreeWidget {
@@ -51,7 +52,7 @@ export class DebugVariablesWidget extends SourceTreeWidget {
     protected init(): void {
         super.init();
         this.id = 'debug:variables:' + this.viewModel.id;
-        this.title.label = 'Variables';
+        this.title.label = nls.localize('vscode/debug.contribution/variables', 'Variables');
         this.toDispose.push(this.variables);
         this.source = this.variables;
     }

--- a/packages/debug/src/browser/view/debug-watch-source.ts
+++ b/packages/debug/src/browser/view/debug-watch-source.ts
@@ -26,12 +26,6 @@ export class DebugWatchSource extends TreeSource {
     @inject(DebugViewModel)
     protected readonly model: DebugViewModel;
 
-    constructor() {
-        super({
-            placeholder: 'No expressions'
-        });
-    }
-
     @postConstruct()
     protected init(): void {
         this.refresh();

--- a/packages/debug/src/browser/view/debug-watch-widget.ts
+++ b/packages/debug/src/browser/view/debug-watch-widget.ts
@@ -19,6 +19,7 @@ import { MenuPath } from '@theia/core/lib/common';
 import { SourceTreeWidget } from '@theia/core/lib/browser/source-tree';
 import { DebugWatchSource } from './debug-watch-source';
 import { DebugViewModel } from './debug-view-model';
+import { nls } from '@theia/core/lib/browser/nls';
 
 @injectable()
 export class DebugWatchWidget extends SourceTreeWidget {
@@ -51,7 +52,7 @@ export class DebugWatchWidget extends SourceTreeWidget {
     protected init(): void {
         super.init();
         this.id = 'debug:watch:' + this.viewModel.id;
-        this.title.label = 'Watch';
+        this.title.label = nls.localize('vscode/debug.contribution/watch', 'Watch');
         this.toDispose.push(this.variables);
         this.source = this.variables;
     }

--- a/packages/debug/src/browser/view/debug-widget.ts
+++ b/packages/debug/src/browser/view/debug-widget.ts
@@ -23,6 +23,7 @@ import { DebugConfigurationWidget } from './debug-configuration-widget';
 import { DebugViewModel } from './debug-view-model';
 import { DebugSessionManager } from '../debug-session-manager';
 import { ProgressBarFactory } from '@theia/core/lib/browser/progress-bar-factory';
+import { nls } from '@theia/core/lib/browser/nls';
 
 @injectable()
 export class DebugWidget extends BaseWidget implements StatefulWidget, ApplicationShell.TrackableWidgetProvider {
@@ -38,7 +39,7 @@ export class DebugWidget extends BaseWidget implements StatefulWidget, Applicati
     }
 
     static ID = 'debug';
-    static LABEL = 'Debug';
+    static LABEL = nls.localize('vscode/settingsLayout/debug', 'Debug');
 
     @inject(DebugViewModel)
     readonly model: DebugViewModel;

--- a/packages/editor-preview/src/browser/editor-preview-contribution.ts
+++ b/packages/editor-preview/src/browser/editor-preview-contribution.ts
@@ -14,17 +14,18 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
-import { ApplicationShell, KeybindingContribution, KeybindingRegistry, SHELL_TABBAR_CONTEXT_MENU, Widget } from '@theia/core/lib/browser';
+import { ApplicationShell, CommonCommands, KeybindingContribution, KeybindingRegistry, SHELL_TABBAR_CONTEXT_MENU, Widget } from '@theia/core/lib/browser';
+import { nls } from '@theia/core/lib/browser/nls';
 import { Command, CommandContribution, CommandRegistry, MenuContribution, MenuModelRegistry } from '@theia/core/lib/common';
 import { inject, injectable } from '@theia/core/shared/inversify';
 import { EditorPreviewWidget } from './editor-preview-widget';
 
 export namespace EditorPreviewCommands {
-    export const PIN_PREVIEW_COMMAND: Command = {
+    export const PIN_PREVIEW_COMMAND = Command.toLocalizedCommand({
         id: 'workbench.action.keepEditor',
-        category: 'View',
+        category: CommonCommands.VIEW_CATEGORY,
         label: 'Keep Editor',
-    };
+    }, 'vscode/editor.contribution/keepEditor', CommonCommands.VIEW_CATEGORY_KEY);
 }
 
 @injectable()
@@ -61,7 +62,7 @@ export class EditorPreviewContribution implements CommandContribution, MenuContr
     registerMenus(registry: MenuModelRegistry): void {
         registry.registerMenuAction(SHELL_TABBAR_CONTEXT_MENU, {
             commandId: EditorPreviewCommands.PIN_PREVIEW_COMMAND.id,
-            label: 'Keep Open',
+            label: nls.localize('vscode/editor.contribution/keepOpen', 'Keep Open'),
             order: '6',
         });
     }

--- a/packages/editor/src/browser/editor-command.ts
+++ b/packages/editor/src/browser/editor-command.ts
@@ -24,11 +24,12 @@ import { ResourceProvider, MessageService } from '@theia/core';
 import { LanguageService, Language } from '@theia/core/lib/browser/language-service';
 import { SUPPORTED_ENCODINGS } from '@theia/core/lib/browser/supported-encodings';
 import { EncodingMode } from './editor';
+import { nls } from '@theia/core/lib/browser/nls';
 
 export namespace EditorCommands {
 
+    const EDITOR_CATEGORY_KEY = 'vscode/textEditor/editor';
     const EDITOR_CATEGORY = 'Editor';
-    const VIEW_CATEGORY = 'View';
 
     /**
      * Show editor references
@@ -43,149 +44,149 @@ export namespace EditorCommands {
         id: 'textEditor.commands.configIndentation'
     };
 
-    export const CONFIG_EOL: Command = {
+    export const CONFIG_EOL = Command.toLocalizedCommand({
         id: 'textEditor.commands.configEol',
         category: EDITOR_CATEGORY,
         label: 'Change End of Line Sequence'
-    };
+    }, 'vscode/editorStatus/selectEOL', EDITOR_CATEGORY_KEY);
 
-    export const INDENT_USING_SPACES: Command = {
+    export const INDENT_USING_SPACES = Command.toLocalizedCommand({
         id: 'textEditor.commands.indentUsingSpaces',
         category: EDITOR_CATEGORY,
         label: 'Indent Using Spaces'
-    };
-    export const INDENT_USING_TABS: Command = {
+    }, 'vscode/indentation/indentUsingSpaces', EDITOR_CATEGORY_KEY);
+    export const INDENT_USING_TABS = Command.toLocalizedCommand({
         id: 'textEditor.commands.indentUsingTabs',
         category: EDITOR_CATEGORY,
         label: 'Indent Using Tabs'
-    };
-    export const CHANGE_LANGUAGE: Command = {
+    }, 'vscode/indentation/indentUsingTabs', EDITOR_CATEGORY_KEY);
+    export const CHANGE_LANGUAGE = Command.toLocalizedCommand({
         id: 'textEditor.change.language',
         category: EDITOR_CATEGORY,
         label: 'Change Language Mode'
-    };
-    export const CHANGE_ENCODING: Command = {
+    }, 'vscode/editorStatus/changeMode', EDITOR_CATEGORY_KEY);
+    export const CHANGE_ENCODING = Command.toLocalizedCommand({
         id: 'textEditor.change.encoding',
         category: EDITOR_CATEGORY,
         label: 'Change File Encoding'
-    };
-    export const REVERT_AND_CLOSE: Command = {
+    }, 'vscode/editorStatus/changeEncoding', EDITOR_CATEGORY_KEY);
+    export const REVERT_AND_CLOSE = Command.toLocalizedCommand({
         id: 'workbench.action.revertAndCloseActiveEditor',
-        category: 'View',
+        category: CommonCommands.VIEW_CATEGORY,
         label: 'Revert and Close Editor'
-    };
+    }, 'vscode/editorActions/revertAndCloseActiveEditor', EDITOR_CATEGORY_KEY);
 
     /**
      * Command for going back to the last editor navigation location.
      */
-    export const GO_BACK: Command = {
+    export const GO_BACK = Command.toLocalizedCommand({
         id: 'textEditor.commands.go.back',
         category: EDITOR_CATEGORY,
         label: 'Go Back'
-    };
+    }, 'vscode/editorActions/navigatePrevious', EDITOR_CATEGORY_KEY);
     /**
      * Command for going to the forthcoming editor navigation location.
      */
-    export const GO_FORWARD: Command = {
+    export const GO_FORWARD = Command.toLocalizedCommand({
         id: 'textEditor.commands.go.forward',
         category: EDITOR_CATEGORY,
         label: 'Go Forward'
-    };
+    }, 'vscode/editorActions/navigateNext', EDITOR_CATEGORY_KEY);
     /**
      * Command that reveals the last text edit location, if any.
      */
-    export const GO_LAST_EDIT: Command = {
+    export const GO_LAST_EDIT = Command.toLocalizedCommand({
         id: 'textEditor.commands.go.lastEdit',
         category: EDITOR_CATEGORY,
         label: 'Go to Last Edit Location'
-    };
+    }, 'vscode/editorActions/navigateToLastEditLocation', EDITOR_CATEGORY_KEY);
     /**
      * Command that clears the editor navigation history.
      */
-    export const CLEAR_EDITOR_HISTORY: Command = {
+    export const CLEAR_EDITOR_HISTORY = Command.toLocalizedCommand({
         id: 'textEditor.commands.clear.history',
         category: EDITOR_CATEGORY,
         label: 'Clear Editor History'
-    };
+    }, 'vscode/editorActions/clearEditorHistory', EDITOR_CATEGORY_KEY);
     /**
      * Command that displays all editors that are currently opened.
      */
-    export const SHOW_ALL_OPENED_EDITORS: Command = {
+    export const SHOW_ALL_OPENED_EDITORS = Command.toLocalizedCommand({
         id: 'workbench.action.showAllEditors',
-        category: VIEW_CATEGORY,
+        category: CommonCommands.VIEW_CATEGORY,
         label: 'Show All Opened Editors'
-    };
+    }, 'theia/editor/showAllEditors', EDITOR_CATEGORY_KEY);
     /**
      * Command that toggles the minimap.
      */
-    export const TOGGLE_MINIMAP: Command = {
+    export const TOGGLE_MINIMAP = Command.toLocalizedCommand({
         id: 'editor.action.toggleMinimap',
-        category: VIEW_CATEGORY,
+        category: CommonCommands.VIEW_CATEGORY,
         label: 'Toggle Minimap'
-    };
+    }, 'vscode/toggleMinimap/toggleMinimap', EDITOR_CATEGORY_KEY);
     /**
      * Command that toggles the rendering of whitespace characters in the editor.
      */
-    export const TOGGLE_RENDER_WHITESPACE: Command = {
+    export const TOGGLE_RENDER_WHITESPACE = Command.toLocalizedCommand({
         id: 'editor.action.toggleRenderWhitespace',
-        category: VIEW_CATEGORY,
+        category: CommonCommands.VIEW_CATEGORY,
         label: 'Toggle Render Whitespace'
-    };
+    }, 'vscode/toggleRenderWhitespace/toggleRenderWhitespace', EDITOR_CATEGORY_KEY);
     /**
      * Command that toggles the word wrap.
      */
-    export const TOGGLE_WORD_WRAP: Command = {
+    export const TOGGLE_WORD_WRAP = Command.toLocalizedCommand({
         id: 'editor.action.toggleWordWrap',
-        category: VIEW_CATEGORY,
+        category: CommonCommands.VIEW_CATEGORY,
         label: 'Toggle Word Wrap'
-    };
+    }, 'vscode/toggleWordWrap/miToggleWordWrap', EDITOR_CATEGORY_KEY);
     /**
      * Command that re-opens the last closed editor.
      */
-    export const REOPEN_CLOSED_EDITOR: Command = {
+    export const REOPEN_CLOSED_EDITOR = Command.toLocalizedCommand({
         id: 'workbench.action.reopenClosedEditor',
-        category: VIEW_CATEGORY,
+        category: CommonCommands.VIEW_CATEGORY,
         label: 'Reopen Closed Editor'
-    };
+    }, 'vscode/editorActions/reopenClosedEditor', EDITOR_CATEGORY_KEY);
     /**
      * Opens a second instance of the current editor, splitting the view in the direction specified.
      */
-    export const SPLIT_EDITOR_RIGHT: Command = {
+    export const SPLIT_EDITOR_RIGHT = Command.toLocalizedCommand({
         id: 'workbench.action.splitEditorRight',
-        category: VIEW_CATEGORY,
+        category: CommonCommands.VIEW_CATEGORY,
         label: 'Split Editor Right'
-    };
-    export const SPLIT_EDITOR_DOWN: Command = {
+    }, 'vscode/editorActions/splitEditorGroupRight', EDITOR_CATEGORY_KEY);
+    export const SPLIT_EDITOR_DOWN = Command.toLocalizedCommand({
         id: 'workbench.action.splitEditorDown',
-        category: VIEW_CATEGORY,
+        category: CommonCommands.VIEW_CATEGORY,
         label: 'Split Editor Down'
-    };
-    export const SPLIT_EDITOR_UP: Command = {
+    }, 'vscode/editorActions/splitEditorGroupDown', EDITOR_CATEGORY_KEY);
+    export const SPLIT_EDITOR_UP = Command.toLocalizedCommand({
         id: 'workbench.action.splitEditorUp',
-        category: VIEW_CATEGORY,
+        category: CommonCommands.VIEW_CATEGORY,
         label: 'Split Editor Up'
-    };
-    export const SPLIT_EDITOR_LEFT: Command = {
+    }, 'vscode/editorActions/splitEditorGroupUp', EDITOR_CATEGORY_KEY);
+    export const SPLIT_EDITOR_LEFT = Command.toLocalizedCommand({
         id: 'workbench.action.splitEditorLeft',
-        category: VIEW_CATEGORY,
+        category: CommonCommands.VIEW_CATEGORY,
         label: 'Split Editor Left'
-    };
+    }, 'vscode/editorActions/splitEditorGroupLeft', EDITOR_CATEGORY_KEY);
     /**
      * Default horizontal split: right.
      */
-    export const SPLIT_EDITOR_HORIZONTAL: Command = {
+    export const SPLIT_EDITOR_HORIZONTAL = Command.toLocalizedCommand({
         id: 'workbench.action.splitEditor',
-        category: VIEW_CATEGORY,
+        category: CommonCommands.VIEW_CATEGORY,
         label: 'Split Editor'
-    };
+    }, 'vscode/editorActions/splitEditor', EDITOR_CATEGORY_KEY);
     /**
      * Default vertical split: down.
      */
-    export const SPLIT_EDITOR_VERTICAL: Command = {
+    export const SPLIT_EDITOR_VERTICAL = Command.toLocalizedCommand({
         id: 'workbench.action.splitEditorOrthogonal',
-        category: VIEW_CATEGORY,
+        category: CommonCommands.VIEW_CATEGORY,
         label: 'Split Editor Orthogonal'
-    };
+    }, 'vscode/editorActions/splitEditorOrthogonal', EDITOR_CATEGORY_KEY);
 }
 
 @injectable()
@@ -274,11 +275,11 @@ export class EditorCommandContribution implements CommandContribution {
         }
         const current = editor.document.languageId;
         const items: Array<QuickPickValue<'autoDetect' | Language> | QuickPickItem> = [
-            { label: 'Auto Detect', value: 'autoDetect' },
-            { type: 'separator', label: 'languages (identifier)' },
+            { label: nls.localize('vscode/editorStatus/autoDetect', 'Auto Detect'), value: 'autoDetect' },
+            { type: 'separator', label: nls.localize('vscode/editorStatus/languagesPicks', 'languages (identifier)') },
             ... (this.languages.languages.map(language => this.toQuickPickLanguage(language, current))).sort((e, e2) => e.label.localeCompare(e2.label))
         ];
-        const selectedMode = await this.quickInputService?.showQuickPick(items, { placeholder: 'Select Language Mode' });
+        const selectedMode = await this.quickInputService?.showQuickPick(items, { placeholder: nls.localize('vscode/editorStatus/selectLanguageMode', 'Select Language Mode') });
         if (selectedMode && ('value' in selectedMode)) {
             if (selectedMode.value === 'autoDetect') {
                 editor.detectLanguage();
@@ -299,13 +300,13 @@ export class EditorCommandContribution implements CommandContribution {
         if (!editor) {
             return;
         }
-        const reopenWithEncodingPick = { label: 'Reopen with Encoding', value: 'reopen' };
-        const saveWithEncodingPick = { label: 'Save with Encoding', value: 'save' };
+        const reopenWithEncodingPick = { label: nls.localize('vscode/editorStatus/reopenWithEncoding', 'Reopen with Encoding'), value: 'reopen' };
+        const saveWithEncodingPick = { label: nls.localize('vscode/editorStatus/saveWithEncoding', 'Save with Encoding'), value: 'save' };
         const actionItems: QuickPickValue<string>[] = [
             reopenWithEncodingPick,
             saveWithEncodingPick
         ];
-        const selectedEncoding = await this.quickInputService?.showQuickPick(actionItems, { placeholder: 'Select Action' });
+        const selectedEncoding = await this.quickInputService?.showQuickPick(actionItems, { placeholder: nls.localize('vscode/editorStatus/pickAction', 'Select Action') });
         if (!selectedEncoding) {
             return;
         }
@@ -338,19 +339,21 @@ export class EditorCommandContribution implements CommandContribution {
         // Insert guessed encoding
         if (guessedEncoding && configuredEncoding !== guessedEncoding && SUPPORTED_ENCODINGS[guessedEncoding]) {
             encodingItems.unshift({
-                label: `Guessed from content: ${SUPPORTED_ENCODINGS[guessedEncoding].labelLong}`,
+                label: `${nls.localize('vscode/editorStatus/guessedEncoding', 'Guessed from content')}: ${SUPPORTED_ENCODINGS[guessedEncoding].labelLong}`,
                 value: { id: guessedEncoding, description: guessedEncoding }
             });
         }
         const selectedFileEncoding = await this.quickInputService?.showQuickPick<QuickPickValue<{ id: string, description: string }>>(encodingItems, {
-            placeholder: isReopenWithEncoding ? 'Select File Encoding to Reopen File' : 'Select File Encoding to Save with'
+            placeholder: isReopenWithEncoding ?
+                nls.localize('vscode/editorStatus/pickEncodingForReopen', 'Select File Encoding to Reopen File') :
+                nls.localize('vscode/editorStatus/pickEncodingForSave', 'Select File Encoding to Save with')
         });
 
         if (!selectedFileEncoding) {
             return;
         }
         if (editor.document.dirty && isReopenWithEncoding) {
-            this.messageService.info('The file is dirty. Please save it first before reopening it with another encoding.');
+            this.messageService.info(nls.localize('theia/editor/reopenDirty', 'The file is dirty. Please save it first before reopening it with another encoding.'));
             return;
         } else if (selectedFileEncoding.value) {
             editor.setEncoding(selectedFileEncoding.value.id, isReopenWithEncoding ? EncodingMode.Decode : EncodingMode.Encode);
@@ -361,10 +364,11 @@ export class EditorCommandContribution implements CommandContribution {
         const languageUri = this.toLanguageUri(value);
         const icon = this.labelProvider.getIcon(languageUri);
         const iconClasses = icon !== '' ? [icon + ' file-icon'] : undefined;
+        const configured = current === value.id;
         return {
             value,
             label: value.name,
-            description: `(${value.id})${current === value.id ? ' - Configured Language' : ''}`,
+            description: nls.localize(`vscode/editorStatus/languageDescription${configured ? '' : 'Configured'}`, `({0})${configured ? ' - Configured Language' : ''}`),
             iconClasses
         };
     }

--- a/packages/editor/src/browser/editor-contribution.ts
+++ b/packages/editor/src/browser/editor-contribution.ts
@@ -26,6 +26,7 @@ import { CommandRegistry, CommandContribution } from '@theia/core/lib/common';
 import { KeybindingRegistry, KeybindingContribution } from '@theia/core/lib/browser';
 import { LanguageService } from '@theia/core/lib/browser/language-service';
 import { SUPPORTED_ENCODINGS } from '@theia/core/lib/browser/supported-encodings';
+import { nls } from '@theia/core/lib/browser/nls';
 
 @injectable()
 export class EditorContribution implements FrontendApplicationContribution, CommandContribution, KeybindingContribution {
@@ -95,7 +96,7 @@ export class EditorContribution implements FrontendApplicationContribution, Comm
             alignment: StatusBarAlignment.RIGHT,
             priority: 1,
             command: EditorCommands.CHANGE_LANGUAGE.id,
-            tooltip: 'Select Language Mode'
+            tooltip: nls.localize('vscode/editorStatus/selectLanguageMode', 'Select Language Mode')
         });
     }
 
@@ -109,7 +110,7 @@ export class EditorContribution implements FrontendApplicationContribution, Comm
             alignment: StatusBarAlignment.RIGHT,
             priority: 10,
             command: EditorCommands.CHANGE_ENCODING.id,
-            tooltip: 'Select Encoding'
+            tooltip: nls.localize('vscode/editorStatus/selectEncoding', 'Select Encoding')
         });
     }
 
@@ -120,10 +121,10 @@ export class EditorContribution implements FrontendApplicationContribution, Comm
         }
         const { cursor } = editor;
         this.statusBar.setElement('editor-status-cursor-position', {
-            text: `Ln ${cursor.line + 1}, Col ${editor.getVisibleColumn(cursor)}`,
+            text: nls.localize('vscode/editorStatus/singleSelection', 'Ln {0}, Col {1}', (cursor.line + 1).toString(), editor.getVisibleColumn(cursor).toString()),
             alignment: StatusBarAlignment.RIGHT,
             priority: 100,
-            tooltip: 'Go To Line',
+            tooltip: nls.localize('vscode/editorStatus/gotoLine', 'Go To Line'),
             command: 'editor.action.gotoLine'
         });
     }

--- a/packages/editor/src/browser/editor-menu.ts
+++ b/packages/editor/src/browser/editor-menu.ts
@@ -18,6 +18,7 @@ import { injectable } from '@theia/core/shared/inversify';
 import { MenuContribution, MenuModelRegistry, MenuPath, MAIN_MENU_BAR } from '@theia/core';
 import { CommonCommands, CommonMenus } from '@theia/core/lib/browser';
 import { EditorCommands } from './editor-command';
+import { nls } from '@theia/core/lib/browser/nls';
 
 export const EDITOR_CONTEXT_MENU: MenuPath = ['editor_context_menu'];
 
@@ -72,18 +73,18 @@ export class EditorMenuContribution implements MenuContribution {
         });
 
         // Editor navigation. Go > Back and Go > Forward.
-        registry.registerSubmenu(EditorMainMenu.GO, 'Go');
+        registry.registerSubmenu(EditorMainMenu.GO, nls.localize('vscode/menubar/mGoto', 'Go'));
         registry.registerMenuAction(EditorMainMenu.NAVIGATION_GROUP, {
             commandId: EditorCommands.GO_BACK.id,
-            label: 'Back'
+            label: EditorCommands.GO_BACK.label
         });
         registry.registerMenuAction(EditorMainMenu.NAVIGATION_GROUP, {
             commandId: EditorCommands.GO_FORWARD.id,
-            label: 'Forward'
+            label: EditorCommands.GO_FORWARD.label
         });
         registry.registerMenuAction(EditorMainMenu.NAVIGATION_GROUP, {
             commandId: EditorCommands.GO_LAST_EDIT.id,
-            label: 'Last Edit Location'
+            label: EditorCommands.GO_LAST_EDIT.label
         });
 
         // Toggle Commands.
@@ -94,12 +95,12 @@ export class EditorMenuContribution implements MenuContribution {
         });
         registry.registerMenuAction(CommonMenus.VIEW_TOGGLE, {
             commandId: EditorCommands.TOGGLE_MINIMAP.id,
-            label: 'Show Minimap',
+            label: EditorCommands.TOGGLE_MINIMAP.label,
             order: '1',
         });
         registry.registerMenuAction(CommonMenus.VIEW_TOGGLE, {
             commandId: EditorCommands.TOGGLE_RENDER_WHITESPACE.id,
-            label: 'Render Whitespace',
+            label: EditorCommands.TOGGLE_RENDER_WHITESPACE.label,
             order: '2'
         });
     }

--- a/packages/external-terminal/src/electron-browser/external-terminal-contribution.ts
+++ b/packages/external-terminal/src/electron-browser/external-terminal-contribution.ts
@@ -23,12 +23,13 @@ import { WorkspaceService } from '@theia/workspace/lib/browser';
 import { ExternalTerminalService } from '../common/external-terminal';
 import { ExternalTerminalPreferenceService } from './external-terminal-preference';
 import { QuickPickService } from '@theia/core/lib/common/quick-pick-service';
+import { nls } from '@theia/core/lib/browser/nls';
 
 export namespace ExternalTerminalCommands {
-    export const OPEN_NATIVE_CONSOLE: Command = {
+    export const OPEN_NATIVE_CONSOLE = Command.toLocalizedCommand({
         id: 'workbench.action.terminal.openNativeConsole',
         label: 'Open New External Terminal'
-    };
+    }, 'vscode/externalTerminal.contribution/globalConsoleAction');
 }
 
 @injectable()
@@ -109,7 +110,7 @@ export class ExternalTerminalFrontendContribution implements CommandContribution
                 description: this.labelProvider.getLongName(resource),
                 value: resource.toString()
             })
-        ), { placeholder: 'Select current working directory for new external terminal' });
+        ), { placeholder: nls.localize('theia/external-terminal/cwd', 'Select current working directory for new external terminal') });
         return selectedItem?.value;
     }
 }

--- a/packages/filesystem/src/browser/download/file-download-command-contribution.ts
+++ b/packages/filesystem/src/browser/download/file-download-command-contribution.ts
@@ -22,6 +22,7 @@ import { SelectionService } from '@theia/core/lib/common/selection-service';
 import { Command, CommandContribution, CommandRegistry } from '@theia/core/lib/common/command';
 import { UriAwareCommandHandler } from '@theia/core/lib/common/uri-command-handler';
 import { FileDownloadService } from './file-download-service';
+import { CommonCommands } from '@theia/core/lib/browser';
 
 @injectable()
 export class FileDownloadCommandContribution implements CommandContribution {
@@ -67,16 +68,16 @@ export class FileDownloadCommandContribution implements CommandContribution {
 
 export namespace FileDownloadCommands {
 
-    export const DOWNLOAD: Command = {
+    export const DOWNLOAD = Command.toLocalizedCommand({
         id: 'file.download',
-        category: 'File',
+        category: CommonCommands.FILE_CATEGORY,
         label: 'Download'
-    };
+    }, 'vscode/fileActions/downloadButton', CommonCommands.FILE_CATEGORY_KEY);
 
-    export const COPY_DOWNLOAD_LINK: Command = {
+    export const COPY_DOWNLOAD_LINK = Command.toLocalizedCommand({
         id: 'file.copyDownloadLink',
-        category: 'File',
+        category: CommonCommands.FILE_CATEGORY,
         label: 'Copy Download Link'
-    };
+    }, 'theia/filesystem/copyDownloadLink', CommonCommands.FILE_CATEGORY_KEY);
 
 }

--- a/packages/filesystem/src/browser/filesystem-frontend-contribution.ts
+++ b/packages/filesystem/src/browser/filesystem-frontend-contribution.ts
@@ -23,7 +23,8 @@ import {
     FrontendApplicationContribution, ApplicationShell,
     NavigatableWidget, NavigatableWidgetOptions,
     Saveable, WidgetManager, StatefulWidget, FrontendApplication, ExpandableTreeNode, waitForClosed,
-    CorePreferences
+    CorePreferences,
+    CommonCommands
 } from '@theia/core/lib/browser';
 import { MimeService } from '@theia/core/lib/browser/mime-service';
 import { TreeWidgetSelection } from '@theia/core/lib/browser/tree/tree-widget-selection';
@@ -36,11 +37,11 @@ import { Deferred } from '@theia/core/lib/common/promise-util';
 
 export namespace FileSystemCommands {
 
-    export const UPLOAD: Command = {
+    export const UPLOAD = Command.toLocalizedCommand({
         id: 'file.upload',
-        category: 'File',
+        category: CommonCommands.FILE_CATEGORY,
         label: 'Upload Files...'
-    };
+    }, 'theia/filesystem/uploadFiles', CommonCommands.FILE_CATEGORY_KEY);
 
 }
 

--- a/packages/getting-started/src/browser/getting-started-widget.tsx
+++ b/packages/getting-started/src/browser/getting-started-widget.tsx
@@ -26,6 +26,7 @@ import { ApplicationInfo, ApplicationServer } from '@theia/core/lib/common/appli
 import { FrontendApplicationConfigProvider } from '@theia/core/lib/browser/frontend-application-config-provider';
 import { EnvVariablesServer } from '@theia/core/lib/common/env-variables';
 import { WindowService } from '@theia/core/lib/browser/window/window-service';
+import { nls } from '@theia/core/lib/browser/nls';
 
 /**
  * Default implementation of the `GettingStartedWidget`.
@@ -47,7 +48,7 @@ export class GettingStartedWidget extends ReactWidget {
     /**
      * The widget `label` which is used for display purposes.
      */
-    static readonly LABEL = 'Getting Started';
+    static readonly LABEL = nls.localize('vscode/gettingStarted.contribution/Getting Started', 'Getting Started');
 
     /**
      * The `ApplicationInfo` for the application if available.
@@ -150,7 +151,7 @@ export class GettingStartedWidget extends ReactWidget {
      */
     protected renderHeader(): React.ReactNode {
         return <div className='gs-header'>
-            <h1>{this.applicationName}<span className='gs-sub-header'> Getting Started</span></h1>
+            <h1>{this.applicationName}<span className='gs-sub-header'>{' ' + GettingStartedWidget.LABEL}</span></h1>
         </div>;
     }
 
@@ -167,7 +168,7 @@ export class GettingStartedWidget extends ReactWidget {
                 tabIndex={0}
                 onClick={this.doOpen}
                 onKeyDown={this.doOpenEnter}>
-                Open
+                {nls.localize('vscode/dialogMainService/open', 'Open')}
             </a>
         </div>;
 
@@ -177,7 +178,7 @@ export class GettingStartedWidget extends ReactWidget {
                 tabIndex={0}
                 onClick={this.doOpenFile}
                 onKeyDown={this.doOpenFileEnter}>
-                Open File
+                {nls.localize('vscode/dialogMainService/openFile', 'Open File')}
             </a>
         </div>;
 
@@ -187,7 +188,7 @@ export class GettingStartedWidget extends ReactWidget {
                 tabIndex={0}
                 onClick={this.doOpenFolder}
                 onKeyDown={this.doOpenFolderEnter}>
-                Open Folder
+                {nls.localize('vscode/dialogMainService/openFolder', 'Open Folder')}
             </a>
         </div>;
 
@@ -197,12 +198,12 @@ export class GettingStartedWidget extends ReactWidget {
                 tabIndex={0}
                 onClick={this.doOpenWorkspace}
                 onKeyDown={this.doOpenWorkspaceEnter}>
-                Open Workspace
+                {nls.localize('vscode/dialogMainService/openWorkspaceTitle', 'Open Workspace')}
             </a>
         );
 
         return <div className='gs-section'>
-            <h3 className='gs-section-header'><i className={codicon('folder-opened')}></i>Open</h3>
+            <h3 className='gs-section-header'><i className={codicon('folder-opened')}></i>{nls.localize('vscode/dialogMainService/open', 'Open')}</h3>
             {open}
             {openFile}
             {openFolder}
@@ -237,14 +238,14 @@ export class GettingStartedWidget extends ReactWidget {
                 tabIndex={0}
                 onClick={this.doOpenRecentWorkspace}
                 onKeyDown={this.doOpenRecentWorkspaceEnter}>
-                More...
+                {nls.localize('vscode/vs_code_welcome_page/welcomePage.moreRecent', 'More...')}
             </a>
         </div>;
         return <div className='gs-section'>
             <h3 className='gs-section-header'>
-                <i className={codicon('history')}></i>Recent Workspaces
+                <i className={codicon('history')}></i>{nls.localize('vscode/vs_code_welcome_page/welcomePage.recent', 'Recently opened')}
             </h3>
-            {items.length > 0 ? content : <p className='gs-no-recent'>No Recent Workspaces</p>}
+            {items.length > 0 ? content : <p className='gs-no-recent'>{nls.localize('vscode/vs_code_welcome_page/welcomePage.noRecentFolders', 'No Recent Workspaces')}</p>}
             {more}
         </div>;
     }
@@ -257,7 +258,7 @@ export class GettingStartedWidget extends ReactWidget {
         return <div className='gs-section'>
             <h3 className='gs-section-header'>
                 <i className={codicon('settings-gear')}></i>
-                Settings
+                {nls.localize('vscode/preferences.contribution/settings', 'Settings')}
             </h3>
             <div className='gs-action-container'>
                 <a
@@ -265,7 +266,7 @@ export class GettingStartedWidget extends ReactWidget {
                     tabIndex={0}
                     onClick={this.doOpenPreferences}
                     onKeyDown={this.doOpenPreferencesEnter}>
-                    Open Preferences
+                    {nls.localize('vscode/menubarControl/goToSetting', 'Open Preferences')}
                 </a>
             </div>
             <div className='gs-action-container'>
@@ -274,7 +275,7 @@ export class GettingStartedWidget extends ReactWidget {
                     tabIndex={0}
                     onClick={this.doOpenKeyboardShortcuts}
                     onKeyDown={this.doOpenKeyboardShortcutsEnter}>
-                    Open Keyboard Shortcuts
+                    {nls.localize('vscode/preferences.contribution/openGlobalKeybindings', 'Open Keyboard Shortcuts')}
                 </a>
             </div>
         </div>;
@@ -287,7 +288,7 @@ export class GettingStartedWidget extends ReactWidget {
         return <div className='gs-section'>
             <h3 className='gs-section-header'>
                 <i className={codicon('question')}></i>
-                Help
+                {nls.localize('vscode/gettingStarted.contribution/help', 'Help')}
             </h3>
             <div className='gs-action-container'>
                 <a
@@ -295,7 +296,7 @@ export class GettingStartedWidget extends ReactWidget {
                     tabIndex={0}
                     onClick={() => this.doOpenExternalLink(this.documentationUrl)}
                     onKeyDown={(e: React.KeyboardEvent) => this.doOpenExternalLinkEnter(e, this.documentationUrl)}>
-                    Documentation
+                    {nls.localize('vscode/helpActions/openDocumentationUrl', 'Documentation')}
                 </a>
             </div>
             <div className='gs-action-container'>
@@ -304,7 +305,7 @@ export class GettingStartedWidget extends ReactWidget {
                     tabIndex={0}
                     onClick={() => this.doOpenExternalLink(this.extensionUrl)}
                     onKeyDown={(e: React.KeyboardEvent) => this.doOpenExternalLinkEnter(e, this.extensionUrl)}>
-                    Building a New Extension
+                    {nls.localize('theia/getting-started/newExtension', 'Building a New Extension')}
                 </a>
             </div>
             <div className='gs-action-container'>
@@ -313,7 +314,7 @@ export class GettingStartedWidget extends ReactWidget {
                     tabIndex={0}
                     onClick={() => this.doOpenExternalLink(this.pluginUrl)}
                     onKeyDown={(e: React.KeyboardEvent) => this.doOpenExternalLinkEnter(e, this.pluginUrl)}>
-                    Building a New Plugin
+                    {nls.localize('theia/getting-started/newPlugin', 'Building a New Plugin')}
                 </a>
             </div>
         </div>;
@@ -326,7 +327,7 @@ export class GettingStartedWidget extends ReactWidget {
         return <div className='gs-section'>
             <div className='gs-action-container'>
                 <p className='gs-sub-header' >
-                    {this.applicationInfo ? 'Version ' + this.applicationInfo.version : ''}
+                    {this.applicationInfo ? nls.localize('vscode/extensions.contribution/extensionInfoVersion', 'Version: {0}', this.applicationInfo.version) : ''}
                 </p>
             </div>
         </div>;

--- a/packages/git/src/browser/blame/blame-contribution.ts
+++ b/packages/git/src/browser/blame/blame-contribution.ts
@@ -26,11 +26,11 @@ import { EDITOR_CONTEXT_MENU_SCM } from '@theia/scm-extra/lib/browser/scm-extra-
 import debounce = require('@theia/core/shared/lodash.debounce');
 
 export namespace BlameCommands {
-    export const TOGGLE_GIT_ANNOTATIONS: Command = {
+    export const TOGGLE_GIT_ANNOTATIONS = Command.toLocalizedCommand({
         id: 'git.editor.toggle.annotations',
         category: 'Git',
         label: 'Toggle Blame Annotations'
-    };
+    }, 'theia/git/toggleBlameAnnotations', 'vscode.git/package/displayName');
     export const CLEAR_GIT_ANNOTATIONS: Command = {
         id: 'git.editor.clear.annotations'
     };

--- a/packages/git/src/browser/diff/git-diff-contribution.ts
+++ b/packages/git/src/browser/diff/git-diff-contribution.ts
@@ -36,36 +36,42 @@ import { WorkspaceService } from '@theia/workspace/lib/browser';
 import { TabBarToolbarContribution, TabBarToolbarRegistry, TabBarToolbarItem } from '@theia/core/lib/browser/shell/tab-bar-toolbar';
 import { Emitter } from '@theia/core/lib/common/event';
 import { FileService } from '@theia/filesystem/lib/browser/file-service';
+import { nls } from '@theia/core/lib/browser/nls';
 
 export namespace GitDiffCommands {
-    export const OPEN_FILE_DIFF: Command = {
+    export const OPEN_FILE_DIFF = Command.toLocalizedCommand({
         id: 'git-diff:open-file-diff',
         category: 'Git Diff',
-        label: 'Compare With...'
-    };
+        originalLabel: 'Compare With...',
+        label: nls.localize('vscode/fileActions/globalCompareFile', 'Compare With...')
+    });
     export const TREE_VIEW_MODE = {
         id: 'git.viewmode.tree',
-        tooltip: 'Toggle to Tree View',
+        tooltip: nls.localize('vscode/scmViewPane/viewModeTree', 'Toggle to Tree View'),
         iconClass: codicon('list-tree'),
-        label: 'Toggle to Tree View',
+        originalLabel: 'Toggle to Tree View',
+        label: nls.localize('vscode/scmViewPane/viewModeTree', 'Toggle to Tree View')
     };
     export const LIST_VIEW_MODE = {
         id: 'git.viewmode.list',
-        tooltip: 'Toggle to List View',
+        tooltip: nls.localize('vscode/scmViewPane/viewModeList', 'Toggle to List View'),
         iconClass: codicon('list-flat'),
-        label: 'Toggle to List View',
+        originalLabel: 'Toggle to List View',
+        label: nls.localize('vscode/scmViewPane/viewModeList', 'Toggle to List View')
     };
     export const PREVIOUS_CHANGE = {
         id: 'git.navigate-changes.previous',
-        tooltip: 'Toggle to List View',
+        tooltip: nls.localize('vscode/editor.contribution/navigate.prev.label', 'Previous Change'),
         iconClass: codicon('arrow-left'),
-        label: 'Previous Change',
+        originalLabel: 'Previous Change',
+        label: nls.localize('vscode/editor.contribution/navigate.prev.label', 'Previous Change')
     };
     export const NEXT_CHANGE = {
         id: 'git.navigate-changes.next',
-        tooltip: 'Toggle to List View',
+        tooltip: nls.localize('vscode/editor.contribution/navigate.next.label', 'Next Change'),
         iconClass: codicon('arrow-right'),
-        label: 'Next Change',
+        originalLabel: 'Next Change',
+        label: nls.localize('vscode/editor.contribution/navigate.next.label', 'Next Change')
     };
 }
 

--- a/packages/git/src/browser/git-contribution.ts
+++ b/packages/git/src/browser/git-contribution.ts
@@ -49,170 +49,189 @@ import { ColorRegistry } from '@theia/core/lib/browser/color-registry';
 import { ScmInputIssueType } from '@theia/scm/lib/browser/scm-input';
 import { DecorationsService } from '@theia/core/lib/browser/decorations-service';
 import { GitDecorationProvider } from './git-decoration-provider';
+import { nls } from '@theia/core/lib/browser/nls';
 
 export namespace GIT_COMMANDS {
-    export const CLONE = {
+
+    const GIT_CATEGORY_KEY = 'vscode.git/package/displayName';
+    const GIT_CATEGORY = 'Git';
+
+    export const CLONE = Command.toLocalizedCommand({
         id: 'git.clone',
-        label: 'Git: Clone...'
-    };
-    export const FETCH = {
+        category: GIT_CATEGORY,
+        label: 'Clone...'
+    }, 'vscode.git/package/command.clone', GIT_CATEGORY_KEY);
+    export const FETCH = Command.toLocalizedCommand({
         id: 'git.fetch',
-        label: 'Git: Fetch...'
-    };
-    export const PULL_DEFAULT = {
+        category: GIT_CATEGORY,
+        label: 'Fetch...'
+    }, 'vscode.git/package/command.fetch', GIT_CATEGORY_KEY);
+    export const PULL_DEFAULT = Command.toLocalizedCommand({
         id: 'git.pull.default',
-        label: 'Git: Pull'
-    };
-    export const PULL_DEFAULT_FAVORITE = {
+        category: GIT_CATEGORY,
+        label: 'Pull'
+    }, 'vscode.git/package/command.pull', GIT_CATEGORY_KEY);
+    export const PULL_DEFAULT_FAVORITE: Command = {
         id: PULL_DEFAULT.id + '.favorite',
-        label: PULL_DEFAULT.label
+        label: PULL_DEFAULT.label,
+        originalLabel: PULL_DEFAULT.originalLabel
     };
-    export const PULL = {
+    export const PULL = Command.toLocalizedCommand({
         id: 'git.pull',
-        label: 'Git: Pull from...'
-    };
-    export const PUSH_DEFAULT = {
+        category: GIT_CATEGORY,
+        label: 'Pull from...'
+    }, 'vscode.git/package/command.pullFrom', GIT_CATEGORY_KEY);
+    export const PUSH_DEFAULT = Command.toLocalizedCommand({
         id: 'git.push.default',
-        label: 'Git: Push'
-    };
-    export const PUSH_DEFAULT_FAVORITE = {
+        category: GIT_CATEGORY,
+        label: 'Push'
+    }, 'vscode.git/package/command.push', GIT_CATEGORY_KEY);
+    export const PUSH_DEFAULT_FAVORITE: Command = {
         id: PUSH_DEFAULT.id + '.favorite',
-        label: PUSH_DEFAULT.label
+        label: PUSH_DEFAULT.label,
+        originalLabel: PUSH_DEFAULT.originalLabel
     };
-    export const PUSH = {
+    export const PUSH = Command.toLocalizedCommand({
         id: 'git.push',
-        label: 'Git: Push to...'
-    };
-    export const MERGE = {
+        category: GIT_CATEGORY,
+        label: 'Push to...'
+    }, 'vscode.git/package/command.pushTo', GIT_CATEGORY_KEY);
+    export const MERGE = Command.toLocalizedCommand({
         id: 'git.merge',
-        label: 'Git: Merge...'
-    };
-    export const CHECKOUT = {
+        category: GIT_CATEGORY,
+        label: 'Merge...'
+    }, 'vscode.git/package/command.merge', GIT_CATEGORY_KEY);
+    export const CHECKOUT = Command.toLocalizedCommand({
         id: 'git.checkout',
-        label: 'Git: Checkout'
-    };
+        category: GIT_CATEGORY,
+        label: 'Checkout'
+    }, 'vscode.git/package/command.checkout', GIT_CATEGORY_KEY);
     export const COMMIT = {
-        id: 'git.commit.all',
+        ...Command.toLocalizedCommand({
+            id: 'git.commit.all',
+            label: 'Commit',
+            iconClass: codicon('check')
+        }, 'vscode.git/package/command.commit'),
         tooltip: 'Commit all the staged changes',
-        label: 'Commit',
-        iconClass: codicon('check')
     };
-    export const COMMIT_ADD_SIGN_OFF = {
+    export const COMMIT_ADD_SIGN_OFF = Command.toLocalizedCommand({
         id: 'git-commit-add-sign-off',
         label: 'Add Signed-off-by',
-        category: 'Git',
+        category: GIT_CATEGORY,
         iconClass: codicon('edit')
-    };
+    }, 'theia/git/addSignedOff', GIT_CATEGORY_KEY);
     export const COMMIT_AMEND = {
         id: 'git.commit.amend'
     };
     export const COMMIT_SIGN_OFF = {
         id: 'git.commit.signOff'
     };
-    export const OPEN_FILE: Command = {
+    export const OPEN_FILE = Command.toLocalizedCommand({
         id: 'git.open.file',
-        category: 'Git',
+        category: GIT_CATEGORY,
         label: 'Open File',
         iconClass: codicon('go-to-file')
-    };
-    export const OPEN_CHANGED_FILE: Command = {
+    }, 'vscode.git/package/command.openFile', GIT_CATEGORY_KEY);
+    export const OPEN_CHANGED_FILE = Command.toLocalizedCommand({
         id: 'git.open.changed.file',
-        category: 'Git',
+        category: GIT_CATEGORY,
         label: 'Open File',
         iconClass: codicon('go-to-file')
-    };
-    export const OPEN_CHANGES: Command = {
+    }, 'vscode.git/package/command.openFile', GIT_CATEGORY_KEY);
+    export const OPEN_CHANGES = Command.toLocalizedCommand({
         id: 'git.open.changes',
-        category: 'Git',
+        category: GIT_CATEGORY,
         label: 'Open Changes',
         iconClass: codicon('git-compare')
-    };
-    export const SYNC = {
+    }, 'vscode.git/package/command.openChange', GIT_CATEGORY_KEY);
+    export const SYNC = Command.toLocalizedCommand({
         id: 'git.sync',
-        label: 'Git: Sync'
-    };
-    export const PUBLISH = {
+        category: GIT_CATEGORY,
+        label: 'Sync'
+    }, 'vscode.git/package/command.sync', GIT_CATEGORY_KEY);
+    export const PUBLISH = Command.toLocalizedCommand({
         id: 'git.publish',
-        label: 'Git: Publish Branch'
-    };
-    export const STAGE = {
+        category: GIT_CATEGORY,
+        label: 'Publish Branch'
+    }, 'vscode.git/package/command.publish', GIT_CATEGORY_KEY);
+    export const STAGE = Command.toLocalizedCommand({
         id: 'git.stage',
-        category: 'Git',
+        category: GIT_CATEGORY,
         label: 'Stage Changes',
         iconClass: codicon('add')
-    };
-    export const STAGE_ALL = {
+    }, 'vscode.git/package/command.stage', GIT_CATEGORY_KEY);
+    export const STAGE_ALL = Command.toLocalizedCommand({
         id: 'git.stage.all',
-        category: 'Git',
+        category: GIT_CATEGORY,
         label: 'Stage All Changes',
         iconClass: codicon('add')
-    };
-    export const UNSTAGE = {
+    }, 'vscode.git/package/command.stageAll', GIT_CATEGORY_KEY);
+    export const UNSTAGE = Command.toLocalizedCommand({
         id: 'git.unstage',
-        category: 'Git',
+        category: GIT_CATEGORY,
         label: 'Unstage Changes',
         iconClass: codicon('dash')
-    };
-    export const UNSTAGE_ALL = {
+    }, 'vscode.git/package/command.unstage', GIT_CATEGORY_KEY);
+    export const UNSTAGE_ALL = Command.toLocalizedCommand({
         id: 'git.unstage.all',
-        category: 'Git',
+        category: GIT_CATEGORY,
         label: 'Unstage All',
         iconClass: codicon('dash')
-    };
-    export const DISCARD = {
+    }, 'vscode.git/package/command.unstageAll', GIT_CATEGORY_KEY);
+    export const DISCARD = Command.toLocalizedCommand({
         id: 'git.discard',
         iconClass: codicon('discard'),
-        category: 'Git',
+        category: GIT_CATEGORY,
         label: 'Discard Changes'
-    };
-    export const DISCARD_ALL = {
+    }, 'vscode.git/package/command.clean', GIT_CATEGORY_KEY);
+    export const DISCARD_ALL = Command.toLocalizedCommand({
         id: 'git.discard.all',
-        category: 'Git',
+        category: GIT_CATEGORY,
         label: 'Discard All Changes',
         iconClass: codicon('discard')
-    };
-    export const STASH = {
+    }, 'vscode.git/package/command.cleanAll', GIT_CATEGORY_KEY);
+    export const STASH = Command.toLocalizedCommand({
         id: 'git.stash',
-        category: 'Git',
+        category: GIT_CATEGORY,
         label: 'Stash...'
-    };
-    export const APPLY_STASH = {
+    }, 'vscode.git/package/command.stash', GIT_CATEGORY_KEY);
+    export const APPLY_STASH = Command.toLocalizedCommand({
         id: 'git.stash.apply',
-        category: 'Git',
+        category: GIT_CATEGORY,
         label: 'Apply Stash...'
-    };
-    export const APPLY_LATEST_STASH = {
+    }, 'vscode.git/package/command.stashApply', GIT_CATEGORY_KEY);
+    export const APPLY_LATEST_STASH = Command.toLocalizedCommand({
         id: 'git.stash.apply.latest',
-        category: 'Git',
+        category: GIT_CATEGORY,
         label: 'Apply Latest Stash'
-    };
-    export const POP_STASH = {
+    }, 'vscode.git/package/command.stashApplyLatest', GIT_CATEGORY_KEY);
+    export const POP_STASH = Command.toLocalizedCommand({
         id: 'git.stash.pop',
-        category: 'Git',
+        category: GIT_CATEGORY,
         label: 'Pop Stash...'
-    };
-    export const POP_LATEST_STASH = {
+    }, 'vscode.git/package/command.stashPop', GIT_CATEGORY_KEY);
+    export const POP_LATEST_STASH = Command.toLocalizedCommand({
         id: 'git.stash.pop.latest',
-        category: 'Git',
+        category: GIT_CATEGORY,
         label: 'Pop Latest Stash'
-    };
-    export const DROP_STASH = {
+    }, 'vscode.git/package/command.stashPopLatest', GIT_CATEGORY_KEY);
+    export const DROP_STASH = Command.toLocalizedCommand({
         id: 'git.stash.drop',
-        category: 'Git',
+        category: GIT_CATEGORY,
         label: 'Drop Stash...'
-    };
-    export const REFRESH = {
+    }, 'vscode.git/package/command.stashDrop', GIT_CATEGORY_KEY);
+    export const REFRESH = Command.toLocalizedCommand({
         id: 'git-refresh',
         label: 'Refresh',
-        category: 'Git',
+        category: GIT_CATEGORY,
         iconClass: codicon('refresh')
-    };
-    export const INIT_REPOSITORY = {
+    }, 'vscode.git/package/command.refresh', GIT_CATEGORY_KEY);
+    export const INIT_REPOSITORY = Command.toLocalizedCommand({
         id: 'git-init',
         label: 'Initialize Repository',
-        category: 'Git',
+        category: GIT_CATEGORY,
         iconClass: codicon('add')
-    };
+    }, 'vscode.git/package/command.init', GIT_CATEGORY_KEY);
 }
 export namespace GIT_MENUS {
     // Top level Groups
@@ -221,22 +240,22 @@ export namespace GIT_MENUS {
 
     export const SUBMENU_COMMIT = {
         group: COMMANDS_GROUP,
-        label: 'Commit',
+        label: nls.localize('vscode.git/package/submenu.commit', 'Commit'),
         menuGroups: ['1_commit'],
     };
     export const SUBMENU_CHANGES = {
         group: COMMANDS_GROUP,
-        label: 'Changes',
+        label: nls.localize('vscode.git/package/submenu.changes', 'Changes'),
         menuGroups: ['1_changes']
     };
     export const SUBMENU_PULL_PUSH = {
         group: COMMANDS_GROUP,
-        label: 'Pull, Push',
+        label: nls.localize('vscode.git/package/submenu.pullpush', 'Pull, Push'),
         menuGroups: ['2_pull', '3_push', '4_fetch']
     };
     export const SUBMENU_STASH = {
         group: COMMANDS_GROUP,
-        label: 'Stash',
+        label: nls.localize('vscode.git/package/submenu.stash', 'Stash'),
         menuGroups: ['1_stash']
     };
 }
@@ -548,7 +567,7 @@ export class GitContribution implements CommandContribution, MenuContribution, T
                 if (lastCommit === undefined) {
                     scmRepository.input.issue = {
                         type: ScmInputIssueType.Error,
-                        message: 'No previous commit to amend'
+                        message: nls.localize('theia/git/noPreviousCommit', 'No previous commit to amend')
                     };
                     scmRepository.input.focus();
                     return;
@@ -620,7 +639,7 @@ export class GitContribution implements CommandContribution, MenuContribution, T
             registerItem({
                 id: command.id + '_fav',
                 command: command.id,
-                tooltip: command.label.slice('Git: '.length),
+                tooltip: command.label,
                 group: GIT_MENUS.FAV_GROUP,
                 priority: 100 - index
             })
@@ -629,20 +648,20 @@ export class GitContribution implements CommandContribution, MenuContribution, T
         registerItem({
             id: GIT_COMMANDS.COMMIT_AMEND.id,
             command: GIT_COMMANDS.COMMIT_AMEND.id,
-            tooltip: 'Commit (Amend)',
+            tooltip: nls.localize('vscode.git/package/command.commitStagedAmend', 'Commit (Amend)'),
             group: this.asSubMenuItemOf(GIT_MENUS.SUBMENU_COMMIT)
         });
         registerItem({
             id: GIT_COMMANDS.COMMIT_SIGN_OFF.id,
             command: GIT_COMMANDS.COMMIT_SIGN_OFF.id,
-            tooltip: 'Commit (Signed Off)',
+            tooltip: nls.localize('vscode.git/package/command.commitStagedSigned', 'Commit (Signed Off)'),
             group: this.asSubMenuItemOf(GIT_MENUS.SUBMENU_COMMIT)
         });
         [GIT_COMMANDS.PULL_DEFAULT, GIT_COMMANDS.PULL].forEach(command =>
             registerItem({
                 id: command.id,
                 command: command.id,
-                tooltip: command.label.slice('Git: '.length),
+                tooltip: command.label,
                 group: this.asSubMenuItemOf(GIT_MENUS.SUBMENU_PULL_PUSH)
             })
         );
@@ -650,14 +669,14 @@ export class GitContribution implements CommandContribution, MenuContribution, T
             registerItem({
                 id: command.id,
                 command: command.id,
-                tooltip: command.label.slice('Git: '.length),
+                tooltip: command.label,
                 group: this.asSubMenuItemOf(GIT_MENUS.SUBMENU_PULL_PUSH, 1)
             })
         );
         registerItem({
             id: GIT_COMMANDS.FETCH.id,
             command: GIT_COMMANDS.FETCH.id,
-            tooltip: GIT_COMMANDS.FETCH.label.slice('Git: '.length),
+            tooltip: GIT_COMMANDS.FETCH.label,
             group: this.asSubMenuItemOf(GIT_MENUS.SUBMENU_PULL_PUSH, 2)
         });
 
@@ -677,28 +696,28 @@ export class GitContribution implements CommandContribution, MenuContribution, T
         registerItem({
             id: GIT_COMMANDS.STAGE_ALL.id,
             command: GIT_COMMANDS.STAGE_ALL.id,
-            tooltip: 'Stage All Changes',
+            tooltip: GIT_COMMANDS.STAGE_ALL.label,
             group: this.asSubMenuItemOf(GIT_MENUS.SUBMENU_CHANGES),
             priority: 30
         });
         registerItem({
             id: GIT_COMMANDS.UNSTAGE_ALL.id,
             command: GIT_COMMANDS.UNSTAGE_ALL.id,
-            tooltip: 'Unstage All Changes',
+            tooltip: GIT_COMMANDS.UNSTAGE_ALL.label,
             group: this.asSubMenuItemOf(GIT_MENUS.SUBMENU_CHANGES),
             priority: 20
         });
         registerItem({
             id: GIT_COMMANDS.DISCARD_ALL.id,
             command: GIT_COMMANDS.DISCARD_ALL.id,
-            tooltip: 'Discard All Changes',
+            tooltip: GIT_COMMANDS.DISCARD_ALL.label,
             group: this.asSubMenuItemOf(GIT_MENUS.SUBMENU_CHANGES),
             priority: 10
         });
         registerItem({
             id: GIT_COMMANDS.MERGE.id,
             command: GIT_COMMANDS.MERGE.id,
-            tooltip: GIT_COMMANDS.MERGE.label.slice('Git: '.length),
+            tooltip: GIT_COMMANDS.MERGE.label,
             group: GIT_MENUS.COMMANDS_GROUP
         });
     }
@@ -802,7 +821,7 @@ export class GitContribution implements CommandContribution, MenuContribution, T
         if (this.syncService.isSyncing()) {
             return {
                 title: '$(codicon-sync~spin)',
-                tooltip: 'Synchronizing Changes...'
+                tooltip: nls.localize('vscode.git/statusbar/syncing changes', 'Synchronizing Changes...')
             };
         }
         const { upstreamBranch, aheadBehind } = status;
@@ -810,13 +829,13 @@ export class GitContribution implements CommandContribution, MenuContribution, T
             return {
                 title: '$(codicon-sync)' + (aheadBehind && (aheadBehind.ahead + aheadBehind.behind) > 0 ? ` ${aheadBehind.behind}↓ ${aheadBehind.ahead}↑` : ''),
                 command: GIT_COMMANDS.SYNC.id,
-                tooltip: 'Synchronize Changes'
+                tooltip: nls.localize('vscode.git/repository/sync changes', 'Synchronize Changes')
             };
         }
         return {
             title: '$(codicon-cloud-upload)',
             command: GIT_COMMANDS.PUBLISH.id,
-            tooltip: 'Publish Changes'
+            tooltip: nls.localize('vscode.git/statusbar/publish changes', 'Publish Changes')
         };
     }
 
@@ -829,7 +848,7 @@ export class GitContribution implements CommandContribution, MenuContribution, T
         if (!message.trim()) {
             scmRepository.input.issue = {
                 type: ScmInputIssueType.Error,
-                message: 'Please provide a commit message'
+                message: nls.localize('vscode.git/repository/commitMessageWhitespacesOnlyWarning', 'Please provide a commit message')
             };
             scmRepository.input.focus();
             return;
@@ -837,7 +856,7 @@ export class GitContribution implements CommandContribution, MenuContribution, T
         if (!scmRepository.provider.stagedChanges.length) {
             scmRepository.input.issue = {
                 type: ScmInputIssueType.Error,
-                message: 'No changes added to commit'
+                message: nls.localize('vscode.git/commands/no changes', 'No changes added to commit')
             };
             scmRepository.input.focus();
             return;
@@ -878,7 +897,7 @@ export class GitContribution implements CommandContribution, MenuContribution, T
         } catch (e) {
             scmRepository.input.issue = {
                 type: ScmInputIssueType.Warning,
-                message: 'Make sure you configure your \'user.name\' and \'user.email\' in git.'
+                message: nls.localize('vscode/commands/missing user info', 'Make sure you configure your \'user.name\' and \'user.email\' in git.')
             };
         }
 

--- a/packages/git/src/browser/git-scm-provider.ts
+++ b/packages/git/src/browser/git-scm-provider.ts
@@ -33,6 +33,7 @@ import { LabelProvider } from '@theia/core/lib/browser/label-provider';
 import { GitCommitDetailWidgetOptions } from './history/git-commit-detail-widget-options';
 import { FileService } from '@theia/filesystem/lib/browser/file-service';
 import { ScmInput } from '@theia/scm/lib/browser/scm-input';
+import { nls } from '@theia/core/lib/browser/nls';
 
 @injectable()
 export class GitScmProviderOptions {
@@ -84,7 +85,7 @@ export class GitScmProvider implements ScmProvider {
     protected readonly labelProvider: LabelProvider;
 
     readonly id = 'git';
-    readonly label = 'Git';
+    readonly label = nls.localize('vscode.git/package/displayName', 'Git');
 
     dispose(): void {
         this.toDispose.dispose();
@@ -110,8 +111,8 @@ export class GitScmProvider implements ScmProvider {
     get acceptInputCommand(): ScmCommand | undefined {
         return {
             command: 'git.commit.all',
-            tooltip: 'Commit all the staged changes',
-            title: 'Commit'
+            tooltip: nls.localize('vscode.git/package/command.commitAll', 'Commit all the staged changes'),
+            title: nls.localize('vscode.git/package/command.commit', 'Commit')
         };
     }
 
@@ -159,11 +160,16 @@ export class GitScmProvider implements ScmProvider {
                 }
             }
         }
-        state.groups.push(this.createGroup('merge', 'Merge Changes', state.mergeChanges, true));
-        state.groups.push(this.createGroup('index', 'Staged changes', state.stagedChanges, true));
-        state.groups.push(this.createGroup('workingTree', 'Changes', state.unstagedChanges, false));
+        state.groups.push(this.createGroup('merge', nls.localize('vscode.git/repository/merge changes', 'Merge Changes'), state.mergeChanges, true));
+        state.groups.push(this.createGroup('index', nls.localize('vscode.git/repository/staged changes', 'Staged changes'), state.stagedChanges, true));
+        state.groups.push(this.createGroup('workingTree', nls.localize('vscode.git/repository/changes', 'Changes'), state.unstagedChanges, false));
         this.state = state;
-        this.input.placeholder = `Message (press {0} to commit${status && status.branch ? ' on \'' + status.branch + '\'' : ''})`;
+        if (status && status.branch) {
+            this.input.placeholder = nls.localize('vscode.git/repository/commitMessageWithHeadLabel', 'Message (press {0} to commit on {1})', '{0}', status.branch);
+        } else {
+            this.input.placeholder = nls.localize('vscode.git/repository/commitMessage', 'Message (press {0} to commit)');
+        }
+
         this.fireDidChange();
     }
 
@@ -392,14 +398,14 @@ export class GitScmProvider implements ScmProvider {
         }
         return new ConfirmDialog({
             title: 'Discard changes',
-            msg: `Do you really want to discard changes in ${fileText}?`
+            msg: nls.localize('vscode.git/commands/confirm discard', 'Do you really want to discard changes in {0}?', fileText)
         }).open();
     }
 
     protected confirmAll(): Promise<boolean | undefined> {
         return new ConfirmDialog({
             title: 'Discard All Changes',
-            msg: 'Do you really want to discard all changes?'
+            msg: nls.localize('vscode.git/commands/confirm discard all', 'Do you really want to discard all changes?')
         }).open();
     }
 

--- a/packages/git/src/common/git-model.ts
+++ b/packages/git/src/common/git-model.ts
@@ -16,6 +16,7 @@
 
 import URI from '@theia/core/lib/common/uri';
 import { Path } from '@theia/core';
+import { nls } from '@theia/core/lib/browser/nls';
 
 export interface WorkingDirectoryStatus {
 
@@ -104,12 +105,12 @@ export namespace GitFileStatus {
      */
     export const toString = (status: GitFileStatus, staged?: boolean): string => {
         switch (status) {
-            case GitFileStatus.New: return !!staged ? 'Added' : 'Unstaged';
-            case GitFileStatus.Renamed: return 'Renamed';
-            case GitFileStatus.Copied: return 'Copied';
-            case GitFileStatus.Modified: return 'Modified';
-            case GitFileStatus.Deleted: return 'Deleted';
-            case GitFileStatus.Conflicted: return 'Conflicted';
+            case GitFileStatus.New: return !!staged ? nls.localize('theia/git/added', 'Added') : nls.localize('theia/git/unstaged', 'Unstaged');
+            case GitFileStatus.Renamed: return nls.localize('theia/git/renamed', 'Renamed');
+            case GitFileStatus.Copied: return nls.localize('theia/git/copied', 'Copied');
+            case GitFileStatus.Modified: return nls.localize('vscode.git/repository/modified', 'Modified');
+            case GitFileStatus.Deleted: return nls.localize('vscode.git/repository/deleted', 'Deleted');
+            case GitFileStatus.Conflicted: return nls.localize('theia/git/conflicted', 'Conflicted');
             default: throw new Error(`Unexpected Git file stats: ${status}.`);
         }
     };

--- a/packages/keymaps/src/browser/keymaps-frontend-contribution.ts
+++ b/packages/keymaps/src/browser/keymaps-frontend-contribution.ts
@@ -22,25 +22,26 @@ import {
     MenuContribution,
     MenuModelRegistry
 } from '@theia/core/lib/common';
-import { codicon, Widget } from '@theia/core/lib/browser';
+import { codicon, CommonCommands, Widget } from '@theia/core/lib/browser';
 import { CommonMenus } from '@theia/core/lib/browser/common-frontend-contribution';
 import { KeymapsService } from './keymaps-service';
 import { KeybindingRegistry } from '@theia/core/lib/browser/keybinding';
 import { AbstractViewContribution } from '@theia/core/lib/browser';
 import { KeybindingWidget } from './keybindings-widget';
 import { TabBarToolbarContribution, TabBarToolbarRegistry } from '@theia/core/lib/browser/shell/tab-bar-toolbar';
+import { nls } from '@theia/core/lib/browser/nls';
 
 export namespace KeymapsCommands {
-    export const OPEN_KEYMAPS: Command = {
+    export const OPEN_KEYMAPS = Command.toLocalizedCommand({
         id: 'keymaps:open',
-        category: 'Settings',
+        category: CommonCommands.PREFERENCES_CATEGORY,
         label: 'Open Keyboard Shortcuts',
-    };
-    export const OPEN_KEYMAPS_JSON: Command = {
+    }, 'vscode/preferences.contribution/openGlobalKeybindings', CommonCommands.PREFERENCES_CATEGORY_KEY);
+    export const OPEN_KEYMAPS_JSON = Command.toLocalizedCommand({
         id: 'keymaps:openJson',
-        category: 'Settings',
+        category: CommonCommands.PREFERENCES_CATEGORY,
         label: 'Open Keyboard Shortcuts (JSON)',
-    };
+    }, 'vscode/preferences.contribution/openGlobalKeybindingsFile', CommonCommands.PREFERENCES_CATEGORY_KEY);
     export const OPEN_KEYMAPS_JSON_TOOLBAR: Command = {
         id: 'keymaps:openJson.toolbar',
         iconClass: codicon('json')
@@ -112,13 +113,13 @@ export class KeymapsFrontendContribution extends AbstractViewContribution<Keybin
         toolbar.registerItem({
             id: KeymapsCommands.OPEN_KEYMAPS_JSON_TOOLBAR.id,
             command: KeymapsCommands.OPEN_KEYMAPS_JSON_TOOLBAR.id,
-            tooltip: 'Open Keyboard Shortcuts in JSON',
+            tooltip: nls.localize('vscode/preferences.contribution/openGlobalKeybindingsFile', 'Open Keyboard Shortcuts in JSON'),
             priority: 0,
         });
         toolbar.registerItem({
             id: KeymapsCommands.CLEAR_KEYBINDINGS_SEARCH.id,
             command: KeymapsCommands.CLEAR_KEYBINDINGS_SEARCH.id,
-            tooltip: 'Clear Keybindings Search Input',
+            tooltip: nls.localize('vscode/preferences.contribution/clear', 'Clear Keybindings Search Input'),
             priority: 1,
             onDidChange,
         });

--- a/packages/markers/src/browser/problem/problem-contribution.ts
+++ b/packages/markers/src/browser/problem/problem-contribution.ts
@@ -27,6 +27,7 @@ import { Command, CommandRegistry } from '@theia/core/lib/common/command';
 import { TabBarToolbarContribution, TabBarToolbarRegistry } from '@theia/core/lib/browser/shell/tab-bar-toolbar';
 import { SelectionService } from '@theia/core/lib/common/selection-service';
 import { ProblemSelection } from './problem-selection';
+import { nls } from '@theia/core/lib/browser/nls';
 
 export const PROBLEMS_CONTEXT_MENU: MenuPath = [PROBLEM_KIND];
 
@@ -49,12 +50,12 @@ export namespace ProblemsCommands {
     export const COPY_MESSAGE: Command = {
         id: 'problems.copy.message',
     };
-    export const CLEAR_ALL: Command = {
+    export const CLEAR_ALL = Command.toLocalizedCommand({
         id: 'problems.clear.all',
         category: 'Problems',
         label: 'Clear All',
         iconClass: codicon('clear-all')
-    };
+    }, 'theia/markers/clearAll', 'vscode/markers.contribution/problems');
 }
 
 @injectable()
@@ -67,7 +68,7 @@ export class ProblemContribution extends AbstractViewContribution<ProblemWidget>
     constructor() {
         super({
             widgetId: PROBLEMS_WIDGET_ID,
-            widgetName: 'Problems',
+            widgetName: nls.localize('vscode/markers.contribution/problems', 'Problems'),
             defaultWidgetOptions: {
                 area: 'bottom'
             },
@@ -109,17 +110,18 @@ export class ProblemContribution extends AbstractViewContribution<ProblemWidget>
      */
     protected getStatusBarTooltip(stat: ProblemStat): string {
         if (stat.errors <= 0 && stat.warnings <= 0 && stat.infos <= 0) {
-            return 'No Problems';
+            return nls.localize('vscode/markers.contribution/noProblems', 'No Problems');
         }
+        const localize = (text: string, value: number): string => nls.localize(`vscode/markers.contribution/total${text}`, `{0} ${text}`, value.toString());
         const tooltip: string[] = [];
         if (stat.errors > 0) {
-            tooltip.push(`${stat.errors} Errors`);
+            tooltip.push(localize('Errors', stat.errors));
         }
         if (stat.warnings > 0) {
-            tooltip.push(`${stat.warnings} Warnings`);
+            tooltip.push(localize('Warnings', stat.warnings));
         }
         if (stat.infos > 0) {
-            tooltip.push(`${stat.infos} Infos`);
+            tooltip.push(localize('Infos', stat.infos));
         }
         return tooltip.join(', ');
 
@@ -162,17 +164,17 @@ export class ProblemContribution extends AbstractViewContribution<ProblemWidget>
         super.registerMenus(menus);
         menus.registerMenuAction(ProblemsMenu.CLIPBOARD, {
             commandId: ProblemsCommands.COPY.id,
-            label: 'Copy',
+            label: nls.localize('vscode/markers.contribution/copyMarker', 'Copy'),
             order: '0'
         });
         menus.registerMenuAction(ProblemsMenu.CLIPBOARD, {
             commandId: ProblemsCommands.COPY_MESSAGE.id,
-            label: 'Copy Message',
+            label: nls.localize('vscode/markers.contribution/copyMessage', 'Copy Message'),
             order: '1'
         });
         menus.registerMenuAction(ProblemsMenu.PROBLEMS, {
             commandId: ProblemsCommands.COLLAPSE_ALL.id,
-            label: 'Collapse All',
+            label: nls.localize('vscode/markers.contribution/collapseAll', 'Collapse All'),
             order: '2'
         });
     }
@@ -181,13 +183,13 @@ export class ProblemContribution extends AbstractViewContribution<ProblemWidget>
         toolbarRegistry.registerItem({
             id: ProblemsCommands.COLLAPSE_ALL_TOOLBAR.id,
             command: ProblemsCommands.COLLAPSE_ALL_TOOLBAR.id,
-            tooltip: 'Collapse All',
+            tooltip: nls.localize('vscode/markers.contribution/collapseAll', 'Collapse All'),
             priority: 0,
         });
         toolbarRegistry.registerItem({
             id: ProblemsCommands.CLEAR_ALL.id,
             command: ProblemsCommands.CLEAR_ALL.id,
-            tooltip: 'Clear All',
+            tooltip: ProblemsCommands.CLEAR_ALL.label,
             priority: 1,
         });
     }

--- a/packages/markers/src/browser/problem/problem-widget.tsx
+++ b/packages/markers/src/browser/problem/problem-widget.tsx
@@ -27,6 +27,7 @@ import { DiagnosticSeverity } from '@theia/core/shared/vscode-languageserver-typ
 import * as React from '@theia/core/shared/react';
 import { ProblemPreferences } from './problem-preferences';
 import { DisposableCollection } from '@theia/core/lib/common/disposable';
+import { nls } from '@theia/core/lib/browser/nls';
 
 export const PROBLEMS_WIDGET_ID = 'problems';
 
@@ -50,8 +51,8 @@ export class ProblemWidget extends TreeWidget {
         super(treeProps, model, contextMenuRenderer);
 
         this.id = PROBLEMS_WIDGET_ID;
-        this.title.label = 'Problems';
-        this.title.caption = 'Problems';
+        this.title.label = nls.localize('vscode/settingsLayout/problems', 'Problems');
+        this.title.caption = this.title.label;
         this.title.iconClass = codicon('warning');
         this.title.closable = true;
         this.addClass('theia-marker-container');

--- a/packages/messages/src/browser/notification-center-component.tsx
+++ b/packages/messages/src/browser/notification-center-component.tsx
@@ -19,6 +19,7 @@ import { DisposableCollection } from '@theia/core';
 import { NotificationManager, NotificationUpdateEvent } from './notifications-manager';
 import { NotificationComponent } from './notification-component';
 import { codicon } from '@theia/core/lib/browser';
+import { nls } from '@theia/core/lib/browser/nls';
 
 const PerfectScrollbar = require('react-perfect-scrollbar');
 
@@ -56,15 +57,19 @@ export class NotificationCenterComponent extends React.Component<NotificationCen
 
     render(): React.ReactNode {
         const empty = this.state.notifications.length === 0;
-        const title = empty ? 'NO NEW NOTIFICATIONS' : 'NOTIFICATIONS';
+        const title = empty
+            ? nls.localize('vscode/notificationsStatus/noNotifications', 'NO NEW NOTIFICATIONS')
+            : nls.localize('vscode/notificationsStatus/status.notifications', 'NOTIFICATIONS');
         return (
             <div className={`theia-notifications-container theia-notification-center ${this.state.visibilityState === 'center' ? 'open' : 'closed'}`}>
                 <div className='theia-notification-center-header'>
                     <div className='theia-notification-center-header-title'>{title}</div>
                     <div className='theia-notification-center-header-actions'>
                         <ul className='theia-notification-actions'>
-                            <li className={codicon('clear-all', true)} title='Clear All' onClick={this.onClearAll} />
-                            <li className={codicon('chevron-down', true)} title='Hide Notification Center' onClick={this.onHide} />
+                            <li className={codicon('clear-all', true)} title={nls.localize('vscode/notificationsCommands/clearAllNotifications', 'Clear All Notifications')}
+                                onClick={this.onClearAll} />
+                            <li className={codicon('chevron-down', true)} title={nls.localize('vscode/notificationsCommands/hideNotifications', 'Hide Notifications')}
+                                onClick={this.onHide} />
                         </ul>
                     </div>
                 </div>

--- a/packages/messages/src/browser/notification-component.tsx
+++ b/packages/messages/src/browser/notification-component.tsx
@@ -18,6 +18,7 @@ import * as React from '@theia/core/shared/react';
 import * as DOMPurify from '@theia/core/shared/dompurify';
 import { NotificationManager, Notification } from './notifications-manager';
 import { codicon } from '@theia/core/lib/browser';
+import { nls } from '@theia/core/lib/browser/nls';
 
 export interface NotificationComponentProps {
     readonly manager: NotificationManager;
@@ -86,7 +87,8 @@ export class NotificationComponent extends React.Component<NotificationComponent
                             <li className={codicon('chevron-down') + collapsed ? ' expand' : ' collapse'} title={collapsed ? 'Expand' : 'Collapse'}
                                 data-message-id={messageId} onClick={this.onToggleExpansion} />
                         )}
-                        {!isProgress && (<li className={codicon('close', true)} title='Clear' data-message-id={messageId} onClick={this.onClear} />)}
+                        {!isProgress && (<li className={codicon('close', true)} title={nls.localize('vscode/abstractTree/clear', 'Clear')} data-message-id={messageId}
+                            onClick={this.onClear} />)}
                     </ul>
                 </div>
                 {(source || !!actions.length) && (

--- a/packages/messages/src/browser/notifications-commands.ts
+++ b/packages/messages/src/browser/notifications-commands.ts
@@ -19,6 +19,7 @@ import { codicon } from '@theia/core/lib/browser';
 
 export namespace NotificationsCommands {
 
+    const NOTIFICATIONS_CATEGORY_KEY = 'vscode/notificationsCommands/notifications';
     const NOTIFICATIONS_CATEGORY = 'Notifications';
 
     export const TOGGLE: Command = {
@@ -28,14 +29,22 @@ export namespace NotificationsCommands {
         label: 'Toggle Notifications'
     };
 
-    export const HIDE: Command = {
-        id: 'notifications.commands.hide',
-    };
+    export const SHOW = Command.toLocalizedCommand({
+        id: 'notifications.commands.show',
+        category: NOTIFICATIONS_CATEGORY,
+        label: 'Show Notifications'
+    }, 'vscode/notificationsCommands/showNotifications', NOTIFICATIONS_CATEGORY_KEY);
 
-    export const CLEAR_ALL: Command = {
+    export const HIDE = Command.toLocalizedCommand({
+        id: 'notifications.commands.hide',
+        category: NOTIFICATIONS_CATEGORY,
+        label: 'Hide Notifications'
+    }, 'vscode/notificationsCommands/hideNotifications', NOTIFICATIONS_CATEGORY_KEY);
+
+    export const CLEAR_ALL = Command.toLocalizedCommand({
         id: 'notifications.commands.clearAll',
         category: NOTIFICATIONS_CATEGORY,
         iconClass: codicon('clear-all'),
         label: 'Clear All Notifications'
-    };
+    }, 'vscode/notificationsCommands/clearAllNotifications', NOTIFICATIONS_CATEGORY_KEY);
 }

--- a/packages/messages/src/browser/notifications-contribution.ts
+++ b/packages/messages/src/browser/notifications-contribution.ts
@@ -25,6 +25,7 @@ import { NotificationManager } from './notifications-manager';
 import { NotificationsRenderer } from './notifications-renderer';
 import { ColorContribution } from '@theia/core/lib/browser/color-application-contribution';
 import { ColorRegistry, Color } from '@theia/core/lib/browser/color-registry';
+import { nls } from '@theia/core/lib/browser/nls';
 
 @injectable()
 export class NotificationsContribution implements FrontendApplicationContribution, CommandContribution, KeybindingContribution, ColorContribution {
@@ -62,17 +63,23 @@ export class NotificationsContribution implements FrontendApplicationContributio
     }
     protected getStatusBarItemTooltip(count: number): string {
         if (this.manager.centerVisible) {
-            return 'Hide Notifications';
+            return nls.localize('vscode/notificationsCommands/hideNotifications', 'Hide Notifications');
         }
         return count === 0
-            ? 'No Notifications'
-            : count === 1 ? '1 Notification' : `${count} Notifications`;
+            ? nls.localize('vscode/notificationsStatus/zeroNotifications', 'No Notifications')
+            : count === 1
+                ? nls.localize('vscode/notificationsStatus/oneNotification', '1 Notification')
+                : nls.localize('vscode/notificationsStatus/notifications', '{0} Notifications', count.toString());
     }
 
     registerCommands(commands: CommandRegistry): void {
         commands.registerCommand(NotificationsCommands.TOGGLE, {
             isEnabled: () => true,
             execute: () => this.manager.toggleCenter()
+        });
+        commands.registerCommand(NotificationsCommands.SHOW, {
+            isEnabled: () => true,
+            execute: () => this.manager.showCenter()
         });
         commands.registerCommand(NotificationsCommands.HIDE, {
             execute: () => this.manager.hide()

--- a/packages/messages/src/browser/notifications-manager.ts
+++ b/packages/messages/src/browser/notifications-manager.ts
@@ -112,6 +112,9 @@ export class NotificationManager extends MessageClient {
     hideCenter(): void {
         this.setVisibilityState('hidden');
     }
+    showCenter(): void {
+        this.setVisibilityState('center');
+    }
     toggleCenter(): void {
         this.setVisibilityState(this.centerVisible ? 'hidden' : 'center');
     }

--- a/packages/mini-browser/src/browser/mini-browser-frontend-security-warnings.ts
+++ b/packages/mini-browser/src/browser/mini-browser-frontend-security-warnings.ts
@@ -15,8 +15,9 @@
  ********************************************************************************/
 
 import { MessageService } from '@theia/core';
-import { FrontendApplicationContribution } from '@theia/core/lib/browser';
+import { Dialog, FrontendApplicationContribution } from '@theia/core/lib/browser';
 import { FrontendApplicationConfigProvider } from '@theia/core/lib/browser/frontend-application-config-provider';
+import { nls } from '@theia/core/lib/browser/nls';
 import { WindowService } from '@theia/core/lib/browser/window/window-service';
 import { inject, injectable } from '@theia/core/shared/inversify';
 import { MiniBrowserEndpoint } from '../common/mini-browser-endpoint';
@@ -44,12 +45,12 @@ export class MiniBrowserFrontendSecurityWarnings implements FrontendApplicationC
         }
         const hostPattern = await this.miniBrowserEnvironment.hostPatternPromise;
         if (hostPattern !== MiniBrowserEndpoint.HOST_PATTERN_DEFAULT) {
-            this.messageService.warn(`\
-The mini-browser endpoint's host pattern has been changed to \`${hostPattern}\`; changing the pattern can lead to security vulnerabilities. \
-See \`@theia/mini-browser/README.md\` for more information.`,
-            /* actions: */ 'Ok', 'Go To README',
-            ).then(action => {
-                if (action === 'Go To README') {
+            const goToReadme = nls.localize('theia/webview/goToReadme', 'Go To README');
+            const message = nls.localize('theia/webview/messageWarning', '\
+            The {0} endpoint\'s host pattern has been changed to `{1}`; changing the pattern can lead to security vulnerabilities. \
+            See `{2}` for more information.', 'mini-browser', hostPattern, '@theia/mini-browser/README.md');
+            this.messageService.warn(message, Dialog.OK, goToReadme).then(action => {
+                if (action === goToReadme) {
                     this.windowService.openNewWindow('https://www.npmjs.com/package/@theia/mini-browser', { external: true });
                 }
             });

--- a/packages/mini-browser/src/browser/mini-browser-open-handler.ts
+++ b/packages/mini-browser/src/browser/mini-browser-open-handler.ts
@@ -31,22 +31,27 @@ import { WidgetOpenerOptions } from '@theia/core/lib/browser/widget-open-handler
 import { MiniBrowserService } from '../common/mini-browser-service';
 import { MiniBrowser, MiniBrowserProps } from './mini-browser';
 import { LocationMapperService } from './location-mapper-service';
+import { nls } from '@theia/core/lib/browser/nls';
 
 export namespace MiniBrowserCommands {
-    export const PREVIEW: Command = {
+
+    export const PREVIEW_CATEGORY_KEY = 'vscode/extensionEditor/preview';
+    export const PREVIEW_CATEGORY = 'Preview';
+
+    export const PREVIEW = Command.toLocalizedCommand({
         id: 'mini-browser.preview',
         label: 'Open Preview',
         iconClass: codicon('open-preview')
-    };
+    }, 'vscode/mainThreadFileSystemEventService/preview');
     export const OPEN_SOURCE: Command = {
         id: 'mini-browser.open.source',
         iconClass: codicon('go-to-file')
     };
-    export const OPEN_URL: Command = {
+    export const OPEN_URL = Command.toLocalizedCommand({
         id: 'mini-browser.openUrl',
-        category: 'Preview',
+        category: PREVIEW_CATEGORY,
         label: 'Open URL'
-    };
+    }, 'vscode/url.contribution/openUrl', PREVIEW_CATEGORY_KEY);
 }
 
 /**
@@ -73,7 +78,7 @@ export class MiniBrowserOpenHandler extends NavigatableWidgetOpenHandler<MiniBro
     protected readonly supportedExtensions: Map<string, number> = new Map();
 
     readonly id = MiniBrowser.ID;
-    readonly label = 'Preview';
+    readonly label = nls.localize(MiniBrowserCommands.PREVIEW_CATEGORY_KEY, MiniBrowserCommands.PREVIEW_CATEGORY);
 
     @inject(OpenerService)
     protected readonly openerService: OpenerService;
@@ -204,12 +209,12 @@ export class MiniBrowserOpenHandler extends NavigatableWidgetOpenHandler<MiniBro
         toolbar.registerItem({
             id: MiniBrowserCommands.PREVIEW.id,
             command: MiniBrowserCommands.PREVIEW.id,
-            tooltip: 'Open Preview to the Side'
+            tooltip: nls.localize('theia/preview/openPreviewSide', 'Open Preview to the Side')
         });
         toolbar.registerItem({
             id: MiniBrowserCommands.OPEN_SOURCE.id,
             command: MiniBrowserCommands.OPEN_SOURCE.id,
-            tooltip: 'Open Source'
+            tooltip: nls.localize('theia/preview/openSource', 'Open Source')
         });
     }
 
@@ -263,8 +268,8 @@ export class MiniBrowserOpenHandler extends NavigatableWidgetOpenHandler<MiniBro
 
     protected async openUrl(arg?: string): Promise<void> {
         const url = arg ? arg : await this.quickInputService?.input({
-            prompt: 'URL to open',
-            placeHolder: 'Type a URL'
+            prompt: nls.localize('vscode/url.contribution/urlToOpen', 'URL to open'),
+            placeHolder: nls.localize('theia/mini-browser/typeUrl', 'Type a URL')
         });
         if (url) {
             await this.openPreview(url);
@@ -279,7 +284,7 @@ export class MiniBrowserOpenHandler extends NavigatableWidgetOpenHandler<MiniBro
     protected async getOpenPreviewProps(startPage: string): Promise<MiniBrowserOpenerOptions> {
         const resetBackground = await this.resetBackground(new URI(startPage));
         return {
-            name: 'Preview',
+            name: nls.localize(MiniBrowserCommands.PREVIEW_CATEGORY_KEY, MiniBrowserCommands.PREVIEW_CATEGORY),
             startPage,
             toolbar: 'read-only',
             widgetOptions: {

--- a/packages/monaco/src/browser/monaco-command.ts
+++ b/packages/monaco/src/browser/monaco-command.ts
@@ -24,6 +24,7 @@ import { MonacoCommandRegistry, MonacoEditorCommandHandler } from './monaco-comm
 import { MonacoEditorService } from './monaco-editor-service';
 import { MonacoTextModelService } from './monaco-text-model-service';
 import { ProtocolToMonacoConverter } from './protocol-to-monaco-converter';
+import { nls } from '@theia/core/lib/browser/nls';
 
 export namespace MonacoCommands {
 
@@ -214,11 +215,10 @@ export class MonacoEditorCommandHandlers implements CommandContribution {
     }
     protected configureIndentation(editor: MonacoEditor): void {
         const items = [true, false].map(useSpaces => ({
-            label: `Indent Using ${useSpaces ? 'Spaces' : 'Tabs'}`,
+            label: nls.localize(`vscode/indentation/indentUsing${useSpaces ? 'Spaces' : 'Tabs'}`, `Indent Using ${useSpaces ? 'Spaces' : 'Tabs'}`),
             execute: () => this.configureTabSize(editor, useSpaces)
-        })
-        );
-        this.quickInputService?.showQuickPick(items, { placeholder: 'Select Action' });
+        }));
+        this.quickInputService?.showQuickPick(items, { placeholder: nls.localize('vscode/editorStatus/pickAction', 'Select Action') });
     }
 
     protected newConfigEolHandler(): MonacoEditorCommandHandler {
@@ -234,7 +234,7 @@ export class MonacoEditorCommandHandlers implements CommandContribution {
             execute: () => this.setEol(editor, lineEnding)
         })
         );
-        this.quickInputService?.showQuickPick(items, { placeholder: 'Select End of Line Sequence' });
+        this.quickInputService?.showQuickPick(items, { placeholder: nls.localize('vscode/editorStatus/selectEOL', 'Select End of Line Sequence') });
     }
 
     protected setEol(editor: MonacoEditor, lineEnding: string): void {
@@ -260,7 +260,7 @@ export class MonacoEditorCommandHandlers implements CommandContribution {
             const sizes = Array.from(Array(8), (_, x) => x + 1);
             const tabSizeOptions = sizes.map(size =>
             ({
-                label: size === tabSize ? `${size}   Configured Tab Size` : size.toString(),
+                label: size === tabSize ? size + '   ' + nls.localize('vscode/indentation/configuredTabSize', 'Configured Tab Size') : size.toString(),
                 // eslint-disable-next-line @typescript-eslint/no-explicit-any
                 execute: () => model.updateOptions({
                     tabSize: size || tabSize,
@@ -268,7 +268,7 @@ export class MonacoEditorCommandHandlers implements CommandContribution {
                 })
             })
             );
-            this.quickInputService?.showQuickPick(tabSizeOptions, { placeholder: 'Select Tab Size for Current File' });
+            this.quickInputService?.showQuickPick(tabSizeOptions, { placeholder: nls.localize('vscode/indentation/selectTabWidth', 'Select Tab Size for Current File') });
         }
     }
 

--- a/packages/monaco/src/browser/monaco-menu.ts
+++ b/packages/monaco/src/browser/monaco-menu.ts
@@ -18,6 +18,7 @@ import { injectable, inject } from '@theia/core/shared/inversify';
 import { MenuContribution, MenuModelRegistry, MAIN_MENU_BAR, MenuPath } from '@theia/core/lib/common';
 import { EDITOR_CONTEXT_MENU } from '@theia/editor/lib/browser';
 import { MonacoCommandRegistry } from './monaco-command-registry';
+import { nls } from '@theia/core/lib/browser/nls';
 import MenuRegistry = monaco.actions.MenuRegistry;
 
 export interface MonacoActionGroup {
@@ -50,7 +51,7 @@ export class MonacoEditorMenuContribution implements MenuContribution {
 
         this.registerPeekSubmenu(registry);
 
-        registry.registerSubmenu(MonacoMenus.SELECTION, 'Selection');
+        registry.registerSubmenu(MonacoMenus.SELECTION, nls.localize('vscode/menubar/mSelection', 'Selection'));
         for (const item of MenuRegistry.getMenuItems(monaco.actions.MenuId.MenubarSelectionMenu)) {
             if (!monaco.actions.isIMenuItem(item)) {
                 continue;
@@ -67,7 +68,7 @@ export class MonacoEditorMenuContribution implements MenuContribution {
     }
 
     protected registerPeekSubmenu(registry: MenuModelRegistry): void {
-        registry.registerSubmenu(MonacoMenus.PEEK_CONTEXT_SUBMENU, 'Peek');
+        registry.registerSubmenu(MonacoMenus.PEEK_CONTEXT_SUBMENU, nls.localize('vscode/goToCommands/peek.submenu', 'Peek'));
 
         for (const item of MenuRegistry.getMenuItems(monaco.actions.MenuId.EditorContextPeek)) {
             if (!monaco.actions.isIMenuItem(item)) {

--- a/packages/navigator/src/browser/navigator-contribution.ts
+++ b/packages/navigator/src/browser/navigator-contribution.ts
@@ -53,7 +53,7 @@ import {
     WorkspacePreferences,
     WorkspaceService
 } from '@theia/workspace/lib/browser';
-import { EXPLORER_VIEW_CONTAINER_ID } from './navigator-widget-factory';
+import { EXPLORER_VIEW_CONTAINER_ID, EXPLORER_VIEW_CONTAINER_TITLE_OPTIONS } from './navigator-widget-factory';
 import { FILE_NAVIGATOR_ID, FileNavigatorWidget } from './navigator-widget';
 import { FileNavigatorPreferences } from './navigator-preferences';
 import { NavigatorKeybindingContexts } from './navigator-keybinding-context';
@@ -77,50 +77,51 @@ import URI from '@theia/core/lib/common/uri';
 import { OpenEditorsWidget } from './open-editors-widget/navigator-open-editors-widget';
 import { OpenEditorsContextMenu } from './open-editors-widget/navigator-open-editors-menus';
 import { OpenEditorsCommands } from './open-editors-widget/navigator-open-editors-commands';
+import { nls } from '@theia/core/lib/browser/nls';
 
 export namespace FileNavigatorCommands {
-    export const REVEAL_IN_NAVIGATOR: Command = {
+    export const REVEAL_IN_NAVIGATOR = Command.toLocalizedCommand({
         id: 'navigator.reveal',
         label: 'Reveal in Explorer'
-    };
-    export const TOGGLE_HIDDEN_FILES: Command = {
+    }, 'theia/navigator/reveal');
+    export const TOGGLE_HIDDEN_FILES = Command.toLocalizedCommand({
         id: 'navigator.toggle.hidden.files',
         label: 'Toggle Hidden Files'
-    };
-    export const TOGGLE_AUTO_REVEAL: Command = {
+    }, 'theia/navigator/toggleHiddenFiles');
+    export const TOGGLE_AUTO_REVEAL = Command.toLocalizedCommand({
         id: 'navigator.toggle.autoReveal',
-        category: 'File',
+        category: CommonCommands.FILE_CATEGORY,
         label: 'Auto Reveal'
-    };
-    export const REFRESH_NAVIGATOR: Command = {
+    }, 'theia/navigator/autoReveal', CommonCommands.FILE_CATEGORY_KEY);
+    export const REFRESH_NAVIGATOR = Command.toLocalizedCommand({
         id: 'navigator.refresh',
-        category: 'File',
+        category: CommonCommands.FILE_CATEGORY,
         label: 'Refresh in Explorer',
         iconClass: codicon('refresh')
-    };
-    export const COLLAPSE_ALL: Command = {
+    }, 'theia/navigator/refresh', CommonCommands.FILE_CATEGORY_KEY);
+    export const COLLAPSE_ALL = Command.toLocalizedCommand({
         id: 'navigator.collapse.all',
-        category: 'File',
+        category: CommonCommands.FILE_CATEGORY,
         label: 'Collapse Folders in Explorer',
         iconClass: codicon('collapse-all')
-    };
+    }, 'vscode/explorerView/collapseExplorerFolders', CommonCommands.FILE_CATEGORY_KEY);
     export const ADD_ROOT_FOLDER: Command = {
         id: 'navigator.addRootFolder'
     };
-    export const FOCUS: Command = {
+    export const FOCUS = Command.toLocalizedCommand({
         id: 'workbench.files.action.focusFilesExplorer',
-        category: 'File',
+        category: CommonCommands.FILE_CATEGORY,
         label: 'Focus on Files Explorer'
-    };
-    export const COPY_RELATIVE_FILE_PATH: Command = {
+    }, 'vscode/fileActions/focusFilesExplorer', CommonCommands.FILE_CATEGORY_KEY);
+    export const COPY_RELATIVE_FILE_PATH = Command.toLocalizedCommand({
         id: 'navigator.copyRelativeFilePath',
         label: 'Copy Relative Path'
-    };
-    export const OPEN: Command = {
+    }, 'vscode/fileActions.contribution/copyRelativePath');
+    export const OPEN = Command.toLocalizedCommand({
         id: 'navigator.open',
-        category: 'File',
+        category: CommonCommands.FILE_CATEGORY,
         label: 'Open'
-    };
+    }, 'vscode/dialogMainService/open', CommonCommands.FILE_CATEGORY_KEY);
 }
 
 /**
@@ -206,7 +207,7 @@ export class FileNavigatorContribution extends AbstractViewContribution<FileNavi
         super({
             viewContainerId: EXPLORER_VIEW_CONTAINER_ID,
             widgetId: FILE_NAVIGATOR_ID,
-            widgetName: 'Explorer',
+            widgetName: EXPLORER_VIEW_CONTAINER_TITLE_OPTIONS.label,
             defaultWidgetOptions: {
                 area: 'left',
                 rank: 100
@@ -428,9 +429,9 @@ export class FileNavigatorContribution extends AbstractViewContribution<FileNavi
 
         registry.registerMenuAction(NavigatorContextMenu.NAVIGATION, {
             commandId: FileNavigatorCommands.OPEN.id,
-            label: 'Open'
+            label: FileNavigatorCommands.OPEN.label
         });
-        registry.registerSubmenu(NavigatorContextMenu.OPEN_WITH, 'Open With');
+        registry.registerSubmenu(NavigatorContextMenu.OPEN_WITH, nls.localize('vscode/fileActions.contribution/explorerOpenWith', 'Open With...'));
         this.openerService.getOpeners().then(openers => {
             for (const opener of openers) {
                 const openWithCommand = WorkspaceCommands.FILE_OPEN_WITH(opener);
@@ -499,7 +500,7 @@ export class FileNavigatorContribution extends AbstractViewContribution<FileNavi
         });
         registry.registerMenuAction(NavigatorContextMenu.MODIFICATION, {
             commandId: FileNavigatorCommands.COLLAPSE_ALL.id,
-            label: 'Collapse All',
+            label: nls.localize('vscode/treeView/collapseAll', 'Collapse All'),
             order: 'z2'
         });
 
@@ -588,13 +589,13 @@ export class FileNavigatorContribution extends AbstractViewContribution<FileNavi
         toolbarRegistry.registerItem({
             id: FileNavigatorCommands.REFRESH_NAVIGATOR.id,
             command: FileNavigatorCommands.REFRESH_NAVIGATOR.id,
-            tooltip: 'Refresh Explorer',
+            tooltip: nls.localize('vscode/explorerView/refreshExplorer', 'Refresh Explorer'),
             priority: 0,
         });
         toolbarRegistry.registerItem({
             id: FileNavigatorCommands.COLLAPSE_ALL.id,
             command: FileNavigatorCommands.COLLAPSE_ALL.id,
-            tooltip: 'Collapse All',
+            tooltip: nls.localize('vscode/treeView/collapseAll', 'Collapse All'),
             priority: 1,
         });
         this.registerMoreToolbarItem({

--- a/packages/navigator/src/browser/navigator-widget-factory.ts
+++ b/packages/navigator/src/browser/navigator-widget-factory.ts
@@ -24,10 +24,11 @@ import {
 } from '@theia/core/lib/browser';
 import { FILE_NAVIGATOR_ID } from './navigator-widget';
 import { OpenEditorsWidget } from './open-editors-widget/navigator-open-editors-widget';
+import { nls } from '@theia/core/lib/browser/nls';
 
 export const EXPLORER_VIEW_CONTAINER_ID = 'explorer-view-container';
 export const EXPLORER_VIEW_CONTAINER_TITLE_OPTIONS: ViewContainerTitleOptions = {
-    label: 'Explorer',
+    label: nls.localize('vscode/settingsLayout/fileExplorer', 'Explorer'),
     iconClass: codicon('files'),
     closeable: true
 };

--- a/packages/navigator/src/browser/navigator-widget.tsx
+++ b/packages/navigator/src/browser/navigator-widget.tsx
@@ -36,9 +36,10 @@ import { isOSX, environment } from '@theia/core';
 import * as React from '@theia/core/shared/react';
 import { NavigatorContextKeyService } from './navigator-context-key-service';
 import { FileNavigatorCommands } from './navigator-contribution';
+import { nls } from '@theia/core/lib/browser/nls';
 
 export const FILE_NAVIGATOR_ID = 'files';
-export const LABEL = 'No folder opened';
+export const LABEL = nls.localize('vscode/emptyView/noWorkspace', 'No folder opened');
 export const CLASS = 'theia-Files';
 
 @injectable()
@@ -70,7 +71,7 @@ export class FileNavigatorWidget extends FileTreeWidget {
         super.init();
         // This ensures that the context menu command to hide this widget receives the label 'Folders'
         // regardless of the name of workspace. See ViewContainer.updateToolbarItems.
-        const dataset = { ...this.title.dataset, visibilityCommandLabel: 'Folders' };
+        const dataset = { ...this.title.dataset, visibilityCommandLabel: nls.localize('vscode/explorerViewlet/folders', 'Folders') };
         this.title.dataset = dataset;
         this.updateSelectionContextKeys();
         this.toDispose.pushAll([
@@ -251,6 +252,7 @@ export class FileNavigatorWidget extends FileTreeWidget {
      * Instead of displaying an empty navigator tree, this will show a button to add more folders.
      */
     protected renderEmptyMultiRootWorkspace(): React.ReactNode {
+        // TODO: @msujew Implement a markdown renderer and use vscode/explorerViewlet/noFolderHelp
         return <div className='theia-navigator-container'>
             <div className='center'>You have not yet added a folder to the workspace.</div>
             <div className='open-workspace-button-container'>

--- a/packages/navigator/src/browser/open-editors-widget/navigator-open-editors-commands.ts
+++ b/packages/navigator/src/browser/open-editors-widget/navigator-open-editors-commands.ts
@@ -14,34 +14,35 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
+import { CommonCommands } from '@theia/core/lib/browser';
 import { Command } from '@theia/core/lib/common';
 
 export namespace OpenEditorsCommands {
-    export const CLOSE_ALL_TABS_FROM_TOOLBAR: Command = {
+    export const CLOSE_ALL_TABS_FROM_TOOLBAR = Command.toLocalizedCommand({
         id: 'navigator.close.all.editors.toolbar',
-        category: 'File',
+        category: CommonCommands.FILE_CATEGORY,
         label: 'Close All Editors',
         iconClass: 'codicon codicon-close-all'
-    };
+    }, 'vscode/editorActions/closeAllEditors', CommonCommands.FILE_CATEGORY_KEY);
 
-    export const SAVE_ALL_TABS_FROM_TOOLBAR: Command = {
+    export const SAVE_ALL_TABS_FROM_TOOLBAR = Command.toLocalizedCommand({
         id: 'navigator.save.all.editors.toolbar',
-        category: 'File',
+        category: CommonCommands.FILE_CATEGORY,
         label: 'Save All Editors',
         iconClass: 'codicon codicon-save-all'
-    };
+    }, 'vscode/fileActions.contribution/saveFiles', CommonCommands.FILE_CATEGORY_KEY);
 
-    export const CLOSE_ALL_EDITORS_IN_GROUP_FROM_ICON: Command = {
+    export const CLOSE_ALL_EDITORS_IN_GROUP_FROM_ICON = Command.toLocalizedCommand({
         id: 'navigator.close.all.in.area.icon',
-        category: 'View',
+        category: CommonCommands.VIEW_CATEGORY,
         label: 'Close Group',
         iconClass: 'codicon codicon-close-all'
-    };
+    }, 'vscode/fileActions/closeGroup', CommonCommands.VIEW_CATEGORY_KEY);
 
-    export const SAVE_ALL_IN_GROUP_FROM_ICON: Command = {
+    export const SAVE_ALL_IN_GROUP_FROM_ICON = Command.toLocalizedCommand({
         id: 'navigator.save.all.in.area.icon',
-        category: 'File',
+        category: CommonCommands.FILE_CATEGORY,
         label: 'Save All in Group',
         iconClass: 'codicon codicon-save-all'
-    };
+    }, 'vscode/fileActions.contribution/saveAllInGroup', CommonCommands.FILE_CATEGORY_KEY);
 }

--- a/packages/navigator/src/browser/open-editors-widget/navigator-open-editors-widget.tsx
+++ b/packages/navigator/src/browser/open-editors-widget/navigator-open-editors-widget.tsx
@@ -38,6 +38,7 @@ import { OpenEditorsTreeDecoratorService } from './navigator-open-editors-decora
 import { OPEN_EDITORS_CONTEXT_MENU } from './navigator-open-editors-menus';
 import { CommandService } from '@theia/core/lib/common';
 import { OpenEditorsCommands } from './navigator-open-editors-commands';
+import { nls } from '@theia/core/lib/browser/nls';
 
 export const OPEN_EDITORS_PROPS: TreeProps = {
     ...defaultTreeProps,
@@ -51,7 +52,7 @@ export interface OpenEditorsNodeRow extends TreeWidget.NodeRow {
 @injectable()
 export class OpenEditorsWidget extends FileTreeWidget {
     static ID = 'theia-open-editors-widget';
-    static LABEL = 'Open Editors';
+    static LABEL = nls.localize('vscode/openEditorsView/openEditors', 'Open Editors');
 
     @inject(ApplicationShell) protected readonly applicationShell: ApplicationShell;
     @inject(CommandService) protected readonly commandService: CommandService;

--- a/packages/outline-view/src/browser/outline-view-contribution.ts
+++ b/packages/outline-view/src/browser/outline-view-contribution.ts
@@ -23,6 +23,7 @@ import { codicon, Widget } from '@theia/core/lib/browser/widgets';
 import { OutlineViewWidget } from './outline-view-widget';
 import { CompositeTreeNode } from '@theia/core/lib/browser/tree';
 import { OS } from '@theia/core/lib/common/os';
+import { nls } from '@theia/core/lib/browser/nls';
 
 export const OUTLINE_WIDGET_FACTORY_ID = 'outline-view';
 
@@ -46,7 +47,7 @@ export class OutlineViewContribution extends AbstractViewContribution<OutlineVie
     constructor() {
         super({
             widgetId: OUTLINE_WIDGET_FACTORY_ID,
-            widgetName: 'Outline',
+            widgetName: OutlineViewWidget.LABEL,
             defaultWidgetOptions: {
                 area: 'right',
                 rank: 500
@@ -75,7 +76,7 @@ export class OutlineViewContribution extends AbstractViewContribution<OutlineVie
         toolbar.registerItem({
             id: OutlineViewCommands.COLLAPSE_ALL.id,
             command: OutlineViewCommands.COLLAPSE_ALL.id,
-            tooltip: 'Collapse All',
+            tooltip: nls.localize('vscode/outlinePane/collapse', 'Collapse All'),
             priority: 0
         });
     }

--- a/packages/outline-view/src/browser/outline-view-widget.tsx
+++ b/packages/outline-view/src/browser/outline-view-widget.tsx
@@ -33,6 +33,7 @@ import { CompositeTreeNode } from '@theia/core/lib/browser';
 import * as React from '@theia/core/shared/react';
 import { Range } from '@theia/core/shared/vscode-languageserver-types';
 import URI from '@theia/core/lib/common/uri';
+import { nls } from '@theia/core/lib/browser/nls';
 
 /**
  * Representation of an outline symbol information node.
@@ -73,6 +74,8 @@ export const OutlineViewWidgetFactory = Symbol('OutlineViewWidgetFactory');
 @injectable()
 export class OutlineViewWidget extends TreeWidget {
 
+    static LABEL = nls.localize('vscode/outline.contribution/name', 'Outline');
+
     readonly onDidChangeOpenStateEmitter = new Emitter<boolean>();
 
     constructor(
@@ -83,8 +86,8 @@ export class OutlineViewWidget extends TreeWidget {
         super(treeProps, model, contextMenuRenderer);
 
         this.id = 'outline-view';
-        this.title.label = 'Outline';
-        this.title.caption = 'Outline';
+        this.title.label = OutlineViewWidget.LABEL;
+        this.title.caption = OutlineViewWidget.LABEL;
         this.title.closable = true;
         this.title.iconClass = codicon('symbol-class');
         this.addClass('theia-outline-view');
@@ -104,7 +107,7 @@ export class OutlineViewWidget extends TreeWidget {
     protected getRoot(children: TreeNode[]): CompositeTreeNode {
         return {
             id: 'outline-view-root',
-            name: 'Outline Root',
+            name: OutlineViewWidget.LABEL,
             visible: false,
             children,
             parent: undefined
@@ -177,7 +180,7 @@ export class OutlineViewWidget extends TreeWidget {
 
     protected renderTree(model: TreeModel): React.ReactNode {
         if (CompositeTreeNode.is(this.model.root) && !this.model.root.children.length) {
-            return <div className='theia-widget-noInfo no-outline'>No outline information available.</div>;
+            return <div className='theia-widget-noInfo no-outline'>{nls.localize('vscode/outlinePane/no-editor', 'No outline information available.')}</div>;
         }
         return super.renderTree(model);
     }

--- a/packages/output/src/browser/output-commands.ts
+++ b/packages/output/src/browser/output-commands.ts
@@ -19,6 +19,7 @@ import { Command } from '@theia/core/lib/common';
 
 export namespace OutputCommands {
 
+    const OUTPUT_CATEGORY_KEY = 'vscode/outputView/output';
     const OUTPUT_CATEGORY = 'Output';
 
     /* #region VS Code `OutputChannel` API */
@@ -50,47 +51,47 @@ export namespace OutputCommands {
 
     /* #endregion VS Code `OutputChannel` API */
 
-    export const CLEAR__WIDGET: Command = {
+    export const CLEAR__WIDGET = Command.toLocalizedCommand({
         id: 'output:widget:clear',
         category: OUTPUT_CATEGORY,
         iconClass: codicon('clear-all')
-    };
+    }, '', OUTPUT_CATEGORY_KEY);
 
-    export const LOCK__WIDGET: Command = {
+    export const LOCK__WIDGET = Command.toLocalizedCommand({
         id: 'output:widget:lock',
         category: OUTPUT_CATEGORY,
         iconClass: codicon('unlock')
-    };
+    }, '', OUTPUT_CATEGORY_KEY);
 
-    export const UNLOCK__WIDGET: Command = {
+    export const UNLOCK__WIDGET = Command.toLocalizedCommand({
         id: 'output:widget:unlock',
         category: OUTPUT_CATEGORY,
         iconClass: codicon('lock')
-    };
+    }, '', OUTPUT_CATEGORY_KEY);
 
-    export const CLEAR__QUICK_PICK: Command = {
+    export const CLEAR__QUICK_PICK = Command.toLocalizedCommand({
         id: 'output:pick-clear',
         label: 'Clear Output Channel...',
         category: OUTPUT_CATEGORY
-    };
+    }, 'theia/output/clearOutputChannel', OUTPUT_CATEGORY_KEY);
 
-    export const SHOW__QUICK_PICK: Command = {
+    export const SHOW__QUICK_PICK = Command.toLocalizedCommand({
         id: 'output:pick-show',
         label: 'Show Output Channel...',
         category: OUTPUT_CATEGORY
-    };
+    }, 'theia/output/showOutputChannel', OUTPUT_CATEGORY_KEY);
 
-    export const HIDE__QUICK_PICK: Command = {
+    export const HIDE__QUICK_PICK = Command.toLocalizedCommand({
         id: 'output:pick-hide',
         label: 'Hide Output Channel...',
         category: OUTPUT_CATEGORY
-    };
+    }, 'theia/output/hideOutputChannel', OUTPUT_CATEGORY_KEY);
 
-    export const DISPOSE__QUICK_PICK: Command = {
+    export const DISPOSE__QUICK_PICK = Command.toLocalizedCommand({
         id: 'output:pick-dispose',
         label: 'Close Output Channel...',
         category: OUTPUT_CATEGORY
-    };
+    }, 'theia/output/closeOutputChannel', OUTPUT_CATEGORY_KEY);
 
     export const COPY_ALL: Command = {
         id: 'output:copy-all',

--- a/packages/output/src/browser/output-contribution.ts
+++ b/packages/output/src/browser/output-contribution.ts
@@ -28,6 +28,7 @@ import { ClipboardService } from '@theia/core/lib/browser/clipboard-service';
 import { OutputChannelManager, OutputChannel } from '../common/output-channel';
 import { OutputCommands } from './output-commands';
 import { QuickPickService } from '@theia/core/lib/common/quick-pick-service';
+import { nls } from '@theia/core/lib/browser/nls';
 
 @injectable()
 export class OutputContribution extends AbstractViewContribution<OutputWidget> implements OpenHandler {
@@ -52,7 +53,7 @@ export class OutputContribution extends AbstractViewContribution<OutputWidget> i
     constructor() {
         super({
             widgetId: OutputWidget.ID,
-            widgetName: 'Output',
+            widgetName: OutputWidget.LABEL,
             defaultWidgetOptions: {
                 area: 'bottom'
             },
@@ -162,7 +163,7 @@ export class OutputContribution extends AbstractViewContribution<OutputWidget> i
         registry.registerCommand(OutputCommands.CLEAR__QUICK_PICK, {
             execute: async () => {
                 const channel = await this.pick({
-                    placeholder: 'Clear output channel.',
+                    placeholder: OutputCommands.CLEAR__QUICK_PICK.label!,
                     channels: this.outputChannelManager.getChannels().slice()
                 });
                 if (channel) {
@@ -175,7 +176,7 @@ export class OutputContribution extends AbstractViewContribution<OutputWidget> i
         registry.registerCommand(OutputCommands.SHOW__QUICK_PICK, {
             execute: async () => {
                 const channel = await this.pick({
-                    placeholder: 'Show output channel.',
+                    placeholder: OutputCommands.SHOW__QUICK_PICK.label!,
                     channels: this.outputChannelManager.getChannels().slice()
                 });
                 if (channel) {
@@ -189,7 +190,7 @@ export class OutputContribution extends AbstractViewContribution<OutputWidget> i
         registry.registerCommand(OutputCommands.HIDE__QUICK_PICK, {
             execute: async () => {
                 const channel = await this.pick({
-                    placeholder: 'Hide output channel.',
+                    placeholder: OutputCommands.HIDE__QUICK_PICK.label!,
                     channels: this.outputChannelManager.getVisibleChannels().slice()
                 });
                 if (channel) {
@@ -203,7 +204,7 @@ export class OutputContribution extends AbstractViewContribution<OutputWidget> i
         registry.registerCommand(OutputCommands.DISPOSE__QUICK_PICK, {
             execute: async () => {
                 const channel = await this.pick({
-                    placeholder: 'Close output channel.',
+                    placeholder: OutputCommands.DISPOSE__QUICK_PICK.label!,
                     channels: this.outputChannelManager.getChannels().slice()
                 });
                 if (channel) {
@@ -223,15 +224,15 @@ export class OutputContribution extends AbstractViewContribution<OutputWidget> i
         });
         registry.registerMenuAction(OutputContextMenu.TEXT_EDIT_GROUP, {
             commandId: OutputCommands.COPY_ALL.id,
-            label: 'Copy All'
+            label: nls.localize('vscode/search.contribution/copyAllLabel', 'Copy All')
         });
         registry.registerMenuAction(OutputContextMenu.COMMAND_GROUP, {
             commandId: quickCommand.id,
-            label: 'Find Command...'
+            label: nls.localize('vscode/quickAccess.contribution/commandsQuickAccess', 'Find Command...')
         });
         registry.registerMenuAction(OutputContextMenu.WIDGET_GROUP, {
             commandId: OutputCommands.CLEAR__WIDGET.id,
-            label: 'Clear Output'
+            label: nls.localize('vscode/output.contribution/clearOutput.label', 'Clear Output')
         });
     }
 
@@ -256,12 +257,14 @@ export class OutputContribution extends AbstractViewContribution<OutputWidget> i
 
     protected async pick({ channels, placeholder }: { channels: OutputChannel[], placeholder: string }): Promise<OutputChannel | undefined> {
         const items: Array<QuickPickValue<OutputChannel> | QuickPickItem> = [];
+        const outputChannels = nls.localize('theia/output/outputChannels', 'Output Channels');
+        const hiddenChannels = nls.localize('theia/output/hiddenChannels', 'Hidden Channels');
         for (let i = 0; i < channels.length; i++) {
             const channel = channels[i];
             if (i === 0) {
-                items.push({ label: channel.isVisible ? 'Output Channels' : 'Hidden Channels', type: 'separator' });
+                items.push({ label: channel.isVisible ? outputChannels : hiddenChannels, type: 'separator' });
             } else if (!channel.isVisible && channels[i - 1].isVisible) {
-                items.push({ label: 'Hidden Channels', type: 'separator' });
+                items.push({ label: hiddenChannels, type: 'separator' });
             }
             items.push({ label: channel.name, value: channel });
         }

--- a/packages/output/src/browser/output-toolbar-contribution.tsx
+++ b/packages/output/src/browser/output-toolbar-contribution.tsx
@@ -22,6 +22,7 @@ import { OutputWidget } from './output-widget';
 import { OutputCommands } from './output-commands';
 import { OutputContribution } from './output-contribution';
 import { OutputChannelManager } from '../common/output-channel';
+import { nls } from '@theia/core/lib/browser/nls';
 
 @injectable()
 export class OutputToolbarContribution implements TabBarToolbarContribution {
@@ -61,20 +62,20 @@ export class OutputToolbarContribution implements TabBarToolbarContribution {
         toolbarRegistry.registerItem({
             id: OutputCommands.CLEAR__WIDGET.id,
             command: OutputCommands.CLEAR__WIDGET.id,
-            tooltip: 'Clear Output',
+            tooltip: nls.localize('vscode/output.contribution/clearOutput.label', 'Clear Output'),
             priority: 1,
         });
         toolbarRegistry.registerItem({
             id: OutputCommands.LOCK__WIDGET.id,
             command: OutputCommands.LOCK__WIDGET.id,
-            tooltip: 'Turn Auto Scrolling Off',
+            tooltip: nls.localize('vscode/output.contribution/outputScrollOff', 'Turn Auto Scrolling Off'),
             onDidChange: this.onOutputWidgetStateChanged,
             priority: 2
         });
         toolbarRegistry.registerItem({
             id: OutputCommands.UNLOCK__WIDGET.id,
             command: OutputCommands.UNLOCK__WIDGET.id,
-            tooltip: 'Turn Auto Scrolling On',
+            tooltip: nls.localize('vscode/output.contribution/outputScrollOn', 'Turn Auto Scrolling On'),
             onDidChange: this.onOutputWidgetStateChanged,
             priority: 2
         });

--- a/packages/output/src/browser/output-widget.ts
+++ b/packages/output/src/browser/output-widget.ts
@@ -27,11 +27,13 @@ import { Message, BaseWidget, DockPanel, Widget, MessageLoop, StatefulWidget, co
 import { OutputUri } from '../common/output-uri';
 import { OutputChannelManager, OutputChannel } from '../common/output-channel';
 import { Emitter, Event, deepClone } from '@theia/core';
+import { nls } from '@theia/core/lib/browser/nls';
 
 @injectable()
 export class OutputWidget extends BaseWidget implements StatefulWidget {
 
     static readonly ID = 'outputView';
+    static readonly LABEL = nls.localize('vscode/settingsLayout/output', 'Output');
 
     @inject(SelectionService)
     protected readonly selectionService: SelectionService;
@@ -50,8 +52,8 @@ export class OutputWidget extends BaseWidget implements StatefulWidget {
     constructor() {
         super();
         this.id = OutputWidget.ID;
-        this.title.label = 'Output';
-        this.title.caption = 'Output';
+        this.title.label = OutputWidget.LABEL;
+        this.title.caption = OutputWidget.LABEL;
         this.title.iconClass = codicon('output');
         this.title.closable = true;
         this.addClass('theia-output');

--- a/packages/plugin-ext-vscode/src/browser/plugin-vscode-commands-contribution.ts
+++ b/packages/plugin-ext-vscode/src/browser/plugin-vscode-commands-contribution.ts
@@ -76,6 +76,7 @@ import {
     fromDefinition,
     toDefinition
 } from '@theia/plugin-ext/lib/main/browser/callhierarchy/callhierarchy-type-converters';
+import { nls } from '@theia/core/lib/browser/nls';
 
 export namespace VscodeCommands {
     export const OPEN: Command = {
@@ -333,13 +334,13 @@ export class PluginVscodeCommandsContribution implements CommandContribution {
 
         commands.registerCommand({
             id: 'workbench.action.closeEditorsInGroup',
-            label: 'Close All Editors in Group'
+            label: nls.localize('vscode/editor.contribution/closeEditorsInGroup', 'Close All Editors in Group')
         }, {
             execute: (uri?: monaco.Uri) => performActionOnGroup(this.shell.closeTabs, uri)
         });
         commands.registerCommand({
             id: 'workbench.files.saveAllInGroup',
-            label: 'Save All in Group'
+            label: nls.localize('vscode/fileActions.contribution/saveAllInGroup', 'Save All in Group')
         }, {
             execute: (uri?: monaco.Uri) => performActionOnGroup(this.shell.saveTabs, uri)
         });

--- a/packages/plugin-ext/src/main/browser/webview/webview-frontend-security-warnings.ts
+++ b/packages/plugin-ext/src/main/browser/webview/webview-frontend-security-warnings.ts
@@ -15,8 +15,9 @@
  ********************************************************************************/
 
 import { MessageService } from '@theia/core';
-import { FrontendApplicationContribution } from '@theia/core/lib/browser';
+import { Dialog, FrontendApplicationContribution } from '@theia/core/lib/browser';
 import { FrontendApplicationConfigProvider } from '@theia/core/lib/browser/frontend-application-config-provider';
+import { nls } from '@theia/core/lib/browser/nls';
 import { WindowService } from '@theia/core/lib/browser/window/window-service';
 import { inject, injectable } from '@theia/core/shared/inversify';
 import { WebviewExternalEndpoint } from '../../common/webview-protocol';
@@ -44,12 +45,12 @@ export class WebviewFrontendSecurityWarnings implements FrontendApplicationContr
         }
         const hostPattern = await this.webviewEnvironment.hostPatternPromise;
         if (hostPattern !== WebviewExternalEndpoint.defaultPattern) {
-            this.messageService.warn(`\
-The webview endpoint's host pattern has been changed to \`${hostPattern}\`; changing the pattern can lead to security vulnerabilities. \
-See \`@theia/plugin-ext/README.md\` for more information.`,
-            /* actions: */ 'Ok', 'Go To README',
-            ).then(action => {
-                if (action === 'Go To README') {
+            const goToReadme = nls.localize('theia/webview/goToReadme', 'Go To README');
+            const message = nls.localize('theia/webview/messageWarning', '\
+            The {0} endpoint\'s host pattern has been changed to `{1}`; changing the pattern can lead to security vulnerabilities. \
+            See `{2}` for more information.', 'webview', hostPattern, '@theia/plugin-ext/README.md');
+            this.messageService.warn(message, Dialog.OK, goToReadme).then(action => {
+                if (action === goToReadme) {
                     this.windowService.openNewWindow('https://www.npmjs.com/package/@theia/plugin-ext', { external: true });
                 }
             });

--- a/packages/preferences/src/browser/util/preference-types.ts
+++ b/packages/preferences/src/browser/util/preference-types.ts
@@ -20,6 +20,7 @@ import {
     TreeNode as BaseTreeNode,
     CompositeTreeNode as BaseCompositeTreeNode,
     PreferenceInspection,
+    CommonCommands,
 } from '@theia/core/lib/browser';
 import { Command, MenuPath } from '@theia/core';
 import { JSONValue } from '@theia/core/shared/@phosphor/coreutils';
@@ -112,55 +113,55 @@ export namespace PreferencesCommands {
         id: 'preferences:openJson.toolbar',
         iconClass: 'codicon codicon-json'
     };
-    export const COPY_JSON_NAME: Command = {
+    export const COPY_JSON_NAME = Command.toLocalizedCommand({
         id: 'preferences:copyJson.name',
         label: 'Copy Setting ID'
-    };
-    export const RESET_PREFERENCE: Command = {
+    }, 'vscode/settingsTree/copySettingIdLabel');
+    export const RESET_PREFERENCE = Command.toLocalizedCommand({
         id: 'preferences:reset',
         label: 'Reset Setting'
-    };
+    }, 'vscode/settingsTree/resetSettingLabel');
 
-    export const COPY_JSON_VALUE: Command = {
+    export const COPY_JSON_VALUE = Command.toLocalizedCommand({
         id: 'preferences:copyJson.value',
         label: 'Copy Setting as JSON',
-    };
+    }, 'vscode/settingsTree/copySettingAsJSONLabel');
 
-    export const OPEN_USER_PREFERENCES: Command = {
+    export const OPEN_USER_PREFERENCES = Command.toLocalizedCommand({
         id: 'workbench.action.openGlobalSettings',
-        category: 'Preferences',
-        label: 'Open User Preferences',
-    };
+        category: CommonCommands.PREFERENCES_CATEGORY,
+        label: 'Open User Settings',
+    }, 'vscode/preferences.contribution/openGlobalSettings', CommonCommands.PREFERENCES_CATEGORY_KEY);
 
-    export const OPEN_WORKSPACE_PREFERENCES: Command = {
+    export const OPEN_WORKSPACE_PREFERENCES = Command.toLocalizedCommand({
         id: 'workbench.action.openWorkspaceSettings',
-        category: 'Preferences',
-        label: 'Open Workspace Preferences',
-    };
+        category: CommonCommands.PREFERENCES_CATEGORY,
+        label: 'Open Workspace Settings',
+    }, 'vscode/preferences.contribution/openWorkspaceSettings', CommonCommands.PREFERENCES_CATEGORY_KEY);
 
-    export const OPEN_FOLDER_PREFERENCES: Command = {
+    export const OPEN_FOLDER_PREFERENCES = Command.toLocalizedCommand({
         id: 'workbench.action.openFolderSettings',
-        category: 'Preferences',
-        label: 'Open Folder Preferences'
-    };
+        category: CommonCommands.PREFERENCES_CATEGORY,
+        label: 'Open Folder Settings'
+    }, 'vscode/preferences.contribution/openFolderSettings', CommonCommands.PREFERENCES_CATEGORY_KEY);
 
-    export const OPEN_USER_PREFERENCES_JSON: Command = {
+    export const OPEN_USER_PREFERENCES_JSON = Command.toLocalizedCommand({
         id: 'workbench.action.openSettingsJson',
-        category: 'Preferences',
-        label: 'Open Preferences (JSON)'
-    };
+        category: CommonCommands.PREFERENCES_CATEGORY,
+        label: 'Open Settings (JSON)'
+    }, 'vscode/preferences.contribution/openSettingsJson', CommonCommands.PREFERENCES_CATEGORY_KEY);
 
-    export const OPEN_WORKSPACE_PREFERENCES_JSON: Command = {
+    export const OPEN_WORKSPACE_PREFERENCES_JSON = Command.toLocalizedCommand({
         id: 'workbench.action.openWorkspaceSettingsFile',
-        category: 'Preferences',
-        label: 'Open Workspace Preferences (JSON)',
-    };
+        category: CommonCommands.PREFERENCES_CATEGORY,
+        label: 'Open Workspace Settings (JSON)',
+    }, 'vscode/preferences.contribution/openWorkspaceSettingsFile', CommonCommands.PREFERENCES_CATEGORY_KEY);
 
-    export const OPEN_FOLDER_PREFERENCES_JSON: Command = {
+    export const OPEN_FOLDER_PREFERENCES_JSON = Command.toLocalizedCommand({
         id: 'workbench.action.openFolderSettingsFile',
-        category: 'Preferences',
-        label: 'Open Folder Preferences (JSON)',
-    };
+        category: CommonCommands.PREFERENCES_CATEGORY,
+        label: 'Open Folder Settings (JSON)',
+    }, 'vscode/preferences.contribution/openFolderSettingsFile', CommonCommands.PREFERENCES_CATEGORY_KEY);
 }
 
 export namespace PreferenceMenus {

--- a/packages/preferences/src/browser/views/preference-widget.tsx
+++ b/packages/preferences/src/browser/views/preference-widget.tsx
@@ -22,6 +22,7 @@ import { PreferencesSearchbarState, PreferencesSearchbarWidget } from './prefere
 import { PreferencesScopeTabBar, PreferencesScopeTabBarState } from './preference-scope-tabbar-widget';
 import { Preference } from '../util/preference-types';
 import URI from '@theia/core/lib/common/uri';
+import { nls } from '@theia/core/lib/browser/nls';
 
 interface PreferencesWidgetState {
     scopeTabBarState: PreferencesScopeTabBarState,
@@ -38,7 +39,7 @@ export class PreferencesWidget extends Panel implements StatefulWidget {
     /**
      * The widget `label` which is used for display purposes.
      */
-    static readonly LABEL = 'Preferences';
+    static readonly LABEL = nls.localize('vscode/actions/preferences', 'Preferences');
 
     @inject(PreferencesEditorWidget) protected readonly editorWidget: PreferencesEditorWidget;
     @inject(PreferencesTreeWidget) protected readonly treeWidget: PreferencesTreeWidget;

--- a/packages/preview/src/browser/preview-contribution.ts
+++ b/packages/preview/src/browser/preview-contribution.ts
@@ -20,12 +20,14 @@ import { FrontendApplicationContribution, WidgetOpenerOptions, NavigatableWidget
 import { EditorManager, TextEditor, EditorWidget, EditorContextMenu } from '@theia/editor/lib/browser';
 import { DisposableCollection, CommandContribution, CommandRegistry, Command, MenuContribution, MenuModelRegistry, Disposable } from '@theia/core/lib/common';
 import { TabBarToolbarContribution, TabBarToolbarRegistry } from '@theia/core/lib/browser/shell/tab-bar-toolbar';
+import { MiniBrowserCommands } from '@theia/mini-browser/lib/browser/mini-browser-open-handler';
 import URI from '@theia/core/lib/common/uri';
 import { Position } from '@theia/core/shared/vscode-languageserver-types';
 import { PreviewWidget } from './preview-widget';
 import { PreviewHandlerProvider, } from './preview-handler';
 import { PreviewUri } from './preview-uri';
 import { PreviewPreferences } from './preview-preferences';
+import { nls } from '@theia/core/lib/browser/nls';
 
 import debounce = require('@theia/core/shared/lodash.debounce');
 
@@ -34,11 +36,11 @@ export namespace PreviewCommands {
      * No `label`. Otherwise, it would show up in the `Command Palette` and we already have the `Preview` open handler.
      * See in (`WorkspaceCommandContribution`)[https://bit.ly/2DncrSD].
      */
-    export const OPEN: Command = {
+    export const OPEN = Command.toLocalizedCommand({
         id: 'preview:open',
         label: 'Open Preview',
         iconClass: codicon('open-preview')
-    };
+    }, 'vscode/mainThreadFileSystemEventService/preview');
     export const OPEN_SOURCE: Command = {
         id: 'preview.open.source',
         iconClass: codicon('go-to-file')
@@ -54,7 +56,7 @@ export interface PreviewOpenerOptions extends WidgetOpenerOptions {
 export class PreviewContribution extends NavigatableWidgetOpenHandler<PreviewWidget> implements CommandContribution, MenuContribution, FrontendApplicationContribution, TabBarToolbarContribution {
 
     readonly id = PreviewUri.id;
-    readonly label = 'Preview';
+    readonly label = nls.localize(MiniBrowserCommands.PREVIEW_CATEGORY_KEY, MiniBrowserCommands.PREVIEW_CATEGORY);
 
     @inject(EditorManager)
     protected readonly editorManager: EditorManager;
@@ -227,12 +229,12 @@ export class PreviewContribution extends NavigatableWidgetOpenHandler<PreviewWid
         registry.registerItem({
             id: PreviewCommands.OPEN.id,
             command: PreviewCommands.OPEN.id,
-            tooltip: 'Open Preview to the Side'
+            tooltip: nls.localize('theia/preview/openPreviewSide', 'Open Preview to the Side')
         });
         registry.registerItem({
             id: PreviewCommands.OPEN_SOURCE.id,
             command: PreviewCommands.OPEN_SOURCE.id,
-            tooltip: 'Open Source'
+            tooltip: nls.localize('theia/preview/openSource', 'Open Source')
         });
     }
 

--- a/packages/property-view/src/browser/property-view-widget.tsx
+++ b/packages/property-view/src/browser/property-view-widget.tsx
@@ -21,12 +21,13 @@ import { DisposableCollection } from '@theia/core/lib/common/disposable';
 import { inject, injectable, postConstruct } from '@theia/core/shared/inversify';
 import { PropertyViewContentWidget } from './property-view-content-widget';
 import { PropertyViewService } from './property-view-service';
+import { nls } from '@theia/core/lib/browser/nls';
 
 @injectable()
 export class PropertyViewWidget extends BaseWidget {
 
     static readonly ID = 'property-view';
-    static readonly LABEL = 'Properties';
+    static readonly LABEL = nls.localize('theia/property-view/properties', 'Properties');
 
     protected contentWidget: PropertyViewContentWidget;
 

--- a/packages/property-view/src/browser/resource-property-view/resource-property-view-tree-widget.tsx
+++ b/packages/property-view/src/browser/resource-property-view/resource-property-view-tree-widget.tsx
@@ -34,6 +34,7 @@ import {
     ResourcePropertiesRoot,
     ROOT_ID
 } from './resource-property-view-tree-items';
+import { nls } from '@theia/core/lib/browser/nls';
 
 @injectable()
 export class ResourcePropertyViewTreeWidget extends TreeWidget implements PropertyViewContentWidget {
@@ -92,18 +93,22 @@ export class ResourcePropertyViewTreeWidget extends TreeWidget implements Proper
     protected fillPropertiesTree(fileStatObject?: FileStat): void {
         if (fileStatObject) {
             this.propertiesTree.clear();
-            const infoNode = this.createCategoryNode('info', 'Info');
+            const infoNode = this.createCategoryNode('info', nls.localize('vscode/logsActions/info', 'Info'));
             this.propertiesTree.set('info', infoNode);
 
-            infoNode.children.push(this.createResultLineNode('isDirectory', 'Directory', fileStatObject.isDirectory, infoNode));
-            infoNode.children.push(this.createResultLineNode('isFile', 'File', fileStatObject.isFile, infoNode));
-            infoNode.children.push(this.createResultLineNode('isSymbolicLink', 'Symbolic link', fileStatObject.isSymbolicLink, infoNode));
-            infoNode.children.push(this.createResultLineNode('location', 'Location', this.getLocationString(fileStatObject), infoNode));
-            infoNode.children.push(this.createResultLineNode('name', 'Name', this.getFileName(fileStatObject), infoNode));
-            infoNode.children.push(this.createResultLineNode('path', 'Path', this.getFilePath(fileStatObject), infoNode));
-            infoNode.children.push(this.createResultLineNode('lastModification', 'Last modified', this.getLastModificationString(fileStatObject), infoNode));
-            infoNode.children.push(this.createResultLineNode('created', 'Created', this.getCreationTimeString(fileStatObject), infoNode));
-            infoNode.children.push(this.createResultLineNode('size', 'Size', this.getSizeString(fileStatObject), infoNode));
+            infoNode.children.push(this.createResultLineNode('isDirectory', nls.localize('theia/property-view/directory', 'Directory'), fileStatObject.isDirectory, infoNode));
+            infoNode.children.push(this.createResultLineNode('isFile', nls.localize('theia/property-view/file', 'File'), fileStatObject.isFile, infoNode));
+            infoNode.children.push(this.createResultLineNode('isSymbolicLink', nls.localize('theia/property-view/symbolicLink', 'Symbolic link'),
+                fileStatObject.isSymbolicLink, infoNode));
+            infoNode.children.push(this.createResultLineNode('location', nls.localize('theia/property-view/location', 'Location'),
+                this.getLocationString(fileStatObject), infoNode));
+            infoNode.children.push(this.createResultLineNode('name', nls.localize('theia/property-view/name', 'Name'), this.getFileName(fileStatObject), infoNode));
+            infoNode.children.push(this.createResultLineNode('path', nls.localize('theia/property-view/path', 'Path'), this.getFilePath(fileStatObject), infoNode));
+            infoNode.children.push(this.createResultLineNode('lastModification', nls.localize('theia/property-view/lastModified', 'Last modified'),
+                this.getLastModificationString(fileStatObject), infoNode));
+            infoNode.children.push(this.createResultLineNode('created', nls.localize('theia/property-view/created', 'Created'),
+                this.getCreationTimeString(fileStatObject), infoNode));
+            infoNode.children.push(this.createResultLineNode('size', nls.localize('theia/property-view/size', 'Size'), this.getSizeString(fileStatObject), infoNode));
             this.refreshModelChildren();
         }
     }
@@ -129,7 +134,7 @@ export class ResourcePropertyViewTreeWidget extends TreeWidget implements Proper
     }
 
     protected getSizeString(fileStat: FileStat): string {
-        return fileStat.size ? fileStat.size + ' bytes' : '';
+        return fileStat.size ? nls.localize('vscode/files/sizeB', '{0} B', fileStat.size.toString()) : '';
     }
 
     /*

--- a/packages/scm-extra/src/browser/history/scm-history-contribution.ts
+++ b/packages/scm-extra/src/browser/history/scm-history-contribution.ts
@@ -23,8 +23,10 @@ import URI from '@theia/core/lib/common/uri';
 import { ScmHistoryWidget } from './scm-history-widget';
 import { ScmService } from '@theia/scm/lib/browser/scm-service';
 import { EDITOR_CONTEXT_MENU_SCM } from '../scm-extra-contribution';
+import { nls } from '@theia/core/lib/browser/nls';
 
 export const SCM_HISTORY_ID = 'scm-history';
+export const SCM_HISTORY_KEY = 'theia/scm/history';
 export const SCM_HISTORY_LABEL = 'History';
 export const SCM_HISTORY_TOGGLE_KEYBINDING = 'alt+h';
 export const SCM_HISTORY_MAX_COUNT = 100;
@@ -33,10 +35,10 @@ export namespace ScmHistoryCommands {
     export const OPEN_FILE_HISTORY: Command = {
         id: 'scm-history:open-file-history',
     };
-    export const OPEN_BRANCH_HISTORY: Command = {
+    export const OPEN_BRANCH_HISTORY = Command.toLocalizedCommand({
         id: 'scm-history:open-branch-history',
         label: SCM_HISTORY_LABEL
-    };
+    }, SCM_HISTORY_KEY);
 }
 
 export interface ScmHistoryOpenViewArguments extends OpenViewArguments {
@@ -54,7 +56,7 @@ export class ScmHistoryContribution extends AbstractViewContribution<ScmHistoryW
     constructor() {
         super({
             widgetId: SCM_HISTORY_ID,
-            widgetName: SCM_HISTORY_LABEL,
+            widgetName: nls.localize(SCM_HISTORY_KEY, SCM_HISTORY_LABEL),
             defaultWidgetOptions: {
                 area: 'left',
                 rank: 500

--- a/packages/scm-extra/src/browser/history/scm-history-widget.tsx
+++ b/packages/scm-extra/src/browser/history/scm-history-widget.tsx
@@ -32,6 +32,7 @@ import { ScmNavigableListWidget } from '../scm-navigable-list-widget';
 import * as React from '@theia/core/shared/react';
 import { AlertMessage } from '@theia/core/lib/browser/widgets/alert-message';
 import { FileService } from '@theia/filesystem/lib/browser/file-service';
+import { nls } from '@theia/core/lib/browser/nls';
 
 export const ScmHistorySupport = Symbol('scm-history-support');
 export interface ScmHistorySupport {
@@ -263,7 +264,10 @@ export class ScmHistoryWidget extends ScmNavigableListWidget<ScmHistoryListNode>
                 this.status = { state: 'error', errorMessage: <React.Fragment>History is not supported for {repository.provider.label} source control.</React.Fragment> };
             }
         } else {
-            this.status = { state: 'error', errorMessage: <React.Fragment>There is no repository selected in this workspace.</React.Fragment> };
+            this.status = {
+                state: 'error',
+                errorMessage: <React.Fragment>{nls.localize('vscode/scm.contribution/no open repo', 'There is no repository selected in this workspace.')}</React.Fragment>
+            };
         }
     }
 

--- a/packages/scm/src/browser/scm-amend-component.tsx
+++ b/packages/scm/src/browser/scm-amend-component.tsx
@@ -23,6 +23,7 @@ import { Disposable, DisposableCollection } from '@theia/core';
 
 import { ScmRepository } from './scm-repository';
 import { ScmAmendSupport, ScmCommit } from './scm-provider';
+import { nls } from '@theia/core/lib/browser/nls';
 
 export interface ScmAmendComponentProps {
     style: React.CSSProperties | undefined,
@@ -298,7 +299,7 @@ export class ScmAmendComponent extends React.Component<ScmAmendComponentProps, S
                         <div>
                             <div id='lastCommit' className='theia-scm-amend'>
                                 <div className='theia-header scm-theia-header'>
-                                    HEAD Commit
+                                    {nls.localize('theia/scm/amendHeadCommit', 'HEAD Commit')}
                                 </div>
                                 {this.renderLastCommit()}
                             </div>
@@ -375,8 +376,8 @@ export class ScmAmendComponent extends React.Component<ScmAmendComponentProps, S
             {
                 canAmend
                     ? <div className={ScmAmendComponent.Styles.FLEX_CENTER}>
-                        <button className='theia-button' title='Amend last commit' onClick={this.amend}>
-                            Amend
+                        <button className='theia-button' title={nls.localize('theia/scm/amendLastCommit', 'Amend last commit')} onClick={this.amend}>
+                            {nls.localize('theia/scm/amend', 'Amend')}
                         </button>
                     </div>
                     : ''
@@ -451,8 +452,8 @@ export class ScmAmendComponent extends React.Component<ScmAmendComponentProps, S
                 {
                     isOldestAmendCommit
                         ? <div className={ScmAmendComponent.Styles.FLEX_CENTER}>
-                            <button className='theia-button' title='Unamend commit' onClick={this.unamend}>
-                                Unamend
+                            <button className='theia-button' title={nls.localize('theia/scm/unamendCommit', 'Unamend commit')} onClick={this.unamend}>
+                                {nls.localize('theia/scm/unamend', 'Unamend')}
                             </button>
                         </div>
                         : ''

--- a/packages/scm/src/browser/scm-contribution.ts
+++ b/packages/scm/src/browser/scm-contribution.ts
@@ -23,7 +23,7 @@ import {
     StatusBarEntry,
     KeybindingRegistry,
     ViewContainerTitleOptions,
-    codicon,
+    codicon
 } from '@theia/core/lib/browser';
 import { TabBarToolbarContribution, TabBarToolbarRegistry, TabBarToolbarItem } from '@theia/core/lib/browser/shell/tab-bar-toolbar';
 import { CommandRegistry, Command, Disposable, DisposableCollection, CommandService } from '@theia/core/lib/common';
@@ -36,42 +36,46 @@ import { ColorContribution } from '@theia/core/lib/browser/color-application-con
 import { ColorRegistry, Color } from '@theia/core/lib/browser/color-registry';
 import { ScmCommand } from './scm-provider';
 import { ScmDecorationsService } from '../browser/decorations/scm-decorations-service';
+import { nls } from '@theia/core/lib/browser/nls';
 
 export const SCM_WIDGET_FACTORY_ID = ScmWidget.ID;
 export const SCM_VIEW_CONTAINER_ID = 'scm-view-container';
 export const SCM_VIEW_CONTAINER_TITLE_OPTIONS: ViewContainerTitleOptions = {
-    label: 'Source Control',
+    label: nls.localize('vscode/scm.contribution/source control', 'Source Control'),
     iconClass: codicon('source-control'),
     closeable: true
 };
 
 export namespace SCM_COMMANDS {
-    export const CHANGE_REPOSITORY = {
+    export const CHANGE_REPOSITORY = Command.toLocalizedCommand({
         id: 'scm.change.repository',
         category: 'SCM',
-        label: 'Change Repository...'
-    };
+        label: nls.localize('theia/scm/changeRepository', 'Change Repository...')
+    });
     export const ACCEPT_INPUT = {
         id: 'scm.acceptInput'
     };
     export const TREE_VIEW_MODE = {
         id: 'scm.viewmode.tree',
-        tooltip: 'Toggle to Tree View',
+        tooltip: nls.localize('vscode/scmViewPane/viewModeTree', 'Toggle to Tree View'),
         iconClass: codicon('list-tree'),
-        label: 'Toggle to Tree View',
+        originalLabel: 'Toggle to Tree View',
+        label: nls.localize('vscode/scmViewPane/viewModeTree', 'Toggle to Tree View')
     };
     export const LIST_VIEW_MODE = {
         id: 'scm.viewmode.list',
-        tooltip: 'Toggle to List View',
+        tooltip: nls.localize('vscode/scmViewPane/viewModeList', 'Toggle to List View'),
         iconClass: codicon('list-flat'),
-        label: 'Toggle to List View',
+        originalLabel: 'Toggle to List View',
+        label: nls.localize('vscode/scmViewPane/viewModeList', 'Toggle to List View')
     };
     export const COLLAPSE_ALL = {
         id: 'scm.collapseAll',
         category: 'SCM',
-        tooltip: 'Collapse All',
+        tooltip: nls.localize('vscode/treeView/collapseAll', 'Collapse All'),
         iconClass: codicon('collapse-all'),
-        label: 'Collapse All',
+        label: nls.localize('vscode/treeView/collapseAll', 'Collapse All'),
+        originalLabel: 'Collapse All'
     };
 }
 
@@ -99,7 +103,7 @@ export class ScmContribution extends AbstractViewContribution<ScmWidget> impleme
         super({
             viewContainerId: SCM_VIEW_CONTAINER_ID,
             widgetId: SCM_WIDGET_FACTORY_ID,
-            widgetName: 'Source Control',
+            widgetName: SCM_VIEW_CONTAINER_TITLE_OPTIONS.label,
             defaultWidgetOptions: {
                 area: 'left',
                 rank: 300

--- a/packages/scm/src/browser/scm-no-repository-widget.tsx
+++ b/packages/scm/src/browser/scm-no-repository-widget.tsx
@@ -18,6 +18,7 @@ import { injectable } from '@theia/core/shared/inversify';
 import * as React from '@theia/core/shared/react';
 import { ReactWidget } from '@theia/core/lib/browser';
 import { AlertMessage } from '@theia/core/lib/browser/widgets/alert-message';
+import { nls } from '@theia/core/lib/browser/nls';
 
 @injectable()
 export class ScmNoRepositoryWidget extends ReactWidget {
@@ -33,7 +34,7 @@ export class ScmNoRepositoryWidget extends ReactWidget {
     protected render(): React.ReactNode {
         return <AlertMessage
             type='WARNING'
-            header='No repository found'
+            header={nls.localize('vscode/scm.contribution/no open repo', 'No repository found')}
         />;
     }
 

--- a/packages/scm/src/browser/scm-widget.tsx
+++ b/packages/scm/src/browser/scm-widget.tsx
@@ -28,6 +28,7 @@ import { ScmNoRepositoryWidget } from './scm-no-repository-widget';
 import { ScmService } from './scm-service';
 import { ScmTreeWidget } from './scm-tree-widget';
 import { ScmPreferences } from './scm-preferences';
+import { nls } from '@theia/core/lib/browser/nls';
 
 @injectable()
 export class ScmWidget extends BaseWidget implements StatefulWidget {
@@ -103,7 +104,7 @@ export class ScmWidget extends BaseWidget implements StatefulWidget {
         this.toDisposeOnRefresh.dispose();
         this.toDispose.push(this.toDisposeOnRefresh);
         const repository = this.scmService.selectedRepository;
-        this.title.label = repository ? repository.provider.label : 'no repository found';
+        this.title.label = repository ? repository.provider.label : nls.localize('vscode/scm.contribution/no open repo', 'No repository found');
         this.title.caption = this.title.label;
         this.update();
         if (repository) {

--- a/packages/search-in-workspace/src/browser/search-in-workspace-frontend-contribution.ts
+++ b/packages/search-in-workspace/src/browser/search-in-workspace-frontend-contribution.ts
@@ -30,51 +30,51 @@ import { Range } from '@theia/core/shared/vscode-languageserver-types';
 import { FileService } from '@theia/filesystem/lib/browser/file-service';
 
 export namespace SearchInWorkspaceCommands {
+    const SEARCH_CATEGORY_KEY = 'vscode/search.contribution/search';
     const SEARCH_CATEGORY = 'Search';
     export const TOGGLE_SIW_WIDGET = {
         id: 'search-in-workspace.toggle'
     };
-    export const OPEN_SIW_WIDGET: Command = {
+    export const OPEN_SIW_WIDGET = Command.toLocalizedCommand({
         id: 'search-in-workspace.open',
         category: SEARCH_CATEGORY,
         label: 'Find in Files'
-
-    };
-    export const FIND_IN_FOLDER: Command = {
+    }, 'vscode/search.contribution/findInFiles', SEARCH_CATEGORY_KEY);
+    export const FIND_IN_FOLDER = Command.toLocalizedCommand({
         id: 'search-in-workspace.in-folder',
         category: SEARCH_CATEGORY,
         label: 'Find in Folder'
-    };
-    export const REFRESH_RESULTS: Command = {
+    }, 'vscode/search.contribution/findInFolder', SEARCH_CATEGORY_KEY);
+    export const REFRESH_RESULTS = Command.toLocalizedCommand({
         id: 'search-in-workspace.refresh',
         category: SEARCH_CATEGORY,
         label: 'Refresh',
         iconClass: codicon('refresh')
-    };
-    export const CANCEL_SEARCH: Command = {
+    }, 'vscode/search.contribution/RefreshAction.label', SEARCH_CATEGORY_KEY);
+    export const CANCEL_SEARCH = Command.toLocalizedCommand({
         id: 'search-in-workspace.cancel',
         category: SEARCH_CATEGORY,
         label: 'Cancel Search',
         iconClass: codicon('search-stop')
-    };
-    export const COLLAPSE_ALL: Command = {
+    }, 'vscode/search.contribution/CancelSearchAction.label', SEARCH_CATEGORY_KEY);
+    export const COLLAPSE_ALL = Command.toLocalizedCommand({
         id: 'search-in-workspace.collapse-all',
         category: SEARCH_CATEGORY,
         label: 'Collapse All',
         iconClass: codicon('collapse-all')
-    };
-    export const EXPAND_ALL: Command = {
+    }, 'vscode/search.contribution/CollapseDeepestExpandedLevelAction.label', SEARCH_CATEGORY_KEY);
+    export const EXPAND_ALL = Command.toLocalizedCommand({
         id: 'search-in-workspace.expand-all',
         category: SEARCH_CATEGORY,
         label: 'Expand All',
         iconClass: codicon('expand-all')
-    };
-    export const CLEAR_ALL: Command = {
+    }, 'vscode/search.contribution/ExpandAllAction.label', SEARCH_CATEGORY_KEY);
+    export const CLEAR_ALL = Command.toLocalizedCommand({
         id: 'search-in-workspace.clear-all',
         category: SEARCH_CATEGORY,
         label: 'Clear Search Results',
         iconClass: codicon('clear-all')
-    };
+    }, 'vscode/search.contribution/ClearSearchResultsAction.label', SEARCH_CATEGORY_KEY);
 }
 
 @injectable()

--- a/packages/search-in-workspace/src/browser/search-in-workspace-widget.tsx
+++ b/packages/search-in-workspace/src/browser/search-in-workspace-widget.tsx
@@ -28,6 +28,7 @@ import { ProgressBarFactory } from '@theia/core/lib/browser/progress-bar-factory
 import { EditorManager } from '@theia/editor/lib/browser';
 import { SearchInWorkspacePreferences } from './search-in-workspace-preferences';
 import { SearchInWorkspaceInput } from './components/search-in-workspace-input';
+import { nls } from '@theia/core/lib/browser/nls';
 
 export interface SearchFieldState {
     className: string;
@@ -39,7 +40,7 @@ export interface SearchFieldState {
 export class SearchInWorkspaceWidget extends BaseWidget implements StatefulWidget {
 
     static ID = 'search-in-workspace';
-    static LABEL = 'Search';
+    static LABEL = nls.localize('vscode/search.contribution/search', 'Search');
 
     protected matchCaseState: SearchFieldState;
     protected wholeWordState: SearchFieldState;
@@ -116,22 +117,22 @@ export class SearchInWorkspaceWidget extends BaseWidget implements StatefulWidge
         this.matchCaseState = {
             className: codicon('case-sensitive'),
             enabled: false,
-            title: 'Match Case'
+            title: nls.localize('vscode/findInputCheckboxes/caseDescription', 'Match Case')
         };
         this.wholeWordState = {
             className: codicon('whole-word'),
             enabled: false,
-            title: 'Match Whole Word'
+            title: nls.localize('vscode/findInputCheckboxes/wordsDescription', 'Match Whole Word')
         };
         this.regExpState = {
             className: codicon('regex'),
             enabled: false,
-            title: 'Use Regular Expression'
+            title: nls.localize('vscode/findInputCheckboxes/regexDescription', 'Use Regular Expression')
         };
         this.includeIgnoredState = {
             className: codicon('eye'),
             enabled: false,
-            title: 'Include Ignored Files'
+            title: nls.localize('theia/siw/includeIgnoredFiles', 'Include Ignored Files')
         };
         this.searchInWorkspaceOptions = {
             matchCase: false,
@@ -194,6 +195,10 @@ export class SearchInWorkspaceWidget extends BaseWidget implements StatefulWidge
         this.wholeWordState = oldState.wholeWordState;
         this.regExpState = oldState.regExpState;
         this.includeIgnoredState = oldState.includeIgnoredState;
+        this.matchCaseState.title = nls.localize('vscode/findInputCheckboxes/caseDescription', 'Match Case');
+        this.wholeWordState.title = nls.localize('vscode/findInputCheckboxes/wordsDescription', 'Match Whole Word');
+        this.regExpState.title = nls.localize('vscode/findInputCheckboxes/regexDescription', 'Use Regular Expression');
+        this.includeIgnoredState.title = nls.localize('theia/siw/includeIgnoredFiles', 'Include Ignored Files');
         this.showSearchDetails = oldState.showSearchDetails;
         this.searchInWorkspaceOptions = oldState.searchInWorkspaceOptions;
         this.searchTerm = oldState.searchTerm;
@@ -356,7 +361,7 @@ export class SearchInWorkspaceWidget extends BaseWidget implements StatefulWidge
     protected renderReplaceFieldToggle(): React.ReactNode {
         const toggle = <span className={codicon(this.showReplaceField ? 'chevron-down' : 'chevron-right')}></span>;
         return <div
-            title='Toggle Replace'
+            title={nls.localize('vscode/findWidget/label.toggleReplaceButton', 'Toggle Replace')}
             className='replace-toggle'
             tabIndex={0}
             onClick={e => {
@@ -375,14 +380,12 @@ export class SearchInWorkspaceWidget extends BaseWidget implements StatefulWidge
     protected renderNotification(): React.ReactNode {
         if (this.workspaceService.tryGetRoots().length <= 0 && this.editorManager.all.length <= 0) {
             return <div className='search-notification show'>
-                <div>You have not opened or specified a folder. Only open files are currently searched.</div>
+                <div>{nls.localize('theia/siw/noFolderSpecified', 'You have not opened or specified a folder. Only open files are currently searched.')}</div>
             </div>;
         }
         return <div
             className={`search-notification ${this.searchInWorkspaceOptions.maxResults && this.resultNumber >= this.searchInWorkspaceOptions.maxResults ? 'show' : ''}`}>
-            <div>
-                This is only a subset of all results. Use a more specific search term to narrow down the result list.
-            </div>
+            <div>{nls.localize('theia/siw/resultSubset', 'This is only a subset of all results. Use a more specific search term to narrow down the result list.')}</div>
         </div>;
     }
 
@@ -465,10 +468,10 @@ export class SearchInWorkspaceWidget extends BaseWidget implements StatefulWidge
         const input = <SearchInWorkspaceInput
             id='search-input-field'
             className='theia-input'
-            title='Search'
+            title={SearchInWorkspaceWidget.LABEL}
             type='text'
             size={1}
-            placeholder='Search'
+            placeholder={SearchInWorkspaceWidget.LABEL}
             defaultValue={this.searchTerm}
             autoComplete='off'
             onKeyUp={this.search}
@@ -505,14 +508,15 @@ export class SearchInWorkspaceWidget extends BaseWidget implements StatefulWidge
 
     protected renderReplaceField(): React.ReactNode {
         const replaceAllButtonContainer = this.renderReplaceAllButtonContainer();
+        const replace = nls.localize('vscode/findWidget/label.replaceButton', 'Replace');
         return <div className={`replace-field${this.showReplaceField ? '' : ' hidden'}`}>
             <SearchInWorkspaceInput
                 id='replace-input-field'
                 className='theia-input'
-                title='Replace'
+                title={replace}
                 type='text'
                 size={1}
-                placeholder='Replace'
+                placeholder={replace}
                 defaultValue={this.replaceTerm}
                 onKeyUp={this.updateReplaceTerm}
                 onFocus={this.handleFocusReplaceInputBox}
@@ -531,7 +535,7 @@ export class SearchInWorkspaceWidget extends BaseWidget implements StatefulWidge
         const enabled: boolean = this.searchTerm !== '' && this.resultNumber > 0;
         return <div className='replace-all-button-container'>
             <span
-                title='Replace All'
+                title={nls.localize('vscode/findWidget/label.replaceAllButton', 'Replace All')}
                 className={`${codicon('replace-all', true)} ${enabled ? ' ' : ' disabled'}`}
                 onClick={() => {
                     if (enabled) {
@@ -587,7 +591,7 @@ export class SearchInWorkspaceWidget extends BaseWidget implements StatefulWidge
     protected renderExpandGlobFieldsButton(): React.ReactNode {
         return <div className='button-container'>
             <span
-                title='Toggle Search Details'
+                title={nls.localize('vscode/searchView/moreSearch', 'Toggle Search Details')}
                 className={codicon('ellipsis')}
                 onClick={() => {
                     this.showSearchDetails = !this.showSearchDetails;
@@ -599,8 +603,9 @@ export class SearchInWorkspaceWidget extends BaseWidget implements StatefulWidge
     protected renderGlobField(kind: 'include' | 'exclude'): React.ReactNode {
         const currentValue = this.searchInWorkspaceOptions[kind];
         const value = currentValue && currentValue.join(', ') || '';
+        const labelKey = `vscode/searchView/searchScope.${kind}s`;
         return <div className='glob-field'>
-            <div className='label'>{'files to ' + kind}</div>
+            <div className='label'>{nls.localize(labelKey, 'files to ' + kind)}</div>
             <SearchInWorkspaceInput
                 className='theia-input'
                 type='text'
@@ -665,22 +670,31 @@ export class SearchInWorkspaceWidget extends BaseWidget implements StatefulWidge
             const isIncludesPresent = this.searchInWorkspaceOptions.include && this.searchInWorkspaceOptions.include.length > 0;
             const isExcludesPresent = this.searchInWorkspaceOptions.exclude && this.searchInWorkspaceOptions.exclude.length > 0;
 
+            let message: string;
             if (isIncludesPresent && isExcludesPresent) {
-                return `No results found in '${this.searchInWorkspaceOptions.include}' excluding '${this.searchInWorkspaceOptions.exclude}'`;
+                message = nls.localize('vscode/searchView/noResultsIncludesExcludes', "No results found in '{0}' excluding '{1}' - ",
+                    this.searchInWorkspaceOptions.include!.toString(), this.searchInWorkspaceOptions.exclude!.toString());
             } else if (isIncludesPresent) {
-                return `No results found in '${this.searchInWorkspaceOptions.include}'`;
+                message = nls.localize('vscode/searchView/noResultsIncludes', "No results found in '{0}' - ",
+                    this.searchInWorkspaceOptions.include!.toString());
             } else if (isExcludesPresent) {
-                return `No results found excluding '${this.searchInWorkspaceOptions.exclude}'`;
+                message = nls.localize('vscode/searchView/noResultsExcludes', "No results found excluding '{0}' - ",
+                    this.searchInWorkspaceOptions.exclude!.toString());
             } else {
-                return 'No results found.';
+                message = nls.localize('vscode/searchView/noResultsFound', 'No results found. - ');
             }
+            // We have to trim here as vscode will always add a trailing " - " string
+            return message.substring(0, message.length - 2).trim();
         } else {
             if (this.resultNumber === 1 && this.resultTreeWidget.fileNumber === 1) {
-                return `${this.resultNumber} result in ${this.resultTreeWidget.fileNumber} file`;
+                return nls.localize('vscode/searchView/search.file.result', '{0} result in {1} file',
+                    this.resultNumber.toString(), this.resultTreeWidget.fileNumber.toString());
             } else if (this.resultTreeWidget.fileNumber === 1) {
-                return `${this.resultNumber} results in ${this.resultTreeWidget.fileNumber} file`;
+                return nls.localize('vscode/searchView/search.file.results', '{0} results in {1} file',
+                    this.resultNumber.toString(), this.resultTreeWidget.fileNumber.toString());
             } else if (this.resultTreeWidget.fileNumber > 0) {
-                return `${this.resultNumber} results in ${this.resultTreeWidget.fileNumber} files`;
+                return nls.localize('vscode/searchView/search.files.results', '{0} results in {1} files',
+                    this.resultNumber.toString(), this.resultTreeWidget.fileNumber.toString());
             } else {
                 // if fileNumber === 0, return undefined so that `onUpdateRequest()` would not re-render component
                 return undefined;

--- a/packages/task/src/browser/task-frontend-contribution.ts
+++ b/packages/task/src/browser/task-frontend-contribution.ts
@@ -32,83 +32,84 @@ import { EditorManager } from '@theia/editor/lib/browser';
 import { WorkspaceService } from '@theia/workspace/lib/browser/workspace-service';
 
 export namespace TaskCommands {
+    const TASK_CATEGORY_KEY = 'vscode/settingsLayout/task';
     const TASK_CATEGORY = 'Task';
-    export const TASK_RUN: Command = {
+    export const TASK_RUN = Command.toLocalizedCommand({
         id: 'task:run',
         category: TASK_CATEGORY,
         label: 'Run Task...'
-    };
+    }, 'vscode/task.contribution/RunTaskAction.label', TASK_CATEGORY_KEY);
 
-    export const TASK_RUN_BUILD: Command = {
+    export const TASK_RUN_BUILD = Command.toLocalizedCommand({
         id: 'task:run:build',
         category: TASK_CATEGORY,
         label: 'Run Build Task...'
-    };
+    }, 'vscode/task.contribution/BuildAction.label', TASK_CATEGORY_KEY);
 
-    export const TASK_RUN_TEST: Command = {
+    export const TASK_RUN_TEST = Command.toLocalizedCommand({
         id: 'task:run:test',
         category: TASK_CATEGORY,
         label: 'Run Test Task...'
-    };
+    }, 'vscode/task.contribution/TestAction.label', TASK_CATEGORY_KEY);
 
-    export const WORKBENCH_RUN_TASK: Command = {
+    export const WORKBENCH_RUN_TASK = Command.toLocalizedCommand({
         id: 'workbench.action.tasks.runTask',
         category: TASK_CATEGORY
-    };
+    }, '', TASK_CATEGORY_KEY);
 
-    export const TASK_RUN_LAST: Command = {
+    export const TASK_RUN_LAST = Command.toLocalizedCommand({
         id: 'task:run:last',
         category: TASK_CATEGORY,
         label: 'Run Last Task'
-    };
+    }, 'vscode/task.contribution/ReRunTaskAction.label', TASK_CATEGORY_KEY);
 
-    export const TASK_ATTACH: Command = {
+    export const TASK_ATTACH = Command.toLocalizedCommand({
         id: 'task:attach',
         category: TASK_CATEGORY,
         label: 'Attach Task...'
-    };
+    }, 'theia/task/attachTask', TASK_CATEGORY_KEY);
 
-    export const TASK_RUN_TEXT: Command = {
+    export const TASK_RUN_TEXT = Command.toLocalizedCommand({
         id: 'task:run:text',
         category: TASK_CATEGORY,
         label: 'Run Selected Text'
-    };
+    }, 'vscode/terminalMenu/miRunSelectedText', TASK_CATEGORY_KEY);
 
-    export const TASK_CONFIGURE: Command = {
+    export const TASK_CONFIGURE = Command.toLocalizedCommand({
         id: 'task:configure',
         category: TASK_CATEGORY,
         label: 'Configure Tasks...'
-    };
+    }, 'vscode/task.contribution/miConfigureTask', TASK_CATEGORY_KEY);
 
-    export const TASK_OPEN_USER: Command = {
+    export const TASK_OPEN_USER = Command.toLocalizedCommand({
         id: 'task:open_user',
         category: TASK_CATEGORY,
         label: 'Open User Tasks'
-    };
+    }, 'theia/task/openUserTasks', TASK_CATEGORY_KEY);
 
-    export const TASK_CLEAR_HISTORY: Command = {
+    export const TASK_CLEAR_HISTORY = Command.toLocalizedCommand({
         id: 'task:clear-history',
         category: TASK_CATEGORY,
         label: 'Clear History'
-    };
+    }, 'theia/task/clearHistory', TASK_CATEGORY_KEY);
 
-    export const TASK_SHOW_RUNNING: Command = {
+    export const TASK_SHOW_RUNNING = Command.toLocalizedCommand({
         id: 'task:show-running',
         category: TASK_CATEGORY,
         label: 'Show Running Tasks'
-    };
+    }, 'vscode/task.contribution/runningTasks', TASK_CATEGORY_KEY);
 
-    export const TASK_TERMINATE: Command = {
+    export const TASK_TERMINATE = Command.toLocalizedCommand({
         id: 'task:terminate',
         category: TASK_CATEGORY,
         label: 'Terminate Task'
-    };
+    }, 'vscode/abstractTaskService/terminateTask', TASK_CATEGORY_KEY);
 
-    export const TASK_RESTART_RUNNING: Command = {
+    export const TASK_RESTART_RUNNING = Command.toLocalizedCommand({
         id: 'task:restart-running',
         category: TASK_CATEGORY,
         label: 'Restart Running Task...'
-    };
+    }, 'vscode/abstractTaskService/restartTask', TASK_CATEGORY_KEY);
 }
 
 const TASKS_STORAGE_KEY = 'tasks';
@@ -202,7 +203,7 @@ export class TaskFrontendContribution implements CommandContribution, MenuContri
         if (!!items.length) {
             this.statusBar.setElement(id, {
                 text: `$(tools) ${items.length}`,
-                tooltip: 'Show Running Tasks',
+                tooltip: TaskCommands.TASK_SHOW_RUNNING.label,
                 alignment: StatusBarAlignment.LEFT,
                 priority: 2,
                 command: TaskCommands.TASK_SHOW_RUNNING.id,
@@ -362,7 +363,7 @@ export class TaskFrontendContribution implements CommandContribution, MenuContri
 
         menus.registerMenuAction(TerminalMenus.TERMINAL_TASKS_INFO, {
             commandId: TaskCommands.TASK_SHOW_RUNNING.id,
-            label: 'Show Running Tasks...',
+            label: TaskCommands.TASK_SHOW_RUNNING.label + '...',
             order: '0'
         });
 
@@ -374,7 +375,7 @@ export class TaskFrontendContribution implements CommandContribution, MenuContri
 
         menus.registerMenuAction(TerminalMenus.TERMINAL_TASKS_INFO, {
             commandId: TaskCommands.TASK_TERMINATE.id,
-            label: 'Terminate Task...',
+            label: TaskCommands.TASK_TERMINATE.label + '...',
             order: '2'
         });
 

--- a/packages/terminal/src/browser/terminal-frontend-contribution.ts
+++ b/packages/terminal/src/browser/terminal-frontend-contribution.ts
@@ -28,12 +28,12 @@ import {
     Event
 } from '@theia/core/lib/common';
 import {
-    ApplicationShell, KeybindingContribution, KeyCode, Key,
-    KeybindingRegistry, Widget, LabelProvider, WidgetOpenerOptions, StorageService, QuickInputService, codicon
+    ApplicationShell, KeybindingContribution, KeyCode, Key, codicon,
+    KeybindingRegistry, Widget, LabelProvider, WidgetOpenerOptions, StorageService, QuickInputService, CommonCommands
 } from '@theia/core/lib/browser';
 import { TabBarToolbarContribution, TabBarToolbarRegistry } from '@theia/core/lib/browser/shell/tab-bar-toolbar';
 import { WidgetManager } from '@theia/core/lib/browser';
-import { TERMINAL_WIDGET_FACTORY_ID, TerminalWidgetFactoryOptions } from './terminal-widget-impl';
+import { TERMINAL_WIDGET_FACTORY_ID, TerminalWidgetFactoryOptions, TerminalWidgetImpl } from './terminal-widget-impl';
 import { TerminalKeybindingContexts } from './terminal-keybinding-contexts';
 import { TerminalService } from './base/terminal-service';
 import { TerminalWidgetOptions, TerminalWidget } from './base/terminal-widget';
@@ -53,6 +53,7 @@ import {
     ENVIRONMENT_VARIABLE_COLLECTIONS_KEY,
     SerializableExtensionEnvironmentVariableCollection
 } from '../common/base-terminal-protocol';
+import { nls } from '@theia/core/lib/browser/nls';
 
 export namespace TerminalMenus {
     export const TERMINAL = [...MAIN_MENU_BAR, '7_terminal'];
@@ -65,77 +66,78 @@ export namespace TerminalMenus {
 }
 
 export namespace TerminalCommands {
+    const TERMINAL_CATEGORY_KEY = 'vscode/settingsLayout/terminal';
     const TERMINAL_CATEGORY = 'Terminal';
-    export const NEW: Command = {
+    export const NEW = Command.toLocalizedCommand({
         id: 'terminal:new',
         category: TERMINAL_CATEGORY,
         label: 'Open New Terminal'
-    };
-    export const NEW_ACTIVE_WORKSPACE: Command = {
+    }, 'vscode/terminalActions/workbench.action.terminal.new', TERMINAL_CATEGORY_KEY);
+    export const NEW_ACTIVE_WORKSPACE = Command.toLocalizedCommand({
         id: 'terminal:new:active:workspace',
         category: TERMINAL_CATEGORY,
         label: 'Open New Terminal (In Active Workspace)'
-    };
-    export const TERMINAL_CLEAR: Command = {
+    }, 'workbench.action.terminal.newInActiveWorkspace', TERMINAL_CATEGORY_KEY);
+    export const TERMINAL_CLEAR = Command.toLocalizedCommand({
         id: 'terminal:clear',
         category: TERMINAL_CATEGORY,
         label: 'Clear Terminal'
-    };
-    export const TERMINAL_CONTEXT: Command = {
+    }, 'workbench.action.terminal.clear', TERMINAL_CATEGORY_KEY);
+    export const TERMINAL_CONTEXT = Command.toLocalizedCommand({
         id: 'terminal:context',
         category: TERMINAL_CATEGORY,
         label: 'Open in Terminal'
-    };
-    export const SPLIT: Command = {
+    }, 'vscode/scm.contribution/open in terminal', TERMINAL_CATEGORY_KEY);
+    export const SPLIT = Command.toLocalizedCommand({
         id: 'terminal:split',
         category: TERMINAL_CATEGORY,
         label: 'Split Terminal'
-    };
-    export const TERMINAL_FIND_TEXT: Command = {
+    }, 'vscode/terminalActions/workbench.action.terminal.split', TERMINAL_CATEGORY_KEY);
+    export const TERMINAL_FIND_TEXT = Command.toLocalizedCommand({
         id: 'terminal:find',
         category: TERMINAL_CATEGORY,
         label: 'Find'
-    };
-    export const TERMINAL_FIND_TEXT_CANCEL: Command = {
+    }, 'vscode/findController/startFindAction', TERMINAL_CATEGORY_KEY);
+    export const TERMINAL_FIND_TEXT_CANCEL = Command.toLocalizedCommand({
         id: 'terminal:find:cancel',
         category: TERMINAL_CATEGORY,
         label: 'Hide find widget'
-    };
+    }, 'vscode/terminalActions/workbench.action.terminal.hideFind', TERMINAL_CATEGORY_KEY);
 
-    export const SCROLL_LINE_UP: Command = {
+    export const SCROLL_LINE_UP = Command.toLocalizedCommand({
         id: 'terminal:scroll:line:up',
         category: TERMINAL_CATEGORY,
         label: 'Scroll line up'
-    };
-    export const SCROLL_LINE_DOWN: Command = {
+    }, 'vscode/terminalActions/workbench.action.terminal.scrollUp', TERMINAL_CATEGORY_KEY);
+    export const SCROLL_LINE_DOWN = Command.toLocalizedCommand({
         id: 'terminal:scroll:line:down',
         category: TERMINAL_CATEGORY,
         label: 'Scroll line down'
-    };
-    export const SCROLL_TO_TOP: Command = {
+    }, 'vscode/terminalActions/workbench.action.terminal.scrollDown', TERMINAL_CATEGORY_KEY);
+    export const SCROLL_TO_TOP = Command.toLocalizedCommand({
         id: 'terminal:scroll:top',
         category: TERMINAL_CATEGORY,
         label: 'Scroll to top'
-    };
-    export const SCROLL_PAGE_UP: Command = {
+    }, 'vscode/terminalActions/workbench.action.terminal.scrollToTop', TERMINAL_CATEGORY_KEY);
+    export const SCROLL_PAGE_UP = Command.toLocalizedCommand({
         id: 'terminal:scroll:page:up',
         category: TERMINAL_CATEGORY,
         label: 'Scroll page up'
-    };
-    export const SCROLL_PAGE_DOWN: Command = {
+    }, 'vscode/terminalActions/workbench.action.terminal.scrollUpPage', TERMINAL_CATEGORY_KEY);
+    export const SCROLL_PAGE_DOWN = Command.toLocalizedCommand({
         id: 'terminal:scroll:page:down',
         category: TERMINAL_CATEGORY,
         label: 'Scroll page down'
-    };
+    }, 'vscode/terminalActions/workbench.action.terminal.scrollDownPage', TERMINAL_CATEGORY_KEY);
 
     /**
      * Command that displays all terminals that are currently opened
      */
-    export const SHOW_ALL_OPENED_TERMINALS: Command = {
+    export const SHOW_ALL_OPENED_TERMINALS = Command.toLocalizedCommand({
         id: 'workbench.action.showAllTerminals',
-        category: 'View',
+        category: CommonCommands.VIEW_CATEGORY,
         label: 'Show All Opened Terminals'
-    };
+    }, 'vscode/terminal.contribution/tasksQuickAccessHelp', CommonCommands.VIEW_CATEGORY_KEY);
 }
 
 @injectable()
@@ -390,10 +392,10 @@ export class TerminalFrontendContribution implements TerminalService, CommandCon
     }
 
     registerMenus(menus: MenuModelRegistry): void {
-        menus.registerSubmenu(TerminalMenus.TERMINAL, 'Terminal');
+        menus.registerSubmenu(TerminalMenus.TERMINAL, TerminalWidgetImpl.LABEL);
         menus.registerMenuAction(TerminalMenus.TERMINAL_NEW, {
             commandId: TerminalCommands.NEW.id,
-            label: 'New Terminal',
+            label: nls.localize('vscode/terminalActions/workbench.action.terminal.new.short', 'New Terminal'),
             order: '0'
         });
         menus.registerMenuAction(TerminalMenus.TERMINAL_NEW, {
@@ -599,7 +601,7 @@ export class TerminalFrontendContribution implements TerminalService, CommandCon
                     resource
                 }));
                 const selectedItem = await this.quickInputService?.showQuickPick(items, {
-                    placeholder: 'Select current working directory for new terminal'
+                    placeholder: nls.localize('vscode/terminalActions/workbench.action.terminal.newWorkspacePlaceholder', 'Select current working directory for new terminal')
                 });
                 resolve(selectedItem?.resource?.toString());
             }

--- a/packages/terminal/src/browser/terminal-linkmatcher.ts
+++ b/packages/terminal/src/browser/terminal-linkmatcher.ts
@@ -87,11 +87,7 @@ export abstract class AbstractCmdClickTerminalContribution implements TerminalCo
     }
 
     protected getHoverMessage(): string {
-        if (isOSX) {
-            return 'Cmd + click to follow link';
-        } else {
-            return 'Ctrl + click to follow link';
-        }
+        return TerminalWidgetImpl.getFollowLinkHover();
     }
 
 }

--- a/packages/terminal/src/browser/terminal-widget-impl.ts
+++ b/packages/terminal/src/browser/terminal-widget-impl.ts
@@ -37,6 +37,7 @@ import { TerminalCopyOnSelectionHandler } from './terminal-copy-on-selection-han
 import { TerminalThemeService } from './terminal-theme-service';
 import { CommandLineOptions, ShellCommandBuilder } from '@theia/process/lib/common/shell-command-builder';
 import { Key } from '@theia/core/lib/browser/keys';
+import { nls } from '@theia/core/lib/browser/nls';
 
 export const TERMINAL_WIDGET_FACTORY_ID = 'terminal';
 
@@ -48,7 +49,7 @@ export interface TerminalWidgetFactoryOptions extends Partial<TerminalWidgetOpti
 @injectable()
 export class TerminalWidgetImpl extends TerminalWidget implements StatefulWidget {
 
-    private readonly TERMINAL = 'Terminal';
+    static LABEL = nls.localize('vscode/settingsLayout/terminal', 'Terminal');
     protected terminalKind = 'user';
     protected _terminalId = -1;
     protected readonly onTermDidClose = new Emitter<TerminalWidget>();
@@ -94,7 +95,7 @@ export class TerminalWidgetImpl extends TerminalWidget implements StatefulWidget
 
     @postConstruct()
     protected init(): void {
-        this.setTitle(this.options.title || this.TERMINAL);
+        this.setTitle(this.options.title || TerminalWidgetImpl.LABEL);
         this.title.iconClass = codicon('terminal');
 
         if (this.options.kind) {
@@ -131,7 +132,7 @@ export class TerminalWidgetImpl extends TerminalWidget implements StatefulWidget
         this.term.loadAddon(this.fitAddon);
 
         this.hoverMessage = document.createElement('div');
-        this.hoverMessage.textContent = 'Cmd + click to follow link';
+        this.hoverMessage.textContent = TerminalWidgetImpl.getFollowLinkHover();
         this.hoverMessage.style.position = 'fixed';
         // TODO use `var(--theia-editorHoverWidget-foreground) with a newer Monaco version
         this.hoverMessage.style.color = 'var(--theia-editorWidget-foreground)';
@@ -240,6 +241,12 @@ export class TerminalWidgetImpl extends TerminalWidget implements StatefulWidget
 
         this.searchBox = this.terminalSearchBoxFactory(this.term);
         this.toDispose.push(this.searchBox);
+    }
+
+    static getFollowLinkHover(): string {
+        const cmdCtrl = isOSX ? 'Cmd' : 'Ctrl';
+        return nls.localize('vscode/terminalLinkManager/followLink', 'Follow link') + ' (' +
+            nls.localize(`vscode/terminalLinkManager/terminalLinkHandler.followLink${cmdCtrl}`, `${cmdCtrl} + Click`) + ')';
     }
 
     get kind(): 'user' | string {

--- a/packages/typehierarchy/src/browser/tree/typehierarchy-tree-widget.tsx
+++ b/packages/typehierarchy/src/browser/tree/typehierarchy-tree-widget.tsx
@@ -26,6 +26,7 @@ import { TreeWidget, TreeProps } from '@theia/core/lib/browser/tree/tree-widget'
 import { TypeHierarchyTreeModel } from './typehierarchy-tree-model';
 import { TypeHierarchyTree } from './typehierarchy-tree';
 import { codicon } from '@theia/core/lib/browser';
+import { nls } from '@theia/core/lib/browser/nls';
 
 @injectable()
 export class TypeHierarchyTreeWidget extends TreeWidget {
@@ -93,7 +94,7 @@ export class TypeHierarchyTreeWidget extends TreeWidget {
 export namespace TypeHierarchyTreeWidget {
 
     export const WIDGET_ID = 'theia-typehierarchy';
-    export const WIDGET_LABEL = 'Type Hierarchy';
+    export const WIDGET_LABEL = nls.localize('theia/typehierarchy/typeHierarchy', 'Type Hierarchy');
 
     /**
      * CSS styles for the `Type Hierarchy` widget.

--- a/packages/typehierarchy/src/browser/typehierarchy-contribution.ts
+++ b/packages/typehierarchy/src/browser/typehierarchy-contribution.ts
@@ -137,14 +137,14 @@ export namespace TypeHierarchyCommands {
         id: 'typehierarchy:toggle'
     };
 
-    export const OPEN_SUBTYPE: Command = {
+    export const OPEN_SUBTYPE = Command.toLocalizedCommand({
         id: 'typehierarchy:open-subtype',
         label: 'Subtype Hierarchy'
-    };
+    }, 'theia/typehierarchy/subtypeHierarchy');
 
-    export const OPEN_SUPERTYPE: Command = {
+    export const OPEN_SUPERTYPE = Command.toLocalizedCommand({
         id: 'typehierarchy:open-supertype',
         label: 'Supertype Hierarchy'
-    };
+    }, 'theia/typehierarchy/supertypeHierarchy');
 
 }

--- a/packages/vsx-registry/src/browser/vsx-extension-commands.ts
+++ b/packages/vsx-registry/src/browser/vsx-extension-commands.ts
@@ -14,24 +14,28 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
+import { nls } from '@theia/core/lib/browser/nls';
 import { codicon } from '@theia/core/lib/browser';
 import { Command } from '@theia/core/lib/common';
 
 export namespace VSXExtensionsCommands {
 
+    const EXTENSIONS_CATEGORY_KEY = 'vscode/settingsLayout/extensions';
     const EXTENSIONS_CATEGORY = 'Extensions';
 
-    export const CLEAR_ALL: Command = {
+    export const CLEAR_ALL = Command.toLocalizedCommand({
         id: 'vsxExtensions.clearAll',
         category: EXTENSIONS_CATEGORY,
         label: 'Clear Search Results',
         iconClass: codicon('clear-all')
-    };
+    }, 'vscode/search.contribution/ClearSearchResultsAction.label', EXTENSIONS_CATEGORY_KEY);
     export const INSTALL_FROM_VSIX: Command & { dialogLabel: string } = {
         id: 'vsxExtensions.installFromVSIX',
-        category: EXTENSIONS_CATEGORY,
-        label: 'Install from VSIX...',
-        dialogLabel: 'Install from VSIX'
+        category: nls.localize(EXTENSIONS_CATEGORY_KEY, EXTENSIONS_CATEGORY),
+        originalCategory: EXTENSIONS_CATEGORY,
+        originalLabel: 'Install from VSIX...',
+        label: nls.localize('theia/vsx-registry/installFromVSIX', 'Install from VSIX') + '...',
+        dialogLabel: nls.localize('theia/vsx-registry/installFromVSIX', 'Install from VSIX')
     };
     export const COPY: Command = {
         id: 'vsxExtensions.copy'
@@ -39,19 +43,19 @@ export namespace VSXExtensionsCommands {
     export const COPY_EXTENSION_ID: Command = {
         id: 'vsxExtensions.copyExtensionId'
     };
-    export const SHOW_BUILTINS: Command = {
+    export const SHOW_BUILTINS = Command.toLocalizedCommand({
         id: 'vsxExtension.showBuiltins',
         label: 'Show Built-in Extensions',
         category: EXTENSIONS_CATEGORY,
-    };
-    export const SHOW_INSTALLED: Command = {
+    }, 'vscode/extensions.contribution/showBuiltInExtensions', EXTENSIONS_CATEGORY_KEY);
+    export const SHOW_INSTALLED = Command.toLocalizedCommand({
         id: 'vsxExtension.showInstalled',
         label: 'Show Installed Extensions',
         category: EXTENSIONS_CATEGORY,
-    };
-    export const SHOW_RECOMMENDATIONS: Command = {
+    }, 'vscode/extensions.contribution/showInstalledExtensions', EXTENSIONS_CATEGORY_KEY);
+    export const SHOW_RECOMMENDATIONS = Command.toLocalizedCommand({
         id: 'vsxExtension.showRecommendations',
         label: 'Show Recommended Extensions',
         category: EXTENSIONS_CATEGORY,
-    };
+    }, 'vscode/extensions.contribution/showRecommendedExtensions', EXTENSIONS_CATEGORY_KEY);
 }

--- a/packages/vsx-registry/src/browser/vsx-extensions-view-container.ts
+++ b/packages/vsx-registry/src/browser/vsx-extensions-view-container.ts
@@ -22,12 +22,13 @@ import { VSXSearchMode } from './vsx-extensions-search-model';
 import { generateExtensionWidgetId } from './vsx-extensions-widget';
 import { VSXExtensionsSourceOptions } from './vsx-extensions-source';
 import { VSXExtensionsCommands } from './vsx-extension-commands';
+import { nls } from '@theia/core/lib/browser/nls';
 
 @injectable()
 export class VSXExtensionsViewContainer extends ViewContainer {
 
     static ID = 'vsx-extensions-view-container';
-    static LABEL = 'Extensions';
+    static LABEL = nls.localize('vscode/settingsLayout/extensions', 'Extensions');
 
     @inject(VSXExtensionsSearchBar)
     protected readonly searchBar: VSXExtensionsSearchBar;
@@ -163,7 +164,7 @@ export class VSXExtensionsViewContainer extends ViewContainer {
     }
 
     protected getToggleVisibilityGroupLabel(): string {
-        return 'a/Views';
+        return 'a/' + nls.localize('vscode/viewPaneContainer/views', 'Views');
     }
 }
 export namespace VSXExtensionsViewContainer {

--- a/packages/vsx-registry/src/browser/vsx-extensions-widget.ts
+++ b/packages/vsx-registry/src/browser/vsx-extensions-widget.ts
@@ -17,6 +17,7 @@
 import { injectable, interfaces, postConstruct, inject } from '@theia/core/shared/inversify';
 import { SourceTreeWidget } from '@theia/core/lib/browser/source-tree';
 import { VSXExtensionsSource, VSXExtensionsSourceOptions } from './vsx-extensions-source';
+import { nls } from '@theia/core/lib/browser/nls';
 
 @injectable()
 export class VSXExtensionsWidgetOptions extends VSXExtensionsSourceOptions {
@@ -66,13 +67,13 @@ export class VSXExtensionsWidget extends SourceTreeWidget {
     protected computeTitle(): string {
         switch (this.options.id) {
             case VSXExtensionsSourceOptions.INSTALLED:
-                return 'Installed';
+                return nls.localize('vscode/extensions.contribution/installed filter', 'Installed');
             case VSXExtensionsSourceOptions.BUILT_IN:
-                return 'Built-in';
+                return nls.localize('vscode/extensions.contribution/builtin filter', 'Built-in');
             case VSXExtensionsSourceOptions.RECOMMENDED:
-                return 'Recommended';
+                return nls.localize('vscode/extensions.contribution/most popular recommended', 'Recommended');
             case VSXExtensionsSourceOptions.SEARCH_RESULT:
-                return 'Open VSX Registry';
+                return nls.localize('theia/vsx-registry/openVSX', 'Open VSX Registry');
             default:
                 return '';
         }

--- a/packages/workspace/src/browser/workspace-commands.ts
+++ b/packages/workspace/src/browser/workspace-commands.ts
@@ -22,8 +22,8 @@ import { Command, CommandContribution, CommandRegistry } from '@theia/core/lib/c
 import { MenuContribution, MenuModelRegistry } from '@theia/core/lib/common/menu';
 import { CommonMenus } from '@theia/core/lib/browser/common-frontend-contribution';
 import { FileDialogService } from '@theia/filesystem/lib/browser';
-import { SingleTextInputDialog, ConfirmDialog } from '@theia/core/lib/browser/dialogs';
-import { OpenerService, OpenHandler, open, FrontendApplication, LabelProvider } from '@theia/core/lib/browser';
+import { SingleTextInputDialog, ConfirmDialog, Dialog } from '@theia/core/lib/browser/dialogs';
+import { OpenerService, OpenHandler, open, FrontendApplication, LabelProvider, CommonCommands } from '@theia/core/lib/browser';
 import { UriCommandHandler, UriAwareCommandHandler } from '@theia/core/lib/common/uri-command-handler';
 import { WorkspaceService } from './workspace-service';
 import { MessageService } from '@theia/core/lib/common/message-service';
@@ -38,108 +38,115 @@ import { WorkspaceInputDialog } from './workspace-input-dialog';
 import { Emitter, Event, OS } from '@theia/core/lib/common';
 import { FileService } from '@theia/filesystem/lib/browser/file-service';
 import { FileStat } from '@theia/filesystem/lib/common/files';
+import { nls } from '@theia/core/lib/browser/nls';
 
 const validFilename: (arg: string) => boolean = require('valid-filename');
 
 export namespace WorkspaceCommands {
 
-    const WORKSPACE_CATEGORY = 'Workspace';
-    const FILE_CATEGORY = 'File';
+    const WORKSPACE_CATEGORY_KEY = 'vscode/workspaceActions/workspaces';
+    const WORKSPACE_CATEGORY = 'Workspaces';
+    const FILE_CATEGORY = CommonCommands.FILE_CATEGORY;
 
     // On Linux and Windows, both files and folders cannot be opened at the same time in electron.
     // `OPEN_FILE` and `OPEN_FOLDER` must be available only on Linux and Windows in electron.
     // `OPEN` must *not* be available on Windows and Linux in electron.
     // VS Code does the same. See: https://github.com/eclipse-theia/theia/pull/3202#issuecomment-430585357
     export const OPEN: Command & { dialogLabel: string } = {
-        id: 'workspace:open',
-        category: FILE_CATEGORY,
-        label: 'Open...',
-        dialogLabel: 'Open'
+        ...Command.toLocalizedCommand({
+            id: 'workspace:open',
+            category: CommonCommands.FILE_CATEGORY,
+            label: 'Open...'
+        }, 'vscode/workspaceActions/openFileFolder', CommonCommands.FILE_CATEGORY_KEY),
+        dialogLabel: nls.localize('vscode/dialogMainService/open', 'Open')
     };
     // No `label`. Otherwise, it shows up in the `Command Palette`.
     export const OPEN_FILE: Command & { dialogLabel: string } = {
         id: 'workspace:openFile',
-        category: FILE_CATEGORY,
+        originalCategory: FILE_CATEGORY,
+        category: nls.localize(CommonCommands.FILE_CATEGORY_KEY, CommonCommands.FILE_CATEGORY),
         dialogLabel: 'Open File'
     };
     export const OPEN_FOLDER: Command & { dialogLabel: string } = {
         id: 'workspace:openFolder',
-        dialogLabel: 'Open Folder' // No `label`. Otherwise, it shows up in the `Command Palette`.
+        dialogLabel: nls.localize('vscode/dialogMainService/openFolder', 'Open Folder') // No `label`. Otherwise, it shows up in the `Command Palette`.
     };
     export const OPEN_WORKSPACE: Command & { dialogLabel: string } = {
-        id: 'workspace:openWorkspace',
-        category: FILE_CATEGORY,
-        label: 'Open Workspace...',
-        dialogLabel: 'Open Workspace'
+        ...Command.toLocalizedCommand({
+            id: 'workspace:openWorkspace',
+            category: CommonCommands.FILE_CATEGORY,
+            label: 'Open Workspace...',
+        }, 'vscode/workspaceActions/openWorkspaceAction', CommonCommands.FILE_CATEGORY_KEY),
+        dialogLabel: nls.localize('vscode/dialogMainService/openWorkspaceTitle', 'Open Workspace')
     };
-    export const OPEN_RECENT_WORKSPACE: Command = {
+    export const OPEN_RECENT_WORKSPACE = Command.toLocalizedCommand({
         id: 'workspace:openRecent',
         category: FILE_CATEGORY,
         label: 'Open Recent Workspace...'
-    };
-    export const CLOSE: Command = {
+    }, 'theia/workspace/openRecentWorkspace', CommonCommands.FILE_CATEGORY_KEY);
+    export const CLOSE = Command.toLocalizedCommand({
         id: 'workspace:close',
         category: WORKSPACE_CATEGORY,
         label: 'Close Workspace'
-    };
-    export const NEW_FILE: Command = {
+    }, 'vscode/workspaceActions/closeWorkspace', WORKSPACE_CATEGORY_KEY);
+    export const NEW_FILE = Command.toLocalizedCommand({
         id: 'file.newFile',
         category: FILE_CATEGORY,
         label: 'New File'
-    };
-    export const NEW_FOLDER: Command = {
+    }, 'vscode/fileActions/newFile', CommonCommands.FILE_CATEGORY_KEY);
+    export const NEW_FOLDER = Command.toLocalizedCommand({
         id: 'file.newFolder',
         category: FILE_CATEGORY,
         label: 'New Folder'
-    };
+    }, 'vscode/fileActions/newFile', CommonCommands.FILE_CATEGORY_KEY);
     export const FILE_OPEN_WITH = (opener: OpenHandler): Command => ({
         id: `file.openWith.${opener.id}`
     });
-    export const FILE_RENAME: Command = {
+    export const FILE_RENAME = Command.toLocalizedCommand({
         id: 'file.rename',
         category: FILE_CATEGORY,
         label: 'Rename'
-    };
-    export const FILE_DELETE: Command = {
+    }, 'vscode/fileActions/rename', CommonCommands.FILE_CATEGORY_KEY);
+    export const FILE_DELETE = Command.toLocalizedCommand({
         id: 'file.delete',
         category: FILE_CATEGORY,
         label: 'Delete'
-    };
-    export const FILE_DUPLICATE: Command = {
+    }, 'vscode/fileActions/delete', CommonCommands.FILE_CATEGORY_KEY);
+    export const FILE_DUPLICATE = Command.toLocalizedCommand({
         id: 'file.duplicate',
         category: FILE_CATEGORY,
         label: 'Duplicate'
-    };
-    export const FILE_COMPARE: Command = {
+    }, 'theia/workspace/duplicate', CommonCommands.FILE_CATEGORY_KEY);
+    export const FILE_COMPARE = Command.toLocalizedCommand({
         id: 'file.compare',
         category: FILE_CATEGORY,
         label: 'Compare with Each Other'
-    };
-    export const ADD_FOLDER: Command = {
+    }, 'vscode/fileActions.contribution/compareSelected', CommonCommands.FILE_CATEGORY_KEY);
+    export const ADD_FOLDER = Command.toLocalizedCommand({
         id: 'workspace:addFolder',
         category: WORKSPACE_CATEGORY,
         label: 'Add Folder to Workspace...'
-    };
-    export const REMOVE_FOLDER: Command = {
+    }, 'vscode/workspaceCommands/addFolderToWorkspace', WORKSPACE_CATEGORY_KEY);
+    export const REMOVE_FOLDER = Command.toLocalizedCommand({
         id: 'workspace:removeFolder',
         category: WORKSPACE_CATEGORY,
         label: 'Remove Folder from Workspace'
-    };
-    export const SAVE_WORKSPACE_AS: Command = {
+    }, 'vscode/fileCommands/removeFolderFromWorkspace', WORKSPACE_CATEGORY_KEY);
+    export const SAVE_WORKSPACE_AS = Command.toLocalizedCommand({
         id: 'workspace:saveAs',
         category: WORKSPACE_CATEGORY,
         label: 'Save Workspace As...'
-    };
-    export const OPEN_WORKSPACE_FILE: Command = {
+    }, 'vscode/workspaceActions/saveWorkspaceAsAction', WORKSPACE_CATEGORY_KEY);
+    export const OPEN_WORKSPACE_FILE = Command.toLocalizedCommand({
         id: 'workspace:openConfigFile',
         category: WORKSPACE_CATEGORY,
         label: 'Open Workspace Configuration File'
-    };
-    export const SAVE_AS: Command = {
+    }, 'vscode/abstractWorkspaceEditingService/openWorkspaceConfigurationFile', WORKSPACE_CATEGORY_KEY);
+    export const SAVE_AS = Command.toLocalizedCommand({
         id: 'file.saveAs',
-        category: 'File',
+        category: CommonCommands.FILE_CATEGORY,
         label: 'Save As...',
-    };
+    }, 'vscode/fileCommands/saveAs', CommonCommands.FILE_CATEGORY_KEY);
 }
 
 @injectable()
@@ -237,7 +244,7 @@ export class WorkspaceCommandContribution implements CommandContribution {
                     const vacantChildUri = FileSystemUtils.generateUniqueResourceURI(parentUri, parent, fileName, fileExtension);
 
                     const dialog = new WorkspaceInputDialog({
-                        title: 'New File',
+                        title: nls.localize('vscode/fileActions/newFile', 'New File'),
                         parentUri: parentUri,
                         initialValue: vacantChildUri.path.base,
                         validate: name => this.validateFileName(name, parent, true)
@@ -260,7 +267,7 @@ export class WorkspaceCommandContribution implements CommandContribution {
                     const parentUri = parent.resource;
                     const vacantChildUri = FileSystemUtils.generateUniqueResourceURI(parentUri, parent, 'Untitled');
                     const dialog = new WorkspaceInputDialog({
-                        title: 'New Folder',
+                        title: nls.localize('vscode/fileActions/newFolder', 'New Folder'),
                         parentUri: parentUri,
                         initialValue: vacantChildUri.path.base,
                         validate: name => this.validateFileName(name, parent, true)
@@ -283,11 +290,8 @@ export class WorkspaceCommandContribution implements CommandContribution {
                     const parent = await this.getParent(uri);
                     if (parent) {
                         const oldName = uri.path.base;
-                        const stat = await this.fileService.resolve(uri);
-                        const fileType = stat.isDirectory ? 'Directory' : 'File';
-                        const titleStr = `Rename ${fileType}`;
                         const dialog = new SingleTextInputDialog({
-                            title: titleStr,
+                            title: nls.localize('vscode/fileActions/rename', 'Rename'),
                             initialValue: oldName,
                             initialSelectionRange: {
                                 start: 0,
@@ -333,10 +337,11 @@ export class WorkspaceCommandContribution implements CommandContribution {
                     if (!workspaceSavedBeforeAdding) {
                         const saveCommand = registry.getCommand(WorkspaceCommands.SAVE_WORKSPACE_AS.id);
                         if (saveCommand && await new ConfirmDialog({
-                            title: 'Folder added to Workspace',
-                            msg: 'A workspace with multiple roots was created. Do you want to save your workspace configuration as a file?',
-                            ok: 'Yes',
-                            cancel: 'No'
+                            title: nls.localize('theia/workspace/workspaceFolderAddedTitle', 'Folder added to Workspace'),
+                            msg: nls.localize('theia/workspace/workspaceFolderAdded',
+                                'A workspace with multiple roots was created. Do you want to save your workspace configuration as a file?'),
+                            ok: Dialog.YES,
+                            cancel: Dialog.NO
                         }).open()) {
                             registry.executeCommand(saveCommand.id);
                         }
@@ -404,21 +409,21 @@ export class WorkspaceCommandContribution implements CommandContribution {
         }
         // do not allow recursive rename
         if (!allowNested && !validFilename(name)) {
-            return 'Invalid file or folder name';
+            return nls.localize('vscode/configureSnippets/bad_name1', 'Invalid file or folder name');
         }
         if (name.startsWith('/')) {
-            return 'Absolute paths or names that starts with / are not allowed';
+            return nls.localize('vscode/fileActions/fileNameStartsWithSlashError', 'Absolute paths or names that starts with / are not allowed');
         } else if (name.startsWith(' ') || name.endsWith(' ')) {
-            return 'Names with leading or trailing whitespaces are not allowed';
+            return nls.localize('vscode/fileActions/fileNameWhitespaceWarning', 'Names with leading or trailing whitespaces are not allowed');
         }
         // check and validate each sub-paths
         if (name.split(/[\\/]/).some(file => !file || !validFilename(file) || /^\s+$/.test(file))) {
-            return `The name "${this.trimFileName(name)}" is not a valid file or folder name.`;
+            return nls.localize('vscode/fileActions/invalidFileNameError', 'The name "{0}" is not a valid file or folder name.', this.trimFileName(name));
         }
         const childUri = parent.resource.resolve(name);
         const exists = await this.fileService.exists(childUri);
         if (exists) {
-            return `A file or folder "${this.trimFileName(name)}" already exists at this location.`;
+            return nls.localize('vscode/fileActions/fileNameExistsError', 'A file or folder "{0}" already exists at this location.', this.trimFileName(name));
         }
         return '';
     }
@@ -489,8 +494,9 @@ export class WorkspaceCommandContribution implements CommandContribution {
         const toRemove = uris.filter(uri => roots.has(uri.toString()));
         if (toRemove.length > 0) {
             const messageContainer = document.createElement('div');
-            messageContainer.textContent = `Are you sure you want to remove the following folder${toRemove.length > 1 ? 's' : ''} from the workspace?`;
-            messageContainer.title = 'Note: Nothing will be erased from disk';
+            messageContainer.textContent = nls.localize(`theia/workspace/removeFolder${toRemove.length > 1 ? 's' : ''}`,
+                `Are you sure you want to remove the following folder${toRemove.length > 1 ? 's' : ''} from the workspace?`);
+            messageContainer.title = nls.localize('theia/workspace/noErasure', 'Note: Nothing will be erased from disk');
             const list = document.createElement('div');
             list.classList.add('theia-dialog-node');
             toRemove.forEach(uri => {
@@ -508,7 +514,7 @@ export class WorkspaceCommandContribution implements CommandContribution {
             });
             messageContainer.appendChild(list);
             const dialog = new ConfirmDialog({
-                title: 'Remove Folder from Workspace',
+                title: nls.localize('vscode/fileCommands/removeFolderFromWorkspace', 'Remove Folder from Workspace'),
                 msg: messageContainer
             });
             if (await dialog.open()) {


### PR DESCRIPTION
#### What it does

Addresses another open issue from #9538: Localization of Theia using (mostly) vscode language packs.

This isn't a 100% solution, as I didn't translate the preferences yet and I'm pretty sure I've missed something.

Be aware that not everything is translated in here:
1. Monaco is translated in #10084
2. Extensions/plugins are localized in #10087
3. Some translated values do not exist in vscode and are therefore untranslated. They are listed in the `nls.json`.

#### How to test

1. Download a language pack of your choice.
2. Run the application and find missing/erroneous translations.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
