### PR TITLE
Implement 'editorHasCallHierarchyProvider' context key

### DIFF
--- a/packages/callhierarchy/src/browser/callhierarchy-service.ts
+++ b/packages/callhierarchy/src/browser/callhierarchy-service.ts
@@ -52,10 +52,13 @@ export class CallHierarchyServiceProvider {
     }
 
     get(languageId: string, uri: URI): CallHierarchyService | undefined {
+        return this.services
+            .filter(service => this.score(service, languageId, uri) > 0)
+            .sort((left, right) => this.score(right, languageId, uri) - this.score(left, languageId, uri))[0];
+    }
 
-        return this.services.sort(
-            (left, right) =>
-                score(right.selector, uri.scheme, uri.path.toString(), languageId, true) - score(left.selector, uri.scheme, uri.path.toString(), languageId, true))[0];
+    protected score(service: CallHierarchyService, languageId: string, uri: URI): number {
+        return score(service.selector, uri.scheme, uri.path.toString(), languageId, true);
     }
 
     add(service: CallHierarchyService): Disposable {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

This PR implements a context key associated with the call hierarchy system and used by the `vscode-references-view` plugin.

![call-hierarchy-context-menu-item](https://user-images.githubusercontent.com/62660806/143958023-70849abc-6173-4c0e-be7d-adbad89cfd0f.png)

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
1. Open a TypeScript workspace.
2. Find a function of interest.
3. Right click on the function to bring up the editor context menu.
4. Observe the presence of a `Show Call Hierarchy` context menu item.
5. Run it, and observe that the `vscode-references-view` call hierarchy view appears.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

Signed-off-by: Colin Grant <colin.grant@ericsson.com>