### PR TITLE
search-in-workspace: correct scrollbar display when no results

### DIFF
--- a/packages/search-in-workspace/src/browser/styles/index.css
+++ b/packages/search-in-workspace/src/browser/styles/index.css
@@ -14,8 +14,12 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
- #search-in-workspace {
+#search-in-workspace {
     height: 100%;
+}
+
+#search-in-workspace .theia-TreeContainer.empty {
+    overflow: hidden;
 }
 
 .t-siw-search-container {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->
fix #10289 
Correct unexpect scrollbar display when no results are present.
Make sure the change don't effect issue #9203 

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
* open the search-in-workspace widget
* confirm that no search term is present
* open the replace field (arrow)
* scrolling the empty area
* confirm no scrollbar show up
* input something in the search field
* confirm search and replace result listed correct
* drag and drop sections between views, confirm it works well in different Theia versions


#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
