### PR TITLE
Increased visibility of selected item in peek

### DIFF
--- a/packages/monaco/src/browser/style/index.css
+++ b/packages/monaco/src/browser/style/index.css
@@ -236,3 +236,10 @@
 .monaco-editor .monaco-action-bar .action-item.active {
 	transform: none;
 }
+
+.monaco-editor .peekview-widget .monaco-list-row.focused.selected .label-name,
+.monaco-editor .peekview-widget .monaco-list-row.focused.selected .label-description,
+.monaco-editor .peekview-widget .monaco-list-row.focused.selected .monaco-highlighted-label,
+.monaco-editor .peekview-widget .monaco-list-row.focused.selected .codicon {
+  color: var(--theia-list-activeSelectionForeground) !important;
+}


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
Text color of selected items from the list when peeking have been changed to white to increase their visibility and look with the rest of the document.

_before_:

https://user-images.githubusercontent.com/40359487/138140855-5022b225-a1d9-41b1-b9c7-5dcf967eec05.mp4

_after_:

https://user-images.githubusercontent.com/40359487/138140746-84e252d3-06c0-47c0-86f1-32217b8ce135.mp4

#### How to test

1. start the example browser or electron application
2. open any `.ts` file, right click on an item and select `Peek` > `Peek References`
3. confirm the styling works well for selected/focused nodes for different UI themes (especially light themes)

<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

#### Review checklist

- [X] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
