### PR TITLE
api-tests: increase timeout for test case

### DIFF
--- a/examples/api-tests/src/typescript.spec.js
+++ b/examples/api-tests/src/typescript.spec.js
@@ -684,6 +684,7 @@ DIV {
     });
 
     it('run reference code lens', async function () {
+        this.timeout(300_000); // 5 min (give time to `tsserver` to initialize and then respond to make this test pass.)
         // @ts-ignore
         const globalValue = preferences.inspect('javascript.referencesCodeLens.enabled').globalValue;
         toTearDown.push({ dispose: () => preferences.set('javascript.referencesCodeLens.enabled', globalValue, PreferenceScope.User) });


### PR DESCRIPTION
Increase the timeout for `TypeScript - run reference code lens` to give
plenty of time for the `tsserver` to fully initialize in order to run
the test case.

#### How to test

- We need to keep an eye on the CI, hopefully the flakiness of `TypeScript - run reference code lens` will be fixed.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
