### PR TITLE
Fix #10369: icons of custom tree view row are not visible on mouse hover

### DIFF
--- a/packages/plugin-ext/src/main/browser/style/tree.css
+++ b/packages/plugin-ext/src/main/browser/style/tree.css
@@ -41,6 +41,6 @@
     margin-left: 17px;
 }
 
-.theia-TreeNode:not(:hover):not(.theia-mod-selected) .theia-tree-view-inline-action {
+.theia-tree-view .theia-TreeNode:not(:hover):not(.theia-mod-selected) .theia-tree-view-inline-action {
     display: none;
 }

--- a/packages/plugin-ext/src/main/browser/style/tree.css
+++ b/packages/plugin-ext/src/main/browser/style/tree.css
@@ -40,3 +40,7 @@
     margin-bottom: 10px;
     margin-left: 17px;
 }
+
+.theia-TreeNode:not(:hover):not(.theia-mod-selected) .theia-tree-view-inline-action {
+    display: none;
+}

--- a/packages/plugin-ext/src/main/browser/view/tree-view-widget.tsx
+++ b/packages/plugin-ext/src/main/browser/view/tree-view-widget.tsx
@@ -45,6 +45,7 @@ import CoreURI from '@theia/core/lib/common/uri';
 import { ContextKeyService } from '@theia/core/lib/browser/context-key-service';
 import * as markdownit from 'markdown-it';
 import { isMarkdownString } from '../../../plugin/markdown-string';
+import debounce = require('p-debounce');
 
 export const TREE_NODE_HYPERLINK = 'theia-TreeNodeHyperlink';
 export const VIEW_ITEM_CONTEXT_MENU: MenuPath = ['view-item-context-menu'];
@@ -359,8 +360,10 @@ export class TreeViewWidget extends TreeViewWelcomeWidget {
     protected hoverNodeId: string | undefined;
     protected setHoverNodeId(hoverNodeId: string | undefined): void {
         this.hoverNodeId = hoverNodeId;
-        this.update();
+        this.forceUpdateGrid();
     }
+
+    protected forceUpdateGrid = debounce(() => this.view?.list?.forceUpdateGrid(), 1);
 
     protected createNodeAttributes(node: TreeNode, props: NodeProps): React.Attributes & React.HTMLAttributes<HTMLElement> {
         return {

--- a/packages/plugin-ext/src/main/browser/view/tree-view-widget.tsx
+++ b/packages/plugin-ext/src/main/browser/view/tree-view-widget.tsx
@@ -37,7 +37,7 @@ import { MenuPath, MenuModelRegistry, ActionMenuNode } from '@theia/core/lib/com
 import * as React from '@theia/core/shared/react';
 import { PluginSharedStyle } from '../plugin-shared-style';
 import { ViewContextKeyService } from './view-context-key-service';
-import { Widget } from '@theia/core/lib/browser/widgets/widget';
+import { ACTION_ITEM, Widget } from '@theia/core/lib/browser/widgets/widget';
 import { Emitter, Event } from '@theia/core/lib/common/event';
 import { MessageService } from '@theia/core/lib/common/message-service';
 import { View } from '../../../common/plugin-protocol';
@@ -45,7 +45,6 @@ import CoreURI from '@theia/core/lib/common/uri';
 import { ContextKeyService } from '@theia/core/lib/browser/context-key-service';
 import * as markdownit from 'markdown-it';
 import { isMarkdownString } from '../../../plugin/markdown-string';
-import debounce = require('p-debounce');
 
 export const TREE_NODE_HYPERLINK = 'theia-TreeNodeHyperlink';
 export const VIEW_ITEM_CONTEXT_MENU: MenuPath = ['view-item-context-menu'];
@@ -328,9 +327,6 @@ export class TreeViewWidget extends TreeViewWelcomeWidget {
     }
 
     protected renderTailDecorations(node: TreeViewNode, props: NodeProps): React.ReactNode {
-        if (this.model.selectedNodes.every(selected => selected.id !== node.id) && node.id !== this.hoverNodeId) {
-            return false;
-        }
         return this.contextKeys.with({ view: this.id, viewItem: node.contextValue }, () => {
             const menu = this.menus.getMenu(VIEW_ITEM_INLINE_MENU);
             const arg = this.toTreeViewSelection(node);
@@ -350,7 +346,7 @@ export class TreeViewWidget extends TreeViewWelcomeWidget {
         if (!icon || !this.commands.isVisible(node.action.commandId, arg) || !this.contextKeys.match(node.action.when)) {
             return false;
         }
-        const className = [TREE_NODE_SEGMENT_CLASS, TREE_NODE_TAIL_CLASS, icon, 'theia-tree-view-inline-action'].join(' ');
+        const className = [TREE_NODE_SEGMENT_CLASS, TREE_NODE_TAIL_CLASS, icon, ACTION_ITEM, 'theia-tree-view-inline-action'].join(' ');
         return <div key={index} className={className} title={node.label} onClick={e => {
             e.stopPropagation();
             this.commands.executeCommand(node.action.commandId, arg);
@@ -360,10 +356,7 @@ export class TreeViewWidget extends TreeViewWelcomeWidget {
     protected hoverNodeId: string | undefined;
     protected setHoverNodeId(hoverNodeId: string | undefined): void {
         this.hoverNodeId = hoverNodeId;
-        this.forceUpdateGrid();
     }
-
-    protected forceUpdateGrid = debounce(() => this.view?.list?.forceUpdateGrid(), 1);
 
     protected createNodeAttributes(node: TreeNode, props: NodeProps): React.Attributes & React.HTMLAttributes<HTMLElement> {
         return {

--- a/packages/plugin-ext/src/main/browser/view/tree-view-widget.tsx
+++ b/packages/plugin-ext/src/main/browser/view/tree-view-widget.tsx
@@ -353,19 +353,6 @@ export class TreeViewWidget extends TreeViewWelcomeWidget {
         }} />;
     }
 
-    protected hoverNodeId: string | undefined;
-    protected setHoverNodeId(hoverNodeId: string | undefined): void {
-        this.hoverNodeId = hoverNodeId;
-    }
-
-    protected createNodeAttributes(node: TreeNode, props: NodeProps): React.Attributes & React.HTMLAttributes<HTMLElement> {
-        return {
-            ...super.createNodeAttributes(node, props),
-            onMouseOver: () => this.setHoverNodeId(node.id),
-            onMouseOut: () => this.setHoverNodeId(undefined)
-        };
-    }
-
     protected toContextMenuArgs(node: SelectableTreeNode): [TreeViewSelection] {
         return [this.toTreeViewSelection(node)];
     }


### PR DESCRIPTION
Signed-off-by: Esther Perelman <esther.perelman@sap.com>

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
Fix #10369 by replacing `update` to `forceUpdateGrid` call on `mouseover` event since the `update` request not activate the rendering of the grid by react (it doesn't pass the internal React.Grid `_calculateChildrenToRender` function because of old caches)

#### How to test (also for buggy result)

1. install `tree-view-sample` extension of vscode-extensions-samples on Theia (you can easily download my [custom-view-sample.zip](https://github.com/eclipse-theia/theia/files/7465409/custom-view-sample.zip) )
2. from the top menu select `View` -> `Open View` -> `Packege Explorer`
3. hover with the mouse on the rows
4. **good result**: see edit icon for each row on hover, **bad result**: see edit icon only on selecting row 

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
