### PR TITLE
workspace: add tabbar-decorator

### DIFF
--- a/packages/core/src/browser/shell/tab-bars.ts
+++ b/packages/core/src/browser/shell/tab-bars.ts
@@ -219,13 +219,43 @@ export class TabBarRenderer extends TabBar.Renderer {
         if (isInSidePanel || (this.tabBar && this.tabBar.titles.length < 2)) {
             return h.div({ className: 'p-TabBar-tabLabel', style }, data.title.label);
         }
+
+        // Collect prefix data.
+        const prefixes: string[] = [];
+        for (const captionPrefixes of this.getDecorationData(data.title, 'captionPrefixes')) {
+            if (captionPrefixes) {
+                for (const prefix of captionPrefixes) {
+                    prefixes.push(prefix.data);
+                }
+            }
+        }
+
+        // Collect suffix data.
+        const suffixes: string[] = [];
+        for (const captionSuffixes of this.getDecorationData(data.title, 'captionSuffixes')) {
+            if (captionSuffixes) {
+                for (const suffix of captionSuffixes) {
+                    suffixes.push(suffix.data);
+                }
+            }
+        }
+
         const originalToDisplayedMap = this.findDuplicateLabels([...this.tabBar!.titles]);
         const labelDetails: string | undefined = originalToDisplayedMap.get(data.title.caption);
-        if (labelDetails) {
+
+        if (labelDetails || prefixes.length > 0 || suffixes.length > 0) {
+            const detailLabel: string[] = [];
+            detailLabel.push(...prefixes);
+            if (labelDetails) {
+                detailLabel.push(labelDetails);
+            }
+            detailLabel.push(...suffixes);
+
             return h.div({ className: 'p-TabBar-tabLabelWrapper' },
                 h.div({ className: 'p-TabBar-tabLabel', style }, data.title.label),
-                h.div({ className: 'p-TabBar-tabLabelDetails', style }, labelDetails));
+                h.div({ className: 'p-TabBar-tabLabelDetails', style }, detailLabel.join(' ')));
         }
+
         return h.div({ className: 'p-TabBar-tabLabel', style }, data.title.label);
     }
 

--- a/packages/workspace/src/browser/workspace-frontend-module.ts
+++ b/packages/workspace/src/browser/workspace-frontend-module.ts
@@ -48,6 +48,8 @@ import { JsonSchemaContribution } from '@theia/core/lib/browser/json-schema-stor
 import { WorkspaceSchemaUpdater } from './workspace-schema-updater';
 import { WorkspaceBreadcrumbsContribution } from './workspace-breadcrumbs-contribution';
 import { FilepathBreadcrumbsContribution } from '@theia/filesystem/lib/browser/breadcrumbs/filepath-breadcrumbs-contribution';
+import { WorkspaceTabBarDecorator } from './workspace-tabbar-decorator';
+import { TabBarDecorator } from '@theia/core/lib/browser/shell/tab-bar-decorator';
 
 export default new ContainerModule((bind: interfaces.Bind, unbind: interfaces.Unbind, isBound: interfaces.IsBound, rebind: interfaces.Rebind) => {
     bindWorkspacePreferences(bind);
@@ -99,4 +101,7 @@ export default new ContainerModule((bind: interfaces.Bind, unbind: interfaces.Un
     bind(WorkspaceSchemaUpdater).toSelf().inSingletonScope();
     bind(JsonSchemaContribution).toService(WorkspaceSchemaUpdater);
     rebind(FilepathBreadcrumbsContribution).to(WorkspaceBreadcrumbsContribution).inSingletonScope();
+
+    bind(WorkspaceTabBarDecorator).toSelf().inSingletonScope();
+    bind(TabBarDecorator).toService(WorkspaceTabBarDecorator);
 });

--- a/packages/workspace/src/browser/workspace-tabbar-decorator.ts
+++ b/packages/workspace/src/browser/workspace-tabbar-decorator.ts
@@ -1,0 +1,90 @@
+/********************************************************************************
+ * Copyright (C) 2021 Ericsson and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import { injectable, inject } from '@theia/core/shared/inversify';
+import { TabBarDecorator } from '@theia/core/lib/browser/shell/tab-bar-decorator';
+import { WidgetDecoration } from '@theia/core/lib/browser/widget-decoration';
+import { Title, Widget } from '@theia/core/lib/browser/widgets';
+import { LabelProvider, ApplicationShell, NavigatableWidget } from '@theia/core/lib/browser';
+import { Emitter, Event } from '@theia/core/lib/common/event';
+import { WorkspaceService } from './workspace-service';
+
+@injectable()
+export class WorkspaceTabBarDecorator implements TabBarDecorator {
+
+    readonly id = 'theia-workspace-tabbar-decorator';
+
+    protected readonly emitter = new Emitter<void>();
+
+    @inject(ApplicationShell)
+    protected readonly shell: ApplicationShell;
+
+    @inject(LabelProvider)
+    protected readonly labelProvider: LabelProvider;
+
+    @inject(WorkspaceService)
+    protected readonly workspaceService: WorkspaceService;
+
+    decorate(title: Title<Widget>): WidgetDecoration.Data[] {
+        if (this.workspaceService.isMultiRootWorkspaceOpened) {
+            const widget = title.owner;
+            if (NavigatableWidget.is(widget)) {
+                const resourceUri = widget.getResourceUri();
+                const navigatableWidgets = this.getNavigatableWidgets();
+                const duplicateExists = navigatableWidgets.some(w => this.isDuplicateTitleOpen(widget, w));
+                if (!duplicateExists) {
+                    return [];
+                }
+                const rootUri = this.workspaceService.getWorkspaceRootUri(resourceUri);
+                if (rootUri) {
+                    const rootName = this.labelProvider.getName(rootUri);
+                    return [{
+                        captionPrefixes: [
+                            {
+                                data: rootName
+                            }
+                        ]
+                    }];
+                }
+            }
+        }
+        return [];
+    }
+
+    get onDidChangeDecorations(): Event<void> {
+        return this.emitter.event;
+    }
+
+    protected fireDidChangeDecorations(): void {
+        this.emitter.fire(undefined);
+    }
+
+    protected getNavigatableWidgets(): NavigatableWidget[] {
+        const navigatableWidgets: NavigatableWidget[] = [];
+        const widgets = this.shell.widgets.filter(w => w.isVisible);
+        for (const widget of widgets) {
+            if (NavigatableWidget.is(widget)) {
+                navigatableWidgets.push(widget);
+            }
+        }
+        return navigatableWidgets;
+    }
+
+    protected isDuplicateTitleOpen(a: NavigatableWidget, b: NavigatableWidget): boolean {
+        return a.title.label === b.title.label;
+    }
+
+}


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

Fixes: https://github.com/eclipse-theia/theia/issues/10236

The commit adds the new `WorkspaceTabBarDecorator` which is used to display the corresponding multi-root root name for an editor as a suffix when more than one editor with the same name is currently opened.

The `tab-bar` was updated to add support for both `prefix` and `suffix` data captions.

![multi-root-decorator](https://user-images.githubusercontent.com/40359487/136247022-296f408b-c39b-47f4-b2a9-b0743a2cfaaf.png)

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

1. using a single-root workspace the decorator should not apply
2. using a multi-root workspace, open two editors with the same name under different roots
3. the corresponding root name should be displayed for each+

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

Signed-off-by: vince-fugnitto <vincent.fugnitto@ericsson.com>
