### PR TITLE
Fix showOpenDialog fallback

### DIFF
--- a/packages/plugin-ext/src/main/browser/dialogs-main.ts
+++ b/packages/plugin-ext/src/main/browser/dialogs-main.ts
@@ -52,14 +52,14 @@ export class DialogsMainImpl implements DialogsMain {
             } catch {
                 rootStat = undefined;
             }
-        }
 
-        // Try to use as root the parent folder of existing file URI/non existing URI
-        if (rootStat && !rootStat.isDirectory || !rootStat) {
-            try {
-                rootStat = await this.fileService.resolve(new URI(defaultUri).parent);
-            } catch {
-                rootStat = undefined;
+            // Try to use as root the parent folder of existing file URI/non existing URI
+            if (rootStat && !rootStat.isDirectory || !rootStat) {
+                try {
+                    rootStat = await this.fileService.resolve(new URI(defaultUri).parent);
+                } catch {
+                    rootStat = undefined;
+                }
             }
         }
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

Fixes https://github.com/eclipse-theia/theia/issues/10572 by correcting logic in the plugin extension. The `showOpenDialog` and other file dialog extension APIs now correctly fall back to the workspace root when the `defaultUri` is not specified.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

Fallback to the workspace root when a `defaultUri` is not specified can be tested with the vscode-xml extension as described in https://github.com/eclipse-theia/theia/issues/10572.

The behaviour when a `defaultUri` is present can be tested as described in https://github.com/eclipse-theia/theia/issues/7451. In this case, the file dialog should open at the parent folder when a file is passed as the `defaultUri`.

#### Review checklist

- [ ] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
