### PR TITLE
Fix potential JSON RPC error in the quick-open plugin API

### DIFF
--- a/packages/plugin-ext/src/plugin/quick-open.ts
+++ b/packages/plugin-ext/src/plugin/quick-open.ts
@@ -613,9 +613,15 @@ export class QuickPickExt<T extends theia.QuickPickItem> extends QuickInputExt i
             this._handlesToItems.set(i, item);
             this._itemsToHandles.set(item, i);
         });
-        items.forEach((item, i) => Object.assign(item, { handle: i }));
         this.update({
-            items
+            items: items.map((item, i) => ({
+                label: item.label,
+                description: item.description,
+                handle: i,
+                detail: item.detail,
+                picked: item.picked,
+                alwaysShow: item.alwaysShow
+            }))
         });
     }
 


### PR DESCRIPTION
Signed-off-by: Igor Vinokur <ivinokur@redhat.com>

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
Remap items to a new known objects to exclude non JSON RPC compatible objects when passing them through the quick-open plugin API.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
1. Turn off the native git plugin by removing it from the [`package.json`](https://github.com/eclipse-theia/theia/blob/master/examples/browser/package.json#L28) of the `examples/browser` folder.
2. Add vscode [git](https://open-vsx.org/api/vscode/git/1.52.1/file/vscode.git-1.52.1.vsix) and [github](https://open-vsx.org/api/vscode/github/1.52.1/file/vscode.github-1.52.1.vsix) plugins to the `plugins` folder.
3. Build and start theia.
4. Run `Git: Clone` command from the command palette.
See: an input box appears.

In the current master version an error appears:
```
2021-10-05 14:39:17.359 root ERROR [hosted-plugin: 46] Promise rejection not handled in one second: TypeError: Converting circular structure to JSON
    --> starting at object with constructor 'f'
    |     property '_onDidOpenRepository' -> object with constructor 'Emitter'
    |     property '_callbacks' -> object with constructor 'CallbackList'
    |     ...
    |     index 2 -> object with constructor 't.GitDecorations'
    --- property 'model' closes the circle , reason: TypeError: Converting circular structure to JSON
    --> starting at object with constructor 'f'
    |     property '_onDidOpenRepository' -> object with constructor 'Emitter'
    |     property '_callbacks' -> object with constructor 'CallbackList'
    |     ...
    |     index 2 -> object with constructor 't.GitDecorations'
    --- property 'model' closes the circle 
2021-10-05 14:39:17.360 root ERROR Promise rejection not handled in one second: TypeError: Converting circular structure to JSON
    --> starting at object with constructor 'f'
    |     property '_onDidOpenRepository' -> object with constructor 'Emitter'
    |     property '_callbacks' -> object with constructor 'CallbackList'
    |     ...
    |     index 2 -> object with constructor 't.GitDecorations'
    --- property 'model' closes the circle , reason: TypeError: Converting circular structure to JSON
    --> starting at object with constructor 'f'
    |     property '_onDidOpenRepository' -> object with constructor 'Emitter'
    |     property '_callbacks' -> object with constructor 'CallbackList'
    |     ...
    |     index 2 -> object with constructor 't.GitDecorations'
    --- property 'model' closes the circle
 
2021-10-05 14:39:17.361 root ERROR [hosted-plugin: 46] With stack trace: TypeError: Converting circular structure to JSON
    --> starting at object with constructor 'f'
    |     property '_onDidOpenRepository' -> object with constructor 'Emitter'
    |     property '_callbacks' -> object with constructor 'CallbackList'
    |     ...
    |     index 2 -> object with constructor 't.GitDecorations'
    --- property 'model' closes the circle
    at JSON.stringify (<anonymous>)
    at RPCProtocolImpl.request (/home/theia/node_modules/@theia/plugin-ext/lib/common/rpc-protocol.js:238:114)
    at RPCProtocolImpl.remoteCall (/home/theia/node_modules/@theia/plugin-ext/lib/common/rpc-protocol.js:134:36)
    at Proxy.target.<computed> (/home/theia/node_modules/@theia/plugin-ext/lib/common/rpc-protocol.js:112:56)
    at QuickPickExt.dispatchUpdate (/home/theia/node_modules/@theia/plugin-ext/lib/plugin/quick-open.js:336:28)
    at QuickPickExt.update (/home/theia/node_modules/@theia/plugin-ext/lib/plugin/quick-open.js:325:18)
    at QuickPickExt.show (/home/theia/node_modules/@theia/plugin-ext/lib/plugin/quick-open.js:299:14)
    at t (/default-theia-plugins/vscode-git/extension/dist/main.js:1:127183)
    at new Promise (<anonymous>)
    at c (/default-theia-plugins/vscode-git/extension/dist/main.js:1:127097) 
2021-10-05 14:39:17.361 root ERROR With stack trace: TypeError: Converting circular structure to JSON
    --> starting at object with constructor 'f'
    |     property '_onDidOpenRepository' -> object with constructor 'Emitter'
    |     property '_callbacks' -> object with constructor 'CallbackList'
    |     ...
    |     index 2 -> object with constructor 't.GitDecorations'
    --- property 'model' closes the circle
    at JSON.stringify (<anonymous>)
    at RPCProtocolImpl.request (/home/theia/node_modules/@theia/plugin-ext/lib/common/rpc-protocol.js:238:114)
    at RPCProtocolImpl.remoteCall (/home/theia/node_modules/@theia/plugin-ext/lib/common/rpc-protocol.js:134:36)
    at Proxy.target.<computed> (/home/theia/node_modules/@theia/plugin-ext/lib/common/rpc-protocol.js:112:56)
    at QuickPickExt.dispatchUpdate (/home/theia/node_modules/@theia/plugin-ext/lib/plugin/quick-open.js:336:28)
    at QuickPickExt.update (/home/theia/node_modules/@theia/plugin-ext/lib/plugin/quick-open.js:325:18)
    at QuickPickExt.show (/home/theia/node_modules/@theia/plugin-ext/lib/plugin/quick-open.js:299:14)
    at t (/default-theia-plugins/vscode-git/extension/dist/main.js:1:127183)
    at new Promise (<anonymous>)
    at c (/default-theia-plugins/vscode-git/extension/dist/main.js:1:127097)
```
#### Review checklist

- [ ] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
