### PR TITLE
debug: add support for `stopDebugging` api

### DIFF
--- a/packages/plugin-ext/src/common/plugin-api-rpc.ts
+++ b/packages/plugin-ext/src/common/plugin-api-rpc.ts
@@ -1636,6 +1636,7 @@ export interface DebugMain {
     $addBreakpoints(breakpoints: Breakpoint[]): Promise<void>;
     $removeBreakpoints(breakpoints: string[]): Promise<void>;
     $startDebugging(folder: theia.WorkspaceFolder | undefined, nameOrConfiguration: string | theia.DebugConfiguration, options: theia.DebugSessionOptions): Promise<boolean>;
+    $stopDebugging(sessionId?: string): Promise<void>;
     $customRequest(sessionId: string, command: string, args?: any): Promise<DebugProtocol.Response>;
 }
 

--- a/packages/plugin-ext/src/main/browser/debug/debug-main.ts
+++ b/packages/plugin-ext/src/main/browser/debug/debug-main.ts
@@ -284,6 +284,17 @@ export class DebugMainImpl implements DebugMain, Disposable {
         return !!session;
     }
 
+    async $stopDebugging(sessionId?: string): Promise<void> {
+        if (sessionId) {
+            const session = this.sessionManager.getSession(sessionId);
+            return this.sessionManager.terminateSession(session);
+        }
+        // Terminate all sessions if no session is provided.
+        for (const session of this.sessionManager.sessions) {
+            this.sessionManager.terminateSession(session);
+        }
+    }
+
     private toTheiaPluginApiBreakpoints(breakpoints: (SourceBreakpoint | FunctionBreakpoint)[]): Breakpoint[] {
         return breakpoints.map(b => this.toTheiaPluginApiBreakpoint(b));
     }

--- a/packages/plugin-ext/src/plugin/node/debug/debug.ts
+++ b/packages/plugin-ext/src/plugin/node/debug/debug.ts
@@ -168,6 +168,10 @@ export class DebugExtImpl implements DebugExt {
         return this.proxy.$startDebugging(folder, nameOrConfiguration, options);
     }
 
+    stopDebugging(session?: theia.DebugSession): PromiseLike<void> {
+        return this.proxy.$stopDebugging(session?.id);
+    }
+
     registerDebugAdapterDescriptorFactory(debugType: string, factory: theia.DebugAdapterDescriptorFactory): Disposable {
         if (this.descriptorFactories.has(debugType)) {
             throw new Error(`Descriptor factory for ${debugType} has been already registered`);

--- a/packages/plugin-ext/src/plugin/plugin-context.ts
+++ b/packages/plugin-ext/src/plugin/plugin-context.ts
@@ -784,6 +784,9 @@ export function createAPIFactory(
                 Thenable<boolean> {
                 return debugExt.startDebugging(folder, nameOrConfiguration, options);
             },
+            stopDebugging(session?: theia.DebugSession): Thenable<void> {
+                return debugExt.stopDebugging(session);
+            },
             addBreakpoints(breakpoints: theia.Breakpoint[]): void {
                 debugExt.addBreakpoints(breakpoints);
             },

--- a/packages/plugin/src/theia.d.ts
+++ b/packages/plugin/src/theia.d.ts
@@ -9763,6 +9763,12 @@ export module '@theia/plugin' {
         export function startDebugging(folder: WorkspaceFolder | undefined, nameOrConfiguration: string | DebugConfiguration, options: DebugSessionOptions): PromiseLike<boolean>;
 
         /**
+         * Stop the given debug session or stop all debug sessions if session is omitted.
+         * @param session The [debug session](#DebugSession) to stop; if omitted all sessions are stopped.
+         */
+        export function stopDebugging(session?: DebugSession): PromiseLike<void>;
+
+        /**
          * Add breakpoints.
          * @param breakpoints The breakpoints to add.
          */


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

The pull-request adds support for the `stopDebugging` VS Code API.
The API terminates the session if provided, else it will terminate all sessions.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

1. include the following [vscode-stop-debugging](https://github.com/vince-fugnitto/vscode-stop-debugging/releases/download/v0.0.1/vscode-stop-debugging-0.0.1.vsix) test plugin
2. start the application using `theia` as a workspace
3. start a debug session (ex: using `run mocha tests`)
4. execute the command `Debug Test: Stop Active Session`) - the session should terminate
5. start multiple simultaneous debug sessions (ex: `run mocha tests` multiple times with different `*.spec.ts` files)
6. execute the command `Debug Test: Stop All Sessions`) - all sessions should terminate

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

Signed-off-by: vince-fugnitto <vincent.fugnitto@ericsson.com>