### PR TITLE
fix default Anchor param of context menu

### DIFF
--- a/packages/core/src/browser/context-menu-renderer.ts
+++ b/packages/core/src/browser/context-menu-renderer.ts
@@ -105,12 +105,12 @@ export namespace RenderContextMenuOptions {
         let args: any[];
         if (Array.isArray(menuPathOrOptions)) {
             menuPath = menuPathOrOptions;
-            args = [anchor!];
+            args = [];
         } else {
             menuPath = menuPathOrOptions.menuPath;
             anchor = menuPathOrOptions.anchor;
             onHide = menuPathOrOptions.onHide;
-            args = menuPathOrOptions.args ? [...menuPathOrOptions.args, anchor] : [anchor];
+            args = menuPathOrOptions.args ? [...menuPathOrOptions.args] : [];
         }
         return {
             menuPath,


### PR DESCRIPTION
Signed-off-by: shuyaqian 717749594@qq.com

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->
Fix default Anchor param of context menu.

#### How to test
1. click 'Start Debugging' menu
![image](https://user-images.githubusercontent.com/6367259/146151120-bf708573-6529-4830-9b9c-bfd0f8702452.png)
2.  you will get error
![image](https://user-images.githubusercontent.com/6367259/146151344-a58c9241-c654-42a2-9527-a977a5f7105f.png)
3. because the param `debugSessionOptions` received is an anchor
![image](https://user-images.githubusercontent.com/6367259/146151426-2194f4ce-949b-4372-9909-bc791827e851.png)


<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
