### PR TITLE
Only fire workspace task events for effective scope

### DIFF
--- a/packages/task/src/browser/task-configuration-manager.ts
+++ b/packages/task/src/browser/task-configuration-manager.ts
@@ -240,7 +240,7 @@ export class TaskConfigurationManager {
                 }));
             }
             this.models.set(TaskScope.Workspace, workspaceModel);
-            this.onDidChangeTaskConfigEmitter.fire({ scope: TaskScope.Workspace, type: FileChangeType.UPDATED });
+            this.onDidChangeTaskConfigEmitter.fire({ scope: effectiveScope, type: FileChangeType.UPDATED });
         }
     }
 }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

Fixes a minor, intermittent bug that causes tasks in folder scope to be double listed as occurring in both folder and workspace scope in an unsaved (single-root) workspace.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
The bug depends on a race condition, but the basic issue is this:
 - At lines 237-241 below, we enforce that we only fire events for workspace scope if the workspace is saved.
 - At line 243, we fire an event for workspace scope unconditionally, which contradicts our intent from 237-241.

https://github.com/eclipse-theia/theia/blob/008c2a1bbee0f3294f8f44556b081bd013bb21e6/packages/task/src/browser/task-configuration-manager.ts#L227-L246

When we fire those events, this listener

https://github.com/eclipse-theia/theia/blob/008c2a1bbee0f3294f8f44556b081bd013bb21e6/packages/task/src/browser/task-configurations.ts#L97-L107

kicks in and populates a list of tasks by scope. We [always](https://github.com/eclipse-theia/theia/blob/008c2a1bbee0f3294f8f44556b081bd013bb21e6/packages/task/src/browser/task-configuration-manager.ts#L125-L128) fire events for folder scope, which is why we only want to fire them for workspace scope if it's different.

The race condition comes in because if the preference provider for `newDelegate` happens not to have read its configuration when the event on line 243 is fired, then the listener finds no tasks for that scope, and so we don't see any duplicates. If the preference provider _has_ read its configuration, then we get the same tasks listed in both folder and workspace scope.

If you really want to reproduce the bug, replace line 243 with 
```typescript
newDelegate.ready.then(() => this.onDidChangeTaskConfigEmitter.fire({ scope: TaskScope.Workspace, type: FileChangeType.UPDATED }));
```
which will guarantee that the configuration has been read then
1. Open a single-root, unsaved workspace with one or more tasks defined in a `tasks.json`
2. Open the Terminal menu and select 'Run task...'
3. Observe that the tasks defined in the `tasks.json` are all listed twice, once in workspace scope, once in folder scope.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

Signed-off-by: Colin Grant <colin.grant@ericsson.com>