### PR TITLE
core: improve Deferred typings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,14 +1,14 @@
 # Change Log
 
-## v1.19.0 - 11/25/2021
+## v1.20.0 - 11/25/2021
 
-[1.20.0 Milestone](https://github.com/eclipse-theia/theia/milestone/26)
+[1.20.0 Milestone](https://github.com/eclipse-theia/theia/milestone/28)
 
 <a name="breaking_changes_1.20.0">[Breaking Changes:](#breaking_changes_1.20.0)</a>
 
-- [plugindev] Renamed HostedPlugin(Server|Client) to PluginDev(Server|Client)
-- [core] `value` is now not optional in `Deferred<T>.resolve(value: T)`
-- [core] `T` defaults to `void` if not specified when defining a `Deferred`
+- [plugindev] Renamed HostedPlugin(Server|Client) to PluginDev(Server|Client) [#10352](https://github.com/eclipse-theia/theia/pull/10352)
+- [core] `value` is now not optional in `Deferred<T>.resolve(value: T)` [#10455](https://github.com/eclipse-theia/theia/pull/10455)
+- [core] `T` defaults to `void` if not specified when defining a `Deferred` [#10455](https://github.com/eclipse-theia/theia/pull/10455)
 
 ## v1.19.0 - 10/28/2021
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Change Log
+
+## v1.19.0 - 11/25/2021
+
+[1.20.0 Milestone](https://github.com/eclipse-theia/theia/milestone/26)
+
+<a name="breaking_changes_1.20.0">[Breaking Changes:](#breaking_changes_1.20.0)</a>
+
 - [plugindev] Renamed HostedPlugin(Server|Client) to PluginDev(Server|Client)
+- [core] `value` is now not optional in `Deferred<T>.resolve(value: T)`
+- [core] `T` defaults to `void` if not specified when defining a `Deferred`
+
 ## v1.19.0 - 10/28/2021
 
 [1.19.0 Milestone](https://github.com/eclipse-theia/theia/milestone/25)

--- a/packages/core/src/common/promise-util.ts
+++ b/packages/core/src/common/promise-util.ts
@@ -20,14 +20,14 @@ import { CancellationToken, cancelled } from './cancellation';
  * Simple implementation of the deferred pattern.
  * An object that exposes a promise and functions to resolve and reject it.
  */
-export class Deferred<T> {
+export class Deferred<T = void> {
     state: 'resolved' | 'rejected' | 'unresolved' = 'unresolved';
-    resolve: (value?: T) => void;
+    resolve: (value: T) => void;
     reject: (err?: any) => void; // eslint-disable-line @typescript-eslint/no-explicit-any
 
     promise = new Promise<T>((resolve, reject) => {
         this.resolve = result => {
-            resolve(result as T);
+            resolve(result);
             if (this.state === 'unresolved') {
                 this.state = 'resolved';
             }

--- a/packages/vsx-registry/src/browser/vsx-extension-editor.tsx
+++ b/packages/vsx-registry/src/browser/vsx-extension-editor.tsx
@@ -77,7 +77,13 @@ export class VSXExtensionEditor extends ReactWidget {
     };
 
     protected resolveScrollContainer = (element: VSXExtensionEditorComponent | null) => {
-        this.deferredScrollContainer.resolve(element?.scrollContainer);
+        if (!element) {
+            this.deferredScrollContainer.reject(new Error('element is null'));
+        } else if (!element.scrollContainer) {
+            this.deferredScrollContainer.reject(new Error('element.scrollContainer is undefined'));
+        } else {
+            this.deferredScrollContainer.resolve(element.scrollContainer);
+        }
     };
 
     protected render(): React.ReactNode {

--- a/packages/workspace/src/node/default-workspace-server.ts
+++ b/packages/workspace/src/node/default-workspace-server.ts
@@ -43,7 +43,7 @@ export class WorkspaceCliContribution implements CliContribution {
         if (!wsPath) {
             wsPath = args['root-dir'] as string;
             if (!wsPath) {
-                this.workspaceRoot.resolve();
+                this.workspaceRoot.resolve(undefined);
                 return;
             }
         }


### PR DESCRIPTION
For some reason `Deferred` objects allow you to resolve them with
`undefined` even though the corresponding promise only mentions `T`.

Remove the optional `value` when resolving.

Default to `void` if `T` is unspecified.

#### How to test

Everything should build and work as before.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)