### PR TITLE
workspace: add `workbenchState` context key

### DIFF
--- a/packages/workspace/src/browser/workspace-frontend-contribution.ts
+++ b/packages/workspace/src/browser/workspace-frontend-contribution.ts
@@ -51,6 +51,7 @@ export enum WorkspaceStates {
     folder = 'folder',
 };
 export type WorkspaceState = keyof typeof WorkspaceStates;
+export type WorkbenchState = keyof typeof WorkspaceStates;
 
 @injectable()
 export class WorkspaceFrontendContribution implements CommandContribution, KeybindingContribution, MenuContribution, FrontendApplicationContribution {
@@ -90,7 +91,7 @@ export class WorkspaceFrontendContribution implements CommandContribution, Keybi
         const updateWorkspaceStateKey = () => workspaceStateKey.set(this.updateWorkspaceStateKey());
         updateWorkspaceStateKey();
 
-        const workbenchStateKey = this.contextKeyService.createKey<WorkspaceState>('workbenchState', 'empty');
+        const workbenchStateKey = this.contextKeyService.createKey<WorkbenchState>('workbenchState', 'empty');
         const updateWorkbenchStateKey = () => workbenchStateKey.set(this.updateWorkbenchStateKey());
         updateWorkbenchStateKey();
 
@@ -500,14 +501,14 @@ export class WorkspaceFrontendContribution implements CommandContribution, Keybi
     }
 
     protected updateWorkspaceStateKey(): WorkspaceState {
-        return this.doUpdateWorkspaceState();
+        return this.doUpdateState();
     }
 
-    protected updateWorkbenchStateKey(): WorkspaceState {
-        return this.doUpdateWorkspaceState();
+    protected updateWorkbenchStateKey(): WorkbenchState {
+        return this.doUpdateState();
     }
 
-    protected doUpdateWorkspaceState(): WorkspaceState {
+    protected doUpdateState(): WorkspaceState | WorkbenchState {
         if (this.workspaceService.opened) {
             return this.workspaceService.isMultiRootWorkspaceOpened ? 'workspace' : 'folder';
         }

--- a/packages/workspace/src/browser/workspace-frontend-contribution.ts
+++ b/packages/workspace/src/browser/workspace-frontend-contribution.ts
@@ -90,11 +90,16 @@ export class WorkspaceFrontendContribution implements CommandContribution, Keybi
         const updateWorkspaceStateKey = () => workspaceStateKey.set(this.updateWorkspaceStateKey());
         updateWorkspaceStateKey();
 
+        const workbenchStateKey = this.contextKeyService.createKey<WorkspaceState>('workbenchState', 'empty');
+        const updateWorkbenchStateKey = () => workbenchStateKey.set(this.updateWorkbenchStateKey());
+        updateWorkbenchStateKey();
+
         this.updateStyles();
         this.workspaceService.onWorkspaceChanged(() => {
             this.updateEncodingOverrides();
             updateWorkspaceFolderCountKey();
             updateWorkspaceStateKey();
+            updateWorkbenchStateKey();
             this.updateStyles();
         });
     }
@@ -495,8 +500,16 @@ export class WorkspaceFrontendContribution implements CommandContribution, Keybi
     }
 
     protected updateWorkspaceStateKey(): WorkspaceState {
+        return this.doUpdateWorkspaceState();
+    }
+
+    protected updateWorkbenchStateKey(): WorkspaceState {
+        return this.doUpdateWorkspaceState();
+    }
+
+    protected doUpdateWorkspaceState(): WorkspaceState {
         if (this.workspaceService.opened) {
-            return this.workspaceService.isMultiRootWorkspaceOpened ? 'folder' : 'workspace';
+            return this.workspaceService.isMultiRootWorkspaceOpened ? 'workspace' : 'folder';
         }
         return 'empty';
     }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

Fixes: #10549

The pull-request adds support for the `workbenchState` context key, which declares if there is no workspace (empty), a folder, or a workspace (multi-root) opened.


#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

1. include [vscode-maven](https://open-vsx.org/api/vscjava/vscode-maven/0.34.1/file/vscjava.vscode-maven-0.34.1.vsix) as a builtin extension
2. start the application using `theia` as a workspace - confirm that the `maven` view in the explorer is not visible
3. perform <kbd>F1</kbd> > `Reset Workbench Layout` - confirm that the `maven` view in the explorer is not visible
4. add a test `pom.xml` in the workspace (one of the activation events for the view)
5. perform <kbd>F1</kbd> > `Reset Workbench Layout` - confirm that the `maven` view is now visible

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

Signed-off-by: vince-fugnitto <vincent.fugnitto@ericsson.com>