### PR TITLE
Handle deleted files in open editors widget

### DIFF
--- a/packages/navigator/src/browser/navigator-frontend-module.ts
+++ b/packages/navigator/src/browser/navigator-frontend-module.ts
@@ -41,6 +41,7 @@ import { bindContributionProvider } from '@theia/core/lib/common';
 import { OpenEditorsTreeDecorator } from './open-editors-widget/navigator-open-editors-decorator-service';
 import { OpenEditorsWidget } from './open-editors-widget/navigator-open-editors-widget';
 import { NavigatorTreeDecorator } from './navigator-decorator-service';
+import { NavigatorDeletedEditorDecorator } from './open-editors-widget/navigator-deleted-editor-decorator';
 
 export default new ContainerModule(bind => {
     bindFileNavigatorPreferences(bind);
@@ -63,6 +64,8 @@ export default new ContainerModule(bind => {
     })).inSingletonScope();
     bindContributionProvider(bind, NavigatorTreeDecorator);
     bindContributionProvider(bind, OpenEditorsTreeDecorator);
+    bind(NavigatorDeletedEditorDecorator).toSelf().inSingletonScope();
+    bind(OpenEditorsTreeDecorator).toService(NavigatorDeletedEditorDecorator);
 
     bind(WidgetFactory).toDynamicValue(({ container }) => ({
         id: OpenEditorsWidget.ID,

--- a/packages/navigator/src/browser/open-editors-widget/navigator-deleted-editor-decorator.ts
+++ b/packages/navigator/src/browser/open-editors-widget/navigator-deleted-editor-decorator.ts
@@ -1,0 +1,91 @@
+/********************************************************************************
+ * Copyright (C) 2021 Ericsson and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import { injectable, inject, postConstruct } from '@theia/core/shared/inversify';
+import { ApplicationShell, DepthFirstTreeIterator, NavigatableWidget, Tree, TreeDecoration, TreeDecorator } from '@theia/core/lib/browser';
+import { FileSystemFrontendContribution } from '@theia/filesystem/lib/browser/filesystem-frontend-contribution';
+import { Emitter } from '@theia/core';
+import { FileChangeType, FileStatNode } from '@theia/filesystem/lib/browser';
+
+@injectable()
+export class NavigatorDeletedEditorDecorator implements TreeDecorator {
+
+    @inject(FileSystemFrontendContribution)
+    protected readonly fileSystemContribution: FileSystemFrontendContribution;
+    @inject(ApplicationShell)
+    protected readonly shell: ApplicationShell;
+
+    readonly id = 'theia-deleted-editor-decorator';
+    protected readonly onDidChangeDecorationsEmitter = new Emitter();
+    readonly onDidChangeDecorations = this.onDidChangeDecorationsEmitter.event;
+    protected deletedURIs = new Set<string>();
+
+    @postConstruct()
+    init(): void {
+        this.fileSystemContribution.onDidChangeEditorFile(({ editor, type }) => {
+            const uri = editor.getResourceUri()?.toString();
+            if (uri) {
+                if (type === FileChangeType.DELETED) {
+                    this.deletedURIs.add(uri);
+                } else if (type === FileChangeType.ADDED) {
+                    this.deletedURIs.delete(uri);
+                }
+                this.fireDidChangeDecorations((tree: Tree) => this.collectDecorators(tree));
+            }
+        });
+        this.shell.onDidAddWidget(() => {
+            const newDeletedURIs = new Set<string>();
+            this.shell.widgets.forEach(widget => {
+                if (NavigatableWidget.is(widget)) {
+                    const uri = widget.getResourceUri()?.toString();
+                    if (uri && this.deletedURIs.has(uri)) {
+                        newDeletedURIs.add(uri);
+                    }
+                }
+            });
+            this.deletedURIs = newDeletedURIs;
+        });
+    }
+
+    decorations(tree: Tree): Map<string, TreeDecoration.Data> {
+        return this.collectDecorators(tree);
+    }
+
+    protected collectDecorators(tree: Tree): Map<string, TreeDecoration.Data> {
+        const result = new Map<string, TreeDecoration.Data>();
+        if (tree.root === undefined) {
+            return result;
+        }
+        for (const node of new DepthFirstTreeIterator(tree.root)) {
+            if (FileStatNode.is(node)) {
+                const uri = node.uri.toString();
+                if (this.deletedURIs.has(uri)) {
+                    const deletedDecoration: TreeDecoration.Data = {
+                        fontData: {
+                            style: 'line-through',
+                        }
+                    };
+                    result.set(node.id, deletedDecoration);
+                }
+            }
+        }
+        return result;
+    }
+
+    protected fireDidChangeDecorations(event: (tree: Tree) => Map<string, TreeDecoration.Data>): void {
+        this.onDidChangeDecorationsEmitter.fire(event);
+    }
+}


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

![image](https://user-images.githubusercontent.com/62660714/139707613-113ccab6-6911-4273-a9d2-4f20a51ac3ab.png)

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->
Fixes #10322 by adding support for deleted editors in the Open Editors widget. Adds a strikethrough decoration when a deleted editor is detected.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
- Build this branch and open a workspace with some files
- Ensure the `Close On File Delete` preference is set to false
- Open several files as editors (both regular and preview editor(s))
- Ensure the open editors widget is shown in the navigator
- In an external terminal delete the files you have opened using, observe that the deleted files are decorated with a strike-through
- Drag the deleted editors around to different tabbars and observe that the decorations persist
- Observe there are no errors in the terminal, and that you can continue to open/add new editors and the Open Editors tree is properly updated
- Restore the deleted files (with `git restore`) and observe the strikethrough is removed

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
