### PR TITLE
Add Electron start-up performance script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,4 @@ dev-packages/electron/compile_commands.json
 .eslintcache
 scripts/download
 license-check-summary.txt*
+*-trace.json

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 [1.21.0 Milestone](https://github.com/eclipse-theia/theia/milestone/29)
 
+- [scripts] added Electron frontend start-up performance measurement script [#10442](https://github.com/eclipse-theia/theia/pull/10442) - Contributed on behalf of STMicroelectronics
 - [core, editor, editor-preview] additional commands added to tabbar context menu for editor widgets. [#10394](https://github.com/eclipse-theia/theia/pull/10394)
 - [preferences] Updated `AbstractResourcePreferenceProvider` to handle multiple preference settings in the same tick and handle open preference files. It will save the file exactly once, and prompt the user if the file is dirty when a programmatic setting is attempted. [#7775](https://github.com/eclipse-theia/theia/pull/7775)
 

--- a/package.json
+++ b/package.json
@@ -79,7 +79,9 @@
     "test:theia": "lerna run --scope \"@theia/!(example-)*\" test --stream --concurrency=1",
     "watch": "concurrently --kill-others -n tsc,browser,electron -c red,yellow,blue \"tsc -b -w --preserveWatchOutput\" \"yarn --cwd examples/browser watch:bundle\" \"yarn --cwd examples/electron watch:bundle\"",
     "watch:compile": "concurrently --kill-others -n cleanup,tsc -c magenta,red \"ts-clean dev-packages/* packages/* -w\" \"tsc -b -w --preserveWatchOutput\"",
-    "performance:startup": "concurrently --success first -k -r \"cd scripts/performance && node measure-performance.js --name Startup --folder startup --runs 10\" \"yarn --cwd examples/browser start\""
+    "performance:startup": "yarn performance:startup:browser && yarn performance:startup:electron",
+    "performance:startup:browser": "concurrently --success first -k -r \"cd scripts/performance && node browser-performance.js --name 'Browser Frontend Startup' --folder browser --runs 10\" \"yarn --cwd examples/browser start\"",
+    "performance:startup:electron": "yarn electron rebuild && cd scripts/performance && node electron-performance.js --name 'Electron Frontend Startup' --folder electron --runs 10"
   },
   "workspaces": [
     "dev-packages/*",

--- a/scripts/performance/.gitignore
+++ b/scripts/performance/.gitignore
@@ -3,3 +3,4 @@ workspace
 *.csv
 *.json
 !base-package.json
+!electron-trace-config.json

--- a/scripts/performance/README.md
+++ b/scripts/performance/README.md
@@ -1,13 +1,14 @@
 # Performance measurements
 
-This directory contains a script that measures the performance of Theia.
-Currently the support is limited to measuring the `browser-app`'s startup time using the `Largest contentful paint (LCP)` value.
+This directory contains scripts that measure the start-up performance of the Theia frontend in both the browser and the Electron examples.
 
-## Running the script
+The frontend's start-up time is measured using the timestamp of the last recorded `Largest contentful paint (LCP)` candidate metric.
+
+## Running the browser start-up script
 
 ### Quick Start
 
-Execute `yarn run performance:startup` in the root directory to startup the backend and execute the script.
+Execute `yarn run performance:startup:browser` in the root directory to startup the backend and execute the script.
 
 ### Prerequisites
 
@@ -16,21 +17,53 @@ This can either be done with the `Launch Browser Backend` launch config or by ru
 
 ### Executing the script
 
-The script can be executed using `node measure-performance.js` in this directory.
+The script can be executed using `node browser-performance.js` in this directory.
 
 The script accepts the following optional parameters:
 
--   `--name`: Specify a name for the current measurement (default: `StartupPerformance`)
+-   `--name`: Specify a name for the current measurement (default: `Browser Frontend Startup`)
 -   `--url`: Point Theia to a url for example for specifying a specifc workspace (default: `http://localhost:3000/#/<pathToMeasurementScript>/workspace`)
--   `--folder`: Folder name for the generated tracing files in the `profiles` folder (default: `profile`)
+-   `--folder`: Folder name for the generated tracing files in the `profiles` folder (default: `browser`)
 -   `--runs`: Number of runs for the measurement (default: `10`)
 -   `--headless`: Boolean, if the tests should be run in headless mode (default: `true`)
 
 _**Note**: When multiple runs are specified the script will calculate the mean and the standard deviation of all values._
 
+## Running the Electron start-up script
+
+### Quick Start
+
+Execute `yarn run performance:startup:electron` in the root directory to execute the script.
+
+### Prerequisites
+
+To run the script the Theia Electron example needs to be built. In the root directory:
+
+```console
+$ yarn
+$ yarn electron build
+```
+
+### Executing the script
+
+The script can be executed using `node electron-performance.js` in this directory.
+
+The script accepts the following optional parameters:
+
+-   `--name`: Specify a name for the current measurement (default: `Electron Frontend Startup`)
+-   `--folder`: Folder name for the generated tracing files in the `profiles` folder (default: `electron`)
+-   `--workspace`: Absolute path to a Theia workspace to open (default: an empty workspace folder)
+-   `--runs`: Number of runs for the measurement (default: `10`)
+-   `--debug`: Whether to log debug information to the console. Currently, this is only the standard error of the Electron app, which ordinarily is suppressed because the child process is detached
+
+_**Note**: When multiple runs are specified the script will calculate the mean and the standard deviation of all values, except for any runs that failed to capture a measurement due to an exception._
+
+It can happen that the Electron app does not start normally because the native browser modules are not properly built for the Electron target.
+The symptom for this is usually an error about a module not self-registering; when this condition is detected, the script stops rather than print out an inevitable series of failures to measure the performance.
+
 ## Measure impact on startup performance of extensions
 
-To measure the startup performance impact that extensions have on the application, another script is avaiable, which uses the measurements from the `measure-performance.js` script.
+To measure the startup performance impact that extensions have on the application, another script is available, which uses the measurements from the `browser-performance.js` or `electron-performance.js` script.
 The `extension-impact.js` script runs the measurement for a defined base application (`base-package.json` in this directory) and then measures the startup time when one of the defined extensions is added to the base application.
 The script will then print a table (in CSV format) to the console (and store it in a file) which contains the mean, standard deviation (Std Dev) and coefficient of variation (CV) for each extensions run.
 Additionally, each extensions entry will contain the difference to the base application time.
@@ -40,7 +73,7 @@ Example Table:
 | Extension Name    | Mean (10 runs) (in s) | Std Dev (in s) | CV (%) | Delta (in s) |
 | ----------------- | --------------------- | -------------- | ------ | ------------ |
 | Base Theia        | 2.027                 | 0.084          | 4.144  | -            |
-| @theia/git:1.17.0 | 2.103                 | 0.041          | 1.950  | 0.076        |
+| @theia/git:1.19.0 | 2.103                 | 0.041          | 1.950  | 0.076        |
 
 ### Script usage
 
@@ -48,6 +81,7 @@ The script can be executed by running `node extension-impact.js` in this directo
 
 The following parameters are available:
 
+-   `--app`: The example app in which to measure performance, either `browser` or `electron` (default: `browser`)
 -   `--runs`: Specify the number of measurements for each extension (default: `10`)
 -   `--base-time`: Provide an existing measurement (mean) for the base Theia application. If none is provided it will be measured.
 -   `--extensions`: Provide a list of extensions (need to be locally installed) that shall be tested (default: all extensions in packages folder)
@@ -58,10 +92,11 @@ The following parameters are available:
     -   _not contain whitespaces_
     -   _and be separated by whitespaces_
 
-    _For example: `--extensions @theia/git:1.18.0 @theia/keymaps:1.18.0`_
+    _For example: `--extensions @theia/git:1.19.0 @theia/keymaps:1.19.0`_
 
 -   `--yarn`: Flag to trigger a full yarn at script startup (e.g. to build changes to extensions)
--   `--url`: Specify a URL that Theia should be launched with (can also be used to specify the workspace to be opened) (default: `http://localhost:3000/#/<pathToMeasurementScript>/workspace`)
--   `--file`: Relative path to the output file (default: `./extensions.csv`)
+-   `--url`: Specify a URL that Theia should be launched with (can be used to specify the workspace to be opened). _Applies only to the `browser` app_ (default: `http://localhost:3000/#/<GIT_ROOT>/scripts/performance/workspace`)
+-   `--workspace`: Specify a workspace on which to launch Theia. _Applies only to the `electron` app_ (default: `/<GIT_ROOT>/scripts/performance/workspace`)
+-   `--file`: Relative path to the output file (default: `./script.csv`)
 
 _**Note**: If no extensions are provided all extensions from the `packages` folder will be measured._

--- a/scripts/performance/base-package.json
+++ b/scripts/performance/base-package.json
@@ -1,31 +1,37 @@
 {
   "private": true,
-  "name": "@theia/example-browser",
-  "version": "1.18.0",
+  "name": "@theia/example-{{app}}",
+  "version": "{{version}}",
   "license": "EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0",
   "theia": {
+    "target": "{{app}}",
     "frontend": {
       "config": {
-        "applicationName": "Theia Browser Example",
+        "applicationName": "Theia {{app}} Example",
         "preferences": {
           "files.enableTrash": false
         }
       }
+    },
+    "backend": {
+      "config": {
+        "resolveSystemPlugins": false
+      }
     }
   },
   "dependencies": {
-    "@theia/core": "1.18.0",
-    "@theia/plugin-ext": "1.18.0"
+    "@theia/core": "{{version}}",
+    "@theia/plugin-ext": "{{version}}"
   },
   "scripts": {
     "clean": "theia clean",
     "build": "yarn compile && yarn bundle",
     "bundle": "theia build --mode development",
     "compile": "tsc -b",
-    "rebuild": "theia rebuild:browser --cacheRoot ../..",
+    "rebuild": "theia rebuild:{{app}} --cacheRoot ../..",
     "start": "yarn rebuild && THEIA_CONFIG_DIR=./theia-config-dir theia start --plugins=local-dir:../../noPlugins --log-level=fatal"
   },
   "devDependencies": {
-    "@theia/cli": "1.18.0"
+    "@theia/cli": "{{version}}"
   }
 }

--- a/scripts/performance/common-performance.js
+++ b/scripts/performance/common-performance.js
@@ -1,0 +1,235 @@
+/********************************************************************************
+ * Copyright (C) 2021 STMicroelectronics and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+// @ts-check
+
+/**
+ * An event in the performance trace (from the Chrome performance API).
+ * @typedef TraceEvent
+ * @property {string} name the event name
+ * @property {number} ts the timestamp, in microseconds since some time after host system start
+ */
+
+/**
+ * A call-back that selects an event from the performance trace.
+ * 
+ * @callback EventPredicate
+ * @param {TraceEvent} event an event to test
+ * @returns {boolean} whether the predicate selects the `event`
+ */
+
+/**
+ * A call-back that runs the test scenario to be analyzed.
+ * 
+ * @async
+ * @callback TestFunction
+ * @param {number} runNr the current run index of the multiple runs being executed
+ * @returns {PromiseLike<string>} the path to the recorded performance profiling trace file
+ */
+
+const fs = require('fs');
+
+const performanceTag = braceText('Performance');
+const lcp = 'Largest Contentful Paint (LCP)';
+
+/**
+ * Measure the performance of a `test` function implementing some `scenario` of interest.
+ * 
+ * @param {string} name the application name to measure
+ * @param {string} scenario a label for the scenario being measured
+ * @param {number} runs the number of times to run the `test` scenario
+ * @param {TestFunction} test a function that executes the `scenario` to be measured, returning the file 
+ *        that records the performance profile trace
+ * @param {EventPredicate} isStartEvent a predicate matching the trace event that marks the start of the measured scenario
+ * @param {EventPredicate} isEndEvent a predicate matching the trace event that marks the end of the measured scenario
+ */
+async function measure(name, scenario, runs, test, isStartEvent, isEndEvent) {
+    const durations = [];
+    for (let i = 0; i < runs; i++) {
+        const runNr = i + 1;
+
+        const file = await test(runNr);
+        let time;
+
+        try {
+            time = await analyzeTrace(file, isStartEvent, isEndEvent);
+
+            durations.push(time);
+            logDuration(name, runNr, scenario, time, runs > 1);
+        } catch (e) {
+            logException(name, runNr, scenario, e, runs > 1);
+        }
+    }
+
+    logSummary(name, scenario, durations);
+}
+
+
+/**
+ * Log a summary of the given measured `durations`.
+ * 
+ * @param {string} name the performance script name
+ * @param {string} scenario the scenario that was measured
+ * @param {number[]} durations the measurements captured for the `scenario`
+ */
+function logSummary(name, scenario, durations) {
+    if (durations.length > 1) {
+        const mean = calculateMean(durations);
+        const stdev = calculateStandardDeviation(mean, durations);
+        logDuration(name, 'MEAN', scenario, mean);
+        logDuration(name, 'STDEV', scenario, stdev);
+    }
+}
+
+/**
+ * Analyze a performance trace file.
+ * 
+ * @param {string} profilePath the profiling trace file path
+ * @param {EventPredicate} isStartEvent a predicate matching the trace event that marks the start of the measured scenario
+ * @param {EventPredicate} isEndEvent a predicate matching the trace event that marks the end of the measured scenario
+ */
+async function analyzeTrace(profilePath, isStartEvent, isEndEvent) {
+    let startEvent;
+    const tracing = JSON.parse(fs.readFileSync(profilePath, 'utf8'));
+    const endEvents = tracing.traceEvents.filter(e => {
+        if (startEvent === undefined && isStartEvent(e)) {
+            startEvent = e;
+            return false;
+        }
+        return isEndEvent(e);
+    });
+
+    if (startEvent !== undefined && endEvents.length > 0) {
+        return duration(endEvents[endEvents.length - 1], startEvent);
+    }
+
+    throw new Error('Could not analyze performance trace');
+}
+
+/**
+ * Query whether a trace `event` is a candidate for the Largest Contentful Paint.
+ * 
+ * @param {TraceEvent} event an event in the performance trace
+ * @returns whether the `event` is an LCP candidate
+ */
+function isLCP(event) {
+    return event.name === 'largestContentfulPaint::Candidate';
+}
+
+/**
+ * Compute the duration, in seconds, to an `event` from a start event.
+ * 
+ * @param {TraceEvent} event the duration end event
+ * @param {TraceEvent} startEvent the duration start event
+ * @returns the duration, in seconds
+ */
+function duration(event, startEvent) {
+    return (event.ts - startEvent.ts) / 1_000_000;
+}
+
+/**
+ * Log a `duration` measured for some scenario.
+ * 
+ * @param {string} name the performance script name
+ * @param {number|string} run the run index number, or some kind of aggregate like 'Total' or 'Avg'
+ * @param {string} metric the scenario that was measured
+ * @param {number} duration the duration, in seconds, of the measured scenario
+ * @param {boolean} [multipleRuns=true] whether the `run` logged is one of many being logged (default: `true`)
+ */
+function logDuration(name, run, metric, duration, multipleRuns = true) {
+    let runText = '';
+    if (multipleRuns) {
+        runText = braceText(run);
+    }
+    console.log(performanceTag + braceText(name) + runText + ' ' + metric + ': ' + duration.toFixed(3) + ' seconds');
+}
+
+/**
+ * Log an `exception` in measurement of some scenario.
+ * 
+ * @param {string} name the performance script name
+ * @param {number|string} run the run index number, or some kind of aggregate like 'Total' or 'Avg'
+ * @param {string} metric the scenario that was measured
+ * @param {Error} exception the duration, in seconds, of the measured scenario
+ * @param {boolean} [multipleRuns=true] whether the `run` logged is one of many being logged (default: `true`)
+ */
+function logException(name, run, metric, exception, multipleRuns = true) {
+    let runText = '';
+    if (multipleRuns) {
+        runText = braceText(run);
+    }
+    console.log(performanceTag + braceText(name) + runText + ' ' + metric + ' failed to obtain a measurement: ' + exception.message);
+    console.error(`Failed to obtain a measurement. The most likely cause is that the performance trace file was incomplete because the script did not wait long enough for "${metric}".`);
+    console.error(exception);
+}
+
+/**
+ * Compute the arithmetic mean of an `array` of numbers.
+ * 
+ * @param {number[]} array an array of numbers to average
+ * @returns the average of the `array`
+ */
+function calculateMean(array) {
+    let sum = 0;
+    array.forEach(x => {
+        sum += x;
+    });
+    return (sum / array.length);
+};
+
+/**
+ * Compute the standard deviation from the mean of an `array` of numbers.
+ * 
+ * @param {number[]} array an array of numbers
+ * @returns the standard deviation of the `array` from its mean
+ */
+function calculateStandardDeviation(mean, array) {
+    let sumOfDiffsSquared = 0;
+    array.forEach(time => {
+        sumOfDiffsSquared += Math.pow((time - mean), 2)
+    });
+    const variance = sumOfDiffsSquared / array.length;
+    return Math.sqrt(variance);
+}
+
+/**
+ * Surround a string of `text` in square braces.
+ * 
+ * @param {string|number} text a string of text or a number that can be rendered as text
+ * @returns the `text` in braces
+ */
+function braceText(text) {
+    return '[' + text + ']';
+}
+
+/**
+ * Obtain a promise that resolves after some delay.
+ * 
+ * @param {number} time a delay, in milliseconds
+ * @returns a promise that will resolve after the given number of milliseconds
+ */
+function delay(time) {
+    return new Promise(function (resolve) {
+        setTimeout(resolve, time)
+    });
+}
+
+module.exports = {
+    measure, analyzeTrace,
+    calculateMean, calculateStandardDeviation,
+    duration, logDuration, logSummary,
+    braceText, delay,
+    lcp, isLCP
+};

--- a/scripts/performance/electron-performance.js
+++ b/scripts/performance/electron-performance.js
@@ -1,0 +1,194 @@
+/********************************************************************************
+ * Copyright (C) 2021 STMicroelectronics and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+// @ts-check
+const fsx = require('fs-extra');
+const { resolve } = require('path');
+const { spawn, ChildProcess } = require('child_process');
+const { delay, lcp, isLCP, measure } = require('./common-performance');
+const traceConfigTemplate = require('./electron-trace-config.json');
+const { exit } = require('process');
+
+const basePath = resolve(__dirname, '../..');
+const profilesPath = resolve(__dirname, './profiles/');
+const electronExample = resolve(basePath, 'examples/electron');
+const theia = resolve(electronExample, 'node_modules/.bin/theia');
+
+let name = 'Electron Frontend Startup';
+let folder = 'electron';
+let runs = 10;
+let workspace = resolve('./workspace');
+let debugging = false;
+
+(async () => {
+    let defaultWorkspace = true;
+
+    const yargs = require('yargs');
+    const args = yargs(process.argv.slice(2)).option('name', {
+        alias: 'n',
+        desc: 'A name for the test suite',
+        type: 'string',
+        default: name
+    }).option('folder', {
+        alias: 'f',
+        desc: 'Name of a folder within the "profiles" folder in which to collect trace logs',
+        type: 'string',
+        default: folder
+    }).option('runs', {
+        alias: 'r',
+        desc: 'The number of times to run the test',
+        type: 'number',
+        default: runs
+    }).option('workspace', {
+        alias: 'w',
+        desc: 'Path to a Theia workspace to open',
+        type: 'string',
+        default: workspace
+    }).option('debug', {
+        alias: 'X',
+        desc: 'Whether to log debug information',
+        boolean: true
+    }).wrap(Math.min(120, yargs.terminalWidth())).argv;
+
+    if (args.name) {
+        name = args.name.toString();
+    }
+    if (args.folder) {
+        folder = args.folder.toString();
+    }
+    if (args.workspace) {
+        workspace = args.workspace.toString();
+        if (resolve(workspace) !== workspace) {
+            console.log('Workspace path must be an absolute path:', workspace);
+            exit(1);
+        }
+        defaultWorkspace = false;
+    }
+    if (args.runs) {
+        runs = parseInt(args.runs.toString());
+    }
+    debugging = args.debug;
+
+    // Verify that the application exists
+    const indexHTML = resolve(electronExample, 'src-gen/frontend/index.html');
+    if (!fsx.existsSync(indexHTML)) {
+        console.error('Electron example app does not exist. Please build it before running this script.');
+        process.exit(1);
+    }
+
+    if (defaultWorkspace) {
+        // Ensure that it exists
+        fsx.ensureDirSync(workspace);
+    }
+
+    await measurePerformance();
+})();
+
+async function measurePerformance() {
+    fsx.emptyDirSync(resolve(profilesPath, folder));
+    const traceConfigPath = resolve(profilesPath, folder, 'trace-config.json');
+
+    /**
+     * Generate trace config from the template.
+     * @param {number} runNr
+     * @returns {string} the output trace file path
+     */
+    const traceConfigGenerator = (runNr) => {
+        const traceConfig = { ...traceConfigTemplate };
+        const traceFilePath = resolve(profilesPath, folder, `${runNr}.json`);
+        traceConfig.result_file = traceFilePath
+        fsx.writeFileSync(traceConfigPath, JSON.stringify(traceConfig, undefined, 2), 'utf-8');
+        return traceFilePath;
+    };
+
+    const exitHandler = (andExit = false) => {
+        return () => {
+            if (electron && !electron.killed) {
+                process.kill(-electron.pid, 'SIGINT');
+            }
+            if (andExit) {
+                process.exit();
+            }
+        }
+    };
+
+    // Be sure not to leave a detached Electron child process
+    process.on('exit', exitHandler());
+    process.on('SIGINT', exitHandler(true));
+    process.on('SIGTERM', exitHandler(true));
+
+    let electron;
+
+    /** @type import('./common-performance').TestFunction */
+    const testScenario = async (runNr) => {
+        const traceFile = traceConfigGenerator(runNr);
+        electron = await launchElectron(traceConfigPath);
+
+        electron.stderr.on('data', data => analyzeStderr(data.toString()));
+
+        // Wait long enough to be sure that tracing has finished. Kill the process group
+        // because the 'theia' child process was detached
+        await delay(traceConfigTemplate.startup_duration * 1_000 * 3 / 2)
+            .then(() => electron.exitCode !== null || process.kill(-electron.pid, 'SIGINT'));
+        electron = undefined;
+        return traceFile;
+    };
+
+    measure(name, lcp, runs, testScenario, hasNonzeroTimestamp, isLCP);
+}
+
+/**
+ * Launch the Electron app as a detached child process with tracing configured to start
+ * immediately upon launch. The child process is detached because otherwise the attempt
+ * to signal it to terminate when the test run is complete will not terminate the entire
+ * process tree but only the root `theia` process, leaving the electron app instance
+ * running until eventually this script itself exits.
+ * 
+ * @param {string} traceConfigPath the path to the tracing configuration file with which to initiate tracing
+ * @returns {Promise<ChildProcess>} the Electron child process, if successfully launched
+ */
+async function launchElectron(traceConfigPath) {
+    const args = ['start', workspace, '--plugins=local-dir:../../plugins', `--trace-config-file=${traceConfigPath}`];
+    if (process.platform === 'linux') {
+        args.push('--headless');
+    }
+    return spawn(theia, args, { cwd: electronExample, detached: true });
+}
+
+function hasNonzeroTimestamp(traceEvent) {
+    return traceEvent.hasOwnProperty('ts') // The traces don't have explicit nulls or undefineds
+        && traceEvent.ts > 0;
+}
+
+/**
+ * Analyze a `chunk` of text on the standard error stream of the child process.
+ * If running in debug mode, this will always at least print out the `chunk` to the console.
+ * In addition, the text is analyzed to look for known conditions that will invalidate the
+ * test procedure and cause the script to bail. These include:
+ * 
+ * - the native browser modules not being built correctly for Electron
+ * 
+ * @param {string} chunk a chunk of standard error text from the child process
+ */
+function analyzeStderr(chunk) {
+    if (debugging) {
+        console.error('>', chunk.trimEnd());
+    }
+
+    if (chunk.includes('Error: Module did not self-register')) {
+        console.error('Native browser modules are not built properly. Please rebuild the workspace and try again.');
+        exit(1);
+    }
+}

--- a/scripts/performance/electron-trace-config.json
+++ b/scripts/performance/electron-trace-config.json
@@ -1,0 +1,16 @@
+{
+  "startup_duration": 10,
+  "result_file": "{{placeholder}}.json",
+  "trace_config": {
+    "enable_argument_filter": false,
+    "enable_systrace": false,
+    "included_categories": [
+      "blink",
+      "loading",
+      "disabled-by-default-devtools.timeline"
+    ],
+    "excluded_categories": [
+      "*"
+    ]
+  }
+}


### PR DESCRIPTION
#### What it does

Adds a new performance script for measurement of frontend start-up performance of the Electron example, similar to what was done in PR #9777. In fact, much of that script is factored out into a module of reusable functions to build the Electron script. This new script runs in much the same way, with similar command-line arguments to specify the number of runs and where to put the Chromium trace files.

Resolves #10440.

Example output:

```console
[Performance][Electron Frontend Startup][1] Largest Contentful Paint (LCP): 6.716 seconds
[Performance][Electron Frontend Startup][2] Largest Contentful Paint (LCP): 6.037 seconds
[Performance][Electron Frontend Startup][3] Largest Contentful Paint (LCP): 5.992 seconds
[Performance][Electron Frontend Startup][4] Largest Contentful Paint (LCP): 6.026 seconds
[Performance][Electron Frontend Startup][5] Largest Contentful Paint (LCP): 6.052 seconds
[Performance][Electron Frontend Startup][6] Largest Contentful Paint (LCP): 6.137 seconds
[Performance][Electron Frontend Startup][7] Largest Contentful Paint (LCP): 6.081 seconds
[Performance][Electron Frontend Startup][8] Largest Contentful Paint (LCP): 5.964 seconds
[Performance][Electron Frontend Startup][9] Largest Contentful Paint (LCP): 5.779 seconds
[Performance][Electron Frontend Startup][10] Largest Contentful Paint (LCP): 6.147 seconds
[Performance][Electron Frontend Startup][MEAN] Largest Contentful Paint (LCP): 6.093 seconds
[Performance][Electron Frontend Startup][STDEV] Largest Contentful Paint (LCP): 0.230 seconds
```

Note that the existing NPM script for the browser start-up performance is renamed from `performance:startup` to `performance:startup:browser` to distinguish it from the Electron case.

A new command-line option `--app` (`-a`) is added to the `extension-impact.js` script that selects the example application to build for execution of the tests. Supported values are `browser` and `electron`; the default if not specified is the browser app as before.

No new package dependencies are added.

Contributed on behalf of STMicroelectronics.

#### How to test

See the readme in the `scripts/performance/` directory for details of how to run the script. For most cases, it is sufficient just to run the NPM script from the monorepo root:

```console
$ yarn performance:startup:electron
```

This will print out performance measurements with summary statistics as shown above. You may also import the traces generated by the script in the `scripts/performance/profiles/electron/` directory into the Performance tab of the Chrome Developer Tools for analysis.

Also, try running the Extension Impact script with the new option to drive the Electron app:

```console
$ cd scripts/performance
$ node ./extension-performance.js --app electron
```

**Note** that executing the extension impact script on the Electron app after having run it on the browser app will often fail to get measurements for the `@theia/git` extension; it throws an exception about a mismatch in node versions in the native modules:

```console
Error: The module '/home/runner/work/theia/theia/node_modules/find-git-repositories/build/Release/findGitRepos.node'
was compiled against a different Node.js version using NODE_MODULE_VERSION 83. This version of Node.js requires
NODE_MODULE_VERSION 80. Please try re-compiling or re-installing the module (for instance, using `npm rebuild` or
`npm install`).
```

This can be remedied by cleaning the Git workspace and building it again before running the script.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
