### PR TITLE
Remove global shortcuts from Electron, use WindowService for reload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 <a name="breaking_changes_1.23.0">[Breaking Changes:](#breaking_changes_1.23.0)</a>
 
 - [plugin] Deprecated `PseudoTerminalOptions`. `ExternalTerminalOptions` should be used from now on instead. [#10683](https://github.com/eclipse-theia/theia/pull/10683) - Contributed on behalf of STMicroelectronics
+- [core] Removed method `attachGlobalShortcuts` from `ElectronMainApplication`. Attaching shortcuts in that way interfered with internal shortcuts. Use internal keybindings instead of global shortcuts. [#10704](https://github.com/eclipse-theia/theia/pull/10704)
 
 ## v1.22.0 - 1/27/2022
 

--- a/packages/core/src/electron-browser/menu/electron-menu-contribution.ts
+++ b/packages/core/src/electron-browser/menu/electron-menu-contribution.ts
@@ -267,7 +267,7 @@ export class ElectronMenuContribution extends BrowserMenuBarContribution impleme
         });
 
         registry.registerCommand(ElectronCommands.RELOAD, {
-            execute: () => currentWindow.reload()
+            execute: () => this.windowService.reload()
         });
         registry.registerCommand(ElectronCommands.CLOSE_WINDOW, {
             execute: () => currentWindow.close()

--- a/packages/core/src/electron-main/electron-main-application.ts
+++ b/packages/core/src/electron-main/electron-main-application.ts
@@ -16,7 +16,7 @@
 
 import { inject, injectable, named } from 'inversify';
 import * as electronRemoteMain from '../../electron-shared/@electron/remote/main';
-import { screen, globalShortcut, ipcMain, app, BrowserWindow, BrowserWindowConstructorOptions, Event as ElectronEvent } from '../../electron-shared/electron';
+import { screen, ipcMain, app, BrowserWindow, BrowserWindowConstructorOptions, Event as ElectronEvent } from '../../electron-shared/electron';
 import * as path from 'path';
 import { Argv } from 'yargs';
 import { AddressInfo } from 'net';
@@ -266,7 +266,6 @@ export class ElectronMainApplication {
         electronWindow.setMenuBarVisibility(false);
         this.attachReadyToShow(electronWindow);
         this.attachSaveWindowState(electronWindow);
-        this.attachGlobalShortcuts(electronWindow);
         this.restoreMaximizedState(electronWindow, options);
         this.attachCloseListeners(electronWindow, options);
         electronRemoteMain.enable(electronWindow.webContents);
@@ -443,26 +442,6 @@ export class ElectronMainApplication {
         return screen.getAllDisplays().map(
             display => `${display.bounds.x}:${display.bounds.y}:${display.bounds.width}:${display.bounds.height}`
         ).sort().join('-');
-    }
-
-    /**
-     * Catch certain keybindings to prevent reloading the window using keyboard shortcuts.
-     */
-    protected attachGlobalShortcuts(electronWindow: BrowserWindow): void {
-        const handler = this.config.electron?.disallowReloadKeybinding
-            ? () => { }
-            : () => this.reload(electronWindow);
-        const accelerators = ['CmdOrCtrl+R', 'F5'];
-        electronWindow.on('focus', () => {
-            for (const accelerator of accelerators) {
-                globalShortcut.register(accelerator, handler);
-            }
-        });
-        electronWindow.on('blur', () => {
-            for (const accelerator of accelerators) {
-                globalShortcut.unregister(accelerator);
-            }
-        });
     }
 
     protected restoreMaximizedState(electronWindow: BrowserWindow, options: TheiaBrowserWindowOptions): void {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

Fixes #10701 by removing the registration of `globalShortcuts` from the `ElectronMainApplication`. There is already a command available internally to reload the window, which can be rebound or unbound and is context-sensitive, so the global shortcut is not necessary.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

1. Run the Electron application
2. Open a `bash` terminal
3. Use the `ctrl+r` shortcut to access 'reverse-i-search'
4. Put focus on some element other than the terminal.
5. Use the ctrl+r shortcut to refresh the window - it should refresh
6. Dirty an editor and use the ctrl+r shortcut - you should be prompted to confirm the refresh
7. If you'd like, rebind the Refresh Window command to some other keybinding and confirm that it behaves correctly.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
