### PR TITLE
Fix #9697: `tasks#taskExecutions` not return running tasks after refresh

### DIFF
--- a/packages/plugin-ext/src/common/plugin-api-rpc.ts
+++ b/packages/plugin-ext/src/common/plugin-api-rpc.ts
@@ -1794,6 +1794,7 @@ export const MAIN_RPC_CONTEXT = {
 };
 
 export interface TasksExt {
+    $initLoadedTasks(executions: TaskExecutionDto[]): Promise<void>;
     $provideTasks(handle: number): Promise<TaskDto[] | undefined>;
     $resolveTask(handle: number, task: TaskDto, token?: CancellationToken): Promise<TaskDto | undefined>;
     $onDidStartTask(execution: TaskExecutionDto, terminalId: number): void;

--- a/packages/plugin-ext/src/main/browser/tasks-main.ts
+++ b/packages/plugin-ext/src/main/browser/tasks-main.ts
@@ -97,6 +97,13 @@ export class TasksMainImpl implements TasksMain, Disposable {
                 this.proxy.$onDidEndTaskProcess(event.code, event.taskId);
             }
         }));
+
+        // Inform proxy about running tasks form previous session
+        this.$taskExecutions().then(executions => {
+            if (executions.length > 0) {
+                this.proxy.$initLoadedTasks(executions);
+            }
+        });
     }
 
     dispose(): void {


### PR DESCRIPTION
Signed-off-by: Esther Perelman <esther.perelman@sap.com>

**The issue:** On `TasksExtImpl` constructor [`this.fetchTaskExecutions()`](https://github.com/eclipse-theia/theia/blob/ed824933d1be2d1a2805f06a3e75d0ca51ae027a/packages/plugin-ext/src/plugin/tasks/tasks.ts#L56) was supposed to initial `executions` map with the running tasks so that when plugins ask for `tasks#taskExecutions` the `executions` map is returned with the running tasks full with the fetched ones, 
But I found that the `fetchTaskExecutions` function never executes - because at this time (inside the constructor) the `RPC` not completely loading the proxy (setting a timeout of several seconds to the execution of `fetchTaskExecutions` - made it work).

**The solution:** So I wrote this PR in which I removed the call to `fetchTaskExecutions` from the `TasksExtImpl` constructor but added `initTaskLoaded` inside `TasksExtImpl` constructor.

#### What it does
Fix #9697

#### How to test (you can use the same steps to reproduce the issue on master)
1. upload the next plugin (inside the zip) to theia:
[task-sample.zip](https://github.com/eclipse-theia/theia/files/7424406/task-sample.zip)
2. create a sleep task, I used this:
`	{
			"label": "sleep",
			"type": "shell",
			"command": "ping -n 88 127.0.0.1 >nul"
	}`
3. run the `sleep` task
4. refresh the browser
5. ensure the task is still running by selecting `Terminal` -> `Show Running Tasks`
6. `ctrl+shift+p` ->  `Show Running Tasks **Length**`
7. A message of `running:1` need to be shown, Otherwise (the buggy result): `running:0`


#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
