### PR TITLE
call-hierarchy: add support for `tags`

### DIFF
--- a/packages/callhierarchy/src/browser/callhierarchy-tree/callhierarchy-tree-widget.tsx
+++ b/packages/callhierarchy/src/browser/callhierarchy-tree/callhierarchy-tree-widget.tsx
@@ -24,7 +24,7 @@ import { DefinitionNode, CallerNode } from './callhierarchy-tree';
 import { CallHierarchyTreeModel } from './callhierarchy-tree-model';
 import { CALLHIERARCHY_ID, Definition, Caller } from '../callhierarchy';
 import URI from '@theia/core/lib/common/uri';
-import { Location, Range, SymbolKind, DocumentUri } from '@theia/core/shared/vscode-languageserver-types';
+import { Location, Range, SymbolKind, DocumentUri, SymbolTag } from '@theia/core/shared/vscode-languageserver-types';
 import { EditorManager } from '@theia/editor/lib/browser';
 import * as React from '@theia/core/shared/react';
 
@@ -103,7 +103,13 @@ export class CallHierarchyTreeWidget extends TreeWidget {
         const symbol = definition.symbolName;
         const location = this.labelProvider.getName(new URI(definition.location.uri));
         const container = (containerName) ? containerName + ' — ' + location : location;
-        return <div className='definitionNode'>
+        const isDeprecated = definition.tags?.includes(SymbolTag.Deprecated);
+        const classNames = ['definitionNode'];
+        if (isDeprecated) {
+            classNames.push('deprecatedDefinition');
+        }
+
+        return <div className={classNames.join(' ')}>
             <div className={'symbol-icon ' + this.toIconClass(definition.symbolKind)}></div>
             <div className='definitionNode-content'>
                 <span className='symbol'>
@@ -123,7 +129,13 @@ export class CallHierarchyTreeWidget extends TreeWidget {
         const referenceCount = caller.references.length;
         const location = this.labelProvider.getName(new URI(definition.location.uri));
         const container = (containerName) ? containerName + ' — ' + location : location;
-        return <div className='definitionNode'>
+        const isDeprecated = definition.tags?.includes(SymbolTag.Deprecated);
+        const classNames = ['definitionNode'];
+        if (isDeprecated) {
+            classNames.push('deprecatedDefinition');
+        }
+
+        return <div className={classNames.join(' ')}>
             <div className={'symbol-icon ' + this.toIconClass(definition.symbolKind)}></div>
             <div className='definitionNode-content'>
                 <span className='symbol'>

--- a/packages/callhierarchy/src/browser/callhierarchy.ts
+++ b/packages/callhierarchy/src/browser/callhierarchy.ts
@@ -14,7 +14,7 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
-import { Range, SymbolKind, Location } from '@theia/core/shared/vscode-languageserver-types';
+import { Range, SymbolKind, Location, SymbolTag } from '@theia/core/shared/vscode-languageserver-types';
 
 export const CALLHIERARCHY_ID = 'callhierarchy';
 
@@ -23,7 +23,8 @@ export interface Definition {
     selectionRange: Range,
     symbolName: string,
     symbolKind: SymbolKind,
-    containerName: string | undefined
+    containerName: string | undefined,
+    tags?: readonly SymbolTag[];
 }
 
 export interface Caller {

--- a/packages/callhierarchy/src/browser/style/index.css
+++ b/packages/callhierarchy/src/browser/style/index.css
@@ -56,3 +56,7 @@
     overflow: hidden;
     text-overflow: ellipsis;
 }
+
+.theia-CallHierarchyTree .definitionNode.deprecatedDefinition .definitionNode-content {
+    text-decoration: line-through;
+}

--- a/packages/plugin-ext/src/common/plugin-api-rpc-model.ts
+++ b/packages/plugin-ext/src/common/plugin-api-rpc-model.ts
@@ -523,6 +523,7 @@ export interface CallHierarchyDefinition {
     uri: UriComponents;
     range: Range;
     selectionRange: Range;
+    tags?: readonly SymbolTag[];
 }
 
 export interface CallHierarchyReference {
@@ -540,6 +541,7 @@ export interface CallHierarchyItem {
     uri: UriComponents;
     range: Range;
     selectionRange: Range;
+    tags?: readonly SymbolTag[];
 }
 
 export interface CallHierarchyIncomingCall {

--- a/packages/plugin-ext/src/main/browser/callhierarchy/callhierarchy-type-converters.ts
+++ b/packages/plugin-ext/src/main/browser/callhierarchy/callhierarchy-type-converters.ts
@@ -151,7 +151,8 @@ export function toDefinition(definition: model.CallHierarchyDefinition | undefin
         selectionRange: toRange(definition.selectionRange),
         symbolName: definition.name,
         symbolKind: SymbolKindConverter.toSymbolKind(definition.kind),
-        containerName: undefined
+        containerName: undefined,
+        tags: definition.tags
     };
 }
 

--- a/packages/plugin-ext/src/plugin/languages/call-hierarchy.ts
+++ b/packages/plugin-ext/src/plugin/languages/call-hierarchy.ts
@@ -72,7 +72,8 @@ export class CallHierarchyAdapter {
             range: this.fromRange(item.range),
             selectionRange: this.fromRange(item.selectionRange),
             name: item.name,
-            kind: item.kind
+            kind: item.kind,
+            tags: item.tags
         };
     }
 

--- a/packages/plugin-ext/src/plugin/type-converters.ts
+++ b/packages/plugin-ext/src/plugin/type-converters.ts
@@ -169,10 +169,7 @@ export function fromRangeOrRangeWithMessage(ranges: theia.Range[] | theia.Decora
             };
         });
     } else {
-        return ranges.map((r): DecorationOptions =>
-        ({
-            range: fromRange(r)!
-        }));
+        return ranges.map(r => ({ range: fromRange(r) }));
     }
 }
 
@@ -682,7 +679,8 @@ export function fromCallHierarchyItem(item: theia.CallHierarchyItem): model.Call
         detail: item.detail,
         uri: item.uri,
         range: fromRange(item.range),
-        selectionRange: fromRange(item.selectionRange)
+        selectionRange: fromRange(item.selectionRange),
+        tags: item.tags
     };
 }
 

--- a/packages/plugin-ext/src/plugin/types-impl.ts
+++ b/packages/plugin-ext/src/plugin/types-impl.ts
@@ -2344,6 +2344,7 @@ export class CallHierarchyItem {
     uri: URI;
     range: Range;
     selectionRange: Range;
+    tags?: readonly SymbolTag[];
 
     constructor(kind: SymbolKind, name: string, detail: string, uri: URI, range: Range, selectionRange: Range) {
         this.kind = kind;

--- a/packages/plugin/src/theia.d.ts
+++ b/packages/plugin/src/theia.d.ts
@@ -10636,6 +10636,11 @@ declare module '@theia/plugin' {
         selectionRange: Range;
 
         /**
+         * Tags for this item.
+         */
+        tags?: readonly SymbolTag[];
+
+        /**
          * Creates a new call hierarchy item.
          */
         constructor(kind: SymbolKind, name: string, detail: string, uri: Uri, range: Range, selectionRange: Range);


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

Fixes: #9987

Add support for `tags` in `CallHierarchyItem`, and includes updates to the rendering of the call-hierarchy-tree in order to display deprecated tags as deprecated (with a line-through) similarly to vscode.

https://user-images.githubusercontent.com/40359487/133489281-f9d66c14-ffee-4b31-850b-e458a16c582f.mp4

#### How to test

 - add [vscode-callhierarchy-test](https://github.com/vince-fugnitto/vscode-callhierarchy-test/releases/download/0.0.1/call-hierarchy-sample-0.0.1.vsix) to the 'plugins' folder
 - start the application
 - follow the steps in the plugin's [readme](https://github.com/vince-fugnitto/vscode-callhierarchy-test/blob/main/README.md)
    - the plugin should open a file from which you can trigger the `call-hierachy` for
    - the nodes should be marked as deprecated (for test purposes)
- confirm that the standard `call-hierarchy` works correctly (ex: typescript files)
 

#### Review checklist

- [X] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
