### PR TITLE
ci: increase Node max memory for docs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -109,6 +109,8 @@ jobs:
       - name: Pre-docs-Publish
         run: |
           yarn docs
+        env:
+          NODE_OPTIONS: --max_old_space_size=8196
 
       - name: Publish GH Pages
         uses: peaceiris/actions-gh-pages@v3


### PR DESCRIPTION
TypeDoc requires a decent amount of memory with our repo.