### PR TITLE
Move `nls` localization namespace to `common`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 <a name="breaking_changes_1.19.0">[Breaking Changes:](#breaking_changes_1.19.0)</a>
 
+- [core] moved `nls` localization namespace from `browser` to `common`. [#10153](https://github.com/eclipse-theia/theia/pull/10153)
 - [output] moved `output-channel` from `common` to `browser` [#10154](https://github.com/eclipse-theia/theia/pull/10154)
 - [output] moved `output-preferences` from `common` to `browser` [#10154](https://github.com/eclipse-theia/theia/pull/10154)
 - [view-container] `ViewContainerPart` constructor takes new 2 parameters: `originalContainerId` and `originalContainerTitle`. The existing `viewContainerId` parameter has been renamed to `currentContainerId` to enable drag & drop views. [#9644](https://github.com/eclipse-theia/theia/pull/9644)

--- a/dev-packages/application-manager/src/generator/frontend-generator.ts
+++ b/dev-packages/application-manager/src/generator/frontend-generator.ts
@@ -84,7 +84,7 @@ FrontendApplicationConfigProvider.set(${this.prettyStringify(this.pck.props.fron
 const { ThemeService } = require('@theia/core/lib/browser/theming');
 ThemeService.get().loadUserTheme();
 
-const nls = require('@theia/core/lib/browser/nls');
+const nls = require('@theia/core/lib/browser/nls-loader');
 
 // nls translations MUST be loaded before requiring any code that uses them
 module.exports = nls.loadTranslations().then(() => {

--- a/packages/core/src/browser/common-frontend-contribution.ts
+++ b/packages/core/src/browser/common-frontend-contribution.ts
@@ -54,7 +54,7 @@ import { AuthenticationService } from './authentication-service';
 import { FormatType } from './saveable';
 import { QuickInputService, QuickPick, QuickPickItem } from './quick-input';
 import { AsyncLocalizationProvider } from '../common/i18n/localization';
-import { nls } from './nls';
+import { nls } from '../common/nls';
 
 export namespace CommonMenus {
 

--- a/packages/core/src/browser/nls-loader.ts
+++ b/packages/core/src/browser/nls-loader.ts
@@ -1,0 +1,26 @@
+/********************************************************************************
+ * Copyright (C) 2021 TypeFox and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import { nls } from '../common/nls';
+import { Endpoint } from './endpoint';
+
+export async function loadTranslations(): Promise<void> {
+    if (nls.locale) {
+        const endpoint = new Endpoint({ path: '/i18n/' + nls.locale }).getRestUrl().toString();
+        const response = await fetch(endpoint);
+        nls.localization = await response.json();
+    }
+}

--- a/packages/core/src/common/command.ts
+++ b/packages/core/src/common/command.ts
@@ -18,8 +18,7 @@ import { injectable, inject, named } from 'inversify';
 import { Event, Emitter, WaitUntilEvent } from './event';
 import { Disposable, DisposableCollection } from './disposable';
 import { ContributionProvider } from './contribution-provider';
-// eslint-disable-next-line @theia/runtime-import-check
-import { nls } from '../browser/nls';
+import { nls } from './nls';
 
 /**
  * A command is a unique identifier of a function

--- a/packages/core/src/common/index.ts
+++ b/packages/core/src/common/index.ts
@@ -38,6 +38,7 @@ export * from './strings';
 export * from './application-error';
 export * from './lsp-types';
 export * from './contribution-filter';
+export * from './nls';
 
 import { environment } from '@theia/application-package/lib/environment';
 export { environment };

--- a/packages/core/src/common/nls.ts
+++ b/packages/core/src/common/nls.ts
@@ -14,34 +14,33 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
-import { Localization } from '../common/i18n/localization';
-import { Endpoint } from './endpoint';
-
-let localization: Localization | undefined;
-
-function format(message: string, args: string[]): string {
-    let result = message;
-    if (args.length > 0) {
-        result = message.replace(/\{(\d+)\}/g, (match, rest) => {
-            const index = rest[0];
-            const arg = args[index];
-            let replacement = match;
-            if (typeof arg === 'string') {
-                replacement = arg;
-            } else if (typeof arg === 'number' || typeof arg === 'boolean' || !arg) {
-                replacement = String(arg);
-            }
-            return replacement;
-        });
-    }
-    return result;
-}
+import { Localization } from './i18n/localization';
 
 export namespace nls {
 
+    export let localization: Localization | undefined;
+
     export const localeId = 'localeId';
 
-    export const locale = typeof window === 'object' && window && window.localStorage.getItem('localeId') || undefined;
+    export const locale = typeof window === 'object' && window && window.localStorage.getItem(localeId) || undefined;
+
+    function format(message: string, args: string[]): string {
+        let result = message;
+        if (args.length > 0) {
+            result = message.replace(/\{(\d+)\}/g, (match, rest) => {
+                const index = rest[0];
+                const arg = args[index];
+                let replacement = match;
+                if (typeof arg === 'string') {
+                    replacement = arg;
+                } else if (typeof arg === 'number' || typeof arg === 'boolean' || !arg) {
+                    replacement = String(arg);
+                }
+                return replacement;
+            });
+        }
+        return result;
+    }
 
     export function localize(key: string, defaultValue: string, ...args: string[]): string {
         let value = defaultValue;
@@ -53,13 +52,5 @@ export namespace nls {
             }
         }
         return format(value, args);
-    }
-}
-
-export async function loadTranslations(): Promise<void> {
-    if (nls.locale) {
-        const endpoint = new Endpoint({ path: '/i18n/' + nls.locale }).getRestUrl().toString();
-        const response = await fetch(endpoint);
-        localization = await response.json();
     }
 }

--- a/packages/monaco/src/browser/monaco-loader.ts
+++ b/packages/monaco/src/browser/monaco-loader.ts
@@ -16,7 +16,7 @@
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
-import { nls } from '@theia/core/lib/browser/nls';
+import { nls } from '@theia/core/lib/common/nls';
 
 export function loadVsRequire(context: any): Promise<any> {
     // Monaco uses a custom amd loader that over-rides node's require.


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

Closes https://github.com/eclipse-theia/theia/issues/10121

Moves the `nls` namespace to the `common` directory. Adds a `nls-loader.ts` in the browser directory that actually loads the translation.

#### How to test

1. The disabled eslint rule `@theia/runtime-import-check` should no longer be needed
2. The application runs as expected

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
