### PR TITLE
cli: allow rebuild to skip missing modules

### DIFF
--- a/dev-packages/cli/src/theia.ts
+++ b/dev-packages/cli/src/theia.ts
@@ -59,16 +59,31 @@ function rebuildCommand(command: string, target: ApplicationProps.Target): yargs
                 describe: 'Root folder where to store the .browser_modules cache'
             },
             'modules': {
-                array: true,
+                alias: 'm',
+                array: true, // === `--modules/-m` can be specified multiple times
                 describe: 'List of modules to rebuild/revert'
             },
             'force': {
                 alias: 'f',
-                type: 'boolean',
-                describe: 'Rebuild modules for Electron anyway'
+                boolean: true,
+                describe: 'Rebuild modules for Electron anyway',
             }
         },
         handler: ({ cacheRoot, modules, force }) => {
+            // Note: `modules` is actually `string[] | undefined`.
+            if (modules) {
+                // It is ergonomic to pass arguments as --modules="a,b,c,..."
+                // but yargs doesn't parse it this way by default.
+                const flattened: string[] = [];
+                for (const value of modules) {
+                    if (value.includes(',')) {
+                        flattened.push(...value.split(',').map(mod => mod.trim()));
+                    } else {
+                        flattened.push(value);
+                    }
+                }
+                modules = flattened;
+            }
             rebuild(target, { cacheRoot, modules, force });
         }
     };


### PR DESCRIPTION
Some Theia applications might be missing some native modules
dependending on the set of extensions they depend on.

Make `theia rebuild:*` resilient to missing modules.

#### How to test

I was running the following command which contains missing packages:

```bash
yarn theia rebuild:electron --modules="native-keymap" --modules="patate,meh" && yarn theia rebuild:browser
```

Only `native-keymap` should end up being rebuilt.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)