### PR TITLE
Removed deprecated activateTerminal method #10521

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
   - add `isSafeToShutDown()` - replaces `canUnload()`.
   - add `setSafeToShutDown()` - ensures that next close event will not be prevented.
   - add `reload()` - to allow different handling in Electron and browser.
+- [terminal] removed deprecated `activateTerminal` method in favor of `open`. [#10529](https://github.com/eclipse-theia/theia/pull/10529)
 
 ## v1.20.0 - 11/25/2021
 

--- a/packages/task/src/browser/task-service.ts
+++ b/packages/task/src/browser/task-service.ts
@@ -1056,7 +1056,7 @@ export class TaskService implements TaskConfigurationClient {
         if (!terminal || terminal.kind !== 'user' || (await terminal.hasChildProcesses())) {
             terminal = <TerminalWidget>await this.terminalService.newTerminal(<TerminalWidgetFactoryOptions>{ created: new Date().toString() });
             await terminal.start();
-            this.terminalService.activateTerminal(terminal);
+            this.terminalService.open(terminal);
         }
         terminal.sendText(selectedText);
     }

--- a/packages/terminal/src/browser/base/terminal-service.ts
+++ b/packages/terminal/src/browser/base/terminal-service.ts
@@ -29,13 +29,6 @@ export interface TerminalService {
      */
     newTerminal(options: TerminalWidgetOptions): Promise<TerminalWidget>;
 
-    /**
-     * Display new terminal widget.
-     * @param terminal - widget to attach.
-     * @deprecated use #open
-     */
-    activateTerminal(terminal: TerminalWidget): void;
-
     open(terminal: TerminalWidget, options?: WidgetOpenerOptions): void;
 
     readonly all: TerminalWidget[];

--- a/packages/terminal/src/browser/terminal-frontend-contribution.ts
+++ b/packages/terminal/src/browser/terminal-frontend-contribution.ts
@@ -427,7 +427,7 @@ export class TerminalFrontendContribution implements FrontendApplicationContribu
         // Open terminal
         const termWidget = await this.newTerminal({ cwd });
         termWidget.start();
-        this.activateTerminal(termWidget);
+        this.open(termWidget);
     }
 
     registerMenus(menus: MenuModelRegistry): void {
@@ -600,10 +600,6 @@ export class TerminalFrontendContribution implements FrontendApplicationContribu
             ...options
         });
         return widget;
-    }
-
-    activateTerminal(widget: TerminalWidget, widgetOptions?: ApplicationShell.WidgetOptions): void {
-        this.open(widget, { widgetOptions });
     }
 
     // TODO: reuse WidgetOpenHandler.open


### PR DESCRIPTION
Signed-off-by: abhisharsinha <abhisharsinha@gmail.com>

#### What it does

Fixes: #10521 

Removed the deprecated `activateTerminal` method. The deprecated method was called in two files which have been updated with the open method. The method definition was also removed. 

#### How to test

No functionality was changed. The project builds without any error.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)