### PR TITLE
repo: add `runtime-import-check` eslint rule

### DIFF
--- a/configs/errors.eslintrc.json
+++ b/configs/errors.eslintrc.json
@@ -130,6 +130,7 @@
         }
       }
     ],
+    "@theia/runtime-import-check": "error",
     "@theia/shared-dependencies": "error",
     "import/no-extraneous-dependencies": "error",
     "import/no-dynamic-require": "error"
@@ -140,6 +141,7 @@
         "**/*.{spec,espec,slow-spec}.{js,ts}"
       ],
       "rules": {
+        "@theia/runtime-import-check": "off",
         "@theia/shared-dependencies": "off",
         "import/no-extraneous-dependencies": "off"
       }

--- a/dev-packages/eslint-plugin/README.md
+++ b/dev-packages/eslint-plugin/README.md
@@ -1,0 +1,44 @@
+<div align='center'>
+
+<br />
+
+<img src='https://raw.githubusercontent.com/eclipse-theia/theia/master/logo/theia.svg?sanitize=true' alt='theia-ext-logo' width='100px' />
+
+<h2>ECLIPSE THEIA - ESLINT PLUGIN</h2>
+
+<hr />
+
+</div>
+
+## Description
+
+The `@theia/eslint-plugin` contributes rules useful for Eclipse Theia development.
+The plugin helps identify problems during development through static analysis including code quality, potential issues and code smells.
+
+## Rules
+
+#### `runtime-import-check`:
+
+The rule prevents imports from folders meant for incompatible runtimes.
+The check enforces the [code organization guidelines](https://github.com/eclipse-theia/theia/wiki/Code-Organization) of the framework and guards against invalid imports which may cause unforeseen issues downstream.
+
+#### `shared-dependencies`:
+
+The rule prevents the following:
+- prevents the implicit use of a shared dependency from `@theia/core`.
+- prevents extensions from depending on a shared dependency without re-using it from `@theia/core`.
+
+## Additional Information
+
+- [Theia - GitHub](https://github.com/eclipse-theia/theia)
+- [Theia - Website](https://theia-ide.org/)
+
+## License
+
+-   [Eclipse Public License 2.0](http://www.eclipse.org/legal/epl-2.0/)
+-   [一 (Secondary) GNU General Public License, version 2 with the GNU Classpath Exception](https://projects.eclipse.org/license/secondary-gpl-2.0-cp)
+
+## Trademark
+
+"Theia" is a trademark of the Eclipse Foundation
+https://www.eclipse.org/theia

--- a/dev-packages/eslint-plugin/index.js
+++ b/dev-packages/eslint-plugin/index.js
@@ -17,5 +17,6 @@
 
 /** @type {{[ruleId: string]: import('eslint').Rule.RuleModule}} */
 exports.rules = {
-    "shared-dependencies": require('./rules/shared-dependencies'),
+    "runtime-import-check": require('./rules/runtime-import-check'),
+    "shared-dependencies": require('./rules/shared-dependencies')
 };

--- a/dev-packages/eslint-plugin/rules/runtime-import-check.js
+++ b/dev-packages/eslint-plugin/rules/runtime-import-check.js
@@ -1,0 +1,119 @@
+// @ts-check
+/********************************************************************************
+ * Copyright (C) 2021 Ericsson and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+/* eslint-disable max-len */
+
+const path = require('path');
+
+/**
+ * Runtime-specific folders according to our coding guidelines.
+ */
+const folders = {
+    common: 'common',
+    browser: 'browser',
+    node: 'node',
+    electronCommon: 'electron-common',
+    electronBrowser: 'electron-browser',
+    electronNode: 'electron-node',
+    electronMain: 'electron-main',
+};
+
+/**
+ * @typedef {object} ImportRule
+ * @property {string[]} allowed
+ * @property {string[]} restricted
+ */
+
+/**
+ * @param {string} src
+ * @param {string[]} allowedFolders
+ * @returns {[string, ImportRule]}
+ */
+function allow(src, allowedFolders) {
+    const allowed = [src, ...allowedFolders];
+    const restricted = Object.values(folders).filter(folder => !allowed.includes(folder));
+    return [src, { allowed, restricted }];
+}
+
+/**
+ * Mapping of folders to the list of allowed/restricted folders to import from.
+ * @type {[string, ImportRule][]}
+ */
+const importRuleMapping = [
+    allow(folders.common, []),
+    allow(folders.browser, [folders.common]),
+    allow(folders.node, [folders.common]),
+    allow(folders.electronCommon, [folders.common]),
+    allow(folders.electronBrowser, [folders.electronCommon, folders.browser, folders.common]),
+    allow(folders.electronNode, [folders.electronCommon, folders.node, folders.common]),
+    allow(folders.electronMain, [folders.electronCommon, folders.node, folders.common]),
+];
+
+/** @type {import('eslint').Rule.RuleModule} */
+module.exports = {
+    meta: {
+        type: 'problem',
+        fixable: 'code',
+        docs: {
+            description: 'prevent imports from folders meant for incompatible runtimes.',
+            url: 'https://github.com/eclipse-theia/theia/wiki/Code-Organization'
+        },
+    },
+    create(context) {
+        let relativeFilePath = path.relative(context.getCwd(), context.getFilename());
+        // Normalize the path so we only deal with forward slashes.
+        if (process.platform === 'win32') {
+            relativeFilePath = relativeFilePath.replace(/\\/g, '/');
+        }
+        // Search for a folder following our naming conventions, keep the left-most match.
+        // e.g. `src/electron-node/browser/node/...` should match `electron-node`
+        let lowestIndex = Infinity;
+        /** @type {ImportRule | undefined} */
+        let matchedImportRule;
+        /** @type {string | undefined} */
+        let matchedFolder;
+        for (const [folder, importRule] of importRuleMapping) {
+            const index = relativeFilePath.indexOf(`/${folder}/`);
+            if (index !== -1 && index < lowestIndex) {
+                matchedImportRule = importRule;
+                matchedFolder = folder;
+                lowestIndex = index;
+            }
+        }
+        // File doesn't follow our naming convention so we'll bail now.
+        if (matchedFolder === undefined) {
+            return {};
+        }
+        return {
+            ImportDeclaration(node) {
+                checkModuleImport(node.source);
+            },
+            TSExternalModuleReference(node) {
+                checkModuleImport(node.expression);
+            },
+        }
+        function checkModuleImport(node) {
+            const module = /** @type {string} */(node.value);
+            if (matchedImportRule.restricted.some(restricted => module.includes(`/${restricted}/`))) {
+                context.report({
+                    node,
+                    message: `'${module}' cannot be imported in '${matchedFolder}', only '${matchedImportRule.allowed.join(', ')}' ${matchedImportRule.allowed.length === 1 ? 'is' : 'are'} allowed.`
+                });
+            }
+        }
+    },
+}

--- a/packages/core/src/common/command.ts
+++ b/packages/core/src/common/command.ts
@@ -18,6 +18,7 @@ import { injectable, inject, named } from 'inversify';
 import { Event, Emitter, WaitUntilEvent } from './event';
 import { Disposable, DisposableCollection } from './disposable';
 import { ContributionProvider } from './contribution-provider';
+// eslint-disable-next-line @theia/runtime-import-check
 import { nls } from '../browser/nls';
 
 /**

--- a/packages/core/src/common/quick-pick-service.ts
+++ b/packages/core/src/common/quick-pick-service.ts
@@ -14,6 +14,7 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 import { Event } from './event';
+// eslint-disable-next-line @theia/runtime-import-check
 import { QuickInputButtonHandle, QuickPick, QuickPickItem, QuickPickOptions } from '../browser/quick-input/quick-input-service';
 
 export const quickPickServicePath = '/services/quickPick';

--- a/packages/core/src/electron-common/electron-main-window-service.ts
+++ b/packages/core/src/electron-common/electron-main-window-service.ts
@@ -14,6 +14,7 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
+// eslint-disable-next-line @theia/runtime-import-check
 import { NewWindowOptions } from '../browser/window/window-service';
 
 export const electronMainWindowServicePath = '/services/electron-window';

--- a/packages/core/src/electron-main/electron-main-application.ts
+++ b/packages/core/src/electron-main/electron-main-application.ts
@@ -30,7 +30,9 @@ import { ContributionProvider } from '../common/contribution-provider';
 import { ElectronSecurityTokenService } from './electron-security-token-service';
 import { ElectronSecurityToken } from '../electron-common/electron-token';
 import Storage = require('electron-store');
+// eslint-disable-next-line @theia/runtime-import-check
 import { DEFAULT_WINDOW_HASH } from '../browser/window/window-service';
+
 const createYargs: (argv?: string[], cwd?: string) => Argv = require('yargs/yargs');
 
 /**

--- a/packages/core/src/electron-main/electron-main-window-service-impl.ts
+++ b/packages/core/src/electron-main/electron-main-window-service-impl.ts
@@ -18,6 +18,7 @@ import { shell } from '../../shared/electron';
 import { injectable, inject } from 'inversify';
 import { ElectronMainWindowService } from '../electron-common/electron-main-window-service';
 import { ElectronMainApplication } from './electron-main-application';
+// eslint-disable-next-line @theia/runtime-import-check
 import { NewWindowOptions } from '../browser/window/window-service';
 
 @injectable()

--- a/packages/filesystem/src/electron-browser/file-dialog/electron-file-dialog-service.ts
+++ b/packages/filesystem/src/electron-browser/file-dialog/electron-file-dialog-service.ts
@@ -35,6 +35,7 @@ type DialogProperties = 'openFile' | 'openDirectory' | 'multiSelections' | 'show
 // and at packaging time, clients can decide whether they need the native or the browser-based
 // solution.
 //
+// eslint-disable-next-line @theia/runtime-import-check
 import { FileUri } from '@theia/core/lib/node/file-uri';
 
 @injectable()

--- a/packages/output/src/common/output-channel.ts
+++ b/packages/output/src/common/output-channel.ts
@@ -20,9 +20,12 @@ import URI from '@theia/core/lib/common/uri';
 import { Deferred } from '@theia/core/lib/common/promise-util';
 import { Resource, ResourceResolver } from '@theia/core/lib/common/resource';
 import { Emitter, Event, Disposable, DisposableCollection } from '@theia/core';
+// eslint-disable-next-line @theia/runtime-import-check
 import { MonacoEditorModel } from '@theia/monaco/lib/browser/monaco-editor-model';
+// eslint-disable-next-line @theia/runtime-import-check
 import { MonacoTextModelService, IReference } from '@theia/monaco/lib/browser/monaco-text-model-service';
 import { OutputUri } from './output-uri';
+// eslint-disable-next-line @theia/runtime-import-check
 import { OutputResource } from '../browser/output-resource';
 import { OutputPreferences } from './output-preferences';
 

--- a/packages/output/src/common/output-preferences.ts
+++ b/packages/output/src/common/output-preferences.ts
@@ -15,12 +15,14 @@
  ********************************************************************************/
 
 import { interfaces } from '@theia/core/shared/inversify';
+
 import {
     createPreferenceProxy,
     PreferenceProxy,
     PreferenceService,
     PreferenceContribution,
     PreferenceSchema
+    // eslint-disable-next-line @theia/runtime-import-check
 } from '@theia/core/lib/browser/preferences';
 
 export const OutputConfigSchema: PreferenceSchema = {

--- a/packages/plugin-dev/src/common/plugin-dev-protocol.ts
+++ b/packages/plugin-dev/src/common/plugin-dev-protocol.ts
@@ -15,6 +15,7 @@
  ********************************************************************************/
 
 import { JsonRpcServer } from '@theia/core/lib/common/messaging/proxy-factory';
+// eslint-disable-next-line @theia/runtime-import-check
 import { DebugPluginConfiguration } from '@theia/debug/lib/browser/debug-contribution';
 import { PluginMetadata } from '@theia/plugin-ext/lib/common/plugin-protocol';
 

--- a/packages/plugin-dev/src/node/hosted-instance-manager.ts
+++ b/packages/plugin-dev/src/node/hosted-instance-manager.ts
@@ -29,6 +29,7 @@ import { FileUri } from '@theia/core/lib/node/file-uri';
 import { LogType } from '@theia/plugin-ext/lib/common/types';
 import { HostedPluginSupport } from '@theia/plugin-ext/lib/hosted/node/hosted-plugin';
 import { MetadataScanner } from '@theia/plugin-ext/lib/hosted/node/metadata-scanner';
+// eslint-disable-next-line @theia/runtime-import-check
 import { DebugPluginConfiguration } from '@theia/debug/lib/browser/debug-contribution';
 import { HostedPluginProcess } from '@theia/plugin-ext/lib/hosted/node/hosted-plugin-process';
 

--- a/packages/plugin-dev/src/node/hosted-plugin-service.ts
+++ b/packages/plugin-dev/src/node/hosted-plugin-service.ts
@@ -22,6 +22,7 @@ import URI from '@theia/core/lib/common/uri';
 import { HostedPluginReader } from './hosted-plugin-reader';
 import { HostedPluginsManager } from './hosted-plugins-manager';
 import { HostedPluginSupport } from '@theia/plugin-ext/lib/hosted/node/hosted-plugin';
+// eslint-disable-next-line @theia/runtime-import-check
 import { DebugPluginConfiguration } from '@theia/debug/lib/browser/debug-contribution';
 
 @injectable()

--- a/packages/plugin-ext/src/common/plugin-api-rpc.ts
+++ b/packages/plugin-ext/src/common/plugin-api-rpc.ts
@@ -91,6 +91,7 @@ import type {
     TimelineProviderDescriptor
 } from '@theia/timeline/lib/common/timeline-model';
 import { SerializableEnvironmentVariableCollection } from '@theia/terminal/lib/common/base-terminal-protocol';
+// eslint-disable-next-line @theia/runtime-import-check
 import { ThemeType } from '@theia/core/lib/browser/theming';
 import { Disposable } from '@theia/core/lib/common/disposable';
 import { PickOptions, QuickInputButtonHandle, QuickPickItem } from '@theia/core/lib/browser';

--- a/packages/plugin-ext/src/common/plugin-protocol.ts
+++ b/packages/plugin-ext/src/common/plugin-protocol.ts
@@ -23,6 +23,7 @@ import { IJSONSchema, IJSONSchemaSnippet } from '@theia/core/lib/common/json-sch
 import { RecursivePartial } from '@theia/core/lib/common/types';
 import { PreferenceSchema, PreferenceSchemaProperties } from '@theia/core/lib/common/preferences/preference-schema';
 import { ProblemMatcherContribution, ProblemPatternContribution, TaskDefinition } from '@theia/task/lib/common';
+// eslint-disable-next-line @theia/runtime-import-check
 import { ColorDefinition } from '@theia/core/lib/browser/color-registry';
 import { ResourceLabelFormatter } from '@theia/core/lib/common/label-protocol';
 

--- a/packages/plugin-ext/src/hosted/browser/worker/debug-stub.ts
+++ b/packages/plugin-ext/src/hosted/browser/worker/debug-stub.ts
@@ -14,6 +14,7 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
+// eslint-disable-next-line @theia/runtime-import-check
 import { DebugExtImpl } from '../../../plugin/node/debug/debug';
 import { RPCProtocol } from '../../../common/rpc-protocol';
 

--- a/packages/plugin-ext/src/hosted/node/scanners/scanner-theia.ts
+++ b/packages/plugin-ext/src/hosted/node/scanners/scanner-theia.ts
@@ -73,6 +73,7 @@ import {
     ProblemPatternContribution,
     TaskDefinition
 } from '@theia/task/lib/common/task-protocol';
+// eslint-disable-next-line @theia/runtime-import-check
 import { ColorDefinition } from '@theia/core/lib/browser/color-registry';
 import { ResourceLabelFormatter } from '@theia/core/lib/common/label-protocol';
 import { PluginUriFactory } from './plugin-uri-factory';


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

Fixes: https://github.com/eclipse-theia/theia/issues/5873

The pull-request adds a custom **eslint** rule meant to check for invalid runtime imports which do not comply to our [code organization guidelines](https://github.com/eclipse-theia/theia/wiki/Code-Organization). The rule will help us identify uses of invalid imports which cause downstream adopters and extenders runtime issues.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

The new rule should report errors when we use invalid imports based on different runtimes.

The pull-request includes a _baseline_ commit meant to suppress the errors currently in the codebase so we can track and fix them, while new errors from contributions should fail linting.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

Signed-off-by: vince-fugnitto <vincent.fugnitto@ericsson.com>