### PR TITLE
filesystem: fix `createFolder` emitter for user gestures

### DIFF
--- a/packages/filesystem/src/browser/file-service.ts
+++ b/packages/filesystem/src/browser/file-service.ts
@@ -1252,7 +1252,7 @@ export class FileService {
         return { exists, isSameResourceWithDifferentPathCase };
     }
 
-    async createFolder(resource: URI): Promise<FileStatWithMetadata> {
+    async createFolder(resource: URI, options?: FileOperationOptions): Promise<FileStatWithMetadata> {
         const provider = this.throwIfFileSystemIsReadonly(await this.withProvider(resource), resource);
 
         // mkdir recursively
@@ -1260,7 +1260,13 @@ export class FileService {
 
         // events
         const fileStat = await this.resolve(resource, { resolveMetadata: true });
-        this.onDidRunOperationEmitter.fire(new FileOperationEvent(resource, FileOperation.CREATE, fileStat));
+
+        if (options?.fromUserGesture === false) {
+            this.onDidRunOperationEmitter.fire(new FileOperationEvent(resource, FileOperation.CREATE, fileStat));
+        } else {
+            const event = { correlationId: this.correlationIds++, operation: FileOperation.CREATE, target: resource };
+            this.onDidRunUserOperationEmitter.fire(event);
+        }
 
         return fileStat;
     }

--- a/packages/plugin-ext/src/hosted/browser/hosted-plugin.ts
+++ b/packages/plugin-ext/src/hosted/browser/hosted-plugin.ts
@@ -542,7 +542,7 @@ export class HostedPluginSupport {
 
         // Make sure that folder by the path exists
         if (!await this.fileService.exists(globalStorageFolderUri)) {
-            await this.fileService.createFolder(globalStorageFolderUri);
+            await this.fileService.createFolder(globalStorageFolderUri, { fromUserGesture: false });
         }
         const globalStorageFolderFsPath = await this.fileService.fsPath(globalStorageFolderUri);
         if (!globalStorageFolderFsPath) {

--- a/packages/plugin-ext/src/main/browser/file-system-main-impl.ts
+++ b/packages/plugin-ext/src/main/browser/file-system-main-impl.ts
@@ -123,7 +123,7 @@ export class FileSystemMainImpl implements FileSystemMain, Disposable {
     }
 
     $mkdir(uri: UriComponents): Promise<void> {
-        return this._fileService.createFolder(new CoreURI(URI.revive(uri)))
+        return this._fileService.createFolder(new CoreURI(URI.revive(uri)), { fromUserGesture: false })
             .then(() => undefined).catch(FileSystemMainImpl._handleError);
     }
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

Fixes: https://github.com/eclipse-theia/theia/issues/10459

The commit fixes an issue where `createFolder` was called by a user-gesture (through the UI) which did not properly fire the
`onDidRunUserOperation` event. The event is ultimately used by the plugin-system to properly listen to file/folder creation through the `vscode.workspace.onDidCreateFiles` event.

The change now aligns with other methods such as `create`, `move` and `delete`.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

1. include the following test plugin [vscode.fs](https://github.com/vince-fugnitto/vscode-fs/releases/download/v0.0.1/vscode-fs-0.0.1.vsix) (which reports a notification when creating file/folders, and when performing a deletion)
2. start the application
3. create file through the UI - a notification should appear
4. create a folder through the UI - a notification should appear (does not on master)
5. deleting a file/folder should display a notification

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

Signed-off-by: vince-fugnitto <vincent.fugnitto@ericsson.com>