### PR TITLE
repo: upgrade to TypeScript 4

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -4,7 +4,6 @@
 // - Linux: $HOME/.config/Code/User/settings.json
 // - Mac: $HOME/Library/Application Support/Code/User/settings.json
 {
-  "tslint.enable": true,
   "editor.formatOnSave": true,
   "search.exclude": {
     "**/node_modules": true,
@@ -55,7 +54,8 @@
   "typescript.tsdk": "node_modules/typescript/lib",
   "files.insertFinalNewline": true,
   "clang-format.language.typescript.enable": false,
+  // ESLint `max-len` rule.
   "editor.rulers": [
     180
-  ], // ESLint `max-len` rule.
+  ],
 }

--- a/dev-packages/localization-manager/package.json
+++ b/dev-packages/localization-manager/package.json
@@ -33,7 +33,7 @@
     "deepmerge": "^4.2.2",
     "fs-extra": "^4.0.2",
     "glob": "^7.2.0",
-    "typescript": "^4.4.3"
+    "typescript": "~4.5.5"
   },
   "devDependencies": {
     "@theia/ext-scripts": "1.22.1"

--- a/doc/Migration.md
+++ b/doc/Migration.md
@@ -19,9 +19,16 @@ For example:
 }
 ```
 
+### v1.23.0
+
+#### TypeScript 4.5.5
+
+If you are using TypeScript <= 4.5.5 and you encounter issues when building your Theia application because your compiler fails to parse our type definitions,
+then you should upgrade to TypeScript >= 4.5.5.
+
 ### v1.22.0
 
-### Electron Update
+#### Electron Update
 
 Electron got updated from 9 to 15, this might involve some modifications in your code based on the new APIs.
 

--- a/license-check-baseline.json
+++ b/license-check-baseline.json
@@ -1,6 +1,5 @@
 {
   "npm/npmjs/-/eslint-plugin-deprecation/1.2.1": "Approved as 'works-with': https://dev.eclipse.org/ipzilla/show_bug.cgi?id=22573",
   "npm/npmjs/-/jschardet/2.3.0": "Approved for Eclipse Theia: https://dev.eclipse.org/ipzilla/show_bug.cgi?id=22481",
-  "npm/npmjs/-/jsdom/11.12.0": "Approved as 'works-with': https://dev.eclipse.org/ipzilla/show_bug.cgi?id=23640https://dev.eclipse.org/ipzilla/show_bug.cgi?id=23640",
-  "npm/npmjs/-/node-pty/0.11.0-beta17": "Manually checked using ClearlyDefined"
+  "npm/npmjs/-/jsdom/11.12.0": "Approved as 'works-with': https://dev.eclipse.org/ipzilla/show_bug.cgi?id=23640https://dev.eclipse.org/ipzilla/show_bug.cgi?id=23640"
 }

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "tslint": "^5.12.0",
     "typedoc": "0.20.36",
     "typedoc-plugin-external-module-map": "1.2.1",
-    "typescript": "^3.9.2",
+    "typescript": "~4.5.5",
     "uuid": "^8.0.0",
     "yargs": "^15.3.1"
   },

--- a/packages/core/src/browser/authentication-service.ts
+++ b/packages/core/src/browser/authentication-service.ts
@@ -160,7 +160,7 @@ export class AuthenticationServiceImpl implements AuthenticationService {
             }
         });
         this.commands.registerCommand(this.noAccountsCommand, {
-            execute: () => {},
+            execute: () => { },
             isEnabled: () => false
         });
     }
@@ -264,7 +264,7 @@ export class AuthenticationServiceImpl implements AuthenticationService {
             // Activate has already been called for the authentication provider, but it cannot block on registering itself
             // since this is sync and returns a disposable. So, wait for registration event to fire that indicates the
             // provider is now in the map.
-            await new Promise((resolve, _) => {
+            await new Promise<void>((resolve, _) => {
                 this.onDidRegisterAuthenticationProvider(e => {
                     if (e.id === providerId) {
                         provider = this.authenticationProviders.get(providerId);

--- a/packages/core/src/browser/shell/tab-bars.ts
+++ b/packages/core/src/browser/shell/tab-bars.ts
@@ -640,6 +640,7 @@ export class ToolbarAwareTabBar extends ScrollableTabBar {
     /**
      * Overrides the `contentNode` property getter in PhosphorJS' TabBar.
      */
+    // @ts-expect-error TS2611 `TabBar<T>.contentNode` is declared as `readonly contentNode` but is implemented as a getter.
     get contentNode(): HTMLUListElement {
         return this.tabBarContainer.getElementsByClassName(ToolbarAwareTabBar.Styles.TAB_BAR_CONTENT)[0] as HTMLUListElement;
     }

--- a/packages/core/src/browser/source-tree/source-tree.ts
+++ b/packages/core/src/browser/source-tree/source-tree.ts
@@ -14,6 +14,8 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
 import { injectable } from 'inversify';
 import { MaybePromise } from '../../common/types';
 import { TreeImpl, CompositeTreeNode, TreeNode, SelectableTreeNode, ExpandableTreeNode } from '../tree';
@@ -67,15 +69,15 @@ export class SourceTree extends TreeImpl {
             } as TreeElementNode;
         }
         if (CompositeTreeElementNode.is(updated)) {
-            delete updated.expanded;
-            delete updated.children;
+            delete (updated as any).expanded;
+            delete (updated as any).children;
         }
         if (updated) {
             if (ExpandableTreeNode.is(updated)) {
-                delete updated.expanded;
+                delete (updated as any).expanded;
             }
             if (CompositeTreeNode.is(updated)) {
-                delete updated.children;
+                delete (updated as any).children;
             }
             return updated;
         }

--- a/packages/core/src/browser/view-container.ts
+++ b/packages/core/src/browser/view-container.ts
@@ -1307,6 +1307,7 @@ export class ViewContainerLayout extends SplitLayout {
         return map(this.items, item => item.widget);
     }
 
+    // @ts-expect-error TS2611 `SplitLayout.widgets` is declared as `readonly widgets` but is implemented as a getter.
     get widgets(): ViewContainerPart[] {
         return toArray(this.iter());
     }

--- a/packages/core/src/common/event.ts
+++ b/packages/core/src/common/event.ts
@@ -330,7 +330,7 @@ export namespace WaitUntilEvent {
             // Asynchronous calls to `waitUntil` should fail.
             Object.freeze(waitables);
         } finally {
-            delete asyncEvent['waitUntil'];
+            delete (asyncEvent as any)['waitUntil'];
         }
         if (!waitables.length) {
             return;
@@ -390,7 +390,7 @@ export class AsyncEmitter<T extends WaitUntilEvent> extends Emitter<T> {
             } catch (e) {
                 console.error(e);
             } finally {
-                delete asyncEvent['waitUntil'];
+                delete (asyncEvent as any)['waitUntil'];
             }
             if (!waitables.length) {
                 return;

--- a/packages/core/src/common/messaging/proxy-factory.ts
+++ b/packages/core/src/common/messaging/proxy-factory.ts
@@ -236,7 +236,7 @@ export class JsonRpcProxyFactory<T extends object> implements ProxyHandler<T> {
             const method = p.toString();
             const capturedError = new Error(`Request '${method}' failed`);
             return this.connectionPromise.then(connection =>
-                new Promise((resolve, reject) => {
+                new Promise<void>((resolve, reject) => {
                     try {
                         if (isNotify) {
                             connection.sendNotification(method, ...args);

--- a/packages/core/src/node/messaging/ipc-connection-provider.ts
+++ b/packages/core/src/node/messaging/ipc-connection-provider.ts
@@ -17,7 +17,7 @@
 import * as cp from 'child_process';
 import * as path from 'path';
 import { injectable, inject } from 'inversify';
-import { Trace, IPCMessageReader, IPCMessageWriter, createMessageConnection, MessageConnection, Message } from 'vscode-ws-jsonrpc';
+import { Trace, Tracer, IPCMessageReader, IPCMessageWriter, createMessageConnection, MessageConnection, Message } from 'vscode-ws-jsonrpc';
 import { ILogger, ConnectionErrorHandler, DisposableCollection, Disposable } from '../../common';
 import { createIpcEnv } from './ipc-protocol';
 
@@ -83,10 +83,14 @@ export class IPCConnectionProvider {
             info: (message: string) => this.logger.info(`[${options.serverName}: ${childProcess.pid}] ${message}`),
             log: (message: string) => this.logger.info(`[${options.serverName}: ${childProcess.pid}] ${message}`)
         });
-        const traceVerbosity = this.logger.isDebug() ? Trace.Verbose : Trace.Off;
-        connection.trace(traceVerbosity, {
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any
-            log: (message: any, data?: string) => this.logger.debug(`[${options.serverName}: ${childProcess.pid}] ${message}` + (typeof data === 'string' ? ' ' + data : ''))
+        const tracer: Tracer = {
+            log: (message: unknown, data?: string) => this.logger.debug(`[${options.serverName}: ${childProcess.pid}] ${message}` + (typeof data === 'string' ? ' ' + data : ''))
+        };
+        connection.trace(Trace.Verbose, tracer);
+        this.logger.isDebug().then(isDebug => {
+            if (!isDebug) {
+                connection.trace(Trace.Off, tracer);
+            }
         });
         return connection;
     }

--- a/packages/filesystem/src/node/download/directory-archiver.spec.ts
+++ b/packages/filesystem/src/node/download/directory-archiver.spec.ts
@@ -45,7 +45,7 @@ describe('directory-archiver', () => {
         await archiver.archive(fromPath, path.join(toPath, 'output.tar'));
         expect(fs.existsSync(path.join(toPath, 'output.tar'))).to.be.true;
         const assertPath = track.mkdirSync('assertPath');
-        return new Promise(resolve => {
+        return new Promise<void>(resolve => {
             fs.createReadStream(path.join(toPath, 'output.tar')).pipe(extract(assertPath)).on('finish', () => {
                 expect(fs.readdirSync(assertPath).sort()).to.be.deep.equal(['A.txt', 'B.txt']);
                 expect(fs.readFileSync(path.join(assertPath, 'A.txt'), { encoding: 'utf8' })).to.be.equal(fs.readFileSync(path.join(fromPath, 'A.txt'), { encoding: 'utf8' }));

--- a/packages/git/src/node/git-repository-watcher.ts
+++ b/packages/git/src/node/git-repository-watcher.ts
@@ -95,7 +95,7 @@ export class GitRepositoryWatcher implements Disposable {
                 this.skipNextIdle = false;
             } else {
                 const idleTimeout = this.watching ? 5000 : /* super long */ 1000 * 60 * 60 * 24;
-                await new Promise(resolve => {
+                await new Promise<void>(resolve => {
                     const id = setTimeout(resolve, idleTimeout);
                     this.interruptIdle = () => { clearTimeout(id); resolve(); };
                 }).then(() => {

--- a/packages/monaco/src/browser/monaco-editor-provider.ts
+++ b/packages/monaco/src/browser/monaco-editor-provider.ts
@@ -209,7 +209,7 @@ export class MonacoEditorProvider {
         let keydownListener: monaco.IDisposable | undefined;
         const keybindingService = editor.getControl()._standaloneKeybindingService;
         for (const listener of keybindingService._store._toDispose) {
-            if ('_type' in listener && listener['_type'] === 'keydown') {
+            if ((listener as any)['_type'] === 'keydown') {
                 keydownListener = listener;
                 break;
             }

--- a/packages/plugin-ext/src/common/plugin-api-rpc-model.ts
+++ b/packages/plugin-ext/src/common/plugin-api-rpc-model.ts
@@ -511,11 +511,6 @@ export interface RenameLocation {
     text: string;
 }
 
-export interface RenameProvider {
-    provideRenameEdits(model: monaco.editor.ITextModel, position: Position, newName: string): PromiseLike<WorkspaceEdit & Rejection>;
-    resolveRenameLocation?(model: monaco.editor.ITextModel, position: Position): PromiseLike<RenameLocation & Rejection>;
-}
-
 export interface CallHierarchyDefinition {
     name: string;
     kind: SymbolKind;

--- a/packages/plugin-ext/src/hosted/node/plugin-reader.ts
+++ b/packages/plugin-ext/src/hosted/node/plugin-reader.ts
@@ -58,7 +58,8 @@ export class HostedPluginReader implements BackendApplicationContribution {
                         // the request was already closed
                         return;
                     }
-                    if ('code' in e && e['code'] === 'ENOENT') {
+                    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                    if ((e as any)['code'] === 'ENOENT') {
                         res.status(404).send(`No such file found in '${escape_html(pluginId)}' plugin.`);
                     } else {
                         res.status(500).send(`Failed to transfer a file from '${escape_html(pluginId)}' plugin.`);

--- a/packages/plugin-ext/src/main/browser/view-column-service.ts
+++ b/packages/plugin-ext/src/main/browser/view-column-service.ts
@@ -32,7 +32,7 @@ export class ViewColumnService {
     ) {
         let oldColumnValues = new Map<string, number>();
         const update = async () => {
-            await new Promise((resolve => setTimeout(() => resolve())));
+            await new Promise<void>((resolve => setTimeout(resolve)));
             this.updateViewColumns();
             this.viewColumnIds.forEach((ids: string[], viewColumn: number) => {
                 ids.forEach((id: string) => {

--- a/packages/plugin-ext/src/main/node/paths/plugin-paths-service.ts
+++ b/packages/plugin-ext/src/main/node/paths/plugin-paths-service.ts
@@ -142,7 +142,7 @@ export class PluginPathsServiceImpl implements PluginPathsService {
 
     private async cleanupOldLogs(parentLogsDir: string): Promise<void> {
         // @ts-ignore - fs-extra types (Even latest version) is not updated with the `withFileTypes` option.
-        const dirEntries = await readdir(parentLogsDir, { withFileTypes: true });
+        const dirEntries = await readdir(parentLogsDir, { withFileTypes: true }) as string[];
         // `Dirent` type is defined in @types/node since 10.10.0
         // However, upgrading the @types/node in theia to 10.11 (as defined in engine field)
         // Causes other packages to break in compilation, so we are using the infamous `any` type...

--- a/packages/preferences/src/browser/util/preference-tree-generator.ts
+++ b/packages/preferences/src/browser/util/preference-tree-generator.ts
@@ -195,7 +195,8 @@ export class PreferenceTreeGenerator {
         };
         const isTopLevel = Preference.TreeNode.isTopLevel(newNode);
         if (!isTopLevel) {
-            delete newNode.expanded;
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            delete (newNode as any).expanded;
         }
         newNode.depth = isTopLevel ? 0 : 1;
         CompositeTreeNode.addChild(root, newNode);

--- a/packages/preview/src/browser/markdown/markdown-preview-handler.ts
+++ b/packages/preview/src/browser/markdown/markdown-preview-handler.ts
@@ -130,7 +130,7 @@ export class MarkdownPreviewHandler implements PreviewHandler {
                 return NodeFilter.FILTER_SKIP;
             }
         };
-        const treeWalker = document.createTreeWalker(content, NodeFilter.SHOW_ELEMENT, filter, false);
+        const treeWalker = document.createTreeWalker(content, NodeFilter.SHOW_ELEMENT, filter);
         if (treeWalker.nextNode()) {
             const element = treeWalker.currentNode as HTMLElement;
             return element;
@@ -198,7 +198,7 @@ export class MarkdownPreviewHandler implements PreviewHandler {
                 return NodeFilter.FILTER_REJECT;
             }
         };
-        const treeWalker = document.createTreeWalker(content, NodeFilter.SHOW_ELEMENT, filter, false);
+        const treeWalker = document.createTreeWalker(content, NodeFilter.SHOW_ELEMENT, filter);
         const lineElements: HTMLElement[] = [];
         while (treeWalker.nextNode()) {
             const element = treeWalker.currentNode as HTMLElement;

--- a/packages/process/src/node/multi-ring-buffer.spec.ts
+++ b/packages/process/src/node/multi-ring-buffer.spec.ts
@@ -329,7 +329,7 @@ describe('MultiRingBuffer', function (): void {
         const buffer = 'abc';
 
         const astream = ringBuffer.getStream();
-        const p = new Promise(resolve => {
+        const p = new Promise<void>(resolve => {
             astream.on('data', (chunk: string) => {
                 expect(chunk).to.be.equal(buffer);
                 resolve();
@@ -347,7 +347,7 @@ describe('MultiRingBuffer', function (): void {
         ringBuffer.enq(buffer);
 
         const astream = ringBuffer.getStream();
-        const p = new Promise(resolve => {
+        const p = new Promise<void>(resolve => {
             astream.on('data', (chunk: string) => {
                 expect(chunk).to.be.equal(buffer);
                 resolve();
@@ -403,7 +403,7 @@ describe('MultiRingBuffer', function (): void {
         ringBuffer.enq(buffer);
 
         const astream = ringBuffer.getStream('hex');
-        const p = new Promise(resolve => {
+        const p = new Promise<void>(resolve => {
             astream.on('data', (chunk: string) => {
                 expect(chunk).to.be.equal('74657374');
                 resolve();

--- a/packages/process/src/node/raw-process.spec.ts
+++ b/packages/process/src/node/raw-process.spec.ts
@@ -100,16 +100,13 @@ describe('RawProcess', function (): void {
         const args = ['--version'];
         const rawProcess = rawProcessFactory({ command: process.execPath, 'args': args });
         const p = new Promise<number>((resolve, reject) => {
-            rawProcess.onError(error => {
-                reject();
-            });
-
+            rawProcess.onError(reject);
             rawProcess.onExit(event => {
                 if (event.code === undefined) {
-                    reject();
+                    reject(new Error('event.code is undefined'));
+                } else {
+                    resolve(event.code);
                 }
-
-                resolve(event.code);
             });
         });
 

--- a/packages/scm-extra/src/browser/history/scm-history-widget.tsx
+++ b/packages/scm-extra/src/browser/history/scm-history-widget.tsx
@@ -401,7 +401,7 @@ export class ScmHistoryWidget extends ScmNavigableListWidget<ScmHistoryListNode>
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     protected doLoadMoreRows(params: IndexRange): Promise<any> {
         let resolver: () => void;
-        const promise = new Promise(resolve => resolver = resolve);
+        const promise = new Promise<void>(resolve => resolver = resolve);
         const lastRow = this.scmNodes[params.stopIndex - 1];
         if (ScmCommitNode.is(lastRow)) {
             const toRevision = lastRow.commitDetails.id;

--- a/packages/search-in-workspace/src/node/ripgrep-search-in-workspace-server.slow-spec.ts
+++ b/packages/search-in-workspace/src/node/ripgrep-search-in-workspace-server.slow-spec.ts
@@ -904,13 +904,16 @@ describe('ripgrep-search-in-workspace-server', function (): void {
     it('fails gracefully when rg isn\'t found', async function (): Promise<void> {
         const errorString = await new Promise<string>((resolve, reject) => {
             const rgServer = createInstance('/non-existent/rg');
-
             rgServer.setClient({
                 onResult: (searchId: number, result: SearchInWorkspaceResult): void => {
                     reject();
                 },
                 onDone: (searchId: number, error?: string): void => {
-                    resolve(error);
+                    if (typeof error === 'string') {
+                        resolve(error);
+                    } else {
+                        reject();
+                    }
                 },
             });
             rgServer.search('pattern', [rootDirA]);
@@ -934,7 +937,11 @@ describe('ripgrep-search-in-workspace-server', function (): void {
                     reject();
                 },
                 onDone: (searchId: number, error?: string): void => {
-                    resolve(error);
+                    if (typeof error === 'string') {
+                        resolve(error);
+                    } else {
+                        reject();
+                    }
                 },
             });
             rgServer.search('pattern', [rootDirA]);

--- a/packages/task/src/node/task-server.slow-spec.ts
+++ b/packages/task/src/node/task-server.slow-spec.ts
@@ -105,7 +105,7 @@ describe('Task server / back-end', function (): void {
         const messages: string[] = [];
 
         // hook-up to terminal's ws and confirm that it outputs expected tasks' output
-        await new Promise((resolve, reject) => {
+        await new Promise<void>((resolve, reject) => {
             const channel = new TestWebSocketChannel({ server, path: `${terminalsPath}/${terminalId}` });
             channel.onError(reject);
             channel.onClose((code, reason) => reject(new Error(`channel is closed with '${code}' code and '${reason}' reason`)));
@@ -137,7 +137,7 @@ describe('Task server / back-end', function (): void {
         // create task using raw process
         const taskInfo: TaskInfo = await taskServer.run(createProcessTaskConfig('process', executable, [someString]), wsRoot);
 
-        await new Promise((resolve, reject) => {
+        await new Promise<void>((resolve, reject) => {
             const toDispose = taskWatcher.onTaskExit((event: TaskExitedEvent) => {
                 if (event.taskId === taskInfo.taskId && event.code === 0) {
                     if (typeof taskInfo.terminalId === 'number') {
@@ -242,8 +242,9 @@ describe('Task server / back-end', function (): void {
             taskWatcher.onTaskExit((event: TaskExitedEvent) => {
                 if (event.taskId !== taskInfo.taskId || event.code === undefined) {
                     reject(new Error(JSON.stringify(event)));
+                } else {
+                    resolve(event.code);
                 }
-                resolve(event.code);
             });
         });
         // node-pty reports different things on Linux/macOS vs Windows when
@@ -422,8 +423,8 @@ function createTaskConfigTaskLongRunning(processType: ProcessType): TaskConfigur
     };
 }
 
-function checkSuccessfulProcessExit(taskInfo: TaskInfo, taskWatcher: TaskWatcher): Promise<object> {
-    return new Promise<object>((resolve, reject) => {
+function checkSuccessfulProcessExit(taskInfo: TaskInfo, taskWatcher: TaskWatcher): Promise<void> {
+    return new Promise<void>((resolve, reject) => {
         const toDispose = taskWatcher.onTaskExit((event: TaskExitedEvent) => {
             if (event.taskId === taskInfo.taskId && event.code === 0) {
                 toDispose.dispose();

--- a/packages/terminal/src/node/terminal-backend-contribution.slow-spec.ts
+++ b/packages/terminal/src/node/terminal-backend-contribution.slow-spec.ts
@@ -44,7 +44,7 @@ describe('Terminal Backend Contribution', function (): void {
 
     it('is data received from the terminal ws server', async () => {
         const terminalId = await shellTerminalServer.create({});
-        await new Promise((resolve, reject) => {
+        await new Promise<void>((resolve, reject) => {
             const channel = new TestWebSocketChannel({ server, path: `${terminalsPath}/${terminalId}` });
             channel.onError(reject);
             channel.onClose((code, reason) => reject(new Error(`channel is closed with '${code}' code and '${reason}' reason`)));

--- a/packages/typehierarchy/src/browser/tree/typehierarchy-tree.ts
+++ b/packages/typehierarchy/src/browser/tree/typehierarchy-tree.ts
@@ -14,6 +14,8 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
 import { injectable } from '@theia/core/shared/inversify';
 import { v4 } from 'uuid';
 import URI from '@theia/core/lib/common/uri';
@@ -31,8 +33,8 @@ export class TypeHierarchyTree extends TreeImpl {
         if (TypeHierarchyTree.Node.is(parent)) {
             await this.ensureResolved(parent);
             if (parent.children.length === 0) {
-                delete parent.children;
-                delete parent.expanded;
+                delete (parent as any).children;
+                delete (parent as any).expanded;
                 return [];
             }
             return parent.children.slice();
@@ -150,7 +152,7 @@ export namespace TypeHierarchyTree {
             };
             // Trick: if the node is `resolved` and have zero `children`, make the node non-expandable.
             if (resolved && node.children.length === 0) {
-                delete node.expanded;
+                delete (node as any).expanded;
             }
             return node;
         }

--- a/yarn.lock
+++ b/yarn.lock
@@ -10552,12 +10552,7 @@ typedoc@0.20.36:
     shiki "^0.9.3"
     typedoc-default-themes "^0.12.10"
 
-typescript@^3.9.2:
-  version "3.9.10"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.9.10.tgz#70f3910ac7a51ed6bef79da7800690b19bf778b8"
-  integrity sha512-w6fIxVE/H1PkLKcCPsFqKE7Kv7QUwhU8qQY2MueZXWx5cPZdwFupLgKK3vntcK98BtNHZtAF4LA/yl2a7k8R6Q==
-
-typescript@^4.4.3:
+typescript@~4.5.5:
   version "4.5.5"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.5.5.tgz#d8c953832d28924a9e3d37c73d729c846c5896f3"
   integrity sha512-TCTIul70LyWe6IJWT8QSYeA54WQe8EjQFU4wY52Fasj5UKx88LNYKCgBEHcOMOrFF1rKGbD8v/xcNWVUq9SymA==


### PR DESCRIPTION
@tsmaeder I remember saying we should avoid upgrading TypeScript, but I changed my mind.

I want to upgrade in order to build slightly faster and hope to fix an issue with our current version of `tsserver` being quite slow on our repo. Switching to TypeScript 4.4 I couldn't notice the lag anymore.

Upgrading the TS version we use to build this repo might lead to breakage in downstream applications in the following case:

- We start using a new TypeScript 4 construct. e.g. Named tuple elements (`type SomeTuple = [a: string, b: number]`)
- Downstream consumers of Theia use TypeScript 3 and it fails to parse this definition.

The solution would be for them to also upgrade their version of TypeScript in such a case. I think this is manageable.

As @msujew mentioned: TypeScript doesn't follow semantic versioning. But patch versions shouldn't bring breaking changes.

Closes https://github.com/eclipse-theia/theia/issues/10354.

#### How to test

- Building this repo should still work.
- Once everything is built, try running a few LS commands and get a feel for the performance. It shouldn't take to long to complete. It's quite subjective...

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
