### PR TITLE
feat: add timestamp for DAP trace and formate output using `JSON.stringify(message, null, 4)`

### DIFF
--- a/packages/debug/src/browser/debug-session-connection.ts
+++ b/packages/debug/src/browser/debug-session-connection.ts
@@ -243,10 +243,9 @@ export class DebugSessionConnection implements Disposable {
         const connection = await this.connectionPromise;
         const messageStr = JSON.stringify(message);
         if (this.traceOutputChannel) {
+            // keep getMilliseconds
             const now = new Date();
-            /// offset in milliseconds
-            const tzoffset = now.getTimezoneOffset() * 60 * 1000;
-            const dateStr = new Date(now.getTime() - tzoffset).toISOString();
+            const dateStr = `${now.toLocaleString(undefined, { hour12: false })}.${now.getMilliseconds()}`;
             this.traceOutputChannel.appendLine(`${this.sessionId.substring(0, 8)} ${dateStr} theia -> adapter: ${messageStr}`);
         }
         connection.send(messageStr);
@@ -254,10 +253,9 @@ export class DebugSessionConnection implements Disposable {
 
     protected handleMessage(data: string): void {
         if (this.traceOutputChannel) {
+            // keep getMilliseconds
             const now = new Date();
-            /// offset in milliseconds
-            const tzoffset = now.getTimezoneOffset() * 60 * 1000;
-            const dateStr = new Date(now.getTime() - tzoffset).toISOString();
+            const dateStr = `${now.toLocaleString(undefined, { hour12: false })}.${now.getMilliseconds()}`;
             this.traceOutputChannel.appendLine(`${this.sessionId.substring(0, 8)} ${dateStr} theia <- adapter: ${data}`);
         }
         const message: DebugProtocol.ProtocolMessage = JSON.parse(data);

--- a/packages/debug/src/browser/debug-session-connection.ts
+++ b/packages/debug/src/browser/debug-session-connection.ts
@@ -243,14 +243,22 @@ export class DebugSessionConnection implements Disposable {
         const connection = await this.connectionPromise;
         const messageStr = JSON.stringify(message);
         if (this.traceOutputChannel) {
-            this.traceOutputChannel.appendLine(`${this.sessionId.substring(0, 8)} theia -> adapter: ${messageStr}`);
+            const now = new Date();
+            /// offset in milliseconds
+            const tzoffset = now.getTimezoneOffset() * 60 * 1000;
+            const dateStr = new Date(now.getTime() - tzoffset).toISOString();
+            this.traceOutputChannel.appendLine(`${this.sessionId.substring(0, 8)} ${dateStr} theia -> adapter: ${messageStr}`);
         }
         connection.send(messageStr);
     }
 
     protected handleMessage(data: string): void {
         if (this.traceOutputChannel) {
-            this.traceOutputChannel.appendLine(`${this.sessionId.substring(0, 8)} theia <- adapter: ${data}`);
+            const now = new Date();
+            /// offset in milliseconds
+            const tzoffset = now.getTimezoneOffset() * 60 * 1000;
+            const dateStr = new Date(now.getTime() - tzoffset).toISOString();
+            this.traceOutputChannel.appendLine(`${this.sessionId.substring(0, 8)} ${dateStr} theia <- adapter: ${data}`);
         }
         const message: DebugProtocol.ProtocolMessage = JSON.parse(data);
         if (message.type === 'request') {

--- a/packages/debug/src/browser/debug-session-connection.ts
+++ b/packages/debug/src/browser/debug-session-connection.ts
@@ -246,7 +246,7 @@ export class DebugSessionConnection implements Disposable {
             // keep getMilliseconds
             const now = new Date();
             const dateStr = `${now.toLocaleString(undefined, { hour12: false })}.${now.getMilliseconds()}`;
-            this.traceOutputChannel.appendLine(`${this.sessionId.substring(0, 8)} ${dateStr} theia -> adapter: ${JSON.stringify(message, null, 4)}`);
+            this.traceOutputChannel.appendLine(`${this.sessionId.substring(0, 8)} ${dateStr} theia -> adapter: ${JSON.stringify(message, undefined, 4)}`);
         }
         connection.send(messageStr);
     }
@@ -257,7 +257,7 @@ export class DebugSessionConnection implements Disposable {
             // keep getMilliseconds
             const now = new Date();
             const dateStr = `${now.toLocaleString(undefined, { hour12: false })}.${now.getMilliseconds()}`;
-            this.traceOutputChannel.appendLine(`${this.sessionId.substring(0, 8)} ${dateStr} theia <- adapter: ${JSON.stringify(message, null, 4)}`);
+            this.traceOutputChannel.appendLine(`${this.sessionId.substring(0, 8)} ${dateStr} theia <- adapter: ${JSON.stringify(message, undefined, 4)}`);
         }
         if (message.type === 'request') {
             this.handleRequest(message as DebugProtocol.Request);

--- a/packages/debug/src/browser/debug-session-connection.ts
+++ b/packages/debug/src/browser/debug-session-connection.ts
@@ -246,19 +246,19 @@ export class DebugSessionConnection implements Disposable {
             // keep getMilliseconds
             const now = new Date();
             const dateStr = `${now.toLocaleString(undefined, { hour12: false })}.${now.getMilliseconds()}`;
-            this.traceOutputChannel.appendLine(`${this.sessionId.substring(0, 8)} ${dateStr} theia -> adapter: ${messageStr}`);
+            this.traceOutputChannel.appendLine(`${this.sessionId.substring(0, 8)} ${dateStr} theia -> adapter: ${JSON.stringify(message, null, 4)}`);
         }
         connection.send(messageStr);
     }
 
     protected handleMessage(data: string): void {
+        const message: DebugProtocol.ProtocolMessage = JSON.parse(data);
         if (this.traceOutputChannel) {
             // keep getMilliseconds
             const now = new Date();
             const dateStr = `${now.toLocaleString(undefined, { hour12: false })}.${now.getMilliseconds()}`;
-            this.traceOutputChannel.appendLine(`${this.sessionId.substring(0, 8)} ${dateStr} theia <- adapter: ${data}`);
+            this.traceOutputChannel.appendLine(`${this.sessionId.substring(0, 8)} ${dateStr} theia <- adapter: ${JSON.stringify(message, null, 4)}`);
         }
-        const message: DebugProtocol.ProtocolMessage = JSON.parse(data);
         if (message.type === 'request') {
             this.handleRequest(message as DebugProtocol.Request);
         } else if (message.type === 'response') {

--- a/packages/debug/src/browser/debug-session-connection.ts
+++ b/packages/debug/src/browser/debug-session-connection.ts
@@ -243,7 +243,6 @@ export class DebugSessionConnection implements Disposable {
         const connection = await this.connectionPromise;
         const messageStr = JSON.stringify(message);
         if (this.traceOutputChannel) {
-            // keep getMilliseconds
             const now = new Date();
             const dateStr = `${now.toLocaleString(undefined, { hour12: false })}.${now.getMilliseconds()}`;
             this.traceOutputChannel.appendLine(`${this.sessionId.substring(0, 8)} ${dateStr} theia -> adapter: ${JSON.stringify(message, undefined, 4)}`);
@@ -254,7 +253,6 @@ export class DebugSessionConnection implements Disposable {
     protected handleMessage(data: string): void {
         const message: DebugProtocol.ProtocolMessage = JSON.parse(data);
         if (this.traceOutputChannel) {
-            // keep getMilliseconds
             const now = new Date();
             const dateStr = `${now.toLocaleString(undefined, { hour12: false })}.${now.getMilliseconds()}`;
             this.traceOutputChannel.appendLine(`${this.sessionId.substring(0, 8)} ${dateStr} theia <- adapter: ${JSON.stringify(message, undefined, 4)}`);


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### ADD timestamp for DAP trace output
DAP trace output does not contain timestamp. it looks like this

```
fabf8f58 theia <- adapter: {"body":{"reason":"exited","threadId":2305159},"event":"thread","seq":0,"type":"event"}
fabf8f58 theia <- adapter: {"body":{"reason":"exited","threadId":2305187},"event":"thread","seq":0,"type":"event"}
fabf8f58 theia <- adapter: {"body":{"reason":"exited","threadId":2305194},"event":"thread","seq":0,"type":"event"}
fabf8f58 theia <- adapter: {"body":{"reason":"exited","threadId":2305286},"event":"thread","seq":0,"type":"event"}
fabf8f58 theia <- adapter: {"body":{"reason":"exited","threadId":2305343},"event":"thread","seq":0,"type":"event"}
fabf8f58 theia <- adapter: {"body":{"reason":"exited","threadId":2305191},"event":"thread","seq":0,"type":"event"}
fabf8f58 theia <- adapter: {"body":{"reason":"exited","threadId":2305281},"event":"thread","seq":0,"type":"event"}
fabf8f58 theia -> adapter: {"seq":18,"type":"request","command":"threads","arguments":{}}
```
It's not easy to get the performance with those trace output. It's better to output a timestamp so you will be easy to get a context.
#### How to test

check the dap trace output is now with timestamp like this

```
fabf8f58 theia <- adapter: {"body":{"reason":"exited","threadId":2305159},"event":"thread","seq":0,"type":"event"}
```

after the changes submit, check the dap trace output is now with timestamp like this

```
fabf8f58 2021-11-27T02:40:06.428Z theia <- adapter: {"body":{"reason":"exited","threadId":2305159},"event":"thread","seq":0,"type":"event"}
```
#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/eclipse-theia/theia/blob/master/doc/pull-requests.md#requesting-a-review)


#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with the review guidelines