### PR TITLE
Open plugin editor view on single click

### DIFF
--- a/packages/vsx-registry/src/browser/vsx-extension.tsx
+++ b/packages/vsx-registry/src/browser/vsx-extension.tsx
@@ -357,7 +357,8 @@ export class VSXExtension implements VSXExtensionData, TreeElement {
 
 export abstract class AbstractVSXExtensionComponent extends React.Component<AbstractVSXExtensionComponent.Props> {
 
-    readonly install = async () => {
+    readonly install = async (event?: React.MouseEvent) => {
+        event?.stopPropagation();
         this.forceUpdate();
         try {
             const pending = this.props.extension.install();
@@ -368,7 +369,8 @@ export abstract class AbstractVSXExtensionComponent extends React.Component<Abst
         }
     };
 
-    readonly uninstall = async () => {
+    readonly uninstall = async (event?: React.MouseEvent) => {
+        event?.stopPropagation();
         try {
             const pending = this.props.extension.uninstall();
             this.forceUpdate();
@@ -379,6 +381,7 @@ export abstract class AbstractVSXExtensionComponent extends React.Component<Abst
     };
 
     protected readonly manage = (e: React.MouseEvent<HTMLElement, MouseEvent>) => {
+        e.stopPropagation();
         this.props.extension.handleContextMenu(e);
     };
 

--- a/packages/vsx-registry/src/browser/vsx-extensions-model.ts
+++ b/packages/vsx-registry/src/browser/vsx-extensions-model.ts
@@ -236,7 +236,7 @@ export class VSXExtensionsModel {
             if (this.workspaceService.saved) {
                 updateRecommendationsForScope('workspaceValue');
             }
-            const recommendedSorted = new Set(Array.from(allRecommendations).sort((a, b) => this.compareExtensions(a, b)).values());
+            const recommendedSorted = new Set(Array.from(allRecommendations).sort((a, b) => this.compareExtensions(a, b)));
             allUnwantedRecommendations.forEach(unwantedRecommendation => recommendedSorted.delete(unwantedRecommendation));
             this._recommended = recommendedSorted;
             return Promise.all(Array.from(recommendedSorted, plugin => this.refresh(plugin)));

--- a/packages/vsx-registry/src/browser/vsx-extensions-widget.ts
+++ b/packages/vsx-registry/src/browser/vsx-extensions-widget.ts
@@ -15,6 +15,7 @@
  ********************************************************************************/
 
 import { injectable, interfaces, postConstruct, inject } from '@theia/core/shared/inversify';
+import { TreeNode } from '@theia/core/lib/browser';
 import { SourceTreeWidget } from '@theia/core/lib/browser/source-tree';
 import { VSXExtensionsSource, VSXExtensionsSourceOptions } from './vsx-extensions-source';
 import { nls } from '@theia/core/lib/common/nls';
@@ -77,5 +78,14 @@ export class VSXExtensionsWidget extends SourceTreeWidget {
             default:
                 return '';
         }
+    }
+
+    protected handleClickEvent(node: TreeNode | undefined, event: React.MouseEvent<HTMLElement>): void {
+        super.handleClickEvent(node, event);
+        this.model.openNode(node); // Open the editor view on a single click.
+    }
+
+    protected handleDblClickEvent(): void {
+        // Don't open the editor view on a double click.
     }
 }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

This PR changes the event handling in the VSX tree views so that a single click on a tree node opens the editor view (main-panel view) for the plugin, and clicking on interactables within the node does not select the node. These changes bring us a bit closer to VSCode's behavior.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
1. Open the extensions view.
2. Click on a tree node.
3. Observe that the plugin editor view opens.
4. Double click on a tree node.
5. Observe that the plugin editor view opens only once (if it wasn't already open)
6. Click on a button inside a non-selected node (gear, install, uninstall)
7. Observe that the action associated with that button takes place, but the node is not selected.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

Signed-off-by: Colin Grant <colin.grant@ericsson.com>