### PR TITLE
Add option to remove `anchor` arg from context menus

### DIFF
--- a/packages/core/src/browser/common-frontend-contribution.ts
+++ b/packages/core/src/browser/common-frontend-contribution.ts
@@ -472,7 +472,7 @@ export class CommonFrontendContribution implements FrontendApplicationContributi
                         id: mainMenuId,
                         iconClass: 'codicon codicon-menu',
                         title: nls.localizeByDefault('Application Menu'),
-                        menuPath: ['menubar'],
+                        menuPath: MAIN_MENU_BAR,
                         order: 0,
                     });
                 } else {

--- a/packages/core/src/browser/context-menu-renderer.ts
+++ b/packages/core/src/browser/context-menu-renderer.ts
@@ -94,10 +94,17 @@ export abstract class ContextMenuRenderer {
 }
 
 export interface RenderContextMenuOptions {
-    menuPath: MenuPath
-    anchor: Anchor
-    args?: any[]
-    onHide?: () => void
+    menuPath: MenuPath;
+    anchor: Anchor;
+    args?: any[];
+    /**
+     * Whether the anchor should be passed as an argument to the handlers of commands for this context menu.
+     * If true, the anchor will be appended to the list of arguments or passed as the only argument if no other
+     * arguments are supplied.
+     * Default is `true`.
+     */
+    includeAnchorArg?: boolean;
+    onHide?: () => void;
 }
 export namespace RenderContextMenuOptions {
     export function resolve(menuPathOrOptions: MenuPath | RenderContextMenuOptions, anchor?: Anchor, onHide?: () => void): RenderContextMenuOptions {
@@ -110,7 +117,10 @@ export namespace RenderContextMenuOptions {
             menuPath = menuPathOrOptions.menuPath;
             anchor = menuPathOrOptions.anchor;
             onHide = menuPathOrOptions.onHide;
-            args = menuPathOrOptions.args ? [...menuPathOrOptions.args, anchor] : [anchor];
+            args = menuPathOrOptions.args ? menuPathOrOptions.args.slice() : [];
+            if (menuPathOrOptions.includeAnchorArg !== false) {
+                args.push(anchor);
+            }
         }
         return {
             menuPath,

--- a/packages/core/src/browser/shell/sidebar-bottom-menu-widget.tsx
+++ b/packages/core/src/browser/shell/sidebar-bottom-menu-widget.tsx
@@ -28,6 +28,7 @@ export class SidebarBottomMenuWidget extends SidebarMenuWidget {
         const button = e.currentTarget.getBoundingClientRect();
         this.contextMenuRenderer.render({
             menuPath,
+            includeAnchorArg: false,
             anchor: {
                 x: button.left + button.width,
                 y: button.top + button.height,

--- a/packages/core/src/browser/shell/sidebar-menu-widget.tsx
+++ b/packages/core/src/browser/shell/sidebar-menu-widget.tsx
@@ -40,6 +40,14 @@ export interface SidebarMenu {
 @injectable()
 export class SidebarMenuWidget extends ReactWidget {
   protected readonly menus: SidebarMenu[];
+  /**
+   * The element that had focus when a menu rendered by this widget was activated.
+   */
+  protected preservedContext: HTMLElement | undefined;
+  /**
+   * Flag indicating whether a context menu is open. While a context menu is open, the `preservedContext` should not be cleared.
+   */
+  protected preservingContext = false;
 
   @inject(ContextMenuRenderer)
   protected readonly contextMenuRenderer: ContextMenuRenderer;
@@ -70,7 +78,21 @@ export class SidebarMenuWidget extends ReactWidget {
     }
   }
 
+  protected readonly onMouseDown = () => {
+    const { activeElement } = document;
+    if (activeElement instanceof HTMLElement && !this.node.contains(activeElement)) {
+      this.preservedContext = activeElement;
+    }
+  };
+
+  protected readonly onMouseOut = () => {
+    if (!this.preservingContext) {
+      this.preservedContext = undefined;
+    }
+  };
+
   protected onClick(e: React.MouseEvent<HTMLElement, MouseEvent>, menuPath: MenuPath): void {
+    this.preservingContext = true;
     const button = e.currentTarget.getBoundingClientRect();
     this.contextMenuRenderer.render({
       menuPath,
@@ -78,6 +100,13 @@ export class SidebarMenuWidget extends ReactWidget {
       anchor: {
         x: button.left + button.width,
         y: button.top,
+      },
+      onHide: () => {
+        this.preservingContext = false;
+        if (this.preservedContext) {
+          this.preservedContext.focus({ preventScroll: true });
+          this.preservedContext = undefined;
+        }
       }
     });
   }
@@ -89,6 +118,8 @@ export class SidebarMenuWidget extends ReactWidget {
         className={menu.iconClass}
         title={menu.title}
         onClick={e => this.onClick(e, menu.menuPath)}
+        onMouseDown={this.onMouseDown}
+        onMouseOut={this.onMouseOut}
       />)}
     </React.Fragment>;
   }

--- a/packages/core/src/browser/shell/sidebar-menu-widget.tsx
+++ b/packages/core/src/browser/shell/sidebar-menu-widget.tsx
@@ -55,6 +55,7 @@ export class SidebarMenuWidget extends ReactWidget {
       return;
     }
     this.menus.push(menu);
+    this.menus.sort((a, b) => a.order - b.order);
     this.update();
   }
 
@@ -73,6 +74,7 @@ export class SidebarMenuWidget extends ReactWidget {
     const button = e.currentTarget.getBoundingClientRect();
     this.contextMenuRenderer.render({
       menuPath,
+      includeAnchorArg: false,
       anchor: {
         x: button.left + button.width,
         y: button.top,
@@ -82,7 +84,7 @@ export class SidebarMenuWidget extends ReactWidget {
 
   protected render(): React.ReactNode {
     return <React.Fragment>
-      {this.menus.sort((a, b) => a.order - b.order).map(menu => <i
+      {this.menus.map(menu => <i
         key={menu.id}
         className={menu.iconClass}
         title={menu.title}


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->
Closes #10540
Fixes #10571 
This PR introduces an additional option for the context menu renderer to remove the `anchor` argument included by default, and applies that option in the handlers for menus from the sidebar. The `anchor` argument is used by a number of commands for identifying a specific widget when several could trigger the same context menu, but it is not intended to be used with either of the side panel menus.

See #9931 for another example of the problem

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
1. Set the `window.menuBarVisibility` preference to `compact`.
2. Run the Run --> Start Debugging command from the main menu.
3. If a default launch configuration is available, a debug session should start.

---

1. Set the `window.menuBarVisibility` preference to `compact`.
2. Open an editor and select some text.
3. Use the menu to run the Edit --> Cut command.
4. The selected text should be cut and be available in the clipboard.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
