### PR TITLE
Removed unnecessary padding-left statement

### DIFF
--- a/packages/search-in-workspace/src/browser/styles/index.css
+++ b/packages/search-in-workspace/src/browser/styles/index.css
@@ -34,7 +34,6 @@
 .t-siw-search-container .theia-input {
     flex: 1;
     line-height: var(--theia-content-line-height);
-    padding-left: 8px;
     padding: 3px 0 3px 4px;
 }
 


### PR DESCRIPTION
fixed #10601

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
Removed padding-left from style .t-siw-search-container .theia-input in index.css.

#### How to test
Increase the first line (padding-left) to 100 and open the "search in workspace" view (Menu "view" => "search"). The input field on top is unchanged.
Change the same value in the line "padding" (third value) and see the effect.

#### Review checklist

- [X] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
