### PR TITLE
Fixed mini browser preview URL shows open source icon 

### DIFF
--- a/packages/mini-browser/src/browser/mini-browser-open-handler.ts
+++ b/packages/mini-browser/src/browser/mini-browser-open-handler.ts
@@ -273,7 +273,7 @@ export class MiniBrowserOpenHandler extends NavigatableWidgetOpenHandler<MiniBro
 
     protected getSourceUri(ref?: Widget): URI | undefined {
         const uri = ref instanceof MiniBrowser && ref.getResourceUri() || undefined;
-        if (!uri || uri.scheme === 'http' || uri.scheme === 'https') {
+        if (!uri || uri.isEqual(MiniBrowserOpenHandler.PREVIEW_URI)) {
             return undefined;
         }
         return uri;


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

Fixes: https://github.com/eclipse-theia/theia/issues/10478 

Since the URI passed to `getSourceUri` function doesn't have "http" or "https" scheme, and since a remote URL opened in preview mode doesn't have a a source URI on disk, a simple check is performed to check if the passed URI is equal to `MiniBrowserOpenHandler`'s `PREVIEW_URI` static variable.
#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
1. Press Command + Shift + P to open up command palette. Type "Open URL" and press enter.
2. Enter any URL that you want to open.
3. Mini browser will open the specified url in preview mode, and will be docked to the right side panel. Look at its top right side, and an "Open Source" icon will not be visible.
#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
