### PR TITLE
quick-input: alter styling of codicon to resemble vscode

### DIFF
--- a/packages/monaco/src/browser/style/index.css
+++ b/packages/monaco/src/browser/style/index.css
@@ -163,6 +163,22 @@
   color: var(--theia-quickInputList-focusForeground) !important;
 }
 
+.quick-input-list .monaco-list-row .codicon {
+  color: var(--theia-foreground) !important;
+  padding-left: 0px !important;
+}
+
+.quick-input-list .monaco-list-row.focused .codicon {
+  color: var(--theia-list-foreground) !important;
+}
+
+.monaco-action-bar .action-item {
+  height: var(--theia-ui-icon-font-size);
+  width: var(--theia-ui-icon-font-size);
+  margin: auto;
+  padding-right: calc(var(--theia-ui-padding) * 0.5);
+}
+
 .quick-input-list .monaco-list-row.focused .monaco-highlighted-label .highlight {
   color: var(--theia-list-focusHighlightForeground) !important;
 }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
Fixes #10389

This commit alters the appearance of the codicons that show in the `Run Task` menu to be similar to vscode.
The color has been changed from blue to one that follows the present color theme.
The background of the icon when hovering over is now a square and centered around the icon to be more aesthetically pleasing.
<!-- Include relevant issues and describe how they are addressed. -->

#### How to test
- Start the application using theia as a workspace
- Execute the command `Run Task` using F1
- Hover over each task to notice the tail icon colored correctly with the theme
- Hover over the tail icon for the hover background
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

#### Review checklist

- [X] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
