### PR TITLE
[ci] decouple GH pages publish from npm publish

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -99,11 +99,10 @@ jobs:
         with:
           python-version: '3.x'
 
-      - name: Pre-Publish
+      - name: Pre-npm-Publish
         run: |
           yarn --skip-integrity-check --network-timeout 100000
           yarn compile
-          yarn docs
         env:
           NODE_OPTIONS: --max_old_space_size=4096
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # https://github.com/microsoft/vscode-ripgrep/issues/9
@@ -118,6 +117,10 @@ jobs:
           command: yarn publish:next
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }} # The variable name comes from here: https://github.com/actions/setup-node/blob/70b9252472eee7495c93bb1588261539c3c2b98d/src/authutil.ts#L48
+
+      - name: Pre-docs-Publish
+        run: |
+          yarn docs
 
       - name: Publish GH Pages
         uses: peaceiris/actions-gh-pages@v3


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->
ATM we have an issue running `yarn docs`. This should
not prevent publishing to npm. This commit attempts to
make it so, by running "yarn docs" just-in-time, after npm
publish but before GH Pages publish

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
Inspect workflow for logic and merge? 

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
