### PR TITLE
Disable http fallback after successful websocket connection

### DIFF
--- a/packages/core/src/browser/messaging/ws-connection-provider.ts
+++ b/packages/core/src/browser/messaging/ws-connection-provider.ts
@@ -98,7 +98,6 @@ export class WebSocketConnectionProvider extends AbstractConnectionProvider<WebS
             this.fireSocketDidClose();
         };
         socket.onmessage = ({ data }) => {
-            this.websocketErrorCounter = 0;
             this.handleIncomingRawMessage(data);
         };
         this.socket = socket;
@@ -218,6 +217,10 @@ export class WebSocketConnectionProvider extends AbstractConnectionProvider<WebS
     }
 
     protected fireSocketDidOpen(): void {
+        // Once a websocket connection has opened, disable the http fallback
+        if (this.httpFallbackOptions?.allowed) {
+            this.httpFallbackOptions.allowed = false;
+        }
         this.onSocketDidOpenEmitter.fire(undefined);
     }
 


### PR DESCRIPTION
#### What it does

Closes #10261

Simply disables the fallback by setting the `allowed` property on the fallback options to `false` once a websocket connection has been established.

#### How to test

1. Start Theia (Browser) on a remote server
2. Open the Theia window in your browser
3. Disconnect from the remote server (unplug your ethernet)
4. The http fallback should not activate
5. After re-establishing network connection, Theia should re-establish its connection as well.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
