### PR TITLE
Add view container resize sash options

### DIFF
--- a/packages/core/src/browser/common-frontend-contribution.ts
+++ b/packages/core/src/browser/common-frontend-contribution.ts
@@ -1140,6 +1140,7 @@ export class CommonFrontendContribution implements FrontendApplicationContributi
             // if not yet contributed by Monaco, check runtime css variables to learn
             { id: 'selection.background', defaults: { dark: '#217daf', light: '#c0dbf1' }, description: 'Overall border color for focused elements. This color is only used if not overridden by a component.' },
             { id: 'icon.foreground', defaults: { dark: '#C5C5C5', light: '#424242', hc: '#FFFFFF' }, description: 'The default color for icons in the workbench.' },
+            { id: 'sash.hoverBorder', defaults: { dark: '#007acc', light: '#007acc', hc: '#007acc' }, description: 'The hover border color for draggable sashes.' },
 
             // Window border colors should be aligned with https://code.visualstudio.com/api/references/theme-color#window-border
             {

--- a/packages/core/src/browser/core-preferences.ts
+++ b/packages/core/src/browser/core-preferences.ts
@@ -136,6 +136,20 @@ export const corePreferenceSchema: PreferenceSchema = {
             default: isOSX ? 1500 : 500,
             description: nls.localizeByDefault('Controls the delay in milliseconds after which the hover is shown.')
         },
+        'workbench.sash.hoverDelay': {
+            type: 'number',
+            default: 300,
+            minimum: 1,
+            maximum: 2000,
+            description: nls.localizeByDefault('Controls the hover feedback delay in milliseconds of the dragging area in between views/editors.')
+        },
+        'workbench.sash.size': {
+            type: 'number',
+            default: 4,
+            minimum: 1,
+            maximum: 20,
+            description: nls.localizeByDefault('Controls the feedback area size in pixels of the dragging area in between views/editors. Set it to a larger value if needed.')
+        },
     }
 };
 

--- a/packages/core/src/browser/style/view-container.css
+++ b/packages/core/src/browser/style/view-container.css
@@ -38,8 +38,14 @@
 
 .theia-view-container > .p-SplitPanel > .p-SplitPanel-handle:after {
     background-color: var(--theia-sideBarSectionHeader-border);
-    min-height: 2px;
+    min-height: 4px;   /* hard-coded at the moment; value should update when preference changes */
     min-width: 2px
+}
+
+.p-SplitPanel > .p-SplitPanel-handle:hover:after {
+    background-color: var(--theia-sash-hoverBorder);
+    transition-delay: 300ms;   /* hard-coded at the moment; value should update when preference changes */
+    min-width: 4px;     /* hard-coded at the moment; value should update when preference changes */
 }
 
 .theia-view-container > .p-SplitPanel > .p-SplitPanel-handle {


### PR DESCRIPTION
#### What it does

**TODO**: apply the changes when the preference values are upduated

Fix: #10416
- Apply focus to the widget borders when you hover over them
- `sash.hoverDelay` controls the hover feedback delay in milliseconds
- `sash.size` controls the feedback area size in pixels for the dragging area
- Add preference to set `workbench.sash.hoverDelay` (value must in the range of 1 to 2000, default is 300ms)
- Add preference to set `workbench.sash.size` (value must in the range of 1 to 20, default is 4px)

<img width="650" alt="Screen Shot 2021-11-16 at 5 56 07 PM" src="https://user-images.githubusercontent.com/23107734/142084786-9f9c97ce-491f-461c-badb-6805cccf0424.png">



#### How to test
1. Start the application
2. Hover the cursor over the border for different view containers in Theia and drag
3. Search for 'workbench sash' in `Preferences` (File > Preferences > Open Settings (UI) )
4. Update the `sash.hoverDelay` and `sash.size` preferences to valid values
5. Repeat Step 2 and verify that the hover delay and feedback area size for the border/sash are updated successfully

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
