### PR TITLE
Fixed statusbar foreground color in debug mode

### DIFF
--- a/packages/monaco/src/browser/monaco-quick-input-service.ts
+++ b/packages/monaco/src/browser/monaco-quick-input-service.ts
@@ -257,16 +257,8 @@ export class MonacoQuickInputService implements QuickInputService {
                             {
                                 ...evt,
                                 removeItem: () => {
-                                    const index = wrapped.items.indexOf(evt.item);
-                                    if (index !== -1) {
-                                        const filteredItems = wrapped.items.slice();
-                                        const removed = filteredItems.splice(index, 1);
-                                        const activeFilteredItems = wrapped.activeItems.filter(item => item !== removed[0]);
-                                        wrapped.items = filteredItems;
-                                        if (activeFilteredItems) {
-                                            wrapped.activeItems = activeFilteredItems;
-                                        }
-                                    }
+                                    wrapped.items = wrapped.items.filter(item => item !== evt.item);
+                                    wrapped.activeItems = wrapped.activeItems.filter(item => item !== evt.item);
                                 }
                             });
                     }

--- a/packages/workspace/src/browser/quick-open-workspace.ts
+++ b/packages/workspace/src/browser/quick-open-workspace.ts
@@ -90,7 +90,7 @@ export class QuickOpenWorkspace {
         }
         this.quickInputService?.showQuickPick(this.items, {
             placeholder: nls.localize(
-                'vscode/windowActions/openRecentPlaceholder',
+                'theia/workspace/openRecentPlaceholder',
                 'Type the name of the workspace you want to open'),
             onDidTriggerItemButton: async context => {
                 const resource = context.item.resource;


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->
Fixed statusbar foreground color in debug mode of color theme

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
1. open a color theme contribution.
2. set the api of statusbar.debuggingForground to desired color (not black to see difference)
3. generate a vsix from the extention
3. install the above vsix in a theia runnable project 
4. click the setting button -> color theme and select the installed theme
5. run the debug.
expected results: statusbar foreground color changed as declared
prev res: statusbar foreground color did not change as declared
#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
