### PR TITLE
terminal: add `confirmOnExit` preference

### DIFF
--- a/packages/terminal/src/browser/terminal-frontend-module.ts
+++ b/packages/terminal/src/browser/terminal-frontend-module.ts
@@ -20,7 +20,7 @@ import 'xterm/css/xterm.css';
 import { ContainerModule, Container } from '@theia/core/shared/inversify';
 import { CommandContribution, MenuContribution } from '@theia/core/lib/common';
 import { bindContributionProvider } from '@theia/core';
-import { KeybindingContribution, WebSocketConnectionProvider, WidgetFactory, KeybindingContext } from '@theia/core/lib/browser';
+import { KeybindingContribution, WebSocketConnectionProvider, WidgetFactory, KeybindingContext, FrontendApplicationContribution } from '@theia/core/lib/browser';
 import { TabBarToolbarContribution } from '@theia/core/lib/browser/shell/tab-bar-toolbar';
 import { TerminalFrontendContribution } from './terminal-frontend-contribution';
 import { TerminalWidgetImpl, TERMINAL_WIDGET_FACTORY_ID } from './terminal-widget-impl';
@@ -122,4 +122,6 @@ export default new ContainerModule(bind => {
 
     bind(TerminalLinkmatcherDiffPost).toSelf().inSingletonScope();
     bind(TerminalContribution).toService(TerminalLinkmatcherDiffPost);
+
+    bind(FrontendApplicationContribution).to(TerminalFrontendContribution);
 });

--- a/packages/terminal/src/browser/terminal-preferences.ts
+++ b/packages/terminal/src/browser/terminal-preferences.ts
@@ -143,12 +143,12 @@ export const TerminalConfigSchema: PreferenceSchema = {
         },
         'terminal.integrated.confirmOnExit': {
             type: 'string',
-            description: nls.localize('vscode/terminalConfiguration/terminal.integrated.confirmOnExit', 'Controls whether to confirm when the window closes if there are active terminal sessions'),
+            description: nls.localizeByDefault('Controls whether to confirm when the window closes if there are active terminal sessions'),
             enum: ['never', 'always', 'hasChildProcesses'],
             enumDescriptions: [
-                nls.localize('vscode/terminalConfiguration/terminal.integrated.confirmOnExit.never', 'Never confirm.'),
-                nls.localize('vscode/terminalConfiguration/terminal.integrated.confirmOnExit.always', 'Always confirm if there are terminals.'),
-                nls.localize('vscode/terminalConfiguration/terminal.integrated.confirmOnExit.hasChildProcesses', 'Confirm if there are any terminals that have child processes.'),
+                nls.localizeByDefault('Never confirm.'),
+                nls.localizeByDefault('Always confirm if there are terminals.'),
+                nls.localizeByDefault('Confirm if there are any terminals that have child processes.'),
             ],
             default: 'never'
         }

--- a/packages/terminal/src/browser/terminal-preferences.ts
+++ b/packages/terminal/src/browser/terminal-preferences.ts
@@ -141,6 +141,17 @@ export const TerminalConfigSchema: PreferenceSchema = {
             markdownDescription: nls.localize('theia/terminal/shellArgsLinux', 'The command line arguments to use when on the Linux terminal.'),
             default: []
         },
+        'terminal.integrated.confirmOnExit': {
+            type: 'string',
+            description: nls.localize('vscode/terminalConfiguration/terminal.integrated.confirmOnExit', 'Controls whether to confirm when the window closes if there are active terminal sessions'),
+            enum: ['never', 'always', 'hasChildProcesses'],
+            enumDescriptions: [
+                nls.localize('vscode/terminalConfiguration/terminal.integrated.confirmOnExit.never', 'Never confirm.'),
+                nls.localize('vscode/terminalConfiguration/terminal.integrated.confirmOnExit.always', 'Always confirm if there are terminals.'),
+                nls.localize('vscode/terminalConfiguration/terminal.integrated.confirmOnExit.hasChildProcesses', 'Confirm if there are any terminals that have child processes.'),
+            ],
+            default: 'never'
+        }
     }
 };
 
@@ -168,6 +179,7 @@ export interface TerminalConfiguration {
     'terminal.integrated.shellArgs.windows': string[],
     'terminal.integrated.shellArgs.osx': string[],
     'terminal.integrated.shellArgs.linux': string[],
+    'terminal.integrated.confirmOnExit': ConfirmOnExitType
 }
 
 type FontWeight = 'normal' | 'bold' | '100' | '200' | '300' | '400' | '500' | '600' | '700' | '800' | '900';
@@ -175,6 +187,7 @@ export type CursorStyle = 'block' | 'underline' | 'bar';
 // VS Code uses 'line' to represent 'bar'. The following conversion is necessary to support their preferences.
 export type CursorStyleVSCode = CursorStyle | 'line';
 export type TerminalRendererType = 'canvas' | 'dom';
+export type ConfirmOnExitType = 'never' | 'always' | 'hasChildProcesses';
 export const DEFAULT_TERMINAL_RENDERER_TYPE = 'canvas';
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export function isTerminalRendererType(arg: any): arg is TerminalRendererType {

--- a/packages/terminal/src/browser/terminal-widget-impl.ts
+++ b/packages/terminal/src/browser/terminal-widget-impl.ts
@@ -166,8 +166,11 @@ export class TerminalWidgetImpl extends TerminalWidget implements StatefulWidget
                 } else if (preferenceName === 'cursorStyle') {
                     preferenceValue = this.getCursorStyle();
                 }
-
-                this.term.setOption(preferenceName, preferenceValue);
+                try {
+                    this.term.setOption(preferenceName, preferenceValue);
+                } catch (e) {
+                    console.debug(`xterm configuration: '${preferenceName}' with value '${preferenceValue}' is not valid.`);
+                }
                 this.needsResize = true;
                 this.update();
             }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

Fixes: https://github.com/eclipse-theia/theia/issues/7590

The pull-request adds support for `terminal.integrated.confirmOnExit` which is used to prevent closing the application if there are any terminals present.

At the moment, the following is supported:
- `never`: never warn when closing the application if terminals are present (default)
- `always`: always warn when closing the application if terminals are present
- `hasChildProcesses` - currently treated like `always` due to `async` limitations

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

Verify the following use-cases:

| Use-Case | Preference Value | Terminals | Expectation |
|:---|:---|:---|:---|
| 1 | `never` | no terminal | should not warn when closing the app |
| 2 | `never` | one or more terminals | should not warn when closing the app |
| 3 | `always` or `hasChildProcesses` | no terminal | should not warn when closing the app |
| 4 | `always` or `hasChildProcesses` | one or more terminals | should warn when closing the app |

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

Signed-off-by: vince-fugnitto <vincent.fugnitto@ericsson.com>


--- 

Note: since `onWillStop` is synchronous, and `hasChildProcesses` is async, the preference was treated like `always` for the time being. If anyone has suggestions on how to better support the actual preference it is most welcome. One idea would maybe be to poll the backend for `hasChildProcesses` on all open terminals every so often, but there were concerns over performance.