### PR TITLE
Ensure preference files only in problems view if open

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,14 +3,17 @@
 
 [1.22.0 Milestone](https://github.com/eclipse-theia/theia/milestone/30)
 
+- [preferences] `AbstractResourcePreferenceProvider` providers no longer maintain a reference to a `MonacoTextModel`. This removes preference files from the Problems view unless the file is opened by the user. [#10562](https://github.com/eclipse-theia/theia/pull/10562)
+
 <a name="breaking_changes_1.22.0">[Breaking Changes:](#breaking_changes_1.22.0)</a>
+
 - [core] Removed `MarkdownRenderer` class [#10589](https://github.com/eclipse-theia/theia/pull/10589)
 - [core] `ContextKeyService` is now an interface. Extenders should extend `ContextKeyServiceDummyImpl` [#10546](https://github.com/eclipse-theia/theia/pull/10546)
 - [plugin] Removed deprecated fields `id` and `label` from `theia.Command` [#10512](https://github.com/eclipse-theia/theia/pull/10512)
 - [plugin-ext] `ViewContextKeyService#with` method removed. Use `ContextKeyService#with` instead. `PluginViewWidget` and `PluginTreeWidget` inject the `ContextKeyService` rather than `ViewContextKeyService`. [#10546](https://github.com/eclipse-theia/theia/pull/10546)
 - [navigator] added `Open Containing Folder` command [#10523](https://github.com/eclipse-theia/theia/pull/10523)
 - [core] Removed deprecated API: `unfocusSearchFieldContainer`, `doUnfocusSearchFieldContainer()` [#10625](https://github.com/eclipse-theia/theia/pull/10625)
-
+- [preferences] `AbstractResourcePreferenceProvider#model, textModelService, workspace, messageService, acquireLocks, releaseLocks, readPreferences, singleChangeLock, transactionLock` removed. `AbstractResourcePreferenceProvider#handleDirtyEditor` moved to `PreferenceTransaction`. `AbstractResourcePreferenceProvider#getEditOperations` moved to `MonacoJSONCEditor`. [#10562](https://github.com/eclipse-theia/theia/pull/10562)
 
 ## v1.21.0 - 12/16/2021
 

--- a/examples/api-tests/src/launch-preferences.spec.js
+++ b/examples/api-tests/src/launch-preferences.spec.js
@@ -30,16 +30,24 @@ describe('Launch Preferences', function () {
 
     const { assert } = chai;
 
+    const { PreferenceProvider } = require('@theia/core/lib/browser');
     const { PreferenceService, PreferenceScope } = require('@theia/core/lib/browser/preferences/preference-service');
     const { WorkspaceService } = require('@theia/workspace/lib/browser/workspace-service');
     const { FileService } = require('@theia/filesystem/lib/browser/file-service');
     const { FileResourceResolver } = require('@theia/filesystem/lib/browser/file-resource');
     const { MonacoTextModelService } = require('@theia/monaco/lib/browser/monaco-text-model-service');
     const { MonacoWorkspace } = require('@theia/monaco/lib/browser/monaco-workspace');
+    const { AbstractResourcePreferenceProvider } = require('@theia/preferences/lib/browser/abstract-resource-preference-provider');
 
     const container = window.theia.container;
     /** @type {import('@theia/core/lib/browser/preferences/preference-service').PreferenceService} */
     const preferences = container.get(PreferenceService);
+    /** @type {import('@theia/preferences/lib/browser/user-configs-preference-provider').UserConfigsPreferenceProvider} */
+    const userPreferences = container.getNamed(PreferenceProvider, PreferenceScope.User);
+    /** @type {import('@theia/preferences/lib/browser/workspace-preference-provider').WorkspacePreferenceProvider} */
+    const workspacePreferences = container.getNamed(PreferenceProvider, PreferenceScope.Workspace);
+    /** @type {import('@theia/preferences/lib/browser/folders-preferences-provider').FoldersPreferencesProvider} */
+    const folderPreferences = container.getNamed(PreferenceProvider, PreferenceScope.Folder);
     const workspaceService = container.get(WorkspaceService);
     const fileService = container.get(FileService);
     const textModelService = container.get(MonacoTextModelService);
@@ -394,25 +402,70 @@ describe('Launch Preferences', function () {
 
     const rootUri = workspaceService.tryGetRoots()[0].resource;
 
+    /**
+     * @param uri the URI of the file to modify
+     * @returns {AbstractResourcePreferenceProvider | undefined} The preference provider matching the provided URI.
+     */
+    function findProvider(uri) {
+        /**
+         * @param {PreferenceProvider} provider
+         * @returns {boolean} whether the provider matches the desired URI.
+         */
+        const isMatch = (provider) => {
+            const configUri = provider.getConfigUri();
+            return configUri && uri.isEqual(configUri);
+        };
+        for (const provider of userPreferences['providers'].values()) {
+            if (isMatch(provider) && provider instanceof AbstractResourcePreferenceProvider) {
+                return provider;
+            }
+        }
+        for (const provider of folderPreferences['providers'].values()) {
+            if (isMatch(provider) && provider instanceof AbstractResourcePreferenceProvider) {
+                return provider;
+            }
+        }
+        /** @type {PreferenceProvider} */
+        const workspaceDelegate = workspacePreferences['delegate'];
+        if (workspaceDelegate !== folderPreferences) {
+            if (isMatch(workspaceDelegate) && workspaceDelegate instanceof AbstractResourcePreferenceProvider) {
+                return workspaceDelegate;
+            }
+        }
+    }
+
     function deleteWorkspacePreferences() {
         const promises = [];
         for (const configPath of ['.theia', '.vscode']) {
             for (const name of ['settings', 'launch']) {
                 promises.push((async () => {
+                    const uri = rootUri.resolve(configPath + '/' + name + '.json');
+                    const provider = findProvider(uri);
                     try {
-                        const reference = await textModelService.createModelReference(rootUri.resolve(configPath + '/' + name + '.json'));
-                        try {
-                            if (!reference.object.valid) {
-                                return;
-                            }
-                            await new Promise(resolve => {
-                                const listener = reference.object.onDidChangeValid(() => {
-                                    listener.dispose();
-                                    resolve();
+                        if (provider) {
+                            const original = provider['readPreferencesFromContent'];
+                            try {
+                                await new Promise(resolve => {
+                                    if (!provider['valid']) {
+                                        return resolve();
+                                    }
+                                    const beginningPreferences = provider['preferences'];
+                                    const timeout = setTimeout(() => console.log("I'm still waiting on an event from this file...", uri.path.toString(), beginningPreferences), 3000);
+                                    const check = () => {
+                                        if (provider && !provider['valid']) {
+                                            clearTimeout(timeout);
+                                            resolve();
+                                        } else {
+                                            console.log('Got a change event, but the provider was still valid.', uri.path.toString());
+                                        }
+                                    };
+                                    provider['readPreferencesFromContent'] = (content) => { check(); return original.bind(provider)(content); };
                                 });
-                            });
-                        } finally {
-                            reference.dispose();
+                            } finally {
+                                provider['readPreferencesFromContent'] = original;
+                            }
+                        } else {
+                            console.log('Unable to find provider for', uri.path.toString());
                         }
                     } catch (e) {
                         console.error(e);
@@ -465,21 +518,18 @@ describe('Launch Preferences', function () {
                 const promises = [];
                 /**
                  * @param {string} name
-                 * @param {string} text
+                 * @param {Record<string, unknown>} value
                  */
-                const ensureConfigModel = (name, text) => {
+                const ensureConfigModel = (name, value) => {
                     for (const configPath of configPaths) {
                         promises.push((async () => {
                             try {
-                                const reference = await textModelService.createModelReference(rootUri.resolve(configPath + '/' + name + '.json'));
-                                try {
-                                    await workspace.applyBackgroundEdit(reference.object, [{
-                                        text,
-                                        range: reference.object.textEditorModel.getFullModelRange(),
-                                        forceMoveMarkers: false
-                                    }]);
-                                } finally {
-                                    reference.dispose();
+                                const uri = rootUri.resolve(configPath + '/' + name + '.json');
+                                const provider = findProvider(uri);
+                                if (provider) {
+                                    await provider['doSetPreference']('', [], value);
+                                } else {
+                                    console.log('Unable to find provider for', uri.path.toString());
                                 }
                             } catch (e) {
                                 console.error(e);
@@ -488,10 +538,10 @@ describe('Launch Preferences', function () {
                     }
                 };
                 if (settings) {
-                    ensureConfigModel('settings', JSON.stringify(settings));
+                    ensureConfigModel('settings', settings);
                 }
                 if (launch) {
-                    ensureConfigModel('launch', JSON.stringify(launch));
+                    ensureConfigModel('launch', launch);
                 }
                 await Promise.all(promises);
             });
@@ -641,7 +691,6 @@ describe('Launch Preferences', function () {
                     }
                     if (settings) {
                         let _settingsLaunch = undefined;
-                        // eslint-disable-next-line no-null/no-null
                         if (typeof settingsLaunch === 'object' && !Array.isArray(settings['launch']) && settings['launch'] !== null) {
                             _settingsLaunch = settingsLaunch;
                         } else {

--- a/examples/api-tests/src/launch-preferences.spec.js
+++ b/examples/api-tests/src/launch-preferences.spec.js
@@ -26,7 +26,7 @@
  * See https://github.com/akosyakov/vscode-launch/blob/master/src/test/extension.test.ts
  */
 describe('Launch Preferences', function () {
-    this.timeout(5000);
+    this.timeout(10_000);
 
     const { assert } = chai;
 

--- a/packages/preferences/src/browser/abstract-resource-preference-provider.spec.ts
+++ b/packages/preferences/src/browser/abstract-resource-preference-provider.spec.ts
@@ -32,11 +32,11 @@ import { FileService } from '@theia/filesystem/lib/browser/file-service';
 import { bindPreferenceService } from '@theia/core/lib/browser/frontend-application-bindings';
 import { bindMockPreferenceProviders } from '@theia/core/lib/browser/preferences/test';
 import { Deferred } from '@theia/core/lib/common/promise-util';
-import { MonacoTextModelService } from '@theia/monaco/lib/browser/monaco-text-model-service';
 import { Disposable, MessageService } from '@theia/core/lib/common';
 import { MonacoWorkspace } from '@theia/monaco/lib/browser/monaco-workspace';
 import { PreferenceSchemaProvider } from '@theia/core/lib/browser';
 import { EditorManager } from '@theia/editor/lib/browser';
+import { PreferenceTransactionFactory } from './preference-transaction-manager';
 
 disableJSDOM();
 
@@ -46,23 +46,11 @@ class MockFileService {
         await this.releaseContent.promise;
         return { value: JSON.stringify({ 'editor.fontSize': 20 }) };
     }
+    watch = RETURN_DISPOSABLE;
+    onDidFilesChange = RETURN_DISPOSABLE;
 }
 
-const DO_NOTHING = () => { };
 const RETURN_DISPOSABLE = () => Disposable.NULL;
-
-class MockTextModelService {
-    createModelReference(): any {
-        return {
-            dispose: DO_NOTHING,
-            object: {
-                onDidChangeContent: RETURN_DISPOSABLE,
-                onDirtyChanged: RETURN_DISPOSABLE,
-                onDidChangeValid: RETURN_DISPOSABLE,
-            }
-        };
-    }
-}
 
 const mockSchemaProvider = { getCombinedSchema: () => ({ properties: {} }) };
 
@@ -82,10 +70,10 @@ describe('AbstractResourcePreferenceProvider', () => {
         bindMockPreferenceProviders(testContainer.bind.bind(testContainer), testContainer.unbind.bind(testContainer));
         testContainer.rebind(<any>PreferenceSchemaProvider).toConstantValue(mockSchemaProvider);
         testContainer.bind(<any>FileService).toConstantValue(fileService);
-        testContainer.bind(<any>MonacoTextModelService).toConstantValue(new MockTextModelService);
         testContainer.bind(<any>MessageService).toConstantValue(undefined);
         testContainer.bind(<any>MonacoWorkspace).toConstantValue(undefined);
         testContainer.bind(<any>EditorManager).toConstantValue(undefined);
+        testContainer.bind(<any>PreferenceTransactionFactory).toConstantValue(undefined);
         provider = testContainer.resolve(<any>LessAbstractPreferenceProvider);
     });
 

--- a/packages/preferences/src/browser/abstract-resource-preference-provider.ts
+++ b/packages/preferences/src/browser/abstract-resource-preference-provider.ts
@@ -95,6 +95,10 @@ export abstract class AbstractResourcePreferenceProvider extends PreferenceProvi
         if (this.toDispose.disposed || !(path = this.getPath(key)) || !this.contains(resourceUri)) {
             return false;
         }
+        return this.doSetPreference(key, path, value);
+    }
+
+    protected async doSetPreference(key: string, path: string[], value: unknown): Promise<boolean> {
         if (!this.transaction?.open) {
             const current = this.transaction;
             this.transaction = this.transactionFactory(this);

--- a/packages/preferences/src/browser/folder-preference-provider.ts
+++ b/packages/preferences/src/browser/folder-preference-provider.ts
@@ -46,7 +46,7 @@ export class FolderPreferenceProvider extends SectionPreferenceProvider {
         }
         return this._folderUri;
     }
-    protected getScope(): PreferenceScope {
+    getScope(): PreferenceScope {
         if (!this.workspaceService.isMultiRootWorkspaceOpened) {
             // when FolderPreferenceProvider is used as a delegate of WorkspacePreferenceProvider in a one-folder workspace
             return PreferenceScope.Workspace;

--- a/packages/preferences/src/browser/monaco-jsonc-editor.ts
+++ b/packages/preferences/src/browser/monaco-jsonc-editor.ts
@@ -1,0 +1,66 @@
+/********************************************************************************
+ * Copyright (C) 2021 Ericsson and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import * as jsoncparser from 'jsonc-parser';
+import { MonacoEditorModel } from '@theia/monaco/lib/browser/monaco-editor-model';
+import { MonacoWorkspace } from '@theia/monaco/lib/browser/monaco-workspace';
+import { inject, injectable } from '@theia/core/shared/inversify';
+
+@injectable()
+export class MonacoJSONCEditor {
+    @inject(MonacoWorkspace) protected readonly workspace: MonacoWorkspace;
+
+    async setValue(model: MonacoEditorModel, path: string[], value: unknown, shouldSave = true): Promise<void> {
+        const edits = this.getEditOperations(model, path, value);
+        if (edits.length > 0) {
+            await this.workspace.applyBackgroundEdit(model, edits, shouldSave);
+        }
+    }
+
+    getEditOperations(model: MonacoEditorModel, path: string[], value: unknown): monaco.editor.IIdentifiedSingleEditOperation[] {
+        const textModel = model.textEditorModel;
+        const content = model.getText().trim();
+        // Everything is already undefined - no need for changes.
+        if (!content && value === undefined) {
+            return [];
+        }
+        // Delete the entire document.
+        if (!path.length && value === undefined) {
+            return [{
+                range: textModel.getFullModelRange(),
+                text: null, // eslint-disable-line no-null/no-null
+                forceMoveMarkers: false
+            }];
+        }
+        const { insertSpaces, tabSize, defaultEOL } = textModel.getOptions();
+        const jsonCOptions = {
+            formattingOptions: {
+                insertSpaces,
+                tabSize,
+                eol: defaultEOL === monaco.editor.DefaultEndOfLine.LF ? '\n' : '\r\n'
+            }
+        };
+        return jsoncparser.modify(content, path, value, jsonCOptions).map(edit => {
+            const start = textModel.getPositionAt(edit.offset);
+            const end = textModel.getPositionAt(edit.offset + edit.length);
+            return {
+                range: monaco.Range.fromPositions(start, end),
+                text: edit.content || null, // eslint-disable-line no-null/no-null
+                forceMoveMarkers: false
+            };
+        });
+    }
+}

--- a/packages/preferences/src/browser/preference-frontend-module.ts
+++ b/packages/preferences/src/browser/preference-frontend-module.ts
@@ -26,6 +26,8 @@ import { PreferencesContribution } from './preferences-contribution';
 import { PreferenceScopeCommandManager } from './util/preference-scope-command-manager';
 import { JsonSchemaContribution } from '@theia/core/lib/browser/json-schema-store';
 import { PreferencesJsonSchemaContribution } from './preferences-json-schema-contribution';
+import { MonacoJSONCEditor } from './monaco-jsonc-editor';
+import { PreferenceContext, PreferenceTransaction, PreferenceTransactionFactory } from './preference-transaction-manager';
 
 export function bindPreferences(bind: interfaces.Bind, unbind: interfaces.Unbind): void {
     bindPreferenceProviders(bind, unbind);
@@ -40,6 +42,14 @@ export function bindPreferences(bind: interfaces.Bind, unbind: interfaces.Unbind
 
     bind(PreferencesJsonSchemaContribution).toSelf().inSingletonScope();
     bind(JsonSchemaContribution).toService(PreferencesJsonSchemaContribution);
+
+    bind(MonacoJSONCEditor).toSelf().inSingletonScope();
+    bind(PreferenceTransaction).toSelf();
+    bind(PreferenceTransactionFactory).toFactory(({ container }) => (context: PreferenceContext) => {
+        const child = container.createChild();
+        child.bind(PreferenceContext).toConstantValue(context);
+        return child.get(PreferenceTransaction);
+    });
 }
 
 export default new ContainerModule((bind, unbind, isBound, rebind) => {

--- a/packages/preferences/src/browser/preference-transaction-manager.ts
+++ b/packages/preferences/src/browser/preference-transaction-manager.ts
@@ -1,0 +1,203 @@
+/********************************************************************************
+ * Copyright (C) 2021 Ericsson and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import { CancellationError, Emitter, Event, MaybePromise, MessageService, nls, WaitUntilEvent } from '@theia/core';
+import { Deferred } from '@theia/core/lib/common/promise-util';
+import { inject, injectable, postConstruct } from '@theia/core/shared/inversify';
+import { PreferenceScope } from '@theia/core/lib/common/preferences/preference-scope';
+import URI from '@theia/core/lib/common/uri';
+import { MonacoEditorModel } from '@theia/monaco/lib/browser/monaco-editor-model';
+import { Mutex, MutexInterface } from 'async-mutex';
+import { MonacoTextModelService } from '@theia/monaco/lib/browser/monaco-text-model-service';
+import { MonacoJSONCEditor } from './monaco-jsonc-editor';
+import { EditorManager } from '@theia/editor/lib/browser/editor-manager';
+
+export interface OnWillConcludeEvent<T> extends WaitUntilEvent {
+    status: T | false;
+}
+
+@injectable()
+export abstract class Transaction<Arguments extends unknown[], Result = unknown, Status = unknown> {
+    protected _open = true;
+    get open(): boolean {
+        return this._open;
+    }
+    protected _result = new Deferred<Result | false>();
+    get result(): Promise<Result | false> {
+        return this._result.promise;
+    }
+    protected readonly queue = new Mutex(new CancellationError);
+    protected readonly onWillConcludeEmitter = new Emitter<OnWillConcludeEvent<Status>>();
+    get onWillConclude(): Event<OnWillConcludeEvent<Status>> {
+        return this.onWillConcludeEmitter.event;
+    }
+
+    protected status = new Deferred<Status>();
+    protected inUse = false;
+
+    @postConstruct()
+    protected async init(): Promise<void> {
+        const release = await this.queue.acquire();
+        try {
+            const status = await this.setUp();
+            this.status.resolve(status);
+        } catch {
+            this.dispose();
+        } finally {
+            release();
+        }
+    }
+
+    async enqueueAction(...args: Arguments): Promise<Result | false> {
+        if (this._open) {
+            let release: MutexInterface.Releaser | undefined;
+            try {
+                release = await this.queue.acquire();
+                if (!this.inUse) {
+                    this.inUse = true;
+                    this.queue.waitForUnlock().then(() => this.dispose());
+                }
+                return this.act(...args);
+            } catch (e) {
+                if (e instanceof CancellationError) {
+                    throw e;
+                }
+                return false;
+            } finally {
+                if (release) {
+                    release();
+                }
+            }
+        } else {
+            throw new Error('Transaction used after disposal.');
+        }
+    }
+
+    protected async conclude(): Promise<void> {
+        if (this._open) {
+            try {
+                this._open = false;
+                this.queue.cancel();
+                const result = await this.tearDown();
+                const status = this.status.state === 'unresolved' || this.status.state === 'rejected' ? false : await this.status.promise;
+                await WaitUntilEvent.fire(this.onWillConcludeEmitter, { status });
+                this.onWillConcludeEmitter.dispose();
+                this._result.resolve(result);
+            } catch {
+                this._result.resolve(false);
+            }
+        }
+    }
+
+    dispose(): void {
+        this.conclude();
+    }
+
+    protected abstract setUp(): MaybePromise<Status>;
+    protected abstract act(...args: Arguments): MaybePromise<Result>;
+    protected abstract tearDown(): MaybePromise<Result>;
+}
+
+export interface PreferenceContext {
+    getConfigUri(): URI;
+    getScope(): PreferenceScope;
+}
+export const PreferenceContext = Symbol('PreferenceContext');
+
+@injectable()
+export class PreferenceTransaction extends Transaction<[string, string[], unknown], boolean, boolean> {
+    reference: monaco.editor.IReference<MonacoEditorModel> | undefined;
+    @inject(PreferenceContext) protected readonly context: PreferenceContext;
+    @inject(MonacoTextModelService) protected readonly textModelService: MonacoTextModelService;
+    @inject(MonacoJSONCEditor) protected readonly jsoncEditor: MonacoJSONCEditor;
+    @inject(MessageService) protected readonly messageService: MessageService;
+    @inject(EditorManager) protected readonly editorManager: EditorManager;
+
+    protected async setUp(): Promise<boolean> {
+        const reference = await this.textModelService.createModelReference(this.context.getConfigUri()!);
+        if (this._open) {
+            this.reference = reference;
+        } else {
+            reference.dispose();
+            return false;
+        }
+        if (reference.object.dirty) {
+            const shouldContinue = await this.handleDirtyEditor();
+            if (!shouldContinue) {
+                this.dispose();
+                return false;
+            }
+        }
+        return true;
+    }
+
+    /**
+     * @returns whether the setting operation in progress, and any others started in the meantime, should continue.
+     */
+    protected async handleDirtyEditor(): Promise<boolean> {
+        const saveAndRetry = nls.localizeByDefault('Save and Retry');
+        const open = nls.localizeByDefault('Open File');
+        const msg = await this.messageService.error(
+            nls.localizeByDefault('Unable to write into {0} settings because the file has unsaved changes. Please save the {0} settings file first and then try again.',
+                nls.localizeByDefault(PreferenceScope[this.context.getScope()].toLocaleLowerCase())
+            ),
+            saveAndRetry, open);
+
+        if (this.reference?.object) {
+            if (msg === open) {
+                this.editorManager.open(new URI(this.reference.object.uri));
+            } else if (msg === saveAndRetry) {
+                await this.reference.object.save();
+                return true;
+            }
+        }
+        return false;
+    }
+
+    protected async act(key: string, path: string[], value: unknown): Promise<boolean> {
+        const model = this.reference?.object;
+        try {
+            if (model) {
+                await this.jsoncEditor.setValue(model, path, value);
+                return this.result;
+            }
+            return false;
+        } catch (e) {
+            const message = `Failed to update the value of '${key}' in '${this.context.getConfigUri()}'.`;
+            this.messageService.error(`${message} Please check if it is corrupted.`);
+            console.error(`${message}`, e);
+            return false;
+        }
+    }
+
+    protected async tearDown(): Promise<boolean> {
+        const model = this.reference?.object;
+        if (model) {
+            if (this.status.state === 'resolved' && await this.status.promise) {
+                await model.save();
+                return true;
+            }
+            this.reference?.dispose();
+            this.reference = undefined;
+        }
+        return false;
+    }
+}
+
+export interface PreferenceTransactionFactory {
+    (context: PreferenceContext): PreferenceTransaction;
+}
+export const PreferenceTransactionFactory = Symbol('PreferenceTransactionFactory');

--- a/packages/preferences/src/browser/user-preference-provider.ts
+++ b/packages/preferences/src/browser/user-preference-provider.ts
@@ -29,7 +29,7 @@ export interface UserPreferenceProviderFactory {
  */
 @injectable()
 export class UserPreferenceProvider extends SectionPreferenceProvider {
-    protected getScope(): PreferenceScope {
+    getScope(): PreferenceScope {
         return PreferenceScope.User;
     }
 }

--- a/packages/preferences/src/browser/workspace-file-preference-provider.ts
+++ b/packages/preferences/src/browser/workspace-file-preference-provider.ts
@@ -86,7 +86,7 @@ export class WorkspaceFilePreferenceProvider extends AbstractResourcePreferenceP
         return this.configurations.isSectionName(firstSegment);
     }
 
-    protected getScope(): PreferenceScope {
+    getScope(): PreferenceScope {
         return PreferenceScope.Workspace;
     }
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->
Fixes #7154 by disposing of the preference system's reference to the `MonacoEditorModel` when not in use. This is similar to [VSCode's approach](https://github.com/microsoft/vscode/blob/edbf56a72a0630649effa940940d0800d42753e2/src/vs/workbench/services/configuration/common/configurationEditingService.ts#L184) in which the model reference is disposed of at the end of the write.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
1. Open the application
2. Open the problems view
3. Open a preference file
4. Ensure that the preference file has some problems (dangling commas, schema violations)
5. Close the file
6. Observe that the problems view does not continue to show the problems for the preference file when it is closed.
---
1. Do normal preference operations (set values in the UI, set values in the file)
2. Observe that the changes take effect as expected.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
