### PR TITLE
Align file icon margins with vscode

### DIFF
--- a/packages/core/src/browser/tree/tree-widget.tsx
+++ b/packages/core/src/browser/tree/tree-widget.tsx
@@ -127,7 +127,7 @@ export interface NodeProps {
  */
 export const defaultTreeProps: TreeProps = {
     leftPadding: 8,
-    expansionTogglePadding: 18
+    expansionTogglePadding: 22
 };
 
 export namespace TreeWidget {

--- a/packages/filesystem/src/browser/style/file-icons.css
+++ b/packages/filesystem/src/browser/style/file-icons.css
@@ -37,11 +37,13 @@
     display: flex;
     justify-content: center;
     align-items: center;
+    padding-left: 2px;
+    padding-right: 4px;
 }
 
-:not(.p-TabBar-tabIcon).default-folder-icon,
-:not(.p-TabBar-tabIcon).default-file-icon {
-    transform: translateX(-2px);
+.default-folder-icon,
+.default-file-icon {
+    padding-right: 6px;
 }
 
 .fa-file:before,

--- a/packages/markers/src/browser/style/index.css
+++ b/packages/markers/src/browser/style/index.css
@@ -29,7 +29,7 @@
 }
 
 .theia-marker-container .markerNode div,
-.theia-marker-container .markerFileNode div {
+.theia-marker-container .markerFileNode div:not(.file-icon) {
     display: flex;
     margin-right: 5px;
 }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

Closes #10089.

Aligns the margins/paddings of file icons in the problems view and navigator with vscode.

#### How to test

For the actual reproduction steps of the issue, see #10089.

For the other changes:

1. Install an icon theme extension that displays folder icons (like the vscode-minimal or material ui icon theme).
2. Change between the default Theia icon theme and the newly installed icon theme.
3. Assert that the icons/labels don't suddenly flicker/change position when changing themes.
4. Open the problem view and create some problem in the workspace
5. Assert that the spacing between the file icon and the file label is aligned with vscode (6px)

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
