### PR TITLE
Implement light-weight Workspace Trust API for plugins

### DIFF
--- a/packages/plugin-ext/src/common/plugin-api-rpc.ts
+++ b/packages/plugin-ext/src/common/plugin-api-rpc.ts
@@ -621,6 +621,7 @@ export interface WorkspaceMain {
     $onTextDocumentContentChange(uri: string, content: string): void;
     $updateWorkspaceFolders(start: number, deleteCount?: number, ...rootsToAdd: string[]): Promise<void>;
     $getWorkspace(): Promise<files.FileStat | undefined>;
+    $requestWorkspaceTrust(options?: theia.WorkspaceTrustRequestOptions): Promise<boolean | undefined>;
 }
 
 export interface WorkspaceExt {
@@ -628,6 +629,7 @@ export interface WorkspaceExt {
     $onWorkspaceLocationChanged(event: files.FileStat | undefined): void;
     $provideTextDocumentContent(uri: string): Promise<string | undefined>;
     $onTextSearchResult(searchRequestId: number, done: boolean, result?: SearchInWorkspaceResult): void;
+    $onWorkspaceTrustChanged(trust: boolean | undefined): void;
 }
 
 export interface TimelineExt {

--- a/packages/plugin-ext/src/plugin/plugin-context.ts
+++ b/packages/plugin-ext/src/plugin/plugin-context.ts
@@ -571,6 +571,15 @@ export function createAPIFactory(
             },
             registerTimelineProvider(scheme: string | string[], provider: theia.TimelineProvider): theia.Disposable {
                 return timelineExt.registerTimelineProvider(plugin, scheme, provider);
+            },
+            get isTrusted(): boolean {
+                return workspaceExt.trusted;
+            },
+            async requestWorkspaceTrust(options?: theia.WorkspaceTrustRequestOptions): Promise<boolean | undefined> {
+                return workspaceExt.requestWorkspaceTrust(options);
+            },
+            get onDidGrantWorkspaceTrust(): theia.Event<void> {
+                return workspaceExt.onDidGrantWorkspaceTrust;
             }
         };
 

--- a/packages/plugin/src/theia.d.ts
+++ b/packages/plugin/src/theia.d.ts
@@ -6049,6 +6049,28 @@ export module '@theia/plugin' {
          * @return A [disposable](#Disposable) that unregisters this provider when being disposed.
          */
         export function registerTaskProvider(type: string, provider: TaskProvider): Disposable;
+
+        /**
+         * When true, the user has explicitly trusted the contents of the workspace.
+         */
+        export const isTrusted: boolean;
+
+        export function requestWorkspaceTrust(options?: WorkspaceTrustRequestOptions): Promise<boolean | undefined>;
+
+        /**
+         * Event that fires when the current workspace has been trusted.
+         */
+        export const onDidGrantWorkspaceTrust: Event<void>;
+    }
+
+    export interface WorkspaceTrustRequestButton {
+        readonly label: string;
+        readonly type: 'ContinueWithTrust' | 'ContinueWithoutTrust' | 'Manage' | 'Cancel'
+    }
+
+    export interface WorkspaceTrustRequestOptions {
+        readonly buttons?: WorkspaceTrustRequestButton[];
+        readonly message?: string;
     }
 
     export namespace env {

--- a/packages/preferences/src/browser/util/preference-tree-generator.ts
+++ b/packages/preferences/src/browser/util/preference-tree-generator.ts
@@ -45,6 +45,7 @@ export class PreferenceTreeGenerator {
         ['window', 'Window'],
         ['features', 'Features'],
         ['application', 'Application'],
+        ['security', 'Security'],
         ['extensions', 'Extensions']
     ]);
     protected readonly sectionAssignments = new Map([

--- a/packages/workspace/src/browser/index.ts
+++ b/packages/workspace/src/browser/index.ts
@@ -19,3 +19,4 @@ export * from './workspace-service';
 export * from './workspace-frontend-contribution';
 export * from './workspace-frontend-module';
 export * from './workspace-preferences';
+export * from './workspace-trust-service';

--- a/packages/workspace/src/browser/workspace-frontend-module.ts
+++ b/packages/workspace/src/browser/workspace-frontend-module.ts
@@ -48,9 +48,12 @@ import { JsonSchemaContribution } from '@theia/core/lib/browser/json-schema-stor
 import { WorkspaceSchemaUpdater } from './workspace-schema-updater';
 import { WorkspaceBreadcrumbsContribution } from './workspace-breadcrumbs-contribution';
 import { FilepathBreadcrumbsContribution } from '@theia/filesystem/lib/browser/breadcrumbs/filepath-breadcrumbs-contribution';
+import { WorkspaceTrustService } from './workspace-trust-service';
+import { bindWorkspaceTrustPreferences } from './workspace-trust-preferences';
 
 export default new ContainerModule((bind: interfaces.Bind, unbind: interfaces.Unbind, isBound: interfaces.IsBound, rebind: interfaces.Rebind) => {
     bindWorkspacePreferences(bind);
+    bindWorkspaceTrustPreferences(bind);
 
     bind(WorkspaceService).toSelf().inSingletonScope();
     bind(FrontendApplicationContribution).toService(WorkspaceService);
@@ -100,4 +103,6 @@ export default new ContainerModule((bind: interfaces.Bind, unbind: interfaces.Un
     bind(WorkspaceSchemaUpdater).toSelf().inSingletonScope();
     bind(JsonSchemaContribution).toService(WorkspaceSchemaUpdater);
     rebind(FilepathBreadcrumbsContribution).to(WorkspaceBreadcrumbsContribution).inSingletonScope();
+
+    bind(WorkspaceTrustService).toSelf().inSingletonScope();
 });

--- a/packages/workspace/src/browser/workspace-trust-preferences.ts
+++ b/packages/workspace/src/browser/workspace-trust-preferences.ts
@@ -1,0 +1,76 @@
+/********************************************************************************
+ * Copyright (C) 2021 EclipseSource and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import {
+    createPreferenceProxy, PreferenceContribution, PreferenceProxy, PreferenceSchema, PreferenceService
+} from '@theia/core/lib/browser/preferences';
+import { nls } from '@theia/core/lib/common/nls';
+import { interfaces } from '@theia/core/shared/inversify';
+
+export const WORKSPACE_TRUST_ENABLED = 'security.workspace.trust.enabled';
+export const WORKSPACE_TRUST_STARTUP_PROMPT = 'security.workspace.trust.startupPrompt';
+export const WORKSPACE_TRUST_EMPTY_WINDOW = 'security.workspace.trust.emptyWindow';
+
+export enum WorkspaceTrustPrompt {
+    ALWAYS = 'always',
+    ONCE = 'once',
+    NEVER = 'never'
+}
+
+export const workspaceTrustPreferenceSchema: PreferenceSchema = {
+    type: 'object',
+    properties: {
+        [WORKSPACE_TRUST_ENABLED]: {
+            description: nls.localize('theia/workspace/trustEnabled', 'Controls whether or not workspace trust is enabled. If disabled, all workspaces are trusted.'),
+            type: 'boolean',
+            defaultValue: true
+        },
+        [WORKSPACE_TRUST_STARTUP_PROMPT]: {
+            description: nls.localizeByDefault('Controls when the startup prompt to trust a workspace is shown.'),
+            enum: Object.values(WorkspaceTrustPrompt),
+            defaultValue: WorkspaceTrustPrompt.ALWAYS
+        },
+        [WORKSPACE_TRUST_EMPTY_WINDOW]: {
+            description: nls.localize('theia/workspace/trustEmptyWindow', 'Controls whether or not the empty workspace is trusted by default.'),
+            type: 'boolean',
+            defaultValue: true
+        }
+    }
+};
+
+export interface WorkspaceTrustConfiguration {
+    [WORKSPACE_TRUST_ENABLED]: boolean,
+    [WORKSPACE_TRUST_STARTUP_PROMPT]: WorkspaceTrustPrompt;
+    [WORKSPACE_TRUST_EMPTY_WINDOW]: boolean;
+}
+
+export const WorkspaceTrustPreferenceContribution = Symbol('WorkspaceTrustPreferenceContribution');
+export const WorkspaceTrustPreferences = Symbol('WorkspaceTrustPreferences');
+export type WorkspaceTrustPreferences = PreferenceProxy<WorkspaceTrustConfiguration>;
+
+export function createWorkspaceTrustPreferences(preferences: PreferenceService, schema: PreferenceSchema = workspaceTrustPreferenceSchema): WorkspaceTrustPreferences {
+    return createPreferenceProxy(preferences, schema);
+}
+
+export function bindWorkspaceTrustPreferences(bind: interfaces.Bind): void {
+    bind(WorkspaceTrustPreferences).toDynamicValue(ctx => {
+        const preferences = ctx.container.get<PreferenceService>(PreferenceService);
+        const contribution = ctx.container.get<PreferenceContribution>(WorkspaceTrustPreferenceContribution);
+        return createWorkspaceTrustPreferences(preferences, contribution.schema);
+    }).inSingletonScope();
+    bind(WorkspaceTrustPreferenceContribution).toConstantValue({ schema: workspaceTrustPreferenceSchema });
+    bind(PreferenceContribution).toService(WorkspaceTrustPreferenceContribution);
+}

--- a/packages/workspace/src/browser/workspace-trust-service.ts
+++ b/packages/workspace/src/browser/workspace-trust-service.ts
@@ -1,0 +1,143 @@
+/********************************************************************************
+ * Copyright (C) 2021 EclipseSource and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import { ConfirmDialog, Dialog, PreferenceChange, StorageService } from '@theia/core/lib/browser';
+import { PreferenceService } from '@theia/core/lib/browser/preferences/preference-service';
+import { MessageService } from '@theia/core/lib/common/message-service';
+import { nls } from '@theia/core/lib/common/nls';
+import { Deferred } from '@theia/core/lib/common/promise-util';
+import { inject, injectable, postConstruct } from '@theia/core/shared/inversify';
+import { WindowService } from '@theia/core/lib/browser/window/window-service';
+import { WorkspaceService } from '.';
+import {
+    WorkspaceTrustPreferences, WORKSPACE_TRUST_EMPTY_WINDOW, WORKSPACE_TRUST_ENABLED, WORKSPACE_TRUST_STARTUP_PROMPT, WorkspaceTrustPrompt
+} from './workspace-trust-preferences';
+import { FrontendApplicationConfigProvider } from '@theia/core/lib/browser/frontend-application-config-provider';
+
+const STORAGE_TRUSTED = 'trusted';
+
+@injectable()
+export class WorkspaceTrustService {
+    @inject(WorkspaceService)
+    protected readonly workspaceService: WorkspaceService;
+
+    @inject(PreferenceService)
+    protected readonly preferences: PreferenceService;
+
+    @inject(StorageService)
+    protected readonly storage: StorageService;
+
+    @inject(MessageService)
+    protected readonly messageService: MessageService;
+
+    @inject(WorkspaceTrustPreferences)
+    protected readonly workspaceTrustPref: WorkspaceTrustPreferences;
+
+    @inject(WindowService)
+    protected readonly windowService: WindowService;
+
+    protected workspaceTrust = new Deferred<boolean>();
+
+    @postConstruct()
+    protected async init(): Promise<void> {
+        await this.workspaceService.ready;
+        await this.resolveWorkspaceTrust();
+        this.preferences.onPreferenceChanged(change => this.handlePreferenceChange(change));
+    }
+
+    getWorkspaceTrust(): Promise<boolean> {
+        return this.workspaceTrust.promise;
+    }
+
+    protected async resolveWorkspaceTrust(givenTrust?: boolean): Promise<void> {
+        if (!this.isWorkspaceTrustResolved()) {
+            const trust = givenTrust ?? await this.calculateWorkspaceTrust();
+            if (trust !== undefined) {
+                await this.storeWorkspaceTrust(trust);
+                this.workspaceTrust.resolve(trust);
+            }
+        }
+    }
+
+    protected isWorkspaceTrustResolved(): boolean {
+        return this.workspaceTrust.state !== 'unresolved';
+    }
+
+    protected async calculateWorkspaceTrust(): Promise<boolean | undefined> {
+        if (!this.workspaceTrustPref[WORKSPACE_TRUST_ENABLED]) {
+            // in VS Code if workspace trust is disabled, we implicitly trust the workspace
+            return true;
+        }
+
+        if (this.workspaceTrustPref[WORKSPACE_TRUST_EMPTY_WINDOW] && !this.workspaceService.workspace) {
+            return true;
+        }
+
+        if (this.workspaceTrustPref[WORKSPACE_TRUST_STARTUP_PROMPT] === WorkspaceTrustPrompt.NEVER) {
+            return false;
+        }
+
+        return this.loadWorkspaceTrust();
+    }
+
+    protected async loadWorkspaceTrust(): Promise<boolean | undefined> {
+        if (this.workspaceTrustPref[WORKSPACE_TRUST_STARTUP_PROMPT] === WorkspaceTrustPrompt.ONCE) {
+            return this.storage.getData<boolean>(STORAGE_TRUSTED);
+        }
+    }
+
+    protected async storeWorkspaceTrust(trust: boolean): Promise<void> {
+        if (this.workspaceTrustPref[WORKSPACE_TRUST_STARTUP_PROMPT] === WorkspaceTrustPrompt.ONCE) {
+            return this.storage.setData(STORAGE_TRUSTED, trust);
+        }
+    }
+
+    protected async handlePreferenceChange(change: PreferenceChange): Promise<void> {
+        if (change.preferenceName === WORKSPACE_TRUST_STARTUP_PROMPT && change.newValue !== WorkspaceTrustPrompt.ONCE) {
+            this.storage.setData(STORAGE_TRUSTED, undefined);
+        }
+
+        if (change.preferenceName === WORKSPACE_TRUST_ENABLED && this.isWorkspaceTrustResolved() && await this.confirmRestart()) {
+            this.windowService.setSafeToShutDown();
+            this.windowService.reload();
+        }
+
+        if (change.preferenceName === WORKSPACE_TRUST_ENABLED || change.preferenceName === WORKSPACE_TRUST_EMPTY_WINDOW) {
+            this.resolveWorkspaceTrust();
+        }
+    }
+
+    protected async confirmRestart(): Promise<boolean> {
+        const shouldRestart = await new ConfirmDialog({
+            title: nls.localizeByDefault('A setting has changed that requires a restart to take effect.'),
+            msg: nls.localizeByDefault('Press the restart button to restart {0} and enable the setting.', FrontendApplicationConfigProvider.get().applicationName),
+            ok: nls.localizeByDefault('Restart'),
+            cancel: Dialog.CANCEL,
+        }).open();
+        return shouldRestart === true;
+    }
+
+    async requestWorkspaceTrust(): Promise<boolean | undefined> {
+        if (!this.isWorkspaceTrustResolved()) {
+            const isTrusted = await this.messageService.info(nls.localize('theia/workspace/trustRequest',
+                'An extension requests workspace trust but the corresponding API is not yet fully supported. Do you want to trust this workspace?'),
+                Dialog.YES, Dialog.NO);
+            const trusted = isTrusted === Dialog.YES;
+            this.resolveWorkspaceTrust(trusted);
+        }
+        return this.workspaceTrust.promise;
+    }
+}


### PR DESCRIPTION
#### What it does
- Add trust-relevant methods and interfaces to the plugin workspace API
- Add request for workspace trust to workspace service
- Allow application setting to auto-respond to trust request

https://github.com/eclipse-theia/theia/issues/10472

**Note: I share this PR to showcase how the issue might be solved as I tried to double-check the issue I was facing. While it is working and hopefully not doing any harm, further discussions and improvements might be needed for a real support of the workspace trust API.**

#### How to test
- Create a Theia Electron application as described in https://github.com/eclipse-theia/theia/issues/10472
- Trigger the remote pickup through: Source Control View > Remote > Add Remote...

![fix_git](https://user-images.githubusercontent.com/19170971/143605667-f93685f6-3ada-4bd5-85af-d7e3da306298.png)
(working Remote query)

![git-trust](https://user-images.githubusercontent.com/19170971/143605941-7999ee23-f4f3-4400-ade7-554a3d3ef6b3.png)
(user trust query)

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
