### PR TITLE
Add localization extraction to Theia CLI

### DIFF
--- a/dev-packages/cli/package.json
+++ b/dev-packages/cli/package.json
@@ -31,6 +31,7 @@
   "dependencies": {
     "@theia/application-manager": "1.18.0",
     "@theia/application-package": "1.18.0",
+    "@theia/localization-manager": "1.18.0",
     "@theia/ovsx-client": "1.18.0",
     "@types/chai": "^4.2.7",
     "@types/mkdirp": "^0.5.2",

--- a/dev-packages/cli/src/theia.ts
+++ b/dev-packages/cli/src/theia.ts
@@ -22,6 +22,7 @@ import { ApplicationProps, DEFAULT_SUPPORTED_API_VERSION } from '@theia/applicat
 import checkHoisted from './check-hoisting';
 import downloadPlugins from './download-plugins';
 import runTest from './run-test';
+import { extract } from '@theia/localization-manager';
 
 process.on('unhandledRejection', (reason, promise) => {
     throw reason;
@@ -223,7 +224,52 @@ function theiaCli(): void {
             handler: async ({ packed }) => {
                 await downloadPlugins({ packed });
             },
-        }).command<{
+        })
+        .command<{
+            root: string,
+            output: string,
+            merge: boolean,
+            exclude?: string,
+            logs?: string,
+            pattern?: string
+        }>({
+            command: 'extract',
+            describe: 'Extract translation key/value pairs from source code',
+            builder: {
+                'output': {
+                    alias: 'o',
+                    describe: 'Output file for the extracted translations',
+                    demandOption: true
+                },
+                'root': {
+                    alias: 'r',
+                    describe: 'The directory which contains the source code',
+                    default: '.'
+                },
+                'merge': {
+                    alias: 'm',
+                    describe: 'Whether to merge new with existing translation values',
+                    boolean: true,
+                    default: false
+                },
+                'exclude': {
+                    alias: 'e',
+                    describe: 'Allows to exclude translation keys starting with this value'
+                },
+                'pattern': {
+                    alias: 'p',
+                    describe: 'A glob pattern for filtering the files used for extraction'
+                },
+                'logs': {
+                    alias: 'l',
+                    describe: 'File path to a log file'
+                }
+            },
+            handler: async options => {
+                await extract(options);
+            }
+        })
+        .command<{
             testInspect: boolean,
             testExtension: string[],
             testFile: string[],

--- a/dev-packages/cli/tsconfig.json
+++ b/dev-packages/cli/tsconfig.json
@@ -16,6 +16,9 @@
       "path": "../application-package"
     },
     {
+      "path": "../localization-manager"
+    },
+    {
       "path": "../ovsx-client"
     }
   ]

--- a/dev-packages/localization-manager/.eslintrc.js
+++ b/dev-packages/localization-manager/.eslintrc.js
@@ -1,0 +1,13 @@
+/** @type {import('eslint').Linter.Config} */
+module.exports = {
+    extends: [
+        '../../configs/build.eslintrc.json'
+    ],
+    parserOptions: {
+        tsconfigRootDir: __dirname,
+        project: 'tsconfig.json'
+    },
+    rules: {
+        'import/no-dynamic-require': 'off'
+    }
+};

--- a/dev-packages/localization-manager/README.md
+++ b/dev-packages/localization-manager/README.md
@@ -1,0 +1,30 @@
+<div align='center'>
+
+<br />
+
+<img src='https://raw.githubusercontent.com/eclipse-theia/theia/master/logo/theia.svg?sanitize=true' alt='theia-ext-logo' width='100px' />
+
+<h2>ECLIPSE THEIA - LOCALIZATION-MANAGER</h2>
+
+<hr />
+
+</div>
+
+## Description
+
+The `@theia/localization-manager` package is used easily create localizations of Theia and Theia extensions for different languages. 
+Its main use case is to extract localization keys and default values from `nls.localize` calls within the codebase.
+
+## Additional Information
+
+- [Theia - GitHub](https://github.com/eclipse-theia/theia)
+- [Theia - Website](https://theia-ide.org/)
+
+## License
+
+- [Eclipse Public License 2.0](http://www.eclipse.org/legal/epl-2.0/)
+- [一 (Secondary) GNU General Public License, version 2 with the GNU Classpath Exception](https://projects.eclipse.org/license/secondary-gpl-2.0-cp)
+
+## Trademark
+"Theia" is a trademark of the Eclipse Foundation
+https://www.eclipse.org/theia

--- a/dev-packages/localization-manager/package.json
+++ b/dev-packages/localization-manager/package.json
@@ -1,0 +1,44 @@
+{
+  "name": "@theia/localization-manager",
+  "version": "1.18.0",
+  "description": "Theia localization manager API.",
+  "publishConfig": {
+    "access": "public"
+  },
+  "license": "EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/eclipse-theia/theia.git"
+  },
+  "bugs": {
+    "url": "https://github.com/eclipse-theia/theia/issues"
+  },
+  "homepage": "https://github.com/eclipse-theia/theia",
+  "files": [
+    "lib",
+    "src"
+  ],
+  "main": "lib/index.js",
+  "typings": "lib/index.d.ts",
+  "scripts": {
+    "build": "theiaext build",
+    "clean": "theiaext clean",
+    "compile": "theiaext compile",
+    "lint": "theiaext lint",
+    "test": "theiaext test",
+    "watch": "theiaext watch"
+  },
+  "dependencies": {
+    "@types/fs-extra": "^4.0.2",
+    "deepmerge": "^4.2.2",
+    "fs-extra": "^4.0.2",
+    "glob": "^7.2.0",
+    "typescript": "^4.4.3"
+  },
+  "devDependencies": {
+    "@theia/ext-scripts": "1.18.0"
+  },
+  "nyc": {
+    "extends": "../../configs/nyc.json"
+  }
+}

--- a/dev-packages/localization-manager/src/index.ts
+++ b/dev-packages/localization-manager/src/index.ts
@@ -1,0 +1,17 @@
+/********************************************************************************
+ * Copyright (C) 2021 TypeFox and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+export * from './localization-extractor';

--- a/dev-packages/localization-manager/src/localization-extractor.spec.ts
+++ b/dev-packages/localization-manager/src/localization-extractor.spec.ts
@@ -1,0 +1,150 @@
+/********************************************************************************
+ * Copyright (C) 2021 TypeFox and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import * as assert from 'assert';
+import { extractFromFile } from './localization-extractor';
+
+const TEST_FILE = 'test.ts';
+
+describe('correctly extracts from file content', () => {
+
+    it('should extract from simple nls.localize() call', async () => {
+        const content = 'nls.localize("key", "value")';
+        assert.deepStrictEqual(await extractFromFile(TEST_FILE, content), {
+            'key': 'value'
+        });
+    });
+
+    it('should extract from nested nls.localize() call', async () => {
+        const content = 'nls.localize("nested/key", "value")';
+        assert.deepStrictEqual(await extractFromFile(TEST_FILE, content), {
+            'nested': {
+                'key': 'value'
+            }
+        });
+    });
+
+    it('should extract IDs from Command.toLocalizedCommand() call', async () => {
+        const content = `
+        Command.toLocalizedCommand({
+            id: 'command-id1',
+            label: 'command-label1'
+        });
+        Command.toLocalizedCommand({
+            id: 'command-id2',
+            label: 'command-label2'
+        }, 'command-key');
+        `;
+        assert.deepStrictEqual(await extractFromFile(TEST_FILE, content), {
+            'command-id1': 'command-label1',
+            'command-key': 'command-label2'
+        });
+    });
+
+    it('should extract category from Command.toLocalizedCommand() call', async () => {
+        const content = `
+        Command.toLocalizedCommand({
+            id: 'id',
+            label: 'label',
+            category: 'category'
+        }, undefined, 'category-key');`;
+        assert.deepStrictEqual(await extractFromFile(TEST_FILE, content), {
+            'id': 'label',
+            'category-key': 'category'
+        });
+    });
+
+    it('should merge different nls.localize() calls', async () => {
+        const content = `
+        nls.localize('nested/key1', 'value1');
+        nls.localize('nested/key2', 'value2');
+        `;
+        assert.deepStrictEqual(await extractFromFile(TEST_FILE, content), {
+            'nested': {
+                'key1': 'value1',
+                'key2': 'value2'
+            }
+        });
+    });
+
+    it('should be able to resolve local references', async () => {
+        const content = `
+        const a = 'key';
+        nls.localize(a, 'value');
+        `;
+        assert.deepStrictEqual(await extractFromFile(TEST_FILE, content), {
+            'key': 'value'
+        });
+    });
+
+    it('should return an error when resolving is not successful', async () => {
+        const content = "nls.localize(a, 'value')";
+        const errors: string[] = [];
+        assert.deepStrictEqual(await extractFromFile(TEST_FILE, content, errors), {});
+        assert.deepStrictEqual(errors, [
+            "test.ts(1,14): Could not resolve reference to 'a'"
+        ]);
+    });
+
+    it('should return an error when resolving from an expression', async () => {
+        const content = "nls.localize(test.value, 'value');";
+        const errors: string[] = [];
+        assert.deepStrictEqual(await extractFromFile(TEST_FILE, content, errors), {});
+        assert.deepStrictEqual(errors, [
+            "test.ts(1,14): 'test.value' is not a string constant"
+        ]);
+    });
+
+    it('should show error when trying to merge an object and a string', async () => {
+        const content = `
+        nls.localize('key', 'value');
+        nls.localize('key/nested', 'value');
+        `.trim();
+        const errors: string[] = [];
+        assert.deepStrictEqual(await extractFromFile(TEST_FILE, content, errors), {
+            'key': 'value'
+        });
+        assert.deepStrictEqual(errors, [
+            "test.ts(2,35): String entry already exists at 'key'"
+        ]);
+    });
+
+    it('should show error when trying to merge a string into an object', async () => {
+        const content = `
+        nls.localize('key/nested', 'value');
+        nls.localize('key', 'value');
+        `.trim();
+        const errors: string[] = [];
+        assert.deepStrictEqual(await extractFromFile(TEST_FILE, content, errors), {
+            'key': {
+                'nested': 'value'
+            }
+        });
+        assert.deepStrictEqual(errors, [
+            "test.ts(2,28): Multiple translation keys already exist at 'key'"
+        ]);
+    });
+
+    it('should show error for template literals', async () => {
+        const content = 'nls.localize("key", `template literal value`)';
+        const errors: string[] = [];
+        assert.deepStrictEqual(await extractFromFile(TEST_FILE, content, errors), {});
+        assert.deepStrictEqual(errors, [
+            "test.ts(1,20): Template literals are not supported for localization. Please use the additional arguments of the 'nls.localize' function to format strings"
+        ]);
+    });
+
+});

--- a/dev-packages/localization-manager/src/localization-extractor.ts
+++ b/dev-packages/localization-manager/src/localization-extractor.ts
@@ -1,0 +1,391 @@
+/********************************************************************************
+ * Copyright (C) 2021 TypeFox and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import * as fs from 'fs-extra';
+import * as ts from 'typescript';
+import * as os from 'os';
+import * as path from 'path';
+import { glob, IOptions } from 'glob';
+import deepmerge = require('deepmerge');
+
+export interface Localization {
+    [key: string]: string | Localization
+}
+
+export interface ExtractionOptions {
+    root: string
+    output: string
+    exclude?: string
+    logs?: string
+    pattern?: string
+    merge: boolean
+}
+
+class SingleFileServiceHost implements ts.LanguageServiceHost {
+
+    private file: ts.IScriptSnapshot;
+    private lib: ts.IScriptSnapshot;
+
+    constructor(private options: ts.CompilerOptions, private filename: string, contents: string) {
+        this.file = ts.ScriptSnapshot.fromString(contents);
+        this.lib = ts.ScriptSnapshot.fromString('');
+    }
+
+    getCompilationSettings = () => this.options;
+    getScriptFileNames = () => [this.filename];
+    getScriptVersion = () => '1';
+    getScriptSnapshot = (name: string) => name === this.filename ? this.file : this.lib;
+    getCurrentDirectory = () => '';
+    getDefaultLibFileName = () => 'lib.d.ts';
+}
+
+class TypeScriptError extends Error {
+    constructor(message: string, node: ts.Node) {
+        super(buildErrorMessage(message, node));
+    }
+}
+
+function buildErrorMessage(message: string, node: ts.Node): string {
+    const source = node.getSourceFile();
+    const sourcePath = source.fileName;
+    const pos = source.getLineAndCharacterOfPosition(node.pos);
+    return `${sourcePath}(${pos.line + 1},${pos.character + 1}): ${message}`;
+}
+
+const tsOptions: ts.CompilerOptions = {
+    allowJs: true
+};
+
+function globPromise(pattern: string, options: IOptions): Promise<string[]> {
+    return new Promise((resolve, reject) => {
+        glob(pattern, options, (err, matches) => {
+            if (err) {
+                reject(err);
+            } else {
+                resolve(matches);
+            }
+        });
+    });
+}
+
+export async function extract(options: ExtractionOptions): Promise<void> {
+    const cwd = path.resolve(process.cwd(), options.root);
+    const files = await globPromise(options.pattern || '**/src/**/*.ts', { cwd });
+    let localization: Localization = {};
+    const errors: string[] = [];
+    for (const file of files) {
+        const filePath = path.resolve(cwd, file);
+        const content = await fs.promises.readFile(filePath, { encoding: 'utf8' });
+        const fileLocalization = await extractFromFile(file, content, errors, options);
+        localization = deepmerge(localization, fileLocalization);
+    }
+    if (errors.length > 0 && options.logs) {
+        await fs.promises.writeFile(options.logs, errors.join(os.EOL));
+    }
+    const output = path.resolve(process.cwd(), options.output);
+    if (options.merge && await fs.pathExists(output)) {
+        const existing = await fs.readJson(output);
+        localization = deepmerge(existing, localization);
+    }
+    await fs.writeJson(options.output, localization, {
+        spaces: 4
+    });
+}
+
+export async function extractFromFile(file: string, content: string, errors?: string[], options?: ExtractionOptions): Promise<Localization> {
+    const serviceHost = new SingleFileServiceHost(tsOptions, file, content);
+    const service = ts.createLanguageService(serviceHost);
+    const sourceFile = service.getProgram()!.getSourceFile(file)!;
+    const localization: Localization = {};
+    const localizationCalls = collect(sourceFile, node => isLocalizeCall(node));
+    for (const call of localizationCalls) {
+        try {
+            const extracted = extractFromLocalizeCall(call);
+            if (!isExcluded(options, extracted[0])) {
+                insert(localization, extracted);
+            }
+        } catch (err) {
+            const tsError = err as Error;
+            errors?.push(tsError.message);
+            console.log(tsError.message);
+        }
+    }
+    const localizedCommands = collect(sourceFile, node => isCommandLocalizeUtility(node));
+    for (const command of localizedCommands) {
+        try {
+            const extracted = extractFromLocalizedCommandCall(command);
+            const label = extracted.label;
+            const category = extracted.category;
+            if (!isExcluded(options, label[0])) {
+                insert(localization, label);
+            }
+            if (category && !isExcluded(options, category[0])) {
+                insert(localization, category);
+            }
+        } catch (err) {
+            const tsError = err as Error;
+            errors?.push(tsError.message);
+            console.log(tsError.message);
+        }
+    }
+    return localization;
+}
+
+function isExcluded(options: ExtractionOptions | undefined, key: string): boolean {
+    return !!options?.exclude && key.startsWith(options.exclude);
+}
+
+function insert(localization: Localization, values: [string, string, ts.Node]): void {
+    const key = values[0];
+    const value = values[1];
+    const node = values[2];
+    const parts = key.split('/');
+    parts.forEach((part, i) => {
+        let entry = localization[part];
+        if (i === parts.length - 1) {
+            if (typeof entry === 'object') {
+                throw new TypeScriptError(`Multiple translation keys already exist at '${key}'`, node);
+            }
+            localization[part] = value;
+        } else {
+            if (typeof entry === 'string') {
+                throw new TypeScriptError(`String entry already exists at '${parts.splice(0, i + 1).join('/')}'`, node);
+            }
+            if (!entry) {
+                entry = {};
+            }
+            localization[part] = entry;
+            localization = entry;
+        }
+    });
+}
+
+function collect(n: ts.Node, fn: (node: ts.Node) => boolean): ts.Node[] {
+    const result: ts.Node[] = [];
+
+    function loop(node: ts.Node): void {
+
+        const stepResult = fn(node);
+
+        if (stepResult) {
+            result.push(node);
+        } else {
+            ts.forEachChild(node, loop);
+        }
+    }
+
+    loop(n);
+    return result;
+}
+
+function isLocalizeCall(node: ts.Node): boolean {
+    if (!ts.isCallExpression(node)) {
+        return false;
+    }
+
+    return node.expression.getText() === 'nls.localize';
+}
+
+function extractFromLocalizeCall(node: ts.Node): [string, string, ts.Node] {
+    if (!ts.isCallExpression(node)) {
+        throw new TypeScriptError('Invalid node type', node);
+    }
+    const args = node.arguments;
+
+    if (args.length < 2) {
+        throw new TypeScriptError('Localize call needs at least 2 arguments', node);
+    }
+
+    const key = extractString(args[0]);
+    const value = extractString(args[1]);
+    return [key, value, args[1]];
+}
+
+function extractFromLocalizedCommandCall(node: ts.Node): { label: [string, string, ts.Node], category?: [string, string, ts.Node] } {
+    if (!ts.isCallExpression(node)) {
+        throw new TypeScriptError('Invalid node type', node);
+    }
+    const args = node.arguments;
+
+    if (args.length < 1) {
+        throw new TypeScriptError('Command localization call needs at least one argument', node);
+    }
+
+    const commandObj = args[0];
+
+    if (!ts.isObjectLiteralExpression(commandObj)) {
+        throw new TypeScriptError('First argument of "toLocalizedCommand" needs to be an object literal', node);
+    }
+
+    const properties = commandObj.properties;
+    const propertyMap = new Map<string, string>();
+    const relevantProps = ['id', 'label', 'category'];
+    let labelNode: ts.Node = node;
+
+    for (const property of properties) {
+        if (!property.name) {
+            continue;
+        }
+        if (!ts.isPropertyAssignment(property)) {
+            throw new TypeScriptError('Only property assignments in "toLocalizedCommand" are allowed', property);
+        }
+        if (!ts.isIdentifier(property.name)) {
+            throw new TypeScriptError('Only identifiers are allowed as property names in "toLocalizedCommand"', property);
+        }
+        const name = property.name.text;
+        if (!relevantProps.includes(property.name.text)) {
+            continue;
+        }
+        if (property.name.text === 'label') {
+            labelNode = property.initializer;
+        }
+
+        const value = extractString(property.initializer);
+        propertyMap.set(name, value);
+    }
+
+    let labelKey = propertyMap.get('id');
+    let categoryKey: string | undefined = undefined;
+    let categoryNode: ts.Node | undefined;
+
+    // We have an explicit label translation key
+    if (args.length > 1) {
+        const labelOverrideKey = extractStringOrUndefined(args[1]);
+        if (labelOverrideKey) {
+            labelKey = labelOverrideKey;
+            labelNode = args[1];
+        }
+    }
+
+    // We have an explicit category translation key
+    if (args.length > 2) {
+        categoryKey = extractStringOrUndefined(args[2]);
+        categoryNode = args[2];
+    }
+
+    if (!labelKey) {
+        throw new TypeScriptError('No label key found', node);
+    }
+
+    if (!propertyMap.get('label')) {
+        throw new TypeScriptError('No default label found', node);
+    }
+
+    let categoryLocalization: [string, string, ts.Node] | undefined = undefined;
+    const categoryLabel = propertyMap.get('category');
+    if (categoryKey && categoryLabel && categoryNode) {
+        categoryLocalization = [categoryKey, categoryLabel, categoryNode];
+    }
+
+    return {
+        label: [labelKey, propertyMap.get('label')!, labelNode],
+        category: categoryLocalization
+    };
+}
+
+function extractStringOrUndefined(node: ts.Expression): string | undefined {
+    if (node.getText() === 'undefined') {
+        return undefined;
+    }
+    return extractString(node);
+}
+
+function extractString(node: ts.Expression): string {
+    if (ts.isIdentifier(node)) {
+        const reference = followReference(node);
+        if (!reference) {
+            throw new TypeScriptError(`Could not resolve reference to '${node.text}'`, node);
+        }
+        node = reference;
+    }
+    if (ts.isTemplateLiteral(node)) {
+        throw new TypeScriptError(
+            "Template literals are not supported for localization. Please use the additional arguments of the 'nls.localize' function to format strings",
+            node
+        );
+    }
+    if (!ts.isStringLiteralLike(node)) {
+        throw new TypeScriptError(`'${node.getText()}' is not a string constant`, node);
+    }
+
+    return unescapeString(node.text);
+}
+
+function followReference(node: ts.Identifier): ts.Expression | undefined {
+    const scope = collectScope(node);
+    const next = scope.get(node.text);
+    if (next && ts.isIdentifier(next)) {
+        return followReference(next);
+    }
+    return next;
+}
+
+function collectScope(node: ts.Node, map: Map<string, ts.Expression> = new Map()): Map<string, ts.Expression> {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const locals = (node as any)['locals'] as Map<string, ts.Symbol>;
+    if (locals) {
+        for (const [key, value] of locals.entries()) {
+            if (!map.has(key)) {
+                const declaration = value.valueDeclaration;
+                if (declaration && ts.isVariableDeclaration(declaration) && declaration.initializer) {
+                    map.set(key, declaration.initializer);
+                }
+            }
+        }
+    }
+    if (node.parent) {
+        collectScope(node.parent, map);
+    }
+    return map;
+}
+
+function isCommandLocalizeUtility(node: ts.Node): boolean {
+    if (!ts.isCallExpression(node)) {
+        return false;
+    }
+
+    return node.expression.getText() === 'Command.toLocalizedCommand';
+}
+
+const unescapeMap: Record<string, string> = {
+    '\'': '\'',
+    '"': '"',
+    '\\': '\\',
+    'n': '\n',
+    'r': '\r',
+    't': '\t',
+    'b': '\b',
+    'f': '\f'
+};
+
+function unescapeString(str: string): string {
+    const result: string[] = [];
+    for (let i = 0; i < str.length; i++) {
+        const ch = str.charAt(i);
+        if (ch === '\\') {
+            if (i + 1 < str.length) {
+                const replace = unescapeMap[str.charAt(i + 1)];
+                if (replace !== undefined) {
+                    result.push(replace);
+                    i++;
+                    continue;
+                }
+            }
+        }
+        result.push(ch);
+    }
+    return result.join('');
+}

--- a/dev-packages/localization-manager/tsconfig.json
+++ b/dev-packages/localization-manager/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "extends": "../../configs/base.tsconfig",
+  "compilerOptions": {
+    "composite": true,
+    "rootDir": "src",
+    "outDir": "lib"
+  },
+  "include": [
+    "src"
+  ],
+  "references": []
+}

--- a/license-check-baseline.json
+++ b/license-check-baseline.json
@@ -3,5 +3,6 @@
   "npm/npmjs/-/jschardet/2.3.0": "Approved for Eclipse Theia: https://dev.eclipse.org/ipzilla/show_bug.cgi?id=22481",
   "npm/npmjs/-/jsdom/11.12.0": "Approved as 'works-with': https://dev.eclipse.org/ipzilla/show_bug.cgi?id=23640https://dev.eclipse.org/ipzilla/show_bug.cgi?id=23640",
   "npm/npmjs/-/jsmin/1.0.1": "Approved as 'works-with': https://dev.eclipse.org/ipzilla/show_bug.cgi?id=23640https://dev.eclipse.org/ipzilla/show_bug.cgi?id=23640",
-  "npm/npmjs/-/seek-bzip/1.0.6": "Approved by CQ: https://dev.eclipse.org/ipzilla/show_bug.cgi?id=17349#c7"
+  "npm/npmjs/-/seek-bzip/1.0.6": "Approved by CQ: https://dev.eclipse.org/ipzilla/show_bug.cgi?id=17349#c7",
+  "npm/npmjs/-/typescript/4.4.3": "Approved manually: https://github.com/eclipse-theia/theia/pull/10247"
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -19,6 +19,9 @@
       "path": "dev-packages/eslint-plugin"
     },
     {
+      "path": "dev-packages/localization-manager"
+    },
+    {
       "path": "dev-packages/ovsx-client"
     },
     {

--- a/yarn.lock
+++ b/yarn.lock
@@ -6054,7 +6054,7 @@ glob@7.1.3:
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
-glob@^7.0.0, glob@^7.1.1, glob@^7.1.2, glob@^7.1.3, glob@^7.1.4, glob@^7.1.6, glob@^7.1.7:
+glob@^7.0.0, glob@^7.1.1, glob@^7.1.2, glob@^7.1.3, glob@^7.1.4, glob@^7.1.6, glob@^7.1.7, glob@^7.2.0:
   version "7.2.0"
   resolved "https://registry.npmjs.org/glob/-/glob-7.2.0.tgz#d15535af7732e02e948f4c41628bd910293f6023"
   integrity sha512-lmLf6gtyrPq8tTjSmrO94wBeQbFR3HbLHbuyD69wuyQkImp2hWqMGB47OX65FBkPffO641IP9jWa1z4ivqG26Q==
@@ -11527,6 +11527,11 @@ typescript@^3.9.2:
   version "3.9.10"
   resolved "https://registry.npmjs.org/typescript/-/typescript-3.9.10.tgz#70f3910ac7a51ed6bef79da7800690b19bf778b8"
   integrity sha512-w6fIxVE/H1PkLKcCPsFqKE7Kv7QUwhU8qQY2MueZXWx5cPZdwFupLgKK3vntcK98BtNHZtAF4LA/yl2a7k8R6Q==
+
+typescript@^4.4.3:
+  version "4.4.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.4.3.tgz#bdc5407caa2b109efd4f82fe130656f977a29324"
+  integrity sha512-4xfscpisVgqqDfPaJo5vkd+Qd/ItkoagnHpufr+i2QCHBsNYp+G7UAoyFl8aPtx879u38wPV65rZ8qbGZijalA==
 
 uc.micro@^1.0.1, uc.micro@^1.0.5:
   version "1.0.6"


### PR DESCRIPTION
#### What it does

Adds an additional CLI command to the Theia-CLI that allows users to extract their localization keys and default values into a json file. This file can later be used to create translations for Theia using different services (e.g. the default mechanism proposed in #10187).

#### How to test

1. Create a dummy TypeScript file like this:
```ts
import { nls } from '@theia/core/lib/browser/nls';
import { Command } from '@theia/core/lib/common';

const v1 = nls.localize('key1', 'value1');
const v2 = nls.localize('nested/key', 'value2');

const categoryKey = 'category-key';
const command = Command.toLocalizedCommand({
	id: 'id',
	label: 'command-label',
        category: 'category'
}, 'nested/command', categoryKey); // The CLI is able to resolve local references to constants
```
2. Call the extract command on it using the following CLI call (tune the glob pattern accordingly to your setup):
```bash
yarn theia extract -p "**/*.ts" -o out.json
```
3. Assert that all keys/default values have been correctly extracted from the input file.
4. Try this with different command parameters
5. Create an error by modifying the dummy file:
```ts
const test = { key: 'key' }; 
const v1 = nls.localize(test.key, 'value1');
```
6. Assert that the cli finishes successfully and that any errors are printed into the console along with the source information (file path, line, character)

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
