### PR TITLE
Fix sorting problem in QuickFileOpenService

### DIFF
--- a/examples/api-tests/src/file-search.spec.js
+++ b/examples/api-tests/src/file-search.spec.js
@@ -31,6 +31,9 @@ describe('file-search', function () {
 
         describe('#compareItems', () => {
 
+            /** @type import ('@theia/file-search/lib/browser/quick-file-open').QuickFileOpenService['compareItems']*/
+            const sortByCompareItems = (a, b) => quickFileOpenService['compareItems'](a, b);
+
             it('should compare two quick-open-items by `label`', () => {
 
                 /** @type import ('@theia/file-search/lib/browser/quick-file-open').FileQuickPickItem*/
@@ -38,8 +41,8 @@ describe('file-search', function () {
                 /** @type import ('@theia/file-search/lib/browser/quick-file-open').FileQuickPickItem*/
                 const b = { label: 'b', uri: new Uri.default('a') };
 
-                assert.equal(quickFileOpenService['compareItems'](a, b), 1, 'a should be before b');
-                assert.equal(quickFileOpenService['compareItems'](b, a), -1, 'a should be before b');
+                assert.deepEqual([a, b].sort(sortByCompareItems), [a, b], 'a should be before b');
+                assert.deepEqual([b, a].sort(sortByCompareItems), [a, b], 'a should be before b');
                 assert.equal(quickFileOpenService['compareItems'](a, a), 0, 'items should be equal');
             });
 
@@ -49,10 +52,23 @@ describe('file-search', function () {
                 const a = { label: 'a', uri: new Uri.default('a') };
                 /** @type import ('@theia/file-search/lib/browser/quick-file-open').FileQuickPickItem*/
                 const b = { label: 'a', uri: new Uri.default('b') };
+                assert.deepEqual([a, b].sort(sortByCompareItems), [a, b], 'a should be before b');
+                assert.deepEqual([b, a].sort(sortByCompareItems), [a, b], 'a should be before b');
+                assert.equal(sortByCompareItems(a, a), 0, 'items should be equal');
+            });
 
-                assert.equal(quickFileOpenService['compareItems'](a, b), 1, 'a should be before b');
-                assert.equal(quickFileOpenService['compareItems'](b, a), -1, 'a should be before b');
-                assert.equal(quickFileOpenService['compareItems'](a, a), 0, 'items should be equal');
+            it('should not place very good matches above exact matches', () => {
+                const exactMatch = 'aa_bb_cc_dd.file';
+                const veryGoodMatch = 'aa_bb_cc_ed_fd.file';
+                quickFileOpenService['filterAndRange'] = { filter: exactMatch };
+                /** @type import ('@theia/file-search/lib/browser/quick-file-open').FileQuickPickItem*/
+                const a = { label: exactMatch, uri: new Uri.default(exactMatch) };
+                /** @type import ('@theia/file-search/lib/browser/quick-file-open').FileQuickPickItem*/
+                const b = { label: veryGoodMatch, uri: new Uri.default(veryGoodMatch) };
+                assert.deepEqual([a, b].sort(sortByCompareItems), [a, b], 'a should be before b');
+                assert.deepEqual([b, a].sort(sortByCompareItems), [a, b], 'a should be before b');
+                assert.equal(sortByCompareItems(a, a), 0, 'items should be equal');
+                quickFileOpenService['filterAndRange'] = quickFileOpenService['filterAndRangeDefault'];
             });
 
         });

--- a/packages/file-search/src/browser/quick-file-open.ts
+++ b/packages/file-search/src/browser/quick-file-open.ts
@@ -198,7 +198,7 @@ export class QuickFileOpenService implements QuickAccessProvider {
                 sortedResults.sort((a, b) => this.compareItems(a, b));
 
                 if (sortedResults.length > 0) {
-                    result.unshift({ type: 'separator', label: 'file results' });
+                    result.push({ type: 'separator', label: 'file results' });
                     result.push(...sortedResults);
                 }
 
@@ -243,7 +243,7 @@ export class QuickFileOpenService implements QuickAccessProvider {
             }, 0);
 
             // Check fuzzy matches.
-            const fuzzyMatch = fuzzy.match(queryJoin, str);
+            const fuzzyMatch = fuzzy.match(queryJoin, str) ?? { score: 0 };
             if (fuzzyMatch.score === Infinity && exactMatch) {
                 return MAX_SAFE_INTEGER;
             }

--- a/packages/file-search/src/browser/quick-file-open.ts
+++ b/packages/file-search/src/browser/quick-file-open.ts
@@ -19,7 +19,7 @@ import { OpenerService, KeybindingRegistry, QuickAccessRegistry, QuickAccessProv
 import { WorkspaceService } from '@theia/workspace/lib/browser/workspace-service';
 import URI from '@theia/core/lib/common/uri';
 import { FileSearchService, WHITESPACE_QUERY_SEPARATOR } from '../common/file-search-service';
-import { CancellationToken, Command } from '@theia/core/lib/common';
+import { CancellationToken, Command, MAX_SAFE_INTEGER } from '@theia/core/lib/common';
 import { LabelProvider } from '@theia/core/lib/browser/label-provider';
 import { NavigationLocationService } from '@theia/editor/lib/browser/navigation/navigation-location-service';
 import * as fuzzy from '@theia/core/shared/fuzzy';
@@ -219,6 +219,7 @@ export class QuickFileOpenService implements QuickAccessProvider {
             return roots.length !== 0 ? recentlyUsedItems : [];
         }
     }
+
     protected compareItems(
         left: FileQuickPickItem,
         right: FileQuickPickItem): number {
@@ -233,47 +234,35 @@ export class QuickFileOpenService implements QuickAccessProvider {
             if (!str) {
                 return 0;
             }
-            // Adjust for whitespaces in the query.
-            const querySplit = query.split(WHITESPACE_QUERY_SEPARATOR);
-            const queryJoin = querySplit.join('');
 
-            // Check exact and partial exact matches.
             let exactMatch = true;
-            let partialMatch = false;
-            querySplit.forEach(part => {
+            const partialMatches = querySplit.reduce((matched, part) => {
                 const partMatches = str.includes(part);
                 exactMatch = exactMatch && partMatches;
-                partialMatch = partialMatch || partMatches;
-            });
+                return partMatches ? matched + QuickFileOpenService.Scores.partial : matched;
+            }, 0);
 
             // Check fuzzy matches.
             const fuzzyMatch = fuzzy.match(queryJoin, str);
-            let matchScore = 0;
-            // eslint-disable-next-line no-null/no-null
-            if (!!fuzzyMatch && matchScore !== null) {
-                matchScore = (fuzzyMatch.score === Infinity) ? QuickFileOpenService.Scores.max : fuzzyMatch.score;
+            if (fuzzyMatch.score === Infinity && exactMatch) {
+                return MAX_SAFE_INTEGER;
             }
 
-            // Prioritize exact matches, then partial exact matches, then fuzzy matches.
-            if (exactMatch) {
-                return matchScore + QuickFileOpenService.Scores.exact;
-            } else if (partialMatch) {
-                return matchScore + QuickFileOpenService.Scores.partial;
-            } else {
-                // eslint-disable-next-line no-null/no-null
-                return (fuzzyMatch === null) ? 0 : matchScore;
-            }
+            return fuzzyMatch.score + partialMatches + (exactMatch ? QuickFileOpenService.Scores.exact : 0);
         }
 
         const query: string = normalize(this.filterAndRange.filter);
+        // Adjust for whitespaces in the query.
+        const querySplit = query.split(WHITESPACE_QUERY_SEPARATOR);
+        const queryJoin = querySplit.join('');
 
         const compareByLabelScore = (l: FileQuickPickItem, r: FileQuickPickItem) => score(r.label) - score(l.label);
         const compareByLabelIndex = (l: FileQuickPickItem, r: FileQuickPickItem) => r.label.indexOf(query) - l.label.indexOf(query);
-        const compareByLabel = (l: FileQuickPickItem, r: FileQuickPickItem) => r.label.localeCompare(l.label);
+        const compareByLabel = (l: FileQuickPickItem, r: FileQuickPickItem) => l.label.localeCompare(r.label);
 
         const compareByPathScore = (l: FileQuickPickItem, r: FileQuickPickItem) => score(r.uri.path.toString()) - score(l.uri.path.toString());
         const compareByPathIndex = (l: FileQuickPickItem, r: FileQuickPickItem) => r.uri.path.toString().indexOf(query) - l.uri.path.toString().indexOf(query);
-        const compareByPathLabel = (l: FileQuickPickItem, r: FileQuickPickItem) => r.uri.path.toString().localeCompare(l.uri.path.toString());
+        const compareByPathLabel = (l: FileQuickPickItem, r: FileQuickPickItem) => l.uri.path.toString().localeCompare(r.uri.path.toString());
 
         return compareWithDiscriminators(left, right, compareByLabelScore, compareByLabelIndex, compareByLabel, compareByPathScore, compareByPathIndex, compareByPathLabel);
     }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->
There were a couple of problems in the sort function for the file quick pick and in the tests for them:

A positive returns means left [_after_](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/sort#description) right, so these values are reversed.

https://github.com/eclipse-theia/theia/blob/be4eba9d5aeb08e29f5a7dcf646c6defb25c28d4/examples/api-tests/src/file-search.spec.js#L41-L42

I've replaced the return expectations with actual passes through a sort function so that we're guaranteed to mirror the actual behavior of the function in its intended context of use.

---

To test whether L before R, these should also be reversed (but since the test expectations were reversed, the tests passed)


https://github.com/eclipse-theia/theia/blob/be4eba9d5aeb08e29f5a7dcf646c6defb25c28d4/packages/file-search/src/browser/quick-file-open.ts#L272

---

Fuzzy scores can be greater than `Scores.max` (1000), so imperfect matches could get a lead over perfect matches.

https://github.com/eclipse-theia/theia/blob/be4eba9d5aeb08e29f5a7dcf646c6defb25c28d4/packages/file-search/src/browser/quick-file-open.ts#L254


#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
1. Mostly see if the tests pass.
2. Create a workspace with files with the filenames used in the new test.
3. Search for the perfect match.
4. Observe that it is ordered above the very good match.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
