### PR TITLE
Add `Replace in Files` command to `Edit` main-menu

### DIFF
--- a/packages/search-in-workspace/src/browser/search-in-workspace-frontend-contribution.ts
+++ b/packages/search-in-workspace/src/browser/search-in-workspace-frontend-contribution.ts
@@ -41,6 +41,11 @@ export namespace SearchInWorkspaceCommands {
         category: SEARCH_CATEGORY,
         label: 'Find in Files'
     }, 'vscode/search.contribution/findInFiles', SEARCH_CATEGORY_KEY);
+    export const REPLACE_IN_FILES = Command.toLocalizedCommand({
+        id: 'search-in-workspace.replace',
+        category: SEARCH_CATEGORY,
+        label: 'Replace in Files'
+    }, 'vscode/searchActions/replaceInFiles', SEARCH_CATEGORY_KEY);
     export const FIND_IN_FOLDER = Command.toLocalizedCommand({
         id: 'search-in-workspace.in-folder',
         category: SEARCH_CATEGORY,
@@ -122,6 +127,14 @@ export class SearchInWorkspaceFrontendContribution extends AbstractViewContribut
             execute: async () => {
                 const widget = await this.openView({ activate: true });
                 widget.updateSearchTerm(this.getSearchTerm());
+            }
+        });
+
+        commands.registerCommand(SearchInWorkspaceCommands.REPLACE_IN_FILES, {
+            isEnabled: () => this.workspaceService.tryGetRoots().length > 0,
+            execute: async () => {
+                const widget = await this.openView({ activate: true });
+                widget.updateSearchTerm(this.getSearchTerm(), true);
             }
         });
 
@@ -214,7 +227,12 @@ export class SearchInWorkspaceFrontendContribution extends AbstractViewContribut
             commandId: SearchInWorkspaceCommands.FIND_IN_FOLDER.id
         });
         menus.registerMenuAction(CommonMenus.EDIT_FIND, {
-            commandId: SearchInWorkspaceCommands.OPEN_SIW_WIDGET.id
+            commandId: SearchInWorkspaceCommands.OPEN_SIW_WIDGET.id,
+            order: '2'
+        });
+        menus.registerMenuAction(CommonMenus.EDIT_FIND, {
+            commandId: SearchInWorkspaceCommands.REPLACE_IN_FILES.id,
+            order: '3'
         });
     }
 

--- a/packages/search-in-workspace/src/browser/search-in-workspace-widget.tsx
+++ b/packages/search-in-workspace/src/browser/search-in-workspace-widget.tsx
@@ -230,12 +230,16 @@ export class SearchInWorkspaceWidget extends BaseWidget implements StatefulWidge
     /**
      * Update the search term and input field.
      * @param term the search term.
+     * @param showReplaceField controls if the replace field should be displayed.
      */
-    updateSearchTerm(term: string): void {
+    updateSearchTerm(term: string, showReplaceField?: boolean): void {
         this.searchTerm = term;
         const search = document.getElementById('search-input-field');
         if (search) {
             (search as HTMLInputElement).value = term;
+        }
+        if (showReplaceField) {
+            this.showReplaceField = true;
         }
         this.refresh();
     }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->
Fixes #10217 

The commit includes the following changes:
Add the `replace in files` command to the `edit` main-menu.
It will open the search-in-workspace with the replace field expanded. If a selection exists in the editor, the search input will be pre-populated.


#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
* start the application
* confirm the replace in files menu item exists under the edit main-menu
* confirm the replace in files command exists in the command palette
* confirm the command will trigger the opening of the search-in-workspace view with the input pre-populated if a selection exists, and the replace field opened

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
