### PR TITLE
file-upload: Ask to overwrite existing files

### DIFF
--- a/packages/filesystem/src/browser/file-upload-service.ts
+++ b/packages/filesystem/src/browser/file-upload-service.ts
@@ -27,6 +27,8 @@ import throttle = require('@theia/core/shared/lodash.throttle');
 import { HTTP_FILE_UPLOAD_PATH } from '../common/file-upload';
 import { Semaphore } from 'async-mutex';
 import { FileSystemPreferences } from './filesystem-preferences';
+import { FileService } from './file-service';
+import { ConfirmDialog } from '@theia/core/lib/browser';
 
 export const HTTP_UPLOAD_URL: string = new Endpoint({ path: HTTP_FILE_UPLOAD_PATH }).getRestUrl().toString(true);
 
@@ -57,6 +59,9 @@ export class FileUploadService {
 
     @inject(FileSystemPreferences)
     protected fileSystemPreferences: FileSystemPreferences;
+
+    @inject(FileService)
+    protected fileService: FileService;
 
     get maxConcurrentUploads(): number {
         const maxConcurrentUploads = this.fileSystemPreferences['files.maxConcurrentUploads'];
@@ -182,6 +187,9 @@ export class FileUploadService {
                 token: params.token,
                 progress: params.progress,
                 accept: async item => {
+                    if (!await this.allowsOverwrite(item.uri)) {
+                        return;
+                    }
                     // Track and initialize the file in the status map:
                     status.set(item.file, { total: item.file.size, done: 0 });
                     report();
@@ -232,6 +240,19 @@ export class FileUploadService {
             }
         }
         return result;
+    }
+
+    protected async allowsOverwrite(fileUri: URI): Promise<boolean> {
+        if (await this.fileService.exists(fileUri)) {
+            const dialog = new ConfirmDialog({
+                title: 'Replace file',
+                msg: `File '${fileUri.path.base}' already exists in the destination folder. Do you want to replace it?`,
+                ok: 'Replace',
+                cancel: 'Cancel'
+            });
+            return !!await dialog.open();
+        }
+        return true;
     }
 
     protected uploadFile(

--- a/packages/filesystem/src/node/node-file-upload-service.ts
+++ b/packages/filesystem/src/node/node-file-upload-service.ts
@@ -63,7 +63,7 @@ export class NodeFileUploadService implements BackendApplicationContribution {
         }
         try {
             const target = FileUri.fsPath(fields.uri);
-            await fs.move(request.file.path, target);
+            await fs.move(request.file.path, target, { overwrite: true });
             response.status(200).send(target); // ok
         } catch (error) {
             console.error(error);


### PR DESCRIPTION
#### What it does

Closes https://github.com/eclipse-theia/theia/issues/10197.

If the file already exists when uploading, the user will be asked to confirm to replace the file. If the user declines, the upload operation for the specific file is canceled.

#### How to test

1. Upload a new file and assert that the file is correctly added to the workspace.
2. Upload the file again to the same directory.
3. Assert that a confirmation dialog shows up which should work as previously indicated.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
