### PR TITLE
search-in-workspace: allow search to follow symlinks

### DIFF
--- a/packages/search-in-workspace/src/browser/search-in-workspace-preferences.ts
+++ b/packages/search-in-workspace/src/browser/search-in-workspace-preferences.ts
@@ -53,6 +53,11 @@ export const searchInWorkspacePreferencesSchema: PreferenceSchema = {
             description: nls.localizeByDefault('Search case-insensitively if the pattern is all lowercase, otherwise, search case-sensitively.'),
             default: false,
             type: 'boolean',
+        },
+        'search.followSymlinks': {
+            description: nls.localizeByDefault('Controls whether to follow symlinks while searching.'),
+            default: true,
+            type: 'boolean',
         }
     }
 };
@@ -64,6 +69,7 @@ export class SearchInWorkspaceConfiguration {
     'search.searchOnTypeDebouncePeriod': number;
     'search.searchOnEditorModification': boolean;
     'search.smartCase': boolean;
+    'search.followSymlinks': boolean;
 }
 
 export const SearchInWorkspacePreferenceContribution = Symbol('SearchInWorkspacePreferenceContribution');

--- a/packages/search-in-workspace/src/browser/search-in-workspace-widget.tsx
+++ b/packages/search-in-workspace/src/browser/search-in-workspace-widget.tsx
@@ -452,9 +452,14 @@ export class SearchInWorkspaceWidget extends BaseWidget implements StatefulWidge
     protected performSearch(): void {
         const searchOptions: SearchInWorkspaceOptions = {
             ...this.searchInWorkspaceOptions,
+            followSymlinks: this.shouldFollowSymlinks(),
             matchCase: this.shouldMatchCase()
         };
         this.resultTreeWidget.search(this.searchTerm, searchOptions);
+    }
+
+    protected shouldFollowSymlinks(): boolean {
+        return this.searchInWorkspacePreferences['search.followSymlinks'];
     }
 
     /**

--- a/packages/search-in-workspace/src/common/search-in-workspace-interface.ts
+++ b/packages/search-in-workspace/src/common/search-in-workspace-interface.ts
@@ -53,6 +53,10 @@ export interface SearchInWorkspaceOptions {
      * Glob pattern for matching files and directories to exclude the search.
      */
     exclude?: string[];
+    /**
+     * Whether symlinks should be followed while searching.
+     */
+    followSymlinks?: boolean;
 }
 
 export interface SearchInWorkspaceResult {

--- a/packages/search-in-workspace/src/node/ripgrep-search-in-workspace-server.ts
+++ b/packages/search-in-workspace/src/node/ripgrep-search-in-workspace-server.ts
@@ -124,6 +124,10 @@ export class RipgrepSearchInWorkspaceServer implements SearchInWorkspaceServer {
             this.addGlobArgs(args, options.exclude, true);
         }
 
+        if (options?.followSymlinks) {
+            args.add('--follow');
+        }
+
         if (options?.useRegExp || options?.matchWholeWord) {
             args.add('--regexp');
         } else {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
Fixes #10390
This commit provides the user to enable a preference to follow symlinks while searching using the `Follow Symlinks` preference, similar to that of vscode. 
<!-- Include relevant issues and describe how they are addressed. -->

#### How to test
- Have a symbolic linked file within a folder
- Open either the electron app or browser and select the folder with the symlinked file as a workspace
- Access `Preferences` and make sure that `Follow Symlinks` is enabled
- Search text within the file in the search widget and make sure results are given
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

#### Review checklist

- [X] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
