### PR TITLE
Use ascii-only labels for Electron menus

### DIFF
--- a/packages/core/src/browser/keybinding.ts
+++ b/packages/core/src/browser/keybinding.ts
@@ -334,8 +334,9 @@ export class KeybindingRegistry {
      * @returns a string representing the {@link KeyCode}
      * @param keyCode the keycode
      * @param separator the separator used to separate keys (key and modifiers) in the returning string
+     * @param asciiOnly if `true`, no special characters will be substituted into the string returned. Ensures correct keyboard shortcuts in Electron menus.
      */
-    acceleratorForKeyCode(keyCode: KeyCode, separator: string = ' '): string {
+    acceleratorForKeyCode(keyCode: KeyCode, separator: string = ' ', asciiOnly = false): string {
         const keyCodeResult = [];
         if (keyCode.meta && isOSX) {
             keyCodeResult.push('Cmd');
@@ -350,16 +351,18 @@ export class KeybindingRegistry {
             keyCodeResult.push('Shift');
         }
         if (keyCode.key) {
-            keyCodeResult.push(this.acceleratorForKey(keyCode.key));
+            keyCodeResult.push(this.acceleratorForKey(keyCode.key, asciiOnly));
         }
         return keyCodeResult.join(separator);
     }
 
     /**
+     * @param asciiOnly if `true`, no special characters will be substituted into the string returned. Ensures correct keyboard shortcuts in Electron menus.
+     *
      * Return a user visible representation of a single key.
      */
-    acceleratorForKey(key: Key): string {
-        if (isOSX) {
+    acceleratorForKey(key: Key, asciiOnly = false): string {
+        if (isOSX && !asciiOnly) {
             if (key === Key.ARROW_LEFT) {
                 return '←';
             }

--- a/packages/core/src/electron-browser/menu/electron-main-menu-factory.ts
+++ b/packages/core/src/electron-browser/menu/electron-main-menu-factory.ts
@@ -184,15 +184,9 @@ export class ElectronMainMenuFactory extends BrowserMainMenuFactory {
 
                 const bindings = this.keybindingRegistry.getKeybindingsForCommand(commandId);
 
-                let accelerator;
+                const accelerator = bindings[0] && this.acceleratorFor(bindings[0]);
 
-                /* Only consider the first keybinding. */
-                if (bindings.length > 0) {
-                    const binding = bindings[0];
-                    accelerator = this.acceleratorFor(binding);
-                }
-
-                const menuItem = {
+                const menuItem: Electron.MenuItemConstructorOptions = {
                     id: node.id,
                     label: node.label,
                     type: this.commandRegistry.getToggledHandler(commandId, ...args) ? 'checkbox' : 'normal',
@@ -201,7 +195,7 @@ export class ElectronMainMenuFactory extends BrowserMainMenuFactory {
                     visible: true,
                     accelerator,
                     click: () => this.execute(commandId, args)
-                } as Electron.MenuItemConstructorOptions;
+                };
 
                 if (isOSX) {
                     const role = this.roleFor(node.id);
@@ -241,7 +235,7 @@ export class ElectronMainMenuFactory extends BrowserMainMenuFactory {
         }
 
         const keyCode = bindingKeySequence[0];
-        return this.keybindingRegistry.acceleratorForKeyCode(keyCode, '+');
+        return this.keybindingRegistry.acceleratorForKeyCode(keyCode, '+', true);
     }
 
     protected roleFor(id: string): ElectronMenuItemRole | undefined {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->
Fixes #10672 by avoiding adding non-ascii arrow characters to 'accelerator' labels in Electron menus.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
1. On MacOS
2. Run the Electron application
3. Open the `Selection` menu.
4. See this (with the arrows that Electron uses):

![image](https://user-images.githubusercontent.com/62660806/151236542-c8147dd5-97b0-4647-990c-d8013d20a0c0.png)

5. Run the Browser application
6. Open the selection menu
7. See this (with arrow characters):

![image](https://user-images.githubusercontent.com/62660806/151236746-07427fbf-9e6c-4a43-b492-ab25b0f57c49.png)


#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
