### PR TITLE
ovsx-client: Use `get` for querying extension data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
   - renamed `createMenuBar` to `createElectronMenuBar`
 - [core] moved `DEFAULT_WINDOW_HASH` to `common/window.ts` [#10291](https://github.com/eclipse-theia/theia/pull/10291)
 - [core] moved `NewWindowOptions` to `common/window.ts` [#10291](https://github.com/eclipse-theia/theia/pull/10291)
+- [ovsx-client] removed `fetchJson` method from `OVSXClient` [#10325](https://github.com/eclipse-theia/theia/pull/10325)
 
 ## v1.18.0 - 9/30/2021
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

In order to improve cache-ability, a few weeks back osvx implemented the option to query extensions by using `get` (see https://github.com/eclipse/openvsx/pull/331).

This change aligns Theia to this decision by using `get` instead of `post` requests. Additionally allows to generically stitch together url-params. (compared to the previous manual approach)

#### How to test

1. Open the `Extensions` view
2. When searching extensions, Theia should use `get` requests (confirm this using your network resources tab in your browsers dev-tools)
3. Other features of the ovsx client should behave as normal

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
