### PR TITLE
search-in-workspace: add `noselect` to line result nodes

### DIFF
--- a/packages/search-in-workspace/src/browser/search-in-workspace-result-tree-widget.tsx
+++ b/packages/search-in-workspace/src/browser/search-in-workspace-result-tree-widget.tsx
@@ -1004,7 +1004,7 @@ export class SearchInWorkspaceResultTreeWidget extends TreeWidget {
             after = node.lineText.text.substr(node.lineText.character + node.length);
             title = node.lineText.text.trim();
         }
-        return <div className={`resultLine noWrapInfo ${node.selected ? 'selected' : ''}`} title={title}>
+        return <div className={`resultLine noWrapInfo noselect ${node.selected ? 'selected' : ''}`} title={title}>
             {this.searchInWorkspacePreferences['search.lineNumbers'] && <span className='theia-siw-lineNumber'>{node.line}</span>}
             <span>
                 {before}


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

Fixes: https://github.com/eclipse-theia/theia/issues/10362

The commit adds `noselect` to the line result nodes so their inner text is 
not selectable, aligning with the rest of the framework and vscode.
<!-- Include relevant issues and describe how they are addressed. -->

#### How to test
- open search-in-workspace widget
- perform a search that yields results
- individual line results should not have their inner content selectable

<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

#### Review checklist

- [X] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
