### PR TITLE
Align vscode: Set theme attributes to webview body element

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@
 - [terminal] removed deprecated `activateTerminal` method in favor of `open`. [#10529](https://github.com/eclipse-theia/theia/pull/10529)
 - [core] removed deprecated `activeChanged` signal emitter in favor of `onDidChangeActiveWidget` [#10515](https://github.com/eclipse-theia/theia/pull/10515)
 - [core] removed deprecated `currentChanged` signal emitter in favor of `onDidChangeCurrentWidget` [#10515](https://github.com/eclipse-theia/theia/pull/10515)
+- [plugin] changed return type of `WebviewThemeDataProvider.getActiveTheme()` to `Theme` instead of `WebviewThemeType` [#10493](https://github.com/eclipse-theia/theia/pull/10493)
+- [plugin] renamed `WebviewThemeData.activeTheme` to `activeThemeType` [#10493](https://github.com/eclipse-theia/theia/pull/10493)
 
 ## v1.20.0 - 11/25/2021
 

--- a/packages/plugin-ext/src/main/browser/webview/pre/main.js
+++ b/packages/plugin-ext/src/main/browser/webview/pre/main.js
@@ -204,7 +204,9 @@
 
             if (body) {
                 body.classList.remove('vscode-light', 'vscode-dark', 'vscode-high-contrast');
-                body.classList.add(initData.activeTheme);
+                body.classList.add(initData.activeThemeType);
+                body.setAttribute('data-vscode-theme-kind', initData.activeThemeType);
+                body.setAttribute('data-vscode-theme-name', initData.activeThemeName);
             }
 
             if (initData.styles) {
@@ -409,7 +411,8 @@
 
             host.onMessage('styles', (_event, data) => {
                 initData.styles = data.styles;
-                initData.activeTheme = data.activeTheme;
+                initData.activeThemeType = data.activeThemeType;
+                initData.activeThemeName = data.activeThemeName;
 
                 const target = getActiveFrame();
                 if (!target) {

--- a/packages/plugin-ext/src/main/browser/webview/webview-theme-data-provider.ts
+++ b/packages/plugin-ext/src/main/browser/webview/webview-theme-data-provider.ts
@@ -22,13 +22,14 @@
 import { inject, postConstruct, injectable } from '@theia/core/shared/inversify';
 import { Emitter } from '@theia/core/lib/common/event';
 import { EditorPreferences, EditorConfiguration } from '@theia/editor/lib/browser/editor-preferences';
-import { ThemeService } from '@theia/core/lib/browser/theming';
+import { Theme, ThemeService } from '@theia/core/lib/browser/theming';
 import { ColorRegistry } from '@theia/core/lib/browser/color-registry';
 import { ColorApplicationContribution } from '@theia/core/lib/browser/color-application-contribution';
 
 export type WebviewThemeType = 'vscode-light' | 'vscode-dark' | 'vscode-high-contrast';
 export interface WebviewThemeData {
-    readonly activeTheme: WebviewThemeType;
+    readonly activeThemeName: string;
+    readonly activeThemeType: WebviewThemeType;
     readonly styles: { readonly [key: string]: string | number; };
 }
 
@@ -104,11 +105,18 @@ export class WebviewThemeDataProvider {
         }
 
         const activeTheme = this.getActiveTheme();
-        return { styles, activeTheme };
+        return {
+            styles,
+            activeThemeName: activeTheme.label,
+            activeThemeType: this.getThemeType(activeTheme)
+        };
     }
 
-    protected getActiveTheme(): WebviewThemeType {
-        const theme = ThemeService.get().getCurrentTheme();
+    protected getActiveTheme(): Theme {
+        return ThemeService.get().getCurrentTheme();
+    }
+
+    protected getThemeType(theme: Theme): WebviewThemeType {
         switch (theme.type) {
             case 'light': return 'vscode-light';
             case 'dark': return 'vscode-dark';

--- a/packages/plugin-ext/src/main/browser/webview/webview.ts
+++ b/packages/plugin-ext/src/main/browser/webview/webview.ts
@@ -420,8 +420,8 @@ export class WebviewWidget extends BaseWidget implements StatefulWidget {
     }
 
     protected style(): void {
-        const { styles, activeTheme } = this.themeDataProvider.getThemeData();
-        this.doSend('styles', { styles, activeTheme });
+        const { styles, activeThemeType, activeThemeName } = this.themeDataProvider.getThemeData();
+        this.doSend('styles', { styles, activeThemeType, activeThemeName });
     }
 
     protected openLink(link: URI): void {


### PR DESCRIPTION
Signed-off-by: Esther Perelman <esther.perelman@sap.com>

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
Align with vscode the ability to set webview style for a specific theme by adding the body data attributes: `data-vscode-theme-name` & `data-vscode-theme-kind` ([See details here](https://code.visualstudio.com/api/extension-guides/webview#theming-webview-content))

![image](https://user-images.githubusercontent.com/71729183/144025196-7066cf3e-ca2e-43a5-b502-e32f22171661.png)

#### How to test

1. In theia project install webview-sample from [sample-vsix.zip](https://github.com/eclipse-theia/theia/files/7624766/cat-coding-zip.zip) or [download from here](https://github.com/microsoft/vscode-extension-samples/tree/main/webview-sample)
2. `Ctrl+shift+p` + `Cat coding: Start cat coding session`
3. Open the developer tools and inspect the webview image - search for the body element...
4. Select the `Preferences` icon -> `Color Theme` and navigate between the themes
5. See the body attributes changing accordingly to the selected theme (you can use vscode theme extensions from the market place)


#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
