### PR TITLE
Integrate Performance Tests in CI

### DIFF
--- a/.github/workflows/performance-tests.yml
+++ b/.github/workflows/performance-tests.yml
@@ -1,0 +1,59 @@
+name: Performance Tests
+
+on:
+  workflow_dispatch:
+
+jobs:
+  build-and-test-performance:
+    name: ubuntu-latest, Node.js 16.x
+    
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Use Node.js 16.x
+        uses: actions/setup-node@v3
+        with:
+          node-version: "16.x"
+          registry-url: "https://registry.npmjs.org"
+
+      - name: Use Python 3.x
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.x"
+
+      - name: Build
+        shell: bash
+        run: |
+          yarn --skip-integrity-check --network-timeout 100000 --ignore-engines
+          yarn build:examples
+        env:
+          NODE_OPTIONS: --max_old_space_size=4096
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # https://github.com/microsoft/vscode-ripgrep/issues/9
+
+      - name: Performance (browser)
+        uses: GabrielBB/xvfb-action@v1
+        with:
+          run: yarn performance:startup:browser
+
+      - name: Performance (Electron)
+        uses: GabrielBB/xvfb-action@v1
+        with:
+          run: yarn performance:startup:electron
+
+      - name: Analyze performance results
+        uses: benchmark-action/github-action-benchmark@v1
+        with:
+          name: Performance Benchmarks
+          tool: "customSmallerIsBetter"
+          output-file-path: performance-result.json
+          alert-threshold: "150%"
+          fail-on-alert: false
+          github-token: ${{ secrets.GITHUB_TOKEN }} # Needed for comments an GH Pages
+          benchmark-data-dir-path: tests/performance
+          auto-push: true # Push to GH Pages
+          comment-on-alert: true # Comment on commit if it causes a performance regression
+          max-items-in-chart: 100 # Don't just collect results forever

--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,4 @@ scripts/download
 dependency-check-summary.txt*
 *-trace.json
 .tours
+/performance-result.json

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ## v1.33.0 - unreleased
 
+- [scripts] integrated start-up performance scripts into nightly master build [#10463](https://github.com/eclipse-theia/theia/pull/10463) - Contributed on behalf of STMicroelectronics
+
 <a name="breaking_changes_1.33.0">[Breaking Changes:](#breaking_changes_1.33.0)</a>
 
 - [core] returns of many methods of `MenuModelRegistry` changed from `CompositeMenuNode` to `MutableCompoundMenuNode`. To mutate a menu, use the `updateOptions` method or add a check for `instanceof CompositeMenuNode`, which will be true in most cases.

--- a/scripts/performance/browser-performance.js
+++ b/scripts/performance/browser-performance.js
@@ -17,7 +17,7 @@
 const puppeteer = require('puppeteer');
 const fsx = require('fs-extra');
 const { resolve } = require('path');
-const { delay, lcp, isLCP, measure } = require('./common-performance');
+const { delay, githubReporting, isLCP, lcp, measure } = require('./common-performance');
 
 const workspacePath = resolve('./workspace');
 const profilesPath = './profiles/';
@@ -72,6 +72,9 @@ let runs = 10;
     }
     if (args.headless !== undefined && args.headless.toString() === 'false') {
         headless = false;
+    }
+    if (process.env.GITHUB_ACTIONS) {
+        githubReporting.enabled = true;
     }
 
     // Verify that the application exists

--- a/scripts/performance/electron-performance.js
+++ b/scripts/performance/electron-performance.js
@@ -17,7 +17,7 @@
 const fsx = require('fs-extra');
 const { resolve } = require('path');
 const { spawn, ChildProcess } = require('child_process');
-const { delay, lcp, isLCP, measure } = require('./common-performance');
+const { delay, githubReporting, isLCP, lcp, measure } = require('./common-performance');
 const traceConfigTemplate = require('./electron-trace-config.json');
 const { exit } = require('process');
 
@@ -80,6 +80,9 @@ let debugging = false;
         runs = parseInt(args.runs.toString());
     }
     debugging = args.debug;
+    if (process.env.GITHUB_ACTIONS) {
+        githubReporting.enabled = true;
+    }
 
     // Verify that the application exists
     const indexHTML = resolve(electronExample, 'src-gen/frontend/index.html');


### PR DESCRIPTION
#### What it does

Adds a “Performance Tests” job to the build workflow in the project’s GitHub Actions to execute the browser and Electron start-up performance scripts, record and chart the results, and compare with past results for regression. The job is configured to

- Run only in the scheduled nightly build on the master branch
- Publish results in the GitHub pages at https://eclipse-theia.github.io/theia/tests/performance/
- On detection of measurements 150% longer than recent history, annotate the commit that was tested with a comment indicating that it may cause a performance regression
- The build does not fail on detection of regression. It is a warning condition only

Example output: an example of the performance history chart produced by these changes [is available here](https://cdamus.github.io/theia/tests/performance/).

A new dependency on the third-party [github-action-benchmark](https://github.com/marketplace/actions/continuous-benchmark) GitHub action is added. It is configured to

- Commit and push performance history updates and visualization charts to the project’s GitHub pages. **Note** that this does not interfere with the `/docs/next/` content already published on this branch. This [can be seen here](https://cdamus.github.io/theia/docs/next/)
- Annotate the `HEAD` commit with comments when performance regression is detected

Resolves #10443.

Contributed on behalf of STMicroelectronics.

#### How to test

Execute the performance scripts pretending the GitHub CI environment:

```console
$ GITHUB_ACTIONS=true yarn performance:startup:browser && \
>   yarn performance:startup:electron
```

This will record performance measurements to the `performance-result.json` file that the GitHub benchmark action picks up for its history recording and analysis.

As the build job is configured not to run on PR branches but only on the master branch, testing the rest of the flow is more tricky. The behaviour can be [observed in this fork](https://github.com/cdamus/theia/actions/workflows/build.yml) in which the changes were initially drafted.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
