### PR TITLE
Fix workspace input dialog style

### DIFF
--- a/packages/workspace/src/browser/workspace-input-dialog.ts
+++ b/packages/workspace/src/browser/workspace-input-dialog.ts
@@ -49,8 +49,12 @@ export class WorkspaceInputDialog extends SingleTextInputDialog {
         const icon = document.createElement('i');
         icon.classList.add(...codiconArray('folder'));
         icon.style.marginRight = '0.5em';
+        icon.style.verticalAlign = 'middle';
         element.appendChild(icon);
-        element.appendChild(document.createTextNode(label));
+        const path = document.createElement('span');
+        path.style.verticalAlign = 'middle';
+        path.textContent = label;
+        element.appendChild(path);
         // Add the path and icon div before the `inputField`.
         this.contentNode.insertBefore(element, this.inputField);
     }


### PR DESCRIPTION
Signed-off-by: shuyaqian 717749594@qq.com

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
Fix workspace input dialog style
<!-- Include relevant issues and describe how they are addressed. -->

#### How to test
1. open `File—New Floder` menu
2. you will find the folder icon and path text are not aligned
![image](https://user-images.githubusercontent.com/6367259/146737451-0d4048ce-8909-4c1f-a3af-5e24a050f45d.png)
3. after fix:
![image](https://user-images.githubusercontent.com/6367259/146737482-72b91d22-acee-4b60-a080-b491088110a9.png)


<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
