### PR TITLE
Add additional startup logging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## v1.19.0 - 10/28/2021
+
+[1.19.0 Milestone](https://github.com/eclipse-theia/theia/milestone/25)
+
+- [plugin-ext] add additional startup logging for plugin starting and application loading [#10116](https://github.com/eclipse-theia/theia/pull/10116) - Contributed on behalf of STMicroelectronics
+
 ## v1.18.0 - 9/30/2021
 
 [1.18.0 Milestone](https://github.com/eclipse-theia/theia/milestone/24)

--- a/packages/core/src/browser/frontend-application.ts
+++ b/packages/core/src/browser/frontend-application.ts
@@ -231,6 +231,7 @@ export class FrontendApplication {
             return new Promise(resolve => {
                 window.requestAnimationFrame(() => {
                     startupElem.classList.add('theia-hidden');
+                    console.log(`Finished loading frontend application after ${(performance.now() / 1000).toFixed(3)} seconds`);
                     const preloadStyle = window.getComputedStyle(startupElem);
                     const transitionDuration = parseCssTime(preloadStyle.transitionDuration, 0);
                     window.setTimeout(() => {

--- a/packages/plugin-ext/src/hosted/browser/hosted-plugin.ts
+++ b/packages/plugin-ext/src/hosted/browser/hosted-plugin.ts
@@ -304,12 +304,15 @@ export class HostedPluginSupport {
      */
     protected async syncPlugins(): Promise<void> {
         let initialized = 0;
-        const syncPluginsMeasurement = this.createMeasurement('syncPlugins');
+        const waitPluginsMeasurement = this.createMeasurement('waitForDeployment');
+        let syncPluginsMeasurement: () => number;
 
         const toUnload = new Set(this.contributions.keys());
         try {
             const pluginIds: string[] = [];
             const deployedPluginIds = await this.server.getDeployedPluginIds();
+            this.logMeasurement('Waiting for backend deployment', waitPluginsMeasurement);
+            syncPluginsMeasurement = this.createMeasurement('syncPlugins');
             for (const pluginId of deployedPluginIds) {
                 toUnload.delete(pluginId);
                 if (!this.contributions.has(pluginId)) {
@@ -338,7 +341,7 @@ export class HostedPluginSupport {
             }
         }
 
-        this.logMeasurement('Sync', initialized, syncPluginsMeasurement);
+        this.logMeasurement(`Sync of ${this.getPluginCount(initialized)}`, syncPluginsMeasurement);
     }
 
     /**
@@ -376,7 +379,7 @@ export class HostedPluginSupport {
             }
         }
 
-        this.logMeasurement('Load contributions', loaded, loadPluginsMeasurement);
+        this.logMeasurement(`Load contributions of ${this.getPluginCount(loaded)}`, loadPluginsMeasurement);
 
         return hostContributions;
     }
@@ -446,7 +449,7 @@ export class HostedPluginSupport {
             return;
         }
 
-        this.logMeasurement('Start', started, startPluginsMeasurement);
+        this.logMeasurement(`Start of ${this.getPluginCount(started)}`, startPluginsMeasurement);
     }
 
     protected async obtainManager(host: string, hostContributions: PluginContributions[], toDisconnect: DisposableCollection): Promise<PluginManagerExt | undefined> {
@@ -714,15 +717,19 @@ export class HostedPluginSupport {
         };
     }
 
-    protected logMeasurement(prefix: string, count: number, measurement: () => number): void {
+    protected logMeasurement(measurementName: string, measurement: () => number): void {
         const duration = measurement();
         if (duration === Number.NaN) {
             // Measurement was prevented by native API, do not log NaN duration
             return;
         }
 
-        const pluginCount = `${count} plugin${count === 1 ? '' : 's'}`;
-        console.log(`[${this.clientId}] ${prefix} of ${pluginCount} took: ${duration.toFixed(1)} ms`);
+        const timeFromFrontendStart = `Finished ${(performance.now() / 1000).toFixed(3)} s after frontend start`;
+        console.log(`[${this.clientId}] ${measurementName} took: ${duration.toFixed(1)} ms [${timeFromFrontendStart}]`);
+    }
+
+    protected getPluginCount(plugins: number): string {
+        return `${plugins} plugin${plugins === 1 ? '' : 's'}`;
     }
 
     protected readonly webviewsToRestore = new Set<WebviewWidget>();


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->
- Add log message with timestamp of finished applicaiton loading
- Add timestamp from frontend start to sync, load and start plugin durations
- Split sync duration in waiting for backend deployment and sync
- This prevents the sync time to be longer because the backend is not yet ready

Contributed on behalf of STMicroelectronics
Signed-off-by: Simon Graband <sgraband@eclipsesource.com>
#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
Start the frontend and inspect the log messages.
#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
