### PR TITLE
debug: prevent the app from closing with an active debug session present

### DIFF
--- a/packages/debug/src/browser/debug-frontend-application-contribution.ts
+++ b/packages/debug/src/browser/debug-frontend-application-contribution.ts
@@ -478,6 +478,10 @@ export class DebugFrontendApplicationContribution extends AbstractViewContributi
         this.watchManager.save();
     }
 
+    onWillStop(): boolean {
+        return this.preference['debug.confirmOnExit'] === 'always' && !!this.manager.currentSession;
+    }
+
     registerMenus(menus: MenuModelRegistry): void {
         super.registerMenus(menus);
         const registerMenuActions = (menuPath: string[], ...commands: Command[]) => {
@@ -1125,8 +1129,8 @@ export class DebugFrontendApplicationContribution extends AbstractViewContributi
     protected async openSession(
         session: DebugSession,
         options?: {
-            debugViewLocation?: DebugViewLocation
-            reveal?: boolean
+            debugViewLocation?: DebugViewLocation;
+            reveal?: boolean;
         }
     ): Promise<DebugWidget | DebugSessionWidget> {
         const { debugViewLocation, reveal } = {

--- a/packages/debug/src/browser/debug-preferences.ts
+++ b/packages/debug/src/browser/debug-preferences.ts
@@ -49,6 +49,16 @@ export const debugPreferencesSchema: PreferenceSchema = {
             enum: ['never', 'always', 'onFirstSessionStart'],
             description: 'Controls when the debug status bar should be visible.',
             default: 'onFirstSessionStart'
+        },
+        'debug.confirmOnExit': {
+            description: 'Controls whether to confirm when the window closes if there are active debug sessions.',
+            type: 'string',
+            enum: ['never', 'always'],
+            enumDescriptions: [
+                'Never confirm.',
+                'Always confirm if there are debug sessions.',
+            ],
+            default: 'never'
         }
     }
 };
@@ -60,6 +70,7 @@ export class DebugConfiguration {
     'debug.internalConsoleOptions': 'neverOpen' | 'openOnSessionStart' | 'openOnFirstSessionStart';
     'debug.inlineValues': boolean;
     'debug.showInStatusBar': 'never' | 'always' | 'onFirstSessionStart';
+    'debug.confirmOnExit': 'never' | 'always';
 }
 
 export const DebugPreferenceContribution = Symbol('DebugPreferenceContribution');


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

Fixes: #10269 

The pull-request implements the `debug.confirmOnExit` preference which is used to prevent the application from closing when there is an active debug session present. The feature will help guard against accidentally closing the application.

<img width="1678" alt="Screen Shot 2021-10-13 at 2 23 32 PM" src="https://user-images.githubusercontent.com/40359487/137192821-619c9336-e04c-4f08-be5e-9d4caa6c76c2.png">


#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

1. start the application using `theia` as a workspace
2. open a `*.spec.ts` file (ex: `cli.spec.ts`)
3. set a breakpoint
4. start the debug session with `run mocha tests` as a configuration - hit the breakpoint

The following should happen for the different use-cases:

| # | Application Preference | Debug Preference | Behavior |
|:---:|:---|:---|:---|
| 1 | `always` | `always` | The prompt should **always** appear on application exit | 
| 2 | `always` | `never` | The prompt should **always** appear on application exit | 
| 3 | `never` | `always` | The prompt should **never** appear on application exit | 
| 4 | `never` | `never` | The prompt should **never** appear on application exit | 
| 5 | `ifRequired` | `always` | The prompt should appear with an active debug session present |
| 6 | `ifRequired` | `never` | The prompt should not appear for an active debug session present | 

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

Signed-off-by: vince-fugnitto <vincent.fugnitto@ericsson.com>
