### PR TITLE
Add preferences wraptabs

### DIFF
--- a/packages/core/src/browser/common-frontend-contribution.ts
+++ b/packages/core/src/browser/common-frontend-contribution.ts
@@ -370,6 +370,7 @@ export class CommonFrontendContribution implements FrontendApplicationContributi
         this.registerCtrlWHandling();
 
         this.updateStyles();
+        this.wrapTabs();
         this.updateThemeFromPreference('workbench.colorTheme');
         this.updateThemeFromPreference('workbench.iconTheme');
         this.preferences.onPreferenceChanged(e => this.handlePreferenceChange(e, app));
@@ -404,6 +405,13 @@ export class CommonFrontendContribution implements FrontendApplicationContributi
         document.body.classList.remove('theia-editor-highlightModifiedTabs');
         if (this.preferences['workbench.editor.highlightModifiedTabs']) {
             document.body.classList.add('theia-editor-highlightModifiedTabs');
+        }
+    }
+
+    protected wrapTabs(): void {
+        document.body.classList.remove('theia-editor-wrapTabs');
+        if (this.preferences['workbench.editor.wraptabs']) {
+            document.body.classList.add('theia-editor-wrapTabs');
         }
     }
 
@@ -458,6 +466,10 @@ export class CommonFrontendContribution implements FrontendApplicationContributi
                 } else {
                     app.shell.leftPanelHandler.removeTopMenu(mainMenuId);
                 }
+                break;
+            }
+            case 'workbench.editor.wraptabs': {
+                this.wrapTabs();
                 break;
             }
         }

--- a/packages/core/src/browser/core-preferences.ts
+++ b/packages/core/src/browser/core-preferences.ts
@@ -92,6 +92,12 @@ export const corePreferenceSchema: PreferenceSchema = {
             'description': nls.localizeByDefault('Controls whether a top border is drawn on modified (dirty) editor tabs or not. This value is ignored when `#workbench.editor.showTabs#` is disabled.'),
             'default': false
         },
+        'workbench.editor.wraptabs': {
+            'type': 'boolean',
+            // eslint-disable-next-line max-len
+            'description': nls.localizeByDefault('Controls whether tabs should be wrapped over multiple lines when exceeding available space or whether a scrollbar should appear instead.'),
+            'default': false
+        },
         'workbench.editor.closeOnFileDelete': {
             'type': 'boolean',
             // eslint-disable-next-line max-len
@@ -148,6 +154,7 @@ export interface CoreConfiguration {
     'workbench.list.openMode': 'singleClick' | 'doubleClick';
     'workbench.commandPalette.history': number;
     'workbench.editor.highlightModifiedTabs': boolean;
+    'workbench.editor.wraptabs': boolean;
     'workbench.editor.closeOnFileDelete': boolean;
     'workbench.colorTheme': string;
     'workbench.iconTheme': string | null;

--- a/packages/core/src/browser/style/tabs.css
+++ b/packages/core/src/browser/style/tabs.css
@@ -442,3 +442,34 @@ body.theia-editor-highlightModifiedTabs
   flex-flow: row nowrap;
   min-width: 100%;
 }
+
+/* When wraptabs is selected*/
+body.theia-editor-wrapTabs
+.p-TabBar .p-TabBar-content {
+  cursor: pointer;
+  display: flex;
+  flex-flow: row wrap;
+}
+
+body.theia-editor-wrapTabs
+#theia-main-content-panel .p-Widget.p-DockPanel-widget {
+    background: var(--theia-editor-background);  
+    position: relative !important;  
+    top:0px !important;
+}
+
+body.theia-editor-wrapTabs
+.p-TabBar.theia-tabBar-multirow[data-orientation='horizontal'] {
+  min-height: calc(var(--theia-breadcrumbs-height) + var(--theia-horizontal-toolbar-height));
+  flex-direction: column;
+  position: static !important;
+  height: fit-content !important;
+}
+
+body.theia-editor-wrapTabs
+.p-TabBar.theia-app-centers {
+  background: var(--theia-editorGroupHeader-tabsBackground);
+  position: static !important;
+  height: fit-content !important;
+}
+


### PR DESCRIPTION
Add `wraptabs` preferences at setting menu, and modify the coresponding css styles to make whole display fit the wrapped tabs.

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->
fix: #10383
#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
1. Open settings
2. Search `tab`
![image](https://user-images.githubusercontent.com/55666061/144495795-b0c87154-1383-4354-9679-3b283d2270a0.png)
3. Check `Workbench › Editor: Wraptabs`
4. Confirm can choose to display editor tabs with wrapping rather than with scrolling
5. Uncheck this preference
6. Confirm display editor tabs with scroll bar.
#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
