### PR TITLE
Change panel location of viewsContainers to align to vscode.

### DIFF
--- a/packages/plugin-ext/src/hosted/node/scanners/scanner-theia.ts
+++ b/packages/plugin-ext/src/hosted/node/scanners/scanner-theia.ts
@@ -218,7 +218,7 @@ export class TheiaPluginScanner implements PluginScanner {
 
                 for (const location of Object.keys(viewsContainers)) {
                     const containers = this.readViewsContainers(viewsContainers[location], rawPlugin);
-                    const loc = location === 'activitybar' ? 'left' : location;
+                    const loc = location === 'activitybar' ? 'left' : location === 'panel' ? 'bottom' : location;
                     if (contributions.viewsContainers[loc]) {
                         contributions.viewsContainers[loc] = contributions.viewsContainers[loc].concat(containers);
                     } else {


### PR DESCRIPTION
Signed-off-by: shuyaqian 717749594@qq.com

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
Change panel location of viewsContainers to align to vscode.
<!-- Include relevant issues and describe how they are addressed. -->

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
Develop a plugin with `viewsContainers` like:
```
"viewsContainers": {
	"panel": [
		{
			"id": "package-explorer",
			"title": "Package Explorer",
			"icon": "media/dep.svg"
		}
	]
}
```
In vscode, this panel will be located in bottom.
But in theia, this panel will be located in left.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
