### PR TITLE
plugin: removed `resolveSystemPlugins` application prop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
 - [core] removed deprecated `currentChanged` signal emitter in favor of `onDidChangeCurrentWidget` [#10515](https://github.com/eclipse-theia/theia/pull/10515)
 - [plugin] changed return type of `WebviewThemeDataProvider.getActiveTheme()` to `Theme` instead of `WebviewThemeType` [#10493](https://github.com/eclipse-theia/theia/pull/10493)
 - [plugin] renamed `WebviewThemeData.activeTheme` to `activeThemeType` [#10493](https://github.com/eclipse-theia/theia/pull/10493)
+- [plugin] removed the application prop `resolveSystemPlugins`, builtin plugins should now be resolved at build time [#10353](https://github.com/eclipse-theia/theia/pull/10353)
 
 ## v1.20.0 - 11/25/2021
 

--- a/doc/Migration.md
+++ b/doc/Migration.md
@@ -31,9 +31,9 @@ You can delete this whole block and replace it by the following:
 
 Introduced in `v1.19.0` was the feature to better support extension-packs which both contribute functionality and reference plugins (by `id`).
 The feature works best when there is no runtime plugin resolvement for system (builtin) plugins as it should be done at build time instead.
-In order not to change behavior today, the feature is behind an application prop (acting as a flag). If you want to enable better support for
-extension-packs and extension-dependencies as builtins the property should be turned off. You can disable the resolvement in your application's
-`package.json` like so:
+The feature is behind an application property, acting as a flag to enable/disable the feature. If you want to enable better support for
+extension-packs and extension-dependencies as builtins the property should be turned off (default). You can enable/disable the resolution of system
+plugin dependencies in your application's `package.json` like so:
 
 
 ```json

--- a/doc/Migration.md
+++ b/doc/Migration.md
@@ -25,27 +25,6 @@ You can delete this whole block and replace it by the following:
       "webRoot": "${workspaceFolder}/examples/electron"
 ```
 
-### v1.19.0
-
-#### Runtime System Plugin Resolvement
-
-Introduced in `v1.19.0` was the feature to better support extension-packs which both contribute functionality and reference plugins (by `id`).
-The feature works best when there is no runtime plugin resolvement for system (builtin) plugins as it should be done at build time instead.
-The feature is behind an application property, acting as a flag to enable/disable the feature. If you want to enable better support for
-extension-packs and extension-dependencies as builtins the property should be turned off (default). You can enable/disable the resolution of system
-plugin dependencies in your application's `package.json` like so:
-
-
-```json
-"theia": {
-  "backend": {
-    "config": {
-      "resolveSystemPlugins": false
-    }
-  }
-}
-```
-
 ### v1.17.0
 
 #### ES2017

--- a/examples/browser/package.json
+++ b/examples/browser/package.json
@@ -11,11 +11,6 @@
           "files.enableTrash": false
         }
       }
-    },
-    "backend": {
-      "config": {
-        "resolveSystemPlugins": false
-      }
     }
   },
   "dependencies": {

--- a/examples/electron/package.json
+++ b/examples/electron/package.json
@@ -11,11 +11,6 @@
       "config": {
         "applicationName": "Theia Electron Example"
       }
-    },
-    "backend": {
-      "config": {
-        "resolveSystemPlugins": false
-      }
     }
   },
   "dependencies": {

--- a/packages/plugin-ext/src/hosted/node/hosted-plugin-deployer-handler.ts
+++ b/packages/plugin-ext/src/hosted/node/hosted-plugin-deployer-handler.ts
@@ -86,7 +86,7 @@ export class HostedPluginDeployerHandler implements PluginDeployerHandler {
             const metadata = this.reader.readMetadata(manifest);
             const dependencies: PluginDependencies = { metadata };
             // Do not resolve system (aka builtin) plugins because it should be done statically at build time.
-            const { resolveSystemPlugins = true } = BackendApplicationConfigProvider.get();
+            const { resolveSystemPlugins = false } = BackendApplicationConfigProvider.get();
             if (resolveSystemPlugins || entry.type !== PluginType.System) {
                 dependencies.mapping = this.reader.readDependencies(manifest);
             }

--- a/packages/plugin-ext/src/hosted/node/hosted-plugin-deployer-handler.ts
+++ b/packages/plugin-ext/src/hosted/node/hosted-plugin-deployer-handler.ts
@@ -21,7 +21,6 @@ import { PluginDeployerHandler, PluginDeployerEntry, PluginEntryPoint, DeployedP
 import { HostedPluginReader } from './plugin-reader';
 import { Deferred } from '@theia/core/lib/common/promise-util';
 import { HostedPluginLocalizationService } from './hosted-plugin-localization-service';
-import { BackendApplicationConfigProvider } from '@theia/core/lib/node/backend-application-config-provider';
 
 @injectable()
 export class HostedPluginDeployerHandler implements PluginDeployerHandler {
@@ -86,8 +85,7 @@ export class HostedPluginDeployerHandler implements PluginDeployerHandler {
             const metadata = this.reader.readMetadata(manifest);
             const dependencies: PluginDependencies = { metadata };
             // Do not resolve system (aka builtin) plugins because it should be done statically at build time.
-            const { resolveSystemPlugins = false } = BackendApplicationConfigProvider.get();
-            if (resolveSystemPlugins || entry.type !== PluginType.System) {
+            if (entry.type !== PluginType.System) {
                 dependencies.mapping = this.reader.readDependencies(manifest);
             }
             return dependencies;


### PR DESCRIPTION


<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

The commit updates the `resolveSystemPlugins` backend application prop to `false` since it has the better behavior. The flag was initially set to `true` not to have breaking behavior changes as part of `v1.19.0`.

The prop is used to not resolve system extension-packs and dependencies at runtime, and instead resolve them at build time.


#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

- confirm that everything works correctly as today when downloading, searching and installing extensions
- confirm with the following builtins, that they are resolved at build time, and excluded plugins are not in the final app:
```json
"theiaPlugins": {
  "vscode.git": "https://open-vsx.org/api/vscode/git/1.52.1/file/vscode.git-1.52.1.vsix",
  "vscode.markdown-language-features": "https://open-vsx.org/api/vscode/markdown-language-features/1.39.2/file/vscode.markdown-language-features-1.39.2.vsix",
  "vscode-builtin-extensions-pack": "https://open-vsx.org/api/eclipse-theia/builtin-extension-pack/1.50.1/file/eclipse-theia.builtin-extension-pack-1.50.1.vsix",
  "redhat.java": "https://open-vsx.org/api/redhat/java/0.73.0/file/redhat.java-0.73.0.vsix",
  "vscjava.vscode-java-debug": "https://open-vsx.org/api/vscjava/vscode-java-debug/0.30.0/file/vscjava.vscode-java-debug-0.30.0.vsix",
  "vscjava.vscode-java-test": "https://open-vsx.org/api/vscjava/vscode-java-test/0.26.1/file/vscjava.vscode-java-test-0.26.1.vsix",
  "vscjava.vscode-maven": "https://open-vsx.org/api/vscjava/vscode-maven/0.21.2/file/vscjava.vscode-maven-0.21.2.vsix",
  "vscjava.vscode-java-dependency": "https://open-vsx.org/api/vscjava/vscode-java-dependency/0.16.0/file/vscjava.vscode-java-dependency-0.16.0.vsix"
},
"theiaPluginsExcludeIds": [
  "vscode.extension-editing",
  "vscode.microsoft-authentication"
]
```
- remove the `plugins` folder (so no builtins are present)
- install the `eclipse-theia.builtin-extension-pack` through the extensions-view - confirm that the individual plugins are resolved and installed

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

Signed-off-by: vince-fugnitto <vincent.fugnitto@ericsson.com>
