### PR TITLE
Tasks: Ensure workspace delegate and scope defined

### DIFF
--- a/packages/task/src/browser/task-configuration-manager.ts
+++ b/packages/task/src/browser/task-configuration-manager.ts
@@ -225,8 +225,9 @@ export class TaskConfigurationManager {
 
     protected readonly toDisposeOnDelegateChange = new DisposableCollection();
     protected updateWorkspaceModel(): void {
-        const newDelegate = this.workspaceService.saved ? this.workspacePreferences : this.folderPreferences;
-        const effectiveScope = this.workspaceService.saved ? TaskScope.Workspace : this.workspaceService.tryGetRoots()[0]?.resource.toString();
+        const isFolderWorkspace = this.workspaceService.opened && !this.workspaceService.saved;
+        const newDelegate = isFolderWorkspace ? this.folderPreferences : this.workspacePreferences;
+        const effectiveScope = isFolderWorkspace ? this.workspaceService.tryGetRoots()[0]?.resource.toString() : TaskScope.Workspace;
         if (newDelegate !== this.workspaceDelegate) {
             this.workspaceDelegate = newDelegate;
             this.toDisposeOnDelegateChange.dispose();

--- a/packages/workspace/src/browser/workspace-service.ts
+++ b/packages/workspace/src/browser/workspace-service.ts
@@ -549,6 +549,11 @@ export class WorkspaceService implements FrontendApplicationContribution {
         return false;
     }
 
+    /**
+     * `true` if the current workspace is configured using a configuration file.
+     *
+     * `false` if there is no workspace or the workspace is simply a folder.
+     */
     get saved(): boolean {
         return !!this._workspace && !this._workspace.isDirectory;
     }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

Fixes #10575 by ensuring that both the scope of workspace delegate and the delegate itself are defined in the `TaskConfigurationManager`.

Closes #10497

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

1. Open the application with no workspace.
2. In the frontend logs, see no message about inabililty to read property `scope` of `undefined`.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
