### PR TITLE
Remove deprecated id/label fields from `theia.Command`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,11 @@
 # Change Log
+## v1.22.0 - 1/??/2022
+
+[1.22.0 Milestone](https://github.com/eclipse-theia/theia/milestone/30)
+
+<a name="breaking_changes_1.22.0">[Breaking Changes:](#breaking_changes_1.22.0)</a>
+- [plugin] Removed deprecated fields `id` and `label` from `theia.Command`
+
 
 ## v1.21.0 - 12/16/2021
 

--- a/packages/plugin-ext/src/plugin/command-registry.ts
+++ b/packages/plugin-ext/src/plugin/command-registry.ts
@@ -197,10 +197,10 @@ export class CommandsConverter {
         // we're deprecating Command.id, so it has to be optional.
         // Existing code will have compiled against a non - optional version of the field, so asserting it to exist is ok
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        return KnownCommands.map((external.command || external.id)!, external.arguments, (mappedId: string, mappedArgs: any[]) =>
+        return KnownCommands.map(external.command, external.arguments, (mappedId: string, mappedArgs: any[]) =>
         ({
             id: mappedId,
-            title: external.title || external.label || ' ',
+            title: external.title || ' ',
             tooltip: external.tooltip,
             arguments: mappedArgs
         }));

--- a/packages/plugin-ext/src/plugin/languages/code-action.ts
+++ b/packages/plugin-ext/src/plugin/languages/code-action.ts
@@ -102,7 +102,7 @@ export class CodeActionAdapter {
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     private static _isCommand(smth: any): smth is theia.Command {
-        return typeof (<theia.Command>smth).command === 'string' || typeof (<theia.Command>smth).id === 'string';
+        return typeof (<theia.Command>smth).command === 'string';
     }
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/packages/plugin/src/theia.d.ts
+++ b/packages/plugin/src/theia.d.ts
@@ -202,7 +202,7 @@ export module '@theia/plugin' {
         /**
          * The identifier of the actual command handler.
          */
-        command?: string;
+        command: string;
         /**
          * Title of the command invocation, like "Add local variable 'foo'".
          */
@@ -216,15 +216,6 @@ export module '@theia/plugin' {
          * invoked with.
          */
         arguments?: any[];
-
-        /**
-         * @deprecated use command instead
-         */
-        id?: string;
-        /**
-         * @deprecated use title instead
-         */
-        label?: string;
     }
 
     /**


### PR DESCRIPTION
Signed-off-by: Thomas Mäder <tmader@redhat.com>

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->
The command removes the id and label fields from the theia command interface which have been deprecated for > 3 years.

fixes https://github.com/eclipse-theia/theia/issues/9271

#### How to test
Use anything that contributes a command from a plugins, for example a code lens. I used the java debugger's "run" code lens on a main method.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
