### PR TITLE
remove upper range on Node.js version

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,7 +20,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [windows-2019, ubuntu-18.04, macos-10.15]
-        node: ['12.x']
+        node: ['12.x', '14.x']
 
     runs-on: ${{ matrix.os }}
     timeout-minutes: 60
@@ -28,8 +28,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-        with:
-          fetch-depth: 0 # To fetch all history for all branches and tags. (Will be required for caching with lerna: https://github.com/markuplint/markuplint/pull/111)
 
       - name: Use Node.js ${{ matrix.node }}
         uses: actions/setup-node@v1
@@ -45,7 +43,7 @@ jobs:
       - name: Build
         shell: bash
         run: |
-          yarn --skip-integrity-check --network-timeout 100000
+          yarn --skip-integrity-check --network-timeout 100000 --ignore-engines
           yarn lint
           npx electron-replace-ffmpeg
           npx electron-codecs-test

--- a/doc/Developing.md
+++ b/doc/Developing.md
@@ -52,8 +52,9 @@ For Windows instructions [click here](#building-on-windows).
 
 ## Prerequisites
 
- - Node.js `>= 12.14.1` **AND** `< 13`.
-   - Preferably, **use** Node version [`12.14.1`](https://nodejs.org/download/release/v12.14.1/), as it is the recommended minimum version according to the framework's supported `electron` version.
+ - Node.js `>= 12.14.1`.
+   - Preferably, **use** Node's [Active LTS version](https://nodejs.org/en/about/releases/).
+   - If you are interested in Theia's VS Code Extension support then you should use a Node version at least compatible with the one included in the version of Electron used by [VS Code](https://github.com/microsoft/vscode).
  - [Yarn package manager](https://yarnpkg.com/en/docs/install)  `>= 1.7.0` **AND** `< 2.x.x`.
  - git (If you would like to use the Git-extension too, you will need to have git version 2.11.0 or higher.)
 

--- a/doc/runtime-policy.md
+++ b/doc/runtime-policy.md
@@ -1,0 +1,49 @@
+# Node.js
+
+## Version Support Policy
+
+We try to support Node.js versions from 12 up to the current _Active LTS_ version.
+
+See https://nodejs.org/en/about/releases/ to see the status of Node.js versions.
+
+We recommend setting up your environment to run Theia using the Node.js _Active LTS_, but any supported version should work as well. File an issue otherwise: https://github.com/eclipse-theia/theia/issues/new/choose.
+
+Note that the Node.js version you should use depends on your own project's dependencies: packages other than Theia might have their own requirements, so we try to support a reasonable range for adopters to be able to satisfy such constraints.
+
+## Update Process
+
+- Follow Node.js LTS cadence and initiate the update when a new Node.js version becomes _Active LTS_.
+- Use `@types/node` for the oldest supported Node version (backward compatibility).
+- Update the CI matrix to include the new Node.js versions to support.
+- Update the CHANGELOG.
+
+# Electron
+
+## Version Support Policy
+
+We aim to use Electron's latest _Stable Release_.
+
+See https://www.electronjs.org/releases/stable to see the latest Electron stable releases.
+
+Note that clearing new Electron releases IP-wise is a lot of work and may cause us to lag behind a bit.
+
+Adopters will benefit from Electron versions upgrades simply by upgrading their version of Theia.
+
+## Update Process
+
+- Follow Electron stable release cadence and initiate the update when a new Electron _Stable Release_ is published.
+- Check the new Electron version for potential IP problems.
+- Update the framework dependencies to target the new Electron version.
+- Update the codebase to replace/use the new Electron APIs.
+- Update the CHANGELOG.
+
+# VS Code Extension Support
+
+If you plan on supporting VS Code Extensions then it is recommended to make sure that both Node and/or Electron match
+with VS Code's Node runtime, which depends on the Electron version that they end up using.
+
+You should look for this information in the [VS Code repository](https://github.com/microsoft/vscode).
+
+VS Code Extensions being meant to run in VS Code, developers may use any API available in the runtime in which their
+extension runs. So if they expect to run in Node 14, then they may use Node 14 APIs. Running your Theia application
+on Node 12 then means that some plugin features might not work because of missing APIs from the Node runtime.

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "version": "0.0.0",
   "engines": {
     "yarn": ">=1.7.0 <2.x.x",
-    "node": ">=12.14.1 <13"
+    "node": ">=12.14.1"
   },
   "resolutions": {
     "**/@types/node": "12",


### PR DESCRIPTION
Support at least Node.js 12 but remove the upper-bound. Downstream
projects should be able to choose their own Node.js version based on
their needs. The framework still expects to run on Node.js 12 at the
minimum. Using a previous version might lead to errors due to our usage
of APIs that might be missing in earlier versions.

Electron is not updated in this commit but it should be done sooner than
later.

Note that one of dependency `dugite-extra` has its own Node.js range
that may prevent using Node.js newer than 12. This only affects
downstream projects that include the `@theia/git` extension. You can
still get around it by running `yarn --ignore-engines <command...>`.

Add `doc/runtime-policy.md`.

Update `doc/Developing.md` to reflect the policy.

Update CI to run on Node 12 and 14.

Closes https://github.com/eclipse-theia/theia/pull/9878.

#### How to test

Build and run using Node 12 and 14.
You may need to run `yarn --ignore-engines` because of `dugite-extra`.
CI should be green.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
