### PR TITLE
Implement revert file command

### DIFF
--- a/packages/editor/src/browser/editor-command.ts
+++ b/packages/editor/src/browser/editor-command.ts
@@ -69,6 +69,11 @@ export namespace EditorCommands {
         category: EDITOR_CATEGORY,
         label: 'Change File Encoding'
     };
+    export const REVERT_EDITOR: Command = {
+        id: 'workbench.action.files.revert',
+        category: 'File',
+        label: 'Revert File',
+    };
     export const REVERT_AND_CLOSE: Command = {
         id: 'workbench.action.revertAndCloseActiveEditor',
         category: 'View',
@@ -234,6 +239,7 @@ export class EditorCommandContribution implements CommandContribution {
         registry.registerCommand(EditorCommands.CONFIG_EOL);
         registry.registerCommand(EditorCommands.INDENT_USING_SPACES);
         registry.registerCommand(EditorCommands.INDENT_USING_TABS);
+        registry.registerCommand(EditorCommands.REVERT_EDITOR);
         registry.registerCommand(EditorCommands.REVERT_AND_CLOSE);
         registry.registerCommand(EditorCommands.CHANGE_LANGUAGE, {
             isEnabled: () => this.canConfigureLanguage(),

--- a/packages/editor/src/browser/editor-menu.ts
+++ b/packages/editor/src/browser/editor-menu.ts
@@ -105,7 +105,7 @@ export class EditorMenuContribution implements MenuContribution {
         registry.registerMenuAction(CommonMenus.FILE_CLOSE, {
             commandId: CommonCommands.CLOSE_MAIN_TAB.id,
             label: 'Close Editor',
-            order: '0'
+            order: '1'
         });
     }
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

VSCode has a command to revert the open file. We recently added one to revert and close, so this borrows that logic to implement just reverting.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
1. Open a file in an editor and dirty it.
2. Open the command palette and execute 'File: Revert File'.
3. Your changes should be reverted and the editor should show as not dirty.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

Signed-off-by: Colin Grant <colin.grant@ericsson.com>