### PR TITLE
Reimplement `window.menuBarVisibility` preference

### DIFF
--- a/examples/api-tests/src/menus.spec.js
+++ b/examples/api-tests/src/menus.spec.js
@@ -45,7 +45,7 @@ describe('Menus', function () {
     const container = window.theia.container;
     const shell = container.get(ApplicationShell);
     const menuBarContribution = container.get(BrowserMenuBarContribution);
-    const menuBar = /** @type {import('@theia/core/lib/browser/menu/browser-menu-plugin').MenuBarWidget} */ (menuBarContribution.menuBar);
+    const menuBar = /** @type {import('@theia/core/lib/browser/menu/browser-menu-plugin').MenuBarWidget} */ (menuBarContribution.browserMenu);
     const pluginService = container.get(HostedPluginSupport);
     const menus = container.get(MenuModelRegistry);
     const commands = container.get(CommandRegistry);

--- a/packages/core/src/browser/core-preferences.ts
+++ b/packages/core/src/browser/core-preferences.ts
@@ -21,6 +21,8 @@ import { FrontendApplicationConfigProvider } from './frontend-application-config
 import { isOSX } from '../common/os';
 import { nls } from '../common/nls';
 
+export const MENU_BAR_VISIBILITY = 'window.menuBarVisibility';
+
 export const corePreferenceSchema: PreferenceSchema = {
     'type': 'object',
     properties: {
@@ -60,7 +62,7 @@ export const corePreferenceSchema: PreferenceSchema = {
             default: 'code',
             markdownDescription: nls.localizeByDefault('Controls the dispatching logic for key presses to use either `code` (recommended) or `keyCode`.')
         },
-        'window.menuBarVisibility': {
+        [MENU_BAR_VISIBILITY]: {
             type: 'string',
             enum: ['classic', 'visible', 'hidden', 'compact'],
             markdownEnumDescriptions: [
@@ -157,7 +159,7 @@ export interface CoreConfiguration {
     'breadcrumbs.enabled': boolean;
     'files.encoding': string
     'keyboard.dispatch': 'code' | 'keyCode';
-    'window.menuBarVisibility': 'classic' | 'visible' | 'hidden' | 'compact';
+    [MENU_BAR_VISIBILITY]: 'classic' | 'visible' | 'hidden' | 'compact';
     'workbench.list.openMode': 'singleClick' | 'doubleClick';
     'workbench.commandPalette.history': number;
     'workbench.editor.highlightModifiedTabs': boolean;

--- a/packages/core/src/browser/menu/browser-menu-module.ts
+++ b/packages/core/src/browser/menu/browser-menu-module.ts
@@ -19,10 +19,11 @@ import { FrontendApplicationContribution } from '../frontend-application';
 import { ContextMenuRenderer } from '../context-menu-renderer';
 import { BrowserMenuBarContribution, BrowserMainMenuFactory } from './browser-menu-plugin';
 import { BrowserContextMenuRenderer } from './browser-context-menu-renderer';
+import { CommandContribution, MenuContribution } from '../../common';
 
 export default new ContainerModule(bind => {
     bind(BrowserMainMenuFactory).toSelf().inSingletonScope();
     bind(ContextMenuRenderer).to(BrowserContextMenuRenderer).inSingletonScope();
     bind(BrowserMenuBarContribution).toSelf().inSingletonScope();
-    bind(FrontendApplicationContribution).toService(BrowserMenuBarContribution);
+    [FrontendApplicationContribution, CommandContribution, MenuContribution].forEach(descriptor => bind(descriptor).toService(BrowserMenuBarContribution));
 });

--- a/packages/core/src/browser/menu/main-menus.ts
+++ b/packages/core/src/browser/menu/main-menus.ts
@@ -1,0 +1,58 @@
+/********************************************************************************
+ * Copyright (C) 2022 Ericsson and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import { MAIN_MENU_BAR, SETTINGS_MENU } from '../../common/menu';
+
+/**
+ * A namespace defining the submenus of the main menu bar.
+ */
+export namespace CommonMenus {
+
+    export const FILE = [...MAIN_MENU_BAR, '1_file'];
+    export const FILE_NEW = [...FILE, '1_new'];
+    export const FILE_OPEN = [...FILE, '2_open'];
+    export const FILE_SAVE = [...FILE, '3_save'];
+    export const FILE_AUTOSAVE = [...FILE, '4_autosave'];
+    export const FILE_SETTINGS = [...FILE, '5_settings'];
+    export const FILE_SETTINGS_SUBMENU = [...FILE_SETTINGS, '1_settings_submenu'];
+    export const FILE_SETTINGS_SUBMENU_OPEN = [...FILE_SETTINGS_SUBMENU, '1_settings_submenu_open'];
+    export const FILE_SETTINGS_SUBMENU_THEME = [...FILE_SETTINGS_SUBMENU, '2_settings_submenu_theme'];
+    export const FILE_CLOSE = [...FILE, '6_close'];
+
+    export const EDIT = [...MAIN_MENU_BAR, '2_edit'];
+    export const EDIT_UNDO = [...EDIT, '1_undo'];
+    export const EDIT_CLIPBOARD = [...EDIT, '2_clipboard'];
+    export const EDIT_FIND = [...EDIT, '3_find'];
+
+    export const VIEW = [...MAIN_MENU_BAR, '4_view'];
+    export const VIEW_PRIMARY = [...VIEW, '0_primary'];
+    export const VIEW_APPEARANCE = [...VIEW, '1_appearance'];
+    export const VIEW_APPEARANCE_SUBMENU = [...VIEW_APPEARANCE, '1_appearance_submenu'];
+    export const VIEW_APPEARANCE_SUBMENU_SCREEN = [...VIEW_APPEARANCE_SUBMENU, '2_appearance_submenu_screen'];
+    export const VIEW_APPEARANCE_SUBMENU_BAR = [...VIEW_APPEARANCE_SUBMENU, '3_appearance_submenu_bar'];
+    export const VIEW_EDITOR_SUBMENU = [...VIEW_APPEARANCE, '2_editor_submenu'];
+    export const VIEW_EDITOR_SUBMENU_SPLIT = [...VIEW_EDITOR_SUBMENU, '1_editor_submenu_split'];
+    export const VIEW_EDITOR_SUBMENU_ORTHO = [...VIEW_EDITOR_SUBMENU, '2_editor_submenu_ortho'];
+    export const VIEW_VIEWS = [...VIEW, '2_views'];
+    export const VIEW_LAYOUT = [...VIEW, '3_layout'];
+    export const VIEW_TOGGLE = [...VIEW, '4_toggle'];
+
+    export const SETTINGS_OPEN = [...SETTINGS_MENU, '1_settings_open'];
+    export const SETTINGS__THEME = [...SETTINGS_MENU, '2_settings_theme'];
+    // last menu item
+    export const HELP = [...MAIN_MENU_BAR, '9_help'];
+
+}

--- a/packages/core/src/browser/shell/application-shell.ts
+++ b/packages/core/src/browser/shell/application-shell.ts
@@ -22,11 +22,11 @@ import {
 } from '@phosphor/widgets';
 import { Message } from '@phosphor/messaging';
 import { IDragEvent } from '@phosphor/dragdrop';
-import { RecursivePartial, Event as CommonEvent, DisposableCollection, Disposable, environment } from '../../common';
+import { RecursivePartial, Event as CommonEvent, DisposableCollection, Disposable } from '../../common';
 import { animationFrame } from '../browser';
 import { Saveable, SaveableWidget, SaveOptions } from '../saveable';
 import { StatusBarImpl, StatusBarEntry, StatusBarAlignment } from '../status-bar/status-bar';
-import { TheiaDockPanel, BOTTOM_AREA_ID, MAIN_AREA_ID } from './theia-dock-panel';
+import { TheiaDockPanel, BOTTOM_AREA_ID, MAIN_AREA_ID, MAXIMIZED_CLASS } from './theia-dock-panel';
 import { SidePanelHandler, SidePanel, SidePanelHandlerFactory } from './side-panel-handler';
 import { TabBarRendererFactory, SHELL_TABBAR_CONTEXT_MENU, ScrollableTabBar, ToolbarAwareTabBar } from './tab-bars';
 import { SplitPositionHandler, SplitPositionOptions } from './split-panels';
@@ -262,17 +262,6 @@ export class ApplicationShell extends Widget {
     protected init(): void {
         this.initSidebarVisibleKeyContext();
         this.initFocusKeyContexts();
-
-        if (!environment.electron.is()) {
-            this.corePreferences.ready.then(() => {
-                this.setTopPanelVisibility(this.corePreferences['window.menuBarVisibility']);
-            });
-            this.corePreferences.onPreferenceChanged(preference => {
-                if (preference.preferenceName === 'window.menuBarVisibility') {
-                    this.setTopPanelVisibility(preference.newValue);
-                }
-            });
-        }
     }
 
     protected initSidebarVisibleKeyContext(): void {
@@ -1827,6 +1816,13 @@ export class ApplicationShell extends Widget {
             area.toggleMaximized();
             this.revealWidget(widget!.id);
         }
+    }
+
+    /**
+     * @returns `true` if any dock panel is currently maximized.
+     */
+    isAreaMaximized(): boolean {
+        return document.getElementsByClassName(MAXIMIZED_CLASS).length > 0;
     }
 }
 

--- a/packages/core/src/browser/shell/side-panel-handler.ts
+++ b/packages/core/src/browser/shell/side-panel-handler.ts
@@ -111,6 +111,7 @@ export class SidePanelHandler {
      * Options that control the behavior of the side panel.
      */
     protected options: SidePanel.Options;
+    protected sideContainer: Panel;
 
     @inject(TabBarToolbarRegistry) protected tabBarToolBarRegistry: TabBarToolbarRegistry;
     @inject(TabBarToolbarFactory) protected tabBarToolBarFactory: () => TabBarToolbar;
@@ -250,6 +251,7 @@ export class SidePanelHandler {
         const sidebarContainerLayout = new PanelLayout();
         const sidebarContainer = new Panel({ layout: sidebarContainerLayout });
         sidebarContainer.addClass('theia-app-sidebar-container');
+        this.sideContainer = sidebarContainer;
         sidebarContainerLayout.addWidget(this.topMenu);
         sidebarContainerLayout.addWidget(this.tabBar);
         sidebarContainerLayout.addWidget(this.bottomMenu);
@@ -402,6 +404,10 @@ export class SidePanelHandler {
             SidePanelHandler.rankProperty.set(widget, options.rank);
         }
         this.dockPanel.addWidget(widget);
+    }
+
+    prependWidgetToTabbar(widget: Widget): void {
+        this.sideContainer.insertWidget(0, widget);
     }
 
     /**

--- a/packages/core/src/browser/shell/theia-dock-panel.ts
+++ b/packages/core/src/browser/shell/theia-dock-panel.ts
@@ -24,7 +24,6 @@ import { inject } from 'inversify';
 import { Emitter, environment } from '../../common';
 
 export const MAXIMIZED_CLASS = 'theia-maximized';
-const VISIBLE_MENU_MAXIMIZED_CLASS = 'theia-visible-menu-maximized';
 
 export const MAIN_AREA_ID = 'theia-main-content-panel';
 export const BOTTOM_AREA_ID = 'theia-bottom-content-panel';
@@ -63,30 +62,10 @@ export class TheiaDockPanel extends DockPanel {
             this.markAsCurrent(args.title);
             super['_onTabActivateRequested'](sender, args);
         };
-        if (preferences) {
-            preferences.onPreferenceChanged(preference => {
-                if (!this.isElectron() && preference.preferenceName === 'window.menuBarVisibility' && (preference.newValue === 'visible' || preference.oldValue === 'visible')) {
-                    this.handleMenuBarVisibility(preference.newValue);
-                }
-            });
-        }
     }
 
     isElectron(): boolean {
         return environment.electron.is();
-    }
-
-    protected handleMenuBarVisibility(newValue: string): void {
-        const areaContainer = this.node.parentElement;
-        const maximizedElement = this.getMaximizedElement();
-
-        if (areaContainer === maximizedElement) {
-            if (newValue === 'visible') {
-                this.addClass(VISIBLE_MENU_MAXIMIZED_CLASS);
-            } else {
-                this.removeClass(VISIBLE_MENU_MAXIMIZED_CLASS);
-            }
-        }
     }
 
     protected _currentTitle: Title<Widget> | undefined;
@@ -179,10 +158,6 @@ export class TheiaDockPanel extends DockPanel {
         }
         maximizedElement.style.display = 'block';
         this.addClass(MAXIMIZED_CLASS);
-        const preference = this.preferences?.get('window.menuBarVisibility');
-        if (!this.isElectron() && preference === 'visible') {
-            this.addClass(VISIBLE_MENU_MAXIMIZED_CLASS);
-        }
         UnsafeWidgetUtilities.attach(this, maximizedElement);
         this.fit();
         this.onDidToggleMaximizedEmitter.fire(this);
@@ -190,9 +165,6 @@ export class TheiaDockPanel extends DockPanel {
             maximizedElement.style.display = 'none';
             this.removeClass(MAXIMIZED_CLASS);
             this.onDidToggleMaximizedEmitter.fire(this);
-            if (!this.isElectron()) {
-                this.removeClass(VISIBLE_MENU_MAXIMIZED_CLASS);
-            }
             if (this.isAttached) {
                 UnsafeWidgetUtilities.detach(this);
             }

--- a/packages/core/src/browser/style/index.css
+++ b/packages/core/src/browser/style/index.css
@@ -78,7 +78,7 @@ blockquote {
     background: var(--theia-editor-background);
 }
 
-.theia-visible-menu-maximized {
+.theia-menu-visible .theia-maximized {
   top: var(--theia-private-menubar-height) !important;
 }
 

--- a/packages/core/src/browser/style/menus.css
+++ b/packages/core/src/browser/style/menus.css
@@ -54,14 +54,14 @@
 }
 
 
-.p-MenuBar-item.p-mod-active {
+#theia-top-panel .p-MenuBar-item.p-mod-active {
   background: var(--theia-menubar-selectionBackground);
   color: var(--theia-menubar-selectionForeground);
   opacity: 1;
 }
 
 
-.p-MenuBar.p-mod-active .p-MenuBar-item.p-mod-active {
+#theia-top-panel .p-MenuBar.p-mod-active .p-MenuBar-item.p-mod-active {
   z-index: calc(var(--theia-menu-z-index) - 1);
   background: var(--theia-menubar-selectionBackground);
   border-left: var(--theia-border-width) solid var(--theia-menubar-selectionBorder);
@@ -212,3 +212,24 @@
 .p-Menu-item[data-type='submenu'] > .p-Menu-itemSubmenuIcon::before {
   content: '\eab6';
 }
+
+/* Menu in side panel when `window.menuBarVisibility` is `'compact'` */
+
+.theia-app-sidebar-container .p-Widget.p-MenuBar {
+  padding: 0;
+}
+
+.theia-app-sidebar-container .p-MenuBar-item {
+  width: var(--theia-private-sidebar-tab-width);
+  height: var(--theia-private-sidebar-tab-width);
+  padding: 0;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  color: var(--theia-activityBar-inactiveForeground);
+}
+
+.theia-app-sidebar-container .p-MenuBar-item:hover {
+  color: var(--theia-activityBar-foreground);
+}
+

--- a/packages/core/src/common/command.ts
+++ b/packages/core/src/common/command.ts
@@ -406,6 +406,14 @@ export class CommandRegistry implements CommandService {
     }
 
     /**
+     * Test whether there is any handler that checks whether an item is toggled.
+     */
+    isToggleable(commandId: string): boolean {
+        const handlers = this._handlers[commandId];
+        return Boolean(handlers?.some(handler => Boolean(handler.isToggled)));
+    }
+
+    /**
      * Returns with all handlers for the given command. If the command does not have any handlers,
      * or the command is not registered, returns an empty array.
      */

--- a/packages/core/src/common/menu.ts
+++ b/packages/core/src/common/menu.ts
@@ -78,7 +78,8 @@ export interface SubMenuOptions {
 
 export type MenuPath = string[];
 
-export const MAIN_MENU_BAR: MenuPath = ['menubar'];
+export const COMPACT_MENU_ROOT: MenuPath = ['main-menu-root'];
+export const MAIN_MENU_BAR: MenuPath = [...COMPACT_MENU_ROOT, 'menubar'];
 
 export const SETTINGS_MENU: MenuPath = ['settings_menu'];
 export const ACCOUNTS_MENU: MenuPath = ['accounts_menu'];
@@ -314,6 +315,17 @@ export interface MenuNode {
  * Node representing a (sub)menu in the menu tree structure.
  */
 export class CompositeMenuNode implements MenuNode {
+    static * depthFirstIterator(parent: CompositeMenuNode): IterableIterator<MenuNode> {
+        yield parent;
+        for (const child of parent.children) {
+            if (child instanceof CompositeMenuNode) {
+                yield* CompositeMenuNode.depthFirstIterator(child);
+            } else {
+                yield child;
+            }
+        }
+    }
+
     protected readonly _children: MenuNode[] = [];
     public iconClass?: string;
     public order?: string;
@@ -447,3 +459,4 @@ export class ActionMenuNode implements MenuNode {
         return this.action.order || this.label;
     }
 }
+

--- a/packages/preferences/src/browser/abstract-resource-preference-provider.ts
+++ b/packages/preferences/src/browser/abstract-resource-preference-provider.ts
@@ -77,6 +77,8 @@ export abstract class AbstractResourcePreferenceProvider extends PreferenceProvi
         const uri = this.getUri();
         this.toDispose.push(Disposable.create(() => this.loading.reject(new Error(`preference provider for '${uri}' was disposed`))));
         await this.readPreferencesFromFile();
+        await this.fireDidPreferencesChanged();
+        // Ready should only resolve when the first round of events has fired.
         this._ready.resolve();
 
         const reference = await this.textModelService.createModelReference(uri);


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

> I'm leaving this in 'Draft' status while I do some more [general](#General) testing...

Fixes #10571 by ensuring that the same logic is used for the main menu when `window.menuBarVisibility` is `compact` as when it is not.

The heart of this PR is a move to use the same menu widget for the (browser-style) main menu regardless of the value of the `window.menuBarVisibility` preference, rather than using a context menu in `compact` mode. That ensures that we get the same behavior as we do with the normal menu bar, and that any fixes apply equally to both. In particular, it ensures that (1) commands invoked from the main menu do _not_ receive an `anchor` argument and (2) the logic for preserving the focus context to use when a command is run is consistent between the menu bar and compact menu.

While working on that, I noticed several other features of the menu implementation that could be improved:
 - the `window.menuBarVisibility` preference handling was scattered across a number of different classes. This PR moves (almost) all references to the preference into the `MainMenuContribution` classes.
 - event handling for menus was also split between the `MainMenuFactory` and `MainMenuContribution` classes. This PR moves all event handling into the `MainMenuContribution` classes, with the factories only responsible for creating the widget.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
##### #10571
1. Set the `window.menuBarVisibility` preference to `'compact'` (non-OSX only)
2. Open an editor
3. Select some text
4. Open the main menu > Edit > Cut
5. The text you selected should be removed and available in your clipboard.

##### <a name="General">General</a>
1. In browser, test various transitions between and startup in different `window.menuBarVisibility` states.
2. In Electron, test various combinations of `window.titleBarStyle` and `window.menuBarVisibility` states and transitions.

#### Review checklist

- [ ] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
