### PR TITLE
electron: restore last window state if the layout still exists

### DIFF
--- a/packages/core/src/electron-main/electron-main-application.ts
+++ b/packages/core/src/electron-main/electron-main-application.ts
@@ -293,7 +293,6 @@ export class ElectronMainApplication {
             title: this.config.applicationName,
             minWidth: 200,
             minHeight: 120,
-            screenLayout: this.getCurrentScreenLayout(),
             webPreferences: {
                 // https://github.com/eclipse-theia/theia/issues/2018
                 nodeIntegration: true,


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->
Fixes #10412
After disconnect extra monitor, electron window display properly.
#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
1. connect one more monitor M1
2. start electron application
3. drag electron window to M1 area.
4. kill electron application
5. start electron application
6. confirm electron window is launching properly
7. kill electron application
8. disconnect M1
9. start electron application
10. confirm electron window is launching properly

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
