### PR TITLE
Run playwright tests in CI

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -1,0 +1,48 @@
+name: Playwright Tests
+
+on:
+  push:
+    branches:
+      - master
+  workflow_dispatch:
+  pull_request:
+    branches:
+      - master
+  schedule:
+    - cron: "0 4 * * *" # Runs every day at 4am: https://docs.github.com/en/actions/reference/events-that-trigger-workflows#scheduled-events-schedule
+
+jobs:
+  build-and-test-playwright:
+    name: ubuntu-18.04,  Node.js 16.x
+
+    runs-on: ubuntu-18.04
+    timeout-minutes: 60
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Use Node.js "16.x"
+        uses: actions/setup-node@v1
+        with:
+          node-version: "16.x"
+          registry-url: "https://registry.npmjs.org"
+
+      - name: Use Python 3.x
+        uses: actions/setup-python@v2
+        with:
+          python-version: "3.x"
+
+      - name: Build
+        shell: bash
+        run: |
+          yarn --skip-integrity-check --network-timeout 100000
+          yarn browser build
+        env:
+          NODE_OPTIONS: --max_old_space_size=4096
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # https://github.com/microsoft/vscode-ripgrep/issues/9
+
+      - name: Test (playwright)
+        uses: GabrielBB/xvfb-action@v1
+        with:
+          run: yarn test:playwright

--- a/examples/playwright/configs/playwright.ci.config.ts
+++ b/examples/playwright/configs/playwright.ci.config.ts
@@ -1,0 +1,26 @@
+/********************************************************************************
+ * Copyright (C) 2022 EclipseSource and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import { PlaywrightTestConfig } from '@playwright/test';
+import baseConfig from './playwright.config';
+
+const ciConfig: PlaywrightTestConfig = {
+    ...baseConfig,
+    workers: 1,
+    retries: 1
+};
+
+export default ciConfig;

--- a/examples/playwright/package.json
+++ b/examples/playwright/package.json
@@ -19,6 +19,7 @@
     "lint": "eslint -c ./.eslintrc.js --ext .ts ./src ./tests",
     "lint:fix": "eslint -c ./.eslintrc.js --ext .ts ./src ./tests --fix",
     "ui-tests": "yarn && playwright test --config=./configs/playwright.config.ts",
+    "ui-tests-ci": "yarn && playwright test --config=./configs/playwright.ci.config.ts",
     "ui-tests-headful": "yarn && playwright test --config=./configs/playwright.headful.config.ts",
     "ui-tests-report-generate": "allure generate ./allure-results --clean -o allure-results/allure-report",
     "ui-tests-report": "yarn ui-tests-report-generate && allure open allure-results/allure-report"

--- a/package.json
+++ b/package.json
@@ -75,6 +75,7 @@
     "rebuild:clean": "rimraf .browser_modules",
     "test": "yarn -s test:theia && yarn -s electron test && yarn -s browser test",
     "test:theia": "lerna run --scope \"@theia/!(example-)*\" test --stream --concurrency=1",
+    "test:playwright": "concurrently --success first -c gray,blue -k -n theia,playwright \"yarn browser start\" \"yarn -s --cwd examples/playwright ui-tests-ci\"",
     "watch": "concurrently --kill-others -n tsc,browser,electron -c red,yellow,blue \"tsc -b -w --preserveWatchOutput\" \"yarn -s --cwd examples/browser watch:bundle\" \"yarn -s --cwd examples/electron watch:bundle\"",
     "watch:compile": "concurrently --kill-others -n cleanup,tsc -c magenta,red \"ts-clean dev-packages/* packages/* -w\" \"tsc -b -w --preserveWatchOutput\"",
     "performance:startup": "yarn -s performance:startup:browser && yarn -s performance:startup:electron",


### PR DESCRIPTION
#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

  * Add script `yarn test:playwright` for conveniently running [playwright tests](https://github.com/eclipse-theia/theia/issues/10337) in the CI
  * Include invocation of above-mentioned script in `build.yml` 
    * Playwright tests are executed only once in `ubuntu-18.04, Node.js v16.x`

If you prefer, we could also run the playwright tests in a separate job on every PR / master commit.
Alternatively, we could only run the playwright tests periodically in a separate action.

I tend to prefer running the tests on every PR and master commit (within build.yml) either as part of the build job (as in this PR) or as a separate build job, as this raises breakages immediately when a change either broke expected behavior or broke the page objects. However, I understand that this would potentially add responsibilities to the committers. So alternatively, we could run those tests in a nightly job and we batch-fix the page objects periodically.

Please let me know what you think! Thanks!

#### How to test

  * To only run playwright tests, run `yarn && yarn build && yarn test:playwright`
  * Check CI build result of `Build / ubuntu-18.04, Node.js v16.x`

#### Review checklist

- [X] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
