### PR TITLE
navigator-decorator: add symlink icon and tooltip to symlinked files in navigator

### DIFF
--- a/packages/navigator/src/browser/navigator-frontend-module.ts
+++ b/packages/navigator/src/browser/navigator-frontend-module.ts
@@ -42,6 +42,7 @@ import { OpenEditorsTreeDecorator } from './open-editors-widget/navigator-open-e
 import { OpenEditorsWidget } from './open-editors-widget/navigator-open-editors-widget';
 import { NavigatorTreeDecorator } from './navigator-decorator-service';
 import { NavigatorDeletedEditorDecorator } from './open-editors-widget/navigator-deleted-editor-decorator';
+import { NavigatorSymlinkDecorator } from './navigator-symlink-decorator';
 
 export default new ContainerModule(bind => {
     bindFileNavigatorPreferences(bind);
@@ -81,4 +82,8 @@ export default new ContainerModule(bind => {
     bind(NavigatorTabBarDecorator).toSelf().inSingletonScope();
     bind(FrontendApplicationContribution).toService(NavigatorTabBarDecorator);
     bind(TabBarDecorator).toService(NavigatorTabBarDecorator);
+
+    bind(NavigatorSymlinkDecorator).toSelf().inSingletonScope();
+    bind(NavigatorTreeDecorator).toService(NavigatorSymlinkDecorator);
+    bind(OpenEditorsTreeDecorator).toService(NavigatorSymlinkDecorator);
 });

--- a/packages/navigator/src/browser/navigator-symlink-decorator.ts
+++ b/packages/navigator/src/browser/navigator-symlink-decorator.ts
@@ -1,0 +1,68 @@
+/********************************************************************************
+ * Copyright (C) 2021 Ericsson and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import { inject, injectable, postConstruct } from '@theia/core/shared/inversify';
+import { Emitter, Event, nls } from '@theia/core';
+import { TreeDecorator, Tree, TreeDecoration, DepthFirstTreeIterator } from '@theia/core/lib/browser';
+import { FileStatNode } from '@theia/filesystem/lib/browser';
+import { DecorationsService } from '@theia/core/lib/browser/decorations-service';
+
+@injectable()
+export class NavigatorSymlinkDecorator implements TreeDecorator {
+
+    readonly id = 'theia-navigator-symlink-decorator';
+
+    @inject(DecorationsService)
+    protected readonly decorationsService: DecorationsService;
+
+    @postConstruct()
+    protected init(): void {
+        this.decorationsService.onDidChangeDecorations(() => {
+            this.fireDidChangeDecorations((tree: Tree) => this.collectDecorator(tree));
+        });
+    }
+
+    async decorations(tree: Tree): Promise<Map<string, TreeDecoration.Data>> {
+        return this.collectDecorator(tree);
+    }
+
+    protected collectDecorator(tree: Tree): Map<string, TreeDecoration.Data> {
+        const result = new Map<string, TreeDecoration.Data>();
+        if (tree.root === undefined) {
+            return result;
+        }
+        for (const node of new DepthFirstTreeIterator(tree.root)) {
+            if (FileStatNode.is(node) && node.fileStat.isSymbolicLink) {
+                const decorations: TreeDecoration.Data = {
+                    tailDecorations: [{ data: '⤷', tooltip: nls.localizeByDefault('Symbolic Link') }]
+                };
+                result.set(node.id, decorations);
+            }
+        }
+        return result;
+    }
+
+    protected readonly onDidChangeDecorationsEmitter = new Emitter<(tree: Tree) => Map<string, TreeDecoration.Data>>();
+
+    get onDidChangeDecorations(): Event<(tree: Tree) => Map<string, TreeDecoration.Data>> {
+        return this.onDidChangeDecorationsEmitter.event;
+    }
+
+    fireDidChangeDecorations(event: (tree: Tree) => Map<string, TreeDecoration.Data>): void {
+        this.onDidChangeDecorationsEmitter.fire(event);
+    }
+
+}


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
This commit adds a new decorator for the file navigator.
It displays a downward right curved arrow at the tail of a file node if that file contains a symbolic link.
A tooltip is also added displaying "Symbolic Link" when hovering over a symbolic linked file node's tail icon.
Hovering over the file itself will display the file path only.
<!-- Include relevant issues and describe how they are addressed. -->

#### How to test
- Have a symbolic linked file within a folder
- Open either the electron app or browser and select the folder with the symlinked file as a workspace
- Confirm symlinked file node contains icon on the tail
- Confirm tooltip displays "Symbolic Link" when hovering over the tail icon
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

#### Review checklist

- [X] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
