### PR TITLE
Fix handling of localhost links in the ExternalUriService

### DIFF
--- a/packages/core/src/browser/external-uri-service.ts
+++ b/packages/core/src/browser/external-uri-service.ts
@@ -14,9 +14,10 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
+import { environment } from '@theia/application-package/lib/environment';
 import { injectable } from 'inversify';
-import URI from '../common/uri';
 import { MaybePromise } from '../common/types';
+import URI from '../common/uri';
 import { Endpoint } from './endpoint';
 
 @injectable()
@@ -24,13 +25,17 @@ export class ExternalUriService {
 
     /**
      * Maps local to remote URLs.
-     * Should be no-op if the given URL is not a localhost URL.
+     * Should be no-op if the given URL is not a localhost URL or when not running in the browser.
      *
      * By default maps to an origin serving Theia.
      *
      * Use `parseLocalhost` to retrieve localhost address and port information.
      */
     resolve(uri: URI): MaybePromise<URI> {
+        if (environment.electron.is()) {
+            // nothing to resolve (window.location.hostname is empty)
+            return uri;
+        }
         const localhost = this.parseLocalhost(uri);
         if (localhost) {
             return this.toRemoteUrl(uri, localhost);


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
In the ExternalUriService, don't try to resolve localhost URIs when running in electron.

#### How to test
1. Start the electron example app
2. Print a link to localhost in the terminal, e.g. `localhost:3000`
3. Ctrl+click on the link
4. The link should open in an external browser.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
