### PR TITLE
preferences: Render markdown descriptions

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -50,6 +50,7 @@
     "keytar": "7.2.0",
     "lodash.debounce": "^4.0.8",
     "lodash.throttle": "^4.1.1",
+    "markdown-it": "^8.4.0",
     "nsfw": "^2.1.2",
     "p-debounce": "^2.1.0",
     "perfect-scrollbar": "^1.3.0",

--- a/packages/core/src/browser/core-preferences.ts
+++ b/packages/core/src/browser/core-preferences.ts
@@ -58,8 +58,7 @@ export const corePreferenceSchema: PreferenceSchema = {
                 'keyCode',
             ],
             default: 'code',
-            description: nls.localizeByDefault(
-                'Controls the dispatching logic for key presses to use either `code` (recommended) or `keyCode`.')
+            markdownDescription: nls.localizeByDefault('Controls the dispatching logic for key presses to use either `code` (recommended) or `keyCode`.')
         },
         'window.menuBarVisibility': {
             type: 'string',
@@ -89,7 +88,7 @@ export const corePreferenceSchema: PreferenceSchema = {
         'workbench.editor.highlightModifiedTabs': {
             'type': 'boolean',
             // eslint-disable-next-line max-len
-            'description': nls.localizeByDefault('Controls whether a top border is drawn on modified (dirty) editor tabs or not. This value is ignored when `#workbench.editor.showTabs#` is disabled.'),
+            'markdownDescription': nls.localize('theia/core/highlightModifiedTabs', 'Controls whether a top border is drawn on modified (dirty) editor tabs or not.'),
             'default': false
         },
         'workbench.editor.closeOnFileDelete': {

--- a/packages/core/src/browser/index.ts
+++ b/packages/core/src/browser/index.ts
@@ -41,3 +41,4 @@ export * from './core-preferences';
 export * from './view-container';
 export * from './breadcrumbs';
 export * from './tooltip-service';
+export * from './markdown-renderer';

--- a/packages/core/src/browser/markdown-renderer.spec.ts
+++ b/packages/core/src/browser/markdown-renderer.spec.ts
@@ -1,0 +1,78 @@
+/********************************************************************************
+ * Copyright (C) 2021 TypeFox and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import { enableJSDOM } from '../browser/test/jsdom';
+let disableJSDOM = enableJSDOM();
+
+import { expect } from 'chai';
+import * as markdownit from 'markdown-it';
+import { MarkdownRenderer } from './markdown-renderer';
+
+disableJSDOM();
+
+describe('MarkdownRenderer', () => {
+
+    before(() => disableJSDOM = enableJSDOM());
+    after(() => disableJSDOM());
+
+    it('Should render markdown', () => {
+        const markdownRenderer = new MarkdownRenderer();
+        const result = markdownRenderer.renderInline('[title](link)').innerHTML;
+        expect(result).to.be.equal('<a href="link">title</a>');
+    });
+
+    it('Should accept and use custom engine', () => {
+        const engine = markdownit();
+        const originalTextRenderer = engine.renderer.rules.text!;
+        engine.renderer.rules.text = (tokens, idx, options, env, self) => `[${originalTextRenderer(tokens, idx, options, env, self)}]`;
+        const markdownRenderer = new MarkdownRenderer(engine);
+        const result = markdownRenderer.renderInline('text').innerHTML;
+        expect(result).to.be.equal('[text]');
+    });
+
+    it('Should modify rendered markdown in place', () => {
+        const markdownRenderer = new MarkdownRenderer().modify('a', a => {
+            a.href = 'something-else';
+        });
+        const result = markdownRenderer.renderInline('[title](link)').innerHTML;
+        expect(result).to.be.equal('<a href="something-else">title</a>');
+    });
+
+    it('Should modify descendants of children', () => {
+        const markdownRenderer = new MarkdownRenderer().modify('em', em => {
+            const strong = document.createElement('strong');
+            // eslint-disable-next-line no-unsanitized/property
+            strong.innerHTML = em.innerHTML;
+            return strong;
+        });
+        const result = markdownRenderer.render('**bold *bold and italic***').innerHTML;
+        expect(result).to.be.equal('<p><strong>bold <strong>bold and italic</strong></strong></p>\n');
+    });
+
+    it('Should modify descendants of children after previous modification', () => {
+        const markdownRenderer = new MarkdownRenderer().modify('em', em => {
+            const strong = document.createElement('strong');
+            // eslint-disable-next-line no-unsanitized/property
+            strong.innerHTML = em.innerHTML;
+            return strong;
+        }).modify('strong', strong => { // Will pick up both the original and modified strong element
+            const textNode = strong.childNodes.item(0);
+            textNode.textContent = `changed_${textNode.textContent}`;
+        });
+        const result = markdownRenderer.render('**bold *bold and italic***').innerHTML;
+        expect(result).to.be.equal('<p><strong>changed_bold <strong>changed_bold and italic</strong></strong></p>\n');
+    });
+});

--- a/packages/core/src/browser/markdown-renderer.ts
+++ b/packages/core/src/browser/markdown-renderer.ts
@@ -1,0 +1,76 @@
+/********************************************************************************
+ * Copyright (C) 2021 TypeFox and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import * as DOMPurify from 'dompurify';
+import * as markdownit from 'markdown-it';
+
+export class MarkdownRenderer {
+
+    protected engine: markdownit;
+    protected callbacks = new Map<string, ((element: Element) => Element | void)[]>();
+
+    constructor(engine?: markdownit) {
+        this.engine = engine ?? markdownit();
+    }
+
+    /**
+     * Adds a modification callback that is applied to every element with the specified tag after rendering to HTML.
+     *
+     * @param tag The tag that this modification applies to.
+     * @param callback The modification to apply on every selected rendered element. Can either modify the element in place or return a new element.
+     */
+    modify<K extends keyof HTMLElementTagNameMap>(tag: K, callback: (element: HTMLElementTagNameMap[K]) => Element | void): MarkdownRenderer {
+        if (this.callbacks.has(tag)) {
+            this.callbacks.get(tag)!.push(callback);
+        } else {
+            this.callbacks.set(tag, [callback]);
+        }
+        return this;
+    }
+
+    render(markdown: string): HTMLElement {
+        return this.renderInternal(this.engine.render(markdown));
+    }
+
+    renderInline(markdown: string): HTMLElement {
+        return this.renderInternal(this.engine.renderInline(markdown));
+    }
+
+    protected renderInternal(renderedHtml: string): HTMLElement {
+        const div = this.sanitizeHtml(renderedHtml);
+        for (const [tag, calls] of this.callbacks) {
+            for (const callback of calls) {
+                const elements = Array.from(div.getElementsByTagName(tag));
+                for (const element of elements) {
+                    const result = callback(element);
+                    if (result) {
+                        const parent = element.parentElement;
+                        if (parent) {
+                            parent.replaceChild(result, element);
+                        }
+                    }
+                }
+            }
+        }
+        return div;
+    }
+
+    protected sanitizeHtml(html: string): HTMLElement {
+        const div = document.createElement('div');
+        div.innerHTML = DOMPurify.sanitize(html);
+        return div;
+    }
+}

--- a/packages/editor/src/browser/editor-preferences.ts
+++ b/packages/editor/src/browser/editor-preferences.ts
@@ -122,7 +122,7 @@ const codeEditorPreferenceProperties = {
     },
     'editor.semanticHighlighting.enabled': {
         'enum': [true, false, 'configuredByTheme'],
-        'enumDescriptions': [
+        'markdownEnumDescriptions': [
             nls.localizeByDefault('Semantic highlighting enabled for all color themes.'),
             nls.localizeByDefault('Semantic highlighting disabled for all color themes.'),
             nls.localizeByDefault('Semantic highlighting is configured by the current color theme\'s `semanticHighlighting` setting.')
@@ -327,7 +327,7 @@ const codeEditorPreferenceProperties = {
         'default': 0,
         'minimum': 0,
         'maximum': 100,
-        'description': nls.localizeByDefault('Controls the font size in pixels for CodeLens. When set to `0`, the 90% of `#editor.fontSize#` is used.')
+        'markdownDescription': nls.localizeByDefault('Controls the font size in pixels for CodeLens. When set to `0`, the 90% of `#editor.fontSize#` is used.')
     },
     'editor.colorDecorators': {
         'description': nls.localizeByDefault('Controls whether the editor should render the inline color decorators and color picker.'),
@@ -392,11 +392,11 @@ const codeEditorPreferenceProperties = {
         'maximum': 1073741824
     },
     'editor.cursorSurroundingLinesStyle': {
-        'enumDescriptions': [
+        'markdownEnumDescriptions': [
             nls.localizeByDefault('`cursorSurroundingLines` is enforced only when triggered via the keyboard or API.'),
             nls.localizeByDefault('`cursorSurroundingLines` is enforced always.')
         ],
-        'description': nls.localizeByDefault('Controls when `cursorSurroundingLines` should be enforced.'),
+        'markdownDescription': nls.localizeByDefault('Controls when `cursorSurroundingLines` should be enforced.'),
         'type': 'string',
         'enum': [
             'default',
@@ -1111,7 +1111,7 @@ const codeEditorPreferenceProperties = {
     'editor.inlineHints.fontSize': {
         'type': 'number',
         'default': EDITOR_FONT_DEFAULTS.fontSize,
-        description: nls.localizeByDefault('Controls font size of inline hints in the editor. When set to `0`, the 90% of `#editor.fontSize#` is used.')
+        markdownDescription: nls.localizeByDefault('Controls font size of inline hints in the editor. When set to `0`, the 90% of `#editor.fontSize#` is used.')
     },
     'editor.inlineHints.fontFamily': {
         'type': 'string',
@@ -1173,7 +1173,7 @@ const codeEditorPreferenceProperties = {
     'editor.suggest.insertHighlight': {
         'type': 'boolean',
         'default': false,
-        'description': nls.localize('theia/editor/suggest.insertHighlight', 'Controls whether unexpected text modifications while accepting completions should be highlighted, e.g `insertMode` is `replace` but the completion only supports `insert`.')
+        'markdownDescription': nls.localize('theia/editor/suggest.insertHighlight', 'Controls whether unexpected text modifications while accepting completions should be highlighted, e.g `insertMode` is `replace` but the completion only supports `insert`.')
     },
     'editor.suggest.filterGraceful': {
         'type': 'boolean',

--- a/packages/filesystem/src/browser/filesystem-preferences.ts
+++ b/packages/filesystem/src/browser/filesystem-preferences.ts
@@ -55,7 +55,7 @@ export const filesystemPreferenceSchema: PreferenceSchema = {
             type: 'object',
             default: { '**/.git': true, '**/.svn': true, '**/.hg': true, '**/CVS': true, '**/.DS_Store': true },
             // eslint-disable-next-line max-len
-            description: nls.localize('theia/filesystem/filesExclude', 'Configure glob patterns for excluding files and folders. For example, the file Explorer decides which files and folders to show or hide based on this setting. Refer to the `#search.exclude#` setting to define search specific excludes.'),
+            markdownDescription: nls.localize('theia/filesystem/filesExclude', 'Configure glob patterns for excluding files and folders. For example, the file Explorer decides which files and folders to show or hide based on this setting.'),
             scope: 'resource'
         },
         'files.enableTrash': {
@@ -65,7 +65,7 @@ export const filesystemPreferenceSchema: PreferenceSchema = {
         },
         'files.associations': {
             type: 'object',
-            description: nls.localizeByDefault(
+            markdownDescription: nls.localizeByDefault(
                 'Configure file associations to languages (e.g. `\"*.extension\": \"html\"`). These have precedence over the default associations of the languages installed.'
             )
         },

--- a/packages/plugin-dev/src/browser/hosted-plugin-preferences.ts
+++ b/packages/plugin-dev/src/browser/hosted-plugin-preferences.ts
@@ -37,7 +37,7 @@ export const HostedPluginConfigSchema: PreferenceSchema = {
             items: {
                 type: 'string'
             },
-            description: nls.localize(
+            markdownDescription: nls.localize(
                 'theia/plugin-dev/launchOutFiles',
                 'Array of glob patterns for locating generated JavaScript files (`${pluginPath}` will be replaced by plugin actual path).'
             ),

--- a/packages/preferences/src/browser/preference-tree-model.ts
+++ b/packages/preferences/src/browser/preference-tree-model.ts
@@ -227,6 +227,11 @@ export class PreferenceTreeModel extends TreeModelImpl {
         }
     }
 
+    getNodeFromPreferenceId(id: string): Preference.TreeNode | undefined {
+        const node = this.getNode(this.treeGenerator.getNodeId(id));
+        return node && Preference.TreeNode.is(node) ? node : undefined;
+    }
+
     /**
      * @returns true if selection changed, false otherwise
      */

--- a/packages/preferences/src/browser/style/index.css
+++ b/packages/preferences/src/browser/style/index.css
@@ -301,6 +301,11 @@
     line-height: 18px;
 }
 
+.theia-settings-container .pref-description a {
+    text-decoration-line: none;
+    cursor: pointer;
+}
+
 .theia-settings-container .theia-select:focus {
     outline-width: 1px;
     outline-style: solid;

--- a/packages/preferences/src/browser/util/preference-tree-generator.ts
+++ b/packages/preferences/src/browser/util/preference-tree-generator.ts
@@ -126,6 +126,12 @@ export class PreferenceTreeGenerator {
         return root;
     };
 
+    getNodeId(preferenceId: string): string {
+        const expectedGroup = this.getGroupName(preferenceId.split('.'));
+        const expectedId = `${expectedGroup}@${preferenceId}`;
+        return expectedId;
+    }
+
     protected getGroupName(labels: string[]): string {
         const defaultGroup = labels[0];
         if (this.topLevelCategories.has(defaultGroup)) {

--- a/packages/preferences/src/browser/util/preference-tree-label-provider.spec.ts
+++ b/packages/preferences/src/browser/util/preference-tree-label-provider.spec.ts
@@ -100,6 +100,7 @@ describe('preference-tree-label-provider', () => {
                 visible: true,
                 selected: false,
                 depth: 2,
+                preferenceId: property,
                 preference: { data: {} }
             };
 

--- a/packages/preferences/src/browser/util/preference-types.ts
+++ b/packages/preferences/src/browser/util/preference-types.ts
@@ -64,6 +64,7 @@ export namespace Preference {
     export interface LeafNode extends BaseTreeNode {
         depth: number;
         preference: { data: PreferenceDataProperty };
+        preferenceId: string;
     }
 
     export namespace LeafNode {

--- a/packages/preferences/src/browser/views/components/preference-json-input.ts
+++ b/packages/preferences/src/browser/views/components/preference-json-input.ts
@@ -16,7 +16,7 @@
 
 import { PreferenceLeafNodeRenderer } from './preference-node-renderer';
 import { injectable, inject } from '@theia/core/shared/inversify';
-import { CommandService } from '@theia/core/lib/common';
+import { CommandService, nls } from '@theia/core/lib/common';
 import { PreferencesCommands } from '../../util/preference-types';
 import { JSONValue } from '@theia/core/shared/@phosphor/coreutils';
 
@@ -25,7 +25,7 @@ export class PreferenceJSONLinkRenderer extends PreferenceLeafNodeRenderer<JSONV
     @inject(CommandService) protected readonly commandService: CommandService;
 
     protected createInteractable(parent: HTMLElement): void {
-        const message = 'Edit in settings.json';
+        const message = nls.localizeByDefault('Edit in settings.json');
         const interactable = document.createElement('a');
         this.interactable = interactable;
         interactable.classList.add('theia-json-input');

--- a/packages/preferences/src/browser/views/preference-searchbar-widget.tsx
+++ b/packages/preferences/src/browser/views/preference-searchbar-widget.tsx
@@ -17,7 +17,7 @@
 import { codicon, ReactWidget, StatefulWidget } from '@theia/core/lib/browser';
 import { injectable, postConstruct } from '@theia/core/shared/inversify';
 import * as React from '@theia/core/shared/react';
-import debounce = require('@theia/core/shared/lodash.debounce');
+import debounce = require('p-debounce');
 import { Disposable, Emitter } from '@theia/core';
 import { nls } from '@theia/core/lib/common/nls';
 
@@ -45,11 +45,9 @@ export class PreferencesSearchbarWidget extends ReactWidget implements StatefulW
         this.update();
     }
 
-    protected handleSearch = (e: React.ChangeEvent<HTMLInputElement>): void => {
-        this.search(e.target.value);
-    };
+    protected handleSearch = (e: React.ChangeEvent<HTMLInputElement>): Promise<void> => this.search(e.target.value);
 
-    protected search = debounce((value: string) => {
+    protected search = debounce(async (value: string) => {
         this.onFilterStringChangedEmitter.fire(value);
         this.update();
     }, 200);
@@ -64,11 +62,11 @@ export class PreferencesSearchbarWidget extends ReactWidget implements StatefulW
      * Clears the search input and all search results.
      * @param e on-click mouse event.
      */
-    protected clearSearchResults = (e: React.MouseEvent): void => {
+    protected clearSearchResults = async (e: React.MouseEvent): Promise<void> => {
         const search = document.getElementById(PreferencesSearchbarWidget.SEARCHBAR_ID) as HTMLInputElement;
         if (search) {
             search.value = '';
-            this.search(search.value);
+            await this.search(search.value);
             this.update();
         }
     };
@@ -127,13 +125,13 @@ export class PreferencesSearchbarWidget extends ReactWidget implements StatefulW
         return search?.value;
     }
 
-    updateSearchTerm(searchTerm: string): void {
+    async updateSearchTerm(searchTerm: string): Promise<void> {
         const search = document.getElementById(PreferencesSearchbarWidget.SEARCHBAR_ID) as HTMLInputElement;
-        if (!search) {
+        if (!search || search.value === searchTerm) {
             return;
         }
         search.value = searchTerm;
-        this.search(search.value);
+        await this.search(search.value);
         this.update();
     }
 

--- a/packages/search-in-workspace/src/browser/search-in-workspace-preferences.ts
+++ b/packages/search-in-workspace/src/browser/search-in-workspace-preferences.ts
@@ -39,7 +39,7 @@ export const searchInWorkspacePreferencesSchema: PreferenceSchema = {
         },
         'search.searchOnTypeDebouncePeriod': {
             // eslint-disable-next-line max-len
-            description: nls.localizeByDefault('When `#search.searchOnType#` is enabled, controls the timeout in milliseconds between a character being typed and the search starting. Has no effect when `search.searchOnType` is disabled.'),
+            markdownDescription: nls.localizeByDefault('When `#search.searchOnType#` is enabled, controls the timeout in milliseconds between a character being typed and the search starting. Has no effect when `search.searchOnType` is disabled.'),
             default: 300,
             type: 'number',
         },

--- a/packages/terminal/src/browser/terminal-preferences.ts
+++ b/packages/terminal/src/browser/terminal-preferences.ts
@@ -36,7 +36,7 @@ export const TerminalConfigSchema: PreferenceSchema = {
         },
         'terminal.integrated.fontFamily': {
             type: 'string',
-            description: nls.localizeByDefault("Controls the font family of the terminal, this defaults to `#editor.fontFamily#`'s value."),
+            markdownDescription: nls.localizeByDefault("Controls the font family of the terminal, this defaults to `#editor.fontFamily#`'s value."),
             default: EDITOR_FONT_DEFAULTS.fontFamily
         },
         'terminal.integrated.fontSize': {
@@ -79,7 +79,7 @@ export const TerminalConfigSchema: PreferenceSchema = {
             default: 1000
         },
         'terminal.integrated.fastScrollSensitivity': {
-            description: nls.localizeByDefault('Scrolling speed multiplier when pressing `Alt`.'),
+            markdownDescription: nls.localizeByDefault('Scrolling speed multiplier when pressing `Alt`.'),
             type: 'number',
             default: 5,
         },


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

Closes #7742

Renders the `markdownDescription` property into html instead of just setting the `textContent` to the `markdownDescription` value. As there are some special semantics related to the rendered markdown like links that have to be opened in a new window or linked preferences that have to be rendered as links instead of `code`, I added a new `MarkdownRenderer` that allows easy post-processing on rendered markdown. Perhaps this is a bit overkill, but I couldn't find any other method to overwrite the `code` rule for `markdown-it`.

Also updates some preferences that were using `description` instead of `markdownDescription`.

Previously:

![image](https://user-images.githubusercontent.com/4377073/142416248-079081e0-bb2b-460f-a16a-40595608262c.png)

Now:

![image](https://user-images.githubusercontent.com/4377073/142554244-80e50d0c-2794-4681-855b-043dcbf08bfb.png)

Compared to vscode:

![image](https://user-images.githubusercontent.com/4377073/142554172-08c6eb90-a5ae-478f-b565-933959ce9741.png)

#### How to test

1. Open the `Preferences` widget.
2. Assert that preferences with a `markdownDescription` property are rendered correctly to html.
3. Assert that preferences with links to other preferences are correctly rendered and clicking the links brings the preference into view
4. Assert that actual http links open a new tab/window when clicking on them.
3. Assert that no preference exists which should use `markdownDescription` instead of `description`. (i.e. no markdown syntax exists in `description` properties)

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
