### PR TITLE
Add closeEditor command

### DIFF
--- a/packages/editor/src/browser/editor-menu.ts
+++ b/packages/editor/src/browser/editor-menu.ts
@@ -102,6 +102,11 @@ export class EditorMenuContribution implements MenuContribution {
             label: 'Render Whitespace',
             order: '2'
         });
+        registry.registerMenuAction(CommonMenus.FILE_CLOSE, {
+            commandId: CommonCommands.CLOSE_MAIN_TAB.id,
+            label: 'Close Editor',
+            order: '0'
+        });
     }
 
 }

--- a/packages/plugin-ext-vscode/src/browser/plugin-vscode-commands-contribution.ts
+++ b/packages/plugin-ext-vscode/src/browser/plugin-vscode-commands-contribution.ts
@@ -333,19 +333,7 @@ export class PluginVscodeCommandsContribution implements CommandContribution {
             execute: () => this.shell.saveAll()
         });
         commands.registerCommand({ id: 'workbench.action.closeActiveEditor' }, {
-            execute: async (uri?: monaco.Uri) => {
-                let widget = this.editorManager.currentEditor || this.shell.currentWidget;
-                if (uri) {
-                    const uriString = uri.toString();
-                    widget = this.shell.widgets.find(w => {
-                        const resourceUri = NavigatableWidget.is(w) && w.getResourceUri();
-                        return (resourceUri && resourceUri.toString()) === uriString;
-                    });
-                }
-                if (this.codeEditorWidgetUtil.is(widget)) {
-                    await this.shell.closeWidget(widget.id);
-                }
-            }
+            execute: () => commands.executeCommand(CommonCommands.CLOSE_MAIN_TAB.id)
         });
         commands.registerCommand({ id: 'workbench.action.closeOtherEditors' }, {
             execute: async (uri?: monaco.Uri) => {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->
Fixes #10138

**editor**
The command `Close Editor` is added on the menu item (in the `File` main-menu), in order to close tabs present in the main-area.

**plugin**
Updates the `workbench.action.closeActiveEditor` mapping present in the plugin-system to use the 
already existing `CLOSE_MAIN_TAB` command. Previously, the mapping would only close actual editors
and not necessarily in the main-area which is a difference in behavior to what vscode supports. Since
vscode treats all content in the main-area as "editors" we want to do the same (since it is what plugins expect).


#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
