### PR TITLE
nls: rename command that extract localizations

### DIFF
--- a/dev-packages/cli/src/theia.ts
+++ b/dev-packages/cli/src/theia.ts
@@ -231,9 +231,9 @@ function theiaCli(): void {
             merge: boolean,
             exclude?: string,
             logs?: string,
-            pattern?: string
+            files?: string[]
         }>({
-            command: 'extract',
+            command: 'nls-extract',
             describe: 'Extract translation key/value pairs from source code',
             builder: {
                 'output': {
@@ -256,9 +256,10 @@ function theiaCli(): void {
                     alias: 'e',
                     describe: 'Allows to exclude translation keys starting with this value'
                 },
-                'pattern': {
-                    alias: 'p',
-                    describe: 'A glob pattern for filtering the files used for extraction'
+                'files': {
+                    alias: 'f',
+                    describe: 'Glob pattern matching the files to extract from (starting from --root).',
+                    array: true
                 },
                 'logs': {
                     alias: 'l',


### PR DESCRIPTION
Rename the `@theia/cli` command to extract localizations from sources to
something that would make it explicit enough. `extract` alone is a bit
too generic.

Change `--pattern/-p` into an array of `--files/-f`.

Minor changes.

#### How to test

Same as https://github.com/eclipse-theia/theia/pull/10247

> 1. Create a dummy TypeScript file like this:
> ```ts
> import { nls } from '@theia/core/lib/browser/nls';
> import { Command } from '@theia/core/lib/common';
> 
> const v1 = nls.localize('key1', 'value1');
> const v2 = nls.localize('nested/key', 'value2');
> 
> const categoryKey = 'category-key';
> const command = Command.toLocalizedCommand({
> 	id: 'id',
> 	label: 'command-label',
>         category: 'category'
> }, 'nested/command', categoryKey); // The CLI is able to resolve local references to constants
> ```
> 2. Call the extract command on it using the following CLI call (tune the glob pattern accordingly to your setup):
> ```bash
> yarn theia nls-extract --files "**/*.ts" -o out.json
> ```
> 3. Assert that all keys/default values have been correctly extracted from the input file.
> 4. Try this with different command parameters
> 5. Create an error by modifying the dummy file:
> ```ts
> const test = { key: 'key' }; 
> const v1 = nls.localize(test.key, 'value1');
> ```
> 6. Assert that the cli finishes successfully and that any errors are printed into the console along with the source information (file path, line, character)

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
