### PR TITLE
electron: Fix path comparison for exit confirmation

### DIFF
--- a/packages/core/src/electron-main/electron-main-application.ts
+++ b/packages/core/src/electron-main/electron-main-application.ts
@@ -487,7 +487,14 @@ export class ElectronMainApplication {
 
     protected async handleStopRequest(electronWindow: BrowserWindow, onSafeCallback: () => unknown, reason: StopReason): Promise<void> {
         // Only confirm close to windows that have loaded our front end.
-        const safeToClose = !electronWindow.webContents.getURL().includes(this.globals.THEIA_FRONTEND_HTML_PATH) || await this.checkSafeToStop(electronWindow, reason);
+        let currentUrl = electronWindow.webContents.getURL();
+        let frontendUri = this.globals.THEIA_FRONTEND_HTML_PATH;
+        // Since our resolved frontend HTML path might contain backward slashes on Windows, we normalize everything first.
+        if (isWindows) {
+            currentUrl = currentUrl.replace(/\\/g, '/');
+            frontendUri = frontendUri.replace(/\\/g, '/');
+        }
+        const safeToClose = !currentUrl.includes(frontendUri) || await this.checkSafeToStop(electronWindow, reason);
         if (safeToClose) {
             onSafeCallback();
         }


### PR DESCRIPTION
#### What it does

Closes #10596 

Before testing for `includes`, we replace all backwards slashes with forward slashes.

#### How to test

1. Start the electron App on Windows.
2. Set the `application.confirmExit` preference to `always`.
3. Exit the application and assert that a confirmation dialog appears.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
