### PR TITLE
Enforce debug content when EditorModel is invalid

### DIFF
--- a/packages/debug/src/browser/debug-configuration-manager.ts
+++ b/packages/debug/src/browser/debug-configuration-manager.ts
@@ -194,6 +194,7 @@ export class DebugConfigurationManager {
             await this.doOpen(model);
         }
     }
+
     async addConfiguration(): Promise<void> {
         const { model } = this;
         if (!model) {
@@ -285,7 +286,7 @@ export class DebugConfigurationManager {
      */
     protected async ensureContent(uri: URI, model: DebugConfigurationModel): Promise<void> {
         const textModel = await this.textModelService.createModelReference(uri);
-        const currentContent = textModel.object.getText();
+        const currentContent = textModel.object.valid ? textModel.object.getText() : '';
         try { // Look for the minimal well-formed launch.json content: {configurations: []}
             const parsedContent = parse(currentContent);
             if (Array.isArray(parsedContent.configurations)) {
@@ -294,7 +295,6 @@ export class DebugConfigurationManager {
         } catch {
             // Just keep going
         }
-
         const debugType = await this.selectDebugType();
         const configurations = debugType ? await this.provideDebugConfigurations(debugType, model.workspaceFolderUri) : [];
         const content = this.getInitialConfigurationContent(configurations);


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

Fixes #10159 by enforcing the addition of content when the editor is in an invalid state.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

1. Create a .theia/launch.json by clicking the Add Configuration... button on theRun menu.
2. Delete the .theia folder manaually and close the editor.
3. Click the Add Configuration menu item again.
4. Observe that an editor is opened with the skeleton of the `launch` configuration.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

Signed-off-by: Colin Grant <colin.grant@ericsson.com>