### PR TITLE
Fix running plugin host on electron windows

### DIFF
--- a/packages/plugin-dev/src/node/hosted-instance-manager.ts
+++ b/packages/plugin-dev/src/node/hosted-instance-manager.ts
@@ -24,7 +24,7 @@ import * as request from 'request';
 import URI from '@theia/core/lib/common/uri';
 import { ContributionProvider } from '@theia/core/lib/common/contribution-provider';
 import { HostedPluginUriPostProcessor, HostedPluginUriPostProcessorSymbolName } from './hosted-plugin-uri-postprocessor';
-import { environment } from '@theia/core';
+import { environment, isWindows } from '@theia/core';
 import { FileUri } from '@theia/core/lib/node/file-uri';
 import { LogType } from '@theia/plugin-ext/lib/common/types';
 import { HostedPluginSupport } from '@theia/plugin-ext/lib/hosted/node/hosted-plugin';
@@ -292,6 +292,12 @@ export abstract class AbstractHostedInstanceManager implements HostedInstanceMan
                     resolve(new URI(match[1]));
                 }
             };
+
+            if (isWindows) {
+                // Has to be set for running on windows (electron).
+                // See also: https://github.com/nodejs/node/issues/3675
+                options.shell = true;
+            }
 
             this.hostedInstanceProcess = cp.spawn(command.shift()!, command, options);
             this.hostedInstanceProcess.on('error', () => { this.isPluginRunning = false; });


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->
Closes https://github.com/eclipse-theia/theia/issues/6846

to run plugins created by yo @theia/plugin on windows.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
1.    Using yo @theia/plugin to make a Hello World plug-in
2.    Adding nodejs  version like "@types/node": "12.20.0" in package.json to avoid error "node_modules@types\node\assert.d.ts"
 3.   Run yarn to build plugin
 4.   Run "Hosted Plug-in: Start Instance" in command, and select the source directory which includes file package.json

A new instance is showed up successfully on windows.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
