### PR TITLE
Properly handle debug console completion

### DIFF
--- a/packages/debug/src/browser/debug-session.tsx
+++ b/packages/debug/src/browser/debug-session.tsx
@@ -34,7 +34,7 @@ import debounce = require('p-debounce');
 import URI from '@theia/core/lib/common/uri';
 import { BreakpointManager } from './breakpoint/breakpoint-manager';
 import { DebugSessionOptions, InternalDebugSessionOptions } from './debug-session-options';
-import { DebugConfiguration } from '../common/debug-common';
+import { DebugConfiguration, DebugConsoleMode } from '../common/debug-common';
 import { SourceBreakpoint, ExceptionBreakpoint } from './breakpoint/breakpoint-marker';
 import { TerminalWidgetOptions, TerminalWidget } from '@theia/terminal/lib/browser/base/terminal-widget';
 import { DebugFunctionBreakpoint } from './model/debug-function-breakpoint';
@@ -817,4 +817,19 @@ export class DebugSession implements CompositeTreeElement {
             contrib.register(configType, connection);
         }
     };
+
+    /**
+     * Returns the top-most parent session that is responsible for the console. If this session uses a {@link DebugConsoleMode.Separate separate console}
+     * or does not have any parent session, undefined is returned.
+     */
+    public findConsoleParent(): DebugSession | undefined {
+        if (this.configuration.consoleMode !== DebugConsoleMode.MergeWithParent) {
+            return undefined;
+        }
+        let debugSession: DebugSession | undefined = this;
+        do {
+            debugSession = this.parentSession;
+        } while (debugSession?.parentSession && debugSession.configuration.consoleMode === DebugConsoleMode.MergeWithParent);
+        return debugSession;
+    }
 }


### PR DESCRIPTION
#### What it does
- Ensure console session is disposed when debug session is destroyed
- Remove  monaco completion item provider on disposal
- Ensure we only provide completion items for our own session
- Sync debug console with the currently selected session

![java_fix](https://user-images.githubusercontent.com/19170971/143573826-f47d6a72-c55e-40a0-ad79-fad991567059.gif)

Fixes https://github.com/eclipse-theia/theia/issues/10468
Fixes #10648 

#### How to test
1. Install Java Debugger
2. Create two simple Java programs with one variable to test the completion capabilities
3. Run both debugging sessions at once and try to use completion in the Debug Console
4. Switch between debug session consoles to see if completion items are available and only provided for the selected session

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
