### PR TITLE
Always show plugin notification regardless of options

### DIFF
--- a/packages/plugin-ext/src/plugin/message-registry.ts
+++ b/packages/plugin-ext/src/plugin/message-registry.ts
@@ -55,12 +55,11 @@ export class MessageRegistryExt {
                     }
                 }
             }
-            for (const item of rest) {
-                pushItem(item);
-            }
-            const actionHandle = await this.proxy.$showMessage(type, message, options, actions);
-            return actionHandle !== undefined ? items[actionHandle] : undefined;
         }
-
+        for (const item of rest) {
+            pushItem(item);
+        }
+        const actionHandle = await this.proxy.$showMessage(type, message, options, actions);
+        return actionHandle !== undefined ? items[actionHandle] : undefined;
     }
 }


### PR DESCRIPTION
#### What it does

Closes #10398
Fixes an issue introduced in #10245 

Always shows notifications/dialogs regardless of whether any options or items exist. As notifications don't have options or items, they were previously not shown.

#### How to test

1. Download and install the [notification extension](https://github.com/vince-fugnitto/message-tests/releases/download/1.0.0/message-tests-0.0.1.vsix).
2. Run the `Message: Show Message` command and assert that it works correctly.
3. Run the `Message: Show Modal Message` command and assert that it continues to work correctly.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
