### PR TITLE
Implement backend to electron IPC channels

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -147,6 +147,9 @@
     {
       "backend": "lib/node/hosting/backend-hosting-module",
       "backendElectron": "lib/electron-node/hosting/electron-backend-hosting-module"
+    },
+    {
+      "backendElectron": "lib/electron-node/messaging/electron-backend-connection-module"
     }
   ],
   "keywords": [

--- a/packages/core/src/electron-common/electron-test-connection.ts
+++ b/packages/core/src/electron-common/electron-test-connection.ts
@@ -1,0 +1,23 @@
+/********************************************************************************
+ * Copyright (C) 2022 TypeFox and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+export const TestConnection = Symbol('TestConnection');
+
+export const TEST_CONNECTION_PATH = '/services/test-connection';
+
+export interface TestConnection {
+    runTest(): Promise<string[]>;
+}

--- a/packages/core/src/electron-common/messaging/electron-backend-connection-handler.ts
+++ b/packages/core/src/electron-common/messaging/electron-backend-connection-handler.ts
@@ -1,0 +1,80 @@
+/********************************************************************************
+ * Copyright (C) 2022 TypeFox and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import { ConnectionHandler } from '../../common/messaging/handler';
+
+/**
+ * Name of the channel used with `process.on/message`.
+ */
+export const THEIA_ELECTRON_BACKEND_IPC_CHANNEL_NAME = 'theia-electron-backend-ipc';
+
+export interface ElectronBackendMessage {
+    [THEIA_ELECTRON_BACKEND_IPC_CHANNEL_NAME]: string
+}
+
+export namespace ElectronBackendMessage {
+    export function is(message: unknown): message is ElectronBackendMessage {
+        return typeof message === 'object' && !!message && THEIA_ELECTRON_BACKEND_IPC_CHANNEL_NAME in message;
+    }
+    export function get(message: ElectronBackendMessage): string {
+        return message[THEIA_ELECTRON_BACKEND_IPC_CHANNEL_NAME];
+    }
+    export function create(data: string): ElectronBackendMessage {
+        return { [THEIA_ELECTRON_BACKEND_IPC_CHANNEL_NAME]: data };
+    }
+}
+
+/**
+ * A class capable of piping messaging data from the backend server to the electron main application.
+ * This should only be used when the app runs in `--no-cluster` mode, since we can't use normal inter-process communication.
+ */
+export class ElectronBackendMessagePipe {
+
+    protected electronHandler?: (data: string) => void;
+    protected backendHandler?: (data: string) => void;
+
+    onMessage(from: 'backend' | 'electron', handler: (data: string) => void): boolean {
+        if (from === 'backend') {
+            this.electronHandler = handler;
+            return !!this.backendHandler;
+        } else {
+            this.backendHandler = handler;
+            return !!this.electronHandler;
+        }
+    }
+
+    pushMessage(to: 'backend' | 'electron', data: string): boolean {
+        if (to === 'backend') {
+            this.electronHandler?.(data);
+            return !!this.electronHandler;
+        } else {
+            this.backendHandler?.(data);
+            return !!this.backendHandler;
+        }
+    }
+
+}
+
+export const ElectronBackendConnectionPipe = new ElectronBackendMessagePipe();
+
+/**
+ * IPC-specific connection handler.
+ * Use this if you want to establish communication from the electron-main to the backend process.
+ */
+export const ElectronMainConnectionHandler = Symbol('ElectronBackendConnectionHandler');
+
+export interface ElectronMainConnectionHandler extends ConnectionHandler {
+}

--- a/packages/core/src/electron-main/electron-main-application-module.ts
+++ b/packages/core/src/electron-main/electron-main-application-module.ts
@@ -26,6 +26,10 @@ import { ElectronMessagingContribution } from './messaging/electron-messaging-co
 import { ElectronMessagingService } from './messaging/electron-messaging-service';
 import { ElectronConnectionHandler } from '../electron-common/messaging/electron-connection-handler';
 import { ElectronSecurityTokenService } from './electron-security-token-service';
+import { ElectronMainMessagingService } from './messaging/electron-main-messaging-service';
+import { ElectronMainConnectionHandler } from '../electron-common/messaging/electron-backend-connection-handler';
+import { TestConnection, TEST_CONNECTION_PATH } from '../electron-common/electron-test-connection';
+import { TestConnectionImpl } from './electron-test-connection';
 
 const electronSecurityToken: ElectronSecurityToken = { value: v4() };
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -34,12 +38,14 @@ const electronSecurityToken: ElectronSecurityToken = { value: v4() };
 export default new ContainerModule(bind => {
     bind(ElectronMainApplication).toSelf().inSingletonScope();
     bind(ElectronMessagingContribution).toSelf().inSingletonScope();
+    bind(ElectronMainMessagingService).toSelf().inSingletonScope();
     bind(ElectronSecurityToken).toConstantValue(electronSecurityToken);
     bind(ElectronSecurityTokenService).toSelf().inSingletonScope();
 
     bindContributionProvider(bind, ElectronConnectionHandler);
     bindContributionProvider(bind, ElectronMessagingService.Contribution);
     bindContributionProvider(bind, ElectronMainApplicationContribution);
+    bindContributionProvider(bind, ElectronMainConnectionHandler);
 
     bind(ElectronMainApplicationContribution).toService(ElectronMessagingContribution);
 
@@ -50,4 +56,10 @@ export default new ContainerModule(bind => {
     ).inSingletonScope();
 
     bind(ElectronMainProcessArgv).toSelf().inSingletonScope();
+
+    bind(TestConnection).to(TestConnectionImpl).inSingletonScope();
+    bind(ElectronMainConnectionHandler).toDynamicValue(context =>
+        new JsonRpcConnectionHandler(TEST_CONNECTION_PATH,
+            () => context.container.get(TestConnection))
+    ).inSingletonScope();
 });

--- a/packages/core/src/electron-main/electron-test-connection.ts
+++ b/packages/core/src/electron-main/electron-test-connection.ts
@@ -1,0 +1,27 @@
+/********************************************************************************
+ * Copyright (C) 2022 TypeFox and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import { TestConnection } from '../electron-common/electron-test-connection';
+import { BrowserWindow } from '@theia/electron/shared/electron';
+import { injectable } from 'inversify';
+
+@injectable()
+export class TestConnectionImpl implements TestConnection {
+    async runTest(): Promise<string[]> {
+        const titles = BrowserWindow.getAllWindows().map(e => e.getTitle());
+        return titles;
+    }
+}

--- a/packages/core/src/electron-main/messaging/electron-main-messaging-service.ts
+++ b/packages/core/src/electron-main/messaging/electron-main-messaging-service.ts
@@ -1,0 +1,120 @@
+/********************************************************************************
+ * Copyright (C) 2022 TypeFox and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+import { inject, injectable, named } from 'inversify';
+import { createWebSocketConnection } from 'vscode-ws-jsonrpc/lib/socket/connection';
+import { ContributionProvider } from '../../common/contribution-provider';
+import { WebSocketChannel } from '../../common/messaging/web-socket-channel';
+import { ConsoleLogger } from '../../node/messaging/logger';
+import { ElectronMainConnectionHandler, ElectronBackendMessage, ElectronBackendConnectionPipe } from '../../electron-common/messaging/electron-backend-connection-handler';
+import { MessagingContribution } from '../../node/messaging/messaging-contribution';
+import { ChildProcess } from 'child_process';
+
+export interface ElectronMainConnectionOptions {
+}
+
+/**
+ * This component replicates the role filled by `MessagingContribution` but for connecting the backend with the electron process.
+ * It is based on process communication using the created backend process.
+ * Alternatively it uses a simple message pipe object when running in `--no-cluster` mode.
+ *
+ * This component allows communication between server process (backend) and electron main process.
+ */
+@injectable()
+export class ElectronMainMessagingService {
+
+    @inject(ContributionProvider) @named(ElectronMainConnectionHandler)
+    protected readonly connectionHandlers: ContributionProvider<ElectronMainConnectionHandler>;
+
+    protected readonly channelHandlers = new MessagingContribution.ConnectionHandlers<WebSocketChannel>();
+    protected readonly channels = new Map<number, WebSocketChannel>();
+    protected backendProcess?: ChildProcess;
+
+    start(backendProcess?: ChildProcess): void {
+        if (backendProcess) {
+            this.backendProcess = backendProcess;
+            this.backendProcess.on('message', message => {
+                if (ElectronBackendMessage.is(message)) {
+                    this.handleMessage(ElectronBackendMessage.get(message));
+                }
+            });
+            this.backendProcess.on('exit', () => {
+                this.closeChannels();
+            });
+        } else {
+            ElectronBackendConnectionPipe.onMessage('electron', message => {
+                this.handleMessage(message);
+            });
+        }
+        for (const connectionHandler of this.connectionHandlers.getContributions()) {
+            this.channelHandlers.push(connectionHandler.path, (params, channel) => {
+                const connection = createWebSocketConnection(channel, new ConsoleLogger());
+                connectionHandler.onConnection(connection);
+            });
+        }
+    }
+
+    protected closeChannels(): void {
+        for (const channel of Array.from(this.channels.values())) {
+            channel.close(undefined, 'Backend exited');
+        }
+        this.channels.clear();
+    }
+
+    protected handleMessage(data: string): void {
+        try {
+            // Start parsing the message to extract the channel id and route
+            const message: WebSocketChannel.Message = JSON.parse(data.toString());
+            // Someone wants to open a logical channel
+            if (message.kind === 'open') {
+                const { id, path } = message;
+                const channel = this.createChannel(id);
+                if (this.channelHandlers.route(path, channel)) {
+                    channel.ready();
+                    this.channels.set(id, channel);
+                    channel.onClose(() => this.channels.delete(id));
+                } else {
+                    console.error('Cannot find a service for the path: ' + path);
+                }
+            } else {
+                const { id } = message;
+                const channel = this.channels.get(id);
+                if (channel) {
+                    channel.handleMessage(message);
+                } else {
+                    console.error('The ipc channel does not exist', id);
+                }
+            }
+        } catch (error) {
+            console.error('IPC: Failed to handle message', { error, data });
+        }
+    }
+
+    protected createChannel(id: number): WebSocketChannel {
+        return new WebSocketChannel(id, content => {
+            if (this.backendProcess) {
+                if (this.backendProcess.send) {
+                    this.backendProcess.send(ElectronBackendMessage.create(content));
+                }
+            } else {
+                ElectronBackendConnectionPipe.pushMessage('backend', content);
+            }
+        });
+    }
+
+}

--- a/packages/core/src/electron-node/messaging/electron-backend-connection-module.ts
+++ b/packages/core/src/electron-node/messaging/electron-backend-connection-module.ts
@@ -1,0 +1,27 @@
+/********************************************************************************
+ * Copyright (C) 2022 TypeFox and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import { ContainerModule } from 'inversify';
+import { TestConnection, TEST_CONNECTION_PATH } from '../../electron-common/electron-test-connection';
+import { ElectronBackendConnectionProvider } from './electron-backend-connection-provider';
+
+export default new ContainerModule(bind => {
+    bind(ElectronBackendConnectionProvider).toSelf().inSingletonScope();
+    bind(TestConnection).toDynamicValue(context =>
+        ElectronBackendConnectionProvider.createProxy(context.container, TEST_CONNECTION_PATH,
+            () => context.container.get(TestConnection))
+    ).inSingletonScope();
+});

--- a/packages/core/src/electron-node/messaging/electron-backend-connection-provider.ts
+++ b/packages/core/src/electron-node/messaging/electron-backend-connection-provider.ts
@@ -1,0 +1,59 @@
+/********************************************************************************
+ * Copyright (C) 2012 TypeFox and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import { injectable, interfaces } from 'inversify';
+import { JsonRpcProxy } from '../../common/messaging';
+import { WebSocketChannel } from '../../common/messaging/web-socket-channel';
+import { AbstractConnectionProvider } from '../../common/messaging/abstract-connection-provider';
+import { ElectronBackendMessage, ElectronBackendConnectionPipe } from '../../electron-common/messaging/electron-backend-connection-handler';
+
+export interface ElectronBackendConnectionOptions {
+}
+
+/**
+ * Connection provider between the Theia frontend and the electron-main process via IPC.
+ */
+@injectable()
+export class ElectronBackendConnectionProvider extends AbstractConnectionProvider<ElectronBackendConnectionOptions> {
+
+    static createProxy<T extends object>(container: interfaces.Container, path: string, arg?: object): JsonRpcProxy<T> {
+        return container.get(ElectronBackendConnectionProvider).createProxy<T>(path, arg);
+    }
+
+    constructor() {
+        super();
+        const usePipe = ElectronBackendConnectionPipe.onMessage('backend', message => {
+            this.handleIncomingRawMessage(message);
+        });
+        // onMessage will return whether the electron main app wants to use the pipe for communication
+        // If backend and electron app are distinct processes, we use normal process messaging
+        if (!usePipe) {
+            process.on('message', message => {
+                if (ElectronBackendMessage.is(message)) {
+                    this.handleIncomingRawMessage(ElectronBackendMessage.get(message));
+                }
+            });
+        }
+    }
+
+    protected createChannel(id: number): WebSocketChannel {
+        return new WebSocketChannel(id, content => {
+            if (!ElectronBackendConnectionPipe.pushMessage('electron', content) && process.send) {
+                process.send(ElectronBackendMessage.create(content));
+            }
+        });
+    }
+}

--- a/packages/core/src/electron-node/token/electron-token-validator.ts
+++ b/packages/core/src/electron-node/token/electron-token-validator.ts
@@ -17,10 +17,10 @@
 import * as http from 'http';
 import * as cookie from 'cookie';
 import * as crypto from 'crypto';
-import { injectable, postConstruct } from 'inversify';
-import { MaybePromise } from '../../common';
+import { inject, injectable, postConstruct } from 'inversify';
 import { ElectronSecurityToken } from '../../electron-common/electron-token';
 import { WsRequestValidatorContribution } from '../../node/ws-request-validators';
+import { TestConnection } from '../../electron-common/electron-test-connection';
 
 /**
  * On Electron, we want to make sure that only Electron's browser-windows access the backend services.
@@ -30,12 +30,17 @@ export class ElectronTokenValidator implements WsRequestValidatorContribution {
 
     protected electronSecurityToken: ElectronSecurityToken;
 
+    @inject(TestConnection)
+    protected readonly testConnection: TestConnection;
+
     @postConstruct()
     protected postConstruct(): void {
         this.electronSecurityToken = this.getToken();
     }
 
-    allowWsUpgrade(request: http.IncomingMessage): MaybePromise<boolean> {
+    async allowWsUpgrade(request: http.IncomingMessage): Promise<boolean> {
+        console.log('Titles: ', await this.testConnection.runTest());
+        console.log('IPC test finished');
         return this.allowRequest(request);
     }
 


### PR DESCRIPTION
#### What it does

Closes https://github.com/eclipse-theia/theia/issues/2162

Uses a similar architecture to the existing Electron Main <-> Frontend communication layer over `ipcRenderer` and `ipcMain`. Contains additional changes to deal with the `--no-cluster` argument by using a special pipe object.

For testing purposes I included a `TestConnection` interface which returns the titles of all opened electron windows on startup to the backend server.

In a second version of this we could mirror the proposed classes/APIs here to also enable electron -> backend requests (this PR only enables backend -> electron requests), since we create only a single backend server for each electron main.

_Note:_ My use case for this change is that I plan to add proxy support for all requests in Theia. In particular, requests from the backend running in Electron should try to resolve to the Chromium proxy (which automatically picks up the OS proxy) in case no proxy is specified using the apps' preferences. For this, we need some kind of way to communicate with the electron process from the backend server process.

#### How to test

1. Start the Electron app.
2. Search for `Titles:` in the console. The console should contain the `title` of the newly opened Electron window.
3. Repeat with the `--no-cluster` argument enabled.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
