### PR TITLE
Normalize and prefix windows paths with Path.separator

### DIFF
--- a/packages/core/src/common/path.spec.ts
+++ b/packages/core/src/common/path.spec.ts
@@ -257,6 +257,20 @@ describe('Path', () => {
         });
     }
 
+    describe('Normalize path separator', () => {
+        it('should handle windows styled paths', async () => {
+            const path = 'C:\\a\\b\\c';
+            const expected = '/c:/a/b/c';
+            expect(new Path(path).toString()).eq(expected);
+        });
+
+        it('should prefix drive letter with /', async () => {
+            const path = 'c:/a/b/c';
+            const expected = '/c:/a/b/c';
+            expect(new Path(path).toString()).eq(expected);
+        });
+    });
+
     const linuxHome = '/home/test-user';
     const windowsHome = '/C:/Users/test-user';
 
@@ -340,5 +354,6 @@ describe('Path', () => {
             const expected = '~/a/b/theia';
             expect(Path.untildify(path, '')).eq(expected);
         });
+
     });
 });

--- a/packages/core/src/common/path.ts
+++ b/packages/core/src/common/path.ts
@@ -53,10 +53,21 @@ export class Path {
         } else if (path.length >= 2 && path.charCodeAt(1) === 58 /* ':' */) {
             const code = path.charCodeAt(0);
             if (code >= 65 /* A */ && code <= 90 /* Z */) {
-                path = `${String.fromCharCode(code + 32)}:${path.substr(2)}`; // "/c:".length === 3
+                path = `${String.fromCharCode(code + 32)}:${path.substr(2)}`; // "c:".length === 2
+            }
+            if (path.charCodeAt(0) !== 47 /* '/' */) {
+                path = `${String.fromCharCode(47)}${path}`;
             }
         }
         return path;
+    }
+    /**
+     * Normalize path separator to use Path.separator
+     * @param Path candidate to normalize
+     * @returns Normalized string path
+     */
+    static normalizePathSeparator(path: string): string {
+        return path.split(/[\\]/).join(Path.separator);
     }
 
     /**
@@ -112,11 +123,12 @@ export class Path {
     constructor(
         raw: string
     ) {
+        raw = Path.normalizePathSeparator(raw);
         this.raw = Path.normalizeDrive(raw);
-        const firstIndex = raw.indexOf(Path.separator);
-        const lastIndex = raw.lastIndexOf(Path.separator);
+        const firstIndex = this.raw.indexOf(Path.separator);
+        const lastIndex = this.raw.lastIndexOf(Path.separator);
         this.isAbsolute = firstIndex === 0;
-        this.base = lastIndex === -1 ? raw : raw.substr(lastIndex + 1);
+        this.base = lastIndex === -1 ? this.raw : this.raw.substr(lastIndex + 1);
         this.isRoot = this.isAbsolute && firstIndex === lastIndex && (!this.base || Path.isDrive(this.base));
         this.root = this.computeRoot();
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

Fixes: #10225 

- Prefix path with / if on the form of "c:/" into "/c:/"
- Normalize windows path-separator paths to use / instead of \\

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

Run any command that produces an output of windows-style-path in terminal and it should be clickable.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

Contributed by STMicroelectronics

Signed-off-by: Emil HAMMARSTEDT <emil.hammarstedt@st.com>
