### PR TITLE
plugin: align `startDebugging` api

### DIFF
--- a/packages/plugin-ext/src/main/browser/debug/debug-main.ts
+++ b/packages/plugin-ext/src/main/browser/debug/debug-main.ts
@@ -274,10 +274,9 @@ export class DebugMainImpl implements DebugMain, Disposable {
             return false;
         }
 
-        Object.assign(configuration, options);
-
+        const debugConfiguration = { ...configuration, ...options };
         const session = await this.sessionManager.start({
-            configuration,
+            configuration: debugConfiguration,
             workspaceFolderUri: folder && Uri.revive(folder.uri).toString()
         });
 

--- a/packages/plugin-ext/src/plugin/plugin-context.ts
+++ b/packages/plugin-ext/src/plugin/plugin-context.ts
@@ -780,9 +780,15 @@ export function createAPIFactory(
             registerDebugAdapterTrackerFactory(debugType: string, factory: theia.DebugAdapterTrackerFactory): Disposable {
                 return debugExt.registerDebugAdapterTrackerFactory(debugType, factory);
             },
-            startDebugging(folder: theia.WorkspaceFolder | undefined, nameOrConfiguration: string | theia.DebugConfiguration, options: theia.DebugSessionOptions):
-                Thenable<boolean> {
-                return debugExt.startDebugging(folder, nameOrConfiguration, options);
+            startDebugging(
+                folder: theia.WorkspaceFolder | undefined,
+                nameOrConfiguration: string | theia.DebugConfiguration,
+                parentSessionOrOptions?: theia.DebugSession | theia.DebugSessionOptions
+            ): Thenable<boolean> {
+                if (!parentSessionOrOptions || (typeof parentSessionOrOptions === 'object' && 'configuration' in parentSessionOrOptions)) {
+                    return debugExt.startDebugging(folder, nameOrConfiguration, { parentSession: parentSessionOrOptions });
+                }
+                return debugExt.startDebugging(folder, nameOrConfiguration, parentSessionOrOptions || {});
             },
             stopDebugging(session?: theia.DebugSession): Thenable<void> {
                 return debugExt.stopDebugging(session);

--- a/packages/plugin/src/theia.d.ts
+++ b/packages/plugin/src/theia.d.ts
@@ -9758,9 +9758,10 @@ export module '@theia/plugin' {
          * Folder specific variables used in the configuration (e.g. '${workspaceFolder}') are resolved against the given folder.
          * @param folder The [workspace folder](#WorkspaceFolder) for looking up named configurations and resolving variables or `undefined` for a non-folder setup.
          * @param nameOrConfiguration Either the name of a debug or compound configuration or a [DebugConfiguration](#DebugConfiguration) object.
+         * @param parentSessionOrOptions Debug session options. When passed a parent debug session, assumes options with just this parent session.
          * @return A thenable that resolves when debugging could be successfully started.
          */
-        export function startDebugging(folder: WorkspaceFolder | undefined, nameOrConfiguration: string | DebugConfiguration, options: DebugSessionOptions): PromiseLike<boolean>;
+        export function startDebugging(folder: WorkspaceFolder | undefined, nameOrConfiguration: string | DebugConfiguration, parentSessionOrOptions?: DebugSession | DebugSessionOptions): PromiseLike<boolean>;
 
         /**
          * Stop the given debug session or stop all debug sessions if session is omitted.


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

### What it does
<!-- Include relevant issues and describe how they are addressed. -->

The pull-request includes the following updates:

**Aligns `startDebugging` API**
- updates `startDebugging` to accept parent `DebugSession` as a possible option
- makes `parentSessionOrOptions` optional

**Updates `startDebugging` to properly respect `DebugSessionOptions`**
- Fixes: https://github.com/eclipse-theia/theia/issues/10655

### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

1. include the following [test](https://github.com/vince-fugnitto/vscode-start-debugging/releases/download/v0.0.1/vscode-startdebugging-0.0.1.vsix) plugin in the application
2. start the application using `theia` as a workspace
3. open a `*.spec.ts` file
4. set breakpoints in the file
5. execute the command `Debug Test: Start (No Config)` - confirm that the debug session works
6. execute the command `Debug Test: Start (No Breakpoints)` - confirm that the the debug session works (breakpoints are skipped) - Note that due to https://github.com/eclipse-theia/theia/issues/10653 the output of the session is lost when the session is over

### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

Signed-off-by: vince-fugnitto <vincent.fugnitto@ericsson.com>

