### PR TITLE
fix toggle bottom panel to align to vscode

### DIFF
--- a/packages/core/src/browser/common-frontend-contribution.ts
+++ b/packages/core/src/browser/common-frontend-contribution.ts
@@ -762,9 +762,10 @@ export class CommonFrontendContribution implements FrontendApplicationContributi
             }
         });
         commandRegistry.registerCommand(CommonCommands.TOGGLE_BOTTOM_PANEL, {
-            isEnabled: () => this.shell.getWidgets('bottom').length > 0,
             execute: () => {
-                if (this.shell.isExpanded('bottom')) {
+                if (this.shell.getWidgets('bottom').length === 0) {
+                    commandRegistry.executeCommand('terminal:new');
+                } else if (this.shell.isExpanded('bottom')) {
                     this.shell.collapsePanel('bottom');
                 } else {
                     this.shell.expandPanel('bottom');

--- a/packages/core/src/browser/shell/application-shell.ts
+++ b/packages/core/src/browser/shell/application-shell.ts
@@ -1369,18 +1369,14 @@ export class ApplicationShell extends Widget {
      * and refers to the command `core.toggle.bottom.panel`.
      */
     protected refreshBottomPanelToggleButton(): void {
-        if (this.bottomPanel.isEmpty) {
-            this.statusBar.removeElement(BOTTOM_PANEL_TOGGLE_ID);
-        } else {
-            const element: StatusBarEntry = {
-                text: '$(codicon-window)',
-                alignment: StatusBarAlignment.RIGHT,
-                tooltip: 'Toggle Bottom Panel',
-                command: 'core.toggle.bottom.panel',
-                priority: -1000
-            };
-            this.statusBar.setElement(BOTTOM_PANEL_TOGGLE_ID, element);
-        }
+        const element: StatusBarEntry = {
+            text: '$(codicon-window)',
+            alignment: StatusBarAlignment.RIGHT,
+            tooltip: 'Toggle Bottom Panel',
+            command: 'core.toggle.bottom.panel',
+            priority: -1000
+        };
+        this.statusBar.setElement(BOTTOM_PANEL_TOGGLE_ID, element);
     }
 
     /**


### PR DESCRIPTION
Signed-off-by: shuyaqian 717749594@qq.com

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

When there is no bottom panel,  we must create a terminal through the top menu or shortcut keys. However, in vscode, the terminal icon on the bottom status bar is always there. If there is no bottom panel, we can click the icon to quickly create a terminal.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
1. click the ‘toggle bottom panel’ icon in status bar
2. if there is no bottom panel, it will create a terminal and expand

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
