### PR TITLE
monaco: fix styling in monaco suggest-overlay

### DIFF
--- a/packages/monaco/src/browser/style/index.css
+++ b/packages/monaco/src/browser/style/index.css
@@ -99,6 +99,13 @@
   font-family: sans-serif;
 }
 
+.monaco-editor .monaco-list .monaco-list-row.focused,
+.monaco-editor .monaco-list .monaco-list-row.focused,
+.monaco-editor .monaco-list .monaco-list-row.focused .suggest-icon {
+  color: var(--theia-list-activeSelectionForeground) !important;
+  background-color: var(--theia-list-activeSelectionBackground) !important;
+}
+
 /* Monaco Quick Input */
 .quick-input-widget {
   width: 600px !important;


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

Fixes: #10239

The commit fixes the styling for focused elements in the monaco suggestion overlay:
- applies the foreground color properly for focused elements
- applies the background color properly for focused elements
- styles the `suggest-icon` properly for focused elements

_Light_:

![monaco-suggest-light](https://user-images.githubusercontent.com/40359487/136253030-80c3b5cb-01bb-4011-a7cd-5d532495e264.gif)

_Dark_:

![monaco-suggest-dark](https://user-images.githubusercontent.com/40359487/136253029-ebe5e01b-4d29-4ac2-8f76-67fc681b4da0.gif)

_Monokai_:

![monaco-suggest-monokai](https://user-images.githubusercontent.com/40359487/136253028-25b74963-eec3-4206-839f-5752a5cdc9a1.gif)

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

1. open editors
2. with different themes confirm that selections when triggering the `suggestions` are correctly styled

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

Signed-off-by: vince-fugnitto <vincent.fugnitto@ericsson.com>
