### PR TITLE
fix default Anchor param of context menu

### DIFF
--- a/packages/core/src/browser/context-menu-renderer.ts
+++ b/packages/core/src/browser/context-menu-renderer.ts
@@ -29,6 +29,13 @@ export function toAnchor(anchor: HTMLElement | Coordinate): Anchor {
     return anchor instanceof HTMLElement ? { x: anchor.offsetLeft, y: anchor.offsetTop } : anchor;
 }
 
+export function isAnchor(arg: unknown): boolean {
+    if (arg && typeof arg === 'object' && 'x' in arg && 'y' in arg && Object.keys(arg).length === 2) {
+        return true;
+    }
+    return false;
+}
+
 export function coordinateFromAnchor(anchor: Anchor): Coordinate {
     const { x, y } = anchor instanceof MouseEvent ? { x: anchor.clientX, y: anchor.clientY } : anchor;
     return { x, y };

--- a/packages/debug/src/browser/debug-frontend-application-contribution.ts
+++ b/packages/debug/src/browser/debug-frontend-application-contribution.ts
@@ -14,7 +14,7 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
-import { AbstractViewContribution, ApplicationShell, KeybindingRegistry, Widget, CompositeTreeNode, LabelProvider, codicon } from '@theia/core/lib/browser';
+import { AbstractViewContribution, ApplicationShell, KeybindingRegistry, Widget, CompositeTreeNode, LabelProvider, codicon, isAnchor } from '@theia/core/lib/browser';
 import { injectable, inject } from '@theia/core/shared/inversify';
 import { ThemeService } from '@theia/core/lib/browser/theming';
 import { MenuModelRegistry, CommandRegistry, MAIN_MENU_BAR, Command, Emitter, Mutable } from '@theia/core/lib/common';
@@ -640,10 +640,10 @@ export class DebugFrontendApplicationContribution extends AbstractViewContributi
     registerCommands(registry: CommandRegistry): void {
         super.registerCommands(registry);
         registry.registerCommand(DebugCommands.START, {
-            execute: (config?: DebugSessionOptions) => this.start(false, config)
+            execute: (config?: DebugSessionOptions) => this.start(false, isAnchor(config) ? undefined : config)
         });
         registry.registerCommand(DebugCommands.START_NO_DEBUG, {
-            execute: (config?: DebugSessionOptions) => this.start(true, config)
+            execute: (config?: DebugSessionOptions) => this.start(true, isAnchor(config) ? undefined : config)
         });
         registry.registerCommand(DebugCommands.STOP, {
             execute: () => this.manager.terminateSessions(),


### PR DESCRIPTION
Signed-off-by: shuyaqian 717749594@qq.com

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->
Fix default Anchor param of context menu.

#### How to test
1. click 'Start Debugging' menu
![image](https://user-images.githubusercontent.com/6367259/146151120-bf708573-6529-4830-9b9c-bfd0f8702452.png)
2.  you will get error
![image](https://user-images.githubusercontent.com/6367259/146151344-a58c9241-c654-42a2-9527-a977a5f7105f.png)
3. because the param `debugSessionOptions` received is an anchor
![image](https://user-images.githubusercontent.com/6367259/146151426-2194f4ce-949b-4372-9909-bc791827e851.png)


<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
