### PR TITLE
console: do not clear output when a session ends

### DIFF
--- a/packages/console/src/browser/console-widget.ts
+++ b/packages/console/src/browser/console-widget.ts
@@ -115,7 +115,10 @@ export class ConsoleWidget extends BaseWidget implements StatefulWidget {
 
         this.session = this.sessionManager.selectedSession;
         this.toDispose.push(this.sessionManager.onDidChangeSelectedSession(session => {
-            this.session = session;
+            // Do not clear the session output when `undefined`.
+            if (session) {
+                this.session = session;
+            }
         }));
 
         this.updateFont();


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

Fixes: https://github.com/eclipse-theia/theia/issues/10653.

The pull-request fixes an issue which caused the debug console output to clear when a session was completed. 
The change now preserves the output so end-users can view the output of their debug session.

It namely reverts a change proposed in https://github.com/eclipse-theia/theia/pull/10333.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

1. start a debug session (with and without debug breakpoints).
2. when the session is terminated, the console output should be preserved.
3. confirm that subsequent sessions also work correctly.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

Signed-off-by: vince-fugnitto <vincent.fugnitto@ericsson.com>

