### PR TITLE
Add CodeActionProvider#resolveCodeAction to plugin API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 [1.23.0 Milestone](https://github.com/eclipse-theia/theia/milestone/31)
 
 - [plugin-ext] add more detail to logging of backend and frontend start-up, especially in plugin management [#10407](https://github.com/eclipse-theia/theia/pull/10407) - Contributed on behalf of STMicroelectronics
+- [plugin] Added support for `vscode.CodeActionProvider.resolveCodeAction` [#10730](https://github.com/eclipse-theia/theia/pull/10730) - Contributed on behalf of STMicroelectronics
 
 <a name="breaking_changes_1.23.0">[Breaking Changes:](#breaking_changes_1.23.0)</a>
 

--- a/packages/plugin-ext/src/common/plugin-api-rpc-model.ts
+++ b/packages/plugin-ext/src/common/plugin-api-rpc-model.ts
@@ -338,6 +338,7 @@ export interface CodeLensSymbol {
 }
 
 export interface CodeAction {
+    cacheId: number;
     title: string;
     command?: Command;
     edit?: WorkspaceEdit;

--- a/packages/plugin-ext/src/common/plugin-api-rpc.ts
+++ b/packages/plugin-ext/src/common/plugin-api-rpc.ts
@@ -72,7 +72,7 @@ import {
     CommentOptions,
     CommentThreadCollapsibleState,
     CommentThread,
-    CommentThreadChangedEvent,
+    CommentThreadChangedEvent
 } from './plugin-api-rpc-model';
 import { ExtPluginApi } from './plugin-ext-api-contribution';
 import { KeysToAnyValues, KeysToKeysToAnyValue } from './types';
@@ -1441,6 +1441,8 @@ export interface LanguagesExt {
         context: CodeActionContext,
         token: CancellationToken
     ): Promise<CodeAction[] | undefined>;
+    $releaseCodeActions(handle: number, cacheIds: number[]): void;
+    $resolveCodeAction(handle: number, cacheId: number, token: CancellationToken): Promise<WorkspaceEditDto | undefined>;
     $provideDocumentSymbols(handle: number, resource: UriComponents, token: CancellationToken): Promise<DocumentSymbol[] | undefined>;
     $provideWorkspaceSymbols(handle: number, query: string, token: CancellationToken): PromiseLike<SymbolInformation[]>;
     $resolveWorkspaceSymbol(handle: number, symbol: SymbolInformation, token: CancellationToken): PromiseLike<SymbolInformation | undefined>;

--- a/packages/plugin-ext/src/main/browser/languages-main.ts
+++ b/packages/plugin-ext/src/main/browser/languages-main.ts
@@ -718,6 +718,8 @@ export class LanguagesMainImpl implements LanguagesMain, Disposable {
                 const markers = monaco.services.StaticServices.markerService.get().read({ resource: model.uri }).filter(m => monaco.Range.areIntersectingOrTouching(m, range));
                 return this.provideCodeActions(handle, model, range, { markers, only: context.only }, token);
             },
+            resolveCodeAction: (codeAction: monaco.languages.CodeAction, token: monaco.CancellationToken): Promise<monaco.languages.CodeAction> =>
+                this.resolveCodeAction(handle, codeAction, token),
             providedCodeActionKinds
         };
         this.register(handle, monaco.modes.CodeActionProviderRegistry.register(languageSelector, quickFixProvider));
@@ -734,10 +736,18 @@ export class LanguagesMainImpl implements LanguagesMain, Disposable {
         }
         return {
             actions: actions.map(a => toMonacoAction(a)),
-            dispose: () => {
-                // TODO this.proxy.$releaseCodeActions(handle, cacheId);
-            }
+            dispose: () => this.proxy.$releaseCodeActions(handle, actions.map(a => a.cacheId))
         };
+    }
+
+    protected async resolveCodeAction(handle: number, codeAction: monaco.languages.CodeAction, token: monaco.CancellationToken): Promise<monaco.languages.CodeAction> {
+        // The cacheId is kept in toMonacoAction when converting a received CodeAction DTO to a monaco code action
+        const cacheId = (codeAction as CodeAction).cacheId;
+        if (cacheId !== undefined) {
+            const resolvedEdit = await this.proxy.$resolveCodeAction(handle, cacheId, token);
+            codeAction.edit = resolvedEdit && toMonacoWorkspaceEdit(resolvedEdit);
+        }
+        return codeAction;
     }
 
     $registerRenameProvider(handle: number, pluginInfo: PluginInfo, selector: SerializedDocumentFilter[], supportsResolveLocation: boolean): void {

--- a/packages/plugin-ext/src/plugin/languages.ts
+++ b/packages/plugin-ext/src/plugin/languages.ts
@@ -463,6 +463,15 @@ export class LanguagesExtImpl implements LanguagesExt {
     ): Promise<CodeAction[] | undefined> {
         return this.withAdapter(handle, CodeActionAdapter, adapter => adapter.provideCodeAction(URI.revive(resource), rangeOrSelection, context, token), undefined);
     }
+
+    $releaseCodeActions(handle: number, cacheIds: number[]): void {
+        this.withAdapter(handle, CodeActionAdapter, adapter => adapter.releaseCodeActions(cacheIds), undefined);
+    }
+
+    $resolveCodeAction(handle: number, cacheId: number, token: theia.CancellationToken): Promise<WorkspaceEditDto | undefined> {
+        return this.withAdapter(handle, CodeActionAdapter, adapter => adapter.resolveCodeAction(cacheId, token), undefined);
+    };
+
     // ### Code Actions Provider end
 
     // ### Code Lens Provider begin

--- a/packages/plugin-ext/src/plugin/languages/code-action.ts
+++ b/packages/plugin-ext/src/plugin/languages/code-action.ts
@@ -16,7 +16,7 @@
 
 import * as theia from '@theia/plugin';
 import { URI } from '@theia/core/shared/vscode-uri';
-import { Selection } from '../../common/plugin-api-rpc';
+import { Selection, WorkspaceEditDto } from '../../common/plugin-api-rpc';
 import { Range, CodeActionContext, CodeAction } from '../../common/plugin-api-rpc-model';
 import * as Converter from '../type-converters';
 import { DocumentsExtImpl } from '../documents';
@@ -34,6 +34,11 @@ export class CodeActionAdapter {
         private readonly pluginId: string,
         private readonly commands: CommandRegistryImpl
     ) { }
+
+    private readonly cache = new Map<number, theia.CodeAction | theia.Command>();
+    private readonly disposables = new Map<number, DisposableCollection>();
+
+    private cacheId = 0;
 
     async provideCodeAction(resource: URI, rangeOrSelection: Range | Selection,
         context: CodeActionContext, token: theia.CancellationToken): Promise<CodeAction[] | undefined> {
@@ -64,15 +69,21 @@ export class CodeActionAdapter {
         if (!Array.isArray(commandsOrActions) || commandsOrActions.length === 0) {
             return undefined;
         }
-        // TODO cache toDispose and dispose it
-        const toDispose = new DisposableCollection();
         const result: CodeAction[] = [];
         for (const candidate of commandsOrActions) {
             if (!candidate) {
                 continue;
             }
+
+            // Cache candidates and created commands.
+            const nextCacheId = this.nextCacheId();
+            const toDispose = new DisposableCollection();
+            this.cache.set(nextCacheId, candidate);
+            this.disposables.set(nextCacheId, toDispose);
+
             if (CodeActionAdapter._isCommand(candidate)) {
                 result.push({
+                    cacheId: nextCacheId,
                     title: candidate.title || '',
                     command: this.commands.converter.toSafeCommand(candidate, toDispose)
                 });
@@ -88,6 +99,7 @@ export class CodeActionAdapter {
                 }
 
                 result.push({
+                    cacheId: nextCacheId,
                     title: candidate.title,
                     command: this.commands.converter.toSafeCommand(candidate.command, toDispose),
                     diagnostics: candidate.diagnostics && candidate.diagnostics.map(Converter.convertDiagnosticToMarkerData),
@@ -98,6 +110,37 @@ export class CodeActionAdapter {
         }
 
         return result;
+    }
+
+    async releaseCodeActions(cacheIds: number[]): Promise<void> {
+        cacheIds.forEach(id => {
+            this.cache.delete(id);
+            const toDispose = this.disposables.get(id);
+            if (toDispose) {
+                toDispose.dispose();
+                this.disposables.delete(id);
+            }
+        });
+    }
+
+    async resolveCodeAction(cacheId: number, token: theia.CancellationToken): Promise<WorkspaceEditDto | undefined> {
+        if (!this.provider.resolveCodeAction) {
+            return undefined;
+        }
+
+        // Code actions are only resolved if they are not legacy commands and don't have an edit property
+        // https://code.visualstudio.com/api/references/vscode-api#CodeActionProvider
+        const candidate = this.cache.get(cacheId);
+        if (!candidate || CodeActionAdapter._isCommand(candidate) || candidate.edit) {
+            return undefined;
+        }
+
+        const resolved = await this.provider.resolveCodeAction(candidate, token);
+        return resolved?.edit && Converter.fromWorkspaceEdit(resolved.edit);
+    }
+
+    private nextCacheId(): number {
+        return this.cacheId++;
     }
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/packages/plugin/src/theia.d.ts
+++ b/packages/plugin/src/theia.d.ts
@@ -7826,6 +7826,22 @@ export module '@theia/plugin' {
             context: CodeActionContext,
             token: CancellationToken | undefined
         ): ProviderResult<(Command | CodeAction)[]>;
+
+        /**
+         * Given a code action fill in its `edit`-property. Changes to
+         * all other properties, like title, are ignored. A code action that has an edit
+         * will not be resolved.
+         *
+         * *Note* that a code action provider that returns commands, not code actions, cannot successfully
+         * implement this function. Returning commands is deprecated and instead code actions should be
+         * returned.
+         *
+         * @param codeAction A code action.
+         * @param token A cancellation token.
+         * @return The resolved code action or a thenable that resolves to such. It is OK to return the given
+         * `item`. When no result is returned, the given `item` will be used.
+         */
+        resolveCodeAction?(codeAction: CodeAction, token: CancellationToken | undefined): ProviderResult<CodeAction>;
     }
 
     /**


### PR DESCRIPTION
#### What it does

Fixes #9992 by extending the plugin API and implementing the corresponding code action resolvement.

Plugin-API:
* Add resolveCodeAction method to CodeActionProvider in  theia.d.ts

RPC-API:
* Add $resolveCodeAction and $releaseCodeActions methods to LanguagesExt
* Extend CodeAction DTO to contain its cache id

Ext:
* Implement methods in LanguageExtImpl delegating to CodeActionAdapter
* Extend CodeActionAdapter
  * Cache provided code actions with an id
  * Handle resolving of code actions given
  * Handle disposing obsolete code actions

Main:
* Extend LanguagesMainImpl
  * Hand resolveCodeAction callback into quick fix providers registered with monaco
  * Dispose cached code actions on Ext side when monaco no longer needs them

Contributed on behalf of STMicroelectronics
Signed-off-by: Lucas Koehler <lkoehler@eclipsesource.com>

#### How to test
* I adapted the VSCode sample code action extension to use code action resolvement. It will also log when an action is resolved. If resolvement wasn't working, the code actions (replacing `:)` with emojis) would fail. One of the provided actions (`Learn more...`) is a command to verify that these do not cause errors. The code actions are provided in `.md` files.
* The extension can be downloaded here: [code-actions-sample-0.0.2.vsix](https://github.com/lucas-koehler/vscode-extension-samples/releases/download/code-actions-resolve-sample/code-actions-sample-0.0.2.vsix)
* Extension source code: [code-actions-sample](https://github.com/lucas-koehler/vscode-extension-samples/tree/894fad55c6f8b652dea16b7d234e476ac2fad41d/code-actions-sample)
* [Add the extension to your theia instance](https://github.com/eclipse-theia/theia/wiki/Testing-VS-Code-extensions)
* Create a file example.md and add `:)` to it. the sample code actions trigger if your curser is right before a `:)`
* Use one or more of the convert actions
* Use the learn more action

![image](https://user-images.githubusercontent.com/6959840/153241134-6c3f118b-0162-48bc-bf87-8f7c543e0d0d.png)

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
