### PR TITLE
Fix joinPath() issue on URIs (#10370)

### DIFF
--- a/packages/plugin-ext/src/plugin/types-impl.ts
+++ b/packages/plugin-ext/src/plugin/types-impl.ts
@@ -82,7 +82,7 @@ export class URI extends CodeURI implements theia.Uri {
         if (!uri.path) {
             throw new Error('\'joinPath\' called on URI without path');
         }
-        const newPath = paths.resolve(uri.path, ...pathSegments);
+        const newPath = paths.posix.join(uri.path, ...pathSegments);
         return new URI(uri.scheme, uri.authority, newPath, uri.query, uri.fragment);
     }
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

Fixes #10370
Fixes #10585

Issues encountered are when calling `joinPath` on Windows.
For consistency, `joinPath` calls `paths.posix.join` instead.
URI then will store all paths with POSIX-like path, and will resolve to filesystem path when calling fsPath.



#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

Tests are added in `types-impl.spec.ts` (based on VS Code ones, with no modification). It should work as is.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

