### PR TITLE
Support codicon icon references for plugin view containers

### DIFF
--- a/packages/plugin-ext/src/common/plugin-protocol.ts
+++ b/packages/plugin-ext/src/common/plugin-protocol.ts
@@ -681,6 +681,7 @@ export interface ViewContainer {
     id: string;
     title: string;
     iconUrl: string;
+    themeIcon?: string;
 }
 
 /**

--- a/packages/plugin-ext/src/hosted/node/scanners/scanner-theia.ts
+++ b/packages/plugin-ext/src/hosted/node/scanners/scanner-theia.ts
@@ -554,10 +554,13 @@ export class TheiaPluginScanner implements PluginScanner {
     }
 
     private readViewContainer(rawViewContainer: PluginPackageViewContainer, pck: PluginPackage): ViewContainer {
+        const themeIcon = rawViewContainer.icon.startsWith('$(') ? rawViewContainer.icon : undefined;
+        const iconUrl = this.toPluginUrl(pck, rawViewContainer.icon);
         return {
             id: rawViewContainer.id,
             title: rawViewContainer.title,
-            iconUrl: this.toPluginUrl(pck, rawViewContainer.icon)
+            iconUrl,
+            themeIcon,
         };
     }
 

--- a/packages/plugin-ext/src/main/browser/view/plugin-view-registry.ts
+++ b/packages/plugin-ext/src/main/browser/view/plugin-view-registry.ts
@@ -218,15 +218,28 @@ export class PluginViewRegistry implements FrontendApplicationContribution {
         }
         const toDispose = new DisposableCollection();
         const containerClass = 'theia-plugin-view-container';
+        let themeIconClass = '';
         const iconClass = 'plugin-view-container-icon-' + viewContainer.id;
-        const iconUrl = PluginSharedStyle.toExternalIconUrl(viewContainer.iconUrl);
-        toDispose.push(this.style.insertRule('.' + containerClass + '.' + iconClass, () => `
+
+        if (viewContainer.themeIcon) {
+            const icon = monaco.theme.ThemeIcon.fromString(viewContainer.themeIcon);
+            if (icon) {
+                themeIconClass = monaco.theme.ThemeIcon.asClassName(icon) ?? '';
+            }
+        }
+
+        if (!themeIconClass) {
+            const iconUrl = PluginSharedStyle.toExternalIconUrl(viewContainer.iconUrl);
+            toDispose.push(this.style.insertRule('.' + containerClass + '.' + iconClass, () => `
                 mask: url('${iconUrl}') no-repeat 50% 50%;
                 -webkit-mask: url('${iconUrl}') no-repeat 50% 50%;
             `));
+        }
+
         toDispose.push(this.doRegisterViewContainer(viewContainer.id, location, {
             label: viewContainer.title,
-            iconClass: containerClass + ' ' + iconClass,
+            // The container class automatically sets a mask; if we're using a theme icon, we don't want one.
+            iconClass: (themeIconClass || containerClass) + ' ' + iconClass,
             closeable: true
         }));
         return toDispose;


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->
Fixes #10490 by implementing handling of `$(icon-name)` strings for plugin view containers.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
1. Change the version of `vscode-references-view` from 47 to 81 in the builtin plugin manifest in `package.json`
2. Delete any existing versions of `vscode-references-view` from your `plugins` folder and run `yarn build`
3. Start the application with the Theia repo as your workspace.
4. Find an interesting variable and run `Find All References` or find an interesting function and run the command palette command `Calls: Show Call Hierarchy`
5. Observe that the `vscode-reference-view` plugin view appears, and the plugin's view container has an icon and that that icon is styled like the rest of our Codicon view container icons.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

Signed-off-by: Colin Grant <colin.grant@ericsson.com>