### PR TITLE
browser: Modal Dialog fixed display issues

### DIFF
--- a/packages/plugin-ext/src/common/plugin-api-rpc.ts
+++ b/packages/plugin-ext/src/common/plugin-api-rpc.ts
@@ -383,6 +383,7 @@ export enum MainMessageType {
 }
 
 export interface MainMessageOptions {
+    detail?: string;
     modal?: boolean
     onCloseActionHandle?: number
 }

--- a/packages/plugin-ext/src/main/browser/dialogs/style/modal-notification.css
+++ b/packages/plugin-ext/src/main/browser/dialogs/style/modal-notification.css
@@ -42,10 +42,10 @@
     order: 1;
 }
 
-.modal-Notification .icon .fa {
+.modal-Notification .icon .codicon {
     line-height: inherit;
     vertical-align: middle;
-    font-size: 120%;
+    font-size: calc(var(--theia-ui-padding)*5);
     color: var(--theia-editorInfo-foreground);
 }
 
@@ -105,4 +105,19 @@
 
 .modal-Notification .buttons > button:hover {
     background-color: var(--theia-button-hoverBackground);
+}
+
+.modal-Notification .detail {
+    align-self: center;
+    order: 3;
+    flex: 1 100%;
+    color: var(--theia-descriptionForeground);
+}
+
+.modal-Notification .detail > p {
+    margin: calc(var(--theia-ui-padding) * 2) 0px 0px 0px;
+}
+
+.modal-Notification .text {
+    padding: calc(var(--theia-ui-padding)*1.5);
 }

--- a/packages/plugin-ext/src/main/browser/message-registry-main.ts
+++ b/packages/plugin-ext/src/main/browser/message-registry-main.ts
@@ -40,7 +40,7 @@ export class MessageRegistryMainImpl implements MessageRegistryMain {
                 type === MainMessageType.Warning ? MessageType.Warning :
                     MessageType.Info;
             const modalNotification = new ModalNotification();
-            return modalNotification.showDialog(messageType, message, actions);
+            return modalNotification.showDialog(messageType, message, options, actions);
         }
         switch (type) {
             case MainMessageType.Info:

--- a/packages/plugin-ext/src/plugin/message-registry.ts
+++ b/packages/plugin-ext/src/plugin/message-registry.ts
@@ -50,14 +50,17 @@ export class MessageRegistryExt {
             } else {
                 if ('modal' in optionsOrFirstItem) {
                     options.modal = optionsOrFirstItem.modal;
+                    if ('detail' in optionsOrFirstItem) {
+                        options.detail = optionsOrFirstItem.detail;
+                    }
                 }
             }
+            for (const item of rest) {
+                pushItem(item);
+            }
+            const actionHandle = await this.proxy.$showMessage(type, message, options, actions);
+            return actionHandle !== undefined ? items[actionHandle] : undefined;
         }
-        for (const item of rest) {
-            pushItem(item);
-        }
-        const actionHandle = await this.proxy.$showMessage(type, message, options, actions);
-        return actionHandle !== undefined ? items[actionHandle] : undefined;
-    }
 
+    }
 }

--- a/packages/plugin/src/theia.d.ts
+++ b/packages/plugin/src/theia.d.ts
@@ -2395,6 +2395,13 @@ declare module '@theia/plugin' {
      */
     export interface MessageOptions {
 
+        /*
+         * Human-readable detail message that is rendered
+         * less prominent. Note that detail is only shown
+         * for modal messages.
+         */
+        detail?: string;
+
         /**
          * Indicates that this message should be modal.
          */


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
fixes #8090
Changes made:
- The `close` button to read `Cancel` instead to be similar to vscode
- Color of `Cancel` button switched to the accent color of the modal dialog
- Eliminated the hard-coded `Theia` title to display the application's name instead
<!-- Include relevant issues and describe how they are addressed. -->

#### How to test
- Download the necessary [plugin](https://github.com/vince-fugnitto/vscode-dialog-test/releases/download/v0.0.2/vscode-dialog-0.0.2.vsix) and place in /plugins
- Start the browser through command line `yarn browser start`
- `F1` to access the command palette and type `Dialog: Open Modal`
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

#### Review checklist

- [X] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
