### PR TITLE
dep: replace `colors` with `chalk`

### DIFF
--- a/dev-packages/cli/package.json
+++ b/dev-packages/cli/package.json
@@ -41,7 +41,7 @@
     "@types/requestretry": "^1.12.3",
     "@types/tar": "^4.0.3",
     "chai": "^4.2.0",
-    "colors": "^1.4.0",
+    "chalk": "4.0.0",
     "decompress": "^4.2.1",
     "https-proxy-agent": "^5.0.0",
     "mocha": "^7.0.0",

--- a/dev-packages/cli/src/download-plugins.ts
+++ b/dev-packages/cli/src/download-plugins.ts
@@ -24,7 +24,7 @@ declare global {
 }
 
 import { OVSXClient } from '@theia/ovsx-client/lib/ovsx-client';
-import { green, red, yellow } from 'colors/safe';
+import * as chalk from 'chalk';
 import * as decompress from 'decompress';
 import { createWriteStream, promises as fs } from 'fs';
 import { HttpsProxyAgent } from 'https-proxy-agent';
@@ -91,7 +91,7 @@ export default async function downloadPlugins(options: DownloadPluginsOptions = 
     await fs.mkdir(pluginsDir, { recursive: true });
 
     if (!pck.theiaPlugins) {
-        console.log(red('error: missing mandatory \'theiaPlugins\' property.'));
+        console.log(chalk.red('error: missing mandatory \'theiaPlugins\' property.'));
         return;
     }
     try {
@@ -171,7 +171,7 @@ async function downloadPluginAsync(failures: string[], plugin: string, pluginUrl
     } else if (pluginUrl.endsWith('theia')) {
         fileExt = '.theia'; // theia plugins.
     } else {
-        failures.push(red(`error: '${plugin}' has an unsupported file type: '${pluginUrl}'`));
+        failures.push(chalk.red(`error: '${plugin}' has an unsupported file type: '${pluginUrl}'`));
         return;
     }
     const targetPath = path.resolve(pluginsDir, `${plugin}${packed === true ? fileExt : ''}`);
@@ -206,15 +206,15 @@ async function downloadPluginAsync(failures: string[], plugin: string, pluginUrl
         }
     }
     if (lastError) {
-        failures.push(red(`x ${plugin}: failed to download, last error:\n ${lastError}`));
+        failures.push(chalk.red(`x ${plugin}: failed to download, last error:\n ${lastError}`));
         return;
     }
     if (typeof response === 'undefined') {
-        failures.push(red(`x ${plugin}: failed to download (unknown reason)`));
+        failures.push(chalk.red(`x ${plugin}: failed to download (unknown reason)`));
         return;
     }
     if (response.status !== 200) {
-        failures.push(red(`x ${plugin}: failed to download with: ${response.status} ${response.statusText}`));
+        failures.push(chalk.red(`x ${plugin}: failed to download with: ${response.status} ${response.statusText}`));
         return;
     }
 
@@ -229,7 +229,7 @@ async function downloadPluginAsync(failures: string[], plugin: string, pluginUrl
         await decompress(tempFile.path, targetPath);
     }
 
-    console.warn(green(`+ ${plugin}${version ? `@${version}` : ''}: downloaded successfully ${attempts > 1 ? `(after ${attempts} attempts)` : ''}`));
+    console.warn(chalk.green(`+ ${plugin}${version ? `@${version}` : ''}: downloaded successfully ${attempts > 1 ? `(after ${attempts} attempts)` : ''}`));
 }
 
 /**
@@ -290,7 +290,7 @@ async function collectExtensionPacks(pluginDir: string, excludedIds: Set<string>
         if (Array.isArray(extensionPack)) {
             extensionPackPaths.set(packageJsonPath, extensionPack.filter(id => {
                 if (excludedIds.has(id)) {
-                    console.log(yellow(`'${id}' referenced by '${json.name}' (ext pack) is excluded because of 'theiaPluginsExcludeIds'`));
+                    console.log(chalk.yellow(`'${id}' referenced by '${json.name}' (ext pack) is excluded because of 'theiaPluginsExcludeIds'`));
                     return false; // remove
                 }
                 return true; // keep
@@ -316,7 +316,7 @@ async function collectPluginDependencies(pluginDir: string, excludedIds: Set<str
         if (Array.isArray(extensionDependencies)) {
             for (const dependency of extensionDependencies) {
                 if (excludedIds.has(dependency)) {
-                    console.log(yellow(`'${dependency}' referenced by '${json.name}' is excluded because of 'theiaPluginsExcludeIds'`));
+                    console.log(chalk.yellow(`'${dependency}' referenced by '${json.name}' is excluded because of 'theiaPluginsExcludeIds'`));
                 } else {
                     dependencyIds.push(dependency);
                 }

--- a/doc/Migration.md
+++ b/doc/Migration.md
@@ -7,6 +7,18 @@ Please see the latest version (`master`) for the most up-to-date information. Pl
 
 ## Guide
 
+### General
+
+Due to a [colors.js](https://github.com/Marak/colors.js) issue, a [resolution](https://classic.yarnpkg.com/lang/en/docs/selective-version-resolutions/) may be necessary for your application in order to workaround the problem:
+
+For example:
+
+```json
+"resolutions": {
+    "**/colors": "<=1.4.0"
+}
+```
+
 ### v1.21.0
 
 #### Frontend Source Maps

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "@typescript-eslint/eslint-plugin-tslint": "^4.8.1",
     "@typescript-eslint/parser": "^4.8.1",
     "chai-string": "^1.4.0",
-    "colors": "^1.4.0",
+    "chalk": "4.0.0",
     "concurrently": "^3.5.0",
     "debug": "^4.3.2",
     "electron-mocha": "^8.2.0",

--- a/packages/process/src/common/shell-command-builder.slow-spec.ts
+++ b/packages/process/src/common/shell-command-builder.slow-spec.ts
@@ -21,14 +21,8 @@
 import { spawn, execSync, SpawnOptions, ChildProcess, spawnSync } from 'child_process';
 import { Readable } from 'stream';
 import { join } from 'path';
-
 import { ShellCommandBuilder, CommandLineOptions, ProcessInfo } from './shell-command-builder';
-
-import {
-    bgRed, bgWhite, bgYellow,
-    black, green, magenta, red, white, yellow,
-    bold,
-} from 'colors/safe'; // tslint:disable-line:no-implicit-dependencies
+import * as chalk from 'chalk'; // tslint:disable-line:no-implicit-dependencies
 
 export interface TestProcessInfo extends ProcessInfo {
     shell: ChildProcess
@@ -67,9 +61,9 @@ const spawnOptions: SpawnOptions = {
 
 // Formatting options, used with `scanLines` for debugging.
 const stdoutFormat = (prefix: string) => (data: string) =>
-    `${bold(yellow(`${prefix} STDOUT:`))} ${bgYellow(black(data))}`;
+    `${chalk.bold(chalk.yellow(`${prefix} STDOUT:`))} ${chalk.bgYellow(chalk.black(data))}`;
 const stderrFormat = (prefix: string) => (data: string) =>
-    `${bold(red(`${prefix} STDERR:`))} ${bgRed(white(data))}`;
+    `${chalk.bold(chalk.red(`${prefix} STDERR:`))} ${chalk.bgRed(chalk.white(data))}`;
 
 // Default error scanner
 const errorScanner = (handle: ScanLineHandle<void>) => {
@@ -352,7 +346,7 @@ async function testCommandLine(
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
 ): Promise<any> {
     const commandLine = shellCommandBuilder.buildCommand(processInfo, options);
-    debug(`${bold(white(`${context.name} STDIN:`))} ${bgWhite(black(displayWhitespaces(commandLine)))}`);
+    debug(`${chalk.bold(chalk.white(`${context.name} STDIN:`))} ${chalk.bgWhite(chalk.black(displayWhitespaces(commandLine)))}`);
     processInfo.shell.stdin!.write(commandLine + context.submit);
     return Promise.race(firstOf);
 }
@@ -366,9 +360,9 @@ function createShell(
     shellArguments: string[] = []
 ): TestProcessInfo {
     const shell = spawn(shellExecutable, shellArguments, spawnOptions);
-    debug(magenta(`${bold(`${context.name} SPAWN:`)} ${shellExecutable} ${shellArguments.join(' ')}`));
-    shell.on('close', (code, signal) => debug(magenta(
-        `${bold(`${context.name} CLOSE:`)} ${shellExecutable} code(${code}) signal(${signal})`
+    debug(chalk.magenta(`${chalk.bold(`${context.name} SPAWN:`)} ${shellExecutable} ${shellArguments.join(' ')}`));
+    shell.on('close', (code, signal) => debug(chalk.magenta(
+        `${chalk.bold(`${context.name} CLOSE:`)} ${shellExecutable} code(${code}) signal(${signal})`
     )));
     return {
         executable: shellExecutable,
@@ -409,21 +403,21 @@ async function scanLines<T = void>(
                             if (!context.resolved) {
                                 context.resolve();
                                 resolve(value);
-                                debug(bold(green(`${context.name} SCANLINES RESOLVED`)));
+                                debug(chalk.bold(chalk.green(`${context.name} SCANLINES RESOLVED`)));
                             }
                         },
                         reject: (reason?: Error) => {
                             if (!context.resolved) {
                                 context.resolve();
                                 reject(reason);
-                                debug(bold(red(`${context.name} SCANLINES REJECTED`)));
+                                debug(chalk.bold(chalk.red(`${context.name} SCANLINES REJECTED`)));
                             }
                         },
                         line,
                         text,
                     });
                 } catch (error) {
-                    debug(bold(red(`${context.name} SCANLINES THROWED`)));
+                    debug(chalk.bold(chalk.red(`${context.name} SCANLINES THROWED`)));
                     context.resolve();
                     reject(error);
                     break;
@@ -485,7 +479,7 @@ class TestCaseContext {
     finalize(): void {
         if (!this.resolved) {
             this.resolve();
-            debug(red(`${bold(`${this.name} CONTEXT:`)} context wasn't resolved when finalizing, resolving!`));
+            debug(chalk.red(`${chalk.bold(`${this.name} CONTEXT:`)} context wasn't resolved when finalizing, resolving!`));
         }
     }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3604,6 +3604,14 @@ chainsaw@~0.1.0:
   dependencies:
     traverse ">=0.3.0 <0.4"
 
+chalk@4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/chalk/-/chalk-4.0.0.tgz#6e98081ed2d17faab615eb52ac66ec1fe6209e72"
+  integrity sha512-N9oWFcegS0sFr9oh1oz2d7Npos6vNoWW9HvtCg5N1KRFpUhaAhvTv5Y58g880fZaEYSNm3qDz8SU1UrGvp+n7A==
+  dependencies:
+    ansi-styles "^4.1.0"
+    supports-color "^7.1.0"
+
 chalk@^2.0.0, chalk@^2.0.1, chalk@^2.3.0, chalk@^2.4.1, chalk@^2.4.2:
   version "2.4.2"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.4.2.tgz#cd42541677a54333cf541a49108c1432b44c9424"


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

The pull-request updates the problematic [colors.js](https://github.com/Marak/colors.js) dependency with [chalk](https://github.com/chalk/chalk). In addition, the migration guide was also updated to include a note about the possibility of using resolutions in order not to pull the problematic dependency version (which may be pulled transitively through `electron-rebuild` for example).

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

1. confirm that the build is successful
2. confirm that starting the example applications is successful
3. confirm that the downloading plugins script works, and that output is correctly colored (success, skip, errors)

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

Signed-off-by: vince-fugnitto <vincent.fugnitto@ericsson.com>