### PR TITLE
Remove from recently opened workspaces list

### DIFF
--- a/packages/core/src/browser/quick-input/quick-input-service.ts
+++ b/packages/core/src/browser/quick-input/quick-input-service.ts
@@ -153,6 +153,10 @@ export interface QuickPickItemButtonEvent<T extends QuickPickItem> {
     item: T;
 }
 
+export interface QuickPickItemButtonContext<T extends QuickPickItem> extends QuickPickItemButtonEvent<T> {
+    removeItem(): void;
+}
+
 export interface QuickPickOptions<T extends QuickPickItem> {
     busy?: boolean;
     enabled?: boolean;
@@ -191,7 +195,7 @@ export interface QuickPickOptions<T extends QuickPickItem> {
     onDidCustom?: () => void,
     onDidHide?: () => void;
     onDidTriggerButton?: (button: QuickInputButton) => void,
-    onDidTriggerItemButton?: (ItemButtonEvent: QuickPickItemButtonEvent<T>) => void
+    onDidTriggerItemButton?: (ItemButtonEvent: QuickPickItemButtonContext<T>) => void
 }
 
 export const QuickInputService = Symbol('QuickInputService');

--- a/packages/monaco/src/browser/monaco-quick-input-service.ts
+++ b/packages/monaco/src/browser/monaco-quick-input-service.ts
@@ -257,16 +257,8 @@ export class MonacoQuickInputService implements QuickInputService {
                             {
                                 ...evt,
                                 removeItem: () => {
-                                    const index = wrapped.items.indexOf(evt.item);
-                                    if (index !== -1) {
-                                        const filteredItems = wrapped.items.slice();
-                                        const removed = filteredItems.splice(index, 1);
-                                        const activeFilteredItems = wrapped.activeItems.filter(item => item !== removed[0]);
-                                        wrapped.items = filteredItems;
-                                        if (activeFilteredItems) {
-                                            wrapped.activeItems = activeFilteredItems;
-                                        }
-                                    }
+                                    wrapped.items = wrapped.items.filter(item => item !== evt.item);
+                                    wrapped.activeItems = wrapped.activeItems.filter(item => item !== evt.item);
                                 }
                             });
                     }

--- a/packages/monaco/src/browser/monaco-quick-input-service.ts
+++ b/packages/monaco/src/browser/monaco-quick-input-service.ts
@@ -261,7 +261,7 @@ export class MonacoQuickInputService implements QuickInputService {
                                     if (index !== -1) {
                                         const filteredItems = wrapped.items.slice();
                                         const removed = filteredItems.splice(index, 1);
-                                        const activeFilteredItems = wrapped.activeItems.filter(ai => ai !== removed[0]);
+                                        const activeFilteredItems = wrapped.activeItems.filter(item => item !== removed[0]);
                                         wrapped.items = filteredItems;
                                         if (activeFilteredItems) {
                                             wrapped.activeItems = activeFilteredItems;

--- a/packages/monaco/src/typings/monaco/index.d.ts
+++ b/packages/monaco/src/typings/monaco/index.d.ts
@@ -1917,6 +1917,11 @@ declare module monaco.quickInput {
         button: IQuickInputButton;
         item: T;
     }
+
+    // https://github.com/theia-ide/vscode/blob/standalone/0.23.x/src/vs/base/parts/quickinput/common/quickInput.ts#L324
+    export interface IQuickPickItemButtonContext<T extends IQuickPickItem> extends IQuickPickItemButtonEvent<T> {
+        removeItem(): void;
+    }
 }
 
 declare module monaco.quickOpen {

--- a/packages/workspace/src/browser/quick-open-workspace.ts
+++ b/packages/workspace/src/browser/quick-open-workspace.ts
@@ -42,7 +42,7 @@ export class QuickOpenWorkspace {
 
     protected readonly removeRecentWorkspaceButton: QuickInputButton = {
         iconClass: 'codicon-remove-close',
-        tooltip: nls.localize('vscode/windowActions/remove', 'Remove from Recently Opened')
+        tooltip: nls.localizeByDefault('Remove from Recently Opened')
     };
 
     async open(workspaces: string[]): Promise<void> {
@@ -55,12 +55,12 @@ export class QuickOpenWorkspace {
         await this.preferences.ready;
         if (!workspaces.length) {
             this.items.push({
-                label: nls.localize('vscode/windowActions/noRecentWorkSpaces', 'No Recent Workspaces')
+                label: nls.localize('theia/windowActions/noRecentWorkSpaces', 'No Recent Workspaces')
             });
         }
         this.items.push({
             type: 'separator',
-            label: nls.localize('vscode/windowActions/workspacesAndFolders', 'folders & workspaces')
+            label: nls.localizeByDefault('folders & workspaces')
         });
         for (const workspace of workspaces) {
             const uri = new URI(workspace);
@@ -95,7 +95,7 @@ export class QuickOpenWorkspace {
         }
         this.quickInputService?.showQuickPick(this.items, {
             placeholder: nls.localize(
-                'vscode/windowActions/openRecentPlaceholder',
+                'theia/windowActions/openRecentPlaceholder',
                 'Type the name of the workspace you want to open'),
             onDidTriggerItemButton: async context => {
                 const resource = context.item.resource;

--- a/packages/workspace/src/browser/quick-open-workspace.ts
+++ b/packages/workspace/src/browser/quick-open-workspace.ts
@@ -53,11 +53,6 @@ export class QuickOpenWorkspace {
         ]);
         const home = new URI(homeDirUri).path.toString();
         await this.preferences.ready;
-        if (!workspaces.length) {
-            this.items.push({
-                label: nls.localize('theia/windowActions/noRecentWorkSpaces', 'No Recent Workspaces')
-            });
-        }
         this.items.push({
             type: 'separator',
             label: nls.localizeByDefault('folders & workspaces')
@@ -95,7 +90,7 @@ export class QuickOpenWorkspace {
         }
         this.quickInputService?.showQuickPick(this.items, {
             placeholder: nls.localize(
-                'theia/windowActions/openRecentPlaceholder',
+                'vscode/windowActions/openRecentPlaceholder',
                 'Type the name of the workspace you want to open'),
             onDidTriggerItemButton: async context => {
                 const resource = context.item.resource;

--- a/packages/workspace/src/browser/quick-open-workspace.ts
+++ b/packages/workspace/src/browser/quick-open-workspace.ts
@@ -90,7 +90,7 @@ export class QuickOpenWorkspace {
         }
         this.quickInputService?.showQuickPick(this.items, {
             placeholder: nls.localize(
-                'vscode/windowActions/openRecentPlaceholder',
+                'theia/workspace/openRecentPlaceholder',
                 'Type the name of the workspace you want to open'),
             onDidTriggerItemButton: async context => {
                 const resource = context.item.resource;

--- a/packages/workspace/src/browser/workspace-service.ts
+++ b/packages/workspace/src/browser/workspace-service.ts
@@ -318,6 +318,10 @@ export class WorkspaceService implements FrontendApplicationContribution {
         return this.server.getRecentWorkspaces();
     }
 
+    async removeRecentWorkspace(uri: string): Promise<void> {
+        return this.server.removeRecentWorkspace(uri);
+    }
+
     /**
      * Returns `true` if theia has an opened workspace or folder
      * @returns {boolean}

--- a/packages/workspace/src/common/test/mock-workspace-server.ts
+++ b/packages/workspace/src/common/test/mock-workspace-server.ts
@@ -24,4 +24,6 @@ export class MockWorkspaceServer implements WorkspaceServer {
     getMostRecentlyUsedWorkspace(): Promise<string | undefined> { return Promise.resolve(''); }
 
     setMostRecentlyUsedWorkspace(uri: string): Promise<void> { return Promise.resolve(); }
+
+    removeRecentWorkspace(uri: string): Promise<void> { return Promise.resolve(); }
 }

--- a/packages/workspace/src/common/workspace-protocol.ts
+++ b/packages/workspace/src/common/workspace-protocol.ts
@@ -34,6 +34,13 @@ export interface WorkspaceServer {
     setMostRecentlyUsedWorkspace(uri: string): Promise<void>;
 
     /**
+     * Removes a workspace from the list of recently opened workspaces.
+     *
+     * @param uri the workspace uri.
+     */
+    removeRecentWorkspace(uri: string): Promise<void>;
+
+    /**
      * Returns list of recently opened workspaces as an array.
      */
     getRecentWorkspaces(): Promise<string[]>

--- a/packages/workspace/src/node/default-workspace-server.ts
+++ b/packages/workspace/src/node/default-workspace-server.ts
@@ -98,12 +98,13 @@ export class DefaultWorkspaceServer implements WorkspaceServer {
     }
 
     async removeRecentWorkspace(uri: string): Promise<void> {
-        // Get the list of recent workspaces.
-        const recent = await this.getRecentWorkspaces();
-        // Filter out the given workspace by uri.
-        // Then update persistent storage to reflect changes.
+        const recentRoots = await this.getRecentWorkspaces();
+        const index = recentRoots.indexOf(uri);
+        if (index !== -1) {
+            recentRoots.splice(index, 1);
+        }
         this.writeToUserHome({
-            recentRoots: recent.filter(e => e !== uri && e.length > 0)
+            recentRoots
         });
     }
 

--- a/packages/workspace/src/node/default-workspace-server.ts
+++ b/packages/workspace/src/node/default-workspace-server.ts
@@ -102,10 +102,10 @@ export class DefaultWorkspaceServer implements WorkspaceServer {
         const index = recentRoots.indexOf(uri);
         if (index !== -1) {
             recentRoots.splice(index, 1);
+            this.writeToUserHome({
+                recentRoots
+            });
         }
-        this.writeToUserHome({
-            recentRoots
-        });
     }
 
     async getRecentWorkspaces(): Promise<string[]> {

--- a/packages/workspace/src/node/default-workspace-server.ts
+++ b/packages/workspace/src/node/default-workspace-server.ts
@@ -97,6 +97,16 @@ export class DefaultWorkspaceServer implements WorkspaceServer {
         this.writeToUserHome({ recentRoots });
     }
 
+    async removeRecentWorkspace(uri: string): Promise<void> {
+        // Get the list of recent workspaces.
+        const recent = await this.getRecentWorkspaces();
+        // Filter out the given workspace by uri.
+        // Then update persistent storage to reflect changes.
+        this.writeToUserHome({
+            recentRoots: recent.filter(e => e !== uri && e.length > 0)
+        });
+    }
+
     async getRecentWorkspaces(): Promise<string[]> {
         const listUri: string[] = [];
         const data = await this.readRecentWorkspacePathsFromUserHome();


### PR DESCRIPTION
#### What it does
Fixes #4884

Added the ability to remove Recent Workspaces from the Open Recent
Workspace... quick-open command palette.

Users can now directly remove items from the list by selecting an
associated remove button (X).

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->
<!-- Include relevant issues and describe how they are addressed. -->

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
1) Open the command palette (Ctrl+Shft+P)
2) Type or select the command "File: Open recent workspace"
3) Using the mouse, hover over the different entries in the list and make sure to locate a `close` icon 'X' at the end of the item in focus.
4) Click the 'X' icon to remove the item from the list
5) Refresh the browser and make sure the workspace removed in the previous step does not appear

Other instances of quick access should not be impacted, try few e.g. from the main menu Terminal -> Run Task, and any other run command, etc.
![remove_from_recent_opened_workspaces](https://user-images.githubusercontent.com/76971376/140387738-8386d8be-95a2-44ce-a7d2-da27cfcaa317.gif)


#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
