### PR TITLE
plugin: stub `setKeysForSync`

### DIFF
--- a/packages/plugin-ext/src/plugin/plugin-context.ts
+++ b/packages/plugin-ext/src/plugin/plugin-context.ts
@@ -135,7 +135,8 @@ import {
     ColorThemeKind,
     SourceControlInputBoxValidationType,
     URI,
-    FileDecoration
+    FileDecoration,
+    ExtensionMode
 } from './types-impl';
 import { AuthenticationExtImpl } from './authentication-ext';
 import { SymbolKind } from '../common/plugin-api-rpc-model';
@@ -959,7 +960,8 @@ export function createAPIFactory(
             ColorThemeKind,
             SourceControlInputBoxValidationType,
             FileDecoration,
-            CancellationError
+            CancellationError,
+            ExtensionMode
         };
     };
 }

--- a/packages/plugin-ext/src/plugin/plugin-manager.ts
+++ b/packages/plugin-ext/src/plugin/plugin-manager.ts
@@ -33,7 +33,7 @@ import * as theia from '@theia/plugin';
 import { join } from './path';
 import { EnvExtImpl } from './env';
 import { PreferenceRegistryExtImpl } from './preference-registry';
-import { Memento, KeyValueStorageProxy } from './plugin-storage';
+import { Memento, KeyValueStorageProxy, GlobalState } from './plugin-storage';
 import { ExtPluginApi } from '../common/plugin-ext-api-contribution';
 import { RPCProtocol } from '../common/rpc-protocol';
 import { Emitter } from '@theia/core/lib/common/event';
@@ -372,7 +372,7 @@ export class PluginManagerExtImpl implements PluginManagerExt, PluginManager {
         const pluginContext: theia.PluginContext = {
             extensionPath: plugin.pluginFolder,
             extensionUri: Uri.file(plugin.pluginFolder),
-            globalState: new Memento(plugin.model.id, true, this.storageProxy),
+            globalState: new GlobalState(plugin.model.id, true, this.storageProxy),
             workspaceState: new Memento(plugin.model.id, false, this.storageProxy),
             subscriptions: subscriptions,
             asAbsolutePath: asAbsolutePath,

--- a/packages/plugin-ext/src/plugin/plugin-manager.ts
+++ b/packages/plugin-ext/src/plugin/plugin-manager.ts
@@ -382,7 +382,8 @@ export class PluginManagerExtImpl implements PluginManagerExt, PluginManager {
             secrets,
             globalStoragePath: globalStoragePath,
             globalStorageUri: Uri.file(globalStoragePath),
-            environmentVariableCollection: this.terminalService.getEnvironmentVariableCollection(plugin.model.id)
+            environmentVariableCollection: this.terminalService.getEnvironmentVariableCollection(plugin.model.id),
+            extensionMode: 1 // @todo: implement proper `extensionMode`.
         };
         this.pluginContextsMap.set(plugin.model.id, pluginContext);
 

--- a/packages/plugin-ext/src/plugin/plugin-storage.ts
+++ b/packages/plugin-ext/src/plugin/plugin-storage.ts
@@ -60,6 +60,12 @@ export class Memento implements theia.Memento {
     }
 }
 
+export class GlobalState extends Memento {
+
+    /** @todo: API is not yet implemented. */
+    setKeysForSync(keys: readonly string[]): void { }
+}
+
 /**
  * Singleton.
  * Is used to proxy storage requests to main side.

--- a/packages/plugin-ext/src/plugin/types-impl.ts
+++ b/packages/plugin-ext/src/plugin/types-impl.ts
@@ -189,6 +189,26 @@ export enum ColorThemeKind {
     HighContrast = 3
 }
 
+export enum ExtensionMode {
+    /**
+     * The extension is installed normally (for example, from the marketplace
+     * or VSIX) in the editor.
+     */
+    Production = 1,
+
+    /**
+     * The extension is running from an `--extensionDevelopmentPath` provided
+     * when launching the editor.
+     */
+    Development = 2,
+
+    /**
+     * The extension is running from an `--extensionTestsPath` and
+     * the extension host is running unit tests.
+     */
+    Test = 3,
+}
+
 /**
  * Represents the validation type of the Source Control input.
  */

--- a/packages/plugin/src/theia.d.ts
+++ b/packages/plugin/src/theia.d.ts
@@ -3064,7 +3064,22 @@ declare module '@theia/plugin' {
          * A memento object that stores state independent
          * of the current opened [workspace](#workspace.workspaceFolders).
          */
-        globalState: Memento;
+        globalState: Memento & {
+            /**
+             * Set the keys whose values should be synchronized across devices when synchronizing user-data
+             * like configuration, extensions, and mementos.
+             *
+             * Note that this function defines the whole set of keys whose values are synchronized:
+             *  - calling it with an empty array stops synchronization for this memento
+             *  - calling it with a non-empty array replaces all keys whose values are synchronized
+             *
+             * For any given set of keys this function needs to be called only once but there is no harm in
+             * repeatedly calling it.
+             *
+             * @param keys The set of keys whose values are synced.
+             */
+            setKeysForSync(keys: readonly string[]): void;
+        };
 
         /**
          * A storage utility for secrets.

--- a/packages/plugin/src/theia.d.ts
+++ b/packages/plugin/src/theia.d.ts
@@ -3040,6 +3040,31 @@ declare module '@theia/plugin' {
     }
 
     /**
+     * The ExtensionMode is provided on the `ExtensionContext` and indicates the
+     * mode the specific extension is running in.
+     */
+    export enum ExtensionMode {
+
+        /**
+         * The extension is installed normally (for example, from the marketplace
+         * or VSIX) in the editor.
+         */
+        Production = 1,
+
+        /**
+         * The extension is running from an `--extensionDevelopmentPath` provided
+         * when launching the editor.
+         */
+        Development = 2,
+
+        /**
+         * The extension is running from an `--extensionTestsPath` and
+         * the extension host is running unit tests.
+         */
+        Test = 3,
+    }
+
+    /**
      * A plug-in context is a collection of utilities private to a
      * plug-in.
      *
@@ -3165,6 +3190,13 @@ declare module '@theia/plugin' {
          * the parent directory is guaranteed to be existent.
          */
         readonly logPath: string;
+
+        /**
+         * The mode the extension is running in. This is specific to the current
+         * extension. One extension may be in `ExtensionMode.Development` while
+         * other extensions in the host run in `ExtensionMode.Release`.
+         */
+        readonly extensionMode: ExtensionMode;
     }
 
     /**


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

Fixes: https://github.com/eclipse-theia/theia/issues/10204.

The commit stubs the method `setKeysForSync` as it is currently not supported by the framework and likely uses vscode online services to store data across machines.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

- start the application
- install `eslint` or `gitlens` through the extensions-view
- confirm there is no activation error due to `setKeysForSync`

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

Signed-off-by: vince-fugnitto <vincent.fugnitto@ericsson.com>