### PR TITLE
Align window.createTerminal API with VSCode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Change Log
 
+## v1.23.0 - 2/24/2022
+
+[1.23.0 Milestone](https://github.com/eclipse-theia/theia/milestone/31)
+
+<a name="breaking_changes_1.23.0">[Breaking Changes:](#breaking_changes_1.23.0)</a>
+
+- [plugin] Deprecated `PseudoTerminalOptions`. `ExternalTerminalOptions` should be used from now on instead. [#10683](https://github.com/eclipse-theia/theia/pull/10683) - Contributed on behalf of STMicroelectronics
+
 ## v1.22.0 - 1/27/2022
 
 [1.22.0 Milestone](https://github.com/eclipse-theia/theia/milestone/30)

--- a/packages/plugin-ext/src/plugin/plugin-context.ts
+++ b/packages/plugin-ext/src/plugin/plugin-context.ts
@@ -416,7 +416,9 @@ export function createAPIFactory(
             onDidChangeWindowState(listener, thisArg?, disposables?): theia.Disposable {
                 return windowStateExt.onDidChangeWindowState(listener, thisArg, disposables);
             },
-            createTerminal(nameOrOptions: theia.TerminalOptions | theia.PseudoTerminalOptions | (string | undefined), shellPath?: string, shellArgs?: string[]): theia.Terminal {
+            createTerminal(nameOrOptions: theia.TerminalOptions | theia.PseudoTerminalOptions | theia.ExtensionTerminalOptions | (string | undefined),
+                shellPath?: string,
+                shellArgs?: string[]): theia.Terminal {
                 return terminalExt.createTerminal(nameOrOptions, shellPath, shellArgs);
             },
             onDidCloseTerminal,

--- a/packages/plugin-ext/src/plugin/terminal-ext.ts
+++ b/packages/plugin-ext/src/plugin/terminal-ext.ts
@@ -14,7 +14,7 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 import { UUID } from '@theia/core/shared/@phosphor/coreutils';
-import { Terminal, TerminalOptions, PseudoTerminalOptions } from '@theia/plugin';
+import { Terminal, TerminalOptions, PseudoTerminalOptions, ExtensionTerminalOptions } from '@theia/plugin';
 import { TerminalServiceExt, TerminalServiceMain, PLUGIN_RPC_CONTEXT } from '../common/plugin-api-rpc';
 import { RPCProtocol } from '../common/rpc-protocol';
 import { Event, Emitter } from '@theia/core/lib/common/event';
@@ -54,7 +54,7 @@ export class TerminalServiceExtImpl implements TerminalServiceExt {
         return [...this._terminals.values()];
     }
 
-    createTerminal(nameOrOptions: TerminalOptions | PseudoTerminalOptions | (string | undefined), shellPath?: string, shellArgs?: string[]): Terminal {
+    createTerminal(nameOrOptions: TerminalOptions | PseudoTerminalOptions | ExtensionTerminalOptions | (string | undefined), shellPath?: string, shellArgs?: string[]): Terminal {
         let options: TerminalOptions;
         let pseudoTerminal: theia.Pseudoterminal | undefined = undefined;
         const id = `plugin-terminal-${UUID.uuid4()}`;

--- a/packages/plugin/src/theia.d.ts
+++ b/packages/plugin/src/theia.d.ts
@@ -2745,8 +2745,25 @@ export module '@theia/plugin' {
 
     /**
      * Options a virtual process terminal.
+     * @deprecated Use [ExtensionTerminalOptions](#ExtensionTerminalOptions) instead.
      */
     export interface PseudoTerminalOptions {
+        /**
+         * The name of the terminal.
+         */
+        name: string;
+
+        /**
+         * An implementation of [Pseudoterminal](#Pseudoterminal) where an extension can
+         * control it.
+         */
+        pty: Pseudoterminal;
+    }
+
+    /**
+     * Options a virtual process terminal.
+     */
+    export interface ExtensionTerminalOptions {
         /**
          * The name of the terminal.
          */
@@ -4438,6 +4455,14 @@ export module '@theia/plugin' {
          * @return A new Terminal.
          */
         export function createTerminal(options: PseudoTerminalOptions): Terminal;
+
+        /**
+         * Creates a pseudo where an extension controls its input and output.
+         *
+         * @param options ExtensionTerminalOptions.
+         * @return A new Terminal.
+         */
+         export function createTerminal(options: ExtensionTerminalOptions): Terminal;
 
         /**
          * Register a [TreeDataProvider](#TreeDataProvider) for the view contributed using the extension point `views`.

--- a/packages/plugin/src/theia.d.ts
+++ b/packages/plugin/src/theia.d.ts
@@ -2745,7 +2745,7 @@ export module '@theia/plugin' {
 
     /**
      * Options a virtual process terminal.
-     * @deprecated Use [ExtensionTerminalOptions](#ExtensionTerminalOptions) instead.
+     * @deprecated since 1.23.0 - Use [ExtensionTerminalOptions](#ExtensionTerminalOptions) instead.
      */
     export interface PseudoTerminalOptions {
         /**


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->
Deprecated PseudoTerminalOptions and created ExternalTerminalOptions to align with VSCode API.

Please let me know if this alternation from the VSCode API was done on purpose. I couldn't find a reason to not align with the VSCode API.

VSCode API for reference: https://code.visualstudio.com/api/references/vscode-api#window.

This ticket works toward resolving #6589.

Contributed on behalf of STMicroelectronics.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
This is rather a renaming, rather than a full change, but to ensure this still works you can use [this](https://github.com/microsoft/vscode-extension-samples/tree/main/extension-terminal-sample) sample extension.


#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)