### PR TITLE
Add localization cli command

### DIFF
--- a/dev-packages/localization-manager/README.md
+++ b/dev-packages/localization-manager/README.md
@@ -12,9 +12,45 @@
 
 ## Description
 
-The `@theia/localization-manager` package is used easily create localizations of Theia and Theia extensions for different languages. 
-Its main use case is to extract localization keys and default values from `nls.localize` calls within the codebase.
-Additionally, it uses the [DeepL API](https://www.deepl.com/docs-api) to automatically translate any missing localization values.
+The `@theia/localization-manager` package is used easily create localizations of Theia and Theia extensions for different languages. It has two main use cases.
+
+First, it allows to extract localization keys and default values from `nls.localize` calls within the codebase using the `nls-extract` Theia-CLI command. Take this code for example:
+
+```ts
+const hi = nls.localize('greetings/hi', 'Hello');
+const bye = nls.localize('greetings/bye', 'Bye');
+```
+
+It will be converted into this JSON file (`nls.json`):
+
+```json
+{
+  "greetings": {
+    "hi": "Hello",
+    "bye": "Bye"
+  }
+}
+```
+
+Afterwards, any manual or automatic translation approach can be used to translate this file into other languages. These JSON files are supposed to be picked up by `LocalizationContribution`s.
+
+Additionally, Theia provides a simple way to translate the generated JSON files out of the box using the [DeepL API](https://www.deepl.com/docs-api). For this, a [DeepL free or pro account](https://www.deepl.com/pro) is needed. Using the `nls-localize` command of the Theia-CLI, a target file can be translated into different languages. For example, when calling the command using the previous JSON file with the `fr` (french) language, the following `nls.fr.json` file will be created in the same directory as the translation source:
+
+```json
+{
+  "greetings": {
+    "hi": "Bonjour",
+    "bye": "Au revoir"
+  }
+}
+```
+
+
+Only JSON entries without corresponding translations are translated using DeepL. This ensures that manual changes to the translated files aren't overwritten and only new translation entries are actually sent to DeepL.
+
+Use `theia nls-localize --help` for more information on how to use the command and supply DeepL API keys.
+
+For more information, see the [internationalization documentation](https://theia-ide.org/docs/i18n/).
 
 ## Additional Information
 

--- a/dev-packages/localization-manager/README.md
+++ b/dev-packages/localization-manager/README.md
@@ -14,6 +14,7 @@
 
 The `@theia/localization-manager` package is used easily create localizations of Theia and Theia extensions for different languages. 
 Its main use case is to extract localization keys and default values from `nls.localize` calls within the codebase.
+Additionally, it uses the [DeepL API](https://www.deepl.com/docs-api) to automatically translate any missing localization values.
 
 ## Additional Information
 

--- a/dev-packages/localization-manager/package.json
+++ b/dev-packages/localization-manager/package.json
@@ -29,7 +29,10 @@
     "watch": "theiaext watch"
   },
   "dependencies": {
+    "@types/bent": "^7.0.1",
     "@types/fs-extra": "^4.0.2",
+    "bent": "^7.1.0",
+    "colors": "^1.4.0",
     "deepmerge": "^4.2.2",
     "fs-extra": "^4.0.2",
     "glob": "^7.2.0",

--- a/dev-packages/localization-manager/package.json
+++ b/dev-packages/localization-manager/package.json
@@ -32,7 +32,7 @@
     "@types/bent": "^7.0.1",
     "@types/fs-extra": "^4.0.2",
     "bent": "^7.1.0",
-    "colors": "^1.4.0",
+    "chalk": "4.0.0",
     "deepmerge": "^4.2.2",
     "fs-extra": "^4.0.2",
     "glob": "^7.2.0",

--- a/dev-packages/localization-manager/src/common.ts
+++ b/dev-packages/localization-manager/src/common.ts
@@ -14,6 +14,6 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
-export * from './common';
-export * from './localization-extractor';
-export * from './localization-manager';
+export interface Localization {
+    [key: string]: string | Localization
+}

--- a/dev-packages/localization-manager/src/deepl-api.ts
+++ b/dev-packages/localization-manager/src/deepl-api.ts
@@ -1,0 +1,122 @@
+/********************************************************************************
+ * Copyright (C) 2021 TypeFox and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import * as bent from 'bent';
+
+const post = bent('POST', 'json', 200);
+// 50 is the maximum amount of translations per request
+const deeplLimit = 50;
+
+export async function deepl(
+    parameters: DeeplParameters
+): Promise<DeeplResponse> {
+    const sub_domain = parameters.free_api ? 'api-free' : 'api';
+    const textChunks: string[][] = [];
+    const textArray = [...parameters.text];
+    while (textArray.length > 0) {
+        textChunks.push(textArray.splice(0, deeplLimit));
+    }
+    const responses: DeeplResponse[] = await Promise.all(textChunks.map(chunk => {
+        const parameterCopy: DeeplParameters = { ...parameters, text: chunk };
+        return post(`https://${sub_domain}.deepl.com/v2/translate`, Buffer.from(toFormData(parameterCopy)), {
+            'Content-Type': 'application/x-www-form-urlencoded',
+            'User-Agent': 'Theia-Localization-Manager'
+        });
+    }));
+    const mergedResponse: DeeplResponse = { translations: [] };
+    for (const response of responses) {
+        mergedResponse.translations.push(...response.translations);
+    }
+    return mergedResponse;
+}
+
+function toFormData(parameters: DeeplParameters): string {
+    const str: string[] = [];
+    for (const [key, value] of Object.entries(parameters)) {
+        if (typeof value === 'string') {
+            str.push(encodeURIComponent(key) + '=' + encodeURIComponent(value.toString()));
+        } else if (Array.isArray(value)) {
+            for (const item of value) {
+                str.push(encodeURIComponent(key) + '=' + encodeURIComponent(item.toString()));
+            }
+        }
+    }
+    return str.join('&');
+}
+
+export type DeeplLanguage =
+    | 'BG'
+    | 'CS'
+    | 'DA'
+    | 'DE'
+    | 'EL'
+    | 'EN-GB'
+    | 'EN-US'
+    | 'EN'
+    | 'ES'
+    | 'ET'
+    | 'FI'
+    | 'FR'
+    | 'HU'
+    | 'IT'
+    | 'JA'
+    | 'LT'
+    | 'LV'
+    | 'NL'
+    | 'PL'
+    | 'PT-PT'
+    | 'PT-BR'
+    | 'PT'
+    | 'RO'
+    | 'RU'
+    | 'SK'
+    | 'SL'
+    | 'SV'
+    | 'ZH';
+
+export const supportedLanguages = [
+    'BG', 'CD', 'DA', 'DE', 'EL', 'EN-GB', 'EN-US', 'EN', 'ES', 'ET', 'FI', 'FR', 'HU', 'IT',
+    'JA', 'LT', 'LV', 'NL', 'PL', 'PT-PT', 'PT-BR', 'PT', 'RO', 'RU', 'SK', 'SL', 'SV', 'ZH'
+];
+
+export function isSupportedLanguage(language: string): language is DeeplLanguage {
+    return supportedLanguages.includes(language.toUpperCase());
+}
+
+export interface DeeplParameters {
+    free_api: Boolean
+    auth_key: string
+    text: string[]
+    source_lang?: DeeplLanguage
+    target_lang: DeeplLanguage
+    split_sentences?: '0' | '1' | 'nonewlines'
+    preserve_formatting?: '0' | '1'
+    formality?: 'default' | 'more' | 'less'
+    tag_handling?: string[]
+    non_splitting_tags?: string[]
+    outline_detection?: string
+    splitting_tags?: string[]
+    ignore_tags?: string[]
+}
+
+export interface DeeplResponse {
+    translations: DeeplTranslation[]
+}
+
+export interface DeeplTranslation {
+    detected_source_language: string
+    text: string
+}

--- a/dev-packages/localization-manager/src/localization-extractor.ts
+++ b/dev-packages/localization-manager/src/localization-extractor.ts
@@ -21,12 +21,9 @@ import * as path from 'path';
 import { glob } from 'glob';
 import { promisify } from 'util';
 import deepmerge = require('deepmerge');
+import { Localization } from './common';
 
 const globPromise = promisify(glob);
-
-export interface Localization {
-    [key: string]: string | Localization
-}
 
 export interface ExtractionOptions {
     root: string

--- a/dev-packages/localization-manager/src/localization-manager.spec.ts
+++ b/dev-packages/localization-manager/src/localization-manager.spec.ts
@@ -1,0 +1,80 @@
+/********************************************************************************
+ * Copyright (C) 2021 TypeFox and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import * as assert from 'assert';
+import { DeeplParameters, DeeplResponse } from './deepl-api';
+import { LocalizationManager, LocalizationOptions } from './localization-manager';
+
+describe('localization-manager#translateLanguage', () => {
+
+    async function mockLocalization(parameters: DeeplParameters): Promise<DeeplResponse> {
+        return {
+            translations: parameters.text.map(value => ({
+                detected_source_language: '',
+                text: `[${value}]`
+            }))
+        };
+    }
+
+    const manager = new LocalizationManager(mockLocalization);
+    const defaultOptions: LocalizationOptions = {
+        authKey: '',
+        freeApi: false,
+        sourceFile: '',
+        targetLanguages: ['EN']
+    };
+
+    it('should translate a single value', async () => {
+        const input = {
+            key: 'value'
+        };
+        const target = {};
+        await manager.translateLanguage(input, target, 'EN', defaultOptions);
+        assert.deepStrictEqual(target, {
+            key: '[value]'
+        });
+    });
+
+    it('should translate nested values', async () => {
+        const input = {
+            a: {
+                b: 'b'
+            },
+            c: 'c'
+        };
+        const target = {};
+        await manager.translateLanguage(input, target, 'EN', defaultOptions);
+        assert.deepStrictEqual(target, {
+            a: {
+                b: '[b]'
+            },
+            c: '[c]'
+        });
+    });
+
+    it('should not override existing targets', async () => {
+        const input = {
+            a: 'a'
+        };
+        const target = {
+            a: 'b'
+        };
+        await manager.translateLanguage(input, target, 'EN', defaultOptions);
+        assert.deepStrictEqual(target, {
+            a: 'b'
+        });
+    });
+});

--- a/dev-packages/localization-manager/src/localization-manager.ts
+++ b/dev-packages/localization-manager/src/localization-manager.ts
@@ -1,0 +1,147 @@
+/********************************************************************************
+ * Copyright (C) 2021 TypeFox and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import 'colors';
+import * as fs from 'fs-extra';
+import * as path from 'path';
+import { Localization } from './common';
+import { deepl, DeeplLanguage, DeeplParameters, isSupportedLanguage, supportedLanguages } from './deepl-api';
+
+export interface LocalizationOptions {
+    freeApi: Boolean
+    authKey: string
+    sourceFile: string
+    sourceLanguage?: string
+    targetLanguages: string[]
+}
+
+export type LocalizationFunction = (parameters: DeeplParameters) => Promise<string[]>;
+
+export class LocalizationManager {
+
+    constructor(private localizationFn = deepl) { }
+
+    async localize(options: LocalizationOptions): Promise<void> {
+        let source: Localization = {};
+        try {
+            source = await fs.readJson(options.sourceFile);
+        } catch {
+            console.log(`Could not read file "${options.sourceFile}"`.red);
+            process.exit(1);
+        }
+        const languages: string[] = [];
+        for (const targetLanguage of options.targetLanguages) {
+            if (!isSupportedLanguage(targetLanguage)) {
+                console.log(`Language "${targetLanguage}" is not supported for automatic localization`.yellow);
+            } else {
+                languages.push(targetLanguage);
+            }
+        }
+        if (languages.length !== options.targetLanguages.length) {
+            console.log('Supported languages: ' + supportedLanguages.join(', '));
+        }
+        const existingTranslations: Map<string, Localization> = new Map();
+        for (const targetLanguage of languages) {
+            try {
+                const targetPath = this.translationFileName(options.sourceFile, targetLanguage);
+                existingTranslations.set(targetLanguage, await fs.readJson(targetPath));
+            } catch {
+                existingTranslations.set(targetLanguage, {});
+            }
+        }
+        await Promise.all(languages.map(language => this.translateLanguage(source, existingTranslations.get(language)!, language, options)));
+
+        for (const targetLanguage of languages) {
+            const targetPath = this.translationFileName(options.sourceFile, targetLanguage);
+            try {
+                await fs.writeFile(targetPath, JSON.stringify(existingTranslations.get(targetLanguage)!, undefined, 4));
+            } catch {
+                console.error(`Error writing translated file to '${targetPath}'`.red);
+            }
+        }
+    }
+
+    protected translationFileName(original: string, language: string): string {
+        const directory = path.dirname(original);
+        const fileName = path.basename(original, '.json');
+        return path.join(directory, `${fileName}.${language.toLowerCase()}.json`);
+    }
+
+    async translateLanguage(source: Localization, target: Localization, targetLanguage: string, options: LocalizationOptions): Promise<void> {
+        const map = this.buildLocalizationMap(source, target);
+        if (map.text.length > 0) {
+            try {
+                const translationResponse = await this.localizationFn({
+                    auth_key: options.authKey,
+                    free_api: options.freeApi,
+                    target_lang: targetLanguage.toUpperCase() as DeeplLanguage,
+                    source_lang: options.sourceLanguage?.toUpperCase() as DeeplLanguage,
+                    text: map.text
+                });
+                translationResponse.translations.forEach(({ text }, i) => {
+                    map.localize(i, text);
+                });
+                console.log(`Successfully translated ${map.text.length} value${map.text.length > 1 ? 's' : ''} for language "${targetLanguage}"`.green);
+            } catch (e) {
+                console.log(`Could not translate into language "${targetLanguage}"`.red, e);
+            }
+        } else {
+            console.log(`No translation necessary for language "${targetLanguage}"`);
+        }
+    }
+
+    protected buildLocalizationMap(source: Localization, target: Localization): LocalizationMap {
+        const functionMap = new Map<number, (value: string) => void>();
+        const text: string[] = [];
+        const process = (s: Localization, t: Localization) => {
+            // Delete all extra keys in the target translation first
+            for (const key of Object.keys(t)) {
+                if (!(key in s)) {
+                    delete t[key];
+                }
+            }
+            for (const [key, value] of Object.entries(s)) {
+                if (!(key in t)) {
+                    if (typeof value === 'string') {
+                        functionMap.set(text.length, translation => t[key] = translation);
+                        text.push(value);
+                    } else {
+                        const newLocalization: Localization = {};
+                        t[key] = newLocalization;
+                        process(value, newLocalization);
+                    }
+                } else if (typeof value === 'object') {
+                    if (typeof t[key] === 'string') {
+                        t[key] = {};
+                    }
+                    process(value, t[key] as Localization);
+                }
+            }
+        };
+
+        process(source, target);
+
+        return {
+            text,
+            localize: (index, value) => functionMap.get(index)!(value)
+        };
+    }
+}
+
+export interface LocalizationMap {
+    text: string[]
+    localize: (index: number, value: string) => void
+}

--- a/dev-packages/localization-manager/src/localization-manager.ts
+++ b/dev-packages/localization-manager/src/localization-manager.ts
@@ -14,7 +14,7 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
-import 'colors';
+import * as chalk from 'chalk';
 import * as fs from 'fs-extra';
 import * as path from 'path';
 import { Localization } from './common';
@@ -39,13 +39,13 @@ export class LocalizationManager {
         try {
             source = await fs.readJson(options.sourceFile);
         } catch {
-            console.log(`Could not read file "${options.sourceFile}"`.red);
+            console.log(chalk.red(`Could not read file "${options.sourceFile}"`));
             process.exit(1);
         }
         const languages: string[] = [];
         for (const targetLanguage of options.targetLanguages) {
             if (!isSupportedLanguage(targetLanguage)) {
-                console.log(`Language "${targetLanguage}" is not supported for automatic localization`.yellow);
+                console.log(chalk.yellow(`Language "${targetLanguage}" is not supported for automatic localization`));
             } else {
                 languages.push(targetLanguage);
             }
@@ -69,7 +69,7 @@ export class LocalizationManager {
             try {
                 await fs.writeFile(targetPath, JSON.stringify(existingTranslations.get(targetLanguage)!, undefined, 4));
             } catch {
-                console.error(`Error writing translated file to '${targetPath}'`.red);
+                console.error(chalk.red(`Error writing translated file to '${targetPath}'`));
             }
         }
     }
@@ -94,9 +94,9 @@ export class LocalizationManager {
                 translationResponse.translations.forEach(({ text }, i) => {
                     map.localize(i, text);
                 });
-                console.log(`Successfully translated ${map.text.length} value${map.text.length > 1 ? 's' : ''} for language "${targetLanguage}"`.green);
+                console.log(chalk.green(`Successfully translated ${map.text.length} value${map.text.length > 1 ? 's' : ''} for language "${targetLanguage}"`));
             } catch (e) {
-                console.log(`Could not translate into language "${targetLanguage}"`.red, e);
+                console.log(chalk.red(`Could not translate into language "${targetLanguage}"`), e);
             }
         } else {
             console.log(`No translation necessary for language "${targetLanguage}"`);


### PR DESCRIPTION
#### What it does
Closes #9708

Uses the machine translation API of DeepL to automatically translate json files.

- [x] [CQ for DeepL usage](https://dev.eclipse.org/ipzilla/show_bug.cgi?id=23832)

#### How to test

Testing this PR requires a DeepL API key. While 500k characters/month are free for developers, even a free account requires a credit card (claiming to reduce the amount of multi-accounts that abuse the free dev-tier). If you want to review this PR but don't have access to an account already, or are hesitant to use your own credit card there, you can send me a mail (linked in my github profile) and I'll send you an API key.

1. Create a sample file that you want to translate:
```json
{
  "test": "This is a value",
  "nested": {
    "hi": "Hello",
    "deeper": {
      "why": "Why"
    }
  }
}
```
2. Run the cli:
```sh
yarn theia localize -f test.json -k <api-key> (--free-api) <language codes like de, it, fr>
```
3. Assert that the output files are correctly translated (they will be in the same directory as the source file)
4. Make use of different arguments, or play around with the `help` of the localize command
5. Change the sample file and assert that only new entries which can't be found in the already translated files are actually translated (the cli will output the amount of translated entries)

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
