### PR TITLE
core: properly handle localhost uris on Electron

### DIFF
--- a/packages/core/src/browser/external-uri-service.ts
+++ b/packages/core/src/browser/external-uri-service.ts
@@ -14,10 +14,16 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
+import { environment } from '@theia/application-package/lib/environment';
 import { injectable } from 'inversify';
-import URI from '../common/uri';
 import { MaybePromise } from '../common/types';
+import URI from '../common/uri';
 import { Endpoint } from './endpoint';
+
+export interface AddressPort {
+    address: string
+    port: number
+}
 
 @injectable()
 export class ExternalUriService {
@@ -31,29 +37,20 @@ export class ExternalUriService {
      * Use `parseLocalhost` to retrieve localhost address and port information.
      */
     resolve(uri: URI): MaybePromise<URI> {
-        const localhost = this.parseLocalhost(uri);
-        if (localhost) {
-            return this.toRemoteUrl(uri, localhost);
+        const address = this.parseLocalhost(uri);
+        if (address) {
+            return this.toRemoteUrl(uri, address);
         }
         return uri;
     }
 
-    protected toRemoteUrl(uri: URI, localhost: { address: string, port: number }): URI {
-        const host = this.toRemoteHost(localhost);
-        return new Endpoint({ host }).getRestUrl().withPath(uri.path).withFragment(uri.fragment).withQuery(uri.query);
-    }
-
-    protected toRemoteHost(localhost: { address: string, port: number }): string {
-        return `${window.location.hostname}:${localhost.port}`;
-    }
-
-    parseLocalhost(uri: URI): { address: string, port: number } | undefined {
+    parseLocalhost(uri: URI): AddressPort | undefined {
         if (uri.scheme !== 'http' && uri.scheme !== 'https') {
-            return undefined;
+            return;
         }
         const localhostMatch = /^(localhost|127\.0\.0\.1|0\.0\.0\.0):(\d+)$/.exec(uri.authority);
         if (!localhostMatch) {
-            return undefined;
+            return;
         }
         return {
             address: localhostMatch[1],
@@ -61,4 +58,22 @@ export class ExternalUriService {
         };
     }
 
+    protected toRemoteUrl(uri: URI, address: AddressPort): URI {
+        return new Endpoint({ host: this.toRemoteHost(address) })
+            .getRestUrl()
+            .withPath(uri.path)
+            .withFragment(uri.fragment)
+            .withQuery(uri.query);
+    }
+
+    protected toRemoteHost(address: AddressPort): string {
+        return `${this.getRemoteHost()}:${address.port}`;
+    }
+
+    /**
+     * @returns The remote host (where the backend is running).
+     */
+    protected getRemoteHost(): string {
+        return environment.electron.is() ? 'localhost' : window.location.hostname;
+    }
 }


### PR DESCRIPTION
When running Electron `window.location` is not a standard HTTP(S) URL,
so we cannot use it to determine the host where the backend is running.

Resolve the remote host to `localhost` when running Electron.

Closes #10574

#### How to test

1. Start the electron example app
2. Print a link to localhost in the terminal, e.g. localhost:3000
3. Ctrl+click on the link
4. The link should open in an external browser.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
