### PR TITLE
Render notification progress update as html

### DIFF
--- a/packages/messages/src/browser/notification-component.tsx
+++ b/packages/messages/src/browser/notification-component.tsx
@@ -78,7 +78,12 @@ export class NotificationComponent extends React.Component<NotificationComponent
                     <div className={`theia-notification-icon ${codicon(type)} ${type}`} />
                     <div className='theia-notification-message'>
                         <span
-                            dangerouslySetInnerHTML={{ __html: DOMPurify.sanitize(message) }} // eslint-disable-line react/no-danger
+                            // eslint-disable-next-line react/no-danger
+                            dangerouslySetInnerHTML={{
+                                __html: DOMPurify.sanitize(message, {
+                                    ALLOW_UNKNOWN_PROTOCOLS: true // DOMPurify usually strips non http(s) links from hrefs
+                                })
+                            }}
                             onClick={this.onMessageClick}
                         />
                     </div>

--- a/packages/messages/src/browser/notifications-manager.ts
+++ b/packages/messages/src/browser/notifications-manager.ts
@@ -276,8 +276,10 @@ export class NotificationManager extends MessageClient {
         if (cancellationToken.isCancellationRequested) {
             this.clear(messageId);
         } else {
-            notification.message = originalMessage.text && update.message ? `${originalMessage.text}: ${update.message}` :
-                originalMessage.text || update?.message || notification.message;
+            const textMessage = originalMessage.text && update.message ? `${originalMessage.text}: ${update.message}` : originalMessage.text || update?.message;
+            if (textMessage) {
+                notification.message = this.contentRenderer.renderMessage(textMessage);
+            }
             notification.progress = this.toPlainProgress(update) || notification.progress;
         }
         this.fireUpdatedEvent();


### PR DESCRIPTION
#### What it does

Closes #10587
Addresses one issue from #10579 

Renders the message of a progress update also to html. Additionally, allows to include unknown protocols in hrefs, which previously lead to `command:some-command` hrefs from being removed by `DOMPurify`.

#### How to test

1. Install the `RedHat Java` extension and open a Java Project.
2. Wait until the "Opening Java Projects" notification appears.
3. Click the link, "check details", which should run the `java.show.server.task.status` command. (be fast, the notification disappears quite quickly)

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
