### PR TITLE
Use  absolute path for "Copy relative path" outside of workspace

### DIFF
--- a/packages/workspace/src/browser/workspace-commands.ts
+++ b/packages/workspace/src/browser/workspace-commands.ts
@@ -331,6 +331,8 @@ export class WorkspaceCommandContribution implements CommandContribution {
                     const workspaceRoot = this.workspaceService.getWorkspaceRootUri(uri);
                     if (workspaceRoot) {
                         return workspaceRoot.relative(uri);
+                    } else {
+                        return uri.path;
                     }
                 }).join(lineDelimiter);
                 await this.clipboardService.writeText(text);


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->
Fixes a bug in the implementation of the `Copy relative path` command. If the file is outside the workspace, it now copies the absolute path.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
1. Open a file outside your current workspace.
2. Open the editor context menu for that file.
3. Run the `Copy relative path` command.
4. Your copy buffer should contain the absolute path of the file. On `master`, it is empty.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
