### PR TITLE
Fix `CopyWebpackPlugin` for missing `@theia/monaco`

### DIFF
--- a/dev-packages/application-manager/src/generator/webpack-generator.ts
+++ b/dev-packages/application-manager/src/generator/webpack-generator.ts
@@ -56,8 +56,8 @@ export class WebpackGenerator extends AbstractGenerator {
 const path = require('path');
 const webpack = require('webpack');
 const yargs = require('yargs');
-const CopyWebpackPlugin = require('copy-webpack-plugin');
-const CircularDependencyPlugin = require('circular-dependency-plugin');
+${this.ifMonaco(() => `const CopyWebpackPlugin = require('copy-webpack-plugin');
+`)}const CircularDependencyPlugin = require('circular-dependency-plugin');
 const CompressionPlugin = require('compression-webpack-plugin')
 
 const outputPath = path.resolve(__dirname, 'lib');
@@ -75,13 +75,13 @@ const development = mode === 'development';${this.ifMonaco(() => `
 const monacoEditorCorePath = development ? '${this.resolve('@theia/monaco-editor-core', 'dev/vs')}' : '${this.resolve('@theia/monaco-editor-core', 'min/vs')}';`)}
 
 const plugins = [
-    new CopyWebpackPlugin({
-        patterns: [${this.ifMonaco(() => `{
+    ${this.ifMonaco(() => `new CopyWebpackPlugin({
+        patterns: [{
             from: monacoEditorCorePath,
             to: 'vs'
-        }`)}]
+        }]
     }),
-    new webpack.ProvidePlugin({
+    `)}new webpack.ProvidePlugin({
         // the Buffer class doesn't exist in the browser but some dependencies rely on it
         Buffer: ['buffer', 'Buffer']
     })


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

Closes #10535

Empty `patterns` arrays are not allowed, so we simply remove the whole `CopyWebpackPlugin` call if we don't use monaco.

#### How to test

0. The example app compiles correctly.
1. Create a Theia app using only `@theia/core`.
2. The app should compile correctly.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
