### PR TITLE
Add eslint rule for localization issues

### DIFF
--- a/configs/errors.eslintrc.json
+++ b/configs/errors.eslintrc.json
@@ -131,6 +131,7 @@
         }
       }
     ],
+    "@theia/localization-check": "error",
     "@theia/no-src-import": "error",
     "@theia/runtime-import-check": "error",
     "@theia/shared-dependencies": "error",

--- a/dev-packages/private-eslint-plugin/README.md
+++ b/dev-packages/private-eslint-plugin/README.md
@@ -17,6 +17,12 @@ The plugin helps identify problems during development through static analysis in
 
 ## Rules
 
+### `localization-check`:
+
+The rule prevents the following localization related issues:
+- incorrect usage of the `nls.localizeByDefault` function by using an incorrect default value.
+- unnecessary call to `nls.localize` which could be replaced by `nls.localizeByDefault`.
+
 ### `no-src-import`:
 
 The rule prevents imports using `/src/` rather than `/lib/` as it causes build failures.

--- a/dev-packages/private-eslint-plugin/index.js
+++ b/dev-packages/private-eslint-plugin/index.js
@@ -17,6 +17,7 @@
 
 /** @type {{[ruleId: string]: import('eslint').Rule.RuleModule}} */
 exports.rules = {
+    "localization-check": require('./rules/localization-check'),
     "no-src-import": require('./rules/no-src-import'),
     "runtime-import-check": require('./rules/runtime-import-check'),
     "shared-dependencies": require('./rules/shared-dependencies')

--- a/dev-packages/private-eslint-plugin/package.json
+++ b/dev-packages/private-eslint-plugin/package.json
@@ -10,6 +10,7 @@
   "dependencies": {
     "@theia/core": "1.22.1",
     "@theia/ext-scripts": "1.22.1",
-    "@theia/re-exports": "1.22.1"
+    "@theia/re-exports": "1.22.1",
+    "js-levenshtein": "^1.1.6"
   }
 }

--- a/dev-packages/private-eslint-plugin/rules/localization-check.js
+++ b/dev-packages/private-eslint-plugin/rules/localization-check.js
@@ -1,0 +1,109 @@
+// @ts-check
+/********************************************************************************
+ * Copyright (C) 2021 TypeFox and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+const levenshtein = require('js-levenshtein');
+
+const metadata = require('@theia/core/src/common/i18n/nls.metadata.json');
+const messages = new Set(Object.values(metadata.messages)
+    .reduceRight((prev, curr) => prev.concat(curr), [])
+    .map(e => e.replace(/&&/g, '')));
+
+/** @type {import('eslint').Rule.RuleModule} */
+module.exports = {
+    meta: {
+        type: 'problem',
+        fixable: 'code',
+        docs: {
+            description: 'prevent incorrect use of \'nls.localize\'.',
+        },
+    },
+    create(context) {
+        return {
+            CallExpression(node) {
+                const callee = node.callee;
+                if (callee.type === 'Super') {
+                    return;
+                }
+                const { value, byDefault, node: localizeNode } = evaluateLocalize(node);
+                if (value !== undefined) {
+                    if (byDefault && !messages.has(value)) {
+                        let lowestDistance = Number.MAX_VALUE;
+                        let lowestMessage = '';
+                        for (const message of messages) {
+                            const distance = levenshtein(value, message);
+                            if (distance < lowestDistance) {
+                                lowestDistance = distance;
+                                lowestMessage = message;
+                            }
+                        }
+                        if (lowestMessage) {
+                            context.report({
+                                node: localizeNode,
+                                message: `'${value}' is not a valid default value. Did you mean '${lowestMessage}'?`,
+                                fix: function (fixer) {
+                                    const updatedCall = `'${lowestMessage.replace(/'/g, "\\'")}'`;
+                                    return fixer.replaceText(localizeNode, updatedCall);
+                                }
+                            });
+                        } else {
+                            context.report({
+                                node: localizeNode,
+                                message: `'${value}' is not a valid default value.`
+                            });
+                        }
+                    } else if (!byDefault && messages.has(value)) {
+                        context.report({
+                            node,
+                            message: `'${value}' can be translated using the 'nls.localizeByDefault' function.`,
+                            fix: function (fixer) {
+                                const code = context.getSourceCode();
+                                const args = node.arguments.slice(1);
+                                const argsCode = args.map(e => code.getText(e)).join(', ');
+                                const updatedCall = `nls.localizeByDefault(${argsCode})`;
+                                return fixer.replaceText(node, updatedCall);
+                            }
+                        });
+                    }
+                }
+            }
+        };
+        function evaluateLocalize(/** @type {import('estree').CallExpression} */ node) {
+            const callee = node.callee;
+            if ('object' in callee && 'name' in callee.object && 'property' in callee && 'name' in callee.property && callee.object.name === 'nls') {
+                if (callee.property.name === 'localize') {
+                    const defaultTextNode = node.arguments[1]; // The default text node is the second argument for `nls.localize`
+                    if (defaultTextNode && defaultTextNode.type === 'Literal' && typeof defaultTextNode.value === 'string') {
+                        return {
+                            value: defaultTextNode.value,
+                            byDefault: false
+                        };
+                    }
+                } else if (callee.property.name === 'localizeByDefault') {
+                    const defaultTextNode = node.arguments[0]; // The default text node is the first argument for ``nls.localizeByDefault`
+                    if (defaultTextNode && defaultTextNode.type === 'Literal' && typeof defaultTextNode.value === 'string') {
+                        return {
+                            node: defaultTextNode,
+                            value: defaultTextNode.value,
+                            byDefault: true
+                        };
+                    }
+                }
+            }
+            return {};
+        }
+    }
+};

--- a/packages/bulk-edit/src/browser/bulk-edit-tree/bulk-edit-tree-widget.tsx
+++ b/packages/bulk-edit/src/browser/bulk-edit-tree/bulk-edit-tree-widget.tsx
@@ -95,7 +95,7 @@ export class BulkEditTreeWidget extends TreeWidget {
         if (CompositeTreeNode.is(model.root) && model.root.children.length > 0) {
             return super.renderTree(model);
         }
-        return <div className='theia-widget-noInfo noEdits'>{nls.localizeByDefault('No edits have been detected in the workspace so far.')}</div>;
+        return <div className='theia-widget-noInfo noEdits'>{nls.localizeByDefault('Made no edits')}</div>;
     }
 
     protected renderCaption(node: TreeNode, props: NodeProps): React.ReactNode {

--- a/packages/core/src/browser/core-preferences.ts
+++ b/packages/core/src/browser/core-preferences.ts
@@ -140,14 +140,19 @@ export const corePreferenceSchema: PreferenceSchema = {
             default: 300,
             minimum: 0,
             maximum: 2000,
-            description: nls.localizeByDefault('Controls the hover feedback delay in milliseconds of the dragging area in between views/editors.')
+            // nls-todo: Will be available with VSCode API 1.55
+            description: nls.localize('theia/core/sashDelay', 'Controls the hover feedback delay in milliseconds of the dragging area in between views/editors.')
         },
         'workbench.sash.size': {
             type: 'number',
             default: 4,
             minimum: 1,
             maximum: 20,
-            description: nls.localizeByDefault('Controls the feedback area size in pixels of the dragging area in between views/editors. Set it to a larger value if needed.')
+            // nls-todo: Will be available with VSCode API 1.55
+            description: nls.localize(
+                'theia/core/sashSize',
+                'Controls the feedback area size in pixels of the dragging area in between views/editors. Set it to a larger value if needed.'
+            )
         },
     }
 };

--- a/packages/core/src/browser/keyboard/browser-keyboard-frontend-contribution.ts
+++ b/packages/core/src/browser/keyboard/browser-keyboard-frontend-contribution.ts
@@ -52,7 +52,7 @@ export class BrowserKeyboardFrontendContribution implements CommandContribution 
     protected async chooseLayout(): Promise<KeyboardLayoutData | undefined> {
         const current = this.layoutProvider.currentLayoutData;
         const autodetect: QuickPickValue<'autodetect'> = {
-            label: nls.localizeByDefault('Auto-detect'),
+            label: nls.localizeByDefault('Auto Detect'),
             description: this.layoutProvider.currentLayoutSource !== 'user-choice' ? nls.localize('theia/core/keyboard/current', '(current: {0})', current.name) : undefined,
             detail: nls.localize('theia/core/keyboard/tryDetect', 'Try to detect the keyboard layout from browser information and pressed keys.'),
             value: 'autodetect'

--- a/packages/core/src/electron-browser/menu/electron-menu-contribution.ts
+++ b/packages/core/src/electron-browser/menu/electron-menu-contribution.ts
@@ -233,7 +233,7 @@ export class ElectronMenuContribution extends BrowserMenuBarContribution impleme
     protected async handleRequiredRestart(): Promise<void> {
         const msgNode = document.createElement('div');
         const message = document.createElement('p');
-        message.textContent = nls.localizeByDefault('A setting has changed that requires a restart to take effect');
+        message.textContent = nls.localizeByDefault('A setting has changed that requires a restart to take effect.');
         const detail = document.createElement('p');
         detail.textContent = nls.localizeByDefault(
             'Press the restart button to restart {0} and enable the setting.', FrontendApplicationConfigProvider.get().applicationName);

--- a/packages/core/src/electron-browser/window/electron-window-preferences.ts
+++ b/packages/core/src/electron-browser/window/electron-window-preferences.ts
@@ -38,7 +38,7 @@ export const electronWindowPreferencesSchema: PreferenceSchema = {
             'maximum': ZoomLevel.MAX,
             'scope': 'application',
             // eslint-disable-next-line max-len
-            'description': nls.localizeByDefault('Adjust the zoom level of the window. The original size is 0 and each increment above (e.g. 1.0) or below (e.g. -1.0) represents zooming 20% larger or smaller. You can also enter decimals to adjust the zoom level with a finer granularity.')
+            'description': nls.localizeByDefault('Adjust the zoom level of the window. The original size is 0 and each increment above (e.g. 1) or below (e.g. -1) represents zooming 20% larger or smaller. You can also enter decimals to adjust the zoom level with a finer granularity.')
         },
         'window.titleBarStyle': {
             type: 'string',

--- a/packages/debug/src/node/vscode/vscode-debug-adapter-contribution.ts
+++ b/packages/debug/src/node/vscode/vscode-debug-adapter-contribution.ts
@@ -14,6 +14,8 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
+/* eslint-disable @theia/localization-check */
+
 import * as fs from '@theia/core/shared/fs-extra';
 import * as path from 'path';
 import { DebugAdapterExecutable, DebugAdapterContribution } from '../debug-model';

--- a/packages/editor/src/browser/editor-command.ts
+++ b/packages/editor/src/browser/editor-command.ts
@@ -364,7 +364,7 @@ export class EditorCommandContribution implements CommandContribution {
             return;
         }
         if (editor.document.dirty && isReopenWithEncoding) {
-            this.messageService.info(nls.localize('theia/editor/reopenDirty', 'The file is dirty. Please save it first before reopening it with another encoding.'));
+            this.messageService.info(nls.localizeByDefault('The file is dirty. Please save it first before reopening it with another encoding.'));
             return;
         } else if (selectedFileEncoding.value) {
             editor.setEncoding(selectedFileEncoding.value.id, isReopenWithEncoding ? EncodingMode.Decode : EncodingMode.Encode);

--- a/packages/editor/src/browser/editor-preferences.ts
+++ b/packages/editor/src/browser/editor-preferences.ts
@@ -685,7 +685,7 @@ const codeEditorPreferenceProperties = {
         'default': false
     },
     'editor.highlightActiveIndentGuide': {
-        'description': nls.localize('theia/editor/highlightActiveIndentGuide', 'Controls whether the editor should highlight the active indent guide.'),
+        'description': nls.localizeByDefault('Controls whether the editor should highlight the active indent guide.'),
         'type': 'boolean',
         'default': true
     },
@@ -743,7 +743,7 @@ const codeEditorPreferenceProperties = {
         'description': nls.localizeByDefault('Controls the display of line numbers.')
     },
     'editor.lineNumbersMinChars': {
-        'description': nls.localize('theia/editor/lineNumbersMinChars', 'Controls the line height. Use 0 to compute the line height from the font size.'),
+        'description': nls.localizeByDefault('Controls the line height. Use 0 to compute the line height from the font size.'),
         'type': 'integer',
         'default': 5,
         'minimum': 1,
@@ -900,15 +900,13 @@ const codeEditorPreferenceProperties = {
     'editor.peekWidgetDefaultFocus': {
         'enumDescriptions': [
             nls.localizeByDefault('Focus the tree when opening peek'),
-            nls.localizeByDefault('Focus the editor when opening peek'),
-            nls.localizeByDefault('Focus the webview when opening peek')
+            nls.localizeByDefault('Focus the editor when opening peek')
         ],
         'description': nls.localizeByDefault('Controls whether to focus the inline editor or the tree in the peek widget.'),
         'type': 'string',
         'enum': [
             'tree',
-            'editor',
-            'webview'
+            'editor'
         ],
         'default': 'tree'
     },
@@ -1399,7 +1397,7 @@ const codeEditorPreferenceProperties = {
         'default': 'off'
     },
     'editor.tabIndex': {
-        'markdownDescription': nls.localize('theia/editor/tabIndex', 'Controls the wrapping column of the editor when `#editor.wordWrap#` is `wordWrapColumn` or `bounded`.'),
+        'markdownDescription': nls.localizeByDefault('Controls the wrapping column of the editor when `#editor.wordWrap#` is `wordWrapColumn` or `bounded`.'),
         'type': 'integer',
         'default': 0,
         'minimum': -1,
@@ -1407,9 +1405,9 @@ const codeEditorPreferenceProperties = {
     },
     'editor.unusualLineTerminators': {
         'markdownEnumDescriptions': [
-            nls.localize('unusualLineTerminators.auto', 'Unusual line terminators are automatically removed.'),
-            nls.localize('unusualLineTerminators.off', 'Unusual line terminators are ignored.'),
-            nls.localize('unusualLineTerminators.prompt', 'Unusual line terminators prompt to be removed.')
+            nls.localizeByDefault('Unusual line terminators are automatically removed.'),
+            nls.localizeByDefault('Unusual line terminators are ignored.'),
+            nls.localizeByDefault('Unusual line terminators prompt to be removed.')
         ],
         'description': nls.localizeByDefault('Remove unusual line terminators that might cause problems.'),
         'type': 'string',

--- a/packages/external-terminal/src/electron-browser/external-terminal-preference.ts
+++ b/packages/external-terminal/src/electron-browser/external-terminal-preference.ts
@@ -92,7 +92,7 @@ export async function getExternalTerminalSchema(externalTerminalService: Externa
             },
             'terminal.external.osxExec': {
                 type: 'string',
-                description: nls.localizeByDefault('Customizes which terminal to run on macOS.'),
+                description: nls.localizeByDefault('Customizes which terminal application to run on macOS.'),
                 default: `${isOSX ? hostExec : 'Terminal.app'}`
             },
             'terminal.external.linuxExec': {

--- a/packages/file-search/src/browser/quick-file-open.ts
+++ b/packages/file-search/src/browser/quick-file-open.ts
@@ -19,7 +19,7 @@ import { OpenerService, KeybindingRegistry, QuickAccessRegistry, QuickAccessProv
 import { WorkspaceService } from '@theia/workspace/lib/browser/workspace-service';
 import URI from '@theia/core/lib/common/uri';
 import { FileSearchService, WHITESPACE_QUERY_SEPARATOR } from '../common/file-search-service';
-import { CancellationToken, Command, MAX_SAFE_INTEGER } from '@theia/core/lib/common';
+import { CancellationToken, Command, nls, MAX_SAFE_INTEGER } from '@theia/core/lib/common';
 import { LabelProvider } from '@theia/core/lib/browser/label-provider';
 import { NavigationLocationService } from '@theia/editor/lib/browser/navigation/navigation-location-service';
 import * as fuzzy from '@theia/core/shared/fuzzy';
@@ -328,10 +328,10 @@ export class QuickFileOpenService implements QuickAccessProvider {
     }
 
     private getPlaceHolder(): string {
-        let placeholder = 'File name to search (append : to go to line).';
+        let placeholder = nls.localizeByDefault('Search files by name (append {0} to go to line or {1} to go to symbol)', ':', '@');
         const keybinding = this.getKeyCommand();
         if (keybinding) {
-            placeholder += ` (Press ${keybinding} to show/hide ignored files)`;
+            placeholder += nls.localize('theia/file-search/toggleIgnoredFiles', ' (Press {0} to show/hide ignored files)', keybinding);
         }
         return placeholder;
     }

--- a/packages/filesystem/src/browser/file-upload-service.ts
+++ b/packages/filesystem/src/browser/file-upload-service.ts
@@ -245,9 +245,9 @@ export class FileUploadService {
 
     protected async confirmOverwrite(fileUri: URI): Promise<boolean> {
         const dialog = new ConfirmDialog({
-            title: nls.localizeByDefault('Replace file'),
-            msg: nls.localizeByDefault('File "{0}" already exists in the destination folder. Do you want to replace it?', fileUri.path.base),
-            ok: nls.localizeByDefault('Replace file'),
+            title: nls.localizeByDefault('Replace'),
+            msg: nls.localizeByDefault("A file or folder with the name '{0}' already exists in the destination folder. Do you want to replace it?", fileUri.path.base),
+            ok: nls.localizeByDefault('Replace'),
             cancel: Dialog.CANCEL
         });
         return !!await dialog.open();

--- a/packages/getting-started/src/browser/getting-started-widget.tsx
+++ b/packages/getting-started/src/browser/getting-started-widget.tsx
@@ -245,7 +245,7 @@ export class GettingStartedWidget extends ReactWidget {
             <h3 className='gs-section-header'>
                 <i className={codicon('history')}></i>{nls.localizeByDefault('Recent')}
             </h3>
-            {items.length > 0 ? content : <p className='gs-no-recent'>{nls.localizeByDefault('No Recent Workspaces')}</p>}
+            {items.length > 0 ? content : <p className='gs-no-recent'>{nls.localizeByDefault('No recent folders')}</p>}
             {more}
         </div>;
     }

--- a/packages/git/src/browser/git-contribution.ts
+++ b/packages/git/src/browser/git-contribution.ts
@@ -897,7 +897,7 @@ export class GitContribution implements CommandContribution, MenuContribution, T
         } catch (e) {
             scmRepository.input.issue = {
                 type: ScmInputIssueType.Warning,
-                message: nls.localizeByDefault('Make sure you configure your \'user.name\' and \'user.email\' in git.')
+                message: nls.localize('theia/git/missingUserInfo', 'Make sure you configure your \'user.name\' and \'user.email\' in git.')
             };
         }
 

--- a/packages/git/src/common/git-model.ts
+++ b/packages/git/src/common/git-model.ts
@@ -108,6 +108,7 @@ export namespace GitFileStatus {
             case GitFileStatus.New: return !!staged ? nls.localize('theia/git/added', 'Added') : nls.localize('theia/git/unstaged', 'Unstaged');
             case GitFileStatus.Renamed: return nls.localize('theia/git/renamed', 'Renamed');
             case GitFileStatus.Copied: return nls.localize('theia/git/copied', 'Copied');
+            // eslint-disable-next-line @theia/localization-check
             case GitFileStatus.Modified: return nls.localize('vscode.git/repository/modified', 'Modified');
             case GitFileStatus.Deleted: return nls.localize('vscode.git/repository/deleted', 'Deleted');
             case GitFileStatus.Conflicted: return nls.localize('theia/git/conflicted', 'Conflicted');

--- a/packages/outline-view/src/browser/outline-view-widget.tsx
+++ b/packages/outline-view/src/browser/outline-view-widget.tsx
@@ -180,7 +180,7 @@ export class OutlineViewWidget extends TreeWidget {
 
     protected renderTree(model: TreeModel): React.ReactNode {
         if (CompositeTreeNode.is(this.model.root) && !this.model.root.children.length) {
-            return <div className='theia-widget-noInfo no-outline'>{nls.localizeByDefault('No outline information available.')}</div>;
+            return <div className='theia-widget-noInfo no-outline'>{nls.localizeByDefault('The active editor cannot provide outline information.')}</div>;
         }
         return super.renderTree(model);
     }

--- a/packages/plugin-ext/src/hosted/node/scanners/scanner-theia.ts
+++ b/packages/plugin-ext/src/hosted/node/scanners/scanner-theia.ts
@@ -14,6 +14,8 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
+/* eslint-disable @theia/localization-check */
+
 import { inject, injectable } from '@theia/core/shared/inversify';
 import {
     AutoClosingPair,

--- a/packages/plugin-ext/src/main/browser/authentication-main.ts
+++ b/packages/plugin-ext/src/main/browser/authentication-main.ts
@@ -210,7 +210,7 @@ export class AuthenticationMainImpl implements AuthenticationMain {
 
     protected async loginPrompt(providerName: string, extensionName: string, recreatingSession: boolean, _detail?: string): Promise<boolean> {
         const message = recreatingSession
-            ? nls.localizeByDefault("The extension '{0}' wants you to sign in again using {1}.", extensionName, providerName)
+            ? nls.localize('theia/plugin-ext/signInAgain', "The extension '{0}' wants you to sign in again using {1}.", extensionName, providerName)
             : nls.localizeByDefault("The extension '{0}' wants to sign in using {1}.", extensionName, providerName);
         const choice = await this.messageService.info(message, 'Allow', 'Cancel');
         return choice === 'Allow';
@@ -306,9 +306,9 @@ export class AuthenticationProviderImpl implements AuthenticationProvider {
         const accountUsages = await readAccountUsages(this.storageService, this.id, accountName);
         const sessionsForAccount = this.accounts.get(accountName);
         const result = await this.messageService.info(accountUsages.length
-            ? nls.localizeByDefault("The account '{0}' has been used by: \n\n{1}\n\n Sign out from these extensions?", accountName,
+            ? nls.localizeByDefault('The account {0} has been used by: \n\n{1}\n\n Sign out of these features?', accountName,
                 accountUsages.map(usage => usage.extensionName).join(', '))
-            : nls.localizeByDefault("Sign out of '{0}'?", accountName),
+            : nls.localizeByDefault('Sign out of {0}?', accountName),
             nls.localizeByDefault('Sign Out'),
             Dialog.CANCEL);
 

--- a/packages/preferences/src/browser/preference-transaction-manager.ts
+++ b/packages/preferences/src/browser/preference-transaction-manager.ts
@@ -190,6 +190,7 @@ export class PreferenceTransaction extends Transaction<[string, string[], unknow
         const saveAndRetry = nls.localizeByDefault('Save and Retry');
         const open = nls.localizeByDefault('Open File');
         const msg = await this.messageService.error(
+            // eslint-disable-next-line @theia/localization-check
             nls.localizeByDefault('Unable to write into {0} settings because the file has unsaved changes. Please save the {0} settings file first and then try again.',
                 nls.localizeByDefault(PreferenceScope[this.context.getScope()].toLocaleLowerCase())
             ),

--- a/packages/property-view/src/browser/resource-property-view/resource-property-view-tree-widget.tsx
+++ b/packages/property-view/src/browser/resource-property-view/resource-property-view-tree-widget.tsx
@@ -97,12 +97,12 @@ export class ResourcePropertyViewTreeWidget extends TreeWidget implements Proper
             this.propertiesTree.set('info', infoNode);
 
             infoNode.children.push(this.createResultLineNode('isDirectory', nls.localize('theia/property-view/directory', 'Directory'), fileStatObject.isDirectory, infoNode));
-            infoNode.children.push(this.createResultLineNode('isFile', nls.localize('theia/property-view/file', 'File'), fileStatObject.isFile, infoNode));
+            infoNode.children.push(this.createResultLineNode('isFile', nls.localizeByDefault('File'), fileStatObject.isFile, infoNode));
             infoNode.children.push(this.createResultLineNode('isSymbolicLink', nls.localize('theia/property-view/symbolicLink', 'Symbolic link'),
                 fileStatObject.isSymbolicLink, infoNode));
             infoNode.children.push(this.createResultLineNode('location', nls.localize('theia/property-view/location', 'Location'),
                 this.getLocationString(fileStatObject), infoNode));
-            infoNode.children.push(this.createResultLineNode('name', nls.localize('theia/property-view/name', 'Name'), this.getFileName(fileStatObject), infoNode));
+            infoNode.children.push(this.createResultLineNode('name', nls.localizeByDefault('Name'), this.getFileName(fileStatObject), infoNode));
             infoNode.children.push(this.createResultLineNode('path', nls.localize('theia/property-view/path', 'Path'), this.getFilePath(fileStatObject), infoNode));
             infoNode.children.push(this.createResultLineNode('lastModification', nls.localize('theia/property-view/lastModified', 'Last modified'),
                 this.getLastModificationString(fileStatObject), infoNode));
@@ -134,7 +134,7 @@ export class ResourcePropertyViewTreeWidget extends TreeWidget implements Proper
     }
 
     protected getSizeString(fileStat: FileStat): string {
-        return fileStat.size ? nls.localizeByDefault('{0} B', fileStat.size.toString()) : '';
+        return fileStat.size ? nls.localizeByDefault('{0}B', fileStat.size.toString()) : '';
     }
 
     /*

--- a/packages/scm-extra/src/browser/history/scm-history-widget.tsx
+++ b/packages/scm-extra/src/browser/history/scm-history-widget.tsx
@@ -264,7 +264,7 @@ export class ScmHistoryWidget extends ScmNavigableListWidget<ScmHistoryListNode>
         } else {
             this.status = {
                 state: 'error',
-                errorMessage: <React.Fragment>{nls.localizeByDefault('There is no repository selected in this workspace.')}</React.Fragment>
+                errorMessage: <React.Fragment>{nls.localizeByDefault('No source control providers registered.')}</React.Fragment>
             };
         }
     }

--- a/packages/search-in-workspace/src/browser/search-in-workspace-factory.ts
+++ b/packages/search-in-workspace/src/browser/search-in-workspace-factory.ts
@@ -23,10 +23,11 @@ import {
     WidgetManager
 } from '@theia/core/lib/browser';
 import { SearchInWorkspaceWidget } from './search-in-workspace-widget';
+import { nls } from '@theia/core/lib/common/nls';
 
 export const SEARCH_VIEW_CONTAINER_ID = 'search-view-container';
 export const SEARCH_VIEW_CONTAINER_TITLE_OPTIONS: ViewContainerTitleOptions = {
-    label: 'Search',
+    label: nls.localizeByDefault('Search'),
     iconClass: codicon('search'),
     closeable: true
 };

--- a/packages/search-in-workspace/src/browser/search-in-workspace-frontend-contribution.ts
+++ b/packages/search-in-workspace/src/browser/search-in-workspace-frontend-contribution.ts
@@ -50,10 +50,10 @@ export namespace SearchInWorkspaceCommands {
         category: SEARCH_CATEGORY,
         label: 'Replace in Files'
     });
-    export const FIND_IN_FOLDER = Command.toLocalizedCommand({
+    export const FIND_IN_FOLDER = Command.toDefaultLocalizedCommand({
         id: 'search-in-workspace.in-folder',
         category: SEARCH_CATEGORY,
-        label: 'Find in Folder'
+        label: 'Find in Folder...'
     });
     export const REFRESH_RESULTS = Command.toDefaultLocalizedCommand({
         id: 'search-in-workspace.refresh',

--- a/packages/search-in-workspace/src/browser/search-in-workspace-result-tree-widget.tsx
+++ b/packages/search-in-workspace/src/browser/search-in-workspace-result-tree-widget.tsx
@@ -125,7 +125,7 @@ export class SearchInWorkspaceResultTreeWidget extends TreeWidget {
     protected readonly toDisposeOnActiveEditorChanged = new DisposableCollection();
 
     // The default root name to add external search results in the case that a workspace is opened.
-    protected readonly defaultRootName = nls.localize('theia/searchResultsView/searchFolderMatch.other.label', 'Other files');
+    protected readonly defaultRootName = nls.localizeByDefault('Other files');
     protected forceVisibleRootNode = false;
 
     protected appliedDecorations = new Map<string, string[]>();

--- a/packages/search-in-workspace/src/browser/search-in-workspace-widget.tsx
+++ b/packages/search-in-workspace/src/browser/search-in-workspace-widget.tsx
@@ -686,7 +686,7 @@ export class SearchInWorkspaceWidget extends BaseWidget implements StatefulWidge
                 message = nls.localizeByDefault("No results found excluding '{0}' - ",
                     this.searchInWorkspaceOptions.exclude!.toString());
             } else {
-                message = nls.localizeByDefault('No results found. - ');
+                message = nls.localizeByDefault('No results found') + ' - ';
             }
             // We have to trim here as vscode will always add a trailing " - " string
             return message.substring(0, message.length - 2).trim();

--- a/packages/terminal/src/browser/terminal-preferences.ts
+++ b/packages/terminal/src/browser/terminal-preferences.ts
@@ -143,12 +143,13 @@ export const TerminalConfigSchema: PreferenceSchema = {
         },
         'terminal.integrated.confirmOnExit': {
             type: 'string',
-            description: nls.localizeByDefault('Controls whether to confirm when the window closes if there are active terminal sessions'),
+            // nls-todo: Will be included by default in VSCode version 1.58.0
+            description: nls.localize('theia/terminal/confirmClose', 'Controls whether to confirm when the window closes if there are active terminal sessions.'),
             enum: ['never', 'always', 'hasChildProcesses'],
             enumDescriptions: [
-                nls.localizeByDefault('Never confirm.'),
-                nls.localizeByDefault('Always confirm if there are terminals.'),
-                nls.localizeByDefault('Confirm if there are any terminals that have child processes.'),
+                nls.localize('theia/terminal/confirmCloseNever', 'Never confirm.'),
+                nls.localize('theia/terminal/confirmCloseAlways', 'Always confirm if there are terminals.'),
+                nls.localize('theia/terminal/confirmCloseChildren', 'Confirm if there are any terminals that have child processes.'),
             ],
             default: 'never'
         }

--- a/packages/vsx-registry/src/browser/vsx-extension-commands.ts
+++ b/packages/vsx-registry/src/browser/vsx-extension-commands.ts
@@ -33,8 +33,8 @@ export namespace VSXExtensionsCommands {
         category: nls.localizeByDefault(EXTENSIONS_CATEGORY),
         originalCategory: EXTENSIONS_CATEGORY,
         originalLabel: 'Install from VSIX...',
-        label: nls.localize('theia/vsx-registry/installFromVSIX', 'Install from VSIX') + '...',
-        dialogLabel: nls.localize('theia/vsx-registry/installFromVSIX', 'Install from VSIX')
+        label: nls.localizeByDefault('Install from VSIX') + '...',
+        dialogLabel: nls.localizeByDefault('Install from VSIX')
     };
     export const COPY: Command = {
         id: 'vsxExtensions.copy'

--- a/packages/workspace/src/browser/workspace-commands.ts
+++ b/packages/workspace/src/browser/workspace-commands.ts
@@ -421,21 +421,21 @@ export class WorkspaceCommandContribution implements CommandContribution {
         }
         // do not allow recursive rename
         if (!allowNested && !validFilename(name)) {
-            return nls.localizeByDefault('Invalid file or folder name');
+            return nls.localizeByDefault('The name **{0}** is not valid as a file or folder name. Please choose a different name.');
         }
         if (name.startsWith('/')) {
-            return nls.localizeByDefault('Absolute paths or names that starts with / are not allowed');
+            return nls.localizeByDefault('A file or folder name cannot start with a slash.');
         } else if (name.startsWith(' ') || name.endsWith(' ')) {
-            return nls.localizeByDefault('Names with leading or trailing whitespaces are not allowed');
+            return nls.localizeByDefault('Leading or trailing whitespace detected in file or folder name.');
         }
         // check and validate each sub-paths
         if (name.split(/[\\/]/).some(file => !file || !validFilename(file) || /^\s+$/.test(file))) {
-            return nls.localizeByDefault('The name "{0}" is not a valid file or folder name.', this.trimFileName(name));
+            return nls.localizeByDefault('\'{0}\' is not a valid file name', this.trimFileName(name));
         }
         const childUri = parent.resource.resolve(name);
         const exists = await this.fileService.exists(childUri);
         if (exists) {
-            return nls.localizeByDefault('A file or folder "{0}" already exists at this location.', this.trimFileName(name));
+            return nls.localizeByDefault('A file or folder **{0}** already exists at this location. Please choose a different name.', this.trimFileName(name));
         }
         return '';
     }

--- a/packages/workspace/src/browser/workspace-frontend-contribution.ts
+++ b/packages/workspace/src/browser/workspace-frontend-contribution.ts
@@ -568,7 +568,7 @@ export class WorkspaceFrontendContribution implements CommandContribution, Keybi
         // Prompt users for confirmation before overwriting.
         const confirmed = await new ConfirmDialog({
             title: nls.localizeByDefault('Overwrite'),
-            msg: nls.localizeByDefault('Do you really want to overwrite "{0}"?', uri.toString())
+            msg: nls.localizeByDefault('{0} already exists. Are you sure you want to overwrite it?', uri.toString())
         }).open();
         return !!confirmed;
     }

--- a/packages/workspace/src/browser/workspace-trust-preferences.ts
+++ b/packages/workspace/src/browser/workspace-trust-preferences.ts
@@ -39,7 +39,8 @@ export const workspaceTrustPreferenceSchema: PreferenceSchema = {
             defaultValue: true
         },
         [WORKSPACE_TRUST_STARTUP_PROMPT]: {
-            description: nls.localizeByDefault('Controls when the startup prompt to trust a workspace is shown.'),
+            // nls-todo: This string will be available in vscode starting from API version 1.57.0
+            description: nls.localize('theia/workspace/trustPrompt', 'Controls when the startup prompt to trust a workspace is shown.'),
             enum: Object.values(WorkspaceTrustPrompt),
             defaultValue: WorkspaceTrustPrompt.ALWAYS
         },

--- a/yarn.lock
+++ b/yarn.lock
@@ -6995,6 +6995,11 @@ jpeg-js@^0.4.2:
   resolved "https://registry.yarnpkg.com/jpeg-js/-/jpeg-js-0.4.3.tgz#6158e09f1983ad773813704be80680550eff977b"
   integrity sha512-ru1HWKek8octvUHFHvE5ZzQ1yAsJmIvRdGWvSoKV52XKyuyYA437QWDttXT8eZXDSbuMpHlLzPDZUPd6idIz+Q==
 
+js-levenshtein@^1.1.6:
+  version "1.1.6"
+  resolved "https://registry.yarnpkg.com/js-levenshtein/-/js-levenshtein-1.1.6.tgz#c6cee58eb3550372df8deb85fad5ce66ce01d59d"
+  integrity sha512-X2BB11YZtrRqY4EnQcLX5Rh373zbK4alC1FW7D7MBhL2gtcC17cTnr6DmfHZeS0s2rTHjUTMMHfG7gO8SSdw+g==
+
 "js-tokens@^3.0.0 || ^4.0.0", js-tokens@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"


### PR DESCRIPTION
#### What it does

Adds a new eslint rule that helps developers of Theia to correctly localize the application:

1. Flags calls to `nls.localizeByDefault` which use a default value which does not exist inside of the `nls.metadata.json` file. Once such a call is detected, the rule tries to find the best fitting existing default value using the levenshtein distance.
2. Flags calls to `nls.localize` which could be replaced by `nls.localizeByDefault`.

#### How to test

1. Assert that `yarn lint` does not yield any errors (CI is green)
2. Changing the default value of an existing `localizeByDefault` call slightly should lead to an eslint error and a quickfix is provided.
3. Changing an existing `localizeByDefault(default)` call to `localize(key, default)` should lead to an eslint error and a quickfix is provided here as well.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
