### PR TITLE
core: added appearance and editor layout sub-menus

### DIFF
--- a/packages/core/src/browser/common-frontend-contribution.ts
+++ b/packages/core/src/browser/common-frontend-contribution.ts
@@ -80,13 +80,19 @@ export namespace CommonMenus {
 
     export const VIEW = [...MAIN_MENU_BAR, '4_view'];
     export const VIEW_PRIMARY = [...VIEW, '0_primary'];
-    export const VIEW_VIEWS = [...VIEW, '1_views'];
-    export const VIEW_LAYOUT = [...VIEW, '2_layout'];
-    export const VIEW_TOGGLE = [...VIEW, '3_toggle'];
+    export const VIEW_APPEARANCE = [...VIEW, '1_appearance'];
+    export const VIEW_APPEARANCE_SUBMENU = [...VIEW_APPEARANCE, '1_appearance_submenu'];
+    export const VIEW_APPEARANCE_SUBMENU_SCREEN = [...VIEW_APPEARANCE_SUBMENU, '2_appearance_submenu_screen'];
+    export const VIEW_APPEARANCE_SUBMENU_BAR = [...VIEW_APPEARANCE_SUBMENU, '3_appearance_submenu_bar'];
+    export const VIEW_EDITOR_SUBMENU = [...VIEW_APPEARANCE, '2_editor_submenu'];
+    export const VIEW_EDITOR_SUBMENU_SPLIT = [...VIEW_EDITOR_SUBMENU, '1_editor_submenu_split'];
+    export const VIEW_EDITOR_SUBMENU_ORTHO = [...VIEW_EDITOR_SUBMENU, '2_editor_submenu_ortho'];
+    export const VIEW_VIEWS = [...VIEW, '2_views'];
+    export const VIEW_LAYOUT = [...VIEW, '3_layout'];
+    export const VIEW_TOGGLE = [...VIEW, '4_toggle'];
 
     export const SETTINGS_OPEN = [...SETTINGS_MENU, '1_settings_open'];
     export const SETTINGS__THEME = [...SETTINGS_MENU, '2_settings_theme'];
-
     // last menu item
     export const HELP = [...MAIN_MENU_BAR, '9_help'];
 
@@ -245,6 +251,11 @@ export namespace CommonCommands {
         category: VIEW_CATEGORY,
         label: 'Open View...'
     });
+    export const SHOW_MENU_BAR = Command.toDefaultLocalizedCommand({
+        id: 'window.menuBarVisibility',
+        category: VIEW_CATEGORY,
+        label: 'Show Menu Bar'
+    });
 
     export const SAVE = Command.toDefaultLocalizedCommand({
         id: 'core.save',
@@ -294,7 +305,6 @@ export namespace CommonCommands {
         id: 'workbench.action.configureLanguage',
         label: 'Configure Display Language'
     });
-
 }
 
 export const supportCut = browser.isNative || document.queryCommandSupported('cut');
@@ -562,18 +572,18 @@ export class CommonFrontendContribution implements FrontendApplicationContributi
             order: '3'
         });
 
-        registry.registerMenuAction(CommonMenus.VIEW_LAYOUT, {
+        registry.registerMenuAction(CommonMenus.VIEW_APPEARANCE_SUBMENU_BAR, {
             commandId: CommonCommands.TOGGLE_BOTTOM_PANEL.id,
-            order: '0'
+            order: '1'
         });
-        registry.registerMenuAction(CommonMenus.VIEW_LAYOUT, {
+        registry.registerMenuAction(CommonMenus.VIEW_APPEARANCE_SUBMENU_BAR, {
             commandId: CommonCommands.TOGGLE_STATUS_BAR.id,
-            order: '1',
-            label: 'Toggle Status Bar'
+            order: '2',
+            label: nls.localizeByDefault('Toggle Status Bar Visibility')
         });
-        registry.registerMenuAction(CommonMenus.VIEW_LAYOUT, {
+        registry.registerMenuAction(CommonMenus.VIEW_APPEARANCE_SUBMENU_BAR, {
             commandId: CommonCommands.COLLAPSE_ALL_PANELS.id,
-            order: '2'
+            order: '3'
         });
 
         registry.registerMenuAction(SHELL_TABBAR_CONTEXT_CLOSE, {
@@ -611,10 +621,20 @@ export class CommonFrontendContribution implements FrontendApplicationContributi
             label: CommonCommands.TOGGLE_MAXIMIZED.label,
             order: '6'
         });
+        registry.registerMenuAction(CommonMenus.VIEW_APPEARANCE_SUBMENU_SCREEN, {
+            commandId: CommonCommands.TOGGLE_MAXIMIZED.id,
+            label: CommonCommands.TOGGLE_MAXIMIZED.label,
+            order: '6'
+        });
         registry.registerMenuAction(SHELL_TABBAR_CONTEXT_COPY, {
             commandId: CommonCommands.COPY_PATH.id,
             label: CommonCommands.COPY_PATH.label,
             order: '1',
+        });
+        registry.registerMenuAction(CommonMenus.VIEW_APPEARANCE_SUBMENU_BAR, {
+            commandId: CommonCommands.SHOW_MENU_BAR.id,
+            label: nls.localizeByDefault('Toggle Menu Bar'),
+            order: '0'
         });
         registry.registerMenuAction(CommonMenus.HELP, {
             commandId: CommonCommands.ABOUT_COMMAND.id,
@@ -639,6 +659,8 @@ export class CommonFrontendContribution implements FrontendApplicationContributi
         registry.registerMenuAction(CommonMenus.SETTINGS__THEME, {
             commandId: CommonCommands.SELECT_ICON_THEME.id
         });
+
+        registry.registerSubmenu(CommonMenus.VIEW_APPEARANCE_SUBMENU, nls.localizeByDefault('Appearance'));
     }
 
     registerCommands(commandRegistry: CommandRegistry): void {
@@ -818,6 +840,19 @@ export class CommonFrontendContribution implements FrontendApplicationContributi
             isVisible: title => Boolean(title?.owner && this.shell.canToggleMaximized(title?.owner)),
             execute: title => title?.owner && this.shell.toggleMaximized(title?.owner),
         }));
+        commandRegistry.registerCommand(CommonCommands.SHOW_MENU_BAR, {
+            isEnabled: () => !isOSX,
+            isVisible: () => !isOSX,
+            execute: () => {
+                const menuBarVisibility = 'window.menuBarVisibility';
+                const visibility = this.preferences[menuBarVisibility];
+                if (visibility !== 'compact') {
+                    this.preferenceService.updateValue(menuBarVisibility, 'compact');
+                } else {
+                    this.preferenceService.updateValue(menuBarVisibility, 'classic');
+                }
+            }
+        });
 
         commandRegistry.registerCommand(CommonCommands.SAVE, {
             execute: () => this.shell.save({ formatType: FormatType.ON })

--- a/packages/core/src/electron-browser/menu/electron-menu-contribution.ts
+++ b/packages/core/src/electron-browser/menu/electron-menu-contribution.ts
@@ -68,7 +68,7 @@ export namespace ElectronCommands {
 
 export namespace ElectronMenus {
     export const VIEW_WINDOW = [...CommonMenus.VIEW, 'window'];
-    export const VIEW_ZOOM = [...CommonMenus.VIEW, 'zoom'];
+    export const VIEW_ZOOM = [...CommonMenus.VIEW_APPEARANCE_SUBMENU, '4_appearance_submenu_zoom'];
 }
 
 export namespace ElectronMenus {
@@ -363,6 +363,11 @@ export class ElectronMenuContribution extends BrowserMenuBarContribution impleme
         });
         registry.registerMenuAction(ElectronMenus.FILE_CLOSE, {
             commandId: ElectronCommands.CLOSE_WINDOW.id,
+        });
+        registry.registerMenuAction(CommonMenus.VIEW_APPEARANCE_SUBMENU_SCREEN, {
+            commandId: ElectronCommands.TOGGLE_FULL_SCREEN.id,
+            label: nls.localizeByDefault('Full Screen'),
+            order: '0'
         });
     }
 }

--- a/packages/editor/src/browser/editor-contribution.ts
+++ b/packages/editor/src/browser/editor-contribution.ts
@@ -140,7 +140,6 @@ export class EditorContribution implements FrontendApplicationContribution, Comm
         });
         const splitHandlerFactory = (splitMode: DockLayout.InsertMode): CommandHandler => new CurrentWidgetCommandAdapter(this.shell, {
             isEnabled: title => title?.owner instanceof EditorWidget,
-            isVisible: title => title?.owner instanceof EditorWidget,
             execute: async title => {
                 if (title?.owner instanceof EditorWidget) {
                     const selection = title.owner.editor.selection;

--- a/packages/editor/src/browser/editor-menu.ts
+++ b/packages/editor/src/browser/editor-menu.ts
@@ -130,6 +130,43 @@ export class EditorMenuContribution implements MenuContribution {
             label: nls.localizeByDefault('Close Editor'),
             order: '1'
         });
+        registry.registerMenuAction(CommonMenus.VIEW_EDITOR_SUBMENU_SPLIT, {
+            commandId: EditorCommands.SPLIT_EDITOR_RIGHT.id,
+            label: nls.localizeByDefault('Split Editor Right'),
+            order: '0'
+        });
+
+        registry.registerMenuAction(CommonMenus.VIEW_EDITOR_SUBMENU_SPLIT, {
+            commandId: EditorCommands.SPLIT_EDITOR_LEFT.id,
+            label: nls.localizeByDefault('Split Editor Left'),
+            order: '1'
+        });
+
+        registry.registerMenuAction(CommonMenus.VIEW_EDITOR_SUBMENU_SPLIT, {
+            commandId: EditorCommands.SPLIT_EDITOR_UP.id,
+            label: nls.localizeByDefault('Split Editor Up'),
+            order: '2'
+        });
+
+        registry.registerMenuAction(CommonMenus.VIEW_EDITOR_SUBMENU_SPLIT, {
+            commandId: EditorCommands.SPLIT_EDITOR_DOWN.id,
+            label: nls.localizeByDefault('Split Editor Down'),
+            order: '3'
+        });
+
+        registry.registerMenuAction(CommonMenus.VIEW_EDITOR_SUBMENU_ORTHO, {
+            commandId: EditorCommands.SPLIT_EDITOR_HORIZONTAL.id,
+            label: nls.localize('theia/editor/splitHorizontal', 'Split Editor Horizontal'),
+            order: '1'
+        });
+
+        registry.registerMenuAction(CommonMenus.VIEW_EDITOR_SUBMENU_ORTHO, {
+            commandId: EditorCommands.SPLIT_EDITOR_VERTICAL.id,
+            label: nls.localize('theia/editor/splitVertical', 'Split Editor Vertical'),
+            order: '2'
+        });
+
+        registry.registerSubmenu(CommonMenus.VIEW_EDITOR_SUBMENU, nls.localizeByDefault('Editor Layout'));
     }
 
 }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
The commit adds the registration of an `appearance` and `editor layout` submenu to the `view` main-menu.
The `appearance` menu is used to group menu items related to the appearance of the workbench or layout.
The `editor layout` menu groups items related to splitting the workbench.
Commands present in vscode's appearance and editor layout menu that exist in the framework were moved to these new submenus.
<!-- Include relevant issues and describe how they are addressed. -->

#### How to test
Follow steps to open the Electron app:
 - `yarn electron build`
 - `yarn`
 - `yarn electron start`

Click on the `View` menu from the top bar and then the `Appearance` and `Editor Layout` sub-menus within.  The list of options will be present, click on each one to test their features, but some require prerequisites to be useful.
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

#### Review checklist

- [X] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
