### PR TITLE
Support VS Code Web extensions

### DIFF
--- a/packages/plugin-ext-vscode/src/node/context/plugin-vscode-init-fe.ts
+++ b/packages/plugin-ext-vscode/src/node/context/plugin-vscode-init-fe.ts
@@ -1,0 +1,43 @@
+/********************************************************************************
+ * Copyright (C) 2022 Arm and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const _scope = (this as any);
+_scope.exports = {};
+
+const _getModule = () => {
+    if (!_scope[_scope.frontendModuleName]) {
+        _scope[_scope.frontendModuleName] = {};
+    }
+    return _scope[_scope.frontendModuleName];
+};
+
+Object.defineProperty(_scope.exports, 'activate', {
+    set: value => _getModule().activate = value
+});
+
+Object.defineProperty(_scope.exports, 'deactivate', {
+    set: value => _getModule().deactivate = value
+});
+
+_scope.require = (moduleName: string) => {
+    const vscodeModuleName = 'vscode';
+
+    if (moduleName === vscodeModuleName) {
+        // Return the defaultApi
+        return _scope.theia._empty;
+    }
+};

--- a/packages/plugin-ext-vscode/src/node/plugin-reader.ts
+++ b/packages/plugin-ext-vscode/src/node/plugin-reader.ts
@@ -1,0 +1,28 @@
+/********************************************************************************
+ * Copyright (C) 2022 Arm and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import * as path from 'path';
+import { injectable } from '@theia/core/shared/inversify';
+import { Application, static as ExpressStatic } from '@theia/core/shared/express';
+import { BackendApplicationContribution } from '@theia/core/lib/node/backend-application';
+
+@injectable()
+export class HostedPluginReader implements BackendApplicationContribution {
+
+    configure(app: Application): void {
+        app.use('/context', ExpressStatic(path.join(__dirname, 'context')));
+    }
+}

--- a/packages/plugin-ext-vscode/src/node/plugin-vscode-backend-module.ts
+++ b/packages/plugin-ext-vscode/src/node/plugin-vscode-backend-module.ts
@@ -22,10 +22,11 @@ import { PluginVsCodeFileHandler } from './plugin-vscode-file-handler';
 import { PluginVsCodeDirectoryHandler } from './plugin-vscode-directory-handler';
 import { VsCodePluginScanner } from './scanner-vscode';
 import { PluginVsCodeCliContribution } from './plugin-vscode-cli-contribution';
-import { CliContribution } from '@theia/core/lib/node';
+import { BackendApplicationContribution, CliContribution } from '@theia/core/lib/node';
 import { PluginHostEnvironmentVariable } from '@theia/plugin-ext/lib/common';
 import { PluginVSCodeEnvironment } from '../common/plugin-vscode-environment';
 import { PluginVSCodeDeployerParticipant } from './plugin-vscode-deployer-participant';
+import { HostedPluginReader } from './plugin-reader';
 
 export default new ContainerModule(bind => {
     bind(PluginVSCodeEnvironment).toSelf().inSingletonScope();
@@ -40,4 +41,7 @@ export default new ContainerModule(bind => {
     bind(PluginVsCodeCliContribution).toSelf().inSingletonScope();
     bind(CliContribution).toService(PluginVsCodeCliContribution);
     bind(PluginHostEnvironmentVariable).toService(PluginVsCodeCliContribution);
+
+    bind(HostedPluginReader).toSelf().inSingletonScope();
+    bind(BackendApplicationContribution).toService(HostedPluginReader);
 });

--- a/packages/plugin-ext-vscode/src/node/scanner-vscode.ts
+++ b/packages/plugin-ext-vscode/src/node/scanner-vscode.ts
@@ -16,8 +16,11 @@
 
 import * as path from 'path';
 import { injectable } from '@theia/core/shared/inversify';
-import { PluginScanner, PluginEngine, PluginPackage, PluginModel, PluginLifecycle } from '@theia/plugin-ext';
+import { PluginScanner, PluginEngine, PluginPackage, PluginModel, PluginLifecycle, PluginEntryPoint, buildFrontendModuleName, UIKind } from '@theia/plugin-ext';
 import { TheiaPluginScanner } from '@theia/plugin-ext/lib/hosted/node/scanners/scanner-theia';
+import { environment } from '@theia/core/shared/@theia/application-package/lib/environment';
+
+const uiKind = environment.electron.is() ? UIKind.Desktop : UIKind.Web;
 
 @injectable()
 export class VsCodePluginScanner extends TheiaPluginScanner implements PluginScanner {
@@ -32,6 +35,23 @@ export class VsCodePluginScanner extends TheiaPluginScanner implements PluginSca
     getModel(plugin: PluginPackage): PluginModel {
         // publisher can be empty on vscode extension development
         const publisher = plugin.publisher || '';
+
+        // Only one entrypoint is valid in vscode extensions
+        // Mimic choosing frontend (web extension) and backend (local/remote extension) as described here:
+        // https://code.visualstudio.com/api/advanced-topics/extension-host#preferred-extension-location
+        const entryPoint: PluginEntryPoint = {};
+
+        // Act like codespaces when run in the browser (UIKind === 'web' and extensionKind is ['ui'])
+        const preferFrontend = uiKind === UIKind.Web && (plugin.extensionKind?.length === 1 && plugin.extensionKind[0] === 'ui');
+
+        if (plugin.browser && (!plugin.main || preferFrontend)) {
+            // Use frontend if available and there is no backend or frontend is preferred
+            entryPoint.frontend = plugin.browser;
+        } else {
+            // Default to using backend
+            entryPoint.backend = plugin.main;
+        }
+
         const result: PluginModel = {
             packagePath: plugin.packagePath,
             packageUri: this.pluginUriFactory.createUri(plugin).toString(),
@@ -46,9 +66,7 @@ export class VsCodePluginScanner extends TheiaPluginScanner implements PluginSca
                 type: this.VSCODE_TYPE,
                 version: plugin.engines[this.VSCODE_TYPE]
             },
-            entryPoint: {
-                backend: plugin.main
-            },
+            entryPoint,
             iconUrl: plugin.icon && PluginPackage.toPluginUrl(plugin, plugin.icon),
             readmeUrl: PluginPackage.toPluginUrl(plugin, './README.md'),
             licenseUrl: PluginPackage.toPluginUrl(plugin, './LICENSE')
@@ -80,7 +98,9 @@ export class VsCodePluginScanner extends TheiaPluginScanner implements PluginSca
         return {
             startMethod: 'activate',
             stopMethod: 'deactivate',
+            frontendModuleName: buildFrontendModuleName(plugin),
 
+            frontendInitPath: 'plugin-vscode-init-fe.js',
             backendInitPath: path.join(__dirname, 'plugin-vscode-init'),
         };
     }

--- a/packages/plugin-ext/src/common/plugin-protocol.ts
+++ b/packages/plugin-ext/src/common/plugin-protocol.ts
@@ -48,6 +48,7 @@ export interface PluginPackage {
         backend?: string;
     };
     main?: string;
+    browser?: string;
     displayName: string;
     description: string;
     contributes?: PluginPackageContribution;
@@ -56,6 +57,7 @@ export interface PluginPackage {
     extensionDependencies?: string[];
     extensionPack?: string[];
     icon?: string;
+    extensionKind?: Array<'ui' | 'workspace'>
 }
 export namespace PluginPackage {
     export function toPluginUrl(pck: PluginPackage | PluginModel, relativePath: string): string {

--- a/packages/plugin-ext/src/hosted/browser/worker/worker-main.ts
+++ b/packages/plugin-ext/src/hosted/browser/worker/worker-main.ts
@@ -57,8 +57,16 @@ const rpc = new RPCProtocolImpl({
 addEventListener('message', (message: any) => {
     emitter.fire(message.data);
 });
+
+const scripts = new Set<string>();
+
 function initialize(contextPath: string, pluginMetadata: PluginMetadata): void {
-    ctx.importScripts('/context/' + contextPath);
+    const path = '/context/' + contextPath;
+
+    if (!scripts.has(path)) {
+        ctx.importScripts(path);
+        scripts.add(path);
+    }
 }
 const envExt = new WorkerEnvExtImpl(rpc);
 const storageProxy = new KeyValueStorageProxy(rpc);
@@ -79,6 +87,11 @@ const pluginManager = new PluginManagerExtImpl({
             if (isElectron()) {
                 ctx.importScripts(plugin.pluginPath);
             } else {
+                if (plugin.lifecycle.frontendModuleName) {
+                    // Set current module name being imported
+                    ctx.frontendModuleName = plugin.lifecycle.frontendModuleName;
+                }
+
                 ctx.importScripts('/hostedPlugin/' + getPluginId(plugin.model) + '/' + plugin.pluginPath);
             }
         }


### PR DESCRIPTION
Signed-off-by: thegecko <rob.moran@arm.com>

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

Implemented support for [VSCode Web Extensions](https://code.visualstudio.com/api/extension-guides/web-extensions) in Theia browser.

__Note:__ this works in Theia browser only, even though VS Code supports Web Extensions in desktop, too.
This is due to [frontend modules being disabled](https://github.com/eclipse-theia/theia/pull/9715)

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

Load a VS Code web extension. I've created a [modified vscode.mock-debug](https://github.com/thegecko/vscode-mock-debug/tree/web-extension) which only runs as a web extension. Download here:

https://github.com/thegecko/vscode-mock-debug/releases/tag/web-1.0.0

Using this should simply show a message to prove it ran.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
