### PR TITLE
Support VSCode WebviewView API

### DIFF
--- a/packages/editor/src/browser/editor-preferences.ts
+++ b/packages/editor/src/browser/editor-preferences.ts
@@ -900,13 +900,15 @@ const codeEditorPreferenceProperties = {
     'editor.peekWidgetDefaultFocus': {
         'enumDescriptions': [
             nls.localizeByDefault('Focus the tree when opening peek'),
-            nls.localizeByDefault('Focus the editor when opening peek')
+            nls.localizeByDefault('Focus the editor when opening peek'),
+            nls.localizeByDefault('Focus the webview when opening peek')
         ],
         'description': nls.localizeByDefault('Controls whether to focus the inline editor or the tree in the peek widget.'),
         'type': 'string',
         'enum': [
             'tree',
-            'editor'
+            'editor',
+            'webview'
         ],
         'default': 'tree'
     },

--- a/packages/plugin-ext/src/common/plugin-api-rpc.ts
+++ b/packages/plugin-ext/src/common/plugin-api-rpc.ts
@@ -1549,6 +1549,27 @@ export interface WebviewsMain {
     $unregisterSerializer(viewType: string): void;
 }
 
+export interface WebviewViewsExt {
+    $resolveWebviewView(handle: string,
+        viewType: string,
+        title: string | undefined,
+        state: any,
+        cancellation: CancellationToken): Promise<void>;
+    $onDidChangeWebviewViewVisibility(handle: string, visible: boolean): void;
+    $disposeWebviewView(handle: string): void;
+}
+
+export interface WebviewViewsMain extends Disposable {
+    $registerWebviewViewProvider(viewType: string,
+        options: { retainContextWhenHidden?: boolean, serializeBuffersForPostMessage: boolean }): void;
+    $unregisterWebviewViewProvider(viewType: string): void;
+
+    $setWebviewViewTitle(handle: string, value: string | undefined): void;
+    $setWebviewViewDescription(handle: string, value: string | undefined): void;
+
+    $show(handle: string, preserveFocus: boolean): void;
+}
+
 export interface CustomEditorsExt {
     $resolveWebviewEditor(
         resource: UriComponents,
@@ -1743,6 +1764,7 @@ export const PLUGIN_RPC_CONTEXT = {
     CONNECTION_MAIN: createProxyIdentifier<ConnectionMain>('ConnectionMain'),
     WEBVIEWS_MAIN: createProxyIdentifier<WebviewsMain>('WebviewsMain'),
     CUSTOM_EDITORS_MAIN: createProxyIdentifier<CustomEditorsMain>('CustomEditorsMain'),
+    WEBVIEW_VIEWS_MAIN: createProxyIdentifier<WebviewViewsMain>('WebviewViewsMain'),
     STORAGE_MAIN: createProxyIdentifier<StorageMain>('StorageMain'),
     TASKS_MAIN: createProxyIdentifier<TasksMain>('TasksMain'),
     DEBUG_MAIN: createProxyIdentifier<DebugMain>('DebugMain'),
@@ -1777,6 +1799,7 @@ export const MAIN_RPC_CONTEXT = {
     CONNECTION_EXT: createProxyIdentifier<ConnectionExt>('ConnectionExt'),
     WEBVIEWS_EXT: createProxyIdentifier<WebviewsExt>('WebviewsExt'),
     CUSTOM_EDITORS_EXT: createProxyIdentifier<CustomEditorsExt>('CustomEditorsExt'),
+    WEBVIEW_VIEWS_EXT: createProxyIdentifier<WebviewViewsExt>('WebviewViewsExt'),
     STORAGE_EXT: createProxyIdentifier<StorageExt>('StorageExt'),
     TASKS_EXT: createProxyIdentifier<TasksExt>('TasksExt'),
     DEBUG_EXT: createProxyIdentifier<DebugExt>('DebugExt'),

--- a/packages/plugin-ext/src/common/plugin-protocol.ts
+++ b/packages/plugin-ext/src/common/plugin-protocol.ts
@@ -128,10 +128,16 @@ export interface PluginPackageViewContainer {
     icon: string;
 }
 
+export enum PluginViewType {
+    Tree = 'tree',
+    Webview = 'webview'
+}
+
 export interface PluginPackageView {
     id: string;
     name: string;
     when?: string;
+    type?: string;
 }
 
 export interface PluginPackageViewWelcome {
@@ -696,6 +702,7 @@ export interface View {
     id: string;
     name: string;
     when?: string;
+    type?: string;
 }
 
 /**

--- a/packages/plugin-ext/src/hosted/node/scanners/scanner-theia.ts
+++ b/packages/plugin-ext/src/hosted/node/scanners/scanner-theia.ts
@@ -572,7 +572,8 @@ export class TheiaPluginScanner implements PluginScanner {
         const result: View = {
             id: rawView.id,
             name: rawView.name,
-            when: rawView.when
+            when: rawView.when,
+            type: rawView.type
         };
 
         return result;

--- a/packages/plugin-ext/src/main/browser/main-context.ts
+++ b/packages/plugin-ext/src/main/browser/main-context.ts
@@ -56,6 +56,7 @@ import { ThemingMainImpl } from './theming-main';
 import { CommentsMainImp } from './comments/comments-main';
 import { CustomEditorsMainImpl } from './custom-editors/custom-editors-main';
 import { SecretsMainImpl } from './secrets-main';
+import { WebviewViewsMainImpl } from './webview-views/webview-views-main';
 
 export function setUpPluginApi(rpc: RPCProtocol, container: interfaces.Container): void {
     const authenticationMain = new AuthenticationMainImpl(rpc, container);
@@ -126,6 +127,9 @@ export function setUpPluginApi(rpc: RPCProtocol, container: interfaces.Container
 
     const customEditorsMain = new CustomEditorsMainImpl(rpc, container, webviewsMain);
     rpc.set(PLUGIN_RPC_CONTEXT.CUSTOM_EDITORS_MAIN, customEditorsMain);
+
+    const webviewViewsMain = new WebviewViewsMainImpl(rpc, container, webviewsMain);
+    rpc.set(PLUGIN_RPC_CONTEXT.WEBVIEW_VIEWS_MAIN, webviewViewsMain);
 
     const storageMain = new StorageMainImpl(container);
     rpc.set(PLUGIN_RPC_CONTEXT.STORAGE_MAIN, storageMain);

--- a/packages/plugin-ext/src/main/browser/webview-views/webview-views-main.ts
+++ b/packages/plugin-ext/src/main/browser/webview-views/webview-views-main.ts
@@ -1,0 +1,142 @@
+/********************************************************************************
+ * Copyright (C) 2021 SAP SE or an SAP affiliate company and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+// some code copied and modified from https://github.com/microsoft/vscode/blob/e1f0f8f51390dea5df9096718fb6b647ed5a9534/src/vs/workbench/api/browser/mainThreadWebviewViews.ts
+
+import { inject, interfaces } from '@theia/core/shared/inversify';
+import { WebviewViewsMain, MAIN_RPC_CONTEXT, WebviewViewsExt } from '../../../common/plugin-api-rpc';
+import { RPCProtocol } from '../../../common/rpc-protocol';
+import { Disposable, DisposableCollection, ILogger } from '@theia/core';
+import { WebviewView } from './webview-views';
+import { CancellationToken } from '@theia/core/lib/common/cancellation';
+import { WebviewsMainImpl } from '../webviews-main';
+import { Widget, WidgetManager } from '@theia/core/lib/browser';
+import { PluginViewRegistry } from '../view/plugin-view-registry';
+
+export class WebviewViewsMainImpl implements WebviewViewsMain, Disposable {
+
+    protected readonly proxy: WebviewViewsExt;
+    protected readonly toDispose = new DisposableCollection(
+        Disposable.create(() => { /* mark as not disposed */ })
+    );
+
+    protected readonly webviewViews = new Map<string, WebviewView>();
+    protected readonly webviewViewProviders = new Map<string, Disposable>();
+    protected readonly widgetManager: WidgetManager;
+    protected readonly pluginViewRegistry: PluginViewRegistry;
+
+    @inject(ILogger)
+    protected readonly logger: ILogger;
+
+    constructor(rpc: RPCProtocol,
+        container: interfaces.Container,
+        readonly webviewsMain: WebviewsMainImpl
+    ) {
+        this.proxy = rpc.getProxy(MAIN_RPC_CONTEXT.WEBVIEW_VIEWS_EXT);
+        this.widgetManager = container.get(WidgetManager);
+        this.pluginViewRegistry = container.get(PluginViewRegistry);
+    }
+
+    dispose(): void {
+        this.toDispose.dispose();
+    }
+
+    async $registerWebviewViewProvider(viewType: string, options: { retainContextWhenHidden?: boolean, serializeBuffersForPostMessage: boolean }): Promise<void> {
+
+        if (this.webviewViewProviders.has(viewType)) {
+            throw new Error(`View provider for ${viewType} already registered`);
+        }
+
+        const registration = await this.pluginViewRegistry.registerWebviewView(viewType, {
+            resolve: async (webviewView: WebviewView, cancellation: CancellationToken) => {
+                const handle = webviewView.webview.identifier.id;
+                this.webviewViews.set(handle, webviewView);
+                this.webviewsMain.hookWebview(webviewView.webview);
+
+                let state: string | undefined;
+                if (webviewView.webview.state) {
+                    try {
+                        state = JSON.parse(webviewView.webview.state);
+                        console.log(state);
+                    } catch (e) {
+                        console.error('Could not load webview state', e, webviewView.webview.state);
+                    }
+                }
+                if (options) {
+                    webviewView.webview.options = options;
+                }
+
+                webviewView.onDidChangeVisibility(visible => {
+                    this.proxy.$onDidChangeWebviewViewVisibility(handle, visible);
+                });
+
+                webviewView.onDidDispose(() => {
+                    this.proxy.$disposeWebviewView(handle);
+                    this.webviewViews.delete(handle);
+                });
+
+                try {
+                    this.proxy.$resolveWebviewView(handle, viewType, webviewView.title, state, cancellation);
+                } catch (error) {
+                    this.logger.error(`Error resolving webview view '${viewType}': ${error}`);
+                    webviewView.webview.setHTML('failed to load plugin webview view');
+                }
+            }
+        });
+
+        this.webviewViewProviders.set(viewType, registration);
+    }
+
+    protected getWebview(handle: string): Widget | undefined {
+        return this.widgetManager.tryGetWidget(handle);
+    }
+
+    $unregisterWebviewViewProvider(viewType: string): void {
+        const provider = this.webviewViewProviders.get(viewType);
+        if (!provider) {
+            throw new Error(`No view provider for ${viewType} registered`);
+        }
+        provider.dispose();
+        this.webviewViewProviders.delete(viewType);
+    }
+
+    $setWebviewViewTitle(handle: string, value: string | undefined): void {
+        const webviewView = this.getWebviewView(handle);
+        webviewView.title = value;
+    }
+
+    $setWebviewViewDescription(handle: string, value: string | undefined): void {
+        const webviewView = this.getWebviewView(handle);
+        webviewView.description = value;
+    }
+
+    $show(handle: string, preserveFocus: boolean): void {
+        const webviewView = this.getWebviewView(handle);
+        webviewView.show(preserveFocus);
+    }
+
+    protected getWebviewView(handle: string): WebviewView {
+        const webviewView = this.webviewViews.get(handle);
+        if (!webviewView) {
+            throw new Error(`No webview view registered for handle '${handle}'`);
+        }
+        return webviewView;
+    }
+
+}

--- a/packages/plugin-ext/src/main/browser/webview-views/webview-views.ts
+++ b/packages/plugin-ext/src/main/browser/webview-views/webview-views.ts
@@ -1,0 +1,38 @@
+/********************************************************************************
+ * Copyright (C) 2021 SAP SE or an SAP affiliate company and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+/*---------------------------------------------------------------------------------------------
+*  Copyright (c) Microsoft Corporation. All rights reserved.
+*  Licensed under the MIT License. See License.txt in the project root for license information.
+*--------------------------------------------------------------------------------------------*/
+// copied and modified from https://github.com/microsoft/vscode/blob/a4a4cf5ace4472bc4f5176396bb290cafa15c518/src/vs/workbench/contrib/webviewView/browser/webviewViewService.ts
+
+import { CancellationToken, Event } from '@theia/core/lib/common';
+import { WebviewWidget } from '../webview/webview';
+
+export interface WebviewView {
+    title?: string;
+    description?: string;
+    readonly webview: WebviewWidget;
+    readonly onDidChangeVisibility: Event<boolean>;
+    readonly onDidDispose: Event<void>;
+
+    dispose(): void;
+    show(preserveFocus: boolean): void;
+}
+
+export interface WebviewViewResolver {
+    resolve(webviewView: WebviewView, cancellation: CancellationToken): Promise<void>;
+}

--- a/packages/plugin-ext/src/plugin/plugin-context.ts
+++ b/packages/plugin-ext/src/plugin/plugin-context.ts
@@ -173,6 +173,7 @@ import { TimelineExtImpl } from './timeline';
 import { ThemingExtImpl } from './theming';
 import { CommentsExtImpl } from './comments';
 import { CustomEditorsExtImpl } from './custom-editors';
+import { WebviewViewsExtImpl } from './webview-views';
 
 export function createAPIFactory(
     rpc: RPCProtocol,
@@ -211,6 +212,7 @@ export function createAPIFactory(
     const themingExt = rpc.set(MAIN_RPC_CONTEXT.THEMING_EXT, new ThemingExtImpl(rpc));
     const commentsExt = rpc.set(MAIN_RPC_CONTEXT.COMMENTS_EXT, new CommentsExtImpl(rpc, commandRegistry, documents));
     const customEditorExt = rpc.set(MAIN_RPC_CONTEXT.CUSTOM_EDITORS_EXT, new CustomEditorsExtImpl(rpc, documents, webviewExt, workspaceExt));
+    const webviewViewsExt = rpc.set(MAIN_RPC_CONTEXT.WEBVIEW_VIEWS_EXT, new WebviewViewsExtImpl(rpc, webviewExt));
     rpc.set(MAIN_RPC_CONTEXT.DEBUG_EXT, debugExt);
 
     return function (plugin: InternalPlugin): typeof theia {
@@ -409,6 +411,15 @@ export function createAPIFactory(
                 provider: theia.CustomTextEditorProvider | theia.CustomReadonlyEditorProvider,
                 options: { webviewOptions?: theia.WebviewPanelOptions, supportsMultipleEditorsPerDocument?: boolean } = {}): theia.Disposable {
                 return customEditorExt.registerCustomEditorProvider(viewType, provider, options, plugin);
+            },
+            registerWebviewViewProvider(viewType: string,
+                provider: theia.WebviewViewProvider,
+                options?: {
+                    webviewOptions?: {
+                        retainContextWhenHidden?: boolean
+                    }
+                }): theia.Disposable {
+                return webviewViewsExt.registerWebviewViewProvider(viewType, provider, plugin, options?.webviewOptions);
             },
             get state(): theia.WindowState {
                 return windowStateExt.getWindowState();

--- a/packages/plugin-ext/src/plugin/webview-views.ts
+++ b/packages/plugin-ext/src/plugin/webview-views.ts
@@ -1,0 +1,213 @@
+/********************************************************************************
+ * Copyright (C) 2021 SAP SE or an SAP affiliate company and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+/*---------------------------------------------------------------------------------------------
+*  Copyright (c) Microsoft Corporation. All rights reserved.
+*  Licensed under the MIT License. See License.txt in the project root for license information.
+*--------------------------------------------------------------------------------------------*/
+// some of the code is copied and modified from https://github.com/microsoft/vscode/blob/e1f0f8f51390dea5df9096718fb6b647ed5a9534/src/vs/workbench/api/common/extHostWebviewView.ts
+
+import { Disposable } from './types-impl';
+import { RPCProtocol } from '../common/rpc-protocol';
+import { PLUGIN_RPC_CONTEXT, WebviewViewsMain, WebviewViewsExt, Plugin } from '../common/plugin-api-rpc';
+import { CancellationToken } from '@theia/core/lib/common/cancellation';
+import { WebviewImpl, WebviewsExtImpl } from './webviews';
+import { WebviewViewProvider } from '@theia/plugin';
+import { Emitter, Event } from '@theia/core/lib/common/event';
+import * as theia from '@theia/plugin';
+
+export class WebviewViewsExtImpl implements WebviewViewsExt {
+
+    private readonly proxy: WebviewViewsMain;
+
+    protected readonly viewProviders = new Map<string, {
+        readonly provider: WebviewViewProvider;
+        readonly plugin: Plugin;
+    }>();
+    protected readonly webviewViews = new Map<string, WebviewViewExtImpl>();
+
+    constructor(rpc: RPCProtocol,
+        private readonly webviewsExt: WebviewsExtImpl) {
+        this.proxy = rpc.getProxy(PLUGIN_RPC_CONTEXT.WEBVIEW_VIEWS_MAIN);
+    }
+
+    registerWebviewViewProvider(
+        viewType: string,
+        provider: WebviewViewProvider,
+        plugin: Plugin,
+        webviewOptions?: {
+            retainContextWhenHidden?: boolean
+        }
+    ): Disposable {
+        if (this.viewProviders.has(viewType)) {
+            throw new Error(`View provider for '${viewType}' already registered`);
+        }
+
+        this.viewProviders.set(viewType, { provider: provider, plugin: plugin });
+
+        this.proxy.$registerWebviewViewProvider(viewType, {
+            retainContextWhenHidden: webviewOptions?.retainContextWhenHidden,
+            serializeBuffersForPostMessage: false,
+        });
+
+        return new Disposable(() => {
+            this.viewProviders.delete(viewType);
+            this.proxy.$unregisterWebviewViewProvider(viewType);
+        });
+    }
+
+    async $resolveWebviewView(handle: string,
+        viewType: string,
+        title: string | undefined,
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        state: any,
+        cancellation: CancellationToken
+    ): Promise<void> {
+        const entry = this.viewProviders.get(viewType);
+        if (!entry) {
+            throw new Error(`No view provider found for '${viewType}'`);
+        }
+
+        const { provider, plugin } = entry;
+
+        const webviewNoPanel = this.webviewsExt.createNewWebview({}, plugin, handle);
+        const revivedView = new WebviewViewExtImpl(handle, this.proxy, viewType, title, webviewNoPanel, true);
+        this.webviewViews.set(handle, revivedView);
+        await provider.resolveWebviewView(revivedView, { state }, cancellation);
+    }
+
+    async $onDidChangeWebviewViewVisibility(
+        handle: string,
+        visible: boolean
+    ): Promise<void> {
+        const webviewView = this.getWebviewView(handle);
+        webviewView.setVisible(visible);
+        webviewView.onDidChangeVisibilityEmitter.fire(visible);
+    }
+
+    async $disposeWebviewView(handle: string): Promise<void> {
+        const webviewView = this.getWebviewView(handle);
+        this.webviewViews.delete(handle);
+        webviewView.dispose();
+
+        this.webviewsExt.deleteWebview(handle);
+    }
+
+    protected getWebviewView(handle: string): WebviewViewExtImpl {
+        const entry = this.webviewViews.get(handle);
+        if (!entry) {
+            throw new Error('No webview found');
+        }
+
+        return entry;
+    }
+}
+
+export class WebviewViewExtImpl implements theia.WebviewView {
+
+    readonly onDidChangeVisibilityEmitter = new Emitter<boolean>();
+    readonly onDidChangeVisibility = this.onDidChangeVisibilityEmitter.event;
+
+    readonly onDidDisposeEmitter = new Emitter<void>();
+    readonly onDidDispose = this.onDidDisposeEmitter.event;
+
+    readonly handle: string;
+    readonly proxy: WebviewViewsMain;
+
+    readonly _viewType: string;
+    readonly _webview: WebviewImpl;
+
+    _isDisposed = false;
+    _isVisible: boolean;
+    _title: string | undefined;
+    _description: string | undefined;
+
+    constructor(
+        handle: string,
+        proxy: WebviewViewsMain,
+        viewType: string,
+        title: string | undefined,
+        webview: WebviewImpl,
+        isVisible: boolean,
+    ) {
+        this._viewType = viewType;
+        this._title = title;
+        this.handle = handle;
+        this.proxy = proxy;
+        this._webview = webview;
+        this._isVisible = isVisible;
+    }
+    onDispose: Event<void>;
+
+    dispose(): void {
+        if (this._isDisposed) {
+            return;
+        }
+
+        this._isDisposed = true;
+        this.onDidDisposeEmitter.fire();
+    }
+
+    get title(): string | undefined {
+        this.assertNotDisposed();
+        return this._title;
+    }
+
+    set title(value: string | undefined) {
+        this.assertNotDisposed();
+        if (this.title !== value) {
+            this.title = value;
+            this.proxy.$setWebviewViewTitle(this.handle, value);
+        }
+    }
+
+    get description(): string | undefined {
+        this.assertNotDisposed();
+        return this._description;
+    }
+
+    set description(value: string | undefined) {
+        this.assertNotDisposed();
+        if (this._description !== value) {
+            this._description = value;
+            this.proxy.$setWebviewViewDescription(this.handle, value);
+        }
+    }
+
+    get visible(): boolean { return this._isVisible; }
+    get webview(): WebviewImpl { return this._webview; }
+    get viewType(): string { return this._viewType; }
+
+    setVisible(visible: boolean): void {
+        if (visible === this._isVisible || this._isDisposed) {
+            return;
+        }
+
+        this._isVisible = visible;
+        this.onDidChangeVisibilityEmitter.fire(this._isVisible);
+    }
+
+    show(preserveFocus?: boolean): void {
+        this.assertNotDisposed();
+        this.proxy.$show(this.handle, !!preserveFocus);
+    }
+
+    protected assertNotDisposed(): void {
+        if (this._isDisposed) {
+            throw new Error('Webview is disposed');
+        }
+    }
+}
+

--- a/packages/plugin-ext/src/plugin/webviews.ts
+++ b/packages/plugin-ext/src/plugin/webviews.ts
@@ -27,11 +27,15 @@ import { PluginIconPath } from './plugin-icon-path';
 export class WebviewsExtImpl implements WebviewsExt {
     private readonly proxy: WebviewsMain;
     private readonly webviewPanels = new Map<string, WebviewPanelImpl>();
+    private readonly webviews = new Map<string, WebviewImpl>();
     private readonly serializers = new Map<string, {
         serializer: theia.WebviewPanelSerializer,
         plugin: Plugin
     }>();
     private initData: WebviewInitData | undefined;
+
+    readonly onDidDisposeEmitter = new Emitter<void>();
+    readonly onDidDispose: Event<void> = this.onDidDisposeEmitter.event;
 
     constructor(
         rpc: RPCProtocol,
@@ -49,6 +53,11 @@ export class WebviewsExtImpl implements WebviewsExt {
         const panel = this.getWebviewPanel(handle);
         if (panel) {
             panel.webview.onMessageEmitter.fire(message);
+        } else {
+            const webview = this.getWebview(handle);
+            if (webview) {
+                webview.onMessageEmitter.fire(message);
+            }
         }
     }
     $onDidChangeWebviewPanelViewState(handle: string, newState: WebviewPanelViewState): void {
@@ -128,6 +137,19 @@ export class WebviewsExtImpl implements WebviewsExt {
         return panel;
     }
 
+    createNewWebview(
+        options: theia.WebviewPanelOptions & theia.WebviewOptions,
+        plugin: Plugin,
+        viewId: string
+    ): WebviewImpl {
+        if (!this.initData) {
+            throw new Error('Webviews are not initialized');
+        }
+        const webview = new WebviewImpl(viewId, this.proxy, options, this.initData, this.workspace, plugin);
+        this.webviews.set(viewId, webview);
+        return webview;
+    }
+
     registerWebviewPanelSerializer(
         viewType: string,
         serializer: theia.WebviewPanelSerializer,
@@ -151,6 +173,14 @@ export class WebviewsExtImpl implements WebviewsExt {
             return this.webviewPanels.get(viewId);
         }
         return undefined;
+    }
+
+    public deleteWebview(handle: string): void {
+        this.webviews.delete(handle);
+    }
+
+    public getWebview(handle: string): WebviewImpl | undefined {
+        return this.webviews.get(handle);
     }
 }
 

--- a/packages/plugin/src/theia.d.ts
+++ b/packages/plugin/src/theia.d.ts
@@ -3988,6 +3988,87 @@ export module '@theia/plugin' {
 
     }
 
+    export interface WebviewView {
+        /**
+         * Identifies the type of the webview view, such as `'hexEditor.dataView'`.
+         */
+        readonly viewType: string;
+
+        /**
+         * The underlying webview for the view.
+         */
+        readonly webview: Webview;
+
+        /**
+         * View title displayed in the UI.
+         *
+         * The view title is initially taken from the extension `package.json` contribution.
+         */
+        title?: string;
+
+        /**
+         * Human-readable string which is rendered less prominently in the title.
+         */
+        description?: string;
+
+        /**
+         * Event fired when the view is disposed.
+         *
+         * Views are disposed when they are explicitly hidden by a user (this happens when a user
+         * right clicks in a view and unchecks the webview view).
+         *
+         * Trying to use the view after it has been disposed throws an exception.
+         */
+        readonly onDidDispose: Event<void>;
+
+        /**
+         * Tracks if the webview is currently visible.
+         *
+         * Views are visible when they are on the screen and expanded.
+         */
+        readonly visible: boolean;
+
+        /**
+         * Event fired when the visibility of the view changes.
+         *
+         * Actions that trigger a visibility change:
+         *
+         * - The view is collapsed or expanded.
+         * - The user switches to a different view group in the sidebar or panel.
+         *
+         * Note that hiding a view using the context menu instead disposes of the view and fires `onDidDispose`.
+         */
+        readonly onDidChangeVisibility: Event<boolean>;
+
+        /**
+         * Reveal the view in the UI.
+         *
+         * If the view is collapsed, this will expand it.
+         *
+         * @param preserveFocus When `true` the view will not take focus.
+         */
+        show(preserveFocus?: boolean): void;
+    }
+    /**
+     * Provider for creating `WebviewView` elements.
+     */
+    export interface WebviewViewProvider {
+        /**
+         * Revolves a webview view.
+         *
+         * `resolveWebviewView` is called when a view first becomes visible. This may happen when the view is
+         * first loaded or when the user hides and then shows a view again.
+         *
+         * @param webviewView Webview view to restore. The provider should take ownership of this view. The
+         *    provider must set the webview's `.html` and hook up all webview events it is interested in.
+         * @param context Additional metadata about the view being resolved.
+         * @param token Cancellation token indicating that the view being provided is no longer needed.
+         *
+         * @return Optional thenable indicating that the view has been fully resolved.
+         */
+        resolveWebviewView(webviewView: WebviewView, context: WebviewViewResolveContext, token: CancellationToken): Thenable<void> | void;
+    }
+
     /**
      * Common namespace for dealing with window and editor, showing messages and user input.
      */
@@ -4321,6 +4402,70 @@ export module '@theia/plugin' {
          * @param viewType Type of the webview panel that can be serialized.
          * @param serializer Webview serializer.
          */
+
+        /**
+         * Additional information the webview view being resolved.
+         *
+         * @param T Type of the webview's state.
+         */
+        interface WebviewViewResolveContext<T = unknown> {
+            /**
+             * Persisted state from the webview content.
+             *
+             * To save resources, VS Code normally deallocates webview documents (the iframe content) that are not visible.
+             * For example, when the user collapse a view or switches to another top level activity in the sidebar, the
+             * `WebviewView` itself is kept alive but the webview's underlying document is deallocated. It is recreated when
+             * the view becomes visible again.
+             *
+             * You can prevent this behavior by setting `retainContextWhenHidden` in the `WebviewOptions`. However this
+             * increases resource usage and should be avoided wherever possible. Instead, you can use persisted state to
+             * save off a webview's state so that it can be quickly recreated as needed.
+             *
+             * To save off a persisted state, inside the webview call `acquireVsCodeApi().setState()` with
+             * any json serializable object. To restore the state again, call `getState()`. For example:
+             *
+             * ```js
+             * // Within the webview
+             * const vscode = acquireVsCodeApi();
+             *
+             * // Get existing state
+             * const oldState = vscode.getState() || { value: 0 };
+             *
+             * // Update state
+             * setState({ value: oldState.value + 1 })
+             * ```
+             *
+             * VS Code ensures that the persisted state is saved correctly when a webview is hidden and across
+             * editor restarts.
+             */
+            readonly state: T | undefined;
+        }
+
+        export function registerWebviewViewProvider(viewId: string, provider: WebviewViewProvider, options?: {
+            /**
+             * Content settings for the webview created for this view.
+             */
+            readonly webviewOptions?: {
+                /**
+                 * Controls if the webview element itself (iframe) is kept around even when the view
+                 * is no longer visible.
+                 *
+                 * Normally the webview's html context is created when the view becomes visible
+                 * and destroyed when it is hidden. Extensions that have complex state
+                 * or UI can set the `retainContextWhenHidden` to make the editor keep the webview
+                 * context around, even when the webview moves to a background tab. When a webview using
+                 * `retainContextWhenHidden` becomes hidden, its scripts and other dynamic content are suspended.
+                 * When the view becomes visible again, the context is automatically restored
+                 * in the exact same state it was in originally. You cannot send messages to a
+                 * hidden webview, even with `retainContextWhenHidden` enabled.
+                 *
+                 * `retainContextWhenHidden` has a high memory overhead and should only be used if
+                 * your view's context cannot be quickly saved and restored.
+                 */
+                readonly retainContextWhenHidden?: boolean;
+            };
+        }): Disposable;
+
         export function registerWebviewPanelSerializer(viewType: string, serializer: WebviewPanelSerializer): Disposable;
 
         /**
@@ -4462,7 +4607,7 @@ export module '@theia/plugin' {
          * @param options ExtensionTerminalOptions.
          * @return A new Terminal.
          */
-         export function createTerminal(options: ExtensionTerminalOptions): Terminal;
+        export function createTerminal(options: ExtensionTerminalOptions): Terminal;
 
         /**
          * Register a [TreeDataProvider](#TreeDataProvider) for the view contributed using the extension point `views`.


### PR DESCRIPTION
#### What it does

Closes https://github.com/eclipse-theia/theia/issues/8740
Closes https://github.com/eclipse-theia/theia/pull/10137

Implements the VSCode WebviewView API mostly based on the changes done by #10137.

- [x] CQ for [`webview-views-main.ts`](https://dev.eclipse.org/ipzilla/show_bug.cgi?id=23825)

#### How to test

1. Install the [`webview-view-sample`](https://github.com/microsoft/vscode-extension-samples/tree/main/webview-view-sample) extension. (download [here](https://github.com/eclipse-theia/theia/files/7988388/calico-colors-0.0.1.zip))
2. Open the `Calico Colors` container in the explorer view.
3. Assert that everything in there works as expected (opening/collapsing the view, adding colors, clearing colors)

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
