### PR TITLE
Implement multiroot Open Folder command

### DIFF
--- a/packages/core/src/browser/dialogs.ts
+++ b/packages/core/src/browser/dialogs.ts
@@ -336,12 +336,16 @@ export abstract class AbstractDialog<T> extends BaseWidget {
         this.errorMessageNode.innerText = DialogError.getMessage(error);
     }
 
+    protected addAction<K extends keyof HTMLElementEventMap>(element: HTMLElement, callback: () => void, ...additionalEventTypes: K[]): void {
+        this.addKeyListener(element, Key.ENTER, callback, ...additionalEventTypes);
+    }
+
     protected addCloseAction<K extends keyof HTMLElementEventMap>(element: HTMLElement, ...additionalEventTypes: K[]): void {
-        this.addKeyListener(element, Key.ENTER, () => this.close(), ...additionalEventTypes);
+        this.addAction(element, () => this.close(), ...additionalEventTypes);
     }
 
     protected addAcceptAction<K extends keyof HTMLElementEventMap>(element: HTMLElement, ...additionalEventTypes: K[]): void {
-        this.addKeyListener(element, Key.ENTER, () => this.accept(), ...additionalEventTypes);
+        this.addAction(element, () => this.accept(), ...additionalEventTypes);
     }
 
 }

--- a/packages/core/src/browser/frontend-application.ts
+++ b/packages/core/src/browser/frontend-application.ts
@@ -86,6 +86,12 @@ export interface OnWillStopAction {
      * A descriptive string for the reason preventing close.
      */
     reason: string;
+    /**
+     * A number representing priority. Higher priority items are run later.
+     * High priority implies that some options of this check will have negative impacts if
+     * the user subsequently cancels the shutdown.
+     */
+    priority?: number;
 }
 
 export namespace OnWillStopAction {

--- a/packages/core/src/browser/window/default-window-service.ts
+++ b/packages/core/src/browser/window/default-window-service.ts
@@ -74,6 +74,7 @@ export class DefaultWindowService implements WindowService, FrontendApplicationC
                     }
                 }
             }
+            vetoes.sort((a, b) => (a.priority ?? -Infinity) - (b.priority ?? -Infinity));
             if (vetoes.length === 0 && shouldConfirmExit === 'always') {
                 vetoes.push({ reason: 'application.confirmExit preference', action: () => confirmExit() });
             }

--- a/packages/core/src/common/path.spec.ts
+++ b/packages/core/src/common/path.spec.ts
@@ -356,4 +356,16 @@ describe('Path', () => {
         });
 
     });
+
+    function checkResolution(original: string, segments: string[], expected: string | undefined): void {
+        it(`should resolve ${original} and ${segments.join(', ')} to ${expected}`, () => {
+            const start = new Path(original);
+            const result = start.resolve(...segments);
+            expect(result?.toString()).eq(expected);
+        });
+    }
+
+    checkResolution('a/b/c', ['/d/e/f'], '/d/e/f');
+    checkResolution('a/b/c', ['../d/e/f'], undefined);
+    checkResolution('/a/b/c', ['../d', 'e', './f'], '/a/b/d/e/f');
 });

--- a/packages/core/src/common/path.ts
+++ b/packages/core/src/common/path.ts
@@ -202,6 +202,30 @@ export class Path {
         return new Path(this.raw + Path.separator + relativePath);
     }
 
+    /**
+     *
+     * @param paths portions of a path
+     * @returns a new Path if an absolute path can be computed from the segments passed in + this.raw
+     * If no absolute path can be computed, returns undefined.
+     *
+     * Processes the path segments passed in from right to left (reverse order) concatenating until an
+     * absolute path is found.
+     */
+    resolve(...paths: string[]): Path | undefined {
+        const segments = paths.slice().reverse(); // Don't mutate the caller's array.
+        segments.push(this.raw);
+        let result = new Path('');
+        for (const segment of segments) {
+            if (segment) {
+                const next = new Path(segment).join(result.raw);
+                if (next.isAbsolute) {
+                    return next.normalize();
+                }
+                result = next;
+            }
+        }
+    }
+
     toString(): string {
         return this.raw;
     }

--- a/packages/core/src/common/uri.spec.ts
+++ b/packages/core/src/common/uri.spec.ts
@@ -15,6 +15,7 @@
  ********************************************************************************/
 
 import * as chai from 'chai';
+import { Path } from './path';
 import URI from './uri';
 
 const expect = chai.expect;
@@ -260,6 +261,18 @@ describe('uri', () => {
             const b = new URI('b:///C:/projects/theia/foo/a.ts');
             expect(a.isEqual(b)).equals(false);
         });
+    });
+
+    describe('#resolveToAbsolute', () => {
+        function checkResolution(original: string, segments: Array<Path | string>, expected: string | undefined): void {
+            it.only(`should resolve ${original.toString()} and ${segments.map(segment => segment.toString()).join(', ')} to ${expected}`, () => {
+                const start = new URI(original);
+                const result = start.resolveToAbsolute(...segments);
+                expect(result?.toString()).equals(expected);
+            });
+        }
+        checkResolution('file:///home/hello/', ['some-segment'], 'file:///home/hello/some-segment');
+        checkResolution('file:///home/hello', ['/this/is-already/absolute'], 'file:///this/is-already/absolute');
     });
 
 });

--- a/packages/core/src/common/uri.spec.ts
+++ b/packages/core/src/common/uri.spec.ts
@@ -265,7 +265,7 @@ describe('uri', () => {
 
     describe('#resolveToAbsolute', () => {
         function checkResolution(original: string, segments: Array<Path | string>, expected: string | undefined): void {
-            it.only(`should resolve ${original.toString()} and ${segments.map(segment => segment.toString()).join(', ')} to ${expected}`, () => {
+            it(`should resolve ${original.toString()} and ${segments.map(segment => segment.toString()).join(', ')} to ${expected}`, () => {
                 const start = new URI(original);
                 const result = start.resolveToAbsolute(...segments);
                 expect(result?.toString()).equals(expected);

--- a/packages/core/src/common/uri.ts
+++ b/packages/core/src/common/uri.ts
@@ -79,6 +79,16 @@ export default class URI {
     }
 
     /**
+     * @returns a new, absolute URI if one can be computed from the path segments passed in.
+     */
+    resolveToAbsolute(...pathSegments: Array<string | Path>): URI | undefined {
+        const absolutePath = this.path.resolve(...pathSegments.map(path => path.toString()));
+        if (absolutePath) {
+            return this.withPath(absolutePath);
+        }
+    }
+
+    /**
      * return a new URI replacing the current with the given scheme
      */
     withScheme(scheme: string): URI {

--- a/packages/workspace/src/browser/untitled-workspace-exit-dialog.ts
+++ b/packages/workspace/src/browser/untitled-workspace-exit-dialog.ts
@@ -1,0 +1,70 @@
+/********************************************************************************
+ * Copyright (C) 2021 YourCompany and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import { nls } from '@theia/core';
+import { inject } from '@theia/core/shared/inversify';
+import { AbstractDialog, Dialog, DialogProps, Message } from '@theia/core/lib/browser';
+
+export class UntitledWorkspaceExitDialog extends AbstractDialog<UntitledWorkspaceExitDialog.Options> {
+    protected readonly dontSaveButton: HTMLButtonElement;
+    protected _value: UntitledWorkspaceExitDialog.Options = 'Cancel';
+
+    get value(): UntitledWorkspaceExitDialog.Options {
+        return this._value;
+    }
+
+    constructor(
+        @inject(DialogProps) protected readonly props: DialogProps
+    ) {
+        super(props);
+        const messageNode = document.createElement('div');
+        messageNode.textContent = nls.localizeByDefault('Save your workspace if you plan to open it again.');
+        this.contentNode.appendChild(messageNode);
+        this.dontSaveButton = this.createButton(nls.localizeByDefault(UntitledWorkspaceExitDialog.Values["Don't Save"]));
+        this.dontSaveButton.classList.add('secondary');
+        this.controlPanel.appendChild(this.dontSaveButton);
+        this.appendCloseButton(Dialog.CANCEL);
+        this.appendAcceptButton(nls.localizeByDefault(UntitledWorkspaceExitDialog.Values.Save));
+    }
+
+    protected onAfterAttach(msg: Message): void {
+        super.onAfterAttach(msg);
+        this.addAction(this.dontSaveButton, () => this.dontSave(), 'click');
+    }
+
+    protected addAcceptAction<K extends keyof HTMLElementEventMap>(element: HTMLElement, ...additionalEventTypes: K[]): void {
+        this.addAction(element, () => this.doSave(), 'click');
+    }
+
+    protected dontSave(): void {
+        this._value = UntitledWorkspaceExitDialog.Values["Don't Save"];
+        this.accept();
+    }
+
+    protected doSave(): void {
+        this._value = UntitledWorkspaceExitDialog.Values.Save;
+        this.accept();
+    }
+}
+
+export namespace UntitledWorkspaceExitDialog {
+    export const enum Values {
+        "Don't Save" = "Don't Save",
+        Cancel = 'Cancel',
+        Save = 'Save',
+    };
+    export type Options = keyof typeof Values;
+}

--- a/packages/workspace/src/browser/untitled-workspace-exit-dialog.ts
+++ b/packages/workspace/src/browser/untitled-workspace-exit-dialog.ts
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (C) 2021 YourCompany and others.
+ * Copyright (C) 2021 Ericsson and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/packages/workspace/src/browser/workspace-commands.ts
+++ b/packages/workspace/src/browser/workspace-commands.ts
@@ -354,16 +354,7 @@ export class WorkspaceCommandContribution implements CommandContribution {
                     const workspaceSavedBeforeAdding = this.workspaceService.saved;
                     await this.addFolderToWorkspace(...uris);
                     if (!workspaceSavedBeforeAdding) {
-                        const saveCommand = registry.getCommand(WorkspaceCommands.SAVE_WORKSPACE_AS.id);
-                        if (saveCommand && await new ConfirmDialog({
-                            title: nls.localize('theia/workspace/workspaceFolderAddedTitle', 'Folder added to Workspace'),
-                            msg: nls.localize('theia/workspace/workspaceFolderAdded',
-                                'A workspace with multiple roots was created. Do you want to save your workspace configuration as a file?'),
-                            ok: Dialog.YES,
-                            cancel: Dialog.NO
-                        }).open()) {
-                            registry.executeCommand(saveCommand.id);
-                        }
+                        this.saveWorkspaceWithPrompt(registry);
                     }
                 }
             });
@@ -539,6 +530,19 @@ export class WorkspaceCommandContribution implements CommandContribution {
             if (await dialog.open()) {
                 await this.workspaceService.removeRoots(toRemove);
             }
+        }
+    }
+
+    async saveWorkspaceWithPrompt(registry: CommandRegistry): Promise<void> {
+        const saveCommand = registry.getCommand(WorkspaceCommands.SAVE_WORKSPACE_AS.id);
+        if (saveCommand && await new ConfirmDialog({
+            title: nls.localize('theia/workspace/workspaceFolderAddedTitle', 'Folder added to Workspace'),
+            msg: nls.localize('theia/workspace/workspaceFolderAdded',
+                'A workspace with multiple roots was created. Do you want to save your workspace configuration as a file?'),
+            ok: Dialog.YES,
+            cancel: Dialog.NO
+        }).open()) {
+            return registry.executeCommand(saveCommand.id);
         }
     }
 

--- a/packages/workspace/src/browser/workspace-frontend-contribution.ts
+++ b/packages/workspace/src/browser/workspace-frontend-contribution.ts
@@ -595,9 +595,7 @@ export class WorkspaceFrontendContribution implements CommandContribution, Keybi
                         title: nls.localizeByDefault('Do you want to save your workspace configuration as a file?')
                     }).open();
                     if (shouldSaveFile === "Don't Save") {
-                        // TODO: Move this somewhere where it can be done more safely.
-                        // E.g. on start up, the first window should delete all untitled workspaces that it isn't using.
-                        return this.fileService.delete(this.workspaceService.workspace!.resource).then(() => true, () => true);
+                        return true;
                     } else if (shouldSaveFile === 'Save') {
                         return this.saveWorkspaceAs();
                     }

--- a/packages/workspace/src/browser/workspace-frontend-contribution.ts
+++ b/packages/workspace/src/browser/workspace-frontend-contribution.ts
@@ -15,7 +15,7 @@
  ********************************************************************************/
 
 import { injectable, inject } from '@theia/core/shared/inversify';
-import { CommandContribution, CommandRegistry, MenuContribution, MenuModelRegistry, SelectionService, MessageService, isWindows } from '@theia/core/lib/common';
+import { CommandContribution, CommandRegistry, MenuContribution, MenuModelRegistry, SelectionService, MessageService, isWindows, MaybeArray } from '@theia/core/lib/common';
 import { isOSX, environment, OS } from '@theia/core';
 import {
     open, OpenerService, CommonMenus, StorageService, LabelProvider, ConfirmDialog, KeybindingRegistry, KeybindingContribution,
@@ -25,7 +25,7 @@ import { FileDialogService, OpenFileDialogProps, FileDialogTreeFilters } from '@
 import { ContextKeyService } from '@theia/core/lib/browser/context-key-service';
 import { WorkspaceService } from './workspace-service';
 import { THEIA_EXT, VSCODE_EXT } from '../common';
-import { WorkspaceCommands } from './workspace-commands';
+import { WorkspaceCommands, WorkspaceCommandContribution } from './workspace-commands';
 import { QuickOpenWorkspace } from './quick-open-workspace';
 import { WorkspacePreferences } from './workspace-preferences';
 import URI from '@theia/core/lib/common/uri';
@@ -35,6 +35,8 @@ import { UTF8 } from '@theia/core/lib/common/encodings';
 import { DisposableCollection } from '@theia/core/lib/common/disposable';
 import { PreferenceConfigurations } from '@theia/core/lib/browser/preferences/preference-configurations';
 import { nls } from '@theia/core/lib/common/nls';
+import { BinaryBuffer } from '@theia/core/lib/common/buffer';
+import { FileStat } from '@theia/filesystem/lib/common/files';
 
 export enum WorkspaceStates {
     /**
@@ -68,6 +70,7 @@ export class WorkspaceFrontendContribution implements CommandContribution, Keybi
     @inject(WorkspacePreferences) protected preferences: WorkspacePreferences;
     @inject(SelectionService) protected readonly selectionService: SelectionService;
     @inject(CommandRegistry) protected readonly commandRegistry: CommandRegistry;
+    @inject(WorkspaceCommandContribution) protected readonly workspaceCommands: WorkspaceCommandContribution;
 
     @inject(ContextKeyService)
     protected readonly contextKeyService: ContextKeyService;
@@ -314,30 +317,67 @@ export class WorkspaceFrontendContribution implements CommandContribution, Keybi
     }
 
     /**
-     * Opens a folder after prompting the `Open Folder` dialog. Resolves to `undefined`, if
-     *  - the workspace root is not set,
-     *  - the folder to open does not exist, or
-     *  - it was not a directory, but a file resource.
+     * Opens one or more folders after prompting the `Open Folder` dialog. Resolves to `undefined`, if
+     *  - the user's selection is empty or contains only files.
+     *  - the new workspace is equal to the old workspace.
      *
-     * Otherwise, resolves to the URI of the folder.
+     * Otherwise, resolves to the URI of the new workspace:
+     *  - a single folder if a single folder was selected.
+     *  - a new, untitled workspace file if multiple folders were selected.
      */
     protected async doOpenFolder(): Promise<URI | undefined> {
         const props: OpenFileDialogProps = {
             title: WorkspaceCommands.OPEN_FOLDER.dialogLabel,
             canSelectFolders: true,
-            canSelectFiles: false
+            canSelectFiles: false,
+            canSelectMany: this.preferences['workspace.supportMultiRootWorkspace'],
         };
         const [rootStat] = await this.workspaceService.roots;
-        const destinationFolderUri = await this.fileDialogService.showOpenDialog(props, rootStat);
-        if (destinationFolderUri &&
-            this.getCurrentWorkspaceUri()?.toString() !== destinationFolderUri.toString()) {
-            const destinationFolder = await this.fileService.resolve(destinationFolderUri);
-            if (destinationFolder.isDirectory) {
-                this.workspaceService.open(destinationFolderUri);
-                return destinationFolderUri;
-            }
+        const targetFolders = await this.fileDialogService.showOpenDialog(props, rootStat);
+        if (targetFolders) {
+            const [openableURI, defaultWorkspaceURI] = await Promise.all([this.getOpenableWorkspaceUri(targetFolders), this.workspaceService.getUntitledWorkspace()]);
+            if (openableURI) {
+                // Handle case of move from one untitled workspace to another
+                if (this.workspaceService.workspace?.isFile && openableURI.isEqual(this.workspaceService.workspace.resource) && openableURI.isEqual(defaultWorkspaceURI)) {
+                    await this.workspaceCommands.saveWorkspaceWithPrompt(this.commandRegistry);
+                    this.workspaceService.open(openableURI, { preserveWindow: true });
+                    return openableURI;
+                } else if (!this.workspaceService.workspace || !openableURI.isEqual(this.workspaceService.workspace.resource)) {
+                    this.workspaceService.open(openableURI);
+                    return openableURI;
+                }
+            };
         }
         return undefined;
+    }
+
+    protected async getOpenableWorkspaceUri(uris: MaybeArray<URI>): Promise<URI | undefined> {
+        if (Array.isArray(uris)) {
+            if (uris.length < 2) {
+                return uris[0];
+            } else {
+                const foldersToOpen = (await Promise.all(uris.map(uri => this.fileService.resolve(uri))))
+                    .filter(fileStat => !!fileStat?.isDirectory);
+                if (foldersToOpen.length === 1) {
+                    return foldersToOpen[0].resource;
+                } else {
+                    return this.createMultiRootWorkspace(foldersToOpen);
+                }
+            }
+        } else {
+            return uris;
+        }
+    }
+
+    protected async createMultiRootWorkspace(roots: FileStat[]): Promise<URI> {
+        const untitledWorkspace = await this.workspaceService.getUntitledWorkspace();
+        const folders = Array.from(new Set(roots.map(stat => stat.resource.path.toString())), path => ({ path }));
+        const workspaceStat = await this.fileService.createFile(
+            untitledWorkspace,
+            BinaryBuffer.fromString(JSON.stringify({ folders }, null, 4)), // eslint-disable-line no-null/no-null
+            { overwrite: true }
+        );
+        return workspaceStat.resource;
     }
 
     /**
@@ -424,7 +464,7 @@ export class WorkspaceFrontendContribution implements CommandContribution, Keybi
         } while (selected && exist && !overwrite);
 
         if (selected) {
-            this.workspaceService.save(selected);
+            await this.workspaceService.save(selected);
         }
     }
 

--- a/packages/workspace/src/browser/workspace-frontend-module.ts
+++ b/packages/workspace/src/browser/workspace-frontend-module.ts
@@ -30,7 +30,7 @@ import {
 import { StorageService } from '@theia/core/lib/browser/storage-service';
 import { LabelProviderContribution } from '@theia/core/lib/browser/label-provider';
 import { VariableContribution } from '@theia/variable-resolver/lib/browser';
-import { WorkspaceServer, workspacePath } from '../common';
+import { WorkspaceServer, workspacePath, CommonWorkspaceUtils } from '../common';
 import { WorkspaceFrontendContribution } from './workspace-frontend-contribution';
 import { WorkspaceService } from './workspace-service';
 import { WorkspaceCommandContribution, FileMenuContribution, EditMenuContribution } from './workspace-commands';
@@ -95,6 +95,7 @@ export default new ContainerModule((bind: interfaces.Bind, unbind: interfaces.Un
     bind(QuickOpenWorkspace).toSelf().inSingletonScope();
 
     bind(WorkspaceUtils).toSelf().inSingletonScope();
+    bind(CommonWorkspaceUtils).toSelf().inSingletonScope();
 
     bind(WorkspaceSchemaUpdater).toSelf().inSingletonScope();
     bind(JsonSchemaContribution).toService(WorkspaceSchemaUpdater);

--- a/packages/workspace/src/browser/workspace-service.ts
+++ b/packages/workspace/src/browser/workspace-service.ts
@@ -24,7 +24,7 @@ import {
 } from '@theia/core/lib/browser';
 import { Deferred } from '@theia/core/lib/common/promise-util';
 import { EnvVariablesServer } from '@theia/core/lib/common/env-variables';
-import { ILogger, Disposable, DisposableCollection, Emitter, Event, MaybePromise, MessageService } from '@theia/core';
+import { ILogger, Disposable, DisposableCollection, Emitter, Event, MaybePromise, MessageService, nls } from '@theia/core';
 import { WorkspacePreferences } from './workspace-preferences';
 import * as jsoncparser from 'jsonc-parser';
 import * as Ajv from 'ajv';
@@ -298,7 +298,7 @@ export class WorkspaceService implements FrontendApplicationContribution {
         if (this._workspace) {
             const displayName = this._workspace.name;
             if (this.isWorkspaceFile(this._workspace)) {
-                title = this.isUntitledWorkspace(this._workspace.resource) ? 'Untitled (Workspace)' : displayName.slice(0, displayName.lastIndexOf('.'));
+                title = this.isUntitledWorkspace(this._workspace.resource) ? nls.localizeByDefault('Untitled (Workspace)') : displayName.slice(0, displayName.lastIndexOf('.'));
             } else {
                 title = displayName;
             }
@@ -515,7 +515,7 @@ export class WorkspaceService implements FrontendApplicationContribution {
             this.setURLFragment('');
         }
 
-        window.location.reload(true);
+        this.windowService.reload();
     }
 
     protected openNewWindow(workspacePath: string): void {

--- a/packages/workspace/src/node/workspace-backend-module.ts
+++ b/packages/workspace/src/node/workspace-backend-module.ts
@@ -16,15 +16,18 @@
 
 import { ContainerModule } from '@theia/core/shared/inversify';
 import { ConnectionHandler, JsonRpcConnectionHandler } from '@theia/core/lib/common';
-import { WorkspaceServer, workspacePath } from '../common';
+import { WorkspaceServer, workspacePath, CommonWorkspaceUtils } from '../common';
 import { DefaultWorkspaceServer, WorkspaceCliContribution } from './default-workspace-server';
 import { CliContribution } from '@theia/core/lib/node/cli';
+import { BackendApplicationContribution } from '@theia/core/lib/node';
 
 export default new ContainerModule(bind => {
     bind(WorkspaceCliContribution).toSelf().inSingletonScope();
     bind(CliContribution).toService(WorkspaceCliContribution);
     bind(DefaultWorkspaceServer).toSelf().inSingletonScope();
     bind(WorkspaceServer).toService(DefaultWorkspaceServer);
+    bind(BackendApplicationContribution).toService(WorkspaceServer);
+    bind(CommonWorkspaceUtils).toSelf().inSingletonScope();
 
     bind(ConnectionHandler).toDynamicValue(ctx =>
         new JsonRpcConnectionHandler(workspacePath, () =>


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->
Fixes #10334 by adding handling for multiselection to the `Open Folder...` command.
Fixes #10366 by implementing `resolveToAbsolute`  for URI's.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

1. Use the 'Open Folder...' command.
2. Select multiple folders.
3. Observe that a new multi-root workspace is created and opened.
4. It should work from either an existing workspace or a no-workspace state.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

Signed-off-by: Colin Grant <colin.grant@ericsson.com>