### PR TITLE
Add possibility of DebugVariables navigation

### DIFF
--- a/packages/debug/src/browser/console/debug-console-items.tsx
+++ b/packages/debug/src/browser/console/debug-console-items.tsx
@@ -137,7 +137,7 @@ export class DebugVariable extends ExpressionContainer {
     constructor(
         session: DebugSessionProvider,
         protected readonly variable: DebugProtocol.Variable,
-        protected readonly parent: ExpressionContainer
+        readonly parent: ExpressionContainer
     ) {
         super({
             session,
@@ -359,7 +359,7 @@ export class DebugScope extends ExpressionContainer {
     }
 
     render(): React.ReactNode {
-        return this.raw.name;
+        return this.name;
     }
 
     get expensive(): boolean {
@@ -372,6 +372,10 @@ export class DebugScope extends ExpressionContainer {
             return new monaco.Range(line, column, endLine, endColumn);
         }
         return undefined;
+    }
+
+    get name(): string {
+        return this.raw.name;
     }
 
 }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

In some cases it might be useful to allow navigating `DebugVariable`s, making it possible to understand things like what is their parent in the Debug panel or in which scope they are defined.

An example might be [the `theia-cpp-extension`](https://github.com/eclipse-theia/theia-cpp-extensions/blob/master/packages/cpp-debug/src/browser/cpp-debug-frontend-contribution.ts#L92) where the context of a variable is important. Another example is adding different menus on C modules if they are shown as sub-elements of a scope.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

To test this some new code needs to be defined. It would be possible to just add a new command that as an example prints the name of the scope of a variable in `debug-frontend-contribution`:

```javascript
        registry.registerCommand(DebugCommands.PRINT_SCOPE, {
            execute: () => {
                if (this.selectedVariable) {
                    let v: ExpressionContainer = this.selectedVariable;
                    while (v instanceof DebugVariable) {
                        v = v.parent;
                    }
                    if (v instanceof DebugScope) {
                        console.log(v.name);
                    }
                }
            },
            isEnabled: () => true,
            isVisible: () => true,
        });
```

with the necessary code on top of it. If a local variable is selected and the command `PRINT_SCOPE` is executed `Local` will be printed.

#### Review checklist

- [X] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
