### PR TITLE
Avoid throwing error when the scope is undefined

### DIFF
--- a/packages/task/src/browser/task-configurations.ts
+++ b/packages/task/src/browser/task-configurations.ts
@@ -264,7 +264,7 @@ export class TaskConfigurations implements Disposable {
         for (const change of fileChanges) {
             if (change.type === FileChangeType.DELETED) {
                 this.removeTasks(change.scope);
-            } else {
+            } else if (change.scope) {
                 // re-parse the config file
                 await this.refreshTasks(change.scope);
             }


### PR DESCRIPTION
Signed-off-by:  Bassem Girgis <brgirgis@gmail.com>

#### What it does
Avoid throwing an error when the scope is `undefined`.

#### How to test
Not sure

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
