### PR TITLE
typedoc: fix docs for `@theia/plugin`

### DIFF
--- a/configs/typedoc.json
+++ b/configs/typedoc.json
@@ -2,7 +2,6 @@
   "emit": false,
   "exclude": [
     "+(dev-packages|examples|typings|scripts)",
-    "packages/plugin/src/theia-proposed.d.ts",
     "packages/*/lib",
     "**/node_modules",
     "**/*spec.ts"

--- a/packages/plugin/src/theia-proposed.d.ts
+++ b/packages/plugin/src/theia-proposed.d.ts
@@ -20,7 +20,7 @@
  * This is the place for API experiments and proposals.
  * These API are NOT stable and subject to change. Use it on own risk.
  */
-declare module '@theia/plugin' {
+export module '@theia/plugin' {
     // #region auth provider
 
     /**

--- a/packages/plugin/src/theia.d.ts
+++ b/packages/plugin/src/theia.d.ts
@@ -25,7 +25,7 @@ import './theia-proposed';
 /* eslint-disable @typescript-eslint/no-explicit-any */
 /* eslint-disable max-len */
 
-declare module '@theia/plugin' {
+export module '@theia/plugin' {
 
     /**
      * The version of the Theia API.
@@ -11034,4 +11034,3 @@ declare module '@theia/plugin' {
         export const onDidChangeSessions: Event<AuthenticationSessionsChangeEvent>;
     }
 }
-


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

Fixes: https://github.com/eclipse-theia/theia/issues/10227

The pull-request fixes the generated typedoc documentation for the `@theia/plugin` extension including `theia.d.ts` and `theia-proposed.d.ts` following a [breaking change](https://github.com/TypeStrong/typedoc/releases/tag/v0.20.0) in typedoc regarding `modules`:

> Version 0.20 completely reworks how documentation is generated by TypeDoc. In previous versions, there was --mode file and --mode modules, which documented files according to their content on the filesystem. This worked reasonably well before ES modules were commonly used, but was insufficient for the modern ecosystem. In 0.20, TypeDoc documents your project according to what you export.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

1, confirm that plugins still work correctly 
2. confirm that typings for `theia.d.ts` and `theia-proposed.d.ts` works correctly
3. performing a `yarn docs` should now generate the typedoc correctly for `@theia/plugins` (both `theia.d.ts` and `theia-proposed.d.ts` combined) - note `export NODE_OPTIONS=--max-old-space-size=8196` may be necessary:

![image](https://user-images.githubusercontent.com/40359487/137387412-be17b254-5af4-45fa-a142-0bc18820cd43.png)



#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

Signed-off-by: vince-fugnitto <vincent.fugnitto@ericsson.com>