### PR TITLE
No save dialog if another widget shares identical model

### DIFF
--- a/packages/core/src/browser/saveable.ts
+++ b/packages/core/src/browser/saveable.ts
@@ -125,7 +125,7 @@ export namespace Saveable {
                     if (result) {
                         await Saveable.save(this);
                     }
-                    await this.closeWithoutSaving(result);
+                    await this.closeWithoutSaving();
                 }
             } finally {
                 closing = false;

--- a/packages/core/src/browser/saveable.ts
+++ b/packages/core/src/browser/saveable.ts
@@ -94,7 +94,7 @@ export namespace Saveable {
         }
     }
 
-    async function closeWithoutSaving(this: SaveableWidget, doRevert: boolean = true): Promise<void> {
+    async function closeWithoutSaving(this: PostCreationSaveableWidget, doRevert: boolean = true): Promise<void> {
         const saveable = get(this);
         if (saveable && doRevert && saveable.dirty && saveable.revert) {
             await saveable.revert();
@@ -195,15 +195,22 @@ export namespace Saveable {
     }
 }
 
-export const close = Symbol('close');
 export interface SaveableWidget extends Widget {
     /**
      * @param doRevert whether the saveable should be reverted before being saved. Defaults to `true`.
      */
     closeWithoutSaving(doRevert?: boolean): Promise<void>;
     closeWithSaving(options?: SaveableWidget.CloseOptions): Promise<void>;
+}
+
+export const close = Symbol('close');
+/**
+ * An interface describing saveable widgets that are created by the `Saveable.apply` function.
+ * The original `close` function is reassigned to a locally-defined `Symbol`
+ */
+export interface PostCreationSaveableWidget extends SaveableWidget {
     /**
-     * The original close function of the widget
+     * The original `close` function of the widget
      */
     [close](): void;
 }

--- a/packages/core/src/browser/shell/application-shell.ts
+++ b/packages/core/src/browser/shell/application-shell.ts
@@ -24,7 +24,7 @@ import { Message } from '@phosphor/messaging';
 import { IDragEvent } from '@phosphor/dragdrop';
 import { RecursivePartial, Event as CommonEvent, DisposableCollection, Disposable, environment } from '../../common';
 import { animationFrame } from '../browser';
-import { Saveable, SaveableWidget, SaveOptions } from '../saveable';
+import { Saveable, SaveableWidget, SaveOptions, SaveableSource } from '../saveable';
 import { StatusBarImpl, StatusBarEntry, StatusBarAlignment } from '../status-bar/status-bar';
 import { TheiaDockPanel, BOTTOM_AREA_ID, MAIN_AREA_ID } from './theia-dock-panel';
 import { SidePanelHandler, SidePanel, SidePanelHandlerFactory } from './side-panel-handler';
@@ -1025,7 +1025,7 @@ export class ApplicationShell extends Widget {
         }
         this.tracker.add(widget);
         this.checkActivation(widget);
-        Saveable.apply(widget);
+        Saveable.apply(widget, () => this.widgets.filter((maybeSaveable): maybeSaveable is Widget & SaveableSource => !!Saveable.get(maybeSaveable)));
         if (ApplicationShell.TrackableWidgetProvider.is(widget)) {
             for (const toTrack of widget.getTrackableWidgets()) {
                 this.track(toTrack);

--- a/packages/core/src/browser/shell/application-shell.ts
+++ b/packages/core/src/browser/shell/application-shell.ts
@@ -1445,8 +1445,7 @@ export class ApplicationShell extends Widget {
      * @return an array of all the widgets that were actually closed.
      */
     async closeMany(targets: Widget[], options?: ApplicationShell.CloseOptions): Promise<Widget[]> {
-        const others = this.widgets.filter(widget => !targets.includes(widget));
-        if (options?.save === false || await Saveable.confirmSaveBeforeClose(targets, others)) {
+        if (options?.save === false || await Saveable.confirmSaveBeforeClose(targets, this.widgets.filter(widget => !targets.includes(widget)))) {
             return (await Promise.all(targets.map(target => this.closeWidget(target.id, options)))).filter((widget): widget is Widget => widget !== undefined);
         }
         return [];

--- a/packages/core/src/browser/shell/application-shell.ts
+++ b/packages/core/src/browser/shell/application-shell.ts
@@ -1036,6 +1036,11 @@ export class ApplicationShell extends Widget {
         }
     }
 
+    /**
+     * @returns an array of Widgets, all of which are tracked by the focus tracker
+     * The first member of the array is the widget whose id is passed in, and the other widgets
+     * are its tracked parents in ascending order
+     */
     protected toTrackedStack(id: string): Widget[] {
         const tracked = new Map<string, Widget>(this.tracker.widgets.map(w => [w.id, w] as [string, Widget]));
         let current = tracked.get(id);
@@ -1392,24 +1397,23 @@ export class ApplicationShell extends Widget {
      * @param filter
      *      If undefined, all tabs are closed; otherwise only those tabs that match the filter are closed.
      */
-    closeTabs(tabBarOrArea: TabBar<Widget> | ApplicationShell.Area,
-        filter?: (title: Title<Widget>, index: number) => boolean): void {
+    async closeTabs(tabBarOrArea: TabBar<Widget> | ApplicationShell.Area,
+        filter?: (title: Title<Widget>, index: number) => boolean): Promise<void> {
+        const titles: Array<Title<Widget>> = [];
         if (tabBarOrArea === 'main') {
-            this.mainAreaTabBars.forEach(tb => this.closeTabs(tb, filter));
+            this.mainAreaTabBars.forEach(tabbar => titles.push(...toArray(tabbar.titles)));
         } else if (tabBarOrArea === 'bottom') {
-            this.bottomAreaTabBars.forEach(tb => this.closeTabs(tb, filter));
+            this.bottomAreaTabBars.forEach(tabbar => titles.push(...toArray(tabbar.titles)));
         } else if (typeof tabBarOrArea === 'string') {
-            const tabBar = this.getTabBarFor(tabBarOrArea);
-            if (tabBar) {
-                this.closeTabs(tabBar, filter);
+            const tabbar = this.getTabBarFor(tabBarOrArea);
+            if (tabbar) {
+                titles.push(...toArray(tabbar.titles));
             }
         } else if (tabBarOrArea) {
-            const titles = toArray(tabBarOrArea.titles);
-            for (let i = 0; i < titles.length; i++) {
-                if (filter === undefined || filter(titles[i], i)) {
-                    titles[i].owner.close();
-                }
-            }
+            titles.push(...toArray(tabBarOrArea.titles));
+        }
+        if (titles.length) {
+            await this.closeMany((filter ? titles.filter(filter) : titles).map(title => title.owner));
         }
     }
 
@@ -1436,6 +1440,23 @@ export class ApplicationShell extends Widget {
         }
     }
 
+    /**
+     * @param targets the widgets to be closed
+     * @return an array of all the widgets that were actually closed.
+     */
+    async closeMany(targets: Widget[], options?: ApplicationShell.CloseOptions): Promise<Widget[]> {
+        const others = this.widgets.filter(widget => !targets.includes(widget));
+        if (options?.save === false || await Saveable.confirmSaveBeforeClose(targets, others)) {
+            return (await Promise.all(targets.map(target => this.closeWidget(target.id, options)))).filter((widget): widget is Widget => widget !== undefined);
+        }
+        return [];
+    }
+
+    /**
+     * @returns the widget that was closed, if any, `undefined` otherwise.
+     *
+     * If your use case requires closing multiple widgets, use {@link ApplicationShell#closeMany} instead. That method handles closing saveable widgets more reliably.
+     */
     async closeWidget(id: string, options?: ApplicationShell.CloseOptions): Promise<Widget | undefined> {
         // TODO handle save for composite widgets, i.e. the preference widget has 2 editors
         const stack = this.toTrackedStack(id);
@@ -1443,17 +1464,10 @@ export class ApplicationShell extends Widget {
         if (!current) {
             return undefined;
         }
-        let pendingClose;
-        if (SaveableWidget.is(current)) {
-            let shouldSave;
-            if (options && 'save' in options) {
-                shouldSave = () => options.save;
-            }
-            pendingClose = current.closeWithSaving({ shouldSave });
-        } else {
-            current.close();
-            pendingClose = waitForClosed(current);
-        };
+        const saveableOptions = options && { shouldSave: () => options.save };
+        const pendingClose = SaveableWidget.is(current)
+            ? current.closeWithSaving(saveableOptions)
+            : (current.close(), waitForClosed(current));
         await Promise.all([
             pendingClose,
             this.pendingUpdates

--- a/packages/core/src/browser/widget-open-handler.ts
+++ b/packages/core/src/browser/widget-open-handler.ts
@@ -160,8 +160,6 @@ export abstract class WidgetOpenHandler<W extends BaseWidget> implements OpenHan
      * @returns a promise of all closed widgets that resolves after they have been closed.
      */
     async closeAll(options?: ApplicationShell.CloseOptions): Promise<W[]> {
-        const closed = await Promise.all(this.all.map(widget => this.shell.closeWidget(widget.id, options)));
-        return closed.filter(widget => !!widget) as W[];
+        return this.shell.closeMany(this.all, options) as Promise<W[]>;
     }
-
 }

--- a/packages/navigator/src/browser/navigator-contribution.ts
+++ b/packages/navigator/src/browser/navigator-contribution.ts
@@ -348,7 +348,7 @@ export class FileNavigatorContribution extends AbstractViewContribution<FileNavi
             }
         });
         registry.registerCommand(OpenEditorsCommands.CLOSE_ALL_TABS_FROM_TOOLBAR, {
-            execute: widget => this.withOpenEditorsWidget(widget, () => this.editorWidgets.forEach(editor => editor.close())),
+            execute: widget => this.withOpenEditorsWidget(widget, () => this.shell.closeMany(this.editorWidgets)),
             isEnabled: widget => this.withOpenEditorsWidget(widget, () => !!this.editorWidgets.length),
             isVisible: widget => this.withOpenEditorsWidget(widget, () => !!this.editorWidgets.length)
         });

--- a/packages/plugin-ext-vscode/src/browser/plugin-vscode-commands-contribution.ts
+++ b/packages/plugin-ext-vscode/src/browser/plugin-vscode-commands-contribution.ts
@@ -349,11 +349,8 @@ export class PluginVscodeCommandsContribution implements CommandContribution {
                         return (resourceUri && resourceUri.toString()) === uriString;
                     });
                 }
-                for (const widget of this.shell.widgets) {
-                    if (this.codeEditorWidgetUtil.is(widget) && widget !== editor) {
-                        await this.shell.closeWidget(widget.id);
-                    }
-                }
+                const toClose = this.shell.widgets.filter(widget => widget !== editor && this.codeEditorWidgetUtil.is(widget));
+                await this.shell.closeMany(toClose);
             }
         });
 
@@ -449,13 +446,8 @@ export class PluginVscodeCommandsContribution implements CommandContribution {
         });
         commands.registerCommand({ id: 'workbench.action.closeAllEditors' }, {
             execute: async () => {
-                const promises = [];
-                for (const widget of this.shell.widgets) {
-                    if (this.codeEditorWidgetUtil.is(widget)) {
-                        promises.push(this.shell.closeWidget(widget.id));
-                    }
-                }
-                await Promise.all(promises);
+                const toClose = this.shell.widgets.filter(widget => this.codeEditorWidgetUtil.is(widget));
+                await this.shell.closeMany(toClose);
             }
         });
         commands.registerCommand({ id: 'workbench.action.nextEditor' }, {

--- a/packages/workspace/src/browser/workspace-delete-handler.ts
+++ b/packages/workspace/src/browser/workspace-delete-handler.ts
@@ -206,12 +206,7 @@ export class WorkspaceDeleteHandler implements UriCommandHandler<URI[]> {
      * @param uri URI of a selected resource.
      */
     protected async closeWithoutSaving(uri: URI): Promise<void> {
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        const pending: Promise<any>[] = [];
-        for (const [, widget] of NavigatableWidget.getAffected(this.shell.widgets, uri)) {
-            pending.push(this.shell.closeWidget(widget.id, { save: false }));
-        }
-        await Promise.all(pending);
+        const toClose = [...NavigatableWidget.getAffected(this.shell.widgets, uri)].map(([, widget]) => widget);
+        await this.shell.closeMany(toClose, { save: false });
     }
-
 }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

Fixes #9474 by modifying `Saveable.apply` to accept a function to generate a list of widgets that may share the same underlying saveable resource as the widget being closed. If any widget does, then the widget is closed without saving *and* without reverting the saveable's state.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
1. Open two editors for the same file.
2. Dirty the file.
3. Close one editor.
4. Observe that no dialog is shown asking whether you would like to save and that the other editor remains dirty.
5. Close the other editor.
6. Observe that a dialog is shown asking whether you would like to save.

---

The tricky part is the multi-close commands, close all, close others, and close to the right.

1. Use one of the above named command such that you would not close all instances of a document open in multiple editors.
2. You should not be prompted to save.
3. Use the same command in such a way that you would close all instances
4. You should be prompted to save, and if you cancel, nothing should be closed.

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
