### PR TITLE
Improve tabbar context menu

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,14 @@
 
 [1.21.0 Milestone](https://github.com/eclipse-theia/theia/milestone/29)
 
+- [core, editor, editor-preview] additional commands added to tabbar context menu for editor widgets. [#10394](https://github.com/eclipse-theia/theia/pull/10394)
+
 <a name="breaking_changes_1.21.0">[Breaking Changes:](#breaking_changes_1.21.0)</a>
 
 - [webpack] Source maps for the frontend renamed from `webpack://[namespace]/[resource-filename]...`
   to `webpack:///[resource-path]?[loaders]` where `resource-path` is the path to the file relative
   to your application package's root.
+- [core] `SelectionService` added to constructor arguments of `TabBarRenderer`. [#10394](https://github.com/eclipse-theia/theia/pull/10394)
 
 ## v1.20.0 - 11/25/2021
 

--- a/packages/core/src/browser/common-frontend-contribution.ts
+++ b/packages/core/src/browser/common-frontend-contribution.ts
@@ -648,6 +648,8 @@ export class CommonFrontendContribution implements FrontendApplicationContributi
             }
         });
         commandRegistry.registerCommand(CommonCommands.COPY_PATH, UriAwareCommandHandler.MultiSelect(this.selectionService, {
+            isVisible: uris => Array.isArray(uris) && uris.some(uri => uri instanceof URI),
+            isEnabled: uris => Array.isArray(uris) && uris.some(uri => uri instanceof URI),
             execute: async uris => {
                 if (uris.length) {
                     const lineDelimiter = isWindows ? '\r\n' : '\n';

--- a/packages/core/src/browser/common-frontend-contribution.ts
+++ b/packages/core/src/browser/common-frontend-contribution.ts
@@ -474,7 +474,6 @@ export class CommonFrontendContribution implements FrontendApplicationContributi
     }
 
     protected initResourceContextKeys(): void {
-        console.log('SENTINEL FOR SETTING UP THE RESOURCE CONTEXT KEYS!');
         const updateContextKeys = () => {
             const selection = this.selectionService.selection;
             const resourceUri = Navigatable.is(selection) && selection.getResourceUri() || UriSelection.getUri(selection);
@@ -788,9 +787,9 @@ export class CommonFrontendContribution implements FrontendApplicationContributi
             execute: () => this.preferenceService.updateValue('workbench.statusBar.visible', !this.preferences['workbench.statusBar.visible'])
         });
         commandRegistry.registerCommand(CommonCommands.TOGGLE_MAXIMIZED, new CurrentWidgetCommandAdapter(this.shell, {
-            isEnabled: title => this.shell.canToggleMaximized(title?.owner),
-            isVisible: title => this.shell.canToggleMaximized(title?.owner),
-            execute: title => this.shell.toggleMaximized(title?.owner),
+            isEnabled: title => Boolean(title?.owner && this.shell.canToggleMaximized(title?.owner)),
+            isVisible: title => Boolean(title?.owner && this.shell.canToggleMaximized(title?.owner)),
+            execute: title => title?.owner && this.shell.toggleMaximized(title?.owner),
         }));
 
         commandRegistry.registerCommand(CommonCommands.SAVE, {

--- a/packages/core/src/browser/frontend-application-module.ts
+++ b/packages/core/src/browser/frontend-application-module.ts
@@ -50,7 +50,7 @@ import { StatusBar, StatusBarImpl } from './status-bar/status-bar';
 import { LabelParser } from './label-parser';
 import { LabelProvider, LabelProviderContribution, DefaultUriLabelProviderContribution } from './label-provider';
 import { PreferenceService } from './preferences';
-import { Coordinate } from './context-menu-renderer';
+import { ContextMenuRenderer, Coordinate } from './context-menu-renderer';
 import { ThemeService } from './theming';
 import { ConnectionStatusService, FrontendConnectionStatusService, ApplicationConnectionStatusContribution, PingService } from './connection-status-service';
 import { DiffUriLabelProviderContribution } from './diff-uris';
@@ -165,7 +165,13 @@ export const frontendApplicationModule = new ContainerModule((bind, unbind, isBo
 
     bind(DockPanelRendererFactory).toFactory(context => () => context.container.get(DockPanelRenderer));
     bind(DockPanelRenderer).toSelf();
-    bind(TabBarRendererFactory).toFactory(({ container }) => () => container.resolve(TabBarRenderer));
+    bind(TabBarRendererFactory).toFactory(({ container }) => () => {
+        const contextMenuRenderer = container.get(ContextMenuRenderer);
+        const tabBarDecoratorService = container.get(TabBarDecoratorService);
+        const iconThemeService = container.get(IconThemeService);
+        const selectionService = container.get(SelectionService);
+        return new TabBarRenderer(contextMenuRenderer, tabBarDecoratorService, iconThemeService, selectionService);
+    });
 
     bindContributionProvider(bind, TabBarDecorator);
     bind(TabBarDecoratorService).toSelf().inSingletonScope();

--- a/packages/core/src/browser/frontend-application-module.ts
+++ b/packages/core/src/browser/frontend-application-module.ts
@@ -50,7 +50,7 @@ import { StatusBar, StatusBarImpl } from './status-bar/status-bar';
 import { LabelParser } from './label-parser';
 import { LabelProvider, LabelProviderContribution, DefaultUriLabelProviderContribution } from './label-provider';
 import { PreferenceService } from './preferences';
-import { ContextMenuRenderer, Coordinate } from './context-menu-renderer';
+import { Coordinate } from './context-menu-renderer';
 import { ThemeService } from './theming';
 import { ConnectionStatusService, FrontendConnectionStatusService, ApplicationConnectionStatusContribution, PingService } from './connection-status-service';
 import { DiffUriLabelProviderContribution } from './diff-uris';
@@ -165,12 +165,7 @@ export const frontendApplicationModule = new ContainerModule((bind, unbind, isBo
 
     bind(DockPanelRendererFactory).toFactory(context => () => context.container.get(DockPanelRenderer));
     bind(DockPanelRenderer).toSelf();
-    bind(TabBarRendererFactory).toFactory(context => () => {
-        const contextMenuRenderer = context.container.get<ContextMenuRenderer>(ContextMenuRenderer);
-        const decoratorService = context.container.get<TabBarDecoratorService>(TabBarDecoratorService);
-        const iconThemeService = context.container.get<IconThemeService>(IconThemeService);
-        return new TabBarRenderer(contextMenuRenderer, decoratorService, iconThemeService);
-    });
+    bind(TabBarRendererFactory).toFactory(({ container }) => () => container.resolve(TabBarRenderer));
 
     bindContributionProvider(bind, TabBarDecorator);
     bind(TabBarDecoratorService).toSelf().inSingletonScope();

--- a/packages/core/src/browser/shell/application-shell.ts
+++ b/packages/core/src/browser/shell/application-shell.ts
@@ -29,10 +29,10 @@ import { Saveable, SaveableWidget, SaveOptions } from '../saveable';
 import { StatusBarImpl, StatusBarEntry, StatusBarAlignment } from '../status-bar/status-bar';
 import { TheiaDockPanel, BOTTOM_AREA_ID, MAIN_AREA_ID } from './theia-dock-panel';
 import { SidePanelHandler, SidePanel, SidePanelHandlerFactory } from './side-panel-handler';
-import { TabBarRendererFactory, TabBarRenderer, SHELL_TABBAR_CONTEXT_MENU, ScrollableTabBar, ToolbarAwareTabBar } from './tab-bars';
+import { TabBarRendererFactory, SHELL_TABBAR_CONTEXT_MENU, ScrollableTabBar, ToolbarAwareTabBar } from './tab-bars';
 import { SplitPositionHandler, SplitPositionOptions } from './split-panels';
 import { FrontendApplicationStateService } from '../frontend-application-state';
-import { TabBarToolbarRegistry, TabBarToolbarFactory, TabBarToolbar } from './tab-bar-toolbar';
+import { TabBarToolbarRegistry, TabBarToolbarFactory } from './tab-bar-toolbar';
 import { ContextKeyService } from '../context-key-service';
 import { Emitter } from '../../common/event';
 import { waitForRevealed, waitForClosed } from '../widgets';
@@ -1827,12 +1827,12 @@ export class ApplicationShell extends Widget {
         return undefined;
     }
 
-    canToggleMaximized(widget?: Widget): boolean {
+    canToggleMaximized(widget: Widget | undefined = this.currentWidget): boolean {
         const area = widget && this.getAreaFor(widget);
         return area === 'main' || area === 'bottom';
     }
 
-    toggleMaximized(widget?: Widget): void {
+    toggleMaximized(widget: Widget | undefined = this.currentWidget): void {
         const area = widget && this.getAreaPanelFor(widget);
         if (area instanceof TheiaDockPanel && (area === this.mainPanel || area === this.bottomPanel)) {
             area.toggleMaximized();

--- a/packages/core/src/browser/shell/application-shell.ts
+++ b/packages/core/src/browser/shell/application-shell.ts
@@ -846,6 +846,13 @@ export class ApplicationShell extends Widget {
      * @returns the selected title widget, else returns the currentTitle or undefined.
      */
     findTitle(tabBar: TabBar<Widget>, event?: Event): Title<Widget> | undefined {
+        return this.findTitleForEvent(tabBar, event) || tabBar.currentTitle || undefined;
+    }
+
+    /**
+     * @returns the title of the widget whose tab was targeted by the event, if any.
+     */
+    findTitleForEvent(tabBar: TabBar<Widget>, event?: Event): Title<Widget> | undefined {
         if (event?.target instanceof HTMLElement) {
             let tabNode: HTMLElement | null = event.target;
             while (tabNode && !tabNode.classList.contains('p-TabBar-tab')) {
@@ -862,7 +869,6 @@ export class ApplicationShell extends Widget {
                 }
             }
         }
-        return tabBar.currentTitle || undefined;
     }
 
     /**
@@ -870,13 +876,19 @@ export class ApplicationShell extends Widget {
      * @returns the selected tab-bar, else returns the currentTabBar.
      */
     findTabBar(event?: Event): TabBar<Widget> | undefined {
+        return this.findTabBarForEvent(event) ?? this.currentTabBar;
+    }
+
+    /**
+     * @returns the tabbar targeted by the event, if any.
+     */
+    findTabBarForEvent(event?: Event): TabBar<Widget> | undefined {
         if (event?.target instanceof HTMLElement) {
             const tabBar = this.findWidgetForElement(event.target);
             if (tabBar instanceof TabBar) {
                 return tabBar;
             }
         }
-        return this.currentTabBar;
     }
 
     /**

--- a/packages/core/src/browser/shell/current-widget-command-adapter.ts
+++ b/packages/core/src/browser/shell/current-widget-command-adapter.ts
@@ -18,21 +18,24 @@ import { CommandHandler } from '../../common';
 import { TabBar, Title, Widget } from '../widgets';
 import { ApplicationShell } from './application-shell';
 
-type TabBarContextMenuCommandAdapterBooleanCheck = undefined | ((event: Event) => boolean);
-type TabBarContextMenuCommandHandlerBooleanCheck = undefined | ((widget: Title<Widget> | undefined, tabbar: TabBar<Widget> | undefined, event: Event) => boolean);
+type CurrentWidgetCommandAdapterBooleanCheck = (event: Event) => boolean;
+type CurrentWidgetCommandHandlerBooleanCheck = (title: Title<Widget> | undefined, tabbar: TabBar<Widget> | undefined, event: Event) => boolean;
 
 export interface TabBarContextMenuCommandHandler extends CommandHandler {
-    execute(widget: Title<Widget> | undefined, tabbar: TabBar<Widget> | undefined, event: Event): unknown;
-    isEnabled: TabBarContextMenuCommandHandlerBooleanCheck;
-    isVisible: TabBarContextMenuCommandHandlerBooleanCheck;
-    isToggled: TabBarContextMenuCommandHandlerBooleanCheck;
+    execute(title: Title<Widget> | undefined, tabbar: TabBar<Widget> | undefined, event: Event): unknown;
+    isEnabled?: CurrentWidgetCommandHandlerBooleanCheck;
+    isVisible?: CurrentWidgetCommandHandlerBooleanCheck;
+    isToggled?: CurrentWidgetCommandHandlerBooleanCheck;
 }
 
-export class TabBarContextMenuCommandAdapter implements CommandHandler {
+/**
+ * Creates a command handler that acts on either the widget targeted by a DOM event or the current widget.
+ */
+export class CurrentWidgetCommandAdapter implements CommandHandler {
     execute: (event: Event) => unknown;
-    isEnabled: TabBarContextMenuCommandAdapterBooleanCheck;
-    isVisible: TabBarContextMenuCommandAdapterBooleanCheck;
-    isToggled: TabBarContextMenuCommandAdapterBooleanCheck;
+    isEnabled?: CurrentWidgetCommandAdapterBooleanCheck;
+    isVisible?: CurrentWidgetCommandAdapterBooleanCheck;
+    isToggled?: CurrentWidgetCommandAdapterBooleanCheck;
     constructor(shell: ApplicationShell, handler: TabBarContextMenuCommandHandler) {
         this.execute = (event: Event) => handler.execute(...this.transformArguments(shell, event));
         if (handler.isEnabled) {
@@ -47,9 +50,9 @@ export class TabBarContextMenuCommandAdapter implements CommandHandler {
     }
 
     protected transformArguments(shell: ApplicationShell, event: Event): [Title<Widget> | undefined, TabBar<Widget> | undefined, Event] {
-        const tabBar = shell.findTabBarForEvent(event);
+        const tabBar = shell.findTabBar(event);
         if (tabBar) {
-            const title = shell.findTitleForEvent(tabBar, event);
+            const title = shell.findTitle(tabBar, event);
             if (title) {
                 return [title, tabBar, event];
             }

--- a/packages/core/src/browser/shell/current-widget-command-adapter.ts
+++ b/packages/core/src/browser/shell/current-widget-command-adapter.ts
@@ -51,12 +51,7 @@ export class CurrentWidgetCommandAdapter implements CommandHandler {
 
     protected transformArguments(shell: ApplicationShell, event: Event): [Title<Widget> | undefined, TabBar<Widget> | undefined, Event] {
         const tabBar = shell.findTabBar(event);
-        if (tabBar) {
-            const title = shell.findTitle(tabBar, event);
-            if (title) {
-                return [title, tabBar, event];
-            }
-        }
-        return [undefined, tabBar, event];
+        const title = tabBar && shell.findTitle(tabBar, event);
+        return [title, tabBar, event];
     }
 }

--- a/packages/core/src/browser/shell/tab-bar-context-menu-command-handler.ts
+++ b/packages/core/src/browser/shell/tab-bar-context-menu-command-handler.ts
@@ -1,0 +1,59 @@
+/********************************************************************************
+ * Copyright (C) 2021 Ericsson and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import { CommandHandler } from '../../common';
+import { TabBar, Title, Widget } from '../widgets';
+import { ApplicationShell } from './application-shell';
+
+type TabBarContextMenuCommandAdapterBooleanCheck = undefined | ((event: Event) => boolean);
+type TabBarContextMenuCommandHandlerBooleanCheck = undefined | ((widget: Title<Widget> | undefined, tabbar: TabBar<Widget> | undefined, event: Event) => boolean);
+
+export interface TabBarContextMenuCommandHandler extends CommandHandler {
+    execute(widget: Title<Widget> | undefined, tabbar: TabBar<Widget> | undefined, event: Event): unknown;
+    isEnabled: TabBarContextMenuCommandHandlerBooleanCheck;
+    isVisible: TabBarContextMenuCommandHandlerBooleanCheck;
+    isToggled: TabBarContextMenuCommandHandlerBooleanCheck;
+}
+
+export class TabBarContextMenuCommandAdapter implements CommandHandler {
+    execute: (event: Event) => unknown;
+    isEnabled: TabBarContextMenuCommandAdapterBooleanCheck;
+    isVisible: TabBarContextMenuCommandAdapterBooleanCheck;
+    isToggled: TabBarContextMenuCommandAdapterBooleanCheck;
+    constructor(shell: ApplicationShell, handler: TabBarContextMenuCommandHandler) {
+        this.execute = (event: Event) => handler.execute(...this.transformArguments(shell, event));
+        if (handler.isEnabled) {
+            this.isEnabled = (event: Event) => !!handler.isEnabled?.(...this.transformArguments(shell, event));
+        }
+        if (handler.isVisible) {
+            this.isVisible = (event: Event) => !!handler.isVisible?.(...this.transformArguments(shell, event));
+        }
+        if (handler.isToggled) {
+            this.isToggled = (event: Event) => !!handler.isToggled?.(...this.transformArguments(shell, event));
+        }
+    }
+
+    protected transformArguments(shell: ApplicationShell, event: Event): [Title<Widget> | undefined, TabBar<Widget> | undefined, Event] {
+        const tabBar = shell.findTabBarForEvent(event);
+        if (tabBar) {
+            const title = shell.findTitleForEvent(tabBar, event);
+            if (title) {
+                return [title, tabBar, event];
+            }
+        }
+        return [undefined, tabBar, event];
+    }
+}

--- a/packages/core/src/browser/shell/tab-bars.ts
+++ b/packages/core/src/browser/shell/tab-bars.ts
@@ -37,6 +37,11 @@ const HIDDEN_CONTENT_CLASS = 'theia-TabBar-hidden-content';
 
 /** Menu path for tab bars used throughout the application shell. */
 export const SHELL_TABBAR_CONTEXT_MENU: MenuPath = ['shell-tabbar-context-menu'];
+export const SHELL_TABBAR_CONTEXT_CLOSE: MenuPath = [...SHELL_TABBAR_CONTEXT_MENU, '0_close'];
+export const SHELL_TABBAR_CONTEXT_COPY: MenuPath = [...SHELL_TABBAR_CONTEXT_MENU, '1_copy'];
+// Kept here in anticipation of tab pinning behavior implemented in tab-bars.ts
+export const SHELL_TABBAR_CONTEXT_PIN: MenuPath = [...SHELL_TABBAR_CONTEXT_MENU, '4_pin'];
+export const SHELL_TABBAR_CONTEXT_SPLIT: MenuPath = [...SHELL_TABBAR_CONTEXT_MENU, '5_split'];
 
 export const TabBarRendererFactory = Symbol('TabBarRendererFactory');
 

--- a/packages/core/src/browser/shell/tab-bars.ts
+++ b/packages/core/src/browser/shell/tab-bars.ts
@@ -31,7 +31,6 @@ import { IconThemeService } from '../icon-theme-service';
 import { BreadcrumbsRenderer, BreadcrumbsRendererFactory } from '../breadcrumbs/breadcrumbs-renderer';
 import { NavigatableWidget } from '../navigatable-types';
 import { IDragEvent } from '@phosphor/dragdrop';
-import { inject, injectable } from 'shared/inversify';
 
 /** The class name added to hidden content nodes, which are required to render vertical side bars. */
 const HIDDEN_CONTENT_CLASS = 'theia-TabBar-hidden-content';
@@ -72,11 +71,7 @@ export interface SideBarRenderData extends TabBar.IRenderData<Widget> {
  * `transform` property, disrupting the browser's ability to arrange those elements
  * automatically.
  */
-@injectable()
 export class TabBarRenderer extends TabBar.Renderer {
-
-    @inject(SelectionService) protected readonly selectionService?: SelectionService;
-
     /**
      * The menu path used to render the context menu.
      */
@@ -88,9 +83,10 @@ export class TabBarRenderer extends TabBar.Renderer {
     // events should be handled by clients, like ApplicationShell
     // right now it is mess: (1) client logic belong to renderer, (2) cyclic dependencies between renderers and clients
     constructor(
-        @inject(ContextMenuRenderer) protected readonly contextMenuRenderer?: ContextMenuRenderer,
-        @inject(TabBarDecoratorService) protected readonly decoratorService?: TabBarDecoratorService,
-        @inject(IconThemeService) protected readonly iconThemeService?: IconThemeService,
+        protected readonly contextMenuRenderer?: ContextMenuRenderer,
+        protected readonly decoratorService?: TabBarDecoratorService,
+        protected readonly iconThemeService?: IconThemeService,
+        protected readonly selectionService?: SelectionService,
     ) {
         super();
         if (this.decoratorService) {

--- a/packages/editor-preview/src/browser/editor-preview-contribution.ts
+++ b/packages/editor-preview/src/browser/editor-preview-contribution.ts
@@ -14,7 +14,7 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
-import { ApplicationShell, CommonCommands, KeybindingContribution, KeybindingRegistry, SHELL_TABBAR_CONTEXT_MENU, Widget } from '@theia/core/lib/browser';
+import { ApplicationShell, CommonCommands, KeybindingContribution, KeybindingRegistry, SHELL_TABBAR_CONTEXT_PIN, Widget } from '@theia/core/lib/browser';
 import { nls } from '@theia/core/lib/common/nls';
 import { Command, CommandContribution, CommandRegistry, MenuContribution, MenuModelRegistry } from '@theia/core/lib/common';
 import { inject, injectable } from '@theia/core/shared/inversify';
@@ -60,7 +60,7 @@ export class EditorPreviewContribution implements CommandContribution, MenuContr
     }
 
     registerMenus(registry: MenuModelRegistry): void {
-        registry.registerMenuAction(SHELL_TABBAR_CONTEXT_MENU, {
+        registry.registerMenuAction(SHELL_TABBAR_CONTEXT_PIN, {
             commandId: EditorPreviewCommands.PIN_PREVIEW_COMMAND.id,
             label: nls.localizeByDefault('Keep Open'),
             order: '6',

--- a/packages/editor/src/browser/editor-contribution.ts
+++ b/packages/editor/src/browser/editor-contribution.ts
@@ -18,9 +18,12 @@ import { EditorManager } from './editor-manager';
 import { TextEditor } from './editor';
 import { injectable, inject, optional } from '@theia/core/shared/inversify';
 import { StatusBarAlignment, StatusBar } from '@theia/core/lib/browser/status-bar/status-bar';
-import { FrontendApplicationContribution, DiffUris, DockLayout, QuickInputService, KeybindingRegistry, KeybindingContribution } from '@theia/core/lib/browser';
+import {
+    FrontendApplicationContribution, DiffUris, DockLayout,
+    QuickInputService, KeybindingRegistry, KeybindingContribution, SHELL_TABBAR_CONTEXT_SPLIT
+} from '@theia/core/lib/browser';
 import { ContextKeyService } from '@theia/core/lib/browser/context-key-service';
-import { CommandHandler, DisposableCollection } from '@theia/core';
+import { CommandHandler, DisposableCollection, MenuContribution, MenuModelRegistry } from '@theia/core';
 import { EditorCommands } from './editor-command';
 import { CommandRegistry, CommandContribution } from '@theia/core/lib/common';
 import { LanguageService } from '@theia/core/lib/browser/language-service';
@@ -28,7 +31,7 @@ import { SUPPORTED_ENCODINGS } from '@theia/core/lib/browser/supported-encodings
 import { nls } from '@theia/core/lib/common/nls';
 
 @injectable()
-export class EditorContribution implements FrontendApplicationContribution, CommandContribution, KeybindingContribution {
+export class EditorContribution implements FrontendApplicationContribution, CommandContribution, KeybindingContribution, MenuContribution {
 
     @inject(StatusBar) protected readonly statusBar: StatusBar;
     @inject(EditorManager) protected readonly editorManager: EditorManager;
@@ -165,6 +168,29 @@ export class EditorContribution implements FrontendApplicationContribution, Comm
         keybindings.registerKeybinding({
             command: EditorCommands.SPLIT_EDITOR_VERTICAL.id,
             keybinding: 'ctrlcmd+k ctrlcmd+\\',
+        });
+    }
+
+    registerMenus(registry: MenuModelRegistry): void {
+        registry.registerMenuAction(SHELL_TABBAR_CONTEXT_SPLIT, {
+            commandId: EditorCommands.SPLIT_EDITOR_UP.id,
+            label: nls.localizeByDefault('Split Up'),
+            order: '1',
+        });
+        registry.registerMenuAction(SHELL_TABBAR_CONTEXT_SPLIT, {
+            commandId: EditorCommands.SPLIT_EDITOR_DOWN.id,
+            label: nls.localizeByDefault('Split Down'),
+            order: '2',
+        });
+        registry.registerMenuAction(SHELL_TABBAR_CONTEXT_SPLIT, {
+            commandId: EditorCommands.SPLIT_EDITOR_LEFT.id,
+            label: nls.localizeByDefault('Split Left'),
+            order: '3',
+        });
+        registry.registerMenuAction(SHELL_TABBAR_CONTEXT_SPLIT, {
+            commandId: EditorCommands.SPLIT_EDITOR_RIGHT.id,
+            label: nls.localizeByDefault('Split Right'),
+            order: '4',
         });
     }
 }

--- a/packages/editor/src/browser/editor-contribution.ts
+++ b/packages/editor/src/browser/editor-contribution.ts
@@ -144,7 +144,7 @@ export class EditorContribution implements FrontendApplicationContribution, Comm
             execute: async title => {
                 if (title?.owner instanceof EditorWidget) {
                     const selection = title.owner.editor.selection;
-                    const newEditor = await this.editorManager.openToSide(title.owner.editor.uri, { selection, widgetOptions: { mode: splitMode } });
+                    const newEditor = await this.editorManager.openToSide(title.owner.editor.uri, { selection, widgetOptions: { mode: splitMode, ref: title.owner } });
                     const oldEditorState = title.owner.editor.storeViewState();
                     newEditor.editor.restoreViewState(oldEditorState);
                 }

--- a/packages/editor/src/browser/editor-frontend-module.ts
+++ b/packages/editor/src/browser/editor-frontend-module.ts
@@ -69,7 +69,7 @@ export default new ContainerModule(bind => {
 
     bind(VariableContribution).to(EditorVariableContribution).inSingletonScope();
 
-    [CommandContribution, KeybindingContribution].forEach(serviceIdentifier => {
+    [CommandContribution, KeybindingContribution, MenuContribution].forEach(serviceIdentifier => {
         bind(serviceIdentifier).toService(EditorContribution);
     });
     bind(QuickEditorService).toSelf().inSingletonScope();

--- a/packages/navigator/src/browser/navigator-contribution.ts
+++ b/packages/navigator/src/browser/navigator-contribution.ts
@@ -27,13 +27,13 @@ import {
     PreferenceScope,
     PreferenceService,
     SelectableTreeNode,
-    SHELL_TABBAR_CONTEXT_MENU,
     Widget,
     NavigatableWidget,
     ApplicationShell,
     TabBar,
     Title,
-    codicon
+    codicon,
+    SHELL_TABBAR_CONTEXT_MENU
 } from '@theia/core/lib/browser';
 import { FileDownloadCommands } from '@theia/filesystem/lib/browser/download/file-download-command-contribution';
 import {
@@ -44,7 +44,6 @@ import {
     MenuModelRegistry,
     MenuPath,
     Mutable,
-    isWindows
 } from '@theia/core/lib/common';
 import {
     DidCreateNewResourceEvent,
@@ -72,8 +71,6 @@ import { DirNode, FileNode } from '@theia/filesystem/lib/browser';
 import { FileNavigatorModel } from './navigator-model';
 import { ClipboardService } from '@theia/core/lib/browser/clipboard-service';
 import { SelectionService } from '@theia/core/lib/common/selection-service';
-import { UriAwareCommandHandler } from '@theia/core/lib/common/uri-command-handler';
-import URI from '@theia/core/lib/common/uri';
 import { OpenEditorsWidget } from './open-editors-widget/navigator-open-editors-widget';
 import { OpenEditorsContextMenu } from './open-editors-widget/navigator-open-editors-menus';
 import { OpenEditorsCommands } from './open-editors-widget/navigator-open-editors-commands';
@@ -113,15 +110,15 @@ export namespace FileNavigatorCommands {
         category: CommonCommands.FILE_CATEGORY,
         label: 'Focus on Files Explorer'
     });
-    export const COPY_RELATIVE_FILE_PATH = Command.toDefaultLocalizedCommand({
-        id: 'navigator.copyRelativeFilePath',
-        label: 'Copy Relative Path'
-    });
     export const OPEN = Command.toDefaultLocalizedCommand({
         id: 'navigator.open',
         category: CommonCommands.FILE_CATEGORY,
         label: 'Open'
     });
+    /**
+     * @deprecated since 1.20.0. Use WorkspaceCommands.COPY_RELATIVE_FILE_COMMAND instead.
+     */
+    export const COPY_RELATIVE_FILE_PATH = WorkspaceCommands.COPY_RELATIVE_FILE_PATH;
 }
 
 /**
@@ -135,6 +132,7 @@ export namespace NavigatorMoreToolbarGroups {
 }
 
 export const NAVIGATOR_CONTEXT_MENU: MenuPath = ['navigator-context-menu'];
+export const SHELL_TABBAR_CONTEXT_REVEAL: MenuPath = [...SHELL_TABBAR_CONTEXT_MENU, '2_reveal'];
 
 /**
  * Navigator context menu default groups should be aligned
@@ -343,20 +341,6 @@ export class FileNavigatorContribution extends AbstractViewContribution<FileNavi
             isEnabled: () => this.navigatorDiff.isFirstFileSelected,
             isVisible: () => this.navigatorDiff.isFirstFileSelected
         });
-        registry.registerCommand(FileNavigatorCommands.COPY_RELATIVE_FILE_PATH, UriAwareCommandHandler.MultiSelect(this.selectionService, {
-            isEnabled: uris => !!uris.length,
-            isVisible: uris => !!uris.length,
-            execute: async uris => {
-                const lineDelimiter = isWindows ? '\r\n' : '\n';
-                const text = uris.map((uri: URI) => {
-                    const workspaceRoot = this.workspaceService.getWorkspaceRootUri(uri);
-                    if (workspaceRoot) {
-                        return workspaceRoot.relative(uri);
-                    }
-                }).join(lineDelimiter);
-                await this.clipboardService.writeText(text);
-            }
-        }));
         registry.registerCommand(FileNavigatorCommands.OPEN, {
             isEnabled: () => this.getSelectedFileNodes().length > 0,
             isVisible: () => this.getSelectedFileNodes().length > 0,
@@ -421,7 +405,7 @@ export class FileNavigatorContribution extends AbstractViewContribution<FileNavi
 
     registerMenus(registry: MenuModelRegistry): void {
         super.registerMenus(registry);
-        registry.registerMenuAction(SHELL_TABBAR_CONTEXT_MENU, {
+        registry.registerMenuAction(SHELL_TABBAR_CONTEXT_REVEAL, {
             commandId: FileNavigatorCommands.REVEAL_IN_NAVIGATOR.id,
             label: FileNavigatorCommands.REVEAL_IN_NAVIGATOR.label,
             order: '5'
@@ -460,8 +444,8 @@ export class FileNavigatorContribution extends AbstractViewContribution<FileNavi
             order: 'c'
         });
         registry.registerMenuAction(NavigatorContextMenu.CLIPBOARD, {
-            commandId: FileNavigatorCommands.COPY_RELATIVE_FILE_PATH.id,
-            label: FileNavigatorCommands.COPY_RELATIVE_FILE_PATH.label,
+            commandId: WorkspaceCommands.COPY_RELATIVE_FILE_PATH.id,
+            label: WorkspaceCommands.COPY_RELATIVE_FILE_PATH.label,
             order: 'd'
         });
         registry.registerMenuAction(NavigatorContextMenu.CLIPBOARD, {
@@ -519,7 +503,7 @@ export class FileNavigatorContribution extends AbstractViewContribution<FileNavi
             order: 'a'
         });
         registry.registerMenuAction(OpenEditorsContextMenu.CLIPBOARD, {
-            commandId: FileNavigatorCommands.COPY_RELATIVE_FILE_PATH.id,
+            commandId: WorkspaceCommands.COPY_RELATIVE_FILE_PATH.id,
             order: 'b'
         });
         registry.registerMenuAction(OpenEditorsContextMenu.SAVE, {
@@ -576,12 +560,6 @@ export class FileNavigatorContribution extends AbstractViewContribution<FileNavi
             command: FileNavigatorCommands.TOGGLE_HIDDEN_FILES.id,
             keybinding: 'ctrlcmd+i',
             context: NavigatorKeybindingContexts.navigatorActive
-        });
-
-        registry.registerKeybinding({
-            command: FileNavigatorCommands.COPY_RELATIVE_FILE_PATH.id,
-            keybinding: isWindows ? 'ctrl+k ctrl+shift+c' : 'ctrlcmd+shift+alt+c',
-            when: '!editorFocus'
         });
     }
 

--- a/packages/navigator/src/browser/navigator-contribution.ts
+++ b/packages/navigator/src/browser/navigator-contribution.ts
@@ -117,7 +117,7 @@ export namespace FileNavigatorCommands {
         label: 'Open'
     });
     /**
-     * @deprecated since 1.20.0. Use WorkspaceCommands.COPY_RELATIVE_FILE_COMMAND instead.
+     * @deprecated since 1.21.0. Use WorkspaceCommands.COPY_RELATIVE_FILE_COMMAND instead.
      */
     export const COPY_RELATIVE_FILE_PATH = WorkspaceCommands.COPY_RELATIVE_FILE_PATH;
 }

--- a/packages/workspace/src/browser/workspace-commands.spec.ts
+++ b/packages/workspace/src/browser/workspace-commands.spec.ts
@@ -39,6 +39,7 @@ import { WorkspaceDuplicateHandler } from './workspace-duplicate-handler';
 import { WorkspacePreferences } from './workspace-preferences';
 import { WorkspaceService } from './workspace-service';
 import { ApplicationServer } from '@theia/core/lib/common/application-protocol';
+import { ClipboardService } from '@theia/core/lib/browser/clipboard-service';
 
 disableJSDOM();
 
@@ -88,6 +89,7 @@ describe('workspace-commands', () => {
         container.bind(WorkspaceDuplicateHandler).toConstantValue(<WorkspaceDuplicateHandler>{});
         container.bind(WorkspacePreferences).toConstantValue(<WorkspacePreferences>{});
         container.bind(WorkspaceService).toConstantValue(<WorkspaceService>{});
+        container.bind(ClipboardService).toConstantValue(<ClipboardService>{});
         container.bind(ApplicationServer).toConstantValue(<ApplicationServer>{
             getBackendOS(): Promise<OS.Type> {
                 return Promise.resolve(OS.type());

--- a/packages/workspace/src/browser/workspace-frontend-contribution.ts
+++ b/packages/workspace/src/browser/workspace-frontend-contribution.ts
@@ -15,11 +15,11 @@
  ********************************************************************************/
 
 import { injectable, inject } from '@theia/core/shared/inversify';
-import { CommandContribution, CommandRegistry, MenuContribution, MenuModelRegistry, SelectionService, MessageService } from '@theia/core/lib/common';
+import { CommandContribution, CommandRegistry, MenuContribution, MenuModelRegistry, SelectionService, MessageService, isWindows } from '@theia/core/lib/common';
 import { isOSX, environment, OS } from '@theia/core';
 import {
-    open, OpenerService, CommonMenus, StorageService, LabelProvider,
-    ConfirmDialog, KeybindingRegistry, KeybindingContribution, CommonCommands, FrontendApplicationContribution, ApplicationShell, Saveable, SaveableSource, Widget, Navigatable
+    open, OpenerService, CommonMenus, StorageService, LabelProvider, ConfirmDialog, KeybindingRegistry, KeybindingContribution,
+    CommonCommands, FrontendApplicationContribution, ApplicationShell, Saveable, SaveableSource, Widget, Navigatable, SHELL_TABBAR_CONTEXT_COPY
 } from '@theia/core/lib/browser';
 import { FileDialogService, OpenFileDialogProps, FileDialogTreeFilters } from '@theia/filesystem/lib/browser';
 import { ContextKeyService } from '@theia/core/lib/browser/context-key-service';
@@ -214,6 +214,11 @@ export class WorkspaceFrontendContribution implements CommandContribution, Keybi
         menus.registerMenuAction(CommonMenus.FILE_SAVE, {
             commandId: WorkspaceCommands.SAVE_AS.id,
         });
+
+        menus.registerMenuAction(SHELL_TABBAR_CONTEXT_COPY, {
+            commandId: WorkspaceCommands.COPY_RELATIVE_FILE_PATH.id,
+            label: WorkspaceCommands.COPY_RELATIVE_FILE_PATH.label,
+        });
     }
 
     registerKeybindings(keybindings: KeybindingRegistry): void {
@@ -242,6 +247,11 @@ export class WorkspaceFrontendContribution implements CommandContribution, Keybi
         keybindings.registerKeybinding({
             command: WorkspaceCommands.SAVE_AS.id,
             keybinding: 'ctrlcmd+shift+s',
+        });
+        keybindings.registerKeybinding({
+            command: WorkspaceCommands.COPY_RELATIVE_FILE_PATH.id,
+            keybinding: isWindows ? 'ctrl+k ctrl+shift+c' : 'ctrlcmd+shift+alt+c',
+            when: '!editorFocus'
         });
     }
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

This PR improves the state of the tabbar context menu, adding a number of missing commands.

Top left, before; top right, after; right, VSCode

![image](https://user-images.githubusercontent.com/62660806/140582922-fd0f2489-c60e-4263-9897-cdab5f382b0b.png)


#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

#### Review checklist
1. Run through each of the new commands see that it does what you expect
> New commands are: `Close saved` (only new implementation), `Copy Path`, `Copy Relative Path`, `Keep Open` (previews only), `Split Up/Down/Left/Right`.

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
