### PR TITLE
tasks: Use valid column when creating range for problem matcher

### DIFF
--- a/packages/core/src/common/index.ts
+++ b/packages/core/src/common/index.ts
@@ -39,6 +39,7 @@ export * from './application-error';
 export * from './lsp-types';
 export * from './contribution-filter';
 export * from './nls';
+export * from './numbers';
 
 import { environment } from '@theia/application-package/lib/environment';
 export { environment };

--- a/packages/core/src/common/numbers.ts
+++ b/packages/core/src/common/numbers.ts
@@ -1,0 +1,21 @@
+/********************************************************************************
+ * Copyright (C) 2021 TypeFox and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+/**
+ * The maximum safe integer (`2^32-1`) is used as a placeholder for large numbers which are not allowed to be floats.
+ * For example as line/column arguments for monaco-ranges.
+ */
+export const MAX_SAFE_INTEGER = 2147483647;

--- a/packages/task/src/node/task-abstract-line-matcher.ts
+++ b/packages/task/src/node/task-abstract-line-matcher.ts
@@ -29,6 +29,7 @@ import URI from '@theia/core/lib/common/uri';
 // TODO use only URI from '@theia/core'
 import { URI as vscodeURI } from '@theia/core/shared/vscode-uri';
 import { Severity } from '@theia/core/lib/common/severity';
+import { MAX_SAFE_INTEGER } from '@theia/core/lib/common/numbers';
 
 const endOfLine: string = isWindows ? '\r\n' : '\n';
 
@@ -201,7 +202,7 @@ export abstract class AbstractLineMatcher {
                 range = Range.create(startLine, startColumn, startLine, startColumn);
             }
         } else {
-            range = Range.create(startLine, 1, startLine, Number.MAX_VALUE);
+            range = Range.create(startLine, 1, startLine, MAX_SAFE_INTEGER);
         }
 
         // range indexes should be zero-based


### PR DESCRIPTION
#### What it does

When calling [`Range.create`](https://github.com/microsoft/vscode-languageserver-node/blob/2794f5bd7436d2545e542ac86a291bc4bbe6d2af/types/src/main.ts#L166) with a value larger than > [`2^32-1`](https://github.com/microsoft/vscode-languageserver-node/blob/2794f5bd7436d2545e542ac86a291bc4bbe6d2af/types/src/main.ts#L4137), the function will throw an error. We do this when building ranges parsed from matched problems where we don't receive start/end columns:

https://github.com/eclipse-theia/theia/blob/afd980a4d4ff6b48d70fc0ce1e459f6496c62624/packages/task/src/node/task-abstract-line-matcher.ts#L204

`Number.MAX_VALUE` is something like 10^308. Since `Range.create` always throws in this case, we never receive any matched problems from the server, and any errors are swallowed by a `catch { return undefined }`.

#### How to test

0. Use this reproducible setup:

A file named `test.js` in the project root:
```js
console.log('[DUMMY] WARNING test.js:1 This is a dummy warning')
console.log('[DUMMY] ERROR test.js:2 This is a dummy error')
```
A task definition like this:
```json
{
  "label": "Test Matcher",
  "type": "shell",
  "command": "node",
  "args": [
    "test.js"
  ],
  "problemMatcher": {
    "name": "test-matcher",
    "owner": "test-matcher",
    "fileLocation": [
      "relative",
      "${workspaceFolder}"
    ],
    "pattern": {
      "regexp": "^\\[[A-Z]+\\] (INFO|WARNING|ERROR) (.*):(\\d+) (.*)$",
      "severity": 1,
      "file": 2,
      "line": 3,
      "message": 4
    }
  }
}
```

1. Run the `Test Matcher` task
2. Open `test.js` and assert that the first line is marked with a warning
3. Assert that the second line is marked with an error

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
