### PR TITLE
Add support for `PluginContext.logUri` and `PluginContext.extension`

### DIFF
--- a/packages/plugin-ext/src/plugin/plugin-manager.ts
+++ b/packages/plugin-ext/src/plugin/plugin-manager.ts
@@ -383,7 +383,9 @@ export class PluginManagerExtImpl implements PluginManagerExt, PluginManager {
             globalStoragePath: globalStoragePath,
             globalStorageUri: Uri.file(globalStoragePath),
             environmentVariableCollection: this.terminalService.getEnvironmentVariableCollection(plugin.model.id),
-            extensionMode: 1 // @todo: implement proper `extensionMode`.
+            extensionMode: 1, // @todo: implement proper `extensionMode`.
+            extension: plugin,
+            logUri: Uri.file(logPath)
         };
         this.pluginContextsMap.set(plugin.model.id, pluginContext);
 

--- a/packages/plugin/src/theia.d.ts
+++ b/packages/plugin/src/theia.d.ts
@@ -3204,6 +3204,19 @@ export module '@theia/plugin' {
          * other extensions in the host run in `ExtensionMode.Release`.
          */
         readonly extensionMode: ExtensionMode;
+
+        /**
+         * The current Extension instance.
+         */
+        readonly extension: Extension<any>;
+
+        /**
+         * The uri of a directory in which the extension can create log files. The directory might
+         * not exist on disk and creation is up to the extension. However, the parent directory is
+         * guaranteed to be existent.
+         * see - workspace.fs for how to read and write files and folders from an uri.
+         */
+        readonly logUri: Uri;
     }
 
     /**


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
Fixes #10033
The commit adds the properties `logUri` and `extension` to the `PluginContext` interface and enables their support.
<!-- Include relevant issues and describe how they are addressed. -->

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

#### Review checklist

- [X] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
