### PR TITLE
cli: update `download:plugins` script to better handle `extension-packs`

### DIFF
--- a/doc/Migration.md
+++ b/doc/Migration.md
@@ -7,6 +7,27 @@ Please see the latest version (`master`) for the most up-to-date information. Pl
 
 ## Guide
 
+### v1.19.0
+
+#### Runtime System Plugin Resolvement
+
+Introduced in `v1.19.0` was the feature to better support extension-packs which both contribute functionality and reference plugins (by `id`).
+The feature works best when there is no runtime plugin resolvement for system (builtin) plugins as it should be done at build time instead.
+In order not to change behavior today, the feature is behind an application prop (acting as a flag). If you want to enable better support for
+extension-packs and extension-dependencies as builtins the property should be turned off. You can disable the resolvement in your application's 
+`package.json` like so:
+
+
+```json
+"theia": {
+  "backend": {
+    "config": {
+      "resolveSystemPlugins": false
+    }
+  }
+}
+```
+
 ### v1.17.0
 
 #### ES2017

--- a/examples/browser/package.json
+++ b/examples/browser/package.json
@@ -11,6 +11,11 @@
           "files.enableTrash": false
         }
       }
+    },
+    "backend": {
+      "config": {
+        "resolveSystemPlugins": false
+      }
     }
   },
   "dependencies": {

--- a/examples/electron/package.json
+++ b/examples/electron/package.json
@@ -11,6 +11,11 @@
       "config": {
         "applicationName": "Theia Electron Example"
       }
+    },
+    "backend": {
+      "config": {
+        "resolveSystemPlugins": false
+      }
     }
   },
   "dependencies": {

--- a/packages/plugin-ext/README.md
+++ b/packages/plugin-ext/README.md
@@ -33,6 +33,11 @@ The implementation is inspired from: https://blog.mattbierner.com/vscode-webview
   When you change the host pattern via the `THEIA_WEBVIEW_ENDPOINT_PATTERN` environment variable warning will be emitted both from the frontend and from the backend.
   You can disable those warnings by setting `warnOnPotentiallyInsecureHostPattern: false` in the appropriate application configurations in your application's `package.json`.
 
+## Runtime System Plugin Resolvement
+
+The backend application property `resolveSystemPlugins` is used to control the resolvement behavior for system plugins (builtins).
+The property is used to control whether or not extension-packs and extension-dependencies are resolved at runtime.
+
 ## Additional Information
 
 - [API documentation for `@theia/plugin-ext`](https://eclipse-theia.github.io/theia/docs/next/modules/plugin_ext.html)


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

Fixes: #10308

The pull-request includes the following high-level updates:
- includes better handling of build time `extensionPack`
- includes handling of build time `extensionDependencies`

Previously, `extensionPack` extensions were dismissed at build time in order for the plugin-system to not resolve them later at runtime. This was problematic as there are extension-packs which actually contain extension functionality themselves in addition to referencing extension `ids` which they want included. The code was modified to better handle packs at buildtime, and update the logic in the plugin-system to not resolve extension dependencies for `system` (bundled) extensions as they should be resolved instead at build time.

The download script was also enhanced to now also support `extensionDependencies` rather than delegate their resolvement at runtime.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

1. build, download and start the application - the app should work like today
2. include [vscode-cmake-tools](https://open-vsx.org/api/ms-vscode/cmake-tools/1.8.1/file/ms-vscode.cmake-tools-1.8.1.vsix) as a builtin extension - once downloaded the pack and referenced extension-pack id should be part of the final application (can be viewed under the `plugins-view`)
3. use the following extensions (as a replacement of what's in `package.json`):
```json
"theiaPlugins": {
  "vscode.git": "https://open-vsx.org/api/vscode/git/1.52.1/file/vscode.git-1.52.1.vsix",
  "vscode.markdown-language-features": "https://open-vsx.org/api/vscode/markdown-language-features/1.39.2/file/vscode.markdown-language-features-1.39.2.vsix",
  "vscode-builtin-extensions-pack": "https://open-vsx.org/api/eclipse-theia/builtin-extension-pack/1.50.1/file/eclipse-theia.builtin-extension-pack-1.50.1.vsix",
  "redhat.java": "https://open-vsx.org/api/redhat/java/0.73.0/file/redhat.java-0.73.0.vsix",
  "vscjava.vscode-java-debug": "https://open-vsx.org/api/vscjava/vscode-java-debug/0.30.0/file/vscjava.vscode-java-debug-0.30.0.vsix",
  "vscjava.vscode-java-test": "https://open-vsx.org/api/vscjava/vscode-java-test/0.26.1/file/vscjava.vscode-java-test-0.26.1.vsix",
  "vscjava.vscode-maven": "https://open-vsx.org/api/vscjava/vscode-maven/0.21.2/file/vscjava.vscode-maven-0.21.2.vsix",
  "vscjava.vscode-java-dependency": "https://open-vsx.org/api/vscjava/vscode-java-dependency/0.16.0/file/vscjava.vscode-java-dependency-0.16.0.vsix"
},
"theiaPluginsExcludeIds": [
  "vscode.extension-editing",
  "vscode.microsoft-authentication"
]
```
4. confirm when running `download:plugins` the extensions and packs are resolved, and excluded ids are excluded
5. start the application - the excluded ids should not be resolved and not be part of the final application

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

Signed-off-by: vince-fugnitto <vincent.fugnitto@ericsson.com>
