### PR TITLE
webview: fix host.js logic

### DIFF
--- a/packages/plugin-ext/src/main/browser/webview/pre/host.js
+++ b/packages/plugin-ext/src/main/browser/webview/pre/host.js
@@ -26,6 +26,8 @@
         constructor() {
             this.handlers = new Map();
             window.addEventListener('message', e => {
+                // Note: `window.parent === window` when there is no parent...
+                const sourceIsSelfOrParentFrame = e.source === window.parent;
                 let sourceIsChildFrame = false;
                 for (let i = 0; i < window.frames.length; i++) {
                     const frame = window.frames[i];
@@ -35,11 +37,8 @@
                     }
                 }
                 if (sourceIsChildFrame && e.data && (e.data.command === 'onmessage' || e.data.command === 'do-update-state')) {
-                    // Came from inner iframe
                     this.postMessage(e.data.command, e.data.data);
-                }
-                // Note: `window.parent === window` when there is no parent...
-                if (sourceIsChildFrame || e.source === window.parent) {
+                } else if (sourceIsChildFrame || sourceIsSelfOrParentFrame) {
                     const channel = e.data.channel;
                     const handler = this.handlers.get(channel);
                     if (handler) {


### PR DESCRIPTION
The logic previously stopped the handler after running
`this.postMessage` but I forgot to follow this when modifying this code
in another PR.

Fix the logic by respecting what was previously done.

Fix https://github.com/eclipse-theia/theia/issues/10331.

cc @StanZGenchev.

#### How to test

- Open `custom-editor-sample` from the official https://github.com/microsoft/vscode-extension-samples and run it.
- Open the developer tools and switch to console.
- Open the `example.cscratch` file in `exampleFiles` in the `custom-editor-sample` folder.
- Trigger any action in the custom editor.
- See no error in the console.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
