### PR TITLE
Add SIW context menu

### DIFF
--- a/packages/core/src/browser/navigatable-types.ts
+++ b/packages/core/src/browser/navigatable-types.ts
@@ -63,6 +63,11 @@ export namespace NavigatableWidget {
             }
         }
     }
+    export function getUri(widget?: Widget): URI | undefined {
+        if (is(widget)) {
+            return widget.getResourceUri();
+        }
+    }
 }
 
 export interface NavigatableWidgetOptions {

--- a/packages/core/src/browser/tree/tree-widget-selection.ts
+++ b/packages/core/src/browser/tree/tree-widget-selection.ts
@@ -21,7 +21,7 @@ export type TreeWidgetSelection = ReadonlyArray<Readonly<SelectableTreeNode>> & 
     source: TreeWidget
 };
 export namespace TreeWidgetSelection {
-    export function isSource(selection: Object | undefined, source: TreeWidget): boolean {
+    export function isSource(selection: Object | undefined, source: TreeWidget): selection is TreeWidgetSelection {
         return getSource(selection) === source;
     }
     export function getSource(selection: Object | undefined): TreeWidget | undefined {

--- a/packages/search-in-workspace/src/browser/search-in-workspace-frontend-contribution.ts
+++ b/packages/search-in-workspace/src/browser/search-in-workspace-frontend-contribution.ts
@@ -14,12 +14,14 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
-import { AbstractViewContribution, KeybindingRegistry, LabelProvider, CommonMenus, FrontendApplication, FrontendApplicationContribution } from '@theia/core/lib/browser';
+import {
+    AbstractViewContribution, KeybindingRegistry, LabelProvider, CommonMenus, FrontendApplication, FrontendApplicationContribution, CommonCommands
+} from '@theia/core/lib/browser';
 import { SearchInWorkspaceWidget } from './search-in-workspace-widget';
 import { injectable, inject, postConstruct } from '@theia/core/shared/inversify';
 import { CommandRegistry, MenuModelRegistry, SelectionService, Command } from '@theia/core';
 import { codicon, Widget } from '@theia/core/lib/browser/widgets';
-import { NavigatorContextMenu } from '@theia/navigator/lib/browser/navigator-contribution';
+import { FileNavigatorCommands, NavigatorContextMenu } from '@theia/navigator/lib/browser/navigator-contribution';
 import { UriCommandHandler, UriAwareCommandHandler } from '@theia/core/lib/common/uri-command-handler';
 import URI from '@theia/core/lib/common/uri';
 import { WorkspaceService } from '@theia/workspace/lib/browser';
@@ -29,6 +31,9 @@ import { EditorManager } from '@theia/editor/lib/browser/editor-manager';
 import { Range } from '@theia/core/shared/vscode-languageserver-protocol';
 import { FileService } from '@theia/filesystem/lib/browser/file-service';
 import { SEARCH_VIEW_CONTAINER_ID } from './search-in-workspace-factory';
+import { SearchInWorkspaceResultTreeWidget } from './search-in-workspace-result-tree-widget';
+import { TreeWidgetSelection } from '@theia/core/lib/browser/tree/tree-widget-selection';
+import { ClipboardService } from '@theia/core/lib/browser/clipboard-service';
 
 export namespace SearchInWorkspaceCommands {
     const SEARCH_CATEGORY = 'Search';
@@ -80,6 +85,21 @@ export namespace SearchInWorkspaceCommands {
         label: 'Clear Search Results',
         iconClass: codicon('clear-all')
     });
+    export const COPY_ALL = Command.toDefaultLocalizedCommand({
+        id: 'search.action.copyAll',
+        category: SEARCH_CATEGORY,
+        label: 'Copy All',
+    });
+    export const COPY_ONE = Command.toDefaultLocalizedCommand({
+        id: 'search.action.copyMatch',
+        category: SEARCH_CATEGORY,
+        label: 'Copy',
+    });
+    export const DISMISS_RESULT = Command.toDefaultLocalizedCommand({
+        id: 'search.action.remove',
+        category: SEARCH_CATEGORY,
+        label: 'Dismiss',
+    });
 }
 
 @injectable()
@@ -90,6 +110,7 @@ export class SearchInWorkspaceFrontendContribution extends AbstractViewContribut
     @inject(WorkspaceService) protected readonly workspaceService: WorkspaceService;
     @inject(FileService) protected readonly fileService: FileService;
     @inject(EditorManager) protected readonly editorManager: EditorManager;
+    @inject(ClipboardService) protected readonly clipboardService: ClipboardService;
 
     @inject(SearchInWorkspaceContextKeyService)
     protected readonly contextKeyService: SearchInWorkspaceContextKeyService;
@@ -180,6 +201,60 @@ export class SearchInWorkspaceFrontendContribution extends AbstractViewContribut
             isEnabled: w => this.withWidget(w, widget => widget.hasResultList()),
             isVisible: w => this.withWidget(w, () => true)
         });
+        commands.registerCommand(SearchInWorkspaceCommands.DISMISS_RESULT, {
+            isEnabled: () => this.withWidget(undefined, widget => {
+                const { selection } = this.selectionService;
+                return TreeWidgetSelection.isSource(selection, widget.resultTreeWidget) && selection.length > 0;
+            }),
+            isVisible: () => this.withWidget(undefined, widget => {
+                const { selection } = this.selectionService;
+                return TreeWidgetSelection.isSource(selection, widget.resultTreeWidget) && selection.length > 0;
+            }),
+            execute: () => this.withWidget(undefined, widget => {
+                const { selection } = this.selectionService;
+                if (TreeWidgetSelection.is(selection)) {
+                    widget.resultTreeWidget.removeNode(selection[0]);
+                }
+            })
+        });
+        commands.registerCommand(SearchInWorkspaceCommands.COPY_ONE, {
+            isEnabled: () => this.withWidget(undefined, widget => {
+                const { selection } = this.selectionService;
+                return TreeWidgetSelection.isSource(selection, widget.resultTreeWidget) && selection.length > 0;
+            }),
+            isVisible: () => this.withWidget(undefined, widget => {
+                const { selection } = this.selectionService;
+                return TreeWidgetSelection.isSource(selection, widget.resultTreeWidget) && selection.length > 0;
+            }),
+            execute: () => this.withWidget(undefined, widget => {
+                const { selection } = this.selectionService;
+                if (TreeWidgetSelection.is(selection)) {
+                    const string = widget.resultTreeWidget.nodeToString(selection[0], true);
+                    if (string.length !== 0) {
+                        this.clipboardService.writeText(string);
+                    }
+                }
+            })
+        });
+        commands.registerCommand(SearchInWorkspaceCommands.COPY_ALL, {
+            isEnabled: () => this.withWidget(undefined, widget => {
+                const { selection } = this.selectionService;
+                return TreeWidgetSelection.isSource(selection, widget.resultTreeWidget) && selection.length > 0;
+            }),
+            isVisible: () => this.withWidget(undefined, widget => {
+                const { selection } = this.selectionService;
+                return TreeWidgetSelection.isSource(selection, widget.resultTreeWidget) && selection.length > 0;
+            }),
+            execute: () => this.withWidget(undefined, widget => {
+                const { selection } = this.selectionService;
+                if (TreeWidgetSelection.is(selection)) {
+                    const string = widget.resultTreeWidget.treeToString();
+                    if (string.length !== 0) {
+                        this.clipboardService.writeText(string);
+                    }
+                }
+            })
+        });
     }
 
     protected withWidget<T>(widget: Widget | undefined = this.tryGetWidget(), fn: (widget: SearchInWorkspaceWidget) => T): T | false {
@@ -232,6 +307,26 @@ export class SearchInWorkspaceFrontendContribution extends AbstractViewContribut
         menus.registerMenuAction(CommonMenus.EDIT_FIND, {
             commandId: SearchInWorkspaceCommands.REPLACE_IN_FILES.id,
             order: '3'
+        });
+        menus.registerMenuAction(SearchInWorkspaceResultTreeWidget.Menus.internal, {
+            commandId: SearchInWorkspaceCommands.DISMISS_RESULT.id,
+            order: '1'
+        });
+        menus.registerMenuAction(SearchInWorkspaceResultTreeWidget.Menus.copy, {
+            commandId: SearchInWorkspaceCommands.COPY_ONE.id,
+            order: '1',
+        });
+        menus.registerMenuAction(SearchInWorkspaceResultTreeWidget.Menus.copy, {
+            commandId: CommonCommands.COPY_PATH.id,
+            order: '2',
+        });
+        menus.registerMenuAction(SearchInWorkspaceResultTreeWidget.Menus.copy, {
+            commandId: SearchInWorkspaceCommands.COPY_ALL.id,
+            order: '3',
+        });
+        menus.registerMenuAction(SearchInWorkspaceResultTreeWidget.Menus.external, {
+            commandId: FileNavigatorCommands.REVEAL_IN_NAVIGATOR.id,
+            order: '1',
         });
     }
 

--- a/packages/search-in-workspace/src/browser/search-in-workspace-frontend-contribution.ts
+++ b/packages/search-in-workspace/src/browser/search-in-workspace-frontend-contribution.ts
@@ -308,23 +308,23 @@ export class SearchInWorkspaceFrontendContribution extends AbstractViewContribut
             commandId: SearchInWorkspaceCommands.REPLACE_IN_FILES.id,
             order: '3'
         });
-        menus.registerMenuAction(SearchInWorkspaceResultTreeWidget.Menus.internal, {
+        menus.registerMenuAction(SearchInWorkspaceResultTreeWidget.Menus.INTERNAL, {
             commandId: SearchInWorkspaceCommands.DISMISS_RESULT.id,
             order: '1'
         });
-        menus.registerMenuAction(SearchInWorkspaceResultTreeWidget.Menus.copy, {
+        menus.registerMenuAction(SearchInWorkspaceResultTreeWidget.Menus.COPY, {
             commandId: SearchInWorkspaceCommands.COPY_ONE.id,
             order: '1',
         });
-        menus.registerMenuAction(SearchInWorkspaceResultTreeWidget.Menus.copy, {
+        menus.registerMenuAction(SearchInWorkspaceResultTreeWidget.Menus.COPY, {
             commandId: CommonCommands.COPY_PATH.id,
             order: '2',
         });
-        menus.registerMenuAction(SearchInWorkspaceResultTreeWidget.Menus.copy, {
+        menus.registerMenuAction(SearchInWorkspaceResultTreeWidget.Menus.COPY, {
             commandId: SearchInWorkspaceCommands.COPY_ALL.id,
             order: '3',
         });
-        menus.registerMenuAction(SearchInWorkspaceResultTreeWidget.Menus.external, {
+        menus.registerMenuAction(SearchInWorkspaceResultTreeWidget.Menus.EXTERNAL, {
             commandId: FileNavigatorCommands.REVEAL_IN_NAVIGATOR.id,
             order: '1',
         });

--- a/packages/search-in-workspace/src/browser/search-in-workspace-frontend-module.ts
+++ b/packages/search-in-workspace/src/browser/search-in-workspace-frontend-module.ts
@@ -21,7 +21,9 @@ import { SearchInWorkspaceService, SearchInWorkspaceClientImpl } from './search-
 import { SearchInWorkspaceServer, SIW_WS_PATH } from '../common/search-in-workspace-interface';
 import {
     WebSocketConnectionProvider, WidgetFactory, createTreeContainer, TreeWidget, bindViewContribution, FrontendApplicationContribution, LabelProviderContribution,
-    ApplicationShellLayoutMigration
+    ApplicationShellLayoutMigration,
+    TreeProps,
+    defaultTreeProps
 } from '@theia/core/lib/browser';
 import { SearchInWorkspaceWidget } from './search-in-workspace-widget';
 import { SearchInWorkspaceResultTreeWidget } from './search-in-workspace-result-tree-widget';
@@ -72,6 +74,7 @@ export function createSearchTreeWidget(parent: interfaces.Container): SearchInWo
 
     child.unbind(TreeWidget);
     child.bind(SearchInWorkspaceResultTreeWidget).toSelf();
+    child.rebind(TreeProps).toConstantValue(<TreeProps>{ ...defaultTreeProps, contextMenuPath: SearchInWorkspaceResultTreeWidget.Menus.base, globalSelection: true });
 
     return child.get(SearchInWorkspaceResultTreeWidget);
 }

--- a/packages/search-in-workspace/src/browser/search-in-workspace-frontend-module.ts
+++ b/packages/search-in-workspace/src/browser/search-in-workspace-frontend-module.ts
@@ -74,7 +74,7 @@ export function createSearchTreeWidget(parent: interfaces.Container): SearchInWo
 
     child.unbind(TreeWidget);
     child.bind(SearchInWorkspaceResultTreeWidget).toSelf();
-    child.rebind(TreeProps).toConstantValue(<TreeProps>{ ...defaultTreeProps, contextMenuPath: SearchInWorkspaceResultTreeWidget.Menus.base, globalSelection: true });
+    child.rebind(TreeProps).toConstantValue(<TreeProps>{ ...defaultTreeProps, contextMenuPath: SearchInWorkspaceResultTreeWidget.Menus.BASE, globalSelection: true });
 
     return child.get(SearchInWorkspaceResultTreeWidget);
 }

--- a/packages/search-in-workspace/src/browser/search-in-workspace-result-tree-widget.tsx
+++ b/packages/search-in-workspace/src/browser/search-in-workspace-result-tree-widget.tsx
@@ -1209,12 +1209,12 @@ export class SearchInWorkspaceResultTreeWidget extends TreeWidget {
 
 export namespace SearchInWorkspaceResultTreeWidget {
     export namespace Menus {
-        export const base = ['siw-tree-context-menu'];
+        export const BASE = ['siw-tree-context-menu'];
         /** Dismiss command, or others that only affect the widget itself */
-        export const internal = [...base, '1_internal'];
+        export const INTERNAL = [...BASE, '1_internal'];
         /** Copy a stringified representation of content */
-        export const copy = [...base, '2_copy'];
+        export const COPY = [...BASE, '2_copy'];
         /** Commands that lead out of the widget, like revealing a file in the navigator */
-        export const external = [...base, '3_external'];
+        export const EXTERNAL = [...BASE, '3_external'];
     }
 }

--- a/packages/search-in-workspace/src/browser/search-in-workspace-result-tree-widget.tsx
+++ b/packages/search-in-workspace/src/browser/search-in-workspace-result-tree-widget.tsx
@@ -30,9 +30,10 @@ import {
     ApplicationShell,
     DiffUris,
     TREE_NODE_INFO_CLASS,
-    codicon
+    codicon,
+    TopDownTreeIterator
 } from '@theia/core/lib/browser';
-import { CancellationTokenSource, Emitter, Event, ProgressService } from '@theia/core';
+import { CancellationTokenSource, Emitter, Event, isWindows, ProgressService } from '@theia/core';
 import {
     EditorManager, EditorDecoration, TrackedRangeStickiness, OverviewRulerLane,
     EditorWidget, ReplaceOperation, EditorOpenerOptions, FindMatch
@@ -70,6 +71,7 @@ export interface SearchInWorkspaceRootFolderNode extends ExpandableTreeNode, Sel
     parent: SearchInWorkspaceRoot;
     path: string;
     folderUri: string;
+    uri: URI;
 }
 export namespace SearchInWorkspaceRootFolderNode {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -85,6 +87,7 @@ export interface SearchInWorkspaceFileNode extends ExpandableTreeNode, Selectabl
     parent: SearchInWorkspaceRootFolderNode;
     path: string;
     fileUri: string;
+    uri: URI;
 }
 export namespace SearchInWorkspaceFileNode {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -656,6 +659,7 @@ export class SearchInWorkspaceResultTreeWidget extends TreeWidget {
             selected: false,
             path: uri.path.toString(),
             folderUri: rootUri,
+            uri: new URI(rootUri),
             children: [],
             expanded: true,
             id: rootUri,
@@ -672,7 +676,8 @@ export class SearchInWorkspaceResultTreeWidget extends TreeWidget {
             expanded: true,
             id: `${rootUri}::${fileUri}`,
             parent,
-            fileUri
+            fileUri,
+            uri: new URI(fileUri),
         };
     }
 
@@ -707,7 +712,7 @@ export class SearchInWorkspaceResultTreeWidget extends TreeWidget {
         const uri: URI = new URI(uriStr);
         const relativePath = new URI(rootUriStr).relative(uri.parent);
         return {
-            name: uri.displayName,
+            name: this.labelProvider.getName(uri),
             path: relativePath ? relativePath.toString() : ''
         };
     }
@@ -899,7 +904,7 @@ export class SearchInWorkspaceResultTreeWidget extends TreeWidget {
         return <span className={codicon('close')} onClick={e => this.remove(node, e)} title='Dismiss'></span>;
     }
 
-    protected removeNode(node: TreeNode): void {
+    removeNode(node: TreeNode): void {
         if (SearchInWorkspaceRootFolderNode.is(node)) {
             this.removeRootFolderNode(node);
         } else if (SearchInWorkspaceFileNode.is(node)) {
@@ -1164,4 +1169,52 @@ export class SearchInWorkspaceResultTreeWidget extends TreeWidget {
         return itemA.localeCompare(itemB);
     }
 
+    /**
+     * @param recursive if true, all child nodes will be included in the stringified result.
+     */
+    nodeToString(node: TreeNode, recursive: boolean): string {
+        if (SearchInWorkspaceFileNode.is(node) || SearchInWorkspaceRootFolderNode.is(node)) {
+            if (recursive) {
+                return this.nodeIteratorToString(new TopDownTreeIterator(node, { pruneSiblings: true }));
+            }
+            return this.labelProvider.getLongName(node.uri);
+        }
+        if (SearchInWorkspaceResultLineNode.is(node)) {
+            return `  ${node.line}:${node.character}: ${node.lineText}`;
+        }
+        return '';
+    }
+
+    treeToString(): string {
+        return this.nodeIteratorToString(this.getVisibleNodes());
+    }
+
+    protected *getVisibleNodes(): IterableIterator<TreeNode> {
+        for (const { node } of this.rows.values()) {
+            yield node;
+        }
+    }
+
+    protected nodeIteratorToString(nodes: Iterable<TreeNode>): string {
+        const strings = [];
+        for (const node of nodes) {
+            const string = this.nodeToString(node, false);
+            if (string.length !== 0) {
+                strings.push(string);
+            }
+        }
+        return strings.join(isWindows ? '\r\n' : '\n');
+    }
+}
+
+export namespace SearchInWorkspaceResultTreeWidget {
+    export namespace Menus {
+        export const base = ['siw-tree-context-menu'];
+        /** Dismiss command, or others that only affect the widget itself */
+        export const internal = [...base, '1_internal'];
+        /** Copy a stringified representation of content */
+        export const copy = [...base, '2_copy'];
+        /** Commands that lead out of the widget, like revealing a file in the navigator */
+        export const external = [...base, '3_external'];
+    }
 }

--- a/packages/search-in-workspace/src/browser/search-in-workspace-widget.tsx
+++ b/packages/search-in-workspace/src/browser/search-in-workspace-widget.tsx
@@ -86,7 +86,7 @@ export class SearchInWorkspaceWidget extends BaseWidget implements StatefulWidge
     protected readonly onDidUpdateEmitter = new Emitter<void>();
     readonly onDidUpdate: Event<void> = this.onDidUpdateEmitter.event;
 
-    @inject(SearchInWorkspaceResultTreeWidget) protected readonly resultTreeWidget: SearchInWorkspaceResultTreeWidget;
+    @inject(SearchInWorkspaceResultTreeWidget) readonly resultTreeWidget: SearchInWorkspaceResultTreeWidget;
     @inject(WorkspaceService) protected readonly workspaceService: WorkspaceService;
 
     @inject(SearchInWorkspaceContextKeyService)


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->
Fixes #10629 by implementing a context menu for the SIW tree that aligns with VSCode's.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
1. Search in your workspace and get some results.
2. Right click on a file.
3. You should have five options:
    - Dismiss: should remove the node from the tree, same as clicking the `x` icon.
    - Copy: Should copy the workspace-relative path of the file together with all of its results.
    - Copy path: should copy the full absolute path
    - Copy all: should do the same as 'copy', but concatenate the stringifications of all the nodes of the tree
    - Reveal in navigator: Should open the explorer and select the file (if it's in the workspace)
4. Right click on a single result
5. You should have three options:
    - Dismiss: same as above
    - Copy: should copy just the stringified representation of the result
    - Copy all: same as above

Those should all match the behavior of the corresponding VSCode commands.

---

I also observed a bug in the `Reveal in Explorer Command`: it was selecting the node, but not revealing the widget.

1. Open an editor in the workspace
2. Hide the file explorer.
3. Use the `Reveal in Explorer` context command from the editor tabbar context menu.
4. The explorer should be revealed with the editor's file selected.
5. Hide the file explorer again.
6. In the editor, use the keyboard shortcut `alt+r`
7. See 4.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
