### PR TITLE
eslint-plugin: enable linting of rules

### DIFF
--- a/dev-packages/eslint-plugin/.eslintrc.js
+++ b/dev-packages/eslint-plugin/.eslintrc.js
@@ -1,0 +1,10 @@
+/** @type {import('eslint').Linter.Config} */
+module.exports = {
+    extends: [
+        '../../configs/build.eslintrc.json'
+    ],
+    parserOptions: {
+        tsconfigRootDir: __dirname,
+        project: 'tsconfig.json'
+    }
+};

--- a/dev-packages/eslint-plugin/rules/runtime-import-check.js
+++ b/dev-packages/eslint-plugin/rules/runtime-import-check.js
@@ -105,7 +105,7 @@ module.exports = {
             TSExternalModuleReference(node) {
                 checkModuleImport(node.expression);
             },
-        }
+        };
         function checkModuleImport(node) {
             const module = /** @type {string} */(node.value);
             if (matchedImportRule.restricted.some(restricted => module.includes(`/${restricted}/`))) {
@@ -116,4 +116,4 @@ module.exports = {
             }
         }
     },
-}
+};

--- a/dev-packages/eslint-plugin/rules/shared-dependencies.js
+++ b/dev-packages/eslint-plugin/rules/shared-dependencies.js
@@ -15,6 +15,8 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
+/* eslint-disable max-len */
+
 const fs = require('fs');
 const path = require('path');
 
@@ -27,7 +29,7 @@ const {
 /** @type {import('eslint').Rule.RuleModule} */
 module.exports = {
     meta: {
-        type: "problem",
+        type: 'problem',
         fixable: 'code',
         docs: {
             description: 'Errors when a dependency shared by @theia/core is used implicitly, or when a package depends on a shared dependency instead of reusing it from @theia/core/shared. This rule only affects files from packages that depend on @theia/core.',
@@ -49,9 +51,6 @@ module.exports = {
                     });
                 }
             }
-            /**
-             * @param {import('estree').Literal} node
-             */
             function checkModuleImport(node) {
                 const module = /** @type {string} */(node.value);
                 if (isSharedModule(module)) {

--- a/dev-packages/eslint-plugin/tsconfig.json
+++ b/dev-packages/eslint-plugin/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../configs/base.tsconfig",
+  "compilerOptions": {
+    "composite": true
+  },
+  "include": [
+    "rules"
+  ],
+  "references": []
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,6 +16,9 @@
       "path": "dev-packages/cli"
     },
     {
+      "path": "dev-packages/eslint-plugin"
+    },
+    {
       "path": "dev-packages/ovsx-client"
     },
     {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

The pull-request enables linting of the rules defined in `eslint-plugin` (which contains the custom rules for the framework).
Previously, despite `@ts-check` being set, the files were not actually linted which may cause issues for future development. 

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

- confirm that opening the following files does not produce eslint errors:
    - `dev-packages/eslint-plugin/rules/runtime-import-check.js`
    -  `dev-packages/eslint-plugin/rules/shared-dependencies.js`
- confirm the changes to the root `tsconfig.json` does not affect the build of the framework 

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

Signed-off-by: vince-fugnitto <vincent.fugnitto@ericsson.com>