### PR TITLE
Search additional roots

### DIFF
--- a/examples/api-tests/src/file-search.spec.js
+++ b/examples/api-tests/src/file-search.spec.js
@@ -64,8 +64,8 @@ describe('file-search', function () {
                 assert.equal(filterAndRange, quickFileOpenService['filterAndRangeDefault']);
             });
 
-            it('should update when searching', () => {
-                quickFileOpenService['getPicks']('a:2:1', new CancellationTokenSource().token); // perform a mock search.
+            it('should update when searching', async () => {
+                await quickFileOpenService['getPicks']('a:2:1', new CancellationTokenSource().token); // perform a mock search.
                 const filterAndRange = quickFileOpenService['filterAndRange'];
                 assert.equal(filterAndRange.filter, 'a');
                 assert.deepEqual(filterAndRange.range, { start: { line: 1, character: 0 }, end: { line: 1, character: 0 } });

--- a/packages/file-search/package.json
+++ b/packages/file-search/package.json
@@ -8,6 +8,7 @@
     "@theia/filesystem": "1.20.0",
     "@theia/monaco": "1.20.0",
     "@theia/process": "1.20.0",
+    "@theia/variable-resolver": "1.20.0",
     "@theia/workspace": "1.20.0",
     "vscode-ripgrep": "^1.2.4"
   },

--- a/packages/file-search/tsconfig.json
+++ b/packages/file-search/tsconfig.json
@@ -25,6 +25,9 @@
       "path": "../process"
     },
     {
+      "path": "../variable-resolver"
+    },
+    {
       "path": "../workspace"
     }
   ]

--- a/packages/search-in-workspace/package.json
+++ b/packages/search-in-workspace/package.json
@@ -8,6 +8,7 @@
     "@theia/filesystem": "1.20.0",
     "@theia/navigator": "1.20.0",
     "@theia/process": "1.20.0",
+    "@theia/variable-resolver": "1.20.0",
     "@theia/workspace": "1.20.0",
     "minimatch": "^3.0.4",
     "vscode-ripgrep": "^1.2.4"

--- a/packages/search-in-workspace/src/browser/search-in-workspace-preferences.ts
+++ b/packages/search-in-workspace/src/browser/search-in-workspace-preferences.ts
@@ -58,6 +58,11 @@ export const searchInWorkspacePreferencesSchema: PreferenceSchema = {
             description: nls.localizeByDefault('Controls whether to follow symlinks while searching.'),
             default: true,
             type: 'boolean',
+        },
+        'search.additionalRoots': {
+            description: nls.localize('theia/search-in-workspace/additionalRoots', 'Directories outside the current workspace that should be included in searches.'),
+            default: [],
+            type: 'array',
         }
     }
 };
@@ -70,6 +75,7 @@ export class SearchInWorkspaceConfiguration {
     'search.searchOnEditorModification': boolean;
     'search.smartCase': boolean;
     'search.followSymlinks': boolean;
+    'search.additionalRoots': string[];
 }
 
 export const SearchInWorkspacePreferenceContribution = Symbol('SearchInWorkspacePreferenceContribution');

--- a/packages/search-in-workspace/tsconfig.json
+++ b/packages/search-in-workspace/tsconfig.json
@@ -25,6 +25,9 @@
       "path": "../process"
     },
     {
+      "path": "../variable-resolver"
+    },
+    {
       "path": "../workspace"
     }
   ]


### PR DESCRIPTION
Signed-off-by: Gabriel Bodeen <gabriel.bodeen@ericsson.com>

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

This adds a preference for additional root directories to search in both the Search-In-Workspace widget and the File-Search (ctrl+p) menu.

In interviews with our users, one of their requests was for the search features to be able to find code that wasn't technically within their workspace, but that was located in other, closely-related directories. For particularly large directories, it can be advantageous to make the code easily searchable with Theia without incurring other costs such as file watching.

I wanted to check whether there was appetite for this preference to be added directly to the Theia project.  This preference explicitly goes beyond what is currently available in VS Code.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

1. Build Theia and launch with the Theia repository as the workspace.
2. Search the preferences for `additional`, switch to Workspace scope, and edit the JSON to enter one or more paths, e.g. to the Blueprint repo and to a non-existent directory. You can use variable substitutions. For example, in my settings.json I added `"search.additionalRoots": ["${env:HOME}/test/", "/repo/${env:USER}/theia-blueprint"]`.
3. Use the Search-In-Workspace widget and the File-Search (ctrl+p) menu with various terms and filenames. You should observe entries from both the Theia and Blueprint repos; the presence of a non-existent directory should not cause any errors.


#### Review checklist

- [X] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

** Note: I haven't tested on Windows or Mac.

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
