### PR TITLE
Properly render 'expand' and 'collapse' action on notification

### DIFF
--- a/packages/messages/src/browser/notification-component.tsx
+++ b/packages/messages/src/browser/notification-component.tsx
@@ -84,7 +84,7 @@ export class NotificationComponent extends React.Component<NotificationComponent
                     </div>
                     <ul className='theia-notification-actions'>
                         {expandable && (
-                            <li className={codicon('chevron-down') + collapsed ? ' expand' : ' collapse'} title={collapsed ? 'Expand' : 'Collapse'}
+                            <li className={codicon('chevron-down', true) + (collapsed ? ' expand' : ' collapse')} title={collapsed ? 'Expand' : 'Collapse'}
                                 data-message-id={messageId} onClick={this.onToggleExpansion} />
                         )}
                         {!isProgress && (<li className={codicon('close', true)} title={nls.localizeByDefault('Clear')} data-message-id={messageId}

--- a/packages/messages/src/browser/notification-component.tsx
+++ b/packages/messages/src/browser/notification-component.tsx
@@ -84,7 +84,7 @@ export class NotificationComponent extends React.Component<NotificationComponent
                     </div>
                     <ul className='theia-notification-actions'>
                         {expandable && (
-                            <li className={codicon('chevron-down') + (collapsed ? ' expand' : ' collapse')} title={collapsed ? 'Expand' : 'Collapse'}
+                            <li className={codicon('chevron-down', true) + (collapsed ? ' expand' : ' collapse')} title={collapsed ? 'Expand' : 'Collapse'}
                                 data-message-id={messageId} onClick={this.onToggleExpansion} />
                         )}
                         {!isProgress && (<li className={codicon('close', true)} title={nls.localizeByDefault('Clear')} data-message-id={messageId}

--- a/packages/messages/src/browser/notification-component.tsx
+++ b/packages/messages/src/browser/notification-component.tsx
@@ -84,7 +84,7 @@ export class NotificationComponent extends React.Component<NotificationComponent
                     </div>
                     <ul className='theia-notification-actions'>
                         {expandable && (
-                            <li className={codicon('chevron-down', true) + (collapsed ? ' expand' : ' collapse')} title={collapsed ? 'Expand' : 'Collapse'}
+                            <li className={codicon('chevron-down') + (collapsed ? ' expand' : ' collapse')} title={collapsed ? 'Expand' : 'Collapse'}
                                 data-message-id={messageId} onClick={this.onToggleExpansion} />
                         )}
                         {!isProgress && (<li className={codicon('close', true)} title={nls.localizeByDefault('Clear')} data-message-id={messageId}

--- a/packages/messages/src/browser/style/notifications.css
+++ b/packages/messages/src/browser/style/notifications.css
@@ -195,10 +195,6 @@
     transform: rotate(180deg);
 }
 
-.theia-notification-actions > .collapse {
-    transform: rotate(0deg);
-}
-
 .theia-notification-list-item-content-bottom {
     display: flex;
     flex-direction: row;

--- a/packages/messages/src/browser/style/notifications.css
+++ b/packages/messages/src/browser/style/notifications.css
@@ -192,11 +192,11 @@
 }
 
 .theia-notification-actions > .expand {
-    transform: rotate(0deg);
+    transform: rotate(180deg);
 }
 
 .theia-notification-actions > .collapse {
-    transform: rotate(-90deg);
+    transform: rotate(0deg);
 }
 
 .theia-notification-list-item-content-bottom {

--- a/packages/messages/src/browser/style/notifications.css
+++ b/packages/messages/src/browser/style/notifications.css
@@ -191,27 +191,17 @@
     margin-left: 4px;
 }
 
-.theia-notification-actions > li:hover {
-    /* remove default background change as due to the different scaling of the items it might look odd */ 
-    background-color: transparent;
-    transform: scale(1.5);
-}
-
 .theia-notification-actions > .expand {
     transform: rotate(0deg) scale(1.35);
 }
-
-.theia-notification-actions > .expand:active,
-.theia-notification-actions > li.expand:hover {
+.theia-notification-actions > .expand:active {
     transform: rotate(0deg) scale(1.8);
 }
 
 .theia-notification-actions > .collapse {
     transform: rotate(-90deg) scale(1.35);
 }
-
-.theia-notification-actions > .collapse:active,
-.theia-notification-actions > li.collapse:hover {
+.theia-notification-actions > .collapse:active {
     transform: rotate(-90deg) scale(1.8);
 }
 

--- a/packages/messages/src/browser/style/notifications.css
+++ b/packages/messages/src/browser/style/notifications.css
@@ -192,17 +192,11 @@
 }
 
 .theia-notification-actions > .expand {
-    transform: rotate(0deg) scale(1.35);
-}
-.theia-notification-actions > .expand:active {
-    transform: rotate(0deg) scale(1.8);
+    transform: rotate(0deg);
 }
 
 .theia-notification-actions > .collapse {
-    transform: rotate(-90deg) scale(1.35);
-}
-.theia-notification-actions > .collapse:active {
-    transform: rotate(-90deg) scale(1.8);
+    transform: rotate(-90deg);
 }
 
 .theia-notification-list-item-content-bottom {

--- a/packages/messages/src/browser/style/notifications.css
+++ b/packages/messages/src/browser/style/notifications.css
@@ -191,17 +191,27 @@
     margin-left: 4px;
 }
 
-.theia-notification-actions > .expand {
-    transform: rotate(0deg) scale(1.5);
+.theia-notification-actions > li:hover {
+    /* remove default background change as due to the different scaling of the items it might look odd */ 
+    background-color: transparent;
+    transform: scale(1.5);
 }
-.theia-notification-actions > .expand:active {
+
+.theia-notification-actions > .expand {
+    transform: rotate(0deg) scale(1.35);
+}
+
+.theia-notification-actions > .expand:active,
+.theia-notification-actions > li.expand:hover {
     transform: rotate(0deg) scale(1.8);
 }
 
 .theia-notification-actions > .collapse {
-    transform: rotate(-90deg) scale(1.5);
+    transform: rotate(-90deg) scale(1.35);
 }
-.theia-notification-actions > .collapse:active {
+
+.theia-notification-actions > .collapse:active,
+.theia-notification-actions > li.collapse:hover {
     transform: rotate(-90deg) scale(1.8);
 }
 


### PR DESCRIPTION
#### What it does
- Fix assignment of class names
- Scale icons to better fit the 'close icon'
-- Remove hover background as due to the scaling it looks weird
-- Use scaling as indicator instead

![fix_expandCollapse](https://user-images.githubusercontent.com/19170971/143581539-055a536c-25ed-4812-8ecb-b0dfd966391b.gif)

Fixes https://github.com/eclipse-theia/theia/issues/10470

#### How to test

1. Produce a message over 500 characters (for example through a sample menu contribution)
2. See that the expand/collapse action is there and working

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
