### PR TITLE
Offer permanent deletion if Trash deletion fails

### DIFF
--- a/packages/workspace/src/browser/workspace-delete-handler.ts
+++ b/packages/workspace/src/browser/workspace-delete-handler.ts
@@ -168,10 +168,10 @@ export class WorkspaceDeleteHandler implements UriCommandHandler<URI[]> {
         try {
             this.fileService.delete(uri, { ...options, useTrash: true });
         } catch (error) {
+            console.error('Error deleting with trash:', error);
             if (await this.confirmDeletePermanently(uri)) {
                 return this.deleteFilePermanently(uri, options);
             }
-            throw error;
         }
     }
 
@@ -181,7 +181,7 @@ export class WorkspaceDeleteHandler implements UriCommandHandler<URI[]> {
      * @param uri URI of selected resource.
      */
     protected async confirmDeletePermanently(uri: URI): Promise<boolean> {
-        const title = 'Move File to Trash';
+        const title = 'Error deleting file';
 
         const msg = document.createElement('div');
 
@@ -190,7 +190,7 @@ export class WorkspaceDeleteHandler implements UriCommandHandler<URI[]> {
         msg.append(question);
 
         const info = document.createElement('p');
-        info.textContent = 'You can disable the usage of Trash in the preferences.';
+        info.textContent = 'You can disable the use of Trash in the preferences.';
         msg.append(info);
 
         const response = await new ConfirmDialog({ title, msg }).open();

--- a/packages/workspace/src/browser/workspace-delete-handler.ts
+++ b/packages/workspace/src/browser/workspace-delete-handler.ts
@@ -23,6 +23,7 @@ import { WorkspaceUtils } from './workspace-utils';
 import { FileService } from '@theia/filesystem/lib/browser/file-service';
 import { FileSystemPreferences } from '@theia/filesystem/lib/browser/filesystem-preferences';
 import { FileDeleteOptions, FileSystemProviderCapabilities } from '@theia/filesystem/lib/common/files';
+import { nls } from '@theia/core/lib/common/nls';
 
 @injectable()
 export class WorkspaceDeleteHandler implements UriCommandHandler<URI[]> {
@@ -181,16 +182,18 @@ export class WorkspaceDeleteHandler implements UriCommandHandler<URI[]> {
      * @param uri URI of selected resource.
      */
     protected async confirmDeletePermanently(uri: URI): Promise<boolean> {
-        const title = 'Error deleting file';
+        const title = nls.localize('theia/workspace/confirmDeletePermanently.title', 'Error deleting file');
 
         const msg = document.createElement('div');
 
         const question = document.createElement('p');
-        question.textContent = `Failed to delete ${uri.path.base} using the Trash. Do you want to permanently delete instead?`;
+        question.textContent = nls.localize('theia/workspace/confirmDeletePermanently.description',
+            'Failed to delete "{0}" using the Trash. Do you want to permanently delete instead?',
+            uri.path.base);
         msg.append(question);
 
         const info = document.createElement('p');
-        info.textContent = 'You can disable the use of Trash in the preferences.';
+        info.textContent = nls.localize('theia/workspace/confirmDeletePermanently.solution', 'You can disable the use of Trash in the preferences.');
         msg.append(info);
 
         const response = await new ConfirmDialog({ title, msg }).open();

--- a/packages/workspace/src/browser/workspace-delete-handler.ts
+++ b/packages/workspace/src/browser/workspace-delete-handler.ts
@@ -144,7 +144,7 @@ export class WorkspaceDeleteHandler implements UriCommandHandler<URI[]> {
     }
 
     /**
-     * Perform deletion of a given URI and closes all open editors without saving if necessary.
+     * Perform deletion of a given URI.
      *
      * @param uri URI of selected resource.
      * @param options deletion options.
@@ -160,27 +160,15 @@ export class WorkspaceDeleteHandler implements UriCommandHandler<URI[]> {
         }
     }
 
-    /**
-     * Permanently deletes the given resource from the file system.
-     *
-     * @param uri URI of selected resource.
-     * @param options deletion options.
-     */
     protected async deleteFilePermanently(uri: URI, options: FileDeleteOptions): Promise<void> {
         this.fileService.delete(uri, { ...options, useTrash: false });
     }
 
-    /**
-     * Moves the given resource to the Trash of the file system.
-     *
-     * @param uri URI of selected resource.
-     * @param options deletion options.
-     */
     protected async moveFileToTrash(uri: URI, options: FileDeleteOptions): Promise<void> {
         try {
             this.fileService.delete(uri, { ...options, useTrash: true });
         } catch (error) {
-            if (await this.confirmDeletePermanently(uri, error)) {
+            if (await this.confirmDeletePermanently(uri)) {
                 return this.deleteFilePermanently(uri, options);
             }
             throw error;
@@ -191,10 +179,9 @@ export class WorkspaceDeleteHandler implements UriCommandHandler<URI[]> {
      * Display dialog to confirm the permanent deletion of a file.
      *
      * @param uri URI of selected resource.
-     * @param error error caused during Trash deletion.
      */
-    protected async confirmDeletePermanently(uri: URI, error?: Error): Promise<boolean> {
-        const title = `Move File to Trash ${error?.message || 'Error'}`;
+    protected async confirmDeletePermanently(uri: URI): Promise<boolean> {
+        const title = 'Move File to Trash';
 
         const msg = document.createElement('div');
 


### PR DESCRIPTION
Fixes https://github.com/eclipse-theia/theia/issues/10150

#### What it does
If there is a failure during file deletion using the Trash option, we will offer to delete the file permanently instead.

![dialog](https://user-images.githubusercontent.com/19170971/134327019-8e76b2ce-d92d-4660-bc3e-e13777a13c45.png)

#### How to test
Option 1 (You have a file system that does not support moving to Trash)
- Ensure that you enable the preference 'Enable Trash'
- Delete a file. This will cause an error since your file system does not support it and the new permanent deletion dialog should occur.

Option 2 (We need to throw an error ourselves)
- Ensure that you enable the preference 'Enable Trash'
- The only way I found to throw an error is to add the following snippet into the new `deleteFile` method before we call the deletion with the file service. This should make us move to the catch block and retry the delete without the useTrash option.
```
if (options.useTrash) {
   throw new Error('Error: Unknown Issue');
}
```

#### Review checklist
- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers
- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
