### PR TITLE
webpack: fix the frontend source map names

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -20,18 +20,18 @@
       "type": "node",
       "request": "launch",
       "name": "Launch Electron Backend",
-      "runtimeExecutable": "${workspaceRoot}/node_modules/.bin/electron",
+      "runtimeExecutable": "${workspaceFolder}/node_modules/.bin/electron",
       "windows": {
-        "runtimeExecutable": "${workspaceRoot}/node_modules/.bin/electron.cmd"
+        "runtimeExecutable": "${workspaceFolder}/node_modules/.bin/electron.cmd"
       },
-      "cwd": "${workspaceRoot}/examples/electron",
+      "cwd": "${workspaceFolder}/examples/electron",
       "protocol": "inspector",
       "args": [
         ".",
         "--log-level=debug",
         "--hostname=localhost",
         "--no-cluster",
-        "--app-project-path=${workspaceRoot}/examples/electron",
+        "--app-project-path=${workspaceFolder}/examples/electron",
         "--remote-debugging-port=9222",
         "--no-app-auto-install",
         "--plugins=local-dir:../../plugins"
@@ -41,11 +41,11 @@
       },
       "sourceMaps": true,
       "outFiles": [
-        "${workspaceRoot}/examples/electron/src-gen/frontend/electron-main.js",
-        "${workspaceRoot}/examples/electron/src-gen/backend/main.js",
-        "${workspaceRoot}/examples/electron/lib/**/*.js",
-        "${workspaceRoot}/packages/*/lib/**/*.js",
-        "${workspaceRoot}/dev-packages/*/lib/**/*.js"
+        "${workspaceFolder}/examples/electron/src-gen/frontend/electron-main.js",
+        "${workspaceFolder}/examples/electron/src-gen/backend/main.js",
+        "${workspaceFolder}/examples/electron/lib/**/*.js",
+        "${workspaceFolder}/packages/*/lib/**/*.js",
+        "${workspaceFolder}/dev-packages/*/lib/**/*.js"
       ],
       "smartStep": true,
       "internalConsoleOptions": "openOnSessionStart",
@@ -55,12 +55,12 @@
       "type": "node",
       "request": "launch",
       "name": "Launch Browser Backend",
-      "program": "${workspaceRoot}/examples/browser/src-gen/backend/main.js",
+      "program": "${workspaceFolder}/examples/browser/src-gen/backend/main.js",
       "args": [
         "--hostname=0.0.0.0",
         "--port=3000",
         "--no-cluster",
-        "--app-project-path=${workspaceRoot}/examples/browser",
+        "--app-project-path=${workspaceFolder}/examples/browser",
         "--plugins=local-dir:plugins",
         "--hosted-plugin-inspect=9339"
       ],
@@ -69,10 +69,10 @@
       },
       "sourceMaps": true,
       "outFiles": [
-        "${workspaceRoot}/examples/browser/src-gen/backend/*.js",
-        "${workspaceRoot}/examples/browser/lib/**/*.js",
-        "${workspaceRoot}/packages/*/lib/**/*.js",
-        "${workspaceRoot}/dev-packages/*/lib/**/*.js"
+        "${workspaceFolder}/examples/browser/src-gen/backend/*.js",
+        "${workspaceFolder}/examples/browser/lib/**/*.js",
+        "${workspaceFolder}/packages/*/lib/**/*.js",
+        "${workspaceFolder}/dev-packages/*/lib/**/*.js"
       ],
       "smartStep": true,
       "internalConsoleOptions": "openOnSessionStart",
@@ -89,18 +89,18 @@
       "sourceMaps": true,
       "internalConsoleOptions": "openOnSessionStart",
       "outFiles": [
-        "${workspaceRoot}/packages/plugin-ext/lib/**/*.js",
-        "${workspaceRoot}/plugins/**/*.js"
+        "${workspaceFolder}/packages/plugin-ext/lib/**/*.js",
+        "${workspaceFolder}/plugins/**/*.js"
       ]
     },
     {
       "type": "node",
       "request": "launch",
       "name": "Launch Browser Backend (eclipse.jdt.ls)",
-      "program": "${workspaceRoot}/examples/browser/src-gen/backend/main.js",
+      "program": "${workspaceFolder}/examples/browser/src-gen/backend/main.js",
       "args": [
         "--log-level=debug",
-        "--root-dir=${workspaceRoot}/../eclipse.jdt.ls/org.eclipse.jdt.ls.core",
+        "--root-dir=${workspaceFolder}/../eclipse.jdt.ls/org.eclipse.jdt.ls.core",
         "--port=3000",
         "--no-cluster",
         "--no-app-auto-install"
@@ -110,10 +110,10 @@
       },
       "sourceMaps": true,
       "outFiles": [
-        "${workspaceRoot}/examples/browser/src-gen/backend/*.js",
-        "${workspaceRoot}/examples/browser/lib/**/*.js",
-        "${workspaceRoot}/packages/*/lib/**/*.js",
-        "${workspaceRoot}/dev-packages/*/lib/**/*.js"
+        "${workspaceFolder}/examples/browser/src-gen/backend/*.js",
+        "${workspaceFolder}/examples/browser/lib/**/*.js",
+        "${workspaceFolder}/packages/*/lib/**/*.js",
+        "${workspaceFolder}/dev-packages/*/lib/**/*.js"
       ],
       "smartStep": true,
       "internalConsoleOptions": "openOnSessionStart",
@@ -124,16 +124,16 @@
       "request": "launch",
       "protocol": "inspector",
       "name": "Run Mocha Tests",
-      "program": "${workspaceRoot}/node_modules/mocha/bin/_mocha",
+      "program": "${workspaceFolder}/node_modules/mocha/bin/_mocha",
       "args": [
         "--no-timeouts",
         "--colors",
         "--opts",
-        "${workspaceRoot}/configs/mocha.opts",
+        "${workspaceFolder}/configs/mocha.opts",
         "**/${fileBasenameNoExtension}.js"
       ],
       "env": {
-        "TS_NODE_PROJECT": "${workspaceRoot}/tsconfig.json"
+        "TS_NODE_PROJECT": "${workspaceFolder}/tsconfig.json"
       },
       "sourceMaps": true,
       "smartStep": true,
@@ -145,7 +145,7 @@
       "type": "chrome",
       "request": "launch",
       "url": "http://localhost:3000/",
-      "webRoot": "${workspaceRoot}/examples/browser"
+      "webRoot": "${workspaceFolder}/examples/browser"
     },
     {
       "type": "chrome",

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -145,16 +145,14 @@
       "type": "chrome",
       "request": "launch",
       "url": "http://localhost:3000/",
-      "webRoot": "${workspaceRoot}"
+      "webRoot": "${workspaceRoot}/examples/browser"
     },
     {
       "type": "chrome",
       "request": "attach",
       "name": "Attach to Electron Frontend",
       "port": 9222,
-      "sourceMapPathOverrides": {
-        "webpack://@theia/example-electron/*": "${workspaceFolder}/examples/electron/*"
-      }
+      "webRoot": "${workspaceFolder}/examples/electron"
     },
     {
       "name": "Launch VS Code Tests",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Change Log
 
+## v1.21.0 - 12/??/2021
+
+[1.21.0 Milestone](https://github.com/eclipse-theia/theia/milestone/29)
+
+<a name="breaking_changes_1.21.0">[Breaking Changes:](#breaking_changes_1.21.0)</a>
+
+- [webpack] Source maps for the frontend renamed from `webpack://[namespace]/[resource-filename]...`
+  to `webpack:///[resource-path]?[loaders]` where `resource-path` is the path to the file relative
+  to your application package's root.
+
 ## v1.20.0 - 11/25/2021
 
 [1.20.0 Milestone](https://github.com/eclipse-theia/theia/milestone/28)

--- a/dev-packages/application-manager/src/generator/webpack-generator.ts
+++ b/dev-packages/application-manager/src/generator/webpack-generator.ts
@@ -102,7 +102,8 @@ module.exports = {
     entry: path.resolve(__dirname, 'src-gen/frontend/index.js'),
     output: {
         filename: 'bundle.js',
-        path: outputPath
+        path: outputPath,
+        devtoolModuleFilenameTemplate: 'webpack:///[resource-path]?[loaders]'
     },
     target: '${this.ifBrowser('web', 'electron-renderer')}',
     cache: staticCompression,

--- a/doc/Migration.md
+++ b/doc/Migration.md
@@ -7,6 +7,24 @@ Please see the latest version (`master`) for the most up-to-date information. Pl
 
 ## Guide
 
+### v1.21.0
+
+#### Frontend Source Maps
+
+The frontend's source map naming changed. If you had something like the following in your debug configurations:
+
+```json
+      "sourceMapPathOverrides": {
+        "webpack://@theia/example-electron/*": "${workspaceFolder}/examples/electron/*"
+      }
+```
+
+You can delete this whole block and replace it by the following:
+
+```json
+      "webRoot": "${workspaceFolder}/examples/electron"
+```
+
 ### v1.19.0
 
 #### Runtime System Plugin Resolvement
@@ -14,7 +32,7 @@ Please see the latest version (`master`) for the most up-to-date information. Pl
 Introduced in `v1.19.0` was the feature to better support extension-packs which both contribute functionality and reference plugins (by `id`).
 The feature works best when there is no runtime plugin resolvement for system (builtin) plugins as it should be done at build time instead.
 In order not to change behavior today, the feature is behind an application prop (acting as a flag). If you want to enable better support for
-extension-packs and extension-dependencies as builtins the property should be turned off. You can disable the resolvement in your application's 
+extension-packs and extension-dependencies as builtins the property should be turned off. You can disable the resolvement in your application's
 `package.json` like so:
 
 


### PR DESCRIPTION
Webpack 5 changed the default for source map names to something like
`@theia/example-browser/<path/to/file>` which confused the JS debugger.

Use `output.devtoolModuleFilenameTemplate` to define a "simpler" source
map filename.

https://webpack.js.org/configuration/output/#outputdevtoolmodulefilenametemplate

#### How to test

- You should be able to put breakpoints in frontend code from your IDE and have them bound and hit.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
