### PR TITLE
electron: fix `canRead` implementation

### DIFF
--- a/packages/filesystem/src/electron-browser/file-dialog/electron-file-dialog-service.ts
+++ b/packages/filesystem/src/electron-browser/file-dialog/electron-file-dialog-service.ts
@@ -91,13 +91,17 @@ export class ElectronFileDialogService extends DefaultFileDialogService {
     }
 
     protected async canRead(uris: MaybeArray<URI>): Promise<boolean> {
-        const inaccessibleFilePaths = await Promise.all((Array.isArray(uris) ? uris : [uris]).map(
-            async uri => (!await this.fileService.access(uri, FileAccess.Constants.R_OK) && uri.path || '')
-        ).filter(e => e));
-        if (inaccessibleFilePaths.length) {
-            this.messageService.error(`Cannot read ${inaccessibleFilePaths.length} resources: ${inaccessibleFilePaths.join(', ')}`);
+        const resources = Array.isArray(uris) ? uris : [uris];
+        const unreadableResourcePaths: string[] = [];
+        await Promise.all(resources.map(async resource => {
+            if (!await this.fileService.access(resource, FileAccess.Constants.R_OK)) {
+                unreadableResourcePaths.push(resource.path.toString());
+            }
+        }));
+        if (unreadableResourcePaths.length > 0) {
+            this.messageService.error(`Cannot read ${unreadableResourcePaths.length} resource(s): ${unreadableResourcePaths.join(', ')}`);
         }
-        return !!inaccessibleFilePaths.length;
+        return unreadableResourcePaths.length === 0;
     }
 
     protected toDialogOptions(uri: URI, props: SaveFileDialogProps | OpenFileDialogProps, dialogTitle: string): electron.FileDialogProps {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

Fixes: #10103 

The pull-request updates and simplifies the `ElectronFileDialogService.canRead` method which previously produced false positive messages to end-users about unreadable resources.

The changes should:
- fix the bug reported in #10103 
- fail to open a resource when it is unreadable
- not introduce any regressions when opening resources in electron through the `open file` or `open folder` dialogs

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

- start the example-electron application
- confirm that `open file` and `open folder` work correctly
- confirm that `readonly` files can in fact be opened
- confirm that if a file is unreadable (no permissions) that it cannot be opened and will display an error notification:

<br />

<div align='center'>

![image](https://user-images.githubusercontent.com/40359487/133805685-1f11d0bb-00ec-4712-898a-5dcd622c23cf.png)

</div>

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

Signed-off-by: vince-fugnitto <vincent.fugnitto@ericsson.com>