### PR TITLE
electron: define "files" in package.json

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -126,5 +126,6 @@ jobs:
           max_attempts: 3
           retry_on: error
           command: yarn publish:next
+          on_retry_command: git reset --hard
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }} # The variable name comes from here: https://github.com/actions/setup-node/blob/70b9252472eee7495c93bb1588261539c3c2b98d/src/authutil.ts#L48

--- a/dev-packages/electron/package.json
+++ b/dev-packages/electron/package.json
@@ -14,6 +14,14 @@
     "url": "https://github.com/eclipse-theia/theia/issues"
   },
   "homepage": "https://github.com/eclipse-theia/theia",
+  "files": [
+    "native/src",
+    "native/binding.gyp",
+    "scripts",
+    "*.js",
+    "*.d.ts",
+    "!.eslintrc.js"
+  ],
   "bin": {
     "electron": "electron-cli.js",
     "electron-codecs-test": "electron-codecs-test.js",


### PR DESCRIPTION
`lerna@4` seems to include almost EVERYTHING unless told otherwise when
publishing. `dev-packages/electron` is the only published package we
have that didn't define a `files` field and `lerna` tried to publish
symlinked binaries...

Add `files` field to `dev-packages/electron/package.json`.

#### How to test

Not sure how to test beside CI passing.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)