### PR TITLE
changelog: fix changelog for v1.19.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -126,7 +126,7 @@
   - renamed `createMenuBar` to `createElectronMenuBar`
 - [output] moved `output-channel` from `common` to `browser` [#10154](https://github.com/eclipse-theia/theia/pull/10154)
 - [output] moved `output-preferences` from `common` to `browser` [#10154](https://github.com/eclipse-theia/theia/pull/10154)
-- [ovsx-client] removed `fetchJson` method from `OVSXClient` [#10325](https://github.com/eclipse-theia/theia/pull/10325)
+- [ovsx-client] removed `postJson` method from `OVSXClient` [#10325](https://github.com/eclipse-theia/theia/pull/10325)
 - [plugin] removed unnecessary function `getCaption` [#10253](https://github.com/eclipse-theia/theia/pull/10253)
 - [view-container] updated the `ViewContainerPart` constructor to take two new parameters: `originalContainerId` and `originalContainerTitle` [#9644](https://github.com/eclipse-theia/theia/pull/9644)
   - the existing `viewContainerId` parameter has been renamed to `currentContainerId` to enable drag & drop views.


### PR DESCRIPTION
Signed-off-by: Roman Nikitenko <rnikiten@redhat.com>

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->
Fixes one of the records of changelog for v1.19.0.
Actually `postJson` method (not `fetchJson`) was removed from `OVSXClient` within https://github.com/eclipse-theia/theia/pull/10325.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
Just check which method was removed within https://github.com/eclipse-theia/theia/pull/10325. 
#### Review checklist

- [ ] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
