### PR TITLE
Align preference and notification styling with VSCode

### DIFF
--- a/packages/core/src/browser/common-frontend-contribution.ts
+++ b/packages/core/src/browser/common-frontend-contribution.ts
@@ -1740,6 +1740,27 @@ export class CommonFrontendContribution implements FrontendApplicationContributi
                     dark: 'input.border', light: 'input.border', hc: 'input.border'
                 }, description: 'Settings editor number input box border.'
             },
+            {
+                id: 'settings.focusedRowBackground', defaults: {
+                    dark: Color.transparent('#808080', 0.14),
+                    light: Color.transparent('#808080', 0.03),
+                    hc: undefined
+                }, description: 'The background color of a settings row when focused.'
+            },
+            {
+                id: 'settings.rowHoverBackground', defaults: {
+                    dark: Color.transparent('#808080', 0.07),
+                    light: Color.transparent('#808080', 0.05),
+                    hc: undefined
+                }, description: 'The background color of a settings row when hovered.'
+            },
+            {
+                id: 'settings.focusedRowBorder', defaults: {
+                    dark: Color.rgba(255, 255, 255, 0.12),
+                    light: Color.rgba(0, 0, 0, 0.12),
+                    hc: 'focusBorder'
+                }, description: "The color of the row's top and bottom border when the row is focused."
+            },
 
             // Theia Variable colors
             {

--- a/packages/messages/src/browser/notification-component.tsx
+++ b/packages/messages/src/browser/notification-component.tsx
@@ -72,7 +72,7 @@ export class NotificationComponent extends React.Component<NotificationComponent
     render(): React.ReactNode {
         const { messageId, message, type, progress, collapsed, expandable, source, actions } = this.props.notification;
         const isProgress = typeof progress === 'number';
-        return (<div key={messageId} className='theia-notification-list-item'>
+        return (<div key={messageId} className='theia-notification-list-item' tabIndex={0}>
             <div className={`theia-notification-list-item-content ${collapsed ? 'collapsed' : ''}`}>
                 <div className='theia-notification-list-item-content-main'>
                     <div className={`theia-notification-icon ${codicon(type)} ${type}`} />

--- a/packages/messages/src/browser/style/notifications.css
+++ b/packages/messages/src/browser/style/notifications.css
@@ -38,7 +38,6 @@
 /* Toasts */
 
 .theia-notifications-container.theia-notification-toasts .theia-notification-list-item {
-    background-color: var(--theia-notifications-background);
     box-shadow: 0px 0px 4px 0px var(--theia-widget-shadow);
     border: 1px solid var(--theia-notificationToast-border);
     margin-top: 6px;
@@ -93,6 +92,7 @@
 /* List > Item */
 
 .theia-notification-list-item {
+    background-color: var(--theia-notifications-background);
     width: 100%;
     cursor: pointer;
     flex-grow: 1;
@@ -101,9 +101,15 @@
     flex-wrap: nowrap;
     justify-content: space-between;
 }
-.theia-notification-list-item:hover {
+
+.theia-notification-list-item:focus {
+    border-color: var(--theia-focusBorder);
+}
+
+.theia-notification-list-item:hover:not(:focus) {
     background-color: var(--theia-list-hoverBackground);
 }
+
 .theia-notification-list > .theia-notification-list-item:not(:last-child) {
     border-top: 1px var(--theia-notifications-border) solid;
 }

--- a/packages/preferences/src/browser/style/index.css
+++ b/packages/preferences/src/browser/style/index.css
@@ -224,20 +224,28 @@
 
 .theia-settings-container li.single-pref {
     list-style-type: none;
-    margin: 12px 0 18px 0;
+    padding: 12px 14px 18px;
     width: 100%;
     display: flex;
     flex-direction: column;
     box-sizing: border-box;
-    padding-left: calc(2 * var(--theia-ui-padding));
     position: relative;
+}
+
+.theia-settings-container li.single-pref:hover:not(:focus) {
+    background-color: var(--theia-settings-rowHoverBackground);
+}
+
+.theia-settings-container li.single-pref:focus {
+    background-color: var(--theia-settings-focusedRowBackground);
+    outline: 1px solid var(--theia-settings-focusedRowBorder);
 }
 
 .theia-settings-container li.single-pref .pref-context-gutter {
     position: absolute;
-    height: 100%;
-    left: -16px;
-    padding-right: 4px;
+    height: calc(100% - 36px);
+    left: -22px;
+    padding-right: 8px;
     border-right: 2px hidden;
 }
 

--- a/packages/preferences/src/browser/views/components/preference-node-renderer.ts
+++ b/packages/preferences/src/browser/views/components/preference-node-renderer.ts
@@ -227,13 +227,16 @@ export abstract class PreferenceLeafNodeRenderer<ValueType extends JSONValue, In
         // Selects the rendered html preference node that does not belong to the commonly used group
         const selector = `li[data-pref-id="${preferenceId}"]:not([data-node-id^="commonly-used@"])`;
         const element = document.querySelector(selector);
-        if (element) {
+        if (element instanceof HTMLElement) {
             if (element.classList.contains('hidden')) {
                 // We clear the search term as we have clicked on a hidden preference
                 await this.searchbar.updateSearchTerm('');
                 await animationFrame();
             }
-            element.scrollIntoView();
+            element.scrollIntoView({
+                block: 'center'
+            });
+            element.focus();
         }
     }
 
@@ -241,6 +244,7 @@ export abstract class PreferenceLeafNodeRenderer<ValueType extends JSONValue, In
         const wrapper = document.createElement('li');
         wrapper.classList.add('single-pref');
         wrapper.id = `${this.id}-editor`;
+        wrapper.tabIndex = 0;
         wrapper.setAttribute('data-pref-id', this.id);
         wrapper.setAttribute('data-node-id', this.preferenceNode.id);
 


### PR DESCRIPTION
#### What it does

Updates our hovering and focus behavior for preferences and notifications to behave like the current version of VSCode.

#### How to test

Both of these tests should be performed for different light/dark themes. I changed the color slightly for preferences in the light theme compared to VSCode, since hovering and focus color were completely transparent. In my opinion this didn't really look good.

---

1. Open the example app, hover over and click on one of the browser-endpoint notifications.
2. Open the notification center, again, checking hover and click/focus behavior
3. Assert that it aligns to VSCode's behavior

---

1. Open the preference widget
2. Hover over different preferences and click on them (focus). The `More Actions...` gear should only appear when a preference is focused.
3. Change a preference so that it deviates from its original default value. Assert that the appearing vertical bar looks correct.
4. When clicking on a referenced preference, the target preference should be displayed in the center of the widget and should automatically gain the focus.
5. Assert that is aligns to VSCode's behavior

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
