### PR TITLE
Use fixed font-size for compact sidebar menu

### DIFF
--- a/packages/core/src/browser/style/sidepanel.css
+++ b/packages/core/src/browser/style/sidepanel.css
@@ -219,7 +219,7 @@
 }
 
 .theia-sidebar-menu > i.codicon-menu {
-  font-size: calc(var(--theia-private-sidebar-icon-size)*0.7);
+  font-size: 16px;
 }
 
 /*-----------------------------------------------------------------------------


### PR DESCRIPTION
#### What it does

Due to #9864, the width of the sidebar menu icons increased. The compact menubar visibility icon relied on a specific width which it used to calculate it's own size, resulting in a bleeding effect, as it's font-size was calculated as being `16.8px`:

![image](https://user-images.githubusercontent.com/4377073/135066337-22dd37a5-cb92-4aac-b9c0-219f3463df24.png)

This change fixes the size to 16px, regardless of the size of other icons.

#### How to test

1. Change your `Menu Bar Visibility` setting to `compact`.
2. Observe the non-bleeding menu icon:

![image](https://user-images.githubusercontent.com/4377073/135066468-02379306-f400-432b-af22-5402747f8577.png)


#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
