### PR TITLE
Group views in view menu by location

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 <a name="breaking_changes_1.25.0">[Breaking Changes:](#breaking_changes_1.25.0)</a>
 
+- [core] The view menu now shows the view location, and groups the views by location.menus by the view location. The `onDidAddWidget` and `onDidRemoveWidget` events now pass a tuple with both the widget and area.
 
 ## v1.24.0 - 3/31/2022
 

--- a/packages/core/src/browser/quick-input/quick-view-service.ts
+++ b/packages/core/src/browser/quick-input/quick-view-service.ts
@@ -14,14 +14,17 @@
 // SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
 // *****************************************************************************
 
-import { inject, injectable } from 'inversify';
-import { filterItems, QuickPickItem, QuickPicks } from '..';
+import { inject, injectable, postConstruct } from 'inversify';
+import { filterItems, QuickPickItem, QuickPickSeparator, QuickPicks } from '..';
 import { CancellationToken, Disposable } from '../../common';
 import { ContextKeyService } from '../context-key-service';
 import { QuickAccessContribution, QuickAccessProvider, QuickAccessRegistry } from './quick-access';
+import { ApplicationShell, WidgetArea } from '../shell';
 
 export interface QuickViewItem {
     readonly label: string;
+    readonly viewId: string;
+    readonly location: string;
     readonly when?: string;
     readonly open: () => void;
 }
@@ -30,18 +33,56 @@ export interface QuickViewItem {
 export class QuickViewService implements QuickAccessContribution, QuickAccessProvider {
     static PREFIX = 'view ';
 
-    protected readonly items: (QuickPickItem & { when?: string })[] = [];
+    protected readonly items: (QuickPickItem & {
+        viewId: string,
+        location: string,
+        defaultLocation: string,
+        viewContainerTitle?: string,
+        when?: string
+    })[] = [];
+    protected readonly containers = new Map<string, string>();
     private hiddenItemLabels = new Set<string | undefined>();
+
+    @inject(ApplicationShell)
+    protected readonly shell: ApplicationShell;
 
     @inject(QuickAccessRegistry)
     protected readonly quickAccessRegistry: QuickAccessRegistry;
 
     @inject(ContextKeyService)
-    protected readonly contextKexService: ContextKeyService;
+    protected readonly contextKeyService: ContextKeyService;
+
+    @postConstruct()
+    init(): void {
+        this.shell.onDidAddWidget(widget => {
+            const item = this.items.find(i => i.viewId === widget.id);
+            if (item) {
+                item.location = widget[WidgetArea];
+            }
+        });
+
+        this.shell.onDidRemoveWidget(widget => {
+            const item = this.items.find(i => i.viewId === widget.id);
+            if (item) {
+                item.location = item.defaultLocation;
+            }
+        });
+    }
+
+    registerContainer(id: string, location: string, title: string): Disposable {
+        const label = this.getLocationLabel(location) + ' / ' + title;
+        this.containers.set(id, label);
+        return Disposable.create(() => {
+            this.containers.delete(id);
+        });
+    }
 
     registerItem(item: QuickViewItem): Disposable {
         const quickOpenItem = {
             label: item.label,
+            viewId: item.viewId,
+            location: item.location,
+            defaultLocation: item.location,
             execute: () => item.open(),
             when: item.when
         };
@@ -75,9 +116,39 @@ export class QuickViewService implements QuickAccessContribution, QuickAccessPro
 
     getPicks(filter: string, token: CancellationToken): QuickPicks {
         const items = this.items.filter(item =>
-            (item.when === undefined || this.contextKexService.match(item.when)) &&
+            (item.when === undefined || this.contextKeyService.match(item.when)) &&
             (!this.hiddenItemLabels.has(item.label))
         );
-        return filterItems(items, filter);
+
+        // Reversing is a trick to ensure any others (indexOf = -1) appear at the end of the sorted array.
+        const locationOrder = [ 'left', 'bottom', 'right', 'main' ].reverse();
+        const filteredItems = filterItems(items, filter)
+            .sort((a, b) => a.location.localeCompare(b.location))
+            .sort((a, b) => this.getLocationLabel(a.location).localeCompare(this.getLocationLabel(a.location)))
+            .sort((a, b) => locationOrder.indexOf(b.location) - locationOrder.indexOf(a.location));
+
+        let previousLocation: string | undefined;
+        const itemsWithSeparators: (QuickPickSeparator|QuickPickItem)[] = [];
+        for (const it of filteredItems) {
+            const locationLabel = this.getLocationLabel(it.location);
+            if (locationLabel !== previousLocation) {
+                previousLocation = locationLabel;
+                itemsWithSeparators.push({ type: 'separator', label: locationLabel });
+            }
+            itemsWithSeparators.push(it);
+        }
+
+        return itemsWithSeparators;
+    }
+
+    protected getLocationLabel(location: string): string {
+        switch (location) {
+            case 'left': return 'Side Bar';
+            case 'bottom': return 'Panel';
+            case 'right': return 'Right';
+            case 'main': return 'Editor';
+            default:
+                return this.containers.get(location) ?? location;
+        }
     }
 }

--- a/packages/core/src/browser/shell/application-shell.ts
+++ b/packages/core/src/browser/shell/application-shell.ts
@@ -134,10 +134,9 @@ interface WidgetDragState {
     leaveTimeout?: number;
 }
 
-export const WidgetArea = Symbol('WidgetArea');
-
-export type AreaWidget = Widget & {
-    [WidgetArea]: ApplicationShell.Area;
+export type AreaWidget = {
+    widget: Widget,
+    area: ApplicationShell.Area
 };
 
 /**
@@ -198,17 +197,13 @@ export class ApplicationShell extends Widget {
     protected readonly onDidAddWidgetEmitter = new Emitter<AreaWidget>();
     readonly onDidAddWidget = this.onDidAddWidgetEmitter.event;
     protected fireDidAddWidget(widget: Widget, area: ApplicationShell.Area): void {
-        const areaWidget = widget as AreaWidget;
-        areaWidget[WidgetArea] = area;
-        this.onDidAddWidgetEmitter.fire(areaWidget);
+        this.onDidAddWidgetEmitter.fire({ widget, area });
     }
 
     protected readonly onDidRemoveWidgetEmitter = new Emitter<AreaWidget>();
     readonly onDidRemoveWidget = this.onDidRemoveWidgetEmitter.event;
     protected fireDidRemoveWidget(widget: Widget, area: ApplicationShell.Area): void {
-        const areaWidget = widget as AreaWidget;
-        areaWidget[WidgetArea] = area;
-        this.onDidRemoveWidgetEmitter.fire(areaWidget);
+        this.onDidRemoveWidgetEmitter.fire({ widget, area });
     }
 
     protected readonly onDidChangeActiveWidgetEmitter = new Emitter<FocusTracker.IChangedArgs<Widget>>();

--- a/packages/core/src/browser/shell/application-shell.ts
+++ b/packages/core/src/browser/shell/application-shell.ts
@@ -217,6 +217,14 @@ export class ApplicationShell extends Widget {
     protected readonly onDidChangeCurrentWidgetEmitter = new Emitter<FocusTracker.IChangedArgs<Widget>>();
     readonly onDidChangeCurrentWidget = this.onDidChangeCurrentWidgetEmitter.event;
 
+    protected readonly onDidMoveContainerPartEmitter = new Emitter<{
+        widget: Widget, sourceContainerId: string, destinationContainerId: string, originalContainerId: string, destinationPanelId: string
+    }>();
+    readonly onDidMoveContainerPart = this.onDidMoveContainerPartEmitter.event;
+    fireDidMoveContainerPart(widget: Widget, sourceContainerId: string, destinationContainerId: string, originalContainerId: string, destinationPanelId: string): void {
+        this.onDidMoveContainerPartEmitter.fire({ widget, sourceContainerId, destinationContainerId, originalContainerId, destinationPanelId });
+    }
+
     /**
      * Construct a new application shell.
      */
@@ -671,6 +679,14 @@ export class ApplicationShell extends Widget {
         }
     }
 
+    protected registerViewPositions(area: ApplicationShell.Area, widgets: (Widget | undefined)[]): void {
+        for (const widget of widgets) {
+            if (widget) {
+                this.fireDidAddWidget(widget, area);
+            }
+        }
+    }
+
     /**
      * Apply a shell layout that has been previously created with `getLayoutData`.
      */
@@ -679,10 +695,16 @@ export class ApplicationShell extends Widget {
         if (leftPanel) {
             this.leftPanelHandler.setLayoutData(leftPanel);
             this.registerWithFocusTracker(leftPanel);
+            if (leftPanel.items) {
+                this.registerViewPositions('left', leftPanel.items.map(i => i.widget));
+            }
         }
         if (rightPanel) {
             this.rightPanelHandler.setLayoutData(rightPanel);
             this.registerWithFocusTracker(rightPanel);
+            if (rightPanel.items) {
+                this.registerViewPositions('right', rightPanel.items.map(i => i.widget));
+            }
         }
         // Proceed with the bottom panel once the side panels are set up
         await Promise.all([this.leftPanelHandler.state.pendingUpdate, this.rightPanelHandler.state.pendingUpdate]);
@@ -709,6 +731,7 @@ export class ApplicationShell extends Widget {
                 });
             }
             this.refreshBottomPanelToggleButton();
+            this.registerViewPositions('bottom', widgets);
         }
         // Proceed with the main panel once all others are set up
         await this.bottomPanelState.pendingUpdate;
@@ -724,6 +747,7 @@ export class ApplicationShell extends Widget {
                     }
                 });
             }
+            this.registerViewPositions('main', widgets);
         }
         if (activeWidgetId) {
             this.activateWidget(activeWidgetId);

--- a/packages/core/src/browser/shell/view-contribution.ts
+++ b/packages/core/src/browser/shell/view-contribution.ts
@@ -143,6 +143,7 @@ export abstract class AbstractViewContribution<T extends Widget> implements Comm
         this.quickView?.registerItem({
             label: this.viewLabel,
             viewId: this.viewId,
+            widgetId: this.viewId,
             location: this.options.viewContainerId ?? this.options.defaultWidgetOptions.area ?? '',
             open: () => this.openView({ activate: true })
         });

--- a/packages/core/src/browser/shell/view-contribution.ts
+++ b/packages/core/src/browser/shell/view-contribution.ts
@@ -142,6 +142,8 @@ export abstract class AbstractViewContribution<T extends Widget> implements Comm
         }
         this.quickView?.registerItem({
             label: this.viewLabel,
+            viewId: this.viewId,
+            location: this.options.viewContainerId ?? this.options.defaultWidgetOptions.area ?? '',
             open: () => this.openView({ activate: true })
         });
     }

--- a/packages/core/src/browser/view-container.ts
+++ b/packages/core/src/browser/view-container.ts
@@ -385,6 +385,9 @@ export class ViewContainer extends BaseWidget implements StatefulWidget, Applica
         this.updateSplitterVisibility();
         this.update();
         this.fireDidChangeTrackableWidgets();
+
+        this.shell.fireDidMoveContainerPart(newPart.wrapped, newPart.currentViewContainerId, this.options.id, newPart.originalContainerId, this.id);
+
         toRemoveWidget.pushAll([
             Disposable.create(() => {
                 if (newPart.currentViewContainerId === this.id) {

--- a/packages/core/src/common/quick-pick-service.ts
+++ b/packages/core/src/common/quick-pick-service.ts
@@ -312,7 +312,7 @@ export interface QuickInputService {
  * @param filter the filter to search for.
  * @returns the list of quick pick items that satisfy the filter.
  */
-export function filterItems(items: QuickPickItemOrSeparator[], filter: string): QuickPickItemOrSeparator[] {
+export function filterItems<T extends QuickPickItemOrSeparator>(items: T[], filter: string): T[] {
     filter = filter.trim().toLowerCase();
 
     if (filter.length === 0) {
@@ -324,7 +324,7 @@ export function filterItems(items: QuickPickItemOrSeparator[], filter: string): 
         return items;
     }
 
-    const filteredItems: QuickPickItemOrSeparator[] = [];
+    const filteredItems: T[] = [];
     for (const item of items) {
         if (item.type === 'separator') {
             filteredItems.push(item);

--- a/packages/editor-preview/src/browser/editor-preview-tree-decorator.ts
+++ b/packages/editor-preview/src/browser/editor-preview-tree-decorator.ts
@@ -46,8 +46,8 @@ export class EditorPreviewTreeDecorator implements TreeDecorator, FrontendApplic
     protected readonly toDisposeOnPreviewPinned = new Map<string, Disposable>();
 
     onDidInitializeLayout(app: FrontendApplication): void {
-        this.shell.onDidAddWidget(widget => this.registerEditorListeners(widget));
-        this.shell.onDidRemoveWidget(widget => this.unregisterEditorListeners(widget));
+        this.shell.onDidAddWidget(w => this.registerEditorListeners(w.widget));
+        this.shell.onDidRemoveWidget(w => this.unregisterEditorListeners(w.widget));
         this.editorWidgets.forEach(widget => this.registerEditorListeners(widget));
     }
 

--- a/packages/navigator/src/browser/navigator-tab-bar-decorator.ts
+++ b/packages/navigator/src/browser/navigator-tab-bar-decorator.ts
@@ -37,13 +37,13 @@ export class NavigatorTabBarDecorator implements TabBarDecorator, FrontendApplic
             this.fireDidChangeDecorations();
         }
         this.toDispose.pushAll([
-            this.applicationShell.onDidAddWidget(widget => {
-                const saveable = Saveable.get(widget);
+            this.applicationShell.onDidAddWidget(w => {
+                const saveable = Saveable.get(w.widget);
                 if (saveable) {
-                    this.toDisposeOnDirtyChanged.set(widget.id, saveable.onDirtyChanged(() => this.fireDidChangeDecorations()));
+                    this.toDisposeOnDirtyChanged.set(w.widget.id, saveable.onDirtyChanged(() => this.fireDidChangeDecorations()));
                 }
             }),
-            this.applicationShell.onDidRemoveWidget(widget => this.toDisposeOnDirtyChanged.get(widget.id)?.dispose())
+            this.applicationShell.onDidRemoveWidget(w => this.toDisposeOnDirtyChanged.get(w.widget.id)?.dispose())
         ]);
     }
 

--- a/packages/plugin-ext/src/main/browser/view/plugin-view-registry.ts
+++ b/packages/plugin-ext/src/main/browser/view/plugin-view-registry.ts
@@ -118,6 +118,15 @@ export class PluginViewRegistry implements FrontendApplicationContribution {
         this.trackVisibleWidget(TERMINAL_WIDGET_FACTORY_ID, { panelId: 'workbench.panel.terminal' });
         // TODO workbench.panel.comments - Theia does not have a proper comments view yet
 
+        this.quickView?.registerContainer(EXPLORER_VIEW_CONTAINER_ID, 'left', 'Explorer');
+        this.quickView?.registerContainer(SCM_VIEW_CONTAINER_ID, 'left', 'Source Control');
+        this.quickView?.registerContainer(SEARCH_VIEW_CONTAINER_ID, 'left', 'Search');
+
+        this.quickView?.registerContainer('explorer', 'left', 'Explorer');
+        this.quickView?.registerContainer('scm', 'left', 'Source Control');
+        this.quickView?.registerContainer('search', 'left', 'Search');
+        this.quickView?.registerContainer('debug', 'left', 'Debug');
+
         this.updateFocusedView();
         this.shell.onDidChangeActiveWidget(() => this.updateFocusedView());
 
@@ -279,8 +288,11 @@ export class PluginViewRegistry implements FrontendApplicationContribution {
             commandId: toggleCommandId,
             label: options.label
         }));
+        toDispose.push(this.quickView?.registerContainer(id, location, options.label));
         toDispose.push(this.quickView?.registerItem({
             label: options.label,
+            viewId: id,
+            location,
             open: async () => {
                 const widget = await this.openViewContainer(id);
                 if (widget) {
@@ -331,6 +343,8 @@ export class PluginViewRegistry implements FrontendApplicationContribution {
         }
         toDispose.push(this.quickView?.registerItem({
             label: view.name,
+            viewId: view.id,
+            location: viewContainerId,
             when: view.when,
             open: () => this.openView(view.id, { activate: true })
         }));
@@ -822,7 +836,7 @@ export class PluginViewRegistry implements FrontendApplicationContribution {
             if (view.sideArea !== undefined) {
                 toDispose.pushAll([
                     this.shell.onDidAddWidget(w => {
-                        if (w === widget) {
+                        if ((w as Widget) === widget) {
                             this.updateVisibleWidget(widget, view);
                         }
                     })

--- a/packages/plugin-ext/src/main/browser/view/plugin-view-registry.ts
+++ b/packages/plugin-ext/src/main/browser/view/plugin-view-registry.ts
@@ -288,10 +288,11 @@ export class PluginViewRegistry implements FrontendApplicationContribution {
             commandId: toggleCommandId,
             label: options.label
         }));
-        toDispose.push(this.quickView?.registerContainer(id, location, options.label));
+        toDispose.push(this.quickView?.registerContainer(this.toViewContainerIdentifier(id).id, location, options.label));
         toDispose.push(this.quickView?.registerItem({
             label: options.label,
             viewId: id,
+            widgetId: this.toPluginViewWidgetIdentifier(id).id,
             location,
             open: async () => {
                 const widget = await this.openViewContainer(id);
@@ -344,7 +345,8 @@ export class PluginViewRegistry implements FrontendApplicationContribution {
         toDispose.push(this.quickView?.registerItem({
             label: view.name,
             viewId: view.id,
-            location: viewContainerId,
+            widgetId: this.toPluginViewWidgetIdentifier(view.id).id,
+            location: this.toViewContainerIdentifier(viewContainerId).id,
             when: view.when,
             open: () => this.openView(view.id, { activate: true })
         }));

--- a/packages/plugin-ext/src/main/browser/view/plugin-view-registry.ts
+++ b/packages/plugin-ext/src/main/browser/view/plugin-view-registry.ts
@@ -838,7 +838,7 @@ export class PluginViewRegistry implements FrontendApplicationContribution {
             if (view.sideArea !== undefined) {
                 toDispose.pushAll([
                     this.shell.onDidAddWidget(w => {
-                        if ((w as Widget) === widget) {
+                        if (w.widget === widget) {
                             this.updateVisibleWidget(widget, view);
                         }
                     })


### PR DESCRIPTION
#### What it does
Updates the 'Open View...' menu so the views are now grouped like they are in vscode.

So without the changes in this PR, the open view menu looks something like:

![Screenshot from 2022-01-17 12-33-55](https://user-images.githubusercontent.com/87310/149775110-280761d5-fca6-427c-95b9-8d5b6f93f9fc.png)

and with the changes it now looks like:

![Screenshot from 2022-01-17 12-28-40](https://user-images.githubusercontent.com/87310/149775125-c5419c61-2a96-4e47-b0cd-414728826d77.png)

Note how the AWS plugin contributes a view also called 'Explorer'. The two 'Explorer' views are indistinguishable in Theia but appear in different groups in vscode.
 
#### How to test
Try out the view menu with various packages and plugins. Check that the groupings are correct and there is nothing that will confuse users.
- drag views to various places in the shell
- drag view container parts to other view containers
- check that the menu shows dragged views correctly after a refresh
- 
#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
