### PR TITLE
incorrect preference value for editor.renderWhitespace fixed typo

### DIFF
--- a/packages/editor/src/browser/editor-preferences.ts
+++ b/packages/editor/src/browser/editor-preferences.ts
@@ -1022,7 +1022,7 @@ const codeEditorPreferenceProperties = {
             'none',
             'boundary',
             'selection',
-            'trailin',
+            'trailing',
             'all'
         ],
         'default': 'none'


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
Fixes #10316 by changing the typo in `editor.renderWhitespace` from `trailin` to `trailing`
<!-- Include relevant issues and describe how they are addressed. -->

#### How to test
Test steps are similar to #10316 issue.
1. start the application
2. set the preference for editor.renderWhitespace to trailing
3. trailing whitespaces are visible
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

Signed-off-by: Yash Soni <yash.soni2737@gmail.com>