### PR TITLE
Ensure menu remains visible when fullscreen on Linux

### DIFF
--- a/packages/core/src/electron-browser/menu/electron-menu-contribution.ts
+++ b/packages/core/src/electron-browser/menu/electron-menu-contribution.ts
@@ -207,7 +207,10 @@ export class ElectronMenuContribution implements FrontendApplicationContribution
         registry.registerCommand(ElectronCommands.TOGGLE_FULL_SCREEN, {
             isEnabled: () => currentWindow.isFullScreenable(),
             isVisible: () => currentWindow.isFullScreenable(),
-            execute: () => currentWindow.setFullScreen(!currentWindow.isFullScreen())
+            execute: () => {
+                currentWindow.setFullScreen(!currentWindow.isFullScreen());
+                currentWindow.menuBarVisible = true; // Ensure menu remains visible on Linux
+            }
         });
     }
 


### PR DESCRIPTION
Fixes: https://github.com/eclipse-theia/theia/issues/10077

#### What it does
On Linux Electron, when `window.menuBarVisibility` is set to visible, switch to fullscreen (F11).  Previously the menu would disappear.  This PR fixes that, so the menu now remains.

#### How to test
Check that the menu now operates correctly in Electron on Linux.  Check also that the menu still works correctly on Windows and Mac.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
