### PR TITLE
Remove double colon in indentation status item

### DIFF
--- a/packages/editor/src/browser/editor-command.ts
+++ b/packages/editor/src/browser/editor-command.ts
@@ -379,7 +379,7 @@ export class EditorCommandContribution implements CommandContribution {
         return {
             value,
             label: value.name,
-            description: nls.localizeByDefault(`({0})${configured ? ' - Configured Language' : ''}`),
+            description: nls.localizeByDefault(`({0})${configured ? ' - Configured Language' : ''}`, value.id),
             iconClasses
         };
     }

--- a/packages/monaco/src/browser/monaco-status-bar-contribution.ts
+++ b/packages/monaco/src/browser/monaco-status-bar-contribution.ts
@@ -66,11 +66,11 @@ export class MonacoStatusBarContribution implements FrontendApplicationContribut
         if (editor && editorModel) {
             const modelOptions = editorModel.getOptions();
             const tabSize = modelOptions.tabSize;
-            const useSpaceOrTab = modelOptions.insertSpaces
+            const spaceOrTabSizeMessage = modelOptions.insertSpaces
                 ? nls.localizeByDefault('Spaces: {0}', tabSize)
                 : nls.localizeByDefault('Tab Size: {0}', tabSize);
             this.statusBar.setElement('editor-status-tabbing-config', {
-                text: `${useSpaceOrTab}: ${tabSize}`,
+                text: spaceOrTabSizeMessage,
                 alignment: StatusBarAlignment.RIGHT,
                 priority: 10,
                 command: EditorCommands.CONFIG_INDENTATION.id,


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

Fixes #10489

A change in the text formatting that came in with localization adjustments has led to a minor bug in the status bar:

Before:

![image](https://user-images.githubusercontent.com/62660806/144910535-71ec68ec-ca09-4919-89d7-b7df513a5f17.png)


After:

![image](https://user-images.githubusercontent.com/62660806/144910706-1482c34d-7ce3-44d8-94f6-d22bd8f6f127.png)


#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

1. Open an editor.
2. Check the indentation status bar item.
3. Confirm that it only has `: #` once.
4. Do the same in various languages, if you'd like.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
