### PR TITLE
Show Folder Icon for Workspace Roots

### DIFF
--- a/packages/workspace/src/browser/workspace-uri-contribution.spec.ts
+++ b/packages/workspace/src/browser/workspace-uri-contribution.spec.ts
@@ -120,9 +120,9 @@ describe('WorkspaceUriLabelProviderContribution class', () => {
             expect(labelProvider.getIcon(FileStat.file('file:///home/test'))).eq(ret);
         });
 
-        it('should return rootfolder-icon for a URI or file stat that corresponds to a workspace root', () => {
-            expect(labelProvider.getIcon(new URI('file:///workspace'))).eq('rootfolder-icon');
-            expect(labelProvider.getIcon(FileStat.dir('file:///workspace'))).eq('rootfolder-icon');
+        it('should return the default folder icon for a URI or file stat that corresponds to a workspace root', () => {
+            expect(labelProvider.getIcon(new URI('file:///workspace'))).eq(labelProvider.defaultFolderIcon);
+            expect(labelProvider.getIcon(FileStat.dir('file:///workspace'))).eq(labelProvider.defaultFolderIcon);
         });
     });
 

--- a/packages/workspace/src/browser/workspace-uri-contribution.ts
+++ b/packages/workspace/src/browser/workspace-uri-contribution.ts
@@ -39,10 +39,6 @@ export class WorkspaceUriLabelProviderContribution extends DefaultUriLabelProvid
     }
 
     getIcon(element: URI | URIIconReference | FileStat): string {
-        const uri = this.getUri(element);
-        if (uri && this.workspaceVariable.getWorkspaceRootUri(uri)?.isEqual(uri)) {
-            return 'rootfolder-icon';
-        }
         return super.getIcon(this.asURIIconReference(element));
     }
 
@@ -68,6 +64,10 @@ export class WorkspaceUriLabelProviderContribution extends DefaultUriLabelProvid
     protected asURIIconReference(element: URI | URIIconReference | FileStat): URI | URIIconReference {
         if (FileStat.is(element)) {
             return URIIconReference.create(element.isDirectory ? 'folder' : 'file', element.resource);
+        }
+        const uri = this.getUri(element);
+        if (uri && this.workspaceVariable.getWorkspaceRootUri(uri)?.isEqual(uri)) {
+            return URIIconReference.create('folder', uri);
         }
         return element;
     }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

Fixes #10173 by removing the unused 'rootfolder-icon' from the non-plugin label provider system and adding code to identify root folders as folders using the URI alone.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

1. Switch your icon theme to File Icons (Theia)
2. Open a folder as a workpace
3. Use the 'Open recent workspace' command
4. Observe that the icon for the current workspace renders as a folder
---
1. Open a multi-root workspace
2. Open a file in a given root
3. Observe that the breadcrumbs for that file start with a folder icon (not a file icon) corresponding to the workspace root of the file.
4. Observe that the nodes for workspace roots in the file tree have folder icons.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
