### PR TITLE
Add sash option for widget resize

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - [core, editor, editor-preview] additional commands added to tabbar context menu for editor widgets. [#10394](https://github.com/eclipse-theia/theia/pull/10394)
 - [preferences] Updated `AbstractResourcePreferenceProvider` to handle multiple preference settings in the same tick and handle open preference files. It will save the file exactly once, and prompt the user if the file is dirty when a programmatic setting is attempted. [#7775](https://github.com/eclipse-theia/theia/pull/7775)
 - [core] `WindowService` and `ElectronMainApplication` updated to allow for asynchronous pre-exit code in Electron. [#10379](https://github.com/eclipse-theia/theia/pull/10379)
+- [core] added sash option for widget resize [#10441](https://github.com/eclipse-theia/theia/pull/10441)
 
 <a name="breaking_changes_1.21.0">[Breaking Changes:](#breaking_changes_1.21.0)</a>
 
@@ -28,6 +29,7 @@
 - [plugin] renamed `WebviewThemeData.activeTheme` to `activeThemeType` [#10493](https://github.com/eclipse-theia/theia/pull/10493)
 - [plugin] removed the application prop `resolveSystemPlugins`, builtin plugins should now be resolved at build time [#10353](https://github.com/eclipse-theia/theia/pull/10353)
 - [core/shared] removed `vscode-languageserver-types`; use `vscode-languageserver-protocol` instead. [#10500](https://github.com/eclipse-theia/theia/pull/10500)
+- [editor] moved the utilities for creating and manipulating dynamic stylesheets from `editor-decoration-style.ts` to `decoration-style.ts` in `core`. Each namespace now has its indepednent style sheet. Only one rule should exist for a given selector in the provided stylesheet. [#10441](https://github.com/eclipse-theia/theia/pull/10441)
 
 ## v1.20.0 - 11/25/2021
 

--- a/packages/core/src/browser/core-preferences.ts
+++ b/packages/core/src/browser/core-preferences.ts
@@ -135,6 +135,20 @@ export const corePreferenceSchema: PreferenceSchema = {
             default: isOSX ? 1500 : 500,
             description: nls.localizeByDefault('Controls the delay in milliseconds after which the hover is shown.')
         },
+        'workbench.sash.hoverDelay': {
+            type: 'number',
+            default: 300,
+            minimum: 0,
+            maximum: 2000,
+            description: nls.localizeByDefault('Controls the hover feedback delay in milliseconds of the dragging area in between views/editors.')
+        },
+        'workbench.sash.size': {
+            type: 'number',
+            default: 4,
+            minimum: 1,
+            maximum: 20,
+            description: nls.localizeByDefault('Controls the feedback area size in pixels of the dragging area in between views/editors. Set it to a larger value if needed.')
+        },
     }
 };
 
@@ -154,6 +168,8 @@ export interface CoreConfiguration {
     'workbench.statusBar.visible': boolean;
     'workbench.tree.renderIndentGuides': 'onHover' | 'none' | 'always';
     'workbench.hover.delay': number;
+    'workbench.sash.hoverDelay': number;
+    'workbench.sash.size': number;
 }
 
 export const CorePreferenceContribution = Symbol('CorePreferenceContribution');

--- a/packages/core/src/browser/decoration-style.ts
+++ b/packages/core/src/browser/decoration-style.ts
@@ -1,0 +1,61 @@
+/********************************************************************************
+ * Copyright (C) 2021 Ericsson and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+export namespace DecorationStyle {
+
+    export function createStyleSheet(styleId: string, container: HTMLElement = document.getElementsByTagName('head')[0]): CSSStyleSheet {
+        const style = document.createElement('style');
+        style.id = styleId;
+        style.type = 'text/css';
+        style.media = 'screen';
+        style.appendChild(document.createTextNode('')); // trick for webkit
+        container.appendChild(style);
+        return <CSSStyleSheet>style.sheet;
+    }
+
+    function getRuleIndex(selector: string, styleSheet: CSSStyleSheet): number {
+        return Array.from(styleSheet.cssRules || styleSheet.rules).findIndex(rule => rule.type === CSSRule.STYLE_RULE && (<CSSStyleRule>rule).selectorText === selector);
+    }
+
+    export function getOrCreateStyleRule(selector: string, styleSheet: CSSStyleSheet): CSSStyleRule {
+        let index = getRuleIndex(selector, styleSheet);
+        if (index === -1) {
+            // The given selector does not exist in the provided independent style sheet, rule index = 0
+            index = styleSheet.insertRule(selector + '{}', 0);
+        }
+
+        const rules = styleSheet.cssRules || styleSheet.rules;
+        const rule = rules[index];
+        if (rule && rule.type === CSSRule.STYLE_RULE) {
+            return rule as CSSStyleRule;
+        }
+        styleSheet.deleteRule(index);
+        throw new Error('This function is only for CSS style rules. Other types of CSS rules are not allowed.');
+    }
+
+    export function deleteStyleRule(selector: string, styleSheet: CSSStyleSheet): void {
+        if (!styleSheet) {
+            return;
+        }
+
+        // In general, only one rule exists for a given selector in the provided independent style sheet
+        const index = getRuleIndex(selector, styleSheet);
+        if (index !== -1) {
+            styleSheet.deleteRule(index);
+        }
+    }
+}
+

--- a/packages/core/src/browser/index.ts
+++ b/packages/core/src/browser/index.ts
@@ -42,3 +42,4 @@ export * from './view-container';
 export * from './breadcrumbs';
 export * from './tooltip-service';
 export * from './markdown-renderer';
+export * from './decoration-style';

--- a/packages/core/src/browser/shell/application-shell.ts
+++ b/packages/core/src/browser/shell/application-shell.ts
@@ -973,8 +973,11 @@ export class ApplicationShell extends Widget {
             if (panel instanceof TheiaDockPanel) {
                 panel.markAsCurrent(newValue.title);
             }
-            // Set the z-index so elements with `position: fixed` contained in the active widget are displayed correctly
-            this.setZIndex(newValue.node, '1');
+            // Add checks to ensure that the 'sash' for left panel is displayed correctly
+            if (newValue.node.className === 'p-Widget theia-view-container p-DockPanel-widget') {
+                // Set the z-index so elements with `position: fixed` contained in the active widget are displayed correctly
+                this.setZIndex(newValue.node, '1');
+            }
 
             // activate another widget if an active widget will be closed
             const onCloseRequest = newValue['onCloseRequest'];

--- a/packages/core/src/browser/style/dockpanel.css
+++ b/packages/core/src/browser/style/dockpanel.css
@@ -25,10 +25,34 @@
 
 .p-DockPanel-handle[data-orientation='vertical'] {
   min-height: var(--theia-border-width);
+  z-index: 3;
 }
 
 .p-DockPanel-handle[data-orientation='horizontal'] {
   min-width: var(--theia-border-width);
+}
+
+.p-DockPanel-handle[data-orientation='horizontal']::after {
+  min-width: var(--theia-sash-width);
+  transform: translateX(0%);
+  left: calc(-1*var(--theia-sash-width)/2);
+}
+
+.p-DockPanel-handle[data-orientation='vertical']::after {
+  min-height: var(--theia-sash-width);
+  width: 100%;
+  transform: translateY(0%);
+  top: calc(-1*var(--theia-sash-width)/2);
+}
+
+.p-DockPanel-handle:hover::after {
+  background-color: var(--theia-sash-hoverBorder);
+  transition-delay: var(--theia-sash-hoverDelay);
+}
+
+.p-DockPanel-handle:active::after {
+  background-color: var(--theia-sash-activeBorder);
+  transition-delay: 0s !important;
 }
 
 .p-DockPanel-overlay {

--- a/packages/core/src/browser/style/view-container.css
+++ b/packages/core/src/browser/style/view-container.css
@@ -36,14 +36,39 @@
     min-height: var(--theia-content-line-height);
 }
 
-.theia-view-container > .p-SplitPanel > .p-SplitPanel-handle:after {
-    background-color: var(--theia-sideBarSectionHeader-border);
+.theia-view-container > .p-SplitPanel > .p-SplitPanel-handle::after {
     min-height: 2px;
-    min-width: 2px
+    min-width: 2px;
 }
 
 .theia-view-container > .p-SplitPanel > .p-SplitPanel-handle {
     background-color: var(--theia-sideBarSectionHeader-border);
+}
+
+.p-SplitPanel > .p-SplitPanel-handle:hover::after {
+    background-color: var(--theia-sash-hoverBorder);
+    transition-delay: var(--theia-sash-hoverDelay);
+}
+
+.p-SplitPanel > .p-SplitPanel-handle:active::after {
+    background-color: var(--theia-sash-activeBorder);
+    transition-delay: 0s !important;
+}
+
+.p-SplitPanel[data-orientation='horizontal'] > .p-SplitPanel-handle::after {
+    min-width: var(--theia-sash-width);
+}
+
+.p-SplitPanel[data-orientation='vertical'] > .p-SplitPanel-handle::after {
+    min-height: var(--theia-sash-width);
+}
+
+.p-SplitPanel[data-orientation='vertical'] > .p-SplitPanel-handle.sash-hidden {
+    visibility: hidden;
+}
+
+.p-SplitPanel[data-orientation='vertical'] > .p-SplitPanel-handle.sash-hidden::after {
+    min-height: 0px;
 }
 
 .theia-view-container .part {

--- a/packages/core/src/browser/view-container.ts
+++ b/packages/core/src/browser/view-container.ts
@@ -46,6 +46,11 @@ export interface ViewContainerTitleOptions {
     closeable?: boolean;
 }
 
+enum SashType {
+    TopSash = 'top-sash',
+    BottomSash = 'bottom-sash'
+}
+
 @injectable()
 export class ViewContainerIdentifier {
     id: string;
@@ -994,6 +999,11 @@ export class ViewContainerPart extends BaseWidget {
         }
         this._collapsed = collapsed;
         this.node.classList.toggle('collapsed', collapsed);
+
+        // Update the sashes for the active `horizontal` container when the container is collapsed/expanded
+        this.updateSashState(SashType.TopSash, this.node.previousElementSibling, collapsed);
+        this.updateSashState(SashType.BottomSash, this.node.nextElementSibling, collapsed);
+
         if (collapsed && this.wrapped.node.contains(document.activeElement)) {
             this.header.focus();
         }
@@ -1230,6 +1240,26 @@ export class ViewContainerPart extends BaseWidget {
         }
     }
 
+    protected updateSashState(sashType: SashType, sashElement: Element | null, activeContainerCollapsed: boolean): void {
+        if (sashElement && sashElement.className.includes('p-SplitPanel-handle')) {
+            // Hide the sash when the active `horizontal` container in the left panel is collapsed
+            sashElement.classList.toggle('sash-hidden', activeContainerCollapsed);
+
+            let adjacentContainer: Element | null;
+            if (sashType === SashType.TopSash) {
+                adjacentContainer = sashElement.previousElementSibling;
+            } else {
+                adjacentContainer = sashElement.nextElementSibling;
+            }
+
+            // Sash should only appear when the following two conditions are met:
+            //    1.  the active `horizontal` container is expanded
+            //    2.  the container that is above/below the active `horizontal` container is also expanded
+            if (!activeContainerCollapsed && adjacentContainer) {
+                sashElement.classList.toggle('sash-hidden', adjacentContainer.className.includes('collapsed'));
+            }
+        }
+    }
 }
 
 export namespace ViewContainerPart {

--- a/packages/editor/src/browser/decorations/editor-decoration-style.ts
+++ b/packages/editor/src/browser/decorations/editor-decoration-style.ts
@@ -15,14 +15,19 @@
  ********************************************************************************/
 
 import { Disposable } from '@theia/core';
+import { DecorationStyle } from '@theia/core/lib/browser';
 
 export class EditorDecorationStyle implements Disposable {
 
     constructor(
         readonly selector: string,
         styleProvider: (style: CSSStyleDeclaration) => void,
+        protected decorationsStyleSheet: CSSStyleSheet
     ) {
-        EditorDecorationStyle.createRule(selector, styleProvider);
+        const styleRule = DecorationStyle.getOrCreateStyleRule(selector, decorationsStyleSheet);
+        if (styleRule) {
+            styleProvider(styleRule.style);
+        }
     }
 
     get className(): string {
@@ -30,62 +35,7 @@ export class EditorDecorationStyle implements Disposable {
     }
 
     dispose(): void {
-        EditorDecorationStyle.deleteRule(this.selector);
-    }
-
-}
-
-export namespace EditorDecorationStyle {
-
-    export function copyStyle(from: CSSStyleDeclaration, to: CSSStyleDeclaration): void {
-        Object.keys(from).forEach(key => {
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any
-            (<any>to)[key] = (<any>from)[key];
-        });
-    }
-
-    export function createStyleSheet(container: HTMLElement = document.getElementsByTagName('head')[0]): CSSStyleSheet | undefined {
-        if (!container) {
-            return undefined;
-        }
-        const style = document.createElement('style');
-        style.id = 'editorDecorationsStyle';
-        style.type = 'text/css';
-        style.media = 'screen';
-        style.appendChild(document.createTextNode('')); // trick for webkit
-        container.appendChild(style);
-        return <CSSStyleSheet>style.sheet;
-    }
-
-    const editorDecorationsStyleSheet: CSSStyleSheet | undefined = createStyleSheet();
-
-    export function createRule(selector: string, styleProvider: (style: CSSStyleDeclaration) => void,
-        styleSheet: CSSStyleSheet | undefined = editorDecorationsStyleSheet
-    ): void {
-        if (!styleSheet) {
-            return;
-        }
-        const index = styleSheet.insertRule('.' + selector + '{}', 0);
-        const rules = styleSheet.cssRules || styleSheet.rules;
-        const rule = rules[index];
-        if (rule && rule.type === CSSRule.STYLE_RULE) {
-            const styleRule = rule as CSSStyleRule;
-            styleProvider(styleRule.style);
-        }
-    }
-
-    export function deleteRule(selector: string, styleSheet: CSSStyleSheet | undefined = editorDecorationsStyleSheet): void {
-        if (!styleSheet) {
-            return;
-        }
-        const rules = styleSheet.cssRules || styleSheet.rules;
-        for (let i = 0; i < rules.length; i++) {
-            if (rules[i].type === CSSRule.STYLE_RULE) {
-                if ((rules[i] as CSSStyleRule).selectorText === selector) {
-                    styleSheet.removeRule(i);
-                }
-            }
-        }
+        DecorationStyle.deleteStyleRule(this.selector, this.decorationsStyleSheet);
     }
 
 }


### PR DESCRIPTION
#### What it does
Fixes #10416

https://user-images.githubusercontent.com/23107734/143316416-621fb965-b0b1-4c0a-8d72-6fc51cc38cf6.mov

- Apply focus to a widget handle when you hover over it
- `sash.hoverDelay` controls the hover feedback delay in milliseconds
- `sash.size` controls the feedback area size in pixels for the dragging area
- Add preference to set workbench.sash.hoverDelay (value must be in the range of 0 to 2000, default is 0ms)
- Add preference to set workbench.sash.size (value must be in the range of 1 to 20, default is 4px)
- In the left panel, a sash should only appear when the following two conditions are met:
            1. the active `horizontal` container is expanded
            2. the container that is above/below the active `horizontal` container is also expanded
- Move the utilities for creating and manipulating dynamic stylesheets from `editor-decoration-style.ts` to `decoration-style.ts` in `core` so that: 
    - Each namespace now has its indepednent style sheet
    - Only one rule should exist for a given selector in the provided stylesheet



| Senario  | Demo | Sash State |
| ------------- | ------------- | ------------- | 
| Active container expanded, Container below collapsed |  <img width="300" alt="container-below-collapsed" src="https://user-images.githubusercontent.com/23107734/144340100-9f799ca5-843d-41c0-bd72-66b436247021.png"> | Hidden  |
| Active container expanded, Container below expanded | <img width="300" alt="container-below-expanded" src="https://user-images.githubusercontent.com/23107734/144340104-e5433c92-2e2a-4239-9b8a-d14440909f05.png">  | **Shown***  |
| Active container expanded, Container above collapsed | <img width="300" alt="container-above-collapsed" src="https://user-images.githubusercontent.com/23107734/144339969-28c9dde7-21cd-482c-bf03-acfe03069fcc.png"> | Hidden  |
| Active container expanded, Container above expanded | <img width="300" alt="container-above-expanded" src="https://user-images.githubusercontent.com/23107734/144340023-db249883-68e1-4d39-b95f-00d90b209a79.png">  | **Shown***  |
| Active container collapsed  | see first video below | Hidden  |
| No active container, All containers collapsed  | see second video below  | Hidden |

https://user-images.githubusercontent.com/23107734/144339788-7d484181-2bb0-4417-990d-9dbd9390061f.mov

https://user-images.githubusercontent.com/23107734/144339924-8d186a8b-03b6-4f96-ace8-60a2631e72d3.mov


#### How to test
1.	Start the application
2.	Hover the cursor over the horizontal and vertical handles for different view containers in Theia and drag 
**(please refer to the screencast above for more details)**
3.	Search for 'workbench sash' in Preferences (File > Preferences > Open Settings (UI) )
4.	Update the `sash.hoverDelay` and `sash.size` preferences to valid values
5.	Repeat Step 2 and verify that the hover delay and feedback area size for the border/sash are updated successfull
6. Verify the sash behaviors for the horizontal containers in the left panel based on the info provided in the table above

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

Signed-off-by: Kaiyue Pan <kaiyue.pan@ericsson.com>