### PR TITLE
problems: add additional tabbar support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@
 
 - [plugin] added support for `DocumentSymbolProviderMetadata` [#10811](https://github.com/eclipse-theia/theia/pull/10811) - Contributed on behalf of STMicroelectronics
 
+<a name="breaking_changes_1.24.0">[Breaking Changes:](#breaking_changes_1.24.0)</a>
+
+- [markers] `getOverlayIconColor` renamed to `getSeverityColor` [#10273](https://github.com/eclipse-theia/theia/pull/10273)
+- [markers] removed method `getOverlayIcon` - marker decorations now use `tailDecorations` instead [#10273](https://github.com/eclipse-theia/theia/pull/10273)
+
 ## v1.23.0 - 2/24/2022
 
 [1.23.0 Milestone](https://github.com/eclipse-theia/theia/milestone/31)

--- a/packages/markers/src/browser/problem/problem-tabbar-decorator.ts
+++ b/packages/markers/src/browser/problem/problem-tabbar-decorator.ts
@@ -72,7 +72,7 @@ export class ProblemTabBarDecorator implements TabBarDecorator {
                     }
                 }
                 // Decorate the tabbar with the highest marker severity if available.
-                return maxSeverity ? [this.toDecorator(maxSeverity)] : [];
+                return maxSeverity ? [this.toDecorator(maxSeverity, markers.length)] : [];
             }
         }
         return [];
@@ -102,44 +102,25 @@ export class ProblemTabBarDecorator implements TabBarDecorator {
      * @param {Marker<Diagnostic>} marker A diagnostic marker.
      * @returns {WidgetDecoration.Data} The decoration data.
      */
-    protected toDecorator(marker: Marker<Diagnostic>): WidgetDecoration.Data {
-        const position = WidgetDecoration.IconOverlayPosition.BOTTOM_RIGHT;
-        const icon = this.getOverlayIcon(marker);
-        const color = this.getOverlayIconColor(marker);
+    protected toDecorator(marker: Marker<Diagnostic>, count: number): WidgetDecoration.Data {
+        const color = this.getSeverityColor(marker);
         return {
-            iconOverlay: {
-                position,
-                icon,
-                color,
-                background: {
-                    shape: 'circle',
-                    color: 'transparent'
-                }
-            }
+            priority: 1000,
+            fontData: {
+                color
+            },
+            tailDecorations: [{
+                data: count >= 10 ? '9+' : count.toFixed(0)
+            }]
         };
     }
 
     /**
-     * Get the appropriate overlay icon for decoration.
-     * @param {Marker<Diagnostic>} marker A diagnostic marker.
-     * @returns {string} A string representing the overlay icon class.
-     */
-    protected getOverlayIcon(marker: Marker<Diagnostic>): string {
-        const { severity } = marker.data;
-        switch (severity) {
-            case 1: return 'times-circle';
-            case 2: return 'exclamation-circle';
-            case 3: return 'info-circle';
-            default: return 'hand-o-up';
-        }
-    }
-
-    /**
-     * Get the appropriate overlay icon color for decoration.
+     * Get the appropriate severity color for the decoration.
      * @param {Marker<Diagnostic>} marker A diagnostic marker.
      * @returns {WidgetDecoration.Color} The decoration color.
      */
-    protected getOverlayIconColor(marker: Marker<Diagnostic>): WidgetDecoration.Color {
+    protected getSeverityColor(marker: Marker<Diagnostic>): WidgetDecoration.Color {
         const { severity } = marker.data;
         switch (severity) {
             case 1: return 'var(--theia-editorError-foreground)';


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

The pull-request adds support for additional decoration types when rendering tabbars (`fontData` and `tailDecorations`).

The changes also include the addition of improved tab decorations for editors based on problem markers:
- editor tabs are colored based on problem-marker severity
- the number of markers for a given editor tab is displayed
- the `iconOverlay` is removed in favor of `tailDecorations` similarly to vscode

![image](https://user-images.githubusercontent.com/40359487/156207629-db0ca4b1-a04b-46d9-8e05-2aff6f4d77dc.png)

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

1. start the application, and open a few editors
2. confirm that when problem markers exist the tabs are correctly styled, and the number of markers is reflected
3. confirm that fixing the markers (or reverting) resets the decorations

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

Signed-off-by: vince-fugnitto <vincent.fugnitto@ericsson.com>

