### PR TITLE
Simplify localization for vscode related strings

### DIFF
--- a/packages/bulk-edit/src/browser/bulk-edit-contribution.ts
+++ b/packages/bulk-edit/src/browser/bulk-edit-contribution.ts
@@ -63,13 +63,13 @@ export class BulkEditContribution extends AbstractViewContribution<BulkEditTreeW
         toolbarRegistry.registerItem({
             id: BulkEditCommands.APPLY.id,
             command: BulkEditCommands.APPLY.id,
-            tooltip: nls.localize('vscode/bulkEdit.contribution/apply', 'Apply Refactoring'),
+            tooltip: nls.localizeByDefault('Apply Refactoring'),
             priority: 0,
         });
         toolbarRegistry.registerItem({
             id: BulkEditCommands.DISCARD.id,
             command: BulkEditCommands.DISCARD.id,
-            tooltip: nls.localize('vscode/bulkEdit.contribution/Discard', 'Discard Refactoring'),
+            tooltip: nls.localizeByDefault('Discard Refactoring'),
             priority: 1,
         });
     }

--- a/packages/bulk-edit/src/browser/bulk-edit-tree/bulk-edit-tree-widget.tsx
+++ b/packages/bulk-edit/src/browser/bulk-edit-tree/bulk-edit-tree-widget.tsx
@@ -30,7 +30,7 @@ import { Disposable } from '@theia/core/lib/common/disposable';
 import { nls } from '@theia/core/lib/common/nls';
 
 export const BULK_EDIT_TREE_WIDGET_ID = 'bulkedit';
-export const BULK_EDIT_WIDGET_NAME = nls.localize('vscode/bulkEdit.contribution/panel', 'Refactor Preview');
+export const BULK_EDIT_WIDGET_NAME = nls.localizeByDefault('Refactor Preview');
 
 @injectable()
 export class BulkEditTreeWidget extends TreeWidget {
@@ -95,7 +95,7 @@ export class BulkEditTreeWidget extends TreeWidget {
         if (CompositeTreeNode.is(model.root) && model.root.children.length > 0) {
             return super.renderTree(model);
         }
-        return <div className='theia-widget-noInfo noEdits'>{nls.localize('vscode/bulkEditService/nothing', 'No edits have been detected in the workspace so far.')}</div>;
+        return <div className='theia-widget-noInfo noEdits'>{nls.localizeByDefault('No edits have been detected in the workspace so far.')}</div>;
     }
 
     protected renderCaption(node: TreeNode, props: NodeProps): React.ReactNode {

--- a/packages/console/src/browser/console-contribution.ts
+++ b/packages/console/src/browser/console-contribution.ts
@@ -102,12 +102,12 @@ export class ConsoleContribution implements FrontendApplicationContribution, Com
         });
         menus.registerMenuAction(ConsoleContextMenu.CLIPBOARD, {
             commandId: ConsoleCommands.COLLAPSE_ALL.id,
-            label: nls.localize('vscode/repl/collapse', 'Collapse All'),
+            label: nls.localizeByDefault('Collapse All'),
             order: 'a3'
         });
         menus.registerMenuAction(ConsoleContextMenu.CLEAR, {
             commandId: ConsoleCommands.CLEAR.id,
-            label: nls.localize('vscode/repl/clearRepl', 'Clear Console')
+            label: nls.localizeByDefault('Clear Console')
         });
     }
 

--- a/packages/core/src/browser/common-frontend-contribution.ts
+++ b/packages/core/src/browser/common-frontend-contribution.ts
@@ -90,67 +90,67 @@ export namespace CommonMenus {
 
 export namespace CommonCommands {
 
-    export const FILE_CATEGORY_KEY = 'vscode/menubarControl/mFile';
-    export const VIEW_CATEGORY_KEY = 'vscode/menubarControl/mView';
-    export const PREFERENCES_CATEGORY_KEY = 'vscode/actions/preferences';
     export const FILE_CATEGORY = 'File';
     export const VIEW_CATEGORY = 'View';
     export const PREFERENCES_CATEGORY = 'Preferences';
+    export const FILE_CATEGORY_KEY = nls.getDefaultKey(FILE_CATEGORY);
+    export const VIEW_CATEGORY_KEY = nls.getDefaultKey(VIEW_CATEGORY);
+    export const PREFERENCES_CATEGORY_KEY = nls.getDefaultKey(PREFERENCES_CATEGORY);
 
     export const OPEN: Command = {
         id: 'core.open',
     };
 
-    export const CUT = Command.toLocalizedCommand({
+    export const CUT = Command.toDefaultLocalizedCommand({
         id: 'core.cut',
         label: 'Cut'
-    }, 'vscode/fileActions.contribution/cut');
-    export const COPY = Command.toLocalizedCommand({
+    });
+    export const COPY = Command.toDefaultLocalizedCommand({
         id: 'core.copy',
         label: 'Copy'
-    }, 'vscode/fileActions/copyFile');
-    export const PASTE = Command.toLocalizedCommand({
+    });
+    export const PASTE = Command.toDefaultLocalizedCommand({
         id: 'core.paste',
         label: 'Paste'
-    }, 'vscode/fileActions/pasteFile');
+    });
 
-    export const COPY_PATH = Command.toLocalizedCommand({
+    export const COPY_PATH = Command.toDefaultLocalizedCommand({
         id: 'core.copy.path',
         label: 'Copy Path'
-    }, 'vscode/fileActions.contribution/copyPath');
+    });
 
-    export const UNDO = Command.toLocalizedCommand({
+    export const UNDO = Command.toDefaultLocalizedCommand({
         id: 'core.undo',
         label: 'Undo'
-    }, 'vscode/textInputActions/undo');
-    export const REDO = Command.toLocalizedCommand({
+    });
+    export const REDO = Command.toDefaultLocalizedCommand({
         id: 'core.redo',
         label: 'Redo'
-    }, 'vscode/textInputActions/redo');
-    export const SELECT_ALL = Command.toLocalizedCommand({
+    });
+    export const SELECT_ALL = Command.toDefaultLocalizedCommand({
         id: 'core.selectAll',
         label: 'Select All'
-    }, 'vscode/textInputActions/selectAll');
+    });
 
-    export const FIND = Command.toLocalizedCommand({
+    export const FIND = Command.toDefaultLocalizedCommand({
         id: 'core.find',
         label: 'Find'
-    }, 'vscode/simpleFindReplaceWidget/label.find');
-    export const REPLACE = Command.toLocalizedCommand({
+    });
+    export const REPLACE = Command.toDefaultLocalizedCommand({
         id: 'core.replace',
         label: 'Replace'
-    }, 'vscode/simpleFindReplaceWidget/label.replace');
+    });
 
-    export const NEXT_TAB = Command.toLocalizedCommand({
+    export const NEXT_TAB = Command.toDefaultLocalizedCommand({
         id: 'core.nextTab',
         category: VIEW_CATEGORY,
-        label: 'Switch to Next Tab'
-    }, 'vscode/menubar/mShowNextTab', VIEW_CATEGORY_KEY);
-    export const PREVIOUS_TAB = Command.toLocalizedCommand({
+        label: 'Show Next Tab'
+    });
+    export const PREVIOUS_TAB = Command.toDefaultLocalizedCommand({
         id: 'core.previousTab',
         category: VIEW_CATEGORY,
-        label: 'Switch to Previous Tab'
-    }, 'vscode/menubar/mShowPreviousTab', VIEW_CATEGORY_KEY);
+        label: 'Show Previous Tab'
+    });
     export const NEXT_TAB_IN_GROUP = Command.toLocalizedCommand({
         id: 'core.nextTabInGroup',
         category: VIEW_CATEGORY,
@@ -221,70 +221,70 @@ export namespace CommonCommands {
         category: VIEW_CATEGORY,
         label: 'Toggle Bottom Panel'
     }, 'theia/core/common/collapseBottomPanel', VIEW_CATEGORY_KEY);
-    export const TOGGLE_STATUS_BAR = Command.toLocalizedCommand({
+    export const TOGGLE_STATUS_BAR = Command.toDefaultLocalizedCommand({
         id: 'workbench.action.toggleStatusbarVisibility',
         category: VIEW_CATEGORY,
         label: 'Toggle Status Bar Visibility'
-    }, 'vscode/layoutActions/toggleStatusbar');
+    });
     export const TOGGLE_MAXIMIZED = Command.toLocalizedCommand({
         id: 'core.toggleMaximized',
         category: VIEW_CATEGORY,
         label: 'Toggle Maximized'
     }, 'theia/core/common/toggleMaximized', VIEW_CATEGORY_KEY);
-    export const OPEN_VIEW = Command.toLocalizedCommand({
+    export const OPEN_VIEW = Command.toDefaultLocalizedCommand({
         id: 'core.openView',
         category: VIEW_CATEGORY,
         label: 'Open View...'
-    }, 'vscode/quickAccess.contribution/miOpenView', VIEW_CATEGORY_KEY);
+    });
 
-    export const SAVE = Command.toLocalizedCommand({
+    export const SAVE = Command.toDefaultLocalizedCommand({
         id: 'core.save',
         category: FILE_CATEGORY,
         label: 'Save',
-    }, 'vscode/fileCommands/save', FILE_CATEGORY_KEY);
-    export const SAVE_WITHOUT_FORMATTING = Command.toLocalizedCommand({
+    });
+    export const SAVE_WITHOUT_FORMATTING = Command.toDefaultLocalizedCommand({
         id: 'core.saveWithoutFormatting',
         category: FILE_CATEGORY,
         label: 'Save without Formatting',
-    }, 'vscode/fileCommands/saveWithoutFormatting', FILE_CATEGORY_KEY);
-    export const SAVE_ALL = Command.toLocalizedCommand({
+    });
+    export const SAVE_ALL = Command.toDefaultLocalizedCommand({
         id: 'core.saveAll',
         category: FILE_CATEGORY,
         label: 'Save All',
-    }, 'vscode/fileCommands/saveAll', FILE_CATEGORY_KEY);
+    });
 
-    export const AUTO_SAVE = Command.toLocalizedCommand({
+    export const AUTO_SAVE = Command.toDefaultLocalizedCommand({
         id: 'textEditor.commands.autosave',
         category: FILE_CATEGORY,
         label: 'Auto Save',
-    }, 'vscode/fileActions.contribution/miAutoSave', FILE_CATEGORY_KEY);
+    });
 
-    export const ABOUT_COMMAND = Command.toLocalizedCommand({
+    export const ABOUT_COMMAND = Command.toDefaultLocalizedCommand({
         id: 'core.about',
         label: 'About'
-    }, 'vscode/windowActions/about');
+    });
 
-    export const OPEN_PREFERENCES = Command.toLocalizedCommand({
+    export const OPEN_PREFERENCES = Command.toDefaultLocalizedCommand({
         id: 'preferences:open',
         category: PREFERENCES_CATEGORY,
-        label: 'Open Preferences',
-    }, 'vscode/preferences.contribution/preferences', PREFERENCES_CATEGORY_KEY);
+        label: 'Open Settings (UI)',
+    });
 
-    export const SELECT_COLOR_THEME = Command.toLocalizedCommand({
+    export const SELECT_COLOR_THEME = Command.toDefaultLocalizedCommand({
         id: 'workbench.action.selectTheme',
         label: 'Color Theme',
         category: PREFERENCES_CATEGORY
-    }, 'vscode/themes.contribution/selectTheme.label', PREFERENCES_CATEGORY_KEY);
-    export const SELECT_ICON_THEME = Command.toLocalizedCommand({
+    });
+    export const SELECT_ICON_THEME = Command.toDefaultLocalizedCommand({
         id: 'workbench.action.selectIconTheme',
         label: 'File Icon Theme',
         category: PREFERENCES_CATEGORY
-    }, 'vscode/themes.contribution/selectIconTheme.label', PREFERENCES_CATEGORY_KEY);
+    });
 
-    export const CONFIGURE_DISPLAY_LANGUAGE = Command.toLocalizedCommand({
+    export const CONFIGURE_DISPLAY_LANGUAGE = Command.toDefaultLocalizedCommand({
         id: 'workbench.action.configureLanguage',
         label: 'Configure Display Language'
-    }, 'vscode/localizationsActions/configureLocale');
+    });
 
 }
 
@@ -374,14 +374,14 @@ export class CommonFrontendContribution implements FrontendApplicationContributi
         app.shell.leftPanelHandler.addBottomMenu({
             id: 'settings-menu',
             iconClass: 'codicon codicon-settings-gear',
-            title: nls.localize(CommonCommands.PREFERENCES_CATEGORY_KEY, CommonCommands.PREFERENCES_CATEGORY),
+            title: nls.localizeByDefault(CommonCommands.PREFERENCES_CATEGORY),
             menuPath: SETTINGS_MENU,
             order: 0,
         });
         const accountsMenu = {
             id: 'accounts-menu',
             iconClass: 'codicon codicon-person',
-            title: nls.localize('vscode/activitybarPart/accounts', 'Accounts'),
+            title: nls.localizeByDefault('Accounts'),
             menuPath: ACCOUNTS_MENU,
             order: 1,
         };
@@ -446,7 +446,7 @@ export class CommonFrontendContribution implements FrontendApplicationContributi
                     this.shell.leftPanelHandler.addTopMenu({
                         id: mainMenuId,
                         iconClass: 'codicon codicon-menu',
-                        title: nls.localize('vscode/menubar/mAppMenu', 'Application Menu'),
+                        title: nls.localizeByDefault('Application Menu'),
                         menuPath: ['menubar'],
                         order: 0,
                     });
@@ -479,10 +479,10 @@ export class CommonFrontendContribution implements FrontendApplicationContributi
     }
 
     registerMenus(registry: MenuModelRegistry): void {
-        registry.registerSubmenu(CommonMenus.FILE, nls.localize('vscode/menubarControl/mFile', 'File'));
-        registry.registerSubmenu(CommonMenus.EDIT, nls.localize('vscode/menubarControl/mEdit', 'Edit'));
-        registry.registerSubmenu(CommonMenus.VIEW, nls.localize('vscode/menubarControl/mView', 'View'));
-        registry.registerSubmenu(CommonMenus.HELP, nls.localize('vscode/menubarControl/mHelp', 'Help'));
+        registry.registerSubmenu(CommonMenus.FILE, nls.localizeByDefault('File'));
+        registry.registerSubmenu(CommonMenus.EDIT, nls.localizeByDefault('Edit'));
+        registry.registerSubmenu(CommonMenus.VIEW, nls.localizeByDefault('View'));
+        registry.registerSubmenu(CommonMenus.HELP, nls.localizeByDefault('Help'));
 
         registry.registerMenuAction(CommonMenus.FILE_SAVE, {
             commandId: CommonCommands.SAVE.id
@@ -495,7 +495,7 @@ export class CommonFrontendContribution implements FrontendApplicationContributi
             commandId: CommonCommands.AUTO_SAVE.id
         });
 
-        registry.registerSubmenu(CommonMenus.FILE_SETTINGS_SUBMENU, nls.localize(CommonCommands.PREFERENCES_CATEGORY_KEY, CommonCommands.PREFERENCES_CATEGORY));
+        registry.registerSubmenu(CommonMenus.FILE_SETTINGS_SUBMENU, nls.localizeByDefault(CommonCommands.PREFERENCES_CATEGORY));
 
         registry.registerMenuAction(CommonMenus.EDIT_UNDO, {
             commandId: CommonCommands.UNDO.id,
@@ -548,22 +548,22 @@ export class CommonFrontendContribution implements FrontendApplicationContributi
 
         registry.registerMenuAction(SHELL_TABBAR_CONTEXT_MENU, {
             commandId: CommonCommands.CLOSE_TAB.id,
-            label: nls.localize('vscode/editor.contribution/close', 'Close'),
+            label: nls.localizeByDefault('Close'),
             order: '0'
         });
         registry.registerMenuAction(SHELL_TABBAR_CONTEXT_MENU, {
             commandId: CommonCommands.CLOSE_OTHER_TABS.id,
-            label: nls.localize('vscode/editor.contribution/closeOthers', 'Close Others'),
+            label: nls.localizeByDefault('Close Others'),
             order: '1'
         });
         registry.registerMenuAction(SHELL_TABBAR_CONTEXT_MENU, {
             commandId: CommonCommands.CLOSE_RIGHT_TABS.id,
-            label: nls.localize('vscode/editor.contribution/closeRight', 'Close to the Right'),
+            label: nls.localizeByDefault('Close to the Right'),
             order: '2'
         });
         registry.registerMenuAction(SHELL_TABBAR_CONTEXT_MENU, {
             commandId: CommonCommands.CLOSE_ALL_TABS.id,
-            label: nls.localize('vscode/editor.contribution/closeAll', 'Close All'),
+            label: nls.localizeByDefault('Close All'),
             order: '3'
         });
         registry.registerMenuAction(SHELL_TABBAR_CONTEXT_MENU, {
@@ -1076,7 +1076,7 @@ export class CommonFrontendContribution implements FrontendApplicationContributi
 
         this.quickInputService?.showQuickPick(items,
             {
-                placeholder: nls.localize('vscode/extensionsActions/select file icon theme', 'Select File Icon Theme'),
+                placeholder: nls.localizeByDefault('Select File Icon Theme'),
                 activeItem: items.find(item => item.id === resetTo),
                 onDidChangeSelection: (quickPick: QuickPick<QuickPickItem>, selectedItems: Array<QuickPickItem>) => {
                     resetTo = undefined;
@@ -1115,7 +1115,7 @@ export class CommonFrontendContribution implements FrontendApplicationContributi
         const items = [...itemsByTheme.light, ...itemsByTheme.dark, ...itemsByTheme.hc];
         this.quickInputService?.showQuickPick(items,
             {
-                placeholder: nls.localize('vscode/extensionActions/select color theme', 'Select Color Theme (Up/Down Keys to Preview)'),
+                placeholder: nls.localizeByDefault('Select Color Theme (Up/Down Keys to Preview)'),
                 activeItem: items.find((item: QuickPickItem) => item.id === resetTo),
                 // eslint-disable-next-line @typescript-eslint/no-explicit-any
                 onDidChangeSelection: (quickPick: any, selectedItems: Array<QuickPickItem>) => {

--- a/packages/core/src/browser/core-preferences.ts
+++ b/packages/core/src/browser/core-preferences.ts
@@ -32,19 +32,20 @@ export const corePreferenceSchema: PreferenceSchema = {
                 'always',
             ],
             default: 'ifRequired',
-            description: nls.localize('vscode/workbench.contribution/confirmBeforeCloseWeb', 'When to confirm before closing the application window.'),
+            // eslint-disable-next-line max-len
+            description: nls.localizeByDefault('Controls whether to show a confirmation dialog before closing the browser tab or window. Note that even if enabled, browsers may still decide to close a tab or window without confirmation and that this setting is only a hint that may not work in all cases.'),
         },
         'breadcrumbs.enabled': {
             'type': 'boolean',
             'default': true,
-            'description': nls.localize('vscode/breadcrumbs/enabled', 'Enable/disable navigation breadcrumbs.'),
+            'description': nls.localizeByDefault('Enable/disable navigation breadcrumbs.'),
             'scope': 'application'
         },
         'files.encoding': {
             'type': 'string',
             'enum': Object.keys(SUPPORTED_ENCODINGS),
             'default': 'utf8',
-            'description': nls.localize('vscode/files.contribution/encoding',
+            'description': nls.localizeByDefault(
                 'The default character set encoding to use when reading and writing files. This setting can also be configured per language.'),
             'scope': 'language-overridable',
             'enumDescriptions': Object.keys(SUPPORTED_ENCODINGS).map(key => SUPPORTED_ENCODINGS[key].labelLong),
@@ -57,22 +58,22 @@ export const corePreferenceSchema: PreferenceSchema = {
                 'keyCode',
             ],
             default: 'code',
-            description: nls.localize('vscode/keybindingService/dispatch',
-                'Whether to interpret keypresses by the `code` of the physical key, or by the `keyCode` provided by the OS.')
+            description: nls.localizeByDefault(
+                'Controls the dispatching logic for key presses to use either `code` (recommended) or `keyCode`.')
         },
         'window.menuBarVisibility': {
             type: 'string',
             enum: ['classic', 'visible', 'hidden', 'compact'],
             markdownEnumDescriptions: [
-                nls.localize('vscode/workbench.contribution/window.menuBarVisibility.default', 'Menu is displayed at the top of the window and only hidden in full screen mode.'),
-                nls.localize('vscode/workbench.contribution/window.menuBarVisibility.visible', 'Menu is always visible at the top of the window even in full screen mode.'),
-                nls.localize('vscode/workbench.contribution/window.menuBarVisibility.hidden', 'Menu is always hidden.'),
-                nls.localize('vscode/workbench.contribution/window.menuBarVisibility.compact', 'Menu is displayed as a compact button in the sidebar.')
+                nls.localizeByDefault('Menu is only hidden in full screen mode.'),
+                nls.localizeByDefault('Menu is always visible even in full screen mode.'),
+                nls.localizeByDefault('Menu is always hidden.'),
+                nls.localizeByDefault('Menu is displayed as a compact button in the sidebar. This value is ignored when `#window.titleBarStyle#` is `native`.')
             ],
             default: 'classic',
             scope: 'application',
-            markdownDescription: nls.localize('vscode/workbench.contribution/menuBarVisibility', `Control the visibility of the menu bar.
-            A setting of 'compact' will move the menu into the sidebar.`),
+            // eslint-disable-next-line max-len
+            markdownDescription: nls.localizeByDefault("Control the visibility of the menu bar. A setting of 'toggle' means that the menu bar is hidden and a single press of the Alt key will show it. By default, the menu bar will be visible, unless the window is full screen."),
             included: !isOSX
         },
         'workbench.list.openMode': {
@@ -82,17 +83,19 @@ export const corePreferenceSchema: PreferenceSchema = {
                 'doubleClick'
             ],
             default: 'singleClick',
-            description: nls.localize('vscode/listService/openModeModifier', 'Controls how to open items in trees using the mouse.')
+            // eslint-disable-next-line max-len
+            description: nls.localizeByDefault('Controls how to open items in trees and lists using the mouse (if supported). For parents with children in trees, this setting will control if a single click expands the parent or a double click. Note that some trees and lists might choose to ignore this setting if it is not applicable. ')
         },
         'workbench.editor.highlightModifiedTabs': {
             'type': 'boolean',
-            'description': nls.localize('vscode/workbench.contribution/highlightModifiedTabs', 'Controls whether a top border is drawn on modified (dirty) editor tabs or not.'),
+            // eslint-disable-next-line max-len
+            'description': nls.localizeByDefault('Controls whether a top border is drawn on modified (dirty) editor tabs or not. This value is ignored when `#workbench.editor.showTabs#` is disabled.'),
             'default': false
         },
         'workbench.editor.closeOnFileDelete': {
             'type': 'boolean',
             // eslint-disable-next-line max-len
-            'description': nls.localize('vscode/workbench.contribution/closeOnFileDelete', 'Controls whether editors showing a file that was opened during the session should close automatically when getting deleted or renamed by some other process. Disabling this will keep the editor open  on such an event. Note that deleting from within the application will always close the editor and that dirty files will never close to preserve your data.'),
+            'description': nls.localizeByDefault('Controls whether editors showing a file that was opened during the session should close automatically when getting deleted or renamed by some other process. Disabling this will keep the editor open  on such an event. Note that deleting from within the application will always close the editor and that dirty files will never close to preserve your data.'),
             'default': false
         },
         'workbench.commandPalette.history': {
@@ -100,38 +103,38 @@ export const corePreferenceSchema: PreferenceSchema = {
             default: 50,
             minimum: 0,
             // eslint-disable-next-line max-len
-            description: nls.localize('vscode/workbench.contribution/commandHistory', 'Controls the number of recently used commands to keep in history for the command palette. Set to 0 to disable command history.')
+            description: nls.localizeByDefault('Controls the number of recently used commands to keep in history for the command palette. Set to 0 to disable command history.')
         },
         'workbench.colorTheme': {
             type: 'string',
             default: FrontendApplicationConfigProvider.get().defaultTheme,
-            description: nls.localize('vscode/themeConfiguration/colorTheme', 'Specifies the color theme used in the workbench.')
+            description: nls.localizeByDefault('Specifies the color theme used in the workbench.')
         },
         'workbench.iconTheme': {
             type: ['string', 'null'],
             default: FrontendApplicationConfigProvider.get().defaultIconTheme,
-            description: nls.localize('vscode/themeConfiguration/iconTheme', "Specifies the icon theme used in the workbench or 'null' to not show any file icons.")
+            description: nls.localizeByDefault("Specifies the file icon theme used in the workbench or 'null' to not show any file icons.")
         },
         'workbench.silentNotifications': {
             type: 'boolean',
             default: false,
-            description: nls.localize('vscode/workbench.contribution/zenMode.silentNotifications', 'Controls whether to suppress notification popups.')
+            description: nls.localize('theia/core/silentNotifications', 'Controls whether to suppress notification popups.')
         },
         'workbench.statusBar.visible': {
             type: 'boolean',
             default: true,
-            description: 'Controls the visibility of the status bar at the bottom of the workbench.'
+            description: nls.localizeByDefault('Controls the visibility of the status bar at the bottom of the workbench.')
         },
         'workbench.tree.renderIndentGuides': {
             type: 'string',
             enum: ['onHover', 'none', 'always'],
             default: 'onHover',
-            description: nls.localize('vscode/listService/render tree indent guides', 'Controls whether the tree should render indent guides.')
+            description: nls.localizeByDefault('Controls whether the tree should render indent guides.')
         },
         'workbench.hover.delay': {
             type: 'number',
             default: isOSX ? 1500 : 500,
-            description: 'Controls the delay in milliseconds after which the hover is shown for workbench items (ex. some extension provided tree view items).'
+            description: nls.localizeByDefault('Controls the delay in milliseconds after which the hover is shown.')
         },
     }
 };

--- a/packages/core/src/browser/dialogs.ts
+++ b/packages/core/src/browser/dialogs.ts
@@ -67,10 +67,10 @@ export namespace DialogError {
 }
 
 export namespace Dialog {
-    export const YES = nls.localize('vscode/extensionsUtils/yes', 'Yes');
-    export const NO = nls.localize('vscode/extensionsUtils/no', 'No');
-    export const OK = nls.localize('vscode/dialog/ok', 'OK');
-    export const CANCEL = nls.localize('vscode/explorerViewer/cancel', 'Cancel');
+    export const YES = nls.localizeByDefault('Yes');
+    export const NO = nls.localizeByDefault('No');
+    export const OK = nls.localizeByDefault('OK');
+    export const CANCEL = nls.localizeByDefault('Cancel');
 }
 
 @injectable()

--- a/packages/core/src/browser/keyboard/browser-keyboard-frontend-contribution.ts
+++ b/packages/core/src/browser/keyboard/browser-keyboard-frontend-contribution.ts
@@ -23,8 +23,8 @@ import { nls } from '../../common/nls';
 
 export namespace KeyboardCommands {
 
-    const KEYBOARD_CATEGORY_KEY = 'vscode/settingsLayout/keyboard';
     const KEYBOARD_CATEGORY = 'Keyboard';
+    const KEYBOARD_CATEGORY_KEY = nls.getDefaultKey(KEYBOARD_CATEGORY);
 
     export const CHOOSE_KEYBOARD_LAYOUT = Command.toLocalizedCommand({
         id: 'core.keyboard.choose',
@@ -52,7 +52,7 @@ export class BrowserKeyboardFrontendContribution implements CommandContribution 
     protected async chooseLayout(): Promise<KeyboardLayoutData | undefined> {
         const current = this.layoutProvider.currentLayoutData;
         const autodetect: QuickPickValue<'autodetect'> = {
-            label: nls.localize('vscode/editorStatus/autoDetect', 'Auto-detect'),
+            label: nls.localizeByDefault('Auto-detect'),
             description: this.layoutProvider.currentLayoutSource !== 'user-choice' ? nls.localize('theia/core/keyboard/current', '(current: {0})', current.name) : undefined,
             detail: nls.localize('theia/core/keyboard/tryDetect', 'Try to detect the keyboard layout from browser information and pressed keys.'),
             value: 'autodetect'

--- a/packages/core/src/browser/quick-input/quick-command-frontend-contribution.ts
+++ b/packages/core/src/browser/quick-input/quick-command-frontend-contribution.ts
@@ -43,7 +43,7 @@ export class QuickCommandFrontendContribution implements CommandContribution, Ke
     registerMenus(menus: MenuModelRegistry): void {
         menus.registerMenuAction(CommonMenus.VIEW_PRIMARY, {
             commandId: quickCommand.id,
-            label: nls.localize('vscode/quickAccess.contribution/commandsQuickAccess', 'Find Command...')
+            label: nls.localizeByDefault('Command Palette...')
         });
     }
 

--- a/packages/core/src/browser/quick-input/quick-command-service.ts
+++ b/packages/core/src/browser/quick-input/quick-command-service.ts
@@ -28,10 +28,10 @@ export const quickCommand: Command = {
     id: 'workbench.action.showCommands'
 };
 
-export const CLEAR_COMMAND_HISTORY = Command.toLocalizedCommand({
+export const CLEAR_COMMAND_HISTORY = Command.toDefaultLocalizedCommand({
     id: 'clear.command.history',
     label: 'Clear Command History'
-}, 'vscode/commandsQuickAccess/clearCommandHistory');
+});
 
 @injectable()
 export class QuickCommandService implements QuickAccessContribution, QuickAccessProvider {

--- a/packages/core/src/browser/shell/tab-bar-toolbar.tsx
+++ b/packages/core/src/browser/shell/tab-bar-toolbar.tsx
@@ -405,7 +405,7 @@ export class TabBarToolbar extends ReactWidget {
     protected renderMore(): React.ReactNode {
         return !!this.more.size && <div key='__more__' className={TabBarToolbar.Styles.TAB_BAR_TOOLBAR_ITEM + ' enabled'}>
             <div id='__more__' className={codicon('ellipsis', true)} onClick={this.showMoreContextMenu}
-                title={nls.localize('vscode/compositePart/viewsAndMoreActions', 'More Actions...')} />
+                title={nls.localizeByDefault('More Actions...')} />
         </div>;
     }
 

--- a/packages/core/src/browser/window-contribution.ts
+++ b/packages/core/src/browser/window-contribution.ts
@@ -23,10 +23,10 @@ import { CommonMenus } from '../browser/common-frontend-contribution';
 
 export namespace WindowCommands {
 
-    export const NEW_WINDOW = Command.toLocalizedCommand({
+    export const NEW_WINDOW = Command.toDefaultLocalizedCommand({
         id: 'workbench.action.newWindow',
         label: 'New Window'
-    }, 'vscode/windowActions/newWindow');
+    });
 }
 
 @injectable()

--- a/packages/core/src/common/command.ts
+++ b/packages/core/src/common/command.ts
@@ -64,6 +64,16 @@ export namespace Command {
         };
     }
 
+    export function toDefaultLocalizedCommand(command: Command): Command {
+        return {
+            ...command,
+            label: command.label && nls.localizeByDefault(command.label),
+            originalLabel: command.label,
+            category: command.category && nls.localizeByDefault(command.category),
+            originalCategory: command.category,
+        };
+    }
+
     /** Comparator function for when sorting commands */
     export function compareCommands(a: Command, b: Command): number {
         if (a.label && b.label) {

--- a/packages/core/src/common/i18n/localization.ts
+++ b/packages/core/src/common/i18n/localization.ts
@@ -36,7 +36,7 @@ export type FormatType = string | number | boolean | undefined;
 
 export namespace Localization {
 
-    function format(message: string, args: FormatType[]): string {
+    export function format(message: string, args: FormatType[]): string {
         let result = message;
         if (args.length > 0) {
             result = message.replace(/\{(\d+)\}/g, (match, rest) => {

--- a/packages/core/src/common/i18n/localization.ts
+++ b/packages/core/src/common/i18n/localization.ts
@@ -59,11 +59,21 @@ export namespace Localization {
         if (localization) {
             const translation = localization.translations[key];
             if (translation) {
-                // vscode's localizations often contain additional '&&' symbols, which we simply ignore
-                value = translation.replace(/&&/g, '');
+                value = normalize(translation);
             }
         }
         return format(value, args);
+    }
+
+    /**
+     * This function normalizes values from VSCode's localizations, which often contain additional mnemonics (`&&`).
+     * The normalization removes the mnemonics from the input string.
+     *
+     * @param value Localization value coming from VSCode
+     * @returns A normalized localized value
+     */
+    export function normalize(value: string): string {
+        return value.replace(/&&/g, '');
     }
 
     export function transformKey(key: string): string {

--- a/packages/core/src/common/i18n/nls.metadata.json
+++ b/packages/core/src/common/i18n/nls.metadata.json
@@ -1,0 +1,20421 @@
+{
+	"keys": {
+		"vs/code/electron-main/main": [
+			"secondInstanceAdmin",
+			"secondInstanceAdminDetail",
+			"secondInstanceNoResponse",
+			"secondInstanceNoResponseDetail",
+			"startupDataDirError",
+			"startupUserDataAndExtensionsDirErrorDetail",
+			{
+				"key": "close",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			}
+		],
+		"vs/code/electron-sandbox/issue/issueReporterMain": [
+			"hide",
+			"show",
+			"createOnGitHub",
+			"previewOnGitHub",
+			"loadingData",
+			"rateLimited",
+			"similarIssues",
+			"open",
+			"closed",
+			"open",
+			"closed",
+			"noSimilarIssues",
+			"bugReporter",
+			"featureRequest",
+			"performanceIssue",
+			"selectSource",
+			"vscode",
+			"extension",
+			"selectSource",
+			"vscode",
+			"extension",
+			"unknown",
+			"stepsToReproduce",
+			"bugDescription",
+			"stepsToReproduce",
+			"performanceIssueDesciption",
+			"description",
+			"featureRequestDescription",
+			"pasteData",
+			"disabledExtensions",
+			"noCurrentExperiments"
+		],
+		"vs/code/electron-sandbox/processExplorer/processExplorerMain": [
+			"name",
+			"cpu",
+			"pid",
+			"memory",
+			"killProcess",
+			"forceKillProcess",
+			"copy",
+			"copyAll",
+			"debug"
+		],
+		"vs/workbench/services/integrity/node/integrityService": [
+			"integrity.prompt",
+			"integrity.moreInformation",
+			"integrity.dontShowAgain"
+		],
+		"vs/workbench/services/textfile/electron-browser/nativeTextFileService": [
+			"fileReadOnlyError"
+		],
+		"vs/workbench/services/extensionManagement/electron-browser/extensionManagementServerService": [
+			"local",
+			"remote"
+		],
+		"vs/workbench/services/extensions/electron-browser/extensionService": [
+			"extensionService.versionMismatchCrash",
+			"relaunch",
+			"extensionService.crash",
+			"devTools",
+			"restart",
+			"getEnvironmentFailure",
+			"looping",
+			"enableResolver",
+			"enable",
+			"installResolver",
+			"install",
+			"resolverExtensionNotFound",
+			"restartExtensionHost"
+		],
+		"vs/workbench/contrib/extensions/electron-browser/extensions.contribution": [
+			"runtimeExtension"
+		],
+		"vs/workbench/contrib/externalTerminal/node/externalTerminal.contribution": [
+			"globalConsoleAction",
+			"terminalConfigurationTitle",
+			"terminal.explorerKind.integrated",
+			"terminal.explorerKind.external",
+			"explorer.openInTerminalKind",
+			"terminal.external.windowsExec",
+			"terminal.external.osxExec",
+			"terminal.external.linuxExec"
+		],
+		"vs/workbench/contrib/cli/node/cli.contribution": [
+			"shellCommand",
+			"install",
+			"not available",
+			"ok",
+			"cancel2",
+			"warnEscalation",
+			"cantCreateBinFolder",
+			"aborted",
+			"successIn",
+			"uninstall",
+			"not available",
+			"ok",
+			"cancel2",
+			"warnEscalationUninstall",
+			"cantUninstall",
+			"aborted",
+			"successFrom"
+		],
+		"vs/workbench/contrib/tasks/electron-browser/taskService": [
+			"TaskSystem.runningTask",
+			{
+				"key": "TaskSystem.terminateTask",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			"TaskSystem.noProcess",
+			{
+				"key": "TaskSystem.exitAnyways",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			}
+		],
+		"vs/workbench/contrib/userDataSync/electron-browser/userDataSync.contribution": [
+			"operationId",
+			{
+				"key": "too many requests",
+				"comment": [
+					"Settings Sync is the name of the feature"
+				]
+			},
+			"settings sync",
+			"show sync logs",
+			"report issue",
+			"Open Backup folder",
+			"no backups"
+		],
+		"vs/platform/environment/node/argvHelper": [
+			"unknownOption",
+			"multipleValues",
+			"gotoValidation"
+		],
+		"vs/platform/request/common/request": [
+			"httpConfigurationTitle",
+			"proxy",
+			"strictSSL",
+			"proxyAuthorization",
+			"proxySupportOff",
+			"proxySupportOn",
+			"proxySupportOverride",
+			"proxySupport",
+			"systemCertificates"
+		],
+		"vs/code/electron-main/app": [
+			"trace.message",
+			"trace.detail",
+			"trace.ok",
+			{
+				"key": "open",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			{
+				"key": "cancel",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			"confirmOpenMessage",
+			"confirmOpenDetail"
+		],
+		"vs/platform/files/node/diskFileSystemProvider": [
+			"fileExists",
+			"fileNotExists",
+			"moveError",
+			"copyError",
+			"fileCopyErrorPathCase",
+			"fileCopyErrorExists"
+		],
+		"vs/platform/files/common/fileService": [
+			"invalidPath",
+			"noProviderFound",
+			"fileNotFoundError",
+			"fileExists",
+			"err.write",
+			"fileIsDirectoryWriteError",
+			"fileModifiedError",
+			"err.read",
+			"err.read",
+			"err.read",
+			"fileIsDirectoryReadError",
+			"fileNotModifiedError",
+			"fileTooLargeError",
+			"unableToMoveCopyError1",
+			"unableToMoveCopyError2",
+			"unableToMoveCopyError3",
+			"unableToMoveCopyError4",
+			"mkdirExistsError",
+			"deleteFailedTrashUnsupported",
+			"deleteFailedNotFound",
+			"deleteFailedNonEmptyFolder",
+			"err.readonly"
+		],
+		"vs/platform/files/common/files": [
+			"unknownError",
+			"sizeB",
+			"sizeKB",
+			"sizeMB",
+			"sizeGB",
+			"sizeTB"
+		],
+		"vs/base/common/errorMessage": [
+			"stackTrace.format",
+			"nodeExceptionMessage",
+			"error.defaultMessage",
+			"error.defaultMessage",
+			"error.moreErrors",
+			"error.defaultMessage"
+		],
+		"vs/platform/update/common/update.config.contribution": [
+			"updateConfigurationTitle",
+			"updateMode",
+			"none",
+			"manual",
+			"start",
+			"default",
+			"updateMode",
+			"deprecated",
+			"enableWindowsBackgroundUpdatesTitle",
+			"enableWindowsBackgroundUpdates",
+			"showReleaseNotes"
+		],
+		"vs/platform/environment/node/argv": [
+			"optionsUpperCase",
+			"extensionsManagement",
+			"troubleshooting",
+			"diff",
+			"add",
+			"goto",
+			"newWindow",
+			"reuseWindow",
+			"wait",
+			"locale",
+			"userDataDir",
+			"help",
+			"extensionHomePath",
+			"listExtensions",
+			"showVersions",
+			"category",
+			"installExtension",
+			"uninstallExtension",
+			"experimentalApis",
+			"version",
+			"verbose",
+			"log",
+			"status",
+			"prof-startup",
+			"disableExtensions",
+			"disableExtension",
+			"turn sync",
+			"inspect-extensions",
+			"inspect-brk-extensions",
+			"disableGPU",
+			"maxMemory",
+			"telemetry",
+			"usage",
+			"options",
+			"paths",
+			"stdinWindows",
+			"stdinUnix",
+			"unknownVersion",
+			"unknownCommit"
+		],
+		"vs/platform/extensionManagement/common/extensionManagement": [
+			"extensions",
+			"preferences"
+		],
+		"vs/platform/extensionManagement/node/extensionManagementService": [
+			"incompatible",
+			"restartCode",
+			"restartCode",
+			"MarketPlaceDisabled",
+			"malicious extension",
+			"notFoundCompatibleDependency",
+			"MarketPlaceDisabled",
+			"Not a Marketplace extension",
+			"removeError",
+			"quitCode",
+			"exitCode",
+			"notInstalled",
+			"singleDependentError",
+			"twoDependentsError",
+			"multipleDependentsError",
+			"singleIndirectDependentError",
+			"twoIndirectDependentsError",
+			"multipleIndirectDependentsError",
+			"notExists"
+		],
+		"vs/platform/telemetry/common/telemetryService": [
+			"telemetryConfigurationTitle",
+			"telemetry.enableTelemetry",
+			"telemetry.enableTelemetryMd"
+		],
+		"vs/platform/extensionManagement/common/extensionManagementCLIService": [
+			"notFound",
+			"useId",
+			"listFromLocation",
+			"installingExtensionsOnLocation",
+			"installingExtensions",
+			"alreadyInstalled-checkAndUpdate",
+			"alreadyInstalled",
+			"installation failed",
+			"successVsixInstall",
+			"cancelVsixInstall",
+			"alreadyInstalled",
+			"updateMessage",
+			"installing builtin ",
+			"installing",
+			"successInstall",
+			"cancelInstall",
+			"forceDowngrade",
+			"builtin",
+			"forceUninstall",
+			"uninstalling",
+			"successUninstallFromLocation",
+			"successUninstall",
+			"notInstalleddOnLocation",
+			"notInstalled"
+		],
+		"vs/code/electron-sandbox/issue/issueReporterPage": [
+			"completeInEnglish",
+			"issueTypeLabel",
+			"issueSourceLabel",
+			"issueSourceEmptyValidation",
+			"disableExtensionsLabelText",
+			"disableExtensions",
+			"chooseExtension",
+			"extensionWithNonstandardBugsUrl",
+			"extensionWithNoBugsUrl",
+			"issueTitleLabel",
+			"issueTitleRequired",
+			"titleEmptyValidation",
+			"titleLengthValidation",
+			"details",
+			"descriptionEmptyValidation",
+			{
+				"key": "sendSystemInfo",
+				"comment": [
+					"{0} is either \"show\" or \"hide\" and is a button to toggle the visibility of the system information"
+				]
+			},
+			"show",
+			{
+				"key": "sendProcessInfo",
+				"comment": [
+					"{0} is either \"show\" or \"hide\" and is a button to toggle the visibility of the process info"
+				]
+			},
+			"show",
+			{
+				"key": "sendWorkspaceInfo",
+				"comment": [
+					"{0} is either \"show\" or \"hide\" and is a button to toggle the visibility of the workspace information"
+				]
+			},
+			"show",
+			{
+				"key": "sendExtensions",
+				"comment": [
+					"{0} is either \"show\" or \"hide\" and is a button to toggle the visibility of the enabled extensions list"
+				]
+			},
+			"show",
+			{
+				"key": "sendExperiments",
+				"comment": [
+					"{0} is either \"show\" or \"hide\" and is a button to toggle the visibility of the current experiment information"
+				]
+			},
+			"show"
+		],
+		"vs/platform/userDataSync/common/userDataSync": [
+			"settings sync",
+			"settingsSync.keybindingsPerPlatform",
+			"settingsSync.ignoredExtensions",
+			"app.extension.identifier.errorMessage",
+			"settingsSync.ignoredSettings"
+		],
+		"vs/platform/userDataSync/common/userDataSyncMachines": [
+			"error incompatible"
+		],
+		"vs/platform/extensionManagement/electron-sandbox/extensionTipsService": [
+			{
+				"key": "exeRecommended",
+				"comment": [
+					"Placeholder string is the name of the software that is installed."
+				]
+			}
+		],
+		"vs/platform/userDataSync/common/userDataAutoSyncService": [
+			"default service changed",
+			"service changed",
+			"turned off",
+			"default service changed",
+			"service changed",
+			"session expired",
+			"turned off machine"
+		],
+		"vs/workbench/services/lifecycle/electron-sandbox/lifecycleService": [
+			"errorClose",
+			"errorQuit",
+			"errorReload",
+			"errorLoad"
+		],
+		"vs/workbench/services/workspaces/electron-sandbox/workspaceEditingService": [
+			"save",
+			"doNotSave",
+			"cancel",
+			"saveWorkspaceMessage",
+			"saveWorkspaceDetail",
+			"workspaceOpenedMessage",
+			"ok",
+			"workspaceOpenedDetail"
+		],
+		"vs/workbench/contrib/localizations/browser/localizations.contribution": [
+			"updateLocale",
+			"activateLanguagePack",
+			"changeAndRestart",
+			"restart",
+			"neverAgain",
+			"vscode.extension.contributes.localizations",
+			"vscode.extension.contributes.localizations.languageId",
+			"vscode.extension.contributes.localizations.languageName",
+			"vscode.extension.contributes.localizations.languageNameLocalized",
+			"vscode.extension.contributes.localizations.translations",
+			"vscode.extension.contributes.localizations.translations.id",
+			"vscode.extension.contributes.localizations.translations.id.pattern",
+			"vscode.extension.contributes.localizations.translations.path"
+		],
+		"vs/workbench/electron-sandbox/desktop.contribution": [
+			"newTab",
+			"showPreviousTab",
+			"showNextWindowTab",
+			"moveWindowTabToNewWindow",
+			"mergeAllWindowTabs",
+			"toggleWindowTabsBar",
+			{
+				"key": "miCloseWindow",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			{
+				"key": "miExit",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			{
+				"key": "miZoomIn",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			{
+				"key": "miZoomOut",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			{
+				"key": "miZoomReset",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			{
+				"key": "miReportIssue",
+				"comment": [
+					"&& denotes a mnemonic",
+					"Translate this to \"Report Issue in English\" in all languages please!"
+				]
+			},
+			{
+				"key": "miOpenProcessExplorerer",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			"windowConfigurationTitle",
+			"window.openWithoutArgumentsInNewWindow.on",
+			"window.openWithoutArgumentsInNewWindow.off",
+			"openWithoutArgumentsInNewWindow",
+			"window.reopenFolders.preserve",
+			"window.reopenFolders.all",
+			"window.reopenFolders.folders",
+			"window.reopenFolders.one",
+			"window.reopenFolders.none",
+			"restoreWindows",
+			"restoreFullscreen",
+			"zoomLevel",
+			"window.newWindowDimensions.default",
+			"window.newWindowDimensions.inherit",
+			"window.newWindowDimensions.offset",
+			"window.newWindowDimensions.maximized",
+			"window.newWindowDimensions.fullscreen",
+			"newWindowDimensions",
+			"closeWhenEmpty",
+			"window.doubleClickIconToClose",
+			"titleBarStyle",
+			"dialogStyle",
+			"window.nativeTabs",
+			"window.nativeFullScreen",
+			"window.clickThroughInactive",
+			"telemetryConfigurationTitle",
+			"telemetry.enableCrashReporting",
+			"keyboardConfigurationTitle",
+			"touchbar.enabled",
+			"touchbar.ignored",
+			"argv.locale",
+			"argv.disableHardwareAcceleration",
+			"argv.disableColorCorrectRendering",
+			"argv.forceColorProfile",
+			"argv.enableCrashReporter",
+			"argv.crashReporterId",
+			"argv.enebleProposedApi",
+			"argv.force-renderer-accessibility"
+		],
+		"vs/workbench/contrib/files/electron-sandbox/files.contribution": [
+			"textFileEditor"
+		],
+		"vs/workbench/contrib/files/electron-sandbox/fileActions.contribution": [
+			"revealInWindows",
+			"revealInMac",
+			"openContainer",
+			"filesCategory"
+		],
+		"vs/workbench/contrib/issue/electron-sandbox/issue.contribution": [
+			{
+				"key": "reportIssueInEnglish",
+				"comment": [
+					"Translate this to \"Report Issue in English\" in all languages please!"
+				]
+			}
+		],
+		"vs/workbench/contrib/remote/electron-sandbox/remote.contribution": [
+			"remote",
+			"remote.downloadExtensionsLocally"
+		],
+		"vs/workbench/browser/workbench": [
+			"loaderErrorNative"
+		],
+		"vs/workbench/electron-sandbox/window": [
+			"learnMore",
+			"shellEnvSlowWarning",
+			"shellEnvTimeoutError",
+			"proxyAuthRequired",
+			{
+				"key": "loginButton",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			{
+				"key": "cancelButton",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			"username",
+			"password",
+			"proxyDetail",
+			"rememberCredentials",
+			"runningAsRoot",
+			"loaderCycle",
+			"ok"
+		],
+		"vs/platform/workspaces/common/workspaces": [
+			"codeWorkspace"
+		],
+		"vs/workbench/services/remote/electron-sandbox/remoteAgentServiceImpl": [
+			"connectionError"
+		],
+		"vs/platform/files/electron-browser/diskFileSystemProvider": [
+			"binFailed",
+			"trashFailed"
+		],
+		"vs/workbench/services/textfile/browser/textFileService": [
+			"fileBinaryError",
+			"confirmOverwrite",
+			"irreversible",
+			{
+				"key": "replaceButtonLabel",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			}
+		],
+		"vs/platform/dialogs/common/dialogs": [
+			"moreFile",
+			"moreFiles"
+		],
+		"vs/workbench/services/extensionManagement/electron-sandbox/remoteExtensionManagementService": [
+			"incompatible"
+		],
+		"vs/workbench/services/extensions/electron-browser/localProcessExtensionHost": [
+			"extensionHost.startupFailDebug",
+			"extensionHost.startupFail",
+			"reloadWindow",
+			"extension host Log",
+			"extensionHost.error"
+		],
+		"vs/workbench/services/extensions/electron-browser/cachedExtensionScanner": [
+			"overwritingExtension",
+			"overwritingExtension",
+			"extensionUnderDevelopment",
+			"extensionCache.invalid",
+			"reloadWindow"
+		],
+		"vs/workbench/services/extensions/common/abstractExtensionService": [
+			"looping"
+		],
+		"vs/workbench/services/extensions/common/remoteExtensionHost": [
+			"remote extension host Log"
+		],
+		"vs/workbench/services/extensions/browser/webWorkerExtensionHost": [
+			"name"
+		],
+		"vs/workbench/common/actions": [
+			"view",
+			"help",
+			"preferences",
+			{
+				"key": "developer",
+				"comment": [
+					"A developer on Code itself or someone diagnosing issues in Code"
+				]
+			}
+		],
+		"vs/base/common/date": [
+			"date.fromNow.in",
+			"date.fromNow.now",
+			"date.fromNow.seconds.singular.ago",
+			"date.fromNow.seconds.plural.ago",
+			"date.fromNow.seconds.singular",
+			"date.fromNow.seconds.plural",
+			"date.fromNow.minutes.singular.ago",
+			"date.fromNow.minutes.plural.ago",
+			"date.fromNow.minutes.singular",
+			"date.fromNow.minutes.plural",
+			"date.fromNow.hours.singular.ago",
+			"date.fromNow.hours.plural.ago",
+			"date.fromNow.hours.singular",
+			"date.fromNow.hours.plural",
+			"date.fromNow.days.singular.ago",
+			"date.fromNow.days.plural.ago",
+			"date.fromNow.days.singular",
+			"date.fromNow.days.plural",
+			"date.fromNow.weeks.singular.ago",
+			"date.fromNow.weeks.plural.ago",
+			"date.fromNow.weeks.singular",
+			"date.fromNow.weeks.plural",
+			"date.fromNow.months.singular.ago",
+			"date.fromNow.months.plural.ago",
+			"date.fromNow.months.singular",
+			"date.fromNow.months.plural",
+			"date.fromNow.years.singular.ago",
+			"date.fromNow.years.plural.ago",
+			"date.fromNow.years.singular",
+			"date.fromNow.years.plural"
+		],
+		"vs/platform/theme/common/colorRegistry": [
+			"foreground",
+			"errorForeground",
+			"descriptionForeground",
+			"iconForeground",
+			"focusBorder",
+			"contrastBorder",
+			"activeContrastBorder",
+			"selectionBackground",
+			"textSeparatorForeground",
+			"textLinkForeground",
+			"textLinkActiveForeground",
+			"textPreformatForeground",
+			"textBlockQuoteBackground",
+			"textBlockQuoteBorder",
+			"textCodeBlockBackground",
+			"widgetShadow",
+			"inputBoxBackground",
+			"inputBoxForeground",
+			"inputBoxBorder",
+			"inputBoxActiveOptionBorder",
+			"inputOption.activeBackground",
+			"inputOption.activeForeground",
+			"inputPlaceholderForeground",
+			"inputValidationInfoBackground",
+			"inputValidationInfoForeground",
+			"inputValidationInfoBorder",
+			"inputValidationWarningBackground",
+			"inputValidationWarningForeground",
+			"inputValidationWarningBorder",
+			"inputValidationErrorBackground",
+			"inputValidationErrorForeground",
+			"inputValidationErrorBorder",
+			"dropdownBackground",
+			"dropdownListBackground",
+			"dropdownForeground",
+			"dropdownBorder",
+			"checkbox.background",
+			"checkbox.foreground",
+			"checkbox.border",
+			"buttonForeground",
+			"buttonBackground",
+			"buttonHoverBackground",
+			"buttonSecondaryForeground",
+			"buttonSecondaryBackground",
+			"buttonSecondaryHoverBackground",
+			"badgeBackground",
+			"badgeForeground",
+			"scrollbarShadow",
+			"scrollbarSliderBackground",
+			"scrollbarSliderHoverBackground",
+			"scrollbarSliderActiveBackground",
+			"progressBarBackground",
+			"editorError.background",
+			"editorError.foreground",
+			"errorBorder",
+			"editorWarning.background",
+			"editorWarning.foreground",
+			"warningBorder",
+			"editorInfo.background",
+			"editorInfo.foreground",
+			"infoBorder",
+			"editorHint.foreground",
+			"hintBorder",
+			"sashActiveBorder",
+			"editorBackground",
+			"editorForeground",
+			"editorWidgetBackground",
+			"editorWidgetForeground",
+			"editorWidgetBorder",
+			"editorWidgetResizeBorder",
+			"pickerBackground",
+			"pickerForeground",
+			"pickerTitleBackground",
+			"pickerGroupForeground",
+			"pickerGroupBorder",
+			"editorSelectionBackground",
+			"editorSelectionForeground",
+			"editorInactiveSelection",
+			"editorSelectionHighlight",
+			"editorSelectionHighlightBorder",
+			"editorFindMatch",
+			"findMatchHighlight",
+			"findRangeHighlight",
+			"editorFindMatchBorder",
+			"findMatchHighlightBorder",
+			"findRangeHighlightBorder",
+			"searchEditor.queryMatch",
+			"searchEditor.editorFindMatchBorder",
+			"hoverHighlight",
+			"hoverBackground",
+			"hoverForeground",
+			"hoverBorder",
+			"statusBarBackground",
+			"activeLinkForeground",
+			"editorInlineHintForeground",
+			"editorInlineHintBackground",
+			"editorLightBulbForeground",
+			"editorLightBulbAutoFixForeground",
+			"diffEditorInserted",
+			"diffEditorRemoved",
+			"diffEditorInsertedOutline",
+			"diffEditorRemovedOutline",
+			"diffEditorBorder",
+			"diffDiagonalFill",
+			"listFocusBackground",
+			"listFocusForeground",
+			"listActiveSelectionBackground",
+			"listActiveSelectionForeground",
+			"listInactiveSelectionBackground",
+			"listInactiveSelectionForeground",
+			"listInactiveFocusBackground",
+			"listHoverBackground",
+			"listHoverForeground",
+			"listDropBackground",
+			"highlight",
+			"invalidItemForeground",
+			"listErrorForeground",
+			"listWarningForeground",
+			"listFilterWidgetBackground",
+			"listFilterWidgetOutline",
+			"listFilterWidgetNoMatchesOutline",
+			"listFilterMatchHighlight",
+			"listFilterMatchHighlightBorder",
+			"treeIndentGuidesStroke",
+			"listDeemphasizedForeground",
+			"menuBorder",
+			"menuForeground",
+			"menuBackground",
+			"menuSelectionForeground",
+			"menuSelectionBackground",
+			"menuSelectionBorder",
+			"menuSeparatorBackground",
+			"snippetTabstopHighlightBackground",
+			"snippetTabstopHighlightBorder",
+			"snippetFinalTabstopHighlightBackground",
+			"snippetFinalTabstopHighlightBorder",
+			"breadcrumbsFocusForeground",
+			"breadcrumbsBackground",
+			"breadcrumbsFocusForeground",
+			"breadcrumbsSelectedForegound",
+			"breadcrumbsSelectedBackground",
+			"mergeCurrentHeaderBackground",
+			"mergeCurrentContentBackground",
+			"mergeIncomingHeaderBackground",
+			"mergeIncomingContentBackground",
+			"mergeCommonHeaderBackground",
+			"mergeCommonContentBackground",
+			"mergeBorder",
+			"overviewRulerCurrentContentForeground",
+			"overviewRulerIncomingContentForeground",
+			"overviewRulerCommonContentForeground",
+			"overviewRulerFindMatchForeground",
+			"overviewRulerSelectionHighlightForeground",
+			"minimapFindMatchHighlight",
+			"minimapSelectionHighlight",
+			"minimapError",
+			"overviewRuleWarning",
+			"minimapBackground",
+			"minimapSliderBackground",
+			"minimapSliderHoverBackground",
+			"minimapSliderActiveBackground",
+			"problemsErrorIconForeground",
+			"problemsWarningIconForeground",
+			"problemsInfoIconForeground",
+			"chartsForeground",
+			"chartsLines",
+			"chartsRed",
+			"chartsBlue",
+			"chartsYellow",
+			"chartsOrange",
+			"chartsGreen",
+			"chartsPurple"
+		],
+		"vs/workbench/common/theme": [
+			"tabActiveBackground",
+			"tabUnfocusedActiveBackground",
+			"tabInactiveBackground",
+			"tabUnfocusedInactiveBackground",
+			"tabActiveForeground",
+			"tabInactiveForeground",
+			"tabUnfocusedActiveForeground",
+			"tabUnfocusedInactiveForeground",
+			"tabHoverBackground",
+			"tabUnfocusedHoverBackground",
+			"tabHoverForeground",
+			"tabUnfocusedHoverForeground",
+			"tabBorder",
+			"lastPinnedTabBorder",
+			"tabActiveBorder",
+			"tabActiveUnfocusedBorder",
+			"tabActiveBorderTop",
+			"tabActiveUnfocusedBorderTop",
+			"tabHoverBorder",
+			"tabUnfocusedHoverBorder",
+			"tabActiveModifiedBorder",
+			"tabInactiveModifiedBorder",
+			"unfocusedActiveModifiedBorder",
+			"unfocusedINactiveModifiedBorder",
+			"editorPaneBackground",
+			"editorGroupBackground",
+			"deprecatedEditorGroupBackground",
+			"editorGroupEmptyBackground",
+			"editorGroupFocusedEmptyBorder",
+			"tabsContainerBackground",
+			"tabsContainerBorder",
+			"editorGroupHeaderBackground",
+			"editorTitleContainerBorder",
+			"editorGroupBorder",
+			"editorDragAndDropBackground",
+			"imagePreviewBorder",
+			"panelBackground",
+			"panelBorder",
+			"panelActiveTitleForeground",
+			"panelInactiveTitleForeground",
+			"panelActiveTitleBorder",
+			"panelInputBorder",
+			"panelDragAndDropBorder",
+			"panelSectionDragAndDropBackground",
+			"panelSectionHeaderBackground",
+			"panelSectionHeaderForeground",
+			"panelSectionHeaderBorder",
+			"panelSectionBorder",
+			"statusBarForeground",
+			"statusBarNoFolderForeground",
+			"statusBarBackground",
+			"statusBarNoFolderBackground",
+			"statusBarBorder",
+			"statusBarNoFolderBorder",
+			"statusBarItemActiveBackground",
+			"statusBarItemHoverBackground",
+			"statusBarProminentItemForeground",
+			"statusBarProminentItemBackground",
+			"statusBarProminentItemHoverBackground",
+			"statusBarErrorItemBackground",
+			"statusBarErrorItemForeground",
+			"activityBarBackground",
+			"activityBarForeground",
+			"activityBarInActiveForeground",
+			"activityBarBorder",
+			"activityBarActiveBorder",
+			"activityBarActiveFocusBorder",
+			"activityBarActiveBackground",
+			"activityBarDragAndDropBorder",
+			"activityBarBadgeBackground",
+			"activityBarBadgeForeground",
+			"statusBarItemHostBackground",
+			"statusBarItemHostForeground",
+			"extensionBadge.remoteBackground",
+			"extensionBadge.remoteForeground",
+			"sideBarBackground",
+			"sideBarForeground",
+			"sideBarBorder",
+			"sideBarTitleForeground",
+			"sideBarDragAndDropBackground",
+			"sideBarSectionHeaderBackground",
+			"sideBarSectionHeaderForeground",
+			"sideBarSectionHeaderBorder",
+			"titleBarActiveForeground",
+			"titleBarInactiveForeground",
+			"titleBarActiveBackground",
+			"titleBarInactiveBackground",
+			"titleBarBorder",
+			"menubarSelectionForeground",
+			"menubarSelectionBackground",
+			"menubarSelectionBorder",
+			"notificationCenterBorder",
+			"notificationToastBorder",
+			"notificationsForeground",
+			"notificationsBackground",
+			"notificationsLink",
+			"notificationCenterHeaderForeground",
+			"notificationCenterHeaderBackground",
+			"notificationsBorder",
+			"notificationsErrorIconForeground",
+			"notificationsWarningIconForeground",
+			"notificationsInfoIconForeground",
+			"windowActiveBorder",
+			"windowInactiveBorder"
+		],
+		"vs/workbench/contrib/debug/common/debug": [
+			"internalConsoleOptions"
+		],
+		"vs/workbench/contrib/webview/electron-browser/webviewCommands": [
+			"openToolsLabel"
+		],
+		"vs/editor/contrib/clipboard/clipboard": [
+			{
+				"key": "miCut",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			"actions.clipboard.cutLabel",
+			"actions.clipboard.cutLabel",
+			{
+				"key": "miCopy",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			"actions.clipboard.copyLabel",
+			"actions.clipboard.copyLabel",
+			{
+				"key": "miPaste",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			"actions.clipboard.pasteLabel",
+			"actions.clipboard.pasteLabel",
+			"actions.clipboard.copyWithSyntaxHighlightingLabel"
+		],
+		"vs/editor/browser/editorExtensions": [
+			{
+				"key": "miUndo",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			"undo",
+			{
+				"key": "miRedo",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			"redo",
+			{
+				"key": "miSelectAll",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			"selectAll"
+		],
+		"vs/workbench/contrib/notebook/browser/contrib/coreActions": [
+			"notebookActions.category",
+			"notebookActions.execute",
+			"notebookActions.execute",
+			"notebookActions.cancel",
+			"notebookActions.cancel",
+			"notebookActions.executeCell",
+			"notebookActions.CancelCell",
+			"notebookActions.deleteCell",
+			"notebookActions.executeAndSelectBelow",
+			"notebookActions.executeAndInsertBelow",
+			"notebookActions.renderMarkdown",
+			"notebookActions.executeNotebook",
+			"notebookActions.executeNotebook",
+			"notebookActions.cancelNotebook",
+			"notebookActions.cancelNotebook",
+			"notebookMenu.insertCell",
+			"notebookMenu.cellTitle",
+			"notebookActions.menu.executeNotebook",
+			"notebookActions.menu.cancelNotebook",
+			"notebookActions.changeCellToCode",
+			"notebookActions.changeCellToMarkdown",
+			"notebookActions.insertCodeCellAbove",
+			"notebookActions.insertCodeCellBelow",
+			"notebookActions.insertCodeCellAtTop",
+			"notebookActions.insertMarkdownCellAtTop",
+			"notebookActions.menu.insertCode",
+			"notebookActions.menu.insertCode.tooltip",
+			"notebookActions.menu.insertCode",
+			"notebookActions.menu.insertCode.tooltip",
+			"notebookActions.insertMarkdownCellAbove",
+			"notebookActions.insertMarkdownCellBelow",
+			"notebookActions.menu.insertMarkdown",
+			"notebookActions.menu.insertMarkdown.tooltip",
+			"notebookActions.menu.insertMarkdown",
+			"notebookActions.menu.insertMarkdown.tooltip",
+			"notebookActions.editCell",
+			"notebookActions.quitEdit",
+			"notebookActions.deleteCell",
+			"notebookActions.moveCellUp",
+			"notebookActions.moveCellDown",
+			"notebookActions.copy",
+			"notebookActions.cut",
+			"notebookActions.paste",
+			"notebookActions.pasteAbove",
+			"notebookActions.copyCellUp",
+			"notebookActions.copyCellDown",
+			"cursorMoveDown",
+			"cursorMoveUp",
+			"focusOutput",
+			"focusOutputOut",
+			"focusFirstCell",
+			"focusLastCell",
+			"clearCellOutputs",
+			"changeLanguage",
+			"languageDescription",
+			"languageDescriptionConfigured",
+			"pickLanguageToConfigure",
+			"clearAllCellsOutputs",
+			"notebookActions.splitCell",
+			"notebookActions.joinCellAbove",
+			"notebookActions.joinCellBelow",
+			"notebookActions.centerActiveCell",
+			"notebookActions.collapseCellInput",
+			"notebookActions.expandCellContent",
+			"notebookActions.collapseCellOutput",
+			"notebookActions.expandCellOutput",
+			"notebookActions.inspectLayout"
+		],
+		"vs/workbench/contrib/extensions/electron-browser/runtimeExtensionsEditor": [
+			"extensionHostProfileStart",
+			"stopExtensionHostProfileStart",
+			"saveExtensionHostProfile"
+		],
+		"vs/workbench/contrib/extensions/electron-browser/debugExtensionHostAction": [
+			"debugExtensionHost",
+			"restart1",
+			"restart2",
+			"restart3",
+			"cancel",
+			"debugExtensionHost.launch.name"
+		],
+		"vs/workbench/common/editor": [
+			"sideBySideLabels",
+			"preview",
+			"pinned"
+		],
+		"vs/workbench/contrib/extensions/electron-browser/extensionProfileService": [
+			"profilingExtensionHost",
+			"profilingExtensionHost",
+			"selectAndStartDebug",
+			"profilingExtensionHostTime",
+			"status.profiler",
+			"restart1",
+			"restart2",
+			"restart3",
+			"cancel"
+		],
+		"vs/workbench/contrib/extensions/common/runtimeExtensionsInput": [
+			"extensionsInputName"
+		],
+		"vs/workbench/contrib/extensions/electron-browser/extensionsAutoProfiler": [
+			"unresponsive-exthost",
+			"show"
+		],
+		"vs/workbench/contrib/extensions/electron-sandbox/extensionsActions": [
+			"openExtensionsFolder"
+		],
+		"vs/platform/configuration/common/configurationRegistry": [
+			"defaultLanguageConfigurationOverrides.title",
+			"defaultLanguageConfiguration.description",
+			"overrideSettings.defaultDescription",
+			"overrideSettings.errorMessage",
+			"config.property.empty",
+			"config.property.languageDefault",
+			"config.property.duplicate"
+		],
+		"vs/workbench/contrib/terminal/common/terminalConfiguration": [
+			"terminalIntegratedConfigurationTitle",
+			"terminal.integrated.sendKeybindingsToShell",
+			{
+				"key": "terminal.integrated.automationShell.linux",
+				"comment": [
+					"{0} and {1} are the `shell` and `shellArgs` settings keys"
+				]
+			},
+			{
+				"key": "terminal.integrated.automationShell.osx",
+				"comment": [
+					"{0} and {1} are the `shell` and `shellArgs` settings keys"
+				]
+			},
+			{
+				"key": "terminal.integrated.automationShell.windows",
+				"comment": [
+					"{0} and {1} are the `shell` and `shellArgs` settings keys"
+				]
+			},
+			"terminal.integrated.shellArgs.linux",
+			"terminal.integrated.shellArgs.osx",
+			"terminal.integrated.shellArgs.windows",
+			"terminal.integrated.shellArgs.windows",
+			"terminal.integrated.shellArgs.windows.string",
+			"terminal.integrated.macOptionIsMeta",
+			"terminal.integrated.macOptionClickForcesSelection",
+			"terminal.integrated.altClickMovesCursor",
+			"terminal.integrated.copyOnSelection",
+			"terminal.integrated.drawBoldTextInBrightColors",
+			"terminal.integrated.fontFamily",
+			"terminal.integrated.fontSize",
+			"terminal.integrated.letterSpacing",
+			"terminal.integrated.lineHeight",
+			"terminal.integrated.minimumContrastRatio",
+			"terminal.integrated.fastScrollSensitivity",
+			"terminal.integrated.mouseWheelScrollSensitivity",
+			"terminal.integrated.fontWeightError",
+			"terminal.integrated.fontWeight",
+			"terminal.integrated.fontWeightError",
+			"terminal.integrated.fontWeightBold",
+			"terminal.integrated.cursorBlinking",
+			"terminal.integrated.cursorStyle",
+			"terminal.integrated.cursorWidth",
+			"terminal.integrated.scrollback",
+			"terminal.integrated.detectLocale",
+			"terminal.integrated.detectLocale.auto",
+			"terminal.integrated.detectLocale.off",
+			"terminal.integrated.detectLocale.on",
+			"terminal.integrated.rendererType.auto",
+			"terminal.integrated.rendererType.canvas",
+			"terminal.integrated.rendererType.dom",
+			"terminal.integrated.rendererType.experimentalWebgl",
+			"terminal.integrated.rendererType",
+			"terminal.integrated.rightClickBehavior.default",
+			"terminal.integrated.rightClickBehavior.copyPaste",
+			"terminal.integrated.rightClickBehavior.paste",
+			"terminal.integrated.rightClickBehavior.selectWord",
+			"terminal.integrated.rightClickBehavior",
+			"terminal.integrated.cwd",
+			"terminal.integrated.confirmOnExit",
+			"terminal.integrated.enableBell",
+			"terminal.integrated.commandsToSkipShell",
+			"terminal.integrated.allowChords",
+			"terminal.integrated.allowMnemonics",
+			"terminal.integrated.inheritEnv",
+			"terminal.integrated.env.osx",
+			"terminal.integrated.env.linux",
+			"terminal.integrated.env.windows",
+			"terminal.integrated.environmentChangesIndicator",
+			"terminal.integrated.environmentChangesIndicator.off",
+			"terminal.integrated.environmentChangesIndicator.on",
+			"terminal.integrated.environmentChangesIndicator.warnonly",
+			"terminal.integrated.showExitAlert",
+			"terminal.integrated.splitCwd",
+			"terminal.integrated.splitCwd.workspaceRoot",
+			"terminal.integrated.splitCwd.initial",
+			"terminal.integrated.splitCwd.inherited",
+			"terminal.integrated.windowsEnableConpty",
+			"terminal.integrated.wordSeparators",
+			"terminal.integrated.experimentalUseTitleEvent",
+			"terminal.integrated.enableFileLinks",
+			"terminal.integrated.unicodeVersion.six",
+			"terminal.integrated.unicodeVersion.eleven",
+			"terminal.integrated.unicodeVersion",
+			"terminal.integrated.experimentalLinkProvider",
+			"terminal.integrated.localEchoLatencyThreshold",
+			"terminal.integrated.localEchoExcludePrograms",
+			"terminal.integrated.localEchoStyle",
+			"terminal.integrated.serverSpawn",
+			"terminal.integrated.enablePersistentSessions",
+			"terminal.integrated.flowControl",
+			"terminalIntegratedConfigurationTitle",
+			"terminal.integrated.shell.linux.noDefault",
+			"terminal.integrated.shell.osx.noDefault",
+			"terminal.integrated.shell.windows.noDefault",
+			"terminal.integrated.shell.linux",
+			"terminal.integrated.shell.osx",
+			"terminal.integrated.shell.windows"
+		],
+		"vs/workbench/contrib/codeEditor/electron-browser/startDebugTextMate": [
+			"startDebugTextMate"
+		],
+		"vs/workbench/contrib/terminal/common/terminal": [
+			"terminalCategory",
+			"vscode.extension.contributes.terminal",
+			"vscode.extension.contributes.terminal.types",
+			"vscode.extension.contributes.terminal.types.command",
+			"vscode.extension.contributes.terminal.types.title"
+		],
+		"vs/workbench/contrib/externalTerminal/node/externalTerminalService": [
+			"console.title",
+			"mac.terminal.script.failed",
+			"mac.terminal.type.not.supported",
+			"press.any.key",
+			"linux.term.failed",
+			"ext.term.app.not.found"
+		],
+		"vs/workbench/contrib/performance/electron-browser/startupProfiler": [
+			"prof.message",
+			"prof.detail",
+			"prof.restartAndFileIssue",
+			"prof.restart",
+			"prof.thanks",
+			"prof.detail.restart",
+			"prof.restart.button"
+		],
+		"vs/workbench/contrib/tasks/common/tasks": [
+			"tasksCategory",
+			"TaskDefinition.missingRequiredProperty"
+		],
+		"vs/workbench/contrib/tasks/common/taskConfiguration": [
+			"ConfigurationParser.invalidCWD",
+			"ConfigurationParser.inValidArg",
+			"ConfigurationParser.noShell",
+			"ConfigurationParser.noName",
+			"ConfigurationParser.unknownMatcherKind",
+			"ConfigurationParser.invalidVariableReference",
+			"ConfigurationParser.noTaskType",
+			"ConfigurationParser.noTypeDefinition",
+			"ConfigurationParser.missingType",
+			"ConfigurationParser.incorrectType",
+			"ConfigurationParser.notCustom",
+			"ConfigurationParser.noTaskName",
+			"taskConfiguration.providerUnavailable",
+			"taskConfiguration.noCommandOrDependsOn",
+			"taskConfiguration.noCommand",
+			{
+				"key": "TaskParse.noOsSpecificGlobalTasks",
+				"comment": [
+					"\"Task version 2.0.0\" refers to the 2.0.0 version of the task system. The \"version 2.0.0\" is not localizable as it is a json key and value."
+				]
+			}
+		],
+		"vs/workbench/contrib/tasks/node/processTaskSystem": [
+			"version1_0",
+			"TaskRunnerSystem.unknownError",
+			"TaskRunnerSystem.watchingBuildTaskFinished",
+			"TaskRunnerSystem.childProcessError",
+			"TaskRunnerSystem.cancelRequested",
+			"unknownProblemMatcher"
+		],
+		"vs/workbench/contrib/tasks/node/processRunnerDetector": [
+			"TaskSystemDetector.noGulpTasks",
+			"TaskSystemDetector.noJakeTasks",
+			"TaskSystemDetector.noGulpProgram",
+			"TaskSystemDetector.noJakeProgram",
+			"TaskSystemDetector.noGruntProgram",
+			"TaskSystemDetector.noProgram",
+			"TaskSystemDetector.buildTaskDetected",
+			"TaskSystemDetector.testTaskDetected"
+		],
+		"vs/platform/markers/common/markers": [
+			"sev.error",
+			"sev.warning",
+			"sev.info"
+		],
+		"vs/workbench/common/views": [
+			"defaultViewIcon",
+			"duplicateId"
+		],
+		"vs/workbench/contrib/tasks/browser/terminalTaskSystem": [
+			"TerminalTaskSystem.unknownError",
+			"dependencyCycle",
+			"dependencyFailed",
+			"TerminalTaskSystem.nonWatchingMatcher",
+			"TerminalTaskSystem.terminalName",
+			"closeTerminal",
+			"reuseTerminal",
+			"TerminalTaskSystem",
+			"unknownProblemMatcher"
+		],
+		"vs/workbench/contrib/tasks/browser/abstractTaskService": [
+			"ConfigureTaskRunnerAction.label",
+			"tasks",
+			"TaskSystem.noHotSwap",
+			"reloadWindow",
+			"TaskService.pickBuildTaskForLabel",
+			"taskServiceOutputPrompt",
+			"showOutput",
+			"TaskServer.folderIgnored",
+			"TaskService.providerUnavailable",
+			"TaskService.noBuildTask1",
+			"TaskService.noBuildTask2",
+			"TaskService.noTestTask1",
+			"TaskService.noTestTask2",
+			"TaskServer.noTask",
+			"TaskService.associate",
+			"TaskService.attachProblemMatcher.continueWithout",
+			"TaskService.attachProblemMatcher.never",
+			"TaskService.attachProblemMatcher.neverType",
+			"TaskService.attachProblemMatcher.learnMoreAbout",
+			"selectProblemMatcher",
+			"customizeParseErrors",
+			"tasksJsonComment",
+			"moreThanOneBuildTask",
+			"TaskSystem.saveBeforeRun.prompt.title",
+			"saveBeforeRun.save",
+			"saveBeforeRun.dontSave",
+			"detail",
+			"TaskSystem.activeSame.noBackground",
+			"terminateTask",
+			"restartTask",
+			"TaskSystem.active",
+			"TaskSystem.restartFailed",
+			"unexpectedTaskType",
+			"TaskService.providerUnavailable",
+			"TaskService.noConfiguration",
+			"TaskSystem.configurationErrors",
+			{
+				"key": "TaskSystem.invalidTaskJsonOther",
+				"comment": [
+					"Message notifies of an error in one of several places there is tasks related json, not necessarily in a file named tasks.json"
+				]
+			},
+			"TasksSystem.locationWorkspaceConfig",
+			"TaskSystem.versionWorkspaceFile",
+			"TasksSystem.locationUserConfig",
+			"TaskSystem.versionSettings",
+			"TaskSystem.configurationErrors",
+			"taskService.ignoreingFolder",
+			"TaskSystem.invalidTaskJson",
+			"TerminateAction.label",
+			"TaskSystem.unknownError",
+			"configureTask",
+			"recentlyUsed",
+			"configured",
+			"detected",
+			"TaskService.ignoredFolder",
+			"TaskService.notAgain",
+			"TaskService.pickRunTask",
+			"TaskService.noEntryToRunSlow",
+			"TaskService.noEntryToRun",
+			"TaskService.fetchingBuildTasks",
+			"TaskService.pickBuildTask",
+			"TaskService.noBuildTask",
+			"TaskService.fetchingTestTasks",
+			"TaskService.pickTestTask",
+			"TaskService.noTestTaskTerminal",
+			"TaskService.taskToTerminate",
+			"TaskService.noTaskRunning",
+			"TaskService.terminateAllRunningTasks",
+			"TerminateAction.noProcess",
+			"TerminateAction.failed",
+			"TaskService.taskToRestart",
+			"TaskService.noTaskToRestart",
+			"TaskService.template",
+			"taskQuickPick.userSettings",
+			"TaskService.createJsonFile",
+			"TaskService.openJsonFile",
+			"TaskService.pickTask",
+			"TaskService.defaultBuildTaskExists",
+			"TaskService.pickDefaultBuildTask",
+			"TaskService.defaultTestTaskExists",
+			"TaskService.pickDefaultTestTask",
+			"TaskService.pickShowTask",
+			"TaskService.noTaskIsRunning"
+		],
+		"vs/workbench/services/preferences/common/preferences": [
+			"userSettingsTarget",
+			"workspaceSettingsTarget"
+		],
+		"vs/base/common/actions": [
+			"submenu.empty"
+		],
+		"vs/workbench/services/userDataSync/common/userDataSync": [
+			"settings",
+			"keybindings",
+			"snippets",
+			"extensions",
+			"ui state label",
+			"sync category",
+			"syncViewIcon"
+		],
+		"vs/workbench/api/common/extHostExtensionService": [
+			"extensionTestError"
+		],
+		"vs/workbench/api/common/extHostTerminalService": [
+			"launchFail.idMissingOnExtHost"
+		],
+		"vs/workbench/api/common/extHostWorkspace": [
+			"updateerror"
+		],
+		"vs/base/node/processes": [
+			"TaskRunner.UNC"
+		],
+		"vs/platform/windows/electron-main/windowsMainService": [
+			"ok",
+			"pathNotExistTitle",
+			"uriInvalidTitle",
+			"pathNotExistDetail",
+			"uriInvalidDetail"
+		],
+		"vs/platform/issue/electron-main/issueMainService": [
+			"local",
+			"issueReporterWriteToClipboard",
+			"ok",
+			"cancel",
+			"confirmCloseIssueReporter",
+			"yes",
+			"cancel",
+			"issueReporter",
+			"processExplorer"
+		],
+		"vs/platform/workspaces/electron-main/workspacesHistoryMainService": [
+			"newWindow",
+			"newWindowDesc",
+			"folderDesc",
+			"workspaceDesc",
+			"recentFoldersAndWorkspaces",
+			"recentFolders",
+			"untitledWorkspace",
+			"workspaceName"
+		],
+		"vs/platform/workspaces/electron-main/workspacesManagementMainService": [
+			"ok",
+			"workspaceOpenedMessage",
+			"workspaceOpenedDetail"
+		],
+		"vs/platform/dialogs/electron-main/dialogMainService": [
+			"open",
+			"openFolder",
+			"openFile",
+			"openWorkspaceTitle",
+			{
+				"key": "openWorkspace",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			}
+		],
+		"vs/platform/files/common/io": [
+			"fileTooLargeForHeapError",
+			"fileTooLargeError"
+		],
+		"vs/base/node/zip": [
+			"invalid file",
+			"incompleteExtract",
+			"notFound"
+		],
+		"vs/platform/extensions/common/extensionValidator": [
+			"versionSyntax",
+			"versionSpecificity1",
+			"versionSpecificity2",
+			"versionMismatch"
+		],
+		"vs/platform/extensionManagement/node/extensionManagementUtil": [
+			"invalidManifest"
+		],
+		"vs/platform/extensionManagement/node/extensionsScanner": [
+			"errorDeleting",
+			"cannot read",
+			"renameError",
+			"invalidManifest"
+		],
+		"vs/platform/userDataSync/common/keybindingsSync": [
+			"errorInvalidSettings",
+			"errorInvalidSettings"
+		],
+		"vs/platform/userDataSync/common/settingsSync": [
+			"errorInvalidSettings"
+		],
+		"vs/base/browser/ui/tree/abstractTree": [
+			"clear",
+			"disable filter on type",
+			"enable filter on type",
+			"empty",
+			"found"
+		],
+		"vs/workbench/services/authentication/browser/authenticationService": [
+			"authentication.id",
+			"authentication.label",
+			{
+				"key": "authenticationExtensionPoint",
+				"comment": [
+					"'Contributes' means adds here"
+				]
+			},
+			"loading",
+			"authentication.missingId",
+			"authentication.missingLabel",
+			"authentication.idConflict",
+			"noAccounts",
+			"loading",
+			"sign in",
+			{
+				"key": "signInRequest",
+				"comment": [
+					"The placeholder {0} will be replaced with an extension name. (1) is to indicate that this menu item contributes to a badge count."
+				]
+			},
+			"sign in"
+		],
+		"vs/platform/list/browser/listService": [
+			"workbenchConfigurationTitle",
+			"multiSelectModifier.ctrlCmd",
+			"multiSelectModifier.alt",
+			{
+				"key": "multiSelectModifier",
+				"comment": [
+					"- `ctrlCmd` refers to a value the setting can take and should not be localized.",
+					"- `Control` and `Command` refer to the modifier keys Ctrl or Cmd on the keyboard and can be localized."
+				]
+			},
+			{
+				"key": "openModeModifier",
+				"comment": [
+					"`singleClick` and `doubleClick` refers to a value the setting can take and should not be localized."
+				]
+			},
+			"horizontalScrolling setting",
+			"tree indent setting",
+			"render tree indent guides",
+			"list smoothScrolling setting",
+			"keyboardNavigationSettingKey.simple",
+			"keyboardNavigationSettingKey.highlight",
+			"keyboardNavigationSettingKey.filter",
+			"keyboardNavigationSettingKey",
+			"automatic keyboard navigation setting",
+			"expand mode"
+		],
+		"vs/workbench/browser/workbench.contribution": [
+			"workbench.editor.titleScrollbarSizing.default",
+			"workbench.editor.titleScrollbarSizing.large",
+			"tabScrollbarHeight",
+			"showEditorTabs",
+			"wrapTabs",
+			{
+				"comment": [
+					"This is the description for a setting. Values surrounded by single quotes are not to be translated."
+				],
+				"key": "scrollToSwitchTabs"
+			},
+			"highlightModifiedTabs",
+			"decorations.badges",
+			"decorations.colors",
+			"workbench.editor.labelFormat.default",
+			"workbench.editor.labelFormat.short",
+			"workbench.editor.labelFormat.medium",
+			"workbench.editor.labelFormat.long",
+			{
+				"comment": [
+					"This is the description for a setting. Values surrounded by parenthesis are not to be translated."
+				],
+				"key": "tabDescription"
+			},
+			"workbench.editor.untitled.labelFormat.content",
+			"workbench.editor.untitled.labelFormat.name",
+			{
+				"comment": [
+					"This is the description for a setting. Values surrounded by parenthesis are not to be translated."
+				],
+				"key": "untitledLabelFormat"
+			},
+			{
+				"comment": [
+					"This is the description for a setting. Values surrounded by single quotes are not to be translated."
+				],
+				"key": "editorTabCloseButton"
+			},
+			"workbench.editor.tabSizing.fit",
+			"workbench.editor.tabSizing.shrink",
+			{
+				"comment": [
+					"This is the description for a setting. Values surrounded by single quotes are not to be translated."
+				],
+				"key": "tabSizing"
+			},
+			"workbench.editor.pinnedTabSizing.normal",
+			"workbench.editor.pinnedTabSizing.compact",
+			"workbench.editor.pinnedTabSizing.shrink",
+			{
+				"comment": [
+					"This is the description for a setting. Values surrounded by single quotes are not to be translated."
+				],
+				"key": "pinnedTabSizing"
+			},
+			"workbench.editor.splitSizingDistribute",
+			"workbench.editor.splitSizingSplit",
+			{
+				"comment": [
+					"This is the description for a setting. Values surrounded by single quotes are not to be translated."
+				],
+				"key": "splitSizing"
+			},
+			"splitOnDragAndDrop",
+			"focusRecentEditorAfterClose",
+			"showIcons",
+			"enablePreview",
+			"enablePreviewFromQuickOpen",
+			"enablePreviewFromCodeNavigation",
+			"closeOnFileDelete",
+			{
+				"comment": [
+					"This is the description for a setting. Values surrounded by single quotes are not to be translated."
+				],
+				"key": "editorOpenPositioning"
+			},
+			"sideBySideDirection",
+			"closeEmptyGroups",
+			"revealIfOpen",
+			"mouseBackForwardToNavigate",
+			"restoreViewState",
+			"centeredLayoutAutoResize",
+			"limitEditorsEnablement",
+			"limitEditorsMaximum",
+			"perEditorGroup",
+			"commandHistory",
+			"preserveInput",
+			"closeOnFocusLost",
+			"workbench.quickOpen.preserveInput",
+			"openDefaultSettings",
+			"useSplitJSON",
+			"openDefaultKeybindings",
+			"sideBarLocation",
+			"panelDefaultLocation",
+			"panelOpensMaximized",
+			"workbench.panel.opensMaximized.always",
+			"workbench.panel.opensMaximized.never",
+			"workbench.panel.opensMaximized.preserve",
+			"statusBarVisibility",
+			"activityBarVisibility",
+			"activityBarIconClickBehavior",
+			"workbench.activityBar.iconClickBehavior.toggle",
+			"workbench.activityBar.iconClickBehavior.focus",
+			"viewVisibility",
+			"fontAliasing",
+			"workbench.fontAliasing.default",
+			"workbench.fontAliasing.antialiased",
+			"workbench.fontAliasing.none",
+			"workbench.fontAliasing.auto",
+			"settings.editor.ui",
+			"settings.editor.json",
+			"settings.editor.desc",
+			"windowTitle",
+			"activeEditorShort",
+			"activeEditorMedium",
+			"activeEditorLong",
+			"activeFolderShort",
+			"activeFolderMedium",
+			"activeFolderLong",
+			"folderName",
+			"folderPath",
+			"rootName",
+			"rootPath",
+			"appName",
+			"remoteName",
+			"dirty",
+			"separator",
+			"windowConfigurationTitle",
+			"window.titleSeparator",
+			"window.menuBarVisibility.default",
+			"window.menuBarVisibility.visible",
+			"window.menuBarVisibility.toggle",
+			"window.menuBarVisibility.hidden",
+			"window.menuBarVisibility.compact",
+			"menuBarVisibility",
+			"enableMenuBarMnemonics",
+			"customMenuBarAltFocus",
+			"window.openFilesInNewWindow.on",
+			"window.openFilesInNewWindow.off",
+			"window.openFilesInNewWindow.defaultMac",
+			"window.openFilesInNewWindow.default",
+			"openFilesInNewWindowMac",
+			"openFilesInNewWindow",
+			"window.openFoldersInNewWindow.on",
+			"window.openFoldersInNewWindow.off",
+			"window.openFoldersInNewWindow.default",
+			"openFoldersInNewWindow",
+			"window.confirmBeforeClose.always",
+			"window.confirmBeforeClose.keyboardOnly",
+			"window.confirmBeforeClose.never",
+			"confirmBeforeCloseWeb",
+			"zenModeConfigurationTitle",
+			"zenMode.fullScreen",
+			"zenMode.centerLayout",
+			"zenMode.hideTabs",
+			"zenMode.hideStatusBar",
+			"zenMode.hideActivityBar",
+			"zenMode.hideLineNumbers",
+			"zenMode.restore",
+			"zenMode.silentNotifications"
+		],
+		"vs/workbench/browser/actions/textInputActions": [
+			"undo",
+			"redo",
+			"cut",
+			"copy",
+			"paste",
+			"selectAll"
+		],
+		"vs/workbench/browser/actions/developerActions": [
+			"inspect context keys",
+			"toggle screencast mode",
+			{
+				"key": "logStorage",
+				"comment": [
+					"A developer only action to log the contents of the storage for the current window."
+				]
+			},
+			{
+				"key": "logWorkingCopies",
+				"comment": [
+					"A developer only action to log the working copies that exist."
+				]
+			},
+			"screencastModeConfigurationTitle",
+			"screencastMode.location.verticalPosition",
+			"screencastMode.fontSize",
+			"screencastMode.onlyKeyboardShortcuts",
+			"screencastMode.keyboardOverlayTimeout",
+			"screencastMode.mouseIndicatorColor",
+			"screencastMode.mouseIndicatorSize"
+		],
+		"vs/workbench/browser/actions/helpActions": [
+			"keybindingsReference",
+			"openDocumentationUrl",
+			"openIntroductoryVideosUrl",
+			"openTipsAndTricksUrl",
+			"newsletterSignup",
+			"openTwitterUrl",
+			"openUserVoiceUrl",
+			"openLicenseUrl",
+			"openPrivacyStatement",
+			{
+				"key": "miDocumentation",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			{
+				"key": "miKeyboardShortcuts",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			{
+				"key": "miIntroductoryVideos",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			{
+				"key": "miTipsAndTricks",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			{
+				"key": "miTwitter",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			{
+				"key": "miUserVoice",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			{
+				"key": "miLicense",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			{
+				"key": "miPrivacyStatement",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			}
+		],
+		"vs/workbench/browser/actions/layoutActions": [
+			"closeSidebar",
+			"toggleActivityBar",
+			{
+				"key": "miShowActivityBar",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			"toggleCenteredLayout",
+			{
+				"key": "miToggleCenteredLayout",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			"toggleSidebarPosition",
+			"moveSidebarRight",
+			"moveSidebarLeft",
+			"toggleSidebarPosition",
+			"move sidebar right",
+			"move sidebar right",
+			"move sidebar left",
+			"move sidebar left",
+			{
+				"key": "miMoveSidebarRight",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			{
+				"key": "miMoveSidebarLeft",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			"toggleEditor",
+			{
+				"key": "miShowEditorArea",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			{
+				"key": "miAppearance",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			"toggleSidebar",
+			"compositePart.hideSideBarLabel",
+			"compositePart.hideSideBarLabel",
+			{
+				"key": "miShowSidebar",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			"toggleStatusbar",
+			{
+				"key": "miShowStatusbar",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			"toggleTabs",
+			"toggleZenMode",
+			"miToggleZenMode",
+			"toggleMenuBar",
+			{
+				"key": "miShowMenuBar",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			"resetViewLocations",
+			"moveView",
+			"sidebarContainer",
+			"panelContainer",
+			"moveFocusedView.selectView",
+			"moveFocusedView",
+			"moveFocusedView.error.noFocusedView",
+			"moveFocusedView.error.nonMovableView",
+			"moveFocusedView.selectDestination",
+			{
+				"key": "moveFocusedView.title",
+				"comment": [
+					"{0} indicates the title of the view the user has selected to move."
+				]
+			},
+			{
+				"key": "moveFocusedView.newContainerInPanel",
+				"comment": [
+					"Creates a new top-level tab in the panel."
+				]
+			},
+			"moveFocusedView.newContainerInSidebar",
+			"sidebar",
+			"panel",
+			"resetFocusedViewLocation",
+			"resetFocusedView.error.noFocusedView",
+			"increaseViewSize",
+			"increaseEditorWidth",
+			"increaseEditorHeight",
+			"decreaseViewSize",
+			"decreaseEditorWidth",
+			"decreaseEditorHeight"
+		],
+		"vs/workbench/browser/actions/navigationActions": [
+			"navigateLeft",
+			"navigateRight",
+			"navigateUp",
+			"navigateDown",
+			"focusNextPart",
+			"focusPreviousPart"
+		],
+		"vs/workbench/browser/actions/windowActions": [
+			"remove",
+			"dirtyRecentlyOpenedFolder",
+			"dirtyRecentlyOpenedWorkspace",
+			"workspacesAndFolders",
+			"folders",
+			"files",
+			"openRecentPlaceholderMac",
+			"openRecentPlaceholder",
+			"dirtyWorkspace",
+			"dirtyFolder",
+			"dirtyWorkspaceConfirm",
+			"dirtyFolderConfirm",
+			"dirtyWorkspaceConfirmDetail",
+			"dirtyFolderConfirmDetail",
+			"recentDirtyWorkspaceAriaLabel",
+			"recentDirtyFolderAriaLabel",
+			"openRecent",
+			"quickOpenRecent",
+			"toggleFullScreen",
+			"reloadWindow",
+			"about",
+			"newWindow",
+			"blur",
+			"file",
+			"miConfirmClose",
+			{
+				"key": "miNewWindow",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			{
+				"key": "miOpenRecent",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			{
+				"key": "miMore",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			{
+				"key": "miToggleFullScreen",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			{
+				"key": "miAbout",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			}
+		],
+		"vs/workbench/browser/actions/workspaceActions": [
+			"openFile",
+			"openFolder",
+			"openFileFolder",
+			"openWorkspaceAction",
+			"closeWorkspace",
+			"noWorkspaceOrFolderOpened",
+			"openWorkspaceConfigFile",
+			"globalRemoveFolderFromWorkspace",
+			"saveWorkspaceAsAction",
+			"duplicateWorkspaceInNewWindow",
+			"workspaces",
+			{
+				"key": "miAddFolderToWorkspace",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			"miSaveWorkspaceAs",
+			{
+				"key": "miCloseFolder",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			{
+				"key": "miCloseWorkspace",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			}
+		],
+		"vs/workbench/browser/actions/workspaceCommands": [
+			"addFolderToWorkspace",
+			{
+				"key": "add",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			"addFolderToWorkspaceTitle",
+			"workspaceFolderPickerPlaceholder"
+		],
+		"vs/workbench/browser/actions/quickAccessActions": [
+			"quickOpen",
+			"quickNavigateNext",
+			"quickNavigatePrevious",
+			"quickSelectNext",
+			"quickSelectPrevious"
+		],
+		"vs/workbench/api/common/menusExtensionPoint": [
+			"menus.commandPalette",
+			"menus.touchBar",
+			"menus.editorTitle",
+			"menus.editorContext",
+			"menus.explorerContext",
+			"menus.editorTabContext",
+			"menus.debugCallstackContext",
+			"menus.debugVariablesContext",
+			"menus.debugToolBar",
+			"menus.file",
+			"menus.home",
+			"menus.scmTitle",
+			"menus.scmSourceControl",
+			"menus.resourceGroupContext",
+			"menus.resourceStateContext",
+			"menus.resourceFolderContext",
+			"menus.changeTitle",
+			"menus.statusBarWindowIndicator",
+			"view.viewTitle",
+			"view.itemContext",
+			"commentThread.title",
+			"commentThread.actions",
+			"comment.title",
+			"comment.actions",
+			"notebook.cell.title",
+			"menus.extensionContext",
+			"view.timelineTitle",
+			"view.timelineContext",
+			"requirestring",
+			"optstring",
+			"optstring",
+			"optstring",
+			"requirestring",
+			"optstring",
+			"optstring",
+			"requirearray",
+			"require",
+			"requirestring",
+			"requirestring",
+			"vscode.extension.contributes.menuItem.command",
+			"vscode.extension.contributes.menuItem.alt",
+			"vscode.extension.contributes.menuItem.when",
+			"vscode.extension.contributes.menuItem.group",
+			"vscode.extension.contributes.menuItem.submenu",
+			"vscode.extension.contributes.menuItem.when",
+			"vscode.extension.contributes.menuItem.group",
+			"vscode.extension.contributes.submenu.id",
+			"vscode.extension.contributes.submenu.label",
+			"vscode.extension.contributes.submenu.icon",
+			"vscode.extension.contributes.submenu.icon.light",
+			"vscode.extension.contributes.submenu.icon.dark",
+			"vscode.extension.contributes.menus",
+			"proposed",
+			"vscode.extension.contributes.submenus",
+			"nonempty",
+			"requirestring",
+			"optstring",
+			"opticon",
+			"requireStringOrObject",
+			"requirestring",
+			"requirestrings",
+			"vscode.extension.contributes.commandType.command",
+			"vscode.extension.contributes.commandType.title",
+			"vscode.extension.contributes.commandType.category",
+			"vscode.extension.contributes.commandType.precondition",
+			"vscode.extension.contributes.commandType.icon",
+			"vscode.extension.contributes.commandType.icon.light",
+			"vscode.extension.contributes.commandType.icon.dark",
+			"vscode.extension.contributes.commands",
+			"dup",
+			"submenuId.invalid.id",
+			"submenuId.duplicate.id",
+			"submenuId.invalid.label",
+			"menuId.invalid",
+			"proposedAPI.invalid",
+			"missing.command",
+			"missing.altCommand",
+			"dupe.command",
+			"unsupported.submenureference",
+			"missing.submenu",
+			"submenuItem.duplicate"
+		],
+		"vs/workbench/api/common/configurationExtensionPoint": [
+			"vscode.extension.contributes.configuration.title",
+			"vscode.extension.contributes.configuration.properties",
+			"vscode.extension.contributes.configuration.property.empty",
+			"scope.application.description",
+			"scope.machine.description",
+			"scope.window.description",
+			"scope.resource.description",
+			"scope.language-overridable.description",
+			"scope.machine-overridable.description",
+			"scope.description",
+			"scope.enumDescriptions",
+			"scope.markdownEnumDescriptions",
+			"scope.markdownDescription",
+			"scope.deprecationMessage",
+			"scope.markdownDeprecationMessage",
+			"vscode.extension.contributes.defaultConfiguration",
+			"config.property.defaultConfiguration.languageExpected",
+			"config.property.defaultConfiguration.warning",
+			"vscode.extension.contributes.configuration",
+			"invalid.title",
+			"invalid.properties",
+			"invalid.property",
+			"invalid.allOf",
+			"workspaceConfig.folders.description",
+			"workspaceConfig.path.description",
+			"workspaceConfig.name.description",
+			"workspaceConfig.uri.description",
+			"workspaceConfig.name.description",
+			"workspaceConfig.settings.description",
+			"workspaceConfig.launch.description",
+			"workspaceConfig.tasks.description",
+			"workspaceConfig.extensions.description",
+			"workspaceConfig.remoteAuthority",
+			"unknownWorkspaceProperty"
+		],
+		"vs/workbench/api/browser/viewsExtensionPoint": [
+			{
+				"key": "vscode.extension.contributes.views.containers.id",
+				"comment": [
+					"Contribution refers to those that an extension contributes to VS Code through an extension/contribution point. "
+				]
+			},
+			"vscode.extension.contributes.views.containers.title",
+			"vscode.extension.contributes.views.containers.icon",
+			"vscode.extension.contributes.viewsContainers",
+			"views.container.activitybar",
+			"views.container.panel",
+			"vscode.extension.contributes.view.type",
+			"vscode.extension.contributes.view.tree",
+			"vscode.extension.contributes.view.webview",
+			"vscode.extension.contributes.view.id",
+			"vscode.extension.contributes.view.name",
+			"vscode.extension.contributes.view.when",
+			"vscode.extension.contributes.view.icon",
+			"vscode.extension.contributes.view.contextualTitle",
+			"vscode.extension.contributes.view.initialState",
+			"vscode.extension.contributes.view.initialState.visible",
+			"vscode.extension.contributes.view.initialState.hidden",
+			"vscode.extension.contributes.view.initialState.collapsed",
+			"vscode.extension.contributes.view.id",
+			"vscode.extension.contributes.view.name",
+			"vscode.extension.contributes.view.when",
+			"vscode.extension.contributes.view.group",
+			"vscode.extension.contributes.view.remoteName",
+			"vscode.extension.contributes.views",
+			"views.explorer",
+			"views.debug",
+			"views.scm",
+			"views.test",
+			"views.remote",
+			"views.contributed",
+			"viewcontainer requirearray",
+			"requireidstring",
+			"requireidstring",
+			"requirestring",
+			"requirestring",
+			"showViewlet",
+			"ViewContainerRequiresProposedAPI",
+			"ViewContainerDoesnotExist",
+			"duplicateView1",
+			"duplicateView2",
+			"unknownViewType",
+			"requirearray",
+			"requirestring",
+			"requirestring",
+			"optstring",
+			"optstring",
+			"optstring",
+			"optenum"
+		],
+		"vs/workbench/browser/parts/activitybar/activitybarPart": [
+			"settingsViewBarIcon",
+			"accountsViewBarIcon",
+			"homeButton",
+			"homeButton",
+			"menu",
+			"menu",
+			"accounts",
+			"accounts",
+			"hideActivitBar",
+			"resetLocation",
+			"resetLocation",
+			"homeIndicator",
+			"home",
+			"home",
+			"manage",
+			"manage",
+			"accounts",
+			"accounts",
+			"focusActivityBar"
+		],
+		"vs/workbench/browser/parts/panel/panelPart": [
+			"hidePanel",
+			"resetLocation",
+			"resetLocation",
+			"panel.emptyMessage"
+		],
+		"vs/workbench/browser/parts/sidebar/sidebarPart": [
+			"focusSideBar"
+		],
+		"vs/workbench/browser/parts/views/viewsService": [
+			{
+				"key": "focus view",
+				"comment": [
+					"{0} indicates the name of the view to be focused."
+				]
+			},
+			"resetViewLocation"
+		],
+		"vs/workbench/browser/parts/statusbar/statusbarPart": [
+			"hide",
+			"hideStatusBar"
+		],
+		"vs/platform/undoRedo/common/undoRedoService": [
+			{
+				"key": "externalRemoval",
+				"comment": [
+					"{0} is a list of filenames"
+				]
+			},
+			{
+				"key": "noParallelUniverses",
+				"comment": [
+					"{0} is a list of filenames"
+				]
+			},
+			{
+				"key": "cannotWorkspaceUndo",
+				"comment": [
+					"{0} is a label for an operation. {1} is another message."
+				]
+			},
+			{
+				"key": "cannotWorkspaceUndo",
+				"comment": [
+					"{0} is a label for an operation. {1} is another message."
+				]
+			},
+			{
+				"key": "cannotWorkspaceUndoDueToChanges",
+				"comment": [
+					"{0} is a label for an operation. {1} is a list of filenames."
+				]
+			},
+			{
+				"key": "cannotWorkspaceUndoDueToInProgressUndoRedo",
+				"comment": [
+					"{0} is a label for an operation. {1} is a list of filenames."
+				]
+			},
+			{
+				"key": "cannotWorkspaceUndoDueToInMeantimeUndoRedo",
+				"comment": [
+					"{0} is a label for an operation. {1} is a list of filenames."
+				]
+			},
+			"confirmWorkspace",
+			{
+				"key": "ok",
+				"comment": [
+					"{0} denotes a number that is > 1"
+				]
+			},
+			"nok",
+			"cancel",
+			{
+				"key": "cannotResourceUndoDueToInProgressUndoRedo",
+				"comment": [
+					"{0} is a label for an operation."
+				]
+			},
+			"confirmDifferentSource",
+			"confirmDifferentSource.ok",
+			"cancel",
+			{
+				"key": "cannotWorkspaceRedo",
+				"comment": [
+					"{0} is a label for an operation. {1} is another message."
+				]
+			},
+			{
+				"key": "cannotWorkspaceRedo",
+				"comment": [
+					"{0} is a label for an operation. {1} is another message."
+				]
+			},
+			{
+				"key": "cannotWorkspaceRedoDueToChanges",
+				"comment": [
+					"{0} is a label for an operation. {1} is a list of filenames."
+				]
+			},
+			{
+				"key": "cannotWorkspaceRedoDueToInProgressUndoRedo",
+				"comment": [
+					"{0} is a label for an operation. {1} is a list of filenames."
+				]
+			},
+			{
+				"key": "cannotWorkspaceRedoDueToInMeantimeUndoRedo",
+				"comment": [
+					"{0} is a label for an operation. {1} is a list of filenames."
+				]
+			},
+			{
+				"key": "cannotResourceRedoDueToInProgressUndoRedo",
+				"comment": [
+					"{0} is a label for an operation."
+				]
+			}
+		],
+		"vs/workbench/services/extensions/browser/extensionUrlHandler": [
+			"confirmUrl",
+			"rememberConfirmUrl",
+			"open",
+			"reloadAndHandle",
+			"reloadAndOpen",
+			"enableAndHandle",
+			"enableAndReload",
+			"installAndHandle",
+			"install",
+			"Installing",
+			"reload",
+			"Reload",
+			"manage",
+			"extensions",
+			"no"
+		],
+		"vs/workbench/services/keybinding/common/keybindingEditing": [
+			"errorKeybindingsFileDirty",
+			"parseErrors",
+			"errorInvalidConfiguration",
+			"emptyKeybindingsHeader"
+		],
+		"vs/workbench/services/decorations/browser/decorationsService": [
+			"bubbleTitle"
+		],
+		"vs/workbench/services/progress/browser/progressService": [
+			"progress.text2",
+			"progress.title3",
+			"progress.title2",
+			"progress.title2",
+			"status.progress",
+			"cancel",
+			"cancel",
+			"dismiss"
+		],
+		"vs/workbench/services/preferences/browser/preferencesService": [
+			"openFolderFirst",
+			"emptyKeybindingsHeader",
+			"defaultKeybindings",
+			"defaultKeybindings",
+			"defaultSettings",
+			"folderSettingsName",
+			"fail.createSettings"
+		],
+		"vs/workbench/services/configuration/common/jsonEditingService": [
+			"errorInvalidFile",
+			"errorFileDirty"
+		],
+		"vs/workbench/services/editor/browser/editorService": [
+			"editorAssociations.viewType.sourceDescription"
+		],
+		"vs/workbench/services/keybinding/browser/keybindingService": [
+			"nonempty",
+			"requirestring",
+			"optstring",
+			"optstring",
+			"optstring",
+			"optstring",
+			"optstring",
+			"vscode.extension.contributes.keybindings.command",
+			"vscode.extension.contributes.keybindings.args",
+			"vscode.extension.contributes.keybindings.key",
+			"vscode.extension.contributes.keybindings.mac",
+			"vscode.extension.contributes.keybindings.linux",
+			"vscode.extension.contributes.keybindings.win",
+			"vscode.extension.contributes.keybindings.when",
+			"vscode.extension.contributes.keybindings",
+			"invalid.keybindings",
+			"unboundCommands",
+			"keybindings.json.title",
+			"keybindings.json.key",
+			"keybindings.json.command",
+			"keybindings.json.when",
+			"keybindings.json.args",
+			"keyboardConfigurationTitle",
+			"dispatch"
+		],
+		"vs/workbench/services/mode/common/workbenchModeService": [
+			"vscode.extension.contributes.languages",
+			"vscode.extension.contributes.languages.id",
+			"vscode.extension.contributes.languages.aliases",
+			"vscode.extension.contributes.languages.extensions",
+			"vscode.extension.contributes.languages.filenames",
+			"vscode.extension.contributes.languages.filenamePatterns",
+			"vscode.extension.contributes.languages.mimetypes",
+			"vscode.extension.contributes.languages.firstLine",
+			"vscode.extension.contributes.languages.configuration",
+			"invalid",
+			"invalid.empty",
+			"require.id",
+			"opt.extensions",
+			"opt.filenames",
+			"opt.firstLine",
+			"opt.configuration",
+			"opt.aliases",
+			"opt.mimetypes"
+		],
+		"vs/workbench/services/themes/browser/workbenchThemeService": [
+			"error.cannotloadtheme"
+		],
+		"vs/workbench/services/label/common/labelService": [
+			"vscode.extension.contributes.resourceLabelFormatters",
+			"vscode.extension.contributes.resourceLabelFormatters.scheme",
+			"vscode.extension.contributes.resourceLabelFormatters.authority",
+			"vscode.extension.contributes.resourceLabelFormatters.formatting",
+			"vscode.extension.contributes.resourceLabelFormatters.label",
+			"vscode.extension.contributes.resourceLabelFormatters.separator",
+			"vscode.extension.contributes.resourceLabelFormatters.stripPathStartingSeparator",
+			"vscode.extension.contributes.resourceLabelFormatters.tildify",
+			"vscode.extension.contributes.resourceLabelFormatters.formatting.workspaceSuffix",
+			"untitledWorkspace",
+			"workspaceNameVerbose",
+			"workspaceName"
+		],
+		"vs/workbench/services/extensionManagement/common/webExtensionsScannerService": [
+			"cannot be installed"
+		],
+		"vs/workbench/services/extensionManagement/browser/extensionEnablementService": [
+			"extensionsDisabled",
+			"Reload",
+			"cannot disable language pack extension",
+			"cannot disable auth extension",
+			"noWorkspace",
+			"cannot disable auth extension in workspace"
+		],
+		"vs/workbench/services/extensionRecommendations/common/workspaceExtensionsConfig": [
+			"select for remove",
+			"select for add",
+			"select for remove",
+			"select for add",
+			"workspace folder",
+			"workspace"
+		],
+		"vs/workbench/services/notification/common/notificationService": [
+			"neverShowAgain",
+			"neverShowAgain"
+		],
+		"vs/workbench/services/userDataSync/browser/userDataSyncWorkbenchService": [
+			"no authentication providers",
+			"no account",
+			"show log",
+			"sync turned on",
+			"sync in progress",
+			"settings sync",
+			{
+				"key": "yes",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			{
+				"key": "no",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			"turning on",
+			"syncing resource",
+			"conflicts detected",
+			"merge Manually",
+			"resolve",
+			"merge or replace",
+			"merge",
+			"replace local",
+			"merge Manually",
+			"cancel",
+			"first time sync detail",
+			"reset",
+			"reset title",
+			{
+				"key": "resetButton",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			"choose account placeholder",
+			"signed in",
+			"last used",
+			"others",
+			"sign in using account",
+			"successive auth failures",
+			"sign in"
+		],
+		"vs/workbench/services/views/browser/viewDescriptorService": [
+			"hideView",
+			"resetViewLocation"
+		],
+		"vs/workbench/contrib/preferences/browser/preferences.contribution": [
+			"defaultPreferencesEditor",
+			"settingsEditor2",
+			"keybindingsEditor",
+			"openSettings2",
+			"preferences",
+			"settings",
+			{
+				"key": "miOpenSettings",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			"openSettings2",
+			"openSettingsJson",
+			"openGlobalSettings",
+			"openRawDefaultSettings",
+			"openSettingsJson",
+			"openWorkspaceSettings",
+			"openWorkspaceSettingsFile",
+			"openFolderSettings",
+			"openFolderSettingsFile",
+			"openFolderSettings",
+			"filterModifiedLabel",
+			"filterOnlineServicesLabel",
+			{
+				"key": "miOpenOnlineSettings",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			"onlineServices",
+			"openRemoteSettings",
+			"settings.focusSearch",
+			"settings.clearResults",
+			"settings.focusFile",
+			"settings.focusFile",
+			"settings.focusNextSetting",
+			"settings.focusPreviousSetting",
+			"settings.editFocusedSetting",
+			"settings.focusSettingsList",
+			"settings.focusSettingsTOC",
+			"settings.focusSettingControl",
+			"settings.showContextMenu",
+			"settings.focusLevelUp",
+			"preferences",
+			"openGlobalKeybindings",
+			"Keyboard Shortcuts",
+			"Keyboard Shortcuts",
+			"openDefaultKeybindingsFile",
+			"openGlobalKeybindingsFile",
+			"showDefaultKeybindings",
+			"showExtensionKeybindings",
+			"showUserKeybindings",
+			"clear",
+			{
+				"key": "miPreferences",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			}
+		],
+		"vs/workbench/contrib/preferences/browser/keybindingsEditorContribution": [
+			"defineKeybinding.start",
+			"defineKeybinding.kbLayoutErrorMessage",
+			{
+				"key": "defineKeybinding.kbLayoutLocalAndUSMessage",
+				"comment": [
+					"Please translate maintaining the stars (*) around the placeholders such that they will be rendered in bold.",
+					"The placeholders will contain a keyboard combination e.g. Ctrl+Shift+/"
+				]
+			},
+			{
+				"key": "defineKeybinding.kbLayoutLocalMessage",
+				"comment": [
+					"Please translate maintaining the stars (*) around the placeholder such that it will be rendered in bold.",
+					"The placeholder will contain a keyboard combination e.g. Ctrl+Shift+/"
+				]
+			}
+		],
+		"vs/workbench/contrib/performance/browser/performance.contribution": [
+			"show.label"
+		],
+		"vs/workbench/contrib/testing/browser/testing.contribution": [
+			"test",
+			"noTestProvidersRegistered",
+			{
+				"key": "searchMarketplaceForTestExtensions",
+				"comment": [
+					"Please do not translate the word \"commmand\", it is part of our internal syntax which must not change"
+				]
+			},
+			"testExplorer"
+		],
+		"vs/workbench/contrib/notebook/browser/notebook.contribution": [
+			"diffLeftRightLabel",
+			"notebookConfigurationTitle",
+			"notebook.displayOrder.description",
+			"notebook.cellToolbarLocation.description",
+			"notebook.showCellStatusbar.description",
+			"notebook.diff.enablePreview.description"
+		],
+		"vs/workbench/contrib/logs/common/logs.contribution": [
+			"userDataSyncLog",
+			"rendererLog",
+			"telemetryLog",
+			"show window log",
+			"mainLog",
+			"sharedLog"
+		],
+		"vs/workbench/contrib/quickaccess/browser/quickAccess.contribution": [
+			"helpQuickAccessPlaceholder",
+			"helpQuickAccess",
+			"viewQuickAccessPlaceholder",
+			"viewQuickAccess",
+			"commandsQuickAccessPlaceholder",
+			"commandsQuickAccess",
+			{
+				"key": "miCommandPalette",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			{
+				"key": "miOpenView",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			{
+				"key": "miGotoSymbolInEditor",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			{
+				"key": "miGotoLine",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			"commandPalette",
+			"commandPalette"
+		],
+		"vs/workbench/contrib/files/browser/explorerViewlet": [
+			"explorerViewIcon",
+			"openEditorsIcon",
+			"folders",
+			"explore",
+			{
+				"key": "noWorkspaceHelp",
+				"comment": [
+					"Please do not translate the word \"commmand\", it is part of our internal syntax which must not change"
+				]
+			},
+			{
+				"key": "remoteNoFolderHelp",
+				"comment": [
+					"Please do not translate the word \"commmand\", it is part of our internal syntax which must not change"
+				]
+			},
+			{
+				"key": "noFolderHelp",
+				"comment": [
+					"Please do not translate the word \"commmand\", it is part of our internal syntax which must not change"
+				]
+			}
+		],
+		"vs/workbench/contrib/files/browser/fileActions.contribution": [
+			"filesCategory",
+			"workspaces",
+			"file",
+			"copyPath",
+			"copyRelativePath",
+			"revealInSideBar",
+			"acceptLocalChanges",
+			"revertLocalChanges",
+			"copyPathOfActive",
+			"copyRelativePathOfActive",
+			"saveAllInGroup",
+			"saveFiles",
+			"revert",
+			"compareActiveWithSaved",
+			"openToSide",
+			"revert",
+			"saveAll",
+			"compareWithSaved",
+			"compareWithSelected",
+			"compareSource",
+			"compareSelected",
+			"close",
+			"closeOthers",
+			"closeSaved",
+			"closeAll",
+			"explorerOpenWith",
+			"cut",
+			"deleteFile",
+			"deleteFile",
+			"newFile",
+			"openFile",
+			{
+				"key": "miNewFile",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			{
+				"key": "miSave",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			{
+				"key": "miSaveAs",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			{
+				"key": "miSaveAll",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			{
+				"key": "miOpen",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			{
+				"key": "miOpenFile",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			{
+				"key": "miOpenFolder",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			{
+				"key": "miOpenWorkspace",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			{
+				"key": "miAutoSave",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			{
+				"key": "miRevert",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			{
+				"key": "miCloseEditor",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			{
+				"key": "miGotoFile",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			}
+		],
+		"vs/workbench/contrib/files/browser/files.contribution": [
+			"showExplorerViewlet",
+			"binaryFileEditor",
+			"hotExit.off",
+			"hotExit.onExit",
+			"hotExit.onExitAndWindowClose",
+			"hotExit",
+			"hotExit.off",
+			"hotExit.onExitAndWindowCloseBrowser",
+			"hotExit",
+			"filesConfigurationTitle",
+			"exclude",
+			"files.exclude.boolean",
+			"files.exclude.when",
+			"associations",
+			"encoding",
+			"autoGuessEncoding",
+			"eol.LF",
+			"eol.CRLF",
+			"eol.auto",
+			"eol",
+			"useTrash",
+			"trimTrailingWhitespace",
+			"insertFinalNewline",
+			"trimFinalNewlines",
+			{
+				"comment": [
+					"This is the description for a setting. Values surrounded by single quotes are not to be translated."
+				],
+				"key": "files.autoSave.off"
+			},
+			{
+				"comment": [
+					"This is the description for a setting. Values surrounded by single quotes are not to be translated."
+				],
+				"key": "files.autoSave.afterDelay"
+			},
+			{
+				"comment": [
+					"This is the description for a setting. Values surrounded by single quotes are not to be translated."
+				],
+				"key": "files.autoSave.onFocusChange"
+			},
+			{
+				"comment": [
+					"This is the description for a setting. Values surrounded by single quotes are not to be translated."
+				],
+				"key": "files.autoSave.onWindowChange"
+			},
+			{
+				"comment": [
+					"This is the description for a setting. Values surrounded by single quotes are not to be translated."
+				],
+				"key": "autoSave"
+			},
+			{
+				"comment": [
+					"This is the description for a setting. Values surrounded by single quotes are not to be translated."
+				],
+				"key": "autoSaveDelay"
+			},
+			"watcherExclude",
+			"defaultLanguage",
+			"maxMemoryForLargeFilesMB",
+			"files.restoreUndoStack",
+			"askUser",
+			"overwriteFileOnDisk",
+			"files.saveConflictResolution",
+			"files.simpleDialog.enable",
+			"formatOnSave",
+			{
+				"key": "everything",
+				"comment": [
+					"This is the description of an option"
+				]
+			},
+			{
+				"key": "modification",
+				"comment": [
+					"This is the description of an option"
+				]
+			},
+			"formatOnSaveMode",
+			"explorerConfigurationTitle",
+			{
+				"key": "openEditorsVisible",
+				"comment": [
+					"Open is an adjective"
+				]
+			},
+			{
+				"key": "openEditorsSortOrder",
+				"comment": [
+					"Open is an adjective"
+				]
+			},
+			"sortOrder.editorOrder",
+			"sortOrder.alphabetical",
+			"autoReveal.on",
+			"autoReveal.off",
+			"autoReveal.focusNoScroll",
+			"autoReveal",
+			"enableDragAndDrop",
+			"confirmDragAndDrop",
+			"confirmDelete",
+			"sortOrder.default",
+			"sortOrder.mixed",
+			"sortOrder.filesFirst",
+			"sortOrder.type",
+			"sortOrder.modified",
+			"sortOrder",
+			"explorer.decorations.colors",
+			"explorer.decorations.badges",
+			"simple",
+			"smart",
+			"explorer.incrementalNaming",
+			"compressSingleChildFolders",
+			{
+				"key": "miViewExplorer",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			}
+		],
+		"vs/workbench/contrib/bulkEdit/browser/bulkEditService": [
+			"summary.0",
+			"summary.nm",
+			"summary.n0",
+			"workspaceEdit",
+			"workspaceEdit",
+			"nothing",
+			"fileOperation",
+			"areYouSureQuiteBulkEdit",
+			"quit"
+		],
+		"vs/workbench/contrib/bulkEdit/browser/preview/bulkEdit.contribution": [
+			"overlap",
+			"cancel",
+			"continue",
+			"detail",
+			"apply",
+			"cat",
+			"Discard",
+			"cat",
+			"toogleSelection",
+			"cat",
+			"groupByFile",
+			"cat",
+			"groupByType",
+			"cat",
+			"groupByType",
+			"cat",
+			"refactorPreviewViewIcon",
+			"panel",
+			"panel"
+		],
+		"vs/workbench/contrib/search/browser/search.contribution": [
+			"search",
+			"copyMatchLabel",
+			"copyPathLabel",
+			"copyAllLabel",
+			"CancelSearchAction.label",
+			"RefreshAction.label",
+			"CollapseDeepestExpandedLevelAction.label",
+			"ExpandAllAction.label",
+			"ClearSearchResultsAction.label",
+			"revealInSideBar",
+			"clearSearchHistoryLabel",
+			"focusSearchListCommandLabel",
+			"findInFolder",
+			"findInWorkspace",
+			"showTriggerActions",
+			"name",
+			"search",
+			"findInFiles.description",
+			"findInFiles.args",
+			"findInFiles",
+			{
+				"key": "miFindInFiles",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			{
+				"key": "miReplaceInFiles",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			"anythingQuickAccessPlaceholder",
+			"anythingQuickAccess",
+			"symbolsQuickAccessPlaceholder",
+			"symbolsQuickAccess",
+			"searchConfigurationTitle",
+			"exclude",
+			"exclude.boolean",
+			"exclude.when",
+			"search.mode",
+			"search.mode.view",
+			"search.mode.reuseEditor",
+			"search.mode.newEditor",
+			"useRipgrep",
+			"useRipgrepDeprecated",
+			"search.maintainFileSearchCache",
+			"useIgnoreFiles",
+			"useGlobalIgnoreFiles",
+			"search.quickOpen.includeSymbols",
+			"search.quickOpen.includeHistory",
+			"filterSortOrder.default",
+			"filterSortOrder.recency",
+			"filterSortOrder",
+			"search.followSymlinks",
+			"search.smartCase",
+			"search.globalFindClipboard",
+			"search.location",
+			"search.location.deprecationMessage",
+			"search.collapseResults.auto",
+			"search.collapseAllResults",
+			"search.useReplacePreview",
+			"search.showLineNumbers",
+			"search.usePCRE2",
+			"usePCRE2Deprecated",
+			"search.actionsPositionAuto",
+			"search.actionsPositionRight",
+			"search.actionsPosition",
+			"search.searchOnType",
+			"search.seedWithNearestWord",
+			"search.seedOnFocus",
+			"search.searchOnTypeDebouncePeriod",
+			"search.searchEditor.doubleClickBehaviour.selectWord",
+			"search.searchEditor.doubleClickBehaviour.goToLocation",
+			"search.searchEditor.doubleClickBehaviour.openLocationToSide",
+			"search.searchEditor.doubleClickBehaviour",
+			{
+				"key": "search.searchEditor.reusePriorSearchConfiguration",
+				"comment": [
+					"\"Search Editor\" is a type of editor that can display search results. \"includes, excludes, and flags\" refers to the \"files to include\" and \"files to exclude\" input boxes, and the flags that control whether a query is case-sensitive or a regex."
+				]
+			},
+			"search.searchEditor.defaultNumberOfContextLines",
+			"searchSortOrder.default",
+			"searchSortOrder.filesOnly",
+			"searchSortOrder.type",
+			"searchSortOrder.modified",
+			"searchSortOrder.countDescending",
+			"searchSortOrder.countAscending",
+			"search.sortOrder",
+			"search.experimental.searchInOpenEditors",
+			{
+				"key": "miViewSearch",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			{
+				"key": "miGotoSymbolInWorkspace",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			}
+		],
+		"vs/workbench/contrib/search/browser/searchView": [
+			"searchCanceled",
+			"moreSearch",
+			"searchScope.includes",
+			"label.includes",
+			"searchScope.excludes",
+			"label.excludes",
+			"replaceAll.confirmation.title",
+			"replaceAll.confirm.button",
+			"replaceAll.occurrence.file.message",
+			"removeAll.occurrence.file.message",
+			"replaceAll.occurrence.files.message",
+			"removeAll.occurrence.files.message",
+			"replaceAll.occurrences.file.message",
+			"removeAll.occurrences.file.message",
+			"replaceAll.occurrences.files.message",
+			"removeAll.occurrences.files.message",
+			"removeAll.occurrence.file.confirmation.message",
+			"replaceAll.occurrence.file.confirmation.message",
+			"removeAll.occurrence.files.confirmation.message",
+			"replaceAll.occurrence.files.confirmation.message",
+			"removeAll.occurrences.file.confirmation.message",
+			"replaceAll.occurrences.file.confirmation.message",
+			"removeAll.occurrences.files.confirmation.message",
+			"replaceAll.occurrences.files.confirmation.message",
+			"emptySearch",
+			"ariaSearchResultsClearStatus",
+			"searchPathNotFoundError",
+			"searchMaxResultsWarning",
+			"noOpenEditorResultsIncludesExcludes",
+			"noOpenEditorResultsIncludes",
+			"noOpenEditorResultsExcludes",
+			"noOpenEditorResultsFound",
+			"noResultsIncludesExcludes",
+			"noResultsIncludes",
+			"noResultsExcludes",
+			"noResultsFound",
+			"rerunSearch.message",
+			"rerunSearchInAll.message",
+			"openSettings.message",
+			"openSettings.learnMore",
+			"ariaSearchResultsStatus",
+			"forTerm",
+			"useIgnoresAndExcludesDisabled",
+			"openInEditor.message",
+			"openInEditor.tooltip",
+			"search.file.result",
+			"search.files.result",
+			"search.file.results",
+			"search.files.results",
+			"searchWithoutFolder",
+			"openFolder"
+		],
+		"vs/workbench/contrib/sash/browser/sash.contribution": [
+			"sashSize"
+		],
+		"vs/workbench/contrib/searchEditor/browser/searchEditor.contribution": [
+			"searchEditor",
+			"search",
+			"searchEditor.deleteResultBlock",
+			"search.openNewSearchEditor",
+			"search.openSearchEditor",
+			"search.openNewEditorToSide",
+			"search.openResultsInEditor",
+			"search.rerunSearchInEditor",
+			"search.action.focusQueryEditorWidget",
+			"searchEditor.action.toggleSearchEditorCaseSensitive",
+			"searchEditor.action.toggleSearchEditorWholeWord",
+			"searchEditor.action.toggleSearchEditorRegex",
+			"searchEditor.action.toggleSearchEditorContextLines",
+			"searchEditor.action.increaseSearchEditorContextLines",
+			"searchEditor.action.decreaseSearchEditorContextLines",
+			"searchEditor.action.selectAllSearchEditorMatches",
+			"search.openNewEditor"
+		],
+		"vs/workbench/contrib/scm/browser/scm.contribution": [
+			"sourceControlViewIcon",
+			"source control",
+			"no open repo",
+			"source control",
+			"source control repositories",
+			"toggleSCMViewlet",
+			"scmConfigurationTitle",
+			"scm.diffDecorations.all",
+			"scm.diffDecorations.gutter",
+			"scm.diffDecorations.overviewRuler",
+			"scm.diffDecorations.minimap",
+			"scm.diffDecorations.none",
+			"diffDecorations",
+			"diffGutterWidth",
+			"scm.diffDecorationsGutterVisibility.always",
+			"scm.diffDecorationsGutterVisibility.hover",
+			"scm.diffDecorationsGutterVisibility",
+			"scm.diffDecorationsGutterAction.diff",
+			"scm.diffDecorationsGutterAction.none",
+			"scm.diffDecorationsGutterAction",
+			"alwaysShowActions",
+			"scm.countBadge.all",
+			"scm.countBadge.focused",
+			"scm.countBadge.off",
+			"scm.countBadge",
+			"scm.providerCountBadge.hidden",
+			"scm.providerCountBadge.auto",
+			"scm.providerCountBadge.visible",
+			"scm.providerCountBadge",
+			"scm.defaultViewMode.tree",
+			"scm.defaultViewMode.list",
+			"scm.defaultViewMode",
+			"autoReveal",
+			"inputFontFamily",
+			"alwaysShowRepository",
+			"providersVisible",
+			{
+				"key": "miViewSCM",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			"scm accept",
+			"scm view next commit",
+			"scm view previous commit",
+			"open in terminal"
+		],
+		"vs/workbench/contrib/debug/browser/debug.contribution": [
+			"debugCategory",
+			"startDebugPlaceholder",
+			"startDebuggingHelp",
+			"terminateThread",
+			{
+				"comment": [
+					"Debug is a noun in this context, not a verb."
+				],
+				"key": "debugFocusConsole"
+			},
+			"jumpToCursor",
+			"SetNextStatement",
+			"inlineBreakpoint",
+			"terminateThread",
+			"restartFrame",
+			"copyStackTrace",
+			"setValue",
+			"copyValue",
+			"copyAsExpression",
+			"addToWatchExpressions",
+			"breakWhenValueChanges",
+			"editWatchExpression",
+			"copyValue",
+			"removeWatchExpression",
+			{
+				"key": "miViewRun",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			{
+				"key": "miStartDebugging",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			{
+				"key": "miRun",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			{
+				"key": "miStopDebugging",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			{
+				"key": "miRestart Debugging",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			{
+				"key": "miAddConfiguration",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			{
+				"key": "miStepOver",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			{
+				"key": "miStepInto",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			{
+				"key": "miStepOut",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			{
+				"key": "miContinue",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			{
+				"key": "miInlineBreakpoint",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			{
+				"key": "miNewBreakpoint",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			{
+				"key": "miInstallAdditionalDebuggers",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			{
+				"comment": [
+					"Debug is a noun in this context, not a verb."
+				],
+				"key": "debugPanel"
+			},
+			{
+				"comment": [
+					"Debug is a noun in this context, not a verb."
+				],
+				"key": "debugPanel"
+			},
+			"run",
+			"variables",
+			"watch",
+			"callStack",
+			"breakpoints",
+			"loadedScripts",
+			"debugConfigurationTitle",
+			{
+				"comment": [
+					"This is the description for a setting"
+				],
+				"key": "allowBreakpointsEverywhere"
+			},
+			{
+				"comment": [
+					"This is the description for a setting"
+				],
+				"key": "openExplorerOnEnd"
+			},
+			{
+				"comment": [
+					"This is the description for a setting"
+				],
+				"key": "inlineValues"
+			},
+			{
+				"comment": [
+					"This is the description for a setting"
+				],
+				"key": "toolBarLocation"
+			},
+			"never",
+			"always",
+			"onFirstSessionStart",
+			{
+				"comment": [
+					"This is the description for a setting"
+				],
+				"key": "showInStatusBar"
+			},
+			"debug.console.closeOnEnd",
+			"openDebug",
+			{
+				"comment": [
+					"This is the description for a setting"
+				],
+				"key": "showSubSessionsInToolBar"
+			},
+			"debug.console.fontSize",
+			"debug.console.fontFamily",
+			"debug.console.lineHeight",
+			"debug.console.wordWrap",
+			"debug.console.historySuggestions",
+			{
+				"comment": [
+					"This is the description for a setting"
+				],
+				"key": "launch"
+			},
+			"debug.focusWindowOnBreak",
+			"debugAnyway",
+			"showErrors",
+			"prompt",
+			"cancel",
+			"debug.onTaskErrors",
+			{
+				"comment": [
+					"This is the description for a setting"
+				],
+				"key": "showBreakpointsInOverviewRuler"
+			},
+			{
+				"comment": [
+					"This is the description for a setting"
+				],
+				"key": "showInlineBreakpointCandidates"
+			}
+		],
+		"vs/workbench/contrib/debug/browser/debugEditorContribution": [
+			"addConfiguration"
+		],
+		"vs/workbench/contrib/debug/browser/breakpointEditorContribution": [
+			"logPoint",
+			"breakpoint",
+			"breakpointHasConditionDisabled",
+			"message",
+			"condition",
+			"breakpointHasConditionEnabled",
+			"message",
+			"condition",
+			"removeLogPoint",
+			"disableLogPoint",
+			"disable",
+			"enable",
+			"cancel",
+			"logPoint",
+			"breakpoint",
+			"removeBreakpoint",
+			"editBreakpoint",
+			"disableBreakpoint",
+			"enableBreakpoint",
+			"removeBreakpoints",
+			"removeInlineBreakpointOnColumn",
+			"removeLineBreakpoint",
+			"editBreakpoints",
+			"editInlineBreakpointOnColumn",
+			"editLineBrekapoint",
+			"enableDisableBreakpoints",
+			"disableInlineColumnBreakpoint",
+			"disableBreakpointOnLine",
+			"enableBreakpoints",
+			"enableBreakpointOnLine",
+			"addBreakpoint",
+			"addConditionalBreakpoint",
+			"addLogPoint",
+			"debugIcon.breakpointForeground",
+			"debugIcon.breakpointDisabledForeground",
+			"debugIcon.breakpointUnverifiedForeground",
+			"debugIcon.breakpointCurrentStackframeForeground",
+			"debugIcon.breakpointStackframeForeground"
+		],
+		"vs/workbench/contrib/debug/browser/callStackEditorContribution": [
+			"topStackFrameLineHighlight",
+			"focusedStackFrameLineHighlight"
+		],
+		"vs/workbench/contrib/debug/browser/debugViewlet": [
+			"toggleDebugViewlet",
+			{
+				"key": "miOpenConfigurations",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			{
+				"key": "selectWorkspaceFolder",
+				"comment": [
+					"User picks a workspace folder or a workspace configuration file here. Workspace configuration files can contain settings and thus a launch.json configuration can be written into one."
+				]
+			},
+			"debugPanel",
+			{
+				"key": "miToggleDebugConsole",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			"debugPanel",
+			"startAdditionalSession"
+		],
+		"vs/workbench/contrib/debug/browser/repl": [
+			{
+				"key": "workbench.debug.filter.placeholder",
+				"comment": [
+					"Text in the brackets after e.g. is not localizable"
+				]
+			},
+			"debugConsole",
+			"startDebugFirst",
+			{
+				"key": "actions.repl.acceptInput",
+				"comment": [
+					"Apply input from the debug console input box"
+				]
+			},
+			"repl.action.filter",
+			"actions.repl.copyAll",
+			"filter",
+			"selectRepl",
+			"clearRepl",
+			"debugConsoleCleared",
+			"collapse",
+			"paste",
+			"copyAll",
+			"copy"
+		],
+		"vs/workbench/contrib/markers/browser/markers.contribution": [
+			"markersViewIcon",
+			{
+				"key": "miMarker",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			"copyMarker",
+			"copyMessage",
+			"copyMessage",
+			"focusProblemsList",
+			"focusProblemsFilter",
+			"show multiline",
+			"problems",
+			"show singleline",
+			"problems",
+			"clearFiltersText",
+			"problems",
+			"collapseAll",
+			"filter",
+			"status.problems",
+			"totalErrors",
+			"totalWarnings",
+			"totalInfos",
+			"noProblems",
+			"manyProblems"
+		],
+		"vs/workbench/contrib/comments/browser/comments.contribution": [
+			"commentsConfigurationTitle",
+			"openComments"
+		],
+		"vs/workbench/contrib/url/browser/url.contribution": [
+			"openUrl",
+			"urlToOpen"
+		],
+		"vs/workbench/contrib/webviewPanel/browser/webviewPanel.contribution": [
+			"webview.editor.label"
+		],
+		"vs/workbench/contrib/extensions/browser/extensions.contribution": [
+			"manageExtensionsQuickAccessPlaceholder",
+			"manageExtensionsHelp",
+			"extension",
+			"extensions",
+			"extensionsConfigurationTitle",
+			"extensionsAutoUpdate",
+			"extensionsCheckUpdates",
+			"extensionsIgnoreRecommendations",
+			"extensionsShowRecommendationsOnlyOnDemand_Deprecated",
+			"extensionsCloseExtensionDetailsOnViewChange",
+			"handleUriConfirmedExtensions",
+			"extensionsWebWorker",
+			"workbench.extensions.installExtension.description",
+			"workbench.extensions.installExtension.arg.name",
+			"notFound",
+			"workbench.extensions.uninstallExtension.description",
+			"workbench.extensions.uninstallExtension.arg.name",
+			"id required",
+			"notInstalled",
+			"builtin",
+			"workbench.extensions.search.description",
+			"workbench.extensions.search.arg.name",
+			"installExtensionQuickAccessPlaceholder",
+			"installExtensionQuickAccessHelp",
+			"toggleExtensionsViewlet",
+			{
+				"key": "miPreferencesExtensions",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			{
+				"key": "miViewExtensions",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			"showExtensions",
+			"installExtensions",
+			"showRecommendedKeymapExtensionsShort",
+			{
+				"key": "miOpenKeymapExtensions",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			"miOpenKeymapExtensions2",
+			"showLanguageExtensionsShort",
+			"checkForUpdates",
+			"noUpdatesAvailable",
+			"singleUpdateAvailable",
+			"updatesAvailable",
+			"singleDisabledUpdateAvailable",
+			"updatesAvailableOneDisabled",
+			"updatesAvailableAllDisabled",
+			"updatesAvailableIncludingDisabled",
+			"disableAutoUpdate",
+			"updateAll",
+			"enableAutoUpdate",
+			"enableAll",
+			"enableAllWorkspace",
+			"disableAll",
+			"disableAllWorkspace",
+			"InstallFromVSIX",
+			"installFromVSIX",
+			{
+				"key": "installButton",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			"installVSIX",
+			"InstallVSIXAction.successReload",
+			"InstallVSIXAction.success",
+			"InstallVSIXAction.reloadNow",
+			"filterExtensions",
+			"showFeaturedExtensions",
+			"featured filter",
+			"showPopularExtensions",
+			"most popular filter",
+			"showRecommendedExtensions",
+			"most popular recommended",
+			"recentlyPublishedExtensions",
+			"recently published filter",
+			"filter by category",
+			"showBuiltInExtensions",
+			"builtin filter",
+			"showInstalledExtensions",
+			"installed filter",
+			"showEnabledExtensions",
+			"enabled filter",
+			"showDisabledExtensions",
+			"disabled filter",
+			"showOutdatedExtensions",
+			"outdated filter",
+			"sorty by",
+			"sort by installs",
+			"sort by rating",
+			"sort by name",
+			"sort by date",
+			"clearExtensionsSearchResults",
+			"refreshExtension",
+			"installWorkspaceRecommendedExtensions",
+			"workbench.extensions.action.copyExtension",
+			"extensionInfoName",
+			"extensionInfoId",
+			"extensionInfoDescription",
+			"extensionInfoVersion",
+			"extensionInfoPublisher",
+			"extensionInfoVSMarketplaceLink",
+			"workbench.extensions.action.copyExtensionId",
+			"workbench.extensions.action.configure",
+			"workbench.extensions.action.toggleIgnoreExtension",
+			"workbench.extensions.action.ignoreRecommendation",
+			"workbench.extensions.action.undoIgnoredRecommendation",
+			"workbench.extensions.action.addExtensionToWorkspaceRecommendations",
+			"workbench.extensions.action.removeExtensionFromWorkspaceRecommendations",
+			"workbench.extensions.action.addToWorkspaceRecommendations",
+			"extensions",
+			"workbench.extensions.action.addToWorkspaceFolderRecommendations",
+			"extensions",
+			"workbench.extensions.action.addToWorkspaceIgnoredRecommendations",
+			"extensions",
+			"workbench.extensions.action.addToWorkspaceFolderIgnoredRecommendations",
+			"extensions",
+			"extensions"
+		],
+		"vs/workbench/contrib/output/browser/output.contribution": [
+			"outputViewIcon",
+			"output",
+			"output",
+			"logViewer",
+			"switchToOutput.label",
+			"clearOutput.label",
+			"outputCleared",
+			"toggleAutoScroll",
+			"outputScrollOff",
+			"outputScrollOn",
+			"openActiveLogOutputFile",
+			"toggleOutput",
+			"showLogs",
+			"selectlog",
+			"openLogFile",
+			"selectlogFile",
+			{
+				"key": "miToggleOutput",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			"output",
+			"output.smartScroll.enabled"
+		],
+		"vs/workbench/contrib/extensions/browser/extensionsViewlet": [
+			"installed",
+			"select and install local extensions",
+			{
+				"key": "remote",
+				"comment": [
+					"Remote as in remote machine"
+				]
+			},
+			"install remote in local",
+			{
+				"key": "remote",
+				"comment": [
+					"Remote as in remote machine"
+				]
+			},
+			"popularExtensions",
+			"recommendedExtensions",
+			"enabledExtensions",
+			"disabledExtensions",
+			"marketPlace",
+			"installed",
+			"enabled",
+			"disabled",
+			"outdated",
+			"builtin",
+			"workspaceRecommendedExtensions",
+			"otherRecommendedExtensions",
+			"builtinFeatureExtensions",
+			"builtInThemesExtensions",
+			"builtinProgrammingLanguageExtensions",
+			"searchExtensions",
+			"extensionFoundInSection",
+			"extensionFound",
+			"extensionsFoundInSection",
+			"extensionsFound",
+			"suggestProxyError",
+			"open user settings",
+			"outdatedExtensions",
+			"malicious warning",
+			"reloadNow"
+		],
+		"vs/workbench/contrib/output/browser/outputView": [
+			"output model title",
+			"channel",
+			"output",
+			"outputViewWithInputAriaLabel",
+			"outputViewAriaLabel",
+			"outputChannels",
+			"logChannel"
+		],
+		"vs/workbench/contrib/terminal/browser/terminal.contribution": [
+			"tasksQuickAccessPlaceholder",
+			"tasksQuickAccessHelp",
+			"terminal",
+			"terminal"
+		],
+		"vs/workbench/contrib/terminal/browser/terminalView": [
+			"terminal.useMonospace",
+			"terminal.monospaceOnly"
+		],
+		"vs/workbench/contrib/terminal/browser/remoteTerminalService": [
+			"terminal.integrated.starting"
+		],
+		"vs/workbench/contrib/relauncher/browser/relauncher.contribution": [
+			"relaunchSettingMessage",
+			"relaunchSettingMessageWeb",
+			"relaunchSettingDetail",
+			"relaunchSettingDetailWeb",
+			"restart",
+			"restartWeb"
+		],
+		"vs/workbench/contrib/tasks/browser/task.contribution": [
+			"building",
+			"numberOfRunningTasks",
+			"runningTasks",
+			"status.runningTasks",
+			{
+				"key": "miRunTask",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			{
+				"key": "miBuildTask",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			{
+				"key": "miRunningTask",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			{
+				"key": "miRestartTask",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			{
+				"key": "miTerminateTask",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			{
+				"key": "miConfigureTask",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			{
+				"key": "miConfigureBuildTask",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			"workbench.action.tasks.openWorkspaceFileTasks",
+			"ShowLogAction.label",
+			"RunTaskAction.label",
+			"ReRunTaskAction.label",
+			"RestartTaskAction.label",
+			"ShowTasksAction.label",
+			"TerminateAction.label",
+			"BuildAction.label",
+			"TestAction.label",
+			"ConfigureDefaultBuildTask.label",
+			"ConfigureDefaultTestTask.label",
+			"workbench.action.tasks.openUserTasks",
+			"tasksQuickAccessPlaceholder",
+			"tasksQuickAccessHelp",
+			"tasksConfigurationTitle",
+			"task.problemMatchers.neverPrompt",
+			"task.problemMatchers.neverPrompt.boolean",
+			"task.problemMatchers.neverPrompt.array",
+			"task.autoDetect",
+			"task.slowProviderWarning",
+			"task.slowProviderWarning.boolean",
+			"task.slowProviderWarning.array",
+			"task.quickOpen.history",
+			"task.quickOpen.detail",
+			"task.quickOpen.skip",
+			"task.quickOpen.showAll",
+			"task.saveBeforeRun",
+			"task.saveBeforeRun.always",
+			"task.saveBeforeRun.never",
+			"task.SaveBeforeRun.prompt"
+		],
+		"vs/workbench/contrib/remote/common/remote.contribution": [
+			"remoteExtensionLog",
+			"ui",
+			"workspace",
+			"web",
+			"remote",
+			"remote.extensionKind",
+			"remote.restoreForwardedPorts",
+			"remote.autoForwardPorts",
+			"remote.portsAttributes.port",
+			"remote.portsAttributes.notify",
+			"remote.portsAttributes.openBrowser",
+			"remote.portsAttributes.silent",
+			"remote.portsAttributes.ignore",
+			"remote.portsAttributes.onForward",
+			"remote.portsAttributes.elevateIfNeeded",
+			"remote.portsAttributes.label",
+			"remote.portsAttributes.labelDefault",
+			"remote.portsAttributes.labelDefault",
+			"remote.portsAttributes"
+		],
+		"vs/workbench/contrib/remote/browser/remote": [
+			"RemoteHelpInformationExtPoint",
+			"RemoteHelpInformationExtPoint.getStarted",
+			"RemoteHelpInformationExtPoint.documentation",
+			"RemoteHelpInformationExtPoint.feedback",
+			"RemoteHelpInformationExtPoint.issues",
+			"remote.help.getStarted",
+			"remote.help.documentation",
+			"remote.help.feedback",
+			"remote.help.issues",
+			"remote.help.report",
+			"pickRemoteExtension",
+			"remote.help",
+			"remotehelp",
+			"remote.explorer",
+			"remote.explorer",
+			"toggleRemoteViewlet",
+			"reconnectionWaitOne",
+			"reconnectionWaitMany",
+			"reconnectNow",
+			"reloadWindow",
+			"connectionLost",
+			"reconnectionRunning",
+			"reconnectionPermanentFailure",
+			"reloadWindow",
+			"cancel"
+		],
+		"vs/workbench/contrib/keybindings/browser/keybindings.contribution": [
+			"toggleKeybindingsLog"
+		],
+		"vs/workbench/contrib/externalTerminal/browser/externalTerminal.contribution": [
+			"scopedConsoleAction",
+			"scopedConsoleAction.integrated",
+			"scopedConsoleAction.integrated",
+			"scopedConsoleAction.wt",
+			"scopedConsoleAction.external"
+		],
+		"vs/workbench/contrib/snippets/browser/snippets.contribution": [
+			"snippetSchema.json.prefix",
+			"snippetSchema.json.body",
+			"snippetSchema.json.description",
+			"snippetSchema.json.default",
+			"snippetSchema.json",
+			"snippetSchema.json.default",
+			"snippetSchema.json",
+			"snippetSchema.json.scope"
+		],
+		"vs/workbench/contrib/snippets/browser/snippetsService": [
+			"invalid.path.0",
+			"invalid.language.0",
+			"invalid.language",
+			"invalid.path.1",
+			"vscode.extension.contributes.snippets",
+			"vscode.extension.contributes.snippets-language",
+			"vscode.extension.contributes.snippets-path",
+			"badVariableUse",
+			"badFile"
+		],
+		"vs/workbench/contrib/snippets/browser/insertSnippet": [
+			"snippet.suggestions.label",
+			"sep.userSnippet",
+			"sep.extSnippet",
+			"sep.workspaceSnippet",
+			"disableSnippet",
+			"isDisabled",
+			"enable.snippet",
+			"pick.placeholder"
+		],
+		"vs/workbench/contrib/snippets/browser/configureSnippets": [
+			"global.scope",
+			"global.1",
+			"name",
+			"bad_name1",
+			"bad_name2",
+			"bad_name3",
+			"new.global_scope",
+			"new.global",
+			"new.workspace_scope",
+			"new.folder",
+			"group.global",
+			"new.global.sep",
+			"new.global.sep",
+			"openSnippet.pickLanguage",
+			"openSnippet.label",
+			"preferences",
+			{
+				"key": "miOpenSnippets",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			"userSnippets"
+		],
+		"vs/workbench/contrib/themes/browser/themes.contribution": [
+			"selectTheme.label",
+			"themes.category.light",
+			"themes.category.dark",
+			"themes.category.hc",
+			"installColorThemes",
+			"themes.selectTheme",
+			"selectIconTheme.label",
+			"noIconThemeLabel",
+			"noIconThemeDesc",
+			"installIconThemes",
+			"themes.selectIconTheme",
+			"selectProductIconTheme.label",
+			"defaultProductIconThemeLabel",
+			"installProductIconThemes",
+			"themes.selectProductIconTheme",
+			"generateColorTheme.label",
+			"preferences",
+			{
+				"key": "miSelectColorTheme",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			{
+				"key": "miSelectIconTheme",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			{
+				"key": "miSelectProductIconTheme",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			"selectTheme.label",
+			"themes.selectIconTheme.label",
+			"themes.selectProductIconTheme.label"
+		],
+		"vs/workbench/contrib/update/browser/update.contribution": [
+			{
+				"key": "miReleaseNotes",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			}
+		],
+		"vs/workbench/contrib/watermark/browser/watermark": [
+			"watermark.showCommands",
+			"watermark.quickAccess",
+			"watermark.openFile",
+			"watermark.openFolder",
+			"watermark.openFileFolder",
+			"watermark.openRecent",
+			"watermark.newUntitledFile",
+			{
+				"key": "watermark.toggleTerminal",
+				"comment": [
+					"toggle is a verb here"
+				]
+			},
+			"watermark.findInFiles",
+			"watermark.startDebugging",
+			"tips.enabled"
+		],
+		"vs/workbench/contrib/surveys/browser/nps.contribution": [
+			"surveyQuestion",
+			"takeSurvey",
+			"remindLater",
+			"neverAgain"
+		],
+		"vs/workbench/contrib/surveys/browser/languageSurveys.contribution": [
+			"helpUs",
+			"takeShortSurvey",
+			"remindLater",
+			"neverAgain"
+		],
+		"vs/workbench/contrib/welcome/overlay/browser/welcomeOverlay": [
+			"welcomeOverlay.explorer",
+			"welcomeOverlay.search",
+			"welcomeOverlay.git",
+			"welcomeOverlay.debug",
+			"welcomeOverlay.extensions",
+			"welcomeOverlay.problems",
+			"welcomeOverlay.terminal",
+			"welcomeOverlay.commandPalette",
+			"welcomeOverlay.notifications",
+			"welcomeOverlay",
+			"hideWelcomeOverlay"
+		],
+		"vs/workbench/contrib/welcome/page/browser/welcomePage.contribution": [
+			{
+				"comment": [
+					"This is the description for a setting. Values surrounded by single quotes are not to be translated."
+				],
+				"key": "workbench.startupEditor.none"
+			},
+			{
+				"comment": [
+					"This is the description for a setting. Values surrounded by single quotes are not to be translated."
+				],
+				"key": "workbench.startupEditor.welcomePage"
+			},
+			{
+				"comment": [
+					"This is the description for a setting. Values surrounded by single quotes are not to be translated."
+				],
+				"key": "workbench.startupEditor.readme"
+			},
+			{
+				"comment": [
+					"This is the description for a setting. Values surrounded by single quotes are not to be translated."
+				],
+				"key": "workbench.startupEditor.newUntitledFile"
+			},
+			{
+				"comment": [
+					"This is the description for a setting. Values surrounded by single quotes are not to be translated."
+				],
+				"key": "workbench.startupEditor.welcomePageInEmptyWorkbench"
+			},
+			{
+				"comment": [
+					"This is the description for a setting. Values surrounded by single quotes are not to be translated."
+				],
+				"key": "workbench.startupEditor.gettingStarted"
+			},
+			"workbench.startupEditor",
+			{
+				"key": "miWelcome",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			}
+		],
+		"vs/workbench/contrib/welcome/gettingStarted/browser/gettingStarted.contribution": [
+			"Getting Started",
+			"help",
+			"gettingStartedDescription"
+		],
+		"vs/workbench/contrib/welcome/walkThrough/browser/walkThrough.contribution": [
+			"walkThrough.editor.label",
+			{
+				"key": "miInteractivePlayground",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			}
+		],
+		"vs/workbench/contrib/callHierarchy/browser/callHierarchy.contribution": [
+			"no.item",
+			"error",
+			"title",
+			"title.incoming",
+			"showIncomingCallsIcons",
+			"title.outgoing",
+			"showOutgoingCallsIcon",
+			"title.refocus",
+			"close"
+		],
+		"vs/workbench/contrib/codeEditor/browser/outline/documentSymbolsOutline": [
+			"document"
+		],
+		"vs/workbench/contrib/outline/browser/outline.contribution": [
+			"outlineViewIcon",
+			"name",
+			"outlineConfigurationTitle",
+			"outline.showIcons",
+			"outline.showProblem",
+			"outline.problem.colors",
+			"outline.problems.badges",
+			"filteredTypes.file",
+			"filteredTypes.module",
+			"filteredTypes.namespace",
+			"filteredTypes.package",
+			"filteredTypes.class",
+			"filteredTypes.method",
+			"filteredTypes.property",
+			"filteredTypes.field",
+			"filteredTypes.constructor",
+			"filteredTypes.enum",
+			"filteredTypes.interface",
+			"filteredTypes.function",
+			"filteredTypes.variable",
+			"filteredTypes.constant",
+			"filteredTypes.string",
+			"filteredTypes.number",
+			"filteredTypes.boolean",
+			"filteredTypes.array",
+			"filteredTypes.object",
+			"filteredTypes.key",
+			"filteredTypes.null",
+			"filteredTypes.enumMember",
+			"filteredTypes.struct",
+			"filteredTypes.event",
+			"filteredTypes.operator",
+			"filteredTypes.typeParameter"
+		],
+		"vs/workbench/contrib/experiments/browser/experiments.contribution": [
+			"workbench.enableExperiments"
+		],
+		"vs/workbench/contrib/userDataSync/browser/userDataSync.contribution": [
+			"operationId",
+			"too many requests"
+		],
+		"vs/workbench/contrib/timeline/browser/timeline.contribution": [
+			"timelineViewIcon",
+			"timelineOpenIcon",
+			"timelineConfigurationTitle",
+			"timeline.excludeSources",
+			"timeline.pageSize",
+			"timeline.pageOnScroll",
+			"files.openTimeline"
+		],
+		"vs/workbench/contrib/workspaces/browser/workspaces.contribution": [
+			"workspaceFound",
+			"openWorkspace",
+			"workspacesFound",
+			"selectWorkspace",
+			"selectToOpen"
+		],
+		"vs/workbench/browser/parts/dialogs/dialogHandler": [
+			{
+				"key": "yesButton",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			"cancelButton",
+			"aboutDetail",
+			"copy",
+			"ok"
+		],
+		"vs/workbench/electron-sandbox/parts/dialogs/dialogHandler": [
+			{
+				"key": "yesButton",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			"cancelButton",
+			{
+				"key": "aboutDetail",
+				"comment": [
+					"Electron, Chrome, Node.js and V8 are product names that need no translation"
+				]
+			},
+			"okButton",
+			{
+				"key": "copy",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			}
+		],
+		"vs/workbench/services/dialogs/browser/abstractFileDialogService": [
+			"saveChangesDetail",
+			"saveChangesMessage",
+			"saveChangesMessages",
+			{
+				"key": "saveAll",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			{
+				"key": "save",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			{
+				"key": "dontSave",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			"cancel",
+			"openFileOrFolder.title",
+			"openFile.title",
+			"openFolder.title",
+			"openWorkspace.title",
+			"filterName.workspace",
+			"saveFileAs.title",
+			"saveAsTitle",
+			"allFiles",
+			"noExt"
+		],
+		"vs/workbench/services/textMate/browser/abstractTextMateService": [
+			"alreadyDebugging",
+			"stop",
+			"progress1",
+			"progress2",
+			"invalid.language",
+			"invalid.scopeName",
+			"invalid.path.0",
+			"invalid.injectTo",
+			"invalid.embeddedLanguages",
+			"invalid.tokenTypes",
+			"invalid.path.1",
+			"too many characters",
+			"neverAgain"
+		],
+		"vs/workbench/services/workspaces/browser/abstractWorkspaceEditingService": [
+			"save",
+			"saveWorkspace",
+			"errorInvalidTaskConfiguration",
+			"errorWorkspaceConfigurationFileDirty",
+			"openWorkspaceConfigurationFile"
+		],
+		"vs/workbench/services/configurationResolver/browser/configurationResolverService": [
+			"commandVariable.noStringType",
+			"inputVariable.noInputSection",
+			"inputVariable.missingAttribute",
+			"inputVariable.defaultInputValue",
+			"inputVariable.command.noStringType",
+			"inputVariable.unknownType",
+			"inputVariable.undefinedVariable"
+		],
+		"vs/workbench/services/extensionManagement/common/extensionManagementService": [
+			"singleDependentError",
+			"twoDependentsError",
+			"multipleDependentsError",
+			"Manifest is not found",
+			"cannot be installed",
+			"cannot be installed on web",
+			"install extension",
+			"install extensions",
+			"install",
+			"install and do no sync",
+			"cancel",
+			"install single extension",
+			"install multiple extensions"
+		],
+		"vs/workbench/contrib/logs/electron-sandbox/logsActions": [
+			"openLogsFolder",
+			"openExtensionLogsFolder"
+		],
+		"vs/workbench/contrib/localizations/browser/localizationsActions": [
+			"configureLocale",
+			"installAdditionalLanguages",
+			"chooseDisplayLanguage",
+			"relaunchDisplayLanguageMessage",
+			"relaunchDisplayLanguageDetail",
+			"restart"
+		],
+		"vs/workbench/services/extensions/common/extensionsRegistry": [
+			"ui",
+			"workspace",
+			"web",
+			"vscode.extension.engines",
+			"vscode.extension.engines.vscode",
+			"vscode.extension.publisher",
+			"vscode.extension.displayName",
+			"vscode.extension.categories",
+			"vscode.extension.category.languages.deprecated",
+			"vscode.extension.galleryBanner",
+			"vscode.extension.galleryBanner.color",
+			"vscode.extension.galleryBanner.theme",
+			"vscode.extension.contributes",
+			"vscode.extension.preview",
+			"vscode.extension.activationEvents",
+			"vscode.extension.activationEvents.onLanguage",
+			"vscode.extension.activationEvents.onCommand",
+			"vscode.extension.activationEvents.onDebug",
+			"vscode.extension.activationEvents.onDebugInitialConfigurations",
+			"vscode.extension.activationEvents.onDebugDynamicConfigurations",
+			"vscode.extension.activationEvents.onDebugResolve",
+			"vscode.extension.activationEvents.onDebugAdapterProtocolTracker",
+			"vscode.extension.activationEvents.workspaceContains",
+			"vscode.extension.activationEvents.onStartupFinished",
+			"vscode.extension.activationEvents.onFileSystem",
+			"vscode.extension.activationEvents.onSearch",
+			"vscode.extension.activationEvents.onView",
+			"vscode.extension.activationEvents.onIdentity",
+			"vscode.extension.activationEvents.onUri",
+			"vscode.extension.activationEvents.onCustomEditor",
+			"vscode.extension.activationEvents.onNotebook",
+			"vscode.extension.activationEvents.star",
+			"vscode.extension.badges",
+			"vscode.extension.badges.url",
+			"vscode.extension.badges.href",
+			"vscode.extension.badges.description",
+			"vscode.extension.markdown",
+			"vscode.extension.qna",
+			"vscode.extension.extensionDependencies",
+			"vscode.extension.contributes.extensionPack",
+			"extensionKind",
+			"extensionKind.ui",
+			"extensionKind.workspace",
+			"extensionKind.ui-workspace",
+			"extensionKind.workspace-ui",
+			"extensionKind.empty",
+			"vscode.extension.scripts.prepublish",
+			"vscode.extension.scripts.uninstall",
+			"vscode.extension.icon"
+		],
+		"vs/workbench/contrib/localizations/browser/minimalTranslations": [
+			"showLanguagePackExtensions",
+			"searchMarketplace",
+			"installAndRestartMessage",
+			"installAndRestart"
+		],
+		"vs/workbench/electron-sandbox/actions/developerActions": [
+			"toggleDevTools",
+			"configureRuntimeArguments",
+			"toggleSharedProcess",
+			"reloadWindowWithExtensionsDisabled"
+		],
+		"vs/workbench/electron-sandbox/actions/windowActions": [
+			"closeWindow",
+			"zoomIn",
+			"zoomOut",
+			"zoomReset",
+			"close",
+			"close",
+			"switchWindowPlaceHolder",
+			"windowDirtyAriaLabel",
+			"current",
+			"switchWindow",
+			"quickSwitchWindow"
+		],
+		"vs/workbench/contrib/files/common/editors/fileEditorInput": [
+			"orphanedReadonlyFile",
+			"orphanedFile",
+			"readonlyFile"
+		],
+		"vs/workbench/contrib/files/electron-sandbox/textFileEditor": [
+			"fileTooLargeForHeapError",
+			"relaunchWithIncreasedMemoryLimit",
+			"configureMemoryLimit"
+		],
+		"vs/workbench/contrib/backup/electron-sandbox/backupTracker": [
+			"backupTrackerBackupFailed",
+			"backupTrackerConfirmFailed",
+			"backupErrorDetails",
+			"ok",
+			"saveBeforeShutdown"
+		],
+		"vs/workbench/contrib/files/electron-sandbox/fileCommands": [
+			"openFileToReveal"
+		],
+		"vs/workbench/contrib/codeEditor/electron-sandbox/selectionClipboard": [
+			"actions.pasteSelectionClipboard"
+		],
+		"vs/workbench/contrib/issue/electron-sandbox/issueActions": [
+			"openProcessExplorer",
+			{
+				"key": "reportPerformanceIssue",
+				"comment": [
+					"Here, 'issue' means problem or bug"
+				]
+			}
+		],
+		"vs/workbench/services/dialogs/browser/simpleFileDialog": [
+			"openLocalFile",
+			"saveLocalFile",
+			"openLocalFolder",
+			"openLocalFileFolder",
+			"remoteFileDialog.notConnectedToRemote",
+			"remoteFileDialog.local",
+			"remoteFileDialog.badPath",
+			"remoteFileDialog.cancel",
+			"remoteFileDialog.invalidPath",
+			"remoteFileDialog.validateFolder",
+			"remoteFileDialog.validateExisting",
+			"remoteFileDialog.validateBadFilename",
+			"remoteFileDialog.validateNonexistentDir",
+			"remoteFileDialog.validateNonexistentDir",
+			"remoteFileDialog.windowsDriveLetter",
+			"remoteFileDialog.validateFileOnly",
+			"remoteFileDialog.validateFolderOnly"
+		],
+		"vs/workbench/browser/parts/notifications/notificationsCenter": [
+			"notificationsEmpty",
+			"notifications",
+			"notificationsToolbar"
+		],
+		"vs/workbench/browser/parts/notifications/notificationsAlerts": [
+			"alertErrorMessage",
+			"alertWarningMessage",
+			"alertInfoMessage"
+		],
+		"vs/workbench/browser/parts/notifications/notificationsStatus": [
+			"status.notifications",
+			"status.notifications",
+			"hideNotifications",
+			"zeroNotifications",
+			"noNotifications",
+			"oneNotification",
+			{
+				"key": "notifications",
+				"comment": [
+					"{0} will be replaced by a number"
+				]
+			},
+			{
+				"key": "noNotificationsWithProgress",
+				"comment": [
+					"{0} will be replaced by a number"
+				]
+			},
+			{
+				"key": "oneNotificationWithProgress",
+				"comment": [
+					"{0} will be replaced by a number"
+				]
+			},
+			{
+				"key": "notificationsWithProgress",
+				"comment": [
+					"{0} and {1} will be replaced by a number"
+				]
+			},
+			"status.message"
+		],
+		"vs/workbench/browser/parts/notifications/notificationsCommands": [
+			"notifications",
+			"showNotifications",
+			"hideNotifications",
+			"clearAllNotifications",
+			"focusNotificationToasts"
+		],
+		"vs/platform/actions/browser/menuEntryActionViewItem": [
+			"titleAndKb"
+		],
+		"vs/workbench/services/configuration/common/configurationEditingService": [
+			"openTasksConfiguration",
+			"openLaunchConfiguration",
+			"open",
+			"openTasksConfiguration",
+			"openLaunchConfiguration",
+			"saveAndRetry",
+			"saveAndRetry",
+			"open",
+			"errorUnknownKey",
+			"errorInvalidWorkspaceConfigurationApplication",
+			"errorInvalidWorkspaceConfigurationMachine",
+			"errorInvalidFolderConfiguration",
+			"errorInvalidUserTarget",
+			"errorInvalidWorkspaceTarget",
+			"errorInvalidFolderTarget",
+			"errorInvalidResourceLanguageConfiguraiton",
+			"errorNoWorkspaceOpened",
+			"errorInvalidTaskConfiguration",
+			"errorInvalidLaunchConfiguration",
+			"errorInvalidConfiguration",
+			"errorInvalidRemoteConfiguration",
+			"errorInvalidConfigurationWorkspace",
+			"errorInvalidConfigurationFolder",
+			"errorTasksConfigurationFileDirty",
+			"errorLaunchConfigurationFileDirty",
+			"errorConfigurationFileDirty",
+			"errorRemoteConfigurationFileDirty",
+			"errorConfigurationFileDirtyWorkspace",
+			"errorConfigurationFileDirtyFolder",
+			"errorTasksConfigurationFileModifiedSince",
+			"errorLaunchConfigurationFileModifiedSince",
+			"errorConfigurationFileModifiedSince",
+			"errorRemoteConfigurationFileModifiedSince",
+			"errorConfigurationFileModifiedSinceWorkspace",
+			"errorConfigurationFileModifiedSinceFolder",
+			"userTarget",
+			"remoteUserTarget",
+			"workspaceTarget",
+			"folderTarget"
+		],
+		"vs/workbench/services/textfile/common/textFileEditorModelManager": [
+			{
+				"key": "genericSaveError",
+				"comment": [
+					"{0} is the resource that failed to save and {1} the error message"
+				]
+			}
+		],
+		"vs/editor/common/modes/modesRegistry": [
+			"plainText.alias"
+		],
+		"vs/workbench/services/extensions/node/extensionPoints": [
+			"jsonParseInvalidType",
+			"jsonParseFail",
+			"fileReadFail",
+			"jsonsParseReportErrors",
+			"jsonInvalidFormat",
+			"missingNLSKey",
+			"notSemver",
+			"extensionDescription.empty",
+			"extensionDescription.publisher",
+			"extensionDescription.name",
+			"extensionDescription.version",
+			"extensionDescription.engines",
+			"extensionDescription.engines.vscode",
+			"extensionDescription.extensionDependencies",
+			"extensionDescription.activationEvents1",
+			"extensionDescription.activationEvents2",
+			"extensionDescription.main1",
+			"extensionDescription.main2",
+			"extensionDescription.main3",
+			"extensionDescription.browser1",
+			"extensionDescription.browser2",
+			"extensionDescription.browser3"
+		],
+		"vs/workbench/services/extensions/common/extensionHostManager": [
+			"measureExtHostLatency"
+		],
+		"vs/workbench/contrib/webview/browser/baseWebviewElement": [
+			"fatalErrorMessage"
+		],
+		"vs/workbench/contrib/notebook/browser/notebookIcons": [
+			"configureKernel",
+			"selectKernelIcon",
+			"executeIcon",
+			"stopIcon",
+			"deleteCellIcon",
+			"executeAllIcon",
+			"editIcon",
+			"stopEditIcon",
+			"moveUpIcon",
+			"moveDownIcon",
+			"clearIcon",
+			"splitCellIcon",
+			"unfoldIcon",
+			"successStateIcon",
+			"errorStateIcon",
+			"collapsedIcon",
+			"expandedIcon",
+			"openAsTextIcon",
+			"revertIcon",
+			"renderOutputIcon",
+			"mimetypeIcon"
+		],
+		"vs/workbench/contrib/extensions/electron-browser/extensionsSlowActions": [
+			"cmd.reportOrShow",
+			"cmd.report",
+			"attach.title",
+			"ok",
+			"attach.msg",
+			"cmd.show",
+			"attach.title",
+			"ok",
+			"attach.msg2"
+		],
+		"vs/workbench/contrib/extensions/electron-browser/reportExtensionIssueAction": [
+			"reportExtensionIssue"
+		],
+		"vs/workbench/contrib/extensions/browser/abstractRuntimeExtensionsEditor": [
+			{
+				"key": "starActivation",
+				"comment": [
+					"{0} will be an extension identifier"
+				]
+			},
+			{
+				"key": "workspaceContainsGlobActivation",
+				"comment": [
+					"{0} will be a glob pattern",
+					"{1} will be an extension identifier"
+				]
+			},
+			{
+				"key": "workspaceContainsFileActivation",
+				"comment": [
+					"{0} will be a file name",
+					"{1} will be an extension identifier"
+				]
+			},
+			{
+				"key": "workspaceContainsTimeout",
+				"comment": [
+					"{0} will be a glob pattern",
+					"{1} will be an extension identifier"
+				]
+			},
+			{
+				"key": "startupFinishedActivation",
+				"comment": [
+					"This refers to an extension. {0} will be an activation event."
+				]
+			},
+			"languageActivation",
+			{
+				"key": "workspaceGenericActivation",
+				"comment": [
+					"{0} will be an activation event, like e.g. 'language:typescript', 'debug', etc.",
+					"{1} will be an extension identifier"
+				]
+			},
+			"unresponsive.title",
+			"errors",
+			"runtimeExtensions",
+			"disable workspace",
+			"disable",
+			"showRuntimeExtensions"
+		],
+		"vs/workbench/contrib/terminal/node/terminalProcess": [
+			"launchFail.cwdNotDirectory",
+			"launchFail.cwdDoesNotExist",
+			"launchFail.executableIsNotFileOrSymlink",
+			"launchFail.executableDoesNotExist"
+		],
+		"vs/workbench/contrib/terminal/electron-browser/terminalRemote": [
+			"workbench.action.terminal.newLocal"
+		],
+		"vs/editor/common/config/editorOptions": [
+			"accessibilitySupport.auto",
+			"accessibilitySupport.on",
+			"accessibilitySupport.off",
+			"accessibilitySupport",
+			"comments.insertSpace",
+			"comments.ignoreEmptyLines",
+			"emptySelectionClipboard",
+			"find.cursorMoveOnType",
+			"find.seedSearchStringFromSelection",
+			"editor.find.autoFindInSelection.never",
+			"editor.find.autoFindInSelection.always",
+			"editor.find.autoFindInSelection.multiline",
+			"find.autoFindInSelection",
+			"find.globalFindClipboard",
+			"find.addExtraSpaceOnTop",
+			"find.loop",
+			"fontLigatures",
+			"fontFeatureSettings",
+			"fontLigaturesGeneral",
+			"fontSize",
+			"fontWeightErrorMessage",
+			"fontWeight",
+			"editor.gotoLocation.multiple.peek",
+			"editor.gotoLocation.multiple.gotoAndPeek",
+			"editor.gotoLocation.multiple.goto",
+			"editor.gotoLocation.multiple.deprecated",
+			"editor.editor.gotoLocation.multipleDefinitions",
+			"editor.editor.gotoLocation.multipleTypeDefinitions",
+			"editor.editor.gotoLocation.multipleDeclarations",
+			"editor.editor.gotoLocation.multipleImplemenattions",
+			"editor.editor.gotoLocation.multipleReferences",
+			"alternativeDefinitionCommand",
+			"alternativeTypeDefinitionCommand",
+			"alternativeDeclarationCommand",
+			"alternativeImplementationCommand",
+			"alternativeReferenceCommand",
+			"hover.enabled",
+			"hover.delay",
+			"hover.sticky",
+			"codeActions",
+			"inlineHints.enable",
+			"inlineHints.fontSize",
+			"inlineHints.fontFamily",
+			"lineHeight",
+			"minimap.enabled",
+			"minimap.size.proportional",
+			"minimap.size.fill",
+			"minimap.size.fit",
+			"minimap.size",
+			"minimap.side",
+			"minimap.showSlider",
+			"minimap.scale",
+			"minimap.renderCharacters",
+			"minimap.maxColumn",
+			"padding.top",
+			"padding.bottom",
+			"parameterHints.enabled",
+			"parameterHints.cycle",
+			"quickSuggestions.strings",
+			"quickSuggestions.comments",
+			"quickSuggestions.other",
+			"quickSuggestions",
+			"lineNumbers.off",
+			"lineNumbers.on",
+			"lineNumbers.relative",
+			"lineNumbers.interval",
+			"lineNumbers",
+			"rulers.size",
+			"rulers.color",
+			"rulers",
+			"suggest.insertMode.insert",
+			"suggest.insertMode.replace",
+			"suggest.insertMode",
+			"suggest.filterGraceful",
+			"suggest.localityBonus",
+			"suggest.shareSuggestSelections",
+			"suggest.snippetsPreventQuickSuggestions",
+			"suggest.showIcons",
+			"suggest.showStatusBar",
+			"suggest.showInlineDetails",
+			"suggest.maxVisibleSuggestions.dep",
+			"deprecated",
+			"editor.suggest.showMethods",
+			"editor.suggest.showFunctions",
+			"editor.suggest.showConstructors",
+			"editor.suggest.showFields",
+			"editor.suggest.showVariables",
+			"editor.suggest.showClasss",
+			"editor.suggest.showStructs",
+			"editor.suggest.showInterfaces",
+			"editor.suggest.showModules",
+			"editor.suggest.showPropertys",
+			"editor.suggest.showEvents",
+			"editor.suggest.showOperators",
+			"editor.suggest.showUnits",
+			"editor.suggest.showValues",
+			"editor.suggest.showConstants",
+			"editor.suggest.showEnums",
+			"editor.suggest.showEnumMembers",
+			"editor.suggest.showKeywords",
+			"editor.suggest.showTexts",
+			"editor.suggest.showColors",
+			"editor.suggest.showFiles",
+			"editor.suggest.showReferences",
+			"editor.suggest.showCustomcolors",
+			"editor.suggest.showFolders",
+			"editor.suggest.showTypeParameters",
+			"editor.suggest.showSnippets",
+			"editor.suggest.showUsers",
+			"editor.suggest.showIssues",
+			"selectLeadingAndTrailingWhitespace",
+			"acceptSuggestionOnCommitCharacter",
+			"acceptSuggestionOnEnterSmart",
+			"acceptSuggestionOnEnter",
+			"accessibilityPageSize",
+			"editorViewAccessibleLabel",
+			"editor.autoClosingBrackets.languageDefined",
+			"editor.autoClosingBrackets.beforeWhitespace",
+			"autoClosingBrackets",
+			"editor.autoClosingOvertype.auto",
+			"autoClosingOvertype",
+			"editor.autoClosingQuotes.languageDefined",
+			"editor.autoClosingQuotes.beforeWhitespace",
+			"autoClosingQuotes",
+			"editor.autoIndent.none",
+			"editor.autoIndent.keep",
+			"editor.autoIndent.brackets",
+			"editor.autoIndent.advanced",
+			"editor.autoIndent.full",
+			"autoIndent",
+			"editor.autoSurround.languageDefined",
+			"editor.autoSurround.quotes",
+			"editor.autoSurround.brackets",
+			"autoSurround",
+			"stickyTabStops",
+			"codeLens",
+			"codeLensFontFamily",
+			"codeLensFontSize",
+			"colorDecorators",
+			"columnSelection",
+			"copyWithSyntaxHighlighting",
+			"cursorBlinking",
+			"cursorSmoothCaretAnimation",
+			"cursorStyle",
+			"cursorSurroundingLines",
+			"cursorSurroundingLinesStyle.default",
+			"cursorSurroundingLinesStyle.all",
+			"cursorSurroundingLinesStyle",
+			"cursorWidth",
+			"dragAndDrop",
+			"fastScrollSensitivity",
+			"folding",
+			"foldingStrategy.auto",
+			"foldingStrategy.indentation",
+			"foldingStrategy",
+			"foldingHighlight",
+			"unfoldOnClickAfterEndOfLine",
+			"fontFamily",
+			"formatOnPaste",
+			"formatOnType",
+			"glyphMargin",
+			"hideCursorInOverviewRuler",
+			"highlightActiveIndentGuide",
+			"letterSpacing",
+			"linkedEditing",
+			"links",
+			"matchBrackets",
+			"mouseWheelScrollSensitivity",
+			"mouseWheelZoom",
+			"multiCursorMergeOverlapping",
+			"multiCursorModifier.ctrlCmd",
+			"multiCursorModifier.alt",
+			{
+				"key": "multiCursorModifier",
+				"comment": [
+					"- `ctrlCmd` refers to a value the setting can take and should not be localized.",
+					"- `Control` and `Command` refer to the modifier keys Ctrl or Cmd on the keyboard and can be localized."
+				]
+			},
+			"multiCursorPaste.spread",
+			"multiCursorPaste.full",
+			"multiCursorPaste",
+			"occurrencesHighlight",
+			"overviewRulerBorder",
+			"peekWidgetDefaultFocus.tree",
+			"peekWidgetDefaultFocus.editor",
+			"peekWidgetDefaultFocus",
+			"definitionLinkOpensInPeek",
+			"quickSuggestionsDelay",
+			"renameOnType",
+			"renameOnTypeDeprecate",
+			"renderControlCharacters",
+			"renderIndentGuides",
+			"renderFinalNewline",
+			"renderLineHighlight.all",
+			"renderLineHighlight",
+			"renderLineHighlightOnlyWhenFocus",
+			"renderWhitespace.boundary",
+			"renderWhitespace.selection",
+			"renderWhitespace.trailing",
+			"renderWhitespace",
+			"roundedSelection",
+			"scrollBeyondLastColumn",
+			"scrollBeyondLastLine",
+			"scrollPredominantAxis",
+			"selectionClipboard",
+			"selectionHighlight",
+			"showFoldingControls.always",
+			"showFoldingControls.mouseover",
+			"showFoldingControls",
+			"showUnused",
+			"showDeprecated",
+			"snippetSuggestions.top",
+			"snippetSuggestions.bottom",
+			"snippetSuggestions.inline",
+			"snippetSuggestions.none",
+			"snippetSuggestions",
+			"smoothScrolling",
+			"suggestFontSize",
+			"suggestLineHeight",
+			"suggestOnTriggerCharacters",
+			"suggestSelection.first",
+			"suggestSelection.recentlyUsed",
+			"suggestSelection.recentlyUsedByPrefix",
+			"suggestSelection",
+			"tabCompletion.on",
+			"tabCompletion.off",
+			"tabCompletion.onlySnippets",
+			"tabCompletion",
+			"unusualLineTerminators.auto",
+			"unusualLineTerminators.off",
+			"unusualLineTerminators.prompt",
+			"unusualLineTerminators",
+			"useTabStops",
+			"wordSeparators",
+			"wordWrap.off",
+			"wordWrap.on",
+			{
+				"key": "wordWrap.wordWrapColumn",
+				"comment": [
+					"- `editor.wordWrapColumn` refers to a different setting and should not be localized."
+				]
+			},
+			{
+				"key": "wordWrap.bounded",
+				"comment": [
+					"- viewport means the edge of the visible window size.",
+					"- `editor.wordWrapColumn` refers to a different setting and should not be localized."
+				]
+			},
+			{
+				"key": "wordWrap",
+				"comment": [
+					"- 'off', 'on', 'wordWrapColumn' and 'bounded' refer to values the setting can take and should not be localized.",
+					"- `editor.wordWrapColumn` refers to a different setting and should not be localized."
+				]
+			},
+			{
+				"key": "wordWrapColumn",
+				"comment": [
+					"- `editor.wordWrap` refers to a different setting and should not be localized.",
+					"- 'wordWrapColumn' and 'bounded' refer to values the different setting can take and should not be localized."
+				]
+			},
+			"wrappingIndent.none",
+			"wrappingIndent.same",
+			"wrappingIndent.indent",
+			"wrappingIndent.deepIndent",
+			"wrappingIndent",
+			"wrappingStrategy.simple",
+			"wrappingStrategy.advanced",
+			"wrappingStrategy"
+		],
+		"vs/workbench/contrib/performance/browser/perfviewEditor": [
+			"name"
+		],
+		"vs/workbench/contrib/tasks/common/taskDefinitionRegistry": [
+			"TaskDefinition.description",
+			"TaskDefinition.properties",
+			"TaskDefinition.when",
+			"TaskTypeConfiguration.noType",
+			"TaskDefinitionExtPoint"
+		],
+		"vs/workbench/contrib/tasks/common/problemMatcher": [
+			"ProblemPatternParser.problemPattern.missingRegExp",
+			"ProblemPatternParser.loopProperty.notLast",
+			"ProblemPatternParser.problemPattern.kindProperty.notFirst",
+			"ProblemPatternParser.problemPattern.missingProperty",
+			"ProblemPatternParser.problemPattern.missingLocation",
+			"ProblemPatternParser.invalidRegexp",
+			"ProblemPatternSchema.regexp",
+			"ProblemPatternSchema.kind",
+			"ProblemPatternSchema.file",
+			"ProblemPatternSchema.location",
+			"ProblemPatternSchema.line",
+			"ProblemPatternSchema.column",
+			"ProblemPatternSchema.endLine",
+			"ProblemPatternSchema.endColumn",
+			"ProblemPatternSchema.severity",
+			"ProblemPatternSchema.code",
+			"ProblemPatternSchema.message",
+			"ProblemPatternSchema.loop",
+			"NamedProblemPatternSchema.name",
+			"NamedMultiLineProblemPatternSchema.name",
+			"NamedMultiLineProblemPatternSchema.patterns",
+			"ProblemPatternExtPoint",
+			"ProblemPatternRegistry.error",
+			"ProblemPatternRegistry.error",
+			"ProblemMatcherParser.noProblemMatcher",
+			"ProblemMatcherParser.noProblemPattern",
+			"ProblemMatcherParser.noOwner",
+			"ProblemMatcherParser.noFileLocation",
+			"ProblemMatcherParser.unknownSeverity",
+			"ProblemMatcherParser.noDefinedPatter",
+			"ProblemMatcherParser.noIdentifier",
+			"ProblemMatcherParser.noValidIdentifier",
+			"ProblemMatcherParser.problemPattern.watchingMatcher",
+			"ProblemMatcherParser.invalidRegexp",
+			"WatchingPatternSchema.regexp",
+			"WatchingPatternSchema.file",
+			"PatternTypeSchema.name",
+			"PatternTypeSchema.description",
+			"ProblemMatcherSchema.base",
+			"ProblemMatcherSchema.owner",
+			"ProblemMatcherSchema.source",
+			"ProblemMatcherSchema.severity",
+			"ProblemMatcherSchema.applyTo",
+			"ProblemMatcherSchema.fileLocation",
+			"ProblemMatcherSchema.background",
+			"ProblemMatcherSchema.background.activeOnStart",
+			"ProblemMatcherSchema.background.beginsPattern",
+			"ProblemMatcherSchema.background.endsPattern",
+			"ProblemMatcherSchema.watching.deprecated",
+			"ProblemMatcherSchema.watching",
+			"ProblemMatcherSchema.watching.activeOnStart",
+			"ProblemMatcherSchema.watching.beginsPattern",
+			"ProblemMatcherSchema.watching.endsPattern",
+			"LegacyProblemMatcherSchema.watchedBegin.deprecated",
+			"LegacyProblemMatcherSchema.watchedBegin",
+			"LegacyProblemMatcherSchema.watchedEnd.deprecated",
+			"LegacyProblemMatcherSchema.watchedEnd",
+			"NamedProblemMatcherSchema.name",
+			"NamedProblemMatcherSchema.label",
+			"ProblemMatcherExtPoint",
+			"msCompile",
+			"lessCompile",
+			"gulp-tsc",
+			"jshint",
+			"jshint-stylish",
+			"eslint-compact",
+			"eslint-stylish",
+			"go"
+		],
+		"vs/platform/theme/common/iconRegistry": [
+			"iconDefintion.fontId",
+			"iconDefintion.fontCharacter",
+			"widgetClose",
+			"previousChangeIcon",
+			"nextChangeIcon"
+		],
+		"vs/workbench/contrib/tasks/common/taskTemplates": [
+			"dotnetCore",
+			"msbuild",
+			"externalCommand",
+			"Maven"
+		],
+		"vs/workbench/contrib/tasks/browser/runAutomaticTasks": [
+			"tasks.run.allowAutomatic",
+			"allow",
+			"disallow",
+			"openTasks",
+			"workbench.action.tasks.manageAutomaticRunning",
+			"workbench.action.tasks.allowAutomaticTasks",
+			"workbench.action.tasks.disallowAutomaticTasks"
+		],
+		"vs/workbench/contrib/tasks/browser/taskQuickPick": [
+			"taskQuickPick.showAll",
+			"configureTaskIcon",
+			"removeTaskIcon",
+			"configureTask",
+			"contributedTasks",
+			"taskType",
+			"removeRecent",
+			"recentlyUsed",
+			"configured",
+			"configured",
+			"TaskQuickPick.goBack",
+			"TaskQuickPick.noTasksForType",
+			"noProviderForTask"
+		],
+		"vs/workbench/api/common/extHostExtensionActivator": [
+			"failedDep1",
+			"activationError"
+		],
+		"vs/workbench/contrib/debug/common/abstractDebugAdapter": [
+			"timeout"
+		],
+		"vs/workbench/services/configurationResolver/common/variableResolver": [
+			"canNotResolveFile",
+			"canNotResolveFolderForFile",
+			"canNotFindFolder",
+			"canNotResolveWorkspaceFolderMultiRoot",
+			"canNotResolveWorkspaceFolder",
+			"missingEnvVarName",
+			"configNotFound",
+			"configNoString",
+			"missingConfigName",
+			"canNotResolveLineNumber",
+			"canNotResolveSelectedText",
+			"noValueForCommand"
+		],
+		"vs/workbench/api/common/extHost.api.impl": [
+			"extensionLabel"
+		],
+		"vs/workbench/api/node/extHostDebugService": [
+			"debug.terminal.title"
+		],
+		"vs/code/electron-main/window": [
+			{
+				"key": "reopen",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			{
+				"key": "wait",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			{
+				"key": "close",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			"appStalled",
+			"appStalledDetail",
+			"appCrashedDetails",
+			"appCrashed",
+			{
+				"key": "reopen",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			{
+				"key": "close",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			"appCrashedDetail",
+			"hiddenMenuBar"
+		],
+		"vs/platform/menubar/electron-main/menubar": [
+			{
+				"key": "miNewWindow",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			{
+				"key": "mFile",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			{
+				"key": "mEdit",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			{
+				"key": "mSelection",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			{
+				"key": "mView",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			{
+				"key": "mGoto",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			{
+				"key": "mRun",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			{
+				"key": "mTerminal",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			"mWindow",
+			{
+				"key": "mHelp",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			"mAbout",
+			{
+				"key": "miPreferences",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			"mServices",
+			"mHide",
+			"mHideOthers",
+			"mShowAll",
+			"miQuit",
+			"mMinimize",
+			"mZoom",
+			"mBringToFront",
+			{
+				"key": "miSwitchWindow",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			"mNewTab",
+			"mShowPreviousTab",
+			"mShowNextTab",
+			"mMoveTabToNewWindow",
+			"mMergeAllWindows",
+			"miCheckForUpdates",
+			"miCheckingForUpdates",
+			"miDownloadUpdate",
+			"miDownloadingUpdate",
+			"miInstallUpdate",
+			"miInstallingUpdate",
+			"miRestartToUpdate"
+		],
+		"vs/platform/userDataSync/common/abstractSynchronizer": [
+			{
+				"key": "incompatible",
+				"comment": [
+					"This is an error while syncing a resource that its local version is not compatible with its remote version."
+				]
+			},
+			"incompatible sync data"
+		],
+		"vs/editor/common/view/editorColorRegistry": [
+			"lineHighlight",
+			"lineHighlightBorderBox",
+			"rangeHighlight",
+			"rangeHighlightBorder",
+			"symbolHighlight",
+			"symbolHighlightBorder",
+			"caret",
+			"editorCursorBackground",
+			"editorWhitespaces",
+			"editorIndentGuides",
+			"editorActiveIndentGuide",
+			"editorLineNumbers",
+			"editorActiveLineNumber",
+			"deprecatedEditorActiveLineNumber",
+			"editorActiveLineNumber",
+			"editorRuler",
+			"editorCodeLensForeground",
+			"editorBracketMatchBackground",
+			"editorBracketMatchBorder",
+			"editorOverviewRulerBorder",
+			"editorOverviewRulerBackground",
+			"editorGutter",
+			"unnecessaryCodeBorder",
+			"unnecessaryCodeOpacity",
+			"overviewRulerRangeHighlight",
+			"overviewRuleError",
+			"overviewRuleWarning",
+			"overviewRuleInfo"
+		],
+		"vs/editor/common/model/editStack": [
+			"edit"
+		],
+		"vs/editor/browser/controller/coreCommands": [
+			"stickydesc",
+			"stickydesc"
+		],
+		"vs/editor/browser/widget/codeEditorWidget": [
+			"cursors.maximum"
+		],
+		"vs/editor/contrib/anchorSelect/anchorSelect": [
+			"selectionAnchor",
+			"anchorSet",
+			"setSelectionAnchor",
+			"goToSelectionAnchor",
+			"selectFromAnchorToCursor",
+			"cancelSelectionAnchor"
+		],
+		"vs/editor/browser/widget/diffEditorWidget": [
+			"diffInsertIcon",
+			"diffRemoveIcon",
+			"diff.tooLarge"
+		],
+		"vs/editor/contrib/caretOperations/caretOperations": [
+			"caret.moveLeft",
+			"caret.moveRight"
+		],
+		"vs/editor/contrib/caretOperations/transpose": [
+			"transposeLetters.label"
+		],
+		"vs/editor/contrib/bracketMatching/bracketMatching": [
+			"overviewRulerBracketMatchForeground",
+			"smartSelect.jumpBracket",
+			"smartSelect.selectToBracket",
+			{
+				"key": "miGoToBracket",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			}
+		],
+		"vs/editor/contrib/codelens/codelensController": [
+			"showLensOnLine"
+		],
+		"vs/editor/contrib/comment/comment": [
+			"comment.line",
+			{
+				"key": "miToggleLineComment",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			"comment.line.add",
+			"comment.line.remove",
+			"comment.block",
+			{
+				"key": "miToggleBlockComment",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			}
+		],
+		"vs/editor/contrib/contextmenu/contextmenu": [
+			"action.showContextMenu.label"
+		],
+		"vs/editor/contrib/cursorUndo/cursorUndo": [
+			"cursor.undo",
+			"cursor.redo"
+		],
+		"vs/editor/contrib/find/findController": [
+			"startFindAction",
+			{
+				"key": "miFind",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			"startFindWithSelectionAction",
+			"findNextMatchAction",
+			"findNextMatchAction",
+			"findPreviousMatchAction",
+			"findPreviousMatchAction",
+			"nextSelectionMatchFindAction",
+			"previousSelectionMatchFindAction",
+			"startReplace",
+			{
+				"key": "miReplace",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			}
+		],
+		"vs/editor/contrib/fontZoom/fontZoom": [
+			"EditorFontZoomIn.label",
+			"EditorFontZoomOut.label",
+			"EditorFontZoomReset.label"
+		],
+		"vs/editor/contrib/folding/folding": [
+			"unfoldAction.label",
+			"unFoldRecursivelyAction.label",
+			"foldAction.label",
+			"toggleFoldAction.label",
+			"foldRecursivelyAction.label",
+			"foldAllBlockComments.label",
+			"foldAllMarkerRegions.label",
+			"unfoldAllMarkerRegions.label",
+			"foldAllAction.label",
+			"unfoldAllAction.label",
+			"foldLevelAction.label",
+			"foldBackgroundBackground",
+			"editorGutter.foldingControlForeground"
+		],
+		"vs/editor/contrib/format/formatActions": [
+			"formatDocument.label",
+			"formatSelection.label"
+		],
+		"vs/editor/contrib/gotoSymbol/goToCommands": [
+			"peek.submenu",
+			"def.title",
+			"noResultWord",
+			"generic.noResults",
+			"actions.goToDecl.label",
+			{
+				"key": "miGotoDefinition",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			"actions.goToDeclToSide.label",
+			"actions.previewDecl.label",
+			"decl.title",
+			"decl.noResultWord",
+			"decl.generic.noResults",
+			"actions.goToDeclaration.label",
+			{
+				"key": "miGotoDeclaration",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			"decl.noResultWord",
+			"decl.generic.noResults",
+			"actions.peekDecl.label",
+			"typedef.title",
+			"goToTypeDefinition.noResultWord",
+			"goToTypeDefinition.generic.noResults",
+			"actions.goToTypeDefinition.label",
+			{
+				"key": "miGotoTypeDefinition",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			"actions.peekTypeDefinition.label",
+			"impl.title",
+			"goToImplementation.noResultWord",
+			"goToImplementation.generic.noResults",
+			"actions.goToImplementation.label",
+			{
+				"key": "miGotoImplementation",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			"actions.peekImplementation.label",
+			"references.no",
+			"references.noGeneric",
+			"goToReferences.label",
+			{
+				"key": "miGotoReference",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			"ref.title",
+			"references.action.label",
+			"ref.title",
+			"label.generic",
+			"generic.title",
+			"generic.noResult",
+			"ref.title"
+		],
+		"vs/editor/contrib/gotoSymbol/link/goToDefinitionAtPosition": [
+			"multipleResults"
+		],
+		"vs/editor/contrib/gotoError/gotoError": [
+			"markerAction.next.label",
+			"nextMarkerIcon",
+			"markerAction.previous.label",
+			"previousMarkerIcon",
+			"markerAction.nextInFiles.label",
+			{
+				"key": "miGotoNextProblem",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			"markerAction.previousInFiles.label",
+			{
+				"key": "miGotoPreviousProblem",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			}
+		],
+		"vs/editor/contrib/hover/hover": [
+			{
+				"key": "showHover",
+				"comment": [
+					"Label for action that will trigger the showing of a hover in the editor.",
+					"This allows for users to show the hover without using the mouse."
+				]
+			},
+			{
+				"key": "showDefinitionPreviewHover",
+				"comment": [
+					"Label for action that will trigger the showing of definition preview hover in the editor.",
+					"This allows for users to show the definition preview hover without using the mouse."
+				]
+			}
+		],
+		"vs/editor/contrib/indentation/indentation": [
+			"indentationToSpaces",
+			"indentationToTabs",
+			"configuredTabSize",
+			{
+				"key": "selectTabWidth",
+				"comment": [
+					"Tab corresponds to the tab key"
+				]
+			},
+			"indentUsingTabs",
+			"indentUsingSpaces",
+			"detectIndentation",
+			"editor.reindentlines",
+			"editor.reindentselectedlines"
+		],
+		"vs/editor/contrib/inPlaceReplace/inPlaceReplace": [
+			"InPlaceReplaceAction.previous.label",
+			"InPlaceReplaceAction.next.label"
+		],
+		"vs/editor/contrib/linesOperations/linesOperations": [
+			"lines.copyUp",
+			{
+				"key": "miCopyLinesUp",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			"lines.copyDown",
+			{
+				"key": "miCopyLinesDown",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			"duplicateSelection",
+			{
+				"key": "miDuplicateSelection",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			"lines.moveUp",
+			{
+				"key": "miMoveLinesUp",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			"lines.moveDown",
+			{
+				"key": "miMoveLinesDown",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			"lines.sortAscending",
+			"lines.sortDescending",
+			"lines.trimTrailingWhitespace",
+			"lines.delete",
+			"lines.indent",
+			"lines.outdent",
+			"lines.insertBefore",
+			"lines.insertAfter",
+			"lines.deleteAllLeft",
+			"lines.deleteAllRight",
+			"lines.joinLines",
+			"editor.transpose",
+			"editor.transformToUppercase",
+			"editor.transformToLowercase",
+			"editor.transformToTitlecase",
+			"editor.transformToSnakecase"
+		],
+		"vs/editor/contrib/linkedEditing/linkedEditing": [
+			"linkedEditing.label",
+			"editorLinkedEditingBackground"
+		],
+		"vs/editor/contrib/links/links": [
+			"links.navigate.executeCmd",
+			"links.navigate.follow",
+			"links.navigate.kb.meta.mac",
+			"links.navigate.kb.meta",
+			"links.navigate.kb.alt.mac",
+			"links.navigate.kb.alt",
+			"tooltip.explanation",
+			"invalid.url",
+			"missing.url",
+			"label"
+		],
+		"vs/editor/contrib/parameterHints/parameterHints": [
+			"parameterHints.trigger.label"
+		],
+		"vs/editor/contrib/multicursor/multicursor": [
+			"mutlicursor.insertAbove",
+			{
+				"key": "miInsertCursorAbove",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			"mutlicursor.insertBelow",
+			{
+				"key": "miInsertCursorBelow",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			"mutlicursor.insertAtEndOfEachLineSelected",
+			{
+				"key": "miInsertCursorAtEndOfEachLineSelected",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			"mutlicursor.addCursorsToBottom",
+			"mutlicursor.addCursorsToTop",
+			"addSelectionToNextFindMatch",
+			{
+				"key": "miAddSelectionToNextFindMatch",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			"addSelectionToPreviousFindMatch",
+			{
+				"key": "miAddSelectionToPreviousFindMatch",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			"moveSelectionToNextFindMatch",
+			"moveSelectionToPreviousFindMatch",
+			"selectAllOccurrencesOfFindMatch",
+			{
+				"key": "miSelectHighlights",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			"changeAll.label"
+		],
+		"vs/editor/contrib/rename/rename": [
+			"no result",
+			"resolveRenameLocationFailed",
+			"label",
+			"quotableLabel",
+			"aria",
+			"rename.failedApply",
+			"rename.failed",
+			"rename.label",
+			"enablePreview"
+		],
+		"vs/editor/contrib/smartSelect/smartSelect": [
+			"smartSelect.expand",
+			{
+				"key": "miSmartSelectGrow",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			"smartSelect.shrink",
+			{
+				"key": "miSmartSelectShrink",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			}
+		],
+		"vs/editor/contrib/suggest/suggestController": [
+			"aria.alert.snippet",
+			"suggest.trigger.label",
+			"accept.insert",
+			"accept.insert",
+			"accept.replace",
+			"accept.replace",
+			"accept.insert",
+			"detail.more",
+			"detail.less",
+			"suggest.reset.label"
+		],
+		"vs/editor/contrib/tokenization/tokenization": [
+			"forceRetokenize"
+		],
+		"vs/editor/contrib/toggleTabFocusMode/toggleTabFocusMode": [
+			{
+				"key": "toggle.tabMovesFocus",
+				"comment": [
+					"Turn on/off use of tab key for moving focus around VS Code"
+				]
+			},
+			"toggle.tabMovesFocus.on",
+			"toggle.tabMovesFocus.off"
+		],
+		"vs/editor/contrib/unusualLineTerminators/unusualLineTerminators": [
+			"unusualLineTerminators.title",
+			"unusualLineTerminators.message",
+			"unusualLineTerminators.detail",
+			"unusualLineTerminators.fix",
+			"unusualLineTerminators.ignore"
+		],
+		"vs/editor/contrib/wordHighlighter/wordHighlighter": [
+			"wordHighlight",
+			"wordHighlightStrong",
+			"wordHighlightBorder",
+			"wordHighlightStrongBorder",
+			"overviewRulerWordHighlightForeground",
+			"overviewRulerWordHighlightStrongForeground",
+			"wordHighlight.next.label",
+			"wordHighlight.previous.label",
+			"wordHighlight.trigger.label"
+		],
+		"vs/editor/contrib/wordOperations/wordOperations": [
+			"deleteInsideWord"
+		],
+		"vs/editor/common/standaloneStrings": [
+			"noSelection",
+			"singleSelectionRange",
+			"singleSelection",
+			"multiSelectionRange",
+			"multiSelection",
+			"emergencyConfOn",
+			"openingDocs",
+			"readonlyDiffEditor",
+			"editableDiffEditor",
+			"readonlyEditor",
+			"editableEditor",
+			"changeConfigToOnMac",
+			"changeConfigToOnWinLinux",
+			"auto_on",
+			"auto_off",
+			"tabFocusModeOnMsg",
+			"tabFocusModeOnMsgNoKb",
+			"tabFocusModeOffMsg",
+			"tabFocusModeOffMsgNoKb",
+			"openDocMac",
+			"openDocWinLinux",
+			"outroMsg",
+			"showAccessibilityHelpAction",
+			"inspectTokens",
+			"gotoLineActionLabel",
+			"helpQuickAccess",
+			"quickCommandActionLabel",
+			"quickCommandActionHelp",
+			"quickOutlineActionLabel",
+			"quickOutlineByCategoryActionLabel",
+			"editorViewAccessibleLabel",
+			"accessibilityHelpMessage",
+			"toggleHighContrast",
+			"bulkEditServiceSummary"
+		],
+		"vs/workbench/api/common/jsonValidationExtensionPoint": [
+			"contributes.jsonValidation",
+			"contributes.jsonValidation.fileMatch",
+			"contributes.jsonValidation.url",
+			"invalid.jsonValidation",
+			"invalid.fileMatch",
+			"invalid.url",
+			"invalid.path.1",
+			"invalid.url.fileschema",
+			"invalid.url.schema"
+		],
+		"vs/workbench/services/themes/common/colorExtensionPoint": [
+			"contributes.color",
+			"contributes.color.id",
+			"contributes.color.id.format",
+			"contributes.color.description",
+			"contributes.defaults.light",
+			"contributes.defaults.dark",
+			"contributes.defaults.highContrast",
+			"invalid.colorConfiguration",
+			"invalid.default.colorType",
+			"invalid.id",
+			"invalid.id.format",
+			"invalid.description",
+			"invalid.defaults"
+		],
+		"vs/workbench/services/themes/common/tokenClassificationExtensionPoint": [
+			"contributes.semanticTokenTypes",
+			"contributes.semanticTokenTypes.id",
+			"contributes.semanticTokenTypes.id.format",
+			"contributes.semanticTokenTypes.superType",
+			"contributes.semanticTokenTypes.superType.format",
+			"contributes.color.description",
+			"contributes.semanticTokenModifiers",
+			"contributes.semanticTokenModifiers.id",
+			"contributes.semanticTokenModifiers.id.format",
+			"contributes.semanticTokenModifiers.description",
+			"contributes.semanticTokenScopes",
+			"contributes.semanticTokenScopes.languages",
+			"contributes.semanticTokenScopes.scopes",
+			"invalid.id",
+			"invalid.id.format",
+			"invalid.superType.format",
+			"invalid.description",
+			"invalid.semanticTokenTypeConfiguration",
+			"invalid.semanticTokenModifierConfiguration",
+			"invalid.semanticTokenScopes.configuration",
+			"invalid.semanticTokenScopes.language",
+			"invalid.semanticTokenScopes.scopes",
+			"invalid.semanticTokenScopes.scopes.value",
+			"invalid.semanticTokenScopes.scopes.selector"
+		],
+		"vs/workbench/contrib/codeEditor/browser/languageConfigurationExtensionPoint": [
+			"parseErrors",
+			"formatError",
+			"schema.openBracket",
+			"schema.closeBracket",
+			"schema.comments",
+			"schema.blockComments",
+			"schema.blockComment.begin",
+			"schema.blockComment.end",
+			"schema.lineComment",
+			"schema.brackets",
+			"schema.autoClosingPairs",
+			"schema.autoClosingPairs.notIn",
+			"schema.autoCloseBefore",
+			"schema.surroundingPairs",
+			"schema.wordPattern",
+			"schema.wordPattern.pattern",
+			"schema.wordPattern.flags",
+			"schema.wordPattern.flags.errorMessage",
+			"schema.indentationRules",
+			"schema.indentationRules.increaseIndentPattern",
+			"schema.indentationRules.increaseIndentPattern.pattern",
+			"schema.indentationRules.increaseIndentPattern.flags",
+			"schema.indentationRules.increaseIndentPattern.errorMessage",
+			"schema.indentationRules.decreaseIndentPattern",
+			"schema.indentationRules.decreaseIndentPattern.pattern",
+			"schema.indentationRules.decreaseIndentPattern.flags",
+			"schema.indentationRules.decreaseIndentPattern.errorMessage",
+			"schema.indentationRules.indentNextLinePattern",
+			"schema.indentationRules.indentNextLinePattern.pattern",
+			"schema.indentationRules.indentNextLinePattern.flags",
+			"schema.indentationRules.indentNextLinePattern.errorMessage",
+			"schema.indentationRules.unIndentedLinePattern",
+			"schema.indentationRules.unIndentedLinePattern.pattern",
+			"schema.indentationRules.unIndentedLinePattern.flags",
+			"schema.indentationRules.unIndentedLinePattern.errorMessage",
+			"schema.folding",
+			"schema.folding.offSide",
+			"schema.folding.markers",
+			"schema.folding.markers.start",
+			"schema.folding.markers.end",
+			"schema.onEnterRules",
+			"schema.onEnterRules",
+			"schema.onEnterRules.beforeText",
+			"schema.onEnterRules.beforeText.pattern",
+			"schema.onEnterRules.beforeText.flags",
+			"schema.onEnterRules.beforeText.errorMessage",
+			"schema.onEnterRules.afterText",
+			"schema.onEnterRules.afterText.pattern",
+			"schema.onEnterRules.afterText.flags",
+			"schema.onEnterRules.afterText.errorMessage",
+			"schema.onEnterRules.previousLineText",
+			"schema.onEnterRules.previousLineText.pattern",
+			"schema.onEnterRules.previousLineText.flags",
+			"schema.onEnterRules.previousLineText.errorMessage",
+			"schema.onEnterRules.action",
+			"schema.onEnterRules.action.indent",
+			"schema.onEnterRules.action.indent.none",
+			"schema.onEnterRules.action.indent.indent",
+			"schema.onEnterRules.action.indent.indentOutdent",
+			"schema.onEnterRules.action.indent.outdent",
+			"schema.onEnterRules.action.appendText",
+			"schema.onEnterRules.action.removeText"
+		],
+		"vs/workbench/api/browser/mainThreadCLICommands": [
+			"cannot be installed"
+		],
+		"vs/workbench/api/browser/mainThreadExtensionService": [
+			"reload window",
+			"reload",
+			"disabledDep",
+			"enable dep",
+			"uninstalledDep",
+			"install missing dep",
+			"unknownDep"
+		],
+		"vs/workbench/api/browser/mainThreadFileSystemEventService": [
+			"ask.1.create",
+			"ask.1.copy",
+			"ask.1.move",
+			"ask.1.delete",
+			"ask.N.create",
+			"ask.N.copy",
+			"ask.N.move",
+			"ask.N.delete",
+			"preview",
+			"cancel",
+			"ok",
+			"preview",
+			"cancel",
+			"again",
+			"msg-create",
+			"msg-rename",
+			"msg-copy",
+			"msg-delete",
+			"label",
+			"files.participants.timeout"
+		],
+		"vs/workbench/api/browser/mainThreadMessageService": [
+			"extensionSource",
+			"defaultSource",
+			"manageExtension",
+			"cancel",
+			"ok"
+		],
+		"vs/workbench/api/browser/mainThreadProgress": [
+			"manageExtension"
+		],
+		"vs/workbench/api/browser/mainThreadSaveParticipant": [
+			"timeout.onWillSave"
+		],
+		"vs/workbench/api/browser/mainThreadUriOpeners": [
+			"openerFailedUseDefault",
+			"openerFailedMessage"
+		],
+		"vs/workbench/api/browser/mainThreadWorkspace": [
+			"folderStatusMessageAddSingleFolder",
+			"folderStatusMessageAddMultipleFolders",
+			"folderStatusMessageRemoveSingleFolder",
+			"folderStatusMessageRemoveMultipleFolders",
+			"folderStatusChangeFolder"
+		],
+		"vs/workbench/api/browser/mainThreadComments": [
+			"commentsViewIcon"
+		],
+		"vs/workbench/api/browser/mainThreadTask": [
+			"task.label"
+		],
+		"vs/workbench/api/browser/mainThreadTunnelService": [
+			"remote.tunnel.openTunnel",
+			"remote.tunnelsView.elevationButton"
+		],
+		"vs/workbench/api/browser/mainThreadAuthentication": [
+			"noTrustedExtensions",
+			{
+				"key": "accountLastUsedDate",
+				"comment": [
+					"The placeholder {0} is a string with time information, such as \"3 days ago\""
+				]
+			},
+			"notUsed",
+			"manageTrustedExtensions",
+			"manageExensions",
+			"signOutConfirm",
+			"signOutMessagve",
+			"signOutMessageSimple",
+			"signedOut",
+			"useOtherAccount",
+			{
+				"key": "selectAccount",
+				"comment": [
+					"The placeholder {0} is the name of an extension. {1} is the name of the type of account, such as Microsoft or GitHub."
+				]
+			},
+			"getSessionPlateholder",
+			"confirmAuthenticationAccess",
+			"allow",
+			"cancel",
+			"confirmLogin",
+			"allow",
+			"cancel"
+		],
+		"vs/workbench/common/configuration": [
+			"workbenchConfigurationTitle"
+		],
+		"vs/workbench/browser/parts/views/treeView": [
+			"no-dataprovider",
+			"refresh",
+			"collapseAll",
+			"command-error"
+		],
+		"vs/workbench/browser/parts/views/viewPaneContainer": [
+			"views",
+			"viewMoveUp",
+			"viewMoveLeft",
+			"viewMoveDown",
+			"viewMoveRight"
+		],
+		"vs/workbench/contrib/remote/browser/remoteExplorer": [
+			"ports",
+			"1forwardedPort",
+			"nForwardedPorts",
+			"status.forwardedPorts",
+			"remote.forwardedPorts.statusbarTextNone",
+			"remote.forwardedPorts.statusbarTooltip",
+			"remote.tunnelsView.automaticForward",
+			"remote.tunnelsView.notificationLink",
+			"remote.tunnelsView.elevationMessage",
+			"remote.tunnelsView.elevationButton"
+		],
+		"vs/workbench/browser/parts/editor/editorGroupView": [
+			"ariaLabelGroupActions",
+			"closeGroupAction",
+			"emptyEditorGroup",
+			"groupLabel",
+			"groupAriaLabel",
+			"ok",
+			"cancel",
+			"editorOpenErrorDialog",
+			"editorOpenError"
+		],
+		"vs/workbench/browser/parts/editor/editorDropTarget": [
+			"fileTooLarge"
+		],
+		"vs/workbench/browser/parts/editor/editor.contribution": [
+			"textEditor",
+			"textDiffEditor",
+			"binaryDiffEditor",
+			"sideBySideEditor",
+			"editorQuickAccessPlaceholder",
+			"activeGroupEditorsByMostRecentlyUsedQuickAccess",
+			"editorQuickAccessPlaceholder",
+			"allEditorsByAppearanceQuickAccess",
+			"editorQuickAccessPlaceholder",
+			"allEditorsByMostRecentlyUsedQuickAccess",
+			"file",
+			"splitUp",
+			"splitDown",
+			"splitLeft",
+			"splitRight",
+			"close",
+			"close",
+			"closeOthers",
+			"closeRight",
+			"closeAllSaved",
+			"closeAll",
+			"keepOpen",
+			"pin",
+			"unpin",
+			"splitUp",
+			"splitDown",
+			"splitLeft",
+			"splitRight",
+			"toggleInlineView",
+			"showOpenedEditors",
+			"closeAll",
+			"closeAllSaved",
+			"toggleKeepEditors",
+			"splitEditorRight",
+			"splitEditorDown",
+			"splitEditorDown",
+			"splitEditorRight",
+			"close",
+			"closeAll",
+			"close",
+			"closeAll",
+			"unpin",
+			"close",
+			"unpin",
+			"close",
+			"previousChangeIcon",
+			"nextChangeIcon",
+			"toggleWhitespace",
+			"navigate.prev.label",
+			"navigate.next.label",
+			"ignoreTrimWhitespace.label",
+			"showTrimWhitespace.label",
+			"keepEditor",
+			"pinEditor",
+			"unpinEditor",
+			"closeEditor",
+			"closePinnedEditor",
+			"closeEditorsInGroup",
+			"closeSavedEditors",
+			"closeOtherEditors",
+			"closeRightEditors",
+			"closeEditorGroup",
+			{
+				"key": "miReopenClosedEditor",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			{
+				"key": "miClearRecentOpen",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			{
+				"key": "miEditorLayout",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			{
+				"key": "miSplitEditorUp",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			{
+				"key": "miSplitEditorDown",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			{
+				"key": "miSplitEditorLeft",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			{
+				"key": "miSplitEditorRight",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			{
+				"key": "miSingleColumnEditorLayout",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			{
+				"key": "miTwoColumnsEditorLayout",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			{
+				"key": "miThreeColumnsEditorLayout",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			{
+				"key": "miTwoRowsEditorLayout",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			{
+				"key": "miThreeRowsEditorLayout",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			{
+				"key": "miTwoByTwoGridEditorLayout",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			{
+				"key": "miTwoRowsRightEditorLayout",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			{
+				"key": "miTwoColumnsBottomEditorLayout",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			{
+				"key": "miBack",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			{
+				"key": "miForward",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			{
+				"key": "miLastEditLocation",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			{
+				"key": "miNextEditor",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			{
+				"key": "miPreviousEditor",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			{
+				"key": "miNextRecentlyUsedEditor",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			{
+				"key": "miPreviousRecentlyUsedEditor",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			{
+				"key": "miNextEditorInGroup",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			{
+				"key": "miPreviousEditorInGroup",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			{
+				"key": "miNextUsedEditorInGroup",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			{
+				"key": "miPreviousUsedEditorInGroup",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			{
+				"key": "miSwitchEditor",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			{
+				"key": "miFocusFirstGroup",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			{
+				"key": "miFocusSecondGroup",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			{
+				"key": "miFocusThirdGroup",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			{
+				"key": "miFocusFourthGroup",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			{
+				"key": "miFocusFifthGroup",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			{
+				"key": "miNextGroup",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			{
+				"key": "miPreviousGroup",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			{
+				"key": "miFocusLeftGroup",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			{
+				"key": "miFocusRightGroup",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			{
+				"key": "miFocusAboveGroup",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			{
+				"key": "miFocusBelowGroup",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			{
+				"key": "miSwitchGroup",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			}
+		],
+		"vs/workbench/browser/parts/activitybar/activitybarActions": [
+			"goHome",
+			"hideHomeButton",
+			"manageTrustedExtensions",
+			"signOut",
+			"authProviderUnavailable",
+			"hideAccounts",
+			"previousSideBarView",
+			"nextSideBarView"
+		],
+		"vs/workbench/browser/parts/compositeBar": [
+			"activityBarAriaLabel"
+		],
+		"vs/workbench/browser/parts/compositeBarActions": [
+			"badgeTitle",
+			"additionalViews",
+			"numberBadge",
+			"manageExtension",
+			"titleKeybinding",
+			"hide",
+			"keep",
+			"toggle"
+		],
+		"vs/workbench/browser/parts/titlebar/menubarControl": [
+			{
+				"key": "mFile",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			{
+				"key": "mEdit",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			{
+				"key": "mSelection",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			{
+				"key": "mView",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			{
+				"key": "mGoto",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			{
+				"key": "mRun",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			{
+				"key": "mTerminal",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			{
+				"key": "mHelp",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			"menubar.customTitlebarAccessibilityNotification",
+			"goToSetting",
+			"focusMenu",
+			{
+				"key": "checkForUpdates",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			"checkingForUpdates",
+			{
+				"key": "download now",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			"DownloadingUpdate",
+			{
+				"key": "installUpdate...",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			"installingUpdate",
+			{
+				"key": "restartToUpdate",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			"goHome"
+		],
+		"vs/workbench/browser/parts/compositePart": [
+			"ariaCompositeToolbarLabel",
+			"viewsAndMoreActions",
+			"titleTooltip"
+		],
+		"vs/workbench/browser/parts/panel/panelActions": [
+			"maximizeIcon",
+			"restoreIcon",
+			"closeIcon",
+			"togglePanel",
+			"focusPanel",
+			"positionPanelLeft",
+			"positionPanelRight",
+			"positionPanelBottom",
+			"previousPanelView",
+			"nextPanelView",
+			"toggleMaximizedPanel",
+			"maximizePanel",
+			"minimizePanel",
+			"closePanel",
+			{
+				"key": "miShowPanel",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			"hidePanel"
+		],
+		"vs/base/browser/ui/dialog/dialog": [
+			"ok",
+			"dialogInfoMessage",
+			"dialogErrorMessage",
+			"dialogWarningMessage",
+			"dialogPendingMessage",
+			"dialogClose"
+		],
+		"vs/workbench/services/preferences/browser/preferencesEditorInput": [
+			"settingsEditorName",
+			"keybindingsInputName",
+			"settingsEditor2InputName"
+		],
+		"vs/workbench/services/preferences/common/preferencesModels": [
+			"commonlyUsed",
+			"defaultKeybindingsHeader"
+		],
+		"vs/workbench/services/textfile/common/textFileEditorModel": [
+			"saveFileFirst"
+		],
+		"vs/workbench/common/editor/diffEditorInput": [
+			"sideBySideLabels"
+		],
+		"vs/workbench/services/editor/common/editorOpenWith": [
+			"promptOpenWith.currentlyActive",
+			"promptOpenWith.setDefaultTooltip",
+			"promptOpenWith.placeHolder",
+			"builtinProviderDisplayName",
+			"promptOpenWith.defaultEditor.displayName",
+			"editor.editorAssociations",
+			"editor.editorAssociations.viewType",
+			"editor.editorAssociations.filenamePattern",
+			"promptOpenWith.defaultEditor.displayName"
+		],
+		"vs/platform/keybinding/common/abstractKeybindingService": [
+			"first.chord",
+			"missing.chord"
+		],
+		"vs/workbench/services/themes/common/fileIconThemeSchema": [
+			"schema.folderExpanded",
+			"schema.folder",
+			"schema.file",
+			"schema.folderNames",
+			"schema.folderName",
+			"schema.folderNamesExpanded",
+			"schema.folderNameExpanded",
+			"schema.fileExtensions",
+			"schema.fileExtension",
+			"schema.fileNames",
+			"schema.fileName",
+			"schema.languageIds",
+			"schema.languageId",
+			"schema.fonts",
+			"schema.id",
+			"schema.id.formatError",
+			"schema.src",
+			"schema.font-path",
+			"schema.font-format",
+			"schema.font-weight",
+			"schema.font-style",
+			"schema.font-size",
+			"schema.iconDefinitions",
+			"schema.iconDefinition",
+			"schema.iconPath",
+			"schema.fontCharacter",
+			"schema.fontColor",
+			"schema.fontSize",
+			"schema.fontId",
+			"schema.light",
+			"schema.highContrast",
+			"schema.hidesExplorerArrows"
+		],
+		"vs/workbench/services/themes/common/colorThemeData": [
+			"error.cannotparsejson",
+			"error.invalidformat",
+			{
+				"key": "error.invalidformat.colors",
+				"comment": [
+					"{0} will be replaced by a path. Values in quotes should not be translated."
+				]
+			},
+			{
+				"key": "error.invalidformat.tokenColors",
+				"comment": [
+					"{0} will be replaced by a path. Values in quotes should not be translated."
+				]
+			},
+			{
+				"key": "error.invalidformat.semanticTokenColors",
+				"comment": [
+					"{0} will be replaced by a path. Values in quotes should not be translated."
+				]
+			},
+			"error.plist.invalidformat",
+			"error.cannotparse",
+			"error.cannotload"
+		],
+		"vs/workbench/services/themes/browser/fileIconThemeData": [
+			"error.cannotparseicontheme",
+			"error.invalidformat"
+		],
+		"vs/workbench/services/themes/common/colorThemeSchema": [
+			"schema.token.settings",
+			"schema.token.foreground",
+			"schema.token.background.warning",
+			"schema.token.fontStyle",
+			"schema.fontStyle.error",
+			"schema.token.fontStyle.none",
+			"schema.properties.name",
+			"schema.properties.scope",
+			"schema.workbenchColors",
+			"schema.tokenColors.path",
+			"schema.colors",
+			"schema.supportsSemanticHighlighting",
+			"schema.semanticTokenColors"
+		],
+		"vs/workbench/services/themes/common/themeExtensionPoints": [
+			"vscode.extension.contributes.themes",
+			"vscode.extension.contributes.themes.id",
+			"vscode.extension.contributes.themes.label",
+			"vscode.extension.contributes.themes.uiTheme",
+			"vscode.extension.contributes.themes.path",
+			"vscode.extension.contributes.iconThemes",
+			"vscode.extension.contributes.iconThemes.id",
+			"vscode.extension.contributes.iconThemes.label",
+			"vscode.extension.contributes.iconThemes.path",
+			"vscode.extension.contributes.productIconThemes",
+			"vscode.extension.contributes.productIconThemes.id",
+			"vscode.extension.contributes.productIconThemes.label",
+			"vscode.extension.contributes.productIconThemes.path",
+			"reqarray",
+			"reqpath",
+			"reqid",
+			"invalid.path.1"
+		],
+		"vs/workbench/services/themes/common/themeConfiguration": [
+			"colorTheme",
+			"colorThemeError",
+			{
+				"key": "preferredDarkColorTheme",
+				"comment": [
+					"`#{0}#` will become a link to an other setting. Do not remove backtick or #"
+				]
+			},
+			"colorThemeError",
+			{
+				"key": "preferredLightColorTheme",
+				"comment": [
+					"`#{0}#` will become a link to an other setting. Do not remove backtick or #"
+				]
+			},
+			"colorThemeError",
+			{
+				"key": "preferredHCColorTheme",
+				"comment": [
+					"`#{0}#` will become a link to an other setting. Do not remove backtick or #"
+				]
+			},
+			"colorThemeError",
+			"detectColorScheme",
+			"workbenchColors",
+			"iconTheme",
+			"noIconThemeLabel",
+			"noIconThemeDesc",
+			"iconThemeError",
+			"productIconTheme",
+			"defaultProductIconThemeLabel",
+			"defaultProductIconThemeDesc",
+			"productIconThemeError",
+			"autoDetectHighContrast",
+			"editorColors.comments",
+			"editorColors.strings",
+			"editorColors.keywords",
+			"editorColors.numbers",
+			"editorColors.types",
+			"editorColors.functions",
+			"editorColors.variables",
+			"editorColors.textMateRules",
+			"editorColors.semanticHighlighting",
+			"editorColors.semanticHighlighting.deprecationMessage",
+			"editorColors.semanticHighlighting.deprecationMessageMarkdown",
+			"editorColors",
+			"editorColors.semanticHighlighting.enabled",
+			"editorColors.semanticHighlighting.rules",
+			"semanticTokenColors",
+			"editorColors.experimentalTokenStyling.deprecationMessage",
+			"editorColors.experimentalTokenStyling.deprecationMessageMarkdown"
+		],
+		"vs/workbench/services/themes/browser/productIconThemeData": [
+			"error.parseicondefs",
+			"defaultTheme",
+			"error.cannotparseicontheme",
+			"error.invalidformat",
+			"error.missingProperties",
+			"error.fontWeight",
+			"error.fontStyle",
+			"error.fontId",
+			"error.icon.fontId",
+			"error.icon.fontCharacter"
+		],
+		"vs/workbench/services/extensionManagement/browser/extensionBisect": [
+			"bisect",
+			"title.start",
+			"help",
+			"msg.start",
+			"detail.start",
+			"msg2",
+			"title.isBad",
+			"help",
+			"done.msg",
+			"done.detail2",
+			"done.msg",
+			"report",
+			"done",
+			"done.detail",
+			"done.disbale",
+			"bisect",
+			"msg.next",
+			"next.good",
+			"next.bad",
+			"next.stop",
+			"next.cancel",
+			"title.stop",
+			"help"
+		],
+		"vs/workbench/services/themes/common/productIconThemeSchema": [
+			"schema.id",
+			"schema.id.formatError",
+			"schema.src",
+			"schema.font-path",
+			"schema.font-format",
+			"schema.font-weight",
+			"schema.font-style",
+			"schema.iconDefinitions"
+		],
+		"vs/workbench/contrib/preferences/browser/preferencesActions": [
+			"configureLanguageBasedSettings",
+			"languageDescriptionConfigured",
+			"pickLanguage"
+		],
+		"vs/workbench/contrib/preferences/browser/keybindingsEditor": [
+			"recordKeysLabel",
+			"recordKeysLabelWithKeybinding",
+			"sortByPrecedeneLabel",
+			"sortByPrecedeneLabelWithKeybinding",
+			"SearchKeybindings.FullTextSearchPlaceholder",
+			"SearchKeybindings.KeybindingsSearchPlaceholder",
+			"clearInput",
+			"recording",
+			"command",
+			"keybinding",
+			"when",
+			"source",
+			"show sorted keybindings",
+			"show keybindings",
+			"changeLabel",
+			"addLabel",
+			"addLabel",
+			"editWhen",
+			"removeLabel",
+			"resetLabel",
+			"showSameKeybindings",
+			"copyLabel",
+			"copyCommandLabel",
+			"error",
+			"editKeybindingLabelWithKey",
+			"editKeybindingLabel",
+			"addKeybindingLabelWithKey",
+			"addKeybindingLabel",
+			"title",
+			"whenContextInputAriaLabel",
+			"keybindingsLabel",
+			"noKeybinding",
+			"noWhen"
+		],
+		"vs/workbench/contrib/preferences/browser/preferencesEditor": [
+			"SearchSettingsWidget.AriaLabel",
+			"SearchSettingsWidget.Placeholder",
+			"noSettingsFound",
+			"oneSettingFound",
+			"settingsFound",
+			"totalSettingsMessage",
+			"nlpResult",
+			"filterResult",
+			"defaultSettings",
+			"defaultUserSettings",
+			"defaultWorkspaceSettings",
+			"defaultFolderSettings",
+			"defaultEditorReadonly",
+			"preferencesAriaLabel"
+		],
+		"vs/workbench/contrib/preferences/browser/settingsEditor2": [
+			"SearchSettings.AriaLabel",
+			"clearInput",
+			"noResults",
+			"clearSearchFilters",
+			"settings",
+			"settingsNoSaveNeeded",
+			"noResults",
+			"oneResult",
+			"moreThanOneResult",
+			"turnOnSyncButton",
+			"lastSyncedLabel"
+		],
+		"vs/workbench/contrib/preferences/common/preferencesContribution": [
+			"enableNaturalLanguageSettingsSearch",
+			"settingsSearchTocBehavior.hide",
+			"settingsSearchTocBehavior.filter",
+			"settingsSearchTocBehavior"
+		],
+		"vs/workbench/contrib/preferences/browser/preferencesIcons": [
+			"settingsGroupExpandedIcon",
+			"settingsGroupCollapsedIcon",
+			"settingsScopeDropDownIcon",
+			"settingsMoreActionIcon",
+			"keybindingsRecordKeysIcon",
+			"keybindingsSortIcon",
+			"keybindingsEditIcon",
+			"keybindingsAddIcon",
+			"settingsEditIcon",
+			"settingsAddIcon",
+			"settingsRemoveIcon",
+			"preferencesDiscardIcon",
+			"preferencesClearInput",
+			"preferencesOpenSettings"
+		],
+		"vs/workbench/contrib/preferences/browser/keybindingWidgets": [
+			"defineKeybinding.initial",
+			"defineKeybinding.oneExists",
+			"defineKeybinding.existing",
+			"defineKeybinding.chordsTo"
+		],
+		"vs/workbench/browser/codeeditor": [
+			"openWorkspace"
+		],
+		"vs/workbench/contrib/testing/browser/icons": [
+			"testViewIcon",
+			"testingRunIcon",
+			"testingRunAllIcon",
+			"testingDebugIcon",
+			"testingCancelIcon",
+			"testingShowAsList",
+			"testingShowAsTree",
+			"testingErrorIcon",
+			"testingFailedIcon",
+			"testingPassedIcon",
+			"testingQueuedIcon",
+			"testingSkippedIcon",
+			"testingUnsetIcon"
+		],
+		"vs/workbench/contrib/testing/browser/testingDecorations": [
+			"testing.clickToRun",
+			"run test",
+			"debug test",
+			"reveal test"
+		],
+		"vs/workbench/contrib/testing/browser/testingExplorerFilter": [
+			"testExplorerFilter",
+			"filter"
+		],
+		"vs/workbench/contrib/testing/browser/testingExplorerView": [
+			"testExplorer",
+			{
+				"key": "testing.treeElementLabel",
+				"comment": [
+					"label then the unit tests state, for example \"Addition Tests (Running)\""
+				]
+			},
+			"testProgress",
+			"testProgressWithSkip",
+			"testResultStarting",
+			"testBadgeRunning",
+			"testBadgeFailures"
+		],
+		"vs/workbench/contrib/testing/browser/testingOutputPeek": [
+			"close"
+		],
+		"vs/workbench/contrib/testing/browser/testingViewPaneContainer": [
+			"testing"
+		],
+		"vs/workbench/contrib/testing/common/testServiceImpl": [
+			"testError"
+		],
+		"vs/workbench/contrib/testing/browser/testExplorerActions": [
+			"testing.category",
+			"debug test",
+			"run test",
+			"runSelectedTests",
+			"debugSelectedTests",
+			"runAllTests",
+			"noTestProvider",
+			"debugAllTests",
+			"noDebugTestProvider",
+			"testing.cancelRun",
+			"testing.viewAsList",
+			"testing.viewAsTree",
+			"testing.groupByLocation",
+			"testing.groupByStatus",
+			"testing.collapseAll",
+			"testing.refresh",
+			"showTestViewley",
+			"testing.editFocusedTest"
+		],
+		"vs/workbench/contrib/notebook/browser/notebookEditor": [
+			"fail.noEditor",
+			"fail.reOpen"
+		],
+		"vs/workbench/contrib/notebook/browser/notebookServiceImpl": [
+			"builtinProviderDisplayName"
+		],
+		"vs/workbench/contrib/notebook/browser/diff/notebookTextDiffEditor": [
+			"notebookTreeAriaLabel"
+		],
+		"vs/workbench/contrib/notebook/browser/contrib/find/findController": [
+			"notebookActions.hideFind",
+			"notebookActions.findInNotebook"
+		],
+		"vs/workbench/contrib/notebook/browser/contrib/fold/folding": [
+			"fold.cell",
+			"unfold.cell",
+			"fold.cell"
+		],
+		"vs/workbench/contrib/notebook/browser/contrib/format/formatting": [
+			"format.title",
+			"label",
+			"formatCell.label"
+		],
+		"vs/workbench/contrib/notebook/browser/contrib/outline/notebookOutline": [
+			"empty",
+			"outline.showCodeCells",
+			"breadcrumbs.showCodeCells"
+		],
+		"vs/workbench/contrib/notebook/browser/contrib/status/editorStatus": [
+			"notebookActions.selectKernel",
+			"notebookActions.selectKernel.args",
+			"notebook.runCell.selectKernel",
+			"currentActiveKernel",
+			"notebook.promptKernel.setDefaultTooltip",
+			"chooseActiveKernel",
+			"notebook.selectKernel"
+		],
+		"vs/workbench/contrib/notebook/browser/diff/notebookDiffActions": [
+			"notebook.diff.switchToText",
+			"notebook.diff.cell.revertMetadata",
+			"notebook.diff.cell.switchOutputRenderingStyleToText",
+			"notebook.diff.cell.revertOutputs",
+			"notebook.diff.cell.revertInput"
+		],
+		"vs/workbench/contrib/logs/common/logsActions": [
+			"setLogLevel",
+			"trace",
+			"debug",
+			"info",
+			"warn",
+			"err",
+			"critical",
+			"off",
+			"selectLogLevel",
+			"default and current",
+			"default",
+			"current",
+			"openSessionLogFile",
+			"current",
+			"sessions placeholder",
+			"log placeholder"
+		],
+		"vs/workbench/contrib/quickaccess/browser/viewQuickAccess": [
+			"noViewResults",
+			"views",
+			"panels",
+			"terminalTitle",
+			"terminals",
+			"logChannel",
+			"channels",
+			"openView",
+			"quickOpenView"
+		],
+		"vs/workbench/contrib/quickaccess/browser/commandsQuickAccess": [
+			"noCommandResults",
+			"configure keybinding",
+			"commandWithCategory",
+			"showTriggerActions",
+			"clearCommandHistory"
+		],
+		"vs/platform/quickinput/browser/helpQuickAccess": [
+			"globalCommands",
+			"editorCommands",
+			"helpPickAriaLabel"
+		],
+		"vs/workbench/contrib/files/browser/views/explorerView": [
+			"explorerSection",
+			"createNewFile",
+			"createNewFolder",
+			"refreshExplorer",
+			"collapseExplorerFolders"
+		],
+		"vs/workbench/contrib/files/browser/views/emptyView": [
+			"noWorkspace"
+		],
+		"vs/workbench/contrib/files/browser/views/openEditorsView": [
+			{
+				"key": "openEditors",
+				"comment": [
+					"Open is an adjective"
+				]
+			},
+			"dirtyCounter",
+			"openEditors",
+			"flipLayout",
+			{
+				"key": "miToggleEditorLayout",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			}
+		],
+		"vs/workbench/contrib/files/browser/fileActions": [
+			"newFile",
+			"newFolder",
+			"rename",
+			"delete",
+			"copyFile",
+			"pasteFile",
+			"download",
+			"deleteButtonLabelRecycleBin",
+			{
+				"key": "deleteButtonLabelTrash",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			{
+				"key": "deleteButtonLabel",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			"dirtyMessageFilesDelete",
+			"dirtyMessageFolderOneDelete",
+			"dirtyMessageFolderDelete",
+			"dirtyMessageFileDelete",
+			"dirtyWarning",
+			"irreversible",
+			"restorePlural",
+			"restore",
+			"undoBinFiles",
+			"undoBin",
+			"undoTrashFiles",
+			"undoTrash",
+			"doNotAskAgain",
+			{
+				"key": "deleteBulkEdit",
+				"comment": [
+					"Placeholder will be replaced by the number of files deleted"
+				]
+			},
+			{
+				"key": "deleteFileBulkEdit",
+				"comment": [
+					"Placeholder will be replaced by the name of the file deleted"
+				]
+			},
+			{
+				"key": "deletingBulkEdit",
+				"comment": [
+					"Placeholder will be replaced by the number of files deleted"
+				]
+			},
+			{
+				"key": "deletingFileBulkEdit",
+				"comment": [
+					"Placeholder will be replaced by the name of the file deleted"
+				]
+			},
+			"binFailed",
+			"trashFailed",
+			{
+				"key": "deletePermanentlyButtonLabel",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			{
+				"key": "retryButtonLabel",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			"confirmMoveTrashMessageFilesAndDirectories",
+			"confirmMoveTrashMessageMultipleDirectories",
+			"confirmMoveTrashMessageMultiple",
+			"confirmMoveTrashMessageFolder",
+			"confirmMoveTrashMessageFile",
+			"confirmDeleteMessageFilesAndDirectories",
+			"confirmDeleteMessageMultipleDirectories",
+			"confirmDeleteMessageMultiple",
+			"confirmDeleteMessageFolder",
+			"confirmDeleteMessageFile",
+			"globalCompareFile",
+			"fileToCompareNoFile",
+			"openFileToCompare",
+			"toggleAutoSave",
+			"saveAllInGroup",
+			"closeGroup",
+			"focusFilesExplorer",
+			"showInExplorer",
+			"openFileToShow",
+			"openFileInNewWindow",
+			"openFileToShowInNewWindow.unsupportedschema",
+			"openFileToShowInNewWindow.nofile",
+			"emptyFileNameError",
+			"fileNameStartsWithSlashError",
+			"fileNameExistsError",
+			"invalidFileNameError",
+			"fileNameWhitespaceWarning",
+			"compareWithClipboard",
+			"clipboardComparisonLabel",
+			"retry",
+			"createBulkEdit",
+			"creatingBulkEdit",
+			"renameBulkEdit",
+			"renamingBulkEdit",
+			"downloadingFiles",
+			"downloadProgressSmallMany",
+			"downloadProgressLarge",
+			"downloadButton",
+			"chooseWhereToDownload",
+			"downloadBulkEdit",
+			"downloadingBulkEdit",
+			"fileIsAncestor",
+			{
+				"key": "movingBulkEdit",
+				"comment": [
+					"Placeholder will be replaced by the number of files being moved"
+				]
+			},
+			{
+				"key": "movingFileBulkEdit",
+				"comment": [
+					"Placeholder will be replaced by the name of the file moved."
+				]
+			},
+			{
+				"key": "moveBulkEdit",
+				"comment": [
+					"Placeholder will be replaced by the number of files being moved"
+				]
+			},
+			{
+				"key": "moveFileBulkEdit",
+				"comment": [
+					"Placeholder will be replaced by the name of the file moved."
+				]
+			},
+			{
+				"key": "copyingBulkEdit",
+				"comment": [
+					"Placeholder will be replaced by the number of files being copied"
+				]
+			},
+			{
+				"key": "copyingFileBulkEdit",
+				"comment": [
+					"Placeholder will be replaced by the name of the file copied."
+				]
+			},
+			{
+				"key": "copyBulkEdit",
+				"comment": [
+					"Placeholder will be replaced by the number of files being copied"
+				]
+			},
+			{
+				"key": "copyFileBulkEdit",
+				"comment": [
+					"Placeholder will be replaced by the name of the file copied."
+				]
+			},
+			"fileDeleted"
+		],
+		"vs/workbench/contrib/files/browser/editors/textFileSaveErrorHandler": [
+			"userGuide",
+			"staleSaveError",
+			"retry",
+			"discard",
+			"readonlySaveErrorAdmin",
+			"readonlySaveErrorSudo",
+			"readonlySaveError",
+			"permissionDeniedSaveError",
+			"permissionDeniedSaveErrorSudo",
+			{
+				"key": "genericSaveError",
+				"comment": [
+					"{0} is the resource that failed to save and {1} the error message"
+				]
+			},
+			"learnMore",
+			"dontShowAgain",
+			"compareChanges",
+			"saveConflictDiffLabel",
+			"overwriteElevated",
+			"overwriteElevatedSudo",
+			"saveElevated",
+			"saveElevatedSudo",
+			"overwrite",
+			"overwrite",
+			"configure"
+		],
+		"vs/workbench/contrib/files/browser/fileCommands": [
+			"saveAs",
+			"save",
+			"saveWithoutFormatting",
+			"saveAll",
+			"removeFolderFromWorkspace",
+			"newUntitledFile",
+			"modifiedLabel",
+			"openFileToCopy",
+			{
+				"key": "genericSaveError",
+				"comment": [
+					"{0} is the resource that failed to save and {1} the error message"
+				]
+			},
+			"genericRevertError"
+		],
+		"vs/workbench/browser/parts/editor/editorCommands": [
+			"editorCommand.activeEditorMove.description",
+			"editorCommand.activeEditorMove.arg.name",
+			"editorCommand.activeEditorMove.arg.description",
+			"toggleInlineView",
+			"compare"
+		],
+		"vs/workbench/contrib/files/browser/editors/binaryFileEditor": [
+			"binaryFileEditor"
+		],
+		"vs/workbench/contrib/files/common/workspaceWatcher": [
+			"netVersionError",
+			"installNet",
+			"enospcError",
+			"learnMore"
+		],
+		"vs/editor/common/config/commonEditorConfig": [
+			"editorConfigurationTitle",
+			"tabSize",
+			"insertSpaces",
+			"detectIndentation",
+			"trimAutoWhitespace",
+			"largeFileOptimizations",
+			"wordBasedSuggestions",
+			"wordBasedSuggestionsMode.currentDocument",
+			"wordBasedSuggestionsMode.matchingDocuments",
+			"wordBasedSuggestionsMode.allDocuments",
+			"wordBasedSuggestionsMode",
+			"semanticHighlighting.true",
+			"semanticHighlighting.false",
+			"semanticHighlighting.configuredByTheme",
+			"semanticHighlighting.enabled",
+			"stablePeek",
+			"maxTokenizationLineLength",
+			"maxComputationTime",
+			"sideBySide",
+			"ignoreTrimWhitespace",
+			"renderIndicators",
+			"codeLens",
+			"wordWrap.off",
+			"wordWrap.on",
+			"wordWrap.inherit"
+		],
+		"vs/workbench/contrib/files/common/dirtyFilesIndicator": [
+			"dirtyFile",
+			"dirtyFiles"
+		],
+		"vs/workbench/contrib/bulkEdit/browser/preview/bulkEditPane": [
+			"empty.msg",
+			"conflict.1",
+			"conflict.N",
+			"edt.title.del",
+			"rename",
+			"create",
+			"edt.title.2",
+			"edt.title.1"
+		],
+		"vs/workbench/contrib/bulkEdit/browser/preview/bulkEditPreview": [
+			"default"
+		],
+		"vs/editor/contrib/quickAccess/gotoLineQuickAccess": [
+			"cannotRunGotoLine",
+			"gotoLineColumnLabel",
+			"gotoLineLabel",
+			"gotoLineLabelEmptyWithLimit",
+			"gotoLineLabelEmpty"
+		],
+		"vs/workbench/contrib/codeEditor/browser/quickaccess/gotoSymbolQuickAccess": [
+			"empty",
+			"gotoSymbolQuickAccessPlaceholder",
+			"gotoSymbolQuickAccess",
+			"gotoSymbolByCategoryQuickAccess",
+			"gotoSymbol"
+		],
+		"vs/workbench/contrib/search/browser/anythingQuickAccess": [
+			"noAnythingResults",
+			"recentlyOpenedSeparator",
+			"fileAndSymbolResultsSeparator",
+			"fileResultsSeparator",
+			"filePickAriaLabelDirty",
+			{
+				"key": "openToSide",
+				"comment": [
+					"Open this file in a split editor on the left/right side"
+				]
+			},
+			{
+				"key": "openToBottom",
+				"comment": [
+					"Open this file in a split editor on the bottom"
+				]
+			},
+			"closeEditor"
+		],
+		"vs/workbench/contrib/search/browser/searchActions": [
+			"showSearch",
+			"replaceInFiles",
+			"toggleTabs",
+			"FocusNextSearchResult.label",
+			"FocusPreviousSearchResult.label",
+			"RemoveAction.label",
+			"file.replaceAll.label",
+			"file.replaceAll.label",
+			"match.replace.label"
+		],
+		"vs/workbench/contrib/search/browser/searchIcons": [
+			"searchDetailsIcon",
+			"searchShowContextIcon",
+			"searchHideReplaceIcon",
+			"searchShowReplaceIcon",
+			"searchReplaceAllIcon",
+			"searchReplaceIcon",
+			"searchRemoveIcon",
+			"searchRefreshIcon",
+			"searchCollapseAllIcon",
+			"searchExpandAllIcon",
+			"searchClearIcon",
+			"searchStopIcon",
+			"searchViewIcon",
+			"searchNewEditorIcon"
+		],
+		"vs/workbench/contrib/search/browser/searchWidget": [
+			"search.action.replaceAll.disabled.label",
+			"search.action.replaceAll.enabled.label",
+			"search.replace.toggle.button.title",
+			"label.Search",
+			"search.placeHolder",
+			"showContext",
+			"label.Replace",
+			"search.replace.placeHolder"
+		],
+		"vs/workbench/contrib/search/browser/symbolsQuickAccess": [
+			"noSymbolResults",
+			"openToSide",
+			"openToBottom"
+		],
+		"vs/workbench/contrib/search/common/queryBuilder": [
+			"search.noWorkspaceWithName"
+		],
+		"vs/workbench/browser/parts/views/viewPane": [
+			"viewPaneContainerExpandedIcon",
+			"viewPaneContainerCollapsedIcon",
+			"viewToolbarAriaLabel"
+		],
+		"vs/workbench/contrib/search/browser/patternInputWidget": [
+			"defaultLabel",
+			"onlySearchInOpenEditors",
+			"useExcludesAndIgnoreFilesDescription"
+		],
+		"vs/workbench/contrib/search/browser/searchResultsView": [
+			"searchFolderMatch.other.label",
+			"searchFileMatches",
+			"searchFileMatch",
+			"searchMatches",
+			"searchMatch",
+			"lineNumStr",
+			"numLinesStr",
+			"search",
+			"folderMatchAriaLabel",
+			"otherFilesAriaLabel",
+			"fileMatchAriaLabel",
+			"replacePreviewResultAria",
+			"searchResultAria"
+		],
+		"vs/workbench/contrib/searchEditor/browser/searchEditor": [
+			"moreSearch",
+			"searchScope.includes",
+			"label.includes",
+			"searchScope.excludes",
+			"label.excludes",
+			"runSearch",
+			"searchResultItem",
+			"searchEditor",
+			"textInputBoxBorder"
+		],
+		"vs/workbench/contrib/searchEditor/browser/searchEditorInput": [
+			"searchTitle.withQuery",
+			"searchTitle.withQuery",
+			"searchTitle"
+		],
+		"vs/workbench/contrib/searchEditor/browser/searchEditorSerialization": [
+			"invalidQueryStringError",
+			"numFiles",
+			"oneFile",
+			"numResults",
+			"oneResult",
+			"noResults",
+			"searchMaxResultsWarning"
+		],
+		"vs/workbench/contrib/scm/browser/activity": [
+			"status.scm",
+			"scmPendingChangesBadge"
+		],
+		"vs/workbench/contrib/scm/browser/dirtydiffDecorator": [
+			"changes",
+			"change",
+			"show previous change",
+			"show next change",
+			{
+				"key": "miGotoNextChange",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			{
+				"key": "miGotoPreviousChange",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			"move to previous change",
+			"move to next change",
+			"editorGutterModifiedBackground",
+			"editorGutterAddedBackground",
+			"editorGutterDeletedBackground",
+			"minimapGutterModifiedBackground",
+			"minimapGutterAddedBackground",
+			"minimapGutterDeletedBackground",
+			"overviewRulerModifiedForeground",
+			"overviewRulerAddedForeground",
+			"overviewRulerDeletedForeground"
+		],
+		"vs/workbench/contrib/scm/browser/scmViewPaneContainer": [
+			"source control"
+		],
+		"vs/workbench/contrib/scm/browser/scmRepositoriesViewPane": [
+			"scm"
+		],
+		"vs/workbench/contrib/scm/browser/scmViewPane": [
+			"scm",
+			"input",
+			"repositories",
+			"sortAction",
+			"toggleViewMode",
+			"viewModeList",
+			"viewModeTree",
+			"sortByName",
+			"sortByPath",
+			"sortByStatus",
+			"expand all",
+			"collapse all",
+			"scm.providerBorder"
+		],
+		"vs/workbench/contrib/debug/browser/breakpointsView": [
+			"expressionCondition",
+			"expressionAndHitCount",
+			"functionBreakpointsNotSupported",
+			"dataBreakpointsNotSupported",
+			"functionBreakpointPlaceholder",
+			"functionBreakPointInputAriaLabel",
+			"functionBreakpointExpressionPlaceholder",
+			"functionBreakPointExpresionAriaLabel",
+			"functionBreakpointHitCountPlaceholder",
+			"functionBreakPointHitCountAriaLabel",
+			"exceptionBreakpointPlaceholder",
+			"exceptionBreakpointAriaLabel",
+			"breakpoints",
+			"disabledLogpoint",
+			"disabledBreakpoint",
+			"unverifiedLogpoint",
+			"unverifiedBreakopint",
+			"dataBreakpointUnsupported",
+			"dataBreakpoint",
+			"functionBreakpointUnsupported",
+			"functionBreakpoint",
+			"expression",
+			"hitCount",
+			"breakpointUnsupported",
+			"logMessage",
+			"expression",
+			"hitCount",
+			"breakpoint",
+			"addFunctionBreakpoint",
+			{
+				"key": "miFunctionBreakpoint",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			"activateBreakpoints",
+			"removeBreakpoint",
+			"removeAllBreakpoints",
+			{
+				"key": "miRemoveAllBreakpoints",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			"enableAllBreakpoints",
+			{
+				"key": "miEnableAllBreakpoints",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			"disableAllBreakpoints",
+			{
+				"key": "miDisableAllBreakpoints",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			"reapplyAllBreakpoints",
+			"editCondition",
+			"editBreakpoint",
+			"editHitCount"
+		],
+		"vs/workbench/contrib/debug/browser/callStackView": [
+			{
+				"key": "running",
+				"comment": [
+					"indicates state"
+				]
+			},
+			"showMoreStackFrames2",
+			{
+				"key": "session",
+				"comment": [
+					"Session is a noun"
+				]
+			},
+			{
+				"key": "running",
+				"comment": [
+					"indicates state"
+				]
+			},
+			"thread",
+			"restartFrame",
+			"loadAllStackFrames",
+			"showMoreAndOrigin",
+			"showMoreStackFrames",
+			{
+				"comment": [
+					"Debug is a noun in this context, not a verb."
+				],
+				"key": "callStackAriaLabel"
+			},
+			{
+				"key": "threadAriaLabel",
+				"comment": [
+					"Placeholders stand for the thread name and the thread state.For example \"Thread 1\" and \"Stopped"
+				]
+			},
+			"stackFrameAriaLabel",
+			{
+				"key": "running",
+				"comment": [
+					"indicates state"
+				]
+			},
+			{
+				"key": "sessionLabel",
+				"comment": [
+					"Placeholders stand for the session name and the session state. For example \"Launch Program\" and \"Running\""
+				]
+			},
+			"showMoreStackFrames",
+			"collapse"
+		],
+		"vs/workbench/contrib/debug/browser/debugToolBar": [
+			"stepBackDebug",
+			"reverseContinue"
+		],
+		"vs/workbench/contrib/debug/browser/debugService": [
+			"1activeSession",
+			"nActiveSessions",
+			{
+				"key": "compoundMustHaveConfigurations",
+				"comment": [
+					"compound indicates a \"compounds\" configuration item",
+					"\"configurations\" is an attribute and should not be localized"
+				]
+			},
+			"noConfigurationNameInWorkspace",
+			"multipleConfigurationNamesInWorkspace",
+			"noFolderWithName",
+			"configMissing",
+			"launchJsonDoesNotExist",
+			"debugRequestNotSupported",
+			"debugRequesMissing",
+			"debugTypeNotSupported",
+			"debugTypeMissing",
+			{
+				"key": "installAdditionalDebuggers",
+				"comment": [
+					"Placeholder is the debug type, so for example \"node\", \"python\""
+				]
+			},
+			"noFolderWorkspaceDebugError",
+			"debugAdapterCrash",
+			"cancel",
+			{
+				"key": "debuggingPaused",
+				"comment": [
+					"First placeholder is the stack frame name, second is the line number, third placeholder is the reason why debugging is stopped, for example \"breakpoint\" and the last one is the file line content."
+				]
+			},
+			"breakpointAdded",
+			"breakpointRemoved"
+		],
+		"vs/workbench/contrib/debug/browser/debugCommands": [
+			"restartDebug",
+			"stepOverDebug",
+			"stepIntoDebug",
+			"stepOutDebug",
+			"pauseDebug",
+			"disconnect",
+			"stop",
+			"continueDebug",
+			"focusSession",
+			"selectAndStartDebugging",
+			"openLaunchJson",
+			"startDebug",
+			"startWithoutDebugging",
+			"chooseLocation",
+			"noExecutableCode",
+			"jumpToCursor",
+			"debug",
+			"noFolderDebugConfig",
+			"addInlineBreakpoint",
+			"debug"
+		],
+		"vs/workbench/contrib/debug/browser/statusbarColorProvider": [
+			"statusBarDebuggingBackground",
+			"statusBarDebuggingForeground",
+			"statusBarDebuggingBorder"
+		],
+		"vs/workbench/contrib/debug/browser/debugStatus": [
+			"status.debug",
+			"debugTarget",
+			"selectAndStartDebug"
+		],
+		"vs/workbench/contrib/debug/browser/loadedScriptsView": [
+			"loadedScriptsSession",
+			{
+				"comment": [
+					"Debug is a noun in this context, not a verb."
+				],
+				"key": "loadedScriptsAriaLabel"
+			},
+			"loadedScriptsRootFolderAriaLabel",
+			"loadedScriptsSessionAriaLabel",
+			"loadedScriptsFolderAriaLabel",
+			"loadedScriptsSourceAriaLabel"
+		],
+		"vs/workbench/contrib/debug/browser/debugEditorActions": [
+			"toggleBreakpointAction",
+			{
+				"key": "miToggleBreakpoint",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			"conditionalBreakpointEditorAction",
+			{
+				"key": "miConditionalBreakpoint",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			"logPointEditorAction",
+			{
+				"key": "miLogPoint",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			"runToCursor",
+			"evaluateInDebugConsole",
+			"addToWatch",
+			"showDebugHover",
+			{
+				"key": "stepIntoTargets",
+				"comment": [
+					"Step Into Targets lets the user step into an exact function he or she is interested in."
+				]
+			},
+			"goToNextBreakpoint",
+			"goToPreviousBreakpoint",
+			"closeExceptionWidget"
+		],
+		"vs/workbench/contrib/debug/browser/watchExpressionsView": [
+			"watchExpressionInputAriaLabel",
+			"watchExpressionPlaceholder",
+			{
+				"comment": [
+					"Debug is a noun in this context, not a verb."
+				],
+				"key": "watchAriaTreeLabel"
+			},
+			"watchExpressionAriaLabel",
+			"watchVariableAriaLabel",
+			"collapse",
+			"addWatchExpression",
+			"removeAllWatchExpressions"
+		],
+		"vs/workbench/contrib/debug/browser/variablesView": [
+			"variableValueAriaLabel",
+			"variablesAriaTreeLabel",
+			"variableScopeAriaLabel",
+			{
+				"key": "variableAriaLabel",
+				"comment": [
+					"Placeholders are variable name and variable value respectivly. They should not be translated."
+				]
+			},
+			"collapse"
+		],
+		"vs/workbench/contrib/debug/common/debugContentProvider": [
+			"unable",
+			"canNotResolveSourceWithError",
+			"canNotResolveSource"
+		],
+		"vs/workbench/contrib/debug/browser/welcomeView": [
+			"run",
+			{
+				"key": "openAFileWhichCanBeDebugged",
+				"comment": [
+					"Please do not translate the word \"commmand\", it is part of our internal syntax which must not change"
+				]
+			},
+			{
+				"key": "runAndDebugAction",
+				"comment": [
+					"Please do not translate the word \"commmand\", it is part of our internal syntax which must not change"
+				]
+			},
+			{
+				"key": "detectThenRunAndDebug",
+				"comment": [
+					"Please do not translate the word \"commmand\", it is part of our internal syntax which must not change"
+				]
+			},
+			{
+				"key": "customizeRunAndDebug",
+				"comment": [
+					"Please do not translate the word \"commmand\", it is part of our internal syntax which must not change"
+				]
+			},
+			{
+				"key": "customizeRunAndDebugOpenFolder",
+				"comment": [
+					"Please do not translate the word \"commmand\", it is part of our internal syntax which must not change"
+				]
+			}
+		],
+		"vs/workbench/contrib/debug/browser/debugQuickAccess": [
+			"noDebugResults",
+			"customizeLaunchConfig",
+			{
+				"key": "contributed",
+				"comment": [
+					"contributed is lower case because it looks better like that in UI. Nothing preceeds it. It is a name of the grouping of debug configurations."
+				]
+			},
+			{
+				"key": "providerAriaLabel",
+				"comment": [
+					"Placeholder stands for the provider label. For example \"NodeJS\"."
+				]
+			},
+			"configure",
+			"addConfigTo",
+			"addConfiguration"
+		],
+		"vs/workbench/contrib/debug/browser/debugColors": [
+			"debugToolBarBackground",
+			"debugToolBarBorder",
+			"debugIcon.startForeground",
+			"debugIcon.pauseForeground",
+			"debugIcon.stopForeground",
+			"debugIcon.disconnectForeground",
+			"debugIcon.restartForeground",
+			"debugIcon.stepOverForeground",
+			"debugIcon.stepIntoForeground",
+			"debugIcon.stepOutForeground",
+			"debugIcon.continueForeground",
+			"debugIcon.stepBackForeground"
+		],
+		"vs/workbench/contrib/debug/browser/debugIcons": [
+			"debugConsoleViewIcon",
+			"runViewIcon",
+			"variablesViewIcon",
+			"watchViewIcon",
+			"callStackViewIcon",
+			"breakpointsViewIcon",
+			"loadedScriptsViewIcon",
+			"debugBreakpoint",
+			"debugBreakpointDisabled",
+			"debugBreakpointUnverified",
+			"debugBreakpointFunction",
+			"debugBreakpointFunctionDisabled",
+			"debugBreakpointFunctionUnverified",
+			"debugBreakpointConditional",
+			"debugBreakpointConditionalDisabled",
+			"debugBreakpointConditionalUnverified",
+			"debugBreakpointData",
+			"debugBreakpointDataDisabled",
+			"debugBreakpointDataUnverified",
+			"debugBreakpointLog",
+			"debugBreakpointLogDisabled",
+			"debugBreakpointLogUnverified",
+			"debugBreakpointHint",
+			"debugBreakpointUnsupported",
+			"debugStackframe",
+			"debugStackframeFocused",
+			"debugGripper",
+			"debugRestartFrame",
+			"debugStop",
+			"debugDisconnect",
+			"debugRestart",
+			"debugStepOver",
+			"debugStepInto",
+			"debugStepOut",
+			"debugStepBack",
+			"debugPause",
+			"debugContinue",
+			"debugReverseContinue",
+			"debugStart",
+			"debugConfigure",
+			"debugConsole",
+			"debugCollapseAll",
+			"callstackViewSession",
+			"debugConsoleClearAll",
+			"watchExpressionsRemoveAll",
+			"watchExpressionsAdd",
+			"watchExpressionsAddFuncBreakpoint",
+			"breakpointsRemoveAll",
+			"breakpointsActivate",
+			"debugConsoleEvaluationInput",
+			"debugConsoleEvaluationPrompt"
+		],
+		"vs/workbench/contrib/debug/browser/exceptionWidget": [
+			"debugExceptionWidgetBorder",
+			"debugExceptionWidgetBackground",
+			"exceptionThrownWithId",
+			"exceptionThrown",
+			"close"
+		],
+		"vs/workbench/contrib/debug/browser/debugHover": [
+			{
+				"key": "quickTip",
+				"comment": [
+					"\"switch to editor language hover\" means to show the programming language hover widget instead of the debug hover"
+				]
+			},
+			"treeAriaLabel",
+			{
+				"key": "variableAriaLabel",
+				"comment": [
+					"Do not translate placeholders. Placeholders are name and value of a variable."
+				]
+			}
+		],
+		"vs/workbench/contrib/debug/browser/breakpointWidget": [
+			"breakpointWidgetLogMessagePlaceholder",
+			"breakpointWidgetHitCountPlaceholder",
+			"breakpointWidgetExpressionPlaceholder",
+			"expression",
+			"hitCount",
+			"logMessage",
+			"breakpointType"
+		],
+		"vs/workbench/contrib/debug/browser/debugActionViewItems": [
+			"debugLaunchConfigurations",
+			"noConfigurations",
+			"addConfigTo",
+			"addConfiguration",
+			"debugSession"
+		],
+		"vs/workbench/contrib/debug/browser/replViewer": [
+			"debugConsole",
+			"replVariableAriaLabel",
+			{
+				"key": "occurred",
+				"comment": [
+					"Front will the value of the debug console element. Placeholder will be replaced by a number which represents occurrance count."
+				]
+			},
+			"replRawObjectAriaLabel",
+			"replGroup"
+		],
+		"vs/workbench/contrib/debug/common/replModel": [
+			"consoleCleared",
+			"snapshotObj"
+		],
+		"vs/workbench/contrib/debug/browser/replFilter": [
+			"showing filtered repl lines"
+		],
+		"vs/workbench/contrib/markers/browser/messages": [
+			"problems.view.toggle.label",
+			"problems.view.focus.label",
+			"problems.panel.configuration.title",
+			"problems.panel.configuration.autoreveal",
+			"problems.panel.configuration.showCurrentInStatus",
+			"markers.panel.title.problems",
+			"markers.panel.no.problems.build",
+			"markers.panel.no.problems.activeFile.build",
+			"markers.panel.no.problems.filters",
+			"markers.panel.action.moreFilters",
+			"markers.panel.filter.showErrors",
+			"markers.panel.filter.showWarnings",
+			"markers.panel.filter.showInfos",
+			"markers.panel.filter.useFilesExclude",
+			"markers.panel.filter.activeFile",
+			"markers.panel.action.filter",
+			"markers.panel.action.quickfix",
+			"markers.panel.filter.ariaLabel",
+			"markers.panel.filter.placeholder",
+			"markers.panel.filter.errors",
+			"markers.panel.filter.warnings",
+			"markers.panel.filter.infos",
+			"markers.panel.single.error.label",
+			"markers.panel.multiple.errors.label",
+			"markers.panel.single.warning.label",
+			"markers.panel.multiple.warnings.label",
+			"markers.panel.single.info.label",
+			"markers.panel.multiple.infos.label",
+			"markers.panel.single.unknown.label",
+			"markers.panel.multiple.unknowns.label",
+			"markers.panel.at.ln.col.number",
+			"problems.tree.aria.label.resource",
+			"problems.tree.aria.label.marker.relatedInformation",
+			"problems.tree.aria.label.error.marker",
+			"problems.tree.aria.label.error.marker.nosource",
+			"problems.tree.aria.label.warning.marker",
+			"problems.tree.aria.label.warning.marker.nosource",
+			"problems.tree.aria.label.info.marker",
+			"problems.tree.aria.label.info.marker.nosource",
+			"problems.tree.aria.label.marker",
+			"problems.tree.aria.label.marker.nosource",
+			"problems.tree.aria.label.relatedinfo.message",
+			"errors.warnings.show.label"
+		],
+		"vs/workbench/contrib/markers/browser/markersView": [
+			"No problems filtered",
+			"problems filtered",
+			"clearFilter"
+		],
+		"vs/workbench/contrib/markers/browser/markers": [
+			"totalProblems"
+		],
+		"vs/workbench/contrib/markers/browser/markersFileDecorations": [
+			"label",
+			"tooltip.1",
+			"tooltip.N",
+			"markers.showOnFile"
+		],
+		"vs/workbench/contrib/comments/browser/commentsEditorContribution": [
+			"pickCommentService",
+			"nextCommentThreadAction"
+		],
+		"vs/workbench/contrib/url/browser/trustedDomains": [
+			"trustedDomain.manageTrustedDomain",
+			"trustedDomain.trustDomain",
+			"trustedDomain.trustAllPorts",
+			"trustedDomain.trustSubDomain",
+			"trustedDomain.trustAllDomains",
+			"trustedDomain.manageTrustedDomains",
+			"configuringURL"
+		],
+		"vs/workbench/contrib/url/browser/trustedDomainsValidator": [
+			"openExternalLinkAt",
+			"open",
+			"copy",
+			"cancel",
+			"configureTrustedDomains"
+		],
+		"vs/workbench/contrib/webviewPanel/browser/webviewCommands": [
+			"editor.action.webvieweditor.showFind",
+			"editor.action.webvieweditor.hideFind",
+			"editor.action.webvieweditor.findNext",
+			"editor.action.webvieweditor.findPrevious",
+			"refreshWebviewLabel"
+		],
+		"vs/workbench/contrib/customEditor/browser/customEditors": [
+			"openWithCurrentlyActive",
+			"promptOpenWith.setDefaultTooltip",
+			"promptOpenWith.placeHolder"
+		],
+		"vs/workbench/contrib/externalUriOpener/common/configuration": [
+			"externalUriOpeners",
+			"externalUriOpeners.uri",
+			"externalUriOpeners.uri",
+			"externalUriOpeners.defaultId"
+		],
+		"vs/workbench/contrib/externalUriOpener/common/externalUriOpenerService": [
+			"selectOpenerDefaultLabel.web",
+			"selectOpenerDefaultLabel",
+			"selectOpenerConfigureTitle",
+			"selectOpenerPlaceHolder"
+		],
+		"vs/workbench/contrib/extensions/common/extensionsInput": [
+			"extensionsInputName"
+		],
+		"vs/workbench/contrib/extensions/common/extensionsUtils": [
+			"disableOtherKeymapsConfirmation",
+			"yes",
+			"no"
+		],
+		"vs/workbench/contrib/extensions/browser/extensionEditor": [
+			"name",
+			"extension id",
+			"preview",
+			"preview",
+			"builtin",
+			"publisher",
+			"install count",
+			"rating",
+			"repository",
+			"license",
+			"version",
+			"details",
+			"detailstooltip",
+			"contributions",
+			"contributionstooltip",
+			"changelog",
+			"changelogtooltip",
+			"dependencies",
+			"dependenciestooltip",
+			"recommendationHasBeenIgnored",
+			"noReadme",
+			"extension pack",
+			"noReadme",
+			"noChangelog",
+			"noContributions",
+			"noContributions",
+			"noDependencies",
+			"settings",
+			"setting name",
+			"description",
+			"default",
+			"debuggers",
+			"debugger name",
+			"debugger type",
+			"viewContainers",
+			"view container id",
+			"view container title",
+			"view container location",
+			"views",
+			"view id",
+			"view name",
+			"view location",
+			"localizations",
+			"localizations language id",
+			"localizations language name",
+			"localizations localized language name",
+			"customEditors",
+			"customEditors view type",
+			"customEditors priority",
+			"customEditors filenamePattern",
+			"codeActions",
+			"codeActions.title",
+			"codeActions.kind",
+			"codeActions.description",
+			"codeActions.languages",
+			"authentication",
+			"authentication.label",
+			"authentication.id",
+			"colorThemes",
+			"iconThemes",
+			"colors",
+			"colorId",
+			"description",
+			"defaultDark",
+			"defaultLight",
+			"defaultHC",
+			"JSON Validation",
+			"fileMatch",
+			"schema",
+			"commands",
+			"command name",
+			"description",
+			"keyboard shortcuts",
+			"menuContexts",
+			"languages",
+			"language id",
+			"language name",
+			"file extensions",
+			"grammar",
+			"snippets",
+			"activation events",
+			"find",
+			"find next",
+			"find previous"
+		],
+		"vs/workbench/contrib/extensions/common/extensionsFileTemplate": [
+			"app.extensions.json.title",
+			"app.extensions.json.recommendations",
+			"app.extension.identifier.errorMessage",
+			"app.extensions.json.unwantedRecommendations",
+			"app.extension.identifier.errorMessage"
+		],
+		"vs/workbench/contrib/extensions/browser/extensionsActivationProgress": [
+			"activation"
+		],
+		"vs/workbench/contrib/extensions/browser/extensionsDependencyChecker": [
+			"extensions",
+			"auto install missing deps",
+			"finished installing missing deps",
+			"reload",
+			"no missing deps"
+		],
+		"vs/workbench/contrib/extensions/browser/extensionsQuickAccess": [
+			"type",
+			"searchFor",
+			"install",
+			"manage"
+		],
+		"vs/workbench/contrib/extensions/browser/extensionsActions": [
+			"noOfYearsAgo",
+			"one year ago",
+			"noOfMonthsAgo",
+			"one month ago",
+			"noOfDaysAgo",
+			"one day ago",
+			"noOfHoursAgo",
+			"one hour ago",
+			"just now",
+			"update operation",
+			"install operation",
+			"download",
+			"install vsix",
+			"installVSIX",
+			"check logs",
+			"installExtensionStart",
+			"installExtensionComplete",
+			"install",
+			"install and do no sync",
+			"install",
+			{
+				"key": "install in remote and do not sync",
+				"comment": [
+					"This is the name of the action to install an extension in remote server and do not sync it. Placeholder is for the name of remote server."
+				]
+			},
+			{
+				"key": "install in remote",
+				"comment": [
+					"This is the name of the action to install an extension in remote server. Placeholder is for the name of remote server."
+				]
+			},
+			"install locally and do not sync",
+			"install locally",
+			"install",
+			{
+				"key": "install everywhere tooltip",
+				"comment": [
+					"Placeholder is the name of the product. Eg: Visual Studio Code or Visual Studio Code - Insiders"
+				]
+			},
+			"installing",
+			"install",
+			"installing",
+			"installExtensionStart",
+			{
+				"key": "install in remote",
+				"comment": [
+					"This is the name of the action to install an extension in remote server. Placeholder is for the name of remote server."
+				]
+			},
+			"install locally",
+			"install browser",
+			"uninstallAction",
+			"Uninstalling",
+			"uninstallExtensionStart",
+			"uninstallExtensionComplete",
+			"updateExtensionStart",
+			"updateExtensionComplete",
+			"updateTo",
+			"updateAction",
+			"manage",
+			"ManageExtensionAction.uninstallingTooltip",
+			"manage",
+			"install another version",
+			"selectVersion",
+			"current",
+			"enableForWorkspaceAction",
+			"enableForWorkspaceActionToolTip",
+			"enableGloballyAction",
+			"enableGloballyActionToolTip",
+			"disableForWorkspaceAction",
+			"disableForWorkspaceActionToolTip",
+			"disableGloballyAction",
+			"disableGloballyActionToolTip",
+			"enableAction",
+			"disableAction",
+			"reloadAction",
+			"reloadRequired",
+			"postUninstallTooltip",
+			"uninstallExtensionComplete",
+			"reloadRequired",
+			"postUpdateTooltip",
+			"reloadRequired",
+			"enable locally",
+			"reloadRequired",
+			"enable remote",
+			"reloadRequired",
+			"postEnableTooltip",
+			"reloadRequired",
+			"postEnableTooltip",
+			"reloadRequired",
+			"postDisableTooltip",
+			"reloadRequired",
+			"postEnableTooltip",
+			"reloadRequired",
+			"postEnableTooltip",
+			"installExtensionCompletedAndReloadRequired",
+			"current",
+			"color theme",
+			"select color theme",
+			"file icon theme",
+			"select file icon theme",
+			"product icon theme",
+			"select product icon theme",
+			"showRecommendedExtension",
+			"installRecommendedExtension",
+			"ignoreExtensionRecommendation",
+			"undo",
+			"search recommendations",
+			"OpenExtensionsFile.failed",
+			"configureWorkspaceRecommendedExtensions",
+			"configureWorkspaceFolderRecommendedExtensions",
+			"updated",
+			"installed",
+			"uninstalled",
+			"enabled",
+			"disabled",
+			"malicious tooltip",
+			{
+				"key": "malicious",
+				"comment": [
+					"Refers to a malicious extension"
+				]
+			},
+			"malicious tooltip",
+			"ignored",
+			"synced",
+			"sync",
+			"do not sync",
+			"extension enabled on remote",
+			"globally enabled",
+			"workspace enabled",
+			"globally disabled",
+			"workspace disabled",
+			"Install language pack also in remote server",
+			"Install language pack also locally",
+			"Install in other server to enable",
+			"disabled because of extension kind",
+			"disabled locally",
+			"disabled remotely",
+			"reinstall",
+			"selectExtensionToReinstall",
+			"ReinstallAction.successReload",
+			"ReinstallAction.success",
+			"InstallVSIXAction.reloadNow",
+			"install previous version",
+			"selectExtension",
+			"current",
+			"selectVersion",
+			"InstallAnotherVersionExtensionAction.successReload",
+			"InstallAnotherVersionExtensionAction.success",
+			"InstallAnotherVersionExtensionAction.reloadNow",
+			"select extensions to install",
+			"no local extensions",
+			"installing extensions",
+			"finished installing",
+			"select and install local extensions",
+			"install local extensions title",
+			"select and install remote extensions",
+			"install remote extensions",
+			"extensionButtonProminentBackground",
+			"extensionButtonProminentForeground",
+			"extensionButtonProminentHoverBackground"
+		],
+		"vs/workbench/contrib/extensions/browser/extensionsWorkbenchService": [
+			"Manifest is not found",
+			"malicious",
+			"uninstallingExtension",
+			"incompatible",
+			"installing named extension",
+			"installing extension",
+			"disable all",
+			"singleDependentError",
+			"twoDependentsError",
+			"multipleDependentsError"
+		],
+		"vs/workbench/contrib/extensions/browser/extensionsIcons": [
+			"extensionsViewIcon",
+			"manageExtensionIcon",
+			"clearSearchResultsIcon",
+			"refreshIcon",
+			"filterIcon",
+			"installLocalInRemoteIcon",
+			"installWorkspaceRecommendedIcon",
+			"configureRecommendedIcon",
+			"syncEnabledIcon",
+			"syncIgnoredIcon",
+			"remoteIcon",
+			"installCountIcon",
+			"ratingIcon",
+			"starFullIcon",
+			"starHalfIcon",
+			"starEmptyIcon",
+			"warningIcon",
+			"infoIcon"
+		],
+		"vs/workbench/contrib/extensions/browser/extensionRecommendationNotificationService": [
+			"neverShowAgain",
+			"ignoreExtensionRecommendations",
+			"ignoreAll",
+			"no",
+			"workspaceRecommended",
+			"install",
+			"install and do no sync",
+			"show recommendations"
+		],
+		"vs/workbench/contrib/output/browser/logViewer": [
+			"logViewerAriaLabel"
+		],
+		"vs/workbench/contrib/extensions/browser/extensionsViews": [
+			"extension-arialabel",
+			"extensions",
+			"galleryError",
+			"error",
+			"no extensions found",
+			"suggestProxyError",
+			"open user settings",
+			"no local extensions"
+		],
+		"vs/workbench/browser/parts/editor/textResourceEditor": [
+			"textEditor"
+		],
+		"vs/base/browser/ui/actionbar/actionViewItems": [
+			{
+				"key": "titleLabel",
+				"comment": [
+					"action title",
+					"action keybinding"
+				]
+			}
+		],
+		"vs/workbench/contrib/terminal/common/terminalColorRegistry": [
+			"terminal.background",
+			"terminal.foreground",
+			"terminalCursor.foreground",
+			"terminalCursor.background",
+			"terminal.selectionBackground",
+			"terminal.border",
+			"terminal.ansiColor"
+		],
+		"vs/workbench/contrib/terminal/browser/terminalActions": [
+			"workbench.action.terminal.newWorkspacePlaceholder",
+			"workbench.action.terminal.toggleTerminal",
+			"workbench.action.terminal.kill",
+			"workbench.action.terminal.kill.short",
+			"workbench.action.terminal.copySelection",
+			"workbench.action.terminal.copySelection.short",
+			"workbench.action.terminal.selectAll",
+			"workbench.action.terminal.new",
+			"workbench.action.terminal.new.short",
+			"workbench.action.terminal.newWorkspacePlaceholder",
+			"workbench.action.terminal.split",
+			"workbench.action.terminal.split.short",
+			"workbench.action.terminal.splitInActiveWorkspace",
+			"workbench.action.terminal.paste",
+			"workbench.action.terminal.paste.short",
+			"workbench.action.terminal.selectDefaultShell",
+			"workbench.action.terminal.openSettings",
+			"workbench.action.terminal.switchTerminal",
+			"terminals",
+			"terminalConnectingLabel",
+			"workbench.action.terminal.clear",
+			"terminalLaunchHelp",
+			"workbench.action.terminal.newInActiveWorkspace",
+			"workbench.action.terminal.focusPreviousPane",
+			"workbench.action.terminal.focusNextPane",
+			"workbench.action.terminal.resizePaneLeft",
+			"workbench.action.terminal.resizePaneRight",
+			"workbench.action.terminal.resizePaneUp",
+			"workbench.action.terminal.resizePaneDown",
+			"workbench.action.terminal.focus",
+			"workbench.action.terminal.focusNext",
+			"workbench.action.terminal.focusPrevious",
+			"workbench.action.terminal.runSelectedText",
+			"workbench.action.terminal.runActiveFile",
+			"workbench.action.terminal.runActiveFile.noFile",
+			"workbench.action.terminal.scrollDown",
+			"workbench.action.terminal.scrollDownPage",
+			"workbench.action.terminal.scrollToBottom",
+			"workbench.action.terminal.scrollUp",
+			"workbench.action.terminal.scrollUpPage",
+			"workbench.action.terminal.scrollToTop",
+			"workbench.action.terminal.navigationModeExit",
+			"workbench.action.terminal.navigationModeFocusPrevious",
+			"workbench.action.terminal.navigationModeFocusNext",
+			"workbench.action.terminal.clearSelection",
+			"workbench.action.terminal.manageWorkspaceShellPermissions",
+			"workbench.action.terminal.rename",
+			"workbench.action.terminal.rename.prompt",
+			"workbench.action.terminal.focusFind",
+			"workbench.action.terminal.hideFind",
+			"workbench.action.terminal.attachToRemote",
+			"quickAccessTerminal",
+			"workbench.action.terminal.scrollToPreviousCommand",
+			"workbench.action.terminal.scrollToNextCommand",
+			"workbench.action.terminal.selectToPreviousCommand",
+			"workbench.action.terminal.selectToNextCommand",
+			"workbench.action.terminal.selectToPreviousLine",
+			"workbench.action.terminal.selectToNextLine",
+			"workbench.action.terminal.toggleEscapeSequenceLogging",
+			"workbench.action.terminal.sendSequence",
+			"workbench.action.terminal.newWithCwd",
+			"workbench.action.terminal.newWithCwd.cwd",
+			"workbench.action.terminal.renameWithArg",
+			"workbench.action.terminal.renameWithArg.name",
+			"workbench.action.terminal.renameWithArg.noName",
+			"workbench.action.terminal.toggleFindRegex",
+			"workbench.action.terminal.toggleFindWholeWord",
+			"workbench.action.terminal.toggleFindCaseSensitive",
+			"workbench.action.terminal.findNext",
+			"workbench.action.terminal.findPrevious",
+			"workbench.action.terminal.searchWorkspace",
+			"workbench.action.terminal.relaunch",
+			"workbench.action.terminal.showEnvironmentInformation"
+		],
+		"vs/workbench/contrib/terminal/common/terminalMenu": [
+			{
+				"key": "miToggleIntegratedTerminal",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			{
+				"key": "miNewTerminal",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			{
+				"key": "miSplitTerminal",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			{
+				"key": "miRunActiveFile",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			{
+				"key": "miRunSelectedText",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			}
+		],
+		"vs/workbench/contrib/terminal/browser/terminalQuickAccess": [
+			"renameTerminal",
+			"killTerminal",
+			"workbench.action.terminal.newplus"
+		],
+		"vs/workbench/contrib/terminal/browser/terminalIcons": [
+			"terminalViewIcon",
+			"renameTerminalIcon",
+			"killTerminalIcon",
+			"newTerminalIcon"
+		],
+		"vs/workbench/contrib/terminal/browser/terminalService": [
+			"workbench.action.terminal.allowWorkspaceShell",
+			"workbench.action.terminal.disallowWorkspaceShell",
+			"terminalService.terminalCloseConfirmationSingular",
+			"terminalService.terminalCloseConfirmationPlural",
+			"terminal.integrated.chooseWindowsShell"
+		],
+		"vs/workbench/contrib/tasks/common/jsonSchema_v1": [
+			"JsonSchema.version.deprecated",
+			"JsonSchema.version",
+			"JsonSchema._runner",
+			"JsonSchema.runner",
+			"JsonSchema.windows",
+			"JsonSchema.mac",
+			"JsonSchema.linux",
+			"JsonSchema.shell"
+		],
+		"vs/workbench/contrib/tasks/common/jsonSchema_v2": [
+			"JsonSchema.shell",
+			"JsonSchema.tasks.isShellCommand.deprecated",
+			"JsonSchema.tasks.dependsOn.identifier",
+			"JsonSchema.tasks.dependsOn.string",
+			"JsonSchema.tasks.dependsOn.array",
+			"JsonSchema.tasks.dependsOn",
+			"JsonSchema.tasks.dependsOrder.parallel",
+			"JsonSchema.tasks.dependsOrder.sequence",
+			"JsonSchema.tasks.dependsOrder",
+			"JsonSchema.tasks.detail",
+			"JsonSchema.tasks.presentation",
+			"JsonSchema.tasks.presentation.echo",
+			"JsonSchema.tasks.presentation.focus",
+			"JsonSchema.tasks.presentation.revealProblems.always",
+			"JsonSchema.tasks.presentation.revealProblems.onProblem",
+			"JsonSchema.tasks.presentation.revealProblems.never",
+			"JsonSchema.tasks.presentation.revealProblems",
+			"JsonSchema.tasks.presentation.reveal.always",
+			"JsonSchema.tasks.presentation.reveal.silent",
+			"JsonSchema.tasks.presentation.reveal.never",
+			"JsonSchema.tasks.presentation.reveal",
+			"JsonSchema.tasks.presentation.instance",
+			"JsonSchema.tasks.presentation.showReuseMessage",
+			"JsonSchema.tasks.presentation.clear",
+			"JsonSchema.tasks.presentation.group",
+			"JsonSchema.tasks.terminal",
+			"JsonSchema.tasks.group.kind",
+			"JsonSchema.tasks.group.isDefault",
+			"JsonSchema.tasks.group.defaultBuild",
+			"JsonSchema.tasks.group.defaultTest",
+			"JsonSchema.tasks.group.build",
+			"JsonSchema.tasks.group.test",
+			"JsonSchema.tasks.group.none",
+			"JsonSchema.tasks.group",
+			"JsonSchema.tasks.type",
+			"JsonSchema.commandArray",
+			"JsonSchema.commandArray",
+			"JsonSchema.command.quotedString.value",
+			"JsonSchema.tasks.quoting.escape",
+			"JsonSchema.tasks.quoting.strong",
+			"JsonSchema.tasks.quoting.weak",
+			"JsonSchema.command.quotesString.quote",
+			"JsonSchema.command",
+			"JsonSchema.args.quotedString.value",
+			"JsonSchema.tasks.quoting.escape",
+			"JsonSchema.tasks.quoting.strong",
+			"JsonSchema.tasks.quoting.weak",
+			"JsonSchema.args.quotesString.quote",
+			"JsonSchema.tasks.args",
+			"JsonSchema.tasks.label",
+			"JsonSchema.version",
+			"JsonSchema.tasks.identifier",
+			"JsonSchema.tasks.identifier.deprecated",
+			"JsonSchema.tasks.reevaluateOnRerun",
+			"JsonSchema.tasks.runOn",
+			"JsonSchema.tasks.instanceLimit",
+			"JsonSchema.tasks.runOptions",
+			"JsonSchema.tasks.taskLabel",
+			"JsonSchema.tasks.taskName",
+			"JsonSchema.tasks.taskName.deprecated",
+			"JsonSchema.tasks.background",
+			"JsonSchema.tasks.promptOnClose",
+			"JsonSchema.tasks.matchers",
+			"JsonSchema.customizations.customizes.type",
+			"JsonSchema.tasks.customize.deprecated",
+			"JsonSchema.tasks.taskName.deprecated",
+			"JsonSchema.tasks.showOutput.deprecated",
+			"JsonSchema.tasks.echoCommand.deprecated",
+			"JsonSchema.tasks.suppressTaskName.deprecated",
+			"JsonSchema.tasks.isBuildCommand.deprecated",
+			"JsonSchema.tasks.isTestCommand.deprecated",
+			"JsonSchema.tasks.type",
+			"JsonSchema.tasks.suppressTaskName.deprecated",
+			"JsonSchema.tasks.taskSelector.deprecated",
+			"JsonSchema.windows",
+			"JsonSchema.mac",
+			"JsonSchema.linux"
+		],
+		"vs/workbench/contrib/tasks/browser/tasksQuickAccess": [
+			"noTaskResults",
+			"TaskService.pickRunTask"
+		],
+		"vs/workbench/contrib/emmet/browser/actions/expandAbbreviation": [
+			"expandAbbreviationAction",
+			{
+				"key": "miEmmetExpandAbbreviation",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			}
+		],
+		"vs/workbench/contrib/remote/browser/explorerViewItems": [
+			"remotes",
+			"remote.explorer.switch"
+		],
+		"vs/workbench/contrib/remote/browser/remoteIndicator": [
+			"remote.category",
+			"remote.showMenu",
+			"remote.close",
+			{
+				"key": "miCloseRemote",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			"host.open",
+			"host.open",
+			"host.reconnecting",
+			"host.tooltipReconnecting",
+			"disconnectedFrom",
+			"host.tooltipDisconnected",
+			"host.tooltip",
+			"noHost.tooltip",
+			"remoteHost",
+			"cat.title",
+			"closeRemote.title"
+		],
+		"vs/workbench/contrib/remote/browser/remoteIcons": [
+			"getStartedIcon",
+			"documentationIcon",
+			"feedbackIcon",
+			"reviewIssuesIcon",
+			"reportIssuesIcon",
+			"remoteExplorerViewIcon",
+			"portsViewIcon",
+			"portIcon",
+			"privatePortIcon",
+			"publicPortIcon",
+			"forwardPortIcon",
+			"stopForwardIcon",
+			"openBrowserIcon"
+		],
+		"vs/workbench/contrib/codeEditor/browser/accessibility/accessibility": [
+			"emergencyConfOn",
+			"openingDocs",
+			"introMsg",
+			"status",
+			"changeConfigToOnMac",
+			"changeConfigToOnWinLinux",
+			"auto_unknown",
+			"auto_on",
+			"auto_off",
+			"configuredOn",
+			"configuredOff",
+			"tabFocusModeOnMsg",
+			"tabFocusModeOnMsgNoKb",
+			"tabFocusModeOffMsg",
+			"tabFocusModeOffMsgNoKb",
+			"openDocMac",
+			"openDocWinLinux",
+			"outroMsg",
+			"ShowAccessibilityHelpAction"
+		],
+		"vs/workbench/contrib/codeEditor/browser/diffEditorHelper": [
+			"hintTimeout",
+			"removeTimeout",
+			"hintWhitespace"
+		],
+		"vs/workbench/contrib/codeEditor/browser/inspectKeybindings": [
+			"workbench.action.inspectKeyMap",
+			"workbench.action.inspectKeyMapJSON"
+		],
+		"vs/workbench/contrib/codeEditor/browser/largeFileOptimizations": [
+			{
+				"key": "largeFile",
+				"comment": [
+					"Variable 0 will be a file name."
+				]
+			},
+			"removeOptimizations",
+			"reopenFilePrompt"
+		],
+		"vs/workbench/contrib/codeEditor/browser/inspectEditorTokens/inspectEditorTokens": [
+			"inspectEditorTokens",
+			"inspectTMScopesWidget.loading"
+		],
+		"vs/workbench/contrib/codeEditor/browser/quickaccess/gotoLineQuickAccess": [
+			"gotoLineQuickAccessPlaceholder",
+			"gotoLineQuickAccess",
+			"gotoLine"
+		],
+		"vs/workbench/contrib/codeEditor/browser/saveParticipants": [
+			"formatting",
+			"codeaction",
+			"codeaction.get",
+			"codeAction.apply"
+		],
+		"vs/workbench/contrib/codeEditor/browser/toggleMinimap": [
+			"toggleMinimap",
+			{
+				"key": "miShowMinimap",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			}
+		],
+		"vs/workbench/contrib/codeEditor/browser/toggleMultiCursorModifier": [
+			"toggleLocation",
+			"miMultiCursorAlt",
+			"miMultiCursorCmd",
+			"miMultiCursorCtrl"
+		],
+		"vs/workbench/contrib/codeEditor/browser/toggleRenderControlCharacter": [
+			"toggleRenderControlCharacters",
+			{
+				"key": "miToggleRenderControlCharacters",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			}
+		],
+		"vs/workbench/contrib/codeEditor/browser/toggleColumnSelection": [
+			"toggleColumnSelection",
+			{
+				"key": "miColumnSelection",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			}
+		],
+		"vs/workbench/contrib/codeEditor/browser/toggleRenderWhitespace": [
+			"toggleRenderWhitespace",
+			{
+				"key": "miToggleRenderWhitespace",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			}
+		],
+		"vs/workbench/contrib/codeEditor/browser/toggleWordWrap": [
+			"toggle.wordwrap",
+			"unwrapMinified",
+			"wrapMinified",
+			{
+				"key": "miToggleWordWrap",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			}
+		],
+		"vs/workbench/contrib/snippets/browser/snippetsFile": [
+			"source.workspaceSnippetGlobal",
+			"source.userSnippetGlobal",
+			"source.userSnippet"
+		],
+		"vs/workbench/contrib/snippets/browser/snippetCompletionProvider": [
+			"detail.snippet",
+			"snippetSuggest.longLabel",
+			"snippetSuggest.longLabel"
+		],
+		"vs/workbench/contrib/format/browser/formatActionsMultiple": [
+			"nullFormatterDescription",
+			"miss",
+			"config.needed",
+			"config.bad",
+			"do.config",
+			"cancel",
+			"do.config",
+			"select",
+			"formatter.default",
+			"def",
+			"config",
+			"format.placeHolder",
+			"select",
+			"formatDocument.label.multiple",
+			"formatSelection.label.multiple"
+		],
+		"vs/workbench/contrib/format/browser/formatActionsNone": [
+			"formatDocument.label.multiple",
+			"too.large",
+			"no.provider",
+			"install.formatter"
+		],
+		"vs/workbench/contrib/format/browser/formatModified": [
+			"formatChanges"
+		],
+		"vs/workbench/contrib/update/browser/update": [
+			"releaseNotes",
+			"update.noReleaseNotesOnline",
+			"releaseNotes",
+			"showReleaseNotes",
+			"read the release notes",
+			"releaseNotes",
+			"licenseChanged",
+			"updateIsReady",
+			"checkingForUpdates",
+			"update service",
+			"noUpdatesAvailable",
+			"ok",
+			"thereIsUpdateAvailable",
+			"download update",
+			"later",
+			"releaseNotes",
+			"updateAvailable",
+			"installUpdate",
+			"later",
+			"releaseNotes",
+			"updateInstalling",
+			"updateNow",
+			"later",
+			"releaseNotes",
+			"updateAvailableAfterRestart",
+			"checkForUpdates",
+			"checkingForUpdates",
+			"download update_1",
+			"DownloadingUpdate",
+			"installUpdate...",
+			"installingUpdate",
+			"restartToUpdate",
+			"relaunchMessage",
+			"relaunchDetailInsiders",
+			"relaunchDetailStable",
+			"reload",
+			"switchToInsiders",
+			"switchToStable",
+			"checkForUpdates"
+		],
+		"vs/base/browser/ui/keybindingLabel/keybindingLabel": [
+			"unbound"
+		],
+		"vs/workbench/contrib/welcome/page/browser/welcomePage": [
+			"welcomePage",
+			"welcomePage.javaScript",
+			"welcomePage.python",
+			"welcomePage.java",
+			"welcomePage.php",
+			"welcomePage.azure",
+			"welcomePage.showAzureExtensions",
+			"welcomePage.docker",
+			"welcomePage.vim",
+			"welcomePage.sublime",
+			"welcomePage.atom",
+			"welcomePage.extensionPackAlreadyInstalled",
+			"welcomePage.willReloadAfterInstallingExtensionPack",
+			"welcomePage.installingExtensionPack",
+			"welcomePage.extensionPackNotFound",
+			"welcomePage.keymapAlreadyInstalled",
+			"welcomePage.willReloadAfterInstallingKeymap",
+			"welcomePage.installingKeymap",
+			"welcomePage.keymapNotFound",
+			"welcome.title",
+			"welcomePage.openFolderWithPath",
+			"welcomePage.extensionListSeparator",
+			"welcomePage.installKeymap",
+			"welcomePage.installExtensionPack",
+			"welcomePage.installedKeymap",
+			"welcomePage.installedExtensionPack",
+			"ok",
+			"details"
+		],
+		"vs/workbench/contrib/welcome/gettingStarted/browser/gettingStarted": [
+			"editorGettingStarted.title",
+			"gettingStarted.skip",
+			"next"
+		],
+		"vs/workbench/contrib/welcome/gettingStarted/browser/gettingStartedIcons": [
+			"gettingStartedUnchecked",
+			"gettingStartedChecked"
+		],
+		"vs/workbench/contrib/welcome/walkThrough/browser/walkThroughPart": [
+			"walkThrough.unboundCommand",
+			"walkThrough.gitNotFound",
+			"walkThrough.embeddedEditorBackground"
+		],
+		"vs/workbench/contrib/welcome/walkThrough/browser/editor/editorWalkThrough": [
+			"editorWalkThrough.title",
+			"editorWalkThrough"
+		],
+		"vs/workbench/contrib/callHierarchy/browser/callHierarchyPeek": [
+			"callFrom",
+			"callsTo",
+			"title.loading",
+			"empt.callsFrom",
+			"empt.callsTo"
+		],
+		"vs/editor/contrib/peekView/peekView": [
+			"label.close",
+			"peekViewTitleBackground",
+			"peekViewTitleForeground",
+			"peekViewTitleInfoForeground",
+			"peekViewBorder",
+			"peekViewResultsBackground",
+			"peekViewResultsMatchForeground",
+			"peekViewResultsFileForeground",
+			"peekViewResultsSelectionBackground",
+			"peekViewResultsSelectionForeground",
+			"peekViewEditorBackground",
+			"peekViewEditorGutterBackground",
+			"peekViewResultsMatchHighlight",
+			"peekViewEditorMatchHighlight",
+			"peekViewEditorMatchHighlightBorder"
+		],
+		"vs/workbench/contrib/codeEditor/browser/outline/documentSymbolsTree": [
+			"title.template",
+			"1.problem",
+			"N.problem",
+			"deep.problem",
+			"Array",
+			"Boolean",
+			"Class",
+			"Constant",
+			"Constructor",
+			"Enum",
+			"EnumMember",
+			"Event",
+			"Field",
+			"File",
+			"Function",
+			"Interface",
+			"Key",
+			"Method",
+			"Module",
+			"Namespace",
+			"Null",
+			"Number",
+			"Object",
+			"Operator",
+			"Package",
+			"Property",
+			"String",
+			"Struct",
+			"TypeParameter",
+			"Variable",
+			"symbolIcon.arrayForeground",
+			"symbolIcon.booleanForeground",
+			"symbolIcon.classForeground",
+			"symbolIcon.colorForeground",
+			"symbolIcon.constantForeground",
+			"symbolIcon.constructorForeground",
+			"symbolIcon.enumeratorForeground",
+			"symbolIcon.enumeratorMemberForeground",
+			"symbolIcon.eventForeground",
+			"symbolIcon.fieldForeground",
+			"symbolIcon.fileForeground",
+			"symbolIcon.folderForeground",
+			"symbolIcon.functionForeground",
+			"symbolIcon.interfaceForeground",
+			"symbolIcon.keyForeground",
+			"symbolIcon.keywordForeground",
+			"symbolIcon.methodForeground",
+			"symbolIcon.moduleForeground",
+			"symbolIcon.namespaceForeground",
+			"symbolIcon.nullForeground",
+			"symbolIcon.numberForeground",
+			"symbolIcon.objectForeground",
+			"symbolIcon.operatorForeground",
+			"symbolIcon.packageForeground",
+			"symbolIcon.propertyForeground",
+			"symbolIcon.referenceForeground",
+			"symbolIcon.snippetForeground",
+			"symbolIcon.stringForeground",
+			"symbolIcon.structForeground",
+			"symbolIcon.textForeground",
+			"symbolIcon.typeParameterForeground",
+			"symbolIcon.unitForeground",
+			"symbolIcon.variableForeground"
+		],
+		"vs/workbench/contrib/outline/browser/outlinePane": [
+			"no-editor",
+			"loading",
+			"no-symbols",
+			"collapse",
+			"followCur",
+			"filterOnType",
+			"sortByPosition",
+			"sortByName",
+			"sortByKind"
+		],
+		"vs/workbench/contrib/feedback/browser/feedbackStatusbarItem": [
+			"status.feedback",
+			"status.feedback",
+			"status.feedback",
+			"status.feedback"
+		],
+		"vs/workbench/contrib/userDataSync/browser/userDataSync": [
+			"turn on sync with category",
+			"stop sync",
+			"configure sync",
+			"showConflicts",
+			"showKeybindingsConflicts",
+			"showSnippetsConflicts",
+			"sync now",
+			"syncing",
+			"synced with time",
+			"sync settings",
+			"show synced data",
+			"conflicts detected",
+			"replace remote",
+			"replace local",
+			"show conflicts",
+			"accept failed",
+			"accept failed",
+			"session expired",
+			"turn on sync",
+			"turned off",
+			"turn on sync",
+			"too large",
+			"error upgrade required",
+			"operationId",
+			"error reset required",
+			"reset",
+			"show synced data action",
+			"switched to insiders",
+			"operationId",
+			"open file",
+			"errorInvalidConfiguration",
+			"open file",
+			"has conflicts",
+			"turning on syncing",
+			"sign in to sync",
+			"no authentication providers",
+			"too large while starting sync",
+			"error upgrade required while starting sync",
+			"operationId",
+			"error reset required while starting sync",
+			"reset",
+			"show synced data action",
+			"auth failed",
+			"turn on failed",
+			"sync preview message",
+			"turn on",
+			"open doc",
+			"cancel",
+			"sign in and turn on",
+			"configure and turn on sync detail",
+			"per platform",
+			"configure sync",
+			"configure sync placeholder",
+			"turn off sync confirmation",
+			"turn off sync detail",
+			{
+				"key": "turn off",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			"turn off sync everywhere",
+			{
+				"key": "leftResourceName",
+				"comment": [
+					"remote as in file in cloud"
+				]
+			},
+			"merges",
+			"sideBySideLabels",
+			"sideBySideDescription",
+			"switchSyncService.title",
+			"switchSyncService.description",
+			"default",
+			"insiders",
+			"stable",
+			"global activity turn on sync",
+			"global activity turn on sync",
+			"global activity turn on sync",
+			"turnin on sync",
+			"sign in global",
+			"sign in accounts",
+			"resolveConflicts_global",
+			"resolveConflicts_global",
+			"resolveKeybindingsConflicts_global",
+			"resolveKeybindingsConflicts_global",
+			"resolveSnippetsConflicts_global",
+			"resolveSnippetsConflicts_global",
+			"sync is on",
+			"workbench.action.showSyncRemoteBackup",
+			"turn off failed",
+			"configure",
+			"show sync log title",
+			"show sync log toolrip",
+			"workbench.actions.syncData.reset",
+			"accept remote",
+			"accept merges",
+			"accept remote button",
+			"accept merges button",
+			"Sync accept remote",
+			"Sync accept merges",
+			"confirm replace and overwrite local",
+			"confirm replace and overwrite remote",
+			"update conflicts",
+			"accept failed"
+		],
+		"vs/workbench/contrib/codeActions/common/codeActionsContribution": [
+			"codeActionsOnSave.fixAll",
+			"codeActionsOnSave",
+			"codeActionsOnSave.generic"
+		],
+		"vs/workbench/contrib/codeActions/common/codeActionsExtensionPoint": [
+			"contributes.codeActions",
+			"contributes.codeActions.languages",
+			"contributes.codeActions.kind",
+			"contributes.codeActions.title",
+			"contributes.codeActions.description"
+		],
+		"vs/workbench/contrib/codeActions/common/documentationExtensionPoint": [
+			"contributes.documentation",
+			"contributes.documentation.refactorings",
+			"contributes.documentation.refactoring",
+			"contributes.documentation.refactoring.title",
+			"contributes.documentation.refactoring.when",
+			"contributes.documentation.refactoring.command"
+		],
+		"vs/workbench/contrib/welcome/common/viewsWelcomeContribution": [
+			"ViewsWelcomeExtensionPoint.proposedAPI"
+		],
+		"vs/workbench/contrib/welcome/common/viewsWelcomeExtensionPoint": [
+			"contributes.viewsWelcome",
+			"contributes.viewsWelcome.view",
+			"contributes.viewsWelcome.view.view",
+			"contributes.viewsWelcome.view.view",
+			"contributes.viewsWelcome.view.contents",
+			"contributes.viewsWelcome.view.when",
+			"contributes.viewsWelcome.view.group",
+			"contributes.viewsWelcome.view.enablement"
+		],
+		"vs/workbench/contrib/timeline/browser/timelinePane": [
+			"timeline.loadingMore",
+			"timeline.loadMore",
+			"timeline",
+			"timeline.editorCannotProvideTimeline",
+			"timeline.noTimelineInfo",
+			"timeline.editorCannotProvideTimeline",
+			"timeline.aria.item",
+			"timeline",
+			"timeline.loading",
+			"timelineRefresh",
+			"timelinePin",
+			"timelineUnpin",
+			"refresh",
+			"timeline",
+			"timeline.toggleFollowActiveEditorCommand.follow",
+			"timeline",
+			"timeline.toggleFollowActiveEditorCommand.unfollow",
+			"timeline",
+			"timeline.filterSource",
+			"timeline"
+		],
+		"vs/workbench/services/textMate/common/TMGrammars": [
+			"vscode.extension.contributes.grammars",
+			"vscode.extension.contributes.grammars.language",
+			"vscode.extension.contributes.grammars.scopeName",
+			"vscode.extension.contributes.grammars.path",
+			"vscode.extension.contributes.grammars.embeddedLanguages",
+			"vscode.extension.contributes.grammars.tokenTypes",
+			"vscode.extension.contributes.grammars.injectTo"
+		],
+		"vs/workbench/services/textMate/common/TMGrammarFactory": [
+			"no-tm-grammar",
+			"no-tm-grammar"
+		],
+		"vs/workbench/browser/parts/titlebar/titlebarPart": [
+			"patchedWindowTitle",
+			"userIsAdmin",
+			"userIsSudo",
+			"devExtensionWindowTitlePrefix"
+		],
+		"vs/workbench/electron-sandbox/parts/titlebar/menubarControl": [
+			"mPreferences"
+		],
+		"vs/workbench/contrib/files/browser/editors/textFileEditor": [
+			"textFileEditor",
+			"openFolderError",
+			"createFile"
+		],
+		"vs/workbench/contrib/welcome/telemetryOptOut/browser/telemetryOptOut": [
+			"telemetryOptOut.optOutNotice",
+			"telemetryOptOut.optInNotice",
+			"telemetryOptOut.readMore",
+			"telemetryOptOut.optOutOption",
+			"telemetryOptOut.OptIn",
+			"telemetryOptOut.OptOut"
+		],
+		"vs/workbench/browser/parts/notifications/notificationsList": [
+			"notificationAriaLabel",
+			"notificationWithSourceAriaLabel",
+			"notificationsList"
+		],
+		"vs/workbench/browser/parts/notifications/notificationsActions": [
+			"clearIcon",
+			"clearAllIcon",
+			"hideIcon",
+			"expandIcon",
+			"collapseIcon",
+			"configureIcon",
+			"clearNotification",
+			"clearNotifications",
+			"hideNotificationsCenter",
+			"expandNotification",
+			"collapseNotification",
+			"configureNotification",
+			"copyNotification"
+		],
+		"vs/base/common/keybindingLabels": [
+			{
+				"key": "ctrlKey",
+				"comment": [
+					"This is the short form for the Control key on the keyboard"
+				]
+			},
+			{
+				"key": "shiftKey",
+				"comment": [
+					"This is the short form for the Shift key on the keyboard"
+				]
+			},
+			{
+				"key": "altKey",
+				"comment": [
+					"This is the short form for the Alt key on the keyboard"
+				]
+			},
+			{
+				"key": "windowsKey",
+				"comment": [
+					"This is the short form for the Windows key on the keyboard"
+				]
+			},
+			{
+				"key": "ctrlKey",
+				"comment": [
+					"This is the short form for the Control key on the keyboard"
+				]
+			},
+			{
+				"key": "shiftKey",
+				"comment": [
+					"This is the short form for the Shift key on the keyboard"
+				]
+			},
+			{
+				"key": "altKey",
+				"comment": [
+					"This is the short form for the Alt key on the keyboard"
+				]
+			},
+			{
+				"key": "superKey",
+				"comment": [
+					"This is the short form for the Super key on the keyboard"
+				]
+			},
+			{
+				"key": "ctrlKey.long",
+				"comment": [
+					"This is the long form for the Control key on the keyboard"
+				]
+			},
+			{
+				"key": "shiftKey.long",
+				"comment": [
+					"This is the long form for the Shift key on the keyboard"
+				]
+			},
+			{
+				"key": "altKey.long",
+				"comment": [
+					"This is the long form for the Alt key on the keyboard"
+				]
+			},
+			{
+				"key": "cmdKey.long",
+				"comment": [
+					"This is the long form for the Command key on the keyboard"
+				]
+			},
+			{
+				"key": "ctrlKey.long",
+				"comment": [
+					"This is the long form for the Control key on the keyboard"
+				]
+			},
+			{
+				"key": "shiftKey.long",
+				"comment": [
+					"This is the long form for the Shift key on the keyboard"
+				]
+			},
+			{
+				"key": "altKey.long",
+				"comment": [
+					"This is the long form for the Alt key on the keyboard"
+				]
+			},
+			{
+				"key": "windowsKey.long",
+				"comment": [
+					"This is the long form for the Windows key on the keyboard"
+				]
+			},
+			{
+				"key": "ctrlKey.long",
+				"comment": [
+					"This is the long form for the Control key on the keyboard"
+				]
+			},
+			{
+				"key": "shiftKey.long",
+				"comment": [
+					"This is the long form for the Shift key on the keyboard"
+				]
+			},
+			{
+				"key": "altKey.long",
+				"comment": [
+					"This is the long form for the Alt key on the keyboard"
+				]
+			},
+			{
+				"key": "superKey.long",
+				"comment": [
+					"This is the long form for the Super key on the keyboard"
+				]
+			}
+		],
+		"vs/workbench/services/textfile/common/textFileSaveParticipant": [
+			"saveParticipants"
+		],
+		"vs/base/common/jsonErrorMessages": [
+			"error.invalidSymbol",
+			"error.invalidNumberFormat",
+			"error.propertyNameExpected",
+			"error.valueExpected",
+			"error.colonExpected",
+			"error.commaExpected",
+			"error.closeBraceExpected",
+			"error.closeBracketExpected",
+			"error.endOfFileExpected"
+		],
+		"vs/workbench/contrib/codeEditor/browser/find/simpleFindWidget": [
+			"label.find",
+			"placeholder.find",
+			"label.previousMatchButton",
+			"label.nextMatchButton",
+			"label.closeButton"
+		],
+		"vs/workbench/api/common/extHostDiagnostics": [
+			{
+				"key": "limitHit",
+				"comment": [
+					"amount of errors/warning skipped due to limits"
+				]
+			}
+		],
+		"vs/workbench/api/common/extHostProgress": [
+			"extensionSource"
+		],
+		"vs/workbench/api/common/extHostStatusBar": [
+			"status.extensionMessage"
+		],
+		"vs/workbench/api/common/extHostTreeViews": [
+			"treeView.notRegistered",
+			"treeView.notRegistered",
+			"treeView.notRegistered",
+			"treeView.notRegistered",
+			"treeView.notRegistered",
+			"treeView.notRegistered",
+			"treeView.duplicateElement"
+		],
+		"vs/workbench/contrib/debug/node/debugAdapter": [
+			"debugAdapterBinNotFound",
+			{
+				"key": "debugAdapterCannotDetermineExecutable",
+				"comment": [
+					"Adapter executable file not found"
+				]
+			},
+			"unableToLaunchDebugAdapter",
+			"unableToLaunchDebugAdapterNoArgs"
+		],
+		"vs/editor/browser/widget/diffReview": [
+			"diffReviewInsertIcon",
+			"diffReviewRemoveIcon",
+			"diffReviewCloseIcon",
+			"label.close",
+			"no_lines_changed",
+			"one_line_changed",
+			"more_lines_changed",
+			{
+				"key": "header",
+				"comment": [
+					"This is the ARIA label for a git diff header.",
+					"A git diff header looks like this: @@ -154,12 +159,39 @@.",
+					"That encodes that at original line 154 (which is now line 159), 12 lines were removed/changed with 39 lines.",
+					"Variables 0 and 1 refer to the diff index out of total number of diffs.",
+					"Variables 2 and 4 will be numbers (a line number).",
+					"Variables 3 and 5 will be \"no lines changed\", \"1 line changed\" or \"X lines changed\", localized separately."
+				]
+			},
+			"blankLine",
+			{
+				"key": "unchangedLine",
+				"comment": [
+					"The placeholders are contents of the line and should not be translated."
+				]
+			},
+			"equalLine",
+			"insertLine",
+			"deleteLine",
+			"editor.action.diffReview.next",
+			"editor.action.diffReview.prev"
+		],
+		"vs/editor/browser/widget/inlineDiffMargin": [
+			"diff.clipboard.copyDeletedLinesContent.label",
+			"diff.clipboard.copyDeletedLinesContent.single.label",
+			"diff.clipboard.copyDeletedLineContent.label",
+			"diff.inline.revertChange.label",
+			"diff.clipboard.copyDeletedLineContent.label"
+		],
+		"vs/editor/contrib/codeAction/codeActionCommands": [
+			"args.schema.kind",
+			"args.schema.apply",
+			"args.schema.apply.first",
+			"args.schema.apply.ifSingle",
+			"args.schema.apply.never",
+			"args.schema.preferred",
+			"applyCodeActionFailed",
+			"quickfix.trigger.label",
+			"editor.action.quickFix.noneMessage",
+			"editor.action.codeAction.noneMessage.preferred.kind",
+			"editor.action.codeAction.noneMessage.kind",
+			"editor.action.codeAction.noneMessage.preferred",
+			"editor.action.codeAction.noneMessage",
+			"refactor.label",
+			"editor.action.refactor.noneMessage.preferred.kind",
+			"editor.action.refactor.noneMessage.kind",
+			"editor.action.refactor.noneMessage.preferred",
+			"editor.action.refactor.noneMessage",
+			"source.label",
+			"editor.action.source.noneMessage.preferred.kind",
+			"editor.action.source.noneMessage.kind",
+			"editor.action.source.noneMessage.preferred",
+			"editor.action.source.noneMessage",
+			"organizeImports.label",
+			"editor.action.organize.noneMessage",
+			"fixAll.label",
+			"fixAll.noneMessage",
+			"autoFix.label",
+			"editor.action.autoFix.noneMessage"
+		],
+		"vs/editor/contrib/find/findWidget": [
+			"findSelectionIcon",
+			"findCollapsedIcon",
+			"findExpandedIcon",
+			"findReplaceIcon",
+			"findReplaceAllIcon",
+			"findPreviousMatchIcon",
+			"findNextMatchIcon",
+			"label.find",
+			"placeholder.find",
+			"label.previousMatchButton",
+			"label.nextMatchButton",
+			"label.toggleSelectionFind",
+			"label.closeButton",
+			"label.replace",
+			"placeholder.replace",
+			"label.replaceButton",
+			"label.replaceAllButton",
+			"label.toggleReplaceButton",
+			"title.matchesCountLimit",
+			"label.matchesLocation",
+			"label.noResults",
+			"ariaSearchNoResultEmpty",
+			"ariaSearchNoResult",
+			"ariaSearchNoResultWithLineNum",
+			"ariaSearchNoResultWithLineNumNoCurrentMatch",
+			"ctrlEnter.keybindingChanged"
+		],
+		"vs/editor/contrib/folding/foldingDecorations": [
+			"foldingExpandedIcon",
+			"foldingCollapsedIcon"
+		],
+		"vs/editor/contrib/format/format": [
+			"hint11",
+			"hintn1",
+			"hint1n",
+			"hintnn"
+		],
+		"vs/editor/contrib/message/messageController": [
+			"editor.readonly"
+		],
+		"vs/editor/contrib/gotoSymbol/peek/referencesController": [
+			"labelLoading",
+			"metaTitle.N"
+		],
+		"vs/editor/contrib/gotoSymbol/referencesModel": [
+			"aria.oneReference",
+			{
+				"key": "aria.oneReference.preview",
+				"comment": [
+					"Placeholders are: 0: filename, 1:line number, 2: column number, 3: preview snippet of source code"
+				]
+			},
+			"aria.fileReferences.1",
+			"aria.fileReferences.N",
+			"aria.result.0",
+			"aria.result.1",
+			"aria.result.n1",
+			"aria.result.nm"
+		],
+		"vs/editor/contrib/gotoSymbol/symbolNavigation": [
+			"location.kb",
+			"location"
+		],
+		"vs/editor/contrib/gotoError/gotoErrorWidget": [
+			"Error",
+			"Warning",
+			"Info",
+			"Hint",
+			"marker aria",
+			"problems",
+			"change",
+			"editorMarkerNavigationError",
+			"editorMarkerNavigationWarning",
+			"editorMarkerNavigationInfo",
+			"editorMarkerNavigationBackground"
+		],
+		"vs/editor/contrib/rename/renameInputField": [
+			"renameAriaLabel",
+			{
+				"key": "label",
+				"comment": [
+					"placeholders are keybindings, e.g \"F2 to Rename, Shift+F2 to Preview\""
+				]
+			}
+		],
+		"vs/editor/contrib/parameterHints/parameterHintsWidget": [
+			"parameterHintsNextIcon",
+			"parameterHintsPreviousIcon",
+			"hint"
+		],
+		"vs/editor/contrib/suggest/suggestWidget": [
+			"editorSuggestWidgetBackground",
+			"editorSuggestWidgetBorder",
+			"editorSuggestWidgetForeground",
+			"editorSuggestWidgetSelectedBackground",
+			"editorSuggestWidgetHighlightForeground",
+			"suggestWidget.loading",
+			"suggestWidget.noSuggestions",
+			"ariaCurrenttSuggestionReadDetails",
+			"suggest"
+		],
+		"vs/platform/theme/common/tokenClassificationRegistry": [
+			"schema.token.settings",
+			"schema.token.foreground",
+			"schema.token.background.warning",
+			"schema.token.fontStyle",
+			"schema.fontStyle.error",
+			"schema.token.fontStyle.none",
+			"schema.token.bold",
+			"schema.token.italic",
+			"schema.token.underline",
+			"comment",
+			"string",
+			"keyword",
+			"number",
+			"regexp",
+			"operator",
+			"namespace",
+			"type",
+			"struct",
+			"class",
+			"interface",
+			"enum",
+			"typeParameter",
+			"function",
+			"member",
+			"method",
+			"macro",
+			"variable",
+			"parameter",
+			"property",
+			"enumMember",
+			"event",
+			"labels",
+			"declaration",
+			"documentation",
+			"static",
+			"abstract",
+			"deprecated",
+			"modification",
+			"async",
+			"readonly"
+		],
+		"vs/workbench/browser/parts/editor/textEditor": [
+			"editor"
+		],
+		"vs/workbench/api/browser/mainThreadCustomEditors": [
+			"defaultEditLabel"
+		],
+		"vs/workbench/api/browser/mainThreadWebviews": [
+			"errorMessage"
+		],
+		"vs/workbench/contrib/comments/browser/commentsView": [
+			"rootCommentsLabel",
+			"resourceWithCommentThreadsLabel",
+			"resourceWithCommentLabel",
+			"collapseAll"
+		],
+		"vs/workbench/contrib/comments/browser/commentsTreeViewer": [
+			"imageWithLabel",
+			"image"
+		],
+		"vs/workbench/contrib/remote/browser/tunnelView": [
+			"remote.tunnelsView.add",
+			"remote.tunnelsView.detected",
+			"remote.tunnelsView.candidates",
+			"remote.tunnelsView.input",
+			"remote.tunnelsView.forwardedPortLabel0",
+			"remote.tunnelsView.forwardedPortLabel1",
+			"remote.tunnelsView.forwardedPortLabel2",
+			"remote.tunnelsView.forwardedPortDescription0",
+			"remote.tunnel",
+			"remote.tunnel.ariaLabelForwarded",
+			"remote.tunnel.ariaLabelCandidate",
+			"tunnelView",
+			"remote.tunnel.label",
+			"remote.tunnelsView.labelPlaceholder",
+			"remote.tunnelsView.portNumberValid",
+			"remote.tunnelsView.portNumberToHigh",
+			"remote.tunnelView.inlineElevationMessage",
+			"remote.tunnel.forward",
+			"remote.tunnel.forwardItem",
+			"remote.tunnel.forwardPrompt",
+			"remote.tunnel.forwardError",
+			"remote.tunnel.closeNoPorts",
+			"remote.tunnel.close",
+			"remote.tunnel.closePlaceholder",
+			"remote.tunnel.open",
+			"remote.tunnel.openCommandPalette",
+			"remote.tunnel.openCommandPaletteNone",
+			"remote.tunnel.openCommandPaletteView",
+			"remote.tunnel.openCommandPalettePick",
+			"remote.tunnel.copyAddressInline",
+			"remote.tunnel.copyAddressCommandPalette",
+			"remote.tunnel.copyAddressPlaceholdter",
+			"remote.tunnel.changeLocalPort",
+			"remote.tunnel.changeLocalPortNumber",
+			"remote.tunnelsView.changePort",
+			"remote.tunnel.makePublic",
+			"remote.tunnel.makePrivate"
+		],
+		"vs/base/browser/ui/tree/treeDefaults": [
+			"collapse all"
+		],
+		"vs/base/browser/ui/splitview/paneview": [
+			"viewSection"
+		],
+		"vs/workbench/browser/parts/editor/tabsTitleControl": [
+			"ariaLabelTabActions"
+		],
+		"vs/workbench/browser/parts/editor/textDiffEditor": [
+			"textDiffEditor"
+		],
+		"vs/workbench/browser/parts/editor/binaryDiffEditor": [
+			"metadataDiff"
+		],
+		"vs/workbench/browser/parts/editor/editorQuickAccess": [
+			"noViewResults",
+			"entryAriaLabelWithGroupDirty",
+			"entryAriaLabelWithGroup",
+			"entryAriaLabelDirty",
+			"closeEditor"
+		],
+		"vs/workbench/browser/parts/editor/editorStatus": [
+			"singleSelectionRange",
+			"singleSelection",
+			"multiSelectionRange",
+			"multiSelection",
+			"endOfLineLineFeed",
+			"endOfLineCarriageReturnLineFeed",
+			"screenReaderDetectedExplanation.question",
+			"screenReaderDetectedExplanation.answerYes",
+			"screenReaderDetectedExplanation.answerNo",
+			"noEditor",
+			"noWritableCodeEditor",
+			"indentConvert",
+			"indentView",
+			"pickAction",
+			"tabFocusModeEnabled",
+			"disableTabMode",
+			"status.editor.tabFocusMode",
+			"columnSelectionModeEnabled",
+			"disableColumnSelectionMode",
+			"status.editor.columnSelectionMode",
+			"screenReaderDetected",
+			"status.editor.screenReaderMode",
+			"gotoLine",
+			"status.editor.selection",
+			"selectIndentation",
+			"status.editor.indentation",
+			"selectEncoding",
+			"status.editor.encoding",
+			"selectEOL",
+			"status.editor.eol",
+			"selectLanguageMode",
+			"status.editor.mode",
+			"fileInfo",
+			"status.editor.info",
+			"spacesSize",
+			{
+				"key": "tabSize",
+				"comment": [
+					"Tab corresponds to the tab key"
+				]
+			},
+			"currentProblem",
+			"showLanguageExtensions",
+			"changeMode",
+			"noEditor",
+			"languageDescription",
+			"languageDescriptionConfigured",
+			"languagesPicks",
+			"configureModeSettings",
+			"configureAssociationsExt",
+			"autoDetect",
+			"pickLanguage",
+			"currentAssociation",
+			"pickLanguageToConfigure",
+			"changeEndOfLine",
+			"noEditor",
+			"noWritableCodeEditor",
+			"pickEndOfLine",
+			"changeEncoding",
+			"noEditor",
+			"noEditor",
+			"noFileEditor",
+			"saveWithEncoding",
+			"reopenWithEncoding",
+			"pickAction",
+			"guessedEncoding",
+			"pickEncodingForReopen",
+			"pickEncodingForSave"
+		],
+		"vs/workbench/browser/parts/editor/editorActions": [
+			"splitEditor",
+			"splitEditorOrthogonal",
+			"splitEditorGroupLeft",
+			"splitEditorGroupRight",
+			"splitEditorGroupUp",
+			"splitEditorGroupDown",
+			"joinTwoGroups",
+			"joinAllGroups",
+			"navigateEditorGroups",
+			"focusActiveEditorGroup",
+			"focusFirstEditorGroup",
+			"focusLastEditorGroup",
+			"focusNextGroup",
+			"focusPreviousGroup",
+			"focusLeftGroup",
+			"focusRightGroup",
+			"focusAboveGroup",
+			"focusBelowGroup",
+			"closeEditor",
+			"unpinEditor",
+			"closeOneEditor",
+			"revertAndCloseActiveEditor",
+			"closeEditorsToTheLeft",
+			"closeAllEditors",
+			"closeAllGroups",
+			"closeEditorsInOtherGroups",
+			"closeEditorInAllGroups",
+			"moveActiveGroupLeft",
+			"moveActiveGroupRight",
+			"moveActiveGroupUp",
+			"moveActiveGroupDown",
+			"duplicateActiveGroupLeft",
+			"duplicateActiveGroupRight",
+			"duplicateActiveGroupUp",
+			"duplicateActiveGroupDown",
+			"minimizeOtherEditorGroups",
+			"evenEditorGroups",
+			"toggleEditorWidths",
+			"maximizeEditor",
+			"openNextEditor",
+			"openPreviousEditor",
+			"nextEditorInGroup",
+			"openPreviousEditorInGroup",
+			"firstEditorInGroup",
+			"lastEditorInGroup",
+			"navigateNext",
+			"navigatePrevious",
+			"navigateToLastEditLocation",
+			"navigateLast",
+			"reopenClosedEditor",
+			"clearRecentFiles",
+			"showEditorsInActiveGroup",
+			"showAllEditors",
+			"showAllEditorsByMostRecentlyUsed",
+			"quickOpenPreviousRecentlyUsedEditor",
+			"quickOpenLeastRecentlyUsedEditor",
+			"quickOpenPreviousRecentlyUsedEditorInGroup",
+			"quickOpenLeastRecentlyUsedEditorInGroup",
+			"navigateEditorHistoryByInput",
+			"openNextRecentlyUsedEditor",
+			"openPreviousRecentlyUsedEditor",
+			"openNextRecentlyUsedEditorInGroup",
+			"openPreviousRecentlyUsedEditorInGroup",
+			"clearEditorHistory",
+			"moveEditorLeft",
+			"moveEditorRight",
+			"moveEditorToPreviousGroup",
+			"moveEditorToNextGroup",
+			"moveEditorToAboveGroup",
+			"moveEditorToBelowGroup",
+			"moveEditorToLeftGroup",
+			"moveEditorToRightGroup",
+			"moveEditorToFirstGroup",
+			"moveEditorToLastGroup",
+			"editorLayoutSingle",
+			"editorLayoutTwoColumns",
+			"editorLayoutThreeColumns",
+			"editorLayoutTwoRows",
+			"editorLayoutThreeRows",
+			"editorLayoutTwoByTwoGrid",
+			"editorLayoutTwoColumnsBottom",
+			"editorLayoutTwoRowsRight",
+			"newEditorLeft",
+			"newEditorRight",
+			"newEditorAbove",
+			"newEditorBelow",
+			"workbench.action.reopenWithEditor",
+			"workbench.action.toggleEditorType"
+		],
+		"vs/base/browser/ui/menu/menubar": [
+			"mAppMenu",
+			"mMore"
+		],
+		"vs/base/browser/ui/menu/menu": [
+			{
+				"key": "titleLabel",
+				"comment": [
+					"action title",
+					"action keybinding"
+				]
+			}
+		],
+		"vs/base/browser/ui/toolbar/toolbar": [
+			"moreActions"
+		],
+		"vs/base/browser/ui/inputbox/inputBox": [
+			"alertErrorMessage",
+			"alertWarningMessage",
+			"alertInfoMessage"
+		],
+		"vs/workbench/services/preferences/browser/keybindingsEditorModel": [
+			"default",
+			"extension",
+			"user",
+			"cat.title",
+			"cat.title",
+			"option",
+			"meta"
+		],
+		"vs/workbench/services/preferences/common/preferencesValidation": [
+			"validations.expectedNumeric",
+			"invalidTypeError",
+			"validations.maxLength",
+			"validations.minLength",
+			"validations.regex",
+			"validations.colorFormat",
+			"validations.uriEmpty",
+			"validations.uriMissing",
+			"validations.uriSchemeMissing",
+			"validations.exclusiveMax",
+			"validations.exclusiveMin",
+			"validations.max",
+			"validations.min",
+			"validations.multipleOf",
+			"validations.expectedInteger",
+			"validations.stringArrayUniqueItems",
+			"validations.stringArrayMinItem",
+			"validations.stringArrayMaxItem",
+			"validations.stringArrayItemPattern",
+			"validations.stringArrayItemEnum"
+		],
+		"vs/base/parts/quickinput/browser/quickInput": [
+			"quickInput.back",
+			"quickInput.steps",
+			"quickInputBox.ariaLabel",
+			"inputModeEntry",
+			"inputModeEntryDescription",
+			{
+				"key": "quickInput.visibleCount",
+				"comment": [
+					"This tells the user how many items are shown in a list of items to select from. The items can be anything. Currently not visible, but read by screen readers."
+				]
+			},
+			{
+				"key": "quickInput.countSelected",
+				"comment": [
+					"This tells the user how many items are selected in a list of items to select from. The items can be anything."
+				]
+			},
+			"ok",
+			"custom",
+			"quickInput.backWithKeybinding",
+			"quickInput.back"
+		],
+		"vs/workbench/contrib/preferences/browser/preferencesWidgets": [
+			"defaultSettings",
+			"noSettingsFound",
+			"settingsSwitcherBarAriaLabel",
+			"userSettings",
+			"userSettingsRemote",
+			"workspaceSettings",
+			"folderSettings",
+			"workspaceSettings",
+			"userSettings"
+		],
+		"vs/workbench/contrib/preferences/browser/settingsLayout": [
+			"commonlyUsed",
+			"textEditor",
+			"cursor",
+			"find",
+			"font",
+			"formatting",
+			"diffEditor",
+			"minimap",
+			"suggestions",
+			"files",
+			"workbench",
+			"appearance",
+			"breadcrumbs",
+			"editorManagement",
+			"settings",
+			"zenMode",
+			"screencastMode",
+			"window",
+			"newWindow",
+			"features",
+			"fileExplorer",
+			"search",
+			"debug",
+			"scm",
+			"extensions",
+			"terminal",
+			"task",
+			"problems",
+			"output",
+			"comments",
+			"remote",
+			"timeline",
+			"notebook",
+			"application",
+			"proxy",
+			"keyboard",
+			"update",
+			"telemetry",
+			"settingsSync"
+		],
+		"vs/workbench/contrib/preferences/browser/preferencesRenderers": [
+			"emptyUserSettingsHeader",
+			"emptyWorkspaceSettingsHeader",
+			"emptyFolderSettingsHeader",
+			"editTtile",
+			"replaceDefaultValue",
+			"copyDefaultValue",
+			"unknown configuration setting",
+			"unsupportedRemoteMachineSetting",
+			"unsupportedWindowSetting",
+			"unsupportedApplicationSetting",
+			"unsupportedMachineSetting",
+			"unsupportedProperty"
+		],
+		"vs/workbench/contrib/preferences/browser/settingsTreeModels": [
+			"workspace",
+			"remote",
+			"user"
+		],
+		"vs/workbench/contrib/preferences/browser/tocTree": [
+			{
+				"key": "settingsTOC",
+				"comment": [
+					"A label for the table of contents for the full settings list"
+				]
+			},
+			"groupRowAriaLabel"
+		],
+		"vs/workbench/contrib/preferences/browser/settingsWidgets": [
+			"headerForeground",
+			"modifiedItemForeground",
+			"settingsDropdownBackground",
+			"settingsDropdownForeground",
+			"settingsDropdownBorder",
+			"settingsDropdownListBorder",
+			"settingsCheckboxBackground",
+			"settingsCheckboxForeground",
+			"settingsCheckboxBorder",
+			"textInputBoxBackground",
+			"textInputBoxForeground",
+			"textInputBoxBorder",
+			"numberInputBoxBackground",
+			"numberInputBoxForeground",
+			"numberInputBoxBorder",
+			"focusedRowBackground",
+			"notebook.rowHoverBackground",
+			"notebook.focusedRowBorder",
+			"okButton",
+			"cancelButton",
+			"listValueHintLabel",
+			"listSiblingHintLabel",
+			"removeItem",
+			"editItem",
+			"addItem",
+			"itemInputPlaceholder",
+			"listSiblingInputPlaceholder",
+			"excludePatternHintLabel",
+			"excludeSiblingHintLabel",
+			"removeExcludeItem",
+			"editExcludeItem",
+			"addPattern",
+			"excludePatternInputPlaceholder",
+			"excludeSiblingInputPlaceholder",
+			"okButton",
+			"cancelButton",
+			"objectKeyInputPlaceholder",
+			"objectValueInputPlaceholder",
+			"objectPairHintLabel",
+			"removeItem",
+			"resetItem",
+			"editItem",
+			"addItem",
+			"objectKeyHeader",
+			"objectValueHeader"
+		],
+		"vs/workbench/contrib/preferences/browser/settingsTree": [
+			"extensions",
+			"extensionSyncIgnoredLabel",
+			"modified",
+			"settingsContextMenuTitle",
+			"alsoConfiguredIn",
+			"configuredIn",
+			"newExtensionsButtonLabel",
+			"editInSettingsJson",
+			"settings.Default",
+			"modified",
+			"resetSettingLabel",
+			"validationError",
+			"validationError",
+			"settings.Modified",
+			"alsoConfiguredIn",
+			"configuredIn",
+			"settings",
+			"copySettingIdLabel",
+			"copySettingAsJSONLabel",
+			"stopSyncingSetting"
+		],
+		"vs/workbench/contrib/testing/browser/theme": [
+			"testing.iconFailed",
+			"testing.iconErrored",
+			"testing.iconPassed",
+			"testing.runAction",
+			"testing.iconQueued",
+			"testing.iconUnset",
+			"testing.iconSkipped",
+			"testing.peekBorder",
+			"testing.message.error.decorationForeground",
+			"testing.message.error.marginBackground",
+			"testing.message.warning.decorationForeground",
+			"testing.message.warning.marginBackground",
+			"testing.message.info.decorationForeground",
+			"testing.message.info.marginBackground",
+			"testing.message.hint.decorationForeground",
+			"testing.message.hint.marginBackground"
+		],
+		"vs/workbench/contrib/testing/common/constants": [
+			"testState.errored",
+			"testState.failed",
+			"testState.passed",
+			"testState.queued",
+			"testState.running",
+			"testState.skipped",
+			"testState.unset"
+		],
+		"vs/workbench/contrib/notebook/browser/extensionPoint": [
+			"contributes.notebook.provider",
+			"contributes.notebook.provider.viewType",
+			"contributes.notebook.provider.displayName",
+			"contributes.notebook.provider.selector",
+			"contributes.notebook.provider.selector.filenamePattern",
+			"contributes.notebook.selector.provider.excludeFileNamePattern",
+			"contributes.priority",
+			"contributes.priority.default",
+			"contributes.priority.option",
+			"contributes.notebook.renderer",
+			"contributes.notebook.renderer.viewType",
+			"contributes.notebook.provider.viewType.deprecated",
+			"contributes.notebook.renderer.viewType",
+			"contributes.notebook.renderer.displayName",
+			"contributes.notebook.selector",
+			"contributes.notebook.renderer.entrypoint"
+		],
+		"vs/workbench/contrib/notebook/browser/notebookKernelAssociation": [
+			"notebook.kernelProviderAssociations"
+		],
+		"vs/workbench/contrib/notebook/common/model/notebookTextModel": [
+			"defaultEditLabel"
+		],
+		"vs/workbench/contrib/notebook/common/notebookEditorModel": [
+			"notebook.staleSaveError",
+			"notebook.staleSaveError.revert",
+			"notebook.staleSaveError.overwrite."
+		],
+		"vs/workbench/contrib/notebook/browser/notebookEditorWidget": [
+			"notebookTreeAriaLabel",
+			"notebook.runCell.selectKernel",
+			"notebook.promptKernel.setDefaultTooltip",
+			"notebook.cellBorderColor",
+			"notebook.focusedEditorBorder",
+			"notebookStatusSuccessIcon.foreground",
+			"notebookStatusErrorIcon.foreground",
+			"notebookStatusRunningIcon.foreground",
+			"notebook.outputContainerBackgroundColor",
+			"notebook.cellToolbarSeparator",
+			"focusedCellBackground",
+			"notebook.cellHoverBackground",
+			"notebook.selectedCellBorder",
+			"notebook.focusedCellBorder",
+			"notebook.inactiveFocusedCellBorder",
+			"notebook.cellStatusBarItemHoverBackground",
+			"notebook.cellInsertionIndicator",
+			"notebookScrollbarSliderBackground",
+			"notebookScrollbarSliderHoverBackground",
+			"notebookScrollbarSliderActiveBackground",
+			"notebook.symbolHighlightBackground"
+		],
+		"vs/workbench/contrib/codeEditor/browser/find/simpleFindReplaceWidget": [
+			"label.find",
+			"placeholder.find",
+			"label.previousMatchButton",
+			"label.nextMatchButton",
+			"label.closeButton",
+			"label.toggleReplaceButton",
+			"label.replace",
+			"placeholder.replace",
+			"label.replaceButton",
+			"label.replaceAllButton"
+		],
+		"vs/base/browser/ui/iconLabel/iconLabel": [
+			"iconLabel.loading"
+		],
+		"vs/platform/quickinput/browser/commandsQuickAccess": [
+			"commandPickAriaLabelWithKeybinding",
+			"recentlyUsed",
+			"morecCommands",
+			"canNotRun"
+		],
+		"vs/workbench/contrib/files/browser/views/explorerDecorationsProvider": [
+			"canNotResolve",
+			"symbolicLlink",
+			"unknown",
+			"label"
+		],
+		"vs/workbench/contrib/files/browser/views/explorerViewer": [
+			"treeAriaLabel",
+			"fileInputAriaLabel",
+			"confirmOverwrite",
+			"irreversible",
+			{
+				"key": "replaceButtonLabel",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			"confirmManyOverwrites",
+			"irreversible",
+			{
+				"key": "replaceButtonLabel",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			"uploadingFiles",
+			"overwrite",
+			"overwriting",
+			"uploadProgressSmallMany",
+			"uploadProgressLarge",
+			"copyFolders",
+			"copyFolder",
+			"cancel",
+			"copyfolders",
+			"copyfolder",
+			"addFolders",
+			"addFolder",
+			"dropFolders",
+			"dropFolder",
+			"copyFile",
+			"copynFile",
+			"copyingFile",
+			"copyingnFile",
+			"confirmRootsMove",
+			"confirmMultiMove",
+			"confirmRootMove",
+			"confirmMove",
+			"doNotAskAgain",
+			{
+				"key": "moveButtonLabel",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			"copy",
+			"copying",
+			"move",
+			"moving"
+		],
+		"vs/workbench/browser/parts/editor/binaryEditor": [
+			"binaryEditor",
+			"nativeFileTooLargeError",
+			"nativeBinaryError",
+			"openAsText"
+		],
+		"vs/workbench/contrib/bulkEdit/browser/preview/bulkEditTree": [
+			"bulkEdit",
+			"aria.renameAndEdit",
+			"aria.createAndEdit",
+			"aria.deleteAndEdit",
+			"aria.editOnly",
+			"aria.rename",
+			"aria.create",
+			"aria.delete",
+			"aria.replace",
+			"aria.del",
+			"aria.insert",
+			"rename.label",
+			"detail.rename",
+			"detail.create",
+			"detail.del",
+			"title"
+		],
+		"vs/editor/contrib/quickAccess/gotoSymbolQuickAccess": [
+			"cannotRunGotoSymbolWithoutEditor",
+			"cannotRunGotoSymbolWithoutSymbolProvider",
+			"noMatchingSymbolResults",
+			"noSymbolResults",
+			"openToSide",
+			"openToBottom",
+			"symbols",
+			"property",
+			"method",
+			"function",
+			"_constructor",
+			"variable",
+			"class",
+			"struct",
+			"event",
+			"operator",
+			"interface",
+			"namespace",
+			"package",
+			"typeParameter",
+			"modules",
+			"property",
+			"enum",
+			"enumMember",
+			"string",
+			"file",
+			"array",
+			"number",
+			"boolean",
+			"object",
+			"key",
+			"field",
+			"constant"
+		],
+		"vs/workbench/contrib/search/browser/replaceService": [
+			"fileReplaceChanges"
+		],
+		"vs/workbench/contrib/debug/common/debugModel": [
+			"invalidVariableAttributes",
+			"startDebugFirst",
+			"notAvailable",
+			{
+				"key": "pausedOn",
+				"comment": [
+					"indicates reason for program being paused"
+				]
+			},
+			"paused",
+			{
+				"key": "running",
+				"comment": [
+					"indicates state"
+				]
+			},
+			"breakpointDirtydHover"
+		],
+		"vs/workbench/contrib/debug/browser/debugConfigurationManager": [
+			"selectConfiguration",
+			"editLaunchConfig",
+			"DebugConfig.failed",
+			"workspace",
+			"user settings"
+		],
+		"vs/workbench/contrib/debug/browser/debugTaskRunner": [
+			"preLaunchTaskErrors",
+			"preLaunchTaskError",
+			"preLaunchTaskExitCode",
+			"preLaunchTaskTerminated",
+			"debugAnyway",
+			"showErrors",
+			"abort",
+			"remember",
+			"invalidTaskReference",
+			"DebugTaskNotFoundWithTaskId",
+			"DebugTaskNotFound",
+			"taskNotTrackedWithTaskId",
+			"taskNotTracked"
+		],
+		"vs/workbench/contrib/debug/browser/debugSession": [
+			"noDebugAdapter",
+			"noDebugAdapter",
+			"noDebugAdapter",
+			"noDebugAdapter",
+			"noDebugAdapter",
+			"noDebugAdapter",
+			"sessionNotReadyForBreakpoints",
+			"noDebugAdapter",
+			"noDebugAdapter",
+			"noDebugAdapter",
+			"noDebugAdapter",
+			"noDebugAdapter",
+			"noDebugAdapter",
+			"noDebugAdapter",
+			"noDebugAdapter",
+			"noDebugAdapter",
+			"noDebugAdapter",
+			"noDebugAdapter",
+			"noDebugAdapter",
+			"noDebugAdapter",
+			"noDebugAdapter",
+			"noDebugAdapter",
+			"noDebugAdapter",
+			"noDebugAdapter",
+			"noDebugAdapter",
+			"noDebugAdapter",
+			"noDebugAdapter",
+			"noDebugAdapter",
+			"noDebugAdapter",
+			"noDebugAdapter",
+			"noDebugAdapter",
+			"noDebugAdapter",
+			"debuggingStarted",
+			"debuggingStopped"
+		],
+		"vs/workbench/contrib/debug/browser/debugAdapterManager": [
+			"debugNoType",
+			"more",
+			"selectDebug"
+		],
+		"vs/workbench/contrib/debug/common/debugSource": [
+			"unknownSource"
+		],
+		"vs/base/browser/ui/findinput/findInput": [
+			"defaultLabel"
+		],
+		"vs/base/browser/ui/findinput/replaceInput": [
+			"defaultLabel",
+			"label.preserveCaseCheckbox"
+		],
+		"vs/workbench/contrib/markers/browser/markersViewActions": [
+			"filterIcon",
+			"showing filtered problems"
+		],
+		"vs/workbench/contrib/markers/browser/markersTreeViewer": [
+			"problemsView",
+			"expandedIcon",
+			"collapsedIcon",
+			"single line",
+			"multi line",
+			"links.navigate.follow",
+			"links.navigate.kb.meta",
+			"links.navigate.kb.meta.mac",
+			"links.navigate.kb.meta",
+			"links.navigate.kb.alt.mac",
+			"links.navigate.kb.alt"
+		],
+		"vs/workbench/contrib/comments/browser/commentGlyphWidget": [
+			"editorGutterCommentRangeForeground"
+		],
+		"vs/workbench/contrib/comments/browser/commentThreadWidget": [
+			"collapseIcon",
+			"label.collapse",
+			"startThread",
+			"reply",
+			"reply",
+			"reply",
+			"newComment"
+		],
+		"vs/workbench/contrib/customEditor/common/contributedCustomEditors": [
+			"builtinProviderDisplayName",
+			"promptOpenWith.defaultEditor.displayName"
+		],
+		"vs/workbench/contrib/extensions/browser/extensionsWidgets": [
+			"ratedBySingleUser",
+			"ratedByUsers",
+			"noRating",
+			"remote extension title",
+			"syncingore.label"
+		],
+		"vs/workbench/contrib/extensions/browser/extensionsViewer": [
+			"error",
+			"Unknown Extension",
+			"extension-arialabel",
+			"extensions"
+		],
+		"vs/workbench/contrib/extensions/browser/dynamicWorkspaceRecommendations": [
+			"dynamicWorkspaceRecommendation"
+		],
+		"vs/workbench/contrib/extensions/browser/exeBasedRecommendations": [
+			"exeBasedRecommendation"
+		],
+		"vs/workbench/contrib/extensions/browser/workspaceRecommendations": [
+			"workspaceRecommendation"
+		],
+		"vs/workbench/contrib/extensions/browser/configBasedRecommendations": [
+			"exeBasedRecommendation"
+		],
+		"vs/workbench/contrib/extensions/browser/fileBasedRecommendations": [
+			"searchMarketplace",
+			"fileBasedRecommendation",
+			"reallyRecommended",
+			"showLanguageExtensions",
+			"dontShowAgainExtension"
+		],
+		"vs/workbench/contrib/terminal/browser/terminalConfigHelper": [
+			"terminal.integrated.allowWorkspaceShell",
+			"allow",
+			"disallow",
+			"useWslExtension.title",
+			"install"
+		],
+		"vs/workbench/contrib/tasks/common/jsonSchemaCommon": [
+			"JsonSchema.options",
+			"JsonSchema.options.cwd",
+			"JsonSchema.options.env",
+			"JsonSchema.tasks.matcherError",
+			"JsonSchema.tasks.matcherError",
+			"JsonSchema.shellConfiguration",
+			"JsonSchema.shell.executable",
+			"JsonSchema.shell.args",
+			"JsonSchema.command",
+			"JsonSchema.tasks.args",
+			"JsonSchema.tasks.taskName",
+			"JsonSchema.command",
+			"JsonSchema.tasks.args",
+			"JsonSchema.tasks.windows",
+			"JsonSchema.tasks.matchers",
+			"JsonSchema.tasks.mac",
+			"JsonSchema.tasks.matchers",
+			"JsonSchema.tasks.linux",
+			"JsonSchema.tasks.matchers",
+			"JsonSchema.tasks.suppressTaskName",
+			"JsonSchema.tasks.showOutput",
+			"JsonSchema.echoCommand",
+			"JsonSchema.tasks.watching.deprecation",
+			"JsonSchema.tasks.watching",
+			"JsonSchema.tasks.background",
+			"JsonSchema.tasks.promptOnClose",
+			"JsonSchema.tasks.build",
+			"JsonSchema.tasks.test",
+			"JsonSchema.tasks.matchers",
+			"JsonSchema.command",
+			"JsonSchema.args",
+			"JsonSchema.showOutput",
+			"JsonSchema.watching.deprecation",
+			"JsonSchema.watching",
+			"JsonSchema.background",
+			"JsonSchema.promptOnClose",
+			"JsonSchema.echoCommand",
+			"JsonSchema.suppressTaskName",
+			"JsonSchema.taskSelector",
+			"JsonSchema.matchers",
+			"JsonSchema.tasks"
+		],
+		"vs/workbench/contrib/terminal/browser/terminalInstance": [
+			"terminal.integrated.a11yPromptLabel",
+			"terminal.integrated.a11yTooMuchOutput",
+			"configure terminal settings",
+			"configureTerminalSettings",
+			"yes",
+			"no",
+			"dontShowAgain",
+			"terminal.slowRendering",
+			"terminal.integrated.copySelection.noSelection",
+			"launchFailed.exitCodeAndCommandLine",
+			"launchFailed.exitCodeOnly",
+			"terminated.exitCodeAndCommandLine",
+			"terminated.exitCodeOnly",
+			"launchFailed.errorMessage",
+			"terminalTextBoxAriaLabelNumberAndTitle",
+			"terminalTextBoxAriaLabel",
+			"terminalStaleTextBoxAriaLabel"
+		],
+		"vs/workbench/services/configurationResolver/common/configurationResolverUtils": [
+			"deprecatedVariables"
+		],
+		"vs/workbench/services/configurationResolver/common/configurationResolverSchema": [
+			"JsonSchema.input.id",
+			"JsonSchema.input.type",
+			"JsonSchema.input.description",
+			"JsonSchema.input.default",
+			"JsonSchema.inputs",
+			"JsonSchema.input.type.promptString",
+			"JsonSchema.input.password",
+			"JsonSchema.input.type.pickString",
+			"JsonSchema.input.options",
+			"JsonSchema.input.pickString.optionLabel",
+			"JsonSchema.input.pickString.optionValue",
+			"JsonSchema.input.type.command",
+			"JsonSchema.input.command.command",
+			"JsonSchema.input.command.args",
+			"JsonSchema.input.command.args",
+			"JsonSchema.input.command.args"
+		],
+		"vs/editor/contrib/snippet/snippetVariables": [
+			"Sunday",
+			"Monday",
+			"Tuesday",
+			"Wednesday",
+			"Thursday",
+			"Friday",
+			"Saturday",
+			"SundayShort",
+			"MondayShort",
+			"TuesdayShort",
+			"WednesdayShort",
+			"ThursdayShort",
+			"FridayShort",
+			"SaturdayShort",
+			"January",
+			"February",
+			"March",
+			"April",
+			"May",
+			"June",
+			"July",
+			"August",
+			"September",
+			"October",
+			"November",
+			"December",
+			"JanuaryShort",
+			"FebruaryShort",
+			"MarchShort",
+			"AprilShort",
+			"MayShort",
+			"JuneShort",
+			"JulyShort",
+			"AugustShort",
+			"SeptemberShort",
+			"OctoberShort",
+			"NovemberShort",
+			"DecemberShort"
+		],
+		"vs/workbench/contrib/update/browser/releaseNotesEditor": [
+			"releaseNotesInputName",
+			"unassigned"
+		],
+		"vs/workbench/contrib/welcome/page/browser/welcomePageColors": [
+			"welcomePage.buttonBackground",
+			"welcomePage.buttonHoverBackground",
+			"welcomePage.background",
+			"welcomePage.progress.background",
+			"welcomePage.progress.foreground"
+		],
+		"vs/workbench/contrib/welcome/page/browser/vs_code_welcome_page": [
+			"welcomePage.vscode",
+			{
+				"key": "welcomePage.editingEvolved",
+				"comment": [
+					"Shown as subtitle on the Welcome page."
+				]
+			},
+			"welcomePage.start",
+			"welcomePage.newFile",
+			"welcomePage.openFolder",
+			"welcomePage.gitClone",
+			"welcomePage.openFolder",
+			"welcomePage.gitClone",
+			"welcomePage.recent",
+			"welcomePage.moreRecent",
+			"welcomePage.noRecentFolders",
+			"welcomePage.help",
+			"welcomePage.keybindingsCheatsheet",
+			"welcomePage.introductoryVideos",
+			"welcomePage.tipsAndTricks",
+			"welcomePage.productDocumentation",
+			"welcomePage.gitHubRepository",
+			"welcomePage.stackOverflow",
+			"welcomePage.newsletterSignup",
+			"welcomePage.showOnStartup",
+			"welcomePage.customize",
+			"welcomePage.installExtensionPacks",
+			"welcomePage.installExtensionPacksDescription",
+			"welcomePage.showLanguageExtensions",
+			"welcomePage.moreExtensions",
+			"welcomePage.installKeymapDescription",
+			"welcomePage.installKeymapExtension",
+			"welcomePage.showKeymapExtensions",
+			"welcomePage.others",
+			"welcomePage.colorTheme",
+			"welcomePage.colorThemeDescription",
+			"welcomePage.learn",
+			"welcomePage.showCommands",
+			"welcomePage.showCommandsDescription",
+			"welcomePage.interfaceOverview",
+			"welcomePage.interfaceOverviewDescription",
+			"welcomePage.interactivePlayground",
+			"welcomePage.interactivePlaygroundDescription"
+		],
+		"vs/workbench/contrib/welcome/gettingStarted/browser/vs_code_editor_getting_started": [
+			"gettingStarted.vscode",
+			{
+				"key": "gettingStarted.editingRedefined",
+				"comment": [
+					"Shown as subtitle on the Welcome page."
+				]
+			}
+		],
+		"vs/workbench/contrib/callHierarchy/browser/callHierarchyTree": [
+			"tree.aria",
+			"from",
+			"to"
+		],
+		"vs/workbench/contrib/userDataSync/browser/userDataSyncViews": [
+			"merges",
+			"synced machines",
+			"workbench.actions.sync.editMachineName",
+			"workbench.actions.sync.turnOffSyncOnMachine",
+			"remote sync activity title",
+			"local sync activity title",
+			"workbench.actions.sync.resolveResourceRef",
+			"workbench.actions.sync.replaceCurrent",
+			{
+				"key": "confirm replace",
+				"comment": [
+					"A confirmation message to replace current user data (settings, extensions, keybindings, snippets) with selected version"
+				]
+			},
+			{
+				"key": "workbench.actions.sync.compareWithLocal",
+				"comment": [
+					"This is an action title to show the changes between local and remote version of resources"
+				]
+			},
+			{
+				"key": "leftResourceName",
+				"comment": [
+					"remote as in file in cloud"
+				]
+			},
+			{
+				"key": "rightResourceName",
+				"comment": [
+					"local as in file in disk"
+				]
+			},
+			"sideBySideLabels",
+			"sideBySideDescription",
+			"reset",
+			{
+				"key": "current",
+				"comment": [
+					"Represents current machine"
+				]
+			},
+			"no machines",
+			{
+				"key": "current",
+				"comment": [
+					"Current machine"
+				]
+			},
+			"not found",
+			"turn off sync on machine",
+			{
+				"key": "turn off",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			"placeholder",
+			"not found",
+			"valid message"
+		],
+		"vs/workbench/contrib/feedback/browser/feedback": [
+			"sendFeedback",
+			"label.sendASmile",
+			"close",
+			"patchedVersion1",
+			"patchedVersion2",
+			"sentiment",
+			"smileCaption",
+			"smileCaption",
+			"frownCaption",
+			"frownCaption",
+			"other ways to contact us",
+			"submit a bug",
+			"request a missing feature",
+			"tell us why",
+			"feedbackTextInput",
+			"showFeedback",
+			"tweet",
+			"tweetFeedback",
+			"character left",
+			"characters left"
+		],
+		"vs/workbench/browser/parts/notifications/notificationsViewer": [
+			"executeCommand",
+			"notificationActions",
+			"notificationSource"
+		],
+		"vs/editor/browser/controller/textAreaHandler": [
+			"editor",
+			"accessibilityOffAriaLabel"
+		],
+		"vs/base/browser/ui/findinput/findInputCheckboxes": [
+			"caseDescription",
+			"wordsDescription",
+			"regexDescription"
+		],
+		"vs/editor/contrib/gotoSymbol/peek/referencesWidget": [
+			"missingPreviewMessage",
+			"noResults",
+			"peekView.alternateTitle"
+		],
+		"vs/editor/contrib/hover/markerHoverParticipant": [
+			"peek problem",
+			"noQuickFixes",
+			"checkingForQuickFixes",
+			"noQuickFixes",
+			"quick fixes"
+		],
+		"vs/editor/contrib/hover/markdownHoverParticipant": [
+			"modesContentHover.loading"
+		],
+		"vs/editor/contrib/suggest/suggestWidgetDetails": [
+			"details.close",
+			"loading"
+		],
+		"vs/editor/contrib/suggest/suggestWidgetStatus": [
+			"ddd"
+		],
+		"vs/editor/contrib/suggest/suggestWidgetRenderer": [
+			"suggestMoreInfoIcon",
+			"readMore"
+		],
+		"vs/workbench/contrib/comments/common/commentModel": [
+			"noComments"
+		],
+		"vs/workbench/browser/parts/editor/titleControl": [
+			"ariaLabelEditorActions",
+			"draggedEditorGroup"
+		],
+		"vs/workbench/browser/parts/editor/breadcrumbsControl": [
+			"cmd.toggle",
+			"miShowBreadcrumbs",
+			"cmd.focus"
+		],
+		"vs/base/parts/quickinput/browser/quickInputList": [
+			"quickInput"
+		],
+		"vs/workbench/contrib/notebook/browser/view/renderers/cellRenderer": [
+			"cellExpandButtonLabel"
+		],
+		"vs/workbench/contrib/debug/common/debugSchemas": [
+			"vscode.extension.contributes.debuggers",
+			"vscode.extension.contributes.debuggers.type",
+			"vscode.extension.contributes.debuggers.label",
+			"vscode.extension.contributes.debuggers.program",
+			"vscode.extension.contributes.debuggers.args",
+			"vscode.extension.contributes.debuggers.runtime",
+			"vscode.extension.contributes.debuggers.runtimeArgs",
+			"vscode.extension.contributes.debuggers.variables",
+			"vscode.extension.contributes.debuggers.initialConfigurations",
+			"vscode.extension.contributes.debuggers.languages",
+			"vscode.extension.contributes.debuggers.configurationSnippets",
+			"vscode.extension.contributes.debuggers.configurationAttributes",
+			"vscode.extension.contributes.debuggers.windows",
+			"vscode.extension.contributes.debuggers.windows.runtime",
+			"vscode.extension.contributes.debuggers.osx",
+			"vscode.extension.contributes.debuggers.osx.runtime",
+			"vscode.extension.contributes.debuggers.linux",
+			"vscode.extension.contributes.debuggers.linux.runtime",
+			"vscode.extension.contributes.breakpoints",
+			"vscode.extension.contributes.breakpoints.language",
+			"presentation",
+			"presentation.hidden",
+			"presentation.group",
+			"presentation.order",
+			"app.launch.json.title",
+			"app.launch.json.version",
+			"app.launch.json.configurations",
+			"app.launch.json.compounds",
+			"app.launch.json.compound.name",
+			"useUniqueNames",
+			"app.launch.json.compound.name",
+			"app.launch.json.compound.folder",
+			"app.launch.json.compounds.configurations",
+			"app.launch.json.compound.stopAll",
+			"compoundPrelaunchTask"
+		],
+		"vs/workbench/contrib/debug/common/debugger": [
+			"cannot.find.da",
+			"launch.config.comment1",
+			"launch.config.comment2",
+			"launch.config.comment3",
+			"debugType",
+			"debugTypeNotRecognised",
+			"node2NotSupported",
+			"debugName",
+			"debugRequest",
+			"debugServer",
+			"debugPrelaunchTask",
+			"debugPostDebugTask",
+			"debugWindowsConfiguration",
+			"debugOSXConfiguration",
+			"debugLinuxConfiguration"
+		],
+		"vs/workbench/contrib/debug/browser/rawDebugSession": [
+			"noDebugAdapterStart",
+			"noDebugAdapter",
+			"moreInfo"
+		],
+		"vs/base/browser/ui/selectBox/selectBoxCustom": [
+			{
+				"key": "selectBox",
+				"comment": [
+					"Behave like native select dropdown element."
+				]
+			}
+		],
+		"vs/workbench/contrib/comments/browser/commentNode": [
+			"commentToggleReaction",
+			"commentToggleReactionError",
+			"commentToggleReactionDefaultError",
+			"commentDeleteReactionError",
+			"commentDeleteReactionDefaultError",
+			"commentAddReactionError",
+			"commentAddReactionDefaultError"
+		],
+		"vs/workbench/contrib/customEditor/common/extensionPoint": [
+			"contributes.customEditors",
+			"contributes.viewType",
+			"contributes.displayName",
+			"contributes.selector",
+			"contributes.selector.filenamePattern",
+			"contributes.priority",
+			"contributes.priority.default",
+			"contributes.priority.option"
+		],
+		"vs/workbench/contrib/terminal/browser/links/terminalLinkManager": [
+			"terminalLinkHandler.followLinkAlt.mac",
+			"terminalLinkHandler.followLinkAlt",
+			"terminalLinkHandler.followLinkCmd",
+			"terminalLinkHandler.followLinkCtrl",
+			"followForwardedLink",
+			"followLink",
+			"followLinkUrl"
+		],
+		"vs/workbench/services/gettingStarted/common/gettingStartedContent": [
+			"getting-started-setup-icon",
+			"getting-started-beginner-icon",
+			"getting-started-codespaces-icon",
+			"gettingStarted.codespaces.title",
+			"gettingStarted.codespaces.description",
+			"gettingStarted.runProject.title",
+			"gettingStarted.runProject.description",
+			"gettingStarted.runProject.button",
+			"gettingStarted.forwardPorts.title",
+			"gettingStarted.forwardPorts.description",
+			"gettingStarted.forwardPorts.button",
+			"gettingStarted.pullRequests.title",
+			"gettingStarted.pullRequests.description",
+			"gettingStarted.pullRequests.button",
+			"gettingStarted.remoteTerminal.title",
+			"gettingStarted.remoteTerminal.description",
+			"gettingStarted.remoteTerminal.button",
+			"gettingStarted.openVSC.title",
+			"gettingStarted.openVSC.description",
+			"gettingStarted.openVSC.button",
+			"gettingStarted.setup.title",
+			"gettingStarted.setup.description",
+			"gettingStarted.pickColor.title",
+			"gettingStarted.pickColor.description",
+			"gettingStarted.pickColor.button",
+			"gettingStarted.findLanguageExts.title",
+			"gettingStarted.findLanguageExts.description",
+			"gettingStarted.findLanguageExts.button",
+			"gettingStarted.settingsSync.title",
+			"gettingStarted.settingsSync.description",
+			"gettingStarted.settingsSync.button",
+			"gettingStarted.setup.OpenFolder.title",
+			"gettingStarted.setup.OpenFolder.description",
+			"gettingStarted.setup.OpenFolder.button",
+			"gettingStarted.setup.OpenFolder.title",
+			"gettingStarted.setup.OpenFolder.description2",
+			"gettingStarted.setup.OpenFolder.button",
+			"gettingStarted.beginner.title",
+			"gettingStarted.beginner.description",
+			"gettingStarted.commandPalette.title",
+			"gettingStarted.commandPalette.description",
+			"gettingStarted.commandPalette.button",
+			"gettingStarted.terminal.title",
+			"gettingStarted.terminal.description",
+			"gettingStarted.terminal.button",
+			"gettingStarted.extensions.title",
+			"gettingStarted.extensions.description",
+			"gettingStarted.extensions.button",
+			"gettingStarted.settings.title",
+			"gettingStarted.settings.description",
+			"gettingStarted.settings.button",
+			"gettingStarted.videoTutorial.title",
+			"gettingStarted.videoTutorial.description",
+			"gettingStarted.videoTutorial.button"
+		],
+		"vs/workbench/contrib/userDataSync/browser/userDataSyncMergesView": [
+			"explanation",
+			"turn on sync",
+			"cancel",
+			"workbench.actions.sync.acceptRemote",
+			"workbench.actions.sync.acceptLocal",
+			"workbench.actions.sync.merge",
+			"workbench.actions.sync.discard",
+			{
+				"key": "workbench.actions.sync.showChanges",
+				"comment": [
+					"This is an action title to show the changes between local and remote version of resources"
+				]
+			},
+			"conflicts detected",
+			"resolve",
+			"turning on",
+			"preview",
+			{
+				"key": "leftResourceName",
+				"comment": [
+					"remote as in file in cloud"
+				]
+			},
+			"merges",
+			{
+				"key": "rightResourceName",
+				"comment": [
+					"local as in file in disk"
+				]
+			},
+			"sideBySideLabels",
+			"sideBySideDescription",
+			"label",
+			"conflict",
+			"accepted",
+			"accept remote",
+			"accept local",
+			"accept merges"
+		],
+		"vs/editor/contrib/codeAction/lightBulbWidget": [
+			"prefferedQuickFixWithKb",
+			"quickFixWithKb",
+			"quickFix"
+		],
+		"vs/editor/contrib/gotoSymbol/peek/referencesTree": [
+			"referencesCount",
+			"referenceCount",
+			"treeAriaLabel"
+		],
+		"vs/workbench/browser/parts/editor/breadcrumbs": [
+			"title",
+			"enabled",
+			"filepath",
+			"filepath.on",
+			"filepath.off",
+			"filepath.last",
+			"symbolpath",
+			"symbolpath.on",
+			"symbolpath.off",
+			"symbolpath.last",
+			"symbolSortOrder",
+			"symbolSortOrder.position",
+			"symbolSortOrder.name",
+			"symbolSortOrder.type",
+			"icons",
+			"filteredTypes.file",
+			"filteredTypes.module",
+			"filteredTypes.namespace",
+			"filteredTypes.package",
+			"filteredTypes.class",
+			"filteredTypes.method",
+			"filteredTypes.property",
+			"filteredTypes.field",
+			"filteredTypes.constructor",
+			"filteredTypes.enum",
+			"filteredTypes.interface",
+			"filteredTypes.function",
+			"filteredTypes.variable",
+			"filteredTypes.constant",
+			"filteredTypes.string",
+			"filteredTypes.number",
+			"filteredTypes.boolean",
+			"filteredTypes.array",
+			"filteredTypes.object",
+			"filteredTypes.key",
+			"filteredTypes.null",
+			"filteredTypes.enumMember",
+			"filteredTypes.struct",
+			"filteredTypes.event",
+			"filteredTypes.operator",
+			"filteredTypes.typeParameter"
+		],
+		"vs/workbench/browser/parts/editor/breadcrumbsPicker": [
+			"breadcrumbs"
+		],
+		"vs/workbench/contrib/notebook/browser/diff/diffElementOutputs": [
+			"mimeTypePicker",
+			"curruentActiveMimeType",
+			"promptChooseMimeTypeInSecure.placeHolder",
+			"promptChooseMimeType.placeHolder",
+			"builtinRenderInfo",
+			"builtinRenderInfo"
+		],
+		"vs/workbench/contrib/notebook/browser/viewModel/markdownCellViewModel": [
+			"notebook.emptyMarkdownPlaceholder"
+		],
+		"vs/workbench/contrib/notebook/browser/view/renderers/cellWidgets": [
+			"notebook.cell.status.language"
+		],
+		"vs/workbench/contrib/comments/browser/reactionsAction": [
+			"pickReactions"
+		],
+		"vs/workbench/contrib/terminal/browser/links/terminalWordLinkProvider": [
+			"searchWorkspace"
+		],
+		"vs/workbench/contrib/terminal/browser/terminalProcessExtHostProxy": [
+			"terminal.integrated.starting"
+		],
+		"vs/workbench/contrib/terminal/browser/environmentVariableInfo": [
+			"extensionEnvironmentContributionChanges",
+			"extensionEnvironmentContributionRemoval",
+			"relaunchTerminalLabel",
+			"extensionEnvironmentContributionInfo"
+		],
+		"vs/workbench/contrib/notebook/browser/view/renderers/cellOutput": [
+			"mimeTypePicker",
+			"curruentActiveMimeType",
+			"promptChooseMimeTypeInSecure.placeHolder",
+			"promptChooseMimeType.placeHolder",
+			"builtinRenderInfo",
+			"builtinRenderInfo"
+		],
+		"vs/workbench/contrib/terminal/browser/links/terminalLink": [
+			"openFile",
+			"focusFolder",
+			"openFolder"
+		]
+	},
+	"messages": {
+		"vs/code/electron-main/main": [
+			"A second instance of {0} is already running as administrator.",
+			"Please close the other instance and try again.",
+			"Another instance of {0} is running but not responding",
+			"Please close all other instances and try again.",
+			"Unable to write program user data.",
+			"{0}\n\nPlease make sure the following directories are writeable:\n\n{1}",
+			"&&Close"
+		],
+		"vs/code/electron-sandbox/issue/issueReporterMain": [
+			"hide",
+			"show",
+			"Create on GitHub",
+			"Preview on GitHub",
+			"Loading data...",
+			"GitHub query limit exceeded. Please wait.",
+			"Similar issues",
+			"Open",
+			"Closed",
+			"Open",
+			"Closed",
+			"No similar issues found",
+			"Bug Report",
+			"Feature Request",
+			"Performance Issue",
+			"Select source",
+			"Visual Studio Code",
+			"An extension",
+			"Select source",
+			"Visual Studio Code",
+			"An extension",
+			"Don't Know",
+			"Steps to Reproduce",
+			"Share the steps needed to reliably reproduce the problem. Please include actual and expected results. We support GitHub-flavored Markdown. You will be able to edit your issue and add screenshots when we preview it on GitHub.",
+			"Steps to Reproduce",
+			"When did this performance issue happen? Does it occur on startup or after a specific series of actions? We support GitHub-flavored Markdown. You will be able to edit your issue and add screenshots when we preview it on GitHub.",
+			"Description",
+			"Please describe the feature you would like to see. We support GitHub-flavored Markdown. You will be able to edit your issue and add screenshots when we preview it on GitHub.",
+			"We have written the needed data into your clipboard because it was too large to send. Please paste.",
+			"Extensions are disabled",
+			"No current experiments."
+		],
+		"vs/code/electron-sandbox/processExplorer/processExplorerMain": [
+			"Process Name",
+			"CPU %",
+			"PID",
+			"Memory (MB)",
+			"Kill Process",
+			"Force Kill Process",
+			"Copy",
+			"Copy All",
+			"Debug"
+		],
+		"vs/workbench/services/integrity/node/integrityService": [
+			"Your {0} installation appears to be corrupt. Please reinstall.",
+			"More Information",
+			"Don't Show Again"
+		],
+		"vs/workbench/services/textfile/electron-browser/nativeTextFileService": [
+			"File is Read Only"
+		],
+		"vs/workbench/services/extensionManagement/electron-browser/extensionManagementServerService": [
+			"Local",
+			"Remote"
+		],
+		"vs/workbench/services/extensions/electron-browser/extensionService": [
+			"Extension host cannot start: version mismatch.",
+			"Relaunch VS Code",
+			"Extension host terminated unexpectedly.",
+			"Open Developer Tools",
+			"Restart Extension Host",
+			"Could not fetch remote environment",
+			"The following extensions contain dependency loops and have been disabled: {0}",
+			"Extension '{0}' is required to open the remote window.\nOK to enable?",
+			"Enable and Reload",
+			"Extension '{0}' is required to open the remote window.\nDo you want to install the extension?",
+			"Install and Reload",
+			"`{0}` not found on marketplace",
+			"Restart Extension Host"
+		],
+		"vs/workbench/contrib/extensions/electron-browser/extensions.contribution": [
+			"Running Extensions"
+		],
+		"vs/workbench/contrib/externalTerminal/node/externalTerminal.contribution": [
+			"Open New External Terminal",
+			"External Terminal",
+			"Use VS Code's integrated terminal.",
+			"Use the configured external terminal.",
+			"Customizes what kind of terminal to launch.",
+			"Customizes which terminal to run on Windows.",
+			"Customizes which terminal application to run on macOS.",
+			"Customizes which terminal to run on Linux."
+		],
+		"vs/workbench/contrib/cli/node/cli.contribution": [
+			"Shell Command",
+			"Install '{0}' command in PATH",
+			"This command is not available",
+			"OK",
+			"Cancel",
+			"Code will now prompt with 'osascript' for Administrator privileges to install the shell command.",
+			"Unable to create '/usr/local/bin'.",
+			"Aborted",
+			"Shell command '{0}' successfully installed in PATH.",
+			"Uninstall '{0}' command from PATH",
+			"This command is not available",
+			"OK",
+			"Cancel",
+			"Code will now prompt with 'osascript' for Administrator privileges to uninstall the shell command.",
+			"Unable to uninstall the shell command '{0}'.",
+			"Aborted",
+			"Shell command '{0}' successfully uninstalled from PATH."
+		],
+		"vs/workbench/contrib/tasks/electron-browser/taskService": [
+			"There is a task running. Do you want to terminate it?",
+			"&&Terminate Task",
+			"The launched task doesn't exist anymore. If the task spawned background processes exiting VS Code might result in orphaned processes. To avoid this start the last background process with a wait flag.",
+			"&&Exit Anyways"
+		],
+		"vs/workbench/contrib/userDataSync/electron-browser/userDataSync.contribution": [
+			"Operation Id: {0}",
+			"Settings sync is disabled because the current device is making too many requests. Please report an issue by providing the sync logs.",
+			"Settings Sync. Operation Id: {0}",
+			"Show Log",
+			"Report Issue",
+			"Open Local Backups Folder",
+			"Local backups folder does not exist"
+		],
+		"vs/platform/environment/node/argvHelper": [
+			"Warning: '{0}' is not in the list of known options, but still passed to Electron/Chromium.",
+			"Option '{0}' is defined more than once. Using value '{1}.'",
+			"Arguments in `--goto` mode should be in the format of `FILE(:LINE(:CHARACTER))`."
+		],
+		"vs/platform/request/common/request": [
+			"HTTP",
+			"The proxy setting to use. If not set, will be inherited from the `http_proxy` and `https_proxy` environment variables.",
+			"Controls whether the proxy server certificate should be verified against the list of supplied CAs.",
+			"The value to send as the `Proxy-Authorization` header for every network request.",
+			"Disable proxy support for extensions.",
+			"Enable proxy support for extensions.",
+			"Enable proxy support for extensions, override request options.",
+			"Use the proxy support for extensions.",
+			"Controls whether CA certificates should be loaded from the OS. (On Windows and macOS a reload of the window is required after turning this off.)"
+		],
+		"vs/code/electron-main/app": [
+			"Successfully created trace.",
+			"Please create an issue and manually attach the following file:\n{0}",
+			"OK",
+			"&&Yes",
+			"&&No",
+			"An external application wants to open '{0}' in {1}. Do you want to open this file or folder?",
+			"If you did not initiate this request, it may represent an attempted attack on your system. Unless you took an explicit action to initiate this request, you should press 'No'"
+		],
+		"vs/platform/files/node/diskFileSystemProvider": [
+			"File already exists",
+			"File does not exist",
+			"Unable to move '{0}' into '{1}' ({2}).",
+			"Unable to copy '{0}' into '{1}' ({2}).",
+			"'File cannot be copied to same path with different path case",
+			"File at target already exists"
+		],
+		"vs/platform/files/common/fileService": [
+			"Unable to resolve filesystem provider with relative file path '{0}'",
+			"No file system provider found for resource '{0}'",
+			"Unable to resolve non-existing file '{0}'",
+			"Unable to create file '{0}' that already exists when overwrite flag is not set",
+			"Unable to write file '{0}' ({1})",
+			"Unable to write file '{0}' that is actually a directory",
+			"File Modified Since",
+			"Unable to read file '{0}' ({1})",
+			"Unable to read file '{0}' ({1})",
+			"Unable to read file '{0}' ({1})",
+			"Unable to read file '{0}' that is actually a directory",
+			"File not modified since",
+			"Unable to read file '{0}' that is too large to open",
+			"Unable to copy when source '{0}' is same as target '{1}' with different path case on a case insensitive file system",
+			"Unable to move/copy when source '{0}' is parent of target '{1}'.",
+			"Unable to move/copy '{0}' because target '{1}' already exists at destination.",
+			"Unable to move/copy '{0}' into '{1}' since a file would replace the folder it is contained in.",
+			"Unable to create folder '{0}' that already exists but is not a directory",
+			"Unable to delete file '{0}' via trash because provider does not support it.",
+			"Unable to delete non-existing file '{0}'",
+			"Unable to delete non-empty folder '{0}'.",
+			"Unable to modify readonly file '{0}'"
+		],
+		"vs/platform/files/common/files": [
+			"Unknown Error",
+			"{0}B",
+			"{0}KB",
+			"{0}MB",
+			"{0}GB",
+			"{0}TB"
+		],
+		"vs/base/common/errorMessage": [
+			"{0}: {1}",
+			"A system error occurred ({0})",
+			"An unknown error occurred. Please consult the log for more details.",
+			"An unknown error occurred. Please consult the log for more details.",
+			"{0} ({1} errors in total)",
+			"An unknown error occurred. Please consult the log for more details."
+		],
+		"vs/platform/update/common/update.config.contribution": [
+			"Update",
+			"Configure whether you receive automatic updates. Requires a restart after change. The updates are fetched from a Microsoft online service.",
+			"Disable updates.",
+			"Disable automatic background update checks. Updates will be available if you manually check for updates.",
+			"Check for updates only on startup. Disable automatic background update checks.",
+			"Enable automatic update checks. Code will check for updates automatically and periodically.",
+			"Configure whether you receive automatic updates. Requires a restart after change. The updates are fetched from a Microsoft online service.",
+			"This setting is deprecated, please use '{0}' instead.",
+			"Enable Background Updates on Windows",
+			"Enable to download and install new VS Code Versions in the background on Windows",
+			"Show Release Notes after an update. The Release Notes are fetched from a Microsoft online service."
+		],
+		"vs/platform/environment/node/argv": [
+			"Options",
+			"Extensions Management",
+			"Troubleshooting",
+			"Compare two files with each other.",
+			"Add folder(s) to the last active window.",
+			"Open a file at the path on the specified line and character position.",
+			"Force to open a new window.",
+			"Force to open a file or folder in an already opened window.",
+			"Wait for the files to be closed before returning.",
+			"The locale to use (e.g. en-US or zh-TW).",
+			"Specifies the directory that user data is kept in. Can be used to open multiple distinct instances of Code.",
+			"Print usage.",
+			"Set the root path for extensions.",
+			"List the installed extensions.",
+			"Show versions of installed extensions, when using --list-extensions.",
+			"Filters installed extensions by provided category, when using --list-extensions.",
+			"Installs or updates the extension. The identifier of an extension is always `${publisher}.${name}`. Use `--force` argument to update to latest version. To install a specific version provide `@${version}`. For example: 'vscode.csharp@1.2.3'.",
+			"Uninstalls an extension.",
+			"Enables proposed API features for extensions. Can receive one or more extension IDs to enable individually.",
+			"Print version.",
+			"Print verbose output (implies --wait).",
+			"Log level to use. Default is 'info'. Allowed values are 'critical', 'error', 'warn', 'info', 'debug', 'trace', 'off'.",
+			"Print process usage and diagnostics information.",
+			"Run CPU profiler during startup",
+			"Disable all installed extensions.",
+			"Disable an extension.",
+			"Turn sync on or off",
+			"Allow debugging and profiling of extensions. Check the developer tools for the connection URI.",
+			"Allow debugging and profiling of extensions with the extension host being paused after start. Check the developer tools for the connection URI.",
+			"Disable GPU hardware acceleration.",
+			"Max memory size for a window (in Mbytes).",
+			"Shows all telemetry events which VS code collects.",
+			"Usage",
+			"options",
+			"paths",
+			"To read output from another program, append '-' (e.g. 'echo Hello World | {0} -')",
+			"To read from stdin, append '-' (e.g. 'ps aux | grep code | {0} -')",
+			"Unknown version",
+			"Unknown commit"
+		],
+		"vs/platform/extensionManagement/common/extensionManagement": [
+			"Extensions",
+			"Preferences"
+		],
+		"vs/platform/extensionManagement/node/extensionManagementService": [
+			"Unable to install extension '{0}' as it is not compatible with VS Code '{1}'.",
+			"Please restart VS Code before reinstalling {0}.",
+			"Please restart VS Code before reinstalling {0}.",
+			"Marketplace is not enabled",
+			"Can't install extension since it was reported to be problematic.",
+			"Unable to install '{0}' extension because it is not compatible with the current version of VS Code (version {1}).",
+			"Marketplace is not enabled",
+			"Only Marketplace Extensions can be reinstalled",
+			"Error while removing the extension: {0}. Please Quit and Start VS Code before trying again.",
+			"Unable to install the extension. Please Quit and Start VS Code before reinstalling.",
+			"Unable to install the extension. Please Exit and Start VS Code before reinstalling.",
+			"Extension '{0}' is not installed.",
+			"Cannot uninstall '{0}' extension. '{1}' extension depends on this.",
+			"Cannot uninstall '{0}' extension. '{1}' and '{2}' extensions depend on this.",
+			"Cannot uninstall '{0}' extension. '{1}', '{2}' and other extension depend on this.",
+			"Cannot uninstall '{0}' extension . It includes uninstalling '{1}' extension and '{2}' extension depends on this.",
+			"Cannot uninstall '{0}' extension. It includes uninstalling '{1}' extension and '{2}' and '{3}' extensions depend on this.",
+			"Cannot uninstall '{0}' extension. It includes uninstalling '{1}' extension and '{2}', '{3}' and other extensions depend on this.",
+			"Could not find extension"
+		],
+		"vs/platform/telemetry/common/telemetryService": [
+			"Telemetry",
+			"Enable usage data and errors to be sent to a Microsoft online service.",
+			"Enable usage data and errors to be sent to a Microsoft online service. Read our privacy statement [here]({0})."
+		],
+		"vs/platform/extensionManagement/common/extensionManagementCLIService": [
+			"Extension '{0}' not found.",
+			"Make sure you use the full extension ID, including the publisher, e.g.: {0}",
+			"Extensions installed on {0}:",
+			"Installing extensions on {0}...",
+			"Installing extensions...",
+			"Extension '{0}' v{1} is already installed. Use '--force' option to update to latest version or provide '@<version>' to install a specific version, for example: '{2}@1.2.3'.",
+			"Extension '{0}' is already installed.",
+			"Failed Installing Extensions: {0}",
+			"Extension '{0}' was successfully installed.",
+			"Cancelled installing extension '{0}'.",
+			"Extension '{0}' is already installed.",
+			"Updating the extension '{0}' to the version {1}",
+			"Installing builtin extension '{0}' v{1}...",
+			"Installing extension '{0}' v{1}...",
+			"Extension '{0}' v{1} was successfully installed.",
+			"Cancelled installing extension '{0}'.",
+			"A newer version of extension '{0}' v{1} is already installed. Use '--force' option to downgrade to older version.",
+			"Extension '{0}' is a Built-in extension and cannot be uninstalled",
+			"Extension '{0}' is marked as a Built-in extension by user. Please use '--force' option to uninstall it.",
+			"Uninstalling {0}...",
+			"Extension '{0}' was successfully uninstalled from {1}!",
+			"Extension '{0}' was successfully uninstalled!",
+			"Extension '{0}' is not installed on {1}.",
+			"Extension '{0}' is not installed."
+		],
+		"vs/code/electron-sandbox/issue/issueReporterPage": [
+			"Please complete the form in English.",
+			"This is a",
+			"File on",
+			"An issue source is required.",
+			"Try to reproduce the problem after {0}. If the problem only reproduces when extensions are active, it is likely an issue with an extension.",
+			"disabling all extensions and reloading the window",
+			"Extension",
+			"The issue reporter is unable to create issues for this extension. Please visit {0} to report an issue.",
+			"The issue reporter is unable to create issues for this extension, as it does not specify a URL for reporting issues. Please check the marketplace page of this extension to see if other instructions are available.",
+			"Title",
+			"Please enter a title.",
+			"A title is required.",
+			"The title is too long.",
+			"Please enter details.",
+			"A description is required.",
+			"Include my system information ({0})",
+			"show",
+			"Include my currently running processes ({0})",
+			"show",
+			"Include my workspace metadata ({0})",
+			"show",
+			"Include my enabled extensions ({0})",
+			"show",
+			"Include A/B experiment info ({0})",
+			"show"
+		],
+		"vs/platform/userDataSync/common/userDataSync": [
+			"Settings Sync",
+			"Synchronize keybindings for each platform.",
+			"List of extensions to be ignored while synchronizing. The identifier of an extension is always `${publisher}.${name}`. For example: `vscode.csharp`.",
+			"Expected format '${publisher}.${name}'. Example: 'vscode.csharp'.",
+			"Configure settings to be ignored while synchronizing."
+		],
+		"vs/platform/userDataSync/common/userDataSyncMachines": [
+			"Cannot read machines data as the current version is incompatible. Please update {0} and try again."
+		],
+		"vs/platform/extensionManagement/electron-sandbox/extensionTipsService": [
+			"You have {0} installed on your system. Do you want to install the recommended extensions for it?"
+		],
+		"vs/platform/userDataSync/common/userDataAutoSyncService": [
+			"Cannot sync because default service has changed",
+			"Cannot sync because sync service has changed",
+			"Cannot sync because syncing is turned off in the cloud",
+			"Cannot sync because default service has changed",
+			"Cannot sync because sync service has changed",
+			"Cannot sync because current session is expired",
+			"Cannot sync because syncing is turned off on this machine from another machine."
+		],
+		"vs/workbench/services/lifecycle/electron-sandbox/lifecycleService": [
+			"An unexpected error was thrown while attempting to close the window ({0}).",
+			"An unexpected error was thrown while attempting to quit the application ({0}).",
+			"An unexpected error was thrown while attempting to reload the window ({0}).",
+			"An unexpected error was thrown while attempting to change the workspace of the window ({0})."
+		],
+		"vs/workbench/services/workspaces/electron-sandbox/workspaceEditingService": [
+			"Save",
+			"Don't Save",
+			"Cancel",
+			"Do you want to save your workspace configuration as a file?",
+			"Save your workspace if you plan to open it again.",
+			"Unable to save workspace '{0}'",
+			"OK",
+			"The workspace is already opened in another window. Please close that window first and then try again."
+		],
+		"vs/workbench/contrib/localizations/browser/localizations.contribution": [
+			"Would you like to change VS Code's UI language to {0} and restart?",
+			"In order to use VS Code in {0}, VS Code needs to restart.",
+			"Change Language and Restart",
+			"Restart",
+			"Don't Show Again",
+			"Contributes localizations to the editor",
+			"Id of the language into which the display strings are translated.",
+			"Name of the language in English.",
+			"Name of the language in contributed language.",
+			"List of translations associated to the language.",
+			"Id of VS Code or Extension for which this translation is contributed to. Id of VS Code is always `vscode` and of extension should be in format `publisherId.extensionName`.",
+			"Id should be `vscode` or in format `publisherId.extensionName` for translating VS code or an extension respectively.",
+			"A relative path to a file containing translations for the language."
+		],
+		"vs/workbench/electron-sandbox/desktop.contribution": [
+			"New Window Tab",
+			"Show Previous Window Tab",
+			"Show Next Window Tab",
+			"Move Window Tab to New Window",
+			"Merge All Windows",
+			"Toggle Window Tabs Bar",
+			"Clos&&e Window",
+			"E&&xit",
+			"&&Zoom In",
+			"&&Zoom Out",
+			"&&Reset Zoom",
+			"Report &&Issue",
+			"Open &&Process Explorer",
+			"Window",
+			"Open a new empty window.",
+			"Focus the last active running instance.",
+			"Controls whether a new empty window should open when starting a second instance without arguments or if the last running instance should get focus.\nNote that there can still be cases where this setting is ignored (e.g. when using the `--new-window` or `--reuse-window` command line option).",
+			"Always reopen all windows. If a folder or workspace is opened (e.g. from the command line) it opens as a new window unless it was opened before. If files are opened they will open in one of the restored windows.",
+			"Reopen all windows unless a folder, workspace or file is opened (e.g. from the command line).",
+			"Reopen all windows that had folders or workspaces opened unless a folder, workspace or file is opened (e.g. from the command line).",
+			"Reopen the last active window unless a folder, workspace or file is opened (e.g. from the command line).",
+			"Never reopen a window. Unless a folder or workspace is opened (e.g. from the command line), an empty window will appear.",
+			"Controls how windows are being reopened after starting for the first time. This setting has no effect when the application is already running.",
+			"Controls whether a window should restore to full screen mode if it was exited in full screen mode.",
+			"Adjust the zoom level of the window. The original size is 0 and each increment above (e.g. 1) or below (e.g. -1) represents zooming 20% larger or smaller. You can also enter decimals to adjust the zoom level with a finer granularity.",
+			"Open new windows in the center of the screen.",
+			"Open new windows with same dimension as last active one.",
+			"Open new windows with same dimension as last active one with an offset position.",
+			"Open new windows maximized.",
+			"Open new windows in full screen mode.",
+			"Controls the dimensions of opening a new window when at least one window is already opened. Note that this setting does not have an impact on the first window that is opened. The first window will always restore the size and location as you left it before closing.",
+			"Controls whether closing the last editor should also close the window. This setting only applies for windows that do not show folders.",
+			"If enabled, double clicking the application icon in the title bar will close the window and the window cannot be dragged by the icon. This setting only has an effect when `#window.titleBarStyle#` is set to `custom`.",
+			"Adjust the appearance of the window title bar. On Linux and Windows, this setting also affects the application and context menu appearances. Changes require a full restart to apply.",
+			"Adjust the appearance of dialog windows.",
+			"Enables macOS Sierra window tabs. Note that changes require a full restart to apply and that native tabs will disable a custom title bar style if configured.",
+			"Controls if native full-screen should be used on macOS. Disable this option to prevent macOS from creating a new space when going full-screen.",
+			"If enabled, clicking on an inactive window will both activate the window and trigger the element under the mouse if it is clickable. If disabled, clicking anywhere on an inactive window will activate it only and a second click is required on the element.",
+			"Telemetry",
+			"Enable crash reports to be sent to a Microsoft online service. \nThis option requires restart to take effect.",
+			"Keyboard",
+			"Enables the macOS touchbar buttons on the keyboard if available.",
+			"A set of identifiers for entries in the touchbar that should not show up (for example `workbench.action.navigateBack`.",
+			"The display Language to use. Picking a different language requires the associated language pack to be installed.",
+			"Disables hardware acceleration. ONLY change this option if you encounter graphic issues.",
+			"Resolves issues around color profile selection. ONLY change this option if you encounter graphic issues.",
+			"Allows to override the color profile to use. If you experience colors appear badly, try to set this to `srgb` and restart.",
+			"Allows to disable crash reporting, should restart the app if the value is changed.",
+			"Unique id used for correlating crash reports sent from this app instance.",
+			"Enable proposed APIs for a list of extension ids (such as `vscode.git`). Proposed APIs are unstable and subject to breaking without warning at any time. This should only be set for extension development and testing purposes.",
+			"Forces the renderer to be accessible. ONLY change this if you are using a screen reader on Linux. On other platforms the renderer will automatically be accessible. This flag is automatically set if you have editor.accessibilitySupport: on."
+		],
+		"vs/workbench/contrib/files/electron-sandbox/files.contribution": [
+			"Text File Editor"
+		],
+		"vs/workbench/contrib/files/electron-sandbox/fileActions.contribution": [
+			"Reveal in File Explorer",
+			"Reveal in Finder",
+			"Open Containing Folder",
+			"File"
+		],
+		"vs/workbench/contrib/issue/electron-sandbox/issue.contribution": [
+			"Report Issue..."
+		],
+		"vs/workbench/contrib/remote/electron-sandbox/remote.contribution": [
+			"Remote",
+			"When enabled extensions are downloaded locally and installed on remote."
+		],
+		"vs/workbench/browser/workbench": [
+			"Failed to load a required file. Please restart the application to try again. Details: {0}"
+		],
+		"vs/workbench/electron-sandbox/window": [
+			"Learn More",
+			"Resolving your shell environment is taking very long. Please review your shell configuration.",
+			"Unable to resolve your shell environment in a reasonable time. Please review your shell configuration.",
+			"Proxy Authentication Required",
+			"&&Log In",
+			"&&Cancel",
+			"Username",
+			"Password",
+			"The proxy {0} requires a username and password.",
+			"Remember my credentials",
+			"It is not recommended to run {0} as root user.",
+			"There is a dependency cycle in the AMD modules that needs to be resolved!",
+			"OK"
+		],
+		"vs/platform/workspaces/common/workspaces": [
+			"Code Workspace"
+		],
+		"vs/workbench/services/remote/electron-sandbox/remoteAgentServiceImpl": [
+			"Failed to connect to the remote extension host server (Error: {0})"
+		],
+		"vs/platform/files/electron-browser/diskFileSystemProvider": [
+			"Failed to move '{0}' to the recycle bin",
+			"Failed to move '{0}' to the trash"
+		],
+		"vs/workbench/services/textfile/browser/textFileService": [
+			"File seems to be binary and cannot be opened as text",
+			"'{0}' already exists. Do you want to replace it?",
+			"A file or folder with the name '{0}' already exists in the folder '{1}'. Replacing it will overwrite its current contents.",
+			"&&Replace"
+		],
+		"vs/platform/dialogs/common/dialogs": [
+			"...1 additional file not shown",
+			"...{0} additional files not shown"
+		],
+		"vs/workbench/services/extensionManagement/electron-sandbox/remoteExtensionManagementService": [
+			"Unable to install extension '{0}' as it is not compatible with VS Code '{1}'."
+		],
+		"vs/workbench/services/extensions/electron-browser/localProcessExtensionHost": [
+			"Extension host did not start in 10 seconds, it might be stopped on the first line and needs a debugger to continue.",
+			"Extension host did not start in 10 seconds, that might be a problem.",
+			"Reload Window",
+			"Extension Host",
+			"Error from the extension host: {0}"
+		],
+		"vs/workbench/services/extensions/electron-browser/cachedExtensionScanner": [
+			"Overwriting extension {0} with {1}.",
+			"Overwriting extension {0} with {1}.",
+			"Loading development extension at {0}",
+			"Extensions have been modified on disk. Please reload the window.",
+			"Reload Window"
+		],
+		"vs/workbench/services/extensions/common/abstractExtensionService": [
+			"The following extensions contain dependency loops and have been disabled: {0}"
+		],
+		"vs/workbench/services/extensions/common/remoteExtensionHost": [
+			"Remote Extension Host"
+		],
+		"vs/workbench/services/extensions/browser/webWorkerExtensionHost": [
+			"Worker Extension Host"
+		],
+		"vs/workbench/common/actions": [
+			"View",
+			"Help",
+			"Preferences",
+			"Developer"
+		],
+		"vs/base/common/date": [
+			"in {0}",
+			"now",
+			"{0} sec ago",
+			"{0} secs ago",
+			"{0} sec",
+			"{0} secs",
+			"{0} min ago",
+			"{0} mins ago",
+			"{0} min",
+			"{0} mins",
+			"{0} hr ago",
+			"{0} hrs ago",
+			"{0} hr",
+			"{0} hrs",
+			"{0} day ago",
+			"{0} days ago",
+			"{0} day",
+			"{0} days",
+			"{0} wk ago",
+			"{0} wks ago",
+			"{0} wk",
+			"{0} wks",
+			"{0} mo ago",
+			"{0} mos ago",
+			"{0} mo",
+			"{0} mos",
+			"{0} yr ago",
+			"{0} yrs ago",
+			"{0} yr",
+			"{0} yrs"
+		],
+		"vs/platform/theme/common/colorRegistry": [
+			"Overall foreground color. This color is only used if not overridden by a component.",
+			"Overall foreground color for error messages. This color is only used if not overridden by a component.",
+			"Foreground color for description text providing additional information, for example for a label.",
+			"The default color for icons in the workbench.",
+			"Overall border color for focused elements. This color is only used if not overridden by a component.",
+			"An extra border around elements to separate them from others for greater contrast.",
+			"An extra border around active elements to separate them from others for greater contrast.",
+			"The background color of text selections in the workbench (e.g. for input fields or text areas). Note that this does not apply to selections within the editor.",
+			"Color for text separators.",
+			"Foreground color for links in text.",
+			"Foreground color for links in text when clicked on and on mouse hover.",
+			"Foreground color for preformatted text segments.",
+			"Background color for block quotes in text.",
+			"Border color for block quotes in text.",
+			"Background color for code blocks in text.",
+			"Shadow color of widgets such as find/replace inside the editor.",
+			"Input box background.",
+			"Input box foreground.",
+			"Input box border.",
+			"Border color of activated options in input fields.",
+			"Background color of activated options in input fields.",
+			"Foreground color of activated options in input fields.",
+			"Input box foreground color for placeholder text.",
+			"Input validation background color for information severity.",
+			"Input validation foreground color for information severity.",
+			"Input validation border color for information severity.",
+			"Input validation background color for warning severity.",
+			"Input validation foreground color for warning severity.",
+			"Input validation border color for warning severity.",
+			"Input validation background color for error severity.",
+			"Input validation foreground color for error severity.",
+			"Input validation border color for error severity.",
+			"Dropdown background.",
+			"Dropdown list background.",
+			"Dropdown foreground.",
+			"Dropdown border.",
+			"Background color of checkbox widget.",
+			"Foreground color of checkbox widget.",
+			"Border color of checkbox widget.",
+			"Button foreground color.",
+			"Button background color.",
+			"Button background color when hovering.",
+			"Secondary button foreground color.",
+			"Secondary button background color.",
+			"Secondary button background color when hovering.",
+			"Badge background color. Badges are small information labels, e.g. for search results count.",
+			"Badge foreground color. Badges are small information labels, e.g. for search results count.",
+			"Scrollbar shadow to indicate that the view is scrolled.",
+			"Scrollbar slider background color.",
+			"Scrollbar slider background color when hovering.",
+			"Scrollbar slider background color when clicked on.",
+			"Background color of the progress bar that can show for long running operations.",
+			"Background color of error text in the editor. The color must not be opaque so as not to hide underlying decorations.",
+			"Foreground color of error squigglies in the editor.",
+			"Border color of error boxes in the editor.",
+			"Background color of warning text in the editor. The color must not be opaque so as not to hide underlying decorations.",
+			"Foreground color of warning squigglies in the editor.",
+			"Border color of warning boxes in the editor.",
+			"Background color of info text in the editor. The color must not be opaque so as not to hide underlying decorations.",
+			"Foreground color of info squigglies in the editor.",
+			"Border color of info boxes in the editor.",
+			"Foreground color of hint squigglies in the editor.",
+			"Border color of hint boxes in the editor.",
+			"Border color of active sashes.",
+			"Editor background color.",
+			"Editor default foreground color.",
+			"Background color of editor widgets, such as find/replace.",
+			"Foreground color of editor widgets, such as find/replace.",
+			"Border color of editor widgets. The color is only used if the widget chooses to have a border and if the color is not overridden by a widget.",
+			"Border color of the resize bar of editor widgets. The color is only used if the widget chooses to have a resize border and if the color is not overridden by a widget.",
+			"Quick picker background color. The quick picker widget is the container for pickers like the command palette.",
+			"Quick picker foreground color. The quick picker widget is the container for pickers like the command palette.",
+			"Quick picker title background color. The quick picker widget is the container for pickers like the command palette.",
+			"Quick picker color for grouping labels.",
+			"Quick picker color for grouping borders.",
+			"Color of the editor selection.",
+			"Color of the selected text for high contrast.",
+			"Color of the selection in an inactive editor. The color must not be opaque so as not to hide underlying decorations.",
+			"Color for regions with the same content as the selection. The color must not be opaque so as not to hide underlying decorations.",
+			"Border color for regions with the same content as the selection.",
+			"Color of the current search match.",
+			"Color of the other search matches. The color must not be opaque so as not to hide underlying decorations.",
+			"Color of the range limiting the search. The color must not be opaque so as not to hide underlying decorations.",
+			"Border color of the current search match.",
+			"Border color of the other search matches.",
+			"Border color of the range limiting the search. The color must not be opaque so as not to hide underlying decorations.",
+			"Color of the Search Editor query matches.",
+			"Border color of the Search Editor query matches.",
+			"Highlight below the word for which a hover is shown. The color must not be opaque so as not to hide underlying decorations.",
+			"Background color of the editor hover.",
+			"Foreground color of the editor hover.",
+			"Border color of the editor hover.",
+			"Background color of the editor hover status bar.",
+			"Color of active links.",
+			"Foreground color of inline hints",
+			"Background color of inline hints",
+			"The color used for the lightbulb actions icon.",
+			"The color used for the lightbulb auto fix actions icon.",
+			"Background color for text that got inserted. The color must not be opaque so as not to hide underlying decorations.",
+			"Background color for text that got removed. The color must not be opaque so as not to hide underlying decorations.",
+			"Outline color for the text that got inserted.",
+			"Outline color for text that got removed.",
+			"Border color between the two text editors.",
+			"Color of the diff editor's diagonal fill. The diagonal fill is used in side-by-side diff views.",
+			"List/Tree background color for the focused item when the list/tree is active. An active list/tree has keyboard focus, an inactive does not.",
+			"List/Tree foreground color for the focused item when the list/tree is active. An active list/tree has keyboard focus, an inactive does not.",
+			"List/Tree background color for the selected item when the list/tree is active. An active list/tree has keyboard focus, an inactive does not.",
+			"List/Tree foreground color for the selected item when the list/tree is active. An active list/tree has keyboard focus, an inactive does not.",
+			"List/Tree background color for the selected item when the list/tree is inactive. An active list/tree has keyboard focus, an inactive does not.",
+			"List/Tree foreground color for the selected item when the list/tree is inactive. An active list/tree has keyboard focus, an inactive does not.",
+			"List/Tree background color for the focused item when the list/tree is inactive. An active list/tree has keyboard focus, an inactive does not.",
+			"List/Tree background when hovering over items using the mouse.",
+			"List/Tree foreground when hovering over items using the mouse.",
+			"List/Tree drag and drop background when moving items around using the mouse.",
+			"List/Tree foreground color of the match highlights when searching inside the list/tree.",
+			"List/Tree foreground color for invalid items, for example an unresolved root in explorer.",
+			"Foreground color of list items containing errors.",
+			"Foreground color of list items containing warnings.",
+			"Background color of the type filter widget in lists and trees.",
+			"Outline color of the type filter widget in lists and trees.",
+			"Outline color of the type filter widget in lists and trees, when there are no matches.",
+			"Background color of the filtered match.",
+			"Border color of the filtered match.",
+			"Tree stroke color for the indentation guides.",
+			"List/Tree foreground color for items that are deemphasized. ",
+			"Border color of menus.",
+			"Foreground color of menu items.",
+			"Background color of menu items.",
+			"Foreground color of the selected menu item in menus.",
+			"Background color of the selected menu item in menus.",
+			"Border color of the selected menu item in menus.",
+			"Color of a separator menu item in menus.",
+			"Highlight background color of a snippet tabstop.",
+			"Highlight border color of a snippet tabstop.",
+			"Highlight background color of the final tabstop of a snippet.",
+			"Highlight border color of the final tabstop of a snippet.",
+			"Color of focused breadcrumb items.",
+			"Background color of breadcrumb items.",
+			"Color of focused breadcrumb items.",
+			"Color of selected breadcrumb items.",
+			"Background color of breadcrumb item picker.",
+			"Current header background in inline merge-conflicts. The color must not be opaque so as not to hide underlying decorations.",
+			"Current content background in inline merge-conflicts. The color must not be opaque so as not to hide underlying decorations.",
+			"Incoming header background in inline merge-conflicts. The color must not be opaque so as not to hide underlying decorations.",
+			"Incoming content background in inline merge-conflicts. The color must not be opaque so as not to hide underlying decorations.",
+			"Common ancestor header background in inline merge-conflicts. The color must not be opaque so as not to hide underlying decorations.",
+			"Common ancestor content background in inline merge-conflicts. The color must not be opaque so as not to hide underlying decorations.",
+			"Border color on headers and the splitter in inline merge-conflicts.",
+			"Current overview ruler foreground for inline merge-conflicts.",
+			"Incoming overview ruler foreground for inline merge-conflicts.",
+			"Common ancestor overview ruler foreground for inline merge-conflicts.",
+			"Overview ruler marker color for find matches. The color must not be opaque so as not to hide underlying decorations.",
+			"Overview ruler marker color for selection highlights. The color must not be opaque so as not to hide underlying decorations.",
+			"Minimap marker color for find matches.",
+			"Minimap marker color for the editor selection.",
+			"Minimap marker color for errors.",
+			"Minimap marker color for warnings.",
+			"Minimap background color.",
+			"Minimap slider background color.",
+			"Minimap slider background color when hovering.",
+			"Minimap slider background color when clicked on.",
+			"The color used for the problems error icon.",
+			"The color used for the problems warning icon.",
+			"The color used for the problems info icon.",
+			"The foreground color used in charts.",
+			"The color used for horizontal lines in charts.",
+			"The red color used in chart visualizations.",
+			"The blue color used in chart visualizations.",
+			"The yellow color used in chart visualizations.",
+			"The orange color used in chart visualizations.",
+			"The green color used in chart visualizations.",
+			"The purple color used in chart visualizations."
+		],
+		"vs/workbench/common/theme": [
+			"Active tab background color in an active group. Tabs are the containers for editors in the editor area. Multiple tabs can be opened in one editor group. There can be multiple editor groups.",
+			"Active tab background color in an unfocused group. Tabs are the containers for editors in the editor area. Multiple tabs can be opened in one editor group. There can be multiple editor groups.",
+			"Inactive tab background color in an active group. Tabs are the containers for editors in the editor area. Multiple tabs can be opened in one editor group. There can be multiple editor groups.",
+			"Inactive tab background color in an unfocused group. Tabs are the containers for editors in the editor area. Multiple tabs can be opened in one editor group. There can be multiple editor groups.",
+			"Active tab foreground color in an active group. Tabs are the containers for editors in the editor area. Multiple tabs can be opened in one editor group. There can be multiple editor groups.",
+			"Inactive tab foreground color in an active group. Tabs are the containers for editors in the editor area. Multiple tabs can be opened in one editor group. There can be multiple editor groups.",
+			"Active tab foreground color in an unfocused group. Tabs are the containers for editors in the editor area. Multiple tabs can be opened in one editor group. There can be multiple editor groups.",
+			"Inactive tab foreground color in an unfocused group. Tabs are the containers for editors in the editor area. Multiple tabs can be opened in one editor group. There can be multiple editor groups.",
+			"Tab background color when hovering. Tabs are the containers for editors in the editor area. Multiple tabs can be opened in one editor group. There can be multiple editor groups.",
+			"Tab background color in an unfocused group when hovering. Tabs are the containers for editors in the editor area. Multiple tabs can be opened in one editor group. There can be multiple editor groups.",
+			"Tab foreground color when hovering. Tabs are the containers for editors in the editor area. Multiple tabs can be opened in one editor group. There can be multiple editor groups.",
+			"Tab foreground color in an unfocused group when hovering. Tabs are the containers for editors in the editor area. Multiple tabs can be opened in one editor group. There can be multiple editor groups.",
+			"Border to separate tabs from each other. Tabs are the containers for editors in the editor area. Multiple tabs can be opened in one editor group. There can be multiple editor groups.",
+			"Border to separate pinned tabs from other tabs. Tabs are the containers for editors in the editor area. Multiple tabs can be opened in one editor group. There can be multiple editor groups.",
+			"Border on the bottom of an active tab. Tabs are the containers for editors in the editor area. Multiple tabs can be opened in one editor group. There can be multiple editor groups.",
+			"Border on the bottom of an active tab in an unfocused group. Tabs are the containers for editors in the editor area. Multiple tabs can be opened in one editor group. There can be multiple editor groups.",
+			"Border to the top of an active tab. Tabs are the containers for editors in the editor area. Multiple tabs can be opened in one editor group. There can be multiple editor groups.",
+			"Border to the top of an active tab in an unfocused group. Tabs are the containers for editors in the editor area. Multiple tabs can be opened in one editor group. There can be multiple editor groups.",
+			"Border to highlight tabs when hovering. Tabs are the containers for editors in the editor area. Multiple tabs can be opened in one editor group. There can be multiple editor groups.",
+			"Border to highlight tabs in an unfocused group when hovering. Tabs are the containers for editors in the editor area. Multiple tabs can be opened in one editor group. There can be multiple editor groups.",
+			"Border on the top of modified (dirty) active tabs in an active group. Tabs are the containers for editors in the editor area. Multiple tabs can be opened in one editor group. There can be multiple editor groups.",
+			"Border on the top of modified (dirty) inactive tabs in an active group. Tabs are the containers for editors in the editor area. Multiple tabs can be opened in one editor group. There can be multiple editor groups.",
+			"Border on the top of modified (dirty) active tabs in an unfocused group. Tabs are the containers for editors in the editor area. Multiple tabs can be opened in one editor group. There can be multiple editor groups.",
+			"Border on the top of modified (dirty) inactive tabs in an unfocused group. Tabs are the containers for editors in the editor area. Multiple tabs can be opened in one editor group. There can be multiple editor groups.",
+			"Background color of the editor pane visible on the left and right side of the centered editor layout.",
+			"Deprecated background color of an editor group.",
+			"Deprecated: Background color of an editor group is no longer being supported with the introduction of the grid editor layout. You can use editorGroup.emptyBackground to set the background color of empty editor groups.",
+			"Background color of an empty editor group. Editor groups are the containers of editors.",
+			"Border color of an empty editor group that is focused. Editor groups are the containers of editors.",
+			"Background color of the editor group title header when tabs are enabled. Editor groups are the containers of editors.",
+			"Border color of the editor group title header when tabs are enabled. Editor groups are the containers of editors.",
+			"Background color of the editor group title header when tabs are disabled (`\"workbench.editor.showTabs\": false`). Editor groups are the containers of editors.",
+			"Border color of the editor group title header. Editor groups are the containers of editors.",
+			"Color to separate multiple editor groups from each other. Editor groups are the containers of editors.",
+			"Background color when dragging editors around. The color should have transparency so that the editor contents can still shine through.",
+			"Border color for image in image preview.",
+			"Panel background color. Panels are shown below the editor area and contain views like output and integrated terminal.",
+			"Panel border color to separate the panel from the editor. Panels are shown below the editor area and contain views like output and integrated terminal.",
+			"Title color for the active panel. Panels are shown below the editor area and contain views like output and integrated terminal.",
+			"Title color for the inactive panel. Panels are shown below the editor area and contain views like output and integrated terminal.",
+			"Border color for the active panel title. Panels are shown below the editor area and contain views like output and integrated terminal.",
+			"Input box border for inputs in the panel.",
+			"Drag and drop feedback color for the panel titles. Panels are shown below the editor area and contain views like output and integrated terminal.",
+			"Drag and drop feedback color for the panel sections. The color should have transparency so that the panel sections can still shine through. Panels are shown below the editor area and contain views like output and integrated terminal. Panel sections are views nested within the panels.",
+			"Panel section header background color. Panels are shown below the editor area and contain views like output and integrated terminal. Panel sections are views nested within the panels.",
+			"Panel section header foreground color. Panels are shown below the editor area and contain views like output and integrated terminal. Panel sections are views nested within the panels.",
+			"Panel section header border color used when multiple views are stacked vertically in the panel. Panels are shown below the editor area and contain views like output and integrated terminal. Panel sections are views nested within the panels.",
+			"Panel section border color used when multiple views are stacked horizontally in the panel. Panels are shown below the editor area and contain views like output and integrated terminal. Panel sections are views nested within the panels.",
+			"Status bar foreground color when a workspace or folder is opened. The status bar is shown in the bottom of the window.",
+			"Status bar foreground color when no folder is opened. The status bar is shown in the bottom of the window.",
+			"Status bar background color when a workspace or folder is opened. The status bar is shown in the bottom of the window.",
+			"Status bar background color when no folder is opened. The status bar is shown in the bottom of the window.",
+			"Status bar border color separating to the sidebar and editor. The status bar is shown in the bottom of the window.",
+			"Status bar border color separating to the sidebar and editor when no folder is opened. The status bar is shown in the bottom of the window.",
+			"Status bar item background color when clicking. The status bar is shown in the bottom of the window.",
+			"Status bar item background color when hovering. The status bar is shown in the bottom of the window.",
+			"Status bar prominent items foreground color. Prominent items stand out from other status bar entries to indicate importance. Change mode `Toggle Tab Key Moves Focus` from command palette to see an example. The status bar is shown in the bottom of the window.",
+			"Status bar prominent items background color. Prominent items stand out from other status bar entries to indicate importance. Change mode `Toggle Tab Key Moves Focus` from command palette to see an example. The status bar is shown in the bottom of the window.",
+			"Status bar prominent items background color when hovering. Prominent items stand out from other status bar entries to indicate importance. Change mode `Toggle Tab Key Moves Focus` from command palette to see an example. The status bar is shown in the bottom of the window.",
+			"Status bar error items background color. Error items stand out from other status bar entries to indicate error conditions. The status bar is shown in the bottom of the window.",
+			"Status bar error items foreground color. Error items stand out from other status bar entries to indicate error conditions. The status bar is shown in the bottom of the window.",
+			"Activity bar background color. The activity bar is showing on the far left or right and allows to switch between views of the side bar.",
+			"Activity bar item foreground color when it is active. The activity bar is showing on the far left or right and allows to switch between views of the side bar.",
+			"Activity bar item foreground color when it is inactive. The activity bar is showing on the far left or right and allows to switch between views of the side bar.",
+			"Activity bar border color separating to the side bar. The activity bar is showing on the far left or right and allows to switch between views of the side bar.",
+			"Activity bar border color for the active item. The activity bar is showing on the far left or right and allows to switch between views of the side bar.",
+			"Activity bar focus border color for the active item. The activity bar is showing on the far left or right and allows to switch between views of the side bar.",
+			"Activity bar background color for the active item. The activity bar is showing on the far left or right and allows to switch between views of the side bar.",
+			"Drag and drop feedback color for the activity bar items. The activity bar is showing on the far left or right and allows to switch between views of the side bar.",
+			"Activity notification badge background color. The activity bar is showing on the far left or right and allows to switch between views of the side bar.",
+			"Activity notification badge foreground color. The activity bar is showing on the far left or right and allows to switch between views of the side bar.",
+			"Background color for the remote indicator on the status bar.",
+			"Foreground color for the remote indicator on the status bar.",
+			"Background color for the remote badge in the extensions view.",
+			"Foreground color for the remote badge in the extensions view.",
+			"Side bar background color. The side bar is the container for views like explorer and search.",
+			"Side bar foreground color. The side bar is the container for views like explorer and search.",
+			"Side bar border color on the side separating to the editor. The side bar is the container for views like explorer and search.",
+			"Side bar title foreground color. The side bar is the container for views like explorer and search.",
+			"Drag and drop feedback color for the side bar sections. The color should have transparency so that the side bar sections can still shine through. The side bar is the container for views like explorer and search. Side bar sections are views nested within the side bar.",
+			"Side bar section header background color. The side bar is the container for views like explorer and search. Side bar sections are views nested within the side bar.",
+			"Side bar section header foreground color. The side bar is the container for views like explorer and search. Side bar sections are views nested within the side bar.",
+			"Side bar section header border color. The side bar is the container for views like explorer and search. Side bar sections are views nested within the side bar.",
+			"Title bar foreground when the window is active.",
+			"Title bar foreground when the window is inactive.",
+			"Title bar background when the window is active.",
+			"Title bar background when the window is inactive.",
+			"Title bar border color.",
+			"Foreground color of the selected menu item in the menubar.",
+			"Background color of the selected menu item in the menubar.",
+			"Border color of the selected menu item in the menubar.",
+			"Notifications center border color. Notifications slide in from the bottom right of the window.",
+			"Notification toast border color. Notifications slide in from the bottom right of the window.",
+			"Notifications foreground color. Notifications slide in from the bottom right of the window.",
+			"Notifications background color. Notifications slide in from the bottom right of the window.",
+			"Notification links foreground color. Notifications slide in from the bottom right of the window.",
+			"Notifications center header foreground color. Notifications slide in from the bottom right of the window.",
+			"Notifications center header background color. Notifications slide in from the bottom right of the window.",
+			"Notifications border color separating from other notifications in the notifications center. Notifications slide in from the bottom right of the window.",
+			"The color used for the icon of error notifications. Notifications slide in from the bottom right of the window.",
+			"The color used for the icon of warning notifications. Notifications slide in from the bottom right of the window.",
+			"The color used for the icon of info notifications. Notifications slide in from the bottom right of the window.",
+			"The color used for the border of the window when it is active. Only supported in the desktop client when using the custom title bar.",
+			"The color used for the border of the window when it is inactive. Only supported in the desktop client when using the custom title bar."
+		],
+		"vs/workbench/contrib/debug/common/debug": [
+			"Controls when the internal debug console should open."
+		],
+		"vs/workbench/contrib/webview/electron-browser/webviewCommands": [
+			"Open Webview Developer Tools"
+		],
+		"vs/editor/contrib/clipboard/clipboard": [
+			"Cu&&t",
+			"Cut",
+			"Cut",
+			"&&Copy",
+			"Copy",
+			"Copy",
+			"&&Paste",
+			"Paste",
+			"Paste",
+			"Copy With Syntax Highlighting"
+		],
+		"vs/editor/browser/editorExtensions": [
+			"&&Undo",
+			"Undo",
+			"&&Redo",
+			"Redo",
+			"&&Select All",
+			"Select All"
+		],
+		"vs/workbench/contrib/notebook/browser/contrib/coreActions": [
+			"Notebook",
+			"Execute Cell",
+			"Execute Cell",
+			"Stop Cell Execution",
+			"Stop Cell Execution",
+			"Execute Cell",
+			"Cancel Execution",
+			"Delete Cell",
+			"Execute Notebook Cell and Select Below",
+			"Execute Notebook Cell and Insert Below",
+			"Render All Markdown Cells",
+			"Execute Notebook",
+			"Execute Notebook",
+			"Cancel Notebook Execution",
+			"Cancel Notebook Execution",
+			"Insert Cell",
+			"Notebook Cell",
+			"Execute Notebook (Run all cells)",
+			"Stop Notebook Execution",
+			"Change Cell to Code",
+			"Change Cell to Markdown",
+			"Insert Code Cell Above",
+			"Insert Code Cell Below",
+			"Add Code Cell At Top",
+			"Add Markdown Cell At Top",
+			"$(add) Code",
+			"Add Code Cell",
+			"$(add) Code",
+			"Add Code Cell",
+			"Insert Markdown Cell Above",
+			"Insert Markdown Cell Below",
+			"$(add) Markdown",
+			"Add Markdown Cell",
+			"$(add) Markdown",
+			"Add Markdown Cell",
+			"Edit Cell",
+			"Stop Editing Cell",
+			"Delete Cell",
+			"Move Cell Up",
+			"Move Cell Down",
+			"Copy Cell",
+			"Cut Cell",
+			"Paste Cell",
+			"Paste Cell Above",
+			"Copy Cell Up",
+			"Copy Cell Down",
+			"Focus Next Cell Editor",
+			"Focus Previous Cell Editor",
+			"Focus In Active Cell Output",
+			"Focus Out Active Cell Output",
+			"Focus First Cell",
+			"Focus Last Cell",
+			"Clear Cell Outputs",
+			"Change Cell Language",
+			"({0}) - Current Language",
+			"({0})",
+			"Select Language Mode",
+			"Clear All Cells Outputs",
+			"Split Cell",
+			"Join With Previous Cell",
+			"Join With Next Cell",
+			"Center Active Cell",
+			"Collapse Cell Input",
+			"Expand Cell Content",
+			"Collapse Cell Output",
+			"Expand Cell Output",
+			"Inspect Notebook Layout"
+		],
+		"vs/workbench/contrib/extensions/electron-browser/runtimeExtensionsEditor": [
+			"Start Extension Host Profile",
+			"Stop Extension Host Profile",
+			"Save Extension Host Profile"
+		],
+		"vs/workbench/contrib/extensions/electron-browser/debugExtensionHostAction": [
+			"Start Debugging Extension Host",
+			"Profile Extensions",
+			"In order to profile extensions a restart is required. Do you want to restart '{0}' now?",
+			"&&Restart",
+			"&&Cancel",
+			"Attach Extension Host"
+		],
+		"vs/workbench/common/editor": [
+			"{0} - {1}",
+			"{0}, preview",
+			"{0}, pinned"
+		],
+		"vs/workbench/contrib/extensions/electron-browser/extensionProfileService": [
+			"Profiling Extension Host",
+			"Profiling Extension Host",
+			"Click to stop profiling.",
+			"Profiling Extension Host ({0} sec)",
+			"Extension Profiler",
+			"Profile Extensions",
+			"In order to profile extensions a restart is required. Do you want to restart '{0}' now?",
+			"&&Restart",
+			"&&Cancel"
+		],
+		"vs/workbench/contrib/extensions/common/runtimeExtensionsInput": [
+			"Running Extensions"
+		],
+		"vs/workbench/contrib/extensions/electron-browser/extensionsAutoProfiler": [
+			"The extension '{0}' took a very long time to complete its last operation and it has prevented other extensions from running.",
+			"Show Extensions"
+		],
+		"vs/workbench/contrib/extensions/electron-sandbox/extensionsActions": [
+			"Open Extensions Folder"
+		],
+		"vs/platform/configuration/common/configurationRegistry": [
+			"Default Language Configuration Overrides",
+			"Configure settings to be overridden for {0} language.",
+			"Configure editor settings to be overridden for a language.",
+			"This setting does not support per-language configuration.",
+			"Cannot register an empty property",
+			"Cannot register '{0}'. This matches property pattern '\\\\[.*\\\\]$' for describing language specific editor settings. Use 'configurationDefaults' contribution.",
+			"Cannot register '{0}'. This property is already registered."
+		],
+		"vs/workbench/contrib/terminal/common/terminalConfiguration": [
+			"Integrated Terminal",
+			"Dispatches most keybindings to the terminal instead of the workbench, overriding `#terminal.integrated.commandsToSkipShell#`, which can be used alternatively for fine tuning.",
+			"A path that when set will override {0} and ignore {1} values for automation-related terminal usage like tasks and debug.",
+			"A path that when set will override {0} and ignore {1} values for automation-related terminal usage like tasks and debug.",
+			"A path that when set will override {0} and ignore {1} values for automation-related terminal usage like tasks and debug.",
+			"The command line arguments to use when on the Linux terminal. [Read more about configuring the shell](https://code.visualstudio.com/docs/editor/integrated-terminal#_configuration).",
+			"The command line arguments to use when on the macOS terminal. [Read more about configuring the shell](https://code.visualstudio.com/docs/editor/integrated-terminal#_configuration).",
+			"The command line arguments to use when on the Windows terminal. [Read more about configuring the shell](https://code.visualstudio.com/docs/editor/integrated-terminal#_configuration).",
+			"The command line arguments to use when on the Windows terminal. [Read more about configuring the shell](https://code.visualstudio.com/docs/editor/integrated-terminal#_configuration).",
+			"The command line arguments in [command-line format](https://msdn.microsoft.com/en-au/08dfcab2-eb6e-49a4-80eb-87d4076c98c6) to use when on the Windows terminal. [Read more about configuring the shell](https://code.visualstudio.com/docs/editor/integrated-terminal#_configuration).",
+			"Controls whether to treat the option key as the meta key in the terminal on macOS.",
+			"Controls whether to force selection when using Option+click on macOS. This will force a regular (line) selection and disallow the use of column selection mode. This enables copying and pasting using the regular terminal selection, for example, when mouse mode is enabled in tmux.",
+			"If enabled, alt/option + click will reposition the prompt cursor to underneath the mouse when `#editor.multiCursorModifier#` is set to `'alt'` (the default value). This may not work reliably depending on your shell.",
+			"Controls whether text selected in the terminal will be copied to the clipboard.",
+			"Controls whether bold text in the terminal will always use the \"bright\" ANSI color variant.",
+			"Controls the font family of the terminal, this defaults to `#editor.fontFamily#`'s value.",
+			"Controls the font size in pixels of the terminal.",
+			"Controls the letter spacing of the terminal, this is an integer value which represents the amount of additional pixels to add between characters.",
+			"Controls the line height of the terminal, this number is multiplied by the terminal font size to get the actual line-height in pixels.",
+			"When set the foreground color of each cell will change to try meet the contrast ratio specified. Example values:\n\n- 1: The default, do nothing.\n- 4.5: [WCAG AA compliance (minimum)](https://www.w3.org/TR/UNDERSTANDING-WCAG20/visual-audio-contrast-contrast.html).\n- 7: [WCAG AAA compliance (enhanced)](https://www.w3.org/TR/UNDERSTANDING-WCAG20/visual-audio-contrast7.html).\n- 21: White on black or black on white.",
+			"Scrolling speed multiplier when pressing `Alt`.",
+			"A multiplier to be used on the `deltaY` of mouse wheel scroll events.",
+			"Only \"normal\" and \"bold\" keywords or numbers between 1 and 1000 are allowed.",
+			"The font weight to use within the terminal for non-bold text. Accepts \"normal\" and \"bold\" keywords or numbers between 1 and 1000.",
+			"Only \"normal\" and \"bold\" keywords or numbers between 1 and 1000 are allowed.",
+			"The font weight to use within the terminal for bold text. Accepts \"normal\" and \"bold\" keywords or numbers between 1 and 1000.",
+			"Controls whether the terminal cursor blinks.",
+			"Controls the style of terminal cursor.",
+			"Controls the width of the cursor when `#terminal.integrated.cursorStyle#` is set to `line`.",
+			"Controls the maximum amount of lines the terminal keeps in its buffer.",
+			"Controls whether to detect and set the `$LANG` environment variable to a UTF-8 compliant option since VS Code's terminal only supports UTF-8 encoded data coming from the shell.",
+			"Set the `$LANG` environment variable if the existing variable does not exist or it does not end in `'.UTF-8'`.",
+			"Do not set the `$LANG` environment variable.",
+			"Always set the `$LANG` environment variable.",
+			"Let VS Code guess which renderer to use.",
+			"Use the standard GPU/canvas-based renderer.",
+			"Use the fallback DOM-based renderer.",
+			"Use the experimental webgl-based renderer. Note that this has some [known issues](https://github.com/xtermjs/xterm.js/issues?q=is%3Aopen+is%3Aissue+label%3Aarea%2Faddon%2Fwebgl).",
+			"Controls how the terminal is rendered.",
+			"Show the context menu.",
+			"Copy when there is a selection, otherwise paste.",
+			"Paste on right click.",
+			"Select the word under the cursor and show the context menu.",
+			"Controls how terminal reacts to right click.",
+			"An explicit start path where the terminal will be launched, this is used as the current working directory (cwd) for the shell process. This may be particularly useful in workspace settings if the root directory is not a convenient cwd.",
+			"Controls whether to confirm on exit if there are active terminal sessions.",
+			"Controls whether the terminal bell is enabled.",
+			"A set of command IDs whose keybindings will not be sent to the shell but instead always be handled by VS Code. This allows keybindings that would normally be consumed by the shell to act instead the same as when the terminal is not focused, for example `Ctrl+P` to launch Quick Open.\n\n&nbsp;\n\nMany commands are skipped by default. To override a default and pass that command's keybinding to the shell instead, add the command prefixed with the `-` character. For example add `-workbench.action.quickOpen` to allow `Ctrl+P` to reach the shell.\n\n&nbsp;\n\nThe following list of default skipped commands is truncated when viewed in Settings Editor. To see the full list, [open the default settings JSON](command:workbench.action.openRawDefaultSettings 'Open Default Settings (JSON)') and search for the first command from the list below.\n\n&nbsp;\n\nDefault Skipped Commands:\n\n{0}",
+			"Whether or not to allow chord keybindings in the terminal. Note that when this is true and the keystroke results in a chord it will bypass `#terminal.integrated.commandsToSkipShell#`, setting this to false is particularly useful when you want ctrl+k to go to your shell (not VS Code).",
+			"Whether to allow menubar mnemonics (eg. alt+f) to trigger the open the menubar. Note that this will cause all alt keystrokes to skip the shell when true. This does nothing on macOS.",
+			"Whether new shells should inherit their environment from VS Code. This is not supported on Windows.",
+			"Object with environment variables that will be added to the VS Code process to be used by the terminal on macOS. Set to `null` to delete the environment variable.",
+			"Object with environment variables that will be added to the VS Code process to be used by the terminal on Linux. Set to `null` to delete the environment variable.",
+			"Object with environment variables that will be added to the VS Code process to be used by the terminal on Windows. Set to `null` to delete the environment variable.",
+			"Whether to display the environment changes indicator on each terminal which explains whether extensions have made, or want to make changes to the terminal's environment.",
+			"Disable the indicator.",
+			"Enable the indicator.",
+			"Only show the warning indicator when a terminal's environment is 'stale', not the information indicator that shows a terminal has had its environment modified by an extension.",
+			"Controls whether to show the alert \"The terminal process terminated with exit code\" when exit code is non-zero.",
+			"Controls the working directory a split terminal starts with.",
+			"A new split terminal will use the workspace root as the working directory. In a multi-root workspace a choice for which root folder to use is offered.",
+			"A new split terminal will use the working directory that the parent terminal started with.",
+			"On macOS and Linux, a new split terminal will use the working directory of the parent terminal. On Windows, this behaves the same as initial.",
+			"Whether to use ConPTY for Windows terminal process communication (requires Windows 10 build number 18309+). Winpty will be used if this is false.",
+			"A string containing all characters to be considered word separators by the double click to select word feature.",
+			"An experimental setting that will use the terminal title event for the dropdown title. This setting will only apply to new terminals.",
+			"Whether to enable file links in the terminal. Links can be slow when working on a network drive in particular because each file link is verified against the file system. Changing this will take effect only in new terminals.",
+			"Version 6 of unicode, this is an older version which should work better on older systems.",
+			"Version 11 of unicode, this version provides better support on modern systems that use modern versions of unicode.",
+			"Controls what version of unicode to use when evaluating the width of characters in the terminal. If you experience emoji or other wide characters not taking up the right amount of space or backspace either deleting too much or too little then you may want to try tweaking this setting.",
+			"An experimental setting that aims to improve link detection in the terminal by improving when links are detected and by enabling shared link detection with the editor. Currently this only supports web links.",
+			"Experimental: length of network delay, in milliseconds, where local edits will be echoed on the terminal without waiting for server acknowledgement. If '0', local echo will always be on, and if '-1' it will be disabled.",
+			"Experimental: local echo will be disabled when any of these program names are found in the terminal title.",
+			"Experimental: terminal style of locally echoed text; either a font style or an RGB color.",
+			"Experimental: spawn remote terminals from the remote agent process instead of the remote extension host",
+			"Experimental: persist terminal sessions for the workspace across window reloads. Currently only supported in VS Code Remote workspaces.",
+			"Experimental: whether to enable flow control which will slow the program on the remote side to avoid flooding remote connections with terminal output. This setting has no effect for local terminals and terminals where the output/input is controlled by an extension. Changing this will only affect new terminals.",
+			"Integrated Terminal",
+			"The path of the shell that the terminal uses on Linux. [Read more about configuring the shell](https://code.visualstudio.com/docs/editor/integrated-terminal#_configuration).",
+			"The path of the shell that the terminal uses on macOS. [Read more about configuring the shell](https://code.visualstudio.com/docs/editor/integrated-terminal#_configuration).",
+			"The path of the shell that the terminal uses on Windows. [Read more about configuring the shell](https://code.visualstudio.com/docs/editor/integrated-terminal#_configuration).",
+			"The path of the shell that the terminal uses on Linux (default: {0}). [Read more about configuring the shell](https://code.visualstudio.com/docs/editor/integrated-terminal#_configuration).",
+			"The path of the shell that the terminal uses on macOS (default: {0}). [Read more about configuring the shell](https://code.visualstudio.com/docs/editor/integrated-terminal#_configuration).",
+			"The path of the shell that the terminal uses on Windows (default: {0}). [Read more about configuring the shell](https://code.visualstudio.com/docs/editor/integrated-terminal#_configuration)."
+		],
+		"vs/workbench/contrib/codeEditor/electron-browser/startDebugTextMate": [
+			"Start Text Mate Syntax Grammar Logging"
+		],
+		"vs/workbench/contrib/terminal/common/terminal": [
+			"Terminal",
+			"Contributes terminal functionality.",
+			"Defines additional terminal types that the user can create.",
+			"Command to execute when the user creates this type of terminal.",
+			"Title for this type of terminal."
+		],
+		"vs/workbench/contrib/externalTerminal/node/externalTerminalService": [
+			"VS Code Console",
+			"Script '{0}' failed with exit code {1}",
+			"'{0}' not supported",
+			"Press any key to continue...",
+			"'{0}' failed with exit code {1}",
+			"can't find terminal application '{0}'"
+		],
+		"vs/workbench/contrib/performance/electron-browser/startupProfiler": [
+			"Successfully created profiles.",
+			"Please create an issue and manually attach the following files:\n{0}",
+			"&&Create Issue and Restart",
+			"&&Restart",
+			"Thanks for helping us.",
+			"A final restart is required to continue to use '{0}'. Again, thank you for your contribution.",
+			"&&Restart"
+		],
+		"vs/workbench/contrib/tasks/common/tasks": [
+			"Tasks",
+			"Error: the task identifier '{0}' is missing the required property '{1}'. The task identifier will be ignored."
+		],
+		"vs/workbench/contrib/tasks/common/taskConfiguration": [
+			"Warning: options.cwd must be of type string. Ignoring value {0}\n",
+			"Error: command argument must either be a string or a quoted string. Provided value is:\n{0}",
+			"Warning: shell configuration is only supported when executing tasks in the terminal.",
+			"Error: Problem Matcher in declare scope must have a name:\n{0}\n",
+			"Warning: the defined problem matcher is unknown. Supported types are string | ProblemMatcher | Array<string | ProblemMatcher>.\n{0}\n",
+			"Error: Invalid problemMatcher reference: {0}\n",
+			"Error: tasks configuration must have a type property. The configuration will be ignored.\n{0}\n",
+			"Error: there is no registered task type '{0}'. Did you miss to install an extension that provides a corresponding task provider?",
+			"Error: the task configuration '{0}' is missing the required property 'type'. The task configuration will be ignored.",
+			"Error: the task configuration '{0}' is using an unknown type. The task configuration will be ignored.",
+			"Error: tasks is not declared as a custom task. The configuration will be ignored.\n{0}\n",
+			"Error: a task must provide a label property. The task will be ignored.\n{0}\n",
+			"Warning: {0} tasks are unavailable in the current environment.\n",
+			"Error: the task '{0}' neither specifies a command nor a dependsOn property. The task will be ignored. Its definition is:\n{1}",
+			"Error: the task '{0}' doesn't define a command. The task will be ignored. Its definition is:\n{1}",
+			"Task version 2.0.0 doesn't support global OS specific tasks. Convert them to a task with a OS specific command. Affected tasks are:\n{0}"
+		],
+		"vs/workbench/contrib/tasks/node/processTaskSystem": [
+			"The task system is configured for version 0.1.0 (see tasks.json file), which can only execute custom tasks. Upgrade to version 2.0.0 to run the task: {0}",
+			"A unknown error has occurred while executing a task. See task output log for details.",
+			"\nWatching build tasks has finished.",
+			"Failed to launch external program {0} {1}.",
+			"\nThe task '{0}' was terminated per user request.",
+			"Problem matcher {0} can't be resolved. The matcher will be ignored"
+		],
+		"vs/workbench/contrib/tasks/node/processRunnerDetector": [
+			"Running gulp --tasks-simple didn't list any tasks. Did you run npm install?",
+			"Running jake --tasks didn't list any tasks. Did you run npm install?",
+			"Gulp is not installed on your system. Run npm install -g gulp to install it.",
+			"Jake is not installed on your system. Run npm install -g jake to install it.",
+			"Grunt is not installed on your system. Run npm install -g grunt to install it.",
+			"Program {0} was not found. Message is {1}",
+			"Build task named '{0}' detected.",
+			"Test task named '{0}' detected."
+		],
+		"vs/platform/markers/common/markers": [
+			"Error",
+			"Warning",
+			"Info"
+		],
+		"vs/workbench/common/views": [
+			"Default view icon.",
+			"A view with id '{0}' is already registered"
+		],
+		"vs/workbench/contrib/tasks/browser/terminalTaskSystem": [
+			"A unknown error has occurred while executing a task. See task output log for details.",
+			"There is a dependency cycle. See task \"{0}\".",
+			"Couldn't resolve dependent task '{0}' in workspace folder '{1}'",
+			"Task {0} is a background task but uses a problem matcher without a background pattern",
+			"Task - {0}",
+			"Press any key to close the terminal.",
+			"Terminal will be reused by tasks, press any key to close it.",
+			"Can't execute a shell command on an UNC drive using cmd.exe.",
+			"Problem matcher {0} can't be resolved. The matcher will be ignored"
+		],
+		"vs/workbench/contrib/tasks/browser/abstractTaskService": [
+			"Configure Task",
+			"Tasks",
+			"Changing the task execution engine with an active task running requires to reload the Window",
+			"Reload Window",
+			"Select the build task (there is no default build task defined)",
+			"There are task errors. See the output for details.",
+			"Show output",
+			"The folder {0} is ignored since it uses task version 0.1.0",
+			"Warning: {0} tasks are unavailable in the current environment.\n",
+			"No build task defined. Mark a task with 'isBuildCommand' in the tasks.json file.",
+			"No build task defined. Mark a task with as a 'build' group in the tasks.json file.",
+			"No test task defined. Mark a task with 'isTestCommand' in the tasks.json file.",
+			"No test task defined. Mark a task with as a 'test' group in the tasks.json file.",
+			"Task to execute is undefined",
+			"associate",
+			"Continue without scanning the task output",
+			"Never scan the task output for this task",
+			"Never scan the task output for {0} tasks",
+			"Learn more about scanning the task output",
+			"Select for which kind of errors and warnings to scan the task output",
+			"The current task configuration has errors. Please fix the errors first before customizing a task.",
+			"\t// See https://go.microsoft.com/fwlink/?LinkId=733558 \n\t// for the documentation about the tasks.json format",
+			"There are many build tasks defined in the tasks.json. Executing the first one.\n",
+			"Save all editors?",
+			"Save",
+			"Don't save",
+			"Do you want to save all editors before running the task?",
+			"The task '{0}' is already active.",
+			"Terminate Task",
+			"Restart Task",
+			"There is already a task running. Terminate it first before executing another task.",
+			"Failed to terminate and restart task {0}",
+			"The task provider for \"{0}\" tasks unexpectedly provided a task of type \"{1}\".\n",
+			"Warning: {0} tasks are unavailable in the current environment.\n",
+			"Error: The {0} task detection didn't contribute a task for the following configuration:\n{1}\nThe task will be ignored.\n",
+			"Error: the provided task configuration has validation errors and can't not be used. Please correct the errors first.",
+			"Error: The content of the tasks json in {0} has syntax errors. Please correct them before executing a task.\n",
+			"workspace file",
+			"Only tasks version 2.0.0 permitted in workspace configuration files.",
+			"user settings",
+			"Only tasks version 2.0.0 permitted in user settings.",
+			"Error: the provided task configuration has validation errors and can't not be used. Please correct the errors first.",
+			"Ignoring task configurations for workspace folder {0}. Multi folder workspace task support requires that all folders use task version 2.0.0\n",
+			"Error: The content of the tasks.json file has syntax errors. Please correct them before executing a task.\n",
+			"Terminate Task",
+			"An error has occurred while running a task. See task log for details.",
+			"Configure Task",
+			"recently used tasks",
+			"configured tasks",
+			"detected tasks",
+			"The following workspace folders are ignored since they use task version 0.1.0: {0}",
+			"Don't Show Again",
+			"Select the task to run",
+			"$(plus) Configure a Task",
+			"$(plus) Configure a Task",
+			"Fetching build tasks...",
+			"Select the build task to run",
+			"No build task to run found. Configure Build Task...",
+			"Fetching test tasks...",
+			"Select the test task to run",
+			"No test task to run found. Configure Tasks...",
+			"Select a task to terminate",
+			"No task is currently running",
+			"All Running Tasks",
+			"The launched process doesn't exist anymore. If the task spawned background tasks exiting VS Code might result in orphaned processes.",
+			"Failed to terminate running task",
+			"Select the task to restart",
+			"No task to restart",
+			"Select a Task Template",
+			"User Settings",
+			"Create tasks.json file from template",
+			"Open tasks.json file",
+			"Select a task to configure",
+			"{0} is already marked as the default build task",
+			"Select the task to be used as the default build task",
+			"{0} is already marked as the default test task.",
+			"Select the task to be used as the default test task",
+			"Select the task to show its output",
+			"No task is running"
+		],
+		"vs/workbench/services/preferences/common/preferences": [
+			"User Settings",
+			"Workspace Settings"
+		],
+		"vs/base/common/actions": [
+			"(empty)"
+		],
+		"vs/workbench/services/userDataSync/common/userDataSync": [
+			"Settings",
+			"Keyboard Shortcuts",
+			"User Snippets",
+			"Extensions",
+			"UI State",
+			"Settings Sync",
+			"View icon of the settings sync view."
+		],
+		"vs/workbench/api/common/extHostExtensionService": [
+			"Path {0} does not point to a valid extension test runner."
+		],
+		"vs/workbench/api/common/extHostTerminalService": [
+			"Could not find the terminal with id {0} on the extension host"
+		],
+		"vs/workbench/api/common/extHostWorkspace": [
+			"Extension '{0}' failed to update workspace folders: {1}"
+		],
+		"vs/base/node/processes": [
+			"Can't execute a shell command on a UNC drive."
+		],
+		"vs/platform/windows/electron-main/windowsMainService": [
+			"OK",
+			"Path does not exist",
+			"URI can not be opened",
+			"The path '{0}' does not seem to exist anymore on disk.",
+			"The URI '{0}' is not valid and can not be opened."
+		],
+		"vs/platform/issue/electron-main/issueMainService": [
+			"Local",
+			"There is too much data to send to GitHub directly. The data will be copied to the clipboard, please paste it into the GitHub issue page that is opened.",
+			"OK",
+			"Cancel",
+			"Your input will not be saved. Are you sure you want to close this window?",
+			"Yes",
+			"Cancel",
+			"Issue Reporter",
+			"Process Explorer"
+		],
+		"vs/platform/workspaces/electron-main/workspacesHistoryMainService": [
+			"New Window",
+			"Opens a new window",
+			"{0} {1}",
+			"{0} {1}",
+			"Recent Folders & Workspaces",
+			"Recent Folders",
+			"Untitled (Workspace)",
+			"{0} (Workspace)"
+		],
+		"vs/platform/workspaces/electron-main/workspacesManagementMainService": [
+			"OK",
+			"Unable to save workspace '{0}'",
+			"The workspace is already opened in another window. Please close that window first and then try again."
+		],
+		"vs/platform/dialogs/electron-main/dialogMainService": [
+			"Open",
+			"Open Folder",
+			"Open File",
+			"Open Workspace",
+			"&&Open"
+		],
+		"vs/platform/files/common/io": [
+			"To open a file of this size, you need to restart and allow it to use more memory",
+			"File is too large to open"
+		],
+		"vs/base/node/zip": [
+			"Error extracting {0}. Invalid file.",
+			"Incomplete. Found {0} of {1} entries",
+			"{0} not found inside zip."
+		],
+		"vs/platform/extensions/common/extensionValidator": [
+			"Could not parse `engines.vscode` value {0}. Please use, for example: ^1.22.0, ^1.22.x, etc.",
+			"Version specified in `engines.vscode` ({0}) is not specific enough. For vscode versions before 1.0.0, please define at a minimum the major and minor desired version. E.g. ^0.10.0, 0.10.x, 0.11.0, etc.",
+			"Version specified in `engines.vscode` ({0}) is not specific enough. For vscode versions after 1.0.0, please define at a minimum the major desired version. E.g. ^1.10.0, 1.10.x, 1.x.x, 2.x.x, etc.",
+			"Extension is not compatible with Code {0}. Extension requires: {1}."
+		],
+		"vs/platform/extensionManagement/node/extensionManagementUtil": [
+			"VSIX invalid: package.json is not a JSON file."
+		],
+		"vs/platform/extensionManagement/node/extensionsScanner": [
+			"Unable to delete the existing folder '{0}' while installing the extension '{1}'. Please delete the folder manually and try again",
+			"Cannot read the extension from {0}",
+			"Unknown error while renaming {0} to {1}",
+			"Extension invalid: package.json is not a JSON file."
+		],
+		"vs/platform/userDataSync/common/keybindingsSync": [
+			"Unable to sync keybindings because the content in the file is not valid. Please open the file and correct it.",
+			"Unable to sync keybindings because the content in the file is not valid. Please open the file and correct it."
+		],
+		"vs/platform/userDataSync/common/settingsSync": [
+			"Unable to sync settings as there are errors/warning in settings file."
+		],
+		"vs/base/browser/ui/tree/abstractTree": [
+			"Clear",
+			"Disable Filter on Type",
+			"Enable Filter on Type",
+			"No elements found",
+			"Matched {0} out of {1} elements"
+		],
+		"vs/workbench/services/authentication/browser/authenticationService": [
+			"The id of the authentication provider.",
+			"The human readable name of the authentication provider.",
+			"Contributes authentication",
+			"Loading...",
+			"An authentication contribution must specify an id.",
+			"An authentication contribution must specify a label.",
+			"This authentication id '{0}' has already been registered",
+			"You are not signed in to any accounts",
+			"Loading...",
+			"Sign in requested",
+			"Sign in to use {0} (1)",
+			"Sign in requested"
+		],
+		"vs/platform/list/browser/listService": [
+			"Workbench",
+			"Maps to `Control` on Windows and Linux and to `Command` on macOS.",
+			"Maps to `Alt` on Windows and Linux and to `Option` on macOS.",
+			"The modifier to be used to add an item in trees and lists to a multi-selection with the mouse (for example in the explorer, open editors and scm view). The 'Open to Side' mouse gestures - if supported - will adapt such that they do not conflict with the multiselect modifier.",
+			"Controls how to open items in trees and lists using the mouse (if supported). For parents with children in trees, this setting will control if a single click expands the parent or a double click. Note that some trees and lists might choose to ignore this setting if it is not applicable. ",
+			"Controls whether lists and trees support horizontal scrolling in the workbench. Warning: turning on this setting has a performance implication.",
+			"Controls tree indentation in pixels.",
+			"Controls whether the tree should render indent guides.",
+			"Controls whether lists and trees have smooth scrolling.",
+			"Simple keyboard navigation focuses elements which match the keyboard input. Matching is done only on prefixes.",
+			"Highlight keyboard navigation highlights elements which match the keyboard input. Further up and down navigation will traverse only the highlighted elements.",
+			"Filter keyboard navigation will filter out and hide all the elements which do not match the keyboard input.",
+			"Controls the keyboard navigation style for lists and trees in the workbench. Can be simple, highlight and filter.",
+			"Controls whether keyboard navigation in lists and trees is automatically triggered simply by typing. If set to `false`, keyboard navigation is only triggered when executing the `list.toggleKeyboardNavigation` command, for which you can assign a keyboard shortcut.",
+			"Controls how tree folders are expanded when clicking the folder names."
+		],
+		"vs/workbench/browser/workbench.contribution": [
+			"The default size.",
+			"Increases the size, so it can be grabbed more easily with the mouse",
+			"Controls the height of the scrollbars used for tabs and breadcrumbs in the editor title area.",
+			"Controls whether opened editors should show in tabs or not.",
+			"Controls whether tabs should be wrapped over multiple lines when exceeding available space or whether a scrollbar should appear instead. This value is ignored when `#workbench.editor.showTabs#` is disabled.",
+			"Controls whether scrolling over tabs will open them or not. By default tabs will only reveal upon scrolling, but not open. You can press and hold the Shift-key while scrolling to change this behaviour for that duration. This value is ignored when `#workbench.editor.showTabs#` is disabled.",
+			"Controls whether a top border is drawn on modified (dirty) editor tabs or not. This value is ignored when `#workbench.editor.showTabs#` is disabled.",
+			"Controls whether editor file decorations should use badges.",
+			"Controls whether editor file decorations should use colors.",
+			"Show the name of the file. When tabs are enabled and two files have the same name in one group the distinguishing sections of each file's path are added. When tabs are disabled, the path relative to the workspace folder is shown if the editor is active.",
+			"Show the name of the file followed by its directory name.",
+			"Show the name of the file followed by its path relative to the workspace folder.",
+			"Show the name of the file followed by its absolute path.",
+			"Controls the format of the label for an editor.",
+			"The name of the untitled file is derived from the contents of its first line unless it has an associated file path. It will fallback to the name in case the line is empty or contains no word characters.",
+			"The name of the untitled file is not derived from the contents of the file.",
+			"Controls the format of the label for an untitled editor.",
+			"Controls the position of the editor's tabs close buttons, or disables them when set to 'off'. This value is ignored when `#workbench.editor.showTabs#` is disabled.",
+			"Always keep tabs large enough to show the full editor label.",
+			"Allow tabs to get smaller when the available space is not enough to show all tabs at once.",
+			"Controls the sizing of editor tabs. This value is ignored when `#workbench.editor.showTabs#` is disabled.",
+			"A pinned tab inherits the look of non pinned tabs.",
+			"A pinned tab will show in a compact form with only icon or first letter of the editor name.",
+			"A pinned tab shrinks to a compact fixed size showing parts of the editor name.",
+			"Controls the sizing of pinned editor tabs. Pinned tabs are sorted to the beginning of all opened tabs and typically do not close until unpinned. This value is ignored when `#workbench.editor.showTabs#` is disabled.",
+			"Splits all the editor groups to equal parts.",
+			"Splits the active editor group to equal parts.",
+			"Controls the sizing of editor groups when splitting them.",
+			"Controls if editor groups can be split from drag and drop operations by dropping an editor or file on the edges of the editor area.",
+			"Controls whether tabs are closed in most recently used order or from left to right.",
+			"Controls whether opened editors should show with an icon or not. This requires a file icon theme to be enabled as well.",
+			"Controls whether opened editors show as preview. Preview editors do not keep open and are reused until explicitly set to be kept open (e.g. via double click or editing) and show up with an italic font style.",
+			"Controls whether editors opened from Quick Open show as preview. Preview editors do not keep open and are reused until explicitly set to be kept open (e.g. via double click or editing). This value is ignored when `#workbench.editor.enablePreview#` is disabled.",
+			"Controls whether editors remain in preview when a code navigation is started from them. Preview editors do not keep open and are reused until explicitly set to be kept open (e.g. via double click or editing). This value is ignored when `#workbench.editor.enablePreview#` is disabled.",
+			"Controls whether editors showing a file that was opened during the session should close automatically when getting deleted or renamed by some other process. Disabling this will keep the editor open  on such an event. Note that deleting from within the application will always close the editor and that dirty files will never close to preserve your data.",
+			"Controls where editors open. Select `left` or `right` to open editors to the left or right of the currently active one. Select `first` or `last` to open editors independently from the currently active one.",
+			"Controls the default direction of editors that are opened side by side (e.g. from the explorer). By default, editors will open on the right hand side of the currently active one. If changed to `down`, the editors will open below the currently active one.",
+			"Controls the behavior of empty editor groups when the last tab in the group is closed. When enabled, empty groups will automatically close. When disabled, empty groups will remain part of the grid.",
+			"Controls whether an editor is revealed in any of the visible groups if opened. If disabled, an editor will prefer to open in the currently active editor group. If enabled, an already opened editor will be revealed instead of opened again in the currently active editor group. Note that there are some cases where this setting is ignored, e.g. when forcing an editor to open in a specific group or to the side of the currently active group.",
+			"Navigate between open files using mouse buttons four and five if provided.",
+			"Restores the last view state (e.g. scroll position) when re-opening textual editors after they have been closed.",
+			"Controls if the centered layout should automatically resize to maximum width when more than one group is open. Once only one group is open it will resize back to the original centered width.",
+			"Controls if the number of opened editors should be limited or not. When enabled, less recently used editors that are not dirty will close to make space for newly opening editors.",
+			"Controls the maximum number of opened editors. Use the `#workbench.editor.limit.perEditorGroup#` setting to control this limit per editor group or across all groups.",
+			"Controls if the limit of maximum opened editors should apply per editor group or across all editor groups.",
+			"Controls the number of recently used commands to keep in history for the command palette. Set to 0 to disable command history.",
+			"Controls whether the last typed input to the command palette should be restored when opening it the next time.",
+			"Controls whether Quick Open should close automatically once it loses focus.",
+			"Controls whether the last typed input to Quick Open should be restored when opening it the next time.",
+			"Controls whether opening settings also opens an editor showing all default settings.",
+			"Controls whether to use the split JSON editor when editing settings as JSON.",
+			"Controls whether opening keybinding settings also opens an editor showing all default keybindings.",
+			"Controls the location of the sidebar and activity bar. They can either show on the left or right of the workbench.",
+			"Controls the default location of the panel (terminal, debug console, output, problems). It can either show at the bottom, right, or left of the workbench.",
+			"Controls whether the panel opens maximized. It can either always open maximized, never open maximized, or open to the last state it was in before being closed.",
+			"Always maximize the panel when opening it.",
+			"Never maximize the panel when opening it. The panel will open un-maximized.",
+			"Open the panel to the state that it was in, before it was closed.",
+			"Controls the visibility of the status bar at the bottom of the workbench.",
+			"Controls the visibility of the activity bar in the workbench.",
+			"Controls the behavior of clicking an activity bar icon in the workbench.",
+			"Hide the side bar if the clicked item is already visible.",
+			"Focus side bar if the clicked item is already visible.",
+			"Controls the visibility of view header actions. View header actions may either be always visible, or only visible when that view is focused or hovered over.",
+			"Controls font aliasing method in the workbench.",
+			"Sub-pixel font smoothing. On most non-retina displays this will give the sharpest text.",
+			"Smooth the font on the level of the pixel, as opposed to the subpixel. Can make the font appear lighter overall.",
+			"Disables font smoothing. Text will show with jagged sharp edges.",
+			"Applies `default` or `antialiased` automatically based on the DPI of displays.",
+			"Use the settings UI editor.",
+			"Use the JSON file editor.",
+			"Determines which settings editor to use by default.",
+			"Controls the window title based on the active editor. Variables are substituted based on the context:",
+			"`${activeEditorShort}`: the file name (e.g. myFile.txt).",
+			"`${activeEditorMedium}`: the path of the file relative to the workspace folder (e.g. myFolder/myFileFolder/myFile.txt).",
+			"`${activeEditorLong}`: the full path of the file (e.g. /Users/Development/myFolder/myFileFolder/myFile.txt).",
+			"`${activeFolderShort}`: the name of the folder the file is contained in (e.g. myFileFolder).",
+			"`${activeFolderMedium}`: the path of the folder the file is contained in, relative to the workspace folder (e.g. myFolder/myFileFolder).",
+			"`${activeFolderLong}`: the full path of the folder the file is contained in (e.g. /Users/Development/myFolder/myFileFolder).",
+			"`${folderName}`: name of the workspace folder the file is contained in (e.g. myFolder).",
+			"`${folderPath}`: file path of the workspace folder the file is contained in (e.g. /Users/Development/myFolder).",
+			"`${rootName}`: name of the opened workspace or folder (e.g. myFolder or myWorkspace).",
+			"`${rootPath}`: file path of the opened workspace or folder (e.g. /Users/Development/myWorkspace).",
+			"`${appName}`: e.g. VS Code.",
+			"`${remoteName}`: e.g. SSH",
+			"`${dirty}`: a dirty indicator if the active editor is dirty.",
+			"`${separator}`: a conditional separator (\" - \") that only shows when surrounded by variables with values or static text.",
+			"Window",
+			"Separator used by `window.title`.",
+			"Menu is only hidden in full screen mode.",
+			"Menu is always visible even in full screen mode.",
+			"Menu is hidden but can be displayed via Alt key.",
+			"Menu is always hidden.",
+			"Menu is displayed as a compact button in the sidebar. This value is ignored when `#window.titleBarStyle#` is `native`.",
+			"Control the visibility of the menu bar. A setting of 'toggle' means that the menu bar is hidden and a single press of the Alt key will show it. By default, the menu bar will be visible, unless the window is full screen.",
+			"Controls whether the main menus can be opened via Alt-key shortcuts. Disabling mnemonics allows to bind these Alt-key shortcuts to editor commands instead.",
+			"Controls whether the menu bar will be focused by pressing the Alt-key. This setting has no effect on toggling the menu bar with the Alt-key.",
+			"Files will open in a new window.",
+			"Files will open in the window with the files' folder open or the last active window.",
+			"Files will open in the window with the files' folder open or the last active window unless opened via the Dock or from Finder.",
+			"Files will open in a new window unless picked from within the application (e.g. via the File menu).",
+			"Controls whether files should open in a new window. \nNote that there can still be cases where this setting is ignored (e.g. when using the `--new-window` or `--reuse-window` command line option).",
+			"Controls whether files should open in a new window.\nNote that there can still be cases where this setting is ignored (e.g. when using the `--new-window` or `--reuse-window` command line option).",
+			"Folders will open in a new window.",
+			"Folders will replace the last active window.",
+			"Folders will open in a new window unless a folder is picked from within the application (e.g. via the File menu).",
+			"Controls whether folders should open in a new window or replace the last active window.\nNote that there can still be cases where this setting is ignored (e.g. when using the `--new-window` or `--reuse-window` command line option).",
+			"Always try to ask for confirmation. Note that browsers may still decide to close a tab or window without confirmation.",
+			"Only ask for confirmation if a keybinding was detected. Note that detection may not be possible in some cases.",
+			"Never explicitly ask for confirmation unless data loss is imminent.",
+			"Controls whether to show a confirmation dialog before closing the browser tab or window. Note that even if enabled, browsers may still decide to close a tab or window without confirmation and that this setting is only a hint that may not work in all cases.",
+			"Zen Mode",
+			"Controls whether turning on Zen Mode also puts the workbench into full screen mode.",
+			"Controls whether turning on Zen Mode also centers the layout.",
+			"Controls whether turning on Zen Mode also hides workbench tabs.",
+			"Controls whether turning on Zen Mode also hides the status bar at the bottom of the workbench.",
+			"Controls whether turning on Zen Mode also hides the activity bar either at the left or right of the workbench.",
+			"Controls whether turning on Zen Mode also hides the editor line numbers.",
+			"Controls whether a window should restore to zen mode if it was exited in zen mode.",
+			"Controls whether notifications are shown while in zen mode. If true, only error notifications will pop out."
+		],
+		"vs/workbench/browser/actions/textInputActions": [
+			"Undo",
+			"Redo",
+			"Cut",
+			"Copy",
+			"Paste",
+			"Select All"
+		],
+		"vs/workbench/browser/actions/developerActions": [
+			"Inspect Context Keys",
+			"Toggle Screencast Mode",
+			"Log Storage Database Contents",
+			"Log Working Copies",
+			"Screencast Mode",
+			"Controls the vertical offset of the screencast mode overlay from the bottom as a percentage of the workbench height.",
+			"Controls the font size (in pixels) of the screencast mode keyboard.",
+			"Only show keyboard shortcuts in screencast mode.",
+			"Controls how long (in milliseconds) the keyboard overlay is shown in screencast mode.",
+			"Controls the color in hex (#RGB, #RGBA, #RRGGBB or #RRGGBBAA) of the mouse indicator in screencast mode.",
+			"Controls the size (in pixels) of the mouse indicator in screencast mode."
+		],
+		"vs/workbench/browser/actions/helpActions": [
+			"Keyboard Shortcuts Reference",
+			"Documentation",
+			"Introductory Videos",
+			"Tips and Tricks",
+			"Signup for the VS Code Newsletter",
+			"Join Us on Twitter",
+			"Search Feature Requests",
+			"View License",
+			"Privacy Statement",
+			"&&Documentation",
+			"&&Keyboard Shortcuts Reference",
+			"Introductory &&Videos",
+			"Tips and Tri&&cks",
+			"&&Join Us on Twitter",
+			"&&Search Feature Requests",
+			"View &&License",
+			"Privac&&y Statement"
+		],
+		"vs/workbench/browser/actions/layoutActions": [
+			"Close Side Bar",
+			"Toggle Activity Bar Visibility",
+			"Show &&Activity Bar",
+			"Toggle Centered Layout",
+			"&&Centered Layout",
+			"Toggle Side Bar Position",
+			"Move Side Bar Right",
+			"Move Side Bar Left",
+			"Toggle Side Bar Position",
+			"Move Side Bar Right",
+			"Move Side Bar Right",
+			"Move Side Bar Left",
+			"Move Side Bar Left",
+			"&&Move Side Bar Right",
+			"&&Move Side Bar Left",
+			"Toggle Editor Area Visibility",
+			"Show &&Editor Area",
+			"&&Appearance",
+			"Toggle Side Bar Visibility",
+			"Hide Side Bar",
+			"Hide Side Bar",
+			"Show &&Side Bar",
+			"Toggle Status Bar Visibility",
+			"Show S&&tatus Bar",
+			"Toggle Tab Visibility",
+			"Toggle Zen Mode",
+			"Zen Mode",
+			"Toggle Menu Bar",
+			"Show Menu &&Bar",
+			"Reset View Locations",
+			"Move View",
+			"Side Bar / {0}",
+			"Panel / {0}",
+			"Select a View to Move",
+			"Move Focused View",
+			"There is no view currently focused.",
+			"The currently focused view is not movable.",
+			"Select a Destination for the View",
+			"View: Move {0}",
+			"New Panel Entry",
+			"New Side Bar Entry",
+			"Side Bar",
+			"Panel",
+			"Reset Focused View Location",
+			"There is no view currently focused.",
+			"Increase Current View Size",
+			"Increase Editor Width",
+			"Increase Editor Height",
+			"Decrease Current View Size",
+			"Decrease Editor Width",
+			"Decrease Editor Height"
+		],
+		"vs/workbench/browser/actions/navigationActions": [
+			"Navigate to the View on the Left",
+			"Navigate to the View on the Right",
+			"Navigate to the View Above",
+			"Navigate to the View Below",
+			"Focus Next Part",
+			"Focus Previous Part"
+		],
+		"vs/workbench/browser/actions/windowActions": [
+			"Remove from Recently Opened",
+			"Folder With Unsaved Files",
+			"Workspace With Unsaved Files",
+			"folders & workspaces",
+			"folders",
+			"files",
+			"Select to open (hold Cmd-key to force new window or Alt-key for same window)",
+			"Select to open (hold Ctrl-key to force new window or Alt-key for same window)",
+			"Workspace with Unsaved Files",
+			"Folder with Unsaved Files",
+			"Do you want to open the workspace to review the unsaved files?",
+			"Do you want to open the folder to review the unsaved files?",
+			"Workspaces with unsaved files cannot be removed until all unsaved files have been saved or reverted.",
+			"Folders with unsaved files cannot be removed until all unsaved files have been saved or reverted.",
+			"{0}, workspace with unsaved changes",
+			"{0}, folder with unsaved changes",
+			"Open Recent...",
+			"Quick Open Recent...",
+			"Toggle Full Screen",
+			"Reload Window",
+			"About",
+			"New Window",
+			"Remove keyboard focus from focused element",
+			"File",
+			"Confirm Before Close",
+			"New &&Window",
+			"Open &&Recent",
+			"&&More...",
+			"&&Full Screen",
+			"&&About"
+		],
+		"vs/workbench/browser/actions/workspaceActions": [
+			"Open File...",
+			"Open Folder...",
+			"Open...",
+			"Open Workspace...",
+			"Close Workspace",
+			"There is currently no workspace or folder opened in this instance to close.",
+			"Open Workspace Configuration File",
+			"Remove Folder from Workspace...",
+			"Save Workspace As...",
+			"Duplicate As Workspace in New Window",
+			"Workspaces",
+			"A&&dd Folder to Workspace...",
+			"Save Workspace As...",
+			"Close &&Folder",
+			"Close &&Workspace"
+		],
+		"vs/workbench/browser/actions/workspaceCommands": [
+			"Add Folder to Workspace...",
+			"&&Add",
+			"Add Folder to Workspace",
+			"Select workspace folder"
+		],
+		"vs/workbench/browser/actions/quickAccessActions": [
+			"Go to File...",
+			"Navigate Next in Quick Open",
+			"Navigate Previous in Quick Open",
+			"Select Next in Quick Open",
+			"Select Previous in Quick Open"
+		],
+		"vs/workbench/api/common/menusExtensionPoint": [
+			"The Command Palette",
+			"The touch bar (macOS only)",
+			"The editor title menu",
+			"The editor context menu",
+			"The file explorer context menu",
+			"The editor tabs context menu",
+			"The debug callstack view context menu",
+			"The debug variables view context menu",
+			"The debug toolbar menu",
+			"The top level file menu",
+			"The home indicator context menu (web only)",
+			"The Source Control title menu",
+			"The Source Control menu",
+			"The Source Control resource group context menu",
+			"The Source Control resource state context menu",
+			"The Source Control resource folder context menu",
+			"The Source Control inline change menu",
+			"The window indicator menu in the status bar",
+			"The contributed view title menu",
+			"The contributed view item context menu",
+			"The contributed comment thread title menu",
+			"The contributed comment thread context menu, rendered as buttons below the comment editor",
+			"The contributed comment title menu",
+			"The contributed comment context menu, rendered as buttons below the comment editor",
+			"The contributed notebook cell title menu",
+			"The extension context menu",
+			"The Timeline view title menu",
+			"The Timeline view item context menu",
+			"property `{0}` is mandatory and must be of type `string`",
+			"property `{0}` can be omitted or must be of type `string`",
+			"property `{0}` can be omitted or must be of type `string`",
+			"property `{0}` can be omitted or must be of type `string`",
+			"property `{0}` is mandatory and must be of type `string`",
+			"property `{0}` can be omitted or must be of type `string`",
+			"property `{0}` can be omitted or must be of type `string`",
+			"submenu items must be an array",
+			"submenu items must be an object",
+			"property `{0}` is mandatory and must be of type `string`",
+			"property `{0}` is mandatory and must be of type `string`",
+			"Identifier of the command to execute. The command must be declared in the 'commands'-section",
+			"Identifier of an alternative command to execute. The command must be declared in the 'commands'-section",
+			"Condition which must be true to show this item",
+			"Group into which this item belongs",
+			"Identifier of the submenu to display in this item.",
+			"Condition which must be true to show this item",
+			"Group into which this item belongs",
+			"Identifier of the menu to display as a submenu.",
+			"The label of the menu item which leads to this submenu.",
+			"(Optional) Icon which is used to represent the submenu in the UI. Either a file path, an object with file paths for dark and light themes, or a theme icon references, like `\\$(zap)`",
+			"Icon path when a light theme is used",
+			"Icon path when a dark theme is used",
+			"Contributes menu items to the editor",
+			"Proposed API",
+			"Contributes submenu items to the editor",
+			"expected non-empty value.",
+			"property `{0}` is mandatory and must be of type `string`",
+			"property `{0}` can be omitted or must be of type `string`",
+			"property `icon` can be omitted or must be either a string or a literal like `{dark, light}`",
+			"property `{0}` is mandatory and must be of type `string` or `object`",
+			"property `{0}` is mandatory and must be of type `string`",
+			"properties `{0}` and `{1}` are mandatory and must be of type `string`",
+			"Identifier of the command to execute",
+			"Title by which the command is represented in the UI",
+			"(Optional) Category string by the command is grouped in the UI",
+			"(Optional) Condition which must be true to enable the command in the UI (menu and keybindings). Does not prevent executing the command by other means, like the `executeCommand`-api.",
+			"(Optional) Icon which is used to represent the command in the UI. Either a file path, an object with file paths for dark and light themes, or a theme icon references, like `\\$(zap)`",
+			"Icon path when a light theme is used",
+			"Icon path when a dark theme is used",
+			"Contributes commands to the command palette.",
+			"Command `{0}` appears multiple times in the `commands` section.",
+			"`{0}` is not a valid submenu identifier",
+			"The `{0}` submenu was already previously registered.",
+			"`{0}` is not a valid submenu label",
+			"`{0}` is not a valid menu identifier",
+			"{0} is a proposed menu identifier and is only available when running out of dev or with the following command line switch: --enable-proposed-api {1}",
+			"Menu item references a command `{0}` which is not defined in the 'commands' section.",
+			"Menu item references an alt-command `{0}` which is not defined in the 'commands' section.",
+			"Menu item references the same command as default and alt-command",
+			"Menu item references a submenu for a menu which doesn't have submenu support.",
+			"Menu item references a submenu `{0}` which is not defined in the 'submenus' section.",
+			"The `{0}` submenu was already contributed to the `{1}` menu."
+		],
+		"vs/workbench/api/common/configurationExtensionPoint": [
+			"A summary of the settings. This label will be used in the settings file as separating comment.",
+			"Description of the configuration properties.",
+			"Property should not be empty.",
+			"Configuration that can be configured only in the user settings.",
+			"Configuration that can be configured only in the user settings or only in the remote settings.",
+			"Configuration that can be configured in the user, remote or workspace settings.",
+			"Configuration that can be configured in the user, remote, workspace or folder settings.",
+			"Resource configuration that can be configured in language specific settings.",
+			"Machine configuration that can be configured also in workspace or folder settings.",
+			"Scope in which the configuration is applicable. Available scopes are `application`, `machine`, `window`, `resource`, and `machine-overridable`.",
+			"Descriptions for enum values",
+			"Descriptions for enum values in the markdown format.",
+			"The description in the markdown format.",
+			"If set, the property is marked as deprecated and the given message is shown as an explanation.",
+			"If set, the property is marked as deprecated and the given message is shown as an explanation in the markdown format.",
+			"Contributes default editor configuration settings by language.",
+			"Language selector expected (e.g. [\"java\"])",
+			"Cannot register configuration defaults for '{0}'. Only defaults for language specific settings are supported.",
+			"Contributes configuration settings.",
+			"'configuration.title' must be a string",
+			"'configuration.properties' must be an object",
+			"'configuration.property' must be an object",
+			"'configuration.allOf' is deprecated and should no longer be used. Instead, pass multiple configuration sections as an array to the 'configuration' contribution point.",
+			"List of folders to be loaded in the workspace.",
+			"A file path. e.g. `/root/folderA` or `./folderA` for a relative path that will be resolved against the location of the workspace file.",
+			"An optional name for the folder. ",
+			"URI of the folder",
+			"An optional name for the folder. ",
+			"Workspace settings",
+			"Workspace launch configurations",
+			"Workspace task configurations",
+			"Workspace extensions",
+			"The remote server where the workspace is located. Only used by unsaved remote workspaces.",
+			"Unknown workspace configuration property"
+		],
+		"vs/workbench/api/browser/viewsExtensionPoint": [
+			"Unique id used to identify the container in which views can be contributed using 'views' contribution point",
+			"Human readable string used to render the container",
+			"Path to the container icon. Icons are 24x24 centered on a 50x40 block and have a fill color of 'rgb(215, 218, 224)' or '#d7dae0'. It is recommended that icons be in SVG, though any image file type is accepted.",
+			"Contributes views containers to the editor",
+			"Contribute views containers to Activity Bar",
+			"Contribute views containers to Panel",
+			"Type of the view. This can either be `tree` for a tree view based view or `webview` for a webview based view. The default is `tree`.",
+			"The view is backed by a `TreeView` created by `createTreeView`.",
+			"The view is backed by a `WebviewView` registered by `registerWebviewViewProvider`.",
+			"Identifier of the view. This should be unique across all views. It is recommended to include your extension id as part of the view id. Use this to register a data provider through `vscode.window.registerTreeDataProviderForView` API. Also to trigger activating your extension by registering `onView:${id}` event to `activationEvents`.",
+			"The human-readable name of the view. Will be shown",
+			"Condition which must be true to show this view",
+			"Path to the view icon. View icons are displayed when the name of the view cannot be shown. It is recommended that icons be in SVG, though any image file type is accepted.",
+			"Human-readable context for when the view is moved out of its original location. By default, the view's container name will be used. Will be shown",
+			"Initial state of the view when the extension is first installed. Once the user has changed the view state by collapsing, moving, or hiding the view, the initial state will not be used again.",
+			"The default initial state for the view. In most containers the view will be expanded, however; some built-in containers (explorer, scm, and debug) show all contributed views collapsed regardless of the `visibility`.",
+			"The view will not be shown in the view container, but will be discoverable through the views menu and other view entry points and can be un-hidden by the user.",
+			"The view will show in the view container, but will be collapsed.",
+			"Identifier of the view. This should be unique across all views. It is recommended to include your extension id as part of the view id. Use this to register a data provider through `vscode.window.registerTreeDataProviderForView` API. Also to trigger activating your extension by registering `onView:${id}` event to `activationEvents`.",
+			"The human-readable name of the view. Will be shown",
+			"Condition which must be true to show this view",
+			"Nested group in the viewlet",
+			"The name of the remote type associated with this view",
+			"Contributes views to the editor",
+			"Contributes views to Explorer container in the Activity bar",
+			"Contributes views to Debug container in the Activity bar",
+			"Contributes views to SCM container in the Activity bar",
+			"Contributes views to Test container in the Activity bar",
+			"Contributes views to Remote container in the Activity bar. To contribute to this container, enableProposedApi needs to be turned on",
+			"Contributes views to contributed views container",
+			"views containers must be an array",
+			"property `{0}` is mandatory and must be of type `string`. Only alphanumeric characters, '_', and '-' are allowed.",
+			"property `{0}` is mandatory and must be of type `string`. Only alphanumeric characters, '_', and '-' are allowed.",
+			"property `{0}` is mandatory and must be of type `string`",
+			"property `{0}` is mandatory and must be of type `string`",
+			"Show {0}",
+			"View container '{0}' requires 'enableProposedApi' turned on to be added to 'Remote'.",
+			"View container '{0}' does not exist and all views registered to it will be added to 'Explorer'.",
+			"Cannot register multiple views with same id `{0}`",
+			"A view with id `{0}` is already registered.",
+			"Unknown view type `{0}`.",
+			"views must be an array",
+			"property `{0}` is mandatory and must be of type `string`",
+			"property `{0}` is mandatory and must be of type `string`",
+			"property `{0}` can be omitted or must be of type `string`",
+			"property `{0}` can be omitted or must be of type `string`",
+			"property `{0}` can be omitted or must be of type `string`",
+			"property `{0}` can be omitted or must be one of {1}"
+		],
+		"vs/workbench/browser/parts/activitybar/activitybarPart": [
+			"Settings icon in the view bar.",
+			"Accounts icon in the view bar.",
+			"Home Button",
+			"Home Button",
+			"Menu",
+			"Menu",
+			"Accounts",
+			"Accounts",
+			"Hide Activity Bar",
+			"Reset Location",
+			"Reset Location",
+			"Home",
+			"Home",
+			"Home",
+			"Manage",
+			"Manage",
+			"Accounts",
+			"Accounts",
+			"Focus Activity Bar"
+		],
+		"vs/workbench/browser/parts/panel/panelPart": [
+			"Hide Panel",
+			"Reset Location",
+			"Reset Location",
+			"Drag a view into the panel to display."
+		],
+		"vs/workbench/browser/parts/sidebar/sidebarPart": [
+			"Focus into Side Bar"
+		],
+		"vs/workbench/browser/parts/views/viewsService": [
+			"Focus on {0} View",
+			"Reset Location"
+		],
+		"vs/workbench/browser/parts/statusbar/statusbarPart": [
+			"Hide '{0}'",
+			"Hide Status Bar"
+		],
+		"vs/platform/undoRedo/common/undoRedoService": [
+			"The following files have been closed and modified on disk: {0}.",
+			"The following files have been modified in an incompatible way: {0}.",
+			"Could not undo '{0}' across all files. {1}",
+			"Could not undo '{0}' across all files. {1}",
+			"Could not undo '{0}' across all files because changes were made to {1}",
+			"Could not undo '{0}' across all files because there is already an undo or redo operation running on {1}",
+			"Could not undo '{0}' across all files because an undo or redo operation occurred in the meantime",
+			"Would you like to undo '{0}' across all files?",
+			"Undo in {0} Files",
+			"Undo this File",
+			"Cancel",
+			"Could not undo '{0}' because there is already an undo or redo operation running.",
+			"Would you like to undo '{0}'?",
+			"Undo",
+			"Cancel",
+			"Could not redo '{0}' across all files. {1}",
+			"Could not redo '{0}' across all files. {1}",
+			"Could not redo '{0}' across all files because changes were made to {1}",
+			"Could not redo '{0}' across all files because there is already an undo or redo operation running on {1}",
+			"Could not redo '{0}' across all files because an undo or redo operation occurred in the meantime",
+			"Could not redo '{0}' because there is already an undo or redo operation running."
+		],
+		"vs/workbench/services/extensions/browser/extensionUrlHandler": [
+			"Allow an extension to open this URI?",
+			"Don't ask again for this extension.",
+			"&&Open",
+			"Extension '{0}' is not loaded. Would you like to reload the window to load the extension and open the URL?",
+			"&&Reload Window and Open",
+			"Extension '{0}' is disabled. Would you like to enable the extension and reload the window to open the URL?",
+			"&&Enable and Open",
+			"Extension '{0}' is not installed. Would you like to install the extension and reload the window to open this URL?",
+			"&&Install",
+			"Installing Extension '{0}'...",
+			"Would you like to reload the window and open the URL '{0}'?",
+			"Reload Window and Open",
+			"Manage Authorized Extension URIs...",
+			"Extensions",
+			"There are currently no authorized extension URIs."
+		],
+		"vs/workbench/services/keybinding/common/keybindingEditing": [
+			"Unable to write because the keybindings configuration file is dirty. Please save it first and then try again.",
+			"Unable to write to the keybindings configuration file. Please open it to correct errors/warnings in the file and try again.",
+			"Unable to write to the keybindings configuration file. It has an object which is not of type Array. Please open the file to clean up and try again.",
+			"Place your key bindings in this file to override the defaults"
+		],
+		"vs/workbench/services/decorations/browser/decorationsService": [
+			"Contains emphasized items"
+		],
+		"vs/workbench/services/progress/browser/progressService": [
+			"{0}: {1}",
+			"[{0}] {1}: {2}",
+			"[{0}]: {1}",
+			"[{0}]: {1}",
+			"Progress Message",
+			"Cancel",
+			"Cancel",
+			"Dismiss"
+		],
+		"vs/workbench/services/preferences/browser/preferencesService": [
+			"Open a folder or workspace first to create workspace or folder settings.",
+			"Place your key bindings in this file to override the defaults",
+			"Default Keybindings",
+			"Default Keybindings",
+			"Default Settings",
+			"{0} (Folder Settings)",
+			"Unable to create '{0}' ({1})."
+		],
+		"vs/workbench/services/configuration/common/jsonEditingService": [
+			"Unable to write into the file. Please open the file to correct errors/warnings in the file and try again.",
+			"Unable to write into the file because the file is dirty. Please save the file and try again."
+		],
+		"vs/workbench/services/editor/browser/editorService": [
+			"Source: {0}"
+		],
+		"vs/workbench/services/keybinding/browser/keybindingService": [
+			"expected non-empty value.",
+			"property `{0}` is mandatory and must be of type `string`",
+			"property `{0}` can be omitted or must be of type `string`",
+			"property `{0}` can be omitted or must be of type `string`",
+			"property `{0}` can be omitted or must be of type `string`",
+			"property `{0}` can be omitted or must be of type `string`",
+			"property `{0}` can be omitted or must be of type `string`",
+			"Identifier of the command to run when keybinding is triggered.",
+			"Arguments to pass to the command to execute.",
+			"Key or key sequence (separate keys with plus-sign and sequences with space, e.g. Ctrl+O and Ctrl+L L for a chord).",
+			"Mac specific key or key sequence.",
+			"Linux specific key or key sequence.",
+			"Windows specific key or key sequence.",
+			"Condition when the key is active.",
+			"Contributes keybindings.",
+			"Invalid `contributes.{0}`: {1}",
+			"Here are other available commands: ",
+			"Keybindings configuration",
+			"Key or key sequence (separated by space)",
+			"Name of the command to execute",
+			"Condition when the key is active.",
+			"Arguments to pass to the command to execute.",
+			"Keyboard",
+			"Controls the dispatching logic for key presses to use either `code` (recommended) or `keyCode`."
+		],
+		"vs/workbench/services/mode/common/workbenchModeService": [
+			"Contributes language declarations.",
+			"ID of the language.",
+			"Name aliases for the language.",
+			"File extensions associated to the language.",
+			"File names associated to the language.",
+			"File name glob patterns associated to the language.",
+			"Mime types associated to the language.",
+			"A regular expression matching the first line of a file of the language.",
+			"A relative path to a file containing configuration options for the language.",
+			"Invalid `contributes.{0}`. Expected an array.",
+			"Empty value for `contributes.{0}`",
+			"property `{0}` is mandatory and must be of type `string`",
+			"property `{0}` can be omitted and must be of type `string[]`",
+			"property `{0}` can be omitted and must be of type `string[]`",
+			"property `{0}` can be omitted and must be of type `string`",
+			"property `{0}` can be omitted and must be of type `string`",
+			"property `{0}` can be omitted and must be of type `string[]`",
+			"property `{0}` can be omitted and must be of type `string[]`"
+		],
+		"vs/workbench/services/themes/browser/workbenchThemeService": [
+			"Unable to load {0}: {1}"
+		],
+		"vs/workbench/services/label/common/labelService": [
+			"Contributes resource label formatting rules.",
+			"URI scheme on which to match the formatter on. For example \"file\". Simple glob patterns are supported.",
+			"URI authority on which to match the formatter on. Simple glob patterns are supported.",
+			"Rules for formatting uri resource labels.",
+			"Label rules to display. For example: myLabel:/${path}. ${path}, ${scheme} and ${authority} are supported as variables.",
+			"Separator to be used in the uri label display. '/' or '' as an example.",
+			"Controls whether `${path}` substitutions should have starting separator characters stripped.",
+			"Controls if the start of the uri label should be tildified when possible.",
+			"Suffix appended to the workspace label.",
+			"Untitled (Workspace)",
+			"{0} (Workspace)",
+			"{0} (Workspace)"
+		],
+		"vs/workbench/services/extensionManagement/common/webExtensionsScannerService": [
+			"Cannot install '{0}' because this extension is not a web extension."
+		],
+		"vs/workbench/services/extensionManagement/browser/extensionEnablementService": [
+			"All installed extensions are temporarily disabled.",
+			"Reload and Enable Extensions",
+			"Cannot change enablement of {0} extension because it contributes language packs.",
+			"Cannot change enablement {0} extension because Settings Sync depends on it.",
+			"No workspace.",
+			"Cannot change enablement of {0} extension in workspace because it contributes authentication providers"
+		],
+		"vs/workbench/services/extensionRecommendations/common/workspaceExtensionsConfig": [
+			"Remove extension recommendation from",
+			"Add extension recommendation to",
+			"Remove extension recommendation from",
+			"Add extension recommendation to",
+			"Workspace Folder",
+			"Workspace"
+		],
+		"vs/workbench/services/notification/common/notificationService": [
+			"Don't Show Again",
+			"Don't Show Again"
+		],
+		"vs/workbench/services/userDataSync/browser/userDataSyncWorkbenchService": [
+			"Settings sync cannot be turned on because there are no authentication providers available.",
+			"No account available",
+			"show log",
+			"{0} is turned on",
+			"Settings Sync is being turned on. Would you like to cancel it?",
+			"Settings Sync",
+			"&&Yes",
+			"&&No",
+			"Turning on...",
+			"Syncing {0}...",
+			"Conflicts Detected",
+			"Merge Manually...",
+			"Unable to merge due to conflicts. Please merge manually to continue...",
+			"Merge or Replace",
+			"Merge",
+			"Replace Local",
+			"Merge Manually...",
+			"Cancel",
+			"It looks like you last synced from another machine.\nWould you like to merge or replace with your data in the cloud?",
+			"This will clear your data in the cloud and stop sync on all your devices.",
+			"Clear",
+			"&&Reset",
+			"Select an account to sign in",
+			"Signed in",
+			"Last Used with Sync",
+			"Others",
+			"Sign in with {0}",
+			"Settings sync is suspended because of successive authorization failures. Please sign in again to continue synchronizing",
+			"Sign in"
+		],
+		"vs/workbench/services/views/browser/viewDescriptorService": [
+			"Hide '{0}'",
+			"Reset Location"
+		],
+		"vs/workbench/contrib/preferences/browser/preferences.contribution": [
+			"Default Preferences Editor",
+			"Settings Editor 2",
+			"Keybindings Editor",
+			"Open Settings (UI)",
+			"Preferences",
+			"Settings",
+			"&&Settings",
+			"Open Settings (UI)",
+			"Open Settings (JSON)",
+			"Open User Settings",
+			"Open Default Settings (JSON)",
+			"Open Settings (JSON)",
+			"Open Workspace Settings",
+			"Open Workspace Settings (JSON)",
+			"Open Folder Settings",
+			"Open Folder Settings (JSON)",
+			"Open Folder Settings",
+			"Show modified settings",
+			"Show settings for online services",
+			"&&Online Services Settings",
+			"Online Services Settings",
+			"Open Remote Settings ({0})",
+			"Focus Settings Search",
+			"Clear Settings Search Results",
+			"Focus settings file",
+			"Focus settings file",
+			"Focus next setting",
+			"Focus previous setting",
+			"Edit focused setting",
+			"Focus settings list",
+			"Focus Settings Table of Contents",
+			"Focus Setting Control",
+			"Show Setting Context Menu",
+			"Move Focus Up One Level",
+			"Preferences",
+			"Open Keyboard Shortcuts",
+			"Keyboard Shortcuts",
+			"Keyboard Shortcuts",
+			"Open Default Keyboard Shortcuts (JSON)",
+			"Open Keyboard Shortcuts (JSON)",
+			"Show Default Keybindings",
+			"Show Extension Keybindings",
+			"Show User Keybindings",
+			"Clear Search Results",
+			"&&Preferences"
+		],
+		"vs/workbench/contrib/preferences/browser/keybindingsEditorContribution": [
+			"Define Keybinding",
+			"You won't be able to produce this key combination under your current keyboard layout.",
+			"**{0}** for your current keyboard layout (**{1}** for US standard).",
+			"**{0}** for your current keyboard layout."
+		],
+		"vs/workbench/contrib/performance/browser/performance.contribution": [
+			"Startup Performance"
+		],
+		"vs/workbench/contrib/testing/browser/testing.contribution": [
+			"Test",
+			"No test providers are registered for this workspace.",
+			"[Search Marketplace](command:{0})",
+			"Test Explorer"
+		],
+		"vs/workbench/contrib/notebook/browser/notebook.contribution": [
+			"{0} ⟷ {1}",
+			"Notebook",
+			"Priority list for output mime types",
+			"Where the cell toolbar should be shown, or whether it should be hidden.",
+			"Whether the cell status bar should be shown.",
+			"Whether to use the enhanced text diff editor for notebook."
+		],
+		"vs/workbench/contrib/logs/common/logs.contribution": [
+			"Settings Sync",
+			"Window",
+			"Telemetry",
+			"Show Window Log",
+			"Main",
+			"Shared"
+		],
+		"vs/workbench/contrib/quickaccess/browser/quickAccess.contribution": [
+			"Type '{0}' to get help on the actions you can take from here.",
+			"Show all Quick Access Providers",
+			"Type the name of a view, output channel or terminal to open.",
+			"Open View",
+			"Type the name of a command to run.",
+			"Show and Run Commands",
+			"&&Command Palette...",
+			"&&Open View...",
+			"Go to &&Symbol in Editor...",
+			"Go to &&Line/Column...",
+			"Command Palette...",
+			"Command Palette..."
+		],
+		"vs/workbench/contrib/files/browser/explorerViewlet": [
+			"View icon of the explorer view.",
+			"View icon of the open editors view.",
+			"Folders",
+			"Explorer",
+			"You have not yet added a folder to the workspace.\n[Add Folder](command:{0})",
+			"Connected to remote.\n[Open Folder](command:{0})",
+			"You have not yet opened a folder.\n[Open Folder](command:{0})"
+		],
+		"vs/workbench/contrib/files/browser/fileActions.contribution": [
+			"File",
+			"Workspaces",
+			"File",
+			"Copy Path",
+			"Copy Relative Path",
+			"Reveal in Side Bar",
+			"Use your changes and overwrite file contents",
+			"Discard your changes and revert to file contents",
+			"Copy Path of Active File",
+			"Copy Relative Path of Active File",
+			"Save All in Group",
+			"Save All Files",
+			"Revert File",
+			"Compare Active File with Saved",
+			"Open to the Side",
+			"Revert File",
+			"Save All",
+			"Compare with Saved",
+			"Compare with Selected",
+			"Select for Compare",
+			"Compare Selected",
+			"Close",
+			"Close Others",
+			"Close Saved",
+			"Close All",
+			"Open With...",
+			"Cut",
+			"Delete Permanently",
+			"Delete Permanently",
+			"New File",
+			"Open File...",
+			"&&New File",
+			"&&Save",
+			"Save &&As...",
+			"Save A&&ll",
+			"&&Open...",
+			"&&Open File...",
+			"Open &&Folder...",
+			"Open Wor&&kspace...",
+			"A&&uto Save",
+			"Re&&vert File",
+			"&&Close Editor",
+			"Go to &&File..."
+		],
+		"vs/workbench/contrib/files/browser/files.contribution": [
+			"Show Explorer",
+			"Binary File Editor",
+			"Disable hot exit. A prompt will show when attempting to close a window with dirty files.",
+			"Hot exit will be triggered when the last window is closed on Windows/Linux or when the `workbench.action.quit` command is triggered (command palette, keybinding, menu). All windows without folders opened will be restored upon next launch. A list of previously opened windows with unsaved files can be accessed via `File > Open Recent > More...`",
+			"Hot exit will be triggered when the last window is closed on Windows/Linux or when the `workbench.action.quit` command is triggered (command palette, keybinding, menu), and also for any window with a folder opened regardless of whether it's the last window. All windows without folders opened will be restored upon next launch. A list of previously opened windows with unsaved files can be accessed via `File > Open Recent > More...`",
+			"Controls whether unsaved files are remembered between sessions, allowing the save prompt when exiting the editor to be skipped.",
+			"Disable hot exit. A prompt will show when attempting to close a window with dirty files.",
+			"Hot exit will be triggered when the browser quits or the window or tab is closed.",
+			"Controls whether unsaved files are remembered between sessions, allowing the save prompt when exiting the editor to be skipped.",
+			"Files",
+			"Configure glob patterns for excluding files and folders. For example, the file Explorer decides which files and folders to show or hide based on this setting. Refer to the `#search.exclude#` setting to define search specific excludes. Read more about glob patterns [here](https://code.visualstudio.com/docs/editor/codebasics#_advanced-search-options).",
+			"The glob pattern to match file paths against. Set to true or false to enable or disable the pattern.",
+			"Additional check on the siblings of a matching file. Use $(basename) as variable for the matching file name.",
+			"Configure file associations to languages (e.g. `\"*.extension\": \"html\"`). These have precedence over the default associations of the languages installed.",
+			"The default character set encoding to use when reading and writing files. This setting can also be configured per language.",
+			"When enabled, the editor will attempt to guess the character set encoding when opening files. This setting can also be configured per language.",
+			"LF",
+			"CRLF",
+			"Uses operating system specific end of line character.",
+			"The default end of line character.",
+			"Moves files/folders to the OS trash (recycle bin on Windows) when deleting. Disabling this will delete files/folders permanently.",
+			"When enabled, will trim trailing whitespace when saving a file.",
+			"When enabled, insert a final new line at the end of the file when saving it.",
+			"When enabled, will trim all new lines after the final new line at the end of the file when saving it.",
+			"A dirty editor is never automatically saved.",
+			"A dirty editor is automatically saved after the configured `#files.autoSaveDelay#`.",
+			"A dirty editor is automatically saved when the editor loses focus.",
+			"A dirty editor is automatically saved when the window loses focus.",
+			"Controls auto save of dirty editors. Read more about autosave [here](https://code.visualstudio.com/docs/editor/codebasics#_save-auto-save).",
+			"Controls the delay in ms after which a dirty editor is saved automatically. Only applies when `#files.autoSave#` is set to `{0}`.",
+			"Configure glob patterns of file paths to exclude from file watching. Patterns must match on absolute paths (i.e. prefix with ** or the full path to match properly). Changing this setting requires a restart. When you experience Code consuming lots of CPU time on startup, you can exclude large folders to reduce the initial load.",
+			"The default language mode that is assigned to new files. If configured to `${activeEditorLanguage}`, will use the language mode of the currently active text editor if any.",
+			"Controls the memory available to VS Code after restart when trying to open large files. Same effect as specifying `--max-memory=NEWSIZE` on the command line.",
+			"Restore the undo stack when a file is reopened.",
+			"Will refuse to save and ask for resolving the save conflict manually.",
+			"Will resolve the save conflict by overwriting the file on disk with the changes in the editor.",
+			"A save conflict can occur when a file is saved to disk that was changed by another program in the meantime. To prevent data loss, the user is asked to compare the changes in the editor with the version on disk. This setting should only be changed if you frequently encounter save conflict errors and may result in data loss if used without caution.",
+			"Enables the simple file dialog. The simple file dialog replaces the system file dialog when enabled.",
+			"Format a file on save. A formatter must be available, the file must not be saved after delay, and the editor must not be shutting down.",
+			"Format the whole file.",
+			"Format modifications (requires source control).",
+			"Controls if format on save formats the whole file or only modifications. Only applies when `#editor.formatOnSave#` is enabled.",
+			"File Explorer",
+			"Number of editors shown in the Open Editors pane. Setting this to 0 hides the Open Editors pane.",
+			"Controls the sorting order of editors in the Open Editors pane.",
+			"Editors are ordered in the same order editor tabs are shown.",
+			"Editors are ordered in alphabetical order inside each editor group.",
+			"Files will be revealed and selected.",
+			"Files will not be revealed and selected.",
+			"Files will not be scrolled into view, but will still be focused.",
+			"Controls whether the explorer should automatically reveal and select files when opening them.",
+			"Controls whether the explorer should allow to move files and folders via drag and drop. This setting only effects drag and drop from inside the explorer.",
+			"Controls whether the explorer should ask for confirmation to move files and folders via drag and drop.",
+			"Controls whether the explorer should ask for confirmation when deleting a file via the trash.",
+			"Files and folders are sorted by their names, in alphabetical order. Folders are displayed before files.",
+			"Files and folders are sorted by their names, in alphabetical order. Files are interwoven with folders.",
+			"Files and folders are sorted by their names, in alphabetical order. Files are displayed before folders.",
+			"Files and folders are sorted by their extensions, in alphabetical order. Folders are displayed before files.",
+			"Files and folders are sorted by last modified date, in descending order. Folders are displayed before files.",
+			"Controls sorting order of files and folders in the explorer.",
+			"Controls whether file decorations should use colors.",
+			"Controls whether file decorations should use badges.",
+			"Appends the word \"copy\" at the end of the duplicated name potentially followed by a number",
+			"Adds a number at the end of the duplicated name. If some number is already part of the name, tries to increase that number",
+			"Controls what naming strategy to use when a giving a new name to a duplicated explorer item on paste.",
+			"Controls whether the explorer should render folders in a compact form. In such a form, single child folders will be compressed in a combined tree element. Useful for Java package structures, for example.",
+			"&&Explorer"
+		],
+		"vs/workbench/contrib/bulkEdit/browser/bulkEditService": [
+			"Made no edits",
+			"Made {0} text edits in {1} files",
+			"Made {0} text edits in one file",
+			"Workspace Edit",
+			"Workspace Edit",
+			"Made no edits",
+			"File operation",
+			"Are you sure you want to quit? '{0}' is in progress.",
+			"Quit"
+		],
+		"vs/workbench/contrib/bulkEdit/browser/preview/bulkEdit.contribution": [
+			"Another refactoring is being previewed.",
+			"Cancel",
+			"Continue",
+			"Press 'Continue' to discard the previous refactoring and continue with the current refactoring.",
+			"Apply Refactoring",
+			"Refactor Preview",
+			"Discard Refactoring",
+			"Refactor Preview",
+			"Toggle Change",
+			"Refactor Preview",
+			"Group Changes By File",
+			"Refactor Preview",
+			"Group Changes By Type",
+			"Refactor Preview",
+			"Group Changes By Type",
+			"Refactor Preview",
+			"View icon of the refactor preview view.",
+			"Refactor Preview",
+			"Refactor Preview"
+		],
+		"vs/workbench/contrib/search/browser/search.contribution": [
+			"Search",
+			"Copy",
+			"Copy Path",
+			"Copy All",
+			"Cancel Search",
+			"Refresh",
+			"Collapse All",
+			"Expand All",
+			"Clear Search Results",
+			"Reveal in Side Bar",
+			"Clear Search History",
+			"Focus List",
+			"Find in Folder...",
+			"Find in Workspace...",
+			"Go to Symbol in Workspace...",
+			"Search",
+			"Search",
+			"Open the search viewlet",
+			"A set of options for the search viewlet",
+			"Find in Files",
+			"Find &&in Files",
+			"Replace &&in Files",
+			"Search files by name (append {0} to go to line or {1} to go to symbol)",
+			"Go to File",
+			"Type the name of a symbol to open.",
+			"Go to Symbol in Workspace",
+			"Search",
+			"Configure glob patterns for excluding files and folders in fulltext searches and quick open. Inherits all glob patterns from the `#files.exclude#` setting. Read more about glob patterns [here](https://code.visualstudio.com/docs/editor/codebasics#_advanced-search-options).",
+			"The glob pattern to match file paths against. Set to true or false to enable or disable the pattern.",
+			"Additional check on the siblings of a matching file. Use $(basename) as variable for the matching file name.",
+			"Controls where new `Search: Find in Files` and `Find in Folder` operations occur: either in the sidebar's search view, or in a search editor",
+			"Search in the search view, either in the panel or sidebar.",
+			"Search in an existing search editor if present, otherwise in a new search editor",
+			"Search in a new search editor",
+			"This setting is deprecated and now falls back on \"search.usePCRE2\".",
+			"Deprecated. Consider \"search.usePCRE2\" for advanced regex feature support.",
+			"When enabled, the searchService process will be kept alive instead of being shut down after an hour of inactivity. This will keep the file search cache in memory.",
+			"Controls whether to use `.gitignore` and `.ignore` files when searching for files.",
+			"Controls whether to use global `.gitignore` and `.ignore` files when searching for files.",
+			"Whether to include results from a global symbol search in the file results for Quick Open.",
+			"Whether to include results from recently opened files in the file results for Quick Open.",
+			"History entries are sorted by relevance based on the filter value used. More relevant entries appear first.",
+			"History entries are sorted by recency. More recently opened entries appear first.",
+			"Controls sorting order of editor history in quick open when filtering.",
+			"Controls whether to follow symlinks while searching.",
+			"Search case-insensitively if the pattern is all lowercase, otherwise, search case-sensitively.",
+			"Controls whether the search view should read or modify the shared find clipboard on macOS.",
+			"Controls whether the search will be shown as a view in the sidebar or as a panel in the panel area for more horizontal space.",
+			"This setting is deprecated. Please use drag and drop instead by dragging the search icon.",
+			"Files with less than 10 results are expanded. Others are collapsed.",
+			"Controls whether the search results will be collapsed or expanded.",
+			"Controls whether to open Replace Preview when selecting or replacing a match.",
+			"Controls whether to show line numbers for search results.",
+			"Whether to use the PCRE2 regex engine in text search. This enables using some advanced regex features like lookahead and backreferences. However, not all PCRE2 features are supported - only features that are also supported by JavaScript.",
+			"Deprecated. PCRE2 will be used automatically when using regex features that are only supported by PCRE2.",
+			"Position the actionbar to the right when the search view is narrow, and immediately after the content when the search view is wide.",
+			"Always position the actionbar to the right.",
+			"Controls the positioning of the actionbar on rows in the search view.",
+			"Search all files as you type.",
+			"Enable seeding search from the word nearest the cursor when the active editor has no selection.",
+			"Update the search query to the editor's selected text when focusing the search view. This happens either on click or when triggering the `workbench.views.search.focus` command.",
+			"When `#search.searchOnType#` is enabled, controls the timeout in milliseconds between a character being typed and the search starting. Has no effect when `search.searchOnType` is disabled.",
+			"Double clicking selects the word under the cursor.",
+			"Double clicking opens the result in the active editor group.",
+			"Double clicking opens the result in the editor group to the side, creating one if it does not yet exist.",
+			"Configure effect of double clicking a result in a search editor.",
+			"When enabled, new Search Editors will reuse the includes, excludes, and flags of the previously opened Search Editor",
+			"The default number of surrounding context lines to use when creating new Search Editors. If using `#search.searchEditor.reusePriorSearchConfiguration#`, this can be set to `null` (empty) to use the prior Search Editor's configuration.",
+			"Results are sorted by folder and file names, in alphabetical order.",
+			"Results are sorted by file names ignoring folder order, in alphabetical order.",
+			"Results are sorted by file extensions, in alphabetical order.",
+			"Results are sorted by file last modified date, in descending order.",
+			"Results are sorted by count per file, in descending order.",
+			"Results are sorted by count per file, in ascending order.",
+			"Controls sorting order of search results.",
+			"Experimental. When enabled, an option is provided to make workspace search only search files that have been opened. **Requires restart to take effect.**",
+			"&&Search",
+			"Go to Symbol in &&Workspace..."
+		],
+		"vs/workbench/contrib/search/browser/searchView": [
+			"Search was canceled before any results could be found - ",
+			"Toggle Search Details",
+			"files to include",
+			"Search Include Patterns",
+			"files to exclude",
+			"Search Exclude Patterns",
+			"Replace All",
+			"&&Replace",
+			"Replaced {0} occurrence across {1} file with '{2}'.",
+			"Replaced {0} occurrence across {1} file.",
+			"Replaced {0} occurrence across {1} files with '{2}'.",
+			"Replaced {0} occurrence across {1} files.",
+			"Replaced {0} occurrences across {1} file with '{2}'.",
+			"Replaced {0} occurrences across {1} file.",
+			"Replaced {0} occurrences across {1} files with '{2}'.",
+			"Replaced {0} occurrences across {1} files.",
+			"Replace {0} occurrence across {1} file with '{2}'?",
+			"Replace {0} occurrence across {1} file?",
+			"Replace {0} occurrence across {1} files with '{2}'?",
+			"Replace {0} occurrence across {1} files?",
+			"Replace {0} occurrences across {1} file with '{2}'?",
+			"Replace {0} occurrences across {1} file?",
+			"Replace {0} occurrences across {1} files with '{2}'?",
+			"Replace {0} occurrences across {1} files?",
+			"Empty Search",
+			"The search results have been cleared",
+			"Search path not found: {0}",
+			"The result set only contains a subset of all matches. Please be more specific in your search to narrow down the results.",
+			"No results found in open editors matching '{0}' excluding '{1}' - ",
+			"No results found in open editors matching '{0}' - ",
+			"No results found in open editors excluding '{0}' - ",
+			"No results found in open editors. Review your settings for configured exclusions and check your gitignore files - ",
+			"No results found in '{0}' excluding '{1}' - ",
+			"No results found in '{0}' - ",
+			"No results found excluding '{0}' - ",
+			"No results found. Review your settings for configured exclusions and check your gitignore files - ",
+			"Search again",
+			"Search again in all files",
+			"Open Settings",
+			"Learn More",
+			"Search returned {0} results in {1} files",
+			" - Search: {0}",
+			" - exclude settings and ignore files are disabled",
+			"Open in editor",
+			"Copy current search results to an editor",
+			"{0} result in {1} file",
+			"{0} result in {1} files",
+			"{0} results in {1} file",
+			"{0} results in {1} files",
+			"You have not opened or specified a folder. Only open files are currently searched - ",
+			"Open Folder"
+		],
+		"vs/workbench/contrib/sash/browser/sash.contribution": [
+			"Controls the feedback area size in pixels of the dragging area in between views/editors. Set it to a larger value if you feel it's hard to resize views using the mouse."
+		],
+		"vs/workbench/contrib/searchEditor/browser/searchEditor.contribution": [
+			"Search Editor",
+			"Search Editor",
+			"Delete File Results",
+			"New Search Editor",
+			"Open Search Editor",
+			"Open new Search Editor to the Side",
+			"Open Results in Editor",
+			"Search Again",
+			"Focus Search Editor Input",
+			"Toggle Match Case",
+			"Toggle Match Whole Word",
+			"Toggle Use Regular Expression",
+			"Toggle Context Lines",
+			"Increase Context Lines",
+			"Decrease Context Lines",
+			"Select All Matches",
+			"Open New Search Editor from View"
+		],
+		"vs/workbench/contrib/scm/browser/scm.contribution": [
+			"View icon of the source control view.",
+			"Source Control",
+			"No source control providers registered.",
+			"Source Control",
+			"Source Control Repositories",
+			"Show SCM",
+			"SCM",
+			"Show the diff decorations in all available locations.",
+			"Show the diff decorations only in the editor gutter.",
+			"Show the diff decorations only in the overview ruler.",
+			"Show the diff decorations only in the minimap.",
+			"Do not show the diff decorations.",
+			"Controls diff decorations in the editor.",
+			"Controls the width(px) of diff decorations in gutter (added & modified).",
+			"Show the diff decorator in the gutter at all times.",
+			"Show the diff decorator in the gutter only on hover.",
+			"Controls the visibility of the Source Control diff decorator in the gutter.",
+			"Show the inline diff peek view on click.",
+			"Do nothing.",
+			"Controls the behavior of Source Control diff gutter decorations.",
+			"Controls whether inline actions are always visible in the Source Control view.",
+			"Show the sum of all Source Control Provider count badges.",
+			"Show the count badge of the focused Source Control Provider.",
+			"Disable the Source Control count badge.",
+			"Controls the count badge on the Source Control icon on the Activity Bar.",
+			"Hide Source Control Provider count badges.",
+			"Only show count badge for Source Control Provider when non-zero.",
+			"Show Source Control Provider count badges.",
+			"Controls the count badges on Source Control Provider headers. These headers only appear when there is more than one provider.",
+			"Show the repository changes as a tree.",
+			"Show the repository changes as a list.",
+			"Controls the default Source Control repository view mode.",
+			"Controls whether the SCM view should automatically reveal and select files when opening them.",
+			"Controls the font for the input message. Use `default` for the workbench user interface font family, `editor` for the `#editor.fontFamily#`'s value, or a custom font family.",
+			"Controls whether repositories should always be visible in the SCM view.",
+			"Controls how many repositories are visible in the Source Control Repositories section. Set to `0` to be able to manually resize the view.",
+			"S&&CM",
+			"SCM: Accept Input",
+			"SCM: View Next Commit",
+			"SCM: View Previous Commit",
+			"Open In Terminal"
+		],
+		"vs/workbench/contrib/debug/browser/debug.contribution": [
+			"Debug",
+			"Type the name of a launch configuration to run.",
+			"Start Debugging",
+			"Terminate Thread",
+			"Focus on Debug Console View",
+			"Jump to Cursor",
+			"Set Next Statement",
+			"Inline Breakpoint",
+			"Terminate Thread",
+			"Restart Frame",
+			"Copy Call Stack",
+			"Set Value",
+			"Copy Value",
+			"Copy as Expression",
+			"Add to Watch",
+			"Break When Value Changes",
+			"Edit Expression",
+			"Copy Value",
+			"Remove Expression",
+			"&&Run",
+			"&&Start Debugging",
+			"Run &&Without Debugging",
+			"&&Stop Debugging",
+			"&&Restart Debugging",
+			"A&&dd Configuration...",
+			"Step &&Over",
+			"Step &&Into",
+			"Step O&&ut",
+			"&&Continue",
+			"Inline Breakp&&oint",
+			"&&New Breakpoint",
+			"&&Install Additional Debuggers...",
+			"Debug Console",
+			"Debug Console",
+			"Run",
+			"Variables",
+			"Watch",
+			"Call Stack",
+			"Breakpoints",
+			"Loaded Scripts",
+			"Debug",
+			"Allow setting breakpoints in any file.",
+			"Automatically open the explorer view at the end of a debug session.",
+			"Show variable values inline in editor while debugging.",
+			"Controls the location of the debug toolbar. Either `floating` in all views, `docked` in the debug view, or `hidden`.",
+			"Never show debug in status bar",
+			"Always show debug in status bar",
+			"Show debug in status bar only after debug was started for the first time",
+			"Controls when the debug status bar should be visible.",
+			"Controls if the debug console should be automatically closed when the debug session ends.",
+			"Controls when the debug view should open.",
+			"Controls whether the debug sub-sessions are shown in the debug tool bar. When this setting is false the stop command on a sub-session will also stop the parent session.",
+			"Controls the font size in pixels in the debug console.",
+			"Controls the font family in the debug console.",
+			"Controls the line height in pixels in the debug console. Use 0 to compute the line height from the font size.",
+			"Controls if the lines should wrap in the debug console.",
+			"Controls if the debug console should suggest previously typed input.",
+			"Global debug launch configuration. Should be used as an alternative to 'launch.json' that is shared across workspaces.",
+			"Controls whether the workbench window should be focused when the debugger breaks.",
+			"Ignore task errors and start debugging.",
+			"Show the Problems view and do not start debugging.",
+			"Prompt user.",
+			"Cancel debugging.",
+			"Controls what to do when errors are encountered after running a preLaunchTask.",
+			"Controls whether breakpoints should be shown in the overview ruler.",
+			"Controls whether inline breakpoints candidate decorations should be shown in the editor while debugging."
+		],
+		"vs/workbench/contrib/debug/browser/debugEditorContribution": [
+			"Add Configuration..."
+		],
+		"vs/workbench/contrib/debug/browser/breakpointEditorContribution": [
+			"Logpoint",
+			"Breakpoint",
+			"This {0} has a {1} that will get lost on remove. Consider enabling the {0} instead.",
+			"message",
+			"condition",
+			"This {0} has a {1} that will get lost on remove. Consider disabling the {0} instead.",
+			"message",
+			"condition",
+			"Remove {0}",
+			"{0} {1}",
+			"Disable",
+			"Enable",
+			"Cancel",
+			"Logpoint",
+			"Breakpoint",
+			"Remove {0}",
+			"Edit {0}...",
+			"Disable {0}",
+			"Enable {0}",
+			"Remove Breakpoints",
+			"Remove Inline Breakpoint on Column {0}",
+			"Remove Line Breakpoint",
+			"Edit Breakpoints",
+			"Edit Inline Breakpoint on Column {0}",
+			"Edit Line Breakpoint",
+			"Enable/Disable Breakpoints",
+			"Disable Inline Breakpoint on Column {0}",
+			"Disable Line Breakpoint",
+			"Enable Inline Breakpoint on Column {0}",
+			"Enable Line Breakpoint",
+			"Add Breakpoint",
+			"Add Conditional Breakpoint...",
+			"Add Logpoint...",
+			"Icon color for breakpoints.",
+			"Icon color for disabled breakpoints.",
+			"Icon color for unverified breakpoints.",
+			"Icon color for the current breakpoint stack frame.",
+			"Icon color for all breakpoint stack frames."
+		],
+		"vs/workbench/contrib/debug/browser/callStackEditorContribution": [
+			"Background color for the highlight of line at the top stack frame position.",
+			"Background color for the highlight of line at focused stack frame position."
+		],
+		"vs/workbench/contrib/debug/browser/debugViewlet": [
+			"Show Run and Debug",
+			"Open &&Configurations",
+			"Select a workspace folder to create a launch.json file in or add it to the workspace config file",
+			"Debug Console",
+			"De&&bug Console",
+			"Debug Console",
+			"Start Additional Session"
+		],
+		"vs/workbench/contrib/debug/browser/repl": [
+			"Filter (e.g. text, !exclude)",
+			"Debug Console",
+			"Please start a debug session to evaluate expressions",
+			"REPL Accept Input",
+			"REPL Focus Content to Filter",
+			"Debug: Console Copy All",
+			"Filter",
+			"Select Debug Console",
+			"Clear Console",
+			"Debug console was cleared",
+			"Collapse All",
+			"Paste",
+			"Copy All",
+			"Copy"
+		],
+		"vs/workbench/contrib/markers/browser/markers.contribution": [
+			"View icon of the markers view.",
+			"&&Problems",
+			"Copy",
+			"Copy Message",
+			"Copy Message",
+			"Focus problems view",
+			"Focus problems filter",
+			"Show message in multiple lines",
+			"Problems",
+			"Show message in single line",
+			"Problems",
+			"Clear filters text",
+			"Problems",
+			"Collapse All",
+			"Filter",
+			"Problems",
+			"{0} Errors",
+			"{0} Warnings",
+			"{0} Infos",
+			"No Problems",
+			"10K+"
+		],
+		"vs/workbench/contrib/comments/browser/comments.contribution": [
+			"Comments",
+			"Controls when the comments panel should open."
+		],
+		"vs/workbench/contrib/url/browser/url.contribution": [
+			"Open URL",
+			"URL to open"
+		],
+		"vs/workbench/contrib/webviewPanel/browser/webviewPanel.contribution": [
+			"webview editor"
+		],
+		"vs/workbench/contrib/extensions/browser/extensions.contribution": [
+			"Press Enter to manage extensions.",
+			"Manage Extensions",
+			"Extension",
+			"Extensions",
+			"Extensions",
+			"When enabled, automatically installs updates for extensions. The updates are fetched from a Microsoft online service.",
+			"When enabled, automatically checks extensions for updates. If an extension has an update, it is marked as outdated in the Extensions view. The updates are fetched from a Microsoft online service.",
+			"When enabled, the notifications for extension recommendations will not be shown.",
+			"This setting is deprecated. Use extensions.ignoreRecommendations setting to control recommendation notifications. Use Extensions view's visibility actions to hide Recommended view by default.",
+			"When enabled, editors with extension details will be automatically closed upon navigating away from the Extensions View.",
+			"When an extension is listed here, a confirmation prompt will not be shown when that extension handles a URI.",
+			"Enable web worker extension host.",
+			"Install the given extension",
+			"Extension id or VSIX resource uri",
+			"Extension '{0}' not found.",
+			"Uninstall the given extension",
+			"Id of the extension to uninstall",
+			"Extension id required.",
+			"Extension '{0}' is not installed. Make sure you use the full extension ID, including the publisher, e.g.: ms-dotnettools.csharp.",
+			"Extension '{0}' is a Built-in extension and cannot be installed",
+			"Search for a specific extension",
+			"Query to use in search",
+			"Type the name of an extension to install or search.",
+			"Install or Search Extensions",
+			"Show Extensions",
+			"&&Extensions",
+			"E&&xtensions",
+			"Extensions",
+			"Install Extensions",
+			"Keymaps",
+			"&&Keymaps",
+			"Keymaps",
+			"Language Extensions",
+			"Check for Extension Updates",
+			"All extensions are up to date.",
+			"An extension update is available.",
+			"{0} extension updates are available.",
+			"An update to an extension which is disabled is available.",
+			"{0} extension updates are available. One of them is for a disabled extension.",
+			"{0} extension updates are available. All of them are for disabled extensions.",
+			"{0} extension updates are available. {1} of them are for disabled extensions.",
+			"Disable Auto Updating Extensions",
+			"Update All Extensions",
+			"Enable Auto Updating Extensions",
+			"Enable All Extensions",
+			"Enable All Extensions for this Workspace",
+			"Disable All Installed Extensions",
+			"Disable All Installed Extensions for this Workspace",
+			"Install from VSIX...",
+			"Install from VSIX",
+			"&&Install",
+			"Install Extension VSIX",
+			"Completed installing {0} extension from VSIX. Please reload Visual Studio Code to enable it.",
+			"Completed installing {0} extension from VSIX.",
+			"Reload Now",
+			"Filter Extensions...",
+			"Show Featured Extensions",
+			"Featured",
+			"Show Popular Extensions",
+			"Most Popular",
+			"Show Recommended Extensions",
+			"Recommended",
+			"Show Recently Published Extensions",
+			"Recently Published",
+			"Category",
+			"Show Built-in Extensions",
+			"Built-in",
+			"Show Installed Extensions",
+			"Installed",
+			"Show Enabled Extensions",
+			"Enabled",
+			"Show Disabled Extensions",
+			"Disabled",
+			"Show Outdated Extensions",
+			"Outdated",
+			"Sort By",
+			"Install Count",
+			"Rating",
+			"Name",
+			"Published Date",
+			"Clear Extensions Search Results",
+			"Refresh",
+			"Install Workspace Recommended Extensions",
+			"Copy",
+			"Name: {0}",
+			"Id: {0}",
+			"Description: {0}",
+			"Version: {0}",
+			"Publisher: {0}",
+			"VS Marketplace Link: {0}",
+			"Copy Extension Id",
+			"Extension Settings",
+			"Sync This Extension",
+			"Ignore Recommendation",
+			"Undo Ignored Recommendation",
+			"Add to Workspace Recommendations",
+			"Remove from Workspace Recommendations",
+			"Add Extension to Workspace Recommendations",
+			"Extensions",
+			"Add Extension to Workspace Folder Recommendations",
+			"Extensions",
+			"Add Extension to Workspace Ignored Recommendations",
+			"Extensions",
+			"Add Extension to Workspace Folder Ignored Recommendations",
+			"Extensions",
+			"Extensions"
+		],
+		"vs/workbench/contrib/output/browser/output.contribution": [
+			"View icon of the output view.",
+			"Output",
+			"Output",
+			"Log Viewer",
+			"Switch to Output",
+			"Clear Output",
+			"Output was cleared",
+			"Toggle Auto Scrolling",
+			"Turn Auto Scrolling Off",
+			"Turn Auto Scrolling On",
+			"Open Log Output File",
+			"Toggle Output",
+			"Show Logs...",
+			"Select Log",
+			"Open Log File...",
+			"Select Log file",
+			"&&Output",
+			"Output",
+			"Enable/disable the ability of smart scrolling in the output view. Smart scrolling allows you to lock scrolling automatically when you click in the output view and unlocks when you click in the last line."
+		],
+		"vs/workbench/contrib/extensions/browser/extensionsViewlet": [
+			"Installed",
+			"Install Local Extensions in '{0}'...",
+			"Remote",
+			"Install Remote Extensions Locally...",
+			"Remote",
+			"Popular",
+			"Recommended",
+			"Enabled",
+			"Disabled",
+			"Marketplace",
+			"Installed",
+			"Enabled",
+			"Disabled",
+			"Outdated",
+			"Builtin",
+			"Workspace Recommendations",
+			"Other Recommendations",
+			"Features",
+			"Themes",
+			"Programming Languages",
+			"Search Extensions in Marketplace",
+			"1 extension found in the {0} section.",
+			"1 extension found.",
+			"{0} extensions found in the {1} section.",
+			"{0} extensions found.",
+			"Marketplace returned 'ECONNREFUSED'. Please check the 'http.proxy' setting.",
+			"Open User Settings",
+			"{0} Outdated Extensions",
+			"We have uninstalled '{0}' which was reported to be problematic.",
+			"Reload Now"
+		],
+		"vs/workbench/contrib/output/browser/outputView": [
+			"{0} - Output",
+			"Output channel for '{0}'",
+			"Output",
+			"{0}, Output panel",
+			"Output panel",
+			"Output Channels.",
+			"Log ({0})"
+		],
+		"vs/workbench/contrib/terminal/browser/terminal.contribution": [
+			"Type the name of a terminal to open.",
+			"Show All Opened Terminals",
+			"Terminal",
+			"Terminal"
+		],
+		"vs/workbench/contrib/terminal/browser/terminalView": [
+			"Use 'monospace'",
+			"The terminal only supports monospace fonts. Be sure to restart VS Code if this is a newly installed font."
+		],
+		"vs/workbench/contrib/terminal/browser/remoteTerminalService": [
+			"Starting..."
+		],
+		"vs/workbench/contrib/relauncher/browser/relauncher.contribution": [
+			"A setting has changed that requires a restart to take effect.",
+			"A setting has changed that requires a reload to take effect.",
+			"Press the restart button to restart {0} and enable the setting.",
+			"Press the reload button to reload {0} and enable the setting.",
+			"&&Restart",
+			"&&Reload"
+		],
+		"vs/workbench/contrib/tasks/browser/task.contribution": [
+			"Building...",
+			"{0} running tasks",
+			"Show Running Tasks",
+			"Running Tasks",
+			"&&Run Task...",
+			"Run &&Build Task...",
+			"Show Runnin&&g Tasks...",
+			"R&&estart Running Task...",
+			"&&Terminate Task...",
+			"&&Configure Tasks...",
+			"Configure De&&fault Build Task...",
+			"Open Workspace Tasks",
+			"Show Task Log",
+			"Run Task",
+			"Rerun Last Task",
+			"Restart Running Task",
+			"Show Running Tasks",
+			"Terminate Task",
+			"Run Build Task",
+			"Run Test Task",
+			"Configure Default Build Task",
+			"Configure Default Test Task",
+			"Open User Tasks",
+			"Type the name of a task to run.",
+			"Run Task",
+			"Tasks",
+			"Configures whether to show the problem matcher prompt when running a task. Set to `true` to never prompt, or use a dictionary of task types to turn off prompting only for specific task types.",
+			"Sets problem matcher prompting behavior for all tasks.",
+			"An object containing task type-boolean pairs to never prompt for problem matchers on.",
+			"Controls enablement of `provideTasks` for all task provider extension. If the Tasks: Run Task command is slow, disabling auto detect for task providers may help. Individual extensions may also provide settings that disable auto detection.",
+			"Configures whether a warning is shown when a provider is slow",
+			"Sets the slow provider warning for all tasks.",
+			"An array of task types to never show the slow provider warning.",
+			"Controls the number of recent items tracked in task quick open dialog.",
+			"Controls whether to show the task detail for tasks that have a detail in task quick picks, such as Run Task.",
+			"Controls whether the task quick pick is skipped when there is only one task to pick from.",
+			"Causes the Tasks: Run Task command to use the slower \"show all\" behavior instead of the faster two level picker where tasks are grouped by provider.",
+			"Save all dirty editors before running a task.",
+			"Always saves all editors before running.",
+			"Never saves editors before running.",
+			"Prompts whether to save editors before running."
+		],
+		"vs/workbench/contrib/remote/common/remote.contribution": [
+			"Remote Server",
+			"UI extension kind. In a remote window, such extensions are enabled only when available on the local machine.",
+			"Workspace extension kind. In a remote window, such extensions are enabled only when available on the remote.",
+			"Web worker extension kind. Such an extension can execute in a web worker extension host.",
+			"Remote",
+			"Override the kind of an extension. `ui` extensions are installed and run on the local machine while `workspace` extensions are run on the remote. By overriding an extension's default kind using this setting, you specify if that extension should be installed and enabled locally or remotely.",
+			"Restores the ports you forwarded in a workspace.",
+			"When enabled, new running processes are detected and ports that they listen on are automatically forwarded.",
+			"A port, or range of ports (ex. \"40000-55000\") that the attributes should apply to",
+			"Shows a notification when a port is automatically forwarded.",
+			"Opens the browser when the port is automatically forwarded. Depending on your settings, this could open an embedded browser.",
+			"Shows no notification and takes no action when this port is automatically forwarded.",
+			"This port will not be automatically forwarded.",
+			"Defines the action that occurs when the port is discovered for automatic forwarding",
+			"Automatically prompt for elevation (if needed) when this port is forwarded. Elevate is required if the local port is a privileged port.",
+			"Label that will be shown in the UI for this port.",
+			"Labeled Port",
+			"Labeled Port",
+			"Allows setting of default properties that are set when a specific port number is forwarded. For example:\n\n```\n\"3000\": {\n  \"label\": \"Labeled Port\"\n},\n\"40000-55000\": {\n  \"onAutoForward\": \"ignore\"\n}\n```"
+		],
+		"vs/workbench/contrib/remote/browser/remote": [
+			"Contributes help information for Remote",
+			"The url, or a command that returns the url, to your project's Getting Started page",
+			"The url, or a command that returns the url, to your project's documentation page",
+			"The url, or a command that returns the url, to your project's feedback reporter",
+			"The url, or a command that returns the url, to your project's issues list",
+			"Get Started",
+			"Read Documentation",
+			"Provide Feedback",
+			"Review Issues",
+			"Report Issue",
+			"Select url to open",
+			"Help and feedback",
+			"Remote Help",
+			"Remote Explorer",
+			"Remote Explorer",
+			"Show Remote Explorer",
+			"Attempting to reconnect in {0} second...",
+			"Attempting to reconnect in {0} seconds...",
+			"Reconnect Now",
+			"Reload Window",
+			"Connection Lost",
+			"Disconnected. Attempting to reconnect...",
+			"Cannot reconnect. Please reload the window.",
+			"Reload Window",
+			"Cancel"
+		],
+		"vs/workbench/contrib/keybindings/browser/keybindings.contribution": [
+			"Toggle Keyboard Shortcuts Troubleshooting"
+		],
+		"vs/workbench/contrib/externalTerminal/browser/externalTerminal.contribution": [
+			"Open in Terminal",
+			"Open in Integrated Terminal",
+			"Open in Integrated Terminal",
+			"Open in Windows Terminal",
+			"Open in External Terminal"
+		],
+		"vs/workbench/contrib/snippets/browser/snippets.contribution": [
+			"The prefix to use when selecting the snippet in intellisense",
+			"The snippet content. Use `$1`, `${1:defaultText}` to define cursor positions, use `$0` for the final cursor position. Insert variable values with `${varName}` and `${varName:defaultText}`, e.g. `This is file: $TM_FILENAME`.",
+			"The snippet description.",
+			"Empty snippet",
+			"User snippet configuration",
+			"Empty snippet",
+			"User snippet configuration",
+			"A list of language names to which this snippet applies, e.g. 'typescript,javascript'."
+		],
+		"vs/workbench/contrib/snippets/browser/snippetsService": [
+			"Expected string in `contributes.{0}.path`. Provided value: {1}",
+			"When omitting the language, the value of `contributes.{0}.path` must be a `.code-snippets`-file. Provided value: {1}",
+			"Unknown language in `contributes.{0}.language`. Provided value: {1}",
+			"Expected `contributes.{0}.path` ({1}) to be included inside extension's folder ({2}). This might make the extension non-portable.",
+			"Contributes snippets.",
+			"Language identifier for which this snippet is contributed to.",
+			"Path of the snippets file. The path is relative to the extension folder and typically starts with './snippets/'.",
+			"One or more snippets from the extension '{0}' very likely confuse snippet-variables and snippet-placeholders (see https://code.visualstudio.com/docs/editor/userdefinedsnippets#_snippet-syntax for more details)",
+			"The snippet file \"{0}\" could not be read."
+		],
+		"vs/workbench/contrib/snippets/browser/insertSnippet": [
+			"Insert Snippet",
+			"User Snippets",
+			"Extension Snippets",
+			"Workspace Snippets",
+			"Hide from IntelliSense",
+			"(hidden from IntelliSense)",
+			"Show in IntelliSense",
+			"Select a snippet"
+		],
+		"vs/workbench/contrib/snippets/browser/configureSnippets": [
+			"(global)",
+			"({0})",
+			"Type snippet file name",
+			"Invalid file name",
+			"'{0}' is not a valid file name",
+			"'{0}' already exists",
+			"global",
+			"New Global Snippets file...",
+			"{0} workspace",
+			"New Snippets file for '{0}'...",
+			"Existing Snippets",
+			"New Snippets",
+			"New Snippets",
+			"Select Snippets File or Create Snippets",
+			"Configure User Snippets",
+			"Preferences",
+			"User &&Snippets",
+			"User Snippets"
+		],
+		"vs/workbench/contrib/themes/browser/themes.contribution": [
+			"Color Theme",
+			"light themes",
+			"dark themes",
+			"high contrast themes",
+			"Install Additional Color Themes...",
+			"Select Color Theme (Up/Down Keys to Preview)",
+			"File Icon Theme",
+			"None",
+			"Disable File Icons",
+			"Install Additional File Icon Themes...",
+			"Select File Icon Theme",
+			"Product Icon Theme",
+			"Default",
+			"Install Additional Product Icon Themes...",
+			"Select Product Icon Theme",
+			"Generate Color Theme From Current Settings",
+			"Preferences",
+			"&&Color Theme",
+			"File &&Icon Theme",
+			"&&Product Icon Theme",
+			"Color Theme",
+			"File Icon Theme",
+			"Product Icon Theme"
+		],
+		"vs/workbench/contrib/update/browser/update.contribution": [
+			"&&Release Notes"
+		],
+		"vs/workbench/contrib/watermark/browser/watermark": [
+			"Show All Commands",
+			"Go to File",
+			"Open File",
+			"Open Folder",
+			"Open File or Folder",
+			"Open Recent",
+			"New Untitled File",
+			"Toggle Terminal",
+			"Find in Files",
+			"Start Debugging",
+			"When enabled, will show the watermark tips when no editor is open."
+		],
+		"vs/workbench/contrib/surveys/browser/nps.contribution": [
+			"Do you mind taking a quick feedback survey?",
+			"Take Survey",
+			"Remind Me later",
+			"Don't Show Again"
+		],
+		"vs/workbench/contrib/surveys/browser/languageSurveys.contribution": [
+			"Help us improve our support for {0}",
+			"Take Short Survey",
+			"Remind Me later",
+			"Don't Show Again"
+		],
+		"vs/workbench/contrib/welcome/overlay/browser/welcomeOverlay": [
+			"File explorer",
+			"Search across files",
+			"Source code management",
+			"Launch and debug",
+			"Manage extensions",
+			"View errors and warnings",
+			"Toggle integrated terminal",
+			"Find and run all commands",
+			"Show notifications",
+			"User Interface Overview",
+			"Hide Interface Overview"
+		],
+		"vs/workbench/contrib/welcome/page/browser/welcomePage.contribution": [
+			"Start without an editor.",
+			"Open the Welcome page (default).",
+			"Open the README when opening a folder that contains one, fallback to 'welcomePage' otherwise.",
+			"Open a new untitled file (only applies when opening an empty window).",
+			"Open the Welcome page when opening an empty workbench.",
+			"Open the Getting Started page (experimental).",
+			"Controls which editor is shown at startup, if none are restored from the previous session.",
+			"&&Welcome"
+		],
+		"vs/workbench/contrib/welcome/gettingStarted/browser/gettingStarted.contribution": [
+			"Getting Started",
+			"Help",
+			"Enables an experimental Getting Started page, available via the Help menu."
+		],
+		"vs/workbench/contrib/welcome/walkThrough/browser/walkThrough.contribution": [
+			"Interactive Playground",
+			"I&&nteractive Playground"
+		],
+		"vs/workbench/contrib/callHierarchy/browser/callHierarchy.contribution": [
+			"No results",
+			"Failed to show call hierarchy",
+			"Peek Call Hierarchy",
+			"Show Incoming Calls",
+			"Icon for incoming calls in the call hierarchy view.",
+			"Show Outgoing Calls",
+			"Icon for outgoing calls in the call hierarchy view.",
+			"Refocus Call Hierarchy",
+			"Close"
+		],
+		"vs/workbench/contrib/codeEditor/browser/outline/documentSymbolsOutline": [
+			"Document Symbols"
+		],
+		"vs/workbench/contrib/outline/browser/outline.contribution": [
+			"View icon of the outline view.",
+			"Outline",
+			"Outline",
+			"Render Outline Elements with Icons.",
+			"Show Errors & Warnings on Outline Elements.",
+			"Use colors for Errors & Warnings.",
+			"Use badges for Errors & Warnings.",
+			"When enabled outline shows `file`-symbols.",
+			"When enabled outline shows `module`-symbols.",
+			"When enabled outline shows `namespace`-symbols.",
+			"When enabled outline shows `package`-symbols.",
+			"When enabled outline shows `class`-symbols.",
+			"When enabled outline shows `method`-symbols.",
+			"When enabled outline shows `property`-symbols.",
+			"When enabled outline shows `field`-symbols.",
+			"When enabled outline shows `constructor`-symbols.",
+			"When enabled outline shows `enum`-symbols.",
+			"When enabled outline shows `interface`-symbols.",
+			"When enabled outline shows `function`-symbols.",
+			"When enabled outline shows `variable`-symbols.",
+			"When enabled outline shows `constant`-symbols.",
+			"When enabled outline shows `string`-symbols.",
+			"When enabled outline shows `number`-symbols.",
+			"When enabled outline shows `boolean`-symbols.",
+			"When enabled outline shows `array`-symbols.",
+			"When enabled outline shows `object`-symbols.",
+			"When enabled outline shows `key`-symbols.",
+			"When enabled outline shows `null`-symbols.",
+			"When enabled outline shows `enumMember`-symbols.",
+			"When enabled outline shows `struct`-symbols.",
+			"When enabled outline shows `event`-symbols.",
+			"When enabled outline shows `operator`-symbols.",
+			"When enabled outline shows `typeParameter`-symbols."
+		],
+		"vs/workbench/contrib/experiments/browser/experiments.contribution": [
+			"Fetches experiments to run from a Microsoft online service."
+		],
+		"vs/workbench/contrib/userDataSync/browser/userDataSync.contribution": [
+			"Operation Id: {0}",
+			"Turned off syncing settings on this device because it is making too many requests."
+		],
+		"vs/workbench/contrib/timeline/browser/timeline.contribution": [
+			"View icon of the timeline view.",
+			"Icon for the open timeline action.",
+			"Timeline",
+			"An array of Timeline sources that should be excluded from the Timeline view",
+			"The number of items to show in the Timeline view by default and when loading more items. Setting to `null` (the default) will automatically choose a page size based on the visible area of the Timeline view",
+			"Experimental. Controls whether the Timeline view will load the next page of items when you scroll to the end of the list",
+			"Open Timeline"
+		],
+		"vs/workbench/contrib/workspaces/browser/workspaces.contribution": [
+			"This folder contains a workspace file '{0}'. Do you want to open it? [Learn more]({1}) about workspace files.",
+			"Open Workspace",
+			"This folder contains multiple workspace files. Do you want to open one? [Learn more]({0}) about workspace files.",
+			"Select Workspace",
+			"Select a workspace to open"
+		],
+		"vs/workbench/browser/parts/dialogs/dialogHandler": [
+			"&&Yes",
+			"Cancel",
+			"Version: {0}\nCommit: {1}\nDate: {2}\nBrowser: {3}",
+			"Copy",
+			"OK"
+		],
+		"vs/workbench/electron-sandbox/parts/dialogs/dialogHandler": [
+			"&&Yes",
+			"Cancel",
+			"Version: {0}\nCommit: {1}\nDate: {2}\nElectron: {3}\nChrome: {4}\nNode.js: {5}\nV8: {6}\nOS: {7}",
+			"OK",
+			"&&Copy"
+		],
+		"vs/workbench/services/dialogs/browser/abstractFileDialogService": [
+			"Your changes will be lost if you don't save them.",
+			"Do you want to save the changes you made to {0}?",
+			"Do you want to save the changes to the following {0} files?",
+			"&&Save All",
+			"&&Save",
+			"Do&&n't Save",
+			"Cancel",
+			"Open File Or Folder",
+			"Open File",
+			"Open Folder",
+			"Open Workspace",
+			"Workspace",
+			"Save As",
+			"Save As",
+			"All Files",
+			"No Extension"
+		],
+		"vs/workbench/services/textMate/browser/abstractTextMateService": [
+			"Already Logging.",
+			"Stop",
+			"Preparing to log TM Grammar parsing. Press Stop when finished.",
+			"Now logging TM Grammar parsing. Press Stop when finished.",
+			"Unknown language in `contributes.{0}.language`. Provided value: {1}",
+			"Expected string in `contributes.{0}.scopeName`. Provided value: {1}",
+			"Expected string in `contributes.{0}.path`. Provided value: {1}",
+			"Invalid value in `contributes.{0}.injectTo`. Must be an array of language scope names. Provided value: {1}",
+			"Invalid value in `contributes.{0}.embeddedLanguages`. Must be an object map from scope name to language. Provided value: {1}",
+			"Invalid value in `contributes.{0}.tokenTypes`. Must be an object map from scope name to token type. Provided value: {1}",
+			"Expected `contributes.{0}.path` ({1}) to be included inside extension's folder ({2}). This might make the extension non-portable.",
+			"Tokenization is skipped for long lines for performance reasons. The length of a long line can be configured via `editor.maxTokenizationLineLength`.",
+			"Don't Show Again"
+		],
+		"vs/workbench/services/workspaces/browser/abstractWorkspaceEditingService": [
+			"Save",
+			"Save Workspace",
+			"Unable to write into workspace configuration file. Please open the file to correct errors/warnings in it and try again.",
+			"Unable to write into workspace configuration file because the file is dirty. Please save it and try again.",
+			"Open Workspace Configuration"
+		],
+		"vs/workbench/services/configurationResolver/browser/configurationResolverService": [
+			"Cannot substitute command variable '{0}' because command did not return a result of type string.",
+			"Variable '{0}' must be defined in an '{1}' section of the debug or task configuration.",
+			"Input variable '{0}' is of type '{1}' and must include '{2}'.",
+			"(Default)",
+			"Cannot substitute input variable '{0}' because command '{1}' did not return a result of type string.",
+			"Input variable '{0}' can only be of type 'promptString', 'pickString', or 'command'.",
+			"Undefined input variable '{0}' encountered. Remove or define '{0}' to continue."
+		],
+		"vs/workbench/services/extensionManagement/common/extensionManagementService": [
+			"Cannot uninstall extension '{0}'. Extension '{1}' depends on this.",
+			"Cannot uninstall extension '{0}'. Extensions '{1}' and '{2}' depend on this.",
+			"Cannot uninstall extension '{0}'. Extensions '{1}', '{2}' and others depend on this.",
+			"Installing Extension {0} failed: Manifest is not found.",
+			"Cannot install '{0}' because this extension has defined that it cannot run on the remote server.",
+			"Cannot install '{0}' because this extension has defined that it cannot run on the web server.",
+			"Install Extension",
+			"Install Extensions",
+			"Install",
+			"Install (Do not sync)",
+			"Cancel",
+			"Would you like to install and synchronize '{0}' extension across your devices?",
+			"Would you like to install and synchronize extensions across your devices?"
+		],
+		"vs/workbench/contrib/logs/electron-sandbox/logsActions": [
+			"Open Logs Folder",
+			"Open Extension Logs Folder"
+		],
+		"vs/workbench/contrib/localizations/browser/localizationsActions": [
+			"Configure Display Language",
+			"Install additional languages...",
+			"Select Display Language",
+			"A restart is required for the change in display language to take effect.",
+			"Press the restart button to restart {0} and change the display language.",
+			"&&Restart"
+		],
+		"vs/workbench/services/extensions/common/extensionsRegistry": [
+			"UI extension kind. In a remote window, such extensions are enabled only when available on the local machine.",
+			"Workspace extension kind. In a remote window, such extensions are enabled only when available on the remote.",
+			"Web worker extension kind. Such an extension can execute in a web worker extension host.",
+			"Engine compatibility.",
+			"For VS Code extensions, specifies the VS Code version that the extension is compatible with. Cannot be *. For example: ^0.10.5 indicates compatibility with a minimum VS Code version of 0.10.5.",
+			"The publisher of the VS Code extension.",
+			"The display name for the extension used in the VS Code gallery.",
+			"The categories used by the VS Code gallery to categorize the extension.",
+			"Use 'Programming  Languages' instead",
+			"Banner used in the VS Code marketplace.",
+			"The banner color on the VS Code marketplace page header.",
+			"The color theme for the font used in the banner.",
+			"All contributions of the VS Code extension represented by this package.",
+			"Sets the extension to be flagged as a Preview in the Marketplace.",
+			"Activation events for the VS Code extension.",
+			"An activation event emitted whenever a file that resolves to the specified language gets opened.",
+			"An activation event emitted whenever the specified command gets invoked.",
+			"An activation event emitted whenever a user is about to start debugging or about to setup debug configurations.",
+			"An activation event emitted whenever a \"launch.json\" needs to be created (and all provideDebugConfigurations methods need to be called).",
+			"An activation event emitted whenever a list of all debug configurations needs to be created (and all provideDebugConfigurations methods for the \"dynamic\" scope need to be called).",
+			"An activation event emitted whenever a debug session with the specific type is about to be launched (and a corresponding resolveDebugConfiguration method needs to be called).",
+			"An activation event emitted whenever a debug session with the specific type is about to be launched and a debug protocol tracker might be needed.",
+			"An activation event emitted whenever a folder is opened that contains at least a file matching the specified glob pattern.",
+			"An activation event emitted after the start-up finished (after all `*` activated extensions have finished activating).",
+			"An activation event emitted whenever a file or folder is accessed with the given scheme.",
+			"An activation event emitted whenever a search is started in the folder with the given scheme.",
+			"An activation event emitted whenever the specified view is expanded.",
+			"An activation event emitted whenever the specified user identity.",
+			"An activation event emitted whenever a system-wide Uri directed towards this extension is open.",
+			"An activation event emitted whenever the specified custom editor becomes visible.",
+			"An activation event emitted whenever the specified notebook document is opened.",
+			"An activation event emitted on VS Code startup. To ensure a great end user experience, please use this activation event in your extension only when no other activation events combination works in your use-case.",
+			"Array of badges to display in the sidebar of the Marketplace's extension page.",
+			"Badge image URL.",
+			"Badge link.",
+			"Badge description.",
+			"Controls the Markdown rendering engine used in the Marketplace. Either github (default) or standard.",
+			"Controls the Q&A link in the Marketplace. Set to marketplace to enable the default Marketplace Q & A site. Set to a string to provide the URL of a custom Q & A site. Set to false to disable Q & A altogether.",
+			"Dependencies to other extensions. The identifier of an extension is always ${publisher}.${name}. For example: vscode.csharp.",
+			"A set of extensions that can be installed together. The identifier of an extension is always ${publisher}.${name}. For example: vscode.csharp.",
+			"Define the kind of an extension. `ui` extensions are installed and run on the local machine while `workspace` extensions run on the remote.",
+			"Define an extension which can run only on the local machine when connected to remote window.",
+			"Define an extension which can run only on the remote machine when connected remote window.",
+			"Define an extension which can run on either side, with a preference towards running on the local machine.",
+			"Define an extension which can run on either side, with a preference towards running on the remote machine.",
+			"Define an extension which cannot run in a remote context, neither on the local, nor on the remote machine.",
+			"Script executed before the package is published as a VS Code extension.",
+			"Uninstall hook for VS Code extension. Script that gets executed when the extension is completely uninstalled from VS Code which is when VS Code is restarted (shutdown and start) after the extension is uninstalled. Only Node scripts are supported.",
+			"The path to a 128x128 pixel icon."
+		],
+		"vs/workbench/contrib/localizations/browser/minimalTranslations": [
+			"Search language packs in the Marketplace to change the display language to {0}.",
+			"Search Marketplace",
+			"Install language pack to change the display language to {0}.",
+			"Install and Restart"
+		],
+		"vs/workbench/electron-sandbox/actions/developerActions": [
+			"Toggle Developer Tools",
+			"Configure Runtime Arguments",
+			"Toggle Shared Process",
+			"Reload With Extensions Disabled"
+		],
+		"vs/workbench/electron-sandbox/actions/windowActions": [
+			"Close Window",
+			"Zoom In",
+			"Zoom Out",
+			"Reset Zoom",
+			"Close Window",
+			"Close Window",
+			"Select a window to switch to",
+			"{0}, dirty window",
+			"Current Window",
+			"Switch Window...",
+			"Quick Switch Window..."
+		],
+		"vs/workbench/contrib/files/common/editors/fileEditorInput": [
+			"{0} (deleted, read-only)",
+			"{0} (deleted)",
+			"{0} (read-only)"
+		],
+		"vs/workbench/contrib/files/electron-sandbox/textFileEditor": [
+			"To open a file of this size, you need to restart and allow it to use more memory",
+			"Restart with {0} MB",
+			"Configure Memory Limit"
+		],
+		"vs/workbench/contrib/backup/electron-sandbox/backupTracker": [
+			"The following dirty editors could not be saved to the back up location.",
+			"The following dirty editors could not be saved or reverted.",
+			"Try saving or reverting the dirty editors first and then try again.",
+			"OK",
+			"Waiting for dirty editors to save..."
+		],
+		"vs/workbench/contrib/files/electron-sandbox/fileCommands": [
+			"Open a file first to reveal"
+		],
+		"vs/workbench/contrib/codeEditor/electron-sandbox/selectionClipboard": [
+			"Paste Selection Clipboard"
+		],
+		"vs/workbench/contrib/issue/electron-sandbox/issueActions": [
+			"Open Process Explorer",
+			"Report Performance Issue"
+		],
+		"vs/workbench/services/dialogs/browser/simpleFileDialog": [
+			"Open Local File...",
+			"Save Local File...",
+			"Open Local Folder...",
+			"Open Local...",
+			"File system provider for {0} is not available.",
+			"Show Local",
+			"The path does not exist.",
+			"Cancel",
+			"Please enter a valid path.",
+			"The folder already exists. Please use a new file name.",
+			"{0} already exists. Are you sure you want to overwrite it?",
+			"Please enter a valid file name.",
+			"Please enter a path that exists.",
+			"Please enter a path that exists.",
+			"Please start the path with a drive letter.",
+			"Please select a file.",
+			"Please select a folder."
+		],
+		"vs/workbench/browser/parts/notifications/notificationsCenter": [
+			"No new notifications",
+			"Notifications",
+			"Notification Center Actions"
+		],
+		"vs/workbench/browser/parts/notifications/notificationsAlerts": [
+			"Error: {0}",
+			"Warning: {0}",
+			"Info: {0}"
+		],
+		"vs/workbench/browser/parts/notifications/notificationsStatus": [
+			"Notifications",
+			"Notifications",
+			"Hide Notifications",
+			"No Notifications",
+			"No New Notifications",
+			"1 New Notification",
+			"{0} New Notifications",
+			"No New Notifications ({0} in progress)",
+			"1 New Notification ({0} in progress)",
+			"{0} New Notifications ({1} in progress)",
+			"Status Message"
+		],
+		"vs/workbench/browser/parts/notifications/notificationsCommands": [
+			"Notifications",
+			"Show Notifications",
+			"Hide Notifications",
+			"Clear All Notifications",
+			"Focus Notification Toast"
+		],
+		"vs/platform/actions/browser/menuEntryActionViewItem": [
+			"{0} ({1})"
+		],
+		"vs/workbench/services/configuration/common/configurationEditingService": [
+			"Open Tasks Configuration",
+			"Open Launch Configuration",
+			"Open Settings",
+			"Open Tasks Configuration",
+			"Open Launch Configuration",
+			"Save and Retry",
+			"Save and Retry",
+			"Open Settings",
+			"Unable to write to {0} because {1} is not a registered configuration.",
+			"Unable to write {0} to Workspace Settings. This setting can be written only into User settings.",
+			"Unable to write {0} to Workspace Settings. This setting can be written only into User settings.",
+			"Unable to write to Folder Settings because {0} does not support the folder resource scope.",
+			"Unable to write to User Settings because {0} does not support for global scope.",
+			"Unable to write to Workspace Settings because {0} does not support for workspace scope in a multi folder workspace.",
+			"Unable to write to Folder Settings because no resource is provided.",
+			"Unable to write to Language Settings because {0} is not a resource language setting.",
+			"Unable to write to {0} because no workspace is opened. Please open a workspace first and try again.",
+			"Unable to write into the tasks configuration file. Please open it to correct errors/warnings in it and try again.",
+			"Unable to write into the launch configuration file. Please open it to correct errors/warnings in it and try again.",
+			"Unable to write into user settings. Please open the user settings to correct errors/warnings in it and try again.",
+			"Unable to write into remote user settings. Please open the remote user settings to correct errors/warnings in it and try again.",
+			"Unable to write into workspace settings. Please open the workspace settings to correct errors/warnings in the file and try again.",
+			"Unable to write into folder settings. Please open the '{0}' folder settings to correct errors/warnings in it and try again.",
+			"Unable to write into tasks configuration file because the file is dirty. Please save it first and then try again.",
+			"Unable to write into launch configuration file because the file is dirty. Please save it first and then try again.",
+			"Unable to write into user settings because the file is dirty. Please save the user settings file first and then try again.",
+			"Unable to write into remote user settings because the file is dirty. Please save the remote user settings file first and then try again.",
+			"Unable to write into workspace settings because the file is dirty. Please save the workspace settings file first and then try again.",
+			"Unable to write into folder settings because the file is dirty. Please save the '{0}' folder settings file first and then try again.",
+			"Unable to write into tasks configuration file because the content of the file is newer.",
+			"Unable to write into launch configuration file because the content of the file is newer.",
+			"Unable to write into user settings because the content of the file is newer.",
+			"Unable to write into remote user settings because the content of the file is newer.",
+			"Unable to write into workspace settings because the content of the file is newer.",
+			"Unable to write into folder settings because the content of the file is newer.",
+			"User Settings",
+			"Remote User Settings",
+			"Workspace Settings",
+			"Folder Settings"
+		],
+		"vs/workbench/services/textfile/common/textFileEditorModelManager": [
+			"Failed to save '{0}': {1}"
+		],
+		"vs/editor/common/modes/modesRegistry": [
+			"Plain Text"
+		],
+		"vs/workbench/services/extensions/node/extensionPoints": [
+			"Invalid manifest file {0}: Not an JSON object.",
+			"Failed to parse {0}: [{1}, {2}] {3}.",
+			"Cannot read file {0}: {1}.",
+			"Failed to parse {0}: {1}.",
+			"Invalid format {0}: JSON object expected.",
+			"Couldn't find message for key {0}.",
+			"Extension version is not semver compatible.",
+			"Got empty extension description",
+			"property publisher must be of type `string`.",
+			"property `{0}` is mandatory and must be of type `string`",
+			"property `{0}` is mandatory and must be of type `string`",
+			"property `{0}` is mandatory and must be of type `object`",
+			"property `{0}` is mandatory and must be of type `string`",
+			"property `{0}` can be omitted or must be of type `string[]`",
+			"property `{0}` can be omitted or must be of type `string[]`",
+			"properties `{0}` and `{1}` must both be specified or must both be omitted",
+			"property `{0}` can be omitted or must be of type `string`",
+			"Expected `main` ({0}) to be included inside extension's folder ({1}). This might make the extension non-portable.",
+			"properties `{0}` and `{1}` must both be specified or must both be omitted",
+			"property `{0}` can be omitted or must be of type `string`",
+			"Expected `browser` ({0}) to be included inside extension's folder ({1}). This might make the extension non-portable.",
+			"properties `{0}` and `{1}` must both be specified or must both be omitted"
+		],
+		"vs/workbench/services/extensions/common/extensionHostManager": [
+			"Measure Extension Host Latency"
+		],
+		"vs/workbench/contrib/webview/browser/baseWebviewElement": [
+			"Error loading webview: {0}"
+		],
+		"vs/workbench/contrib/notebook/browser/notebookIcons": [
+			"Configure icon in kernel configuation widget in notebook editors.",
+			"Configure icon to select a kernel in notebook editors.",
+			"Icon to execute in notebook editors.",
+			"Icon to stop an execution in notebook editors.",
+			"Icon to delete a cell in notebook editors.",
+			"Icon to execute all cells in notebook editors.",
+			"Icon to edit a cell in notebook editors.",
+			"Icon to stop editing a cell in notebook editors.",
+			"Icon to move a cell up in notebook editors.",
+			"Icon to move a cell down in notebook editors.",
+			"Icon to clear cell outputs in notebook editors.",
+			"Icon to split a cell in notebook editors.",
+			"Icon to unfold a cell in notebook editors.",
+			"Icon to indicate a success state in notebook editors.",
+			"Icon to indicate a error state in notebook editors.",
+			"Icon to annotated a collapsed section in notebook editors.",
+			"Icon to annotated a expanded section in notebook editors.",
+			"Icon to open the notebook in a text editor.",
+			"Icon to revert in notebook editors.",
+			"Icon to render output in diff editor.",
+			"Icon for a mime type in notebook editors."
+		],
+		"vs/workbench/contrib/extensions/electron-browser/extensionsSlowActions": [
+			"Performance Issue",
+			"Report Issue",
+			"Did you attach the CPU-Profile?",
+			"OK",
+			"This is a reminder to make sure that you have not forgotten to attach '{0}' to the issue you have just created.",
+			"Show Issues",
+			"Did you attach the CPU-Profile?",
+			"OK",
+			"This is a reminder to make sure that you have not forgotten to attach '{0}' to an existing performance issue."
+		],
+		"vs/workbench/contrib/extensions/electron-browser/reportExtensionIssueAction": [
+			"Report Issue"
+		],
+		"vs/workbench/contrib/extensions/browser/abstractRuntimeExtensionsEditor": [
+			"Activated by {0} on start-up",
+			"Activated by {1} because a file matching {0} exists in your workspace",
+			"Activated by {1} because file {0} exists in your workspace",
+			"Activated by {1} because searching for {0} took too long",
+			"Activated by {0} after start-up finished",
+			"Activated by {1} because you opened a {0} file",
+			"Activated by {1} on {0}",
+			"Extension has caused the extension host to freeze.",
+			"{0} uncaught errors",
+			"Runtime Extensions",
+			"Disable (Workspace)",
+			"Disable",
+			"Show Running Extensions"
+		],
+		"vs/workbench/contrib/terminal/node/terminalProcess": [
+			"Starting directory (cwd) \"{0}\" is not a directory",
+			"Starting directory (cwd) \"{0}\" does not exist",
+			"Path to shell executable \"{0}\" is not a file of a symlink",
+			"Path to shell executable \"{0}\" does not exist"
+		],
+		"vs/workbench/contrib/terminal/electron-browser/terminalRemote": [
+			"Create New Integrated Terminal (Local)"
+		],
+		"vs/editor/common/config/editorOptions": [
+			"The editor will use platform APIs to detect when a Screen Reader is attached.",
+			"The editor will be permanently optimized for usage with a Screen Reader. Word wrapping will be disabled.",
+			"The editor will never be optimized for usage with a Screen Reader.",
+			"Controls whether the editor should run in a mode where it is optimized for screen readers. Setting to on will disable word wrapping.",
+			"Controls whether a space character is inserted when commenting.",
+			"Controls if empty lines should be ignored with toggle, add or remove actions for line comments.",
+			"Controls whether copying without a selection copies the current line.",
+			"Controls whether the cursor should jump to find matches while typing.",
+			"Controls whether the search string in the Find Widget is seeded from the editor selection.",
+			"Never turn on Find in selection automatically (default)",
+			"Always turn on Find in selection automatically",
+			"Turn on Find in selection automatically when multiple lines of content are selected.",
+			"Controls the condition for turning on find in selection automatically.",
+			"Controls whether the Find Widget should read or modify the shared find clipboard on macOS.",
+			"Controls whether the Find Widget should add extra lines on top of the editor. When true, you can scroll beyond the first line when the Find Widget is visible.",
+			"Controls whether the search automatically restarts from the beginning (or the end) when no further matches can be found.",
+			"Enables/Disables font ligatures ('calt' and 'liga' font features). Change this to a string for fine-grained control of the 'font-feature-settings' CSS property.",
+			"Explicit 'font-feature-settings' CSS property. A boolean can be passed instead if one only needs to turn on/off ligatures.",
+			"Configures font ligatures or font features. Can be either a boolean to enable/disable ligatures or a string for the value of the CSS 'font-feature-settings' property.",
+			"Controls the font size in pixels.",
+			"Only \"normal\" and \"bold\" keywords or numbers between 1 and 1000 are allowed.",
+			"Controls the font weight. Accepts \"normal\" and \"bold\" keywords or numbers between 1 and 1000.",
+			"Show peek view of the results (default)",
+			"Go to the primary result and show a peek view",
+			"Go to the primary result and enable peek-less navigation to others",
+			"This setting is deprecated, please use separate settings like 'editor.editor.gotoLocation.multipleDefinitions' or 'editor.editor.gotoLocation.multipleImplementations' instead.",
+			"Controls the behavior the 'Go to Definition'-command when multiple target locations exist.",
+			"Controls the behavior the 'Go to Type Definition'-command when multiple target locations exist.",
+			"Controls the behavior the 'Go to Declaration'-command when multiple target locations exist.",
+			"Controls the behavior the 'Go to Implementations'-command when multiple target locations exist.",
+			"Controls the behavior the 'Go to References'-command when multiple target locations exist.",
+			"Alternative command id that is being executed when the result of 'Go to Definition' is the current location.",
+			"Alternative command id that is being executed when the result of 'Go to Type Definition' is the current location.",
+			"Alternative command id that is being executed when the result of 'Go to Declaration' is the current location.",
+			"Alternative command id that is being executed when the result of 'Go to Implementation' is the current location.",
+			"Alternative command id that is being executed when the result of 'Go to Reference' is the current location.",
+			"Controls whether the hover is shown.",
+			"Controls the delay in milliseconds after which the hover is shown.",
+			"Controls whether the hover should remain visible when mouse is moved over it.",
+			"Enables the code action lightbulb in the editor.",
+			"Enables the inline hints in the editor.",
+			"Controls font size of inline hints in the editor. When set to `0`, the 90% of `#editor.fontSize#` is used.",
+			"Controls font family of inline hints in the editor.",
+			"Controls the line height. Use 0 to compute the line height from the font size.",
+			"Controls whether the minimap is shown.",
+			"The minimap has the same size as the editor contents (and might scroll).",
+			"The minimap will stretch or shrink as necessary to fill the height of the editor (no scrolling).",
+			"The minimap will shrink as necessary to never be larger than the editor (no scrolling).",
+			"Controls the size of the minimap.",
+			"Controls the side where to render the minimap.",
+			"Controls when the minimap slider is shown.",
+			"Scale of content drawn in the minimap: 1, 2 or 3.",
+			"Render the actual characters on a line as opposed to color blocks.",
+			"Limit the width of the minimap to render at most a certain number of columns.",
+			"Controls the amount of space between the top edge of the editor and the first line.",
+			"Controls the amount of space between the bottom edge of the editor and the last line.",
+			"Enables a pop-up that shows parameter documentation and type information as you type.",
+			"Controls whether the parameter hints menu cycles or closes when reaching the end of the list.",
+			"Enable quick suggestions inside strings.",
+			"Enable quick suggestions inside comments.",
+			"Enable quick suggestions outside of strings and comments.",
+			"Controls whether suggestions should automatically show up while typing.",
+			"Line numbers are not rendered.",
+			"Line numbers are rendered as absolute number.",
+			"Line numbers are rendered as distance in lines to cursor position.",
+			"Line numbers are rendered every 10 lines.",
+			"Controls the display of line numbers.",
+			"Number of monospace characters at which this editor ruler will render.",
+			"Color of this editor ruler.",
+			"Render vertical rulers after a certain number of monospace characters. Use multiple values for multiple rulers. No rulers are drawn if array is empty.",
+			"Insert suggestion without overwriting text right of the cursor.",
+			"Insert suggestion and overwrite text right of the cursor.",
+			"Controls whether words are overwritten when accepting completions. Note that this depends on extensions opting into this feature.",
+			"Controls whether filtering and sorting suggestions accounts for small typos.",
+			"Controls whether sorting favours words that appear close to the cursor.",
+			"Controls whether remembered suggestion selections are shared between multiple workspaces and windows (needs `#editor.suggestSelection#`).",
+			"Controls whether an active snippet prevents quick suggestions.",
+			"Controls whether to show or hide icons in suggestions.",
+			"Controls the visibility of the status bar at the bottom of the suggest widget.",
+			"Controls whether suggest details show inline with the label or only in the details widget",
+			"This setting is deprecated. The suggest widget can now be resized.",
+			"This setting is deprecated, please use separate settings like 'editor.suggest.showKeywords' or 'editor.suggest.showSnippets' instead.",
+			"When enabled IntelliSense shows `method`-suggestions.",
+			"When enabled IntelliSense shows `function`-suggestions.",
+			"When enabled IntelliSense shows `constructor`-suggestions.",
+			"When enabled IntelliSense shows `field`-suggestions.",
+			"When enabled IntelliSense shows `variable`-suggestions.",
+			"When enabled IntelliSense shows `class`-suggestions.",
+			"When enabled IntelliSense shows `struct`-suggestions.",
+			"When enabled IntelliSense shows `interface`-suggestions.",
+			"When enabled IntelliSense shows `module`-suggestions.",
+			"When enabled IntelliSense shows `property`-suggestions.",
+			"When enabled IntelliSense shows `event`-suggestions.",
+			"When enabled IntelliSense shows `operator`-suggestions.",
+			"When enabled IntelliSense shows `unit`-suggestions.",
+			"When enabled IntelliSense shows `value`-suggestions.",
+			"When enabled IntelliSense shows `constant`-suggestions.",
+			"When enabled IntelliSense shows `enum`-suggestions.",
+			"When enabled IntelliSense shows `enumMember`-suggestions.",
+			"When enabled IntelliSense shows `keyword`-suggestions.",
+			"When enabled IntelliSense shows `text`-suggestions.",
+			"When enabled IntelliSense shows `color`-suggestions.",
+			"When enabled IntelliSense shows `file`-suggestions.",
+			"When enabled IntelliSense shows `reference`-suggestions.",
+			"When enabled IntelliSense shows `customcolor`-suggestions.",
+			"When enabled IntelliSense shows `folder`-suggestions.",
+			"When enabled IntelliSense shows `typeParameter`-suggestions.",
+			"When enabled IntelliSense shows `snippet`-suggestions.",
+			"When enabled IntelliSense shows `user`-suggestions.",
+			"When enabled IntelliSense shows `issues`-suggestions.",
+			"Whether leading and trailing whitespace should always be selected.",
+			"Controls whether suggestions should be accepted on commit characters. For example, in JavaScript, the semi-colon (`;`) can be a commit character that accepts a suggestion and types that character.",
+			"Only accept a suggestion with `Enter` when it makes a textual change.",
+			"Controls whether suggestions should be accepted on `Enter`, in addition to `Tab`. Helps to avoid ambiguity between inserting new lines or accepting suggestions.",
+			"Controls the number of lines in the editor that can be read out by a screen reader. Warning: this has a performance implication for numbers larger than the default.",
+			"Editor content",
+			"Use language configurations to determine when to autoclose brackets.",
+			"Autoclose brackets only when the cursor is to the left of whitespace.",
+			"Controls whether the editor should automatically close brackets after the user adds an opening bracket.",
+			"Type over closing quotes or brackets only if they were automatically inserted.",
+			"Controls whether the editor should type over closing quotes or brackets.",
+			"Use language configurations to determine when to autoclose quotes.",
+			"Autoclose quotes only when the cursor is to the left of whitespace.",
+			"Controls whether the editor should automatically close quotes after the user adds an opening quote.",
+			"The editor will not insert indentation automatically.",
+			"The editor will keep the current line's indentation.",
+			"The editor will keep the current line's indentation and honor language defined brackets.",
+			"The editor will keep the current line's indentation, honor language defined brackets and invoke special onEnterRules defined by languages.",
+			"The editor will keep the current line's indentation, honor language defined brackets, invoke special onEnterRules defined by languages, and honor indentationRules defined by languages.",
+			"Controls whether the editor should automatically adjust the indentation when users type, paste, move or indent lines.",
+			"Use language configurations to determine when to automatically surround selections.",
+			"Surround with quotes but not brackets.",
+			"Surround with brackets but not quotes.",
+			"Controls whether the editor should automatically surround selections when typing quotes or brackets.",
+			"Emulate selection behaviour of tab characters when using spaces for indentation. Selection will stick to tab stops.",
+			"Controls whether the editor shows CodeLens.",
+			"Controls the font family for CodeLens.",
+			"Controls the font size in pixels for CodeLens. When set to `0`, the 90% of `#editor.fontSize#` is used.",
+			"Controls whether the editor should render the inline color decorators and color picker.",
+			"Enable that the selection with the mouse and keys is doing column selection.",
+			"Controls whether syntax highlighting should be copied into the clipboard.",
+			"Control the cursor animation style.",
+			"Controls whether the smooth caret animation should be enabled.",
+			"Controls the cursor style.",
+			"Controls the minimal number of visible leading and trailing lines surrounding the cursor. Known as 'scrollOff' or 'scrollOffset' in some other editors.",
+			"`cursorSurroundingLines` is enforced only when triggered via the keyboard or API.",
+			"`cursorSurroundingLines` is enforced always.",
+			"Controls when `cursorSurroundingLines` should be enforced.",
+			"Controls the width of the cursor when `#editor.cursorStyle#` is set to `line`.",
+			"Controls whether the editor should allow moving selections via drag and drop.",
+			"Scrolling speed multiplier when pressing `Alt`.",
+			"Controls whether the editor has code folding enabled.",
+			"Use a language-specific folding strategy if available, else the indentation-based one.",
+			"Use the indentation-based folding strategy.",
+			"Controls the strategy for computing folding ranges.",
+			"Controls whether the editor should highlight folded ranges.",
+			"Controls whether clicking on the empty content after a folded line will unfold the line.",
+			"Controls the font family.",
+			"Controls whether the editor should automatically format the pasted content. A formatter must be available and the formatter should be able to format a range in a document.",
+			"Controls whether the editor should automatically format the line after typing.",
+			"Controls whether the editor should render the vertical glyph margin. Glyph margin is mostly used for debugging.",
+			"Controls whether the cursor should be hidden in the overview ruler.",
+			"Controls whether the editor should highlight the active indent guide.",
+			"Controls the letter spacing in pixels.",
+			"Controls whether the editor has linked editing enabled. Depending on the language, related symbols, e.g. HTML tags, are updated while editing.",
+			"Controls whether the editor should detect links and make them clickable.",
+			"Highlight matching brackets.",
+			"A multiplier to be used on the `deltaX` and `deltaY` of mouse wheel scroll events.",
+			"Zoom the font of the editor when using mouse wheel and holding `Ctrl`.",
+			"Merge multiple cursors when they are overlapping.",
+			"Maps to `Control` on Windows and Linux and to `Command` on macOS.",
+			"Maps to `Alt` on Windows and Linux and to `Option` on macOS.",
+			"The modifier to be used to add multiple cursors with the mouse. The Go To Definition and Open Link mouse gestures will adapt such that they do not conflict with the multicursor modifier. [Read more](https://code.visualstudio.com/docs/editor/codebasics#_multicursor-modifier).",
+			"Each cursor pastes a single line of the text.",
+			"Each cursor pastes the full text.",
+			"Controls pasting when the line count of the pasted text matches the cursor count.",
+			"Controls whether the editor should highlight semantic symbol occurrences.",
+			"Controls whether a border should be drawn around the overview ruler.",
+			"Focus the tree when opening peek",
+			"Focus the editor when opening peek",
+			"Controls whether to focus the inline editor or the tree in the peek widget.",
+			"Controls whether the Go to Definition mouse gesture always opens the peek widget.",
+			"Controls the delay in milliseconds after which quick suggestions will show up.",
+			"Controls whether the editor auto renames on type.",
+			"Deprecated, use `editor.linkedEditing` instead.",
+			"Controls whether the editor should render control characters.",
+			"Controls whether the editor should render indent guides.",
+			"Render last line number when the file ends with a newline.",
+			"Highlights both the gutter and the current line.",
+			"Controls how the editor should render the current line highlight.",
+			"Controls if the editor should render the current line highlight only when the editor is focused",
+			"Render whitespace characters except for single spaces between words.",
+			"Render whitespace characters only on selected text.",
+			"Render only trailing whitespace characters",
+			"Controls how the editor should render whitespace characters.",
+			"Controls whether selections should have rounded corners.",
+			"Controls the number of extra characters beyond which the editor will scroll horizontally.",
+			"Controls whether the editor will scroll beyond the last line.",
+			"Scroll only along the predominant axis when scrolling both vertically and horizontally at the same time. Prevents horizontal drift when scrolling vertically on a trackpad.",
+			"Controls whether the Linux primary clipboard should be supported.",
+			"Controls whether the editor should highlight matches similar to the selection.",
+			"Always show the folding controls.",
+			"Only show the folding controls when the mouse is over the gutter.",
+			"Controls when the folding controls on the gutter are shown.",
+			"Controls fading out of unused code.",
+			"Controls strikethrough deprecated variables.",
+			"Show snippet suggestions on top of other suggestions.",
+			"Show snippet suggestions below other suggestions.",
+			"Show snippets suggestions with other suggestions.",
+			"Do not show snippet suggestions.",
+			"Controls whether snippets are shown with other suggestions and how they are sorted.",
+			"Controls whether the editor will scroll using an animation.",
+			"Font size for the suggest widget. When set to `0`, the value of `#editor.fontSize#` is used.",
+			"Line height for the suggest widget. When set to `0`, the value of `#editor.lineHeight#` is used. The minimum value is 8.",
+			"Controls whether suggestions should automatically show up when typing trigger characters.",
+			"Always select the first suggestion.",
+			"Select recent suggestions unless further typing selects one, e.g. `console.| -> console.log` because `log` has been completed recently.",
+			"Select suggestions based on previous prefixes that have completed those suggestions, e.g. `co -> console` and `con -> const`.",
+			"Controls how suggestions are pre-selected when showing the suggest list.",
+			"Tab complete will insert the best matching suggestion when pressing tab.",
+			"Disable tab completions.",
+			"Tab complete snippets when their prefix match. Works best when 'quickSuggestions' aren't enabled.",
+			"Enables tab completions.",
+			"Unusual line terminators are automatically removed.",
+			"Unusual line terminators are ignored.",
+			"Unusual line terminators prompt to be removed.",
+			"Remove unusual line terminators that might cause problems.",
+			"Inserting and deleting whitespace follows tab stops.",
+			"Characters that will be used as word separators when doing word related navigations or operations.",
+			"Lines will never wrap.",
+			"Lines will wrap at the viewport width.",
+			"Lines will wrap at `#editor.wordWrapColumn#`.",
+			"Lines will wrap at the minimum of viewport and `#editor.wordWrapColumn#`.",
+			"Controls how lines should wrap.",
+			"Controls the wrapping column of the editor when `#editor.wordWrap#` is `wordWrapColumn` or `bounded`.",
+			"No indentation. Wrapped lines begin at column 1.",
+			"Wrapped lines get the same indentation as the parent.",
+			"Wrapped lines get +1 indentation toward the parent.",
+			"Wrapped lines get +2 indentation toward the parent.",
+			"Controls the indentation of wrapped lines.",
+			"Assumes that all characters are of the same width. This is a fast algorithm that works correctly for monospace fonts and certain scripts (like Latin characters) where glyphs are of equal width.",
+			"Delegates wrapping points computation to the browser. This is a slow algorithm, that might cause freezes for large files, but it works correctly in all cases.",
+			"Controls the algorithm that computes wrapping points."
+		],
+		"vs/workbench/contrib/performance/browser/perfviewEditor": [
+			"Startup Performance"
+		],
+		"vs/workbench/contrib/tasks/common/taskDefinitionRegistry": [
+			"The actual task type. Please note that types starting with a '$' are reserved for internal usage.",
+			"Additional properties of the task type",
+			"Condition which must be true to enable this type of task. Consider using `shellExecutionSupported`, `processExecutionSupported`, and `customExecutionSupported` as appropriate for this task definition.",
+			"The task type configuration is missing the required 'taskType' property",
+			"Contributes task kinds"
+		],
+		"vs/workbench/contrib/tasks/common/problemMatcher": [
+			"The problem pattern is missing a regular expression.",
+			"The loop property is only supported on the last line matcher.",
+			"The problem pattern is invalid. The kind property must be provided only in the first element",
+			"The problem pattern is invalid. It must have at least have a file and a message.",
+			"The problem pattern is invalid. It must either have kind: \"file\" or have a line or location match group.",
+			"Error: The string {0} is not a valid regular expression.\n",
+			"The regular expression to find an error, warning or info in the output.",
+			"whether the pattern matches a location (file and line) or only a file.",
+			"The match group index of the filename. If omitted 1 is used.",
+			"The match group index of the problem's location. Valid location patterns are: (line), (line,column) and (startLine,startColumn,endLine,endColumn). If omitted (line,column) is assumed.",
+			"The match group index of the problem's line. Defaults to 2",
+			"The match group index of the problem's line character. Defaults to 3",
+			"The match group index of the problem's end line. Defaults to undefined",
+			"The match group index of the problem's end line character. Defaults to undefined",
+			"The match group index of the problem's severity. Defaults to undefined",
+			"The match group index of the problem's code. Defaults to undefined",
+			"The match group index of the message. If omitted it defaults to 4 if location is specified. Otherwise it defaults to 5.",
+			"In a multi line matcher loop indicated whether this pattern is executed in a loop as long as it matches. Can only specified on a last pattern in a multi line pattern.",
+			"The name of the problem pattern.",
+			"The name of the problem multi line problem pattern.",
+			"The actual patterns.",
+			"Contributes problem patterns",
+			"Invalid problem pattern. The pattern will be ignored.",
+			"Invalid problem pattern. The pattern will be ignored.",
+			"Error: the description can't be converted into a problem matcher:\n{0}\n",
+			"Error: the description doesn't define a valid problem pattern:\n{0}\n",
+			"Error: the description doesn't define an owner:\n{0}\n",
+			"Error: the description doesn't define a file location:\n{0}\n",
+			"Info: unknown severity {0}. Valid values are error, warning and info.\n",
+			"Error: the pattern with the identifier {0} doesn't exist.",
+			"Error: the pattern property refers to an empty identifier.",
+			"Error: the pattern property {0} is not a valid pattern variable name.",
+			"A problem matcher must define both a begin pattern and an end pattern for watching.",
+			"Error: The string {0} is not a valid regular expression.\n",
+			"The regular expression to detect the begin or end of a background task.",
+			"The match group index of the filename. Can be omitted.",
+			"The name of a contributed or predefined pattern",
+			"A problem pattern or the name of a contributed or predefined problem pattern. Can be omitted if base is specified.",
+			"The name of a base problem matcher to use.",
+			"The owner of the problem inside Code. Can be omitted if base is specified. Defaults to 'external' if omitted and base is not specified.",
+			"A human-readable string describing the source of this diagnostic, e.g. 'typescript' or 'super lint'.",
+			"The default severity for captures problems. Is used if the pattern doesn't define a match group for severity.",
+			"Controls if a problem reported on a text document is applied only to open, closed or all documents.",
+			"Defines how file names reported in a problem pattern should be interpreted. A relative fileLocation may be an array, where the second element of the array is the path the relative file location.",
+			"Patterns to track the begin and end of a matcher active on a background task.",
+			"If set to true the background monitor is in active mode when the task starts. This is equals of issuing a line that matches the beginsPattern",
+			"If matched in the output the start of a background task is signaled.",
+			"If matched in the output the end of a background task is signaled.",
+			"The watching property is deprecated. Use background instead.",
+			"Patterns to track the begin and end of a watching matcher.",
+			"If set to true the watcher is in active mode when the task starts. This is equals of issuing a line that matches the beginPattern",
+			"If matched in the output the start of a watching task is signaled.",
+			"If matched in the output the end of a watching task is signaled.",
+			"This property is deprecated. Use the watching property instead.",
+			"A regular expression signaling that a watched tasks begins executing triggered through file watching.",
+			"This property is deprecated. Use the watching property instead.",
+			"A regular expression signaling that a watched tasks ends executing.",
+			"The name of the problem matcher used to refer to it.",
+			"A human readable label of the problem matcher.",
+			"Contributes problem matchers",
+			"Microsoft compiler problems",
+			"Less problems",
+			"Gulp TSC Problems",
+			"JSHint problems",
+			"JSHint stylish problems",
+			"ESLint compact problems",
+			"ESLint stylish problems",
+			"Go problems"
+		],
+		"vs/platform/theme/common/iconRegistry": [
+			"The id of the font to use. If not set, the font that is defined first is used.",
+			"The font character associated with the icon definition.",
+			"Icon for the close action in widgets.",
+			"Icon for goto previous editor location.",
+			"Icon for goto next editor location."
+		],
+		"vs/workbench/contrib/tasks/common/taskTemplates": [
+			"Executes .NET Core build command",
+			"Executes the build target",
+			"Example to run an arbitrary external command",
+			"Executes common maven commands"
+		],
+		"vs/workbench/contrib/tasks/browser/runAutomaticTasks": [
+			"This folder has tasks ({0}) defined in 'tasks.json' that run automatically when you open this folder. Do you allow automatic tasks to run when you open this folder?",
+			"Allow and run",
+			"Disallow",
+			"Open tasks.json",
+			"Manage Automatic Tasks in Folder",
+			"Allow Automatic Tasks in Folder",
+			"Disallow Automatic Tasks in Folder"
+		],
+		"vs/workbench/contrib/tasks/browser/taskQuickPick": [
+			"Show All Tasks...",
+			"Configration icon in the tasks selection list.",
+			"Icon for remove in the tasks selection list.",
+			"Configure Task",
+			"contributed",
+			"All {0} tasks",
+			"Remove Recently Used Task",
+			"recently used",
+			"configured",
+			"configured",
+			"Go back ↩",
+			"No {0} tasks found. Go back ↩",
+			"There is no task provider registered for tasks of type \"{0}\"."
+		],
+		"vs/workbench/api/common/extHostExtensionActivator": [
+			"Cannot activate extension '{0}' because it depends on extension '{1}', which failed to activate.",
+			"Activating extension '{0}' failed: {1}."
+		],
+		"vs/workbench/contrib/debug/common/abstractDebugAdapter": [
+			"Timeout after {0} ms for '{1}'"
+		],
+		"vs/workbench/services/configurationResolver/common/variableResolver": [
+			"Variable {0} can not be resolved. Please open an editor.",
+			"Variable {0}: can not find workspace folder of '{1}'.",
+			"Variable {0} can not be resolved. No such folder '{1}'.",
+			"Variable {0} can not be resolved in a multi folder workspace. Scope this variable using ':' and a workspace folder name.",
+			"Variable {0} can not be resolved. Please open a folder.",
+			"Variable {0} can not be resolved because no environment variable name is given.",
+			"Variable {0} can not be resolved because setting '{1}' not found.",
+			"Variable {0} can not be resolved because '{1}' is a structured value.",
+			"Variable {0} can not be resolved because no settings name is given.",
+			"Variable {0} can not be resolved. Make sure to have a line selected in the active editor.",
+			"Variable {0} can not be resolved. Make sure to have some text selected in the active editor.",
+			"Variable {0} can not be resolved because the command has no value."
+		],
+		"vs/workbench/api/common/extHost.api.impl": [
+			"{0} (Extension)"
+		],
+		"vs/workbench/api/node/extHostDebugService": [
+			"debuggee"
+		],
+		"vs/code/electron-main/window": [
+			"&&Reopen",
+			"&&Keep Waiting",
+			"&&Close",
+			"The window is no longer responding",
+			"You can reopen or close the window or keep waiting.",
+			"The window has crashed (reason: '{0}')",
+			"The window has crashed",
+			"&&Reopen",
+			"&&Close",
+			"We are sorry for the inconvenience! You can reopen the window to continue where you left off.",
+			"You can still access the menu bar by pressing the Alt-key."
+		],
+		"vs/platform/menubar/electron-main/menubar": [
+			"New &&Window",
+			"&&File",
+			"&&Edit",
+			"&&Selection",
+			"&&View",
+			"&&Go",
+			"&&Run",
+			"&&Terminal",
+			"Window",
+			"&&Help",
+			"About {0}",
+			"&&Preferences",
+			"Services",
+			"Hide {0}",
+			"Hide Others",
+			"Show All",
+			"Quit {0}",
+			"Minimize",
+			"Zoom",
+			"Bring All to Front",
+			"Switch &&Window...",
+			"New Tab",
+			"Show Previous Tab",
+			"Show Next Tab",
+			"Move Tab to New Window",
+			"Merge All Windows",
+			"Check for &&Updates...",
+			"Checking for Updates...",
+			"D&&ownload Available Update",
+			"Downloading Update...",
+			"Install &&Update...",
+			"Installing Update...",
+			"Restart to &&Update"
+		],
+		"vs/platform/userDataSync/common/abstractSynchronizer": [
+			"Cannot sync {0} as its local version {1} is not compatible with its remote version {2}",
+			"Cannot parse sync data as it is not compatible with the current version."
+		],
+		"vs/editor/common/view/editorColorRegistry": [
+			"Background color for the highlight of line at the cursor position.",
+			"Background color for the border around the line at the cursor position.",
+			"Background color of highlighted ranges, like by quick open and find features. The color must not be opaque so as not to hide underlying decorations.",
+			"Background color of the border around highlighted ranges.",
+			"Background color of highlighted symbol, like for go to definition or go next/previous symbol. The color must not be opaque so as not to hide underlying decorations.",
+			"Background color of the border around highlighted symbols.",
+			"Color of the editor cursor.",
+			"The background color of the editor cursor. Allows customizing the color of a character overlapped by a block cursor.",
+			"Color of whitespace characters in the editor.",
+			"Color of the editor indentation guides.",
+			"Color of the active editor indentation guides.",
+			"Color of editor line numbers.",
+			"Color of editor active line number",
+			"Id is deprecated. Use 'editorLineNumber.activeForeground' instead.",
+			"Color of editor active line number",
+			"Color of the editor rulers.",
+			"Foreground color of editor CodeLens",
+			"Background color behind matching brackets",
+			"Color for matching brackets boxes",
+			"Color of the overview ruler border.",
+			"Background color of the editor overview ruler. Only used when the minimap is enabled and placed on the right side of the editor.",
+			"Background color of the editor gutter. The gutter contains the glyph margins and the line numbers.",
+			"Border color of unnecessary (unused) source code in the editor.",
+			"Opacity of unnecessary (unused) source code in the editor. For example, \"#000000c0\" will render the code with 75% opacity. For high contrast themes, use the  'editorUnnecessaryCode.border' theme color to underline unnecessary code instead of fading it out.",
+			"Overview ruler marker color for range highlights. The color must not be opaque so as not to hide underlying decorations.",
+			"Overview ruler marker color for errors.",
+			"Overview ruler marker color for warnings.",
+			"Overview ruler marker color for infos."
+		],
+		"vs/editor/common/model/editStack": [
+			"Typing"
+		],
+		"vs/editor/browser/controller/coreCommands": [
+			"Stick to the end even when going to longer lines",
+			"Stick to the end even when going to longer lines"
+		],
+		"vs/editor/browser/widget/codeEditorWidget": [
+			"The number of cursors has been limited to {0}."
+		],
+		"vs/editor/contrib/anchorSelect/anchorSelect": [
+			"Selection Anchor",
+			"Anchor set at {0}:{1}",
+			"Set Selection Anchor",
+			"Go to Selection Anchor",
+			"Select from Anchor to Cursor",
+			"Cancel Selection Anchor"
+		],
+		"vs/editor/browser/widget/diffEditorWidget": [
+			"Line decoration for inserts in the diff editor.",
+			"Line decoration for removals in the diff editor.",
+			"Cannot compare files because one file is too large."
+		],
+		"vs/editor/contrib/caretOperations/caretOperations": [
+			"Move Selected Text Left",
+			"Move Selected Text Right"
+		],
+		"vs/editor/contrib/caretOperations/transpose": [
+			"Transpose Letters"
+		],
+		"vs/editor/contrib/bracketMatching/bracketMatching": [
+			"Overview ruler marker color for matching brackets.",
+			"Go to Bracket",
+			"Select to Bracket",
+			"Go to &&Bracket"
+		],
+		"vs/editor/contrib/codelens/codelensController": [
+			"Show CodeLens Commands For Current Line"
+		],
+		"vs/editor/contrib/comment/comment": [
+			"Toggle Line Comment",
+			"&&Toggle Line Comment",
+			"Add Line Comment",
+			"Remove Line Comment",
+			"Toggle Block Comment",
+			"Toggle &&Block Comment"
+		],
+		"vs/editor/contrib/contextmenu/contextmenu": [
+			"Show Editor Context Menu"
+		],
+		"vs/editor/contrib/cursorUndo/cursorUndo": [
+			"Cursor Undo",
+			"Cursor Redo"
+		],
+		"vs/editor/contrib/find/findController": [
+			"Find",
+			"&&Find",
+			"Find With Selection",
+			"Find Next",
+			"Find Next",
+			"Find Previous",
+			"Find Previous",
+			"Find Next Selection",
+			"Find Previous Selection",
+			"Replace",
+			"&&Replace"
+		],
+		"vs/editor/contrib/fontZoom/fontZoom": [
+			"Editor Font Zoom In",
+			"Editor Font Zoom Out",
+			"Editor Font Zoom Reset"
+		],
+		"vs/editor/contrib/folding/folding": [
+			"Unfold",
+			"Unfold Recursively",
+			"Fold",
+			"Toggle Fold",
+			"Fold Recursively",
+			"Fold All Block Comments",
+			"Fold All Regions",
+			"Unfold All Regions",
+			"Fold All",
+			"Unfold All",
+			"Fold Level {0}",
+			"Background color behind folded ranges. The color must not be opaque so as not to hide underlying decorations.",
+			"Color of the folding control in the editor gutter."
+		],
+		"vs/editor/contrib/format/formatActions": [
+			"Format Document",
+			"Format Selection"
+		],
+		"vs/editor/contrib/gotoSymbol/goToCommands": [
+			"Peek",
+			"Definitions",
+			"No definition found for '{0}'",
+			"No definition found",
+			"Go to Definition",
+			"Go to &&Definition",
+			"Open Definition to the Side",
+			"Peek Definition",
+			"Declarations",
+			"No declaration found for '{0}'",
+			"No declaration found",
+			"Go to Declaration",
+			"Go to &&Declaration",
+			"No declaration found for '{0}'",
+			"No declaration found",
+			"Peek Declaration",
+			"Type Definitions",
+			"No type definition found for '{0}'",
+			"No type definition found",
+			"Go to Type Definition",
+			"Go to &&Type Definition",
+			"Peek Type Definition",
+			"Implementations",
+			"No implementation found for '{0}'",
+			"No implementation found",
+			"Go to Implementations",
+			"Go to &&Implementations",
+			"Peek Implementations",
+			"No references found for '{0}'",
+			"No references found",
+			"Go to References",
+			"Go to &&References",
+			"References",
+			"Peek References",
+			"References",
+			"Go To Any Symbol",
+			"Locations",
+			"No results for '{0}'",
+			"References"
+		],
+		"vs/editor/contrib/gotoSymbol/link/goToDefinitionAtPosition": [
+			"Click to show {0} definitions."
+		],
+		"vs/editor/contrib/gotoError/gotoError": [
+			"Go to Next Problem (Error, Warning, Info)",
+			"Icon for goto next marker.",
+			"Go to Previous Problem (Error, Warning, Info)",
+			"Icon for goto previous marker.",
+			"Go to Next Problem in Files (Error, Warning, Info)",
+			"Next &&Problem",
+			"Go to Previous Problem in Files (Error, Warning, Info)",
+			"Previous &&Problem"
+		],
+		"vs/editor/contrib/hover/hover": [
+			"Show Hover",
+			"Show Definition Preview Hover"
+		],
+		"vs/editor/contrib/indentation/indentation": [
+			"Convert Indentation to Spaces",
+			"Convert Indentation to Tabs",
+			"Configured Tab Size",
+			"Select Tab Size for Current File",
+			"Indent Using Tabs",
+			"Indent Using Spaces",
+			"Detect Indentation from Content",
+			"Reindent Lines",
+			"Reindent Selected Lines"
+		],
+		"vs/editor/contrib/inPlaceReplace/inPlaceReplace": [
+			"Replace with Previous Value",
+			"Replace with Next Value"
+		],
+		"vs/editor/contrib/linesOperations/linesOperations": [
+			"Copy Line Up",
+			"&&Copy Line Up",
+			"Copy Line Down",
+			"Co&&py Line Down",
+			"Duplicate Selection",
+			"&&Duplicate Selection",
+			"Move Line Up",
+			"Mo&&ve Line Up",
+			"Move Line Down",
+			"Move &&Line Down",
+			"Sort Lines Ascending",
+			"Sort Lines Descending",
+			"Trim Trailing Whitespace",
+			"Delete Line",
+			"Indent Line",
+			"Outdent Line",
+			"Insert Line Above",
+			"Insert Line Below",
+			"Delete All Left",
+			"Delete All Right",
+			"Join Lines",
+			"Transpose characters around the cursor",
+			"Transform to Uppercase",
+			"Transform to Lowercase",
+			"Transform to Title Case",
+			"Transform to Snake Case"
+		],
+		"vs/editor/contrib/linkedEditing/linkedEditing": [
+			"Start Linked Editing",
+			"Background color when the editor auto renames on type."
+		],
+		"vs/editor/contrib/links/links": [
+			"Execute command",
+			"Follow link",
+			"cmd + click",
+			"ctrl + click",
+			"option + click",
+			"alt + click",
+			"Execute command {0}",
+			"Failed to open this link because it is not well-formed: {0}",
+			"Failed to open this link because its target is missing.",
+			"Open Link"
+		],
+		"vs/editor/contrib/parameterHints/parameterHints": [
+			"Trigger Parameter Hints"
+		],
+		"vs/editor/contrib/multicursor/multicursor": [
+			"Add Cursor Above",
+			"&&Add Cursor Above",
+			"Add Cursor Below",
+			"A&&dd Cursor Below",
+			"Add Cursors to Line Ends",
+			"Add C&&ursors to Line Ends",
+			"Add Cursors To Bottom",
+			"Add Cursors To Top",
+			"Add Selection To Next Find Match",
+			"Add &&Next Occurrence",
+			"Add Selection To Previous Find Match",
+			"Add P&&revious Occurrence",
+			"Move Last Selection To Next Find Match",
+			"Move Last Selection To Previous Find Match",
+			"Select All Occurrences of Find Match",
+			"Select All &&Occurrences",
+			"Change All Occurrences"
+		],
+		"vs/editor/contrib/rename/rename": [
+			"No result.",
+			"An unknown error occurred while resolving rename location",
+			"Renaming '{0}'",
+			"Renaming {0}",
+			"Successfully renamed '{0}' to '{1}'. Summary: {2}",
+			"Rename failed to apply edits",
+			"Rename failed to compute edits",
+			"Rename Symbol",
+			"Enable/disable the ability to preview changes before renaming"
+		],
+		"vs/editor/contrib/smartSelect/smartSelect": [
+			"Expand Selection",
+			"&&Expand Selection",
+			"Shrink Selection",
+			"&&Shrink Selection"
+		],
+		"vs/editor/contrib/suggest/suggestController": [
+			"Accepting '{0}' made {1} additional edits",
+			"Trigger Suggest",
+			"Insert",
+			"Insert",
+			"Replace",
+			"Replace",
+			"Insert",
+			"show less",
+			"show more",
+			"Reset Suggest Widget Size"
+		],
+		"vs/editor/contrib/tokenization/tokenization": [
+			"Developer: Force Retokenize"
+		],
+		"vs/editor/contrib/toggleTabFocusMode/toggleTabFocusMode": [
+			"Toggle Tab Key Moves Focus",
+			"Pressing Tab will now move focus to the next focusable element",
+			"Pressing Tab will now insert the tab character"
+		],
+		"vs/editor/contrib/unusualLineTerminators/unusualLineTerminators": [
+			"Unusual Line Terminators",
+			"Detected unusual line terminators",
+			"This file contains one or more unusual line terminator characters, like Line Separator (LS) or Paragraph Separator (PS).\n\nIt is recommended to remove them from the file. This can be configured via `editor.unusualLineTerminators`.",
+			"Fix this file",
+			"Ignore problem for this file"
+		],
+		"vs/editor/contrib/wordHighlighter/wordHighlighter": [
+			"Background color of a symbol during read-access, like reading a variable. The color must not be opaque so as not to hide underlying decorations.",
+			"Background color of a symbol during write-access, like writing to a variable. The color must not be opaque so as not to hide underlying decorations.",
+			"Border color of a symbol during read-access, like reading a variable.",
+			"Border color of a symbol during write-access, like writing to a variable.",
+			"Overview ruler marker color for symbol highlights. The color must not be opaque so as not to hide underlying decorations.",
+			"Overview ruler marker color for write-access symbol highlights. The color must not be opaque so as not to hide underlying decorations.",
+			"Go to Next Symbol Highlight",
+			"Go to Previous Symbol Highlight",
+			"Trigger Symbol Highlight"
+		],
+		"vs/editor/contrib/wordOperations/wordOperations": [
+			"Delete Word"
+		],
+		"vs/editor/common/standaloneStrings": [
+			"No selection",
+			"Line {0}, Column {1} ({2} selected)",
+			"Line {0}, Column {1}",
+			"{0} selections ({1} characters selected)",
+			"{0} selections",
+			"Now changing the setting `accessibilitySupport` to 'on'.",
+			"Now opening the Editor Accessibility documentation page.",
+			" in a read-only pane of a diff editor.",
+			" in a pane of a diff editor.",
+			" in a read-only code editor",
+			" in a code editor",
+			"To configure the editor to be optimized for usage with a Screen Reader press Command+E now.",
+			"To configure the editor to be optimized for usage with a Screen Reader press Control+E now.",
+			"The editor is configured to be optimized for usage with a Screen Reader.",
+			"The editor is configured to never be optimized for usage with a Screen Reader, which is not the case at this time.",
+			"Pressing Tab in the current editor will move focus to the next focusable element. Toggle this behavior by pressing {0}.",
+			"Pressing Tab in the current editor will move focus to the next focusable element. The command {0} is currently not triggerable by a keybinding.",
+			"Pressing Tab in the current editor will insert the tab character. Toggle this behavior by pressing {0}.",
+			"Pressing Tab in the current editor will insert the tab character. The command {0} is currently not triggerable by a keybinding.",
+			"Press Command+H now to open a browser window with more information related to editor accessibility.",
+			"Press Control+H now to open a browser window with more information related to editor accessibility.",
+			"You can dismiss this tooltip and return to the editor by pressing Escape or Shift+Escape.",
+			"Show Accessibility Help",
+			"Developer: Inspect Tokens",
+			"Go to Line/Column...",
+			"Show all Quick Access Providers",
+			"Command Palette",
+			"Show And Run Commands",
+			"Go to Symbol...",
+			"Go to Symbol by Category...",
+			"Editor content",
+			"Press Alt+F1 for Accessibility Options.",
+			"Toggle High Contrast Theme",
+			"Made {0} edits in {1} files"
+		],
+		"vs/workbench/api/common/jsonValidationExtensionPoint": [
+			"Contributes json schema configuration.",
+			"The file pattern (or an array of patterns) to match, for example \"package.json\" or \"*.launch\". Exclusion patterns start with '!'",
+			"A schema URL ('http:', 'https:') or relative path to the extension folder ('./').",
+			"'configuration.jsonValidation' must be a array",
+			"'configuration.jsonValidation.fileMatch' must be defined as a string or an array of strings.",
+			"'configuration.jsonValidation.url' must be a URL or relative path",
+			"Expected `contributes.{0}.url` ({1}) to be included inside extension's folder ({2}). This might make the extension non-portable.",
+			"'configuration.jsonValidation.url' is an invalid relative URL: {0}",
+			"'configuration.jsonValidation.url' must be an absolute URL or start with './'  to reference schemas located in the extension."
+		],
+		"vs/workbench/services/themes/common/colorExtensionPoint": [
+			"Contributes extension defined themable colors",
+			"The identifier of the themable color",
+			"Identifiers must only contain letters, digits and dots and can not start with a dot",
+			"The description of the themable color",
+			"The default color for light themes. Either a color value in hex (#RRGGBB[AA]) or the identifier of a themable color which provides the default.",
+			"The default color for dark themes. Either a color value in hex (#RRGGBB[AA]) or the identifier of a themable color which provides the default.",
+			"The default color for high contrast themes. Either a color value in hex (#RRGGBB[AA]) or the identifier of a themable color which provides the default.",
+			"'configuration.colors' must be a array",
+			"{0} must be either a color value in hex (#RRGGBB[AA] or #RGB[A]) or the identifier of a themable color which provides the default.",
+			"'configuration.colors.id' must be defined and can not be empty",
+			"'configuration.colors.id' must only contain letters, digits and dots and can not start with a dot",
+			"'configuration.colors.description' must be defined and can not be empty",
+			"'configuration.colors.defaults' must be defined and must contain 'light', 'dark' and 'highContrast'"
+		],
+		"vs/workbench/services/themes/common/tokenClassificationExtensionPoint": [
+			"Contributes semantic token types.",
+			"The identifier of the semantic token type",
+			"Identifiers should be in the form letterOrDigit[_-letterOrDigit]*",
+			"The super type of the semantic token type",
+			"Super types should be in the form letterOrDigit[_-letterOrDigit]*",
+			"The description of the semantic token type",
+			"Contributes semantic token modifiers.",
+			"The identifier of the semantic token modifier",
+			"Identifiers should be in the form letterOrDigit[_-letterOrDigit]*",
+			"The description of the semantic token modifier",
+			"Contributes semantic token scope maps.",
+			"Lists the languge for which the defaults are.",
+			"Maps a semantic token (described by semantic token selector) to one or more textMate scopes used to represent that token.",
+			"'configuration.{0}.id' must be defined and can not be empty",
+			"'configuration.{0}.id' must follow the pattern letterOrDigit[-_letterOrDigit]*",
+			"'configuration.{0}.superType' must follow the pattern letterOrDigit[-_letterOrDigit]*",
+			"'configuration.{0}.description' must be defined and can not be empty",
+			"'configuration.semanticTokenType' must be an array",
+			"'configuration.semanticTokenModifier' must be an array",
+			"'configuration.semanticTokenScopes' must be an array",
+			"'configuration.semanticTokenScopes.language' must be a string",
+			"'configuration.semanticTokenScopes.scopes' must be defined as an object",
+			"'configuration.semanticTokenScopes.scopes' values must be an array of strings",
+			"configuration.semanticTokenScopes.scopes': Problems parsing selector {0}."
+		],
+		"vs/workbench/contrib/codeEditor/browser/languageConfigurationExtensionPoint": [
+			"Errors parsing {0}: {1}",
+			"{0}: Invalid format, JSON object expected.",
+			"The opening bracket character or string sequence.",
+			"The closing bracket character or string sequence.",
+			"Defines the comment symbols",
+			"Defines how block comments are marked.",
+			"The character sequence that starts a block comment.",
+			"The character sequence that ends a block comment.",
+			"The character sequence that starts a line comment.",
+			"Defines the bracket symbols that increase or decrease the indentation.",
+			"Defines the bracket pairs. When a opening bracket is entered, the closing bracket is inserted automatically.",
+			"Defines a list of scopes where the auto pairs are disabled.",
+			"Defines what characters must be after the cursor in order for bracket or quote autoclosing to occur when using the 'languageDefined' autoclosing setting. This is typically the set of characters which can not start an expression.",
+			"Defines the bracket pairs that can be used to surround a selected string.",
+			"Defines what is considered to be a word in the programming language.",
+			"The RegExp pattern used to match words.",
+			"The RegExp flags used to match words.",
+			"Must match the pattern `/^([gimuy]+)$/`.",
+			"The language's indentation settings.",
+			"If a line matches this pattern, then all the lines after it should be indented once (until another rule matches).",
+			"The RegExp pattern for increaseIndentPattern.",
+			"The RegExp flags for increaseIndentPattern.",
+			"Must match the pattern `/^([gimuy]+)$/`.",
+			"If a line matches this pattern, then all the lines after it should be unindented once (until another rule matches).",
+			"The RegExp pattern for decreaseIndentPattern.",
+			"The RegExp flags for decreaseIndentPattern.",
+			"Must match the pattern `/^([gimuy]+)$/`.",
+			"If a line matches this pattern, then **only the next line** after it should be indented once.",
+			"The RegExp pattern for indentNextLinePattern.",
+			"The RegExp flags for indentNextLinePattern.",
+			"Must match the pattern `/^([gimuy]+)$/`.",
+			"If a line matches this pattern, then its indentation should not be changed and it should not be evaluated against the other rules.",
+			"The RegExp pattern for unIndentedLinePattern.",
+			"The RegExp flags for unIndentedLinePattern.",
+			"Must match the pattern `/^([gimuy]+)$/`.",
+			"The language's folding settings.",
+			"A language adheres to the off-side rule if blocks in that language are expressed by their indentation. If set, empty lines belong to the subsequent block.",
+			"Language specific folding markers such as '#region' and '#endregion'. The start and end regexes will be tested against the contents of all lines and must be designed efficiently",
+			"The RegExp pattern for the start marker. The regexp must start with '^'.",
+			"The RegExp pattern for the end marker. The regexp must start with '^'.",
+			"The language's rules to be evaluated when pressing Enter.",
+			"The language's rules to be evaluated when pressing Enter.",
+			"This rule will only execute if the text before the cursor matches this regular expression.",
+			"The RegExp pattern for beforeText.",
+			"The RegExp flags for beforeText.",
+			"Must match the pattern `/^([gimuy]+)$/`.",
+			"This rule will only execute if the text after the cursor matches this regular expression.",
+			"The RegExp pattern for afterText.",
+			"The RegExp flags for afterText.",
+			"Must match the pattern `/^([gimuy]+)$/`.",
+			"This rule will only execute if the text above the line matches this regular expression.",
+			"The RegExp pattern for previousLineText.",
+			"The RegExp flags for previousLineText.",
+			"Must match the pattern `/^([gimuy]+)$/`.",
+			"The action to execute.",
+			"Describe what to do with the indentation",
+			"Insert new line and copy the previous line's indentation.",
+			"Insert new line and indent once (relative to the previous line's indentation).",
+			"Insert two new lines:\n - the first one indented which will hold the cursor\n - the second one at the same indentation level",
+			"Insert new line and outdent once (relative to the previous line's indentation).",
+			"Describes text to be appended after the new line and after the indentation.",
+			"Describes the number of characters to remove from the new line's indentation."
+		],
+		"vs/workbench/api/browser/mainThreadCLICommands": [
+			"Cannot install '{0}' because this extension has defined that it cannot run on the remote server."
+		],
+		"vs/workbench/api/browser/mainThreadExtensionService": [
+			"Cannot activate the '{0}' extension because it depends on the '{1}' extension, which is not loaded. Would you like to reload the window to load the extension?",
+			"Reload Window",
+			"Cannot activate the '{0}' extension because it depends on the '{1}' extension, which is disabled. Would you like to enable the extension and reload the window?",
+			"Enable and Reload",
+			"Cannot activate the '{0}' extension because it depends on the '{1}' extension, which is not installed. Would you like to install the extension and reload the window?",
+			"Install and Reload",
+			"Cannot activate the '{0}' extension because it depends on an unknown '{1}' extension ."
+		],
+		"vs/workbench/api/browser/mainThreadFileSystemEventService": [
+			"Extension '{0}' wants to make refactoring changes with this file creation",
+			"Extension '{0}' wants to make refactoring changes with this file copy",
+			"Extension '{0}' wants to make refactoring changes with this file move",
+			"Extension '{0}' wants to make refactoring changes with this file deletion",
+			"{0} extensions want to make refactoring changes with this file creation",
+			"{0} extensions want to make refactoring changes with this file copy",
+			"{0} extensions want to make refactoring changes with this file move",
+			"{0} extensions want to make refactoring changes with this file deletion",
+			"Show Preview",
+			"Skip Changes",
+			"OK",
+			"Show Preview",
+			"Skip Changes",
+			"Don't ask again",
+			"Running 'File Create' participants...",
+			"Running 'File Rename' participants...",
+			"Running 'File Copy' participants...",
+			"Running 'File Delete' participants...",
+			"Reset choice for 'File operation needs preview'",
+			"Timeout in milliseconds after which file participants for create, rename, and delete are cancelled. Use `0` to disable participants."
+		],
+		"vs/workbench/api/browser/mainThreadMessageService": [
+			"{0} (Extension)",
+			"Extension",
+			"Manage Extension",
+			"Cancel",
+			"OK"
+		],
+		"vs/workbench/api/browser/mainThreadProgress": [
+			"Manage Extension"
+		],
+		"vs/workbench/api/browser/mainThreadSaveParticipant": [
+			"Aborted onWillSaveTextDocument-event after 1750ms"
+		],
+		"vs/workbench/api/browser/mainThreadUriOpeners": [
+			"Open using default opener",
+			"Could not open uri with '{0}': {1}"
+		],
+		"vs/workbench/api/browser/mainThreadWorkspace": [
+			"Extension '{0}' added 1 folder to the workspace",
+			"Extension '{0}' added {1} folders to the workspace",
+			"Extension '{0}' removed 1 folder from the workspace",
+			"Extension '{0}' removed {1} folders from the workspace",
+			"Extension '{0}' changed folders of the workspace"
+		],
+		"vs/workbench/api/browser/mainThreadComments": [
+			"View icon of the comments view."
+		],
+		"vs/workbench/api/browser/mainThreadTask": [
+			"{0}: {1}"
+		],
+		"vs/workbench/api/browser/mainThreadTunnelService": [
+			"The extension {0} has forwarded port {1}. You'll need to run as superuser to use port {2} locally.",
+			"Use Port {0} as Sudo..."
+		],
+		"vs/workbench/api/browser/mainThreadAuthentication": [
+			"This account has not been used by any extensions.",
+			"Last used this account {0}",
+			"Has not used this account",
+			"Manage Trusted Extensions",
+			"Choose which extensions can access this account",
+			"Sign out of {0}",
+			"The account {0} has been used by: \n\n{1}\n\n Sign out of these features?",
+			"Sign out of {0}?",
+			"Successfully signed out.",
+			"Sign in to another account",
+			"The extension '{0}' wants to access a {1} account",
+			"Select an account for '{0}' to use or Esc to cancel",
+			"The extension '{0}' wants to access the {1} account '{2}'.",
+			"Allow",
+			"Cancel",
+			"The extension '{0}' wants to sign in using {1}.",
+			"Allow",
+			"Cancel"
+		],
+		"vs/workbench/common/configuration": [
+			"Workbench"
+		],
+		"vs/workbench/browser/parts/views/treeView": [
+			"There is no data provider registered that can provide view data.",
+			"Refresh",
+			"Collapse All",
+			"Error running command {1}: {0}. This is likely caused by the extension that contributes {1}."
+		],
+		"vs/workbench/browser/parts/views/viewPaneContainer": [
+			"Views",
+			"Move View Up",
+			"Move View Left",
+			"Move View Down",
+			"Move View Right"
+		],
+		"vs/workbench/contrib/remote/browser/remoteExplorer": [
+			"Ports",
+			"1 forwarded port",
+			"{0} forwarded ports",
+			"Forwarded Ports",
+			"No Ports Forwarded",
+			"Forwarded Ports: {0}",
+			"Your service running on port {0} is available.  ",
+			"[See all forwarded ports](command:{0}.focus)",
+			"You'll need to run as superuser to use port {0} locally.  ",
+			"Use Port {0} as Sudo..."
+		],
+		"vs/workbench/browser/parts/editor/editorGroupView": [
+			"Editor group actions",
+			"Close",
+			"{0} (empty)",
+			"Group {0}",
+			"Editor Group {0}",
+			"OK",
+			"Cancel",
+			"Unable to open '{0}'",
+			"Unable to open '{0}': {1}."
+		],
+		"vs/workbench/browser/parts/editor/editorDropTarget": [
+			"File is too large to open as untitled editor. Please upload it first into the file explorer and then try again."
+		],
+		"vs/workbench/browser/parts/editor/editor.contribution": [
+			"Text Editor",
+			"Text Diff Editor",
+			"Binary Diff Editor",
+			"Side by Side Editor",
+			"Type the name of an editor to open it.",
+			"Show Editors in Active Group by Most Recently Used",
+			"Type the name of an editor to open it.",
+			"Show All Opened Editors By Appearance",
+			"Type the name of an editor to open it.",
+			"Show All Opened Editors By Most Recently Used",
+			"File",
+			"Split Up",
+			"Split Down",
+			"Split Left",
+			"Split Right",
+			"Close",
+			"Close",
+			"Close Others",
+			"Close to the Right",
+			"Close Saved",
+			"Close All",
+			"Keep Open",
+			"Pin",
+			"Unpin",
+			"Split Up",
+			"Split Down",
+			"Split Left",
+			"Split Right",
+			"Toggle Inline View",
+			"Show Opened Editors",
+			"Close All",
+			"Close Saved",
+			"Keep Editors Open",
+			"Split Editor Right",
+			"Split Editor Down",
+			"Split Editor Down",
+			"Split Editor Right",
+			"Close",
+			"Close All",
+			"Close",
+			"Close All",
+			"Unpin",
+			"Close",
+			"Unpin",
+			"Close",
+			"Icon for the previous change action in the diff editor.",
+			"Icon for the next change action in the diff editor.",
+			"Icon for the toggle whitespace action in the diff editor.",
+			"Previous Change",
+			"Next Change",
+			"Ignore Leading/Trailing Whitespace Differences",
+			"Show Leading/Trailing Whitespace Differences",
+			"Keep Editor",
+			"Pin Editor",
+			"Unpin Editor",
+			"Close Editor",
+			"Close Pinned Editor",
+			"Close All Editors in Group",
+			"Close Saved Editors in Group",
+			"Close Other Editors in Group",
+			"Close Editors to the Right in Group",
+			"Close Editor Group",
+			"&&Reopen Closed Editor",
+			"&&Clear Recently Opened",
+			"Editor &&Layout",
+			"Split &&Up",
+			"Split &&Down",
+			"Split &&Left",
+			"Split &&Right",
+			"&&Single",
+			"&&Two Columns",
+			"T&&hree Columns",
+			"T&&wo Rows",
+			"Three &&Rows",
+			"&&Grid (2x2)",
+			"Two R&&ows Right",
+			"Two &&Columns Bottom",
+			"&&Back",
+			"&&Forward",
+			"&&Last Edit Location",
+			"&&Next Editor",
+			"&&Previous Editor",
+			"&&Next Used Editor",
+			"&&Previous Used Editor",
+			"&&Next Editor in Group",
+			"&&Previous Editor in Group",
+			"&&Next Used Editor in Group",
+			"&&Previous Used Editor in Group",
+			"Switch &&Editor",
+			"Group &&1",
+			"Group &&2",
+			"Group &&3",
+			"Group &&4",
+			"Group &&5",
+			"&&Next Group",
+			"&&Previous Group",
+			"Group &&Left",
+			"Group &&Right",
+			"Group &&Above",
+			"Group &&Below",
+			"Switch &&Group"
+		],
+		"vs/workbench/browser/parts/activitybar/activitybarActions": [
+			"Go Home",
+			"Hide Home Button",
+			"Manage Trusted Extensions",
+			"Sign Out",
+			"{0} is currently unavailable",
+			"Hide Accounts",
+			"Previous Side Bar View",
+			"Next Side Bar View"
+		],
+		"vs/workbench/browser/parts/compositeBar": [
+			"Active View Switcher"
+		],
+		"vs/workbench/browser/parts/compositeBarActions": [
+			"{0} - {1}",
+			"Additional Views",
+			"{0} ({1})",
+			"Manage Extension",
+			"{0} ({1})",
+			"Hide '{0}'",
+			"Keep '{0}'",
+			"Toggle View Pinned"
+		],
+		"vs/workbench/browser/parts/titlebar/menubarControl": [
+			"&&File",
+			"&&Edit",
+			"&&Selection",
+			"&&View",
+			"&&Go",
+			"&&Run",
+			"&&Terminal",
+			"&&Help",
+			"Accessibility support is enabled for you. For the most accessible experience, we recommend the custom title bar style.",
+			"Open Settings",
+			"Focus Application Menu",
+			"Check for &&Updates...",
+			"Checking for Updates...",
+			"D&&ownload Update",
+			"Downloading Update...",
+			"Install &&Update...",
+			"Installing Update...",
+			"Restart to &&Update",
+			"Go Home"
+		],
+		"vs/workbench/browser/parts/compositePart": [
+			"{0} actions",
+			"Views and More Actions...",
+			"{0} ({1})"
+		],
+		"vs/workbench/browser/parts/panel/panelActions": [
+			"Icon to maximize a panel.",
+			"Icon to restore a panel.",
+			"Icon to close a panel.",
+			"Toggle Panel",
+			"Focus into Panel",
+			"Move Panel Left",
+			"Move Panel Right",
+			"Move Panel To Bottom",
+			"Previous Panel View",
+			"Next Panel View",
+			"Toggle Maximized Panel",
+			"Maximize Panel Size",
+			"Restore Panel Size",
+			"Close Panel",
+			"Show &&Panel",
+			"Hide Panel"
+		],
+		"vs/base/browser/ui/dialog/dialog": [
+			"OK",
+			"Info",
+			"Error",
+			"Warning",
+			"In Progress",
+			"Close Dialog"
+		],
+		"vs/workbench/services/preferences/browser/preferencesEditorInput": [
+			"Default Settings",
+			"Keyboard Shortcuts",
+			"Settings"
+		],
+		"vs/workbench/services/preferences/common/preferencesModels": [
+			"Commonly Used",
+			"Override key bindings by placing them into your key bindings file."
+		],
+		"vs/workbench/services/textfile/common/textFileEditorModel": [
+			"The file is dirty. Please save it first before reopening it with another encoding."
+		],
+		"vs/workbench/common/editor/diffEditorInput": [
+			"{0} ↔ {1}"
+		],
+		"vs/workbench/services/editor/common/editorOpenWith": [
+			"Currently Active",
+			"Set as default editor for '{0}' files",
+			"Select editor for '{0}'",
+			"Built-in",
+			"Text Editor",
+			"Configure which editor to use for specific file types.",
+			"The unique id of the editor to use.",
+			"Glob pattern specifying which files the editor should be used for.",
+			"Text Editor"
+		],
+		"vs/platform/keybinding/common/abstractKeybindingService": [
+			"({0}) was pressed. Waiting for second key of chord...",
+			"The key combination ({0}, {1}) is not a command."
+		],
+		"vs/workbench/services/themes/common/fileIconThemeSchema": [
+			"The folder icon for expanded folders. The expanded folder icon is optional. If not set, the icon defined for folder will be shown.",
+			"The folder icon for collapsed folders, and if folderExpanded is not set, also for expanded folders.",
+			"The default file icon, shown for all files that don't match any extension, filename or language id.",
+			"Associates folder names to icons. The object key is the folder name, not including any path segments. No patterns or wildcards are allowed. Folder name matching is case insensitive.",
+			"The ID of the icon definition for the association.",
+			"Associates folder names to icons for expanded folders. The object key is the folder name, not including any path segments. No patterns or wildcards are allowed. Folder name matching is case insensitive.",
+			"The ID of the icon definition for the association.",
+			"Associates file extensions to icons. The object key is the file extension name. The extension name is the last segment of a file name after the last dot (not including the dot). Extensions are compared case insensitive.",
+			"The ID of the icon definition for the association.",
+			"Associates file names to icons. The object key is the full file name, but not including any path segments. File name can include dots and a possible file extension. No patterns or wildcards are allowed. File name matching is case insensitive.",
+			"The ID of the icon definition for the association.",
+			"Associates languages to icons. The object key is the language id as defined in the language contribution point.",
+			"The ID of the icon definition for the association.",
+			"Fonts that are used in the icon definitions.",
+			"The ID of the font.",
+			"The ID must only contain letter, numbers, underscore and minus.",
+			"The location of the font.",
+			"The font path, relative to the current file icon theme file.",
+			"The format of the font.",
+			"The weight of the font. See https://developer.mozilla.org/en-US/docs/Web/CSS/font-weight for valid values.",
+			"The style of the font. See https://developer.mozilla.org/en-US/docs/Web/CSS/font-style for valid values.",
+			"The default size of the font. See https://developer.mozilla.org/en-US/docs/Web/CSS/font-size for valid values.",
+			"Description of all icons that can be used when associating files to icons.",
+			"An icon definition. The object key is the ID of the definition.",
+			"When using a SVG or PNG: The path to the image. The path is relative to the icon set file.",
+			"When using a glyph font: The character in the font to use.",
+			"When using a glyph font: The color to use.",
+			"When using a font: The font size in percentage to the text font. If not set, defaults to the size in the font definition.",
+			"When using a font: The id of the font. If not set, defaults to the first font definition.",
+			"Optional associations for file icons in light color themes.",
+			"Optional associations for file icons in high contrast color themes.",
+			"Configures whether the file explorer's arrows should be hidden when this theme is active."
+		],
+		"vs/workbench/services/themes/common/colorThemeData": [
+			"Problems parsing JSON theme file: {0}",
+			"Invalid format for JSON theme file: Object expected.",
+			"Problem parsing color theme file: {0}. Property 'colors' is not of type 'object'.",
+			"Problem parsing color theme file: {0}. Property 'tokenColors' should be either an array specifying colors or a path to a TextMate theme file",
+			"Problem parsing color theme file: {0}. Property 'semanticTokenColors' contains a invalid selector",
+			"Problem parsing tmTheme file: {0}. 'settings' is not array.",
+			"Problems parsing tmTheme file: {0}",
+			"Problems loading tmTheme file {0}: {1}"
+		],
+		"vs/workbench/services/themes/browser/fileIconThemeData": [
+			"Problems parsing file icons file: {0}",
+			"Invalid format for file icons theme file: Object expected."
+		],
+		"vs/workbench/services/themes/common/colorThemeSchema": [
+			"Colors and styles for the token.",
+			"Foreground color for the token.",
+			"Token background colors are currently not supported.",
+			"Font style of the rule: 'italic', 'bold' or 'underline' or a combination. The empty string unsets inherited settings.",
+			"Font style must be 'italic', 'bold' or 'underline' or a combination or the empty string.",
+			"None (clear inherited style)",
+			"Description of the rule.",
+			"Scope selector against which this rule matches.",
+			"Colors in the workbench",
+			"Path to a tmTheme file (relative to the current file).",
+			"Colors for syntax highlighting",
+			"Whether semantic highlighting should be enabled for this theme.",
+			"Colors for semantic tokens"
+		],
+		"vs/workbench/services/themes/common/themeExtensionPoints": [
+			"Contributes textmate color themes.",
+			"Id of the color theme as used in the user settings.",
+			"Label of the color theme as shown in the UI.",
+			"Base theme defining the colors around the editor: 'vs' is the light color theme, 'vs-dark' is the dark color theme. 'hc-black' is the dark high contrast theme.",
+			"Path of the tmTheme file. The path is relative to the extension folder and is typically './colorthemes/awesome-color-theme.json'.",
+			"Contributes file icon themes.",
+			"Id of the file icon theme as used in the user settings.",
+			"Label of the file icon theme as shown in the UI.",
+			"Path of the file icon theme definition file. The path is relative to the extension folder and is typically './fileicons/awesome-icon-theme.json'.",
+			"Contributes product icon themes.",
+			"Id of the product icon theme as used in the user settings.",
+			"Label of the product icon theme as shown in the UI.",
+			"Path of the product icon theme definition file. The path is relative to the extension folder and is typically './producticons/awesome-product-icon-theme.json'.",
+			"Extension point `{0}` must be an array.",
+			"Expected string in `contributes.{0}.path`. Provided value: {1}",
+			"Expected string in `contributes.{0}.id`. Provided value: {1}",
+			"Expected `contributes.{0}.path` ({1}) to be included inside extension's folder ({2}). This might make the extension non-portable."
+		],
+		"vs/workbench/services/themes/common/themeConfiguration": [
+			"Specifies the color theme used in the workbench.",
+			"Theme is unknown or not installed.",
+			"Specifies the preferred color theme for dark OS appearance when `#{0}#` is enabled.",
+			"Theme is unknown or not installed.",
+			"Specifies the preferred color theme for light OS appearance when `#{0}#` is enabled.",
+			"Theme is unknown or not installed.",
+			"Specifies the preferred color theme used in high contrast mode when `#{0}#` is enabled.",
+			"Theme is unknown or not installed.",
+			"If set, automatically switch to the preferred color theme based on the OS appearance.",
+			"Overrides colors from the currently selected color theme.",
+			"Specifies the file icon theme used in the workbench or 'null' to not show any file icons.",
+			"None",
+			"No file icons",
+			"File icon theme is unknown or not installed.",
+			"Specifies the product icon theme used.",
+			"Default",
+			"Default",
+			"Product icon theme is unknown or not installed.",
+			"If enabled, will automatically change to high contrast theme if the OS is using a high contrast theme.",
+			"Sets the colors and styles for comments",
+			"Sets the colors and styles for strings literals.",
+			"Sets the colors and styles for keywords.",
+			"Sets the colors and styles for number literals.",
+			"Sets the colors and styles for type declarations and references.",
+			"Sets the colors and styles for functions declarations and references.",
+			"Sets the colors and styles for variables declarations and references.",
+			"Sets colors and styles using textmate theming rules (advanced).",
+			"Whether semantic highlighting should be enabled for this theme.",
+			"Use `enabled` in `editor.semanticTokenColorCustomizations` setting instead.",
+			"Use `enabled` in `#editor.semanticTokenColorCustomizations#` setting instead.",
+			"Overrides editor syntax colors and font style from the currently selected color theme.",
+			"Whether semantic highlighting is enabled or disabled for this theme",
+			"Semantic token styling rules for this theme.",
+			"Overrides editor semantic token color and styles from the currently selected color theme.",
+			"Use `editor.semanticTokenColorCustomizations` instead.",
+			"Use `#editor.semanticTokenColorCustomizations#` instead."
+		],
+		"vs/workbench/services/themes/browser/productIconThemeData": [
+			"Problems processing product icons definitions in {0}:\n{1}",
+			"Default",
+			"Problems parsing product icons file: {0}",
+			"Invalid format for product icons theme file: Object expected.",
+			"Invalid format for product icons theme file: Must contain iconDefinitions and fonts.",
+			"Invalid font weight in font '{0}'. Ignoring setting.",
+			"Invalid font style in font '{0}'. Ignoring setting.",
+			"Missing or invalid font id '{0}'. Skipping font definition.",
+			"Skipping icon definition '{0}'. Unknown font.",
+			"Skipping icon definition '{0}'. Unknown fontCharacter."
+		],
+		"vs/workbench/services/extensionManagement/browser/extensionBisect": [
+			"Extension Bisect is active and has disabled {0} extensions. Check if you can still reproduce the problem and proceed by selecting from these options.",
+			"Start Extension Bisect",
+			"Help",
+			"Extension Bisect",
+			"Extension Bisect will use binary search to find an extension that causes a problem. During the process the window reloads repeatedly (~{0} times). Each time you must confirm if you are still seeing problems.",
+			"Start Extension Bisect",
+			"Continue Extension Bisect",
+			"Help",
+			"Extension Bisect",
+			"Extension Bisect is done but no extension has been identified. This might be a problem with {0}.",
+			"Extension Bisect",
+			"Report Issue & Continue",
+			"Continue",
+			"Extension Bisect is done and has identified {0} as the extension causing the problem.",
+			"Keep this extension disabled",
+			"Extension Bisect is active and has disabled {0} extensions. Check if you can still reproduce the problem and proceed by selecting from these options.",
+			"Extension Bisect",
+			"Good now",
+			"This is bad",
+			"Stop Bisect",
+			"Cancel",
+			"Stop Extension Bisect",
+			"Help"
+		],
+		"vs/workbench/services/themes/common/productIconThemeSchema": [
+			"The ID of the font.",
+			"The ID must only contain letters, numbers, underscore and minus.",
+			"The location of the font.",
+			"The font path, relative to the current product icon theme file.",
+			"The format of the font.",
+			"The weight of the font. See https://developer.mozilla.org/en-US/docs/Web/CSS/font-weight for valid values.",
+			"The style of the font. See https://developer.mozilla.org/en-US/docs/Web/CSS/font-style for valid values.",
+			"Association of icon name to a font character."
+		],
+		"vs/workbench/contrib/preferences/browser/preferencesActions": [
+			"Configure Language Specific Settings...",
+			"({0})",
+			"Select Language"
+		],
+		"vs/workbench/contrib/preferences/browser/keybindingsEditor": [
+			"Record Keys",
+			"{0} ({1})",
+			"Sort by Precedence",
+			"{0} ({1})",
+			"Type to search in keybindings",
+			"Recording Keys. Press Escape to exit",
+			"Clear Keybindings Search Input",
+			"Recording Keys",
+			"Command",
+			"Keybinding",
+			"When",
+			"Source",
+			"Showing {0} Keybindings in precedence order",
+			"Showing {0} Keybindings in alphabetical order",
+			"Change Keybinding...",
+			"Add Keybinding...",
+			"Add Keybinding...",
+			"Change When Expression",
+			"Remove Keybinding",
+			"Reset Keybinding",
+			"Show Same Keybindings",
+			"Copy",
+			"Copy Command ID",
+			"Error '{0}' while editing the keybinding. Please open 'keybindings.json' file and check for errors.",
+			"Change Keybinding {0}",
+			"Change Keybinding",
+			"Add Keybinding {0}",
+			"Add Keybinding",
+			"{0} ({1})",
+			"Type when context. Press Enter to confirm or Escape to cancel.",
+			"Keybindings",
+			"No Keybinding assigned.",
+			"No when context."
+		],
+		"vs/workbench/contrib/preferences/browser/preferencesEditor": [
+			"Search settings",
+			"Search Settings",
+			"No Settings Found",
+			"1 Setting Found",
+			"{0} Settings Found",
+			"Total {0} Settings",
+			"Natural Language Results",
+			"Filtered Results",
+			"Default Settings",
+			"Default User Settings",
+			"Default Workspace Settings",
+			"Default Folder Settings",
+			"Edit in the right hand side editor to override defaults.",
+			"Default preferences. Readonly."
+		],
+		"vs/workbench/contrib/preferences/browser/settingsEditor2": [
+			"Search settings",
+			"Clear Settings Search Input",
+			"No Settings Found",
+			"Clear Filters",
+			"Settings",
+			"Changes to settings are saved automatically.",
+			"No Settings Found",
+			"1 Setting Found",
+			"{0} Settings Found",
+			"Turn on Settings Sync",
+			"Last synced: {0}"
+		],
+		"vs/workbench/contrib/preferences/common/preferencesContribution": [
+			"Controls whether to enable the natural language search mode for settings. The natural language search is provided by a Microsoft online service.",
+			"Hide the Table of Contents while searching.",
+			"Filter the Table of Contents to just categories that have matching settings. Clicking a category will filter the results to that category.",
+			"Controls the behavior of the settings editor Table of Contents while searching."
+		],
+		"vs/workbench/contrib/preferences/browser/preferencesIcons": [
+			"Icon for an expanded section in the split JSON settings editor.",
+			"Icon for an collapsed section in the split JSON settings editor.",
+			"Icon for the folder dropdown button in the split JSON settings editor.",
+			"Icon for the 'more actions' action in the settings UI.",
+			"Icon for the 'record keys' action in the keybinding UI.",
+			"Icon for the 'sort by precedence' toggle in the keybinding UI.",
+			"Icon for the edit action in the keybinding UI.",
+			"Icon for the add action in the keybinding UI.",
+			"Icon for the edit action in the settings UI.",
+			"Icon for the add action in the settings UI.",
+			"Icon for the remove action in the settings UI.",
+			"Icon for the discard action in the settings UI.",
+			"Icon for clear input in the settings and keybinding UI.",
+			"Icon for open settings commands."
+		],
+		"vs/workbench/contrib/preferences/browser/keybindingWidgets": [
+			"Press desired key combination and then press ENTER.",
+			"1 existing command has this keybinding",
+			"{0} existing commands have this keybinding",
+			"chord to"
+		],
+		"vs/workbench/browser/codeeditor": [
+			"Open Workspace"
+		],
+		"vs/workbench/contrib/testing/browser/icons": [
+			"View icon of the test view.",
+			"Icon of the \"run test\" action.",
+			"Icon of the \"run all tests\" action.",
+			"Icon of the \"debug test\" action.",
+			"Icon to cancel ongoing test runs.",
+			"Icon shown when the test explorer is disabled as a tree.",
+			"Icon shown when the test explorer is disabled as a list.",
+			"Icon shown for tests that have an error.",
+			"Icon shown for tests that failed.",
+			"Icon shown for tests that passed.",
+			"Icon shown for tests that are queued.",
+			"Icon shown for tests that are skipped.",
+			"Icon shown for tests that are in an unset state."
+		],
+		"vs/workbench/contrib/testing/browser/testingDecorations": [
+			"Click to run tests, right click for more options",
+			"Run Test",
+			"Debug Test",
+			"Reveal in Test Explorer"
+		],
+		"vs/workbench/contrib/testing/browser/testingExplorerFilter": [
+			"Filter (e.g. text, !exclude)",
+			"Filter"
+		],
+		"vs/workbench/contrib/testing/browser/testingExplorerView": [
+			"Test Explorer",
+			"{0} ({1})",
+			"{0}/{1} tests passed ({2}%)",
+			"{0}/{1} tests passed ({2}%, {3} skipped)",
+			"Test run is starting...",
+			"Test run in progress",
+			"{0} tests failed"
+		],
+		"vs/workbench/contrib/testing/browser/testingOutputPeek": [
+			"Close"
+		],
+		"vs/workbench/contrib/testing/browser/testingViewPaneContainer": [
+			"Testing"
+		],
+		"vs/workbench/contrib/testing/common/testServiceImpl": [
+			"An error occurred attempting to run tests: {0}"
+		],
+		"vs/workbench/contrib/testing/browser/testExplorerActions": [
+			"Test",
+			"Debug Test",
+			"Run Test",
+			"Run Selected Tests",
+			"Debug Selected Tests",
+			"Run All Tests",
+			"No tests found in this workspace. You may need to install a test provider extension",
+			"Debug All Tests",
+			"No debuggable tests found in this workspace. You may need to install a test provider extension",
+			"Cancel Test Run",
+			"View as List",
+			"View as Tree",
+			"Sort by Name",
+			"Sort by Status",
+			"Collapse All Tests",
+			"Refresh Tests",
+			"Show Test",
+			"Open Focused Test in Editor"
+		],
+		"vs/workbench/contrib/notebook/browser/notebookEditor": [
+			"Cannot open resource with notebook editor type '{0}', please check if you have the right extension installed or enabled.",
+			"Reopen file with VS Code standard text editor"
+		],
+		"vs/workbench/contrib/notebook/browser/notebookServiceImpl": [
+			"Built-in"
+		],
+		"vs/workbench/contrib/notebook/browser/diff/notebookTextDiffEditor": [
+			"Notebook Text Diff"
+		],
+		"vs/workbench/contrib/notebook/browser/contrib/find/findController": [
+			"Hide Find in Notebook",
+			"Find in Notebook"
+		],
+		"vs/workbench/contrib/notebook/browser/contrib/fold/folding": [
+			"Fold Cell",
+			"Unfold Cell",
+			"Fold Cell"
+		],
+		"vs/workbench/contrib/notebook/browser/contrib/format/formatting": [
+			"Format Notebook",
+			"Format Notebook",
+			"Format Cell"
+		],
+		"vs/workbench/contrib/notebook/browser/contrib/outline/notebookOutline": [
+			"empty cell",
+			"When enabled notebook outline shows code cells.",
+			"When enabled notebook breadcrumbs contain code cells."
+		],
+		"vs/workbench/contrib/notebook/browser/contrib/status/editorStatus": [
+			"Select Notebook Kernel",
+			"Notebook Kernel Args",
+			"Select a notebook kernel to run this notebook",
+			" (Currently Active)",
+			"Set as default kernel provider for '{0}'",
+			"Choose kernel for current notebook",
+			"Choose kernel for current notebook"
+		],
+		"vs/workbench/contrib/notebook/browser/diff/notebookDiffActions": [
+			"Open Text Diff Editor",
+			"Revert Metadata",
+			"Switch Output Rendering",
+			"Revert Outputs",
+			"Revert Input"
+		],
+		"vs/workbench/contrib/logs/common/logsActions": [
+			"Set Log Level...",
+			"Trace",
+			"Debug",
+			"Info",
+			"Warning",
+			"Error",
+			"Critical",
+			"Off",
+			"Select log level",
+			"Default & Current",
+			"Default",
+			"Current",
+			"Open Window Log File (Session)...",
+			"Current",
+			"Select Session",
+			"Select Log file"
+		],
+		"vs/workbench/contrib/quickaccess/browser/viewQuickAccess": [
+			"No matching views",
+			"Side Bar",
+			"Panel",
+			"{0}: {1}",
+			"Terminal",
+			"Log ({0})",
+			"Output",
+			"Open View",
+			"Quick Open View"
+		],
+		"vs/workbench/contrib/quickaccess/browser/commandsQuickAccess": [
+			"No matching commands",
+			"Configure Keybinding",
+			"{0}: {1}",
+			"Show All Commands",
+			"Clear Command History"
+		],
+		"vs/platform/quickinput/browser/helpQuickAccess": [
+			"global commands",
+			"editor commands",
+			"{0}, {1}"
+		],
+		"vs/workbench/contrib/files/browser/views/explorerView": [
+			"Explorer Section: {0}",
+			"New File",
+			"New Folder",
+			"Refresh Explorer",
+			"Collapse Folders in Explorer"
+		],
+		"vs/workbench/contrib/files/browser/views/emptyView": [
+			"No Folder Opened"
+		],
+		"vs/workbench/contrib/files/browser/views/openEditorsView": [
+			"Open Editors",
+			"{0} unsaved",
+			"Open Editors",
+			"Toggle Vertical/Horizontal Editor Layout",
+			"Flip &&Layout"
+		],
+		"vs/workbench/contrib/files/browser/fileActions": [
+			"New File",
+			"New Folder",
+			"Rename",
+			"Delete",
+			"Copy",
+			"Paste",
+			"Download...",
+			"&&Move to Recycle Bin",
+			"&&Move to Trash",
+			"&&Delete",
+			"You are deleting files with unsaved changes. Do you want to continue?",
+			"You are deleting a folder {0} with unsaved changes in 1 file. Do you want to continue?",
+			"You are deleting a folder {0} with unsaved changes in {1} files. Do you want to continue?",
+			"You are deleting {0} with unsaved changes. Do you want to continue?",
+			"Your changes will be lost if you don't save them.",
+			"This action is irreversible!",
+			"You can restore these files using the Undo command",
+			"You can restore this file using the Undo command",
+			"You can restore these files from the Recycle Bin.",
+			"You can restore this file from the Recycle Bin.",
+			"You can restore these files from the Trash.",
+			"You can restore this file from the Trash.",
+			"Do not ask me again",
+			"Delete {0} files",
+			"Delete {0}",
+			"Deleting {0} files",
+			"Deleting {0}",
+			"Failed to delete using the Recycle Bin. Do you want to permanently delete instead?",
+			"Failed to delete using the Trash. Do you want to permanently delete instead?",
+			"&&Delete Permanently",
+			"&&Retry",
+			"Are you sure you want to delete the following {0} files/directories and their contents?",
+			"Are you sure you want to delete the following {0} directories and their contents?",
+			"Are you sure you want to delete the following {0} files?",
+			"Are you sure you want to delete '{0}' and its contents?",
+			"Are you sure you want to delete '{0}'?",
+			"Are you sure you want to permanently delete the following {0} files/directories and their contents?",
+			"Are you sure you want to permanently delete the following {0} directories and their contents?",
+			"Are you sure you want to permanently delete the following {0} files?",
+			"Are you sure you want to permanently delete '{0}' and its contents?",
+			"Are you sure you want to permanently delete '{0}'?",
+			"Compare Active File With...",
+			"Please select a file to compare with.",
+			"Open a file first to compare it with another file.",
+			"Toggle Auto Save",
+			"Save All in Group",
+			"Close Group",
+			"Focus on Files Explorer",
+			"Reveal Active File in Side Bar",
+			"Open a file first to show it in the explorer",
+			"Open Active File in New Window",
+			"The active editor must contain an openable resource.",
+			"Open a file first to open in new window",
+			"A file or folder name must be provided.",
+			"A file or folder name cannot start with a slash.",
+			"A file or folder **{0}** already exists at this location. Please choose a different name.",
+			"The name **{0}** is not valid as a file or folder name. Please choose a different name.",
+			"Leading or trailing whitespace detected in file or folder name.",
+			"Compare Active File with Clipboard",
+			"Clipboard ↔ {0}",
+			"Retry",
+			"Create {0}",
+			"Creating {0}",
+			"Rename {0} to {1}",
+			"Renaming {0} to {1}",
+			"Downloading",
+			"{0} of {1} files ({2}/s)",
+			"{0} ({1} of {2}, {3}/s)",
+			"Download",
+			"Choose Where to Download",
+			"Download {0}",
+			"Downloading {0}",
+			"File to paste is an ancestor of the destination folder",
+			"Moving {0} files",
+			"Moving {0}",
+			"Move {0} files",
+			"Move {0}",
+			"Copying {0} files",
+			"Copying {0}",
+			"Copy {0} files",
+			"Copy {0}",
+			"The file(s) to paste have been deleted or moved since you copied them. {0}"
+		],
+		"vs/workbench/contrib/files/browser/editors/textFileSaveErrorHandler": [
+			"Use the actions in the editor tool bar to either undo your changes or overwrite the content of the file with your changes.",
+			"Failed to save '{0}': The content of the file is newer. Please compare your version with the file contents or overwrite the content of the file with your changes.",
+			"Retry",
+			"Discard",
+			"Failed to save '{0}': File is read-only. Select 'Overwrite as Admin' to retry as administrator.",
+			"Failed to save '{0}': File is read-only. Select 'Overwrite as Sudo' to retry as superuser.",
+			"Failed to save '{0}': File is read-only. Select 'Overwrite' to attempt to make it writeable.",
+			"Failed to save '{0}': Insufficient permissions. Select 'Retry as Admin' to retry as administrator.",
+			"Failed to save '{0}': Insufficient permissions. Select 'Retry as Sudo' to retry as superuser.",
+			"Failed to save '{0}': {1}",
+			"Learn More",
+			"Don't Show Again",
+			"Compare",
+			"{0} (in file) ↔ {1} (in {2}) - Resolve save conflict",
+			"Overwrite as Admin...",
+			"Overwrite as Sudo...",
+			"Retry as Admin...",
+			"Retry as Sudo...",
+			"Overwrite",
+			"Overwrite",
+			"Configure"
+		],
+		"vs/workbench/contrib/files/browser/fileCommands": [
+			"Save As...",
+			"Save",
+			"Save without Formatting",
+			"Save All",
+			"Remove Folder from Workspace",
+			"New Untitled File",
+			"{0} (in file) ↔ {1}",
+			"Open a file first to copy its path",
+			"Failed to save '{0}': {1}",
+			"Failed to revert '{0}': {1}"
+		],
+		"vs/workbench/browser/parts/editor/editorCommands": [
+			"Move the active editor by tabs or groups",
+			"Active editor move argument",
+			"Argument Properties:\n\t* 'to': String value providing where to move.\n\t* 'by': String value providing the unit for move (by tab or by group).\n\t* 'value': Number value providing how many positions or an absolute position to move.",
+			"Toggle Inline View",
+			"Compare"
+		],
+		"vs/workbench/contrib/files/browser/editors/binaryFileEditor": [
+			"Binary File Viewer"
+		],
+		"vs/workbench/contrib/files/common/workspaceWatcher": [
+			"The Microsoft .NET Framework 4.5 is required. Please follow the link to install it.",
+			"Download .NET Framework 4.5",
+			"Unable to watch for file changes in this large workspace folder. Please follow the instructions link to resolve this issue.",
+			"Instructions"
+		],
+		"vs/editor/common/config/commonEditorConfig": [
+			"Editor",
+			"The number of spaces a tab is equal to. This setting is overridden based on the file contents when `#editor.detectIndentation#` is on.",
+			"Insert spaces when pressing `Tab`. This setting is overridden based on the file contents when `#editor.detectIndentation#` is on.",
+			"Controls whether `#editor.tabSize#` and `#editor.insertSpaces#` will be automatically detected when a file is opened based on the file contents.",
+			"Remove trailing auto inserted whitespace.",
+			"Special handling for large files to disable certain memory intensive features.",
+			"Controls whether completions should be computed based on words in the document.",
+			"Only suggest words from the active document.",
+			"Suggest words from all open documents of the same language.",
+			"Suggest words from all open documents.",
+			"Controls form what documents word based completions are computed.",
+			"Semantic highlighting enabled for all color themes.",
+			"Semantic highlighting disabled for all color themes.",
+			"Semantic highlighting is configured by the current color theme's `semanticHighlighting` setting.",
+			"Controls whether the semanticHighlighting is shown for the languages that support it.",
+			"Keep peek editors open even when double clicking their content or when hitting `Escape`.",
+			"Lines above this length will not be tokenized for performance reasons",
+			"Timeout in milliseconds after which diff computation is cancelled. Use 0 for no timeout.",
+			"Controls whether the diff editor shows the diff side by side or inline.",
+			"When enabled, the diff editor ignores changes in leading or trailing whitespace.",
+			"Controls whether the diff editor shows +/- indicators for added/removed changes.",
+			"Controls whether the editor shows CodeLens.",
+			"Lines will never wrap.",
+			"Lines will wrap at the viewport width.",
+			"Lines will wrap according to the `#editor.wordWrap#` setting."
+		],
+		"vs/workbench/contrib/files/common/dirtyFilesIndicator": [
+			"1 unsaved file",
+			"{0} unsaved files"
+		],
+		"vs/workbench/contrib/bulkEdit/browser/preview/bulkEditPane": [
+			"Invoke a code action, like rename, to see a preview of its changes here.",
+			"Cannot apply refactoring because '{0}' has changed in the meantime.",
+			"Cannot apply refactoring because {0} other files have changed in the meantime.",
+			"{0} (delete, refactor preview)",
+			"rename",
+			"create",
+			"{0} ({1}, refactor preview)",
+			"{0} (refactor preview)"
+		],
+		"vs/workbench/contrib/bulkEdit/browser/preview/bulkEditPreview": [
+			"Other"
+		],
+		"vs/editor/contrib/quickAccess/gotoLineQuickAccess": [
+			"Open a text editor first to go to a line.",
+			"Go to line {0} and column {1}.",
+			"Go to line {0}.",
+			"Current Line: {0}, Character: {1}. Type a line number between 1 and {2} to navigate to.",
+			"Current Line: {0}, Character: {1}. Type a line number to navigate to."
+		],
+		"vs/workbench/contrib/codeEditor/browser/quickaccess/gotoSymbolQuickAccess": [
+			"No matching entries",
+			"Type the name of a symbol to go to.",
+			"Go to Symbol in Editor",
+			"Go to Symbol in Editor by Category",
+			"Go to Symbol in Editor..."
+		],
+		"vs/workbench/contrib/search/browser/anythingQuickAccess": [
+			"No matching results",
+			"recently opened",
+			"file and symbol results",
+			"file results",
+			"{0} dirty",
+			"Open to the Side",
+			"Open to the Bottom",
+			"Remove from Recently Opened"
+		],
+		"vs/workbench/contrib/search/browser/searchActions": [
+			"Show Search",
+			"Replace in Files",
+			"Toggle Search on Type",
+			"Focus Next Search Result",
+			"Focus Previous Search Result",
+			"Dismiss",
+			"Replace All",
+			"Replace All",
+			"Replace"
+		],
+		"vs/workbench/contrib/search/browser/searchIcons": [
+			"Icon to make search details visible.",
+			"Icon for toggle the context in the search editor.",
+			"Icon to collapse the replace section in the search view.",
+			"Icon to expand the replace section in the search view.",
+			"Icon for replace all in the search view.",
+			"Icon for replace in the search view.",
+			"Icon to remove a search result.",
+			"Icon for refresh in the search view.",
+			"Icon for collapse results in the search view.",
+			"Icon for expand results in the search view.",
+			"Icon for clear results in the search view.",
+			"Icon for stop in the search view.",
+			"View icon of the search view.",
+			"Icon for the action to open a new search editor."
+		],
+		"vs/workbench/contrib/search/browser/searchWidget": [
+			"Replace All (Submit Search to Enable)",
+			"Replace All",
+			"Toggle Replace",
+			"Search: Type Search Term and press Enter to search",
+			"Search",
+			"Toggle Context Lines",
+			"Replace: Type replace term and press Enter to preview",
+			"Replace"
+		],
+		"vs/workbench/contrib/search/browser/symbolsQuickAccess": [
+			"No matching workspace symbols",
+			"Open to the Side",
+			"Open to the Bottom"
+		],
+		"vs/workbench/contrib/search/common/queryBuilder": [
+			"Workspace folder does not exist: {0}"
+		],
+		"vs/workbench/browser/parts/views/viewPane": [
+			"Icon for an expanded view pane container.",
+			"Icon for a collapsed view pane container.",
+			"{0} actions"
+		],
+		"vs/workbench/contrib/search/browser/patternInputWidget": [
+			"input",
+			"Search only in Open Editors",
+			"Use Exclude Settings and Ignore Files"
+		],
+		"vs/workbench/contrib/search/browser/searchResultsView": [
+			"Other files",
+			"{0} files found",
+			"{0} file found",
+			"{0} matches found",
+			"{0} match found",
+			"From line {0}",
+			"{0} more lines",
+			"Search",
+			"{0} matches in folder root {1}, Search result",
+			"{0} matches outside of the workspace, Search result",
+			"{0} matches in file {1} of folder {2}, Search result",
+			"Replace '{0}' with '{1}' at column {2} in line {3}",
+			"Found '{0}' at column {1} in line '{2}'"
+		],
+		"vs/workbench/contrib/searchEditor/browser/searchEditor": [
+			"Toggle Search Details",
+			"files to include",
+			"Search Include Patterns",
+			"files to exclude",
+			"Search Exclude Patterns",
+			"Run Search",
+			"Matched {0} at {1} in file {2}",
+			"Search",
+			"Search editor text input box border."
+		],
+		"vs/workbench/contrib/searchEditor/browser/searchEditorInput": [
+			"Search: {0}",
+			"Search: {0}",
+			"Search"
+		],
+		"vs/workbench/contrib/searchEditor/browser/searchEditorSerialization": [
+			"All backslashes in Query string must be escaped (\\\\)",
+			"{0} files",
+			"1 file",
+			"{0} results",
+			"1 result",
+			"No Results",
+			"The result set only contains a subset of all matches. Please be more specific in your search to narrow down the results."
+		],
+		"vs/workbench/contrib/scm/browser/activity": [
+			"Source Control",
+			"{0} pending changes"
+		],
+		"vs/workbench/contrib/scm/browser/dirtydiffDecorator": [
+			"{0} of {1} changes",
+			"{0} of {1} change",
+			"Show Previous Change",
+			"Show Next Change",
+			"Next &&Change",
+			"Previous &&Change",
+			"Move to Previous Change",
+			"Move to Next Change",
+			"Editor gutter background color for lines that are modified.",
+			"Editor gutter background color for lines that are added.",
+			"Editor gutter background color for lines that are deleted.",
+			"Minimap gutter background color for lines that are modified.",
+			"Minimap gutter background color for lines that are added.",
+			"Minimap gutter background color for lines that are deleted.",
+			"Overview ruler marker color for modified content.",
+			"Overview ruler marker color for added content.",
+			"Overview ruler marker color for deleted content."
+		],
+		"vs/workbench/contrib/scm/browser/scmViewPaneContainer": [
+			"Source Control"
+		],
+		"vs/workbench/contrib/scm/browser/scmRepositoriesViewPane": [
+			"Source Control Repositories"
+		],
+		"vs/workbench/contrib/scm/browser/scmViewPane": [
+			"Source Control Management",
+			"Source Control Input",
+			"Repositories",
+			"View & Sort",
+			"Toggle View Mode",
+			"View as List",
+			"View as Tree",
+			"Sort by Name",
+			"Sort by Path",
+			"Sort by Status",
+			"Expand All Repositories",
+			"Collapse All Repositories",
+			"SCM Provider separator border."
+		],
+		"vs/workbench/contrib/debug/browser/breakpointsView": [
+			"Expression condition: {0}",
+			"Expression: {0} | Hit Count: {1}",
+			"Function breakpoints are not supported by this debug type",
+			"Data breakpoints are not supported by this debug type",
+			"Function to break on",
+			"Type function breakpoint.",
+			"Break when expression evaluates to true",
+			"Type expression. Function breakpoint will break when expression evaluates to true",
+			"Break when hit count is met",
+			"Type hit count. Function breakpoint will break when hit count is met.",
+			"Break when expression evaluates to true",
+			"Type exception breakpoint condition",
+			"Breakpoints",
+			"Disabled Logpoint",
+			"Disabled Breakpoint",
+			"Unverified Logpoint",
+			"Unverified Breakpoint",
+			"Data breakpoints not supported by this debug type",
+			"Data Breakpoint",
+			"Function breakpoints not supported by this debug type",
+			"Function Breakpoint",
+			"Expression condition: {0}",
+			"Hit Count: {0}",
+			"Breakpoints of this type are not supported by the debugger",
+			"Log Message: {0}",
+			"Expression condition: {0}",
+			"Hit Count: {0}",
+			"Breakpoint",
+			"Add Function Breakpoint",
+			"&&Function Breakpoint...",
+			"Toggle Activate Breakpoints",
+			"Remove Breakpoint",
+			"Remove All Breakpoints",
+			"Remove &&All Breakpoints",
+			"Enable All Breakpoints",
+			"&&Enable All Breakpoints",
+			"Disable All Breakpoints",
+			"Disable A&&ll Breakpoints",
+			"Reapply All Breakpoints",
+			"Edit Condition...",
+			"Edit Function Breakpoint...",
+			"Edit Hit Count..."
+		],
+		"vs/workbench/contrib/debug/browser/callStackView": [
+			"Running",
+			"Show More Stack Frames",
+			"Session",
+			"Running",
+			"Thread",
+			"Restart Frame",
+			"Load All Stack Frames",
+			"Show {0} More: {1}",
+			"Show {0} More Stack Frames",
+			"Debug Call Stack",
+			"Thread {0} {1}",
+			"Stack Frame {0}, line {1}, {2}",
+			"Running",
+			"Session {0} {1}",
+			"Show {0} More Stack Frames",
+			"Collapse All"
+		],
+		"vs/workbench/contrib/debug/browser/debugToolBar": [
+			"Step Back",
+			"Reverse"
+		],
+		"vs/workbench/contrib/debug/browser/debugService": [
+			"1 active session",
+			"{0} active sessions",
+			"Compound must have \"configurations\" attribute set in order to start multiple configurations.",
+			"Could not find launch configuration '{0}' in the workspace.",
+			"There are multiple launch configurations '{0}' in the workspace. Use folder name to qualify the configuration.",
+			"Can not find folder with name '{0}' for configuration '{1}' in compound '{2}'.",
+			"Configuration '{0}' is missing in 'launch.json'.",
+			"'launch.json' does not exist for passed workspace folder.",
+			"Attribute '{0}' has an unsupported value '{1}' in the chosen debug configuration.",
+			"Attribute '{0}' is missing from the chosen debug configuration.",
+			"Configured debug type '{0}' is not supported.",
+			"Missing property 'type' for the chosen launch configuration.",
+			"Install {0} Extension",
+			"The active file can not be debugged. Make sure it is saved and that you have a debug extension installed for that file type.",
+			"Debug adapter process has terminated unexpectedly ({0})",
+			"Cancel",
+			"{0}:{1}, debugging paused {2}, {3}",
+			"Added breakpoint, line {0}, file {1}",
+			"Removed breakpoint, line {0}, file {1}"
+		],
+		"vs/workbench/contrib/debug/browser/debugCommands": [
+			"Restart",
+			"Step Over",
+			"Step Into",
+			"Step Out",
+			"Pause",
+			"Disconnect",
+			"Stop",
+			"Continue",
+			"Focus Session",
+			"Select and Start Debugging",
+			"Open {0}",
+			"Start Debugging",
+			"Start Without Debugging",
+			"Choose the specific location",
+			"No executable code is associated at the current cursor position.",
+			"Jump to Cursor",
+			"Debug",
+			"Please first open a folder in order to do advanced debug configuration.",
+			"Add Inline Breakpoint",
+			"Debug"
+		],
+		"vs/workbench/contrib/debug/browser/statusbarColorProvider": [
+			"Status bar background color when a program is being debugged. The status bar is shown in the bottom of the window",
+			"Status bar foreground color when a program is being debugged. The status bar is shown in the bottom of the window",
+			"Status bar border color separating to the sidebar and editor when a program is being debugged. The status bar is shown in the bottom of the window"
+		],
+		"vs/workbench/contrib/debug/browser/debugStatus": [
+			"Debug",
+			"Debug: {0}",
+			"Select and start debug configuration"
+		],
+		"vs/workbench/contrib/debug/browser/loadedScriptsView": [
+			"Debug Session",
+			"Debug Loaded Scripts",
+			"Workspace folder {0}, loaded script, debug",
+			"Session {0}, loaded script, debug",
+			"Folder {0}, loaded script, debug",
+			"{0}, loaded script, debug"
+		],
+		"vs/workbench/contrib/debug/browser/debugEditorActions": [
+			"Debug: Toggle Breakpoint",
+			"Toggle &&Breakpoint",
+			"Debug: Add Conditional Breakpoint...",
+			"&&Conditional Breakpoint...",
+			"Debug: Add Logpoint...",
+			"&&Logpoint...",
+			"Run to Cursor",
+			"Evaluate in Debug Console",
+			"Add to Watch",
+			"Debug: Show Hover",
+			"Step Into Targets...",
+			"Debug: Go To Next Breakpoint",
+			"Debug: Go To Previous Breakpoint",
+			"Close Exception Widget"
+		],
+		"vs/workbench/contrib/debug/browser/watchExpressionsView": [
+			"Type watch expression",
+			"Expression to watch",
+			"Debug Watch Expressions",
+			"{0}, value {1}",
+			"{0}, value {1}",
+			"Collapse All",
+			"Add Expression",
+			"Remove All Expressions"
+		],
+		"vs/workbench/contrib/debug/browser/variablesView": [
+			"Type new variable value",
+			"Debug Variables",
+			"Scope {0}",
+			"{0}, value {1}",
+			"Collapse All"
+		],
+		"vs/workbench/contrib/debug/common/debugContentProvider": [
+			"Unable to resolve the resource without a debug session",
+			"Could not load source '{0}': {1}.",
+			"Could not load source '{0}'."
+		],
+		"vs/workbench/contrib/debug/browser/welcomeView": [
+			"Run",
+			"[Open a file](command:{0}) which can be debugged or run.",
+			"[Run and Debug{0}](command:{1})",
+			"[Show](command:{0}) all automatic debug configurations.",
+			"To customize Run and Debug [create a launch.json file](command:{0}).",
+			"To customize Run and Debug, [open a folder](command:{0}) and create a launch.json file."
+		],
+		"vs/workbench/contrib/debug/browser/debugQuickAccess": [
+			"No matching launch configurations",
+			"Configure Launch Configuration",
+			"contributed",
+			"{0} contributed configurations",
+			"configure",
+			"Add Config ({0})...",
+			"Add Configuration..."
+		],
+		"vs/workbench/contrib/debug/browser/debugColors": [
+			"Debug toolbar background color.",
+			"Debug toolbar border color.",
+			"Debug toolbar icon for start debugging.",
+			"Debug toolbar icon for pause.",
+			"Debug toolbar icon for stop.",
+			"Debug toolbar icon for disconnect.",
+			"Debug toolbar icon for restart.",
+			"Debug toolbar icon for step over.",
+			"Debug toolbar icon for step into.",
+			"Debug toolbar icon for step over.",
+			"Debug toolbar icon for continue.",
+			"Debug toolbar icon for step back."
+		],
+		"vs/workbench/contrib/debug/browser/debugIcons": [
+			"View icon of the debug console view.",
+			"View icon of the run view.",
+			"View icon of the variables view.",
+			"View icon of the watch view.",
+			"View icon of the call stack view.",
+			"View icon of the breakpoints view.",
+			"View icon of the loaded scripts view.",
+			"Icon for breakpoints.",
+			"Icon for disabled breakpoints.",
+			"Icon for unverified breakpoints.",
+			"Icon for function breakpoints.",
+			"Icon for disabled function breakpoints.",
+			"Icon for unverified function breakpoints.",
+			"Icon for conditional breakpoints.",
+			"Icon for disabled conditional breakpoints.",
+			"Icon for unverified conditional breakpoints.",
+			"Icon for data breakpoints.",
+			"Icon for disabled data breakpoints.",
+			"Icon for unverified data breakpoints.",
+			"Icon for log breakpoints.",
+			"Icon for disabled log breakpoint.",
+			"Icon for unverified log breakpoints.",
+			"Icon for breakpoint hints shown on hover in editor glyph margin.",
+			"Icon for unsupported breakpoints.",
+			"Icon for a stackframe shown in the editor glyph margin.",
+			"Icon for a focused stackframe  shown in the editor glyph margin.",
+			"Icon for the debug bar gripper.",
+			"Icon for the debug restart frame action.",
+			"Icon for the debug stop action.",
+			"Icon for the debug disconnect action.",
+			"Icon for the debug restart action.",
+			"Icon for the debug step over action.",
+			"Icon for the debug step into action.",
+			"Icon for the debug step out action.",
+			"Icon for the debug step back action.",
+			"Icon for the debug pause action.",
+			"Icon for the debug continue action.",
+			"Icon for the debug reverse continue action.",
+			"Icon for the debug start action.",
+			"Icon for the debug configure action.",
+			"Icon for the debug console open action.",
+			"Icon for the collapse all action in the debug views.",
+			"Icon for the session icon in the call stack view.",
+			"Icon for the clear all action in the debug console.",
+			"Icon for the remove all action in the watch view.",
+			"Icon for the add action in the watch view.",
+			"Icon for the add function breakpoint action in the watch view.",
+			"Icon for the remove all action in the breakpoints view.",
+			"Icon for the activate action in the breakpoints view.",
+			"Icon for the debug evaluation input marker.",
+			"Icon for the debug evaluation prompt."
+		],
+		"vs/workbench/contrib/debug/browser/exceptionWidget": [
+			"Exception widget border color.",
+			"Exception widget background color.",
+			"Exception has occurred: {0}",
+			"Exception has occurred.",
+			"Close"
+		],
+		"vs/workbench/contrib/debug/browser/debugHover": [
+			"Hold {0} key to switch to editor language hover",
+			"Debug Hover",
+			"{0}, value {1}, variables, debug"
+		],
+		"vs/workbench/contrib/debug/browser/breakpointWidget": [
+			"Message to log when breakpoint is hit. Expressions within {} are interpolated. 'Enter' to accept, 'esc' to cancel.",
+			"Break when hit count condition is met. 'Enter' to accept, 'esc' to cancel.",
+			"Break when expression evaluates to true. 'Enter' to accept, 'esc' to cancel.",
+			"Expression",
+			"Hit Count",
+			"Log Message",
+			"Breakpoint Type"
+		],
+		"vs/workbench/contrib/debug/browser/debugActionViewItems": [
+			"Debug Launch Configurations",
+			"No Configurations",
+			"Add Config ({0})...",
+			"Add Configuration...",
+			"Debug Session"
+		],
+		"vs/workbench/contrib/debug/browser/replViewer": [
+			"Debug Console",
+			"Variable {0}, value {1}",
+			", occured {0} times",
+			"Debug console variable {0}, value {1}",
+			"Debug console group {0}"
+		],
+		"vs/workbench/contrib/debug/common/replModel": [
+			"Console was cleared",
+			"Only primitive values are shown for this object."
+		],
+		"vs/workbench/contrib/debug/browser/replFilter": [
+			"Showing {0} of {1}"
+		],
+		"vs/workbench/contrib/markers/browser/messages": [
+			"Toggle Problems (Errors, Warnings, Infos)",
+			"Focus Problems (Errors, Warnings, Infos)",
+			"Problems View",
+			"Controls whether Problems view should automatically reveal files when opening them.",
+			"When enabled shows the current problem in the status bar.",
+			"Problems",
+			"No problems have been detected in the workspace.",
+			"No problems have been detected in the current file.",
+			"No results found with provided filter criteria.",
+			"More Filters...",
+			"Show Errors",
+			"Show Warnings",
+			"Show Infos",
+			"Hide Excluded Files",
+			"Show Active File Only",
+			"Filter Problems",
+			"Show fixes",
+			"Filter Problems",
+			"Filter (e.g. text, **/*.ts, !**/node_modules/**)",
+			"errors",
+			"warnings",
+			"infos",
+			"1 Error",
+			"{0} Errors",
+			"1 Warning",
+			"{0} Warnings",
+			"1 Info",
+			"{0} Infos",
+			"1 Unknown",
+			"{0} Unknowns",
+			"[{0}, {1}]",
+			"{0} problems in file {1} of folder {2}",
+			" This problem has references to {0} locations.",
+			"Error generated by {0}: {1} at line {2} and character {3}.{4}",
+			"Error: {0} at line {1} and character {2}.{3}",
+			"Warning generated by {0}: {1} at line {2} and character {3}.{4}",
+			"Warning: {0} at line {1} and character {2}.{3}",
+			"Info generated by {0}: {1} at line {2} and character {3}.{4}",
+			"Info: {0} at line {1} and character {2}.{3}",
+			"Problem generated by {0}: {1} at line {2} and character {3}.{4}",
+			"Problem: {0} at line {1} and character {2}.{3}",
+			"{0} at line {1} and character {2} in {3}",
+			"Show Errors and Warnings"
+		],
+		"vs/workbench/contrib/markers/browser/markersView": [
+			"Showing {0} problems",
+			"Showing {0} of {1} problems",
+			"Clear Filters"
+		],
+		"vs/workbench/contrib/markers/browser/markers": [
+			"Total {0} Problems"
+		],
+		"vs/workbench/contrib/markers/browser/markersFileDecorations": [
+			"Problems",
+			"1 problem in this file",
+			"{0} problems in this file",
+			"Show Errors & Warnings on files and folder."
+		],
+		"vs/workbench/contrib/comments/browser/commentsEditorContribution": [
+			"Select Comment Provider",
+			"Go to Next Comment Thread"
+		],
+		"vs/workbench/contrib/url/browser/trustedDomains": [
+			"Manage Trusted Domains",
+			"Trust {0}",
+			"Trust {0} on all ports",
+			"Trust {0} and all its subdomains",
+			"Trust all domains (disables link protection)",
+			"Manage Trusted Domains",
+			"Configuring trust for: {0}"
+		],
+		"vs/workbench/contrib/url/browser/trustedDomainsValidator": [
+			"Do you want {0} to open the external website?",
+			"Open",
+			"Copy",
+			"Cancel",
+			"Configure Trusted Domains"
+		],
+		"vs/workbench/contrib/webviewPanel/browser/webviewCommands": [
+			"Show find",
+			"Stop find",
+			"Find next",
+			"Find previous",
+			"Reload Webviews"
+		],
+		"vs/workbench/contrib/customEditor/browser/customEditors": [
+			"Currently Active",
+			"Set as default editor for '{0}' files",
+			"Select editor to use for '{0}'..."
+		],
+		"vs/workbench/contrib/externalUriOpener/common/configuration": [
+			"Configure the opener to use for external uris (i.e. http, https).",
+			"Map uri pattern to an opener id.\nExample patterns: \n{0}",
+			"Map uri pattern to an opener id.\nExample patterns: \n{0}",
+			"Open using VS Code's standard opener."
+		],
+		"vs/workbench/contrib/externalUriOpener/common/externalUriOpenerService": [
+			"Open in new browser window",
+			"Open in default browser",
+			"Configure default opener...",
+			"How would you like to open: {0}"
+		],
+		"vs/workbench/contrib/extensions/common/extensionsInput": [
+			"Extension: {0}"
+		],
+		"vs/workbench/contrib/extensions/common/extensionsUtils": [
+			"Disable other keymaps ({0}) to avoid conflicts between keybindings?",
+			"Yes",
+			"No"
+		],
+		"vs/workbench/contrib/extensions/browser/extensionEditor": [
+			"Extension name",
+			"Extension identifier",
+			"Preview",
+			"Preview",
+			"Built-in",
+			"Publisher name",
+			"Install count",
+			"Rating",
+			"Repository",
+			"License",
+			"Version",
+			"Details",
+			"Extension details, rendered from the extension's 'README.md' file",
+			"Feature Contributions",
+			"Lists contributions to VS Code by this extension",
+			"Changelog",
+			"Extension update history, rendered from the extension's 'CHANGELOG.md' file",
+			"Dependencies",
+			"Lists extensions this extension depends on",
+			"You have chosen not to receive recommendations for this extension.",
+			"No README available.",
+			"Extension Pack ({0})",
+			"No README available.",
+			"No Changelog available.",
+			"No Contributions",
+			"No Contributions",
+			"No Dependencies",
+			"Settings ({0})",
+			"Name",
+			"Description",
+			"Default",
+			"Debuggers ({0})",
+			"Name",
+			"Type",
+			"View Containers ({0})",
+			"ID",
+			"Title",
+			"Where",
+			"Views ({0})",
+			"ID",
+			"Name",
+			"Where",
+			"Localizations ({0})",
+			"Language Id",
+			"Language Name",
+			"Language Name (Localized)",
+			"Custom Editors ({0})",
+			"View Type",
+			"Priority",
+			"Filename Pattern",
+			"Code Actions ({0})",
+			"Title",
+			"Kind",
+			"Description",
+			"Languages",
+			"Authentication ({0})",
+			"Label",
+			"Id",
+			"Color Themes ({0})",
+			"File Icon Themes ({0})",
+			"Colors ({0})",
+			"Id",
+			"Description",
+			"Dark Default",
+			"Light Default",
+			"High Contrast Default",
+			"JSON Validation ({0})",
+			"File Match",
+			"Schema",
+			"Commands ({0})",
+			"Name",
+			"Description",
+			"Keyboard Shortcuts",
+			"Menu Contexts",
+			"Languages ({0})",
+			"ID",
+			"Name",
+			"File Extensions",
+			"Grammar",
+			"Snippets",
+			"Activation Events ({0})",
+			"Find",
+			"Find Next",
+			"Find Previous"
+		],
+		"vs/workbench/contrib/extensions/common/extensionsFileTemplate": [
+			"Extensions",
+			"List of extensions which should be recommended for users of this workspace. The identifier of an extension is always '${publisher}.${name}'. For example: 'vscode.csharp'.",
+			"Expected format '${publisher}.${name}'. Example: 'vscode.csharp'.",
+			"List of extensions recommended by VS Code that should not be recommended for users of this workspace. The identifier of an extension is always '${publisher}.${name}'. For example: 'vscode.csharp'.",
+			"Expected format '${publisher}.${name}'. Example: 'vscode.csharp'."
+		],
+		"vs/workbench/contrib/extensions/browser/extensionsActivationProgress": [
+			"Activating Extensions..."
+		],
+		"vs/workbench/contrib/extensions/browser/extensionsDependencyChecker": [
+			"Extensions",
+			"Install Missing Dependencies",
+			"Finished installing missing dependencies. Please reload the window now.",
+			"Reload Window",
+			"There are no missing dependencies to install."
+		],
+		"vs/workbench/contrib/extensions/browser/extensionsQuickAccess": [
+			"Type an extension name to install or search.",
+			"Press Enter to search for extension '{0}'.",
+			"Press Enter to install extension '{0}'.",
+			"Press Enter to manage your extensions."
+		],
+		"vs/workbench/contrib/extensions/browser/extensionsActions": [
+			"{0} years ago",
+			"1 year ago",
+			"{0} months ago",
+			"1 month ago",
+			"{0} days ago",
+			"1 day ago",
+			"{0} hours ago",
+			"1 hour ago",
+			"Just now",
+			"Error while updating '{0}' extension.",
+			"Error while installing '{0}' extension.",
+			"Try Downloading Manually...",
+			"Once downloaded, please manually install the downloaded VSIX of '{0}'.",
+			"Install from VSIX...",
+			"Please check the [log]({0}) for more details.",
+			"Installing extension {0} started. An editor is now open with more details on this extension",
+			"Installing extension {0} is completed.",
+			"Install",
+			"Install (Do not sync)",
+			"Install",
+			"Install in {0} (Do not sync)",
+			"Install in {0}",
+			"Install Locally (Do not sync)",
+			"Install Locally",
+			"Install",
+			"Install this extension in all your synced {0} instances",
+			"Installing",
+			"Install",
+			"Installing",
+			"Installing extension {0} started. An editor is now open with more details on this extension",
+			"Install in {0}",
+			"Install Locally",
+			"Install in Browser",
+			"Uninstall",
+			"Uninstalling",
+			"Uninstalling extension {0} started.",
+			"Please reload Visual Studio Code to complete the uninstallation of the extension {0}.",
+			"Updating extension {0} to version {1} started.",
+			"Updating extension {0} to version {1} completed.",
+			"Update to {0}",
+			"Update",
+			"Manage",
+			"Uninstalling",
+			"Manage",
+			"Install Another Version...",
+			"Select Version to Install",
+			"Current",
+			"Enable (Workspace)",
+			"Enable this extension only in this workspace",
+			"Enable",
+			"Enable this extension",
+			"Disable (Workspace)",
+			"Disable this extension only in this workspace",
+			"Disable",
+			"Disable this extension",
+			"Enable",
+			"Disable",
+			"Reload",
+			"Reload Required",
+			"Please reload Visual Studio Code to complete the uninstallation of this extension.",
+			"Please reload Visual Studio Code to complete the uninstallation of the extension {0}.",
+			"Reload Required",
+			"Please reload Visual Studio Code to enable the updated extension.",
+			"Reload Required",
+			"Please reload Visual Studio Code to enable this extension locally.",
+			"Reload Required",
+			"Please reload Visual Studio Code to enable this extension in {0}.",
+			"Reload Required",
+			"Please reload Visual Studio Code to enable this extension.",
+			"Reload Required",
+			"Please reload Visual Studio Code to enable this extension.",
+			"Reload Required",
+			"Please reload Visual Studio Code to disable this extension.",
+			"Reload Required",
+			"Please reload Visual Studio Code to enable this extension.",
+			"Reload Required",
+			"Please reload Visual Studio Code to enable this extension.",
+			"Installing extension {0} is completed. Please reload Visual Studio Code to enable it.",
+			"Current",
+			"Set Color Theme",
+			"Select Color Theme",
+			"Set File Icon Theme",
+			"Select File Icon Theme",
+			"Set Product Icon Theme",
+			"Select Product Icon Theme",
+			"Show Recommended Extension",
+			"Install Recommended Extension",
+			"Do not recommend this extension again",
+			"Undo",
+			"Search Extensions",
+			"Unable to create 'extensions.json' file inside the '.vscode' folder ({0}).",
+			"Configure Recommended Extensions (Workspace)",
+			"Configure Recommended Extensions (Workspace Folder)",
+			"Updated",
+			"Installed",
+			"Uninstalled",
+			"Enabled",
+			"Disabled",
+			"This extension was reported to be problematic.",
+			"Malicious",
+			"This extension was reported to be problematic.",
+			"This extension is ignored during sync",
+			"This extension is synced",
+			"Sync this extension",
+			"Do not sync this extension",
+			"Extension is enabled on '{0}'",
+			"This extension is enabled globally.",
+			"This extension is enabled for this workspace by the user.",
+			"This extension is disabled globally by the user.",
+			"This extension is disabled for this workspace by the user.",
+			"Install the language pack extension on '{0}' to enable it there also.",
+			"Install the language pack extension locally to enable it there also.",
+			"Install the extension on '{0}' to enable.",
+			"This extension has defined that it cannot run on the remote server",
+			"Extension is enabled on '{0}' and disabled locally.",
+			"Extension is enabled locally and disabled on '{0}'.",
+			"Reinstall Extension...",
+			"Select Extension to Reinstall",
+			"Please reload Visual Studio Code to complete reinstalling the extension {0}.",
+			"Reinstalling the extension {0} is completed.",
+			"Reload Now",
+			"Install Specific Version of Extension...",
+			"Select Extension",
+			"Current",
+			"Select Version to Install",
+			"Please reload Visual Studio Code to complete installing the extension {0}.",
+			"Installing the extension {0} is completed.",
+			"Reload Now",
+			"Select extensions to install",
+			"There are no extensions to install.",
+			"Installing Extensions...",
+			"Successfully installed extensions.",
+			"Install Local Extensions in '{0}'...",
+			"Install Local Extensions in '{0}'",
+			"Install Remote Extensions Locally...",
+			"Install Remote Extensions Locally",
+			"Button background color for actions extension that stand out (e.g. install button).",
+			"Button foreground color for actions extension that stand out (e.g. install button).",
+			"Button background hover color for actions extension that stand out (e.g. install button)."
+		],
+		"vs/workbench/contrib/extensions/browser/extensionsWorkbenchService": [
+			"Manifest is not found",
+			"This extension is reported to be problematic.",
+			"Uninstalling extension....",
+			"Unable to install extension '{0}' as it is not compatible with VS Code '{1}'.",
+			"Installing '{0}' extension....",
+			"Installing extension....",
+			"Disable All",
+			"Cannot disable '{0}' extension alone. '{1}' extension depends on this. Do you want to disable all these extensions?",
+			"Cannot disable '{0}' extension alone. '{1}' and '{2}' extensions depend on this. Do you want to disable all these extensions?",
+			"Cannot disable '{0}' extension alone. '{1}', '{2}' and other extensions depend on this. Do you want to disable all these extensions?"
+		],
+		"vs/workbench/contrib/extensions/browser/extensionsIcons": [
+			"View icon of the extensions view.",
+			"Icon for the 'Manage' action in the extensions view.",
+			"Icon for the 'Clear Search Result' action in the extensions view.",
+			"Icon for the 'Refresh' action in the extensions view.",
+			"Icon for the 'Filter' action in the extensions view.",
+			"Icon for the 'Install Local Extension in Remote' action in the extensions view.",
+			"Icon for the 'Install Workspace Recommended Extensions' action in the extensions view.",
+			"Icon for the 'Configure Recommended Extensions' action in the extensions view.",
+			"Icon to indicate that an extension is synced.",
+			"Icon to indicate that an extension is ignored when syncing.",
+			"Icon to indicate that an extension is remote in the extensions view and editor.",
+			"Icon shown along with the install count in the extensions view and editor.",
+			"Icon shown along with the rating in the extensions view and editor.",
+			"Full star icon used for the rating in the extensions editor.",
+			"Half star icon used for the rating in the extensions editor.",
+			"Empty star icon used for the rating in the extensions editor.",
+			"Icon shown with a warning message in the extensions editor.",
+			"Icon shown with an info message in the extensions editor."
+		],
+		"vs/workbench/contrib/extensions/browser/extensionRecommendationNotificationService": [
+			"Don't Show Again",
+			"Do you want to ignore all extension recommendations?",
+			"Yes, Ignore All",
+			"No",
+			"Do you want to install the recommended extensions for this repository?",
+			"Install",
+			"Install (Do not sync)",
+			"Show Recommendations"
+		],
+		"vs/workbench/contrib/output/browser/logViewer": [
+			"Log viewer"
+		],
+		"vs/workbench/contrib/extensions/browser/extensionsViews": [
+			"{0}, {1}, {2}, press enter for extension details.",
+			"Extensions",
+			"We cannot connect to the Extensions Marketplace at this time, please try again later.",
+			"Error while loading extensions. {0}",
+			"No extensions found.",
+			"Marketplace returned 'ECONNREFUSED'. Please check the 'http.proxy' setting.",
+			"Open User Settings",
+			"There are no extensions to install."
+		],
+		"vs/workbench/browser/parts/editor/textResourceEditor": [
+			"Text Editor"
+		],
+		"vs/base/browser/ui/actionbar/actionViewItems": [
+			"{0} ({1})"
+		],
+		"vs/workbench/contrib/terminal/common/terminalColorRegistry": [
+			"The background color of the terminal, this allows coloring the terminal differently to the panel.",
+			"The foreground color of the terminal.",
+			"The foreground color of the terminal cursor.",
+			"The background color of the terminal cursor. Allows customizing the color of a character overlapped by a block cursor.",
+			"The selection background color of the terminal.",
+			"The color of the border that separates split panes within the terminal. This defaults to panel.border.",
+			"'{0}' ANSI color in the terminal."
+		],
+		"vs/workbench/contrib/terminal/browser/terminalActions": [
+			"Select current working directory for new terminal",
+			"Toggle Integrated Terminal",
+			"Kill the Active Terminal Instance",
+			"Kill Terminal",
+			"Copy Selection",
+			"Copy",
+			"Select All",
+			"Create New Integrated Terminal",
+			"New Terminal",
+			"Select current working directory for new terminal",
+			"Split Terminal",
+			"Split",
+			"Split Terminal (In Active Workspace)",
+			"Paste into Active Terminal",
+			"Paste",
+			"Select Default Shell",
+			"Configure Terminal Settings",
+			"Switch Terminal",
+			"Open Terminals.",
+			"Starting...",
+			"Clear",
+			"Open Help",
+			"Create New Integrated Terminal (In Active Workspace)",
+			"Focus Previous Pane",
+			"Focus Next Pane",
+			"Resize Pane Left",
+			"Resize Pane Right",
+			"Resize Pane Up",
+			"Resize Pane Down",
+			"Focus Terminal",
+			"Focus Next Terminal",
+			"Focus Previous Terminal",
+			"Run Selected Text In Active Terminal",
+			"Run Active File In Active Terminal",
+			"Only files on disk can be run in the terminal",
+			"Scroll Down (Line)",
+			"Scroll Down (Page)",
+			"Scroll to Bottom",
+			"Scroll Up (Line)",
+			"Scroll Up (Page)",
+			"Scroll to Top",
+			"Exit Navigation Mode",
+			"Focus Previous Line (Navigation Mode)",
+			"Focus Next Line (Navigation Mode)",
+			"Clear Selection",
+			"Manage Workspace Shell Permissions",
+			"Rename",
+			"Enter terminal name",
+			"Focus Find",
+			"Hide Find",
+			"Attach to Session",
+			"Switch Active Terminal",
+			"Scroll To Previous Command",
+			"Scroll To Next Command",
+			"Select To Previous Command",
+			"Select To Next Command",
+			"Select To Previous Line",
+			"Select To Next Line",
+			"Toggle Escape Sequence Logging",
+			"Send Custom Sequence To Terminal",
+			"Create New Integrated Terminal Starting in a Custom Working Directory",
+			"The directory to start the terminal at",
+			"Rename the Currently Active Terminal",
+			"The new name for the terminal",
+			"No name argument provided",
+			"Toggle Find Using Regex",
+			"Toggle Find Using Whole Word",
+			"Toggle Find Using Case Sensitive",
+			"Find Next",
+			"Find Previous",
+			"Search Workspace",
+			"Relaunch Active Terminal",
+			"Show Environment Information"
+		],
+		"vs/workbench/contrib/terminal/common/terminalMenu": [
+			"&&Terminal",
+			"&&New Terminal",
+			"&&Split Terminal",
+			"Run &&Active File",
+			"Run &&Selected Text"
+		],
+		"vs/workbench/contrib/terminal/browser/terminalQuickAccess": [
+			"Rename Terminal",
+			"Kill Terminal Instance",
+			"Create New Integrated Terminal"
+		],
+		"vs/workbench/contrib/terminal/browser/terminalIcons": [
+			"View icon of the terminal view.",
+			"Icon for rename in the terminal quick menu.",
+			"Icon for killing a terminal instance.",
+			"Icon for creating a new terminal instance."
+		],
+		"vs/workbench/contrib/terminal/browser/terminalService": [
+			"Allow Workspace Shell Configuration",
+			"Disallow Workspace Shell Configuration",
+			"There is an active terminal session, do you want to kill it?",
+			"There are {0} active terminal sessions, do you want to kill them?",
+			"Select your preferred terminal shell, you can change this later in your settings"
+		],
+		"vs/workbench/contrib/tasks/common/jsonSchema_v1": [
+			"Task version 0.1.0 is deprecated. Please use 2.0.0",
+			"The config's version number",
+			"The runner has graduated. Use the official runner property",
+			"Defines whether the task is executed as a process and the output is shown in the output window or inside the terminal.",
+			"Windows specific command configuration",
+			"Mac specific command configuration",
+			"Linux specific command configuration",
+			"Specifies whether the command is a shell command or an external program. Defaults to false if omitted."
+		],
+		"vs/workbench/contrib/tasks/common/jsonSchema_v2": [
+			"Specifies whether the command is a shell command or an external program. Defaults to false if omitted.",
+			"The property isShellCommand is deprecated. Use the type property of the task and the shell property in the options instead. See also the 1.14 release notes.",
+			"The task identifier.",
+			"Another task this task depends on.",
+			"The other tasks this task depends on.",
+			"Either a string representing another task or an array of other tasks that this task depends on.",
+			"Run all dependsOn tasks in parallel.",
+			"Run all dependsOn tasks in sequence.",
+			"Determines the order of the dependsOn tasks for this task. Note that this property is not recursive.",
+			"An optional description of a task that shows in the Run Task quick pick as a detail.",
+			"Configures the panel that is used to present the task's output and reads its input.",
+			"Controls whether the executed command is echoed to the panel. Default is true.",
+			"Controls whether the panel takes focus. Default is false. If set to true the panel is revealed as well.",
+			"Always reveals the problems panel when this task is executed.",
+			"Only reveals the problems panel if a problem is found.",
+			"Never reveals the problems panel when this task is executed.",
+			"Controls whether the problems panel is revealed when running this task or not. Takes precedence over option \"reveal\". Default is \"never\".",
+			"Always reveals the terminal when this task is executed.",
+			"Only reveals the terminal if the task exits with an error or the problem matcher finds an error.",
+			"Never reveals the terminal when this task is executed.",
+			"Controls whether the terminal running the task is revealed or not. May be overridden by option \"revealProblems\". Default is \"always\".",
+			"Controls if the panel is shared between tasks, dedicated to this task or a new one is created on every run.",
+			"Controls whether to show the `Terminal will be reused by tasks, press any key to close it` message.",
+			"Controls whether the terminal is cleared before executing the task.",
+			"Controls whether the task is executed in a specific terminal group using split panes.",
+			"The terminal property is deprecated. Use presentation instead",
+			"The task's execution group.",
+			"Defines if this task is the default task in the group.",
+			"Marks the task as the default build task.",
+			"Marks the task as the default test task.",
+			"Marks the task as a build task accessible through the 'Run Build Task' command.",
+			"Marks the task as a test task accessible through the 'Run Test Task' command.",
+			"Assigns the task to no group",
+			"Defines to which execution group this task belongs to. It supports \"build\" to add it to the build group and \"test\" to add it to the test group.",
+			"Defines whether the task is run as a process or as a command inside a shell.",
+			"The shell command to be executed. Array items will be joined using a space character",
+			"The shell command to be executed. Array items will be joined using a space character",
+			"The actual command value",
+			"Escapes characters using the shell's escape character (e.g. ` under PowerShell and \\ under bash).",
+			"Quotes the argument using the shell's strong quote character (e.g. ' under PowerShell and bash).",
+			"Quotes the argument using the shell's weak quote character (e.g. \" under PowerShell and bash).",
+			"How the command value should be quoted.",
+			"The command to be executed. Can be an external program or a shell command.",
+			"The actual argument value",
+			"Escapes characters using the shell's escape character (e.g. ` under PowerShell and \\ under bash).",
+			"Quotes the argument using the shell's strong quote character (e.g. ' under PowerShell and bash).",
+			"Quotes the argument using the shell's weak quote character (e.g. \" under PowerShell and bash).",
+			"How the argument value should be quoted.",
+			"Arguments passed to the command when this task is invoked.",
+			"The task's user interface label",
+			"The config's version number.",
+			"A user defined identifier to reference the task in launch.json or a dependsOn clause.",
+			"User defined identifiers are deprecated. For custom task use the name as a reference and for tasks provided by extensions use their defined task identifier.",
+			"Whether to reevaluate task variables on rerun.",
+			"Configures when the task should be run. If set to folderOpen, then the task will be run automatically when the folder is opened.",
+			"The number of instances of the task that are allowed to run simultaneously.",
+			"The task's run related options",
+			"The task's label",
+			"The task's name",
+			"The task's name property is deprecated. Use the label property instead.",
+			"Whether the executed task is kept alive and is running in the background.",
+			"Whether the user is prompted when VS Code closes with a running task.",
+			"The problem matcher(s) to use. Can either be a string or a problem matcher definition or an array of strings and problem matchers.",
+			"The task type to customize",
+			"The customize property is deprecated. See the 1.14 release notes on how to migrate to the new task customization approach",
+			"The task's name property is deprecated. Use the label property instead.",
+			"The property showOutput is deprecated. Use the reveal property inside the presentation property instead. See also the 1.14 release notes.",
+			"The property echoCommand is deprecated. Use the echo property inside the presentation property instead. See also the 1.14 release notes.",
+			"The property suppressTaskName is deprecated. Inline the command with its arguments into the task instead. See also the 1.14 release notes.",
+			"The property isBuildCommand is deprecated. Use the group property instead. See also the 1.14 release notes.",
+			"The property isTestCommand is deprecated. Use the group property instead. See also the 1.14 release notes.",
+			"Defines whether the task is run as a process or as a command inside a shell.",
+			"The property suppressTaskName is deprecated. Inline the command with its arguments into the task instead. See also the 1.14 release notes.",
+			"The property taskSelector is deprecated. Inline the command with its arguments into the task instead. See also the 1.14 release notes.",
+			"Windows specific command configuration",
+			"Mac specific command configuration",
+			"Linux specific command configuration"
+		],
+		"vs/workbench/contrib/tasks/browser/tasksQuickAccess": [
+			"No matching tasks",
+			"Select the task to run"
+		],
+		"vs/workbench/contrib/emmet/browser/actions/expandAbbreviation": [
+			"Emmet: Expand Abbreviation",
+			"Emmet: E&&xpand Abbreviation"
+		],
+		"vs/workbench/contrib/remote/browser/explorerViewItems": [
+			"Switch Remote",
+			"Switch Remote"
+		],
+		"vs/workbench/contrib/remote/browser/remoteIndicator": [
+			"Remote",
+			"Show Remote Menu",
+			"Close Remote Connection",
+			"Close Re&&mote Connection",
+			"Opening Remote...",
+			"Opening Remote...",
+			"Reconnecting to {0}...",
+			"Reconnecting to {0}...",
+			"Disconnected from {0}",
+			"Disconnected from {0}",
+			"Editing on {0}",
+			"Open a Remote Window",
+			"Remote Host",
+			"{0}: {1}",
+			"Close Remote Connection"
+		],
+		"vs/workbench/contrib/remote/browser/remoteIcons": [
+			"Getting started icon in the remote explorer view.",
+			"Documentation icon in the remote explorer view.",
+			"Feedback icon in the remote explorer view.",
+			"Review issue icon in the remote explorer view.",
+			"Report issue icon in the remote explorer view.",
+			"View icon of the remote explorer view.",
+			"View icon of the remote ports view.",
+			"Icon representing a remote port.",
+			"Icon representing a private remote port.",
+			"Icon representing a public remote port.",
+			"Icon for the forward action.",
+			"Icon for the stop forwarding action.",
+			"Icon for the open browser action."
+		],
+		"vs/workbench/contrib/codeEditor/browser/accessibility/accessibility": [
+			"Now changing the setting `editor.accessibilitySupport` to 'on'.",
+			"Now opening the VS Code Accessibility documentation page.",
+			"Thank you for trying out VS Code's accessibility options.",
+			"Status:",
+			"To configure the editor to be permanently optimized for usage with a Screen Reader press Command+E now.",
+			"To configure the editor to be permanently optimized for usage with a Screen Reader press Control+E now.",
+			"The editor is configured to use platform APIs to detect when a Screen Reader is attached, but the current runtime does not support this.",
+			"The editor has automatically detected a Screen Reader is attached.",
+			"The editor is configured to automatically detect when a Screen Reader is attached, which is not the case at this time.",
+			"The editor is configured to be permanently optimized for usage with a Screen Reader - you can change this by editing the setting `editor.accessibilitySupport`.",
+			"The editor is configured to never be optimized for usage with a Screen Reader.",
+			"Pressing Tab in the current editor will move focus to the next focusable element. Toggle this behavior by pressing {0}.",
+			"Pressing Tab in the current editor will move focus to the next focusable element. The command {0} is currently not triggerable by a keybinding.",
+			"Pressing Tab in the current editor will insert the tab character. Toggle this behavior by pressing {0}.",
+			"Pressing Tab in the current editor will insert the tab character. The command {0} is currently not triggerable by a keybinding.",
+			"Press Command+H now to open a browser window with more VS Code information related to Accessibility.",
+			"Press Control+H now to open a browser window with more VS Code information related to Accessibility.",
+			"You can dismiss this tooltip and return to the editor by pressing Escape or Shift+Escape.",
+			"Show Accessibility Help"
+		],
+		"vs/workbench/contrib/codeEditor/browser/diffEditorHelper": [
+			"The diff algorithm was stopped early (after {0} ms.)",
+			"Remove Limit",
+			"Show Whitespace Differences"
+		],
+		"vs/workbench/contrib/codeEditor/browser/inspectKeybindings": [
+			"Developer: Inspect Key Mappings",
+			"Inspect Key Mappings (JSON)"
+		],
+		"vs/workbench/contrib/codeEditor/browser/largeFileOptimizations": [
+			"{0}: tokenization, wrapping and folding have been turned off for this large file in order to reduce memory usage and avoid freezing or crashing.",
+			"Forcefully Enable Features",
+			"Please reopen file in order for this setting to take effect."
+		],
+		"vs/workbench/contrib/codeEditor/browser/inspectEditorTokens/inspectEditorTokens": [
+			"Developer: Inspect Editor Tokens and Scopes",
+			"Loading..."
+		],
+		"vs/workbench/contrib/codeEditor/browser/quickaccess/gotoLineQuickAccess": [
+			"Type the line number and optional column to go to (e.g. 42:5 for line 42 and column 5).",
+			"Go to Line/Column",
+			"Go to Line/Column..."
+		],
+		"vs/workbench/contrib/codeEditor/browser/saveParticipants": [
+			"Running '{0}' Formatter ([configure](command:workbench.action.openSettings?%5B%22editor.formatOnSave%22%5D)).",
+			"Quick Fixes",
+			"Getting code actions from '{0}' ([configure](command:workbench.action.openSettings?%5B%22editor.codeActionsOnSave%22%5D)).",
+			"Applying code action '{0}'."
+		],
+		"vs/workbench/contrib/codeEditor/browser/toggleMinimap": [
+			"Toggle Minimap",
+			"Show &&Minimap"
+		],
+		"vs/workbench/contrib/codeEditor/browser/toggleMultiCursorModifier": [
+			"Toggle Multi-Cursor Modifier",
+			"Switch to Alt+Click for Multi-Cursor",
+			"Switch to Cmd+Click for Multi-Cursor",
+			"Switch to Ctrl+Click for Multi-Cursor"
+		],
+		"vs/workbench/contrib/codeEditor/browser/toggleRenderControlCharacter": [
+			"Toggle Control Characters",
+			"Render &&Control Characters"
+		],
+		"vs/workbench/contrib/codeEditor/browser/toggleColumnSelection": [
+			"Toggle Column Selection Mode",
+			"Column &&Selection Mode"
+		],
+		"vs/workbench/contrib/codeEditor/browser/toggleRenderWhitespace": [
+			"Toggle Render Whitespace",
+			"&&Render Whitespace"
+		],
+		"vs/workbench/contrib/codeEditor/browser/toggleWordWrap": [
+			"View: Toggle Word Wrap",
+			"Disable wrapping for this file",
+			"Enable wrapping for this file",
+			"Toggle &&Word Wrap"
+		],
+		"vs/workbench/contrib/snippets/browser/snippetsFile": [
+			"Workspace Snippet",
+			"Global User Snippet",
+			"User Snippet"
+		],
+		"vs/workbench/contrib/snippets/browser/snippetCompletionProvider": [
+			"{0} ({1})",
+			"{0}, {1}",
+			"{0}, {1}"
+		],
+		"vs/workbench/contrib/format/browser/formatActionsMultiple": [
+			"None",
+			"Extension '{0}' cannot format '{1}'",
+			"There are multiple formatters for '{0}' files. Select a default formatter to continue.",
+			"Extension '{0}' is configured as formatter but not available. Select a different default formatter to continue.",
+			"Configure...",
+			"Cancel",
+			"Configure...",
+			"Select a default formatter for '{0}' files",
+			"Defines a default formatter which takes precedence over all other formatter settings. Must be the identifier of an extension contributing a formatter.",
+			"(default)",
+			"Configure Default Formatter...",
+			"Select a formatter",
+			"Select a default formatter for '{0}' files",
+			"Format Document With...",
+			"Format Selection With..."
+		],
+		"vs/workbench/contrib/format/browser/formatActionsNone": [
+			"Format Document",
+			"This file cannot be formatted because it is too large",
+			"There is no formatter for '{0}' files installed.",
+			"Install Formatter..."
+		],
+		"vs/workbench/contrib/format/browser/formatModified": [
+			"Format Modified Lines"
+		],
+		"vs/workbench/contrib/update/browser/update": [
+			"Release Notes",
+			"This version of {0} does not have release notes online",
+			"Release Notes",
+			"Show Release Notes",
+			"Welcome to {0} v{1}! Would you like to read the Release Notes?",
+			"Release Notes",
+			"Our license terms have changed, please click [here]({0}) to go through them.",
+			"New {0} update available.",
+			"Checking for Updates...",
+			"Update Service",
+			"There are currently no updates available.",
+			"OK",
+			"There is an available update.",
+			"Download Update",
+			"Later",
+			"Release Notes",
+			"There's an update available: {0} {1}",
+			"Install Update",
+			"Later",
+			"Release Notes",
+			"{0} {1} is being installed in the background; we'll let you know when it's done.",
+			"Update Now",
+			"Later",
+			"Release Notes",
+			"Restart {0} to apply the latest update.",
+			"Check for Updates...",
+			"Checking for Updates...",
+			"Download Update (1)",
+			"Downloading Update...",
+			"Install Update... (1)",
+			"Installing Update...",
+			"Restart to Update (1)",
+			"Changing the version requires a reload to take effect",
+			"Press the reload button to switch to the nightly pre-production version of VSCode.",
+			"Press the reload button to switch to the monthly released stable version of VSCode.",
+			"&&Reload",
+			"Switch to Insiders Version...",
+			"Switch to Stable Version...",
+			"Check for Updates..."
+		],
+		"vs/base/browser/ui/keybindingLabel/keybindingLabel": [
+			"Unbound"
+		],
+		"vs/workbench/contrib/welcome/page/browser/welcomePage": [
+			"Welcome",
+			"JavaScript",
+			"Python",
+			"Java",
+			"PHP",
+			"Azure",
+			"Show Azure extensions",
+			"Docker",
+			"Vim",
+			"Sublime",
+			"Atom",
+			"Support for {0} is already installed.",
+			"The window will reload after installing additional support for {0}.",
+			"Installing additional support for {0}...",
+			"Support for {0} with id {1} could not be found.",
+			"The {0} keyboard shortcuts are already installed.",
+			"The window will reload after installing the {0} keyboard shortcuts.",
+			"Installing the {0} keyboard shortcuts...",
+			"The {0} keyboard shortcuts with id {1} could not be found.",
+			"Welcome",
+			"Open folder {0} with path {1}",
+			", ",
+			"Install {0} keymap",
+			"Install additional support for {0}",
+			"{0} keymap is already installed",
+			"{0} support is already installed",
+			"OK",
+			"Details"
+		],
+		"vs/workbench/contrib/welcome/gettingStarted/browser/gettingStarted": [
+			"Getting Started",
+			"Skip",
+			"Next"
+		],
+		"vs/workbench/contrib/welcome/gettingStarted/browser/gettingStartedIcons": [
+			"Used to represent getting started items which have not been completed",
+			"Used to represent getting started items which have been completed"
+		],
+		"vs/workbench/contrib/welcome/walkThrough/browser/walkThroughPart": [
+			"unbound",
+			"It looks like Git is not installed on your system.",
+			"Background color for the embedded editors on the Interactive Playground."
+		],
+		"vs/workbench/contrib/welcome/walkThrough/browser/editor/editorWalkThrough": [
+			"Interactive Playground",
+			"Interactive Playground"
+		],
+		"vs/workbench/contrib/callHierarchy/browser/callHierarchyPeek": [
+			"Calls from '{0}'",
+			"Callers of '{0}'",
+			"Loading...",
+			"No calls from '{0}'",
+			"No callers of '{0}'"
+		],
+		"vs/editor/contrib/peekView/peekView": [
+			"Close",
+			"Background color of the peek view title area.",
+			"Color of the peek view title.",
+			"Color of the peek view title info.",
+			"Color of the peek view borders and arrow.",
+			"Background color of the peek view result list.",
+			"Foreground color for line nodes in the peek view result list.",
+			"Foreground color for file nodes in the peek view result list.",
+			"Background color of the selected entry in the peek view result list.",
+			"Foreground color of the selected entry in the peek view result list.",
+			"Background color of the peek view editor.",
+			"Background color of the gutter in the peek view editor.",
+			"Match highlight color in the peek view result list.",
+			"Match highlight color in the peek view editor.",
+			"Match highlight border in the peek view editor."
+		],
+		"vs/workbench/contrib/codeEditor/browser/outline/documentSymbolsTree": [
+			"{0} ({1})",
+			"1 problem in this element",
+			"{0} problems in this element",
+			"Contains elements with problems",
+			"array",
+			"boolean",
+			"class",
+			"constant",
+			"constructor",
+			"enumeration",
+			"enumeration member",
+			"event",
+			"field",
+			"file",
+			"function",
+			"interface",
+			"key",
+			"method",
+			"module",
+			"namespace",
+			"null",
+			"number",
+			"object",
+			"operator",
+			"package",
+			"property",
+			"string",
+			"struct",
+			"type parameter",
+			"variable",
+			"The foreground color for array symbols. These symbols appear in the outline, breadcrumb, and suggest widget.",
+			"The foreground color for boolean symbols. These symbols appear in the outline, breadcrumb, and suggest widget.",
+			"The foreground color for class symbols. These symbols appear in the outline, breadcrumb, and suggest widget.",
+			"The foreground color for color symbols. These symbols appear in the outline, breadcrumb, and suggest widget.",
+			"The foreground color for constant symbols. These symbols appear in the outline, breadcrumb, and suggest widget.",
+			"The foreground color for constructor symbols. These symbols appear in the outline, breadcrumb, and suggest widget.",
+			"The foreground color for enumerator symbols. These symbols appear in the outline, breadcrumb, and suggest widget.",
+			"The foreground color for enumerator member symbols. These symbols appear in the outline, breadcrumb, and suggest widget.",
+			"The foreground color for event symbols. These symbols appear in the outline, breadcrumb, and suggest widget.",
+			"The foreground color for field symbols. These symbols appear in the outline, breadcrumb, and suggest widget.",
+			"The foreground color for file symbols. These symbols appear in the outline, breadcrumb, and suggest widget.",
+			"The foreground color for folder symbols. These symbols appear in the outline, breadcrumb, and suggest widget.",
+			"The foreground color for function symbols. These symbols appear in the outline, breadcrumb, and suggest widget.",
+			"The foreground color for interface symbols. These symbols appear in the outline, breadcrumb, and suggest widget.",
+			"The foreground color for key symbols. These symbols appear in the outline, breadcrumb, and suggest widget.",
+			"The foreground color for keyword symbols. These symbols appear in the outline, breadcrumb, and suggest widget.",
+			"The foreground color for method symbols. These symbols appear in the outline, breadcrumb, and suggest widget.",
+			"The foreground color for module symbols. These symbols appear in the outline, breadcrumb, and suggest widget.",
+			"The foreground color for namespace symbols. These symbols appear in the outline, breadcrumb, and suggest widget.",
+			"The foreground color for null symbols. These symbols appear in the outline, breadcrumb, and suggest widget.",
+			"The foreground color for number symbols. These symbols appear in the outline, breadcrumb, and suggest widget.",
+			"The foreground color for object symbols. These symbols appear in the outline, breadcrumb, and suggest widget.",
+			"The foreground color for operator symbols. These symbols appear in the outline, breadcrumb, and suggest widget.",
+			"The foreground color for package symbols. These symbols appear in the outline, breadcrumb, and suggest widget.",
+			"The foreground color for property symbols. These symbols appear in the outline, breadcrumb, and suggest widget.",
+			"The foreground color for reference symbols. These symbols appear in the outline, breadcrumb, and suggest widget.",
+			"The foreground color for snippet symbols. These symbols appear in the outline, breadcrumb, and suggest widget.",
+			"The foreground color for string symbols. These symbols appear in the outline, breadcrumb, and suggest widget.",
+			"The foreground color for struct symbols. These symbols appear in the outline, breadcrumb, and suggest widget.",
+			"The foreground color for text symbols. These symbols appear in the outline, breadcrumb, and suggest widget.",
+			"The foreground color for type parameter symbols. These symbols appear in the outline, breadcrumb, and suggest widget.",
+			"The foreground color for unit symbols. These symbols appear in the outline, breadcrumb, and suggest widget.",
+			"The foreground color for variable symbols. These symbols appear in the outline, breadcrumb, and suggest widget."
+		],
+		"vs/workbench/contrib/outline/browser/outlinePane": [
+			"The active editor cannot provide outline information.",
+			"Loading document symbols for '{0}'...",
+			"No symbols found in document '{0}'",
+			"Collapse All",
+			"Follow Cursor",
+			"Filter on Type",
+			"Sort By: Position",
+			"Sort By: Name",
+			"Sort By: Category"
+		],
+		"vs/workbench/contrib/feedback/browser/feedbackStatusbarItem": [
+			"Tweet Feedback",
+			"Tweet Feedback",
+			"Tweet Feedback",
+			"Tweet Feedback"
+		],
+		"vs/workbench/contrib/userDataSync/browser/userDataSync": [
+			"{0}: Turn On...",
+			"{0}: Turn Off",
+			"{0}: Configure...",
+			"{0}: Show Settings Conflicts",
+			"{0}: Show Keybindings Conflicts",
+			"{0}: Show User Snippets Conflicts",
+			"{0}: Sync Now",
+			"syncing",
+			"synced {0}",
+			"{0}: Show Settings",
+			"{0}: Show Synced Data",
+			"Unable to sync due to conflicts in {0}. Please resolve them to continue.",
+			"Replace Remote",
+			"Replace Local",
+			"Show Conflicts",
+			"Error while accepting changes. Please check [logs]({0}) for more details.",
+			"Error while accepting changes. Please check [logs]({0}) for more details.",
+			"Settings sync was turned off because current session is expired, please sign in again to turn on sync.",
+			"Turn on Settings Sync...",
+			"Settings sync was turned off from another device, please sign in again to turn on sync.",
+			"Turn on Settings Sync...",
+			"Disabled syncing {0} because size of the {1} file to sync is larger than {2}. Please open the file and reduce the size and enable sync",
+			"Settings sync is disabled because the current version ({0}, {1}) is not compatible with the sync service. Please update before turning on sync.",
+			"Operation Id: {0}",
+			"Settings sync is disabled because your data in the cloud is older than that of the client. Please clear your data in the cloud before turning on sync.",
+			"Clear Data in Cloud...",
+			"Show Synced Data",
+			"Settings sync now uses a separate service, more information is available in the [release notes](https://code.visualstudio.com/updates/v1_48#_settings-sync).",
+			"Operation Id: {0}",
+			"Open {0} File",
+			"Unable to sync {0} because the content in the file is not valid. Please open the file and correct it.",
+			"Open {0} File",
+			"{0}: Conflicts Detected",
+			"Turning on Settings Sync...",
+			"Sign in to Sync Settings",
+			"No authentication providers are available.",
+			"Settings sync cannot be turned on because size of the {0} file to sync is larger than {1}. Please open the file and reduce the size and turn on sync",
+			"Settings sync cannot be turned on because the current version ({0}, {1}) is not compatible with the sync service. Please update before turning on sync.",
+			"Operation Id: {0}",
+			"Settings sync cannot be turned on because your data in the cloud is older than that of the client. Please clear your data in the cloud before turning on sync.",
+			"Clear Data in Cloud...",
+			"Show Synced Data",
+			"Error while turning on Settings Sync: Authentication failed.",
+			"Error while turning on Settings Sync. Please check [logs]({0}) for more details.",
+			"Synchronizing your settings is a preview feature, please read the documentation before turning it on.",
+			"Turn On",
+			"Open Documentation",
+			"Cancel",
+			"Sign in & Turn on",
+			"Please sign in to synchronize your data across devices.",
+			"for each platform",
+			"{0}: Configure...",
+			"Choose what to sync",
+			"Do you want to turn off sync?",
+			"Your settings, keybindings, extensions, snippets and UI State will no longer be synced.",
+			"&&Turn off",
+			"Turn off sync on all your devices and clear the data from the cloud.",
+			"{0} (Remote)",
+			"{0} (Merges)",
+			"{0} ↔ {1}",
+			"Settings Sync",
+			"{0}: Select Service",
+			"Ensure you are using the same settings sync service when syncing with multiple environments",
+			"Default",
+			"Insiders",
+			"Stable",
+			"Turn on Settings Sync...",
+			"Turn on Settings Sync...",
+			"Turn on Settings Sync...",
+			"Turning on Settings Sync...",
+			"Sign in to Sync Settings",
+			"Sign in to Sync Settings (1)",
+			"{0}: Show Settings Conflicts (1)",
+			"{0}: Show Settings Conflicts (1)",
+			"{0}: Show Keybindings Conflicts (1)",
+			"{0}: Show Keybindings Conflicts (1)",
+			"{0}: Show User Snippets Conflicts ({1})",
+			"{0}: Show User Snippets Conflicts ({1})",
+			"Settings Sync is On",
+			"Show Synced Data",
+			"Error while turning off Settings Sync. Please check [logs]({0}) for more details.",
+			"Configure...",
+			"{0}: Show Log",
+			"Show Log",
+			"Clear Data in Cloud...",
+			"Accept Remote",
+			"Accept Merges",
+			"Accept &&Remote",
+			"Accept &&Merges",
+			"{0}: {1}",
+			"{0}: {1}",
+			"Would you like to accept remote {0} and replace local {1}?",
+			"Would you like to accept merges and replace remote {0}?",
+			"Could not resolve conflicts as there is new local version available. Please try again.",
+			"Error while accepting changes. Please check [logs]({0}) for more details."
+		],
+		"vs/workbench/contrib/codeActions/common/codeActionsContribution": [
+			"Controls whether auto fix action should be run on file save.",
+			"Code action kinds to be run on save.",
+			"Controls whether '{0}' actions should be run on file save."
+		],
+		"vs/workbench/contrib/codeActions/common/codeActionsExtensionPoint": [
+			"Configure which editor to use for a resource.",
+			"Language modes that the code actions are enabled for.",
+			"`CodeActionKind` of the contributed code action.",
+			"Label for the code action used in the UI.",
+			"Description of what the code action does."
+		],
+		"vs/workbench/contrib/codeActions/common/documentationExtensionPoint": [
+			"Contributed documentation.",
+			"Contributed documentation for refactorings.",
+			"Contributed documentation for refactoring.",
+			"Label for the documentation used in the UI.",
+			"When clause.",
+			"Command executed."
+		],
+		"vs/workbench/contrib/welcome/common/viewsWelcomeContribution": [
+			"The viewsWelcome contribution in '{0}' requires 'enableProposedApi' to be enabled."
+		],
+		"vs/workbench/contrib/welcome/common/viewsWelcomeExtensionPoint": [
+			"Contributed views welcome content. Welcome content will be rendered in tree based views whenever they have no meaningful content to display, ie. the File Explorer when no folder is open. Such content is useful as in-product documentation to drive users to use certain features before they are available. A good example would be a `Clone Repository` button in the File Explorer welcome view.",
+			"Contributed welcome content for a specific view.",
+			"Target view identifier for this welcome content. Only tree based views are supported.",
+			"Target view identifier for this welcome content. Only tree based views are supported.",
+			"Welcome content to be displayed. The format of the contents is a subset of Markdown, with support for links only.",
+			"Condition when the welcome content should be displayed.",
+			"Group to which this welcome content belongs.",
+			"Condition when the welcome content buttons and command links should be enabled."
+		],
+		"vs/workbench/contrib/timeline/browser/timelinePane": [
+			"Loading...",
+			"Load more",
+			"Timeline",
+			"The active editor cannot provide timeline information.",
+			"No timeline information was provided.",
+			"The active editor cannot provide timeline information.",
+			"{0}: {1}",
+			"Timeline",
+			"Loading timeline for {0}...",
+			"Icon for the refresh timeline action.",
+			"Icon for the pin timeline action.",
+			"Icon for the unpin timeline action.",
+			"Refresh",
+			"Timeline",
+			"Pin the Current Timeline",
+			"Timeline",
+			"Unpin the Current Timeline",
+			"Timeline",
+			"Include: {0}",
+			"Timeline"
+		],
+		"vs/workbench/services/textMate/common/TMGrammars": [
+			"Contributes textmate tokenizers.",
+			"Language identifier for which this syntax is contributed to.",
+			"Textmate scope name used by the tmLanguage file.",
+			"Path of the tmLanguage file. The path is relative to the extension folder and typically starts with './syntaxes/'.",
+			"A map of scope name to language id if this grammar contains embedded languages.",
+			"A map of scope name to token types.",
+			"List of language scope names to which this grammar is injected to."
+		],
+		"vs/workbench/services/textMate/common/TMGrammarFactory": [
+			"No TM Grammar registered for this language.",
+			"No TM Grammar registered for this language."
+		],
+		"vs/workbench/browser/parts/titlebar/titlebarPart": [
+			"[Unsupported]",
+			"[Administrator]",
+			"[Superuser]",
+			"[Extension Development Host]"
+		],
+		"vs/workbench/electron-sandbox/parts/titlebar/menubarControl": [
+			"Preferences"
+		],
+		"vs/workbench/contrib/files/browser/editors/textFileEditor": [
+			"Text File Editor",
+			"File is a directory",
+			"Create File"
+		],
+		"vs/workbench/contrib/welcome/telemetryOptOut/browser/telemetryOptOut": [
+			"Help improve VS Code by allowing Microsoft to collect usage data. Read our [privacy statement]({0}) and learn how to [opt out]({1}).",
+			"Help improve VS Code by allowing Microsoft to collect usage data. Read our [privacy statement]({0}) and learn how to [opt in]({1}).",
+			"Read More",
+			"Please help Microsoft improve Visual Studio Code by allowing the collection of usage data. Read our [privacy statement]({0}) for more details.",
+			"Yes, glad to help",
+			"No, thanks"
+		],
+		"vs/workbench/browser/parts/notifications/notificationsList": [
+			"{0}, notification",
+			"{0}, source: {1}, notification",
+			"Notifications List"
+		],
+		"vs/workbench/browser/parts/notifications/notificationsActions": [
+			"Icon for the clear action in notifications.",
+			"Icon for the clear all action in notifications.",
+			"Icon for the hide action in notifications.",
+			"Icon for the expand action in notifications.",
+			"Icon for the collapse action in notifications.",
+			"Icon for the configure action in notifications.",
+			"Clear Notification",
+			"Clear All Notifications",
+			"Hide Notifications",
+			"Expand Notification",
+			"Collapse Notification",
+			"Configure Notification",
+			"Copy Text"
+		],
+		"vs/base/common/keybindingLabels": [
+			"Ctrl",
+			"Shift",
+			"Alt",
+			"Windows",
+			"Ctrl",
+			"Shift",
+			"Alt",
+			"Super",
+			"Control",
+			"Shift",
+			"Alt",
+			"Command",
+			"Control",
+			"Shift",
+			"Alt",
+			"Windows",
+			"Control",
+			"Shift",
+			"Alt",
+			"Super"
+		],
+		"vs/workbench/services/textfile/common/textFileSaveParticipant": [
+			"Saving '{0}'"
+		],
+		"vs/base/common/jsonErrorMessages": [
+			"Invalid symbol",
+			"Invalid number format",
+			"Property name expected",
+			"Value expected",
+			"Colon expected",
+			"Comma expected",
+			"Closing brace expected",
+			"Closing bracket expected",
+			"End of file expected"
+		],
+		"vs/workbench/contrib/codeEditor/browser/find/simpleFindWidget": [
+			"Find",
+			"Find",
+			"Previous match",
+			"Next match",
+			"Close"
+		],
+		"vs/workbench/api/common/extHostDiagnostics": [
+			"Not showing {0} further errors and warnings."
+		],
+		"vs/workbench/api/common/extHostProgress": [
+			"{0} (Extension)"
+		],
+		"vs/workbench/api/common/extHostStatusBar": [
+			"Extension Status"
+		],
+		"vs/workbench/api/common/extHostTreeViews": [
+			"No tree view with id '{0}' registered.",
+			"No tree view with id '{0}' registered.",
+			"No tree view with id '{0}' registered.",
+			"No tree view with id '{0}' registered.",
+			"No tree view with id '{0}' registered.",
+			"No tree view with id '{0}' registered.",
+			"Element with id {0} is already registered"
+		],
+		"vs/workbench/contrib/debug/node/debugAdapter": [
+			"Debug adapter executable '{0}' does not exist.",
+			"Cannot determine executable for debug adapter '{0}'.",
+			"Unable to launch debug adapter from '{0}'.",
+			"Unable to launch debug adapter."
+		],
+		"vs/editor/browser/widget/diffReview": [
+			"Icon for 'Insert' in diff review.",
+			"Icon for 'Remove' in diff review.",
+			"Icon for 'Close' in diff review.",
+			"Close",
+			"no lines changed",
+			"1 line changed",
+			"{0} lines changed",
+			"Difference {0} of {1}: original line {2}, {3}, modified line {4}, {5}",
+			"blank",
+			"{0} unchanged line {1}",
+			"{0} original line {1} modified line {2}",
+			"+ {0} modified line {1}",
+			"- {0} original line {1}",
+			"Go to Next Difference",
+			"Go to Previous Difference"
+		],
+		"vs/editor/browser/widget/inlineDiffMargin": [
+			"Copy deleted lines",
+			"Copy deleted line",
+			"Copy deleted line ({0})",
+			"Revert this change",
+			"Copy deleted line ({0})"
+		],
+		"vs/editor/contrib/codeAction/codeActionCommands": [
+			"Kind of the code action to run.",
+			"Controls when the returned actions are applied.",
+			"Always apply the first returned code action.",
+			"Apply the first returned code action if it is the only one.",
+			"Do not apply the returned code actions.",
+			"Controls if only preferred code actions should be returned.",
+			"An unknown error occurred while applying the code action",
+			"Quick Fix...",
+			"No code actions available",
+			"No preferred code actions for '{0}' available",
+			"No code actions for '{0}' available",
+			"No preferred code actions available",
+			"No code actions available",
+			"Refactor...",
+			"No preferred refactorings for '{0}' available",
+			"No refactorings for '{0}' available",
+			"No preferred refactorings available",
+			"No refactorings available",
+			"Source Action...",
+			"No preferred source actions for '{0}' available",
+			"No source actions for '{0}' available",
+			"No preferred source actions available",
+			"No source actions available",
+			"Organize Imports",
+			"No organize imports action available",
+			"Fix All",
+			"No fix all action available",
+			"Auto Fix...",
+			"No auto fixes available"
+		],
+		"vs/editor/contrib/find/findWidget": [
+			"Icon for 'Find in Selection' in the editor find widget.",
+			"Icon to indicate that the editor find widget is collapsed.",
+			"Icon to indicate that the editor find widget is expanded.",
+			"Icon for 'Replace' in the editor find widget.",
+			"Icon for 'Replace All' in the editor find widget.",
+			"Icon for 'Find Previous' in the editor find widget.",
+			"Icon for 'Find Next' in the editor find widget.",
+			"Find",
+			"Find",
+			"Previous match",
+			"Next match",
+			"Find in selection",
+			"Close",
+			"Replace",
+			"Replace",
+			"Replace",
+			"Replace All",
+			"Toggle Replace mode",
+			"Only the first {0} results are highlighted, but all find operations work on the entire text.",
+			"{0} of {1}",
+			"No results",
+			"{0} found",
+			"{0} found for '{1}'",
+			"{0} found for '{1}', at {2}",
+			"{0} found for '{1}'",
+			"Ctrl+Enter now inserts line break instead of replacing all. You can modify the keybinding for editor.action.replaceAll to override this behavior."
+		],
+		"vs/editor/contrib/folding/foldingDecorations": [
+			"Icon for expanded ranges in the editor glyph margin.",
+			"Icon for collapsed ranges in the editor glyph margin."
+		],
+		"vs/editor/contrib/format/format": [
+			"Made 1 formatting edit on line {0}",
+			"Made {0} formatting edits on line {1}",
+			"Made 1 formatting edit between lines {0} and {1}",
+			"Made {0} formatting edits between lines {1} and {2}"
+		],
+		"vs/editor/contrib/message/messageController": [
+			"Cannot edit in read-only editor"
+		],
+		"vs/editor/contrib/gotoSymbol/peek/referencesController": [
+			"Loading...",
+			"{0} ({1})"
+		],
+		"vs/editor/contrib/gotoSymbol/referencesModel": [
+			"symbol in {0} on line {1} at column {2}",
+			"symbol in {0} on line {1} at column {2}, {3}",
+			"1 symbol in {0}, full path {1}",
+			"{0} symbols in {1}, full path {2}",
+			"No results found",
+			"Found 1 symbol in {0}",
+			"Found {0} symbols in {1}",
+			"Found {0} symbols in {1} files"
+		],
+		"vs/editor/contrib/gotoSymbol/symbolNavigation": [
+			"Symbol {0} of {1}, {2} for next",
+			"Symbol {0} of {1}"
+		],
+		"vs/editor/contrib/gotoError/gotoErrorWidget": [
+			"Error",
+			"Warning",
+			"Info",
+			"Hint",
+			"{0} at {1}. ",
+			"{0} of {1} problems",
+			"{0} of {1} problem",
+			"Editor marker navigation widget error color.",
+			"Editor marker navigation widget warning color.",
+			"Editor marker navigation widget info color.",
+			"Editor marker navigation widget background."
+		],
+		"vs/editor/contrib/rename/renameInputField": [
+			"Rename input. Type new name and press Enter to commit.",
+			"{0} to Rename, {1} to Preview"
+		],
+		"vs/editor/contrib/parameterHints/parameterHintsWidget": [
+			"Icon for show next parameter hint.",
+			"Icon for show previous parameter hint.",
+			"{0}, hint"
+		],
+		"vs/editor/contrib/suggest/suggestWidget": [
+			"Background color of the suggest widget.",
+			"Border color of the suggest widget.",
+			"Foreground color of the suggest widget.",
+			"Background color of the selected entry in the suggest widget.",
+			"Color of the match highlights in the suggest widget.",
+			"Loading...",
+			"No suggestions.",
+			"{0}, docs: {1}",
+			"Suggest"
+		],
+		"vs/platform/theme/common/tokenClassificationRegistry": [
+			"Colors and styles for the token.",
+			"Foreground color for the token.",
+			"Token background colors are currently not supported.",
+			"Sets the all font styles of the rule: 'italic', 'bold' or 'underline' or a combination. All styles that are not listed are unset. The empty string unsets all styles.",
+			"Font style must be 'italic', 'bold' or 'underline' or a combination. The empty string unsets all styles.",
+			"None (clear inherited style)",
+			"Sets or unsets the font style to bold. Note, the presence of 'fontStyle' overrides this setting.",
+			"Sets or unsets the font style to italic. Note, the presence of 'fontStyle' overrides this setting.",
+			"Sets or unsets the font style to underline. Note, the presence of 'fontStyle' overrides this setting.",
+			"Style for comments.",
+			"Style for strings.",
+			"Style for keywords.",
+			"Style for numbers.",
+			"Style for expressions.",
+			"Style for operators.",
+			"Style for namespaces.",
+			"Style for types.",
+			"Style for structs.",
+			"Style for classes.",
+			"Style for interfaces.",
+			"Style for enums.",
+			"Style for type parameters.",
+			"Style for functions",
+			"Style for member functions",
+			"Style for method (member functions)",
+			"Style for macros.",
+			"Style for variables.",
+			"Style for parameters.",
+			"Style for properties.",
+			"Style for enum members.",
+			"Style for events.",
+			"Style for labels. ",
+			"Style for all symbol declarations.",
+			"Style to use for references in documentation.",
+			"Style to use for symbols that are static.",
+			"Style to use for symbols that are abstract.",
+			"Style to use for symbols that are deprecated.",
+			"Style to use for write accesses.",
+			"Style to use for symbols that are async.",
+			"Style to use for symbols that are readonly."
+		],
+		"vs/workbench/browser/parts/editor/textEditor": [
+			"Editor"
+		],
+		"vs/workbench/api/browser/mainThreadCustomEditors": [
+			"Edit"
+		],
+		"vs/workbench/api/browser/mainThreadWebviews": [
+			"An error occurred while loading view: {0}"
+		],
+		"vs/workbench/contrib/comments/browser/commentsView": [
+			"Comments for current workspace",
+			"Comments in {0}, full path {1}",
+			"Comment from ${0} at line {1} column {2} in {3}, source: {4}",
+			"Collapse All"
+		],
+		"vs/workbench/contrib/comments/browser/commentsTreeViewer": [
+			"Image: {0}",
+			"Image"
+		],
+		"vs/workbench/contrib/remote/browser/tunnelView": [
+			"Forward a Port...",
+			"Existing Tunnels",
+			"Not Forwarded",
+			"Press Enter to confirm or Escape to cancel.",
+			"{0}",
+			"{0} → {1}",
+			"{0}",
+			"{0} → {1}",
+			"Ports",
+			"Remote port {0}:{1} forwarded to local address {2}",
+			"Remote port {0}:{1} not forwarded",
+			"Tunnel View",
+			"Set Label",
+			"Port label",
+			"Forwarded port is invalid.",
+			"Port number must be ≥ 0 and < {0}.",
+			"May Require Sudo",
+			"Forward a Port",
+			"Forward Port",
+			"Port number or address (eg. 3000 or 10.10.10.10:2000).",
+			"Unable to forward {0}:{1}. The host may not be available or that remote port may already be forwarded",
+			"No ports currently forwarded. Try running the {0} command",
+			"Stop Forwarding Port",
+			"Choose a port to stop forwarding",
+			"Open in Browser",
+			"Open Port in Browser",
+			"No ports currently forwarded. Open the Ports view to get started.",
+			"Open the Ports view...",
+			"Choose the port to open",
+			"Copy Address",
+			"Copy Forwarded Port Address",
+			"Choose a forwarded port",
+			"Change Local Port",
+			"The local port {0} is not available. Port number {1} has been used instead",
+			"New local port",
+			"Make Public",
+			"Make Private"
+		],
+		"vs/base/browser/ui/tree/treeDefaults": [
+			"Collapse All"
+		],
+		"vs/base/browser/ui/splitview/paneview": [
+			"{0} Section"
+		],
+		"vs/workbench/browser/parts/editor/tabsTitleControl": [
+			"Tab actions"
+		],
+		"vs/workbench/browser/parts/editor/textDiffEditor": [
+			"Text Diff Editor"
+		],
+		"vs/workbench/browser/parts/editor/binaryDiffEditor": [
+			"{0} ↔ {1}"
+		],
+		"vs/workbench/browser/parts/editor/editorQuickAccess": [
+			"No matching editors",
+			"{0}, dirty, {1}",
+			"{0}, {1}",
+			"{0}, dirty",
+			"Close Editor"
+		],
+		"vs/workbench/browser/parts/editor/editorStatus": [
+			"Ln {0}, Col {1} ({2} selected)",
+			"Ln {0}, Col {1}",
+			"{0} selections ({1} characters selected)",
+			"{0} selections",
+			"LF",
+			"CRLF",
+			"Are you using a screen reader to operate VS Code? (word wrap is disabled when using a screen reader)",
+			"Yes",
+			"No",
+			"No text editor active at this time",
+			"The active code editor is read-only.",
+			"convert file",
+			"change view",
+			"Select Action",
+			"Tab Moves Focus",
+			"Disable Accessibility Mode",
+			"Accessibility Mode",
+			"Column Selection",
+			"Disable Column Selection Mode",
+			"Column Selection Mode",
+			"Screen Reader Optimized",
+			"Screen Reader Mode",
+			"Go to Line/Column",
+			"Editor Selection",
+			"Select Indentation",
+			"Editor Indentation",
+			"Select Encoding",
+			"Editor Encoding",
+			"Select End of Line Sequence",
+			"Editor End of Line",
+			"Select Language Mode",
+			"Editor Language",
+			"File Information",
+			"File Information",
+			"Spaces: {0}",
+			"Tab Size: {0}",
+			"Current Problem",
+			"Search Marketplace Extensions for '{0}'...",
+			"Change Language Mode",
+			"No text editor active at this time",
+			"({0}) - Configured Language",
+			"({0})",
+			"languages (identifier)",
+			"Configure '{0}' language based settings...",
+			"Configure File Association for '{0}'...",
+			"Auto Detect",
+			"Select Language Mode",
+			"Current Association",
+			"Select Language Mode to Associate with '{0}'",
+			"Change End of Line Sequence",
+			"No text editor active at this time",
+			"The active code editor is read-only.",
+			"Select End of Line Sequence",
+			"Change File Encoding",
+			"No text editor active at this time",
+			"No text editor active at this time",
+			"No file active at this time",
+			"Save with Encoding",
+			"Reopen with Encoding",
+			"Select Action",
+			"Guessed from content",
+			"Select File Encoding to Reopen File",
+			"Select File Encoding to Save with"
+		],
+		"vs/workbench/browser/parts/editor/editorActions": [
+			"Split Editor",
+			"Split Editor Orthogonal",
+			"Split Editor Left",
+			"Split Editor Right",
+			"Split Editor Up",
+			"Split Editor Down",
+			"Join Editor Group with Next Group",
+			"Join All Editor Groups",
+			"Navigate Between Editor Groups",
+			"Focus Active Editor Group",
+			"Focus First Editor Group",
+			"Focus Last Editor Group",
+			"Focus Next Editor Group",
+			"Focus Previous Editor Group",
+			"Focus Left Editor Group",
+			"Focus Right Editor Group",
+			"Focus Above Editor Group",
+			"Focus Below Editor Group",
+			"Close Editor",
+			"Unpin Editor",
+			"Close",
+			"Revert and Close Editor",
+			"Close Editors to the Left in Group",
+			"Close All Editors",
+			"Close All Editor Groups",
+			"Close Editors in Other Groups",
+			"Close Editor in All Groups",
+			"Move Editor Group Left",
+			"Move Editor Group Right",
+			"Move Editor Group Up",
+			"Move Editor Group Down",
+			"Duplicate Editor Group Left",
+			"Duplicate Editor Group Right",
+			"Duplicate Editor Group Up",
+			"Duplicate Editor Group Down",
+			"Maximize Editor Group",
+			"Reset Editor Group Sizes",
+			"Toggle Editor Group Sizes",
+			"Maximize Editor Group and Hide Side Bar",
+			"Open Next Editor",
+			"Open Previous Editor",
+			"Open Next Editor in Group",
+			"Open Previous Editor in Group",
+			"Open First Editor in Group",
+			"Open Last Editor in Group",
+			"Go Forward",
+			"Go Back",
+			"Go to Last Edit Location",
+			"Go Last",
+			"Reopen Closed Editor",
+			"Clear Recently Opened",
+			"Show Editors in Active Group By Most Recently Used",
+			"Show All Editors By Appearance",
+			"Show All Editors By Most Recently Used",
+			"Quick Open Previous Recently Used Editor",
+			"Quick Open Least Recently Used Editor",
+			"Quick Open Previous Recently Used Editor in Group",
+			"Quick Open Least Recently Used Editor in Group",
+			"Quick Open Previous Editor from History",
+			"Open Next Recently Used Editor",
+			"Open Previous Recently Used Editor",
+			"Open Next Recently Used Editor In Group",
+			"Open Previous Recently Used Editor In Group",
+			"Clear Editor History",
+			"Move Editor Left",
+			"Move Editor Right",
+			"Move Editor into Previous Group",
+			"Move Editor into Next Group",
+			"Move Editor into Above Group",
+			"Move Editor into Below Group",
+			"Move Editor into Left Group",
+			"Move Editor into Right Group",
+			"Move Editor into First Group",
+			"Move Editor into Last Group",
+			"Single Column Editor Layout",
+			"Two Columns Editor Layout",
+			"Three Columns Editor Layout",
+			"Two Rows Editor Layout",
+			"Three Rows Editor Layout",
+			"Grid Editor Layout (2x2)",
+			"Two Columns Bottom Editor Layout",
+			"Two Rows Right Editor Layout",
+			"New Editor Group to the Left",
+			"New Editor Group to the Right",
+			"New Editor Group Above",
+			"New Editor Group Below",
+			"Reopen Editor With...",
+			"Toggle Editor Type"
+		],
+		"vs/base/browser/ui/menu/menubar": [
+			"Application Menu",
+			"More"
+		],
+		"vs/base/browser/ui/menu/menu": [
+			"{0} ({1})"
+		],
+		"vs/base/browser/ui/toolbar/toolbar": [
+			"More Actions..."
+		],
+		"vs/base/browser/ui/inputbox/inputBox": [
+			"Error: {0}",
+			"Warning: {0}",
+			"Info: {0}"
+		],
+		"vs/workbench/services/preferences/browser/keybindingsEditorModel": [
+			"Default",
+			"Extension",
+			"User",
+			"{0}: {1}",
+			"{0}: {1}",
+			"option",
+			"meta"
+		],
+		"vs/workbench/services/preferences/common/preferencesValidation": [
+			"Value must be a number.",
+			"Setting has an invalid type, expected {0}. Fix in JSON.",
+			"Value must be {0} or fewer characters long.",
+			"Value must be {0} or more characters long.",
+			"Value must match regex `{0}`.",
+			"Invalid color format. Use #RGB, #RGBA, #RRGGBB or #RRGGBBAA.",
+			"URI expected.",
+			"URI is expected.",
+			"URI with a scheme is expected.",
+			"Value must be strictly less than {0}.",
+			"Value must be strictly greater than {0}.",
+			"Value must be less than or equal to {0}.",
+			"Value must be greater than or equal to {0}.",
+			"Value must be a multiple of {0}.",
+			"Value must be an integer.",
+			"Array has duplicate items",
+			"Array must have at least {0} items",
+			"Array must have at most {0} items",
+			"Value {0} must match regex {1}.",
+			"Value {0} is not one of {1}"
+		],
+		"vs/base/parts/quickinput/browser/quickInput": [
+			"Back",
+			"{0}/{1}",
+			"Type to narrow down results.",
+			"Press 'Enter' to confirm your input or 'Escape' to cancel",
+			"{0} (Press 'Enter' to confirm or 'Escape' to cancel)",
+			"{0} Results",
+			"{0} Selected",
+			"OK",
+			"Custom",
+			"Back ({0})",
+			"Back"
+		],
+		"vs/workbench/contrib/preferences/browser/preferencesWidgets": [
+			"Place your settings in the right hand side editor to override.",
+			"No Settings Found.",
+			"Settings Switcher",
+			"User",
+			"Remote",
+			"Workspace",
+			"Folder",
+			"Workspace",
+			"User"
+		],
+		"vs/workbench/contrib/preferences/browser/settingsLayout": [
+			"Commonly Used",
+			"Text Editor",
+			"Cursor",
+			"Find",
+			"Font",
+			"Formatting",
+			"Diff Editor",
+			"Minimap",
+			"Suggestions",
+			"Files",
+			"Workbench",
+			"Appearance",
+			"Breadcrumbs",
+			"Editor Management",
+			"Settings Editor",
+			"Zen Mode",
+			"Screencast Mode",
+			"Window",
+			"New Window",
+			"Features",
+			"Explorer",
+			"Search",
+			"Debug",
+			"SCM",
+			"Extensions",
+			"Terminal",
+			"Task",
+			"Problems",
+			"Output",
+			"Comments",
+			"Remote",
+			"Timeline",
+			"Notebook",
+			"Application",
+			"Proxy",
+			"Keyboard",
+			"Update",
+			"Telemetry",
+			"Settings Sync"
+		],
+		"vs/workbench/contrib/preferences/browser/preferencesRenderers": [
+			"Place your settings here to override the Default Settings.",
+			"Place your settings here to override the User Settings.",
+			"Place your folder settings here to override those from the Workspace Settings.",
+			"Edit",
+			"Replace in Settings",
+			"Copy to Settings",
+			"Unknown Configuration Setting",
+			"This setting cannot be applied in this window. It will be applied when you open local window.",
+			"This setting cannot be applied in this workspace. It will be applied when you open the containing workspace folder directly.",
+			"This setting can be applied only in application user settings",
+			"This setting can only be applied in user settings in local window or in remote settings in remote window.",
+			"Unsupported Property"
+		],
+		"vs/workbench/contrib/preferences/browser/settingsTreeModels": [
+			"Workspace",
+			"Remote",
+			"User"
+		],
+		"vs/workbench/contrib/preferences/browser/tocTree": [
+			"Settings Table of Contents",
+			"{0}, group"
+		],
+		"vs/workbench/contrib/preferences/browser/settingsWidgets": [
+			"The foreground color for a section header or active title.",
+			"The color of the modified setting indicator.",
+			"Settings editor dropdown background.",
+			"Settings editor dropdown foreground.",
+			"Settings editor dropdown border.",
+			"Settings editor dropdown list border. This surrounds the options and separates the options from the description.",
+			"Settings editor checkbox background.",
+			"Settings editor checkbox foreground.",
+			"Settings editor checkbox border.",
+			"Settings editor text input box background.",
+			"Settings editor text input box foreground.",
+			"Settings editor text input box border.",
+			"Settings editor number input box background.",
+			"Settings editor number input box foreground.",
+			"Settings editor number input box border.",
+			"The background color of a settings row when focused.",
+			"The background color of a settings row when hovered.",
+			"The color of the row's top and bottom border when the row is focused.",
+			"OK",
+			"Cancel",
+			"List item `{0}`",
+			"List item `{0}` with sibling `${1}`",
+			"Remove Item",
+			"Edit Item",
+			"Add Item",
+			"String Item...",
+			"Sibling...",
+			"Exclude files matching `{0}`",
+			"Exclude files matching `{0}`, only when a file matching `{1}` is present",
+			"Remove Exclude Item",
+			"Edit Exclude Item",
+			"Add Pattern",
+			"Exclude Pattern...",
+			"When Pattern Is Present...",
+			"OK",
+			"Cancel",
+			"Key",
+			"Value",
+			"The property `{0}` is set to `{1}`.",
+			"Remove Item",
+			"Reset Item",
+			"Edit Item",
+			"Add Item",
+			"Item",
+			"Value"
+		],
+		"vs/workbench/contrib/preferences/browser/settingsTree": [
+			"Extensions",
+			"Sync: Ignored",
+			"Modified",
+			"More Actions... ",
+			"Also modified in",
+			"Modified in",
+			"Show matching extensions",
+			"Edit in settings.json",
+			"default",
+			"Modified",
+			"Reset Setting",
+			"Validation Error.",
+			"Validation Error.",
+			"Modified.",
+			"Also modified in",
+			"Modified in",
+			"Settings",
+			"Copy Setting ID",
+			"Copy Setting as JSON",
+			"Sync This Setting"
+		],
+		"vs/workbench/contrib/testing/browser/theme": [
+			"Color for the 'failed' icon in the test explorer.",
+			"Color for the 'Errored' icon in the test explorer.",
+			"Color for the 'passed' icon in the test explorer.",
+			"Color for 'run' icons in the editor.",
+			"Color for the 'Queued' icon in the test explorer.",
+			"Color for the 'Unset' icon in the test explorer.",
+			"Color for the 'Skipped' icon in the test explorer.",
+			"Color of the peek view borders and arrow.",
+			"Text color of test error messages shown inline in the editor.",
+			"Margin color beside error messages shown inline in the editor.",
+			"Text color of test warning messages shown inline in the editor.",
+			"Margin color beside warning messages shown inline in the editor.",
+			"Text color of test info messages shown inline in the editor.",
+			"Margin color beside info messages shown inline in the editor.",
+			"Text color of test hint messages shown inline in the editor.",
+			"Margin color beside hint messages shown inline in the editor."
+		],
+		"vs/workbench/contrib/testing/common/constants": [
+			"Errored",
+			"Failed",
+			"Passed",
+			"Queued",
+			"Running",
+			"Skipped",
+			"Unset"
+		],
+		"vs/workbench/contrib/notebook/browser/extensionPoint": [
+			"Contributes notebook document provider.",
+			"Unique identifier of the notebook.",
+			"Human readable name of the notebook.",
+			"Set of globs that the notebook is for.",
+			"Glob that the notebook is enabled for.",
+			"Glob that the notebook is disabled for.",
+			"Controls if the custom editor is enabled automatically when the user opens a file. This may be overridden by users using the `workbench.editorAssociations` setting.",
+			"The editor is automatically used when the user opens a resource, provided that no other default custom editors are registered for that resource.",
+			"The editor is not automatically used when the user opens a resource, but a user can switch to the editor using the `Reopen With` command.",
+			"Contributes notebook output renderer provider.",
+			"Unique identifier of the notebook output renderer.",
+			"Rename `viewType` to `id`.",
+			"Unique identifier of the notebook output renderer.",
+			"Human readable name of the notebook output renderer.",
+			"Set of globs that the notebook is for.",
+			"File to load in the webview to render the extension."
+		],
+		"vs/workbench/contrib/notebook/browser/notebookKernelAssociation": [
+			"Defines a default kernel provider which takes precedence over all other kernel providers settings. Must be the identifier of an extension contributing a kernel provider."
+		],
+		"vs/workbench/contrib/notebook/common/model/notebookTextModel": [
+			"Edit"
+		],
+		"vs/workbench/contrib/notebook/common/notebookEditorModel": [
+			"The contents of the file has changed on disk. Would you like to open the updated version or overwrite the file with your changes?",
+			"Revert",
+			"Overwrite"
+		],
+		"vs/workbench/contrib/notebook/browser/notebookEditorWidget": [
+			"Notebook",
+			"Select a notebook kernel to run this notebook",
+			"Set as default kernel provider for '{0}'",
+			"The border color for notebook cells.",
+			"The color of the notebook cell editor border.",
+			"The error icon color of notebook cells in the cell status bar.",
+			"The error icon color of notebook cells in the cell status bar.",
+			"The running icon color of notebook cells in the cell status bar.",
+			"The Color of the notebook output container background.",
+			"The color of the separator in the cell bottom toolbar",
+			"The background color of a cell when the cell is focused.",
+			"The background color of a cell when the cell is hovered.",
+			"The color of the cell's top and bottom border when the cell is selected but not focused.",
+			"The color of the cell's top and bottom border when the cell is focused.",
+			"The color of the cell's top and bottom border when a cell is focused while the primary focus is outside of the editor.",
+			"The background color of notebook cell status bar items.",
+			"The color of the notebook cell insertion indicator.",
+			"Notebook scrollbar slider background color.",
+			"Notebook scrollbar slider background color when hovering.",
+			"Notebook scrollbar slider background color when clicked on.",
+			"Background color of highlighted cell"
+		],
+		"vs/workbench/contrib/codeEditor/browser/find/simpleFindReplaceWidget": [
+			"Find",
+			"Find",
+			"Previous match",
+			"Next match",
+			"Close",
+			"Toggle Replace mode",
+			"Replace",
+			"Replace",
+			"Replace",
+			"Replace All"
+		],
+		"vs/base/browser/ui/iconLabel/iconLabel": [
+			"Loading..."
+		],
+		"vs/platform/quickinput/browser/commandsQuickAccess": [
+			"{0}, {1}",
+			"recently used",
+			"other commands",
+			"Command '{0}' resulted in an error ({1})"
+		],
+		"vs/workbench/contrib/files/browser/views/explorerDecorationsProvider": [
+			"Unable to resolve workspace folder",
+			"Symbolic Link",
+			"Unknown File Type",
+			"Explorer"
+		],
+		"vs/workbench/contrib/files/browser/views/explorerViewer": [
+			"Files Explorer",
+			"Type file name. Press Enter to confirm or Escape to cancel.",
+			"A file or folder with the name '{0}' already exists in the destination folder. Do you want to replace it?",
+			"This action is irreversible!",
+			"&&Replace",
+			"The following {0} files and/or folders already exist in the destination folder. Do you want to replace them?",
+			"This action is irreversible!",
+			"&&Replace",
+			"Uploading",
+			"Overwrite {0}",
+			"Overwriting {0}",
+			"{0} of {1} files ({2}/s)",
+			"{0} ({1} of {2}, {3}/s)",
+			"&&Copy Folders",
+			"&&Copy Folder",
+			"Cancel",
+			"Are you sure to want to copy folders?",
+			"Are you sure to want to copy '{0}'?",
+			"&&Add Folders to Workspace",
+			"&&Add Folder to Workspace",
+			"Do you want to copy the folders or add the folders to the workspace?",
+			"Do you want to copy '{0}' or add '{0}' as a folder to the workspace?",
+			"Copy {0}",
+			"Copy {0} resources",
+			"Copying {0}",
+			"Copying {0} resources",
+			"Are you sure you want to change the order of multiple root folders in your workspace?",
+			"Are you sure you want to move the following {0} files into '{1}'?",
+			"Are you sure you want to change the order of root folder '{0}' in your workspace?",
+			"Are you sure you want to move '{0}' into '{1}'?",
+			"Do not ask me again",
+			"&&Move",
+			"Copy {0}",
+			"Copying {0}",
+			"Move {0}",
+			"Moving {0}"
+		],
+		"vs/workbench/browser/parts/editor/binaryEditor": [
+			"Binary Viewer",
+			"The file is not displayed in the editor because it is too large ({0}).",
+			"The file is not displayed in the editor because it is either binary or uses an unsupported text encoding.",
+			"Do you want to open it anyway?"
+		],
+		"vs/workbench/contrib/bulkEdit/browser/preview/bulkEditTree": [
+			"Bulk Edit",
+			"Renaming {0} to {1}, also making text edits",
+			"Creating {0}, also making text edits",
+			"Deleting {0}, also making text edits",
+			"{0}, making text edits",
+			"Renaming {0} to {1}",
+			"Creating {0}",
+			"Deleting {0}",
+			"line {0}, replacing {1} with {2}",
+			"line {0}, removing {1}",
+			"line {0}, inserting {1}",
+			"{0} → {1}",
+			"(renaming)",
+			"(creating)",
+			"(deleting)",
+			"{0} - {1}"
+		],
+		"vs/editor/contrib/quickAccess/gotoSymbolQuickAccess": [
+			"To go to a symbol, first open a text editor with symbol information.",
+			"The active text editor does not provide symbol information.",
+			"No matching editor symbols",
+			"No editor symbols",
+			"Open to the Side",
+			"Open to the Bottom",
+			"symbols ({0})",
+			"properties ({0})",
+			"methods ({0})",
+			"functions ({0})",
+			"constructors ({0})",
+			"variables ({0})",
+			"classes ({0})",
+			"structs ({0})",
+			"events ({0})",
+			"operators ({0})",
+			"interfaces ({0})",
+			"namespaces ({0})",
+			"packages ({0})",
+			"type parameters ({0})",
+			"modules ({0})",
+			"properties ({0})",
+			"enumerations ({0})",
+			"enumeration members ({0})",
+			"strings ({0})",
+			"files ({0})",
+			"arrays ({0})",
+			"numbers ({0})",
+			"booleans ({0})",
+			"objects ({0})",
+			"keys ({0})",
+			"fields ({0})",
+			"constants ({0})"
+		],
+		"vs/workbench/contrib/search/browser/replaceService": [
+			"{0} ↔ {1} (Replace Preview)"
+		],
+		"vs/workbench/contrib/debug/common/debugModel": [
+			"Invalid variable attributes",
+			"Please start a debug session to evaluate expressions",
+			"not available",
+			"Paused on {0}",
+			"Paused",
+			"Running",
+			"Unverified breakpoint. File is modified, please restart debug session."
+		],
+		"vs/workbench/contrib/debug/browser/debugConfigurationManager": [
+			"Select Launch Configuration",
+			"Edit Debug Configuration in launch.json",
+			"Unable to create 'launch.json' file inside the '.vscode' folder ({0}).",
+			"workspace",
+			"user settings"
+		],
+		"vs/workbench/contrib/debug/browser/debugTaskRunner": [
+			"Errors exist after running preLaunchTask '{0}'.",
+			"Error exists after running preLaunchTask '{0}'.",
+			"The preLaunchTask '{0}' terminated with exit code {1}.",
+			"The preLaunchTask '{0}' terminated.",
+			"Debug Anyway",
+			"Show Errors",
+			"Abort",
+			"Remember my choice in user settings",
+			"Task '{0}' can not be referenced from a launch configuration that is in a different workspace folder.",
+			"Could not find the task '{0}'.",
+			"Could not find the specified task.",
+			"The specified task cannot be tracked.",
+			"The task '{0}' cannot be tracked."
+		],
+		"vs/workbench/contrib/debug/browser/debugSession": [
+			"No debugger available, can not send '{0}'",
+			"No debugger available, can not send '{0}'",
+			"No debugger available, can not send '{0}'",
+			"No debugger available, can not send '{0}'",
+			"No debugger available, can not send '{0}'",
+			"No debugger available, can not send '{0}'",
+			"Session is not ready for breakpoints",
+			"No debugger available, can not send '{0}'",
+			"No debugger available, can not send '{0}'",
+			"No debugger available, can not send '{0}'",
+			"No debugger available, can not send '{0}'",
+			"No debugger available, can not send '{0}'",
+			"No debugger available, can not send '{0}'",
+			"No debugger available, can not send '{0}'",
+			"No debugger available, can not send '{0}'",
+			"No debugger available, can not send '{0}'",
+			"No debugger available, can not send '{0}'",
+			"No debugger available, can not send '{0}'",
+			"No debugger available, can not send '{0}'",
+			"No debugger available, can not send '{0}'",
+			"No debugger available, can not send '{0}'",
+			"No debugger available, can not send '{0}'",
+			"No debugger available, can not send '{0}'",
+			"No debugger available, can not send '{0}'",
+			"No debugger available, can not send '{0}'",
+			"No debugger available, can not send '{0}'",
+			"No debugger available, can not send '{0}'",
+			"No debugger available, can not send '{0}'",
+			"No debugger available, can not send '{0}'",
+			"No debugger available, can not send '{0}'",
+			"No debugger available, can not send '{0}'",
+			"No debugger available, can not send '{0}'",
+			"Debugging started.",
+			"Debugging stopped."
+		],
+		"vs/workbench/contrib/debug/browser/debugAdapterManager": [
+			"Debugger 'type' can not be omitted and must be of type 'string'.",
+			"More...",
+			"Select Environment"
+		],
+		"vs/workbench/contrib/debug/common/debugSource": [
+			"Unknown Source"
+		],
+		"vs/base/browser/ui/findinput/findInput": [
+			"input"
+		],
+		"vs/base/browser/ui/findinput/replaceInput": [
+			"input",
+			"Preserve Case"
+		],
+		"vs/workbench/contrib/markers/browser/markersViewActions": [
+			"Icon for the filter configuration in the markers view.",
+			"Showing {0} of {1}"
+		],
+		"vs/workbench/contrib/markers/browser/markersTreeViewer": [
+			"Problems View",
+			"Icon indicating that multiple lines are shown in the markers view.",
+			"Icon indicating that multiple lines are collapsed in the markers view.",
+			"Show message in single line",
+			"Show message in multiple lines",
+			"Follow link",
+			"ctrl + click",
+			"cmd + click",
+			"ctrl + click",
+			"option + click",
+			"alt + click"
+		],
+		"vs/workbench/contrib/comments/browser/commentGlyphWidget": [
+			"Editor gutter decoration color for commenting ranges."
+		],
+		"vs/workbench/contrib/comments/browser/commentThreadWidget": [
+			"Icon to collapse a review comment.",
+			"Collapse",
+			"Start discussion",
+			"Reply...",
+			"Reply...",
+			"Reply...",
+			"Type a new comment"
+		],
+		"vs/workbench/contrib/customEditor/common/contributedCustomEditors": [
+			"Built-in",
+			"Text Editor"
+		],
+		"vs/workbench/contrib/extensions/browser/extensionsWidgets": [
+			"Rated by 1 user",
+			"Rated by {0} users",
+			"No rating",
+			"Extension in {0}",
+			"This extension is ignored during sync."
+		],
+		"vs/workbench/contrib/extensions/browser/extensionsViewer": [
+			"Error",
+			"Unknown Extension:",
+			"{0}, {1}, {2}, press enter for extension details.",
+			"Extensions"
+		],
+		"vs/workbench/contrib/extensions/browser/dynamicWorkspaceRecommendations": [
+			"This extension may interest you because it's popular among users of the {0} repository."
+		],
+		"vs/workbench/contrib/extensions/browser/exeBasedRecommendations": [
+			"This extension is recommended because you have {0} installed."
+		],
+		"vs/workbench/contrib/extensions/browser/workspaceRecommendations": [
+			"This extension is recommended by users of the current workspace."
+		],
+		"vs/workbench/contrib/extensions/browser/configBasedRecommendations": [
+			"This extension is recommended because of the current workspace configuration"
+		],
+		"vs/workbench/contrib/extensions/browser/fileBasedRecommendations": [
+			"Search Marketplace",
+			"This extension is recommended based on the files you recently opened.",
+			"Do you want to install the recommended extensions for {0}?",
+			"The Marketplace has extensions that can help with '.{0}' files",
+			"Don't Show Again for '.{0}' files"
+		],
+		"vs/workbench/contrib/terminal/browser/terminalConfigHelper": [
+			"Do you allow this workspace to modify your terminal shell? {0}",
+			"Allow",
+			"Disallow",
+			"The '{0}' extension is recommended for opening a terminal in WSL.",
+			"Install"
+		],
+		"vs/workbench/contrib/tasks/common/jsonSchemaCommon": [
+			"Additional command options",
+			"The current working directory of the executed program or script. If omitted Code's current workspace root is used.",
+			"The environment of the executed program or shell. If omitted the parent process' environment is used.",
+			"Unrecognized problem matcher. Is the extension that contributes this problem matcher installed?",
+			"Unrecognized problem matcher. Is the extension that contributes this problem matcher installed?",
+			"Configures the shell to be used.",
+			"The shell to be used.",
+			"The shell arguments.",
+			"The command to be executed. Can be an external program or a shell command.",
+			"Arguments passed to the command when this task is invoked.",
+			"The task's name",
+			"The command to be executed. Can be an external program or a shell command.",
+			"Arguments passed to the command when this task is invoked.",
+			"Windows specific command configuration",
+			"The problem matcher(s) to use. Can either be a string or a problem matcher definition or an array of strings and problem matchers.",
+			"Mac specific command configuration",
+			"The problem matcher(s) to use. Can either be a string or a problem matcher definition or an array of strings and problem matchers.",
+			"Linux specific command configuration",
+			"The problem matcher(s) to use. Can either be a string or a problem matcher definition or an array of strings and problem matchers.",
+			"Controls whether the task name is added as an argument to the command. If omitted the globally defined value is used.",
+			"Controls whether the output of the running task is shown or not. If omitted the globally defined value is used.",
+			"Controls whether the executed command is echoed to the output. Default is false.",
+			"Deprecated. Use isBackground instead.",
+			"Whether the executed task is kept alive and is watching the file system.",
+			"Whether the executed task is kept alive and is running in the background.",
+			"Whether the user is prompted when VS Code closes with a running task.",
+			"Maps this task to Code's default build command.",
+			"Maps this task to Code's default test command.",
+			"The problem matcher(s) to use. Can either be a string or a problem matcher definition or an array of strings and problem matchers.",
+			"The command to be executed. Can be an external program or a shell command.",
+			"Additional arguments passed to the command.",
+			"Controls whether the output of the running task is shown or not. If omitted 'always' is used.",
+			"Deprecated. Use isBackground instead.",
+			"Whether the executed task is kept alive and is watching the file system.",
+			"Whether the executed task is kept alive and is running in the background.",
+			"Whether the user is prompted when VS Code closes with a running background task.",
+			"Controls whether the executed command is echoed to the output. Default is false.",
+			"Controls whether the task name is added as an argument to the command. Default is false.",
+			"Prefix to indicate that an argument is task.",
+			"The problem matcher(s) to use. Can either be a string or a problem matcher definition or an array of strings and problem matchers.",
+			"The task configurations. Usually these are enrichments of task already defined in the external task runner."
+		],
+		"vs/workbench/contrib/terminal/browser/terminalInstance": [
+			"Terminal input",
+			"Too much output to announce, navigate to rows manually to read",
+			"Some keybindings are dispatched to the workbench by default.",
+			"Configure Terminal Settings",
+			"Yes",
+			"No",
+			"Don't Show Again",
+			"The standard renderer for the integrated terminal appears to be slow on your computer. Would you like to switch to the alternative DOM-based renderer which may improve performance? [Read more about terminal settings](https://code.visualstudio.com/docs/editor/integrated-terminal#_changing-how-the-terminal-is-rendered).",
+			"The terminal has no selection to copy",
+			"The terminal process \"{0}\" failed to launch (exit code: {1}).",
+			"The terminal process failed to launch (exit code: {0}).",
+			"The terminal process \"{0}\" terminated with exit code: {1}.",
+			"The terminal process terminated with exit code: {0}.",
+			"The terminal process failed to launch: {0}.",
+			"Terminal {0}, {1}",
+			"Terminal {0}",
+			"Terminal {0} environment is stale, run the 'Show Environment Information' command for more information"
+		],
+		"vs/workbench/services/configurationResolver/common/configurationResolverUtils": [
+			"'env.', 'config.' and 'command.' are deprecated, use 'env:', 'config:' and 'command:' instead."
+		],
+		"vs/workbench/services/configurationResolver/common/configurationResolverSchema": [
+			"The input's id is used to associate an input with a variable of the form ${input:id}.",
+			"The type of user input prompt to use.",
+			"The description is shown when the user is prompted for input.",
+			"The default value for the input.",
+			"User inputs. Used for defining user input prompts, such as free string input or a choice from several options.",
+			"The 'promptString' type opens an input box to ask the user for input.",
+			"Controls if a password input is shown. Password input hides the typed text.",
+			"The 'pickString' type shows a selection list.",
+			"An array of strings that defines the options for a quick pick.",
+			"Label for the option.",
+			"Value for the option.",
+			"The 'command' type executes a command.",
+			"The command to execute for this input variable.",
+			"Optional arguments passed to the command.",
+			"Optional arguments passed to the command.",
+			"Optional arguments passed to the command."
+		],
+		"vs/editor/contrib/snippet/snippetVariables": [
+			"Sunday",
+			"Monday",
+			"Tuesday",
+			"Wednesday",
+			"Thursday",
+			"Friday",
+			"Saturday",
+			"Sun",
+			"Mon",
+			"Tue",
+			"Wed",
+			"Thu",
+			"Fri",
+			"Sat",
+			"January",
+			"February",
+			"March",
+			"April",
+			"May",
+			"June",
+			"July",
+			"August",
+			"September",
+			"October",
+			"November",
+			"December",
+			"Jan",
+			"Feb",
+			"Mar",
+			"Apr",
+			"May",
+			"Jun",
+			"Jul",
+			"Aug",
+			"Sep",
+			"Oct",
+			"Nov",
+			"Dec"
+		],
+		"vs/workbench/contrib/update/browser/releaseNotesEditor": [
+			"Release Notes: {0}",
+			"unassigned"
+		],
+		"vs/workbench/contrib/welcome/page/browser/welcomePageColors": [
+			"Background color for the buttons on the Welcome page.",
+			"Hover background color for the buttons on the Welcome page.",
+			"Background color for the Welcome page.",
+			"Foreground color for the Welcome page progress bars.",
+			"Background color for the Welcome page progress bars."
+		],
+		"vs/workbench/contrib/welcome/page/browser/vs_code_welcome_page": [
+			"Visual Studio Code",
+			"Editing evolved",
+			"Start",
+			"New file",
+			"Open folder...",
+			"clone repository...",
+			"Open folder...",
+			"clone repository...",
+			"Recent",
+			"More...",
+			"No recent folders",
+			"Help",
+			"Printable keyboard cheatsheet",
+			"Introductory videos",
+			"Tips and Tricks",
+			"Product documentation",
+			"GitHub repository",
+			"Stack Overflow",
+			"Join our Newsletter",
+			"Show welcome page on startup",
+			"Customize",
+			"Tools and languages",
+			"Install support for {0} and {1}",
+			"Show more language extensions",
+			"more",
+			"Settings and keybindings",
+			"Install the settings and keyboard shortcuts of {0} and {1}",
+			"Show other keymap extensions",
+			"others",
+			"Color theme",
+			"Make the editor and your code look the way you love",
+			"Learn",
+			"Find and run all commands",
+			"Rapidly access and search commands from the Command Palette ({0})",
+			"Interface overview",
+			"Get a visual overlay highlighting the major components of the UI",
+			"Interactive playground",
+			"Try out essential editor features in a short walkthrough"
+		],
+		"vs/workbench/contrib/welcome/gettingStarted/browser/vs_code_editor_getting_started": [
+			"Visual Studio Code",
+			"Code editing. Redefined"
+		],
+		"vs/workbench/contrib/callHierarchy/browser/callHierarchyTree": [
+			"Call Hierarchy",
+			"calls from {0}",
+			"callers of {0}"
+		],
+		"vs/workbench/contrib/userDataSync/browser/userDataSyncViews": [
+			"Merges",
+			"Synced Machines",
+			"Edit Name",
+			"Turn off Settings Sync",
+			"Sync Activity (Remote)",
+			"Sync Activity (Local)",
+			"Show raw JSON sync data",
+			"Restore",
+			"Would you like to replace your current {0} with selected?",
+			"Open Changes",
+			"{0} (Remote)",
+			"{0} (Local)",
+			"{0} ↔ {1}",
+			"Settings Sync",
+			"Reset Synced Data",
+			"Current",
+			"No Machines",
+			"Current",
+			"machine not found with id: {0}",
+			"Are you sure you want to turn off sync on {0}?",
+			"&&Turn off",
+			"Enter the name of the machine",
+			"machine not found with id: {0}",
+			"Machine name should be unique and not empty"
+		],
+		"vs/workbench/contrib/feedback/browser/feedback": [
+			"Tweet Feedback",
+			"Tweet us your feedback.",
+			"Close",
+			"Your installation is corrupt.",
+			"Please specify this if you submit a bug.",
+			"How was your experience?",
+			"Happy Feedback Sentiment",
+			"Happy Feedback Sentiment",
+			"Sad Feedback Sentiment",
+			"Sad Feedback Sentiment",
+			"Other ways to contact us",
+			"Submit a bug",
+			"Request a missing feature",
+			"Tell us why?",
+			"Tell us your feedback",
+			"Show Feedback Icon in Status Bar",
+			"Tweet",
+			"Tweet Feedback",
+			"character left",
+			"characters left"
+		],
+		"vs/workbench/browser/parts/notifications/notificationsViewer": [
+			"Click to execute command '{0}'",
+			"Notification Actions",
+			"Source: {0}"
+		],
+		"vs/editor/browser/controller/textAreaHandler": [
+			"editor",
+			"The editor is not accessible at this time. Press {0} for options."
+		],
+		"vs/base/browser/ui/findinput/findInputCheckboxes": [
+			"Match Case",
+			"Match Whole Word",
+			"Use Regular Expression"
+		],
+		"vs/editor/contrib/gotoSymbol/peek/referencesWidget": [
+			"no preview available",
+			"No results",
+			"References"
+		],
+		"vs/editor/contrib/hover/markerHoverParticipant": [
+			"Peek Problem",
+			"No quick fixes available",
+			"Checking for quick fixes...",
+			"No quick fixes available",
+			"Quick Fix..."
+		],
+		"vs/editor/contrib/hover/markdownHoverParticipant": [
+			"Loading..."
+		],
+		"vs/editor/contrib/suggest/suggestWidgetDetails": [
+			"Close",
+			"Loading..."
+		],
+		"vs/editor/contrib/suggest/suggestWidgetStatus": [
+			"{0} ({1})"
+		],
+		"vs/editor/contrib/suggest/suggestWidgetRenderer": [
+			"Icon for more information in the suggest widget.",
+			"Read More"
+		],
+		"vs/workbench/contrib/comments/common/commentModel": [
+			"There are no comments in this workspace yet."
+		],
+		"vs/workbench/browser/parts/editor/titleControl": [
+			"Editor actions",
+			"{0} (+{1})"
+		],
+		"vs/workbench/browser/parts/editor/breadcrumbsControl": [
+			"Toggle Breadcrumbs",
+			"Show &&Breadcrumbs",
+			"Focus Breadcrumbs"
+		],
+		"vs/base/parts/quickinput/browser/quickInputList": [
+			"Quick Input"
+		],
+		"vs/workbench/contrib/notebook/browser/view/renderers/cellRenderer": [
+			"Expand"
+		],
+		"vs/workbench/contrib/debug/common/debugSchemas": [
+			"Contributes debug adapters.",
+			"Unique identifier for this debug adapter.",
+			"Display name for this debug adapter.",
+			"Path to the debug adapter program. Path is either absolute or relative to the extension folder.",
+			"Optional arguments to pass to the adapter.",
+			"Optional runtime in case the program attribute is not an executable but requires a runtime.",
+			"Optional runtime arguments.",
+			"Mapping from interactive variables (e.g. ${action.pickProcess}) in `launch.json` to a command.",
+			"Configurations for generating the initial 'launch.json'.",
+			"List of languages for which the debug extension could be considered the \"default debugger\".",
+			"Snippets for adding new configurations in 'launch.json'.",
+			"JSON schema configurations for validating 'launch.json'.",
+			"Windows specific settings.",
+			"Runtime used for Windows.",
+			"macOS specific settings.",
+			"Runtime used for macOS.",
+			"Linux specific settings.",
+			"Runtime used for Linux.",
+			"Contributes breakpoints.",
+			"Allow breakpoints for this language.",
+			"Presentation options on how to show this configuration in the debug configuration dropdown and the command palette.",
+			"Controls if this configuration should be shown in the configuration dropdown and the command palette.",
+			"Group that this configuration belongs to. Used for grouping and sorting in the configuration dropdown and the command palette.",
+			"Order of this configuration within a group. Used for grouping and sorting in the configuration dropdown and the command palette.",
+			"Launch",
+			"Version of this file format.",
+			"List of configurations. Add new configurations or edit existing ones by using IntelliSense.",
+			"List of compounds. Each compound references multiple configurations which will get launched together.",
+			"Name of compound. Appears in the launch configuration drop down menu.",
+			"Please use unique configuration names.",
+			"Name of compound. Appears in the launch configuration drop down menu.",
+			"Name of folder in which the compound is located.",
+			"Names of configurations that will be started as part of this compound.",
+			"Controls whether manually terminating one session will stop all of the compound sessions.",
+			"Task to run before any of the compound configurations start."
+		],
+		"vs/workbench/contrib/debug/common/debugger": [
+			"Cannot find debug adapter for type '{0}'.",
+			"Use IntelliSense to learn about possible attributes.",
+			"Hover to view descriptions of existing attributes.",
+			"For more information, visit: {0}",
+			"Type of configuration.",
+			"The debug type is not recognized. Make sure that you have a corresponding debug extension installed and that it is enabled.",
+			"\"node2\" is no longer supported, use \"node\" instead and set the \"protocol\" attribute to \"inspector\".",
+			"Name of configuration; appears in the launch configuration dropdown menu.",
+			"Request type of configuration. Can be \"launch\" or \"attach\".",
+			"For debug extension development only: if a port is specified VS Code tries to connect to a debug adapter running in server mode",
+			"Task to run before debug session starts.",
+			"Task to run after debug session ends.",
+			"Windows specific launch configuration attributes.",
+			"OS X specific launch configuration attributes.",
+			"Linux specific launch configuration attributes."
+		],
+		"vs/workbench/contrib/debug/browser/rawDebugSession": [
+			"No debug adapter, can not start debug session.",
+			"No debugger available found. Can not send '{0}'.",
+			"More Info"
+		],
+		"vs/base/browser/ui/selectBox/selectBoxCustom": [
+			"Select Box"
+		],
+		"vs/workbench/contrib/comments/browser/commentNode": [
+			"Toggle Reaction",
+			"Toggling the comment reaction failed: {0}.",
+			"Toggling the comment reaction failed",
+			"Deleting the comment reaction failed: {0}.",
+			"Deleting the comment reaction failed",
+			"Deleting the comment reaction failed: {0}.",
+			"Deleting the comment reaction failed"
+		],
+		"vs/workbench/contrib/customEditor/common/extensionPoint": [
+			"Contributed custom editors.",
+			"Identifier for the custom editor. This must be unique across all custom editors, so we recommend including your extension id as part of `viewType`. The `viewType` is used when registering custom editors with `vscode.registerCustomEditorProvider` and in the `onCustomEditor:${id}` [activation event](https://code.visualstudio.com/api/references/activation-events).",
+			"Human readable name of the custom editor. This is displayed to users when selecting which editor to use.",
+			"Set of globs that the custom editor is enabled for.",
+			"Glob that the custom editor is enabled for.",
+			"Controls if the custom editor is enabled automatically when the user opens a file. This may be overridden by users using the `workbench.editorAssociations` setting.",
+			"The editor is automatically used when the user opens a resource, provided that no other default custom editors are registered for that resource.",
+			"The editor is not automatically used when the user opens a resource, but a user can switch to the editor using the `Reopen With` command."
+		],
+		"vs/workbench/contrib/terminal/browser/links/terminalLinkManager": [
+			"option + click",
+			"alt + click",
+			"cmd + click",
+			"ctrl + click",
+			"Follow Link using Forwarded Port",
+			"Follow Link",
+			"Link"
+		],
+		"vs/workbench/services/gettingStarted/common/gettingStartedContent": [
+			"Icon used for the setup category of getting started",
+			"Icon used for the beginner category of getting started",
+			"Icon used for the codespaces category of getting started",
+			"Primer on Codespaces",
+			"Get up and running with your instant code environment.",
+			"Build & run your app",
+			"Build, run & debug your code in the cloud, right from the browser.",
+			"Start Debugging (F5)",
+			"Access your running application",
+			"Ports running within your codespace are automatically forwarded to the web, so you can open them in your browser.",
+			"Show Ports Panel",
+			"Pull requests at your fingertips",
+			"Bring your GitHub workflow closer to your code, so you can review pull requests, add comments, merge branches, and more.",
+			"Open GitHub View",
+			"Run tasks in the integrated terminal",
+			"Perform quick command-line tasks using the built-in terminal.",
+			"Focus Terminal",
+			"Develop remotely in VS Code",
+			"Access the power of your cloud development environment from your local VS Code. Set it up by installing the GitHub Codespaces extension and connecting your GitHub account.",
+			"Open in VS Code",
+			"Quick Setup",
+			"Extend and customize VS Code to make it yours.",
+			"Customize the look with themes",
+			"Pick a color theme to match your taste and mood while coding.",
+			"Pick a Theme",
+			"Code in any language, without switching editors",
+			"VS Code supports over 50+ programming languages. While many are built-in, others can be easily installed as extensions in one click.",
+			"Browse Language Extensions",
+			"Sync your favorite setup",
+			"Never lose the perfect VS Code setup! Settings Sync will back up and share settings, keybindings & extensions across several VS Code instances.",
+			"Enable Settings Sync",
+			"Open your project",
+			"Open a project folder to get started!",
+			"Pick a Folder",
+			"Open your project",
+			"Open a folder to get started!",
+			"Pick a Folder",
+			"Learn the Fundamentals",
+			"Save time with these must-have shortcuts & features.",
+			"Find & run commands",
+			"The easiest way to find everything VS Code can do. If you're ever looking for a feature or a shortcut, check here first!",
+			"Open Command Palette",
+			"Run tasks in the integrated terminal",
+			"Quickly run shell commands and monitor build output, right next to your code.",
+			"Open Terminal",
+			"Limitless extensibility",
+			"Extensions are VS Code's power-ups. They range from handy productivity hacks, expanding out-of-the-box features, to adding completely new capabilities.",
+			"Browse Recommended Extensions",
+			"Everything is a setting",
+			"Optimize every part of VS Code's look & feel to your liking. Enabling Settings Sync lets you share your personal tweaks across machines.",
+			"Tweak my Settings",
+			"Lean back and learn",
+			"Watch the first in a series of short & practical video tutorials for VS Code's key features.",
+			"Watch Tutorial"
+		],
+		"vs/workbench/contrib/userDataSync/browser/userDataSyncMergesView": [
+			"Please go through each entry and merge to enable sync.",
+			"Turn on Settings Sync",
+			"Cancel",
+			"Accept Remote",
+			"Accept Local",
+			"Merge",
+			"Discard",
+			"Open Changes",
+			"Conflicts Detected",
+			"Unable to merge due to conflicts. Please resolve them to continue.",
+			"Turning on...",
+			"{0} (Preview)",
+			"{0} (Remote)",
+			"{0} (Merges)",
+			"{0} (Local)",
+			"{0} ↔ {1}",
+			"Settings Sync",
+			"UserDataSyncResources",
+			"Conflicts Detected",
+			"Accepted",
+			"Accept Remote",
+			"Accept Local",
+			"Accept Merges"
+		],
+		"vs/editor/contrib/codeAction/lightBulbWidget": [
+			"Show Fixes. Preferred Fix Available ({0})",
+			"Show Fixes ({0})",
+			"Show Fixes"
+		],
+		"vs/editor/contrib/gotoSymbol/peek/referencesTree": [
+			"{0} references",
+			"{0} reference",
+			"References"
+		],
+		"vs/workbench/browser/parts/editor/breadcrumbs": [
+			"Breadcrumb Navigation",
+			"Enable/disable navigation breadcrumbs.",
+			"Controls whether and how file paths are shown in the breadcrumbs view.",
+			"Show the file path in the breadcrumbs view.",
+			"Do not show the file path in the breadcrumbs view.",
+			"Only show the last element of the file path in the breadcrumbs view.",
+			"Controls whether and how symbols are shown in the breadcrumbs view.",
+			"Show all symbols in the breadcrumbs view.",
+			"Do not show symbols in the breadcrumbs view.",
+			"Only show the current symbol in the breadcrumbs view.",
+			"Controls how symbols are sorted in the breadcrumbs outline view.",
+			"Show symbol outline in file position order.",
+			"Show symbol outline in alphabetical order.",
+			"Show symbol outline in symbol type order.",
+			"Render breadcrumb items with icons.",
+			"When enabled breadcrumbs show `file`-symbols.",
+			"When enabled breadcrumbs show `module`-symbols.",
+			"When enabled breadcrumbs show `namespace`-symbols.",
+			"When enabled breadcrumbs show `package`-symbols.",
+			"When enabled breadcrumbs show `class`-symbols.",
+			"When enabled breadcrumbs show `method`-symbols.",
+			"When enabled breadcrumbs show `property`-symbols.",
+			"When enabled breadcrumbs show `field`-symbols.",
+			"When enabled breadcrumbs show `constructor`-symbols.",
+			"When enabled breadcrumbs show `enum`-symbols.",
+			"When enabled breadcrumbs show `interface`-symbols.",
+			"When enabled breadcrumbs show `function`-symbols.",
+			"When enabled breadcrumbs show `variable`-symbols.",
+			"When enabled breadcrumbs show `constant`-symbols.",
+			"When enabled breadcrumbs show `string`-symbols.",
+			"When enabled breadcrumbs show `number`-symbols.",
+			"When enabled breadcrumbs show `boolean`-symbols.",
+			"When enabled breadcrumbs show `array`-symbols.",
+			"When enabled breadcrumbs show `object`-symbols.",
+			"When enabled breadcrumbs show `key`-symbols.",
+			"When enabled breadcrumbs show `null`-symbols.",
+			"When enabled breadcrumbs show `enumMember`-symbols.",
+			"When enabled breadcrumbs show `struct`-symbols.",
+			"When enabled breadcrumbs show `event`-symbols.",
+			"When enabled breadcrumbs show `operator`-symbols.",
+			"When enabled breadcrumbs show `typeParameter`-symbols."
+		],
+		"vs/workbench/browser/parts/editor/breadcrumbsPicker": [
+			"Breadcrumbs"
+		],
+		"vs/workbench/contrib/notebook/browser/diff/diffElementOutputs": [
+			"Choose a different output mimetype, available mimetypes: {0}",
+			"Currently Active",
+			"Select mimetype to render for current output. Rich mimetypes are available only when the notebook is trusted",
+			"Select mimetype to render for current output",
+			"built-in",
+			"built-in"
+		],
+		"vs/workbench/contrib/notebook/browser/viewModel/markdownCellViewModel": [
+			"Empty markdown cell, double click or press enter to edit."
+		],
+		"vs/workbench/contrib/notebook/browser/view/renderers/cellWidgets": [
+			"Select Cell Language Mode"
+		],
+		"vs/workbench/contrib/comments/browser/reactionsAction": [
+			"Pick Reactions..."
+		],
+		"vs/workbench/contrib/terminal/browser/links/terminalWordLinkProvider": [
+			"Search workspace"
+		],
+		"vs/workbench/contrib/terminal/browser/terminalProcessExtHostProxy": [
+			"Starting..."
+		],
+		"vs/workbench/contrib/terminal/browser/environmentVariableInfo": [
+			"Extensions want to make the following changes to the terminal's environment:",
+			"Extensions want to remove these existing changes from the terminal's environment:",
+			"Relaunch terminal",
+			"Extensions have made changes to this terminal's environment"
+		],
+		"vs/workbench/contrib/notebook/browser/view/renderers/cellOutput": [
+			"Choose a different output mimetype, available mimetypes: {0}",
+			"Currently Active",
+			"Select mimetype to render for current output. Rich mimetypes are available only when the notebook is trusted",
+			"Select mimetype to render for current output",
+			"built-in",
+			"built-in"
+		],
+		"vs/workbench/contrib/terminal/browser/links/terminalLink": [
+			"Open file in editor",
+			"Focus folder in explorer",
+			"Open folder in new window"
+		]
+	},
+	"bundles": {
+		"vs/workbench/workbench.desktop.main": [
+			"vs/base/browser/ui/actionbar/actionViewItems",
+			"vs/base/browser/ui/dialog/dialog",
+			"vs/base/browser/ui/findinput/findInput",
+			"vs/base/browser/ui/findinput/findInputCheckboxes",
+			"vs/base/browser/ui/findinput/replaceInput",
+			"vs/base/browser/ui/iconLabel/iconLabel",
+			"vs/base/browser/ui/inputbox/inputBox",
+			"vs/base/browser/ui/keybindingLabel/keybindingLabel",
+			"vs/base/browser/ui/menu/menu",
+			"vs/base/browser/ui/menu/menubar",
+			"vs/base/browser/ui/selectBox/selectBoxCustom",
+			"vs/base/browser/ui/splitview/paneview",
+			"vs/base/browser/ui/toolbar/toolbar",
+			"vs/base/browser/ui/tree/abstractTree",
+			"vs/base/browser/ui/tree/treeDefaults",
+			"vs/base/common/actions",
+			"vs/base/common/date",
+			"vs/base/common/errorMessage",
+			"vs/base/common/jsonErrorMessages",
+			"vs/base/common/keybindingLabels",
+			"vs/base/node/processes",
+			"vs/base/parts/quickinput/browser/quickInput",
+			"vs/base/parts/quickinput/browser/quickInputList",
+			"vs/editor/browser/controller/coreCommands",
+			"vs/editor/browser/controller/textAreaHandler",
+			"vs/editor/browser/editorExtensions",
+			"vs/editor/browser/widget/codeEditorWidget",
+			"vs/editor/browser/widget/diffEditorWidget",
+			"vs/editor/browser/widget/diffReview",
+			"vs/editor/browser/widget/inlineDiffMargin",
+			"vs/editor/common/config/commonEditorConfig",
+			"vs/editor/common/config/editorOptions",
+			"vs/editor/common/model/editStack",
+			"vs/editor/common/modes/modesRegistry",
+			"vs/editor/common/standaloneStrings",
+			"vs/editor/common/view/editorColorRegistry",
+			"vs/editor/contrib/anchorSelect/anchorSelect",
+			"vs/editor/contrib/bracketMatching/bracketMatching",
+			"vs/editor/contrib/caretOperations/caretOperations",
+			"vs/editor/contrib/caretOperations/transpose",
+			"vs/editor/contrib/clipboard/clipboard",
+			"vs/editor/contrib/codeAction/codeActionCommands",
+			"vs/editor/contrib/codeAction/lightBulbWidget",
+			"vs/editor/contrib/codelens/codelensController",
+			"vs/editor/contrib/comment/comment",
+			"vs/editor/contrib/contextmenu/contextmenu",
+			"vs/editor/contrib/cursorUndo/cursorUndo",
+			"vs/editor/contrib/find/findController",
+			"vs/editor/contrib/find/findWidget",
+			"vs/editor/contrib/folding/folding",
+			"vs/editor/contrib/folding/foldingDecorations",
+			"vs/editor/contrib/fontZoom/fontZoom",
+			"vs/editor/contrib/format/format",
+			"vs/editor/contrib/format/formatActions",
+			"vs/editor/contrib/gotoError/gotoError",
+			"vs/editor/contrib/gotoError/gotoErrorWidget",
+			"vs/editor/contrib/gotoSymbol/goToCommands",
+			"vs/editor/contrib/gotoSymbol/link/goToDefinitionAtPosition",
+			"vs/editor/contrib/gotoSymbol/peek/referencesController",
+			"vs/editor/contrib/gotoSymbol/peek/referencesTree",
+			"vs/editor/contrib/gotoSymbol/peek/referencesWidget",
+			"vs/editor/contrib/gotoSymbol/referencesModel",
+			"vs/editor/contrib/gotoSymbol/symbolNavigation",
+			"vs/editor/contrib/hover/hover",
+			"vs/editor/contrib/hover/markdownHoverParticipant",
+			"vs/editor/contrib/hover/markerHoverParticipant",
+			"vs/editor/contrib/inPlaceReplace/inPlaceReplace",
+			"vs/editor/contrib/indentation/indentation",
+			"vs/editor/contrib/linesOperations/linesOperations",
+			"vs/editor/contrib/linkedEditing/linkedEditing",
+			"vs/editor/contrib/links/links",
+			"vs/editor/contrib/message/messageController",
+			"vs/editor/contrib/multicursor/multicursor",
+			"vs/editor/contrib/parameterHints/parameterHints",
+			"vs/editor/contrib/parameterHints/parameterHintsWidget",
+			"vs/editor/contrib/peekView/peekView",
+			"vs/editor/contrib/quickAccess/gotoLineQuickAccess",
+			"vs/editor/contrib/quickAccess/gotoSymbolQuickAccess",
+			"vs/editor/contrib/rename/rename",
+			"vs/editor/contrib/rename/renameInputField",
+			"vs/editor/contrib/smartSelect/smartSelect",
+			"vs/editor/contrib/snippet/snippetVariables",
+			"vs/editor/contrib/suggest/suggestController",
+			"vs/editor/contrib/suggest/suggestWidget",
+			"vs/editor/contrib/suggest/suggestWidgetDetails",
+			"vs/editor/contrib/suggest/suggestWidgetRenderer",
+			"vs/editor/contrib/suggest/suggestWidgetStatus",
+			"vs/editor/contrib/toggleTabFocusMode/toggleTabFocusMode",
+			"vs/editor/contrib/tokenization/tokenization",
+			"vs/editor/contrib/unusualLineTerminators/unusualLineTerminators",
+			"vs/editor/contrib/wordHighlighter/wordHighlighter",
+			"vs/editor/contrib/wordOperations/wordOperations",
+			"vs/platform/actions/browser/menuEntryActionViewItem",
+			"vs/platform/configuration/common/configurationRegistry",
+			"vs/platform/dialogs/common/dialogs",
+			"vs/platform/extensionManagement/common/extensionManagement",
+			"vs/platform/extensionManagement/common/extensionManagementCLIService",
+			"vs/platform/extensions/common/extensionValidator",
+			"vs/platform/files/common/fileService",
+			"vs/platform/files/common/files",
+			"vs/platform/files/common/io",
+			"vs/platform/files/electron-browser/diskFileSystemProvider",
+			"vs/platform/files/node/diskFileSystemProvider",
+			"vs/platform/keybinding/common/abstractKeybindingService",
+			"vs/platform/list/browser/listService",
+			"vs/platform/markers/common/markers",
+			"vs/platform/quickinput/browser/commandsQuickAccess",
+			"vs/platform/quickinput/browser/helpQuickAccess",
+			"vs/platform/request/common/request",
+			"vs/platform/telemetry/common/telemetryService",
+			"vs/platform/theme/common/colorRegistry",
+			"vs/platform/theme/common/iconRegistry",
+			"vs/platform/theme/common/tokenClassificationRegistry",
+			"vs/platform/undoRedo/common/undoRedoService",
+			"vs/platform/update/common/update.config.contribution",
+			"vs/platform/userDataSync/common/abstractSynchronizer",
+			"vs/platform/userDataSync/common/keybindingsSync",
+			"vs/platform/userDataSync/common/settingsSync",
+			"vs/platform/userDataSync/common/userDataAutoSyncService",
+			"vs/platform/userDataSync/common/userDataSync",
+			"vs/platform/userDataSync/common/userDataSyncMachines",
+			"vs/platform/workspaces/common/workspaces",
+			"vs/workbench/api/browser/mainThreadAuthentication",
+			"vs/workbench/api/browser/mainThreadCLICommands",
+			"vs/workbench/api/browser/mainThreadComments",
+			"vs/workbench/api/browser/mainThreadCustomEditors",
+			"vs/workbench/api/browser/mainThreadExtensionService",
+			"vs/workbench/api/browser/mainThreadFileSystemEventService",
+			"vs/workbench/api/browser/mainThreadMessageService",
+			"vs/workbench/api/browser/mainThreadProgress",
+			"vs/workbench/api/browser/mainThreadSaveParticipant",
+			"vs/workbench/api/browser/mainThreadTask",
+			"vs/workbench/api/browser/mainThreadTunnelService",
+			"vs/workbench/api/browser/mainThreadUriOpeners",
+			"vs/workbench/api/browser/mainThreadWebviews",
+			"vs/workbench/api/browser/mainThreadWorkspace",
+			"vs/workbench/api/browser/viewsExtensionPoint",
+			"vs/workbench/api/common/configurationExtensionPoint",
+			"vs/workbench/api/common/jsonValidationExtensionPoint",
+			"vs/workbench/api/common/menusExtensionPoint",
+			"vs/workbench/browser/actions/developerActions",
+			"vs/workbench/browser/actions/helpActions",
+			"vs/workbench/browser/actions/layoutActions",
+			"vs/workbench/browser/actions/navigationActions",
+			"vs/workbench/browser/actions/quickAccessActions",
+			"vs/workbench/browser/actions/textInputActions",
+			"vs/workbench/browser/actions/windowActions",
+			"vs/workbench/browser/actions/workspaceActions",
+			"vs/workbench/browser/actions/workspaceCommands",
+			"vs/workbench/browser/codeeditor",
+			"vs/workbench/browser/parts/activitybar/activitybarActions",
+			"vs/workbench/browser/parts/activitybar/activitybarPart",
+			"vs/workbench/browser/parts/compositeBar",
+			"vs/workbench/browser/parts/compositeBarActions",
+			"vs/workbench/browser/parts/compositePart",
+			"vs/workbench/browser/parts/dialogs/dialogHandler",
+			"vs/workbench/browser/parts/editor/binaryDiffEditor",
+			"vs/workbench/browser/parts/editor/binaryEditor",
+			"vs/workbench/browser/parts/editor/breadcrumbs",
+			"vs/workbench/browser/parts/editor/breadcrumbsControl",
+			"vs/workbench/browser/parts/editor/breadcrumbsPicker",
+			"vs/workbench/browser/parts/editor/editor.contribution",
+			"vs/workbench/browser/parts/editor/editorActions",
+			"vs/workbench/browser/parts/editor/editorCommands",
+			"vs/workbench/browser/parts/editor/editorDropTarget",
+			"vs/workbench/browser/parts/editor/editorGroupView",
+			"vs/workbench/browser/parts/editor/editorQuickAccess",
+			"vs/workbench/browser/parts/editor/editorStatus",
+			"vs/workbench/browser/parts/editor/tabsTitleControl",
+			"vs/workbench/browser/parts/editor/textDiffEditor",
+			"vs/workbench/browser/parts/editor/textEditor",
+			"vs/workbench/browser/parts/editor/textResourceEditor",
+			"vs/workbench/browser/parts/editor/titleControl",
+			"vs/workbench/browser/parts/notifications/notificationsActions",
+			"vs/workbench/browser/parts/notifications/notificationsAlerts",
+			"vs/workbench/browser/parts/notifications/notificationsCenter",
+			"vs/workbench/browser/parts/notifications/notificationsCommands",
+			"vs/workbench/browser/parts/notifications/notificationsList",
+			"vs/workbench/browser/parts/notifications/notificationsStatus",
+			"vs/workbench/browser/parts/notifications/notificationsViewer",
+			"vs/workbench/browser/parts/panel/panelActions",
+			"vs/workbench/browser/parts/panel/panelPart",
+			"vs/workbench/browser/parts/sidebar/sidebarPart",
+			"vs/workbench/browser/parts/statusbar/statusbarPart",
+			"vs/workbench/browser/parts/titlebar/menubarControl",
+			"vs/workbench/browser/parts/titlebar/titlebarPart",
+			"vs/workbench/browser/parts/views/treeView",
+			"vs/workbench/browser/parts/views/viewPane",
+			"vs/workbench/browser/parts/views/viewPaneContainer",
+			"vs/workbench/browser/parts/views/viewsService",
+			"vs/workbench/browser/workbench",
+			"vs/workbench/browser/workbench.contribution",
+			"vs/workbench/common/actions",
+			"vs/workbench/common/configuration",
+			"vs/workbench/common/editor",
+			"vs/workbench/common/editor/diffEditorInput",
+			"vs/workbench/common/theme",
+			"vs/workbench/common/views",
+			"vs/workbench/contrib/backup/electron-sandbox/backupTracker",
+			"vs/workbench/contrib/bulkEdit/browser/bulkEditService",
+			"vs/workbench/contrib/bulkEdit/browser/preview/bulkEdit.contribution",
+			"vs/workbench/contrib/bulkEdit/browser/preview/bulkEditPane",
+			"vs/workbench/contrib/bulkEdit/browser/preview/bulkEditPreview",
+			"vs/workbench/contrib/bulkEdit/browser/preview/bulkEditTree",
+			"vs/workbench/contrib/callHierarchy/browser/callHierarchy.contribution",
+			"vs/workbench/contrib/callHierarchy/browser/callHierarchyPeek",
+			"vs/workbench/contrib/callHierarchy/browser/callHierarchyTree",
+			"vs/workbench/contrib/cli/node/cli.contribution",
+			"vs/workbench/contrib/codeActions/common/codeActionsContribution",
+			"vs/workbench/contrib/codeActions/common/codeActionsExtensionPoint",
+			"vs/workbench/contrib/codeActions/common/documentationExtensionPoint",
+			"vs/workbench/contrib/codeEditor/browser/accessibility/accessibility",
+			"vs/workbench/contrib/codeEditor/browser/diffEditorHelper",
+			"vs/workbench/contrib/codeEditor/browser/find/simpleFindReplaceWidget",
+			"vs/workbench/contrib/codeEditor/browser/find/simpleFindWidget",
+			"vs/workbench/contrib/codeEditor/browser/inspectEditorTokens/inspectEditorTokens",
+			"vs/workbench/contrib/codeEditor/browser/inspectKeybindings",
+			"vs/workbench/contrib/codeEditor/browser/languageConfigurationExtensionPoint",
+			"vs/workbench/contrib/codeEditor/browser/largeFileOptimizations",
+			"vs/workbench/contrib/codeEditor/browser/outline/documentSymbolsOutline",
+			"vs/workbench/contrib/codeEditor/browser/outline/documentSymbolsTree",
+			"vs/workbench/contrib/codeEditor/browser/quickaccess/gotoLineQuickAccess",
+			"vs/workbench/contrib/codeEditor/browser/quickaccess/gotoSymbolQuickAccess",
+			"vs/workbench/contrib/codeEditor/browser/saveParticipants",
+			"vs/workbench/contrib/codeEditor/browser/toggleColumnSelection",
+			"vs/workbench/contrib/codeEditor/browser/toggleMinimap",
+			"vs/workbench/contrib/codeEditor/browser/toggleMultiCursorModifier",
+			"vs/workbench/contrib/codeEditor/browser/toggleRenderControlCharacter",
+			"vs/workbench/contrib/codeEditor/browser/toggleRenderWhitespace",
+			"vs/workbench/contrib/codeEditor/browser/toggleWordWrap",
+			"vs/workbench/contrib/codeEditor/electron-browser/startDebugTextMate",
+			"vs/workbench/contrib/codeEditor/electron-sandbox/selectionClipboard",
+			"vs/workbench/contrib/comments/browser/commentGlyphWidget",
+			"vs/workbench/contrib/comments/browser/commentNode",
+			"vs/workbench/contrib/comments/browser/commentThreadWidget",
+			"vs/workbench/contrib/comments/browser/comments.contribution",
+			"vs/workbench/contrib/comments/browser/commentsEditorContribution",
+			"vs/workbench/contrib/comments/browser/commentsTreeViewer",
+			"vs/workbench/contrib/comments/browser/commentsView",
+			"vs/workbench/contrib/comments/browser/reactionsAction",
+			"vs/workbench/contrib/comments/common/commentModel",
+			"vs/workbench/contrib/customEditor/browser/customEditors",
+			"vs/workbench/contrib/customEditor/common/contributedCustomEditors",
+			"vs/workbench/contrib/customEditor/common/extensionPoint",
+			"vs/workbench/contrib/debug/browser/breakpointEditorContribution",
+			"vs/workbench/contrib/debug/browser/breakpointWidget",
+			"vs/workbench/contrib/debug/browser/breakpointsView",
+			"vs/workbench/contrib/debug/browser/callStackEditorContribution",
+			"vs/workbench/contrib/debug/browser/callStackView",
+			"vs/workbench/contrib/debug/browser/debug.contribution",
+			"vs/workbench/contrib/debug/browser/debugActionViewItems",
+			"vs/workbench/contrib/debug/browser/debugAdapterManager",
+			"vs/workbench/contrib/debug/browser/debugColors",
+			"vs/workbench/contrib/debug/browser/debugCommands",
+			"vs/workbench/contrib/debug/browser/debugConfigurationManager",
+			"vs/workbench/contrib/debug/browser/debugEditorActions",
+			"vs/workbench/contrib/debug/browser/debugEditorContribution",
+			"vs/workbench/contrib/debug/browser/debugHover",
+			"vs/workbench/contrib/debug/browser/debugIcons",
+			"vs/workbench/contrib/debug/browser/debugQuickAccess",
+			"vs/workbench/contrib/debug/browser/debugService",
+			"vs/workbench/contrib/debug/browser/debugSession",
+			"vs/workbench/contrib/debug/browser/debugStatus",
+			"vs/workbench/contrib/debug/browser/debugTaskRunner",
+			"vs/workbench/contrib/debug/browser/debugToolBar",
+			"vs/workbench/contrib/debug/browser/debugViewlet",
+			"vs/workbench/contrib/debug/browser/exceptionWidget",
+			"vs/workbench/contrib/debug/browser/loadedScriptsView",
+			"vs/workbench/contrib/debug/browser/rawDebugSession",
+			"vs/workbench/contrib/debug/browser/repl",
+			"vs/workbench/contrib/debug/browser/replFilter",
+			"vs/workbench/contrib/debug/browser/replViewer",
+			"vs/workbench/contrib/debug/browser/statusbarColorProvider",
+			"vs/workbench/contrib/debug/browser/variablesView",
+			"vs/workbench/contrib/debug/browser/watchExpressionsView",
+			"vs/workbench/contrib/debug/browser/welcomeView",
+			"vs/workbench/contrib/debug/common/abstractDebugAdapter",
+			"vs/workbench/contrib/debug/common/debug",
+			"vs/workbench/contrib/debug/common/debugContentProvider",
+			"vs/workbench/contrib/debug/common/debugModel",
+			"vs/workbench/contrib/debug/common/debugSchemas",
+			"vs/workbench/contrib/debug/common/debugSource",
+			"vs/workbench/contrib/debug/common/debugger",
+			"vs/workbench/contrib/debug/common/replModel",
+			"vs/workbench/contrib/emmet/browser/actions/expandAbbreviation",
+			"vs/workbench/contrib/experiments/browser/experiments.contribution",
+			"vs/workbench/contrib/extensions/browser/abstractRuntimeExtensionsEditor",
+			"vs/workbench/contrib/extensions/browser/configBasedRecommendations",
+			"vs/workbench/contrib/extensions/browser/dynamicWorkspaceRecommendations",
+			"vs/workbench/contrib/extensions/browser/exeBasedRecommendations",
+			"vs/workbench/contrib/extensions/browser/extensionEditor",
+			"vs/workbench/contrib/extensions/browser/extensionRecommendationNotificationService",
+			"vs/workbench/contrib/extensions/browser/extensions.contribution",
+			"vs/workbench/contrib/extensions/browser/extensionsActions",
+			"vs/workbench/contrib/extensions/browser/extensionsActivationProgress",
+			"vs/workbench/contrib/extensions/browser/extensionsDependencyChecker",
+			"vs/workbench/contrib/extensions/browser/extensionsIcons",
+			"vs/workbench/contrib/extensions/browser/extensionsQuickAccess",
+			"vs/workbench/contrib/extensions/browser/extensionsViewer",
+			"vs/workbench/contrib/extensions/browser/extensionsViewlet",
+			"vs/workbench/contrib/extensions/browser/extensionsViews",
+			"vs/workbench/contrib/extensions/browser/extensionsWidgets",
+			"vs/workbench/contrib/extensions/browser/extensionsWorkbenchService",
+			"vs/workbench/contrib/extensions/browser/fileBasedRecommendations",
+			"vs/workbench/contrib/extensions/browser/workspaceRecommendations",
+			"vs/workbench/contrib/extensions/common/extensionsFileTemplate",
+			"vs/workbench/contrib/extensions/common/extensionsInput",
+			"vs/workbench/contrib/extensions/common/extensionsUtils",
+			"vs/workbench/contrib/extensions/common/runtimeExtensionsInput",
+			"vs/workbench/contrib/extensions/electron-browser/debugExtensionHostAction",
+			"vs/workbench/contrib/extensions/electron-browser/extensionProfileService",
+			"vs/workbench/contrib/extensions/electron-browser/extensions.contribution",
+			"vs/workbench/contrib/extensions/electron-browser/extensionsAutoProfiler",
+			"vs/workbench/contrib/extensions/electron-browser/extensionsSlowActions",
+			"vs/workbench/contrib/extensions/electron-browser/reportExtensionIssueAction",
+			"vs/workbench/contrib/extensions/electron-browser/runtimeExtensionsEditor",
+			"vs/workbench/contrib/extensions/electron-sandbox/extensionsActions",
+			"vs/workbench/contrib/externalTerminal/browser/externalTerminal.contribution",
+			"vs/workbench/contrib/externalTerminal/node/externalTerminal.contribution",
+			"vs/workbench/contrib/externalTerminal/node/externalTerminalService",
+			"vs/workbench/contrib/externalUriOpener/common/configuration",
+			"vs/workbench/contrib/externalUriOpener/common/externalUriOpenerService",
+			"vs/workbench/contrib/feedback/browser/feedback",
+			"vs/workbench/contrib/feedback/browser/feedbackStatusbarItem",
+			"vs/workbench/contrib/files/browser/editors/binaryFileEditor",
+			"vs/workbench/contrib/files/browser/editors/textFileEditor",
+			"vs/workbench/contrib/files/browser/editors/textFileSaveErrorHandler",
+			"vs/workbench/contrib/files/browser/explorerViewlet",
+			"vs/workbench/contrib/files/browser/fileActions",
+			"vs/workbench/contrib/files/browser/fileActions.contribution",
+			"vs/workbench/contrib/files/browser/fileCommands",
+			"vs/workbench/contrib/files/browser/files.contribution",
+			"vs/workbench/contrib/files/browser/views/emptyView",
+			"vs/workbench/contrib/files/browser/views/explorerDecorationsProvider",
+			"vs/workbench/contrib/files/browser/views/explorerView",
+			"vs/workbench/contrib/files/browser/views/explorerViewer",
+			"vs/workbench/contrib/files/browser/views/openEditorsView",
+			"vs/workbench/contrib/files/common/dirtyFilesIndicator",
+			"vs/workbench/contrib/files/common/editors/fileEditorInput",
+			"vs/workbench/contrib/files/common/workspaceWatcher",
+			"vs/workbench/contrib/files/electron-sandbox/fileActions.contribution",
+			"vs/workbench/contrib/files/electron-sandbox/fileCommands",
+			"vs/workbench/contrib/files/electron-sandbox/files.contribution",
+			"vs/workbench/contrib/files/electron-sandbox/textFileEditor",
+			"vs/workbench/contrib/format/browser/formatActionsMultiple",
+			"vs/workbench/contrib/format/browser/formatActionsNone",
+			"vs/workbench/contrib/format/browser/formatModified",
+			"vs/workbench/contrib/issue/electron-sandbox/issue.contribution",
+			"vs/workbench/contrib/issue/electron-sandbox/issueActions",
+			"vs/workbench/contrib/keybindings/browser/keybindings.contribution",
+			"vs/workbench/contrib/localizations/browser/localizations.contribution",
+			"vs/workbench/contrib/localizations/browser/localizationsActions",
+			"vs/workbench/contrib/localizations/browser/minimalTranslations",
+			"vs/workbench/contrib/logs/common/logs.contribution",
+			"vs/workbench/contrib/logs/common/logsActions",
+			"vs/workbench/contrib/logs/electron-sandbox/logsActions",
+			"vs/workbench/contrib/markers/browser/markers",
+			"vs/workbench/contrib/markers/browser/markers.contribution",
+			"vs/workbench/contrib/markers/browser/markersFileDecorations",
+			"vs/workbench/contrib/markers/browser/markersTreeViewer",
+			"vs/workbench/contrib/markers/browser/markersView",
+			"vs/workbench/contrib/markers/browser/markersViewActions",
+			"vs/workbench/contrib/markers/browser/messages",
+			"vs/workbench/contrib/notebook/browser/contrib/coreActions",
+			"vs/workbench/contrib/notebook/browser/contrib/find/findController",
+			"vs/workbench/contrib/notebook/browser/contrib/fold/folding",
+			"vs/workbench/contrib/notebook/browser/contrib/format/formatting",
+			"vs/workbench/contrib/notebook/browser/contrib/outline/notebookOutline",
+			"vs/workbench/contrib/notebook/browser/contrib/status/editorStatus",
+			"vs/workbench/contrib/notebook/browser/diff/diffElementOutputs",
+			"vs/workbench/contrib/notebook/browser/diff/notebookDiffActions",
+			"vs/workbench/contrib/notebook/browser/diff/notebookTextDiffEditor",
+			"vs/workbench/contrib/notebook/browser/extensionPoint",
+			"vs/workbench/contrib/notebook/browser/notebook.contribution",
+			"vs/workbench/contrib/notebook/browser/notebookEditor",
+			"vs/workbench/contrib/notebook/browser/notebookEditorWidget",
+			"vs/workbench/contrib/notebook/browser/notebookIcons",
+			"vs/workbench/contrib/notebook/browser/notebookKernelAssociation",
+			"vs/workbench/contrib/notebook/browser/notebookServiceImpl",
+			"vs/workbench/contrib/notebook/browser/view/renderers/cellOutput",
+			"vs/workbench/contrib/notebook/browser/view/renderers/cellRenderer",
+			"vs/workbench/contrib/notebook/browser/view/renderers/cellWidgets",
+			"vs/workbench/contrib/notebook/browser/viewModel/markdownCellViewModel",
+			"vs/workbench/contrib/notebook/common/model/notebookTextModel",
+			"vs/workbench/contrib/notebook/common/notebookEditorModel",
+			"vs/workbench/contrib/outline/browser/outline.contribution",
+			"vs/workbench/contrib/outline/browser/outlinePane",
+			"vs/workbench/contrib/output/browser/logViewer",
+			"vs/workbench/contrib/output/browser/output.contribution",
+			"vs/workbench/contrib/output/browser/outputView",
+			"vs/workbench/contrib/performance/browser/performance.contribution",
+			"vs/workbench/contrib/performance/browser/perfviewEditor",
+			"vs/workbench/contrib/performance/electron-browser/startupProfiler",
+			"vs/workbench/contrib/preferences/browser/keybindingWidgets",
+			"vs/workbench/contrib/preferences/browser/keybindingsEditor",
+			"vs/workbench/contrib/preferences/browser/keybindingsEditorContribution",
+			"vs/workbench/contrib/preferences/browser/preferences.contribution",
+			"vs/workbench/contrib/preferences/browser/preferencesActions",
+			"vs/workbench/contrib/preferences/browser/preferencesEditor",
+			"vs/workbench/contrib/preferences/browser/preferencesIcons",
+			"vs/workbench/contrib/preferences/browser/preferencesRenderers",
+			"vs/workbench/contrib/preferences/browser/preferencesWidgets",
+			"vs/workbench/contrib/preferences/browser/settingsEditor2",
+			"vs/workbench/contrib/preferences/browser/settingsLayout",
+			"vs/workbench/contrib/preferences/browser/settingsTree",
+			"vs/workbench/contrib/preferences/browser/settingsTreeModels",
+			"vs/workbench/contrib/preferences/browser/settingsWidgets",
+			"vs/workbench/contrib/preferences/browser/tocTree",
+			"vs/workbench/contrib/preferences/common/preferencesContribution",
+			"vs/workbench/contrib/quickaccess/browser/commandsQuickAccess",
+			"vs/workbench/contrib/quickaccess/browser/quickAccess.contribution",
+			"vs/workbench/contrib/quickaccess/browser/viewQuickAccess",
+			"vs/workbench/contrib/relauncher/browser/relauncher.contribution",
+			"vs/workbench/contrib/remote/browser/explorerViewItems",
+			"vs/workbench/contrib/remote/browser/remote",
+			"vs/workbench/contrib/remote/browser/remoteExplorer",
+			"vs/workbench/contrib/remote/browser/remoteIcons",
+			"vs/workbench/contrib/remote/browser/remoteIndicator",
+			"vs/workbench/contrib/remote/browser/tunnelView",
+			"vs/workbench/contrib/remote/common/remote.contribution",
+			"vs/workbench/contrib/remote/electron-sandbox/remote.contribution",
+			"vs/workbench/contrib/sash/browser/sash.contribution",
+			"vs/workbench/contrib/scm/browser/activity",
+			"vs/workbench/contrib/scm/browser/dirtydiffDecorator",
+			"vs/workbench/contrib/scm/browser/scm.contribution",
+			"vs/workbench/contrib/scm/browser/scmRepositoriesViewPane",
+			"vs/workbench/contrib/scm/browser/scmViewPane",
+			"vs/workbench/contrib/scm/browser/scmViewPaneContainer",
+			"vs/workbench/contrib/search/browser/anythingQuickAccess",
+			"vs/workbench/contrib/search/browser/patternInputWidget",
+			"vs/workbench/contrib/search/browser/replaceService",
+			"vs/workbench/contrib/search/browser/search.contribution",
+			"vs/workbench/contrib/search/browser/searchActions",
+			"vs/workbench/contrib/search/browser/searchIcons",
+			"vs/workbench/contrib/search/browser/searchResultsView",
+			"vs/workbench/contrib/search/browser/searchView",
+			"vs/workbench/contrib/search/browser/searchWidget",
+			"vs/workbench/contrib/search/browser/symbolsQuickAccess",
+			"vs/workbench/contrib/search/common/queryBuilder",
+			"vs/workbench/contrib/searchEditor/browser/searchEditor",
+			"vs/workbench/contrib/searchEditor/browser/searchEditor.contribution",
+			"vs/workbench/contrib/searchEditor/browser/searchEditorInput",
+			"vs/workbench/contrib/searchEditor/browser/searchEditorSerialization",
+			"vs/workbench/contrib/snippets/browser/configureSnippets",
+			"vs/workbench/contrib/snippets/browser/insertSnippet",
+			"vs/workbench/contrib/snippets/browser/snippetCompletionProvider",
+			"vs/workbench/contrib/snippets/browser/snippets.contribution",
+			"vs/workbench/contrib/snippets/browser/snippetsFile",
+			"vs/workbench/contrib/snippets/browser/snippetsService",
+			"vs/workbench/contrib/surveys/browser/languageSurveys.contribution",
+			"vs/workbench/contrib/surveys/browser/nps.contribution",
+			"vs/workbench/contrib/tasks/browser/abstractTaskService",
+			"vs/workbench/contrib/tasks/browser/runAutomaticTasks",
+			"vs/workbench/contrib/tasks/browser/task.contribution",
+			"vs/workbench/contrib/tasks/browser/taskQuickPick",
+			"vs/workbench/contrib/tasks/browser/tasksQuickAccess",
+			"vs/workbench/contrib/tasks/browser/terminalTaskSystem",
+			"vs/workbench/contrib/tasks/common/jsonSchemaCommon",
+			"vs/workbench/contrib/tasks/common/jsonSchema_v1",
+			"vs/workbench/contrib/tasks/common/jsonSchema_v2",
+			"vs/workbench/contrib/tasks/common/problemMatcher",
+			"vs/workbench/contrib/tasks/common/taskConfiguration",
+			"vs/workbench/contrib/tasks/common/taskDefinitionRegistry",
+			"vs/workbench/contrib/tasks/common/taskTemplates",
+			"vs/workbench/contrib/tasks/common/tasks",
+			"vs/workbench/contrib/tasks/electron-browser/taskService",
+			"vs/workbench/contrib/tasks/node/processRunnerDetector",
+			"vs/workbench/contrib/tasks/node/processTaskSystem",
+			"vs/workbench/contrib/terminal/browser/environmentVariableInfo",
+			"vs/workbench/contrib/terminal/browser/links/terminalLink",
+			"vs/workbench/contrib/terminal/browser/links/terminalLinkManager",
+			"vs/workbench/contrib/terminal/browser/links/terminalWordLinkProvider",
+			"vs/workbench/contrib/terminal/browser/remoteTerminalService",
+			"vs/workbench/contrib/terminal/browser/terminal.contribution",
+			"vs/workbench/contrib/terminal/browser/terminalActions",
+			"vs/workbench/contrib/terminal/browser/terminalConfigHelper",
+			"vs/workbench/contrib/terminal/browser/terminalIcons",
+			"vs/workbench/contrib/terminal/browser/terminalInstance",
+			"vs/workbench/contrib/terminal/browser/terminalProcessExtHostProxy",
+			"vs/workbench/contrib/terminal/browser/terminalQuickAccess",
+			"vs/workbench/contrib/terminal/browser/terminalService",
+			"vs/workbench/contrib/terminal/browser/terminalView",
+			"vs/workbench/contrib/terminal/common/terminal",
+			"vs/workbench/contrib/terminal/common/terminalColorRegistry",
+			"vs/workbench/contrib/terminal/common/terminalConfiguration",
+			"vs/workbench/contrib/terminal/common/terminalMenu",
+			"vs/workbench/contrib/terminal/electron-browser/terminalRemote",
+			"vs/workbench/contrib/terminal/node/terminalProcess",
+			"vs/workbench/contrib/testing/browser/icons",
+			"vs/workbench/contrib/testing/browser/testExplorerActions",
+			"vs/workbench/contrib/testing/browser/testing.contribution",
+			"vs/workbench/contrib/testing/browser/testingDecorations",
+			"vs/workbench/contrib/testing/browser/testingExplorerFilter",
+			"vs/workbench/contrib/testing/browser/testingExplorerView",
+			"vs/workbench/contrib/testing/browser/testingOutputPeek",
+			"vs/workbench/contrib/testing/browser/testingViewPaneContainer",
+			"vs/workbench/contrib/testing/browser/theme",
+			"vs/workbench/contrib/testing/common/constants",
+			"vs/workbench/contrib/testing/common/testServiceImpl",
+			"vs/workbench/contrib/themes/browser/themes.contribution",
+			"vs/workbench/contrib/timeline/browser/timeline.contribution",
+			"vs/workbench/contrib/timeline/browser/timelinePane",
+			"vs/workbench/contrib/update/browser/releaseNotesEditor",
+			"vs/workbench/contrib/update/browser/update",
+			"vs/workbench/contrib/update/browser/update.contribution",
+			"vs/workbench/contrib/url/browser/trustedDomains",
+			"vs/workbench/contrib/url/browser/trustedDomainsValidator",
+			"vs/workbench/contrib/url/browser/url.contribution",
+			"vs/workbench/contrib/userDataSync/browser/userDataSync",
+			"vs/workbench/contrib/userDataSync/browser/userDataSync.contribution",
+			"vs/workbench/contrib/userDataSync/browser/userDataSyncMergesView",
+			"vs/workbench/contrib/userDataSync/browser/userDataSyncViews",
+			"vs/workbench/contrib/userDataSync/electron-browser/userDataSync.contribution",
+			"vs/workbench/contrib/watermark/browser/watermark",
+			"vs/workbench/contrib/webview/browser/baseWebviewElement",
+			"vs/workbench/contrib/webview/electron-browser/webviewCommands",
+			"vs/workbench/contrib/webviewPanel/browser/webviewCommands",
+			"vs/workbench/contrib/webviewPanel/browser/webviewPanel.contribution",
+			"vs/workbench/contrib/welcome/common/viewsWelcomeContribution",
+			"vs/workbench/contrib/welcome/common/viewsWelcomeExtensionPoint",
+			"vs/workbench/contrib/welcome/gettingStarted/browser/gettingStarted",
+			"vs/workbench/contrib/welcome/gettingStarted/browser/gettingStarted.contribution",
+			"vs/workbench/contrib/welcome/gettingStarted/browser/gettingStartedIcons",
+			"vs/workbench/contrib/welcome/gettingStarted/browser/vs_code_editor_getting_started",
+			"vs/workbench/contrib/welcome/overlay/browser/welcomeOverlay",
+			"vs/workbench/contrib/welcome/page/browser/vs_code_welcome_page",
+			"vs/workbench/contrib/welcome/page/browser/welcomePage",
+			"vs/workbench/contrib/welcome/page/browser/welcomePage.contribution",
+			"vs/workbench/contrib/welcome/page/browser/welcomePageColors",
+			"vs/workbench/contrib/welcome/telemetryOptOut/browser/telemetryOptOut",
+			"vs/workbench/contrib/welcome/walkThrough/browser/editor/editorWalkThrough",
+			"vs/workbench/contrib/welcome/walkThrough/browser/walkThrough.contribution",
+			"vs/workbench/contrib/welcome/walkThrough/browser/walkThroughPart",
+			"vs/workbench/contrib/workspaces/browser/workspaces.contribution",
+			"vs/workbench/electron-sandbox/actions/developerActions",
+			"vs/workbench/electron-sandbox/actions/windowActions",
+			"vs/workbench/electron-sandbox/desktop.contribution",
+			"vs/workbench/electron-sandbox/parts/dialogs/dialogHandler",
+			"vs/workbench/electron-sandbox/parts/titlebar/menubarControl",
+			"vs/workbench/electron-sandbox/window",
+			"vs/workbench/services/authentication/browser/authenticationService",
+			"vs/workbench/services/configuration/common/configurationEditingService",
+			"vs/workbench/services/configuration/common/jsonEditingService",
+			"vs/workbench/services/configurationResolver/browser/configurationResolverService",
+			"vs/workbench/services/configurationResolver/common/configurationResolverSchema",
+			"vs/workbench/services/configurationResolver/common/configurationResolverUtils",
+			"vs/workbench/services/configurationResolver/common/variableResolver",
+			"vs/workbench/services/decorations/browser/decorationsService",
+			"vs/workbench/services/dialogs/browser/abstractFileDialogService",
+			"vs/workbench/services/dialogs/browser/simpleFileDialog",
+			"vs/workbench/services/editor/browser/editorService",
+			"vs/workbench/services/editor/common/editorOpenWith",
+			"vs/workbench/services/extensionManagement/browser/extensionBisect",
+			"vs/workbench/services/extensionManagement/browser/extensionEnablementService",
+			"vs/workbench/services/extensionManagement/common/extensionManagementService",
+			"vs/workbench/services/extensionManagement/common/webExtensionsScannerService",
+			"vs/workbench/services/extensionManagement/electron-browser/extensionManagementServerService",
+			"vs/workbench/services/extensionManagement/electron-sandbox/remoteExtensionManagementService",
+			"vs/workbench/services/extensionRecommendations/common/workspaceExtensionsConfig",
+			"vs/workbench/services/extensions/browser/extensionUrlHandler",
+			"vs/workbench/services/extensions/browser/webWorkerExtensionHost",
+			"vs/workbench/services/extensions/common/abstractExtensionService",
+			"vs/workbench/services/extensions/common/extensionHostManager",
+			"vs/workbench/services/extensions/common/extensionsRegistry",
+			"vs/workbench/services/extensions/common/remoteExtensionHost",
+			"vs/workbench/services/extensions/electron-browser/cachedExtensionScanner",
+			"vs/workbench/services/extensions/electron-browser/extensionService",
+			"vs/workbench/services/extensions/electron-browser/localProcessExtensionHost",
+			"vs/workbench/services/extensions/node/extensionPoints",
+			"vs/workbench/services/gettingStarted/common/gettingStartedContent",
+			"vs/workbench/services/integrity/node/integrityService",
+			"vs/workbench/services/keybinding/browser/keybindingService",
+			"vs/workbench/services/keybinding/common/keybindingEditing",
+			"vs/workbench/services/label/common/labelService",
+			"vs/workbench/services/lifecycle/electron-sandbox/lifecycleService",
+			"vs/workbench/services/mode/common/workbenchModeService",
+			"vs/workbench/services/notification/common/notificationService",
+			"vs/workbench/services/preferences/browser/keybindingsEditorModel",
+			"vs/workbench/services/preferences/browser/preferencesEditorInput",
+			"vs/workbench/services/preferences/browser/preferencesService",
+			"vs/workbench/services/preferences/common/preferences",
+			"vs/workbench/services/preferences/common/preferencesModels",
+			"vs/workbench/services/preferences/common/preferencesValidation",
+			"vs/workbench/services/progress/browser/progressService",
+			"vs/workbench/services/remote/electron-sandbox/remoteAgentServiceImpl",
+			"vs/workbench/services/textMate/browser/abstractTextMateService",
+			"vs/workbench/services/textMate/common/TMGrammarFactory",
+			"vs/workbench/services/textMate/common/TMGrammars",
+			"vs/workbench/services/textfile/browser/textFileService",
+			"vs/workbench/services/textfile/common/textFileEditorModel",
+			"vs/workbench/services/textfile/common/textFileEditorModelManager",
+			"vs/workbench/services/textfile/common/textFileSaveParticipant",
+			"vs/workbench/services/textfile/electron-browser/nativeTextFileService",
+			"vs/workbench/services/themes/browser/fileIconThemeData",
+			"vs/workbench/services/themes/browser/productIconThemeData",
+			"vs/workbench/services/themes/browser/workbenchThemeService",
+			"vs/workbench/services/themes/common/colorExtensionPoint",
+			"vs/workbench/services/themes/common/colorThemeData",
+			"vs/workbench/services/themes/common/colorThemeSchema",
+			"vs/workbench/services/themes/common/fileIconThemeSchema",
+			"vs/workbench/services/themes/common/productIconThemeSchema",
+			"vs/workbench/services/themes/common/themeConfiguration",
+			"vs/workbench/services/themes/common/themeExtensionPoints",
+			"vs/workbench/services/themes/common/tokenClassificationExtensionPoint",
+			"vs/workbench/services/userDataSync/browser/userDataSyncWorkbenchService",
+			"vs/workbench/services/userDataSync/common/userDataSync",
+			"vs/workbench/services/views/browser/viewDescriptorService",
+			"vs/workbench/services/workspaces/browser/abstractWorkspaceEditingService",
+			"vs/workbench/services/workspaces/electron-sandbox/workspaceEditingService"
+		],
+		"vs/workbench/services/extensions/worker/extensionHostWorker": [
+			"vs/base/common/errorMessage",
+			"vs/editor/common/config/editorOptions",
+			"vs/platform/configuration/common/configurationRegistry",
+			"vs/platform/files/common/files",
+			"vs/platform/markers/common/markers",
+			"vs/platform/theme/common/iconRegistry",
+			"vs/platform/workspaces/common/workspaces",
+			"vs/workbench/api/common/extHost.api.impl",
+			"vs/workbench/api/common/extHostDiagnostics",
+			"vs/workbench/api/common/extHostExtensionActivator",
+			"vs/workbench/api/common/extHostExtensionService",
+			"vs/workbench/api/common/extHostProgress",
+			"vs/workbench/api/common/extHostStatusBar",
+			"vs/workbench/api/common/extHostTerminalService",
+			"vs/workbench/api/common/extHostTreeViews",
+			"vs/workbench/api/common/extHostWorkspace",
+			"vs/workbench/common/views",
+			"vs/workbench/contrib/debug/common/abstractDebugAdapter",
+			"vs/workbench/contrib/search/common/queryBuilder",
+			"vs/workbench/services/configurationResolver/common/variableResolver"
+		],
+		"vs/workbench/contrib/debug/node/telemetryApp": [
+			"vs/base/node/processes",
+			"vs/platform/configuration/common/configurationRegistry"
+		],
+		"vs/workbench/services/search/node/searchApp": [
+			"vs/base/common/errorMessage",
+			"vs/base/node/processes"
+		],
+		"vs/platform/files/node/watcher/unix/watcherApp": [
+			"vs/base/node/processes",
+			"vs/platform/files/common/files"
+		],
+		"vs/platform/files/node/watcher/nsfw/watcherApp": [
+			"vs/base/node/processes",
+			"vs/platform/files/common/files"
+		],
+		"vs/workbench/services/extensions/node/extensionHostProcess": [
+			"vs/base/common/date",
+			"vs/base/common/errorMessage",
+			"vs/base/node/processes",
+			"vs/editor/common/config/editorOptions",
+			"vs/platform/configuration/common/configurationRegistry",
+			"vs/platform/extensionManagement/common/extensionManagement",
+			"vs/platform/files/common/files",
+			"vs/platform/markers/common/markers",
+			"vs/platform/theme/common/iconRegistry",
+			"vs/platform/workspaces/common/workspaces",
+			"vs/workbench/api/common/extHost.api.impl",
+			"vs/workbench/api/common/extHostDiagnostics",
+			"vs/workbench/api/common/extHostExtensionActivator",
+			"vs/workbench/api/common/extHostExtensionService",
+			"vs/workbench/api/common/extHostProgress",
+			"vs/workbench/api/common/extHostStatusBar",
+			"vs/workbench/api/common/extHostTerminalService",
+			"vs/workbench/api/common/extHostTreeViews",
+			"vs/workbench/api/common/extHostWorkspace",
+			"vs/workbench/api/node/extHostDebugService",
+			"vs/workbench/common/views",
+			"vs/workbench/contrib/debug/common/abstractDebugAdapter",
+			"vs/workbench/contrib/debug/node/debugAdapter",
+			"vs/workbench/contrib/externalTerminal/node/externalTerminalService",
+			"vs/workbench/contrib/search/common/queryBuilder",
+			"vs/workbench/contrib/terminal/common/terminal",
+			"vs/workbench/contrib/terminal/node/terminalProcess",
+			"vs/workbench/services/configurationResolver/common/variableResolver"
+		],
+		"vs/code/electron-main/main": [
+			"vs/base/common/date",
+			"vs/base/common/errorMessage",
+			"vs/base/common/keybindingLabels",
+			"vs/base/node/processes",
+			"vs/code/electron-main/app",
+			"vs/code/electron-main/main",
+			"vs/code/electron-main/window",
+			"vs/platform/configuration/common/configurationRegistry",
+			"vs/platform/dialogs/electron-main/dialogMainService",
+			"vs/platform/environment/node/argv",
+			"vs/platform/environment/node/argvHelper",
+			"vs/platform/extensionManagement/common/extensionManagement",
+			"vs/platform/extensions/common/extensionValidator",
+			"vs/platform/files/common/fileService",
+			"vs/platform/files/common/files",
+			"vs/platform/files/common/io",
+			"vs/platform/files/node/diskFileSystemProvider",
+			"vs/platform/issue/electron-main/issueMainService",
+			"vs/platform/menubar/electron-main/menubar",
+			"vs/platform/request/common/request",
+			"vs/platform/telemetry/common/telemetryService",
+			"vs/platform/update/common/update.config.contribution",
+			"vs/platform/windows/electron-main/windowsMainService",
+			"vs/platform/workspaces/common/workspaces",
+			"vs/platform/workspaces/electron-main/workspacesHistoryMainService",
+			"vs/platform/workspaces/electron-main/workspacesManagementMainService"
+		],
+		"vs/code/node/cli": [
+			"vs/platform/environment/node/argv",
+			"vs/platform/environment/node/argvHelper",
+			"vs/platform/files/common/files"
+		],
+		"vs/code/node/cliProcessMain": [
+			"vs/base/common/date",
+			"vs/base/common/errorMessage",
+			"vs/base/node/processes",
+			"vs/base/node/zip",
+			"vs/platform/configuration/common/configurationRegistry",
+			"vs/platform/extensionManagement/common/extensionManagement",
+			"vs/platform/extensionManagement/common/extensionManagementCLIService",
+			"vs/platform/extensionManagement/node/extensionManagementService",
+			"vs/platform/extensionManagement/node/extensionManagementUtil",
+			"vs/platform/extensionManagement/node/extensionsScanner",
+			"vs/platform/extensions/common/extensionValidator",
+			"vs/platform/files/common/fileService",
+			"vs/platform/files/common/io",
+			"vs/platform/files/node/diskFileSystemProvider",
+			"vs/platform/request/common/request",
+			"vs/platform/telemetry/common/telemetryService"
+		],
+		"vs/code/electron-sandbox/issue/issueReporterMain": [
+			"vs/base/common/actions",
+			"vs/code/electron-sandbox/issue/issueReporterMain",
+			"vs/code/electron-sandbox/issue/issueReporterPage"
+		],
+		"vs/code/electron-browser/sharedProcess/sharedProcessMain": [
+			"vs/base/common/date",
+			"vs/base/common/errorMessage",
+			"vs/base/node/processes",
+			"vs/base/node/zip",
+			"vs/platform/configuration/common/configurationRegistry",
+			"vs/platform/extensionManagement/common/extensionManagement",
+			"vs/platform/extensionManagement/electron-sandbox/extensionTipsService",
+			"vs/platform/extensionManagement/node/extensionManagementService",
+			"vs/platform/extensionManagement/node/extensionManagementUtil",
+			"vs/platform/extensionManagement/node/extensionsScanner",
+			"vs/platform/extensions/common/extensionValidator",
+			"vs/platform/files/common/fileService",
+			"vs/platform/files/common/files",
+			"vs/platform/files/common/io",
+			"vs/platform/files/node/diskFileSystemProvider",
+			"vs/platform/request/common/request",
+			"vs/platform/telemetry/common/telemetryService",
+			"vs/platform/userDataSync/common/abstractSynchronizer",
+			"vs/platform/userDataSync/common/keybindingsSync",
+			"vs/platform/userDataSync/common/settingsSync",
+			"vs/platform/userDataSync/common/userDataAutoSyncService",
+			"vs/platform/userDataSync/common/userDataSync",
+			"vs/platform/userDataSync/common/userDataSyncMachines",
+			"vs/platform/workspaces/common/workspaces"
+		],
+		"vs/code/electron-sandbox/processExplorer/processExplorerMain": [
+			"vs/base/browser/ui/tree/abstractTree",
+			"vs/code/electron-sandbox/processExplorer/processExplorerMain",
+			"vs/platform/files/common/files"
+		]
+	}
+}

--- a/packages/core/src/common/nls.ts
+++ b/packages/core/src/common/nls.ts
@@ -30,16 +30,26 @@ export namespace nls {
      * Automatically localizes a text if that text also exists in the vscode repository.
      */
     export function localizeByDefault(defaultValue: string, ...args: FormatType[]): string {
+        const key = getDefaultKey(defaultValue);
+        if (key) {
+            return localize(key, defaultValue, ...args);
+        }
+        return Localization.format(defaultValue, args);
+    }
+
+    export function getDefaultKey(defaultValue: string): string {
         if (localization) {
             if (!keyProvider) {
                 keyProvider = new LocalizationKeyProvider();
             }
             const key = keyProvider.get(defaultValue);
             if (key) {
-                return localize(key, defaultValue, ...args);
+                return key;
+            } else {
+                console.warn(`Could not find translation key for default value: "${defaultValue}"`);
             }
         }
-        return Localization.format(defaultValue, args);
+        return '';
     }
 
     export function localize(key: string, defaultValue: string, ...args: FormatType[]): string {
@@ -64,6 +74,13 @@ class LocalizationKeyProvider {
         return this.data.get(defaultValue);
     }
 
+    /**
+     * Transforms the data coming from the `nls.metadata.json` file into a map.
+     * The original data contains arrays of keys and messages.
+     * The result is a map that matches each message to the key that belongs to it.
+     *
+     * This allows us to skip the key in the localization process and map the original english default values to their translations in different languages.
+     */
     private buildData(): Map<string, string> {
         const bundles = require('../../src/common/i18n/nls.metadata.json');
         const keys: NlsKeys = bundles.keys;
@@ -72,7 +89,7 @@ class LocalizationKeyProvider {
         for (const [fileKey, messageBundle] of Object.entries(messages)) {
             const keyBundle = keys[fileKey];
             for (let i = 0; i < messageBundle.length; i++) {
-                const message = messageBundle[i].replace(/&&/g, '');
+                const message = Localization.normalize(messageBundle[i]);
                 const key = keyBundle[i];
                 const localizationKey = this.buildKey(typeof key === 'string' ? key : key.key, fileKey);
                 data.set(message, localizationKey);

--- a/packages/core/src/electron-browser/menu/electron-menu-contribution.ts
+++ b/packages/core/src/electron-browser/menu/electron-menu-contribution.ts
@@ -34,35 +34,35 @@ import { BrowserMenuBarContribution } from '../../browser/menu/browser-menu-plug
 import '../../../src/electron-browser/menu/electron-menu-style.css';
 
 export namespace ElectronCommands {
-    export const TOGGLE_DEVELOPER_TOOLS = Command.toLocalizedCommand({
+    export const TOGGLE_DEVELOPER_TOOLS = Command.toDefaultLocalizedCommand({
         id: 'theia.toggleDevTools',
         label: 'Toggle Developer Tools'
-    }, 'vscode/developerActions/toggleDevTools');
-    export const RELOAD = Command.toLocalizedCommand({
+    });
+    export const RELOAD = Command.toDefaultLocalizedCommand({
         id: 'view.reload',
         label: 'Reload Window'
-    }, 'vscode/windowActions/reloadWindow');
-    export const ZOOM_IN = Command.toLocalizedCommand({
+    });
+    export const ZOOM_IN = Command.toDefaultLocalizedCommand({
         id: 'view.zoomIn',
         label: 'Zoom In'
-    }, 'vscode/windowActions/zoomIn');
-    export const ZOOM_OUT = Command.toLocalizedCommand({
+    });
+    export const ZOOM_OUT = Command.toDefaultLocalizedCommand({
         id: 'view.zoomOut',
         label: 'Zoom Out'
-    }, 'vscode/windowActions/zoomOut');
-    export const RESET_ZOOM = Command.toLocalizedCommand({
+    });
+    export const RESET_ZOOM = Command.toDefaultLocalizedCommand({
         id: 'view.resetZoom',
         label: 'Reset Zoom'
-    }, 'vscode/windowActions/zoomReset');
-    export const CLOSE_WINDOW = Command.toLocalizedCommand({
+    });
+    export const CLOSE_WINDOW = Command.toDefaultLocalizedCommand({
         id: 'close.window',
         label: 'Close Window'
-    }, 'vscode/windowActions/close');
-    export const TOGGLE_FULL_SCREEN = Command.toLocalizedCommand({
+    });
+    export const TOGGLE_FULL_SCREEN = Command.toDefaultLocalizedCommand({
         id: 'workbench.action.toggleFullScreen',
         category: CommonCommands.VIEW_CATEGORY,
         label: 'Toggle Full Screen'
-    }, 'vscode/windowActions/toggleFullScreen', CommonCommands.VIEW_CATEGORY_KEY);
+    });
 }
 
 export namespace ElectronMenus {
@@ -228,12 +228,12 @@ export class ElectronMenuContribution extends BrowserMenuBarContribution impleme
     protected async handleRequiredRestart(): Promise<void> {
         const msgNode = document.createElement('div');
         const message = document.createElement('p');
-        message.textContent = nls.localize('vscode/relauncher.contribution/relaunchSettingMessage', 'A setting has changed that requires a restart to take effect');
+        message.textContent = nls.localizeByDefault('A setting has changed that requires a restart to take effect');
         const detail = document.createElement('p');
-        detail.textContent = nls.localize('vscode/relauncher.contribution/relaunchSettingDetail',
+        detail.textContent = nls.localizeByDefault(
             'Press the restart button to restart {0} and enable the setting.', FrontendApplicationConfigProvider.get().applicationName);
         msgNode.append(message, detail);
-        const restart = nls.localize('vscode/relauncher.contribution/restart', 'Restart');
+        const restart = nls.localizeByDefault('Restart');
         const dialog = new ConfirmDialog({
             title: restart,
             msg: msgNode,

--- a/packages/core/src/electron-browser/window/electron-window-preferences.ts
+++ b/packages/core/src/electron-browser/window/electron-window-preferences.ts
@@ -38,7 +38,7 @@ export const electronWindowPreferencesSchema: PreferenceSchema = {
             'maximum': ZoomLevel.MAX,
             'scope': 'application',
             // eslint-disable-next-line max-len
-            'description': nls.localize('vscode/desktop.contribution/zoomLevel', 'Adjust the zoom level of the window. The original size is 0 and each increment above (e.g. 1.0) or below (e.g. -1.0) represents zooming 20% larger or smaller. You can also enter decimals to adjust the zoom level with a finer granularity.')
+            'description': nls.localizeByDefault('Adjust the zoom level of the window. The original size is 0 and each increment above (e.g. 1.0) or below (e.g. -1.0) represents zooming 20% larger or smaller. You can also enter decimals to adjust the zoom level with a finer granularity.')
         },
         'window.titleBarStyle': {
             type: 'string',
@@ -46,7 +46,7 @@ export const electronWindowPreferencesSchema: PreferenceSchema = {
             default: isWindows ? 'custom' : 'native',
             scope: 'application',
             // eslint-disable-next-line max-len
-            description: nls.localize('vscode/desktop.contribution/titleBarStyle', 'Adjust the appearance of the window title bar. On Linux and Windows, this setting also affects the application and context menu appearances. Changes require a full restart to apply.'),
+            description: nls.localizeByDefault('Adjust the appearance of the window title bar. On Linux and Windows, this setting also affects the application and context menu appearances. Changes require a full restart to apply.'),
             included: !isOSX
         },
     }

--- a/packages/debug/src/browser/console/debug-console-contribution.tsx
+++ b/packages/debug/src/browser/console/debug-console-contribution.tsx
@@ -34,15 +34,14 @@ export const InDebugReplContextKey = Symbol('inDebugReplContextKey');
 
 export namespace DebugConsoleCommands {
 
-    export const DEBUG_CATEGORY_KEY = 'vscode/debugCommands/debug';
     export const DEBUG_CATEGORY = 'Debug';
 
-    export const CLEAR = Command.toLocalizedCommand({
+    export const CLEAR = Command.toDefaultLocalizedCommand({
         id: 'debug.console.clear',
         category: DEBUG_CATEGORY,
         label: 'Clear Console',
         iconClass: codicon('clear-all')
-    }, 'vscode/repl/clearRepl', DEBUG_CATEGORY_KEY);
+    });
 }
 
 @injectable()
@@ -136,7 +135,7 @@ export class DebugConsoleContribution extends AbstractViewContribution<ConsoleWi
     static options: ConsoleOptions = {
         id: 'debug-console',
         title: {
-            label: nls.localize('vscode/repl/debugConsole', 'Debug Console'),
+            label: nls.localizeByDefault('Debug Console'),
             iconClass: codicon('debug-console')
         },
         input: {

--- a/packages/debug/src/browser/debug-frontend-application-contribution.ts
+++ b/packages/debug/src/browser/debug-frontend-application-contribution.ts
@@ -65,92 +65,93 @@ export namespace DebugMenus {
 }
 
 function nlsEditBreakpoint(breakpointKey: string, breakpoint: string): string {
-    return nls.localize('vscode/breakpointEditorContribution/editBreakpoint', 'Edit {0}...', nls.localize(`vscode/breakpointEditorContribution/${breakpointKey}`, breakpoint));
+    return nls.localizeByDefault('Edit {0}...', nls.localize(`vscode/breakpointEditorContribution/${breakpointKey}`, breakpoint));
 }
 
 function nlsRemoveBreakpoint(breakpointKey: string, breakpoint: string): string {
-    return nls.localize('vscode/breakpointEditorContribution/removeBreakpoint', 'Remove {0}',
+    return nls.localizeByDefault('Remove {0}',
         nls.localize(`vscode/breakpointEditorContribution/${breakpointKey}`, breakpoint));
 }
 
 function nlsEnableBreakpoint(breakpointKey: string, breakpoint: string): string {
-    return nls.localize('vscode/breakpointEditorContribution/enableBreakpoint', 'Enable {0}',
+    return nls.localizeByDefault('Enable {0}',
         nls.localize(`vscode/breakpointEditorContribution/${breakpointKey}`, breakpoint));
 }
 
 function nlsDisableBreakpoint(breakpointKey: string, breakpoint: string): string {
-    return nls.localize('vscode/breakpointEditorContribution/disableBreakpoint', 'Disable {0}',
+    return nls.localizeByDefault('Disable {0}',
         nls.localize(`vscode/breakpointEditorContribution/${breakpointKey}`, breakpoint));
 }
 
 export namespace DebugCommands {
 
-    export const DEBUG_CATEGORY_KEY = 'vscode/debugCommands/debug';
     export const DEBUG_CATEGORY = 'Debug';
+    export const DEBUG_CATEGORY_KEY = nls.getDefaultKey(DEBUG_CATEGORY);
 
-    export const START = Command.toLocalizedCommand({
+    export const START = Command.toDefaultLocalizedCommand({
         id: 'workbench.action.debug.start',
         category: DEBUG_CATEGORY,
         label: 'Start Debugging',
         iconClass: codicon('debug-alt')
-    }, 'vscode/debugCommands/startDebug', DEBUG_CATEGORY_KEY);
-    export const START_NO_DEBUG = Command.toLocalizedCommand({
+    });
+    export const START_NO_DEBUG = Command.toDefaultLocalizedCommand({
         id: 'workbench.action.debug.run',
-        label: 'Debug: Start Without Debugging'
-    }, 'vscode/debugCommands/startWithoutDebugging');
-    export const STOP = Command.toLocalizedCommand({
+        category: DEBUG_CATEGORY,
+        label: 'Start Without Debugging'
+    });
+    export const STOP = Command.toDefaultLocalizedCommand({
         id: 'workbench.action.debug.stop',
         category: DEBUG_CATEGORY,
         label: 'Stop',
         iconClass: codicon('debug-stop')
-    }, 'vscode/debugCommands/stop', DEBUG_CATEGORY_KEY);
-    export const RESTART = Command.toLocalizedCommand({
+    });
+    export const RESTART = Command.toDefaultLocalizedCommand({
         id: 'workbench.action.debug.restart',
         category: DEBUG_CATEGORY,
         label: 'Restart',
-    }, 'vscode/debugCommands/restartDebug', DEBUG_CATEGORY_KEY);
+    });
 
-    export const OPEN_CONFIGURATIONS = Command.toLocalizedCommand({
+    export const OPEN_CONFIGURATIONS = Command.toDefaultLocalizedCommand({
         id: 'debug.configurations.open',
         category: DEBUG_CATEGORY,
         label: 'Open Configurations'
-    }, 'vscode/debugViewlet/miOpenConfigurations', DEBUG_CATEGORY_KEY);
-    export const ADD_CONFIGURATION = Command.toLocalizedCommand({
+    });
+    export const ADD_CONFIGURATION = Command.toDefaultLocalizedCommand({
         id: 'debug.configurations.add',
         category: DEBUG_CATEGORY,
         label: 'Add Configuration...'
-    }, 'vscode/debugActionViewItems/addConfiguration', DEBUG_CATEGORY_KEY);
+    });
 
-    export const STEP_OVER = Command.toLocalizedCommand({
+    export const STEP_OVER = Command.toDefaultLocalizedCommand({
         id: 'workbench.action.debug.stepOver',
         category: DEBUG_CATEGORY,
         label: 'Step Over',
         iconClass: codicon('debug-step-over')
-    }, 'vscode/debugCommands/stepOverDebug', DEBUG_CATEGORY_KEY);
-    export const STEP_INTO = Command.toLocalizedCommand({
+    });
+    export const STEP_INTO = Command.toDefaultLocalizedCommand({
         id: 'workbench.action.debug.stepInto',
         category: DEBUG_CATEGORY,
         label: 'Step Into',
         iconClass: codicon('debug-step-into')
-    }, 'vscode/debugCommands/stepIntoDebug', DEBUG_CATEGORY_KEY);
-    export const STEP_OUT = Command.toLocalizedCommand({
+    });
+    export const STEP_OUT = Command.toDefaultLocalizedCommand({
         id: 'workbench.action.debug.stepOut',
         category: DEBUG_CATEGORY,
         label: 'Step Out',
         iconClass: codicon('debug-step-out')
-    }, 'vscode/debugCommands/stepOutDebug', DEBUG_CATEGORY_KEY);
-    export const CONTINUE = Command.toLocalizedCommand({
+    });
+    export const CONTINUE = Command.toDefaultLocalizedCommand({
         id: 'workbench.action.debug.continue',
         category: DEBUG_CATEGORY,
         label: 'Continue',
         iconClass: codicon('debug-continue')
-    }, 'vscode/debugCommands/continueDebug', DEBUG_CATEGORY_KEY);
-    export const PAUSE = Command.toLocalizedCommand({
+    });
+    export const PAUSE = Command.toDefaultLocalizedCommand({
         id: 'workbench.action.debug.pause',
         category: DEBUG_CATEGORY,
         label: 'Pause',
         iconClass: codicon('debug-pause')
-    }, 'vscode/debugCommands/pauseDebug', DEBUG_CATEGORY_KEY);
+    });
     export const CONTINUE_ALL = Command.toLocalizedCommand({
         id: 'debug.thread.continue.all',
         category: DEBUG_CATEGORY,
@@ -164,41 +165,41 @@ export namespace DebugCommands {
         iconClass: codicon('debug-pause')
     }, 'theia/debug/pauseAll', DEBUG_CATEGORY_KEY);
 
-    export const TOGGLE_BREAKPOINT = Command.toLocalizedCommand({
+    export const TOGGLE_BREAKPOINT = Command.toDefaultLocalizedCommand({
         id: 'editor.debug.action.toggleBreakpoint',
         category: DEBUG_CATEGORY,
         label: 'Toggle Breakpoint',
-    }, 'vscode/debugEditorActions/miToggleBreakpoint', DEBUG_CATEGORY_KEY);
-    export const INLINE_BREAKPOINT = Command.toLocalizedCommand({
+    });
+    export const INLINE_BREAKPOINT = Command.toDefaultLocalizedCommand({
         id: 'editor.debug.action.inlineBreakpoint',
         category: DEBUG_CATEGORY,
         label: 'Inline Breakpoint',
-    }, 'vscode/debug.contribution/inlineBreakpoint', DEBUG_CATEGORY_KEY);
-    export const ADD_CONDITIONAL_BREAKPOINT = Command.toLocalizedCommand({
+    });
+    export const ADD_CONDITIONAL_BREAKPOINT = Command.toDefaultLocalizedCommand({
         id: 'debug.breakpoint.add.conditional',
         category: DEBUG_CATEGORY,
         label: 'Add Conditional Breakpoint...',
-    }, 'vscode/breakpointEditorContribution/addConditionalBreakpoint', DEBUG_CATEGORY_KEY);
-    export const ADD_LOGPOINT = Command.toLocalizedCommand({
+    });
+    export const ADD_LOGPOINT = Command.toDefaultLocalizedCommand({
         id: 'debug.breakpoint.add.logpoint',
         category: DEBUG_CATEGORY,
         label: 'Add Logpoint...',
-    }, 'vscode/breakpointEditorContribution/addLogPoint', DEBUG_CATEGORY_KEY);
-    export const ADD_FUNCTION_BREAKPOINT = Command.toLocalizedCommand({
+    });
+    export const ADD_FUNCTION_BREAKPOINT = Command.toDefaultLocalizedCommand({
         id: 'debug.breakpoint.add.function',
         category: DEBUG_CATEGORY,
-        label: 'Add Function Breakpoint...',
-    }, 'vscode/breakpointsView/addFunctionBreakpoint', DEBUG_CATEGORY_KEY);
-    export const ENABLE_ALL_BREAKPOINTS = Command.toLocalizedCommand({
+        label: 'Add Function Breakpoint',
+    });
+    export const ENABLE_ALL_BREAKPOINTS = Command.toDefaultLocalizedCommand({
         id: 'debug.breakpoint.enableAll',
         category: DEBUG_CATEGORY,
         label: 'Enable All Breakpoints',
-    }, 'vscode/breakpointsView/enableAllBreakpoints', DEBUG_CATEGORY_KEY);
-    export const DISABLE_ALL_BREAKPOINTS = Command.toLocalizedCommand({
+    });
+    export const DISABLE_ALL_BREAKPOINTS = Command.toDefaultLocalizedCommand({
         id: 'debug.breakpoint.disableAll',
         category: DEBUG_CATEGORY,
         label: 'Disable All Breakpoints',
-    }, 'vscode/breakpointsView/disableAllBreakpoints', DEBUG_CATEGORY_KEY);
+    });
     export const EDIT_BREAKPOINT = Command.toLocalizedCommand({
         id: 'debug.breakpoint.edit',
         category: DEBUG_CATEGORY,
@@ -223,82 +224,82 @@ export namespace DebugCommands {
         originalLabel: 'Remove Logpoint',
         label: nlsRemoveBreakpoint('logPoint', 'Logpoint')
     }, '', DEBUG_CATEGORY_KEY);
-    export const REMOVE_ALL_BREAKPOINTS = Command.toLocalizedCommand({
+    export const REMOVE_ALL_BREAKPOINTS = Command.toDefaultLocalizedCommand({
         id: 'debug.breakpoint.removeAll',
         category: DEBUG_CATEGORY,
         label: 'Remove All Breakpoints',
-    }, 'vscode/breakpointsView/removeAllBreakpoints', DEBUG_CATEGORY_KEY);
+    });
     export const TOGGLE_BREAKPOINTS_ENABLED = Command.toLocalizedCommand({
         id: 'debug.breakpoint.toggleEnabled'
     });
-    export const SHOW_HOVER = Command.toLocalizedCommand({
+    export const SHOW_HOVER = Command.toDefaultLocalizedCommand({
         id: 'editor.debug.action.showDebugHover',
         category: DEBUG_CATEGORY,
         label: 'Show Hover'
-    }, 'vscode/hover/showHover', DEBUG_CATEGORY_KEY);
+    });
 
-    export const RESTART_FRAME = Command.toLocalizedCommand({
+    export const RESTART_FRAME = Command.toDefaultLocalizedCommand({
         id: 'debug.frame.restart',
         category: DEBUG_CATEGORY,
         label: 'Restart Frame',
-    }, 'vscode/debug.contribution/restartFrame', DEBUG_CATEGORY_KEY);
-    export const COPY_CALL_STACK = Command.toLocalizedCommand({
+    });
+    export const COPY_CALL_STACK = Command.toDefaultLocalizedCommand({
         id: 'debug.callStack.copy',
         category: DEBUG_CATEGORY,
         label: 'Copy Call Stack',
-    }, 'vscode/debug.contribution/copyStackTrace', DEBUG_CATEGORY_KEY);
+    });
 
-    export const SET_VARIABLE_VALUE = Command.toLocalizedCommand({
+    export const SET_VARIABLE_VALUE = Command.toDefaultLocalizedCommand({
         id: 'debug.variable.setValue',
         category: DEBUG_CATEGORY,
         label: 'Set Value',
-    }, 'vscode/debug.contribution/setValue', DEBUG_CATEGORY_KEY);
-    export const COPY_VARIABLE_VALUE = Command.toLocalizedCommand({
+    });
+    export const COPY_VARIABLE_VALUE = Command.toDefaultLocalizedCommand({
         id: 'debug.variable.copyValue',
         category: DEBUG_CATEGORY,
         label: 'Copy Value',
-    }, 'vscode/debug.contribution/copyValue', DEBUG_CATEGORY_KEY);
-    export const COPY_VARIABLE_AS_EXPRESSION = Command.toLocalizedCommand({
+    });
+    export const COPY_VARIABLE_AS_EXPRESSION = Command.toDefaultLocalizedCommand({
         id: 'debug.variable.copyAsExpression',
         category: DEBUG_CATEGORY,
-        label: 'Copy As Expression',
-    }, 'vscode/debug.contribution/copyAsExpression', DEBUG_CATEGORY_KEY);
-    export const WATCH_VARIABLE = Command.toLocalizedCommand({
+        label: 'Copy as Expression',
+    });
+    export const WATCH_VARIABLE = Command.toDefaultLocalizedCommand({
         id: 'debug.variable.watch',
         category: DEBUG_CATEGORY,
         label: 'Add to Watch',
-    }, 'vscode/debug.contribution/addToWatchExpressions', DEBUG_CATEGORY_KEY);
+    });
 
-    export const ADD_WATCH_EXPRESSION = Command.toLocalizedCommand({
+    export const ADD_WATCH_EXPRESSION = Command.toDefaultLocalizedCommand({
         id: 'debug.watch.addExpression',
         category: DEBUG_CATEGORY,
         label: 'Add Expression'
-    }, 'vscode/watchExpressionsView/addWatchExpression', DEBUG_CATEGORY_KEY);
-    export const EDIT_WATCH_EXPRESSION = Command.toLocalizedCommand({
+    });
+    export const EDIT_WATCH_EXPRESSION = Command.toDefaultLocalizedCommand({
         id: 'debug.watch.editExpression',
         category: DEBUG_CATEGORY,
         label: 'Edit Expression'
-    }, 'vscode/debug.contribution/editWatchExpression', DEBUG_CATEGORY_KEY);
+    });
     export const COPY_WATCH_EXPRESSION_VALUE = Command.toLocalizedCommand({
         id: 'debug.watch.copyExpressionValue',
         category: DEBUG_CATEGORY,
         label: 'Copy Expression Value'
     }, 'theia/debug/copyExpressionValue', DEBUG_CATEGORY_KEY);
-    export const REMOVE_WATCH_EXPRESSION = Command.toLocalizedCommand({
+    export const REMOVE_WATCH_EXPRESSION = Command.toDefaultLocalizedCommand({
         id: 'debug.watch.removeExpression',
         category: DEBUG_CATEGORY,
         label: 'Remove Expression'
-    }, 'vscode/debug.contribution/removeWatchExpression', DEBUG_CATEGORY_KEY);
-    export const COLLAPSE_ALL_WATCH_EXPRESSIONS = Command.toLocalizedCommand({
+    });
+    export const COLLAPSE_ALL_WATCH_EXPRESSIONS = Command.toDefaultLocalizedCommand({
         id: 'debug.watch.collapseAllExpressions',
         category: DEBUG_CATEGORY,
-        label: 'Collapse All Expressions'
-    }, 'vscode/watchExpressionsView/collapse', DEBUG_CATEGORY_KEY);
-    export const REMOVE_ALL_WATCH_EXPRESSIONS = Command.toLocalizedCommand({
+        label: 'Collapse All'
+    });
+    export const REMOVE_ALL_WATCH_EXPRESSIONS = Command.toDefaultLocalizedCommand({
         id: 'debug.watch.removeAllExpressions',
         category: DEBUG_CATEGORY,
         label: 'Remove All Expressions'
-    }, 'vscode/watchExpressionsView/removeAllWatchExpressions', DEBUG_CATEGORY_KEY);
+    });
 }
 export namespace DebugThreadContextCommands {
     export const STEP_OVER = {
@@ -525,7 +526,7 @@ export class DebugFrontendApplicationContribution extends AbstractViewContributi
             }
         };
 
-        menus.registerSubmenu(DebugMenus.DEBUG, nls.localize('vscode/debug.contribution/run', 'Run'));
+        menus.registerSubmenu(DebugMenus.DEBUG, nls.localizeByDefault('Run'));
         registerMenuActions(DebugMenus.DEBUG_CONTROLS,
             DebugCommands.START,
             DebugCommands.START_NO_DEBUG,
@@ -550,7 +551,7 @@ export class DebugFrontendApplicationContribution extends AbstractViewContributi
         registerMenuActions(DebugMenus.DEBUG_BREAKPOINT,
             DebugCommands.TOGGLE_BREAKPOINT
         );
-        menus.registerSubmenu(DebugMenus.DEBUG_NEW_BREAKPOINT, nls.localize('vscode/debug.contribution/miNewBreakpoint', 'New Breakpoint'));
+        menus.registerSubmenu(DebugMenus.DEBUG_NEW_BREAKPOINT, nls.localizeByDefault('New Breakpoint'));
         registerMenuActions(DebugMenus.DEBUG_NEW_BREAKPOINT,
             DebugCommands.ADD_CONDITIONAL_BREAKPOINT,
             DebugCommands.INLINE_BREAKPOINT,
@@ -575,7 +576,7 @@ export class DebugFrontendApplicationContribution extends AbstractViewContributi
         registerMenuActions(DebugThreadsWidget.TERMINATE_MENU,
             { ...DebugCommands.RESTART, ...DebugSessionContextCommands.RESTART },
             { ...DebugCommands.STOP, ...DebugSessionContextCommands.STOP },
-            { ...DebugThreadContextCommands.TERMINATE, label: nls.localize('vscode/debug.contribution/terminateThread', 'Terminate Thread') }
+            { ...DebugThreadContextCommands.TERMINATE, label: nls.localizeByDefault('Terminate Thread') }
         );
         registerMenuActions(DebugThreadsWidget.OPEN_MENU,
             { ...DebugSessionContextCommands.REVEAL, label: nls.localize('theia/debug/reveal', 'Reveal') },
@@ -622,7 +623,7 @@ export class DebugFrontendApplicationContribution extends AbstractViewContributi
         );
 
         registerMenuActions(DebugEditorModel.CONTEXT_MENU,
-            { ...DebugEditorContextCommands.ADD_BREAKPOINT, label: nls.localize('vscode/breakpointEditorContribution/addBreakpoint', 'Add Breakpoint') },
+            { ...DebugEditorContextCommands.ADD_BREAKPOINT, label: nls.localizeByDefault('Add Breakpoint') },
             { ...DebugEditorContextCommands.ADD_CONDITIONAL_BREAKPOINT, label: DebugCommands.ADD_CONDITIONAL_BREAKPOINT.label },
             { ...DebugEditorContextCommands.ADD_LOGPOINT, label: DebugCommands.ADD_LOGPOINT.label },
             { ...DebugEditorContextCommands.REMOVE_BREAKPOINT, label: DebugCommands.REMOVE_BREAKPOINT.label },
@@ -1106,8 +1107,8 @@ export class DebugFrontendApplicationContribution extends AbstractViewContributi
             priority: 1
         };
         const updateToggleBreakpointsEnabled = () => {
-            const activateBreakpoints = nls.localize('vscode/breakpointsView/enableAllBreakpoints', 'Enable Breakpoints');
-            const deactivateBreakpoints = nls.localize('vscode/breakpointsView/disableAllBreakpoints', 'Disable Breakpoints');
+            const activateBreakpoints = nls.localizeByDefault('Enable All Breakpoints');
+            const deactivateBreakpoints = nls.localizeByDefault('Disable All Breakpoints');
             const tooltip = this.breakpointManager.breakpointsEnabled ? deactivateBreakpoints : activateBreakpoints;
             if (toggleBreakpointsEnabled.tooltip !== tooltip) {
                 toggleBreakpointsEnabled.tooltip = tooltip;

--- a/packages/debug/src/browser/debug-preferences.ts
+++ b/packages/debug/src/browser/debug-preferences.ts
@@ -34,26 +34,26 @@ export const debugPreferencesSchema: PreferenceSchema = {
         'debug.openDebug': {
             enum: ['neverOpen', 'openOnSessionStart', 'openOnFirstSessionStart', 'openOnDebugBreak'],
             default: 'openOnSessionStart',
-            description: nls.localize('vscode/debug.contribution/openDebug', 'Controls when the debug view should open.')
+            description: nls.localizeByDefault('Controls when the debug view should open.')
         },
         'debug.internalConsoleOptions': {
             enum: ['neverOpen', 'openOnSessionStart', 'openOnFirstSessionStart'],
             default: 'openOnFirstSessionStart',
-            description: nls.localize('vscode/debug/internalConsoleOptions', 'Controls when the internal debug console should open.')
+            description: nls.localizeByDefault('Controls when the internal debug console should open.')
         },
         'debug.inlineValues': {
             type: 'boolean',
             default: false,
-            description: nls.localize('vscode/debug.contribution/inlineValues', 'Show variable values inline in editor while debugging.')
+            description: nls.localizeByDefault('Show variable values inline in editor while debugging.')
         },
         'debug.showInStatusBar': {
             enum: ['never', 'always', 'onFirstSessionStart'],
             enumDescriptions: [
-                nls.localize('vscode/debug.contribution/never', 'Never show debug in status bar'),
-                nls.localize('vscode/debug.contribution/always', 'Always show debug in status bar'),
-                nls.localize('vscode/debug.contribution/onFirstSessionStart', 'Show debug in status bar only after debug was started for the first time')
+                nls.localizeByDefault('Never show debug in status bar'),
+                nls.localizeByDefault('Always show debug in status bar'),
+                nls.localizeByDefault('Show debug in status bar only after debug was started for the first time')
             ],
-            description: nls.localize('vscode/debug.contribution/showInStatusBar', 'Controls when the debug status bar should be visible.'),
+            description: nls.localizeByDefault('Controls when the debug status bar should be visible.'),
             default: 'onFirstSessionStart'
         },
         'debug.confirmOnExit': {

--- a/packages/debug/src/browser/debug-prefix-configuration.ts
+++ b/packages/debug/src/browser/debug-prefix-configuration.ts
@@ -61,11 +61,11 @@ export class DebugPrefixConfiguration implements CommandContribution, CommandHan
 
     readonly statusBarId = 'select-run-debug-statusbar-item';
 
-    private readonly command = Command.toLocalizedCommand({
+    private readonly command = Command.toDefaultLocalizedCommand({
         id: 'select.debug.configuration',
         category: DebugCommands.DEBUG_CATEGORY,
         label: 'Select and Start Debugging'
-    }, 'vscode/debugCommands/selectAndStartDebugging', DebugCommands.DEBUG_CATEGORY_KEY);
+    });
 
     @postConstruct()
     protected initialize(): void {
@@ -135,7 +135,7 @@ export class DebugPrefixConfiguration implements CommandContribution, CommandHan
             for (const configuration of dynamicConfigurations) {
                 items.push({
                     label: configuration.name,
-                    execute: () => this.runConfiguration({configuration})
+                    execute: () => this.runConfiguration({ configuration })
                 });
             }
         }

--- a/packages/debug/src/browser/model/debug-function-breakpoint.tsx
+++ b/packages/debug/src/browser/model/debug-function-breakpoint.tsx
@@ -20,6 +20,7 @@ import { FunctionBreakpoint } from '../breakpoint/breakpoint-marker';
 import { BreakpointManager } from '../breakpoint/breakpoint-manager';
 import { DebugBreakpoint, DebugBreakpointOptions, DebugBreakpointDecoration } from './debug-breakpoint';
 import { SingleTextInputDialog } from '@theia/core/lib/browser/dialogs';
+import { nls } from '@theia/core';
 
 export class DebugFunctionBreakpoint extends DebugBreakpoint<FunctionBreakpoint> implements TreeElement {
 
@@ -63,7 +64,7 @@ export class DebugFunctionBreakpoint extends DebugBreakpoint<FunctionBreakpoint>
 
     protected doGetDecoration(): DebugBreakpointDecoration {
         if (!this.isSupported()) {
-            return this.getDisabledBreakpointDecoration('Function breakpoints are not supported by this debug type');
+            return this.getDisabledBreakpointDecoration(nls.localizeByDefault('Function breakpoints are not supported by this debug type'));
         }
         return super.doGetDecoration();
     }
@@ -71,13 +72,13 @@ export class DebugFunctionBreakpoint extends DebugBreakpoint<FunctionBreakpoint>
     protected getBreakpointDecoration(message?: string[]): DebugBreakpointDecoration {
         return {
             className: 'theia-debug-function',
-            message: message || ['Function Breakpoint']
+            message: message || [nls.localizeByDefault('Function Breakpoint')]
         };
     }
 
     async open(): Promise<void> {
         const input = new SingleTextInputDialog({
-            title: 'Add Function Breakpoint',
+            title: nls.localizeByDefault('Add Function Breakpoint'),
             initialValue: this.name
         });
         const newValue = await input.open();

--- a/packages/debug/src/browser/preferences/launch-preferences.ts
+++ b/packages/debug/src/browser/preferences/launch-preferences.ts
@@ -26,10 +26,7 @@ export const launchPreferencesSchema: PreferenceSchema = {
     properties: {
         'launch': {
             $ref: launchSchemaId,
-            description: nls.localize(
-                'vscode/debug.contribution/launch',
-                "Global debug launch configuration. Should be used as an alternative to 'launch.json' that is shared across workspaces"
-            ),
+            description: nls.localizeByDefault("Global debug launch configuration. Should be used as an alternative to 'launch.json' that is shared across workspaces."),
             defaultValue: { configurations: [], compounds: [] }
         }
     }

--- a/packages/debug/src/browser/view/debug-breakpoints-widget.ts
+++ b/packages/debug/src/browser/view/debug-breakpoints-widget.ts
@@ -58,7 +58,7 @@ export class DebugBreakpointsWidget extends SourceTreeWidget {
     protected init(): void {
         super.init();
         this.id = 'debug:breakpoints:' + this.viewModel.id;
-        this.title.label = nls.localize('vscode/debug.contribution/breakpoints', 'Breakpoints');
+        this.title.label = nls.localizeByDefault('Breakpoints');
         this.toDispose.push(this.breakpointsSource);
         this.source = this.breakpointsSource;
     }

--- a/packages/debug/src/browser/view/debug-configuration-widget.tsx
+++ b/packages/debug/src/browser/view/debug-configuration-widget.tsx
@@ -79,15 +79,15 @@ export class DebugConfigurationWidget extends ReactWidget {
     render(): React.ReactNode {
         const { options } = this;
         return <React.Fragment>
-            <DebugAction run={this.start} label={nls.localize('vscode/debugCommands/startDebug', 'Start Debugging')} iconClass='debug-start' ref={this.setStepRef} />
+            <DebugAction run={this.start} label={nls.localizeByDefault('Start Debugging')} iconClass='debug-start' ref={this.setStepRef} />
             <select className='theia-select debug-configuration' value={this.currentValue} onChange={this.setCurrentConfiguration}>
-                {options.length ? options : <option value='__NO_CONF__'>{nls.localize('vscode/debugActionViewItems/noConfigurations', 'No Configurations')}</option>}
+                {options.length ? options : <option value='__NO_CONF__'>{nls.localizeByDefault('No Configurations')}</option>}
                 <option disabled>{'Add Configuration...'.replace(/./g, '-')}</option>
-                <option value='__ADD_CONF__'>{nls.localize('vscode/debugActionViewItems/addConfiguration', 'Add Configuration...')}</option>
+                <option value='__ADD_CONF__'>{nls.localizeByDefault('Add Configuration...')}</option>
             </select>
-            <DebugAction run={this.openConfiguration} label={nls.localize('vscode/debugCommands/openLaunchJson', 'Open "launch.json"', '"launch.json"')}
+            <DebugAction run={this.openConfiguration} label={nls.localizeByDefault('Open {0}', '"launch.json"')}
                 iconClass='settings-gear' />
-            <DebugAction run={this.openConsole} label={nls.localize('vscode/repl/debugConsole', 'Debug Console')} iconClass='terminal' />
+            <DebugAction run={this.openConsole} label={nls.localizeByDefault('Debug Console')} iconClass='terminal' />
         </React.Fragment>;
     }
     protected get currentValue(): string {

--- a/packages/debug/src/browser/view/debug-stack-frames-widget.ts
+++ b/packages/debug/src/browser/view/debug-stack-frames-widget.ts
@@ -56,7 +56,7 @@ export class DebugStackFramesWidget extends SourceTreeWidget {
     protected init(): void {
         super.init();
         this.id = 'debug:frames:' + this.viewModel.id;
-        this.title.label = nls.localize('vscode/debug.contribution/callStack', 'Call Stack');
+        this.title.label = nls.localizeByDefault('Call Stack');
         this.toDispose.push(this.frames);
         this.source = this.frames;
 

--- a/packages/debug/src/browser/view/debug-toolbar-widget.tsx
+++ b/packages/debug/src/browser/view/debug-toolbar-widget.tsx
@@ -59,13 +59,13 @@ export class DebugToolBar extends ReactWidget {
         const { state } = this.model;
         return <React.Fragment>
             {this.renderContinue()}
-            <DebugAction enabled={state === DebugState.Stopped} run={this.stepOver} label={nls.localize('vscode/debugCommands/stepOverDebug', 'Step Over')}
+            <DebugAction enabled={state === DebugState.Stopped} run={this.stepOver} label={nls.localizeByDefault('Step Over')}
                 iconClass='debug-step-over' ref={this.setStepRef} />
-            <DebugAction enabled={state === DebugState.Stopped} run={this.stepIn} label={nls.localize('vscode/debugCommands/stepIntoDebug', 'Step Into')}
+            <DebugAction enabled={state === DebugState.Stopped} run={this.stepIn} label={nls.localizeByDefault('Step Into')}
                 iconClass='debug-step-into' />
-            <DebugAction enabled={state === DebugState.Stopped} run={this.stepOut} label={nls.localize('vscode/debugCommands/stepOutDebug', 'Step Out')}
+            <DebugAction enabled={state === DebugState.Stopped} run={this.stepOut} label={nls.localizeByDefault('Step Out')}
                 iconClass='debug-step-out' />
-            <DebugAction enabled={state !== DebugState.Inactive} run={this.restart} label={nls.localize('vscode/debugCommands/restartDebug', 'Restart')}
+            <DebugAction enabled={state !== DebugState.Inactive} run={this.restart} label={nls.localizeByDefault('Restart')}
                 iconClass='debug-restart' />
             {this.renderStart()}
         </React.Fragment>;
@@ -73,16 +73,16 @@ export class DebugToolBar extends ReactWidget {
     protected renderStart(): React.ReactNode {
         const { state } = this.model;
         if (state === DebugState.Inactive && this.model.sessionCount === 1) {
-            return <DebugAction run={this.start} label={nls.localize('vscode/debugCommands/startDebug', 'Start')} iconClass='debug-start' />;
+            return <DebugAction run={this.start} label={nls.localizeByDefault('Start')} iconClass='debug-start' />;
         }
-        return <DebugAction enabled={state !== DebugState.Inactive} run={this.stop} label={nls.localize('vscode/debugCommands/stop', 'Stop')} iconClass='debug-stop' />;
+        return <DebugAction enabled={state !== DebugState.Inactive} run={this.stop} label={nls.localizeByDefault('Stop')} iconClass='debug-stop' />;
     }
     protected renderContinue(): React.ReactNode {
         const { state } = this.model;
         if (state === DebugState.Stopped) {
-            return <DebugAction run={this.continue} label={nls.localize('vscode/debugCommands/continueDebug', 'Continue')} iconClass='debug-continue' />;
+            return <DebugAction run={this.continue} label={nls.localizeByDefault('Continue')} iconClass='debug-continue' />;
         }
-        return <DebugAction enabled={state === DebugState.Running} run={this.pause} label={nls.localize('vscode/debugCommands/pauseDebug', 'Pause')} iconClass='debug-pause' />;
+        return <DebugAction enabled={state === DebugState.Running} run={this.pause} label={nls.localizeByDefault('Pause')} iconClass='debug-pause' />;
     }
 
     protected start = () => this.model.start();

--- a/packages/debug/src/browser/view/debug-variables-widget.ts
+++ b/packages/debug/src/browser/view/debug-variables-widget.ts
@@ -52,7 +52,7 @@ export class DebugVariablesWidget extends SourceTreeWidget {
     protected init(): void {
         super.init();
         this.id = 'debug:variables:' + this.viewModel.id;
-        this.title.label = nls.localize('vscode/debug.contribution/variables', 'Variables');
+        this.title.label = nls.localizeByDefault('Variables');
         this.toDispose.push(this.variables);
         this.source = this.variables;
     }

--- a/packages/debug/src/browser/view/debug-watch-widget.ts
+++ b/packages/debug/src/browser/view/debug-watch-widget.ts
@@ -52,7 +52,7 @@ export class DebugWatchWidget extends SourceTreeWidget {
     protected init(): void {
         super.init();
         this.id = 'debug:watch:' + this.viewModel.id;
-        this.title.label = nls.localize('vscode/debug.contribution/watch', 'Watch');
+        this.title.label = nls.localizeByDefault('Watch');
         this.toDispose.push(this.variables);
         this.source = this.variables;
     }

--- a/packages/debug/src/browser/view/debug-widget.ts
+++ b/packages/debug/src/browser/view/debug-widget.ts
@@ -39,7 +39,7 @@ export class DebugWidget extends BaseWidget implements StatefulWidget, Applicati
     }
 
     static ID = 'debug';
-    static LABEL = nls.localize('vscode/settingsLayout/debug', 'Debug');
+    static LABEL = nls.localizeByDefault('Debug');
 
     @inject(DebugViewModel)
     readonly model: DebugViewModel;

--- a/packages/editor-preview/src/browser/editor-preview-contribution.ts
+++ b/packages/editor-preview/src/browser/editor-preview-contribution.ts
@@ -21,11 +21,11 @@ import { inject, injectable } from '@theia/core/shared/inversify';
 import { EditorPreviewWidget } from './editor-preview-widget';
 
 export namespace EditorPreviewCommands {
-    export const PIN_PREVIEW_COMMAND = Command.toLocalizedCommand({
+    export const PIN_PREVIEW_COMMAND = Command.toDefaultLocalizedCommand({
         id: 'workbench.action.keepEditor',
         category: CommonCommands.VIEW_CATEGORY,
         label: 'Keep Editor',
-    }, 'vscode/editor.contribution/keepEditor', CommonCommands.VIEW_CATEGORY_KEY);
+    });
 }
 
 @injectable()
@@ -62,7 +62,7 @@ export class EditorPreviewContribution implements CommandContribution, MenuContr
     registerMenus(registry: MenuModelRegistry): void {
         registry.registerMenuAction(SHELL_TABBAR_CONTEXT_MENU, {
             commandId: EditorPreviewCommands.PIN_PREVIEW_COMMAND.id,
-            label: nls.localize('vscode/editor.contribution/keepOpen', 'Keep Open'),
+            label: nls.localizeByDefault('Keep Open'),
             order: '6',
         });
     }

--- a/packages/editor-preview/src/browser/editor-preview-preferences.ts
+++ b/packages/editor-preview/src/browser/editor-preview-preferences.ts
@@ -23,7 +23,8 @@ export const EditorPreviewConfigSchema: PreferenceSchema = {
     properties: {
         'editor.enablePreview': {
             type: 'boolean',
-            description: nls.localize('vscode/workbench.contribution/enablePreview', 'Controls whether editors are opened as previews when selected or single-clicked.'),
+            // eslint-disable-next-line max-len
+            description: nls.localizeByDefault('Controls whether opened editors show as preview. Preview editors do not keep open and are reused until explicitly set to be kept open (e.g. via double click or editing) and show up with an italic font style.'),
             default: true
         },
     }

--- a/packages/editor/src/browser/editor-command.ts
+++ b/packages/editor/src/browser/editor-command.ts
@@ -28,8 +28,8 @@ import { nls } from '@theia/core/lib/common/nls';
 
 export namespace EditorCommands {
 
-    const EDITOR_CATEGORY_KEY = 'vscode/textEditor/editor';
     const EDITOR_CATEGORY = 'Editor';
+    const EDITOR_CATEGORY_KEY = nls.getDefaultKey(EDITOR_CATEGORY);
 
     export const GOTO_LINE_COLUMN = Command.toLocalizedCommand({
         id: 'editor.action.gotoLine',
@@ -49,75 +49,75 @@ export namespace EditorCommands {
         id: 'textEditor.commands.configIndentation'
     };
 
-    export const CONFIG_EOL = Command.toLocalizedCommand({
+    export const CONFIG_EOL = Command.toDefaultLocalizedCommand({
         id: 'textEditor.commands.configEol',
         category: EDITOR_CATEGORY,
         label: 'Change End of Line Sequence'
-    }, 'vscode/editorStatus/selectEOL', EDITOR_CATEGORY_KEY);
+    });
 
-    export const INDENT_USING_SPACES = Command.toLocalizedCommand({
+    export const INDENT_USING_SPACES = Command.toDefaultLocalizedCommand({
         id: 'textEditor.commands.indentUsingSpaces',
         category: EDITOR_CATEGORY,
         label: 'Indent Using Spaces'
-    }, 'vscode/indentation/indentUsingSpaces', EDITOR_CATEGORY_KEY);
-    export const INDENT_USING_TABS = Command.toLocalizedCommand({
+    });
+    export const INDENT_USING_TABS = Command.toDefaultLocalizedCommand({
         id: 'textEditor.commands.indentUsingTabs',
         category: EDITOR_CATEGORY,
         label: 'Indent Using Tabs'
-    }, 'vscode/indentation/indentUsingTabs', EDITOR_CATEGORY_KEY);
-    export const CHANGE_LANGUAGE = Command.toLocalizedCommand({
+    });
+    export const CHANGE_LANGUAGE = Command.toDefaultLocalizedCommand({
         id: 'textEditor.change.language',
         category: EDITOR_CATEGORY,
         label: 'Change Language Mode'
-    }, 'vscode/editorStatus/changeMode', EDITOR_CATEGORY_KEY);
-    export const CHANGE_ENCODING = Command.toLocalizedCommand({
+    });
+    export const CHANGE_ENCODING = Command.toDefaultLocalizedCommand({
         id: 'textEditor.change.encoding',
         category: EDITOR_CATEGORY,
         label: 'Change File Encoding'
-    }, 'vscode/editorStatus/changeEncoding', EDITOR_CATEGORY_KEY);
-    export const REVERT_EDITOR = Command.toLocalizedCommand({
+    });
+    export const REVERT_EDITOR = Command.toDefaultLocalizedCommand({
         id: 'workbench.action.files.revert',
         category: CommonCommands.FILE_CATEGORY,
         label: 'Revert File',
-    }, 'vscode/fileActions.contribution/revert', CommonCommands.FILE_CATEGORY_KEY);
-    export const REVERT_AND_CLOSE = Command.toLocalizedCommand({
+    });
+    export const REVERT_AND_CLOSE = Command.toDefaultLocalizedCommand({
         id: 'workbench.action.revertAndCloseActiveEditor',
         category: CommonCommands.VIEW_CATEGORY,
         label: 'Revert and Close Editor'
-    }, 'vscode/editorActions/revertAndCloseActiveEditor', EDITOR_CATEGORY_KEY);
+    });
 
     /**
      * Command for going back to the last editor navigation location.
      */
-    export const GO_BACK = Command.toLocalizedCommand({
+    export const GO_BACK = Command.toDefaultLocalizedCommand({
         id: 'textEditor.commands.go.back',
         category: EDITOR_CATEGORY,
         label: 'Go Back'
-    }, 'vscode/editorActions/navigatePrevious', EDITOR_CATEGORY_KEY);
+    });
     /**
      * Command for going to the forthcoming editor navigation location.
      */
-    export const GO_FORWARD = Command.toLocalizedCommand({
+    export const GO_FORWARD = Command.toDefaultLocalizedCommand({
         id: 'textEditor.commands.go.forward',
         category: EDITOR_CATEGORY,
         label: 'Go Forward'
-    }, 'vscode/editorActions/navigateNext', EDITOR_CATEGORY_KEY);
+    });
     /**
      * Command that reveals the last text edit location, if any.
      */
-    export const GO_LAST_EDIT = Command.toLocalizedCommand({
+    export const GO_LAST_EDIT = Command.toDefaultLocalizedCommand({
         id: 'textEditor.commands.go.lastEdit',
         category: EDITOR_CATEGORY,
         label: 'Go to Last Edit Location'
-    }, 'vscode/editorActions/navigateToLastEditLocation', EDITOR_CATEGORY_KEY);
+    });
     /**
      * Command that clears the editor navigation history.
      */
-    export const CLEAR_EDITOR_HISTORY = Command.toLocalizedCommand({
+    export const CLEAR_EDITOR_HISTORY = Command.toDefaultLocalizedCommand({
         id: 'textEditor.commands.clear.history',
         category: EDITOR_CATEGORY,
         label: 'Clear Editor History'
-    }, 'vscode/editorActions/clearEditorHistory', EDITOR_CATEGORY_KEY);
+    });
     /**
      * Command that displays all editors that are currently opened.
      */
@@ -129,74 +129,74 @@ export namespace EditorCommands {
     /**
      * Command that toggles the minimap.
      */
-    export const TOGGLE_MINIMAP = Command.toLocalizedCommand({
+    export const TOGGLE_MINIMAP = Command.toDefaultLocalizedCommand({
         id: 'editor.action.toggleMinimap',
         category: CommonCommands.VIEW_CATEGORY,
         label: 'Toggle Minimap'
-    }, 'vscode/toggleMinimap/toggleMinimap', EDITOR_CATEGORY_KEY);
+    });
     /**
      * Command that toggles the rendering of whitespace characters in the editor.
      */
-    export const TOGGLE_RENDER_WHITESPACE = Command.toLocalizedCommand({
+    export const TOGGLE_RENDER_WHITESPACE = Command.toDefaultLocalizedCommand({
         id: 'editor.action.toggleRenderWhitespace',
         category: CommonCommands.VIEW_CATEGORY,
         label: 'Toggle Render Whitespace'
-    }, 'vscode/toggleRenderWhitespace/toggleRenderWhitespace', EDITOR_CATEGORY_KEY);
+    });
     /**
      * Command that toggles the word wrap.
      */
-    export const TOGGLE_WORD_WRAP = Command.toLocalizedCommand({
+    export const TOGGLE_WORD_WRAP = Command.toDefaultLocalizedCommand({
         id: 'editor.action.toggleWordWrap',
         category: CommonCommands.VIEW_CATEGORY,
         label: 'Toggle Word Wrap'
-    }, 'vscode/toggleWordWrap/miToggleWordWrap', EDITOR_CATEGORY_KEY);
+    });
     /**
      * Command that re-opens the last closed editor.
      */
-    export const REOPEN_CLOSED_EDITOR = Command.toLocalizedCommand({
+    export const REOPEN_CLOSED_EDITOR = Command.toDefaultLocalizedCommand({
         id: 'workbench.action.reopenClosedEditor',
         category: CommonCommands.VIEW_CATEGORY,
         label: 'Reopen Closed Editor'
-    }, 'vscode/editorActions/reopenClosedEditor', EDITOR_CATEGORY_KEY);
+    });
     /**
      * Opens a second instance of the current editor, splitting the view in the direction specified.
      */
-    export const SPLIT_EDITOR_RIGHT = Command.toLocalizedCommand({
+    export const SPLIT_EDITOR_RIGHT = Command.toDefaultLocalizedCommand({
         id: 'workbench.action.splitEditorRight',
         category: CommonCommands.VIEW_CATEGORY,
         label: 'Split Editor Right'
-    }, 'vscode/editorActions/splitEditorGroupRight', EDITOR_CATEGORY_KEY);
-    export const SPLIT_EDITOR_DOWN = Command.toLocalizedCommand({
+    });
+    export const SPLIT_EDITOR_DOWN = Command.toDefaultLocalizedCommand({
         id: 'workbench.action.splitEditorDown',
         category: CommonCommands.VIEW_CATEGORY,
         label: 'Split Editor Down'
-    }, 'vscode/editorActions/splitEditorGroupDown', EDITOR_CATEGORY_KEY);
-    export const SPLIT_EDITOR_UP = Command.toLocalizedCommand({
+    });
+    export const SPLIT_EDITOR_UP = Command.toDefaultLocalizedCommand({
         id: 'workbench.action.splitEditorUp',
         category: CommonCommands.VIEW_CATEGORY,
         label: 'Split Editor Up'
-    }, 'vscode/editorActions/splitEditorGroupUp', EDITOR_CATEGORY_KEY);
-    export const SPLIT_EDITOR_LEFT = Command.toLocalizedCommand({
+    });
+    export const SPLIT_EDITOR_LEFT = Command.toDefaultLocalizedCommand({
         id: 'workbench.action.splitEditorLeft',
         category: CommonCommands.VIEW_CATEGORY,
         label: 'Split Editor Left'
-    }, 'vscode/editorActions/splitEditorGroupLeft', EDITOR_CATEGORY_KEY);
+    });
     /**
      * Default horizontal split: right.
      */
-    export const SPLIT_EDITOR_HORIZONTAL = Command.toLocalizedCommand({
+    export const SPLIT_EDITOR_HORIZONTAL = Command.toDefaultLocalizedCommand({
         id: 'workbench.action.splitEditor',
         category: CommonCommands.VIEW_CATEGORY,
         label: 'Split Editor'
-    }, 'vscode/editorActions/splitEditor', EDITOR_CATEGORY_KEY);
+    });
     /**
      * Default vertical split: down.
      */
-    export const SPLIT_EDITOR_VERTICAL = Command.toLocalizedCommand({
+    export const SPLIT_EDITOR_VERTICAL = Command.toDefaultLocalizedCommand({
         id: 'workbench.action.splitEditorOrthogonal',
         category: CommonCommands.VIEW_CATEGORY,
         label: 'Split Editor Orthogonal'
-    }, 'vscode/editorActions/splitEditorOrthogonal', EDITOR_CATEGORY_KEY);
+    });
 }
 
 @injectable()
@@ -286,11 +286,11 @@ export class EditorCommandContribution implements CommandContribution {
         }
         const current = editor.document.languageId;
         const items: Array<QuickPickValue<'autoDetect' | Language> | QuickPickItem> = [
-            { label: nls.localize('vscode/editorStatus/autoDetect', 'Auto Detect'), value: 'autoDetect' },
-            { type: 'separator', label: nls.localize('vscode/editorStatus/languagesPicks', 'languages (identifier)') },
+            { label: nls.localizeByDefault('Auto Detect'), value: 'autoDetect' },
+            { type: 'separator', label: nls.localizeByDefault('languages (identifier)') },
             ... (this.languages.languages.map(language => this.toQuickPickLanguage(language, current))).sort((e, e2) => e.label.localeCompare(e2.label))
         ];
-        const selectedMode = await this.quickInputService?.showQuickPick(items, { placeholder: nls.localize('vscode/editorStatus/selectLanguageMode', 'Select Language Mode') });
+        const selectedMode = await this.quickInputService?.showQuickPick(items, { placeholder: nls.localizeByDefault('Select Language Mode') });
         if (selectedMode && ('value' in selectedMode)) {
             if (selectedMode.value === 'autoDetect') {
                 editor.detectLanguage();
@@ -311,13 +311,13 @@ export class EditorCommandContribution implements CommandContribution {
         if (!editor) {
             return;
         }
-        const reopenWithEncodingPick = { label: nls.localize('vscode/editorStatus/reopenWithEncoding', 'Reopen with Encoding'), value: 'reopen' };
-        const saveWithEncodingPick = { label: nls.localize('vscode/editorStatus/saveWithEncoding', 'Save with Encoding'), value: 'save' };
+        const reopenWithEncodingPick = { label: nls.localizeByDefault('Reopen with Encoding'), value: 'reopen' };
+        const saveWithEncodingPick = { label: nls.localizeByDefault('Save with Encoding'), value: 'save' };
         const actionItems: QuickPickValue<string>[] = [
             reopenWithEncodingPick,
             saveWithEncodingPick
         ];
-        const selectedEncoding = await this.quickInputService?.showQuickPick(actionItems, { placeholder: nls.localize('vscode/editorStatus/pickAction', 'Select Action') });
+        const selectedEncoding = await this.quickInputService?.showQuickPick(actionItems, { placeholder: nls.localizeByDefault('Select Action') });
         if (!selectedEncoding) {
             return;
         }
@@ -350,14 +350,14 @@ export class EditorCommandContribution implements CommandContribution {
         // Insert guessed encoding
         if (guessedEncoding && configuredEncoding !== guessedEncoding && SUPPORTED_ENCODINGS[guessedEncoding]) {
             encodingItems.unshift({
-                label: `${nls.localize('vscode/editorStatus/guessedEncoding', 'Guessed from content')}: ${SUPPORTED_ENCODINGS[guessedEncoding].labelLong}`,
+                label: `${nls.localizeByDefault('Guessed from content')}: ${SUPPORTED_ENCODINGS[guessedEncoding].labelLong}`,
                 value: { id: guessedEncoding, description: guessedEncoding }
             });
         }
         const selectedFileEncoding = await this.quickInputService?.showQuickPick<QuickPickValue<{ id: string, description: string }>>(encodingItems, {
             placeholder: isReopenWithEncoding ?
-                nls.localize('vscode/editorStatus/pickEncodingForReopen', 'Select File Encoding to Reopen File') :
-                nls.localize('vscode/editorStatus/pickEncodingForSave', 'Select File Encoding to Save with')
+                nls.localizeByDefault('Select File Encoding to Reopen File') :
+                nls.localizeByDefault('Select File Encoding to Save with')
         });
 
         if (!selectedFileEncoding) {
@@ -379,7 +379,7 @@ export class EditorCommandContribution implements CommandContribution {
         return {
             value,
             label: value.name,
-            description: nls.localize(`vscode/editorStatus/languageDescription${configured ? '' : 'Configured'}`, `({0})${configured ? ' - Configured Language' : ''}`),
+            description: nls.localizeByDefault(`({0})${configured ? ' - Configured Language' : ''}`),
             iconClasses
         };
     }

--- a/packages/editor/src/browser/editor-contribution.ts
+++ b/packages/editor/src/browser/editor-contribution.ts
@@ -95,7 +95,7 @@ export class EditorContribution implements FrontendApplicationContribution, Comm
             alignment: StatusBarAlignment.RIGHT,
             priority: 1,
             command: EditorCommands.CHANGE_LANGUAGE.id,
-            tooltip: nls.localize('vscode/editorStatus/selectLanguageMode', 'Select Language Mode')
+            tooltip: nls.localizeByDefault('Select Language Mode')
         });
     }
 
@@ -109,7 +109,7 @@ export class EditorContribution implements FrontendApplicationContribution, Comm
             alignment: StatusBarAlignment.RIGHT,
             priority: 10,
             command: EditorCommands.CHANGE_ENCODING.id,
-            tooltip: nls.localize('vscode/editorStatus/selectEncoding', 'Select Encoding')
+            tooltip: nls.localizeByDefault('Select Encoding')
         });
     }
 
@@ -120,7 +120,7 @@ export class EditorContribution implements FrontendApplicationContribution, Comm
         }
         const { cursor } = editor;
         this.statusBar.setElement('editor-status-cursor-position', {
-            text: nls.localize('vscode/editorStatus/singleSelection', 'Ln {0}, Col {1}', (cursor.line + 1).toString(), editor.getVisibleColumn(cursor).toString()),
+            text: nls.localizeByDefault('Ln {0}, Col {1}', cursor.line + 1, editor.getVisibleColumn(cursor)),
             alignment: StatusBarAlignment.RIGHT,
             priority: 100,
             tooltip: EditorCommands.GOTO_LINE_COLUMN.label,

--- a/packages/editor/src/browser/editor-menu.ts
+++ b/packages/editor/src/browser/editor-menu.ts
@@ -87,7 +87,7 @@ export class EditorMenuContribution implements MenuContribution {
         });
 
         // Editor navigation. Go > Back and Go > Forward.
-        registry.registerSubmenu(EditorMainMenu.GO, nls.localize('vscode/menubar/mGoto', 'Go'));
+        registry.registerSubmenu(EditorMainMenu.GO, nls.localizeByDefault('Go'));
         registry.registerMenuAction(EditorMainMenu.NAVIGATION_GROUP, {
             commandId: EditorCommands.GO_BACK.id,
             label: EditorCommands.GO_BACK.label,
@@ -100,7 +100,7 @@ export class EditorMenuContribution implements MenuContribution {
         });
         registry.registerMenuAction(EditorMainMenu.NAVIGATION_GROUP, {
             commandId: EditorCommands.GO_LAST_EDIT.id,
-            label: nls.localize('vscode/editor.contribution/miLastEditLocation', 'Last Edit Location'),
+            label: nls.localizeByDefault('Last Edit Location'),
             order: '3'
         });
 
@@ -127,7 +127,7 @@ export class EditorMenuContribution implements MenuContribution {
         });
         registry.registerMenuAction(CommonMenus.FILE_CLOSE, {
             commandId: CommonCommands.CLOSE_MAIN_TAB.id,
-            label: nls.localize('vscode/editor.contribution/closeEditor', 'Close Editor'),
+            label: nls.localizeByDefault('Close Editor'),
             order: '1'
         });
     }

--- a/packages/editor/src/browser/editor-preferences.ts
+++ b/packages/editor/src/browser/editor-preferences.ts
@@ -78,7 +78,7 @@ const codeEditorPreferenceProperties = {
         'type': 'number',
         'default': EDITOR_MODEL_DEFAULTS.tabSize,
         'minimum': 1,
-        'markdownDescription': nls.localize('vscode/commonEditorConfig/tabSize', 'The number of spaces a tab is equal to. This setting is overridden based on the file contents when `#editor.detectIndentation#` is on.')
+        'markdownDescription': nls.localizeByDefault('The number of spaces a tab is equal to. This setting is overridden based on the file contents when `#editor.detectIndentation#` is on.')
     },
     'editor.defaultFormatter': {
         'type': 'string',
@@ -88,105 +88,105 @@ const codeEditorPreferenceProperties = {
     'editor.insertSpaces': {
         'type': 'boolean',
         'default': EDITOR_MODEL_DEFAULTS.insertSpaces,
-        'markdownDescription': nls.localize('vscode/commonEditorConfig/insertSpaces', 'Insert spaces when pressing `Tab`. This setting is overridden based on the file contents when `#editor.detectIndentation#` is on.')
+        'markdownDescription': nls.localizeByDefault('Insert spaces when pressing `Tab`. This setting is overridden based on the file contents when `#editor.detectIndentation#` is on.')
     },
     'editor.detectIndentation': {
         'type': 'boolean',
         'default': EDITOR_MODEL_DEFAULTS.detectIndentation,
-        'markdownDescription': nls.localize('vscode/commonEditorConfig/detectIndentation', 'Controls whether `#editor.tabSize#` and `#editor.insertSpaces#` will be automatically detected when a file is opened based on the file contents.')
+        'markdownDescription': nls.localizeByDefault('Controls whether `#editor.tabSize#` and `#editor.insertSpaces#` will be automatically detected when a file is opened based on the file contents.')
     },
     'editor.trimAutoWhitespace': {
         'type': 'boolean',
         'default': EDITOR_MODEL_DEFAULTS.trimAutoWhitespace,
-        'description': nls.localize('vscode/commonEditorConfig/trimAutoWhitespace', 'Remove trailing auto inserted whitespace.')
+        'description': nls.localizeByDefault('Remove trailing auto inserted whitespace.')
     },
     'editor.largeFileOptimizations': {
         'type': 'boolean',
         'default': EDITOR_MODEL_DEFAULTS.largeFileOptimizations,
-        'description': nls.localize('vscode/commonEditorConfig/largeFileOptimizations', 'Special handling for large files to disable certain memory intensive features.')
+        'description': nls.localizeByDefault('Special handling for large files to disable certain memory intensive features.')
     },
     'editor.wordBasedSuggestions': {
         'type': 'boolean',
         'default': true,
-        'description': nls.localize('vscode/commonEditorConfig/wordBasedSuggestions', 'Controls whether completions should be computed based on words in the document.')
+        'description': nls.localizeByDefault('Controls whether completions should be computed based on words in the document.')
     },
     'editor.wordBasedSuggestionsMode': {
         'enum': ['currentDocument', 'matchingDocuments', 'allDocuments'],
         'default': 'matchingDocuments',
         'enumDescriptions': [
-            nls.localize('vscode/commonEditorConfig/wordBasedSuggestionsMode.currentDocument', 'Only suggest words from the active document.'),
-            nls.localize('vscode/commonEditorConfig/wordBasedSuggestionsMode.matchingDocuments', 'Suggest words from all open documents of the same language.'),
-            nls.localize('vscode/commonEditorConfig/wordBasedSuggestionsMode.allDocuments', 'Suggest words from all open documents.')
+            nls.localizeByDefault('Only suggest words from the active document.'),
+            nls.localizeByDefault('Suggest words from all open documents of the same language.'),
+            nls.localizeByDefault('Suggest words from all open documents.')
         ],
-        'description': nls.localize('vscode/commonEditorConfig/wordBasedSuggestionsMode', 'Controls form what documents word based completions are computed.')
+        'description': nls.localizeByDefault('Controls form what documents word based completions are computed.')
     },
     'editor.semanticHighlighting.enabled': {
         'enum': [true, false, 'configuredByTheme'],
         'enumDescriptions': [
-            nls.localize('vscode/commonEditorConfig/semanticHighlighting.true', 'Semantic highlighting enabled for all color themes.'),
-            nls.localize('vscode/commonEditorConfig/semanticHighlighting.false', 'Semantic highlighting disabled for all color themes.'),
-            nls.localize('vscode/commonEditorConfig/semanticHighlighting.configuredByTheme', 'Semantic highlighting is configured by the current color theme\'s `semanticHighlighting` setting.')
+            nls.localizeByDefault('Semantic highlighting enabled for all color themes.'),
+            nls.localizeByDefault('Semantic highlighting disabled for all color themes.'),
+            nls.localizeByDefault('Semantic highlighting is configured by the current color theme\'s `semanticHighlighting` setting.')
         ],
         'default': 'configuredByTheme',
-        'description': nls.localize('vscode/commonEditorConfig/emanticHighlighting.enabled', 'Controls whether the semanticHighlighting is shown for the languages that support it.')
+        'description': nls.localizeByDefault('Controls whether the semanticHighlighting is shown for the languages that support it.')
     },
     'editor.stablePeek': {
         'type': 'boolean',
         'default': false,
-        'markdownDescription': nls.localize('vscode/commonEditorConfig/stablePeek', 'Keep peek editors open even when double clicking their content or when hitting `Escape`.')
+        'markdownDescription': nls.localizeByDefault('Keep peek editors open even when double clicking their content or when hitting `Escape`.')
     },
     'editor.maxTokenizationLineLength': {
         'type': 'integer',
         'default': 400,
-        'description': nls.localize('vscode/commonEditorConfig/maxTokenizationLineLength', 'Lines above this length will not be tokenized for performance reasons.')
+        'description': nls.localizeByDefault('Lines above this length will not be tokenized for performance reasons')
     },
     'diffEditor.maxComputationTime': {
         'type': 'number',
         'default': 5000,
-        'description': nls.localize('vscode/commonEditorConfig/maxComputationTime', 'Timeout in milliseconds after which diff computation is cancelled. Use 0 for no timeout.')
+        'description': nls.localizeByDefault('Timeout in milliseconds after which diff computation is cancelled. Use 0 for no timeout.')
     },
     'diffEditor.renderSideBySide': {
         'type': 'boolean',
         'default': true,
-        'description': nls.localize('vscode/commonEditorConfig/sideBySide', 'Controls whether the diff editor shows the diff side by side or inline.')
+        'description': nls.localizeByDefault('Controls whether the diff editor shows the diff side by side or inline.')
     },
     'diffEditor.ignoreTrimWhitespace': {
         'type': 'boolean',
         'default': true,
-        'description': nls.localize('vscode/commonEditorConfig/ignoreTrimWhitespace', 'When enabled, the diff editor ignores changes in leading or trailing whitespace.')
+        'description': nls.localizeByDefault('When enabled, the diff editor ignores changes in leading or trailing whitespace.')
     },
     'diffEditor.renderIndicators': {
         'type': 'boolean',
         'default': true,
-        'description': nls.localize('vscode/commonEditorConfig/renderIndicators', 'Controls whether the diff editor shows +/- indicators for added/removed changes.')
+        'description': nls.localizeByDefault('Controls whether the diff editor shows +/- indicators for added/removed changes.')
     },
     'diffEditor.codeLens': {
         'type': 'boolean',
         'default': false,
-        'description': nls.localize('vscode/commonEditorConfig/codeLens', 'Controls whether the editor shows CodeLens.')
+        'description': nls.localizeByDefault('Controls whether the editor shows CodeLens.')
     },
     'diffEditor.wordWrap': {
         'type': 'string',
         'enum': ['off', 'on', 'inherit'],
         'default': 'inherit',
         'markdownEnumDescriptions': [
-            nls.localize('vscode/commonEditorConfig/wordWrap.off', 'Lines will never wrap.'),
-            nls.localize('vscode/commonEditorConfig/wordWrap.on', 'Lines will wrap at the viewport width.'),
-            nls.localize('vscode/commonEditorConfig/wordWrap.inherit', 'Lines will wrap according to the `#editor.wordWrap#` setting.')
+            nls.localizeByDefault('Lines will never wrap.'),
+            nls.localizeByDefault('Lines will wrap at the viewport width.'),
+            nls.localizeByDefault('Lines will wrap according to the `#editor.wordWrap#` setting.')
         ]
     },
     'editor.acceptSuggestionOnCommitCharacter': {
-        'markdownDescription': nls.localize('vscode/editorOptions/acceptSuggestionOnCommitCharacter', 'Controls whether suggestions should be accepted on commit characters. For example, in JavaScript, the semi-colon (`;`) can be a commit character that accepts a suggestion and types that character.'),
+        'markdownDescription': nls.localizeByDefault('Controls whether suggestions should be accepted on commit characters. For example, in JavaScript, the semi-colon (`;`) can be a commit character that accepts a suggestion and types that character.'),
         'type': 'boolean',
         'default': true
     },
     'editor.acceptSuggestionOnEnter': {
         'markdownEnumDescriptions': [
             '',
-            nls.localize('vscode/editorOptions/acceptSuggestionOnEnterSmart', 'Only accept a suggestion with `Enter` when it makes a textual change.'),
+            nls.localizeByDefault('Only accept a suggestion with `Enter` when it makes a textual change.'),
             ''
         ],
-        'markdownDescription': nls.localize('vscode/editorOptions/acceptSuggestionOnEnter', 'Controls whether suggestions should be accepted on `Enter`, in addition to `Tab`. Helps to avoid ambiguity between inserting new lines or accepting suggestions.'),
+        'markdownDescription': nls.localizeByDefault('Controls whether suggestions should be accepted on `Enter`, in addition to `Tab`. Helps to avoid ambiguity between inserting new lines or accepting suggestions.'),
         'type': 'string',
         'enum': [
             'on',
@@ -203,15 +203,15 @@ const codeEditorPreferenceProperties = {
             'off'
         ],
         'enumDescriptions': [
-            nls.localize('vscode/editorOptions/accessibilitySupport.auto', 'The editor will use platform APIs to detect when a Screen Reader is attached.'),
-            nls.localize('vscode/editorOptions/accessibilitySupport.on', 'The editor will be permanently optimized for usage with a Screen Reader.'),
-            nls.localize('vscode/editorOptions/accessibilitySupport.off', 'The editor will never be optimized for usage with a Screen Reader.')
+            nls.localizeByDefault('The editor will use platform APIs to detect when a Screen Reader is attached.'),
+            nls.localizeByDefault('The editor will be permanently optimized for usage with a Screen Reader. Word wrapping will be disabled.'),
+            nls.localizeByDefault('The editor will never be optimized for usage with a Screen Reader.')
         ],
         'default': 'auto',
-        'description': nls.localize('vscode/editorOptions/accessibilitySupport', 'Controls whether the editor should run in a mode where it is optimized for screen readers.')
+        'description': nls.localizeByDefault('Controls whether the editor should run in a mode where it is optimized for screen readers. Setting to on will disable word wrapping.')
     },
     'editor.accessibilityPageSize': {
-        'description': nls.localize('vscode/editorOptions/accessibilityPageSize', 'Controls the number of lines in the editor that can be read out by a screen reader. Warning: this has a performance implication for numbers larger than the default.'),
+        'description': nls.localizeByDefault('Controls the number of lines in the editor that can be read out by a screen reader. Warning: this has a performance implication for numbers larger than the default.'),
         'type': 'integer',
         'default': 10,
         'minimum': 1,
@@ -220,11 +220,11 @@ const codeEditorPreferenceProperties = {
     'editor.autoClosingBrackets': {
         'enumDescriptions': [
             '',
-            nls.localize('vscode/editorOptions/languageDefined', 'Use language configurations to determine when to autoclose brackets.'),
-            nls.localize('vscode/editorOptions/beforeWhitespace', 'Autoclose brackets only when the cursor is to the left of whitespace.'),
+            nls.localizeByDefault('Use language configurations to determine when to autoclose brackets.'),
+            nls.localizeByDefault('Autoclose brackets only when the cursor is to the left of whitespace.'),
             ''
         ],
-        'description': nls.localize('vscode/editorOptions/autoClosingBrackets', 'Controls whether the editor should automatically close brackets after the user adds an opening bracket.'),
+        'description': nls.localizeByDefault('Controls whether the editor should automatically close brackets after the user adds an opening bracket.'),
         'type': 'string',
         'enum': [
             'always',
@@ -237,10 +237,10 @@ const codeEditorPreferenceProperties = {
     'editor.autoClosingOvertype': {
         'enumDescriptions': [
             '',
-            nls.localize('vscode/editorOptions/editor.autoClosingDelete.auto', 'Type over closing quotes or brackets only if they were automatically inserted.'),
+            nls.localizeByDefault('Type over closing quotes or brackets only if they were automatically inserted.'),
             ''
         ],
-        'description': nls.localize('vscode/editorOptions/autoClosingDelete', 'Controls whether the editor should type over closing quotes or brackets.'),
+        'description': nls.localizeByDefault('Controls whether the editor should type over closing quotes or brackets.'),
         'type': 'string',
         'enum': [
             'always',
@@ -252,11 +252,11 @@ const codeEditorPreferenceProperties = {
     'editor.autoClosingQuotes': {
         'enumDescriptions': [
             '',
-            nls.localize('vscode/editorOptions/editor.autoClosingQuotes.languageDefined', 'Use language configurations to determine when to autoclose quotes.'),
-            nls.localize('vscode/editorOptions/editor.autoClosingQuotes.beforeWhitespace', 'Autoclose quotes only when the cursor is to the left of whitespace.'),
+            nls.localizeByDefault('Use language configurations to determine when to autoclose quotes.'),
+            nls.localizeByDefault('Autoclose quotes only when the cursor is to the left of whitespace.'),
             ''
         ],
-        'description': nls.localize('vscode/editorOptions/autoClosingQuotes', 'Controls whether the editor should automatically close quotes after the user adds an opening quote.'),
+        'description': nls.localizeByDefault('Controls whether the editor should automatically close quotes after the user adds an opening quote.'),
         'type': 'string',
         'enum': [
             'always',
@@ -268,13 +268,13 @@ const codeEditorPreferenceProperties = {
     },
     'editor.autoIndent': {
         'enumDescriptions': [
-            nls.localize('vscode/editorOptions/editor.autoIndent.none', 'The editor will not insert indentation automatically.'),
-            nls.localize('vscode/editorOptions/editor.autoIndent.keep', 'The editor will keep the current line\'s indentation.'),
-            nls.localize('vscode/editorOptions/editor.autoIndent.brackets', 'The editor will keep the current line\'s indentation and honor language defined brackets.'),
-            nls.localize('vscode/editorOptions/editor.autoIndent.advanced', 'The editor will keep the current line\'s indentation, honor language defined brackets and invoke special onEnterRules defined by languages.'),
-            nls.localize('vscode/editorOptions/editor.autoIndent.full', 'The editor will keep the current line\'s indentation, honor language defined brackets, invoke special onEnterRules defined by languages, and honor indentationRules defined by languages.')
+            nls.localizeByDefault('The editor will not insert indentation automatically.'),
+            nls.localizeByDefault('The editor will keep the current line\'s indentation.'),
+            nls.localizeByDefault('The editor will keep the current line\'s indentation and honor language defined brackets.'),
+            nls.localizeByDefault('The editor will keep the current line\'s indentation, honor language defined brackets and invoke special onEnterRules defined by languages.'),
+            nls.localizeByDefault('The editor will keep the current line\'s indentation, honor language defined brackets, invoke special onEnterRules defined by languages, and honor indentationRules defined by languages.')
         ],
-        'description': nls.localize('vscode/editorOptions/autoIndent', 'Controls whether the editor should automatically adjust the indentation when users type, paste, move or indent lines.'),
+        'description': nls.localizeByDefault('Controls whether the editor should automatically adjust the indentation when users type, paste, move or indent lines.'),
         'type': 'string',
         'enum': [
             'none',
@@ -287,12 +287,12 @@ const codeEditorPreferenceProperties = {
     },
     'editor.autoSurround': {
         'enumDescriptions': [
-            nls.localize('vscode/editorOptions/editor.autoSurround.languageDefined', 'Use language configurations to determine when to automatically surround selections.'),
-            nls.localize('vscode/editorOptions/editor.autoSurround.quotes', 'Surround with quotes but not brackets.'),
-            nls.localize('vscode/editorOptions/editor.autoSurround.brackets', 'Surround with brackets but not quotes.'),
+            nls.localizeByDefault('Use language configurations to determine when to automatically surround selections.'),
+            nls.localizeByDefault('Surround with quotes but not brackets.'),
+            nls.localizeByDefault('Surround with brackets but not quotes.'),
             ''
         ],
-        'description': nls.localize('vscode/editorOptions/autoSurround', 'Controls whether the editor should automatically surround selections.'),
+        'description': nls.localizeByDefault('Controls whether the editor should automatically surround selections when typing quotes or brackets.'),
         'type': 'string',
         'enum': [
             'languageDefined',
@@ -313,12 +313,12 @@ const codeEditorPreferenceProperties = {
         'description': nls.localize('theia/editor/automaticLayout', 'Enable that the editor will install an interval to check if its container dom node size has changed. Enabling this might have a severe performance impact.')
     },
     'editor.codeLens': {
-        'description': nls.localize('vscode/editorOptions/codeLens', 'Controls whether the editor shows CodeLens.'),
+        'description': nls.localizeByDefault('Controls whether the editor shows CodeLens.'),
         'type': 'boolean',
         'default': true
     },
     'editor.codeLensFontFamily': {
-        'description': nls.localize('vscode/editorOptions/codeLensFontFamily', 'Controls the font family for CodeLens.'),
+        'description': nls.localizeByDefault('Controls the font family for CodeLens.'),
         'type': 'string',
         'default': true
     },
@@ -327,22 +327,22 @@ const codeEditorPreferenceProperties = {
         'default': 0,
         'minimum': 0,
         'maximum': 100,
-        'description': nls.localize('vscode/editorOptions/codeLensFontSize', 'Controls the font size in pixels for CodeLens. When set to `0`, the 90% of `#editor.fontSize#` is used.')
+        'description': nls.localizeByDefault('Controls the font size in pixels for CodeLens. When set to `0`, the 90% of `#editor.fontSize#` is used.')
     },
     'editor.colorDecorators': {
-        'description': nls.localize('vscode/editorOptions/colorDecorators', 'Controls whether the editor should render the inline color decorators and color picker.'),
+        'description': nls.localizeByDefault('Controls whether the editor should render the inline color decorators and color picker.'),
         'type': 'boolean',
         'default': true
     },
     'editor.comments.insertSpace': {
         'type': 'boolean',
         'default': true,
-        'description': nls.localize('vscode/editorOptions/comments.insertSpace', 'Controls whether a space character is inserted when commenting.')
+        'description': nls.localizeByDefault('Controls whether a space character is inserted when commenting.')
     },
     'editor.comments.ignoreEmptyLines': {
         'type': 'boolean',
         'default': true,
-        'description': nls.localize('vscode/editorOptions/comments.ignoreEmptyLines', 'Controls if empty lines should be ignored with toggle, add or remove actions for line comments.')
+        'description': nls.localizeByDefault('Controls if empty lines should be ignored with toggle, add or remove actions for line comments.')
     },
     'editor.contextmenu': {
         'description': nls.localize('theia/editor/contextmenu', 'Controls whether to enable the custom contextmenu.'),
@@ -350,12 +350,12 @@ const codeEditorPreferenceProperties = {
         'default': true,
     },
     'editor.copyWithSyntaxHighlighting': {
-        'description': nls.localize('vscode/editorOptions/copyWithSyntaxHighlighting', 'Controls whether syntax highlighting should be copied into the clipboard.'),
+        'description': nls.localizeByDefault('Controls whether syntax highlighting should be copied into the clipboard.'),
         'type': 'boolean',
         'default': true
     },
     'editor.cursorBlinking': {
-        'description': nls.localize('vscode/editorOptions/cursorBlinking', 'Control the cursor animation style.'),
+        'description': nls.localizeByDefault('Control the cursor animation style.'),
         'type': 'string',
         'enum': [
             'blink',
@@ -367,12 +367,12 @@ const codeEditorPreferenceProperties = {
         'default': 'blink'
     },
     'editor.cursorSmoothCaretAnimation': {
-        'description': nls.localize('vscode/editorOptions/cursorSmoothCaretAnimation', 'Controls whether the smooth caret animation should be enabled.'),
+        'description': nls.localizeByDefault('Controls whether the smooth caret animation should be enabled.'),
         'type': 'boolean',
         'default': false
     },
     'editor.cursorStyle': {
-        'description': nls.localize('vscode/editorOptions/cursorStyle', 'Controls the cursor style.'),
+        'description': nls.localizeByDefault('Controls the cursor style.'),
         'type': 'string',
         'enum': [
             'line',
@@ -385,7 +385,7 @@ const codeEditorPreferenceProperties = {
         'default': 'line'
     },
     'editor.cursorSurroundingLines': {
-        'description': nls.localize('vscode/editorOptions/cursorSurroundingLines', 'Controls the minimal number of visible leading and trailing lines surrounding the cursor. Known as `scrollOff` or `scrollOffset` in some other editors.'),
+        'description': nls.localizeByDefault("Controls the minimal number of visible leading and trailing lines surrounding the cursor. Known as 'scrollOff' or 'scrollOffset' in some other editors."),
         'type': 'integer',
         'default': 0,
         'minimum': 0,
@@ -393,10 +393,10 @@ const codeEditorPreferenceProperties = {
     },
     'editor.cursorSurroundingLinesStyle': {
         'enumDescriptions': [
-            nls.localize('vscode/editorOptions/cursorSurroundingLinesStyle.default', '`cursorSurroundingLines` is enforced only when triggered via the keyboard or API.'),
-            nls.localize('vscode/editorOptions/cursorSurroundingLinesStyle.all', '`cursorSurroundingLines` is enforced always.')
+            nls.localizeByDefault('`cursorSurroundingLines` is enforced only when triggered via the keyboard or API.'),
+            nls.localizeByDefault('`cursorSurroundingLines` is enforced always.')
         ],
-        'description': nls.localize('vscode/editorOptions/cursorSurroundingLinesStyle', 'Controls when `cursorSurroundingLines` should be enforced.'),
+        'description': nls.localizeByDefault('Controls when `cursorSurroundingLines` should be enforced.'),
         'type': 'string',
         'enum': [
             'default',
@@ -405,7 +405,7 @@ const codeEditorPreferenceProperties = {
         'default': 'default'
     },
     'editor.cursorWidth': {
-        'markdownDescription': nls.localize('vscode/editorOptions/cursorWidth', 'Controls the width of the cursor when `#editor.cursorStyle#` is set to `line`.'),
+        'markdownDescription': nls.localizeByDefault('Controls the width of the cursor when `#editor.cursorStyle#` is set to `line`.'),
         'type': 'integer',
         'default': 0,
         'minimum': 0,
@@ -422,12 +422,12 @@ const codeEditorPreferenceProperties = {
         'default': false
     },
     'editor.dragAndDrop': {
-        'description': nls.localize('vscode/editorOptions/dragAndDrop', 'Controls whether the editor should allow moving selections via drag and drop.'),
+        'description': nls.localizeByDefault('Controls whether the editor should allow moving selections via drag and drop.'),
         'type': 'boolean',
         'default': true
     },
     'editor.emptySelectionClipboard': {
-        'description': nls.localize('vscode/editorOptions/emptySelectionClipboard', 'Controls whether copying without a selection copies the current line.'),
+        'description': nls.localizeByDefault('Controls whether copying without a selection copies the current line.'),
         'type': 'boolean',
         'default': true
     },
@@ -437,19 +437,19 @@ const codeEditorPreferenceProperties = {
         'default': ''
     },
     'editor.fastScrollSensitivity': {
-        'markdownDescription': nls.localize('vscode/editorOptions/fastScrollSensitivity', 'Scrolling speed multiplier when pressing `Alt`.'),
+        'markdownDescription': nls.localizeByDefault('Scrolling speed multiplier when pressing `Alt`.'),
         'type': 'number',
         'default': 5
     },
     'editor.find.cursorMoveOnType': {
-        'description': nls.localize('vscode/editorOptions/find.cursorMoveOnType', 'Controls whether the cursor should jump to find matches while typing.'),
+        'description': nls.localizeByDefault('Controls whether the cursor should jump to find matches while typing.'),
         'type': 'boolean',
         'default': true
     },
     'editor.find.seedSearchStringFromSelection': {
         'type': 'boolean',
         'default': true,
-        'description': nls.localize('vscode/editorOptions/find.seedSearchStringFromSelection', 'Controls whether the search string in the Find Widget is seeded from the editor selection.')
+        'description': nls.localizeByDefault('Controls whether the search string in the Find Widget is seeded from the editor selection.')
     },
     'editor.find.autoFindInSelection': {
         'type': 'string',
@@ -460,27 +460,27 @@ const codeEditorPreferenceProperties = {
         ],
         'default': 'never',
         'enumDescriptions': [
-            nls.localize('vscode/editorOptions/editor.find.autoFindInSelection.never', 'Never turn on Find in selection automatically (default)'),
-            nls.localize('vscode/editorOptions/editor.find.autoFindInSelection.always', 'Always turn on Find in selection automatically'),
-            nls.localize('vscode/editorOptions/editor.find.autoFindInSelection.multiline', 'Turn on Find in selection automatically when multiple lines of content are selected.')
+            nls.localizeByDefault('Never turn on Find in selection automatically (default)'),
+            nls.localizeByDefault('Always turn on Find in selection automatically'),
+            nls.localizeByDefault('Turn on Find in selection automatically when multiple lines of content are selected.')
         ],
-        'description': nls.localize('vscode/editorOptions/find.autoFindInSelection', 'Controls whether the find operation is carried out on selected text or the entire file in the editor.')
+        'description': nls.localizeByDefault('Controls the condition for turning on find in selection automatically.')
     },
     'editor.find.globalFindClipboard': {
         'type': 'boolean',
         'default': false,
-        'description': nls.localize('vscode/editorOptions/find.globalFindClipboard', 'Controls whether the Find Widget should read or modify the shared find clipboard on macOS.'),
+        'description': nls.localizeByDefault('Controls whether the Find Widget should read or modify the shared find clipboard on macOS.'),
         'included': isOSX
     },
     'editor.find.addExtraSpaceOnTop': {
         'type': 'boolean',
         'default': true,
-        'description': nls.localize('vscode/editorOptions/find.addExtraSpaceOnTop', 'Controls whether the Find Widget should add extra lines on top of the editor. When true, you can scroll beyond the first line when the Find Widget is visible.')
+        'description': nls.localizeByDefault('Controls whether the Find Widget should add extra lines on top of the editor. When true, you can scroll beyond the first line when the Find Widget is visible.')
     },
     'editor.find.loop': {
         'type': 'boolean',
         'default': true,
-        'description': nls.localize('vscode/editorOptions/find.loop', 'Controls whether the search automatically restarts from the beginning (or the end) when no further matches can be found.')
+        'description': nls.localizeByDefault('Controls whether the search automatically restarts from the beginning (or the end) when no further matches can be found.')
     },
     'editor.fixedOverflowWidgets': {
         'markdownDescription': nls.localize('theia/editor/fixedOverflowWidgets', 'Controls whether to display overflow widgets as `fixed`.'),
@@ -488,35 +488,35 @@ const codeEditorPreferenceProperties = {
         'default': false,
     },
     'editor.folding': {
-        'description': nls.localize('vscode/editorOptions/folding', 'Controls whether the editor has code folding enabled.'),
+        'description': nls.localizeByDefault('Controls whether the editor has code folding enabled.'),
         'type': 'boolean',
         'default': true
     },
     'editor.foldingStrategy': {
-        'markdownDescription': nls.localize('vscode/editorOptions/foldingStrategy', 'Controls the strategy for computing folding ranges. `auto` uses a language specific folding strategy, if available. `indentation` uses the indentation based folding strategy.'),
+        'markdownDescription': nls.localizeByDefault('Controls the strategy for computing folding ranges.'),
         'type': 'string',
         'enum': [
             'auto',
             'indentation'
         ],
         'enumDescriptions': [
-            nls.localize('vscode/editorOptions/foldingStrategy.auto', 'Use a language-specific folding strategy if available, else the indentation-based one.'),
-            nls.localize('vscode/editorOptions/foldingStrategy.indentation', 'Use the indentation-based folding strategy.'),
+            nls.localizeByDefault('Use a language-specific folding strategy if available, else the indentation-based one.'),
+            nls.localizeByDefault('Use the indentation-based folding strategy.'),
         ],
         'default': 'auto'
     },
     'editor.foldingHighlight': {
-        'description': nls.localize('vscode/editorOptions/foldingHighlight', 'Controls whether the editor should highlight folded ranges.'),
+        'description': nls.localizeByDefault('Controls whether the editor should highlight folded ranges.'),
         'type': 'boolean',
         'default': true
     },
     'editor.unfoldOnClickAfterEndOfLine': {
-        'description': nls.localize('vscode/editorOptions/unfoldOnClickAfterEndOfLine', 'Controls whether clicking on the empty content after a folded line will unfold the line.'),
+        'description': nls.localizeByDefault('Controls whether clicking on the empty content after a folded line will unfold the line.'),
         'type': 'boolean',
         'default': false
     },
     'editor.fontFamily': {
-        'description': nls.localize('vscode/editorOptions/fontFamily', 'Controls the font family.'),
+        'description': nls.localizeByDefault('Controls the font family.'),
         'type': 'string',
         'default': EDITOR_FONT_DEFAULTS.fontFamily
     },
@@ -524,14 +524,14 @@ const codeEditorPreferenceProperties = {
         'anyOf': [
             {
                 'type': 'boolean',
-                'description': nls.localize('vscode/editorOptions/fontLigatures', 'Enables/Disables font ligatures.')
+                'description': nls.localizeByDefault("Enables/Disables font ligatures ('calt' and 'liga' font features). Change this to a string for fine-grained control of the 'font-feature-settings' CSS property.")
             },
             {
                 'type': 'string',
-                'description': nls.localize('vscode/editorOptions/fontFeatureSettings', 'Explicit font-feature-settings.')
+                'description': nls.localizeByDefault("Explicit 'font-feature-settings' CSS property. A boolean can be passed instead if one only needs to turn on/off ligatures.")
             }
         ],
-        'description': nls.localize('vscode/editorOptions/fontLigaturesGeneral', 'Configures font ligatures.'),
+        'description': nls.localizeByDefault("Configures font ligatures or font features. Can be either a boolean to enable/disable ligatures or a string for the value of the CSS 'font-feature-settings' property."),
         'default': false
     },
     'editor.fontSize': {
@@ -539,7 +539,7 @@ const codeEditorPreferenceProperties = {
         'minimum': 6,
         'maximum': 100,
         'default': EDITOR_FONT_DEFAULTS.fontSize,
-        'description': nls.localize('vscode/editorOptions/fontSize', 'Controls the font size in pixels.')
+        'description': nls.localizeByDefault('Controls the font size in pixels.')
     },
     'editor.fontWeight': {
         'enum': [
@@ -555,32 +555,32 @@ const codeEditorPreferenceProperties = {
             '800',
             '900'
         ],
-        'description': nls.localize('vscode/editorOptions/fontWeight', 'Controls the font weight.'),
+        'description': nls.localizeByDefault('Controls the font weight. Accepts \"normal\" and \"bold\" keywords or numbers between 1 and 1000.'),
         'type': 'string',
         'default': EDITOR_FONT_DEFAULTS.fontWeight
     },
     'editor.formatOnPaste': {
-        'description': nls.localize('vscode/editorOptions/formatOnPaste', 'Controls whether the editor should automatically format the pasted content. A formatter must be available and the formatter should be able to format a range in a document.'),
+        'description': nls.localizeByDefault('Controls whether the editor should automatically format the pasted content. A formatter must be available and the formatter should be able to format a range in a document.'),
         'type': 'boolean',
         'default': false
     },
     'editor.formatOnType': {
-        'description': nls.localize('vscode/editorOptions/formatOnType', 'Controls whether the editor should automatically format the line after typing.'),
+        'description': nls.localizeByDefault('Controls whether the editor should automatically format the line after typing.'),
         'type': 'boolean',
         'default': false
     },
     'editor.glyphMargin': {
-        'description': nls.localize('vscode/editorOptions/glyphMargin', 'Controls whether the editor should render the vertical glyph margin. Glyph margin is mostly used for debugging.'),
+        'description': nls.localizeByDefault('Controls whether the editor should render the vertical glyph margin. Glyph margin is mostly used for debugging.'),
         'type': 'boolean',
         'default': true
     },
     'editor.gotoLocation.multiple': {
         'type': 'string',
         'default': '',
-        'deprecationMessage': nls.localize('vscode/editorOptions/insertSpaces', 'This setting is deprecated, please use separate settings like `editor.editor.gotoLocation.multipleDefinitions` or `editor.editor.gotoLocation.multipleImplementations` instead.')
+        'deprecationMessage': nls.localizeByDefault("This setting is deprecated, please use separate settings like 'editor.editor.gotoLocation.multipleDefinitions' or 'editor.editor.gotoLocation.multipleImplementations' instead.")
     },
     'editor.gotoLocation.multipleDefinitions': {
-        'description': nls.localize('vscode/editorOptions/editor.editor.gotoLocation.multipleDefinitions', 'Controls the behavior the `Go to Definition`-command when multiple target locations exist.'),
+        'description': nls.localizeByDefault("Controls the behavior the 'Go to Definition'-command when multiple target locations exist."),
         'type': 'string',
         'enum': [
             'peek',
@@ -589,13 +589,13 @@ const codeEditorPreferenceProperties = {
         ],
         'default': 'peek',
         'enumDescriptions': [
-            nls.localize('vscode/editorOptions/editor.gotoLocation.multiple.peek', 'Show peek view of the results (default)'),
-            nls.localize('vscode/editorOptions/editor.gotoLocation.multiple.gotoAndPeek', 'Go to the primary result and show a peek view'),
-            nls.localize('vscode/editorOptions/editor.gotoLocation.multiple.goto', 'Go to the primary result and enable peek-less navigation to others')
+            nls.localizeByDefault('Show peek view of the results (default)'),
+            nls.localizeByDefault('Go to the primary result and show a peek view'),
+            nls.localizeByDefault('Go to the primary result and enable peek-less navigation to others')
         ]
     },
     'editor.gotoLocation.multipleTypeDefinitions': {
-        'description': nls.localize('vscode/editorOptions/editor.editor.gotoLocation.multipleTypeDefinitions', 'Controls the behavior the `Go to Type Definition`-command when multiple target locations exist.'),
+        'description': nls.localizeByDefault("Controls the behavior the 'Go to Type Definition'-command when multiple target locations exist."),
         'type': 'string',
         'enum': [
             'peek',
@@ -604,13 +604,13 @@ const codeEditorPreferenceProperties = {
         ],
         'default': 'peek',
         'enumDescriptions': [
-            nls.localize('vscode/editorOptions/editor.gotoLocation.multiple.peek', 'Show peek view of the results (default)'),
-            nls.localize('vscode/editorOptions/editor.gotoLocation.multiple.gotoAndPeek', 'Go to the primary result and show a peek view'),
-            nls.localize('vscode/editorOptions/editor.gotoLocation.multiple.goto', 'Go to the primary result and enable peek-less navigation to others')
+            nls.localizeByDefault('Show peek view of the results (default)'),
+            nls.localizeByDefault('Go to the primary result and show a peek view'),
+            nls.localizeByDefault('Go to the primary result and enable peek-less navigation to others')
         ]
     },
     'editor.gotoLocation.multipleDeclarations': {
-        'description': nls.localize('vscode/editorOptions/editor.editor.gotoLocation.multipleDeclarations', 'Controls the behavior the `Go to Declaration`-command when multiple target locations exist.'),
+        'description': nls.localizeByDefault("Controls the behavior the 'Go to Declaration'-command when multiple target locations exist."),
         'type': 'string',
         'enum': [
             'peek',
@@ -619,13 +619,13 @@ const codeEditorPreferenceProperties = {
         ],
         'default': 'peek',
         'enumDescriptions': [
-            nls.localize('vscode/editorOptions/editor.gotoLocation.multiple.peek', 'Show peek view of the results (default)'),
-            nls.localize('vscode/editorOptions/editor.gotoLocation.multiple.gotoAndPeek', 'Go to the primary result and show a peek view'),
-            nls.localize('vscode/editorOptions/editor.gotoLocation.multiple.goto', 'Go to the primary result and enable peek-less navigation to others')
+            nls.localizeByDefault('Show peek view of the results (default)'),
+            nls.localizeByDefault('Go to the primary result and show a peek view'),
+            nls.localizeByDefault('Go to the primary result and enable peek-less navigation to others')
         ]
     },
     'editor.gotoLocation.multipleImplementations': {
-        'description': nls.localize('vscode/editorOptions/editor.editor.gotoLocation.multipleImplemenattions', 'Controls the behavior the `Go to Implementations`-command when multiple target locations exist.'),
+        'description': nls.localizeByDefault("Controls the behavior the 'Go to Implementations'-command when multiple target locations exist."),
         'type': 'string',
         'enum': [
             'peek',
@@ -634,13 +634,13 @@ const codeEditorPreferenceProperties = {
         ],
         'default': 'peek',
         'enumDescriptions': [
-            nls.localize('vscode/editorOptions/editor.gotoLocation.multiple.peek', 'Show peek view of the results (default)'),
-            nls.localize('vscode/editorOptions/editor.gotoLocation.multiple.gotoAndPeek', 'Go to the primary result and show a peek view'),
-            nls.localize('vscode/editorOptions/editor.gotoLocation.multiple.goto', 'Go to the primary result and enable peek-less navigation to others')
+            nls.localizeByDefault('Show peek view of the results (default)'),
+            nls.localizeByDefault('Go to the primary result and show a peek view'),
+            nls.localizeByDefault('Go to the primary result and enable peek-less navigation to others')
         ]
     },
     'editor.gotoLocation.multipleReferences': {
-        'description': nls.localize('vscode/editorOptions/editor.editor.gotoLocation.multipleReferences', 'Controls the behavior the `Go to References`-command when multiple target locations exist.'),
+        'description': nls.localizeByDefault("Controls the behavior the 'Go to References'-command when multiple target locations exist."),
         'type': 'string',
         'enum': [
             'peek',
@@ -649,38 +649,38 @@ const codeEditorPreferenceProperties = {
         ],
         'default': 'peek',
         'enumDescriptions': [
-            nls.localize('vscode/editorOptions/editor.gotoLocation.multiple.peek', 'Show peek view of the results (default)'),
-            nls.localize('vscode/editorOptions/editor.gotoLocation.multiple.gotoAndPeek', 'Go to the primary result and show a peek view'),
-            nls.localize('vscode/editorOptions/editor.gotoLocation.multiple.goto', 'Go to the primary result and enable peek-less navigation to others')
+            nls.localizeByDefault('Show peek view of the results (default)'),
+            nls.localizeByDefault('Go to the primary result and show a peek view'),
+            nls.localizeByDefault('Go to the primary result and enable peek-less navigation to others')
         ]
     },
     'editor.gotoLocation.alternativeDefinitionCommand': {
         'type': 'string',
         'default': 'editor.action.goToReferences',
-        'description': nls.localize('vscode/editorOptions/alternativeDefinitionCommand', 'Alternative command id that is being executed when the result of `Go to Definition` is the current location.')
+        'description': nls.localizeByDefault("Alternative command id that is being executed when the result of 'Go to Definition' is the current location.")
     },
     'editor.gotoLocation.alternativeTypeDefinitionCommand': {
         'type': 'string',
         'default': 'editor.action.goToReferences',
-        'description': nls.localize('vscode/editorOptions/alternativeTypeDefinitionCommand', 'Alternative command id that is being executed when the result of `Go to Type Definition` is the current location.')
+        'description': nls.localizeByDefault("Alternative command id that is being executed when the result of 'Go to Type Definition' is the current location.")
     },
     'editor.gotoLocation.alternativeDeclarationCommand': {
         'type': 'string',
         'default': 'editor.action.goToReferences',
-        'description': nls.localize('vscode/editorOptions/alternativeDeclarationCommand', 'Alternative command id that is being executed when the result of `Go to Declaration` is the current location.')
+        'description': nls.localizeByDefault("Alternative command id that is being executed when the result of 'Go to Declaration' is the current location.")
     },
     'editor.gotoLocation.alternativeImplementationCommand': {
         'type': 'string',
         'default': '',
-        'description': nls.localize('vscode/editorOptions/alternativeImplementationCommand', 'Alternative command id that is being executed when the result of `Go to Implementation` is the current location.')
+        'description': nls.localizeByDefault("Alternative command id that is being executed when the result of 'Go to Implementation' is the current location.")
     },
     'editor.gotoLocation.alternativeReferenceCommand': {
         'type': 'string',
         'default': '',
-        'description': nls.localize('vscode/editorOptions/alternativeReferenceCommand', 'Alternative command id that is being executed when the result of `Go to Reference` is the current location.')
+        'description': nls.localizeByDefault("Alternative command id that is being executed when the result of 'Go to Reference' is the current location.")
     },
     'editor.hideCursorInOverviewRuler': {
-        'description': nls.localize('vscode/editorOptions/hideCursorInOverviewRuler', 'Controls whether the cursor should be hidden in the overview ruler.'),
+        'description': nls.localizeByDefault('Controls whether the cursor should be hidden in the overview ruler.'),
         'type': 'boolean',
         'default': false
     },
@@ -692,34 +692,34 @@ const codeEditorPreferenceProperties = {
     'editor.hover.enabled': {
         'type': 'boolean',
         'default': true,
-        'description': nls.localize('vscode/editorOptions/hover.enabled', 'Controls whether the hover is shown.')
+        'description': nls.localizeByDefault('Controls whether the hover is shown.')
     },
     'editor.hover.delay': {
         'type': 'number',
         'default': 300,
-        'description': nls.localize('vscode/editorOptions/hover.delay', 'Controls the delay in milliseconds after which the hover is shown.')
+        'description': nls.localizeByDefault('Controls the delay in milliseconds after which the hover is shown.')
     },
     'editor.hover.sticky': {
         'type': 'boolean',
         'default': true,
-        'description': nls.localize('vscode/editorOptions/hover.sticky', 'Controls whether the hover should remain visible when mouse is moved over it.')
+        'description': nls.localizeByDefault('Controls whether the hover should remain visible when mouse is moved over it.')
     },
     'editor.inDiffEditor': {
         'type': 'boolean',
         'default': true,
     },
     'editor.letterSpacing': {
-        'description': nls.localize('vscode/editorOptions/letterSpacing', 'Controls the letter spacing in pixels.'),
+        'description': nls.localizeByDefault('Controls the letter spacing in pixels.'),
         'type': 'number',
         'default': EDITOR_FONT_DEFAULTS.letterSpacing
     },
     'editor.lightbulb.enabled': {
         'type': 'boolean',
         'default': true,
-        'description': nls.localize('vscode/editorOptions/codeActions', 'Enables the code action lightbulb in the editor.')
+        'description': nls.localizeByDefault('Enables the code action lightbulb in the editor.')
     },
     'editor.lineHeight': {
-        'description': nls.localize('vscode/editorOptions/lineHeight', 'Controls the line height. Use 0 to compute the line height from the font size.'),
+        'description': nls.localizeByDefault('Controls the line height. Use 0 to compute the line height from the font size.'),
         'type': 'integer',
         'default': EDITOR_FONT_DEFAULTS.lineHeight,
         'minimum': 0,
@@ -734,13 +734,13 @@ const codeEditorPreferenceProperties = {
             'interval'
         ],
         'enumDescriptions': [
-            nls.localize('vscode/editorOptions/lineNumbers.off', 'Line numbers are not rendered.'),
-            nls.localize('vscode/editorOptions/lineNumbers.on', 'Line numbers are rendered as absolute number.'),
-            nls.localize('vscode/editorOptions/lineNumbers.relative', 'Line numbers are rendered as distance in lines to cursor position.'),
-            nls.localize('vscode/editorOptions/lineNumbers.interval', 'Line numbers are rendered every 10 lines.')
+            nls.localizeByDefault('Line numbers are not rendered.'),
+            nls.localizeByDefault('Line numbers are rendered as absolute number.'),
+            nls.localizeByDefault('Line numbers are rendered as distance in lines to cursor position.'),
+            nls.localizeByDefault('Line numbers are rendered every 10 lines.')
         ],
         'default': 'on',
-        'description': nls.localize('vscode/editorOptions/lineNumbers', 'Controls the display of line numbers.')
+        'description': nls.localizeByDefault('Controls the display of line numbers.')
     },
     'editor.lineNumbersMinChars': {
         'description': nls.localize('theia/editor/lineNumbersMinChars', 'Controls the line height. Use 0 to compute the line height from the font size.'),
@@ -750,17 +750,17 @@ const codeEditorPreferenceProperties = {
         'maximum': 300
     },
     'editor.linkedEditing': {
-        'description': nls.localize('vscode/editorOptions/linkedEditing', 'Controls whether the editor has linked editing enabled. Depending on the language, related symbols, e.g. HTML tags, are updated while editing.'),
+        'description': nls.localizeByDefault('Controls whether the editor has linked editing enabled. Depending on the language, related symbols, e.g. HTML tags, are updated while editing.'),
         'type': 'boolean',
         'default': false
     },
     'editor.links': {
-        'description': nls.localize('vscode/editorOptions/links', 'Controls whether the editor should detect links and make them clickable.'),
+        'description': nls.localizeByDefault('Controls whether the editor should detect links and make them clickable.'),
         'type': 'boolean',
         'default': true
     },
     'editor.matchBrackets': {
-        'description': nls.localize('vscode/editorOptions/matchBrackets', 'Highlight matching brackets.'),
+        'description': nls.localizeByDefault('Highlight matching brackets.'),
         'type': 'string',
         'enum': [
             'always',
@@ -772,7 +772,7 @@ const codeEditorPreferenceProperties = {
     'editor.minimap.enabled': {
         'type': 'boolean',
         'default': true,
-        'description': nls.localize('vscode/editorOptions/minimap.enabled', 'Controls whether the minimap is shown.')
+        'description': nls.localizeByDefault('Controls whether the minimap is shown.')
     },
     'editor.minimap.side': {
         'type': 'string',
@@ -781,7 +781,7 @@ const codeEditorPreferenceProperties = {
             'right'
         ],
         'default': 'right',
-        'description': nls.localize('vscode/editorOptions/minimap.side', 'Controls the side where to render the minimap.')
+        'description': nls.localizeByDefault('Controls the side where to render the minimap.')
     },
     'editor.minimap.showSlider': {
         'type': 'string',
@@ -790,24 +790,24 @@ const codeEditorPreferenceProperties = {
             'mouseover'
         ],
         'default': 'mouseover',
-        'description': nls.localize('vscode/editorOptions/minimap.showSlider', 'Controls when the minimap slider is shown.')
+        'description': nls.localizeByDefault('Controls when the minimap slider is shown.')
     },
     'editor.minimap.scale': {
         'type': 'number',
         'default': 1,
         'minimum': 1,
         'maximum': 3,
-        'description': nls.localize('vscode/editorOptions/minimap.scale', 'Scale of content drawn in the minimap.')
+        'description': nls.localizeByDefault('Scale of content drawn in the minimap: 1, 2 or 3.')
     },
     'editor.minimap.renderCharacters': {
         'type': 'boolean',
         'default': true,
-        'description': nls.localize('vscode/editorOptions/minimap.renderCharacters', 'Render the actual characters on a line as opposed to color blocks.')
+        'description': nls.localizeByDefault('Render the actual characters on a line as opposed to color blocks.')
     },
     'editor.minimap.maxColumn': {
         'type': 'number',
         'default': 120,
-        'description': nls.localize('vscode/editorOptions/minimap.maxColumn', 'Limit the width of the minimap to render at most a certain number of columns.')
+        'description': nls.localizeByDefault('Limit the width of the minimap to render at most a certain number of columns.')
     },
     'editor.mouseStyle': {
         'description': nls.localize('theia/editor/mouseStyle', 'Controls the mouse pointer style.'),
@@ -816,26 +816,26 @@ const codeEditorPreferenceProperties = {
         'default': 'text'
     },
     'editor.mouseWheelScrollSensitivity': {
-        'markdownDescription': nls.localize('vscode/editorOptions/mouseWheelScrollSensitivity', 'A multiplier to be used on the `deltaX` and `deltaY` of mouse wheel scroll events.'),
+        'markdownDescription': nls.localizeByDefault('A multiplier to be used on the `deltaX` and `deltaY` of mouse wheel scroll events.'),
         'type': 'number',
         'default': 1
     },
     'editor.mouseWheelZoom': {
-        'markdownDescription': nls.localize('vscode/editorOptions/mouseWheelZoom', 'Zoom the font of the editor when using mouse wheel and holding `Ctrl`.'),
+        'markdownDescription': nls.localizeByDefault('Zoom the font of the editor when using mouse wheel and holding `Ctrl`.'),
         'type': 'boolean',
         'default': false
     },
     'editor.multiCursorMergeOverlapping': {
-        'description': nls.localize('vscode/editorOptions/multiCursorMergeOverlapping', 'Merge multiple cursors when they are overlapping.'),
+        'description': nls.localizeByDefault('Merge multiple cursors when they are overlapping.'),
         'type': 'boolean',
         'default': true
     },
     'editor.multiCursorModifier': {
         'markdownEnumDescriptions': [
-            nls.localize('vscode/editorOptions/multiCursorModifier.ctrlCmd', 'Maps to `Control` on Windows and Linux and to `Command` on macOS.'),
-            nls.localize('vscode/editorOptions/multiCursorModifier.alt', 'Maps to `Alt` on Windows and Linux and to `Option` on macOS.')
+            nls.localizeByDefault('Maps to `Control` on Windows and Linux and to `Command` on macOS.'),
+            nls.localizeByDefault('Maps to `Alt` on Windows and Linux and to `Option` on macOS.')
         ],
-        'markdownDescription': nls.localize('vscode/editorOptions/multiCursorModifier', 'The modifier to be used to add multiple cursors with the mouse. The Go To Definition and Open Link mouse gestures will adapt such that they do not conflict with the multicursor modifier. [Read more](https://code.visualstudio.com/docs/editor/codebasics#_multicursor-modifier).'),
+        'markdownDescription': nls.localizeByDefault('The modifier to be used to add multiple cursors with the mouse. The Go To Definition and Open Link mouse gestures will adapt such that they do not conflict with the multicursor modifier. [Read more](https://code.visualstudio.com/docs/editor/codebasics#_multicursor-modifier).'),
         'type': 'string',
         'enum': [
             'ctrlCmd',
@@ -845,10 +845,10 @@ const codeEditorPreferenceProperties = {
     },
     'editor.multiCursorPaste': {
         'markdownEnumDescriptions': [
-            nls.localize('vscode/editorOptions/multiCursorPaste.spread', 'Each cursor pastes a single line of the text.'),
-            nls.localize('vscode/editorOptions/multiCursorPaste.full', 'Each cursor pastes the full text.')
+            nls.localizeByDefault('Each cursor pastes a single line of the text.'),
+            nls.localizeByDefault('Each cursor pastes the full text.')
         ],
-        'markdownDescription': nls.localize('vscode/editorOptions/multiCursorPaste', 'Controls pasting when the line count of the pasted text matches the cursor count.'),
+        'markdownDescription': nls.localizeByDefault('Controls pasting when the line count of the pasted text matches the cursor count.'),
         'type': 'string',
         'enum': [
             'spread',
@@ -857,12 +857,12 @@ const codeEditorPreferenceProperties = {
         'default': 'spread'
     },
     'editor.occurrencesHighlight': {
-        'description': nls.localize('vscode/editorOptions/occurrencesHighlight', 'Controls whether the editor should highlight semantic symbol occurrences.'),
+        'description': nls.localizeByDefault('Controls whether the editor should highlight semantic symbol occurrences.'),
         'type': 'boolean',
         'default': true
     },
     'editor.overviewRulerBorder': {
-        'description': nls.localize('vscode/editorOptions/overviewRulerBorder', 'Controls whether a border should be drawn around the overview ruler.'),
+        'description': nls.localizeByDefault('Controls whether a border should be drawn around the overview ruler.'),
         'type': 'boolean',
         'default': true
     },
@@ -878,31 +878,31 @@ const codeEditorPreferenceProperties = {
         'default': 0,
         'minimum': 0,
         'maximum': 1000,
-        'description': nls.localize('vscode/editorOptions/padding.top', 'Controls the amount of space between the top edge of the editor and the first line.')
+        'description': nls.localizeByDefault('Controls the amount of space between the top edge of the editor and the first line.')
     },
     'editor.padding.bottom': {
         'type': 'number',
         'default': 0,
         'minimum': 0,
         'maximum': 1000,
-        'description': nls.localize('vscode/editorOptions/padding.bottom', 'Controls the amount of space between the bottom edge of the editor and the last line.')
+        'description': nls.localizeByDefault('Controls the amount of space between the bottom edge of the editor and the last line.')
     },
     'editor.parameterHints.enabled': {
         'type': 'boolean',
         'default': true,
-        'description': nls.localize('vscode/editorOptions/parameterHints.enabled', 'Enables a pop-up that shows parameter documentation and type information as you type.')
+        'description': nls.localizeByDefault('Enables a pop-up that shows parameter documentation and type information as you type.')
     },
     'editor.parameterHints.cycle': {
         'type': 'boolean',
         'default': false,
-        'description': nls.localize('vscode/editorOptions/parameterHints.cycle', 'Controls whether the parameter hints menu cycles or closes when reaching the end of the list.')
+        'description': nls.localizeByDefault('Controls whether the parameter hints menu cycles or closes when reaching the end of the list.')
     },
     'editor.peekWidgetDefaultFocus': {
         'enumDescriptions': [
-            nls.localize('vscode/editorOptions/peekWidgetDefaultFocus.tree', 'Focus the tree when opening peek'),
-            nls.localize('vscode/editorOptions/peekWidgetDefaultFocus.editor', 'Focus the editor when opening peek')
+            nls.localizeByDefault('Focus the tree when opening peek'),
+            nls.localizeByDefault('Focus the editor when opening peek')
         ],
-        'description': nls.localize('vscode/editorOptions/peekWidgetDefaultFocus', 'Controls whether to focus the inline editor or the tree in the peek widget.'),
+        'description': nls.localizeByDefault('Controls whether to focus the inline editor or the tree in the peek widget.'),
         'type': 'string',
         'enum': [
             'tree',
@@ -913,7 +913,7 @@ const codeEditorPreferenceProperties = {
     'editor.definitionLinkOpensInPeek': {
         'type': 'boolean',
         'default': false,
-        'description': nls.localize('vscode/editorOptions/definitionLinkOpensInPeek', 'Controls whether the Go to Definition mouse gesture always opens the peek widget.')
+        'description': nls.localizeByDefault('Controls whether the Go to Definition mouse gesture always opens the peek widget.')
     },
     'editor.quickSuggestions': {
         'anyOf': [
@@ -926,17 +926,17 @@ const codeEditorPreferenceProperties = {
                     'strings': {
                         'type': 'boolean',
                         'default': false,
-                        'description': nls.localize('vscode/editorOptions/quickSuggestions.strings', 'Enable quick suggestions inside strings.')
+                        'description': nls.localizeByDefault('Enable quick suggestions inside strings.')
                     },
                     'comments': {
                         'type': 'boolean',
                         'default': false,
-                        'description': nls.localize('vscode/editorOptions/quickSuggestions.comments', 'Enable quick suggestions inside comments.')
+                        'description': nls.localizeByDefault('Enable quick suggestions inside comments.')
                     },
                     'other': {
                         'type': 'boolean',
                         'default': true,
-                        'description': nls.localize('vscode/editorOptions/quickSuggestions.other', 'Enable quick suggestions outside of strings and comments.')
+                        'description': nls.localizeByDefault('Enable quick suggestions outside of strings and comments.')
                     }
                 }
             }
@@ -946,10 +946,10 @@ const codeEditorPreferenceProperties = {
             'comments': false,
             'strings': false
         },
-        'description': nls.localize('vscode/editorOptions/quickSuggestions', 'Controls whether suggestions should automatically show up while typing.')
+        'description': nls.localizeByDefault('Controls whether suggestions should automatically show up while typing.')
     },
     'editor.quickSuggestionsDelay': {
-        'description': nls.localize('vscode/editorOptions/quickSuggestionsDelay', 'Controls the delay in milliseconds after which quick suggestions will show up.'),
+        'description': nls.localizeByDefault('Controls the delay in milliseconds after which quick suggestions will show up.'),
         'type': 'integer',
         'default': 10,
         'minimum': 0,
@@ -961,22 +961,22 @@ const codeEditorPreferenceProperties = {
         'default': false
     },
     'editor.rename.enablePreview': {
-        'description': nls.localize('vscode/rename/enablePreview', 'Controls whether the editor should display refactor preview pane for rename.'),
+        'description': nls.localizeByDefault('Enable/disable the ability to preview changes before renaming'),
         'type': 'boolean',
         'default': true
     },
     'editor.renderControlCharacters': {
-        'description': nls.localize('vscode/editorOptions/renderControlCharacters', 'Controls whether the editor should render control characters.'),
+        'description': nls.localizeByDefault('Controls whether the editor should render control characters.'),
         'type': 'boolean',
         'default': false
     },
     'editor.renderIndentGuides': {
-        'description': nls.localize('vscode/editorOptions/editor.guides.indentation', 'Controls whether the editor should render indent guides.'),
+        'description': nls.localizeByDefault('Controls whether the editor should render indent guides.'),
         'type': 'boolean',
         'default': true
     },
     'editor.renderFinalNewline': {
-        'description': nls.localize('vscode/editorOptions/renderFinalNewline', 'Render last line number when the file ends with a newline.'),
+        'description': nls.localizeByDefault('Render last line number when the file ends with a newline.'),
         'type': 'boolean',
         'default': true
     },
@@ -985,9 +985,9 @@ const codeEditorPreferenceProperties = {
             '',
             '',
             '',
-            nls.localize('vscode/editorOptions/renderLineHighlight.all', 'Highlights both the gutter and the current line.')
+            nls.localizeByDefault('Highlights both the gutter and the current line.')
         ],
-        'description': nls.localize('vscode/editorOptions/renderLineHighlight', 'Controls how the editor should render the current line highlight.'),
+        'description': nls.localizeByDefault('Controls how the editor should render the current line highlight.'),
         'type': 'string',
         'enum': [
             'none',
@@ -998,7 +998,7 @@ const codeEditorPreferenceProperties = {
         'default': 'line'
     },
     'editor.renderLineHighlightOnlyWhenFocus': {
-        'description': nls.localize('vscode/editorOptions/renderLineHighlightOnlyWhenFocus', 'Controls if the editor should render the current line highlight only when the editor is focused.'),
+        'description': nls.localizeByDefault('Controls if the editor should render the current line highlight only when the editor is focused'),
         'type': 'boolean',
         'default': false
     },
@@ -1011,12 +1011,12 @@ const codeEditorPreferenceProperties = {
     'editor.renderWhitespace': {
         'enumDescriptions': [
             '',
-            nls.localize('vscode/editorOptions/renderWhitespace.boundary', 'Render whitespace characters except for single spaces between words.'),
-            nls.localize('vscode/editorOptions/renderWhitespace.selection', 'Render whitespace characters only on selected text.'),
-            nls.localize('vscode/editorOptions/renderWhitespace.trailing', 'Render only trailing whitespace characters.'),
+            nls.localizeByDefault('Render whitespace characters except for single spaces between words.'),
+            nls.localizeByDefault('Render whitespace characters only on selected text.'),
+            nls.localizeByDefault('Render only trailing whitespace characters'),
             ''
         ],
-        'description': nls.localize('vscode/editorOptions/renderWhitespace', 'Controls how the editor should render whitespace characters.'),
+        'description': nls.localizeByDefault('Controls how the editor should render whitespace characters.'),
         'type': 'string',
         'enum': [
             'none',
@@ -1035,7 +1035,7 @@ const codeEditorPreferenceProperties = {
         'maximum': 1000
     },
     'editor.roundedSelection': {
-        'description': nls.localize('vscode/editorOptions/roundedSelection', 'Controls whether selections should have rounded corners.'),
+        'description': nls.localizeByDefault('Controls whether selections should have rounded corners.'),
         'type': 'boolean',
         'default': true
     },
@@ -1045,87 +1045,87 @@ const codeEditorPreferenceProperties = {
             'type': 'number'
         },
         'default': [],
-        'description': nls.localize('vscode/editorOptions/rulers', 'Render vertical rulers after a certain number of monospace characters. Use multiple values for multiple rulers. No rulers are drawn if array is empty.')
+        'description': nls.localizeByDefault('Render vertical rulers after a certain number of monospace characters. Use multiple values for multiple rulers. No rulers are drawn if array is empty.')
     },
     'editor.scrollBeyondLastColumn': {
-        'description': nls.localize('vscode/editorOptions/scrollBeyondLastColumn', 'Controls the number of extra characters beyond which the editor will scroll horizontally.'),
+        'description': nls.localizeByDefault('Controls the number of extra characters beyond which the editor will scroll horizontally.'),
         'type': 'integer',
         'default': 5,
         'minimum': 0,
         'maximum': 1073741824
     },
     'editor.scrollBeyondLastLine': {
-        'description': nls.localize('vscode/editorOptions/scrollBeyondLastLine', 'Controls whether the editor will scroll beyond the last line.'),
+        'description': nls.localizeByDefault('Controls whether the editor will scroll beyond the last line.'),
         'type': 'boolean',
         'default': true
     },
     'editor.scrollPredominantAxis': {
-        'description': nls.localize('vscode/editorOptions/scrollPredominantAxis', 'Scroll only along the predominant axis when scrolling both vertically and horizontally at the same time. Prevents horizontal drift when scrolling vertically on a trackpad.'),
+        'description': nls.localizeByDefault('Scroll only along the predominant axis when scrolling both vertically and horizontally at the same time. Prevents horizontal drift when scrolling vertically on a trackpad.'),
         'type': 'boolean',
         'default': true
     },
     'editor.selectionClipboard': {
-        'description': nls.localize('vscode/editorOptions/selectionClipboard', 'Controls whether the Linux primary clipboard should be supported.'),
+        'description': nls.localizeByDefault('Controls whether the Linux primary clipboard should be supported.'),
         'included': platform.isLinux,
         'type': 'boolean',
         'default': true
     },
     'editor.selectionHighlight': {
-        'description': nls.localize('vscode/editorOptions/selectionHighlight', 'Controls whether the editor should highlight matches similar to the selection.'),
+        'description': nls.localizeByDefault('Controls whether the editor should highlight matches similar to the selection.'),
         'type': 'boolean',
         'default': true
     },
     'editor.selectOnLineNumbers': {
-        'description': nls.localize('vscode/editorOptions/selectOnLineNumbers', 'Controls whether to select the corresponding line when clicking on the line number'),
+        'description': nls.localize('theia/editor/selectOnLineNumbers', 'Controls whether to select the corresponding line when clicking on the line number'),
         'type': 'boolean',
         'default': true
     },
     'editor.showFoldingControls': {
-        'description': nls.localize('vscode/editorOptions/showFoldingControls', 'Controls whether the fold controls on the gutter are automatically hidden.'),
+        'description': nls.localizeByDefault('Controls when the folding controls on the gutter are shown.'),
         'type': 'string',
         'enum': [
             'always',
             'mouseover'
         ],
         'enumDescriptions': [
-            nls.localize('vscode/editorOptions/showFoldingControls.always', 'Always show the folding controls.'),
-            nls.localize('vscode/editorOptions/showFoldingControls.mouseover', 'Only show the folding controls when the mouse is over the gutter.'),
+            nls.localizeByDefault('Always show the folding controls.'),
+            nls.localizeByDefault('Only show the folding controls when the mouse is over the gutter.'),
         ],
         'default': 'mouseover'
     },
     'editor.showUnused': {
-        'description': nls.localize('vscode/editorOptions/showUnused', 'Controls fading out of unused code.'),
+        'description': nls.localizeByDefault('Controls fading out of unused code.'),
         'type': 'boolean',
         'default': true
     },
     'editor.showDeprecated': {
-        'description': nls.localize('vscode/editorOptions/showDeprecated', 'Controls strikethrough deprecated variables.'),
+        'description': nls.localizeByDefault('Controls strikethrough deprecated variables.'),
         'type': 'boolean',
         'default': true
     },
     'editor.inlineHints.enabled': {
         'type': 'boolean',
         'default': true,
-        'description': nls.localize('vscode/editorOptions/editor.inlayHints.enabled', 'Enables the inline hints in the editor.')
+        'description': nls.localizeByDefault('Enables the inline hints in the editor.')
     },
     'editor.inlineHints.fontSize': {
         'type': 'number',
         'default': EDITOR_FONT_DEFAULTS.fontSize,
-        description: nls.localize('vscode/editorOptions/editor.inlayHints.fontSize', 'Controls font size of inline hints in the editor. When set to `0`, the 90% of `#editor.fontSize#` is used.')
+        description: nls.localizeByDefault('Controls font size of inline hints in the editor. When set to `0`, the 90% of `#editor.fontSize#` is used.')
     },
     'editor.inlineHints.fontFamily': {
         'type': 'string',
         'default': EDITOR_FONT_DEFAULTS.fontFamily,
-        'description': nls.localize('vscode/editorOptions/inlayHints.fontFamily', 'Controls font family of inline hints in the editor.')
+        'description': nls.localizeByDefault('Controls font family of inline hints in the editor.')
     },
     'editor.snippetSuggestions': {
         'enumDescriptions': [
-            nls.localize('vscode/editorOptions/snippetSuggestions.top', 'Show snippet suggestions on top of other suggestions.'),
-            nls.localize('vscode/editorOptions/snippetSuggestions.bottom', 'Show snippet suggestions below other suggestions.'),
-            nls.localize('vscode/editorOptions/snippetSuggestions.inline', 'Show snippets suggestions with other suggestions.'),
-            nls.localize('vscode/editorOptions/snippetSuggestions.none', 'Do not show snippet suggestions.')
+            nls.localizeByDefault('Show snippet suggestions on top of other suggestions.'),
+            nls.localizeByDefault('Show snippet suggestions below other suggestions.'),
+            nls.localizeByDefault('Show snippets suggestions with other suggestions.'),
+            nls.localizeByDefault('Do not show snippet suggestions.')
         ],
-        'description': nls.localize('vscode/editorOptions/snippetSuggestions', 'Controls whether snippets are shown with other suggestions and how they are sorted.'),
+        'description': nls.localizeByDefault('Controls whether snippets are shown with other suggestions and how they are sorted.'),
         'type': 'string',
         'enum': [
             'top',
@@ -1136,17 +1136,17 @@ const codeEditorPreferenceProperties = {
         'default': 'inline'
     },
     'editor.smartSelect.selectLeadingAndTrailingWhitespace': {
-        'description': nls.localize('vscode/editorOptions/selectLeadingAndTrailingWhitespace', 'Whether leading and trailing whitespace should always be selected.'),
+        'description': nls.localizeByDefault('Whether leading and trailing whitespace should always be selected.'),
         'default': true,
         'type': 'boolean'
     },
     'editor.smoothScrolling': {
-        'description': nls.localize('vscode/editorOptions/smoothScrolling', 'Controls whether the editor will scroll using an animation.'),
+        'description': nls.localizeByDefault('Controls whether the editor will scroll using an animation.'),
         'type': 'boolean',
         'default': false
     },
     'editor.stickyTabStops': {
-        'description': nls.localize('vscode/editorOptions/stickyTabStops', 'Emulate selection behaviour of tab characters when using spaces for indentation. Selection will stick to tab stops.'),
+        'description': nls.localizeByDefault('Emulate selection behaviour of tab characters when using spaces for indentation. Selection will stick to tab stops.'),
         'type': 'boolean',
         'default': false
     },
@@ -1164,11 +1164,11 @@ const codeEditorPreferenceProperties = {
             'replace'
         ],
         'enumDescriptions': [
-            nls.localize('vscode/editorOptions/suggest.insertMode.insert', 'Insert suggestion without overwriting text right of the cursor.'),
-            nls.localize('vscode/editorOptions/suggest.insertMode.replace', 'Insert suggestion and overwrite text right of the cursor.')
+            nls.localizeByDefault('Insert suggestion without overwriting text right of the cursor.'),
+            nls.localizeByDefault('Insert suggestion and overwrite text right of the cursor.')
         ],
         'default': 'insert',
-        'description': nls.localize('vscode/editorOptions/suggest.insertMode', 'Controls whether words are overwritten when accepting completions. Note that this depends on extensions opting into this feature.')
+        'description': nls.localizeByDefault('Controls whether words are overwritten when accepting completions. Note that this depends on extensions opting into this feature.')
     },
     'editor.suggest.insertHighlight': {
         'type': 'boolean',
@@ -1178,201 +1178,201 @@ const codeEditorPreferenceProperties = {
     'editor.suggest.filterGraceful': {
         'type': 'boolean',
         'default': true,
-        'description': nls.localize('vscode/editorOptions/suggest.filterGraceful', 'Controls whether filtering and sorting suggestions accounts for small typos.')
+        'description': nls.localizeByDefault('Controls whether filtering and sorting suggestions accounts for small typos.')
     },
     'editor.suggest.localityBonus': {
         'type': 'boolean',
         'default': false,
-        'description': nls.localize('vscode/editorOptions/suggest.localityBonus', 'Controls whether sorting favours words that appear close to the cursor.')
+        'description': nls.localizeByDefault('Controls whether sorting favours words that appear close to the cursor.')
     },
     'editor.suggest.shareSuggestSelections': {
         'type': 'boolean',
         'default': false,
-        'markdownDescription': nls.localize('vscode/editorOptions/suggest.shareSuggestSelections', 'Controls whether remembered suggestion selections are shared between multiple workspaces and windows (needs `#editor.suggestSelection#`).')
+        'markdownDescription': nls.localizeByDefault('Controls whether remembered suggestion selections are shared between multiple workspaces and windows (needs `#editor.suggestSelection#`).')
     },
     'editor.suggest.snippetsPreventQuickSuggestions': {
         'type': 'boolean',
         'default': true,
-        'description': nls.localize('vscode/editorOptions/suggest.snippetsPreventQuickSuggestions', 'Controls whether an active snippet prevents quick suggestions.')
+        'description': nls.localizeByDefault('Controls whether an active snippet prevents quick suggestions.')
     },
     'editor.suggest.showIcons': {
         'type': 'boolean',
         'default': true,
-        'description': nls.localize('vscode/editorOptions/suggest.showIcons', 'Controls whether to show or hide icons in suggestions.')
+        'description': nls.localizeByDefault('Controls whether to show or hide icons in suggestions.')
     },
     'editor.suggest.maxVisibleSuggestions': {
         'type': 'number',
         'default': 12,
         'minimum': 1,
         'maximum': 15,
-        'description': nls.localize('vscode/editorOptions/suggest.maxVisibleSuggestions.dep', 'Controls how many suggestions IntelliSense will show before showing a scrollbar (maximum 15).')
+        'description': nls.localizeByDefault('This setting is deprecated. The suggest widget can now be resized.')
     },
     'editor.suggest.filteredTypes': {
         'type': 'object',
         'default': {},
-        'deprecationMessage': nls.localize('vscode/editorOptions/deprecated', 'This setting is deprecated, please use separate settings like `editor.suggest.showKeywords` or `editor.suggest.showSnippets` instead.')
+        'deprecationMessage': nls.localizeByDefault("This setting is deprecated, please use separate settings like 'editor.suggest.showKeywords' or 'editor.suggest.showSnippets' instead.")
     },
     'editor.suggest.showMethods': {
         'type': 'boolean',
         'default': true,
-        'markdownDescription': nls.localize('vscode/editorOptions/editor.suggest.showMethods', 'When enabled IntelliSense shows `method`-suggestions.')
+        'markdownDescription': nls.localizeByDefault('When enabled IntelliSense shows `method`-suggestions.')
     },
     'editor.suggest.showFunctions': {
         'type': 'boolean',
         'default': true,
-        'markdownDescription': nls.localize('vscode/editorOptions/editor.suggest.showFunctions', 'When enabled IntelliSense shows `function`-suggestions.')
+        'markdownDescription': nls.localizeByDefault('When enabled IntelliSense shows `function`-suggestions.')
     },
     'editor.suggest.showConstructors': {
         'type': 'boolean',
         'default': true,
-        'markdownDescription': nls.localize('vscode/editorOptions/editor.suggest.showConstructors', 'When enabled IntelliSense shows `constructor`-suggestions.')
+        'markdownDescription': nls.localizeByDefault('When enabled IntelliSense shows `constructor`-suggestions.')
     },
     'editor.suggest.showFields': {
         'type': 'boolean',
         'default': true,
-        'markdownDescription': nls.localize('vscode/editorOptions/editor.suggest.showFields', 'When enabled IntelliSense shows `field`-suggestions.')
+        'markdownDescription': nls.localizeByDefault('When enabled IntelliSense shows `field`-suggestions.')
     },
     'editor.suggest.showVariables': {
         'type': 'boolean',
         'default': true,
-        'markdownDescription': nls.localize('vscode/editorOptions/editor.suggest.showVariables', 'When enabled IntelliSense shows `variable`-suggestions.')
+        'markdownDescription': nls.localizeByDefault('When enabled IntelliSense shows `variable`-suggestions.')
     },
     'editor.suggest.showClasses': {
         'type': 'boolean',
         'default': true,
-        'markdownDescription': nls.localize('vscode/editorOptions/editor.suggest.showClasss', 'When enabled IntelliSense shows `class`-suggestions.')
+        'markdownDescription': nls.localizeByDefault('When enabled IntelliSense shows `class`-suggestions.')
     },
     'editor.suggest.showStructs': {
         'type': 'boolean',
         'default': true,
-        'markdownDescription': nls.localize('vscode/editorOptions/editor.suggest.showStructs', 'When enabled IntelliSense shows `struct`-suggestions.')
+        'markdownDescription': nls.localizeByDefault('When enabled IntelliSense shows `struct`-suggestions.')
     },
     'editor.suggest.showInterfaces': {
         'type': 'boolean',
         'default': true,
-        'markdownDescription': nls.localize('vscode/editorOptions/editor.suggest.showInterfaces', 'When enabled IntelliSense shows `interface`-suggestions.')
+        'markdownDescription': nls.localizeByDefault('When enabled IntelliSense shows `interface`-suggestions.')
     },
     'editor.suggest.showModules': {
         'type': 'boolean',
         'default': true,
-        'markdownDescription': nls.localize('vscode/editorOptions/editor.suggest.showModules', 'When enabled IntelliSense shows `module`-suggestions.')
+        'markdownDescription': nls.localizeByDefault('When enabled IntelliSense shows `module`-suggestions.')
     },
     'editor.suggest.showProperties': {
         'type': 'boolean',
         'default': true,
-        'markdownDescription': nls.localize('vscode/editorOptions/editor.suggest.showPropertys', 'When enabled IntelliSense shows `property`-suggestions.')
+        'markdownDescription': nls.localizeByDefault('When enabled IntelliSense shows `property`-suggestions.')
     },
     'editor.suggest.showEvents': {
         'type': 'boolean',
         'default': true,
-        'markdownDescription': nls.localize('vscode/editorOptions/editor.suggest.showEvents', 'When enabled IntelliSense shows `event`-suggestions.')
+        'markdownDescription': nls.localizeByDefault('When enabled IntelliSense shows `event`-suggestions.')
     },
     'editor.suggest.showOperators': {
         'type': 'boolean',
         'default': true,
-        'markdownDescription': nls.localize('vscode/editorOptions/editor.suggest.showOperators', 'When enabled IntelliSense shows `operator`-suggestions.')
+        'markdownDescription': nls.localizeByDefault('When enabled IntelliSense shows `operator`-suggestions.')
     },
     'editor.suggest.showUnits': {
         'type': 'boolean',
         'default': true,
-        'markdownDescription': nls.localize('vscode/editorOptions/editor.suggest.showUnits', 'When enabled IntelliSense shows `unit`-suggestions.')
+        'markdownDescription': nls.localizeByDefault('When enabled IntelliSense shows `unit`-suggestions.')
     },
     'editor.suggest.showValues': {
         'type': 'boolean',
         'default': true,
-        'markdownDescription': nls.localize('vscode/editorOptions/editor.suggest.showValues', 'When enabled IntelliSense shows `value`-suggestions.')
+        'markdownDescription': nls.localizeByDefault('When enabled IntelliSense shows `value`-suggestions.')
     },
     'editor.suggest.showConstants': {
         'type': 'boolean',
         'default': true,
-        'markdownDescription': nls.localize('vscode/editorOptions/editor.suggest.showConstants', 'When enabled IntelliSense shows `constant`-suggestions.')
+        'markdownDescription': nls.localizeByDefault('When enabled IntelliSense shows `constant`-suggestions.')
     },
     'editor.suggest.showEnums': {
         'type': 'boolean',
         'default': true,
-        'markdownDescription': nls.localize('vscode/editorOptions/editor.suggest.showEnums', 'When enabled IntelliSense shows `enum`-suggestions.')
+        'markdownDescription': nls.localizeByDefault('When enabled IntelliSense shows `enum`-suggestions.')
     },
     'editor.suggest.showEnumMembers': {
         'type': 'boolean',
         'default': true,
-        'markdownDescription': nls.localize('vscode/editorOptions/editor.suggest.showEnumMembers', 'When enabled IntelliSense shows `enumMember`-suggestions.')
+        'markdownDescription': nls.localizeByDefault('When enabled IntelliSense shows `enumMember`-suggestions.')
     },
     'editor.suggest.showKeywords': {
         'type': 'boolean',
         'default': true,
-        'markdownDescription': nls.localize('vscode/editorOptions/editor.suggest.showKeywords', 'When enabled IntelliSense shows `keyword`-suggestions.')
+        'markdownDescription': nls.localizeByDefault('When enabled IntelliSense shows `keyword`-suggestions.')
     },
     'editor.suggest.showWords': {
         'type': 'boolean',
         'default': true,
-        'markdownDescription': nls.localize('vscode/editorOptions/editor.suggest.showTexts', 'When enabled IntelliSense shows `text`-suggestions.')
+        'markdownDescription': nls.localizeByDefault('When enabled IntelliSense shows `text`-suggestions.')
     },
     'editor.suggest.showColors': {
         'type': 'boolean',
         'default': true,
-        'markdownDescription': nls.localize('vscode/editorOptions/editor.suggest.showColors', 'When enabled IntelliSense shows `color`-suggestions.')
+        'markdownDescription': nls.localizeByDefault('When enabled IntelliSense shows `color`-suggestions.')
     },
     'editor.suggest.showFiles': {
         'type': 'boolean',
         'default': true,
-        'markdownDescription': nls.localize('vscode/editorOptions/editor.suggest.showFiles', 'When enabled IntelliSense shows `file`-suggestions.')
+        'markdownDescription': nls.localizeByDefault('When enabled IntelliSense shows `file`-suggestions.')
     },
     'editor.suggest.showReferences': {
         'type': 'boolean',
         'default': true,
-        'markdownDescription': nls.localize('vscode/editorOptions/editor.suggest.showReferences', 'When enabled IntelliSense shows `reference`-suggestions.')
+        'markdownDescription': nls.localizeByDefault('When enabled IntelliSense shows `reference`-suggestions.')
     },
     'editor.suggest.showCustomcolors': {
         'type': 'boolean',
         'default': true,
-        'markdownDescription': nls.localize('vscode/editorOptions/editor.suggest.showCustomcolors', 'When enabled IntelliSense shows `customcolor`-suggestions.')
+        'markdownDescription': nls.localizeByDefault('When enabled IntelliSense shows `customcolor`-suggestions.')
     },
     'editor.suggest.showFolders': {
         'type': 'boolean',
         'default': true,
-        'markdownDescription': nls.localize('vscode/editorOptions/ineditor.suggest.showFolderssertSpaces', 'When enabled IntelliSense shows `folder`-suggestions.')
+        'markdownDescription': nls.localizeByDefault('When enabled IntelliSense shows `folder`-suggestions.')
     },
     'editor.suggest.showTypeParameters': {
         'type': 'boolean',
         'default': true,
-        'markdownDescription': nls.localize('vscode/editorOptions/editor.suggest.showTypeParameters', 'When enabled IntelliSense shows `typeParameter`-suggestions.')
+        'markdownDescription': nls.localizeByDefault('When enabled IntelliSense shows `typeParameter`-suggestions.')
     },
     'editor.suggest.showSnippets': {
         'type': 'boolean',
         'default': true,
-        'markdownDescription': nls.localize('vscode/editorOptions/editor.suggest.showSnippets', 'When enabled IntelliSense shows `snippet`-suggestions.')
+        'markdownDescription': nls.localizeByDefault('When enabled IntelliSense shows `snippet`-suggestions.')
     },
     'editor.suggest.hideStatusBar': {
         'type': 'boolean',
         'default': true,
-        'markdownDescription': nls.localize('vscode/editorOptions/suggest.showStatusBar', 'Controls the visibility of the status bar at the bottom of the suggest widget.')
+        'markdownDescription': nls.localizeByDefault('Controls the visibility of the status bar at the bottom of the suggest widget.')
     },
     'editor.suggestFontSize': {
-        'markdownDescription': nls.localize('vscode/editorOptions/suggestFontSize', 'Font size for the suggest widget. When set to `0`, the value of `#editor.fontSize#` is used.'),
+        'markdownDescription': nls.localizeByDefault('Font size for the suggest widget. When set to `0`, the value of `#editor.fontSize#` is used.'),
         'type': 'integer',
         'default': 0,
         'minimum': 0,
         'maximum': 1000
     },
     'editor.suggestLineHeight': {
-        'markdownDescription': nls.localize('vscode/editorOptions/suggestLineHeight', 'Line height for the suggest widget. When set to `0`, the value of `#editor.lineHeight#` is used.'),
+        'markdownDescription': nls.localizeByDefault('Line height for the suggest widget. When set to `0`, the value of `#editor.lineHeight#` is used. The minimum value is 8.'),
         'type': 'integer',
         'default': 0,
         'minimum': 0,
         'maximum': 1000
     },
     'editor.suggestOnTriggerCharacters': {
-        'description': nls.localize('vscode/editorOptions/suggestOnTriggerCharacters', 'Controls whether suggestions should automatically show up when typing trigger characters.'),
+        'description': nls.localizeByDefault('Controls whether suggestions should automatically show up when typing trigger characters.'),
         'type': 'boolean',
         'default': true
     },
     'editor.suggestSelection': {
         'markdownEnumDescriptions': [
-            nls.localize('vscode/editorOptions/suggestSelection.first', 'Always select the first suggestion.'),
-            nls.localize('vscode/editorOptions/suggestSelection.recentlyUsed', 'Select recent suggestions unless further typing selects one, e.g. `console.| -> console.log` because `log` has been completed recently.'),
-            nls.localize('vscode/editorOptions/suggestSelection.recentlyUsedByPrefix', 'Select suggestions based on previous prefixes that have completed those suggestions, e.g. `co -> console` and `con -> const`.')
+            nls.localizeByDefault('Always select the first suggestion.'),
+            nls.localizeByDefault('Select recent suggestions unless further typing selects one, e.g. `console.| -> console.log` because `log` has been completed recently.'),
+            nls.localizeByDefault('Select suggestions based on previous prefixes that have completed those suggestions, e.g. `co -> console` and `con -> const`.')
         ],
-        'description': nls.localize('vscode/editorOptions/suggestSelection', 'Controls how suggestions are pre-selected when showing the suggest list.'),
+        'description': nls.localizeByDefault('Controls how suggestions are pre-selected when showing the suggest list.'),
         'type': 'string',
         'enum': [
             'first',
@@ -1383,11 +1383,11 @@ const codeEditorPreferenceProperties = {
     },
     'editor.tabCompletion': {
         'enumDescriptions': [
-            nls.localize('vscode/editorOptions/tabCompletion.on', 'Tab complete will insert the best matching suggestion when pressing tab.'),
-            nls.localize('vscode/editorOptions/tabCompletion.off', 'Disable tab completions.'),
-            nls.localize('vscode/editorOptions/tabCompletion.onlySnippets', 'Tab complete snippets when their prefix match. Works best when `quickSuggestions` aren\'t enabled.')
+            nls.localizeByDefault('Tab complete will insert the best matching suggestion when pressing tab.'),
+            nls.localizeByDefault('Disable tab completions.'),
+            nls.localizeByDefault("Tab complete snippets when their prefix match. Works best when 'quickSuggestions' aren't enabled.")
         ],
-        'description': nls.localize('vscode/editorOptions/tabCompletion', 'Enables tab completions.'),
+        'description': nls.localizeByDefault('Enables tab completions.'),
         'type': 'string',
         'enum': [
             'on',
@@ -1409,29 +1409,29 @@ const codeEditorPreferenceProperties = {
             nls.localize('unusualLineTerminators.off', 'Unusual line terminators are ignored.'),
             nls.localize('unusualLineTerminators.prompt', 'Unusual line terminators prompt to be removed.')
         ],
-        'description': nls.localize('vscode/editorOptions/unusualLineTerminators', 'Remove unusual line terminators that might cause problems.'),
+        'description': nls.localizeByDefault('Remove unusual line terminators that might cause problems.'),
         'type': 'string',
         'enum': ['auto', 'off', 'prompt'],
         'default': 'prompt'
     },
     'editor.useTabStops': {
-        'description': nls.localize('vscode/editorOptions/useTabStops', 'Inserting and deleting whitespace follows tab stops.'),
+        'description': nls.localizeByDefault('Inserting and deleting whitespace follows tab stops.'),
         'type': 'boolean',
         'default': true
     },
     'editor.wordSeparators': {
-        'description': nls.localize('vscode/editorOptions/wordSeparators', 'Characters that will be used as word separators when doing word related navigations or operations.'),
+        'description': nls.localizeByDefault('Characters that will be used as word separators when doing word related navigations or operations.'),
         'type': 'string',
         'default': DEFAULT_WORD_SEPARATORS
     },
     'editor.wordWrap': {
         'markdownEnumDescriptions': [
-            nls.localize('vscode/editorOptions/wordWrap.off', 'Lines will never wrap.'),
-            nls.localize('vscode/editorOptions/wordWrap.on', 'Lines will wrap at the viewport width.'),
-            nls.localize('vscode/editorOptions/wordWrap.wordWrapColumn', 'Lines will wrap at `#editor.wordWrapColumn#`.'),
-            nls.localize('vscode/editorOptions/wordWrap.bounded', 'Lines will wrap at the minimum of viewport and `#editor.wordWrapColumn#`.')
+            nls.localizeByDefault('Lines will never wrap.'),
+            nls.localizeByDefault('Lines will wrap at the viewport width.'),
+            nls.localizeByDefault('Lines will wrap at `#editor.wordWrapColumn#`.'),
+            nls.localizeByDefault('Lines will wrap at the minimum of viewport and `#editor.wordWrapColumn#`.')
         ],
-        'description': nls.localize('vscode/editorOptions/wordWrap', 'Controls how lines should wrap.'),
+        'description': nls.localizeByDefault('Controls how lines should wrap.'),
         'type': 'string',
         'enum': [
             'off',
@@ -1452,7 +1452,7 @@ const codeEditorPreferenceProperties = {
         'default': '([{‘“〈《「『【〔（［｛｢£¥＄￡￥+＋',
     },
     'editor.wordWrapColumn': {
-        'markdownDescription': nls.localize('vscode/editorOptions/wordWrapColumn', 'Controls the wrapping column of the editor when `#editor.wordWrap#` is `wordWrapColumn` or `bounded`.'),
+        'markdownDescription': nls.localizeByDefault('Controls the wrapping column of the editor when `#editor.wordWrap#` is `wordWrapColumn` or `bounded`.'),
         'type': 'integer',
         'default': 80,
         'minimum': 1,
@@ -1472,12 +1472,12 @@ const codeEditorPreferenceProperties = {
     },
     'editor.wrappingIndent': {
         'enumDescriptions': [
-            nls.localize('vscode/editorOptions/wrappingIndent.none', 'No indentation. Wrapped lines begin at column 1.'),
-            nls.localize('vscode/editorOptions/wrappingIndent.same', 'Wrapped lines get the same indentation as the parent.'),
-            nls.localize('vscode/editorOptions/wrappingIndent.indent', 'Wrapped lines get +1 indentation toward the parent.'),
-            nls.localize('vscode/editorOptions/wrappingIndent.deepIndent', 'Wrapped lines get +2 indentation toward the parent.')
+            nls.localizeByDefault('No indentation. Wrapped lines begin at column 1.'),
+            nls.localizeByDefault('Wrapped lines get the same indentation as the parent.'),
+            nls.localizeByDefault('Wrapped lines get +1 indentation toward the parent.'),
+            nls.localizeByDefault('Wrapped lines get +2 indentation toward the parent.')
         ],
-        'description': nls.localize('vscode/editorOptions/wrappingIndent', 'Controls the indentation of wrapped lines.'),
+        'description': nls.localizeByDefault('Controls the indentation of wrapped lines.'),
         'type': 'string',
         'enum': [
             'none',
@@ -1489,10 +1489,10 @@ const codeEditorPreferenceProperties = {
     },
     'editor.wrappingStrategy': {
         'enumDescriptions': [
-            nls.localize('vscode/editorOptions/wrappingStrategy.simple', 'Assumes that all characters are of the same width. This is a fast algorithm that works correctly for monospace fonts and certain scripts (like Latin characters) where glyphs are of equal width.'),
-            nls.localize('vscode/editorOptions/wrappingStrategy.advanced', 'Delegates wrapping points computation to the browser. This is a slow algorithm, that might cause freezes for large files, but it works correctly in all cases.')
+            nls.localizeByDefault('Assumes that all characters are of the same width. This is a fast algorithm that works correctly for monospace fonts and certain scripts (like Latin characters) where glyphs are of equal width.'),
+            nls.localizeByDefault('Delegates wrapping points computation to the browser. This is a slow algorithm, that might cause freezes for large files, but it works correctly in all cases.')
         ],
-        'description': nls.localize('vscode/editorOptions/wrappingStrategy', 'Controls the algorithm that computes wrapping points.'),
+        'description': nls.localizeByDefault('Controls the algorithm that computes wrapping points.'),
         'type': 'string',
         'enum': [
             'simple',
@@ -1515,19 +1515,20 @@ export const editorPreferenceSchema: PreferenceSchema = {
                 'off'
             ],
             'default': 'off',
-            'description': nls.localize('vscode/files.contribution/autoSave', 'Controls auto save of dirty files.'),
+            'description': nls.localize('theia/editor/autoSaveSetting', 'Controls auto save of dirty files.'),
             overridable: false
         },
         'editor.autoSaveDelay': {
             'type': 'number',
             'default': 500,
-            'description': nls.localize('vscode/files.contribution/autoSaveDelay', 'Configure the auto save delay in milliseconds.'),
+            'description': nls.localize('theia/editor/autoSaveDelay', 'Configure the auto save delay in milliseconds.'),
             overridable: false
         },
         'editor.formatOnSave': {
             'type': 'boolean',
             'default': false,
-            'description': nls.localize('vscode/files.contribution/formatOnSave', 'Enable format on manual save.')
+            // eslint-disable-next-line max-len
+            'description': nls.localizeByDefault('Format a file on save. A formatter must be available, the file must not be saved after delay, and the editor must not be shutting down.')
         },
         'editor.formatOnSaveTimeout': {
             'type': 'number',
@@ -1547,12 +1548,12 @@ export const editorPreferenceSchema: PreferenceSchema = {
                 'auto'
             ],
             'enumDescriptions': [
-                nls.localize('vscode/files.contribution/eol.LF', 'LF'),
-                nls.localize('vscode/files.contribution/eol.CRLF', 'CRLF'),
-                nls.localize('vscode/files.contribution/eol.auto', 'Uses operating system specific end of line character.')
+                nls.localizeByDefault('LF'),
+                nls.localizeByDefault('CRLF'),
+                nls.localizeByDefault('Uses operating system specific end of line character.')
             ],
             'default': 'auto',
-            'description': nls.localize('vscode/files.contribution/eol', 'The default end of line character.')
+            'description': nls.localizeByDefault('The default end of line character.')
         }
     }
 };

--- a/packages/external-terminal/src/electron-browser/external-terminal-contribution.ts
+++ b/packages/external-terminal/src/electron-browser/external-terminal-contribution.ts
@@ -26,10 +26,10 @@ import { QuickPickService } from '@theia/core/lib/common/quick-pick-service';
 import { nls } from '@theia/core/lib/common/nls';
 
 export namespace ExternalTerminalCommands {
-    export const OPEN_NATIVE_CONSOLE = Command.toLocalizedCommand({
+    export const OPEN_NATIVE_CONSOLE = Command.toDefaultLocalizedCommand({
         id: 'workbench.action.terminal.openNativeConsole',
         label: 'Open New External Terminal'
-    }, 'vscode/externalTerminal.contribution/globalConsoleAction');
+    });
 }
 
 @injectable()

--- a/packages/external-terminal/src/electron-browser/external-terminal-preference.ts
+++ b/packages/external-terminal/src/electron-browser/external-terminal-preference.ts
@@ -87,17 +87,17 @@ export async function getExternalTerminalSchema(externalTerminalService: Externa
         properties: {
             'terminal.external.windowsExec': {
                 type: 'string',
-                description: nls.localize('vscode/externalTerminal.contribution/terminal.external.windowsExec', 'Customizes which terminal to run on Windows.'),
+                description: nls.localizeByDefault('Customizes which terminal to run on Windows.'),
                 default: `${isWindows ? hostExec : 'C:\\WINDOWS\\System32\\cmd.exe'}`
             },
             'terminal.external.osxExec': {
                 type: 'string',
-                description: nls.localize('vscode/externalTerminal.contribution/terminal.external.osxExec', 'Customizes which terminal to run on macOS.'),
+                description: nls.localizeByDefault('Customizes which terminal to run on macOS.'),
                 default: `${isOSX ? hostExec : 'Terminal.app'}`
             },
             'terminal.external.linuxExec': {
                 type: 'string',
-                description: nls.localize('vscode/externalTerminal.contribution/terminal.external.linuxExec', 'Customizes which terminal to run on Linux.'),
+                description: nls.localizeByDefault('Customizes which terminal to run on Linux.'),
                 default: `${!(isWindows || isOSX) ? hostExec : 'xterm'}`
             }
         }

--- a/packages/file-search/src/browser/quick-file-open-contribution.ts
+++ b/packages/file-search/src/browser/quick-file-open-contribution.ts
@@ -55,7 +55,7 @@ export class QuickFileOpenFrontendContribution implements QuickAccessContributio
     registerMenus(menus: MenuModelRegistry): void {
         menus.registerMenuAction(EditorMainMenu.WORKSPACE_GROUP, {
             commandId: quickFileOpen.id,
-            label: nls.localize('vscode/quickAccessActions/quickOpen', 'Go to File...'),
+            label: nls.localizeByDefault('Go to File...'),
             order: '1',
         });
     }

--- a/packages/file-search/src/browser/quick-file-open.ts
+++ b/packages/file-search/src/browser/quick-file-open.ts
@@ -28,11 +28,11 @@ import { FileSystemPreferences } from '@theia/filesystem/lib/browser';
 import { EditorOpenerOptions, EditorWidget, Position, Range } from '@theia/editor/lib/browser';
 import { findMatches, QuickInputService, QuickPickItem, QuickPicks } from '@theia/core/lib/browser/quick-input/quick-input-service';
 
-export const quickFileOpen = Command.toLocalizedCommand({
+export const quickFileOpen = Command.toDefaultLocalizedCommand({
     id: 'file-search.openFile',
     category: CommonCommands.FILE_CATEGORY,
     label: 'Open File...'
-}, 'vscode/workspaceActions/openFile', CommonCommands.FILE_CATEGORY_KEY);
+});
 export interface FilterAndRange {
     filter: string;
     range?: Range;

--- a/packages/filesystem/src/browser/download/file-download-command-contribution.ts
+++ b/packages/filesystem/src/browser/download/file-download-command-contribution.ts
@@ -68,11 +68,11 @@ export class FileDownloadCommandContribution implements CommandContribution {
 
 export namespace FileDownloadCommands {
 
-    export const DOWNLOAD = Command.toLocalizedCommand({
+    export const DOWNLOAD = Command.toDefaultLocalizedCommand({
         id: 'file.download',
         category: CommonCommands.FILE_CATEGORY,
         label: 'Download'
-    }, 'vscode/fileActions/downloadButton', CommonCommands.FILE_CATEGORY_KEY);
+    });
 
     export const COPY_DOWNLOAD_LINK = Command.toLocalizedCommand({
         id: 'file.copyDownloadLink',

--- a/packages/filesystem/src/browser/file-upload-service.ts
+++ b/packages/filesystem/src/browser/file-upload-service.ts
@@ -245,9 +245,9 @@ export class FileUploadService {
 
     protected async confirmOverwrite(fileUri: URI): Promise<boolean> {
         const dialog = new ConfirmDialog({
-            title: nls.localize('vscode/findWidget/label.replace', 'Replace file'),
-            msg: nls.localize('vscode/explorerViewer/confirmOverwrite', 'File "{0}" already exists in the destination folder. Do you want to replace it?', fileUri.path.base),
-            ok: nls.localize('vscode/findWidget/label.replace', 'Replace file'),
+            title: nls.localizeByDefault('Replace file'),
+            msg: nls.localizeByDefault('File "{0}" already exists in the destination folder. Do you want to replace it?', fileUri.path.base),
+            ok: nls.localizeByDefault('Replace file'),
             cancel: Dialog.CANCEL
         });
         return !!await dialog.open();

--- a/packages/filesystem/src/browser/filesystem-preferences.ts
+++ b/packages/filesystem/src/browser/filesystem-preferences.ts
@@ -39,7 +39,8 @@ export const filesystemPreferenceSchema: PreferenceSchema = {
     type: 'object',
     properties: {
         'files.watcherExclude': {
-            description: nls.localize('vscode/files.contribution/watcherExclude', 'List of paths to exclude from the filesystem watcher'),
+            // eslint-disable-next-line max-len
+            description: nls.localizeByDefault('Configure glob patterns of file paths to exclude from file watching. Patterns must match on absolute paths (i.e. prefix with ** or the full path to match properly). Changing this setting requires a restart. When you experience Code consuming lots of CPU time on startup, you can exclude large folders to reduce the initial load.'),
             additionalProperties: {
                 type: 'boolean'
             },
@@ -53,29 +54,25 @@ export const filesystemPreferenceSchema: PreferenceSchema = {
         'files.exclude': {
             type: 'object',
             default: { '**/.git': true, '**/.svn': true, '**/.hg': true, '**/CVS': true, '**/.DS_Store': true },
-            description: nls.localize('vscode/files.contribution/exclude', 'Configure glob patterns for excluding files and folders.'),
+            // eslint-disable-next-line max-len
+            description: nls.localize('theia/filesystem/filesExclude', 'Configure glob patterns for excluding files and folders. For example, the file Explorer decides which files and folders to show or hide based on this setting. Refer to the `#search.exclude#` setting to define search specific excludes.'),
             scope: 'resource'
         },
         'files.enableTrash': {
             type: 'boolean',
             default: true,
-            description: nls.localize(
-                'vscode/files.contribution/useTrash',
-                'Moves files/folders to the OS trash (recycle bin on Windows) when deleting. Disabling this will delete files/folders permanently.'
-            )
+            description: nls.localizeByDefault('Moves files/folders to the OS trash (recycle bin on Windows) when deleting. Disabling this will delete files/folders permanently.')
         },
         'files.associations': {
             type: 'object',
-            description: nls.localize(
-                'vscode/files.contribution/associations',
-                'Configure file associations to languages (e.g. \"*.extension\": \"html\"). These have precedence over the default associations of the languages installed.'
+            description: nls.localizeByDefault(
+                'Configure file associations to languages (e.g. `\"*.extension\": \"html\"`). These have precedence over the default associations of the languages installed.'
             )
         },
         'files.autoGuessEncoding': {
             type: 'boolean',
             default: false,
-            description: nls.localize(
-                'vscode/files.contribution/autoGuessEncoding',
+            description: nls.localizeByDefault(
                 'When enabled, the editor will attempt to guess the character set encoding when opening files. This setting can also be configured per language.'
             ),
             scope: 'language-overridable',
@@ -84,8 +81,7 @@ export const filesystemPreferenceSchema: PreferenceSchema = {
         'files.participants.timeout': {
             type: 'number',
             default: 5000,
-            markdownDescription: nls.localize(
-                'vscode/mainThreadFileSystemEventService/files.participants.timeout',
+            markdownDescription: nls.localizeByDefault(
                 'Timeout in milliseconds after which file participants for create, rename, and delete are cancelled. Use `0` to disable participants.'
             )
         },
@@ -97,7 +93,7 @@ export const filesystemPreferenceSchema: PreferenceSchema = {
         'files.trimTrailingWhitespace': {
             type: 'boolean',
             default: false,
-            description: nls.localize('vscode/files.contribution/trimTrailingWhitespace', 'When enabled, will trim trailing whitespace when saving a file.'),
+            description: nls.localizeByDefault('When enabled, will trim trailing whitespace when saving a file.'),
             scope: 'language-overridable'
         },
         'files.maxConcurrentUploads': {

--- a/packages/getting-started/src/browser/getting-started-widget.tsx
+++ b/packages/getting-started/src/browser/getting-started-widget.tsx
@@ -48,7 +48,7 @@ export class GettingStartedWidget extends ReactWidget {
     /**
      * The widget `label` which is used for display purposes.
      */
-    static readonly LABEL = nls.localize('vscode/gettingStarted.contribution/Getting Started', 'Getting Started');
+    static readonly LABEL = nls.localizeByDefault('Getting Started');
 
     /**
      * The `ApplicationInfo` for the application if available.
@@ -168,7 +168,7 @@ export class GettingStartedWidget extends ReactWidget {
                 tabIndex={0}
                 onClick={this.doOpen}
                 onKeyDown={this.doOpenEnter}>
-                {nls.localize('vscode/dialogMainService/open', 'Open')}
+                {nls.localizeByDefault('Open')}
             </a>
         </div>;
 
@@ -178,7 +178,7 @@ export class GettingStartedWidget extends ReactWidget {
                 tabIndex={0}
                 onClick={this.doOpenFile}
                 onKeyDown={this.doOpenFileEnter}>
-                {nls.localize('vscode/dialogMainService/openFile', 'Open File')}
+                {nls.localizeByDefault('Open File')}
             </a>
         </div>;
 
@@ -188,7 +188,7 @@ export class GettingStartedWidget extends ReactWidget {
                 tabIndex={0}
                 onClick={this.doOpenFolder}
                 onKeyDown={this.doOpenFolderEnter}>
-                {nls.localize('vscode/dialogMainService/openFolder', 'Open Folder')}
+                {nls.localizeByDefault('Open Folder')}
             </a>
         </div>;
 
@@ -198,12 +198,12 @@ export class GettingStartedWidget extends ReactWidget {
                 tabIndex={0}
                 onClick={this.doOpenWorkspace}
                 onKeyDown={this.doOpenWorkspaceEnter}>
-                {nls.localize('vscode/dialogMainService/openWorkspaceTitle', 'Open Workspace')}
+                {nls.localizeByDefault('Open Workspace')}
             </a>
         );
 
         return <div className='gs-section'>
-            <h3 className='gs-section-header'><i className={codicon('folder-opened')}></i>{nls.localize('vscode/dialogMainService/open', 'Open')}</h3>
+            <h3 className='gs-section-header'><i className={codicon('folder-opened')}></i>{nls.localizeByDefault('Open')}</h3>
             {open}
             {openFile}
             {openFolder}
@@ -238,14 +238,14 @@ export class GettingStartedWidget extends ReactWidget {
                 tabIndex={0}
                 onClick={this.doOpenRecentWorkspace}
                 onKeyDown={this.doOpenRecentWorkspaceEnter}>
-                {nls.localize('vscode/vs_code_welcome_page/welcomePage.moreRecent', 'More...')}
+                {nls.localizeByDefault('More...')}
             </a>
         </div>;
         return <div className='gs-section'>
             <h3 className='gs-section-header'>
-                <i className={codicon('history')}></i>{nls.localize('vscode/vs_code_welcome_page/welcomePage.recent', 'Recently opened')}
+                <i className={codicon('history')}></i>{nls.localizeByDefault('Recent')}
             </h3>
-            {items.length > 0 ? content : <p className='gs-no-recent'>{nls.localize('vscode/vs_code_welcome_page/welcomePage.noRecentFolders', 'No Recent Workspaces')}</p>}
+            {items.length > 0 ? content : <p className='gs-no-recent'>{nls.localizeByDefault('No Recent Workspaces')}</p>}
             {more}
         </div>;
     }
@@ -258,7 +258,7 @@ export class GettingStartedWidget extends ReactWidget {
         return <div className='gs-section'>
             <h3 className='gs-section-header'>
                 <i className={codicon('settings-gear')}></i>
-                {nls.localize('vscode/preferences.contribution/settings', 'Settings')}
+                {nls.localizeByDefault('Settings')}
             </h3>
             <div className='gs-action-container'>
                 <a
@@ -266,7 +266,7 @@ export class GettingStartedWidget extends ReactWidget {
                     tabIndex={0}
                     onClick={this.doOpenPreferences}
                     onKeyDown={this.doOpenPreferencesEnter}>
-                    {nls.localize('vscode/menubarControl/goToSetting', 'Open Preferences')}
+                    {nls.localizeByDefault('Open Settings')}
                 </a>
             </div>
             <div className='gs-action-container'>
@@ -275,7 +275,7 @@ export class GettingStartedWidget extends ReactWidget {
                     tabIndex={0}
                     onClick={this.doOpenKeyboardShortcuts}
                     onKeyDown={this.doOpenKeyboardShortcutsEnter}>
-                    {nls.localize('vscode/preferences.contribution/openGlobalKeybindings', 'Open Keyboard Shortcuts')}
+                    {nls.localizeByDefault('Open Keyboard Shortcuts')}
                 </a>
             </div>
         </div>;
@@ -288,7 +288,7 @@ export class GettingStartedWidget extends ReactWidget {
         return <div className='gs-section'>
             <h3 className='gs-section-header'>
                 <i className={codicon('question')}></i>
-                {nls.localize('vscode/gettingStarted.contribution/help', 'Help')}
+                {nls.localizeByDefault('Help')}
             </h3>
             <div className='gs-action-container'>
                 <a
@@ -296,7 +296,7 @@ export class GettingStartedWidget extends ReactWidget {
                     tabIndex={0}
                     onClick={() => this.doOpenExternalLink(this.documentationUrl)}
                     onKeyDown={(e: React.KeyboardEvent) => this.doOpenExternalLinkEnter(e, this.documentationUrl)}>
-                    {nls.localize('vscode/helpActions/openDocumentationUrl', 'Documentation')}
+                    {nls.localizeByDefault('Documentation')}
                 </a>
             </div>
             <div className='gs-action-container'>
@@ -327,7 +327,7 @@ export class GettingStartedWidget extends ReactWidget {
         return <div className='gs-section'>
             <div className='gs-action-container'>
                 <p className='gs-sub-header' >
-                    {this.applicationInfo ? nls.localize('vscode/extensions.contribution/extensionInfoVersion', 'Version: {0}', this.applicationInfo.version) : ''}
+                    {this.applicationInfo ? nls.localizeByDefault('Version: {0}', this.applicationInfo.version) : ''}
                 </p>
             </div>
         </div>;

--- a/packages/git/src/browser/diff/git-diff-contribution.ts
+++ b/packages/git/src/browser/diff/git-diff-contribution.ts
@@ -41,36 +41,35 @@ export namespace GitDiffCommands {
     export const OPEN_FILE_DIFF = Command.toLocalizedCommand({
         id: 'git-diff:open-file-diff',
         category: 'Git Diff',
-        originalLabel: 'Compare With...',
-        label: nls.localize('vscode/fileActions/globalCompareFile', 'Compare With...')
-    });
+        label: 'Compare With...'
+    }, 'theia/git/compareWith');
     export const TREE_VIEW_MODE = {
         id: 'git.viewmode.tree',
-        tooltip: nls.localize('vscode/scmViewPane/viewModeTree', 'Toggle to Tree View'),
+        tooltip: nls.localizeByDefault('View as Tree'),
         iconClass: codicon('list-tree'),
-        originalLabel: 'Toggle to Tree View',
-        label: nls.localize('vscode/scmViewPane/viewModeTree', 'Toggle to Tree View')
+        originalLabel: 'View as Tree',
+        label: nls.localizeByDefault('View as Tree')
     };
     export const LIST_VIEW_MODE = {
         id: 'git.viewmode.list',
-        tooltip: nls.localize('vscode/scmViewPane/viewModeList', 'Toggle to List View'),
+        tooltip: nls.localizeByDefault('View as List'),
         iconClass: codicon('list-flat'),
-        originalLabel: 'Toggle to List View',
-        label: nls.localize('vscode/scmViewPane/viewModeList', 'Toggle to List View')
+        originalLabel: 'View as List',
+        label: nls.localizeByDefault('View as List')
     };
     export const PREVIOUS_CHANGE = {
         id: 'git.navigate-changes.previous',
-        tooltip: nls.localize('vscode/editor.contribution/navigate.prev.label', 'Previous Change'),
+        tooltip: nls.localizeByDefault('Previous Change'),
         iconClass: codicon('arrow-left'),
         originalLabel: 'Previous Change',
-        label: nls.localize('vscode/editor.contribution/navigate.prev.label', 'Previous Change')
+        label: nls.localizeByDefault('Previous Change')
     };
     export const NEXT_CHANGE = {
         id: 'git.navigate-changes.next',
-        tooltip: nls.localize('vscode/editor.contribution/navigate.next.label', 'Next Change'),
+        tooltip: nls.localizeByDefault('Next Change'),
         iconClass: codicon('arrow-right'),
         originalLabel: 'Next Change',
-        label: nls.localize('vscode/editor.contribution/navigate.next.label', 'Next Change')
+        label: nls.localizeByDefault('Next Change')
     };
 }
 

--- a/packages/git/src/browser/git-contribution.ts
+++ b/packages/git/src/browser/git-contribution.ts
@@ -897,7 +897,7 @@ export class GitContribution implements CommandContribution, MenuContribution, T
         } catch (e) {
             scmRepository.input.issue = {
                 type: ScmInputIssueType.Warning,
-                message: nls.localize('vscode/commands/missing user info', 'Make sure you configure your \'user.name\' and \'user.email\' in git.')
+                message: nls.localizeByDefault('Make sure you configure your \'user.name\' and \'user.email\' in git.')
             };
         }
 

--- a/packages/keymaps/src/browser/keymaps-frontend-contribution.ts
+++ b/packages/keymaps/src/browser/keymaps-frontend-contribution.ts
@@ -31,16 +31,16 @@ import { TabBarToolbarContribution, TabBarToolbarRegistry } from '@theia/core/li
 import { nls } from '@theia/core/lib/common/nls';
 
 export namespace KeymapsCommands {
-    export const OPEN_KEYMAPS = Command.toLocalizedCommand({
+    export const OPEN_KEYMAPS = Command.toDefaultLocalizedCommand({
         id: 'keymaps:open',
         category: CommonCommands.PREFERENCES_CATEGORY,
         label: 'Open Keyboard Shortcuts',
-    }, 'vscode/preferences.contribution/openGlobalKeybindings', CommonCommands.PREFERENCES_CATEGORY_KEY);
-    export const OPEN_KEYMAPS_JSON = Command.toLocalizedCommand({
+    });
+    export const OPEN_KEYMAPS_JSON = Command.toDefaultLocalizedCommand({
         id: 'keymaps:openJson',
         category: CommonCommands.PREFERENCES_CATEGORY,
         label: 'Open Keyboard Shortcuts (JSON)',
-    }, 'vscode/preferences.contribution/openGlobalKeybindingsFile', CommonCommands.PREFERENCES_CATEGORY_KEY);
+    });
     export const OPEN_KEYMAPS_JSON_TOOLBAR: Command = {
         id: 'keymaps:openJson.toolbar',
         iconClass: codicon('json')
@@ -112,13 +112,13 @@ export class KeymapsFrontendContribution extends AbstractViewContribution<Keybin
         toolbar.registerItem({
             id: KeymapsCommands.OPEN_KEYMAPS_JSON_TOOLBAR.id,
             command: KeymapsCommands.OPEN_KEYMAPS_JSON_TOOLBAR.id,
-            tooltip: nls.localize('vscode/preferences.contribution/openGlobalKeybindingsFile', 'Open Keyboard Shortcuts in JSON'),
+            tooltip: nls.localizeByDefault('Open Keyboard Shortcuts (JSON)'),
             priority: 0,
         });
         toolbar.registerItem({
             id: KeymapsCommands.CLEAR_KEYBINDINGS_SEARCH.id,
             command: KeymapsCommands.CLEAR_KEYBINDINGS_SEARCH.id,
-            tooltip: nls.localize('vscode/preferences.contribution/clear', 'Clear Keybindings Search Input'),
+            tooltip: nls.localizeByDefault('Clear Keybindings Search Input'),
             priority: 1,
             onDidChange,
         });

--- a/packages/markers/src/browser/problem/problem-contribution.ts
+++ b/packages/markers/src/browser/problem/problem-contribution.ts
@@ -55,7 +55,7 @@ export namespace ProblemsCommands {
         category: 'Problems',
         label: 'Clear All',
         iconClass: codicon('clear-all')
-    }, 'theia/markers/clearAll', 'vscode/markers.contribution/problems');
+    }, 'theia/markers/clearAll', nls.getDefaultKey('Problems'));
 }
 
 @injectable()
@@ -68,7 +68,7 @@ export class ProblemContribution extends AbstractViewContribution<ProblemWidget>
     constructor() {
         super({
             widgetId: PROBLEMS_WIDGET_ID,
-            widgetName: nls.localize('vscode/markers.contribution/problems', 'Problems'),
+            widgetName: nls.localizeByDefault('Problems'),
             defaultWidgetOptions: {
                 area: 'bottom'
             },
@@ -110,7 +110,7 @@ export class ProblemContribution extends AbstractViewContribution<ProblemWidget>
      */
     protected getStatusBarTooltip(stat: ProblemStat): string {
         if (stat.errors <= 0 && stat.warnings <= 0 && stat.infos <= 0) {
-            return nls.localize('vscode/markers.contribution/noProblems', 'No Problems');
+            return nls.localizeByDefault('No Problems');
         }
         const localize = (text: string, value: number): string => nls.localize(`vscode/markers.contribution/total${text}`, `{0} ${text}`, value.toString());
         const tooltip: string[] = [];
@@ -164,17 +164,17 @@ export class ProblemContribution extends AbstractViewContribution<ProblemWidget>
         super.registerMenus(menus);
         menus.registerMenuAction(ProblemsMenu.CLIPBOARD, {
             commandId: ProblemsCommands.COPY.id,
-            label: nls.localize('vscode/markers.contribution/copyMarker', 'Copy'),
+            label: nls.localizeByDefault('Copy'),
             order: '0'
         });
         menus.registerMenuAction(ProblemsMenu.CLIPBOARD, {
             commandId: ProblemsCommands.COPY_MESSAGE.id,
-            label: nls.localize('vscode/markers.contribution/copyMessage', 'Copy Message'),
+            label: nls.localizeByDefault('Copy Message'),
             order: '1'
         });
         menus.registerMenuAction(ProblemsMenu.PROBLEMS, {
             commandId: ProblemsCommands.COLLAPSE_ALL.id,
-            label: nls.localize('vscode/markers.contribution/collapseAll', 'Collapse All'),
+            label: nls.localizeByDefault('Collapse All'),
             order: '2'
         });
     }
@@ -183,7 +183,7 @@ export class ProblemContribution extends AbstractViewContribution<ProblemWidget>
         toolbarRegistry.registerItem({
             id: ProblemsCommands.COLLAPSE_ALL_TOOLBAR.id,
             command: ProblemsCommands.COLLAPSE_ALL_TOOLBAR.id,
-            tooltip: nls.localize('vscode/markers.contribution/collapseAll', 'Collapse All'),
+            tooltip: nls.localizeByDefault('Collapse All'),
             priority: 0,
         });
         toolbarRegistry.registerItem({

--- a/packages/markers/src/browser/problem/problem-preferences.ts
+++ b/packages/markers/src/browser/problem/problem-preferences.ts
@@ -23,7 +23,7 @@ export const ProblemConfigSchema: PreferenceSchema = {
     'properties': {
         'problems.decorations.enabled': {
             'type': 'boolean',
-            'description': nls.localize('vscode/markersFileDecorations/markers.showOnFile', 'Show Errors & Warnings on files and folder.'),
+            'description': nls.localizeByDefault('Show Errors & Warnings on files and folder.'),
             'default': true,
         },
         'problems.decorations.tabbar.enabled': {
@@ -33,7 +33,7 @@ export const ProblemConfigSchema: PreferenceSchema = {
         },
         'problems.autoReveal': {
             'type': 'boolean',
-            'description': nls.localize('vscode/messages/problems.panel.configuration.autoreveal', 'Controls whether Problems view should reveal markers when file is opened.'),
+            'description': nls.localizeByDefault('Controls whether Problems view should automatically reveal files when opening them.'),
             'default': true
         }
     }

--- a/packages/markers/src/browser/problem/problem-widget.tsx
+++ b/packages/markers/src/browser/problem/problem-widget.tsx
@@ -51,7 +51,7 @@ export class ProblemWidget extends TreeWidget {
         super(treeProps, model, contextMenuRenderer);
 
         this.id = PROBLEMS_WIDGET_ID;
-        this.title.label = nls.localize('vscode/settingsLayout/problems', 'Problems');
+        this.title.label = nls.localizeByDefault('Problems');
         this.title.caption = this.title.label;
         this.title.iconClass = codicon('warning');
         this.title.closable = true;

--- a/packages/messages/src/browser/notification-center-component.tsx
+++ b/packages/messages/src/browser/notification-center-component.tsx
@@ -58,17 +58,17 @@ export class NotificationCenterComponent extends React.Component<NotificationCen
     render(): React.ReactNode {
         const empty = this.state.notifications.length === 0;
         const title = empty
-            ? nls.localize('vscode/notificationsStatus/noNotifications', 'NO NEW NOTIFICATIONS')
-            : nls.localize('vscode/notificationsStatus/status.notifications', 'NOTIFICATIONS');
+            ? nls.localizeByDefault('No New Notifications')
+            : nls.localizeByDefault('Notifications');
         return (
             <div className={`theia-notifications-container theia-notification-center ${this.state.visibilityState === 'center' ? 'open' : 'closed'}`}>
                 <div className='theia-notification-center-header'>
                     <div className='theia-notification-center-header-title'>{title}</div>
                     <div className='theia-notification-center-header-actions'>
                         <ul className='theia-notification-actions'>
-                            <li className={codicon('clear-all', true)} title={nls.localize('vscode/notificationsCommands/clearAllNotifications', 'Clear All Notifications')}
+                            <li className={codicon('clear-all', true)} title={nls.localizeByDefault('Clear All Notifications')}
                                 onClick={this.onClearAll} />
-                            <li className={codicon('chevron-down', true)} title={nls.localize('vscode/notificationsCommands/hideNotifications', 'Hide Notifications')}
+                            <li className={codicon('chevron-down', true)} title={nls.localizeByDefault('Hide Notifications')}
                                 onClick={this.onHide} />
                         </ul>
                     </div>

--- a/packages/messages/src/browser/notification-component.tsx
+++ b/packages/messages/src/browser/notification-component.tsx
@@ -87,7 +87,7 @@ export class NotificationComponent extends React.Component<NotificationComponent
                             <li className={codicon('chevron-down') + collapsed ? ' expand' : ' collapse'} title={collapsed ? 'Expand' : 'Collapse'}
                                 data-message-id={messageId} onClick={this.onToggleExpansion} />
                         )}
-                        {!isProgress && (<li className={codicon('close', true)} title={nls.localize('vscode/abstractTree/clear', 'Clear')} data-message-id={messageId}
+                        {!isProgress && (<li className={codicon('close', true)} title={nls.localizeByDefault('Clear')} data-message-id={messageId}
                             onClick={this.onClear} />)}
                     </ul>
                 </div>

--- a/packages/messages/src/browser/notifications-commands.ts
+++ b/packages/messages/src/browser/notifications-commands.ts
@@ -14,13 +14,13 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
-import { Command } from '@theia/core';
+import { Command, nls } from '@theia/core';
 import { codicon } from '@theia/core/lib/browser';
 
 export namespace NotificationsCommands {
 
-    const NOTIFICATIONS_CATEGORY_KEY = 'vscode/notificationsCommands/notifications';
     const NOTIFICATIONS_CATEGORY = 'Notifications';
+    const NOTIFICATIONS_CATEGORY_KEY = nls.getDefaultKey(NOTIFICATIONS_CATEGORY);
 
     export const TOGGLE = Command.toLocalizedCommand({
         id: 'notifications.commands.toggle',
@@ -29,22 +29,22 @@ export namespace NotificationsCommands {
         label: 'Toggle Notifications'
     }, 'theia/messages/toggleNotifications', NOTIFICATIONS_CATEGORY_KEY);
 
-    export const SHOW = Command.toLocalizedCommand({
+    export const SHOW = Command.toDefaultLocalizedCommand({
         id: 'notifications.commands.show',
         category: NOTIFICATIONS_CATEGORY,
         label: 'Show Notifications'
-    }, 'vscode/notificationsCommands/showNotifications', NOTIFICATIONS_CATEGORY_KEY);
+    });
 
-    export const HIDE = Command.toLocalizedCommand({
+    export const HIDE = Command.toDefaultLocalizedCommand({
         id: 'notifications.commands.hide',
         category: NOTIFICATIONS_CATEGORY,
         label: 'Hide Notifications'
-    }, 'vscode/notificationsCommands/hideNotifications', NOTIFICATIONS_CATEGORY_KEY);
+    });
 
-    export const CLEAR_ALL = Command.toLocalizedCommand({
+    export const CLEAR_ALL = Command.toDefaultLocalizedCommand({
         id: 'notifications.commands.clearAll',
         category: NOTIFICATIONS_CATEGORY,
         iconClass: codicon('clear-all'),
         label: 'Clear All Notifications'
-    }, 'vscode/notificationsCommands/clearAllNotifications', NOTIFICATIONS_CATEGORY_KEY);
+    });
 }

--- a/packages/messages/src/browser/notifications-contribution.ts
+++ b/packages/messages/src/browser/notifications-contribution.ts
@@ -63,13 +63,13 @@ export class NotificationsContribution implements FrontendApplicationContributio
     }
     protected getStatusBarItemTooltip(count: number): string {
         if (this.manager.centerVisible) {
-            return nls.localize('vscode/notificationsCommands/hideNotifications', 'Hide Notifications');
+            return nls.localizeByDefault('Hide Notifications');
         }
         return count === 0
-            ? nls.localize('vscode/notificationsStatus/zeroNotifications', 'No Notifications')
+            ? nls.localizeByDefault('No Notifications')
             : count === 1
-                ? nls.localize('vscode/notificationsStatus/oneNotification', '1 Notification')
-                : nls.localize('vscode/notificationsStatus/notifications', '{0} Notifications', count.toString());
+                ? nls.localizeByDefault('1 New Notification')
+                : nls.localizeByDefault('{0} New Notifications', count.toString());
     }
 
     registerCommands(commands: CommandRegistry): void {

--- a/packages/mini-browser/src/browser/mini-browser-open-handler.ts
+++ b/packages/mini-browser/src/browser/mini-browser-open-handler.ts
@@ -35,23 +35,23 @@ import { nls } from '@theia/core/lib/common/nls';
 
 export namespace MiniBrowserCommands {
 
-    export const PREVIEW_CATEGORY_KEY = 'vscode/extensionEditor/preview';
     export const PREVIEW_CATEGORY = 'Preview';
+    export const PREVIEW_CATEGORY_KEY = nls.getDefaultKey(PREVIEW_CATEGORY);
 
     export const PREVIEW = Command.toLocalizedCommand({
         id: 'mini-browser.preview',
         label: 'Open Preview',
         iconClass: codicon('open-preview')
-    }, 'vscode/mainThreadFileSystemEventService/preview');
+    }, 'vscode.markdown-language-features/package/markdown.preview.title');
     export const OPEN_SOURCE: Command = {
         id: 'mini-browser.open.source',
         iconClass: codicon('go-to-file')
     };
-    export const OPEN_URL = Command.toLocalizedCommand({
+    export const OPEN_URL = Command.toDefaultLocalizedCommand({
         id: 'mini-browser.openUrl',
         category: PREVIEW_CATEGORY,
         label: 'Open URL'
-    }, 'vscode/url.contribution/openUrl', PREVIEW_CATEGORY_KEY);
+    });
 }
 
 /**
@@ -220,12 +220,12 @@ export class MiniBrowserOpenHandler extends NavigatableWidgetOpenHandler<MiniBro
         toolbar.registerItem({
             id: MiniBrowserCommands.PREVIEW.id,
             command: MiniBrowserCommands.PREVIEW.id,
-            tooltip: nls.localize('theia/preview/openPreviewSide', 'Open Preview to the Side')
+            tooltip: nls.localize('vscode.markdown-language-features/package/markdown.previewSide.title', 'Open Preview to the Side')
         });
         toolbar.registerItem({
             id: MiniBrowserCommands.OPEN_SOURCE.id,
             command: MiniBrowserCommands.OPEN_SOURCE.id,
-            tooltip: nls.localize('theia/preview/openSource', 'Open Source')
+            tooltip: nls.localize('vscode.markdown-language-features/package/markdown.showSource.title', 'Open Source')
         });
     }
 
@@ -281,7 +281,7 @@ export class MiniBrowserOpenHandler extends NavigatableWidgetOpenHandler<MiniBro
 
     protected async openUrl(arg?: string): Promise<void> {
         const url = arg ? arg : await this.quickInputService?.input({
-            prompt: nls.localize('vscode/url.contribution/urlToOpen', 'URL to open'),
+            prompt: nls.localizeByDefault('URL to open'),
             placeHolder: nls.localize('theia/mini-browser/typeUrl', 'Type a URL')
         });
         if (url) {

--- a/packages/monaco/src/browser/monaco-command.ts
+++ b/packages/monaco/src/browser/monaco-command.ts
@@ -219,7 +219,7 @@ export class MonacoEditorCommandHandlers implements CommandContribution {
             label: nls.localize(`vscode/indentation/indentUsing${useSpaces ? 'Spaces' : 'Tabs'}`, `Indent Using ${useSpaces ? 'Spaces' : 'Tabs'}`),
             execute: () => this.configureTabSize(editor, useSpaces)
         }));
-        this.quickInputService?.showQuickPick(items, { placeholder: nls.localize('vscode/editorStatus/pickAction', 'Select Action') });
+        this.quickInputService?.showQuickPick(items, { placeholder: nls.localizeByDefault('Select Action') });
     }
 
     protected newConfigEolHandler(): MonacoEditorCommandHandler {
@@ -235,7 +235,7 @@ export class MonacoEditorCommandHandlers implements CommandContribution {
             execute: () => this.setEol(editor, lineEnding)
         })
         );
-        this.quickInputService?.showQuickPick(items, { placeholder: nls.localize('vscode/editorStatus/selectEOL', 'Select End of Line Sequence') });
+        this.quickInputService?.showQuickPick(items, { placeholder: nls.localizeByDefault('Select End of Line Sequence') });
     }
 
     protected setEol(editor: MonacoEditor, lineEnding: string): void {
@@ -261,7 +261,7 @@ export class MonacoEditorCommandHandlers implements CommandContribution {
             const sizes = Array.from(Array(8), (_, x) => x + 1);
             const tabSizeOptions = sizes.map(size =>
             ({
-                label: size === tabSize ? size + '   ' + nls.localize('vscode/indentation/configuredTabSize', 'Configured Tab Size') : size.toString(),
+                label: size === tabSize ? size + '   ' + nls.localizeByDefault('Configured Tab Size') : size.toString(),
                 // eslint-disable-next-line @typescript-eslint/no-explicit-any
                 execute: () => model.updateOptions({
                     tabSize: size || tabSize,
@@ -269,7 +269,7 @@ export class MonacoEditorCommandHandlers implements CommandContribution {
                 })
             })
             );
-            this.quickInputService?.showQuickPick(tabSizeOptions, { placeholder: nls.localize('vscode/indentation/selectTabWidth', 'Select Tab Size for Current File') });
+            this.quickInputService?.showQuickPick(tabSizeOptions, { placeholder: nls.localizeByDefault('Select Tab Size for Current File') });
         }
     }
 

--- a/packages/monaco/src/browser/monaco-menu.ts
+++ b/packages/monaco/src/browser/monaco-menu.ts
@@ -52,7 +52,7 @@ export class MonacoEditorMenuContribution implements MenuContribution {
 
         this.registerPeekSubmenu(registry);
 
-        registry.registerSubmenu(MonacoMenus.SELECTION, nls.localize('vscode/menubar/mSelection', 'Selection'));
+        registry.registerSubmenu(MonacoMenus.SELECTION, nls.localizeByDefault('Selection'));
         for (const item of MenuRegistry.getMenuItems(monaco.actions.MenuId.MenubarSelectionMenu)) {
             if (!monaco.actions.isIMenuItem(item)) {
                 continue;
@@ -70,7 +70,7 @@ export class MonacoEditorMenuContribution implements MenuContribution {
         // Builtin monaco language features commands.
         registry.registerMenuAction(EditorMainMenu.LANGUAGE_FEATURES_GROUP, {
             commandId: 'editor.action.quickOutline',
-            label: nls.localize('vscode/gotoSymbolQuickAccess/gotoSymbol', 'Go to Symbol in Editor...'),
+            label: nls.localizeByDefault('Go to Symbol in Editor...'),
             order: '1'
         });
         registry.registerMenuAction(EditorMainMenu.LANGUAGE_FEATURES_GROUP, {
@@ -102,18 +102,18 @@ export class MonacoEditorMenuContribution implements MenuContribution {
         // Builtin monaco problem commands.
         registry.registerMenuAction(MonacoMenus.MARKERS_GROUP, {
             commandId: 'editor.action.marker.nextInFiles',
-            label: nls.localize('vscode/gotoError/miGotoNextProblem', 'Next Problem'),
+            label: nls.localizeByDefault('Next Problem'),
             order: '1'
         });
         registry.registerMenuAction(MonacoMenus.MARKERS_GROUP, {
             commandId: 'editor.action.marker.prevInFiles',
-            label: nls.localize('vscode/gotoError/miGotoPreviousProblem', 'Previous Problem'),
+            label: nls.localizeByDefault('Previous Problem'),
             order: '2'
         });
     }
 
     protected registerPeekSubmenu(registry: MenuModelRegistry): void {
-        registry.registerSubmenu(MonacoMenus.PEEK_CONTEXT_SUBMENU, nls.localize('vscode/goToCommands/peek.submenu', 'Peek'));
+        registry.registerSubmenu(MonacoMenus.PEEK_CONTEXT_SUBMENU, nls.localizeByDefault('Peek'));
 
         for (const item of MenuRegistry.getMenuItems(monaco.actions.MenuId.EditorContextPeek)) {
             if (!monaco.actions.isIMenuItem(item)) {

--- a/packages/monaco/src/browser/monaco-status-bar-contribution.ts
+++ b/packages/monaco/src/browser/monaco-status-bar-contribution.ts
@@ -15,7 +15,7 @@
  ********************************************************************************/
 
 import { injectable, inject } from '@theia/core/shared/inversify';
-import { DisposableCollection } from '@theia/core';
+import { DisposableCollection, nls } from '@theia/core';
 import { FrontendApplicationContribution, FrontendApplication, StatusBar, StatusBarAlignment } from '@theia/core/lib/browser';
 import { EditorCommands, EditorManager, EditorWidget } from '@theia/editor/lib/browser';
 import { MonacoEditor } from './monaco-editor';
@@ -66,13 +66,15 @@ export class MonacoStatusBarContribution implements FrontendApplicationContribut
         if (editor && editorModel) {
             const modelOptions = editorModel.getOptions();
             const tabSize = modelOptions.tabSize;
-            const useSpaceOrTab = modelOptions.insertSpaces ? 'Spaces' : 'Tab Size';
+            const useSpaceOrTab = modelOptions.insertSpaces
+                ? nls.localizeByDefault('Spaces: {0}', tabSize)
+                : nls.localizeByDefault('Tab Size: {0}', tabSize);
             this.statusBar.setElement('editor-status-tabbing-config', {
                 text: `${useSpaceOrTab}: ${tabSize}`,
                 alignment: StatusBarAlignment.RIGHT,
                 priority: 10,
                 command: EditorCommands.CONFIG_INDENTATION.id,
-                tooltip: 'Select Indentation'
+                tooltip: nls.localizeByDefault('Select Indentation')
             });
         }
     }
@@ -91,7 +93,7 @@ export class MonacoStatusBarContribution implements FrontendApplicationContribut
                 alignment: StatusBarAlignment.RIGHT,
                 priority: 11,
                 command: EditorCommands.CONFIG_EOL.id,
-                tooltip: 'Select End Of Line Sequence'
+                tooltip: nls.localizeByDefault('Select End of Line Sequence')
             });
         }
     }

--- a/packages/monaco/src/browser/workspace-symbol-command.ts
+++ b/packages/monaco/src/browser/workspace-symbol-command.ts
@@ -32,10 +32,10 @@ import { EditorMainMenu } from '@theia/editor/lib/browser';
 export class WorkspaceSymbolCommand implements QuickAccessProvider, CommandContribution, KeybindingContribution, MenuContribution, CommandHandler, QuickAccessContribution {
     public static readonly PREFIX = '#';
 
-    private command = Command.toLocalizedCommand({
+    private command = Command.toDefaultLocalizedCommand({
         id: 'languages.workspace.symbol',
         label: 'Go to Symbol in Workspace...'
-    }, 'vscode/search.contribution/showTriggerActions');
+    });
 
     @inject(MonacoLanguages) protected readonly languages: MonacoLanguages;
     @inject(OpenerService) protected readonly openerService: OpenerService;
@@ -79,7 +79,7 @@ export class WorkspaceSymbolCommand implements QuickAccessProvider, CommandContr
             getInstance: () => this,
             prefix: WorkspaceSymbolCommand.PREFIX,
             placeholder: '',
-            helpEntries: [{ description: nls.localize('vscode/search.contribution/symbolsQuickAccess', 'Go to Symbol in Workspace'), needsEditor: false }]
+            helpEntries: [{ description: nls.localizeByDefault('Go to Symbol in Workspace'), needsEditor: false }]
         });
     }
 

--- a/packages/navigator/src/browser/navigator-contribution.ts
+++ b/packages/navigator/src/browser/navigator-contribution.ts
@@ -99,29 +99,29 @@ export namespace FileNavigatorCommands {
         label: 'Refresh in Explorer',
         iconClass: codicon('refresh')
     }, 'theia/navigator/refresh', CommonCommands.FILE_CATEGORY_KEY);
-    export const COLLAPSE_ALL = Command.toLocalizedCommand({
+    export const COLLAPSE_ALL = Command.toDefaultLocalizedCommand({
         id: 'navigator.collapse.all',
         category: CommonCommands.FILE_CATEGORY,
         label: 'Collapse Folders in Explorer',
         iconClass: codicon('collapse-all')
-    }, 'vscode/explorerView/collapseExplorerFolders', CommonCommands.FILE_CATEGORY_KEY);
+    });
     export const ADD_ROOT_FOLDER: Command = {
         id: 'navigator.addRootFolder'
     };
-    export const FOCUS = Command.toLocalizedCommand({
+    export const FOCUS = Command.toDefaultLocalizedCommand({
         id: 'workbench.files.action.focusFilesExplorer',
         category: CommonCommands.FILE_CATEGORY,
         label: 'Focus on Files Explorer'
-    }, 'vscode/fileActions/focusFilesExplorer', CommonCommands.FILE_CATEGORY_KEY);
-    export const COPY_RELATIVE_FILE_PATH = Command.toLocalizedCommand({
+    });
+    export const COPY_RELATIVE_FILE_PATH = Command.toDefaultLocalizedCommand({
         id: 'navigator.copyRelativeFilePath',
         label: 'Copy Relative Path'
-    }, 'vscode/fileActions.contribution/copyRelativePath');
-    export const OPEN = Command.toLocalizedCommand({
+    });
+    export const OPEN = Command.toDefaultLocalizedCommand({
         id: 'navigator.open',
         category: CommonCommands.FILE_CATEGORY,
         label: 'Open'
-    }, 'vscode/dialogMainService/open', CommonCommands.FILE_CATEGORY_KEY);
+    });
 }
 
 /**
@@ -431,7 +431,7 @@ export class FileNavigatorContribution extends AbstractViewContribution<FileNavi
             commandId: FileNavigatorCommands.OPEN.id,
             label: FileNavigatorCommands.OPEN.label
         });
-        registry.registerSubmenu(NavigatorContextMenu.OPEN_WITH, nls.localize('vscode/fileActions.contribution/explorerOpenWith', 'Open With...'));
+        registry.registerSubmenu(NavigatorContextMenu.OPEN_WITH, nls.localizeByDefault('Open With...'));
         this.openerService.getOpeners().then(openers => {
             for (const opener of openers) {
                 const openWithCommand = WorkspaceCommands.FILE_OPEN_WITH(opener);
@@ -500,7 +500,7 @@ export class FileNavigatorContribution extends AbstractViewContribution<FileNavi
         });
         registry.registerMenuAction(NavigatorContextMenu.MODIFICATION, {
             commandId: FileNavigatorCommands.COLLAPSE_ALL.id,
-            label: nls.localize('vscode/treeView/collapseAll', 'Collapse All'),
+            label: nls.localizeByDefault('Collapse All'),
             order: 'z2'
         });
 
@@ -589,13 +589,13 @@ export class FileNavigatorContribution extends AbstractViewContribution<FileNavi
         toolbarRegistry.registerItem({
             id: FileNavigatorCommands.REFRESH_NAVIGATOR.id,
             command: FileNavigatorCommands.REFRESH_NAVIGATOR.id,
-            tooltip: nls.localize('vscode/explorerView/refreshExplorer', 'Refresh Explorer'),
+            tooltip: nls.localizeByDefault('Refresh Explorer'),
             priority: 0,
         });
         toolbarRegistry.registerItem({
             id: FileNavigatorCommands.COLLAPSE_ALL.id,
             command: FileNavigatorCommands.COLLAPSE_ALL.id,
-            tooltip: nls.localize('vscode/treeView/collapseAll', 'Collapse All'),
+            tooltip: nls.localizeByDefault('Collapse All'),
             priority: 1,
         });
         this.registerMoreToolbarItem({

--- a/packages/navigator/src/browser/navigator-diff.ts
+++ b/packages/navigator/src/browser/navigator-diff.ts
@@ -26,17 +26,16 @@ import { FileOperationError, FileOperationResult } from '@theia/filesystem/lib/c
 
 export namespace NavigatorDiffCommands {
     const COMPARE_CATEGORY = 'Compare';
-    const COMPARE_CATEGORY_KEY = 'vscode/editorCommands/compare';
-    export const COMPARE_FIRST = Command.toLocalizedCommand({
+    export const COMPARE_FIRST = Command.toDefaultLocalizedCommand({
         id: 'compare:first',
         category: COMPARE_CATEGORY,
         label: 'Select for Compare'
-    }, 'vscode/fileActions.contribution/compareSource', COMPARE_CATEGORY_KEY);
-    export const COMPARE_SECOND = Command.toLocalizedCommand({
+    });
+    export const COMPARE_SECOND = Command.toDefaultLocalizedCommand({
         id: 'compare:second',
         category: COMPARE_CATEGORY,
         label: 'Compare with Selected'
-    }, 'vscode/fileActions.contribution/compareWithSelected', COMPARE_CATEGORY_KEY);
+    });
 }
 
 @injectable()

--- a/packages/navigator/src/browser/navigator-preferences.ts
+++ b/packages/navigator/src/browser/navigator-preferences.ts
@@ -23,7 +23,7 @@ export const FileNavigatorConfigSchema: PreferenceSchema = {
     properties: {
         'explorer.autoReveal': {
             type: 'boolean',
-            description: nls.localize('vscode/files.contribution/autoReveal', 'Selects file under editing in the explorer.'),
+            description: nls.localizeByDefault('Controls whether the explorer should automatically reveal and select files when opening them.'),
             default: true
         }
     }

--- a/packages/navigator/src/browser/navigator-widget-factory.ts
+++ b/packages/navigator/src/browser/navigator-widget-factory.ts
@@ -28,7 +28,7 @@ import { nls } from '@theia/core/lib/common/nls';
 
 export const EXPLORER_VIEW_CONTAINER_ID = 'explorer-view-container';
 export const EXPLORER_VIEW_CONTAINER_TITLE_OPTIONS: ViewContainerTitleOptions = {
-    label: nls.localize('vscode/settingsLayout/fileExplorer', 'Explorer'),
+    label: nls.localizeByDefault('Explorer'),
     iconClass: codicon('files'),
     closeable: true
 };

--- a/packages/navigator/src/browser/navigator-widget.tsx
+++ b/packages/navigator/src/browser/navigator-widget.tsx
@@ -34,7 +34,7 @@ import { FileNavigatorCommands } from './navigator-contribution';
 import { nls } from '@theia/core/lib/common/nls';
 
 export const FILE_NAVIGATOR_ID = 'files';
-export const LABEL = nls.localize('vscode/emptyView/noWorkspace', 'No folder opened');
+export const LABEL = nls.localizeByDefault('No Folder Opened');
 export const CLASS = 'theia-Files';
 
 @injectable()
@@ -66,7 +66,7 @@ export class FileNavigatorWidget extends FileTreeWidget {
         super.init();
         // This ensures that the context menu command to hide this widget receives the label 'Folders'
         // regardless of the name of workspace. See ViewContainer.updateToolbarItems.
-        const dataset = { ...this.title.dataset, visibilityCommandLabel: nls.localize('vscode/explorerViewlet/folders', 'Folders') };
+        const dataset = { ...this.title.dataset, visibilityCommandLabel: nls.localizeByDefault('Folders') };
         this.title.dataset = dataset;
         this.updateSelectionContextKeys();
         this.toDispose.pushAll([

--- a/packages/navigator/src/browser/open-editors-widget/navigator-open-editors-commands.ts
+++ b/packages/navigator/src/browser/open-editors-widget/navigator-open-editors-commands.ts
@@ -18,31 +18,31 @@ import { CommonCommands } from '@theia/core/lib/browser';
 import { Command } from '@theia/core/lib/common';
 
 export namespace OpenEditorsCommands {
-    export const CLOSE_ALL_TABS_FROM_TOOLBAR = Command.toLocalizedCommand({
+    export const CLOSE_ALL_TABS_FROM_TOOLBAR = Command.toDefaultLocalizedCommand({
         id: 'navigator.close.all.editors.toolbar',
         category: CommonCommands.FILE_CATEGORY,
         label: 'Close All Editors',
         iconClass: 'codicon codicon-close-all'
-    }, 'vscode/editorActions/closeAllEditors', CommonCommands.FILE_CATEGORY_KEY);
+    });
 
-    export const SAVE_ALL_TABS_FROM_TOOLBAR = Command.toLocalizedCommand({
+    export const SAVE_ALL_TABS_FROM_TOOLBAR = Command.toDefaultLocalizedCommand({
         id: 'navigator.save.all.editors.toolbar',
         category: CommonCommands.FILE_CATEGORY,
-        label: 'Save All Editors',
+        label: 'Save All',
         iconClass: 'codicon codicon-save-all'
-    }, 'vscode/fileActions.contribution/saveFiles', CommonCommands.FILE_CATEGORY_KEY);
+    });
 
-    export const CLOSE_ALL_EDITORS_IN_GROUP_FROM_ICON = Command.toLocalizedCommand({
+    export const CLOSE_ALL_EDITORS_IN_GROUP_FROM_ICON = Command.toDefaultLocalizedCommand({
         id: 'navigator.close.all.in.area.icon',
         category: CommonCommands.VIEW_CATEGORY,
         label: 'Close Group',
         iconClass: 'codicon codicon-close-all'
-    }, 'vscode/fileActions/closeGroup', CommonCommands.VIEW_CATEGORY_KEY);
+    });
 
-    export const SAVE_ALL_IN_GROUP_FROM_ICON = Command.toLocalizedCommand({
+    export const SAVE_ALL_IN_GROUP_FROM_ICON = Command.toDefaultLocalizedCommand({
         id: 'navigator.save.all.in.area.icon',
         category: CommonCommands.FILE_CATEGORY,
         label: 'Save All in Group',
         iconClass: 'codicon codicon-save-all'
-    }, 'vscode/fileActions.contribution/saveAllInGroup', CommonCommands.FILE_CATEGORY_KEY);
+    });
 }

--- a/packages/navigator/src/browser/open-editors-widget/navigator-open-editors-widget.tsx
+++ b/packages/navigator/src/browser/open-editors-widget/navigator-open-editors-widget.tsx
@@ -52,7 +52,7 @@ export interface OpenEditorsNodeRow extends TreeWidget.NodeRow {
 @injectable()
 export class OpenEditorsWidget extends FileTreeWidget {
     static ID = 'theia-open-editors-widget';
-    static LABEL = nls.localize('vscode/openEditorsView/openEditors', 'Open Editors');
+    static LABEL = nls.localizeByDefault('Open Editors');
 
     @inject(ApplicationShell) protected readonly applicationShell: ApplicationShell;
     @inject(CommandService) protected readonly commandService: CommandService;

--- a/packages/outline-view/src/browser/outline-view-contribution.ts
+++ b/packages/outline-view/src/browser/outline-view-contribution.ts
@@ -76,7 +76,7 @@ export class OutlineViewContribution extends AbstractViewContribution<OutlineVie
         toolbar.registerItem({
             id: OutlineViewCommands.COLLAPSE_ALL.id,
             command: OutlineViewCommands.COLLAPSE_ALL.id,
-            tooltip: nls.localize('vscode/outlinePane/collapse', 'Collapse All'),
+            tooltip: nls.localizeByDefault('Collapse All'),
             priority: 0
         });
     }

--- a/packages/outline-view/src/browser/outline-view-widget.tsx
+++ b/packages/outline-view/src/browser/outline-view-widget.tsx
@@ -74,7 +74,7 @@ export const OutlineViewWidgetFactory = Symbol('OutlineViewWidgetFactory');
 @injectable()
 export class OutlineViewWidget extends TreeWidget {
 
-    static LABEL = nls.localize('vscode/outline.contribution/name', 'Outline');
+    static LABEL = nls.localizeByDefault('Outline');
 
     readonly onDidChangeOpenStateEmitter = new Emitter<boolean>();
 
@@ -180,7 +180,7 @@ export class OutlineViewWidget extends TreeWidget {
 
     protected renderTree(model: TreeModel): React.ReactNode {
         if (CompositeTreeNode.is(this.model.root) && !this.model.root.children.length) {
-            return <div className='theia-widget-noInfo no-outline'>{nls.localize('vscode/outlinePane/no-editor', 'No outline information available.')}</div>;
+            return <div className='theia-widget-noInfo no-outline'>{nls.localizeByDefault('No outline information available.')}</div>;
         }
         return super.renderTree(model);
     }

--- a/packages/output/src/browser/output-commands.ts
+++ b/packages/output/src/browser/output-commands.ts
@@ -15,12 +15,12 @@
  ********************************************************************************/
 
 import { codicon } from '@theia/core/lib/browser';
-import { Command } from '@theia/core/lib/common';
+import { Command, nls } from '@theia/core/lib/common';
 
 export namespace OutputCommands {
 
-    const OUTPUT_CATEGORY_KEY = 'vscode/outputView/output';
     const OUTPUT_CATEGORY = 'Output';
+    const OUTPUT_CATEGORY_KEY = nls.getDefaultKey(OUTPUT_CATEGORY);
 
     /* #region VS Code `OutputChannel` API */
     // Based on: https://github.com/theia-ide/vscode/blob/standalone/0.19.x/src/vs/vscode.d.ts#L4692-L4745

--- a/packages/output/src/browser/output-contribution.ts
+++ b/packages/output/src/browser/output-contribution.ts
@@ -224,15 +224,15 @@ export class OutputContribution extends AbstractViewContribution<OutputWidget> i
         });
         registry.registerMenuAction(OutputContextMenu.TEXT_EDIT_GROUP, {
             commandId: OutputCommands.COPY_ALL.id,
-            label: nls.localize('vscode/search.contribution/copyAllLabel', 'Copy All')
+            label: nls.localizeByDefault('Copy All')
         });
         registry.registerMenuAction(OutputContextMenu.COMMAND_GROUP, {
             commandId: quickCommand.id,
-            label: nls.localize('vscode/quickAccess.contribution/commandsQuickAccess', 'Find Command...')
+            label: nls.localizeByDefault('Command Palette...')
         });
         registry.registerMenuAction(OutputContextMenu.WIDGET_GROUP, {
             commandId: OutputCommands.CLEAR__WIDGET.id,
-            label: nls.localize('vscode/output.contribution/clearOutput.label', 'Clear Output')
+            label: nls.localizeByDefault('Clear Output')
         });
     }
 

--- a/packages/output/src/browser/output-toolbar-contribution.tsx
+++ b/packages/output/src/browser/output-toolbar-contribution.tsx
@@ -62,20 +62,20 @@ export class OutputToolbarContribution implements TabBarToolbarContribution {
         toolbarRegistry.registerItem({
             id: OutputCommands.CLEAR__WIDGET.id,
             command: OutputCommands.CLEAR__WIDGET.id,
-            tooltip: nls.localize('vscode/output.contribution/clearOutput.label', 'Clear Output'),
+            tooltip: nls.localizeByDefault('Clear Output'),
             priority: 1,
         });
         toolbarRegistry.registerItem({
             id: OutputCommands.LOCK__WIDGET.id,
             command: OutputCommands.LOCK__WIDGET.id,
-            tooltip: nls.localize('vscode/output.contribution/outputScrollOff', 'Turn Auto Scrolling Off'),
+            tooltip: nls.localizeByDefault('Turn Auto Scrolling Off'),
             onDidChange: this.onOutputWidgetStateChanged,
             priority: 2
         });
         toolbarRegistry.registerItem({
             id: OutputCommands.UNLOCK__WIDGET.id,
             command: OutputCommands.UNLOCK__WIDGET.id,
-            tooltip: nls.localize('vscode/output.contribution/outputScrollOn', 'Turn Auto Scrolling On'),
+            tooltip: nls.localizeByDefault('Turn Auto Scrolling On'),
             onDidChange: this.onOutputWidgetStateChanged,
             priority: 2
         });

--- a/packages/output/src/browser/output-widget.ts
+++ b/packages/output/src/browser/output-widget.ts
@@ -33,7 +33,7 @@ import { nls } from '@theia/core/lib/common/nls';
 export class OutputWidget extends BaseWidget implements StatefulWidget {
 
     static readonly ID = 'outputView';
-    static readonly LABEL = nls.localize('vscode/settingsLayout/output', 'Output');
+    static readonly LABEL = nls.localizeByDefault('Output');
 
     @inject(SelectionService)
     protected readonly selectionService: SelectionService;

--- a/packages/plugin-ext-vscode/src/browser/plugin-vscode-commands-contribution.ts
+++ b/packages/plugin-ext-vscode/src/browser/plugin-vscode-commands-contribution.ts
@@ -379,13 +379,13 @@ export class PluginVscodeCommandsContribution implements CommandContribution {
 
         commands.registerCommand({
             id: 'workbench.action.closeEditorsInGroup',
-            label: nls.localize('vscode/editor.contribution/closeEditorsInGroup', 'Close All Editors in Group')
+            label: nls.localizeByDefault('Close All Editors in Group')
         }, {
             execute: (uri?: monaco.Uri) => performActionOnGroup(this.shell.closeTabs, uri)
         });
         commands.registerCommand({
             id: 'workbench.files.saveAllInGroup',
-            label: nls.localize('vscode/fileActions.contribution/saveAllInGroup', 'Save All in Group')
+            label: nls.localizeByDefault('Save All in Group')
         }, {
             execute: (uri?: monaco.Uri) => performActionOnGroup(this.shell.saveTabs, uri)
         });

--- a/packages/preferences/src/browser/util/preference-types.ts
+++ b/packages/preferences/src/browser/util/preference-types.ts
@@ -113,55 +113,55 @@ export namespace PreferencesCommands {
         id: 'preferences:openJson.toolbar',
         iconClass: 'codicon codicon-json'
     };
-    export const COPY_JSON_NAME = Command.toLocalizedCommand({
+    export const COPY_JSON_NAME = Command.toDefaultLocalizedCommand({
         id: 'preferences:copyJson.name',
         label: 'Copy Setting ID'
-    }, 'vscode/settingsTree/copySettingIdLabel');
-    export const RESET_PREFERENCE = Command.toLocalizedCommand({
+    });
+    export const RESET_PREFERENCE = Command.toDefaultLocalizedCommand({
         id: 'preferences:reset',
         label: 'Reset Setting'
-    }, 'vscode/settingsTree/resetSettingLabel');
+    });
 
-    export const COPY_JSON_VALUE = Command.toLocalizedCommand({
+    export const COPY_JSON_VALUE = Command.toDefaultLocalizedCommand({
         id: 'preferences:copyJson.value',
         label: 'Copy Setting as JSON',
-    }, 'vscode/settingsTree/copySettingAsJSONLabel');
+    });
 
-    export const OPEN_USER_PREFERENCES = Command.toLocalizedCommand({
+    export const OPEN_USER_PREFERENCES = Command.toDefaultLocalizedCommand({
         id: 'workbench.action.openGlobalSettings',
         category: CommonCommands.PREFERENCES_CATEGORY,
         label: 'Open User Settings',
-    }, 'vscode/preferences.contribution/openGlobalSettings', CommonCommands.PREFERENCES_CATEGORY_KEY);
+    });
 
-    export const OPEN_WORKSPACE_PREFERENCES = Command.toLocalizedCommand({
+    export const OPEN_WORKSPACE_PREFERENCES = Command.toDefaultLocalizedCommand({
         id: 'workbench.action.openWorkspaceSettings',
         category: CommonCommands.PREFERENCES_CATEGORY,
         label: 'Open Workspace Settings',
-    }, 'vscode/preferences.contribution/openWorkspaceSettings', CommonCommands.PREFERENCES_CATEGORY_KEY);
+    });
 
-    export const OPEN_FOLDER_PREFERENCES = Command.toLocalizedCommand({
+    export const OPEN_FOLDER_PREFERENCES = Command.toDefaultLocalizedCommand({
         id: 'workbench.action.openFolderSettings',
         category: CommonCommands.PREFERENCES_CATEGORY,
         label: 'Open Folder Settings'
-    }, 'vscode/preferences.contribution/openFolderSettings', CommonCommands.PREFERENCES_CATEGORY_KEY);
+    });
 
-    export const OPEN_USER_PREFERENCES_JSON = Command.toLocalizedCommand({
+    export const OPEN_USER_PREFERENCES_JSON = Command.toDefaultLocalizedCommand({
         id: 'workbench.action.openSettingsJson',
         category: CommonCommands.PREFERENCES_CATEGORY,
         label: 'Open Settings (JSON)'
-    }, 'vscode/preferences.contribution/openSettingsJson', CommonCommands.PREFERENCES_CATEGORY_KEY);
+    });
 
-    export const OPEN_WORKSPACE_PREFERENCES_JSON = Command.toLocalizedCommand({
+    export const OPEN_WORKSPACE_PREFERENCES_JSON = Command.toDefaultLocalizedCommand({
         id: 'workbench.action.openWorkspaceSettingsFile',
         category: CommonCommands.PREFERENCES_CATEGORY,
         label: 'Open Workspace Settings (JSON)',
-    }, 'vscode/preferences.contribution/openWorkspaceSettingsFile', CommonCommands.PREFERENCES_CATEGORY_KEY);
+    });
 
-    export const OPEN_FOLDER_PREFERENCES_JSON = Command.toLocalizedCommand({
+    export const OPEN_FOLDER_PREFERENCES_JSON = Command.toDefaultLocalizedCommand({
         id: 'workbench.action.openFolderSettingsFile',
         category: CommonCommands.PREFERENCES_CATEGORY,
         label: 'Open Folder Settings (JSON)',
-    }, 'vscode/preferences.contribution/openFolderSettingsFile', CommonCommands.PREFERENCES_CATEGORY_KEY);
+    });
 }
 
 export namespace PreferenceMenus {

--- a/packages/preferences/src/browser/views/preference-scope-tabbar-widget.tsx
+++ b/packages/preferences/src/browser/views/preference-scope-tabbar-widget.tsx
@@ -25,11 +25,11 @@ import { Preference, PreferenceMenus } from '../util/preference-types';
 import { CommandRegistry, DisposableCollection, Emitter, MenuModelRegistry } from '@theia/core/lib/common';
 import { nls } from '@theia/core/lib/common/nls';
 
-const USER_TAB_LABEL = nls.localize('vscode/preferencesWidgets/userSettings', 'User');
+const USER_TAB_LABEL = nls.localizeByDefault('User');
 const USER_TAB_INDEX = PreferenceScope['User'];
-const WORKSPACE_TAB_LABEL = nls.localize('vscode/preferencesWidgets/workspaceSettings', 'Workspace');
+const WORKSPACE_TAB_LABEL = nls.localizeByDefault('Workspace');
 const WORKSPACE_TAB_INDEX = PreferenceScope['Workspace'];
-const FOLDER_TAB_LABEL = nls.localize('vscode/preferencesWidgets/folderSettings', 'Folder');
+const FOLDER_TAB_LABEL = nls.localizeByDefault('Folder');
 const FOLDER_TAB_INDEX = PreferenceScope['Folder'];
 
 const PREFERENCE_TAB_CLASSNAME = 'preferences-scope-tab';

--- a/packages/preferences/src/browser/views/preference-searchbar-widget.tsx
+++ b/packages/preferences/src/browser/views/preference-searchbar-widget.tsx
@@ -88,11 +88,11 @@ export class PreferencesSearchbarWidget extends ReactWidget implements StatefulW
     protected renderResultsCountOption(): React.ReactNode {
         let resultsFound: string;
         if (this.resultsCount === 0) {
-            resultsFound = nls.localize('vscode/settingsEditor2/noResults', 'No Settings Found');
+            resultsFound = nls.localizeByDefault('No Settings Found');
         } else if (this.resultsCount === 1) {
-            resultsFound = nls.localize('vscode/settingsEditor2/oneResult', '1 Setting Found');
+            resultsFound = nls.localizeByDefault('1 Setting Found');
         } else {
-            resultsFound = nls.localize('vscode/settingsEditor2/moreThanOneResult', '{0} Settings Found', this.resultsCount.toFixed(0));
+            resultsFound = nls.localizeByDefault('{0} Settings Found', this.resultsCount.toFixed(0));
         }
         return this.searchTermExists() ?
             (<span
@@ -109,7 +109,7 @@ export class PreferencesSearchbarWidget extends ReactWidget implements StatefulW
     protected renderClearAllOption(): React.ReactNode {
         return <span
             className={`${codicon('clear-all')} option ${(this.searchTermExists() ? 'enabled' : '')}`}
-            title={nls.localize('vscode/settingsEditor2/clearInput', 'Clear Search Results')}
+            title={nls.localizeByDefault('Clear Search Results')}
             onClick={this.clearSearchResults}
         />;
     }
@@ -146,7 +146,7 @@ export class PreferencesSearchbarWidget extends ReactWidget implements StatefulW
                         type="text"
                         id={PreferencesSearchbarWidget.SEARCHBAR_ID}
                         spellCheck={false}
-                        placeholder={nls.localize('vscode/settingsEditor2/SearchSettings.AriaLabel', 'Search Settings')}
+                        placeholder={nls.localizeByDefault('Search Settings')}
                         className="settings-search-input theia-input"
                         onChange={this.handleSearch}
                         ref={this.searchbarRef}

--- a/packages/preferences/src/browser/views/preference-widget.tsx
+++ b/packages/preferences/src/browser/views/preference-widget.tsx
@@ -39,7 +39,7 @@ export class PreferencesWidget extends Panel implements StatefulWidget {
     /**
      * The widget `label` which is used for display purposes.
      */
-    static readonly LABEL = nls.localize('vscode/actions/preferences', 'Preferences');
+    static readonly LABEL = nls.localizeByDefault('Preferences');
 
     @inject(PreferencesEditorWidget) protected readonly editorWidget: PreferencesEditorWidget;
     @inject(PreferencesTreeWidget) protected readonly treeWidget: PreferencesTreeWidget;

--- a/packages/preview/src/browser/preview-contribution.ts
+++ b/packages/preview/src/browser/preview-contribution.ts
@@ -40,7 +40,7 @@ export namespace PreviewCommands {
         id: 'preview:open',
         label: 'Open Preview',
         iconClass: codicon('open-preview')
-    }, 'vscode/mainThreadFileSystemEventService/preview');
+    }, 'vscode.markdown-language-features/package/markdown.preview.title');
     export const OPEN_SOURCE: Command = {
         id: 'preview.open.source',
         iconClass: codicon('go-to-file')
@@ -229,12 +229,12 @@ export class PreviewContribution extends NavigatableWidgetOpenHandler<PreviewWid
         registry.registerItem({
             id: PreviewCommands.OPEN.id,
             command: PreviewCommands.OPEN.id,
-            tooltip: nls.localize('theia/preview/openPreviewSide', 'Open Preview to the Side')
+            tooltip: nls.localize('vscode.markdown-language-features/package/markdown.previewSide.title', 'Open Preview to the Side')
         });
         registry.registerItem({
             id: PreviewCommands.OPEN_SOURCE.id,
             command: PreviewCommands.OPEN_SOURCE.id,
-            tooltip: nls.localize('theia/preview/openSource', 'Open Source')
+            tooltip: nls.localize('vscode.markdown-language-features/package/markdown.showSource.title', 'Open Source')
         });
     }
 

--- a/packages/property-view/src/browser/resource-property-view/resource-property-view-tree-widget.tsx
+++ b/packages/property-view/src/browser/resource-property-view/resource-property-view-tree-widget.tsx
@@ -93,7 +93,7 @@ export class ResourcePropertyViewTreeWidget extends TreeWidget implements Proper
     protected fillPropertiesTree(fileStatObject?: FileStat): void {
         if (fileStatObject) {
             this.propertiesTree.clear();
-            const infoNode = this.createCategoryNode('info', nls.localize('vscode/logsActions/info', 'Info'));
+            const infoNode = this.createCategoryNode('info', nls.localizeByDefault('Info'));
             this.propertiesTree.set('info', infoNode);
 
             infoNode.children.push(this.createResultLineNode('isDirectory', nls.localize('theia/property-view/directory', 'Directory'), fileStatObject.isDirectory, infoNode));
@@ -134,7 +134,7 @@ export class ResourcePropertyViewTreeWidget extends TreeWidget implements Proper
     }
 
     protected getSizeString(fileStat: FileStat): string {
-        return fileStat.size ? nls.localize('vscode/files/sizeB', '{0} B', fileStat.size.toString()) : '';
+        return fileStat.size ? nls.localizeByDefault('{0} B', fileStat.size.toString()) : '';
     }
 
     /*

--- a/packages/scm-extra/src/browser/history/scm-history-widget.tsx
+++ b/packages/scm-extra/src/browser/history/scm-history-widget.tsx
@@ -264,7 +264,7 @@ export class ScmHistoryWidget extends ScmNavigableListWidget<ScmHistoryListNode>
         } else {
             this.status = {
                 state: 'error',
-                errorMessage: <React.Fragment>{nls.localize('vscode/scm.contribution/no open repo', 'There is no repository selected in this workspace.')}</React.Fragment>
+                errorMessage: <React.Fragment>{nls.localizeByDefault('There is no repository selected in this workspace.')}</React.Fragment>
             };
         }
     }

--- a/packages/scm/src/browser/scm-contribution.ts
+++ b/packages/scm/src/browser/scm-contribution.ts
@@ -41,7 +41,7 @@ import { nls } from '@theia/core/lib/common/nls';
 export const SCM_WIDGET_FACTORY_ID = ScmWidget.ID;
 export const SCM_VIEW_CONTAINER_ID = 'scm-view-container';
 export const SCM_VIEW_CONTAINER_TITLE_OPTIONS: ViewContainerTitleOptions = {
-    label: nls.localize('vscode/scm.contribution/source control', 'Source Control'),
+    label: nls.localizeByDefault('Source Control'),
     iconClass: codicon('source-control'),
     closeable: true
 };
@@ -57,24 +57,24 @@ export namespace SCM_COMMANDS {
     };
     export const TREE_VIEW_MODE = {
         id: 'scm.viewmode.tree',
-        tooltip: nls.localize('vscode/scmViewPane/viewModeTree', 'Toggle to Tree View'),
+        tooltip: nls.localizeByDefault('View as Tree'),
         iconClass: codicon('list-tree'),
-        originalLabel: 'Toggle to Tree View',
-        label: nls.localize('vscode/scmViewPane/viewModeTree', 'Toggle to Tree View')
+        originalLabel: 'View as Tree',
+        label: nls.localizeByDefault('View as Tree')
     };
     export const LIST_VIEW_MODE = {
         id: 'scm.viewmode.list',
-        tooltip: nls.localize('vscode/scmViewPane/viewModeList', 'Toggle to List View'),
+        tooltip: nls.localizeByDefault('View as List'),
         iconClass: codicon('list-flat'),
-        originalLabel: 'Toggle to List View',
-        label: nls.localize('vscode/scmViewPane/viewModeList', 'Toggle to List View')
+        originalLabel: 'View as List',
+        label: nls.localizeByDefault('View as List')
     };
     export const COLLAPSE_ALL = {
         id: 'scm.collapseAll',
         category: 'SCM',
-        tooltip: nls.localize('vscode/treeView/collapseAll', 'Collapse All'),
+        tooltip: nls.localizeByDefault('Collapse All'),
         iconClass: codicon('collapse-all'),
-        label: nls.localize('vscode/treeView/collapseAll', 'Collapse All'),
+        label: nls.localizeByDefault('Collapse All'),
         originalLabel: 'Collapse All'
     };
 }

--- a/packages/scm/src/browser/scm-no-repository-widget.tsx
+++ b/packages/scm/src/browser/scm-no-repository-widget.tsx
@@ -34,7 +34,7 @@ export class ScmNoRepositoryWidget extends ReactWidget {
     protected render(): React.ReactNode {
         return <AlertMessage
             type='WARNING'
-            header={nls.localize('vscode/scm.contribution/no open repo', 'No repository found')}
+            header={nls.localize('theia/scm/noRepositoryFound', 'No repository found')}
         />;
     }
 

--- a/packages/scm/src/browser/scm-preferences.ts
+++ b/packages/scm/src/browser/scm-preferences.ts
@@ -31,10 +31,10 @@ export const scmPreferenceSchema: PreferenceSchema = {
             type: 'string',
             enum: ['tree', 'list'],
             enumDescriptions: [
-                nls.localize('vscode/scm.contribution/scm.defaultViewMode.tree', 'Show the repository changes as a tree.'),
-                nls.localize('vscode/scm.contribution/scm.defaultViewMode.list', 'Show the repository changes as a list.')
+                nls.localizeByDefault('Show the repository changes as a tree.'),
+                nls.localizeByDefault('Show the repository changes as a list.')
             ],
-            description: nls.localize('vscode/scm.contribution/scm.defaultViewMode', 'Controls the default source control view mode.'),
+            description: nls.localizeByDefault('Controls the default Source Control repository view mode.'),
             default: 'list'
         }
     }

--- a/packages/scm/src/browser/scm-widget.tsx
+++ b/packages/scm/src/browser/scm-widget.tsx
@@ -104,7 +104,7 @@ export class ScmWidget extends BaseWidget implements StatefulWidget {
         this.toDisposeOnRefresh.dispose();
         this.toDispose.push(this.toDisposeOnRefresh);
         const repository = this.scmService.selectedRepository;
-        this.title.label = repository ? repository.provider.label : nls.localize('vscode/scm.contribution/no open repo', 'No repository found');
+        this.title.label = repository ? repository.provider.label : nls.localize('theia/scm/noRepositoryFound', 'No repository found');
         this.title.caption = this.title.label;
         this.update();
         if (repository) {

--- a/packages/search-in-workspace/src/browser/search-in-workspace-frontend-contribution.ts
+++ b/packages/search-in-workspace/src/browser/search-in-workspace-frontend-contribution.ts
@@ -31,56 +31,55 @@ import { FileService } from '@theia/filesystem/lib/browser/file-service';
 import { SEARCH_VIEW_CONTAINER_ID } from './search-in-workspace-factory';
 
 export namespace SearchInWorkspaceCommands {
-    const SEARCH_CATEGORY_KEY = 'vscode/search.contribution/search';
     const SEARCH_CATEGORY = 'Search';
     export const TOGGLE_SIW_WIDGET = {
         id: 'search-in-workspace.toggle'
     };
-    export const OPEN_SIW_WIDGET = Command.toLocalizedCommand({
+    export const OPEN_SIW_WIDGET = Command.toDefaultLocalizedCommand({
         id: 'search-in-workspace.open',
         category: SEARCH_CATEGORY,
         label: 'Find in Files'
-    }, 'vscode/search.contribution/findInFiles', SEARCH_CATEGORY_KEY);
-    export const REPLACE_IN_FILES = Command.toLocalizedCommand({
+    });
+    export const REPLACE_IN_FILES = Command.toDefaultLocalizedCommand({
         id: 'search-in-workspace.replace',
         category: SEARCH_CATEGORY,
         label: 'Replace in Files'
-    }, 'vscode/searchActions/replaceInFiles', SEARCH_CATEGORY_KEY);
+    });
     export const FIND_IN_FOLDER = Command.toLocalizedCommand({
         id: 'search-in-workspace.in-folder',
         category: SEARCH_CATEGORY,
         label: 'Find in Folder'
-    }, 'vscode/search.contribution/findInFolder', SEARCH_CATEGORY_KEY);
-    export const REFRESH_RESULTS = Command.toLocalizedCommand({
+    });
+    export const REFRESH_RESULTS = Command.toDefaultLocalizedCommand({
         id: 'search-in-workspace.refresh',
         category: SEARCH_CATEGORY,
         label: 'Refresh',
         iconClass: codicon('refresh')
-    }, 'vscode/search.contribution/RefreshAction.label', SEARCH_CATEGORY_KEY);
-    export const CANCEL_SEARCH = Command.toLocalizedCommand({
+    });
+    export const CANCEL_SEARCH = Command.toDefaultLocalizedCommand({
         id: 'search-in-workspace.cancel',
         category: SEARCH_CATEGORY,
         label: 'Cancel Search',
         iconClass: codicon('search-stop')
-    }, 'vscode/search.contribution/CancelSearchAction.label', SEARCH_CATEGORY_KEY);
-    export const COLLAPSE_ALL = Command.toLocalizedCommand({
+    });
+    export const COLLAPSE_ALL = Command.toDefaultLocalizedCommand({
         id: 'search-in-workspace.collapse-all',
         category: SEARCH_CATEGORY,
         label: 'Collapse All',
         iconClass: codicon('collapse-all')
-    }, 'vscode/search.contribution/CollapseDeepestExpandedLevelAction.label', SEARCH_CATEGORY_KEY);
-    export const EXPAND_ALL = Command.toLocalizedCommand({
+    });
+    export const EXPAND_ALL = Command.toDefaultLocalizedCommand({
         id: 'search-in-workspace.expand-all',
         category: SEARCH_CATEGORY,
         label: 'Expand All',
         iconClass: codicon('expand-all')
-    }, 'vscode/search.contribution/ExpandAllAction.label', SEARCH_CATEGORY_KEY);
-    export const CLEAR_ALL = Command.toLocalizedCommand({
+    });
+    export const CLEAR_ALL = Command.toDefaultLocalizedCommand({
         id: 'search-in-workspace.clear-all',
         category: SEARCH_CATEGORY,
         label: 'Clear Search Results',
         iconClass: codicon('clear-all')
-    }, 'vscode/search.contribution/ClearSearchResultsAction.label', SEARCH_CATEGORY_KEY);
+    });
 }
 
 @injectable()

--- a/packages/search-in-workspace/src/browser/search-in-workspace-preferences.ts
+++ b/packages/search-in-workspace/src/browser/search-in-workspace-preferences.ts
@@ -22,24 +22,24 @@ export const searchInWorkspacePreferencesSchema: PreferenceSchema = {
     type: 'object',
     properties: {
         'search.lineNumbers': {
-            description: nls.localize('vscode/search.contribution/search.showLineNumbers', 'Controls whether to show line numbers for search results.'),
+            description: nls.localizeByDefault('Controls whether to show line numbers for search results.'),
             default: false,
             type: 'boolean',
         },
         'search.collapseResults': {
-            description: nls.localize('vscode/search.contribution/search.collapseAllResults', 'Controls whether the search results will be collapsed or expanded.'),
+            description: nls.localizeByDefault('Controls whether the search results will be collapsed or expanded.'),
             default: 'auto',
             type: 'string',
             enum: ['auto', 'alwaysCollapse', 'alwaysExpand'],
         },
         'search.searchOnType': {
-            description: nls.localize('vscode/search.contribution/search.searchOnType', 'Search all files as you type in the search field.'),
+            description: nls.localizeByDefault('Search all files as you type.'),
             default: true,
             type: 'boolean',
         },
         'search.searchOnTypeDebouncePeriod': {
             // eslint-disable-next-line max-len
-            description: nls.localize('vscode/search.contribution/search.searchOnTypeDebouncePeriod', 'When `search.searchOnType` is enabled, controls the timeout in milliseconds between a character being typed and the search starting. Has no effect when `search.searchOnType` is disabled.'),
+            description: nls.localizeByDefault('When `#search.searchOnType#` is enabled, controls the timeout in milliseconds between a character being typed and the search starting. Has no effect when `search.searchOnType` is disabled.'),
             default: 300,
             type: 'number',
         },
@@ -50,7 +50,7 @@ export const searchInWorkspacePreferencesSchema: PreferenceSchema = {
         },
         'search.smartCase': {
             // eslint-disable-next-line max-len
-            description: nls.localize('vscode/search.contribution/search.smartCase', 'Search case-insensitively if the pattern is all lowercase, otherwise, search case-sensitively.'),
+            description: nls.localizeByDefault('Search case-insensitively if the pattern is all lowercase, otherwise, search case-sensitively.'),
             default: false,
             type: 'boolean',
         }

--- a/packages/search-in-workspace/src/browser/search-in-workspace-result-tree-widget.tsx
+++ b/packages/search-in-workspace/src/browser/search-in-workspace-result-tree-widget.tsx
@@ -740,8 +740,8 @@ export class SearchInWorkspaceResultTreeWidget extends TreeWidget {
         return <span className={isResultLineNode ? 'replace-result' : 'replace-all-result'}
             onClick={e => this.doReplace(node, e)}
             title={isResultLineNode
-                ? nls.localize('vscode/findWidget/label.replaceButton', 'Replace')
-                : nls.localize('vscode/findWidget/label.replaceAllButton', 'Replace All')
+                ? nls.localizeByDefault('Replace')
+                : nls.localizeByDefault('Replace All')
             }></span>;
     }
 
@@ -786,7 +786,7 @@ export class SearchInWorkspaceResultTreeWidget extends TreeWidget {
 
     protected confirmReplaceAll(resultNumber: number, fileNumber: number): Promise<boolean | undefined> {
         return new ConfirmDialog({
-            title: nls.localize('vscode/findWidget/label.replaceAllButton', 'Replace All'),
+            title: nls.localizeByDefault('Replace All'),
             msg: this.buildReplaceAllConfirmationMessage(resultNumber, fileNumber, this._replaceTerm)
         }).open();
     }
@@ -795,39 +795,39 @@ export class SearchInWorkspaceResultTreeWidget extends TreeWidget {
         if (occurrences === 1) {
             if (fileCount === 1) {
                 if (replaceValue) {
-                    return nls.localize('vscode/searchView/removeAll.occurrence.file.confirmation.message',
+                    return nls.localizeByDefault(
                         "Replace {0} occurrence across {1} file with '{2}'?", occurrences, fileCount, replaceValue);
                 }
 
-                return nls.localize('vscode/searchView/replaceAll.occurrence.file.confirmation.message',
+                return nls.localizeByDefault(
                     'Replace {0} occurrence across {1} file?', occurrences, fileCount);
             }
 
             if (replaceValue) {
-                return nls.localize('vscode/searchView/removeAll.occurrence.files.confirmation.message',
+                return nls.localizeByDefault(
                     "Replace {0} occurrence across {1} files with '{2}'?", occurrences, fileCount, replaceValue);
             }
 
-            return nls.localize('vscode/searchView/replaceAll.occurrence.files.confirmation.message',
+            return nls.localizeByDefault(
                 'Replace {0} occurrence across {1} files?', occurrences, fileCount);
         }
 
         if (fileCount === 1) {
             if (replaceValue) {
-                return nls.localize('vscode/searchView/removeAll.occurrences.file.confirmation.message',
+                return nls.localizeByDefault(
                     "Replace {0} occurrences across {1} file with '{2}'?", occurrences, fileCount, replaceValue);
             }
 
-            return nls.localize('vscode/searchView/replaceAll.occurrences.file.confirmation.message',
+            return nls.localizeByDefault(
                 'Replace {0} occurrences across {1} file?', occurrences, fileCount);
         }
 
         if (replaceValue) {
-            return nls.localize('vscode/searchView/removeAll.occurrences.files.confirmation.message',
+            return nls.localizeByDefault(
                 "Replace {0} occurrences across {1} files with '{2}'?", occurrences, fileCount, replaceValue);
         }
 
-        return nls.localize('vscode/searchView/replaceAll.occurrences.files.confirmation.message',
+        return nls.localizeByDefault(
             'Replace {0} occurrences across {1} files?', occurrences, fileCount);
     }
 

--- a/packages/search-in-workspace/src/browser/search-in-workspace-widget.tsx
+++ b/packages/search-in-workspace/src/browser/search-in-workspace-widget.tsx
@@ -40,7 +40,7 @@ export interface SearchFieldState {
 export class SearchInWorkspaceWidget extends BaseWidget implements StatefulWidget {
 
     static ID = 'search-in-workspace';
-    static LABEL = nls.localize('vscode/search.contribution/search', 'Search');
+    static LABEL = nls.localizeByDefault('Search');
 
     protected matchCaseState: SearchFieldState;
     protected wholeWordState: SearchFieldState;
@@ -118,17 +118,17 @@ export class SearchInWorkspaceWidget extends BaseWidget implements StatefulWidge
         this.matchCaseState = {
             className: codicon('case-sensitive'),
             enabled: false,
-            title: nls.localize('vscode/findInputCheckboxes/caseDescription', 'Match Case')
+            title: nls.localizeByDefault('Match Case')
         };
         this.wholeWordState = {
             className: codicon('whole-word'),
             enabled: false,
-            title: nls.localize('vscode/findInputCheckboxes/wordsDescription', 'Match Whole Word')
+            title: nls.localizeByDefault('Match Whole Word')
         };
         this.regExpState = {
             className: codicon('regex'),
             enabled: false,
-            title: nls.localize('vscode/findInputCheckboxes/regexDescription', 'Use Regular Expression')
+            title: nls.localizeByDefault('Use Regular Expression')
         };
         this.includeIgnoredState = {
             className: codicon('eye'),
@@ -197,9 +197,9 @@ export class SearchInWorkspaceWidget extends BaseWidget implements StatefulWidge
         this.regExpState = oldState.regExpState;
         this.includeIgnoredState = oldState.includeIgnoredState;
         // Override the title of the restored state, as we could have changed languages in between
-        this.matchCaseState.title = nls.localize('vscode/findInputCheckboxes/caseDescription', 'Match Case');
-        this.wholeWordState.title = nls.localize('vscode/findInputCheckboxes/wordsDescription', 'Match Whole Word');
-        this.regExpState.title = nls.localize('vscode/findInputCheckboxes/regexDescription', 'Use Regular Expression');
+        this.matchCaseState.title = nls.localizeByDefault('Match Case');
+        this.wholeWordState.title = nls.localizeByDefault('Match Whole Word');
+        this.regExpState.title = nls.localizeByDefault('Use Regular Expression');
         this.includeIgnoredState.title = nls.localize('theia/search-in-workspace/includeIgnoredFiles', 'Include Ignored Files');
         this.showSearchDetails = oldState.showSearchDetails;
         this.searchInWorkspaceOptions = oldState.searchInWorkspaceOptions;
@@ -367,7 +367,7 @@ export class SearchInWorkspaceWidget extends BaseWidget implements StatefulWidge
     protected renderReplaceFieldToggle(): React.ReactNode {
         const toggle = <span className={codicon(this.showReplaceField ? 'chevron-down' : 'chevron-right')}></span>;
         return <div
-            title={nls.localize('vscode/findWidget/label.toggleReplaceButton', 'Toggle Replace')}
+            title={nls.localizeByDefault('Toggle Replace')}
             className='replace-toggle'
             tabIndex={0}
             onClick={e => {
@@ -515,7 +515,7 @@ export class SearchInWorkspaceWidget extends BaseWidget implements StatefulWidge
 
     protected renderReplaceField(): React.ReactNode {
         const replaceAllButtonContainer = this.renderReplaceAllButtonContainer();
-        const replace = nls.localize('vscode/findWidget/label.replaceButton', 'Replace');
+        const replace = nls.localizeByDefault('Replace');
         return <div className={`replace-field${this.showReplaceField ? '' : ' hidden'}`}>
             <SearchInWorkspaceInput
                 id='replace-input-field'
@@ -542,7 +542,7 @@ export class SearchInWorkspaceWidget extends BaseWidget implements StatefulWidge
         const enabled: boolean = this.searchTerm !== '' && this.resultNumber > 0;
         return <div className='replace-all-button-container'>
             <span
-                title={nls.localize('vscode/findWidget/label.replaceAllButton', 'Replace All')}
+                title={nls.localizeByDefault('Replace All')}
                 className={`${codicon('replace-all', true)} ${enabled ? ' ' : ' disabled'}`}
                 onClick={() => {
                     if (enabled) {
@@ -598,7 +598,7 @@ export class SearchInWorkspaceWidget extends BaseWidget implements StatefulWidge
     protected renderExpandGlobFieldsButton(): React.ReactNode {
         return <div className='button-container'>
             <span
-                title={nls.localize('vscode/searchView/moreSearch', 'Toggle Search Details')}
+                title={nls.localizeByDefault('Toggle Search Details')}
                 className={codicon('ellipsis')}
                 onClick={() => {
                     this.showSearchDetails = !this.showSearchDetails;
@@ -679,28 +679,28 @@ export class SearchInWorkspaceWidget extends BaseWidget implements StatefulWidge
 
             let message: string;
             if (isIncludesPresent && isExcludesPresent) {
-                message = nls.localize('vscode/searchView/noResultsIncludesExcludes', "No results found in '{0}' excluding '{1}' - ",
+                message = nls.localizeByDefault("No results found in '{0}' excluding '{1}' - ",
                     this.searchInWorkspaceOptions.include!.toString(), this.searchInWorkspaceOptions.exclude!.toString());
             } else if (isIncludesPresent) {
-                message = nls.localize('vscode/searchView/noResultsIncludes', "No results found in '{0}' - ",
+                message = nls.localizeByDefault("No results found in '{0}' - ",
                     this.searchInWorkspaceOptions.include!.toString());
             } else if (isExcludesPresent) {
-                message = nls.localize('vscode/searchView/noResultsExcludes', "No results found excluding '{0}' - ",
+                message = nls.localizeByDefault("No results found excluding '{0}' - ",
                     this.searchInWorkspaceOptions.exclude!.toString());
             } else {
-                message = nls.localize('vscode/searchView/noResultsFound', 'No results found. - ');
+                message = nls.localizeByDefault('No results found. - ');
             }
             // We have to trim here as vscode will always add a trailing " - " string
             return message.substring(0, message.length - 2).trim();
         } else {
             if (this.resultNumber === 1 && this.resultTreeWidget.fileNumber === 1) {
-                return nls.localize('vscode/searchView/search.file.result', '{0} result in {1} file',
+                return nls.localizeByDefault('{0} result in {1} file',
                     this.resultNumber.toString(), this.resultTreeWidget.fileNumber.toString());
             } else if (this.resultTreeWidget.fileNumber === 1) {
-                return nls.localize('vscode/searchView/search.file.results', '{0} results in {1} file',
+                return nls.localizeByDefault('{0} results in {1} file',
                     this.resultNumber.toString(), this.resultTreeWidget.fileNumber.toString());
             } else if (this.resultTreeWidget.fileNumber > 0) {
-                return nls.localize('vscode/searchView/search.files.results', '{0} results in {1} files',
+                return nls.localizeByDefault('{0} results in {1} files',
                     this.resultNumber.toString(), this.resultTreeWidget.fileNumber.toString());
             } else {
                 // if fileNumber === 0, return undefined so that `onUpdateRequest()` would not re-render component

--- a/packages/task/src/browser/task-frontend-contribution.ts
+++ b/packages/task/src/browser/task-frontend-contribution.ts
@@ -15,7 +15,7 @@
  ********************************************************************************/
 
 import { inject, injectable, named, postConstruct } from '@theia/core/shared/inversify';
-import { ILogger, ContributionProvider, CommandContribution, Command, CommandRegistry, MenuContribution, MenuModelRegistry } from '@theia/core/lib/common';
+import { ILogger, ContributionProvider, CommandContribution, Command, CommandRegistry, MenuContribution, MenuModelRegistry, nls } from '@theia/core/lib/common';
 import { QuickOpenTask, TaskTerminateQuickOpen, TaskRunningQuickOpen, TaskRestartRunningQuickOpen } from './quick-open-task';
 import {
     FrontendApplication, FrontendApplicationContribution, QuickAccessContribution,
@@ -31,36 +31,36 @@ import { EditorManager } from '@theia/editor/lib/browser';
 import { WorkspaceService } from '@theia/workspace/lib/browser/workspace-service';
 
 export namespace TaskCommands {
-    const TASK_CATEGORY_KEY = 'vscode/settingsLayout/task';
     const TASK_CATEGORY = 'Task';
-    export const TASK_RUN = Command.toLocalizedCommand({
+    const TASK_CATEGORY_KEY = nls.getDefaultKey(TASK_CATEGORY);
+    export const TASK_RUN = Command.toDefaultLocalizedCommand({
         id: 'task:run',
         category: TASK_CATEGORY,
         label: 'Run Task...'
-    }, 'vscode/task.contribution/RunTaskAction.label', TASK_CATEGORY_KEY);
+    });
 
-    export const TASK_RUN_BUILD = Command.toLocalizedCommand({
+    export const TASK_RUN_BUILD = Command.toDefaultLocalizedCommand({
         id: 'task:run:build',
         category: TASK_CATEGORY,
-        label: 'Run Build Task...'
-    }, 'vscode/task.contribution/BuildAction.label', TASK_CATEGORY_KEY);
+        label: 'Run Build Task'
+    });
 
-    export const TASK_RUN_TEST = Command.toLocalizedCommand({
+    export const TASK_RUN_TEST = Command.toDefaultLocalizedCommand({
         id: 'task:run:test',
         category: TASK_CATEGORY,
-        label: 'Run Test Task...'
-    }, 'vscode/task.contribution/TestAction.label', TASK_CATEGORY_KEY);
+        label: 'Run Test Task'
+    });
 
     export const WORKBENCH_RUN_TASK = Command.toLocalizedCommand({
         id: 'workbench.action.tasks.runTask',
         category: TASK_CATEGORY
     }, '', TASK_CATEGORY_KEY);
 
-    export const TASK_RUN_LAST = Command.toLocalizedCommand({
+    export const TASK_RUN_LAST = Command.toDefaultLocalizedCommand({
         id: 'task:run:last',
         category: TASK_CATEGORY,
-        label: 'Run Last Task'
-    }, 'vscode/task.contribution/ReRunTaskAction.label', TASK_CATEGORY_KEY);
+        label: 'Rerun Last Task'
+    });
 
     export const TASK_ATTACH = Command.toLocalizedCommand({
         id: 'task:attach',
@@ -68,17 +68,17 @@ export namespace TaskCommands {
         label: 'Attach Task...'
     }, 'theia/task/attachTask', TASK_CATEGORY_KEY);
 
-    export const TASK_RUN_TEXT = Command.toLocalizedCommand({
+    export const TASK_RUN_TEXT = Command.toDefaultLocalizedCommand({
         id: 'task:run:text',
         category: TASK_CATEGORY,
         label: 'Run Selected Text'
-    }, 'vscode/terminalMenu/miRunSelectedText', TASK_CATEGORY_KEY);
+    });
 
-    export const TASK_CONFIGURE = Command.toLocalizedCommand({
+    export const TASK_CONFIGURE = Command.toDefaultLocalizedCommand({
         id: 'task:configure',
         category: TASK_CATEGORY,
         label: 'Configure Tasks...'
-    }, 'vscode/task.contribution/miConfigureTask', TASK_CATEGORY_KEY);
+    });
 
     export const TASK_OPEN_USER = Command.toLocalizedCommand({
         id: 'task:open_user',
@@ -92,23 +92,23 @@ export namespace TaskCommands {
         label: 'Clear History'
     }, 'theia/task/clearHistory', TASK_CATEGORY_KEY);
 
-    export const TASK_SHOW_RUNNING = Command.toLocalizedCommand({
+    export const TASK_SHOW_RUNNING = Command.toDefaultLocalizedCommand({
         id: 'task:show-running',
         category: TASK_CATEGORY,
         label: 'Show Running Tasks'
-    }, 'vscode/task.contribution/runningTasks', TASK_CATEGORY_KEY);
+    });
 
-    export const TASK_TERMINATE = Command.toLocalizedCommand({
+    export const TASK_TERMINATE = Command.toDefaultLocalizedCommand({
         id: 'task:terminate',
         category: TASK_CATEGORY,
         label: 'Terminate Task'
-    }, 'vscode/abstractTaskService/terminateTask', TASK_CATEGORY_KEY);
+    });
 
-    export const TASK_RESTART_RUNNING = Command.toLocalizedCommand({
+    export const TASK_RESTART_RUNNING = Command.toDefaultLocalizedCommand({
         id: 'task:restart-running',
         category: TASK_CATEGORY,
         label: 'Restart Running Task...'
-    }, 'vscode/abstractTaskService/restartTask', TASK_CATEGORY_KEY);
+    });
 }
 
 const TASKS_STORAGE_KEY = 'tasks';

--- a/packages/terminal/src/browser/terminal-frontend-contribution.ts
+++ b/packages/terminal/src/browser/terminal-frontend-contribution.ts
@@ -65,78 +65,77 @@ export namespace TerminalMenus {
 }
 
 export namespace TerminalCommands {
-    const TERMINAL_CATEGORY_KEY = 'vscode/settingsLayout/terminal';
     const TERMINAL_CATEGORY = 'Terminal';
-    export const NEW = Command.toLocalizedCommand({
+    export const NEW = Command.toDefaultLocalizedCommand({
         id: 'terminal:new',
         category: TERMINAL_CATEGORY,
-        label: 'Open New Terminal'
-    }, 'vscode/terminalActions/workbench.action.terminal.new', TERMINAL_CATEGORY_KEY);
-    export const NEW_ACTIVE_WORKSPACE = Command.toLocalizedCommand({
+        label: 'Create New Integrated Terminal'
+    });
+    export const NEW_ACTIVE_WORKSPACE = Command.toDefaultLocalizedCommand({
         id: 'terminal:new:active:workspace',
         category: TERMINAL_CATEGORY,
-        label: 'Open New Terminal (In Active Workspace)'
-    }, 'vscode/terminalActions/workbench.action.terminal.newInActiveWorkspace', TERMINAL_CATEGORY_KEY);
-    export const TERMINAL_CLEAR = Command.toLocalizedCommand({
+        label: 'Create New Integrated Terminal (In Active Workspace)'
+    });
+    export const TERMINAL_CLEAR = Command.toDefaultLocalizedCommand({
         id: 'terminal:clear',
         category: TERMINAL_CATEGORY,
-        label: 'Clear Terminal'
-    }, 'vscode/terminalActions/workbench.action.terminal.clear', TERMINAL_CATEGORY_KEY);
-    export const TERMINAL_CONTEXT = Command.toLocalizedCommand({
+        label: 'Clear'
+    });
+    export const TERMINAL_CONTEXT = Command.toDefaultLocalizedCommand({
         id: 'terminal:context',
         category: TERMINAL_CATEGORY,
         label: 'Open in Terminal'
-    }, 'vscode/scm.contribution/open in terminal', TERMINAL_CATEGORY_KEY);
-    export const SPLIT = Command.toLocalizedCommand({
+    });
+    export const SPLIT = Command.toDefaultLocalizedCommand({
         id: 'terminal:split',
         category: TERMINAL_CATEGORY,
         label: 'Split Terminal'
-    }, 'vscode/terminalActions/workbench.action.terminal.split', TERMINAL_CATEGORY_KEY);
-    export const TERMINAL_FIND_TEXT = Command.toLocalizedCommand({
+    });
+    export const TERMINAL_FIND_TEXT = Command.toDefaultLocalizedCommand({
         id: 'terminal:find',
         category: TERMINAL_CATEGORY,
         label: 'Find'
-    }, 'vscode/findController/startFindAction', TERMINAL_CATEGORY_KEY);
-    export const TERMINAL_FIND_TEXT_CANCEL = Command.toLocalizedCommand({
+    });
+    export const TERMINAL_FIND_TEXT_CANCEL = Command.toDefaultLocalizedCommand({
         id: 'terminal:find:cancel',
         category: TERMINAL_CATEGORY,
-        label: 'Hide find widget'
-    }, 'vscode/terminalActions/workbench.action.terminal.hideFind', TERMINAL_CATEGORY_KEY);
+        label: 'Hide Find'
+    });
 
-    export const SCROLL_LINE_UP = Command.toLocalizedCommand({
+    export const SCROLL_LINE_UP = Command.toDefaultLocalizedCommand({
         id: 'terminal:scroll:line:up',
         category: TERMINAL_CATEGORY,
-        label: 'Scroll line up'
-    }, 'vscode/terminalActions/workbench.action.terminal.scrollUp', TERMINAL_CATEGORY_KEY);
-    export const SCROLL_LINE_DOWN = Command.toLocalizedCommand({
+        label: 'Scroll Up (Line)'
+    });
+    export const SCROLL_LINE_DOWN = Command.toDefaultLocalizedCommand({
         id: 'terminal:scroll:line:down',
         category: TERMINAL_CATEGORY,
-        label: 'Scroll line down'
-    }, 'vscode/terminalActions/workbench.action.terminal.scrollDown', TERMINAL_CATEGORY_KEY);
-    export const SCROLL_TO_TOP = Command.toLocalizedCommand({
+        label: 'Scroll Down (Line)'
+    });
+    export const SCROLL_TO_TOP = Command.toDefaultLocalizedCommand({
         id: 'terminal:scroll:top',
         category: TERMINAL_CATEGORY,
-        label: 'Scroll to top'
-    }, 'vscode/terminalActions/workbench.action.terminal.scrollToTop', TERMINAL_CATEGORY_KEY);
-    export const SCROLL_PAGE_UP = Command.toLocalizedCommand({
+        label: 'Scroll to Top'
+    });
+    export const SCROLL_PAGE_UP = Command.toDefaultLocalizedCommand({
         id: 'terminal:scroll:page:up',
         category: TERMINAL_CATEGORY,
-        label: 'Scroll page up'
-    }, 'vscode/terminalActions/workbench.action.terminal.scrollUpPage', TERMINAL_CATEGORY_KEY);
-    export const SCROLL_PAGE_DOWN = Command.toLocalizedCommand({
+        label: 'Scroll Up (Page)'
+    });
+    export const SCROLL_PAGE_DOWN = Command.toDefaultLocalizedCommand({
         id: 'terminal:scroll:page:down',
         category: TERMINAL_CATEGORY,
-        label: 'Scroll page down'
-    }, 'vscode/terminalActions/workbench.action.terminal.scrollDownPage', TERMINAL_CATEGORY_KEY);
+        label: 'Scroll Down (Page)'
+    });
 
     /**
      * Command that displays all terminals that are currently opened
      */
-    export const SHOW_ALL_OPENED_TERMINALS = Command.toLocalizedCommand({
+    export const SHOW_ALL_OPENED_TERMINALS = Command.toDefaultLocalizedCommand({
         id: 'workbench.action.showAllTerminals',
         category: CommonCommands.VIEW_CATEGORY,
         label: 'Show All Opened Terminals'
-    }, 'vscode/terminal.contribution/tasksQuickAccessHelp', CommonCommands.VIEW_CATEGORY_KEY);
+    });
 }
 
 @injectable()
@@ -394,7 +393,7 @@ export class TerminalFrontendContribution implements TerminalService, CommandCon
         menus.registerSubmenu(TerminalMenus.TERMINAL, TerminalWidgetImpl.LABEL);
         menus.registerMenuAction(TerminalMenus.TERMINAL_NEW, {
             commandId: TerminalCommands.NEW.id,
-            label: nls.localize('vscode/terminalActions/workbench.action.terminal.new.short', 'New Terminal'),
+            label: nls.localizeByDefault('New Terminal'),
             order: '0'
         });
         menus.registerMenuAction(TerminalMenus.TERMINAL_NEW, {
@@ -600,7 +599,7 @@ export class TerminalFrontendContribution implements TerminalService, CommandCon
                     resource
                 }));
                 const selectedItem = await this.quickInputService?.showQuickPick(items, {
-                    placeholder: nls.localize('vscode/terminalActions/workbench.action.terminal.newWorkspacePlaceholder', 'Select current working directory for new terminal')
+                    placeholder: nls.localizeByDefault('Select current working directory for new terminal')
                 });
                 resolve(selectedItem?.resource?.toString());
             }

--- a/packages/terminal/src/browser/terminal-preferences.ts
+++ b/packages/terminal/src/browser/terminal-preferences.ts
@@ -36,109 +36,109 @@ export const TerminalConfigSchema: PreferenceSchema = {
         },
         'terminal.integrated.fontFamily': {
             type: 'string',
-            description: nls.localize('vscode/terminalConfiguration/terminal.integrated.fontFamily', 'Controls the font family of the terminal.'),
+            description: nls.localizeByDefault("Controls the font family of the terminal, this defaults to `#editor.fontFamily#`'s value."),
             default: EDITOR_FONT_DEFAULTS.fontFamily
         },
         'terminal.integrated.fontSize': {
             type: 'number',
-            description: nls.localize('vscode/terminalConfiguration/terminal.integrated.fontSize', 'Controls the font size in pixels of the terminal.'),
+            description: nls.localizeByDefault('Controls the font size in pixels of the terminal.'),
             minimum: 6,
             default: EDITOR_FONT_DEFAULTS.fontSize
         },
         'terminal.integrated.fontWeight': {
             type: 'string',
             enum: ['normal', 'bold', '100', '200', '300', '400', '500', '600', '700', '800', '900'],
-            description: nls.localize('vscode/terminalConfiguration/terminal.integrated.fontWeight', 'The font weight to use within the terminal for non-bold text.'),
+            description: nls.localizeByDefault('The font weight to use within the terminal for non-bold text. Accepts \"normal\" and \"bold\" keywords or numbers between 1 and 1000.'),
             default: 'normal'
         },
         'terminal.integrated.fontWeightBold': {
             type: 'string',
             enum: ['normal', 'bold', '100', '200', '300', '400', '500', '600', '700', '800', '900'],
-            description: nls.localize('vscode/terminalConfiguration/terminal.integrated.fontWeightBold', 'The font weight to use within the terminal for bold text.'),
+            description: nls.localizeByDefault('The font weight to use within the terminal for bold text. Accepts \"normal\" and \"bold\" keywords or numbers between 1 and 1000.'),
             default: 'bold'
         },
         'terminal.integrated.drawBoldTextInBrightColors': {
-            description: nls.localize('vscode/terminalConfiguration/terminal.integrated.drawBoldTextInBrightColors', 'Controls whether to draw bold text in bright colors.'),
+            description: nls.localizeByDefault('Controls whether bold text in the terminal will always use the \"bright\" ANSI color variant.'),
             type: 'boolean',
             default: true,
         },
         'terminal.integrated.letterSpacing': {
-            description: nls.localize('vscode/terminalConfiguration/terminal.integrated.letterSpacing', 'Controls the letter spacing of the terminal, this is an integer value which represents the amount of additional pixels to add between characters.'),
+            description: nls.localizeByDefault('Controls the letter spacing of the terminal, this is an integer value which represents the amount of additional pixels to add between characters.'),
             type: 'number',
             default: 1
         },
         'terminal.integrated.lineHeight': {
-            description: nls.localize('vscode/terminalConfiguration/terminal.integrated.lineHeight', 'Controls the line height of the terminal, this number is multiplied by the terminal font size to get the actual line-height in pixels.'),
+            description: nls.localizeByDefault('Controls the line height of the terminal, this number is multiplied by the terminal font size to get the actual line-height in pixels.'),
             type: 'number',
             minimum: 1,
             default: 1
         },
         'terminal.integrated.scrollback': {
-            description: nls.localize('vscode/terminalConfiguration/terminal.integrated.scrollback', 'Controls the maximum amount of lines the terminal keeps in its buffer.'),
+            description: nls.localizeByDefault('Controls the maximum amount of lines the terminal keeps in its buffer.'),
             type: 'number',
             default: 1000
         },
         'terminal.integrated.fastScrollSensitivity': {
-            description: nls.localize('vscode/terminalConfiguration/terminal.integrated.fastScrollSensitivity', 'Controls the scrolling speed when pressing \'alt\'.'),
+            description: nls.localizeByDefault('Scrolling speed multiplier when pressing `Alt`.'),
             type: 'number',
             default: 5,
         },
         'terminal.integrated.rendererType': {
-            description: nls.localize('vscode/terminalConfiguration/terminal.integrated.rendererType', 'Controls how the terminal is rendered.'),
+            description: nls.localizeByDefault('Controls how the terminal is rendered.'),
             type: 'string',
             enum: ['canvas', 'dom'],
             default: 'canvas'
         },
         'terminal.integrated.copyOnSelection': {
-            description: nls.localize('vscode/terminalConfiguration/terminal.integrated.copyOnSelection', 'Controls whether text selected in the terminal will be copied to the clipboard.'),
+            description: nls.localizeByDefault('Controls whether text selected in the terminal will be copied to the clipboard.'),
             type: 'boolean',
             default: false,
         },
         'terminal.integrated.cursorBlinking': {
-            description: nls.localize('vscode/terminalConfiguration/terminal.integrated.cursorBlinking', 'Controls whether the terminal cursor blinks.'),
+            description: nls.localizeByDefault('Controls whether the terminal cursor blinks.'),
             type: 'boolean',
             default: false
         },
         'terminal.integrated.cursorStyle': {
-            description: nls.localize('vscode/terminalConfiguration/terminal.integrated.cursorStyle', 'Controls the style of the terminal cursor.'),
+            description: nls.localizeByDefault('Controls the style of terminal cursor.'),
             enum: ['block', 'underline', 'line'],
             default: 'block'
         },
         'terminal.integrated.cursorWidth': {
-            markdownDescription: nls.localize('vscode/terminalConfiguration/terminal.integrated.cursorWidth', 'Controls the width of the cursor when `#terminal.integrated.cursorStyle#` is set to `line`.'),
+            markdownDescription: nls.localizeByDefault('Controls the width of the cursor when `#terminal.integrated.cursorStyle#` is set to `line`.'),
             type: 'number',
             default: 1
         },
         'terminal.integrated.shell.windows': {
             type: ['string', 'null'],
-            markdownDescription: nls.localize('vscode/terminalConfiguration/terminal.integrated.shell.windows', 'The path of the shell that the terminal uses on Windows. (default: C:\\Windows\\System32\\cmd.exe).'),
+            markdownDescription: nls.localize('theia/terminal/shellWindows', 'The path of the shell that the terminal uses on Windows. (default: \'{0}\').', 'C:\\Windows\\System32\\cmd.exe'),
             default: undefined
         },
         'terminal.integrated.shell.osx': {
             type: ['string', 'null'],
-            markdownDescription: nls.localize('vscode/terminalConfiguration/terminal.integrated.shell.osx', 'The path of the shell that the terminal uses on macOS (default: \'/bin/bash\'}).'),
+            markdownDescription: nls.localize('theia/terminal/shellOsx', 'The path of the shell that the terminal uses on macOS (default: \'{0}\'}).', '/bin/bash'),
             default: undefined
         },
         'terminal.integrated.shell.linux': {
             type: ['string', 'null'],
-            markdownDescription: nls.localize('vscode/terminalConfiguration/terminal.integrated.shell.linux', 'The path of the shell that the terminal uses on Linux (default: \'/bin/bash\'}).'),
+            markdownDescription: nls.localize('theia/terminal/shellLinux', 'The path of the shell that the terminal uses on Linux (default: \'{0}\'}).', '/bin/bash'),
             default: undefined
         },
         'terminal.integrated.shellArgs.windows': {
             type: 'array',
-            markdownDescription: nls.localize('vscode/terminalConfiguration/terminal.integrated.shellArgs.windows', 'The command line arguments to use when on the Windows terminal.'),
+            markdownDescription: nls.localize('theia/terminal/shellArgsWindows', 'The command line arguments to use when on the Windows terminal.'),
             default: []
         },
         'terminal.integrated.shellArgs.osx': {
             type: 'array',
-            markdownDescription: nls.localize('vscode/terminalConfiguration/terminal.integrated.shellArgs.osx', 'The command line arguments to use when on the macOS terminal.'),
+            markdownDescription: nls.localize('theia/terminal/shellArgsOsx', 'The command line arguments to use when on the macOS terminal.'),
             default: [
                 '-l'
             ]
         },
         'terminal.integrated.shellArgs.linux': {
             type: 'array',
-            markdownDescription: nls.localize('vscode/terminalConfiguration/terminal.integrated.shellArgs.linux', 'The command line arguments to use when on the Linux terminal.'),
+            markdownDescription: nls.localize('theia/terminal/shellArgsLinux', 'The command line arguments to use when on the Linux terminal.'),
             default: []
         },
     }

--- a/packages/terminal/src/browser/terminal-quick-open-service.ts
+++ b/packages/terminal/src/browser/terminal-quick-open-service.ts
@@ -22,7 +22,7 @@ import {
     QuickAccessRegistry,
     QuickInputService
 } from '@theia/core/lib/browser';
-import { CancellationToken, CommandContribution, CommandRegistry, CommandService } from '@theia/core/lib/common';
+import { CancellationToken, CommandContribution, CommandRegistry, CommandService, nls } from '@theia/core/lib/common';
 import { TerminalWidget } from './base/terminal-widget';
 import { TerminalService } from './base/terminal-service';
 import { TerminalCommands } from './terminal-frontend-contribution';
@@ -60,7 +60,7 @@ export class TerminalQuickOpenService implements QuickAccessProvider {
         }
         // Append a quick open item to create a new terminal.
         items.push({
-            label: 'Open New Terminal',
+            label: nls.localizeByDefault('Create New Integrated Terminal'),
             iconClasses: codiconArray('add'),
             execute: () => this.doCreateNewTerminal()
         });
@@ -73,7 +73,7 @@ export class TerminalQuickOpenService implements QuickAccessProvider {
             getInstance: () => this,
             prefix: TerminalQuickOpenService.PREFIX,
             placeholder: '',
-            helpEntries: [{ description: 'Show All Opened Terminals', needsEditor: false }]
+            helpEntries: [{ description: nls.localizeByDefault('Show All Opened Terminals'), needsEditor: false }]
         });
     }
 

--- a/packages/terminal/src/browser/terminal-widget-impl.ts
+++ b/packages/terminal/src/browser/terminal-widget-impl.ts
@@ -49,7 +49,7 @@ export interface TerminalWidgetFactoryOptions extends Partial<TerminalWidgetOpti
 @injectable()
 export class TerminalWidgetImpl extends TerminalWidget implements StatefulWidget {
 
-    static LABEL = nls.localize('vscode/settingsLayout/terminal', 'Terminal');
+    static LABEL = nls.localizeByDefault('Terminal');
     protected terminalKind = 'user';
     protected _terminalId = -1;
     protected readonly onTermDidClose = new Emitter<TerminalWidget>();
@@ -249,7 +249,7 @@ export class TerminalWidgetImpl extends TerminalWidget implements StatefulWidget
 
     static getFollowLinkHover(): string {
         const cmdCtrl = isOSX ? 'Cmd' : 'Ctrl';
-        return nls.localize('vscode/terminalLinkManager/followLink', 'Follow link') + ' (' +
+        return nls.localizeByDefault('Follow link') + ' (' +
             nls.localize(`vscode/terminalLinkManager/terminalLinkHandler.followLink${cmdCtrl}`, `${cmdCtrl} + Click`) + ')';
     }
 

--- a/packages/vsx-registry/src/browser/vsx-extension-commands.ts
+++ b/packages/vsx-registry/src/browser/vsx-extension-commands.ts
@@ -20,18 +20,17 @@ import { Command } from '@theia/core/lib/common';
 
 export namespace VSXExtensionsCommands {
 
-    const EXTENSIONS_CATEGORY_KEY = 'vscode/settingsLayout/extensions';
     const EXTENSIONS_CATEGORY = 'Extensions';
 
-    export const CLEAR_ALL = Command.toLocalizedCommand({
+    export const CLEAR_ALL = Command.toDefaultLocalizedCommand({
         id: 'vsxExtensions.clearAll',
         category: EXTENSIONS_CATEGORY,
         label: 'Clear Search Results',
         iconClass: codicon('clear-all')
-    }, 'vscode/search.contribution/ClearSearchResultsAction.label', EXTENSIONS_CATEGORY_KEY);
+    });
     export const INSTALL_FROM_VSIX: Command & { dialogLabel: string } = {
         id: 'vsxExtensions.installFromVSIX',
-        category: nls.localize(EXTENSIONS_CATEGORY_KEY, EXTENSIONS_CATEGORY),
+        category: nls.localizeByDefault(EXTENSIONS_CATEGORY),
         originalCategory: EXTENSIONS_CATEGORY,
         originalLabel: 'Install from VSIX...',
         label: nls.localize('theia/vsx-registry/installFromVSIX', 'Install from VSIX') + '...',
@@ -43,19 +42,19 @@ export namespace VSXExtensionsCommands {
     export const COPY_EXTENSION_ID: Command = {
         id: 'vsxExtensions.copyExtensionId'
     };
-    export const SHOW_BUILTINS = Command.toLocalizedCommand({
+    export const SHOW_BUILTINS = Command.toDefaultLocalizedCommand({
         id: 'vsxExtension.showBuiltins',
         label: 'Show Built-in Extensions',
         category: EXTENSIONS_CATEGORY,
-    }, 'vscode/extensions.contribution/showBuiltInExtensions', EXTENSIONS_CATEGORY_KEY);
-    export const SHOW_INSTALLED = Command.toLocalizedCommand({
+    });
+    export const SHOW_INSTALLED = Command.toDefaultLocalizedCommand({
         id: 'vsxExtension.showInstalled',
         label: 'Show Installed Extensions',
         category: EXTENSIONS_CATEGORY,
-    }, 'vscode/extensions.contribution/showInstalledExtensions', EXTENSIONS_CATEGORY_KEY);
-    export const SHOW_RECOMMENDATIONS = Command.toLocalizedCommand({
+    });
+    export const SHOW_RECOMMENDATIONS = Command.toDefaultLocalizedCommand({
         id: 'vsxExtension.showRecommendations',
         label: 'Show Recommended Extensions',
         category: EXTENSIONS_CATEGORY,
-    }, 'vscode/extensions.contribution/showRecommendedExtensions', EXTENSIONS_CATEGORY_KEY);
+    });
 }

--- a/packages/vsx-registry/src/browser/vsx-extensions-view-container.ts
+++ b/packages/vsx-registry/src/browser/vsx-extensions-view-container.ts
@@ -28,7 +28,7 @@ import { nls } from '@theia/core/lib/common/nls';
 export class VSXExtensionsViewContainer extends ViewContainer {
 
     static ID = 'vsx-extensions-view-container';
-    static LABEL = nls.localize('vscode/settingsLayout/extensions', 'Extensions');
+    static LABEL = nls.localizeByDefault('Extensions');
 
     disableDNDBetweenContainers = true;
 
@@ -166,7 +166,7 @@ export class VSXExtensionsViewContainer extends ViewContainer {
     }
 
     protected getToggleVisibilityGroupLabel(): string {
-        return 'a/' + nls.localize('vscode/viewPaneContainer/views', 'Views');
+        return 'a/' + nls.localizeByDefault('Views');
     }
 }
 export namespace VSXExtensionsViewContainer {

--- a/packages/vsx-registry/src/browser/vsx-extensions-widget.ts
+++ b/packages/vsx-registry/src/browser/vsx-extensions-widget.ts
@@ -67,11 +67,11 @@ export class VSXExtensionsWidget extends SourceTreeWidget {
     protected computeTitle(): string {
         switch (this.options.id) {
             case VSXExtensionsSourceOptions.INSTALLED:
-                return nls.localize('vscode/extensions.contribution/installed filter', 'Installed');
+                return nls.localizeByDefault('Installed');
             case VSXExtensionsSourceOptions.BUILT_IN:
-                return nls.localize('vscode/extensions.contribution/builtin filter', 'Built-in');
+                return nls.localizeByDefault('Built-in');
             case VSXExtensionsSourceOptions.RECOMMENDED:
-                return nls.localize('vscode/extensions.contribution/most popular recommended', 'Recommended');
+                return nls.localizeByDefault('Recommended');
             case VSXExtensionsSourceOptions.SEARCH_RESULT:
                 return nls.localize('theia/vsx-registry/openVSX', 'Open VSX Registry');
             default:

--- a/packages/workspace/src/browser/workspace-commands.ts
+++ b/packages/workspace/src/browser/workspace-commands.ts
@@ -44,7 +44,6 @@ const validFilename: (arg: string) => boolean = require('valid-filename');
 
 export namespace WorkspaceCommands {
 
-    const WORKSPACE_CATEGORY_KEY = 'vscode/workspaceActions/workspaces';
     const WORKSPACE_CATEGORY = 'Workspaces';
     const FILE_CATEGORY = CommonCommands.FILE_CATEGORY;
 
@@ -53,65 +52,65 @@ export namespace WorkspaceCommands {
     // `OPEN` must *not* be available on Windows and Linux in electron.
     // VS Code does the same. See: https://github.com/eclipse-theia/theia/pull/3202#issuecomment-430585357
     export const OPEN: Command & { dialogLabel: string } = {
-        ...Command.toLocalizedCommand({
+        ...Command.toDefaultLocalizedCommand({
             id: 'workspace:open',
             category: CommonCommands.FILE_CATEGORY,
             label: 'Open...'
-        }, 'vscode/workspaceActions/openFileFolder', CommonCommands.FILE_CATEGORY_KEY),
-        dialogLabel: nls.localize('vscode/dialogMainService/open', 'Open')
+        }),
+        dialogLabel: nls.localizeByDefault('Open')
     };
     // No `label`. Otherwise, it shows up in the `Command Palette`.
     export const OPEN_FILE: Command & { dialogLabel: string } = {
         id: 'workspace:openFile',
         originalCategory: FILE_CATEGORY,
-        category: nls.localize(CommonCommands.FILE_CATEGORY_KEY, CommonCommands.FILE_CATEGORY),
+        category: nls.localizeByDefault(CommonCommands.FILE_CATEGORY),
         dialogLabel: 'Open File'
     };
     export const OPEN_FOLDER: Command & { dialogLabel: string } = {
         id: 'workspace:openFolder',
-        dialogLabel: nls.localize('vscode/dialogMainService/openFolder', 'Open Folder') // No `label`. Otherwise, it shows up in the `Command Palette`.
+        dialogLabel: nls.localizeByDefault('Open Folder') // No `label`. Otherwise, it shows up in the `Command Palette`.
     };
     export const OPEN_WORKSPACE: Command & { dialogLabel: string } = {
-        ...Command.toLocalizedCommand({
+        ...Command.toDefaultLocalizedCommand({
             id: 'workspace:openWorkspace',
             category: CommonCommands.FILE_CATEGORY,
             label: 'Open Workspace...',
-        }, 'vscode/workspaceActions/openWorkspaceAction', CommonCommands.FILE_CATEGORY_KEY),
-        dialogLabel: nls.localize('vscode/dialogMainService/openWorkspaceTitle', 'Open Workspace')
+        }),
+        dialogLabel: nls.localizeByDefault('Open Workspace')
     };
     export const OPEN_RECENT_WORKSPACE = Command.toLocalizedCommand({
         id: 'workspace:openRecent',
         category: FILE_CATEGORY,
         label: 'Open Recent Workspace...'
     }, 'theia/workspace/openRecentWorkspace', CommonCommands.FILE_CATEGORY_KEY);
-    export const CLOSE = Command.toLocalizedCommand({
+    export const CLOSE = Command.toDefaultLocalizedCommand({
         id: 'workspace:close',
         category: WORKSPACE_CATEGORY,
         label: 'Close Workspace'
-    }, 'vscode/workspaceActions/closeWorkspace', WORKSPACE_CATEGORY_KEY);
-    export const NEW_FILE = Command.toLocalizedCommand({
+    });
+    export const NEW_FILE = Command.toDefaultLocalizedCommand({
         id: 'file.newFile',
         category: FILE_CATEGORY,
         label: 'New File'
-    }, 'vscode/fileActions/newFile', CommonCommands.FILE_CATEGORY_KEY);
-    export const NEW_FOLDER = Command.toLocalizedCommand({
+    });
+    export const NEW_FOLDER = Command.toDefaultLocalizedCommand({
         id: 'file.newFolder',
         category: FILE_CATEGORY,
         label: 'New Folder'
-    }, 'vscode/fileActions/newFile', CommonCommands.FILE_CATEGORY_KEY);
+    });
     export const FILE_OPEN_WITH = (opener: OpenHandler): Command => ({
         id: `file.openWith.${opener.id}`
     });
-    export const FILE_RENAME = Command.toLocalizedCommand({
+    export const FILE_RENAME = Command.toDefaultLocalizedCommand({
         id: 'file.rename',
         category: FILE_CATEGORY,
         label: 'Rename'
-    }, 'vscode/fileActions/rename', CommonCommands.FILE_CATEGORY_KEY);
-    export const FILE_DELETE = Command.toLocalizedCommand({
+    });
+    export const FILE_DELETE = Command.toDefaultLocalizedCommand({
         id: 'file.delete',
         category: FILE_CATEGORY,
         label: 'Delete'
-    }, 'vscode/fileActions/delete', CommonCommands.FILE_CATEGORY_KEY);
+    });
     export const FILE_DUPLICATE = Command.toLocalizedCommand({
         id: 'file.duplicate',
         category: FILE_CATEGORY,
@@ -121,32 +120,32 @@ export namespace WorkspaceCommands {
         id: 'file.compare',
         category: FILE_CATEGORY,
         label: 'Compare with Each Other'
-    }, 'vscode/fileActions.contribution/compareSelected', CommonCommands.FILE_CATEGORY_KEY);
-    export const ADD_FOLDER = Command.toLocalizedCommand({
+    }, 'theia/workspace/compareWithEachOther', CommonCommands.FILE_CATEGORY_KEY);
+    export const ADD_FOLDER = Command.toDefaultLocalizedCommand({
         id: 'workspace:addFolder',
         category: WORKSPACE_CATEGORY,
         label: 'Add Folder to Workspace...'
-    }, 'vscode/workspaceCommands/addFolderToWorkspace', WORKSPACE_CATEGORY_KEY);
-    export const REMOVE_FOLDER = Command.toLocalizedCommand({
+    });
+    export const REMOVE_FOLDER = Command.toDefaultLocalizedCommand({
         id: 'workspace:removeFolder',
         category: WORKSPACE_CATEGORY,
         label: 'Remove Folder from Workspace'
-    }, 'vscode/fileCommands/removeFolderFromWorkspace', WORKSPACE_CATEGORY_KEY);
-    export const SAVE_WORKSPACE_AS = Command.toLocalizedCommand({
+    });
+    export const SAVE_WORKSPACE_AS = Command.toDefaultLocalizedCommand({
         id: 'workspace:saveAs',
         category: WORKSPACE_CATEGORY,
         label: 'Save Workspace As...'
-    }, 'vscode/workspaceActions/saveWorkspaceAsAction', WORKSPACE_CATEGORY_KEY);
-    export const OPEN_WORKSPACE_FILE = Command.toLocalizedCommand({
+    });
+    export const OPEN_WORKSPACE_FILE = Command.toDefaultLocalizedCommand({
         id: 'workspace:openConfigFile',
         category: WORKSPACE_CATEGORY,
         label: 'Open Workspace Configuration File'
-    }, 'vscode/abstractWorkspaceEditingService/openWorkspaceConfigurationFile', WORKSPACE_CATEGORY_KEY);
-    export const SAVE_AS = Command.toLocalizedCommand({
+    });
+    export const SAVE_AS = Command.toDefaultLocalizedCommand({
         id: 'file.saveAs',
         category: CommonCommands.FILE_CATEGORY,
         label: 'Save As...',
-    }, 'vscode/fileCommands/saveAs', CommonCommands.FILE_CATEGORY_KEY);
+    });
 }
 
 @injectable()
@@ -244,7 +243,7 @@ export class WorkspaceCommandContribution implements CommandContribution {
                     const vacantChildUri = FileSystemUtils.generateUniqueResourceURI(parentUri, parent, fileName, fileExtension);
 
                     const dialog = new WorkspaceInputDialog({
-                        title: nls.localize('vscode/fileActions/newFile', 'New File'),
+                        title: nls.localizeByDefault('New File'),
                         parentUri: parentUri,
                         initialValue: vacantChildUri.path.base,
                         validate: name => this.validateFileName(name, parent, true)
@@ -267,7 +266,7 @@ export class WorkspaceCommandContribution implements CommandContribution {
                     const parentUri = parent.resource;
                     const vacantChildUri = FileSystemUtils.generateUniqueResourceURI(parentUri, parent, 'Untitled');
                     const dialog = new WorkspaceInputDialog({
-                        title: nls.localize('vscode/fileActions/newFolder', 'New Folder'),
+                        title: nls.localizeByDefault('New Folder'),
                         parentUri: parentUri,
                         initialValue: vacantChildUri.path.base,
                         validate: name => this.validateFileName(name, parent, true)
@@ -291,7 +290,7 @@ export class WorkspaceCommandContribution implements CommandContribution {
                     if (parent) {
                         const oldName = uri.path.base;
                         const dialog = new SingleTextInputDialog({
-                            title: nls.localize('vscode/fileActions/rename', 'Rename'),
+                            title: nls.localizeByDefault('Rename'),
                             initialValue: oldName,
                             initialSelectionRange: {
                                 start: 0,
@@ -409,21 +408,21 @@ export class WorkspaceCommandContribution implements CommandContribution {
         }
         // do not allow recursive rename
         if (!allowNested && !validFilename(name)) {
-            return nls.localize('vscode/configureSnippets/bad_name1', 'Invalid file or folder name');
+            return nls.localizeByDefault('Invalid file or folder name');
         }
         if (name.startsWith('/')) {
-            return nls.localize('vscode/fileActions/fileNameStartsWithSlashError', 'Absolute paths or names that starts with / are not allowed');
+            return nls.localizeByDefault('Absolute paths or names that starts with / are not allowed');
         } else if (name.startsWith(' ') || name.endsWith(' ')) {
-            return nls.localize('vscode/fileActions/fileNameWhitespaceWarning', 'Names with leading or trailing whitespaces are not allowed');
+            return nls.localizeByDefault('Names with leading or trailing whitespaces are not allowed');
         }
         // check and validate each sub-paths
         if (name.split(/[\\/]/).some(file => !file || !validFilename(file) || /^\s+$/.test(file))) {
-            return nls.localize('vscode/fileActions/invalidFileNameError', 'The name "{0}" is not a valid file or folder name.', this.trimFileName(name));
+            return nls.localizeByDefault('The name "{0}" is not a valid file or folder name.', this.trimFileName(name));
         }
         const childUri = parent.resource.resolve(name);
         const exists = await this.fileService.exists(childUri);
         if (exists) {
-            return nls.localize('vscode/fileActions/fileNameExistsError', 'A file or folder "{0}" already exists at this location.', this.trimFileName(name));
+            return nls.localizeByDefault('A file or folder "{0}" already exists at this location.', this.trimFileName(name));
         }
         return '';
     }
@@ -514,7 +513,7 @@ export class WorkspaceCommandContribution implements CommandContribution {
             });
             messageContainer.appendChild(list);
             const dialog = new ConfirmDialog({
-                title: nls.localize('vscode/fileCommands/removeFolderFromWorkspace', 'Remove Folder from Workspace'),
+                title: nls.localizeByDefault('Remove Folder from Workspace'),
                 msg: messageContainer
             });
             if (await dialog.open()) {

--- a/packages/workspace/src/browser/workspace-frontend-contribution.ts
+++ b/packages/workspace/src/browser/workspace-frontend-contribution.ts
@@ -498,8 +498,8 @@ export class WorkspaceFrontendContribution implements CommandContribution, Keybi
         }
         // Prompt users for confirmation before overwriting.
         const confirmed = await new ConfirmDialog({
-            title: nls.localize('vscode/textFileSaveErrorHandler/overwrite', 'Overwrite'),
-            msg: nls.localize('vscode/simpleFileDialog/remoteFileDialog.validateExisting', 'Do you really want to overwrite "{0}"?', uri.toString())
+            title: nls.localizeByDefault('Overwrite'),
+            msg: nls.localizeByDefault('Do you really want to overwrite "{0}"?', uri.toString())
         }).open();
         return !!confirmed;
     }


### PR DESCRIPTION
#### What it does

Related to the discussions that occurred in #10106 and #10299, 

Heavily simplifies the localization process for strings that are contained inside of vscode. Additionally removes the coupling between vscode internals and Theia's translations calls.

- [x] [CQ for `nls.metadata.json`](https://dev.eclipse.org/ipzilla/show_bug.cgi?id=23798)

#### How it works

Utilizes the `nls.metadata.json` that is generated by the vscode build process (in this case the 1.53.2 version of vscode). It can be produced by running `yarn && yarn gulp vscode-linux-x64` inside of the vscode repository. This files contains every default value and its key of the vscode `nls.localize` calls that occur inside of the vscode codebase. With a little bit of transformation work, we can produce a map that maps every default value to the associated key.

This has the drawback of commiting/polluting the Theia repository with this generated file. I'm open to suggestions on how to improve this.

#### How to test

1. Open Theia in english and observe that everything continues running as usual
2. Install a language pack of your choice and run the `Configure Display Language` command.
3. Assert that the application is (mostly) translated into the target language, even without explicitly referencing vscode keys.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
