### PR TITLE
The Active LTS version of NodeJS does not work

### DIFF
--- a/doc/Developing.md
+++ b/doc/Developing.md
@@ -53,7 +53,7 @@ For Windows instructions [click here](#building-on-windows).
 ## Prerequisites
 
  - Node.js `>= 12.14.1`.
-   - Preferably, **use** Node's [Active LTS version](https://nodejs.org/en/about/releases/).
+   - Preferably, **use** Node's [v12 Maintenance LTS version](https://nodejs.org/en/about/releases/).
    - If you are interested in Theia's VS Code Extension support then you should use a Node version at least compatible with the one included in the version of Electron used by [VS Code](https://github.com/microsoft/vscode).
  - [Yarn package manager](https://yarnpkg.com/en/docs/install)  `>= 1.7.0` **AND** `< 2.x.x`.
  - git (If you would like to use the Git-extension too, you will need to have git version 2.11.0 or higher.)


### PR DESCRIPTION
Standing up the project with the latest Active LTS of NodeJS just doesn't work.  Rolling back through the Maintenance LTS versions I found v12 was the only one that worked.

#### What it does
Corrects documentation for the prerequisites

#### How to test
Create the package.json as described here: https://theia-ide.org/docs/composing_applications#consuming-vs-code-extensions
Using what ever node version manager you use set node to the latest Active LTS and run yarn.
Run `yarn`
Errors ensue and it fails very early.
Switch node to the v12 LTS ([12.22.7 ](https://nodejs.org/download/release/latest-v12.x/) as of this writing).
Run `yarn`
There's still errors, but it gets a lot further and they don't seem related to the version of NodeJS.

