### PR TITLE
vsx-registry: display incompatible extensions

### DIFF
--- a/packages/vsx-registry/src/browser/style/index.css
+++ b/packages/vsx-registry/src/browser/style/index.css
@@ -28,6 +28,11 @@
     min-height: calc(var(--theia-content-line-height)*3)
 }
 
+.theia-vsx-extension.incompatible {
+    opacity: 0.6;
+    cursor: default;
+}
+
 .theia-vsx-extensions-search-bar {
     padding: var(--theia-ui-padding) var(--theia-scrollbar-width) var(--theia-ui-padding) 18px /* expansion toggle padding of tree elements in result list */;
     display: flex;

--- a/packages/vsx-registry/src/browser/vsx-extension-preferences.ts
+++ b/packages/vsx-registry/src/browser/vsx-extension-preferences.ts
@@ -1,0 +1,51 @@
+/********************************************************************************
+ * Copyright (C) 2021 Ericsson and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import { interfaces } from '@theia/core/shared/inversify';
+import { createPreferenceProxy, PreferenceProxy, PreferenceService, PreferenceContribution, PreferenceSchema } from '@theia/core/lib/browser';
+
+export const VSXExtensionConfigSchema: PreferenceSchema = {
+    'type': 'object',
+    properties: {
+        'extensions.displayIncompatible': {
+            type: 'boolean',
+            description: 'Controls whether to display incompatible extensions when searching.',
+            default: true
+        }
+    }
+};
+
+export interface VSXExtensionConfiguration {
+    'extensions.displayIncompatible': boolean;
+}
+
+export const VSXExtensionPreferenceContribution = Symbol('VSXExtensionPreferenceContribution');
+export const VSXExtensionPreferences = Symbol('VSXExtensionPreferences');
+export type VSXExtensionPreferences = PreferenceProxy<VSXExtensionConfiguration>;
+
+export function createVSXExtensionPreferences(preferences: PreferenceService, schema: PreferenceSchema = VSXExtensionConfigSchema): VSXExtensionPreferences {
+    return createPreferenceProxy(preferences, schema);
+}
+
+export function bindVSXExtensionPreferences(bind: interfaces.Bind): void {
+    bind(VSXExtensionPreferences).toDynamicValue(ctx => {
+        const preferences = ctx.container.get<PreferenceService>(PreferenceService);
+        const contribution = ctx.container.get<PreferenceContribution>(VSXExtensionPreferenceContribution);
+        return createVSXExtensionPreferences(preferences, contribution.schema);
+    }).inSingletonScope();
+    bind(VSXExtensionPreferenceContribution).toConstantValue({ schema: VSXExtensionConfigSchema });
+    bind(PreferenceContribution).toService(VSXExtensionPreferenceContribution);
+}

--- a/packages/vsx-registry/src/browser/vsx-extension-preferences.ts
+++ b/packages/vsx-registry/src/browser/vsx-extension-preferences.ts
@@ -16,13 +16,14 @@
 
 import { interfaces } from '@theia/core/shared/inversify';
 import { createPreferenceProxy, PreferenceProxy, PreferenceService, PreferenceContribution, PreferenceSchema } from '@theia/core/lib/browser';
+import { nls } from '@theia/core';
 
 export const VSXExtensionConfigSchema: PreferenceSchema = {
     'type': 'object',
     properties: {
         'extensions.displayIncompatible': {
             type: 'boolean',
-            description: 'Controls whether to display incompatible extensions when searching.',
+            description: nls.localize('theia/vsx-registry/displayIncompatible', 'Controls whether to display incompatible extensions when searching.'),
             default: true
         }
     }

--- a/packages/vsx-registry/src/browser/vsx-extension.tsx
+++ b/packages/vsx-registry/src/browser/vsx-extension.tsx
@@ -28,7 +28,7 @@ import { ProgressService } from '@theia/core/lib/common/progress-service';
 import { Endpoint } from '@theia/core/lib/browser/endpoint';
 import { VSXEnvironment } from '../common/vsx-environment';
 import { VSXExtensionsSearchModel } from './vsx-extensions-search-model';
-import { MenuPath } from '@theia/core/lib/common';
+import { MenuPath, nls } from '@theia/core/lib/common';
 import { codicon, ContextMenuRenderer, TooltipService } from '@theia/core/lib/browser';
 import { VSXExtensionNamespaceAccess, VSXUser } from '@theia/ovsx-client/lib/ovsx-types';
 
@@ -265,7 +265,10 @@ export class VSXExtension implements VSXExtensionData, TreeElement {
     }
 
     get tooltip(): string {
-        let md = `__${this.displayName}__ ${this.version !== undefined ? this.version : 'No Compatible Version'}\n\n${this.description}\n_____\n\nPublisher: ${this.publisher}`;
+        const version = this.version !== undefined
+            ? this.version
+            : nls.localize('theia/vsx-registry/noCompatibleVersion', 'No Compatible Version');
+        let md = `__${this.displayName}__ ${version}\n\n${this.description}\n_____\n\nPublisher: ${this.publisher}`;
 
         if (this.license) {
             md += `  \rLicense: ${this.license}`;
@@ -422,6 +425,9 @@ const downloadCompactFormatter = new Intl.NumberFormat(undefined, { notation: 'c
 export class VSXExtensionComponent extends AbstractVSXExtensionComponent {
     render(): React.ReactNode {
         const { iconUrl, publisher, displayName, description, version, downloadCount, averageRating, tooltipId, tooltip, compatible } = this.props.extension;
+        const extensionVersion = version !== undefined
+            ? version
+            : nls.localize('theia/vsx-registry/noCompatibleVersion', 'No Compatible Version');
 
         return <div className={`theia-vsx-extension noselect ${compatible ? '' : 'incompatible'}`} data-for={tooltipId} data-tip={tooltip}>
             {iconUrl ?
@@ -430,7 +436,7 @@ export class VSXExtensionComponent extends AbstractVSXExtensionComponent {
             <div className='theia-vsx-extension-content'>
                 <div className='title'>
                     <div className='noWrapInfo'>
-                        <span className='name'>{displayName}</span> <span className='version'>{version !== undefined ? version : 'No Compatible Version'}</span>
+                        <span className='name'>{displayName}</span> <span className='version'>{extensionVersion}</span>
                     </div>
                     <div className='stat'>
                         {!!downloadCount && <span className='download-count'><i className={codicon('cloud-download')} />{downloadCompactFormatter.format(downloadCount)}</span>}

--- a/packages/vsx-registry/src/browser/vsx-extension.tsx
+++ b/packages/vsx-registry/src/browser/vsx-extension.tsx
@@ -398,16 +398,20 @@ export abstract class AbstractVSXExtensionComponent extends React.Component<Abst
         }
         if (busy) {
             if (installed) {
-                return <button className="theia-button action theia-mod-disabled">Uninstalling</button>;
+                return <button className="theia-button action theia-mod-disabled">{nls.localizeByDefault('Uninstalling')}</button>;
             }
-            return <button className="theia-button action prominent theia-mod-disabled">Installing</button>;
+            return <button className="theia-button action prominent theia-mod-disabled">{nls.localizeByDefault('Installing')}</button>;
         }
         if (installed) {
-            return <div><button className="theia-button action" onClick={this.uninstall}>Uninstall</button>
-                <div className="codicon codicon-settings-gear action" onClick={this.manage}></div></div>;
+            return (
+                <div>
+                    <button className="theia-button action" onClick={this.uninstall}>{nls.localizeByDefault('Uninstall')}</button>
+                    <div className="codicon codicon-settings-gear action" onClick={this.manage}></div>
+                </div>
+            );
         }
         if (compatible) {
-            return <button className="theia-button prominent action" onClick={this.install}>Install</button>;
+            return <button className="theia-button prominent action" onClick={this.install}>{nls.localizeByDefault('Install')}</button>;
         }
     }
 

--- a/packages/vsx-registry/src/browser/vsx-extensions-model.ts
+++ b/packages/vsx-registry/src/browser/vsx-extensions-model.ts
@@ -31,6 +31,7 @@ import { RecommendedExtensions } from './recommended-extensions/recommended-exte
 import URI from '@theia/core/lib/common/uri';
 import { VSXResponseError, VSXSearchParam } from '@theia/ovsx-client/lib/ovsx-types';
 import { OVSXClientProvider } from '../common/ovsx-client-provider';
+import { VSXExtensionPreferences } from './vsx-extension-preferences';
 
 @injectable()
 export class VSXExtensionsModel {
@@ -55,6 +56,9 @@ export class VSXExtensionsModel {
 
     @inject(WorkspaceService)
     protected readonly workspaceService: WorkspaceService;
+
+    @inject(VSXExtensionPreferences)
+    protected vsxPreferences: VSXExtensionPreferences;
 
     @inject(VSXExtensionsSearchModel)
     readonly search: VSXExtensionsSearchModel;
@@ -175,7 +179,7 @@ export class VSXExtensionsModel {
             for (const data of result.extensions) {
                 const id = data.namespace.toLowerCase() + '.' + data.name.toLowerCase();
                 const extension = client.getLatestCompatibleVersion(data);
-                if (!extension) {
+                if (!extension && this.vsxPreferences.get('extensions.displayIncompatible') === false) {
                     continue;
                 }
                 this.setExtension(id).update(Object.assign(data, {
@@ -184,7 +188,7 @@ export class VSXExtensionsModel {
                     iconUrl: data.files.icon,
                     readmeUrl: data.files.readme,
                     licenseUrl: data.files.license,
-                    version: extension.version
+                    version: extension?.version
                 }));
                 searchResult.add(id);
             }

--- a/packages/vsx-registry/src/browser/vsx-registry-frontend-module.ts
+++ b/packages/vsx-registry/src/browser/vsx-registry-frontend-module.ts
@@ -35,6 +35,7 @@ import { bindExtensionPreferences } from './recommended-extensions/recommended-e
 import { bindPreferenceProviderOverrides } from './recommended-extensions/preference-provider-overrides';
 import { OVSXClientProvider, createOVSXClient } from '../common/ovsx-client-provider';
 import { VSXEnvironment, VSX_ENVIRONMENT_PATH } from '../common/vsx-environment';
+import { bindVSXExtensionPreferences } from './vsx-extension-preferences';
 
 export default new ContainerModule((bind, unbind) => {
     bind<OVSXClientProvider>(OVSXClientProvider).toDynamicValue(ctx => {
@@ -105,4 +106,6 @@ export default new ContainerModule((bind, unbind) => {
 
     bindExtensionPreferences(bind);
     bindPreferenceProviderOverrides(bind, unbind);
+
+    bindVSXExtensionPreferences(bind);
 });


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

Fixes: https://github.com/eclipse-theia/theia/issues/9676.

The commit adds the functionality to display incompatible extensions when performing a search. The changes will now display incompatible extensions but mark them as disabled, and non-installable. The behavior is also controllable by a new preference so users can decide if they want the potential extra noise when searching.

_Example: using an api-version of 1.30.0_:

![incompatible-plugins](https://user-images.githubusercontent.com/40359487/142036189-fedcd16e-b253-4921-8d01-34a1d5f5a008.png)


#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

1. start the application
2. open the extensions-view
3. perform a search - if an extension has no compatible version then it should be marked as disabled and non-installable
  3.1. hovering over the disabled extension should correctly display the tooltip
  3.2 the plugin should not resolve, the readme won't be displayed
4. updating the preference `'extensions.displayIncompatible'` and re-searching should not yield incompatible results
5. repeat the steps by starting with `yarn start --vscode-api-version=1.30.0` for additional incompatible results

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

Signed-off-by: vince-fugnitto <vincent.fugnitto@ericsson.com>
