### PR TITLE
Fix 'Save As' when saving a document with 'untitled' scheme

### DIFF
--- a/packages/core/src/browser/common-frontend-contribution.ts
+++ b/packages/core/src/browser/common-frontend-contribution.ts
@@ -50,7 +50,7 @@ import { EncodingRegistry } from './encoding-registry';
 import { UTF8 } from '../common/encodings';
 import { EnvVariablesServer } from '../common/env-variables';
 import { AuthenticationService } from './authentication-service';
-import { FormatType, Saveable } from './saveable';
+import { FormatType, Saveable, SaveOptions } from './saveable';
 import { QuickInputService, QuickPick, QuickPickItem } from './quick-input';
 import { AsyncLocalizationProvider } from '../common/i18n/localization';
 import { nls } from '../common/nls';
@@ -60,6 +60,7 @@ import { WindowService } from './window/window-service';
 import { FrontendApplicationConfigProvider } from './frontend-application-config-provider';
 import { DecorationStyle } from './decoration-style';
 import { isPinned, Title, togglePinned, Widget } from './widgets';
+import { SaveResourceService } from './save-resource-service';
 
 export namespace CommonMenus {
 
@@ -338,7 +339,8 @@ export class CommonFrontendContribution implements FrontendApplicationContributi
         @inject(MessageService) protected readonly messageService: MessageService,
         @inject(OpenerService) protected readonly openerService: OpenerService,
         @inject(AboutDialog) protected readonly aboutDialog: AboutDialog,
-        @inject(AsyncLocalizationProvider) protected readonly localizationProvider: AsyncLocalizationProvider
+        @inject(AsyncLocalizationProvider) protected readonly localizationProvider: AsyncLocalizationProvider,
+        @inject(SaveResourceService) protected readonly saveResourceService: SaveResourceService,
     ) { }
 
     @inject(ContextKeyService)
@@ -889,10 +891,10 @@ export class CommonFrontendContribution implements FrontendApplicationContributi
         });
 
         commandRegistry.registerCommand(CommonCommands.SAVE, {
-            execute: () => this.shell.save({ formatType: FormatType.ON })
+            execute: () => this.save({ formatType: FormatType.ON })
         });
         commandRegistry.registerCommand(CommonCommands.SAVE_WITHOUT_FORMATTING, {
-            execute: () => this.shell.save({ formatType: FormatType.OFF })
+            execute: () => this.save({ formatType: FormatType.OFF })
         });
         commandRegistry.registerCommand(CommonCommands.SAVE_ALL, {
             execute: () => this.shell.saveAll({ formatType: FormatType.DIRTY })
@@ -1056,6 +1058,11 @@ export class CommonFrontendContribution implements FrontendApplicationContributi
                 when: 'activeEditorIsPinned'
             }
         );
+    }
+
+    protected async save(options?: SaveOptions): Promise<void> {
+        const widget = this.shell.currentWidget;
+        this.saveResourceService.save(widget, options);
     }
 
     protected async openAbout(): Promise<void> {

--- a/packages/core/src/browser/frontend-application-module.ts
+++ b/packages/core/src/browser/frontend-application-module.ts
@@ -120,6 +120,7 @@ import {
 import { RendererHost } from './widgets';
 import { TooltipService, TooltipServiceImpl } from './tooltip-service';
 import { bindFrontendStopwatch, bindBackendStopwatch } from './performance';
+import { SaveResourceService } from './save-resource-service';
 
 export { bindResourceProvider, bindMessageService, bindPreferenceService };
 
@@ -395,4 +396,6 @@ export const frontendApplicationModule = new ContainerModule((bind, unbind, isBo
 
     bindFrontendStopwatch(bind);
     bindBackendStopwatch(bind);
+
+    bind(SaveResourceService).toSelf().inSingletonScope();
 });

--- a/packages/core/src/browser/save-resource-service.ts
+++ b/packages/core/src/browser/save-resource-service.ts
@@ -1,0 +1,45 @@
+/********************************************************************************
+ * Copyright (C) 2022 Arm and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import { injectable } from 'inversify';
+import { Saveable, SaveOptions } from './saveable';
+import { Widget } from './widgets';
+
+@injectable()
+export class SaveResourceService {
+
+    /**
+     * Indicate if the document can be saved ('Save' command should be disable if not).
+     */
+     canSave(saveable: Saveable): boolean {
+        // By default, we never allow a document to be saved if it is untitled.
+        return Saveable.isDirty(saveable) && !Saveable.isUntitled(saveable);
+    }
+
+    /**
+     * Saves the document.
+     *
+     * This function is called only if `canSave` returns true, which means the document is not untitled
+     * and is thus saveable.
+     */
+    async save(widget: Widget | undefined, options?: SaveOptions): Promise<void> {
+        const saveable = Saveable.get(widget);
+        if (saveable && this.canSave(saveable)) {
+            await saveable.save(options);
+        }
+    }
+
+}

--- a/packages/core/src/browser/saveable.ts
+++ b/packages/core/src/browser/saveable.ts
@@ -21,6 +21,7 @@ import { MaybePromise } from '../common/types';
 import { Key } from './keyboard/keys';
 import { AbstractDialog } from './dialogs';
 import { waitForClosed } from './widgets';
+import { URI } from 'vscode-uri';
 
 export interface Saveable {
     readonly dirty: boolean;
@@ -63,6 +64,10 @@ export namespace Saveable {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     export function is(arg: any): arg is Saveable {
         return !!arg && ('dirty' in arg) && ('onDirtyChanged' in arg);
+    }
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    export function isUntitled(arg: any): boolean {
+        return !!arg && ('uri' in arg) && URI.parse((arg as { uri: string; }).uri).scheme === 'untitled';
     }
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     export function get(arg: any): Saveable | undefined {

--- a/packages/plugin-ext/src/main/browser/documents-main.ts
+++ b/packages/plugin-ext/src/main/browser/documents-main.ts
@@ -30,7 +30,6 @@ import { Range } from '@theia/core/shared/vscode-languageserver-protocol';
 import { OpenerService } from '@theia/core/lib/browser/opener-service';
 import { Reference } from '@theia/core/lib/common/reference';
 import { dispose } from '../../common/disposable-util';
-import { FileResourceResolver } from '@theia/filesystem/lib/browser';
 
 /*---------------------------------------------------------------------------------------------
  *  Copyright (c) Microsoft Corporation. All rights reserved.
@@ -95,7 +94,6 @@ export class DocumentsMainImpl implements DocumentsMain, Disposable {
         private openerService: OpenerService,
         private shell: ApplicationShell,
         private untitledResourceResolver: UntitledResourceResolver,
-        private fileResourceResolver: FileResourceResolver
     ) {
         this.proxy = rpc.getProxy(MAIN_RPC_CONTEXT.DOCUMENTS_EXT);
 
@@ -181,7 +179,7 @@ export class DocumentsMainImpl implements DocumentsMain, Disposable {
     async $tryCreateDocument(options?: { language?: string; content?: string; }): Promise<UriComponents> {
         const language = options && options.language;
         const content = options && options.content;
-        const resource = await this.untitledResourceResolver.createUntitledResource(this.fileResourceResolver, content, language);
+        const resource = await this.untitledResourceResolver.createUntitledResource(content, language);
         return monaco.Uri.parse(resource.uri.toString());
     }
 

--- a/packages/plugin-ext/src/main/browser/main-context.ts
+++ b/packages/plugin-ext/src/main/browser/main-context.ts
@@ -47,7 +47,6 @@ import { ApplicationShell } from '@theia/core/lib/browser/shell/application-shel
 import { MonacoBulkEditService } from '@theia/monaco/lib/browser/monaco-bulk-edit-service';
 import { MonacoEditorService } from '@theia/monaco/lib/browser/monaco-editor-service';
 import { UntitledResourceResolver } from './editor/untitled-resource';
-import { FileResourceResolver } from '@theia/filesystem/lib/browser';
 import { MainFileSystemEventService } from './main-file-system-event-service';
 import { LabelServiceMainImpl } from './label-service-main';
 import { TimelineMainImpl } from './timeline-main';
@@ -87,8 +86,7 @@ export function setUpPluginApi(rpc: RPCProtocol, container: interfaces.Container
     const openerService = container.get<OpenerService>(OpenerService);
     const shell = container.get(ApplicationShell);
     const untitledResourceResolver = container.get(UntitledResourceResolver);
-    const fileResourceResolver = container.get(FileResourceResolver);
-    const documentsMain = new DocumentsMainImpl(editorsAndDocuments, modelService, rpc, editorManager, openerService, shell, untitledResourceResolver, fileResourceResolver);
+    const documentsMain = new DocumentsMainImpl(editorsAndDocuments, modelService, rpc, editorManager, openerService, shell, untitledResourceResolver);
     rpc.set(PLUGIN_RPC_CONTEXT.DOCUMENTS_MAIN, documentsMain);
 
     const bulkEditService = container.get(MonacoBulkEditService);

--- a/packages/workspace/src/browser/workspace-frontend-contribution.ts
+++ b/packages/workspace/src/browser/workspace-frontend-contribution.ts
@@ -19,7 +19,7 @@ import { CommandContribution, CommandRegistry, MenuContribution, MenuModelRegist
 import { isOSX, environment, OS } from '@theia/core';
 import {
     open, OpenerService, CommonMenus, StorageService, LabelProvider, ConfirmDialog, KeybindingRegistry, KeybindingContribution,
-    CommonCommands, FrontendApplicationContribution, ApplicationShell, Saveable, SaveableSource, Widget, Navigatable, SHELL_TABBAR_CONTEXT_COPY, OnWillStopAction
+    CommonCommands, FrontendApplicationContribution, ApplicationShell, Saveable, SaveableSource, Widget, Navigatable, SHELL_TABBAR_CONTEXT_COPY, OnWillStopAction, FormatType
 } from '@theia/core/lib/browser';
 import { FileDialogService, OpenFileDialogProps, FileDialogTreeFilters } from '@theia/filesystem/lib/browser';
 import { ContextKeyService } from '@theia/core/lib/browser/context-key-service';
@@ -479,7 +479,7 @@ export class WorkspaceFrontendContribution implements CommandContribution, Keybi
      * - `widget.saveable.createSnapshot` is defined.
      * - `widget.saveable.revert` is defined.
      */
-    protected canBeSavedAs(widget: Widget | undefined): widget is Widget & SaveableSource & Navigatable {
+    canBeSavedAs(widget: Widget | undefined): widget is Widget & SaveableSource & Navigatable {
         return widget !== undefined
             && Saveable.isSource(widget)
             && typeof widget.saveable.createSnapshot === 'function'
@@ -491,7 +491,7 @@ export class WorkspaceFrontendContribution implements CommandContribution, Keybi
     /**
      * Save `sourceWidget` to a new file picked by the user.
      */
-    protected async saveAs(sourceWidget: Widget & SaveableSource & Navigatable): Promise<void> {
+    async saveAs(sourceWidget: Widget & SaveableSource & Navigatable): Promise<void> {
         let exist: boolean = false;
         let overwrite: boolean = false;
         let selected: URI | undefined;
@@ -548,8 +548,7 @@ export class WorkspaceFrontendContribution implements CommandContribution, Keybi
             targetSaveable.applySnapshot(snapshot);
             await sourceWidget.saveable.revert!();
             sourceWidget.close();
-            // At this point `targetWidget` should be `applicationShell.currentWidget` for the save command to pick up:
-            await this.commandRegistry.executeCommand(CommonCommands.SAVE.id);
+            Saveable.save(targetWidget, { formatType: FormatType.ON });
         } else {
             this.messageService.error(nls.localize('theia/workspace/failApply', 'Could not apply changes to new file'));
         }

--- a/packages/workspace/src/browser/workspace-frontend-module.ts
+++ b/packages/workspace/src/browser/workspace-frontend-module.ts
@@ -50,6 +50,8 @@ import { WorkspaceBreadcrumbsContribution } from './workspace-breadcrumbs-contri
 import { FilepathBreadcrumbsContribution } from '@theia/filesystem/lib/browser/breadcrumbs/filepath-breadcrumbs-contribution';
 import { WorkspaceTrustService } from './workspace-trust-service';
 import { bindWorkspaceTrustPreferences } from './workspace-trust-preferences';
+import { SaveResourceService } from '@theia/core/lib/browser/save-resource-service';
+import { WorkspaceSaveResourceService } from './workspace-save-resource-service';
 
 export default new ContainerModule((bind: interfaces.Bind, unbind: interfaces.Unbind, isBound: interfaces.IsBound, rebind: interfaces.Rebind) => {
     bindWorkspacePreferences(bind);
@@ -105,4 +107,6 @@ export default new ContainerModule((bind: interfaces.Bind, unbind: interfaces.Un
     rebind(FilepathBreadcrumbsContribution).to(WorkspaceBreadcrumbsContribution).inSingletonScope();
 
     bind(WorkspaceTrustService).toSelf().inSingletonScope();
+
+    rebind(SaveResourceService).to(WorkspaceSaveResourceService).inSingletonScope();
 });

--- a/packages/workspace/src/browser/workspace-save-resource-service.ts
+++ b/packages/workspace/src/browser/workspace-save-resource-service.ts
@@ -1,0 +1,50 @@
+/********************************************************************************
+ * Copyright (C) 2022 Arm and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import { inject, injectable } from '@theia/core/shared/inversify';
+import { WorkspaceFrontendContribution } from './workspace-frontend-contribution';
+import { Saveable, SaveOptions, Widget } from '@theia/core/lib/browser';
+import { SaveResourceService } from '@theia/core/lib/browser/save-resource-service';
+import { MessageService } from '@theia/core/lib/common';
+
+@injectable()
+export class WorkspaceSaveResourceService extends SaveResourceService {
+
+    @inject(WorkspaceFrontendContribution) protected readonly workspaceFrontendContribution: WorkspaceFrontendContribution;
+
+    @inject(MessageService) protected readonly messageService: MessageService;
+
+    override canSave(saveable: Saveable): boolean {
+        // In addition to dirty documents, untitled documents can be saved because for these we treat 'Save' as 'Save As'.
+        return Saveable.isDirty(saveable) || Saveable.isUntitled(saveable);
+    }
+
+    override async save(widget: Widget | undefined, options?: SaveOptions): Promise<void> {
+        const saveable = Saveable.get(widget);
+        if (widget instanceof Widget && this.workspaceFrontendContribution.canBeSavedAs(widget) && saveable) {
+            if (Saveable.isUntitled(saveable)) {
+                this.workspaceFrontendContribution.saveAs(widget);
+            } else {
+                await saveable.save(options);
+            }
+        } else {
+            // This should not happen because the caller should check this.
+            this.messageService.error(`Cannot save the current widget "${widget?.title}" .`);
+        }
+
+    }
+
+}


### PR DESCRIPTION
#### What it does

This allows the user to save documents with 'untitled' scheme.  These documents are often opened by plugins that want to show content that is not in underlying storage (typically dynamically generated)

#### How to test

To test this you will need a plugin that creates documents with 'untitled' scheme.  The AWS toolkit extension does this (https://open-vsx.org/extension/amazonwebservices/aws-toolkit-vscode). Having configured an Access Key ID and a Secret Access Key and connected to your AWS account, in the AWS Explorer you can either:
- view a policy under IoT / Policies, right-click on a policy version and View...
- view a schema under Schemas / aws.events, right-click and View Schema.

Either of these should open an editor with a document with 'untitled' scheme.

Without this fix you will not be able so use the 'Save As...' menu to save untitled documents. It silently fails. (The FileSystem copy fails because 'untitled' is not a supported scheme).

Note on the fix: It might have been simpler to create an empty file in all cases. However I decided to leave it as is when the FileSystem supports the scheme because I assume there are reasons the file was being copied. This could be to preserve file permissions for example. The FileSystem implementation does support copying across from one provider to another.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
