### PR TITLE
Support to developing in arm64 workspace until compatible node version.

### DIFF
--- a/dev-packages/application-manager/src/application-package-manager.ts
+++ b/dev-packages/application-manager/src/application-package-manager.ts
@@ -186,7 +186,7 @@ export class ApplicationPackageManager {
             await ffmpeg.checkFfmpeg();
         } catch (error) {
             if (error.message.includes('(have \'arm64\', need \'x86_64\')') && process.env.ARCH === 'arm64') {
-                console.warn('WARN: ffmpeg checking skipped because mac-o file incompatible in this step');
+                console.warn('WARN: ffmpeg checking skipped because mach-o file incompatible in this step');
             } else {
                 throw error;
             }

--- a/dev-packages/application-manager/src/application-package-manager.ts
+++ b/dev-packages/application-manager/src/application-package-manager.ts
@@ -182,7 +182,15 @@ export class ApplicationPackageManager {
             throw new AbortError('Dependencies are out of sync, please run "install" again');
         }
         await ffmpeg.replaceFfmpeg();
-        await ffmpeg.checkFfmpeg();
+        try {
+            await ffmpeg.checkFfmpeg();
+        } catch (error) {
+            if (error.message.includes('(have \'arm64\', need \'x86_64\')') && process.env.ARCH === 'arm64') {
+                console.warn('WARN: ffmpeg checking skipped because mac-o file incompatible in this step');
+            } else {
+                throw error;
+            }
+        }
     }
 
     protected insertAlphabetically<T extends Record<string, string>>(object: T, key: string, value: string): T {

--- a/dev-packages/application-manager/src/rebuild.ts
+++ b/dev-packages/application-manager/src/rebuild.ts
@@ -36,6 +36,7 @@ export const DEFAULT_MODULES = [
     'native-keymap',
     'find-git-repositories',
     'drivelist',
+    'keytar'
 ];
 
 export interface RebuildOptions {
@@ -214,6 +215,10 @@ async function runElectronRebuild(modules: string[], forceAbi: NodeABI | undefin
         let command = `npx --no-install electron-rebuild -f -w=${todo} -o=${todo}`;
         if (forceAbi) {
             command += ` --force-abi ${forceAbi}`;
+        }
+        if (process.env.ARCH) {
+            console.warn('WARN: rebuild for arm64');
+            command += ` --arch ${process.env.ARCH}`;
         }
         const electronRebuild = cp.spawn(command, {
             stdio: 'inherit',

--- a/dev-packages/ffmpeg/src/replace-ffmpeg.ts
+++ b/dev-packages/ffmpeg/src/replace-ffmpeg.ts
@@ -50,7 +50,8 @@ export async function replaceFfmpeg(options: ffmpeg.FfmpegOptions = {}): Promise
     if (shouldDownload) {
         const ffmpegZipPath = await electronGet.downloadArtifact({
             version: electronVersion,
-            artifactName: 'ffmpeg'
+            artifactName: 'ffmpeg',
+            arch: process.env.ARCH
         });
         const ffmpegZip = await unzipper.Open.file(ffmpegZipPath);
         const file = ffmpegZip.files.find(f => f.path.endsWith(ffmpegName));


### PR DESCRIPTION
Signed-off-by: Ali Tuğrul Pınar <altgrlpinar@gmail.com>

This issue occurred that electron needs arm64 libs on runtime. Arch of node process is x64 therefore node-gyp compiles these libs as x64.

This PR includes:
 - 'rebuild:electron' command running with given arch from process env.
So, you can rebuild  electron libs as arm64. 
- adds missing keytar module to default modules.
- ignores checkFfmpeg step in build becauseof gives error of mac-o file in building.
- downloads correct libffmpeg.dylib via electron get.

#### What it does
closes #10728

#### How to test

on arm64 platform darwin machine (Apple M1 Machine)
```
git clone https://github.com/eclipse-theia/theia \
    && cd theia \
    && yarn \
    && yarn download:plugins \
    && yarn electron build \
    && yarn electron start
```
You can see error about  arm64 libs.

When apply this PR:
```
export ARCH=arm64
git clone https://github.com/eclipse-theia/theia \
    && cd theia \
    && yarn \
    && yarn download:plugins \
    && yarn electron build \
    && yarn electron start
```
it's running properly.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
