### PR TITLE
search-in-workspace: fix padding when hovering over head node

### DIFF
--- a/packages/search-in-workspace/src/browser/styles/index.css
+++ b/packages/search-in-workspace/src/browser/styles/index.css
@@ -193,6 +193,7 @@
 .t-siw-search-container .result {
     overflow: hidden;
     width: 100%;
+    flex: 1;
 }
 
 .t-siw-search-container .result .result-head {
@@ -266,7 +267,6 @@
 .theia-TreeNode:hover .result-node-buttons {
     display: flex;
     justify-content: flex-end;
-    flex: 1;
     align-items: center;
     align-self: center;
 }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
Fixes #10363
The pull-request fixes an issue which causes content in the search-in-workspace tree nodes to shift when hovered. The fix ensures that the shift no longer happens by update the `flex` property for the `button` container.
<!-- Include relevant issues and describe how they are addressed. -->

#### How to test
- start the application, and open the search-in-workspace view
- perform a search which yields results
- confirm that hovering over nodes does not cause them to move
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

#### Review checklist

- [X] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
