### PR TITLE
ts: enable `noImplicitOverride`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,12 @@
 - [plugin] Added support for `vscode.window.createStatusBarItem` [#10754](https://github.com/eclipse-theia/theia/pull/10754) - Contributed on behalf of STMicroelectronics
 - [core] Replaced raw WebSocket transport with Socket.io protocol, changed internal APIs accordingly
 - [core] Removed all of our own custom HTTP Polling implementation
+- In order to cleanup the code base, the constructor signature of the following classes got changed in an API-breaking way:
+  - `ProblemWidget`
+  - `FileNavigatorWidget`
+  - `TerminalServer`
+  - `TimelineTreeWidget`
+  - `TypeHierarchyTreeWidget`
 
 ## v1.22.0 - 1/27/2022
 

--- a/configs/base.tsconfig.json
+++ b/configs/base.tsconfig.json
@@ -5,6 +5,7 @@
     "declaration": true,
     "declarationMap": true,
     "noImplicitAny": true,
+    "noImplicitOverride": true,
     "noEmitOnError": false,
     "noImplicitThis": true,
     "noUnusedLocals": true,

--- a/examples/api-samples/src/browser/label/sample-dynamic-label-provider-contribution.ts
+++ b/examples/api-samples/src/browser/label/sample-dynamic-label-provider-contribution.ts
@@ -36,7 +36,7 @@ export class SampleDynamicLabelProviderContribution extends DefaultUriLabelProvi
         }, 1000);
     }
 
-    canHandle(element: object): number {
+    override canHandle(element: object): number {
         if (this.isActive && element.toString().includes('test')) {
             return 30;
         }
@@ -54,11 +54,11 @@ export class SampleDynamicLabelProviderContribution extends DefaultUriLabelProvi
         });
     }
 
-    protected getUri(element: URI): URI {
+    protected override getUri(element: URI): URI {
         return new URI(element.toString());
     }
 
-    getIcon(element: URI): string {
+    override getIcon(element: URI): string {
         const uri = this.getUri(element);
         const icon = super.getFileIcon(uri);
         if (!icon) {
@@ -67,10 +67,10 @@ export class SampleDynamicLabelProviderContribution extends DefaultUriLabelProvi
         return icon;
     }
 
-    protected readonly onDidChangeEmitter = new Emitter<DidChangeLabelEvent>();
+    protected override readonly onDidChangeEmitter = new Emitter<DidChangeLabelEvent>();
     private x: number = 0;
 
-    getName(element: URI): string | undefined {
+    override getName(element: URI): string | undefined {
         const uri = this.getUri(element);
         if (this.isActive && uri.toString().includes('test')) {
             return super.getName(uri) + '-' + this.x.toString(10);
@@ -79,12 +79,12 @@ export class SampleDynamicLabelProviderContribution extends DefaultUriLabelProvi
         }
     }
 
-    getLongName(element: URI): string | undefined {
+    override getLongName(element: URI): string | undefined {
         const uri = this.getUri(element);
         return super.getLongName(uri);
     }
 
-    get onDidChange(): Event<DidChangeLabelEvent> {
+    override get onDidChange(): Event<DidChangeLabelEvent> {
         return this.onDidChangeEmitter.event;
     }
 

--- a/examples/api-samples/src/browser/menu/sample-browser-menu-module.ts
+++ b/examples/api-samples/src/browser/menu/sample-browser-menu-module.ts
@@ -28,20 +28,20 @@ export default new ContainerModule((bind, unbind, isBound, rebind) => {
 @injectable()
 class SampleBrowserMainMenuFactory extends BrowserMainMenuFactory {
 
-    protected handleDefault(menuCommandRegistry: MenuCommandRegistry, menuNode: MenuNode): void {
+    protected override handleDefault(menuCommandRegistry: MenuCommandRegistry, menuNode: MenuNode): void {
         if (menuNode instanceof PlaceholderMenuNode && menuCommandRegistry instanceof SampleMenuCommandRegistry) {
             menuCommandRegistry.registerPlaceholderMenu(menuNode);
         }
     }
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    protected createMenuCommandRegistry(menu: CompositeMenuNode, args: any[] = []): MenuCommandRegistry {
+    protected override createMenuCommandRegistry(menu: CompositeMenuNode, args: any[] = []): MenuCommandRegistry {
         const menuCommandRegistry = new SampleMenuCommandRegistry(this.services);
         this.registerMenu(menuCommandRegistry, menu, args);
         return menuCommandRegistry;
     }
 
-    createMenuWidget(menu: CompositeMenuNode, options: MenuWidget.IOptions & { commands: MenuCommandRegistry }): DynamicMenuWidget {
+    override createMenuWidget(menu: CompositeMenuNode, options: MenuWidget.IOptions & { commands: MenuCommandRegistry }): DynamicMenuWidget {
         return new SampleDynamicMenuWidget(menu, options, this.services);
     }
 
@@ -60,7 +60,7 @@ class SampleMenuCommandRegistry extends MenuCommandRegistry {
         this.placeholders.set(id, menu);
     }
 
-    snapshot(): this {
+    override snapshot(): this {
         super.snapshot();
         for (const menu of this.placeholders.values()) {
             this.toDispose.push(this.registerPlaceholder(menu));
@@ -84,7 +84,7 @@ class SampleMenuCommandRegistry extends MenuCommandRegistry {
 
 class SampleDynamicMenuWidget extends DynamicMenuWidget {
 
-    protected handleDefault(menuNode: MenuNode): MenuWidget.IItemOptions[] {
+    protected override handleDefault(menuNode: MenuNode): MenuWidget.IItemOptions[] {
         if (menuNode instanceof PlaceholderMenuNode) {
             return [{
                 command: menuNode.id,

--- a/examples/api-samples/src/browser/view/sample-unclosable-view-contribution.ts
+++ b/examples/api-samples/src/browser/view/sample-unclosable-view-contribution.ts
@@ -46,7 +46,7 @@ export class SampleUnclosableViewContribution extends AbstractViewContribution<S
         });
     }
 
-    registerCommands(registry: CommandRegistry): void {
+    override registerCommands(registry: CommandRegistry): void {
         super.registerCommands(registry);
         registry.registerCommand(SampleToolBarCommand, {
             execute: () => {

--- a/examples/api-samples/src/electron-browser/menu/sample-electron-menu-module.ts
+++ b/examples/api-samples/src/electron-browser/menu/sample-electron-menu-module.ts
@@ -27,7 +27,7 @@ export default new ContainerModule((bind, unbind, isBound, rebind) => {
 class SampleElectronMainMenuFactory extends ElectronMainMenuFactory {
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    protected handleElectronDefault(menuNode: CompositeMenuNode, args: any[] = [], options?: ElectronMenuOptions): Electron.MenuItemConstructorOptions[] {
+    protected override handleElectronDefault(menuNode: CompositeMenuNode, args: any[] = [], options?: ElectronMenuOptions): Electron.MenuItemConstructorOptions[] {
         if (menuNode instanceof PlaceholderMenuNode) {
             return [{
                 label: menuNode.label,

--- a/examples/playwright/src/theia-about-dialog.ts
+++ b/examples/playwright/src/theia-about-dialog.ts
@@ -18,7 +18,7 @@ import { TheiaDialog } from './theia-dialog';
 
 export class TheiaAboutDialog extends TheiaDialog {
 
-    async isVisible(): Promise<boolean> {
+    override async isVisible(): Promise<boolean> {
         const dialog = await this.page.$(`${this.blockSelector} .theia-aboutDialog`);
         return !!dialog && dialog.isVisible();
     }

--- a/examples/playwright/src/theia-explorer-view.ts
+++ b/examples/playwright/src/theia-explorer-view.ts
@@ -64,7 +64,7 @@ export const DOT_FILES_FILTER: TheiaExplorerFileStatNodePredicate = async node =
 
 export class TheiaExplorerView extends TheiaView {
 
-    constructor(override app: TheiaApp) {
+    constructor(app: TheiaApp) {
         super(TheiaExplorerViewData, app);
     }
 

--- a/examples/playwright/src/theia-explorer-view.ts
+++ b/examples/playwright/src/theia-explorer-view.ts
@@ -31,7 +31,7 @@ const TheiaExplorerViewData = {
 
 export class TheiaExplorerFileStatNode extends TheiaTreeNode {
 
-    constructor(protected elementHandle: ElementHandle<SVGElement | HTMLElement>, protected explorerView: TheiaExplorerView) {
+    constructor(protected override elementHandle: ElementHandle<SVGElement | HTMLElement>, protected explorerView: TheiaExplorerView) {
         super(elementHandle, explorerView.app);
     }
 
@@ -64,11 +64,11 @@ export const DOT_FILES_FILTER: TheiaExplorerFileStatNodePredicate = async node =
 
 export class TheiaExplorerView extends TheiaView {
 
-    constructor(public app: TheiaApp) {
+    constructor(override app: TheiaApp) {
         super(TheiaExplorerViewData, app);
     }
 
-    async activate(): Promise<void> {
+    override async activate(): Promise<void> {
         await super.activate();
         const viewElement = await this.viewElement();
         await viewElement?.waitForSelector('.theia-TreeContainer');

--- a/examples/playwright/src/theia-main-menu.ts
+++ b/examples/playwright/src/theia-main-menu.ts
@@ -21,7 +21,7 @@ import { TheiaPageObject } from './theia-page-object';
 import { normalizeId, toTextContentArray } from './util';
 
 export class TheiaMainMenu extends TheiaMenu {
-    selector = '.p-Menu.p-MenuBar-menu';
+    override selector = '.p-Menu.p-MenuBar-menu';
 }
 
 export class TheiaMenuBar extends TheiaPageObject {

--- a/examples/playwright/src/theia-notification-indicator.ts
+++ b/examples/playwright/src/theia-notification-indicator.ts
@@ -26,7 +26,7 @@ export class TheiaNotificationIndicator extends TheiaStatusIndicator {
         return 'Notification';
     }
 
-    async isVisible(): Promise<boolean> {
+    override async isVisible(): Promise<boolean> {
         return super.isVisible(NOTIFICATION_ICONS, this.title);
     }
 
@@ -34,7 +34,7 @@ export class TheiaNotificationIndicator extends TheiaStatusIndicator {
         return super.isVisible(NOTIFICATION_DOT_ICON, this.title);
     }
 
-    async waitForVisible(expectNotifications = false): Promise<void> {
+    override async waitForVisible(expectNotifications = false): Promise<void> {
         await super.waitForVisibleByIcon(expectNotifications ? NOTIFICATION_DOT_ICON : NOTIFICATION_ICON);
     }
 

--- a/examples/playwright/src/theia-notification-overlay.ts
+++ b/examples/playwright/src/theia-notification-overlay.ts
@@ -23,7 +23,7 @@ export class TheiaNotificationOverlay extends TheiaPageObject {
     protected readonly HEADER_NOTIFICATIONS = 'NOTIFICATIONS';
     protected readonly HEADER_NO_NOTIFICATIONS = 'NO NEW NOTIFICATIONS';
 
-    constructor(public app: TheiaApp, protected notificationIndicator: TheiaNotificationIndicator) {
+    constructor(override app: TheiaApp, protected notificationIndicator: TheiaNotificationIndicator) {
         super(app);
     }
 

--- a/examples/playwright/src/theia-notification-overlay.ts
+++ b/examples/playwright/src/theia-notification-overlay.ts
@@ -23,7 +23,7 @@ export class TheiaNotificationOverlay extends TheiaPageObject {
     protected readonly HEADER_NOTIFICATIONS = 'NOTIFICATIONS';
     protected readonly HEADER_NO_NOTIFICATIONS = 'NO NEW NOTIFICATIONS';
 
-    constructor(override app: TheiaApp, protected notificationIndicator: TheiaNotificationIndicator) {
+    constructor(app: TheiaApp, protected notificationIndicator: TheiaNotificationIndicator) {
         super(app);
     }
 

--- a/examples/playwright/src/theia-preference-view.ts
+++ b/examples/playwright/src/theia-preference-view.ts
@@ -55,7 +55,7 @@ export class TheiaPreferenceView extends TheiaView {
         super(TheiaSettingsViewData, app);
     }
 
-    async open(preferenceScope = TheiaPreferenceScope.Workspace): Promise<TheiaView> {
+    override async open(preferenceScope = TheiaPreferenceScope.Workspace): Promise<TheiaView> {
         await this.app.quickCommandPalette.trigger('Preferences: Open Settings (UI)');
         await this.waitForVisible();
         await this.openPreferenceScope(preferenceScope);

--- a/examples/playwright/src/theia-problem-indicator.ts
+++ b/examples/playwright/src/theia-problem-indicator.ts
@@ -21,7 +21,7 @@ const PROBLEM_ICON = 'codicon-error';
 
 export class TheiaProblemIndicator extends TheiaStatusIndicator {
 
-    async isVisible(): Promise<boolean> {
+    override async isVisible(): Promise<boolean> {
         const handle = await super.getElementHandleByIcon(PROBLEM_ICON);
         return !!handle && handle.isVisible();
     }

--- a/examples/playwright/src/theia-toggle-bottom-indicator.ts
+++ b/examples/playwright/src/theia-toggle-bottom-indicator.ts
@@ -19,7 +19,7 @@ import { TheiaStatusIndicator } from './theia-status-indicator';
 const TOGGLE_BOTTOM_ICON = 'codicon-window';
 
 export class TheiaToggleBottomIndicator extends TheiaStatusIndicator {
-    async isVisible(): Promise<boolean> {
+    override async isVisible(): Promise<boolean> {
         return super.isVisible(TOGGLE_BOTTOM_ICON);
     }
 }

--- a/packages/bulk-edit/src/browser/bulk-edit-contribution.ts
+++ b/packages/bulk-edit/src/browser/bulk-edit-contribution.ts
@@ -30,7 +30,7 @@ export class BulkEditContribution extends AbstractViewContribution<BulkEditTreeW
     private edits: monaco.editor.ResourceEdit[];
 
     @inject(QuickViewService) @optional()
-    protected readonly quickView: QuickViewService;
+    protected override readonly quickView: QuickViewService;
 
     constructor(private readonly bulkEditService: MonacoBulkEditService) {
         super({
@@ -43,7 +43,7 @@ export class BulkEditContribution extends AbstractViewContribution<BulkEditTreeW
         this.bulkEditService.setPreviewHandler((edits: monaco.editor.ResourceEdit[]) => this.previewEdit(edits));
     }
 
-    registerCommands(registry: CommandRegistry): void {
+    override registerCommands(registry: CommandRegistry): void {
         super.registerCommands(registry);
         this.quickView?.hideItem(BULK_EDIT_WIDGET_NAME);
 

--- a/packages/bulk-edit/src/browser/bulk-edit-tree/bulk-edit-node-selection.ts
+++ b/packages/bulk-edit/src/browser/bulk-edit-tree/bulk-edit-node-selection.ts
@@ -28,8 +28,8 @@ export namespace BulkEditNodeSelection {
     export class CommandHandler extends SelectionCommandHandler<BulkEditNodeSelection> {
 
         constructor(
-            protected readonly selectionService: SelectionService,
-            protected readonly options: SelectionCommandHandler.Options<BulkEditNodeSelection>
+            protected override readonly selectionService: SelectionService,
+            protected override readonly options: SelectionCommandHandler.Options<BulkEditNodeSelection>
         ) {
             super(
                 selectionService,

--- a/packages/bulk-edit/src/browser/bulk-edit-tree/bulk-edit-tree-model.ts
+++ b/packages/bulk-edit/src/browser/bulk-edit-tree/bulk-edit-tree-model.ts
@@ -20,10 +20,10 @@ import { TreeModelImpl, OpenerService, open, TreeNode } from '@theia/core/lib/br
 
 @injectable()
 export class BulkEditTreeModel extends TreeModelImpl {
-    @inject(BulkEditTree) protected readonly tree: BulkEditTree;
+    @inject(BulkEditTree) protected override readonly tree: BulkEditTree;
     @inject(OpenerService) protected readonly openerService: OpenerService;
 
-    protected doOpenNode(node: TreeNode): void {
+    protected override doOpenNode(node: TreeNode): void {
         if (BulkEditNode.is(node)) {
             open(this.openerService, node.uri, undefined);
         } else {

--- a/packages/bulk-edit/src/browser/bulk-edit-tree/bulk-edit-tree-widget.tsx
+++ b/packages/bulk-edit/src/browser/bulk-edit-tree/bulk-edit-tree-widget.tsx
@@ -47,8 +47,8 @@ export class BulkEditTreeWidget extends TreeWidget {
 
     constructor(
         @inject(TreeProps) readonly treeProps: TreeProps,
-        @inject(BulkEditTreeModel) readonly model: BulkEditTreeModel,
-        @inject(ContextMenuRenderer) readonly contextMenuRenderer: ContextMenuRenderer
+        @inject(BulkEditTreeModel) override readonly model: BulkEditTreeModel,
+        @inject(ContextMenuRenderer) override readonly contextMenuRenderer: ContextMenuRenderer
     ) {
         super(treeProps, model, contextMenuRenderer);
 
@@ -68,14 +68,14 @@ export class BulkEditTreeWidget extends TreeWidget {
         this.quickView?.showItem(BULK_EDIT_WIDGET_NAME);
     }
 
-    protected handleClickEvent(node: TreeNode | undefined, event: React.MouseEvent<HTMLElement>): void {
+    protected override handleClickEvent(node: TreeNode | undefined, event: React.MouseEvent<HTMLElement>): void {
         super.handleClickEvent(node, event);
         if (BulkEditNode.is(node)) {
             this.doOpen(node);
         }
     }
 
-    protected handleDown(event: KeyboardEvent): void {
+    protected override handleDown(event: KeyboardEvent): void {
         const node = this.model.getNextSelectableNode();
         super.handleDown(event);
         if (BulkEditNode.is(node)) {
@@ -83,7 +83,7 @@ export class BulkEditTreeWidget extends TreeWidget {
         }
     }
 
-    protected handleUp(event: KeyboardEvent): void {
+    protected override handleUp(event: KeyboardEvent): void {
         const node = this.model.getPrevSelectableNode();
         super.handleUp(event);
         if (BulkEditNode.is(node)) {
@@ -91,14 +91,14 @@ export class BulkEditTreeWidget extends TreeWidget {
         }
     }
 
-    protected renderTree(model: TreeModel): React.ReactNode {
+    protected override renderTree(model: TreeModel): React.ReactNode {
         if (CompositeTreeNode.is(model.root) && model.root.children.length > 0) {
             return super.renderTree(model);
         }
         return <div className='theia-widget-noInfo noEdits'>{nls.localizeByDefault('No edits have been detected in the workspace so far.')}</div>;
     }
 
-    protected renderCaption(node: TreeNode, props: NodeProps): React.ReactNode {
+    protected override renderCaption(node: TreeNode, props: NodeProps): React.ReactNode {
         if (BulkEditInfoNode.is(node)) {
             return this.decorateBulkEditInfoNode(node);
         } else if (BulkEditNode.is(node)) {

--- a/packages/callhierarchy/src/browser/callhierarchy-contribution.ts
+++ b/packages/callhierarchy/src/browser/callhierarchy-contribution.ts
@@ -68,14 +68,14 @@ export class CallHierarchyContribution extends AbstractViewContribution<CallHier
         return !!selection && !!languageId && !!this.callHierarchyServiceProvider.get(languageId, new URI(selection.uri));
     }
 
-    async openView(args?: Partial<OpenViewArguments>): Promise<CallHierarchyTreeWidget> {
+    override async openView(args?: Partial<OpenViewArguments>): Promise<CallHierarchyTreeWidget> {
         const widget = await super.openView(args);
         const { selection, languageId } = this.editorAccess;
         widget.initializeModel(selection, languageId);
         return widget;
     }
 
-    registerCommands(commands: CommandRegistry): void {
+    override registerCommands(commands: CommandRegistry): void {
         commands.registerCommand(CallHierarchyCommands.OPEN, {
             execute: () => this.openView({
                 toggle: false,
@@ -86,7 +86,7 @@ export class CallHierarchyContribution extends AbstractViewContribution<CallHier
         super.registerCommands(commands);
     }
 
-    registerMenus(menus: MenuModelRegistry): void {
+    override registerMenus(menus: MenuModelRegistry): void {
         const menuPath = [...EDITOR_CONTEXT_MENU, 'navigation'];
         menus.registerMenuAction(menuPath, {
             commandId: CallHierarchyCommands.OPEN.id,
@@ -95,7 +95,7 @@ export class CallHierarchyContribution extends AbstractViewContribution<CallHier
         super.registerMenus(menus);
     }
 
-    registerKeybindings(keybindings: KeybindingRegistry): void {
+    override registerKeybindings(keybindings: KeybindingRegistry): void {
         super.registerKeybindings(keybindings);
         keybindings.registerKeybinding({
             command: CallHierarchyCommands.OPEN.id,

--- a/packages/callhierarchy/src/browser/callhierarchy-tree/callhierarchy-tree-model.ts
+++ b/packages/callhierarchy/src/browser/callhierarchy-tree/callhierarchy-tree-model.ts
@@ -27,7 +27,7 @@ export class CallHierarchyTreeModel extends TreeModelImpl {
 
     private _languageId: string | undefined;
 
-    @inject(CallHierarchyTree) protected readonly tree: CallHierarchyTree;
+    @inject(CallHierarchyTree) protected override readonly tree: CallHierarchyTree;
     @inject(CallHierarchyServiceProvider) protected readonly callHierarchyServiceProvider: CallHierarchyServiceProvider;
 
     getTree(): CallHierarchyTree {
@@ -63,7 +63,7 @@ export class CallHierarchyTreeModel extends TreeModelImpl {
         }
     }
 
-    protected doOpenNode(node: TreeNode): void {
+    protected override doOpenNode(node: TreeNode): void {
         // do nothing (in particular do not expand the node)
     }
 }

--- a/packages/callhierarchy/src/browser/callhierarchy-tree/callhierarchy-tree-widget.tsx
+++ b/packages/callhierarchy/src/browser/callhierarchy-tree/callhierarchy-tree-widget.tsx
@@ -36,10 +36,10 @@ export const DEFINITION_ICON_CLASS = 'theia-CallHierarchyTreeNodeIcon';
 export class CallHierarchyTreeWidget extends TreeWidget {
 
     constructor(
-        @inject(TreeProps) readonly props: TreeProps,
-        @inject(CallHierarchyTreeModel) readonly model: CallHierarchyTreeModel,
+        @inject(TreeProps) override readonly props: TreeProps,
+        @inject(CallHierarchyTreeModel) override readonly model: CallHierarchyTreeModel,
         @inject(ContextMenuRenderer) contextMenuRenderer: ContextMenuRenderer,
-        @inject(LabelProvider) protected readonly labelProvider: LabelProvider,
+        @inject(LabelProvider) protected override readonly labelProvider: LabelProvider,
         @inject(EditorManager) readonly editorManager: EditorManager
     ) {
         super(props, model, contextMenuRenderer);
@@ -68,7 +68,7 @@ export class CallHierarchyTreeWidget extends TreeWidget {
         this.model.initializeCallHierarchy(languageId, selection ? selection.uri : undefined, selection ? selection.range.start : undefined);
     }
 
-    protected createNodeClassNames(node: TreeNode, props: NodeProps): string[] {
+    protected override createNodeClassNames(node: TreeNode, props: NodeProps): string[] {
         const classNames = super.createNodeClassNames(node, props);
         if (DefinitionNode.is(node)) {
             classNames.push(DEFINITION_NODE_CLASS);
@@ -76,19 +76,19 @@ export class CallHierarchyTreeWidget extends TreeWidget {
         return classNames;
     }
 
-    protected createNodeAttributes(node: TreeNode, props: NodeProps): React.Attributes & React.HTMLAttributes<HTMLElement> {
+    protected override createNodeAttributes(node: TreeNode, props: NodeProps): React.Attributes & React.HTMLAttributes<HTMLElement> {
         const elementAttrs = super.createNodeAttributes(node, props);
         return {
             ...elementAttrs,
         };
     }
 
-    protected renderTree(model: TreeModel): React.ReactNode {
+    protected override renderTree(model: TreeModel): React.ReactNode {
         return super.renderTree(model)
             || <div className='theia-widget-noInfo'>No callers have been detected.</div>;
     }
 
-    protected renderCaption(node: TreeNode, props: NodeProps): React.ReactNode {
+    protected override renderCaption(node: TreeNode, props: NodeProps): React.ReactNode {
         if (DefinitionNode.is(node)) {
             return this.decorateDefinitionCaption(node.definition);
         }
@@ -200,7 +200,7 @@ export class CallHierarchyTreeWidget extends TreeWidget {
         });
     }
 
-    storeState(): object {
+    override storeState(): object {
         const callHierarchyService = this.model.getTree().callHierarchyService;
         if (this.model.root && callHierarchyService) {
             return {
@@ -212,7 +212,7 @@ export class CallHierarchyTreeWidget extends TreeWidget {
         }
     }
 
-    restoreState(oldState: object): void {
+    override restoreState(oldState: object): void {
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         if ((oldState as any).root && (oldState as any).languageId) {
             // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/packages/callhierarchy/src/browser/callhierarchy-tree/callhierarchy-tree.ts
+++ b/packages/callhierarchy/src/browser/callhierarchy-tree/callhierarchy-tree.ts
@@ -36,7 +36,7 @@ export class CallHierarchyTree extends TreeImpl {
         return this._callHierarchyService;
     }
 
-    async resolveChildren(parent: CompositeTreeNode): Promise<TreeNode[]> {
+    override async resolveChildren(parent: CompositeTreeNode): Promise<TreeNode[]> {
         if (!this.callHierarchyService) {
             return Promise.resolve([]);
         }

--- a/packages/console/src/browser/console-content-widget.tsx
+++ b/packages/console/src/browser/console-content-widget.tsx
@@ -38,7 +38,7 @@ export class ConsoleContentWidget extends SourceTreeWidget {
         return this._shouldScrollToEnd;
     }
 
-    static createContainer(parent: interfaces.Container, props?: Partial<TreeProps>): Container {
+    static override createContainer(parent: interfaces.Container, props?: Partial<TreeProps>): Container {
         const child = SourceTreeWidget.createContainer(parent, {
             contextMenuPath: ConsoleContentWidget.CONTEXT_MENU,
             ...props
@@ -48,7 +48,7 @@ export class ConsoleContentWidget extends SourceTreeWidget {
         return child;
     }
 
-    protected onAfterAttach(msg: Message): void {
+    protected override onAfterAttach(msg: Message): void {
         super.onAfterAttach(msg);
         this.toDisposeOnDetach.push(this.onScrollUp(() => this.shouldScrollToEnd = false));
         this.toDisposeOnDetach.push(this.onScrollYReachEnd(() => this.shouldScrollToEnd = true));
@@ -62,7 +62,7 @@ export class ConsoleContentWidget extends SourceTreeWidget {
         }
     }
 
-    protected createTreeElementNodeClassNames(node: TreeElementNode): string[] {
+    protected override createTreeElementNodeClassNames(node: TreeElementNode): string[] {
         const classNames = super.createTreeElementNodeClassNames(node);
         if (node.element) {
             const className = this.toClassName((node.element as ConsoleItem));

--- a/packages/console/src/browser/console-keybinding-contexts.ts
+++ b/packages/console/src/browser/console-keybinding-contexts.ts
@@ -65,9 +65,9 @@ export class ConsoleInputFocusContext implements KeybindingContext {
 @injectable()
 export class ConsoleContentFocusContext extends ConsoleInputFocusContext {
 
-    readonly id: string = ConsoleKeybindingContexts.consoleContentFocus;
+    override readonly id: string = ConsoleKeybindingContexts.consoleContentFocus;
 
-    protected isConsoleEnabled(console: ConsoleWidget): boolean {
+    protected override isConsoleEnabled(console: ConsoleWidget): boolean {
         return !console.input.isFocused();
     }
 
@@ -76,9 +76,9 @@ export class ConsoleContentFocusContext extends ConsoleInputFocusContext {
 @injectable()
 export class ConsoleNavigationBackEnabled extends ConsoleInputFocusContext {
 
-    readonly id: string = ConsoleKeybindingContexts.consoleNavigationBackEnabled;
+    override readonly id: string = ConsoleKeybindingContexts.consoleNavigationBackEnabled;
 
-    protected isConsoleEnabled(console: ConsoleWidget): boolean {
+    protected override isConsoleEnabled(console: ConsoleWidget): boolean {
         if (!super.isConsoleEnabled(console)) {
             return false;
         }
@@ -91,9 +91,9 @@ export class ConsoleNavigationBackEnabled extends ConsoleInputFocusContext {
 @injectable()
 export class ConsoleNavigationForwardEnabled extends ConsoleInputFocusContext {
 
-    readonly id: string = ConsoleKeybindingContexts.consoleNavigationForwardEnabled;
+    override readonly id: string = ConsoleKeybindingContexts.consoleNavigationForwardEnabled;
 
-    protected isConsoleEnabled(console: ConsoleWidget): boolean {
+    protected override isConsoleEnabled(console: ConsoleWidget): boolean {
         if (!super.isConsoleEnabled(console)) {
             return false;
         }

--- a/packages/console/src/browser/console-session.ts
+++ b/packages/console/src/browser/console-session.ts
@@ -39,7 +39,7 @@ export abstract class ConsoleSession extends TreeSource {
     protected selectedSeverity?: Severity;
     protected readonly selectionEmitter: Emitter<void> = new Emitter<void>();
     readonly onSelectionChange = this.selectionEmitter.event;
-    id: string;
+    override id: string;
 
     get severity(): Severity | undefined {
         return this.selectedSeverity;
@@ -55,7 +55,7 @@ export abstract class ConsoleSession extends TreeSource {
         this.fireDidChange();
     }
 
-    abstract getElements(): MaybePromise<IterableIterator<ConsoleItem>>;
+    abstract override getElements(): MaybePromise<IterableIterator<ConsoleItem>>;
     abstract execute(value: string): MaybePromise<void>;
     abstract clear(): MaybePromise<void>;
 }

--- a/packages/console/src/browser/console-widget.ts
+++ b/packages/console/src/browser/console-widget.ts
@@ -216,14 +216,14 @@ export class ConsoleWidget extends BaseWidget implements StatefulWidget {
         }
     }
 
-    protected onActivateRequest(msg: Message): void {
+    protected override onActivateRequest(msg: Message): void {
         super.onActivateRequest(msg);
         this._input.focus();
     }
 
     protected totalHeight = -1;
     protected totalWidth = -1;
-    protected onResize(msg: Widget.ResizeMessage): void {
+    protected override onResize(msg: Widget.ResizeMessage): void {
         super.onResize(msg);
         this.totalWidth = msg.width;
         this.totalHeight = msg.height;

--- a/packages/core/src/browser/about-dialog.tsx
+++ b/packages/core/src/browser/about-dialog.tsx
@@ -39,7 +39,7 @@ export class AboutDialog extends ReactDialog<void> {
     protected readonly appServer: ApplicationServer;
 
     constructor(
-        @inject(AboutDialogProps) protected readonly props: AboutDialogProps
+        @inject(AboutDialogProps) protected override readonly props: AboutDialogProps
     ) {
         super({
             title: FrontendApplicationConfigProvider.get().applicationName,
@@ -81,7 +81,7 @@ export class AboutDialog extends ReactDialog<void> {
         </div>;
     }
 
-    protected onAfterAttach(msg: Message): void {
+    protected override onAfterAttach(msg: Message): void {
         super.onAfterAttach(msg);
         this.update();
     }

--- a/packages/core/src/browser/breadcrumbs/breadcrumbs-renderer.tsx
+++ b/packages/core/src/browser/breadcrumbs/breadcrumbs-renderer.tsx
@@ -84,7 +84,7 @@ export class BreadcrumbsRenderer extends ReactRenderer {
         this.toDispose.push(this.labelProvider.onDidChange(() => this.refresh(this.uri)));
     }
 
-    dispose(): void {
+    override dispose(): void {
         super.dispose();
         this.toDispose.dispose();
         if (this.popup) { this.popup.dispose(); }
@@ -149,7 +149,7 @@ export class BreadcrumbsRenderer extends ReactRenderer {
         }
     }
 
-    protected doRender(): React.ReactNode {
+    protected override doRender(): React.ReactNode {
         return <ul className={Styles.BREADCRUMBS}>{this.renderBreadcrumbs()}</ul>;
     }
 

--- a/packages/core/src/browser/connection-status-service.ts
+++ b/packages/core/src/browser/connection-status-service.ts
@@ -83,7 +83,7 @@ export abstract class AbstractConnectionStatusService implements ConnectionStatu
     protected connectionStatus: ConnectionStatus = ConnectionStatus.ONLINE;
 
     @inject(ILogger)
-    protected readonly logger: ILogger;
+    protected logger: ILogger;
 
     constructor(@inject(ConnectionStatusOptions) @optional() protected readonly options: ConnectionStatusOptions = ConnectionStatusOptions.DEFAULT) { }
 
@@ -121,10 +121,6 @@ export class FrontendConnectionStatusService extends AbstractConnectionStatusSer
 
     @inject(WebSocketConnectionProvider) protected readonly wsConnectionProvider: WebSocketConnectionProvider;
     @inject(PingService) protected readonly pingService: PingService;
-
-    constructor(@inject(ConnectionStatusOptions) @optional() protected readonly options: ConnectionStatusOptions = ConnectionStatusOptions.DEFAULT) {
-        super(options);
-    }
 
     @postConstruct()
     protected init(): void {

--- a/packages/core/src/browser/dialogs.ts
+++ b/packages/core/src/browser/dialogs.ts
@@ -219,7 +219,7 @@ export abstract class AbstractDialog<T> extends BaseWidget {
         return button;
     }
 
-    protected onAfterAttach(msg: Message): void {
+    protected override onAfterAttach(msg: Message): void {
         super.onAfterAttach(msg);
         if (this.closeButton) {
             this.addCloseAction(this.closeButton, 'click');
@@ -243,7 +243,7 @@ export abstract class AbstractDialog<T> extends BaseWidget {
         this.accept();
     }
 
-    protected onActivateRequest(msg: Message): void {
+    protected override onActivateRequest(msg: Message): void {
         super.onActivateRequest(msg);
         if (this.acceptButton) {
             this.acceptButton.focus();
@@ -268,7 +268,7 @@ export abstract class AbstractDialog<T> extends BaseWidget {
         });
     }
 
-    close(): void {
+    override close(): void {
         if (this.resolve) {
             if (this.activeElement) {
                 this.activeElement.focus({ preventScroll: true });
@@ -278,7 +278,7 @@ export abstract class AbstractDialog<T> extends BaseWidget {
         this.activeElement = undefined;
         super.close();
     }
-    protected onUpdateRequest(msg: Message): void {
+    protected override onUpdateRequest(msg: Message): void {
         super.onUpdateRequest(msg);
         this.validate();
     }
@@ -362,7 +362,8 @@ export class ConfirmDialog extends AbstractDialog<boolean> {
     protected confirmed = true;
 
     constructor(
-        @inject(ConfirmDialogProps) protected readonly props: ConfirmDialogProps
+        @inject(ConfirmDialogProps)
+        protected override readonly props: ConfirmDialogProps
     ) {
         super(props);
 
@@ -371,7 +372,7 @@ export class ConfirmDialog extends AbstractDialog<boolean> {
         this.appendAcceptButton(props.ok);
     }
 
-    protected onCloseRequest(msg: Message): void {
+    protected override onCloseRequest(msg: Message): void {
         super.onCloseRequest(msg);
         this.confirmed = false;
         this.accept();
@@ -418,7 +419,8 @@ export class SingleTextInputDialog extends AbstractDialog<string> {
     protected readonly inputField: HTMLInputElement;
 
     constructor(
-        @inject(SingleTextInputDialogProps) protected readonly props: SingleTextInputDialogProps
+        @inject(SingleTextInputDialogProps)
+        protected override props: SingleTextInputDialogProps
     ) {
         super(props);
 
@@ -446,23 +448,23 @@ export class SingleTextInputDialog extends AbstractDialog<string> {
         return this.inputField.value;
     }
 
-    protected isValid(value: string, mode: DialogMode): MaybePromise<DialogError> {
+    protected override isValid(value: string, mode: DialogMode): MaybePromise<DialogError> {
         if (this.props.validate) {
             return this.props.validate(value, mode);
         }
         return super.isValid(value, mode);
     }
 
-    protected onAfterAttach(msg: Message): void {
+    protected override onAfterAttach(msg: Message): void {
         super.onAfterAttach(msg);
         this.addUpdateListener(this.inputField, 'input');
     }
 
-    protected onActivateRequest(msg: Message): void {
+    protected override onActivateRequest(msg: Message): void {
         this.inputField.focus();
     }
 
-    protected handleEnter(event: KeyboardEvent): boolean | void {
+    protected override handleEnter(event: KeyboardEvent): boolean | void {
         if (event.target instanceof HTMLInputElement) {
             return super.handleEnter(event);
         }

--- a/packages/core/src/browser/dialogs.ts
+++ b/packages/core/src/browser/dialogs.ts
@@ -362,8 +362,7 @@ export class ConfirmDialog extends AbstractDialog<boolean> {
     protected confirmed = true;
 
     constructor(
-        @inject(ConfirmDialogProps)
-        protected override readonly props: ConfirmDialogProps
+        @inject(ConfirmDialogProps) protected override readonly props: ConfirmDialogProps
     ) {
         super(props);
 
@@ -419,8 +418,7 @@ export class SingleTextInputDialog extends AbstractDialog<string> {
     protected readonly inputField: HTMLInputElement;
 
     constructor(
-        @inject(SingleTextInputDialogProps)
-        protected override props: SingleTextInputDialogProps
+        @inject(SingleTextInputDialogProps) protected override props: SingleTextInputDialogProps
     ) {
         super(props);
 

--- a/packages/core/src/browser/dialogs/react-dialog.tsx
+++ b/packages/core/src/browser/dialogs/react-dialog.tsx
@@ -26,7 +26,7 @@ export abstract class ReactDialog<T> extends AbstractDialog<T> {
     protected readonly onRender = new DisposableCollection();
 
     constructor(
-        @inject(DialogProps) protected readonly props: DialogProps
+        @inject(DialogProps) protected override readonly props: DialogProps
     ) {
         super(props);
         this.toDispose.push(Disposable.create(() => {
@@ -34,7 +34,7 @@ export abstract class ReactDialog<T> extends AbstractDialog<T> {
         }));
     }
 
-    protected onUpdateRequest(msg: Message): void {
+    protected override onUpdateRequest(msg: Message): void {
         super.onUpdateRequest(msg);
         ReactDOM.render(<>{this.render()}</>, this.contentNode, () => this.onRender.dispose());
     }

--- a/packages/core/src/browser/dialogs/react-dialog.tsx
+++ b/packages/core/src/browser/dialogs/react-dialog.tsx
@@ -26,7 +26,7 @@ export abstract class ReactDialog<T> extends AbstractDialog<T> {
     protected readonly onRender = new DisposableCollection();
 
     constructor(
-        @inject(DialogProps) protected override readonly props: DialogProps
+        @inject(DialogProps) props: DialogProps
     ) {
         super(props);
         this.toDispose.push(Disposable.create(() => {

--- a/packages/core/src/browser/menu/browser-menu-plugin.ts
+++ b/packages/core/src/browser/menu/browser-menu-plugin.ts
@@ -267,7 +267,7 @@ export class DynamicMenuWidget extends MenuWidget {
         });
     }
 
-    public open(x: number, y: number, options?: MenuWidget.IOpenOptions): void {
+    public override open(x: number, y: number, options?: MenuWidget.IOpenOptions): void {
         const cb = () => {
             this.restoreFocusedElement();
             this.aboutToClose.disconnect(cb);

--- a/packages/core/src/browser/messaging/ws-connection-provider.ts
+++ b/packages/core/src/browser/messaging/ws-connection-provider.ts
@@ -44,7 +44,7 @@ export class WebSocketConnectionProvider extends AbstractConnectionProvider<WebS
         return this.onSocketDidCloseEmitter.event;
     }
 
-    static createProxy<T extends object>(container: interfaces.Container, path: string, arg?: object): JsonRpcProxy<T> {
+    static override createProxy<T extends object>(container: interfaces.Container, path: string, arg?: object): JsonRpcProxy<T> {
         return container.get(WebSocketConnectionProvider).createProxy<T>(path, arg);
     }
 
@@ -70,7 +70,7 @@ export class WebSocketConnectionProvider extends AbstractConnectionProvider<WebS
         this.socket = socket;
     }
 
-    openChannel(path: string, handler: (channel: WebSocketChannel) => void, options?: WebSocketOptions): void {
+    override openChannel(path: string, handler: (channel: WebSocketChannel) => void, options?: WebSocketOptions): void {
         if (this.socket.connected) {
             super.openChannel(path, handler, options);
         } else {

--- a/packages/core/src/browser/saveable.ts
+++ b/packages/core/src/browser/saveable.ts
@@ -300,7 +300,7 @@ export class ShouldSaveDialog extends AbstractDialog<boolean> {
         return button;
     }
 
-    protected onAfterAttach(msg: Message): void {
+    protected override onAfterAttach(msg: Message): void {
         super.onAfterAttach(msg);
         this.addKeyListener(this.dontSaveButton, Key.ENTER, () => {
             this.shouldSave = false;

--- a/packages/core/src/browser/shell/application-shell.ts
+++ b/packages/core/src/browser/shell/application-shell.ts
@@ -307,14 +307,14 @@ export class ApplicationShell extends Widget {
         this.topPanel.setHidden(hiddenPreferences.includes(preference));
     }
 
-    protected onBeforeAttach(msg: Message): void {
+    protected override onBeforeAttach(msg: Message): void {
         document.addEventListener('p-dragenter', this, true);
         document.addEventListener('p-dragover', this, true);
         document.addEventListener('p-dragleave', this, true);
         document.addEventListener('p-drop', this, true);
     }
 
-    protected onAfterDetach(msg: Message): void {
+    protected override onAfterDetach(msg: Message): void {
         document.removeEventListener('p-dragenter', this, true);
         document.removeEventListener('p-dragover', this, true);
         document.removeEventListener('p-dragleave', this, true);

--- a/packages/core/src/browser/shell/side-panel-toolbar.ts
+++ b/packages/core/src/browser/shell/side-panel-toolbar.ts
@@ -40,14 +40,14 @@ export class SidePanelToolbar extends BaseWidget {
         this.tabBarToolbarRegistry.onDidChange(() => this.update());
     }
 
-    protected onBeforeAttach(msg: Message): void {
+    protected override onBeforeAttach(msg: Message): void {
         super.onBeforeAttach(msg);
         if (this.titleContainer) {
             this.addEventListener(this.titleContainer, 'contextmenu', e => this.onContextMenuEmitter.fire(e));
         }
     }
 
-    protected onAfterAttach(msg: Message): void {
+    protected override onAfterAttach(msg: Message): void {
         if (this.toolbar) {
             if (this.toolbar.isAttached) {
                 Widget.detach(this.toolbar);
@@ -57,7 +57,7 @@ export class SidePanelToolbar extends BaseWidget {
         super.onAfterAttach(msg);
     }
 
-    protected onBeforeDetach(msg: Message): void {
+    protected override onBeforeDetach(msg: Message): void {
         if (this.titleContainer) {
             this.node.removeChild(this.titleContainer);
         }
@@ -67,7 +67,7 @@ export class SidePanelToolbar extends BaseWidget {
         super.onBeforeDetach(msg);
     }
 
-    protected onUpdateRequest(msg: Message): void {
+    protected override onUpdateRequest(msg: Message): void {
         super.onUpdateRequest(msg);
         this.updateToolbar();
     }

--- a/packages/core/src/browser/shell/sidebar-bottom-menu-widget.tsx
+++ b/packages/core/src/browser/shell/sidebar-bottom-menu-widget.tsx
@@ -24,7 +24,7 @@ import { injectable } from 'inversify';
 @injectable()
 export class SidebarBottomMenuWidget extends SidebarMenuWidget {
 
-    protected onClick(e: React.MouseEvent<HTMLElement, MouseEvent>, menuPath: MenuPath): void {
+    protected override onClick(e: React.MouseEvent<HTMLElement, MouseEvent>, menuPath: MenuPath): void {
         const button = e.currentTarget.getBoundingClientRect();
         this.contextMenuRenderer.render({
             menuPath,

--- a/packages/core/src/browser/shell/tab-bars.ts
+++ b/packages/core/src/browser/shell/tab-bars.ts
@@ -139,7 +139,7 @@ export class TabBarRenderer extends TabBar.Renderer {
      * @param {boolean} isInSidePanel An optional check which determines if the tab is in the side-panel.
      * @returns {VirtualElement} The virtual element of the rendered tab.
      */
-    renderTab(data: SideBarRenderData, isInSidePanel?: boolean): VirtualElement {
+    override renderTab(data: SideBarRenderData, isInSidePanel?: boolean): VirtualElement {
         const title = data.title;
         const id = this.createTabId(data.title);
         const key = this.createTabKey(data);
@@ -174,7 +174,7 @@ export class TabBarRenderer extends TabBar.Renderer {
      * If size information is available for the label and icon, set an explicit height on the tab.
      * The height value also considers padding, which should be derived from CSS settings.
      */
-    createTabStyle(data: SideBarRenderData): ElementInlineStyle {
+    override createTabStyle(data: SideBarRenderData): ElementInlineStyle {
         const zIndex = `${data.zIndex}`;
         const labelSize = data.labelSize;
         const iconSize = data.iconSize;
@@ -200,7 +200,7 @@ export class TabBarRenderer extends TabBar.Renderer {
      * @param {boolean} isInSidePanel An optional check which determines if the tab is in the side-panel.
      * @returns {VirtualElement} The virtual element of the rendered label.
      */
-    renderLabel(data: SideBarRenderData, isInSidePanel?: boolean): VirtualElement {
+    override renderLabel(data: SideBarRenderData, isInSidePanel?: boolean): VirtualElement {
         const labelSize = data.labelSize;
         const iconSize = data.iconSize;
         let width: string | undefined;
@@ -389,7 +389,7 @@ export class TabBarRenderer extends TabBar.Renderer {
      * @param {SideBarRenderData} data Data used to render the tab icon.
      * @param {boolean} isInSidePanel An optional check which determines if the tab is in the side-panel.
      */
-    renderIcon(data: SideBarRenderData, isInSidePanel?: boolean): VirtualElement {
+    override renderIcon(data: SideBarRenderData, isInSidePanel?: boolean): VirtualElement {
         if (!isInSidePanel && this.iconThemeService && this.iconThemeService.current === 'none') {
             return h.div();
         }
@@ -497,7 +497,7 @@ export class ScrollableTabBar extends TabBar<Widget> {
         this.scrollBarFactory = () => new PerfectScrollbar(this.scrollbarHost, options);
     }
 
-    dispose(): void {
+    override dispose(): void {
         if (this.isDisposed) {
             return;
         }
@@ -505,14 +505,14 @@ export class ScrollableTabBar extends TabBar<Widget> {
         this.toDispose.dispose();
     }
 
-    protected onAfterAttach(msg: Message): void {
+    protected override onAfterAttach(msg: Message): void {
         if (!this.scrollBar) {
             this.scrollBar = this.scrollBarFactory();
         }
         super.onAfterAttach(msg);
     }
 
-    protected onBeforeDetach(msg: Message): void {
+    protected override onBeforeDetach(msg: Message): void {
         super.onBeforeDetach(msg);
         if (this.scrollBar) {
             this.scrollBar.destroy();
@@ -520,14 +520,14 @@ export class ScrollableTabBar extends TabBar<Widget> {
         }
     }
 
-    protected onUpdateRequest(msg: Message): void {
+    protected override onUpdateRequest(msg: Message): void {
         super.onUpdateRequest(msg);
         if (this.scrollBar) {
             this.scrollBar.update();
         }
     }
 
-    protected onResize(msg: Widget.ResizeMessage): void {
+    protected override onResize(msg: Widget.ResizeMessage): void {
         super.onResize(msg);
         if (this.scrollBar) {
             if (this.currentIndex >= 0) {
@@ -648,7 +648,7 @@ export class ToolbarAwareTabBar extends ScrollableTabBar {
     /**
      * Overrides the scrollable host from the parent class.
      */
-    protected get scrollbarHost(): HTMLElement {
+    protected override get scrollbarHost(): HTMLElement {
         return this.tabBarContainer;
     }
 
@@ -662,7 +662,7 @@ export class ToolbarAwareTabBar extends ScrollableTabBar {
         await this.breadcrumbsRenderer.refresh(uri);
     }
 
-    protected onAfterAttach(msg: Message): void {
+    protected override onAfterAttach(msg: Message): void {
         if (this.toolbar) {
             if (this.toolbar.isAttached) {
                 Widget.detach(this.toolbar);
@@ -676,14 +676,14 @@ export class ToolbarAwareTabBar extends ScrollableTabBar {
         super.onAfterAttach(msg);
     }
 
-    protected onBeforeDetach(msg: Message): void {
+    protected override onBeforeDetach(msg: Message): void {
         if (this.toolbar && this.toolbar.isAttached) {
             Widget.detach(this.toolbar);
         }
         super.onBeforeDetach(msg);
     }
 
-    protected onUpdateRequest(msg: Message): void {
+    protected override onUpdateRequest(msg: Message): void {
         super.onUpdateRequest(msg);
         this.updateToolbar();
     }
@@ -696,7 +696,7 @@ export class ToolbarAwareTabBar extends ScrollableTabBar {
         this.toolbar.updateTarget(widget);
     }
 
-    handleEvent(event: Event): void {
+    override handleEvent(event: Event): void {
         if (this.toolbar && event instanceof MouseEvent && this.toolbar.shouldHandleMouseEvent(event)) {
             // if the mouse event is over the toolbar part don't handle it.
             return;
@@ -789,13 +789,13 @@ export class SideTabBar extends ScrollableTabBar {
         return this.node.getElementsByClassName(HIDDEN_CONTENT_CLASS)[0] as HTMLUListElement;
     }
 
-    insertTab(index: number, value: Title<Widget> | Title.IOptions<Widget>): Title<Widget> {
+    override insertTab(index: number, value: Title<Widget> | Title.IOptions<Widget>): Title<Widget> {
         const result = super.insertTab(index, value);
         this.tabAdded.emit({ title: result });
         return result;
     }
 
-    protected onAfterAttach(msg: Message): void {
+    protected override onAfterAttach(msg: Message): void {
         super.onAfterAttach(msg);
         this.renderTabBar();
         this.node.addEventListener('p-dragenter', this);
@@ -804,7 +804,7 @@ export class SideTabBar extends ScrollableTabBar {
         document.addEventListener('p-drop', this);
     }
 
-    protected onAfterDetach(msg: Message): void {
+    protected override onAfterDetach(msg: Message): void {
         super.onAfterDetach(msg);
         this.node.removeEventListener('p-dragenter', this);
         this.node.removeEventListener('p-dragover', this);
@@ -812,7 +812,7 @@ export class SideTabBar extends ScrollableTabBar {
         document.removeEventListener('p-drop', this);
     }
 
-    protected onUpdateRequest(msg: Message): void {
+    protected override onUpdateRequest(msg: Message): void {
         this.renderTabBar();
         if (this.scrollBar) {
             this.scrollBar.update();
@@ -893,7 +893,7 @@ export class SideTabBar extends ScrollableTabBar {
      * of the TabBar constructor cannot be used here because it is triggered when the
      * mouse goes down, and thus collides with dragging.
      */
-    handleEvent(event: Event): void {
+    override handleEvent(event: Event): void {
         switch (event.type) {
             case 'mousedown':
                 this.onMouseDown(event as MouseEvent);

--- a/packages/core/src/browser/shell/theia-dock-panel.ts
+++ b/packages/core/src/browser/shell/theia-dock-panel.ts
@@ -115,7 +115,7 @@ export class TheiaDockPanel extends DockPanel {
         }
     }
 
-    addWidget(widget: Widget, options?: DockPanel.IAddOptions): void {
+    override addWidget(widget: Widget, options?: DockPanel.IAddOptions): void {
         if (this.mode === 'single-document' && widget.parent === this) {
             return;
         }
@@ -123,12 +123,12 @@ export class TheiaDockPanel extends DockPanel {
         this.widgetAdded.emit(widget);
     }
 
-    activateWidget(widget: Widget): void {
+    override activateWidget(widget: Widget): void {
         super.activateWidget(widget);
         this.widgetActivated.emit(widget);
     }
 
-    protected onChildRemoved(msg: Widget.ChildMessage): void {
+    protected override onChildRemoved(msg: Widget.ChildMessage): void {
         super.onChildRemoved(msg);
         this.widgetRemoved.emit(msg.child);
     }

--- a/packages/core/src/browser/source-tree/source-tree-widget.tsx
+++ b/packages/core/src/browser/source-tree/source-tree-widget.tsx
@@ -35,7 +35,7 @@ export class SourceTreeWidget extends TreeWidget {
     }
 
     @postConstruct()
-    protected init(): void {
+    protected override init(): void {
         super.init();
         this.addClass('theia-source-tree');
         this.toDispose.push(this.model.onOpenNode(node => {
@@ -67,7 +67,7 @@ export class SourceTreeWidget extends TreeWidget {
         return TreeElementNode.is(node) && node.element || undefined;
     }
 
-    protected renderTree(model: TreeModel): React.ReactNode {
+    protected override renderTree(model: TreeModel): React.ReactNode {
         if (TreeSourceNode.is(model.root) && model.root.children.length === 0) {
             const { placeholder } = model.root.source;
             if (placeholder) {
@@ -78,7 +78,7 @@ export class SourceTreeWidget extends TreeWidget {
 
     }
 
-    protected renderCaption(node: TreeNode): React.ReactNode {
+    protected override renderCaption(node: TreeNode): React.ReactNode {
         if (TreeElementNode.is(node)) {
             const classNames = this.createTreeElementNodeClassNames(node);
             return <div className={classNames.join(' ')}>{node.element.render()}</div>;
@@ -89,14 +89,14 @@ export class SourceTreeWidget extends TreeWidget {
         return ['theia-tree-element-node'];
     }
 
-    storeState(): object {
+    override storeState(): object {
         // no-op
         return {};
     }
     protected superStoreState(): object {
         return super.storeState();
     }
-    restoreState(state: object): void {
+    override restoreState(state: object): void {
         // no-op
     }
     protected superRestoreState(state: object): void {

--- a/packages/core/src/browser/source-tree/source-tree.ts
+++ b/packages/core/src/browser/source-tree/source-tree.ts
@@ -24,7 +24,7 @@ import { TreeElement, CompositeTreeElement, TreeSource } from './tree-source';
 @injectable()
 export class SourceTree extends TreeImpl {
 
-    async resolveChildren(parent: TreeElementNodeParent): Promise<TreeNode[]> {
+    override async resolveChildren(parent: TreeElementNodeParent): Promise<TreeNode[]> {
         const elements = await this.resolveElements(parent);
         const nodes: TreeNode[] = [];
         let index = 0;

--- a/packages/core/src/browser/test/mock-connection-status-service.ts
+++ b/packages/core/src/browser/test/mock-connection-status-service.ts
@@ -16,19 +16,17 @@
 
 import { MockLogger } from '../../common/test/mock-logger';
 import { AbstractConnectionStatusService } from '../connection-status-service';
-import { ILogger } from '../../common/logger';
 
 export class MockConnectionStatusService extends AbstractConnectionStatusService {
-
-    protected readonly logger: ILogger = new MockLogger();
 
     constructor() {
         super({
             offlineTimeout: 10
         });
+        this.logger = new MockLogger();
     }
 
-    public set alive(alive: boolean) {
+    set alive(alive: boolean) {
         this.updateStatus(alive);
     }
 

--- a/packages/core/src/browser/tooltip-service.tsx
+++ b/packages/core/src/browser/tooltip-service.tsx
@@ -86,12 +86,12 @@ export class TooltipServiceImpl extends ReactRenderer implements TooltipService 
         ReactTooltip.rebuild();
     }
 
-    protected doRender(): React.ReactNode {
+    protected override doRender(): React.ReactNode {
         const hoverDelay = this.corePreferences.get(DELAY_PREFERENCE);
         return <ReactTooltip id={this.tooltipId} className='theia-tooltip' html={true} delayShow={hoverDelay} />;
     }
 
-    public dispose(): void {
+    public override dispose(): void {
         this.toDispose.dispose();
         super.dispose();
     }

--- a/packages/core/src/browser/tree/search-box.ts
+++ b/packages/core/src/browser/tree/search-box.ts
@@ -168,7 +168,7 @@ export class SearchBox extends BaseWidget {
         this.fireNext();
     }
 
-    onBeforeHide(): void {
+    override onBeforeHide(): void {
         this.removeClass(SearchBox.Styles.NO_MATCH);
         this.doFireFilterToggle(false);
         this.debounce.append(undefined);
@@ -304,7 +304,7 @@ export class SearchBox extends BaseWidget {
 
     }
 
-    protected onAfterAttach(msg: Message): void {
+    protected override onAfterAttach(msg: Message): void {
         super.onAfterAttach(msg);
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         this.addEventListener(this.input, 'selectstart' as any, () => false);

--- a/packages/core/src/browser/tree/tree-compression/compressed-tree-expansion-service.ts
+++ b/packages/core/src/browser/tree/tree-compression/compressed-tree-expansion-service.ts
@@ -23,7 +23,7 @@ export class CompressedExpansionService extends TreeExpansionServiceImpl {
     @inject(CompressionToggle) protected readonly compressionToggle: CompressionToggle;
     @inject(TreeCompressionService) protected readonly compressionService: TreeCompressionService;
 
-    async expandNode(raw: ExpandableTreeNode): Promise<ExpandableTreeNode | undefined> {
+    override async expandNode(raw: ExpandableTreeNode): Promise<ExpandableTreeNode | undefined> {
         if (!this.compressionToggle.compress) { return super.expandNode(raw); }
         const participants = this.compressionService.getCompressionChain(raw);
         let expansionRoot;
@@ -34,7 +34,7 @@ export class CompressedExpansionService extends TreeExpansionServiceImpl {
         return expansionRoot;
     }
 
-    async collapseNode(raw: ExpandableTreeNode): Promise<boolean> {
+    override async collapseNode(raw: ExpandableTreeNode): Promise<boolean> {
         if (!this.compressionToggle.compress) { return super.collapseNode(raw); }
         const participants = this.compressionService.getCompressionChain(raw);
         let didCollapse = false;

--- a/packages/core/src/browser/tree/tree-compression/compressed-tree-model.ts
+++ b/packages/core/src/browser/tree/tree-compression/compressed-tree-model.ts
@@ -23,7 +23,7 @@ import { ExpandableTreeNode } from '../tree-expansion';
 import { TopDownTreeIterator, TreeIterator } from '../tree-iterator';
 
 export class TopDownCompressedTreeIterator extends TopDownTreeIterator {
-    protected isCollapsed(candidate: TreeNode): boolean {
+    protected override isCollapsed(candidate: TreeNode): boolean {
         return ExpandableTreeNode.isCollapsed(candidate) && !TreeCompressionService.prototype.isCompressionParent(candidate);
     }
 }
@@ -68,11 +68,11 @@ export class CompressedTreeModel extends TreeModelImpl {
         this.selectAdjacentRow(BackOrForward.Forward, type);
     }
 
-    protected createForwardIteratorForNode(node: TreeNode): TreeIterator {
+    protected override createForwardIteratorForNode(node: TreeNode): TreeIterator {
         return new TopDownCompressedTreeIterator(node, { pruneCollapsed: true });
     }
 
-    protected selectIfAncestorOfSelected(node: Readonly<ExpandableTreeNode>): void {
+    protected override selectIfAncestorOfSelected(node: Readonly<ExpandableTreeNode>): void {
         if (!this.compressionToggle.compress) { return super.selectIfAncestorOfSelected(node); }
         const tail = this.compressionService.getCompressionChain(node)?.tail() ?? node;
         if (SelectableTreeNode.is(tail) && !tail.expanded && this.selectedNodes.some(selectedNode => CompositeTreeNode.isAncestor(tail, selectedNode))) {

--- a/packages/core/src/browser/tree/tree-compression/compressed-tree-widget.tsx
+++ b/packages/core/src/browser/tree/tree-compression/compressed-tree-widget.tsx
@@ -42,9 +42,9 @@ export class CompressedTreeWidget extends TreeViewWelcomeWidget {
     @inject(TreeCompressionService) protected readonly compressionService: TreeCompressionService;
 
     constructor(
-        @inject(TreeProps) override readonly props: TreeProps,
+        @inject(TreeProps) props: TreeProps,
         @inject(CompressedTreeModel) override readonly model: CompressedTreeModel,
-        @inject(ContextMenuRenderer) protected override readonly contextMenuRenderer: ContextMenuRenderer,
+        @inject(ContextMenuRenderer) contextMenuRenderer: ContextMenuRenderer,
     ) {
         super(props, model, contextMenuRenderer);
     }

--- a/packages/core/src/browser/tree/tree-compression/compressed-tree-widget.tsx
+++ b/packages/core/src/browser/tree/tree-compression/compressed-tree-widget.tsx
@@ -42,14 +42,14 @@ export class CompressedTreeWidget extends TreeViewWelcomeWidget {
     @inject(TreeCompressionService) protected readonly compressionService: TreeCompressionService;
 
     constructor(
-        @inject(TreeProps) readonly props: TreeProps,
-        @inject(CompressedTreeModel) readonly model: CompressedTreeModel,
-        @inject(ContextMenuRenderer) protected readonly contextMenuRenderer: ContextMenuRenderer,
+        @inject(TreeProps) override readonly props: TreeProps,
+        @inject(CompressedTreeModel) override readonly model: CompressedTreeModel,
+        @inject(ContextMenuRenderer) protected override readonly contextMenuRenderer: ContextMenuRenderer,
     ) {
         super(props, model, contextMenuRenderer);
     }
 
-    protected rows = new Map<string, CompressedNodeRow>();
+    protected override rows = new Map<string, CompressedNodeRow>();
 
     toggleCompression(newCompression = !this.compressionToggle.compress): void {
         if (newCompression !== this.compressionToggle.compress) {
@@ -58,21 +58,21 @@ export class CompressedTreeWidget extends TreeViewWelcomeWidget {
         }
     }
 
-    protected shouldDisplayNode(node: TreeNode): boolean {
+    protected override shouldDisplayNode(node: TreeNode): boolean {
         if (this.compressionToggle.compress && this.compressionService.isCompressionParticipant(node) && !this.compressionService.isCompressionHead(node)) {
             return false;
         }
         return super.shouldDisplayNode(node);
     }
 
-    protected getDepthForNode(node: TreeNode, depths: Map<CompositeTreeNode | undefined, number>): number {
+    protected override getDepthForNode(node: TreeNode, depths: Map<CompositeTreeNode | undefined, number>): number {
         if (!this.compressionToggle.compress) { return super.getDepthForNode(node, depths); }
         const parent = this.compressionService.getCompressionHead(node.parent) ?? node.parent;
         const parentDepth = depths.get(parent);
         return parentDepth === undefined ? 0 : TreeNode.isVisible(node.parent) ? parentDepth + 1 : parentDepth;
     }
 
-    protected toNodeRow(node: TreeNode, index: number, depth: number): CompressedNodeRow {
+    protected override toNodeRow(node: TreeNode, index: number, depth: number): CompressedNodeRow {
         if (!this.compressionToggle.compress) { return super.toNodeRow(node, index, depth); }
         const row: CompressedNodeRow = { node, index, depth };
         if (this.compressionService.isCompressionHead(node)) {
@@ -81,7 +81,7 @@ export class CompressedTreeWidget extends TreeViewWelcomeWidget {
         return row;
     }
 
-    protected doRenderNodeRow({ node, depth, compressionChain }: CompressedNodeRow): React.ReactNode {
+    protected override doRenderNodeRow({ node, depth, compressionChain }: CompressedNodeRow): React.ReactNode {
         const nodeProps: CompressedNodeProps = { depth, compressionChain };
         return <>
             {this.renderIndent(node, nodeProps)}
@@ -89,19 +89,19 @@ export class CompressedTreeWidget extends TreeViewWelcomeWidget {
         </>;
     }
 
-    protected rowIsSelected(node: TreeNode, props: CompressedNodeProps): boolean {
+    protected override rowIsSelected(node: TreeNode, props: CompressedNodeProps): boolean {
         if (this.compressionToggle.compress && props.compressionChain) {
             return props.compressionChain.some(participant => SelectableTreeNode.isSelected(participant));
         }
         return SelectableTreeNode.isSelected(node);
     }
 
-    protected getCaptionAttributes(node: TreeNode, props: CompressedNodeProps): React.Attributes & React.HTMLAttributes<HTMLElement> {
+    protected override getCaptionAttributes(node: TreeNode, props: CompressedNodeProps): React.Attributes & React.HTMLAttributes<HTMLElement> {
         const operativeNode = props.compressionChain?.tail() ?? node;
         return super.getCaptionAttributes(operativeNode, props);
     }
 
-    protected getCaptionChildren(node: TreeNode, props: CompressedNodeProps): React.ReactNode {
+    protected override getCaptionChildren(node: TreeNode, props: CompressedNodeProps): React.ReactNode {
         if (!this.compressionToggle.compress || !props.compressionChain) { return super.getCaptionChildren(node, props); }
         return props.compressionChain.map((subNode, index, self) => {
             const classes = ['theia-tree-compressed-label-part'];
@@ -128,19 +128,19 @@ export class CompressedTreeWidget extends TreeViewWelcomeWidget {
         };
     }
 
-    protected handleUp(event: KeyboardEvent): void {
+    protected override handleUp(event: KeyboardEvent): void {
         if (!this.compressionToggle.compress) { return super.handleUp(event); }
         const type = this.props.multiSelect && this.hasShiftMask(event) ? TreeSelection.SelectionType.RANGE : undefined;
         this.model.selectPrevRow(type);
     }
 
-    protected handleDown(event: KeyboardEvent): void {
+    protected override handleDown(event: KeyboardEvent): void {
         if (!this.compressionToggle.compress) { return super.handleDown(event); }
         const type = this.props.multiSelect && this.hasShiftMask(event) ? TreeSelection.SelectionType.RANGE : undefined;
         this.model.selectNextRow(type);
     }
 
-    protected async handleLeft(event: KeyboardEvent): Promise<void> {
+    protected override async handleLeft(event: KeyboardEvent): Promise<void> {
         if (!this.compressionToggle.compress) { return super.handleLeft(event); }
         if (Boolean(this.props.multiSelect) && (this.hasCtrlCmdMask(event) || this.hasShiftMask(event))) {
             return;
@@ -157,7 +157,7 @@ export class CompressedTreeWidget extends TreeViewWelcomeWidget {
         }
     }
 
-    protected async handleRight(event: KeyboardEvent): Promise<void> {
+    protected override async handleRight(event: KeyboardEvent): Promise<void> {
         if (!this.compressionToggle.compress) { return super.handleRight(event); }
         if (Boolean(this.props.multiSelect) && (this.hasCtrlCmdMask(event) || this.hasShiftMask(event))) {
             return;

--- a/packages/core/src/browser/tree/tree-consistency.spec.ts
+++ b/packages/core/src/browser/tree/tree-consistency.spec.ts
@@ -27,7 +27,7 @@ class ConsistencyTestTree extends TreeImpl {
 
     public resolveCounter = 0;
 
-    protected async resolveChildren(parent: CompositeTreeNode): Promise<TreeNode[]> {
+    protected override async resolveChildren(parent: CompositeTreeNode): Promise<TreeNode[]> {
         if (parent.id === 'expandable') {
             const step: () => Promise<TreeNode[]> = async () => {
                 // a predicate to emulate bad timing, i.e.

--- a/packages/core/src/browser/tree/tree-expansion.spec.ts
+++ b/packages/core/src/browser/tree/tree-expansion.spec.ts
@@ -132,7 +132,7 @@ describe('TreeExpansionService', () => {
         const container = createTreeTestContainer();
         container.rebind(Tree).to(class extends TreeImpl {
 
-            protected async resolveChildren(parent: CompositeTreeNode): Promise<TreeNode[]> {
+            protected override async resolveChildren(parent: CompositeTreeNode): Promise<TreeNode[]> {
                 await timeout(200);
                 return [{
                     id: 'child',

--- a/packages/core/src/browser/tree/tree-view-welcome-widget.tsx
+++ b/packages/core/src/browser/tree/tree-view-welcome-widget.tsx
@@ -71,7 +71,7 @@ export class TreeViewWelcomeWidget extends TreeWidget {
         return visibleItems.map(v => v.welcomeInfo);
     }
 
-    protected renderTree(model: TreeModel): React.ReactNode {
+    protected override renderTree(model: TreeModel): React.ReactNode {
         if (this.shouldShowWelcomeView() && this.visibleItems.length) {
             return this.renderViewWelcome();
         }

--- a/packages/core/src/browser/tree/tree-widget.tsx
+++ b/packages/core/src/browser/tree/tree-widget.tsx
@@ -383,7 +383,7 @@ export class TreeWidget extends ReactWidget implements StatefulWidget {
         this.update();
     }
 
-    protected onActivateRequest(msg: Message): void {
+    protected override onActivateRequest(msg: Message): void {
         super.onActivateRequest(msg);
         this.node.focus({ preventScroll: true });
     }
@@ -418,14 +418,14 @@ export class TreeWidget extends ReactWidget implements StatefulWidget {
         return this.model.getNextSelectableNode(root);
     }
 
-    protected onUpdateRequest(msg: Message): void {
+    protected override onUpdateRequest(msg: Message): void {
         if (!this.isAttached || !this.isVisible) {
             return;
         }
         super.onUpdateRequest(msg);
     }
 
-    protected onResize(msg: Widget.ResizeMessage): void {
+    protected override onResize(msg: Widget.ResizeMessage): void {
         super.onResize(msg);
         this.forceUpdate({ resize: true });
     }
@@ -1058,7 +1058,7 @@ export class TreeWidget extends ReactWidget implements StatefulWidget {
     /**
      * Get the scroll container.
      */
-    protected getScrollContainer(): MaybePromise<HTMLElement> {
+    protected override getScrollContainer(): MaybePromise<HTMLElement> {
         this.toDisposeOnDetach.push(Disposable.create(() => {
             const { scrollTop, scrollLeft } = this.node;
             this.lastScrollState = { scrollTop, scrollLeft };
@@ -1071,7 +1071,7 @@ export class TreeWidget extends ReactWidget implements StatefulWidget {
         return this.node;
     }
 
-    protected onAfterAttach(msg: Message): void {
+    protected override onAfterAttach(msg: Message): void {
         const up = [
             Key.ARROW_UP,
             KeyCode.createKeyCode({ first: Key.ARROW_UP, modifiers: [KeyModifier.Shift] })
@@ -1442,7 +1442,7 @@ export namespace TreeWidget {
         readonly cache = new CellMeasurerCache({
             fixedWidth: true
         });
-        render(): React.ReactNode {
+        override render(): React.ReactNode {
             const { rows, width, height, scrollToRow, handleScroll } = this.props;
             return <List
                 ref={list => this.list = (list || undefined)}

--- a/packages/core/src/browser/view-container.ts
+++ b/packages/core/src/browser/view-container.ts
@@ -648,7 +648,7 @@ export class ViewContainer extends BaseWidget implements StatefulWidget, Applica
         return part;
     }
 
-    protected onActivateRequest(msg: Message): void {
+    protected override onActivateRequest(msg: Message): void {
         super.onActivateRequest(msg);
         if (this.currentPart) {
             this.currentPart.activate();
@@ -657,7 +657,7 @@ export class ViewContainer extends BaseWidget implements StatefulWidget, Applica
         }
     }
 
-    protected onAfterAttach(msg: Message): void {
+    protected override onAfterAttach(msg: Message): void {
         const orientation = this.orientation;
         this.containerLayout.orientation = orientation;
         if (orientation === 'horizontal') {
@@ -668,18 +668,18 @@ export class ViewContainer extends BaseWidget implements StatefulWidget, Applica
         super.onAfterAttach(msg);
     }
 
-    protected onBeforeHide(msg: Message): void {
+    protected override onBeforeHide(msg: Message): void {
         super.onBeforeHide(msg);
         this.lastVisibleState = this.storeState();
     }
 
-    protected onAfterShow(msg: Message): void {
+    protected override onAfterShow(msg: Message): void {
         super.onAfterShow(msg);
         this.updateTitle();
         this.lastVisibleState = undefined;
     }
 
-    protected onBeforeAttach(msg: Message): void {
+    protected override onBeforeAttach(msg: Message): void {
         super.onBeforeAttach(msg);
         this.node.addEventListener('p-dragenter', this, true);
         this.node.addEventListener('p-dragover', this, true);
@@ -687,7 +687,7 @@ export class ViewContainer extends BaseWidget implements StatefulWidget, Applica
         this.node.addEventListener('p-drop', this, true);
     }
 
-    protected onAfterDetach(msg: Message): void {
+    protected override onAfterDetach(msg: Message): void {
         super.onAfterDetach(msg);
         this.node.removeEventListener('p-dragenter', this, true);
         this.node.removeEventListener('p-dragover', this, true);
@@ -1049,7 +1049,7 @@ export class ViewContainerPart extends BaseWidget {
         this.onPartMovedEmitter.fire(newContainer);
     }
 
-    setHidden(hidden: boolean): void {
+    override setHidden(hidden: boolean): void {
         if (!this.canHide) {
             return;
         }
@@ -1100,7 +1100,7 @@ export class ViewContainerPart extends BaseWidget {
         return !this.toShowHeader.disposed || this.collapsed;
     }
 
-    protected getScrollContainer(): HTMLElement {
+    protected override getScrollContainer(): HTMLElement {
         return this.body;
     }
 
@@ -1188,21 +1188,21 @@ export class ViewContainerPart extends BaseWidget {
         };
     }
 
-    protected onResize(msg: Widget.ResizeMessage): void {
+    protected override onResize(msg: Widget.ResizeMessage): void {
         if (this.wrapped.isAttached && !this.collapsed) {
             MessageLoop.sendMessage(this.wrapped, Widget.ResizeMessage.UnknownSize);
         }
         super.onResize(msg);
     }
 
-    protected onUpdateRequest(msg: Message): void {
+    protected override onUpdateRequest(msg: Message): void {
         if (this.wrapped.isAttached && !this.collapsed) {
             MessageLoop.sendMessage(this.wrapped, msg);
         }
         super.onUpdateRequest(msg);
     }
 
-    protected onAfterAttach(msg: Message): void {
+    protected override onAfterAttach(msg: Message): void {
         if (!this.wrapped.isAttached) {
             UnsafeWidgetUtilities.attach(this.wrapped, this.body);
         }
@@ -1210,7 +1210,7 @@ export class ViewContainerPart extends BaseWidget {
         super.onAfterAttach(msg);
     }
 
-    protected onBeforeDetach(msg: Message): void {
+    protected override onBeforeDetach(msg: Message): void {
         super.onBeforeDetach(msg);
         if (this.toolbar.isAttached) {
             Widget.detach(this.toolbar);
@@ -1220,42 +1220,42 @@ export class ViewContainerPart extends BaseWidget {
         }
     }
 
-    protected onBeforeShow(msg: Message): void {
+    protected override onBeforeShow(msg: Message): void {
         if (this.wrapped.isAttached && !this.collapsed) {
             MessageLoop.sendMessage(this.wrapped, msg);
         }
         super.onBeforeShow(msg);
     }
 
-    protected onAfterShow(msg: Message): void {
+    protected override onAfterShow(msg: Message): void {
         super.onAfterShow(msg);
         if (this.wrapped.isAttached && !this.collapsed) {
             MessageLoop.sendMessage(this.wrapped, msg);
         }
     }
 
-    protected onBeforeHide(msg: Message): void {
+    protected override onBeforeHide(msg: Message): void {
         if (this.wrapped.isAttached && !this.collapsed) {
             MessageLoop.sendMessage(this.wrapped, msg);
         }
         super.onBeforeShow(msg);
     }
 
-    protected onAfterHide(msg: Message): void {
+    protected override onAfterHide(msg: Message): void {
         super.onAfterHide(msg);
         if (this.wrapped.isAttached && !this.collapsed) {
             MessageLoop.sendMessage(this.wrapped, msg);
         }
     }
 
-    protected onChildRemoved(msg: Widget.ChildMessage): void {
+    protected override onChildRemoved(msg: Widget.ChildMessage): void {
         super.onChildRemoved(msg);
         // if wrapped is not disposed, but detached then we should not dispose it, but only get rid of this part
         this.toNoDisposeWrapped.dispose();
         this.dispose();
     }
 
-    protected onActivateRequest(msg: Message): void {
+    protected override onActivateRequest(msg: Message): void {
         super.onActivateRequest(msg);
         if (this.collapsed) {
             this.header.focus();
@@ -1306,7 +1306,7 @@ export class ViewContainerLayout extends SplitLayout {
         return (this as any)._items as Array<LayoutItem & ViewContainerLayout.Item>;
     }
 
-    iter(): IIterator<ViewContainerPart> {
+    override iter(): IIterator<ViewContainerPart> {
         return map(this.items, item => item.widget);
     }
 
@@ -1315,7 +1315,7 @@ export class ViewContainerLayout extends SplitLayout {
         return toArray(this.iter());
     }
 
-    attachWidget(index: number, widget: ViewContainerPart): void {
+    override attachWidget(index: number, widget: ViewContainerPart): void {
         super.attachWidget(index, widget);
         if (index > -1 && this.parent && this.parent.node.contains(this.widgets[index + 1]?.node)) {
             // Set the correct attach index to the DOM elements.
@@ -1326,7 +1326,7 @@ export class ViewContainerLayout extends SplitLayout {
         }
     }
 
-    moveWidget(fromIndex: number, toIndex: number, widget: Widget): void {
+    override moveWidget(fromIndex: number, toIndex: number, widget: Widget): void {
         const ref = this.widgets[toIndex < fromIndex ? toIndex : toIndex + 1];
         super.moveWidget(fromIndex, toIndex, widget);
         // Keep the order of `_widgets` array just as done before (by `super`) for the `_items` array -
@@ -1511,7 +1511,7 @@ export class ViewContainerLayout extends SplitLayout {
         requestAnimationFrame(updateFunc);
     }
 
-    protected onFitRequest(msg: Message): void {
+    protected override onFitRequest(msg: Message): void {
         for (const part of this.widgets) {
             const style = part.node.style;
             if (part.animatedSize !== undefined) {

--- a/packages/core/src/browser/widgets/alert-message.tsx
+++ b/packages/core/src/browser/widgets/alert-message.tsx
@@ -40,7 +40,7 @@ export interface AlertMessageProps {
 
 export class AlertMessage extends React.Component<AlertMessageProps> {
 
-    render(): React.ReactNode {
+    override render(): React.ReactNode {
         return <div className='theia-alert-message-container'>
             <div className={`theia-${this.props.type.toLowerCase()}-alert`}>
                 <div className='theia-message-header'>

--- a/packages/core/src/browser/widgets/react-widget.tsx
+++ b/packages/core/src/browser/widgets/react-widget.tsx
@@ -37,7 +37,7 @@ export abstract class ReactWidget extends BaseWidget {
         }));
     }
 
-    protected onUpdateRequest(msg: Message): void {
+    protected override onUpdateRequest(msg: Message): void {
         super.onUpdateRequest(msg);
         ReactDOM.render(<React.Fragment>{this.render()}</React.Fragment>, this.node, () => this.onRender.dispose());
     }

--- a/packages/core/src/browser/widgets/widget.ts
+++ b/packages/core/src/browser/widgets/widget.ts
@@ -113,7 +113,7 @@ export class BaseWidget extends Widget {
     protected scrollBar?: PerfectScrollbar;
     protected scrollOptions?: PerfectScrollbar.Options;
 
-    dispose(): void {
+    override dispose(): void {
         if (this.isDisposed) {
             return;
         }
@@ -121,31 +121,31 @@ export class BaseWidget extends Widget {
         this.toDispose.dispose();
     }
 
-    protected onCloseRequest(msg: Message): void {
+    protected override onCloseRequest(msg: Message): void {
         super.onCloseRequest(msg);
         this.dispose();
     }
 
-    protected onBeforeAttach(msg: Message): void {
+    protected override onBeforeAttach(msg: Message): void {
         if (this.title.iconClass === '') {
             this.title.iconClass = 'no-icon';
         }
         super.onBeforeAttach(msg);
     }
 
-    protected onAfterDetach(msg: Message): void {
+    protected override onAfterDetach(msg: Message): void {
         if (this.title.iconClass === 'no-icon') {
             this.title.iconClass = '';
         }
         super.onAfterDetach(msg);
     }
 
-    protected onBeforeDetach(msg: Message): void {
+    protected override onBeforeDetach(msg: Message): void {
         this.toDisposeOnDetach.dispose();
         super.onBeforeDetach(msg);
     }
 
-    protected onAfterAttach(msg: Message): void {
+    protected override onAfterAttach(msg: Message): void {
         super.onAfterAttach(msg);
         if (this.scrollOptions) {
             (async () => {
@@ -181,7 +181,7 @@ export class BaseWidget extends Widget {
         }
     }
 
-    protected onUpdateRequest(msg: Message): void {
+    protected override onUpdateRequest(msg: Message): void {
         super.onUpdateRequest(msg);
         if (this.scrollBar) {
             this.scrollBar.update();
@@ -210,14 +210,14 @@ export class BaseWidget extends Widget {
         this.toDisposeOnDetach.push(addClipboardListener(element, type, listener));
     }
 
-    setFlag(flag: Widget.Flag): void {
+    override setFlag(flag: Widget.Flag): void {
         super.setFlag(flag);
         if (flag === Widget.Flag.IsVisible) {
             this.onDidChangeVisibilityEmitter.fire(this.isVisible);
         }
     }
 
-    clearFlag(flag: Widget.Flag): void {
+    override clearFlag(flag: Widget.Flag): void {
         super.clearFlag(flag);
         if (flag === Widget.Flag.IsVisible) {
             this.onDidChangeVisibilityEmitter.fire(this.isVisible);

--- a/packages/core/src/common/event.ts
+++ b/packages/core/src/common/event.ts
@@ -352,7 +352,7 @@ export class AsyncEmitter<T extends WaitUntilEvent> extends Emitter<T> {
     /**
      * Fire listeners async one after another.
      */
-    fire(event: Omit<T, 'waitUntil'>, token: CancellationToken = CancellationToken.None,
+    override fire(event: Omit<T, 'waitUntil'>, token: CancellationToken = CancellationToken.None,
         promiseJoin?: (p: Promise<any>, listener: Function) => Promise<any>): Promise<void> {
         const callbacks = this._callbacks;
         if (!callbacks) {

--- a/packages/core/src/common/messaging/proxy-factory.spec.ts
+++ b/packages/core/src/common/messaging/proxy-factory.spec.ts
@@ -25,7 +25,7 @@ const expect = chai.expect;
 class NoTransform extends stream.Transform {
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    public _transform(chunk: any, encoding: string, callback: Function): void {
+    override _transform(chunk: any, encoding: string, callback: Function): void {
         callback(undefined, chunk);
     }
 }

--- a/packages/core/src/common/test/mock-menu.ts
+++ b/packages/core/src/common/test/mock-menu.ts
@@ -25,11 +25,11 @@ export class MockMenuModelRegistry extends MenuModelRegistry {
         super({ getContributions: () => [] }, commands);
     }
 
-    registerMenuAction(menuPath: MenuPath, item: MenuAction): Disposable {
+    override registerMenuAction(menuPath: MenuPath, item: MenuAction): Disposable {
         return Disposable.NULL;
     }
 
-    registerSubmenu(menuPath: MenuPath, label: string): Disposable {
+    override registerSubmenu(menuPath: MenuPath, label: string): Disposable {
         return Disposable.NULL;
     }
 }

--- a/packages/core/src/electron-browser/menu/electron-context-menu-renderer.ts
+++ b/packages/core/src/electron-browser/menu/electron-context-menu-renderer.ts
@@ -99,7 +99,7 @@ export class ElectronContextMenuRenderer extends BrowserContextMenuRenderer {
         electron.ipcRenderer.send(RequestTitleBarStyle);
     }
 
-    protected doRender(options: RenderContextMenuOptions): ContextMenuAccess {
+    protected override doRender(options: RenderContextMenuOptions): ContextMenuAccess {
         if (this.useNativeStyle) {
             const { menuPath, anchor, args, onHide } = options;
             const menu = this.electronMenuFactory.createElectronContextMenu(menuPath, args);

--- a/packages/core/src/electron-browser/menu/electron-main-menu-factory.ts
+++ b/packages/core/src/electron-browser/menu/electron-main-menu-factory.ts
@@ -17,13 +17,12 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
 import * as electronRemote from '../../../electron-shared/@electron/remote';
-import { inject, injectable } from 'inversify';
+import { inject, injectable, postConstruct } from 'inversify';
 import {
-    CommandRegistry, isOSX, ActionMenuNode, CompositeMenuNode,
-    MAIN_MENU_BAR, MenuModelRegistry, MenuPath, MenuNode
+    isOSX, ActionMenuNode, CompositeMenuNode, MAIN_MENU_BAR, MenuPath, MenuNode
 } from '../../common';
 import { Keybinding } from '../../common/keybinding';
-import { PreferenceService, KeybindingRegistry, CommonCommands } from '../../browser';
+import { PreferenceService, CommonCommands } from '../../browser';
 import debounce = require('lodash.debounce');
 import { MAXIMIZED_CLASS } from '../../browser/shell/theia-dock-panel';
 import { BrowserMainMenuFactory } from '../../browser/menu/browser-menu-plugin';
@@ -59,14 +58,12 @@ export class ElectronMainMenuFactory extends BrowserMainMenuFactory {
     protected _menu?: Electron.Menu;
     protected _toggledCommands: Set<string> = new Set();
 
-    constructor(
-        @inject(CommandRegistry) protected readonly commandRegistry: CommandRegistry,
-        @inject(PreferenceService) protected readonly preferencesService: PreferenceService,
-        @inject(MenuModelRegistry) protected readonly menuProvider: MenuModelRegistry,
-        @inject(KeybindingRegistry) protected readonly keybindingRegistry: KeybindingRegistry
-    ) {
-        super();
-        preferencesService.onPreferenceChanged(
+    @inject(PreferenceService)
+    protected preferencesService: PreferenceService;
+
+    @postConstruct()
+    postConstruct(): void {
+        this.preferencesService.onPreferenceChanged(
             debounce(e => {
                 if (e.preferenceName === 'window.menuBarVisibility') {
                     this.setMenuBar();
@@ -82,7 +79,7 @@ export class ElectronMainMenuFactory extends BrowserMainMenuFactory {
                 }
             }, 10)
         );
-        keybindingRegistry.onKeybindingsChanged(() => {
+        this.keybindingRegistry.onKeybindingsChanged(() => {
             this.setMenuBar();
         });
     }

--- a/packages/core/src/electron-browser/menu/electron-menu-contribution.ts
+++ b/packages/core/src/electron-browser/menu/electron-menu-contribution.ts
@@ -22,7 +22,7 @@ import {
     isOSX, isWindows, MenuModelRegistry, MenuContribution, Disposable, nls
 } from '../../common';
 import {
-    ApplicationShell, codicon, ConfirmDialog, KeybindingContribution, KeybindingRegistry,
+    codicon, ConfirmDialog, KeybindingContribution, KeybindingRegistry,
     PreferenceScope, Widget, FrontendApplication, FrontendApplicationContribution, CommonMenus, CommonCommands, Dialog,
 } from '../../browser';
 import { ElectronMainMenuFactory } from './electron-main-menu-factory';
@@ -93,13 +93,12 @@ export class ElectronMenuContribution extends BrowserMenuBarContribution impleme
     protected titleBarStyle?: string;
 
     constructor(
-        @inject(ElectronMainMenuFactory) protected readonly factory: ElectronMainMenuFactory,
-        @inject(ApplicationShell) protected shell: ApplicationShell
+        @inject(ElectronMainMenuFactory) protected override readonly factory: ElectronMainMenuFactory
     ) {
         super(factory);
     }
 
-    onStart(app: FrontendApplication): void {
+    override onStart(app: FrontendApplication): void {
         this.handleTitleBarStyling(app);
         if (isOSX) {
             // OSX: Recreate the menus when changing windows.

--- a/packages/core/src/electron-browser/messaging/electron-ipc-connection-provider.ts
+++ b/packages/core/src/electron-browser/messaging/electron-ipc-connection-provider.ts
@@ -30,7 +30,7 @@ export interface ElectronIpcOptions {
 @injectable()
 export class ElectronIpcConnectionProvider extends AbstractConnectionProvider<ElectronIpcOptions> {
 
-    static createProxy<T extends object>(container: interfaces.Container, path: string, arg?: object): JsonRpcProxy<T> {
+    static override createProxy<T extends object>(container: interfaces.Container, path: string, arg?: object): JsonRpcProxy<T> {
         return container.get(ElectronIpcConnectionProvider).createProxy<T>(path, arg);
     }
 

--- a/packages/core/src/electron-browser/messaging/electron-ws-connection-provider.ts
+++ b/packages/core/src/electron-browser/messaging/electron-ws-connection-provider.ts
@@ -43,7 +43,7 @@ export class ElectronWebSocketConnectionProvider extends WebSocketConnectionProv
         }
     }
 
-    openChannel(path: string, handler: (channel: WebSocketChannel) => void, options?: WebSocketOptions): void {
+    override openChannel(path: string, handler: (channel: WebSocketChannel) => void, options?: WebSocketOptions): void {
         if (!this.stopping) {
             super.openChannel(path, handler, options);
         }

--- a/packages/core/src/electron-browser/window/electron-window-service.ts
+++ b/packages/core/src/electron-browser/window/electron-window-service.ts
@@ -42,12 +42,12 @@ export class ElectronWindowService extends DefaultWindowService {
     @inject(ElectronWindowPreferences)
     protected readonly electronWindowPreferences: ElectronWindowPreferences;
 
-    openNewWindow(url: string, { external }: NewWindowOptions = {}): undefined {
+    override openNewWindow(url: string, { external }: NewWindowOptions = {}): undefined {
         this.delegate.openNewWindow(url, { external });
         return undefined;
     }
 
-    openNewDefaultWindow(): void {
+    override openNewDefaultWindow(): void {
         this.delegate.openNewDefaultWindow();
     }
 
@@ -61,7 +61,7 @@ export class ElectronWindowService extends DefaultWindowService {
         });
     }
 
-    protected registerUnloadListeners(): void {
+    protected override registerUnloadListeners(): void {
         electron.ipcRenderer.on(CLOSE_REQUESTED_SIGNAL, (_event, closeRequestEvent: CloseRequestArguments) => this.handleCloseRequestedEvent(closeRequestEvent));
         window.addEventListener('unload', () => this.onUnloadEmitter.fire());
     }
@@ -92,7 +92,7 @@ export class ElectronWindowService extends DefaultWindowService {
         }
     }
 
-    reload(): void {
+    override reload(): void {
         electron.ipcRenderer.send(RELOAD_REQUESTED_SIGNAL);
     }
 }

--- a/packages/core/src/electron-node/token/electron-token-messaging-contribution.ts
+++ b/packages/core/src/electron-node/token/electron-token-messaging-contribution.ts
@@ -32,7 +32,7 @@ export class ElectronMessagingContribution extends MessagingContribution {
     /**
      * Only allow token-bearers.
      */
-    protected async allowConnect(request: http.IncomingMessage): Promise<boolean> {
+    protected override async allowConnect(request: http.IncomingMessage): Promise<boolean> {
         if (this.tokenValidator.allowRequest(request)) {
             return super.allowConnect(request);
         }

--- a/packages/debug/src/browser/breakpoint/breakpoint-manager.ts
+++ b/packages/debug/src/browser/breakpoint/breakpoint-manager.ts
@@ -53,7 +53,7 @@ export class BreakpointManager extends MarkerManager<SourceBreakpoint> {
     protected readonly onDidChangeFunctionBreakpointsEmitter = new Emitter<FunctionBreakpointsChangeEvent>();
     readonly onDidChangeFunctionBreakpoints = this.onDidChangeFunctionBreakpointsEmitter.event;
 
-    setMarkers(uri: URI, owner: string, newMarkers: SourceBreakpoint[]): Marker<SourceBreakpoint>[] {
+    override setMarkers(uri: URI, owner: string, newMarkers: SourceBreakpoint[]): Marker<SourceBreakpoint>[] {
         const result = super.setMarkers(uri, owner, newMarkers);
         const added: SourceBreakpoint[] = [];
         const removed: SourceBreakpoint[] = [];

--- a/packages/debug/src/browser/console/debug-console-contribution.tsx
+++ b/packages/debug/src/browser/console/debug-console-contribution.tsx
@@ -102,7 +102,7 @@ export class DebugConsoleContribution extends AbstractViewContribution<ConsoleWi
         }
     }
 
-    registerCommands(commands: CommandRegistry): void {
+    override registerCommands(commands: CommandRegistry): void {
         super.registerCommands(commands);
         commands.registerCommand(DebugConsoleCommands.CLEAR, {
             isEnabled: widget => this.withWidget(widget, () => true),

--- a/packages/debug/src/browser/console/debug-console-items.tsx
+++ b/packages/debug/src/browser/console/debug-console-items.tsx
@@ -159,7 +159,7 @@ export class DebugVariable extends ExpressionContainer {
         return this._value || this.variable.value;
     }
 
-    render(): React.ReactNode {
+    override render(): React.ReactNode {
         const { type, value, name } = this;
         return <div className={this.variableClassName}>
             <span title={type || name} className='name' ref={this.setNameRef}>{name}{!!value && ': '}</span>
@@ -255,7 +255,7 @@ export class DebugVirtualVariable extends ExpressionContainer {
         super(options);
     }
 
-    render(): React.ReactNode {
+    override render(): React.ReactNode {
         return this.options.name;
     }
 }
@@ -295,7 +295,7 @@ export class ExpressionItem extends ExpressionContainer {
         return this._expression;
     }
 
-    render(): React.ReactNode {
+    override render(): React.ReactNode {
         const valueClassNames: string[] = [];
         if (!this._available) {
             valueClassNames.push(ConsoleItem.errorClassName);
@@ -358,7 +358,7 @@ export class DebugScope extends ExpressionContainer {
         });
     }
 
-    render(): React.ReactNode {
+    override render(): React.ReactNode {
         return this.name;
     }
 

--- a/packages/debug/src/browser/console/debug-console-session.ts
+++ b/packages/debug/src/browser/console/debug-console-session.ts
@@ -195,6 +195,6 @@ export class DebugConsoleSession extends ConsoleSession {
         this.fireDidChange();
     }
 
-    protected fireDidChange = throttle(() => super.fireDidChange(), 50);
+    protected override fireDidChange = throttle(() => super.fireDidChange(), 50);
 
 }

--- a/packages/debug/src/browser/debug-frontend-application-contribution.ts
+++ b/packages/debug/src/browser/debug-frontend-application-contribution.ts
@@ -422,9 +422,6 @@ export class DebugFrontendApplicationContribution extends AbstractViewContributi
     @inject(BreakpointManager)
     protected readonly breakpointManager: BreakpointManager;
 
-    @inject(ApplicationShell)
-    protected readonly shell: ApplicationShell;
-
     @inject(DebugSessionWidgetFactory)
     protected readonly sessionWidgetFactory: DebugSessionWidgetFactory;
 
@@ -511,7 +508,7 @@ export class DebugFrontendApplicationContribution extends AbstractViewContributi
         return this.preference['debug.confirmOnExit'] === 'always' && !!this.manager.currentSession;
     }
 
-    registerMenus(menus: MenuModelRegistry): void {
+    override registerMenus(menus: MenuModelRegistry): void {
         super.registerMenus(menus);
         const registerMenuActions = (menuPath: string[], ...commands: Command[]) => {
             for (const [index, command] of commands.entries()) {
@@ -637,7 +634,7 @@ export class DebugFrontendApplicationContribution extends AbstractViewContributi
         );
     }
 
-    registerCommands(registry: CommandRegistry): void {
+    override registerCommands(registry: CommandRegistry): void {
         super.registerCommands(registry);
         registry.registerCommand(DebugCommands.START, {
             execute: (config?: DebugSessionOptions) => this.start(false, config)
@@ -1027,7 +1024,7 @@ export class DebugFrontendApplicationContribution extends AbstractViewContributi
         });
     }
 
-    registerKeybindings(keybindings: KeybindingRegistry): void {
+    override registerKeybindings(keybindings: KeybindingRegistry): void {
         super.registerKeybindings(keybindings);
         keybindings.registerKeybinding({
             command: DebugCommands.START.id,

--- a/packages/debug/src/browser/debug-keybinding-contexts.ts
+++ b/packages/debug/src/browser/debug-keybinding-contexts.ts
@@ -66,9 +66,9 @@ export class BreakpointWidgetInputFocusContext implements KeybindingContext {
 @injectable()
 export class BreakpointWidgetInputStrictFocusContext extends BreakpointWidgetInputFocusContext {
 
-    readonly id: string = DebugKeybindingContexts.breakpointWidgetInputStrictFocus;
+    override readonly id: string = DebugKeybindingContexts.breakpointWidgetInputStrictFocus;
 
-    protected isFocused(model: DebugEditorModel): boolean {
+    protected override isFocused(model: DebugEditorModel): boolean {
         return super.isFocused(model) || model.editor.isFocused({ strict: true });
     }
 

--- a/packages/debug/src/browser/editor/debug-exception-widget.tsx
+++ b/packages/debug/src/browser/editor/debug-exception-widget.tsx
@@ -30,7 +30,7 @@ export interface ShowDebugExceptionParams {
 
 export class DebugExceptionMonacoEditorZoneWidget extends MonacoEditorZoneWidget {
 
-    protected computeContainerHeight(zoneHeight: number): {
+    protected override computeContainerHeight(zoneHeight: number): {
         height: number,
         frameWidth: number
     } {

--- a/packages/debug/src/browser/editor/debug-hover-widget.ts
+++ b/packages/debug/src/browser/editor/debug-hover-widget.ts
@@ -56,7 +56,8 @@ export function createDebugHoverWidgetContainer(parent: interfaces.Container, ed
 @injectable()
 export class DebugHoverWidget extends SourceTreeWidget implements monaco.editor.IContentWidget {
 
-    protected readonly toDispose = new DisposableCollection();
+    // TODO: Is this still needed?
+    // protected override toDispose = new DisposableCollection();
 
     @inject(DebugEditor)
     protected readonly editor: DebugEditor;
@@ -85,7 +86,7 @@ export class DebugHoverWidget extends SourceTreeWidget implements monaco.editor.
     }
 
     @postConstruct()
-    protected init(): void {
+    protected override init(): void {
         super.init();
         this.domNode.className = 'theia-debug-hover';
         this.titleNode.className = 'theia-debug-hover-title';
@@ -107,15 +108,15 @@ export class DebugHoverWidget extends SourceTreeWidget implements monaco.editor.
         ]);
     }
 
-    dispose(): void {
+    override dispose(): void {
         this.toDispose.dispose();
     }
 
-    show(options?: ShowDebugHoverOptions): void {
+    override show(options?: ShowDebugHoverOptions): void {
         this.schedule(() => this.doShow(options), options && options.immediate);
     }
 
-    hide(options?: HideDebugHoverOptions): void {
+    override hide(options?: HideDebugHoverOptions): void {
         this.schedule(() => this.doHide(), options && options.immediate);
     }
 
@@ -228,7 +229,7 @@ export class DebugHoverWidget extends SourceTreeWidget implements monaco.editor.
         } : undefined!;
     }
 
-    protected onUpdateRequest(msg: Message): void {
+    protected override onUpdateRequest(msg: Message): void {
         super.onUpdateRequest(msg);
         const { expression } = this.hoverSource;
         const value = expression && expression.value || '';
@@ -236,7 +237,7 @@ export class DebugHoverWidget extends SourceTreeWidget implements monaco.editor.
         this.titleNode.title = value;
     }
 
-    protected onAfterAttach(msg: Message): void {
+    protected override onAfterAttach(msg: Message): void {
         super.onAfterAttach(msg);
         this.addKeyListener(this.domNode, Key.ESCAPE, () => this.hide());
     }

--- a/packages/debug/src/browser/editor/debug-hover-widget.ts
+++ b/packages/debug/src/browser/editor/debug-hover-widget.ts
@@ -56,9 +56,6 @@ export function createDebugHoverWidgetContainer(parent: interfaces.Container, ed
 @injectable()
 export class DebugHoverWidget extends SourceTreeWidget implements monaco.editor.IContentWidget {
 
-    // TODO: Is this still needed?
-    // protected override toDispose = new DisposableCollection();
-
     @inject(DebugEditor)
     protected readonly editor: DebugEditor;
 

--- a/packages/debug/src/browser/model/debug-function-breakpoint.tsx
+++ b/packages/debug/src/browser/model/debug-function-breakpoint.tsx
@@ -37,7 +37,7 @@ export class DebugFunctionBreakpoint extends DebugBreakpoint<FunctionBreakpoint>
         }
     }
 
-    protected isEnabled(): boolean {
+    protected override isEnabled(): boolean {
         return super.isEnabled() && this.isSupported();
     }
 
@@ -62,7 +62,7 @@ export class DebugFunctionBreakpoint extends DebugBreakpoint<FunctionBreakpoint>
         return <span className='line-info'>{this.name}</span>;
     }
 
-    protected doGetDecoration(): DebugBreakpointDecoration {
+    protected override doGetDecoration(): DebugBreakpointDecoration {
         if (!this.isSupported()) {
             return this.getDisabledBreakpointDecoration(nls.localizeByDefault('Function breakpoints are not supported by this debug type'));
         }

--- a/packages/debug/src/browser/model/debug-source-breakpoint.tsx
+++ b/packages/debug/src/browser/model/debug-source-breakpoint.tsx
@@ -38,7 +38,7 @@ export class DebugSourceBreakpoint extends DebugBreakpoint<SourceBreakpoint> imp
         this.origins = [origin];
     }
 
-    update(data: Partial<DebugSourceBreakpointData>): void {
+    override update(data: Partial<DebugSourceBreakpointData>): void {
         super.update(data);
     }
 
@@ -140,7 +140,7 @@ export class DebugSourceBreakpoint extends DebugBreakpoint<SourceBreakpoint> imp
         }
     }
 
-    protected readonly setBreakpointEnabled = (event: React.ChangeEvent<HTMLInputElement>) => {
+    protected override setBreakpointEnabled = (event: React.ChangeEvent<HTMLInputElement>) => {
         this.setEnabled(event.target.checked);
     };
 
@@ -158,7 +158,7 @@ export class DebugSourceBreakpoint extends DebugBreakpoint<SourceBreakpoint> imp
         return this.line + (typeof this.column === 'number' ? ':' + this.column : '');
     }
 
-    doGetDecoration(messages: string[] = []): DebugBreakpointDecoration {
+    override doGetDecoration(messages: string[] = []): DebugBreakpointDecoration {
         if (this.logMessage || this.condition || this.hitCondition) {
             const { session } = this;
             if (this.logMessage) {

--- a/packages/debug/src/browser/view/debug-action.tsx
+++ b/packages/debug/src/browser/view/debug-action.tsx
@@ -19,7 +19,7 @@ import { codiconArray, DISABLED_CLASS } from '@theia/core/lib/browser';
 
 export class DebugAction extends React.Component<DebugAction.Props> {
 
-    render(): React.ReactNode {
+    override render(): React.ReactNode {
         const { enabled, label, iconClass } = this.props;
         const classNames = ['debug-action', ...codiconArray(iconClass, true)];
         if (enabled === false) {

--- a/packages/debug/src/browser/view/debug-breakpoints-widget.ts
+++ b/packages/debug/src/browser/view/debug-breakpoints-widget.ts
@@ -30,7 +30,7 @@ export class DebugBreakpointsWidget extends SourceTreeWidget {
     static EDIT_MENU = [...DebugBreakpointsWidget.CONTEXT_MENU, 'a_edit'];
     static REMOVE_MENU = [...DebugBreakpointsWidget.CONTEXT_MENU, 'b_remove'];
     static ENABLE_MENU = [...DebugBreakpointsWidget.CONTEXT_MENU, 'c_enable'];
-    static createContainer(parent: interfaces.Container): Container {
+    static override createContainer(parent: interfaces.Container): Container {
         const child = SourceTreeWidget.createContainer(parent, {
             contextMenuPath: DebugBreakpointsWidget.CONTEXT_MENU,
             virtualized: false,
@@ -55,7 +55,7 @@ export class DebugBreakpointsWidget extends SourceTreeWidget {
     protected readonly breakpointsSource: DebugBreakpointsSource;
 
     @postConstruct()
-    protected init(): void {
+    protected override init(): void {
         super.init();
         this.id = 'debug:breakpoints:' + this.viewModel.id;
         this.title.label = nls.localizeByDefault('Breakpoints');
@@ -63,7 +63,7 @@ export class DebugBreakpointsWidget extends SourceTreeWidget {
         this.source = this.breakpointsSource;
     }
 
-    protected getDefaultNodeStyle(node: TreeNode, props: NodeProps): React.CSSProperties | undefined {
+    protected override getDefaultNodeStyle(node: TreeNode, props: NodeProps): React.CSSProperties | undefined {
         return undefined;
     }
 

--- a/packages/debug/src/browser/view/debug-session-widget.ts
+++ b/packages/debug/src/browser/view/debug-session-widget.ts
@@ -110,12 +110,12 @@ export class DebugSessionWidget extends BaseWidget implements StatefulWidget, Ap
         layout.addWidget(this.viewContainer);
     }
 
-    protected onActivateRequest(msg: Message): void {
+    protected override onActivateRequest(msg: Message): void {
         super.onActivateRequest(msg);
         this.toolbar.focus();
     }
 
-    protected onAfterShow(msg: Message): void {
+    protected override onAfterShow(msg: Message): void {
         super.onAfterShow(msg);
         this.getTrackableWidgets().forEach(w => w.update());
     }

--- a/packages/debug/src/browser/view/debug-stack-frames-widget.ts
+++ b/packages/debug/src/browser/view/debug-stack-frames-widget.ts
@@ -28,7 +28,7 @@ import { nls } from '@theia/core/lib/common/nls';
 export class DebugStackFramesWidget extends SourceTreeWidget {
 
     static CONTEXT_MENU: MenuPath = ['debug-frames-context-menu'];
-    static createContainer(parent: interfaces.Container): Container {
+    static override createContainer(parent: interfaces.Container): Container {
         const child = SourceTreeWidget.createContainer(parent, {
             contextMenuPath: DebugStackFramesWidget.CONTEXT_MENU,
             virtualized: false,
@@ -53,7 +53,7 @@ export class DebugStackFramesWidget extends SourceTreeWidget {
     protected readonly debugCallStackItemTypeKey: DebugCallStackItemTypeKey;
 
     @postConstruct()
-    protected init(): void {
+    protected override init(): void {
         super.init();
         this.id = 'debug:frames:' + this.viewModel.id;
         this.title.label = nls.localizeByDefault('Call Stack');
@@ -101,7 +101,7 @@ export class DebugStackFramesWidget extends SourceTreeWidget {
         }
     }
 
-    protected toContextMenuArgs(node: SelectableTreeNode): [string | number] | undefined {
+    protected override toContextMenuArgs(node: SelectableTreeNode): [string | number] | undefined {
         if (TreeElementNode.is(node)) {
             if (node.element instanceof DebugStackFrame) {
                 const source = node.element.source;
@@ -120,14 +120,14 @@ export class DebugStackFramesWidget extends SourceTreeWidget {
         return undefined;
     }
 
-    protected handleClickEvent(node: TreeNode | undefined, event: React.MouseEvent<HTMLElement>): void {
+    protected override handleClickEvent(node: TreeNode | undefined, event: React.MouseEvent<HTMLElement>): void {
         if (TreeElementNode.is(node) && node.element instanceof LoadMoreStackFrames) {
             node.element.open();
         }
         super.handleClickEvent(node, event);
     }
 
-    protected getDefaultNodeStyle(node: TreeNode, props: NodeProps): React.CSSProperties | undefined {
+    protected override getDefaultNodeStyle(node: TreeNode, props: NodeProps): React.CSSProperties | undefined {
         return undefined;
     }
 

--- a/packages/debug/src/browser/view/debug-threads-widget.ts
+++ b/packages/debug/src/browser/view/debug-threads-widget.ts
@@ -32,7 +32,7 @@ export class DebugThreadsWidget extends SourceTreeWidget {
     static CONTROL_MENU = [...DebugThreadsWidget.CONTEXT_MENU, 'a_control'];
     static TERMINATE_MENU = [...DebugThreadsWidget.CONTEXT_MENU, 'b_terminate'];
     static OPEN_MENU = [...DebugThreadsWidget.CONTEXT_MENU, 'c_open'];
-    static createContainer(parent: interfaces.Container): Container {
+    static override createContainer(parent: interfaces.Container): Container {
         const child = SourceTreeWidget.createContainer(parent, {
             contextMenuPath: DebugThreadsWidget.CONTEXT_MENU,
             virtualized: false,
@@ -57,7 +57,7 @@ export class DebugThreadsWidget extends SourceTreeWidget {
     protected readonly debugCallStackItemTypeKey: DebugCallStackItemTypeKey;
 
     @postConstruct()
-    protected init(): void {
+    protected override init(): void {
         super.init();
         this.id = 'debug:threads:' + this.viewModel.id;
         this.title.label = nls.localize('theia/debug/threads', 'Threads');
@@ -107,14 +107,14 @@ export class DebugThreadsWidget extends SourceTreeWidget {
         }
     }
 
-    protected toContextMenuArgs(node: SelectableTreeNode): [number] | undefined {
+    protected override toContextMenuArgs(node: SelectableTreeNode): [number] | undefined {
         if (TreeElementNode.is(node) && node.element instanceof DebugThread) {
             return [node.element.raw.id];
         }
         return undefined;
     }
 
-    protected getDefaultNodeStyle(node: TreeNode, props: NodeProps): React.CSSProperties | undefined {
+    protected override getDefaultNodeStyle(node: TreeNode, props: NodeProps): React.CSSProperties | undefined {
         if (this.threads.multiSession) {
             return super.getDefaultNodeStyle(node, props);
         }

--- a/packages/debug/src/browser/view/debug-variables-widget.ts
+++ b/packages/debug/src/browser/view/debug-variables-widget.ts
@@ -27,7 +27,7 @@ export class DebugVariablesWidget extends SourceTreeWidget {
     static CONTEXT_MENU: MenuPath = ['debug-variables-context-menu'];
     static EDIT_MENU: MenuPath = [...DebugVariablesWidget.CONTEXT_MENU, 'a_edit'];
     static WATCH_MENU: MenuPath = [...DebugVariablesWidget.CONTEXT_MENU, 'b_watch'];
-    static createContainer(parent: interfaces.Container): Container {
+    static override createContainer(parent: interfaces.Container): Container {
         const child = SourceTreeWidget.createContainer(parent, {
             contextMenuPath: DebugVariablesWidget.CONTEXT_MENU,
             virtualized: false,
@@ -49,7 +49,7 @@ export class DebugVariablesWidget extends SourceTreeWidget {
     protected readonly variables: DebugVariablesSource;
 
     @postConstruct()
-    protected init(): void {
+    protected override init(): void {
         super.init();
         this.id = 'debug:variables:' + this.viewModel.id;
         this.title.label = nls.localizeByDefault('Variables');

--- a/packages/debug/src/browser/view/debug-watch-expression.tsx
+++ b/packages/debug/src/browser/view/debug-watch-expression.tsx
@@ -33,17 +33,17 @@ export class DebugWatchExpression extends ExpressionItem {
         this.id = options.id;
     }
 
-    async evaluate(): Promise<void> {
+    override async evaluate(): Promise<void> {
         await super.evaluate('watch');
     }
 
-    protected setResult(body?: DebugProtocol.EvaluateResponse['body']): void {
+    protected override setResult(body?: DebugProtocol.EvaluateResponse['body']): void {
         // overridden to ignore error
         super.setResult(body);
         this.options.onDidChange();
     }
 
-    render(): React.ReactNode {
+    override render(): React.ReactNode {
         return <div className='theia-debug-console-variable'>
             <span title={this.type || this._expression} className='name'>{this._expression}: </span>
             <span title={this._value} ref={this.setValueRef}>{this._value}</span>

--- a/packages/debug/src/browser/view/debug-watch-widget.ts
+++ b/packages/debug/src/browser/view/debug-watch-widget.ts
@@ -27,7 +27,7 @@ export class DebugWatchWidget extends SourceTreeWidget {
     static CONTEXT_MENU: MenuPath = ['debug-watch-context-menu'];
     static EDIT_MENU = [...DebugWatchWidget.CONTEXT_MENU, 'a_edit'];
     static REMOVE_MENU = [...DebugWatchWidget.CONTEXT_MENU, 'b_remove'];
-    static createContainer(parent: interfaces.Container): Container {
+    static override createContainer(parent: interfaces.Container): Container {
         const child = SourceTreeWidget.createContainer(parent, {
             contextMenuPath: DebugWatchWidget.CONTEXT_MENU,
             virtualized: false,
@@ -49,7 +49,7 @@ export class DebugWatchWidget extends SourceTreeWidget {
     protected readonly variables: DebugWatchSource;
 
     @postConstruct()
-    protected init(): void {
+    protected override init(): void {
         super.init();
         this.id = 'debug:watch:' + this.viewModel.id;
         this.title.label = nls.localizeByDefault('Watch');

--- a/packages/debug/src/browser/view/debug-widget.ts
+++ b/packages/debug/src/browser/view/debug-widget.ts
@@ -81,7 +81,7 @@ export class DebugWidget extends BaseWidget implements StatefulWidget, Applicati
         this.toDispose.push(this.progressBarFactory({ container: this.node, insertMode: 'prepend', locationId: 'debug' }));
     }
 
-    protected onActivateRequest(msg: Message): void {
+    protected override onActivateRequest(msg: Message): void {
         super.onActivateRequest(msg);
         this.toolbar.focus();
     }

--- a/packages/editor-preview/src/browser/editor-preview-manager.ts
+++ b/packages/editor-preview/src/browser/editor-preview-manager.ts
@@ -25,7 +25,7 @@ import { FrontendApplicationStateService } from '@theia/core/lib/browser/fronten
 
 @injectable()
 export class EditorPreviewManager extends EditorManager {
-    readonly id = EditorPreviewWidgetFactory.ID;
+    override readonly id = EditorPreviewWidgetFactory.ID;
 
     @inject(EditorPreviewPreferences) protected readonly preferences: EditorPreviewPreferences;
     @inject(FrontendApplicationStateService) protected readonly stateService: FrontendApplicationStateService;
@@ -38,7 +38,7 @@ export class EditorPreviewManager extends EditorManager {
     protected layoutIsSet = false;
 
     @postConstruct()
-    protected init(): void {
+    protected override init(): void {
         super.init();
         // All editors are created, but not all are opened. This sets up the logic to swap previews when the editor is attached.
         this.onCreated((widget: EditorPreviewWidget) => {
@@ -70,7 +70,7 @@ export class EditorPreviewManager extends EditorManager {
         document.addEventListener('dblclick', this.convertEditorOnDoubleClick.bind(this));
     }
 
-    protected async doOpen(widget: EditorPreviewWidget, options?: EditorOpenerOptions): Promise<void> {
+    protected override async doOpen(widget: EditorPreviewWidget, options?: EditorOpenerOptions): Promise<void> {
         const { preview, widgetOptions = { area: 'main' }, mode = 'activate' } = options ?? {};
         if (!widget.isAttached) {
             if (preview) {
@@ -98,19 +98,19 @@ export class EditorPreviewManager extends EditorManager {
         this.toDisposeOnPreviewChange.push(widget.onDidDispose(() => this.toDisposeOnPreviewChange.dispose()));
     }
 
-    protected tryGetPendingWidget(uri: URI, options?: EditorOpenerOptions): MaybePromise<EditorWidget> | undefined {
+    protected override tryGetPendingWidget(uri: URI, options?: EditorOpenerOptions): MaybePromise<EditorWidget> | undefined {
         return super.tryGetPendingWidget(uri, { ...options, preview: true }) ?? super.tryGetPendingWidget(uri, { ...options, preview: false });
     }
 
-    protected async getWidget(uri: URI, options?: EditorOpenerOptions): Promise<EditorWidget | undefined> {
+    protected override async getWidget(uri: URI, options?: EditorOpenerOptions): Promise<EditorWidget | undefined> {
         return (await super.getWidget(uri, { ...options, preview: true })) ?? super.getWidget(uri, { ...options, preview: false });
     }
 
-    protected async getOrCreateWidget(uri: URI, options?: EditorOpenerOptions): Promise<EditorWidget> {
+    protected override async getOrCreateWidget(uri: URI, options?: EditorOpenerOptions): Promise<EditorWidget> {
         return this.tryGetPendingWidget(uri, options) ?? super.getOrCreateWidget(uri, options);
     }
 
-    protected createWidgetOptions(uri: URI, options?: EditorOpenerOptions): EditorPreviewOptions {
+    protected override createWidgetOptions(uri: URI, options?: EditorOpenerOptions): EditorPreviewOptions {
         const navigatableOptions = super.createWidgetOptions(uri, options) as EditorPreviewOptions;
         navigatableOptions.preview = !!(options?.preview && this.preferences['editor.enablePreview']);
         return navigatableOptions;

--- a/packages/editor-preview/src/browser/editor-preview-widget-factory.ts
+++ b/packages/editor-preview/src/browser/editor-preview-widget-factory.ts
@@ -26,10 +26,10 @@ export interface EditorPreviewOptions extends NavigatableWidgetOptions {
 
 @injectable()
 export class EditorPreviewWidgetFactory extends EditorWidgetFactory {
-    static ID: string = 'editor-preview-widget';
-    readonly id = EditorPreviewWidgetFactory.ID;
+    static override ID: string = 'editor-preview-widget';
+    override readonly id = EditorPreviewWidgetFactory.ID;
 
-    async createWidget(options: EditorPreviewOptions): Promise<EditorPreviewWidget> {
+    override async createWidget(options: EditorPreviewOptions): Promise<EditorPreviewWidget> {
         const uri = new URI(options.uri);
         const editor = await this.createEditor(uri, options) as EditorPreviewWidget;
         if (options.preview) {
@@ -38,7 +38,7 @@ export class EditorPreviewWidgetFactory extends EditorWidgetFactory {
         return editor;
     }
 
-    protected async constructEditor(uri: URI): Promise<EditorPreviewWidget> {
+    protected override async constructEditor(uri: URI): Promise<EditorPreviewWidget> {
         const textEditor = await this.editorProvider(uri);
         return new EditorPreviewWidget(textEditor, this.selectionService);
     }

--- a/packages/editor-preview/src/browser/editor-preview-widget.ts
+++ b/packages/editor-preview/src/browser/editor-preview-widget.ts
@@ -35,8 +35,8 @@ export class EditorPreviewWidget extends EditorWidget {
     }
 
     constructor(
-        override readonly editor: TextEditor,
-        protected override readonly selectionService: SelectionService
+        editor: TextEditor,
+        selectionService: SelectionService
     ) {
         super(editor, selectionService);
         this.toDispose.push(this.onDidChangePreviewStateEmitter);

--- a/packages/editor-preview/src/browser/editor-preview-widget.ts
+++ b/packages/editor-preview/src/browser/editor-preview-widget.ts
@@ -35,8 +35,8 @@ export class EditorPreviewWidget extends EditorWidget {
     }
 
     constructor(
-        readonly editor: TextEditor,
-        protected readonly selectionService: SelectionService
+        override readonly editor: TextEditor,
+        protected override readonly selectionService: SelectionService
     ) {
         super(editor, selectionService);
         this.toDispose.push(this.onDidChangePreviewStateEmitter);
@@ -64,7 +64,7 @@ export class EditorPreviewWidget extends EditorWidget {
         }
     }
 
-    protected onAfterAttach(msg: Message): void {
+    protected override onAfterAttach(msg: Message): void {
         super.onAfterAttach(msg);
         if (this._isPreview) {
             this.checkForTabbarChange();
@@ -87,12 +87,12 @@ export class EditorPreviewWidget extends EditorWidget {
         }
     }
 
-    storeState(): { isPreview: boolean, editorState: object } {
+    override storeState(): { isPreview: boolean, editorState: object } {
         const { _isPreview: isPreview } = this;
         return { isPreview, editorState: this.editor.storeViewState() };
     }
 
-    restoreState(oldState: { isPreview: boolean, editorState: object }): void {
+    override restoreState(oldState: { isPreview: boolean, editorState: object }): void {
         if (!oldState.isPreview) {
             this.convertToNonPreview();
         }

--- a/packages/editor/src/browser/editor-keybinding-contexts.ts
+++ b/packages/editor/src/browser/editor-keybinding-contexts.ts
@@ -67,9 +67,9 @@ export class EditorTextFocusContext implements KeybindingContext {
 @injectable()
 export class DiffEditorTextFocusContext extends EditorTextFocusContext {
 
-    readonly id: string = EditorKeybindingContexts.diffEditorTextFocus;
+    override readonly id: string = EditorKeybindingContexts.diffEditorTextFocus;
 
-    protected canHandle(widget: EditorWidget): boolean {
+    protected override canHandle(widget: EditorWidget): boolean {
         return super.canHandle(widget) && DiffUris.isDiffUri(widget.editor.uri);
     }
 
@@ -82,6 +82,6 @@ export class DiffEditorTextFocusContext extends EditorTextFocusContext {
 @injectable()
 export class StrictEditorTextFocusContext extends EditorTextFocusContext {
 
-    readonly id: string = EditorKeybindingContexts.strictEditorTextFocus;
+    override readonly id: string = EditorKeybindingContexts.strictEditorTextFocus;
 
 }

--- a/packages/editor/src/browser/editor-manager.ts
+++ b/packages/editor/src/browser/editor-manager.ts
@@ -55,7 +55,7 @@ export class EditorManager extends NavigatableWidgetOpenHandler<EditorWidget> {
     readonly onCurrentEditorChanged: Event<EditorWidget | undefined> = this.onCurrentEditorChangedEmitter.event;
 
     @postConstruct()
-    protected init(): void {
+    protected override init(): void {
         super.init();
         this.shell.onDidChangeActiveWidget(() => this.updateActiveEditor());
         this.shell.onDidChangeCurrentWidget(() => this.updateCurrentEditor());
@@ -81,15 +81,15 @@ export class EditorManager extends NavigatableWidgetOpenHandler<EditorWidget> {
         this.updateCurrentEditor();
     }
 
-    getByUri(uri: URI, options?: EditorOpenerOptions): Promise<EditorWidget | undefined> {
+    override getByUri(uri: URI, options?: EditorOpenerOptions): Promise<EditorWidget | undefined> {
         return this.getWidget(uri, options);
     }
 
-    getOrCreateByUri(uri: URI, options?: EditorOpenerOptions): Promise<EditorWidget> {
+    override getOrCreateByUri(uri: URI, options?: EditorOpenerOptions): Promise<EditorWidget> {
         return this.getOrCreateWidget(uri, options);
     }
 
-    protected tryGetPendingWidget(uri: URI, options?: EditorOpenerOptions): MaybePromise<EditorWidget> | undefined {
+    protected override tryGetPendingWidget(uri: URI, options?: EditorOpenerOptions): MaybePromise<EditorWidget> | undefined {
         const editorPromise = super.tryGetPendingWidget(uri, options);
         if (editorPromise) {
             // Reveal selection before attachment to manage nav stack. (https://github.com/eclipse-theia/theia/issues/8955)
@@ -102,7 +102,7 @@ export class EditorManager extends NavigatableWidgetOpenHandler<EditorWidget> {
         return editorPromise;
     }
 
-    protected async getWidget(uri: URI, options?: EditorOpenerOptions): Promise<EditorWidget | undefined> {
+    protected override async getWidget(uri: URI, options?: EditorOpenerOptions): Promise<EditorWidget | undefined> {
         const editor = await super.getWidget(uri, options);
         if (editor) {
             // Reveal selection before attachment to manage nav stack. (https://github.com/eclipse-theia/theia/issues/8955)
@@ -111,7 +111,7 @@ export class EditorManager extends NavigatableWidgetOpenHandler<EditorWidget> {
         return editor;
     }
 
-    protected async getOrCreateWidget(uri: URI, options?: EditorOpenerOptions): Promise<EditorWidget> {
+    protected override async getOrCreateWidget(uri: URI, options?: EditorOpenerOptions): Promise<EditorWidget> {
         const editor = await super.getOrCreateWidget(uri, options);
         // Reveal selection before attachment to manage nav stack. (https://github.com/eclipse-theia/theia/issues/8955)
         this.revealSelection(editor, options, uri);
@@ -186,7 +186,7 @@ export class EditorManager extends NavigatableWidgetOpenHandler<EditorWidget> {
     }
 
     // This override only serves to inform external callers that they can use EditorOpenerOptions.
-    open(uri: URI, options?: EditorOpenerOptions): Promise<EditorWidget> {
+    override open(uri: URI, options?: EditorOpenerOptions): Promise<EditorWidget> {
         return super.open(uri, options);
     }
 
@@ -299,7 +299,7 @@ export class EditorManager extends NavigatableWidgetOpenHandler<EditorWidget> {
         return this.getCounterForUri(uri) ?? this.createCounterForUri(uri);
     }
 
-    protected createWidgetOptions(uri: URI, options?: EditorOpenerOptions): NavigatableWidgetOptions {
+    protected override createWidgetOptions(uri: URI, options?: EditorOpenerOptions): NavigatableWidgetOptions {
         const navigatableOptions = super.createWidgetOptions(uri, options);
         navigatableOptions.counter = options?.counter ?? this.getOrCreateCounterForUri(uri);
         return navigatableOptions;

--- a/packages/editor/src/browser/editor-widget.ts
+++ b/packages/editor/src/browser/editor-widget.ts
@@ -54,25 +54,25 @@ export class EditorWidget extends BaseWidget implements SaveableSource, Navigata
         return this.editor.createMoveToUri(resourceUri);
     }
 
-    protected onActivateRequest(msg: Message): void {
+    protected override onActivateRequest(msg: Message): void {
         super.onActivateRequest(msg);
         this.editor.focus();
         this.selectionService.selection = this.editor;
     }
 
-    protected onAfterAttach(msg: Message): void {
+    protected override onAfterAttach(msg: Message): void {
         super.onAfterAttach(msg);
         if (this.isVisible) {
             this.editor.refresh();
         }
     }
 
-    protected onAfterShow(msg: Message): void {
+    protected override onAfterShow(msg: Message): void {
         super.onAfterShow(msg);
         this.editor.refresh();
     }
 
-    protected onResize(msg: Widget.ResizeMessage): void {
+    protected override onResize(msg: Widget.ResizeMessage): void {
         if (msg.width < 0 || msg.height < 0) {
             this.editor.resizeToFit();
         } else {

--- a/packages/editor/src/browser/navigation/test/mock-navigation-location-updater.ts
+++ b/packages/editor/src/browser/navigation/test/mock-navigation-location-updater.ts
@@ -22,7 +22,7 @@ import { NavigationLocationUpdater } from '../navigation-location-updater';
  */
 export class MockNavigationLocationUpdater extends NavigationLocationUpdater {
 
-    contained(subRange: Range, range: Range): boolean {
+    override contained(subRange: Range, range: Range): boolean {
         return super.contained(subRange, range);
     }
 
@@ -34,7 +34,7 @@ export class MockNavigationLocationUpdater extends NavigationLocationUpdater {
  */
 export class NoopNavigationLocationUpdater extends NavigationLocationUpdater {
 
-    affects(): false {
+    override affects(): false {
         return false;
     }
 

--- a/packages/filesystem/src/browser/breadcrumbs/filepath-breadcrumbs-container.ts
+++ b/packages/filesystem/src/browser/breadcrumbs/filepath-breadcrumbs-container.ts
@@ -40,7 +40,7 @@ export class BreadcrumbsFileTreeWidget extends FileTreeWidget {
     protected readonly openerService: OpenerService;
 
     constructor(
-        @inject(TreeProps) override readonly props: TreeProps,
+        @inject(TreeProps) props: TreeProps,
         @inject(FileTreeModel) override readonly model: FileTreeModel,
         @inject(ContextMenuRenderer) contextMenuRenderer: ContextMenuRenderer
     ) {

--- a/packages/filesystem/src/browser/breadcrumbs/filepath-breadcrumbs-container.ts
+++ b/packages/filesystem/src/browser/breadcrumbs/filepath-breadcrumbs-container.ts
@@ -40,15 +40,15 @@ export class BreadcrumbsFileTreeWidget extends FileTreeWidget {
     protected readonly openerService: OpenerService;
 
     constructor(
-        @inject(TreeProps) readonly props: TreeProps,
-        @inject(FileTreeModel) readonly model: FileTreeModel,
+        @inject(TreeProps) override readonly props: TreeProps,
+        @inject(FileTreeModel) override readonly model: FileTreeModel,
         @inject(ContextMenuRenderer) contextMenuRenderer: ContextMenuRenderer
     ) {
         super(props, model, contextMenuRenderer);
         this.addClass(BREADCRUMBS_FILETREE_CLASS);
     }
 
-    protected createNodeAttributes(node: TreeNode, props: NodeProps): React.Attributes & React.HTMLAttributes<HTMLElement> {
+    protected override createNodeAttributes(node: TreeNode, props: NodeProps): React.Attributes & React.HTMLAttributes<HTMLElement> {
         const elementAttrs = super.createNodeAttributes(node, props);
         return {
             ...elementAttrs,
@@ -56,7 +56,7 @@ export class BreadcrumbsFileTreeWidget extends FileTreeWidget {
         };
     }
 
-    protected handleClickEvent(node: TreeNode | undefined, event: React.MouseEvent<HTMLElement>): void {
+    protected override handleClickEvent(node: TreeNode | undefined, event: React.MouseEvent<HTMLElement>): void {
         if (FileStatNode.is(node) && !node.fileStat.isDirectory) {
             open(this.openerService, node.uri, { preview: true });
         } else {

--- a/packages/filesystem/src/browser/file-dialog/file-dialog-model.ts
+++ b/packages/filesystem/src/browser/file-dialog/file-dialog-model.ts
@@ -24,13 +24,13 @@ import { FileDialogTree } from './file-dialog-tree';
 @injectable()
 export class FileDialogModel extends FileTreeModel {
 
-    @inject(FileDialogTree) readonly tree: FileDialogTree;
+    @inject(FileDialogTree) override readonly tree: FileDialogTree;
     protected readonly onDidOpenFileEmitter = new Emitter<void>();
     protected _initialLocation: URI | undefined;
     private _disableFileSelection: boolean = false;
 
     @postConstruct()
-    protected init(): void {
+    protected override init(): void {
         super.init();
         this.toDispose.push(this.onDidOpenFileEmitter);
     }
@@ -47,7 +47,7 @@ export class FileDialogModel extends FileTreeModel {
         this._disableFileSelection = isSelectable;
     }
 
-    async navigateTo(nodeOrId: TreeNode | string | undefined): Promise<TreeNode | undefined> {
+    override async navigateTo(nodeOrId: TreeNode | string | undefined): Promise<TreeNode | undefined> {
         const result = await super.navigateTo(nodeOrId);
         if (!this._initialLocation && FileStatNode.is(result)) {
             this._initialLocation = result.uri;
@@ -59,7 +59,7 @@ export class FileDialogModel extends FileTreeModel {
         return this.onDidOpenFileEmitter.event;
     }
 
-    protected doOpenNode(node: TreeNode): void {
+    protected override doOpenNode(node: TreeNode): void {
         if (FileNode.is(node)) {
             this.onDidOpenFileEmitter.fire(undefined);
         } else if (DirNode.is(node)) {
@@ -69,7 +69,7 @@ export class FileDialogModel extends FileTreeModel {
         }
     }
 
-    getNextSelectableNode(node: SelectableTreeNode = this.selectedNodes[0]): SelectableTreeNode | undefined {
+    override getNextSelectableNode(node: SelectableTreeNode = this.selectedNodes[0]): SelectableTreeNode | undefined {
         let nextNode: SelectableTreeNode | undefined = node;
         do {
             nextNode = super.getNextSelectableNode(nextNode);
@@ -77,7 +77,7 @@ export class FileDialogModel extends FileTreeModel {
         return nextNode;
     }
 
-    getPrevSelectableNode(node: SelectableTreeNode = this.selectedNodes[0]): SelectableTreeNode | undefined {
+    override getPrevSelectableNode(node: SelectableTreeNode = this.selectedNodes[0]): SelectableTreeNode | undefined {
         let prevNode: SelectableTreeNode | undefined = node;
         do {
             prevNode = super.getPrevSelectableNode(prevNode);

--- a/packages/filesystem/src/browser/file-dialog/file-dialog-tree-filters-renderer.tsx
+++ b/packages/filesystem/src/browser/file-dialog/file-dialog-tree-filters-renderer.tsx
@@ -64,7 +64,7 @@ export class FileDialogTreeFiltersRenderer extends ReactRenderer {
 
     protected readonly handleFilterChanged = (e: React.ChangeEvent<HTMLSelectElement>) => this.onFilterChanged(e);
 
-    protected doRender(): React.ReactNode {
+    protected override doRender(): React.ReactNode {
         if (!this.appliedFilters) {
             return undefined;
         }

--- a/packages/filesystem/src/browser/file-dialog/file-dialog-tree.ts
+++ b/packages/filesystem/src/browser/file-dialog/file-dialog-tree.ts
@@ -37,7 +37,7 @@ export class FileDialogTree extends FileTree {
         this.refresh();
     }
 
-    protected async toNodes(fileStat: FileStat, parent: CompositeTreeNode): Promise<TreeNode[]> {
+    protected override async toNodes(fileStat: FileStat, parent: CompositeTreeNode): Promise<TreeNode[]> {
         if (!fileStat.children) {
             return [];
         }

--- a/packages/filesystem/src/browser/file-dialog/file-dialog-widget.ts
+++ b/packages/filesystem/src/browser/file-dialog/file-dialog-widget.ts
@@ -28,8 +28,8 @@ export class FileDialogWidget extends FileTreeWidget {
     private _disableFileSelection: boolean = false;
 
     constructor(
-        @inject(TreeProps) readonly props: TreeProps,
-        @inject(FileDialogModel) readonly model: FileDialogModel,
+        @inject(TreeProps) override readonly props: TreeProps,
+        @inject(FileDialogModel) override readonly model: FileDialogModel,
         @inject(ContextMenuRenderer) contextMenuRenderer: ContextMenuRenderer
     ) {
         super(props, model, contextMenuRenderer);
@@ -41,7 +41,7 @@ export class FileDialogWidget extends FileTreeWidget {
         this.model.disableFileSelection = isSelectable;
     }
 
-    protected createNodeAttributes(node: TreeNode, props: NodeProps): React.Attributes & React.HTMLAttributes<HTMLElement> {
+    protected override createNodeAttributes(node: TreeNode, props: NodeProps): React.Attributes & React.HTMLAttributes<HTMLElement> {
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         const attr = super.createNodeAttributes(node, props) as any;
         if (this.shouldDisableSelection(node)) {
@@ -55,7 +55,7 @@ export class FileDialogWidget extends FileTreeWidget {
         return attr;
     }
 
-    protected createNodeClassNames(node: TreeNode, props: NodeProps): string[] {
+    protected override createNodeClassNames(node: TreeNode, props: NodeProps): string[] {
         const classNames = super.createNodeClassNames(node, props);
         if (this.shouldDisableSelection(node)) {
             [SELECTED_CLASS, FOCUS_CLASS].forEach(name => {

--- a/packages/filesystem/src/browser/file-dialog/file-dialog-widget.ts
+++ b/packages/filesystem/src/browser/file-dialog/file-dialog-widget.ts
@@ -28,7 +28,7 @@ export class FileDialogWidget extends FileTreeWidget {
     private _disableFileSelection: boolean = false;
 
     constructor(
-        @inject(TreeProps) override readonly props: TreeProps,
+        @inject(TreeProps) props: TreeProps,
         @inject(FileDialogModel) override readonly model: FileDialogModel,
         @inject(ContextMenuRenderer) contextMenuRenderer: ContextMenuRenderer
     ) {

--- a/packages/filesystem/src/browser/file-dialog/file-dialog.ts
+++ b/packages/filesystem/src/browser/file-dialog/file-dialog.ts
@@ -127,7 +127,7 @@ export abstract class FileDialog<T> extends AbstractDialog<T> {
     @inject(FileDialogTreeFiltersRendererFactory) readonly treeFiltersFactory: FileDialogTreeFiltersRendererFactory;
 
     constructor(
-        @inject(FileDialogProps) readonly props: FileDialogProps
+        @inject(FileDialogProps) override readonly props: FileDialogProps
     ) {
         super(props);
     }
@@ -177,7 +177,7 @@ export abstract class FileDialog<T> extends AbstractDialog<T> {
         return this.widget.model;
     }
 
-    protected onUpdateRequest(msg: Message): void {
+    protected override onUpdateRequest(msg: Message): void {
         super.onUpdateRequest(msg);
         setEnabled(this.back, this.model.canNavigateBackward());
         setEnabled(this.forward, this.model.canNavigateForward());
@@ -194,14 +194,14 @@ export abstract class FileDialog<T> extends AbstractDialog<T> {
         this.widget.update();
     }
 
-    protected handleEnter(event: KeyboardEvent): boolean | void {
+    protected override handleEnter(event: KeyboardEvent): boolean | void {
         if (event.target instanceof HTMLTextAreaElement || this.targetIsDirectoryInput(event.target) || this.targetIsInputToggle(event.target)) {
             return false;
         }
         this.accept();
     }
 
-    protected handleEscape(event: KeyboardEvent): boolean | void {
+    protected override handleEscape(event: KeyboardEvent): boolean | void {
         if (event.target instanceof HTMLTextAreaElement || this.targetIsDirectoryInput(event.target)) {
             return false;
         }
@@ -232,7 +232,7 @@ export abstract class FileDialog<T> extends AbstractDialog<T> {
         }
     }
 
-    protected onAfterAttach(msg: Message): void {
+    protected override onAfterAttach(msg: Message): void {
         Widget.attach(this.treePanel, this.contentNode);
         this.toDisposeOnDetach.push(Disposable.create(() => {
             Widget.detach(this.treePanel);
@@ -279,7 +279,7 @@ export abstract class FileDialog<T> extends AbstractDialog<T> {
 
     protected abstract getAcceptButtonLabel(): string;
 
-    protected onActivateRequest(msg: Message): void {
+    protected override onActivateRequest(msg: Message): void {
         this.widget.activate();
     }
 
@@ -288,12 +288,12 @@ export abstract class FileDialog<T> extends AbstractDialog<T> {
 @injectable()
 export class OpenFileDialog extends FileDialog<MaybeArray<FileStatNode>> {
 
-    constructor(@inject(OpenFileDialogProps) readonly props: OpenFileDialogProps) {
+    constructor(@inject(OpenFileDialogProps) override readonly props: OpenFileDialogProps) {
         super(props);
     }
 
     @postConstruct()
-    init(): void {
+    override init(): void {
         super.init();
         const { props } = this;
         if (props.canSelectFiles !== undefined) {
@@ -305,7 +305,7 @@ export class OpenFileDialog extends FileDialog<MaybeArray<FileStatNode>> {
         return this.props.openLabel ? this.props.openLabel : 'Open';
     }
 
-    protected isValid(value: MaybeArray<FileStatNode>): string {
+    protected override isValid(value: MaybeArray<FileStatNode>): string {
         if (value && !this.props.canSelectMany && value instanceof Array) {
             return 'You can select only one item';
         }
@@ -320,7 +320,7 @@ export class OpenFileDialog extends FileDialog<MaybeArray<FileStatNode>> {
         }
     }
 
-    protected async accept(): Promise<void> {
+    protected override async accept(): Promise<void> {
         const selection = this.value;
         if (!this.props.canSelectFolders
             && !Array.isArray(selection)
@@ -340,12 +340,12 @@ export class SaveFileDialog extends FileDialog<URI | undefined> {
     @inject(LabelProvider)
     protected readonly labelProvider: LabelProvider;
 
-    constructor(@inject(SaveFileDialogProps) readonly props: SaveFileDialogProps) {
+    constructor(@inject(SaveFileDialogProps) override readonly props: SaveFileDialogProps) {
         super(props);
     }
 
     @postConstruct()
-    init(): void {
+    override init(): void {
         super.init();
         const { widget } = this;
         widget.addClass(SAVE_DIALOG_CLASS);
@@ -355,7 +355,7 @@ export class SaveFileDialog extends FileDialog<URI | undefined> {
         return this.props.saveLabel ? this.props.saveLabel : 'Save';
     }
 
-    protected onUpdateRequest(msg: Message): void {
+    protected override onUpdateRequest(msg: Message): void {
         // Update file name field when changing a selection
         if (this.fileNameField) {
             if (this.widget.model.selectedFileStatNodes.length === 1) {
@@ -372,7 +372,7 @@ export class SaveFileDialog extends FileDialog<URI | undefined> {
         super.onUpdateRequest(msg);
     }
 
-    protected isValid(value: URI | undefined): string | boolean {
+    protected override isValid(value: URI | undefined): string | boolean {
         if (this.fileNameField && this.fileNameField.value) {
             return '';
         }
@@ -393,7 +393,7 @@ export class SaveFileDialog extends FileDialog<URI | undefined> {
         return undefined;
     }
 
-    protected onAfterAttach(msg: Message): void {
+    protected override onAfterAttach(msg: Message): void {
         super.onAfterAttach(msg);
 
         const fileNamePanel = document.createElement('div');

--- a/packages/filesystem/src/browser/file-selection.ts
+++ b/packages/filesystem/src/browser/file-selection.ts
@@ -28,8 +28,8 @@ export namespace FileSelection {
     export class CommandHandler extends SelectionCommandHandler<FileSelection> {
 
         constructor(
-            protected readonly selectionService: SelectionService,
-            protected readonly options: SelectionCommandHandler.Options<FileSelection>
+            protected override readonly selectionService: SelectionService,
+            protected override readonly options: SelectionCommandHandler.Options<FileSelection>
         ) {
             super(
                 selectionService,

--- a/packages/filesystem/src/browser/file-service.ts
+++ b/packages/filesystem/src/browser/file-service.ts
@@ -253,7 +253,7 @@ export class TextFileOperationError extends FileOperationError {
     constructor(
         message: string,
         public textFileOperationResult: TextFileOperationResult,
-        public options?: ReadTextFileOptions & WriteTextFileOptions
+        override options?: ReadTextFileOptions & WriteTextFileOptions
     ) {
         super(message, FileOperationResult.FILE_OTHER_ERROR);
         Object.setPrototypeOf(this, TextFileOperationError.prototype);

--- a/packages/filesystem/src/browser/file-tree/file-tree-model.ts
+++ b/packages/filesystem/src/browser/file-tree/file-tree-model.ts
@@ -41,7 +41,7 @@ export class FileTreeModel extends CompressedTreeModel implements LocationServic
     protected readonly environments: EnvVariablesServer;
 
     @postConstruct()
-    protected init(): void {
+    protected override init(): void {
         super.init();
         this.toDispose.push(this.fileService.onDidFilesChange(changes => this.onFilesChanged(changes)));
         this.toDispose.push(this.fileService.onDidRunOperation(event => this.onDidMove(event)));

--- a/packages/filesystem/src/browser/file-tree/file-tree-widget.tsx
+++ b/packages/filesystem/src/browser/file-tree/file-tree-widget.tsx
@@ -44,8 +44,8 @@ export class FileTreeWidget extends CompressedTreeWidget {
     protected readonly iconThemeService: IconThemeService;
 
     constructor(
-        @inject(TreeProps) readonly props: TreeProps,
-        @inject(FileTreeModel) readonly model: FileTreeModel,
+        @inject(TreeProps) override readonly props: TreeProps,
+        @inject(FileTreeModel) override readonly model: FileTreeModel,
         @inject(ContextMenuRenderer) contextMenuRenderer: ContextMenuRenderer
     ) {
         super(props, model, contextMenuRenderer);
@@ -53,7 +53,7 @@ export class FileTreeWidget extends CompressedTreeWidget {
         this.toDispose.push(this.toCancelNodeExpansion);
     }
 
-    protected createNodeClassNames(node: TreeNode, props: NodeProps): string[] {
+    protected override createNodeClassNames(node: TreeNode, props: NodeProps): string[] {
         const classNames = super.createNodeClassNames(node, props);
         if (FileStatNode.is(node)) {
             classNames.push(FILE_STAT_NODE_CLASS);
@@ -64,7 +64,7 @@ export class FileTreeWidget extends CompressedTreeWidget {
         return classNames;
     }
 
-    protected renderIcon(node: TreeNode, props: NodeProps): React.ReactNode {
+    protected override renderIcon(node: TreeNode, props: NodeProps): React.ReactNode {
         const icon = this.toNodeIcon(node);
         if (icon) {
             return <div className={icon + ' file-icon'}></div>;
@@ -73,7 +73,7 @@ export class FileTreeWidget extends CompressedTreeWidget {
         return null;
     }
 
-    protected createContainerAttributes(): React.HTMLAttributes<HTMLElement> {
+    protected override createContainerAttributes(): React.HTMLAttributes<HTMLElement> {
         const attrs = super.createContainerAttributes();
         return {
             ...attrs,
@@ -84,7 +84,7 @@ export class FileTreeWidget extends CompressedTreeWidget {
         };
     }
 
-    protected createNodeAttributes(node: TreeNode, props: NodeProps): React.Attributes & React.HTMLAttributes<HTMLElement> {
+    protected override createNodeAttributes(node: TreeNode, props: NodeProps): React.Attributes & React.HTMLAttributes<HTMLElement> {
         return {
             ...super.createNodeAttributes(node, props),
             ...this.getNodeDragHandlers(node, props),
@@ -98,7 +98,7 @@ export class FileTreeWidget extends CompressedTreeWidget {
         return uri ? uri.path.toString() : undefined;
     }
 
-    protected getCaptionChildEventHandlers(node: TreeNode, props: CompressedNodeProps): React.Attributes & React.HtmlHTMLAttributes<HTMLElement> {
+    protected override getCaptionChildEventHandlers(node: TreeNode, props: CompressedNodeProps): React.Attributes & React.HtmlHTMLAttributes<HTMLElement> {
         return {
             ...super.getCaptionChildEventHandlers(node, props),
             ...this.getNodeDragHandlers(node, props),
@@ -234,7 +234,7 @@ export class FileTreeWidget extends CompressedTreeWidget {
         return !!theme && !!theme.hidesExplorerArrows;
     }
 
-    protected renderExpansionToggle(node: TreeNode, props: NodeProps): React.ReactNode {
+    protected override renderExpansionToggle(node: TreeNode, props: NodeProps): React.ReactNode {
         if (this.hidesExplorerArrows) {
             // eslint-disable-next-line no-null/no-null
             return null;
@@ -242,7 +242,7 @@ export class FileTreeWidget extends CompressedTreeWidget {
         return super.renderExpansionToggle(node, props);
     }
 
-    protected getPaddingLeft(node: TreeNode, props: NodeProps): number {
+    protected override getPaddingLeft(node: TreeNode, props: NodeProps): number {
         if (this.hidesExplorerArrows) {
             // additional left padding instead of top-level expansion toggle
             return super.getPaddingLeft(node, props) + this.props.leftPadding;
@@ -250,7 +250,7 @@ export class FileTreeWidget extends CompressedTreeWidget {
         return super.getPaddingLeft(node, props);
     }
 
-    protected needsExpansionTogglePadding(node: TreeNode): boolean {
+    protected override needsExpansionTogglePadding(node: TreeNode): boolean {
         const theme = this.iconThemeService.getDefinition(this.iconThemeService.current);
         if (theme && (theme.hidesExplorerArrows || (theme.hasFileIcons && !theme.hasFolderIcons))) {
             return false;
@@ -258,7 +258,7 @@ export class FileTreeWidget extends CompressedTreeWidget {
         return super.needsExpansionTogglePadding(node);
     }
 
-    protected deflateForStorage(node: TreeNode): object {
+    protected override deflateForStorage(node: TreeNode): object {
         const deflated = super.deflateForStorage(node);
         if (FileStatNode.is(node) && FileStatNodeData.is(deflated)) {
             deflated.uri = node.uri.toString();
@@ -269,7 +269,7 @@ export class FileTreeWidget extends CompressedTreeWidget {
     }
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    protected inflateFromStorage(node: any, parent?: TreeNode): TreeNode {
+    protected override inflateFromStorage(node: any, parent?: TreeNode): TreeNode {
         if (FileStatNodeData.is(node)) {
             // eslint-disable-next-line @typescript-eslint/no-explicit-any
             const fileStatNode: FileStatNode = node as any;

--- a/packages/filesystem/src/browser/file-tree/file-tree-widget.tsx
+++ b/packages/filesystem/src/browser/file-tree/file-tree-widget.tsx
@@ -44,7 +44,7 @@ export class FileTreeWidget extends CompressedTreeWidget {
     protected readonly iconThemeService: IconThemeService;
 
     constructor(
-        @inject(TreeProps) override readonly props: TreeProps,
+        @inject(TreeProps) props: TreeProps,
         @inject(FileTreeModel) override readonly model: FileTreeModel,
         @inject(ContextMenuRenderer) contextMenuRenderer: ContextMenuRenderer
     ) {

--- a/packages/filesystem/src/browser/file-tree/file-tree.ts
+++ b/packages/filesystem/src/browser/file-tree/file-tree.ts
@@ -34,7 +34,7 @@ export class FileTree extends TreeImpl {
     @inject(MessageService)
     protected readonly messagingService: MessageService;
 
-    async resolveChildren(parent: CompositeTreeNode): Promise<TreeNode[]> {
+    override async resolveChildren(parent: CompositeTreeNode): Promise<TreeNode[]> {
         if (FileStatNode.is(parent)) {
             const fileStat = await this.resolveFileStat(parent);
             if (fileStat) {

--- a/packages/filesystem/src/browser/location/location-renderer.tsx
+++ b/packages/filesystem/src/browser/location/location-renderer.tsx
@@ -117,7 +117,7 @@ export class LocationListRenderer extends ReactRenderer {
         this.homeDir = (new URI(homeDirWithPrefix)).path.toString();
     }
 
-    render(): void {
+    override render(): void {
         ReactDOM.render(this.doRender(), this.host, this.doAfterRender);
     }
 
@@ -153,7 +153,7 @@ export class LocationListRenderer extends ReactRenderer {
     protected readonly handleTextInputOnBlur = () => this.toggleToSelectInput();
     protected readonly handleTextInputMouseDown = (e: React.MouseEvent<HTMLSpanElement>) => this.toggleToTextInputOnMouseDown(e);
 
-    protected doRender(): React.ReactElement {
+    protected override doRender(): React.ReactElement {
         return (
             <>
                 {this.renderInputIcon()}
@@ -372,7 +372,7 @@ export class LocationListRenderer extends ReactRenderer {
         return undefined;
     }
 
-    dispose(): void {
+    override dispose(): void {
         super.dispose();
         this.toDisposeOnNewCache.dispose();
     }

--- a/packages/filesystem/src/common/remote-file-system-provider.ts
+++ b/packages/filesystem/src/common/remote-file-system-provider.ts
@@ -82,7 +82,7 @@ export const RemoteFileSystemProviderError = ApplicationError.declare(-33005,
 export class RemoteFileSystemProxyFactory<T extends object> extends JsonRpcProxyFactory<T> {
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    protected serializeError(e: any): any {
+    protected override serializeError(e: any): any {
         if (e instanceof FileSystemProviderError) {
             const { code, name } = e;
             return super.serializeError(RemoteFileSystemProviderError(e.message, { code, name }, e.stack));
@@ -91,7 +91,7 @@ export class RemoteFileSystemProxyFactory<T extends object> extends JsonRpcProxy
     }
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    protected deserializeError(capturedError: Error, e: any): any {
+    protected override deserializeError(capturedError: Error, e: any): any {
         const error = super.deserializeError(capturedError, e);
         if (RemoteFileSystemProviderError.is(error)) {
             const fileOperationError = new FileSystemProviderError(error.message, error.data.code);

--- a/packages/filesystem/src/electron-browser/file-dialog/electron-file-dialog-service.ts
+++ b/packages/filesystem/src/electron-browser/file-dialog/electron-file-dialog-service.ts
@@ -44,9 +44,9 @@ export class ElectronFileDialogService extends DefaultFileDialogService {
 
     @inject(MessageService) protected readonly messageService: MessageService;
 
-    async showOpenDialog(props: OpenFileDialogProps & { canSelectMany: true }, folder?: FileStat): Promise<MaybeArray<URI> | undefined>;
-    async showOpenDialog(props: OpenFileDialogProps, folder?: FileStat): Promise<URI | undefined>;
-    async showOpenDialog(props: OpenFileDialogProps, folder?: FileStat): Promise<MaybeArray<URI> | undefined> {
+    override async showOpenDialog(props: OpenFileDialogProps & { canSelectMany: true }, folder?: FileStat): Promise<MaybeArray<URI> | undefined>;
+    override async showOpenDialog(props: OpenFileDialogProps, folder?: FileStat): Promise<URI | undefined>;
+    override async showOpenDialog(props: OpenFileDialogProps, folder?: FileStat): Promise<MaybeArray<URI> | undefined> {
         const rootNode = await this.getRootNode(folder);
         if (rootNode) {
             const { filePaths } = await electronRemote.dialog.showOpenDialog(this.toOpenDialogOptions(rootNode.uri, props));
@@ -62,7 +62,7 @@ export class ElectronFileDialogService extends DefaultFileDialogService {
         return undefined;
     }
 
-    async showSaveDialog(props: SaveFileDialogProps, folder?: FileStat): Promise<URI | undefined> {
+    override async showSaveDialog(props: SaveFileDialogProps, folder?: FileStat): Promise<URI | undefined> {
         const rootNode = await this.getRootNode(folder);
         if (rootNode) {
             const { filePath } = await electronRemote.dialog.showSaveDialog(this.toSaveDialogOptions(rootNode.uri, props));

--- a/packages/filesystem/src/node/download/test/mock-directory-archiver.ts
+++ b/packages/filesystem/src/node/download/test/mock-directory-archiver.ts
@@ -23,7 +23,7 @@ export class MockDirectoryArchiver extends DirectoryArchiver {
         super();
     }
 
-    protected async isDir(uri: URI): Promise<boolean> {
+    protected override async isDir(uri: URI): Promise<boolean> {
         return !!this.folders && this.folders.map(u => u.toString()).indexOf(uri.toString()) !== -1;
     }
 

--- a/packages/getting-started/src/browser/getting-started-contribution.ts
+++ b/packages/getting-started/src/browser/getting-started-contribution.ts
@@ -56,13 +56,13 @@ export class GettingStartedContribution extends AbstractViewContribution<Getting
         }
     }
 
-    registerCommands(registry: CommandRegistry): void {
+    override registerCommands(registry: CommandRegistry): void {
         registry.registerCommand(GettingStartedCommand, {
             execute: () => this.openView({ reveal: true }),
         });
     }
 
-    registerMenus(menus: MenuModelRegistry): void {
+    override registerMenus(menus: MenuModelRegistry): void {
         menus.registerMenuAction(CommonMenus.HELP, {
             commandId: GettingStartedCommand.id,
             label: GettingStartedCommand.label,

--- a/packages/git/src/browser/blame/blame-contribution.ts
+++ b/packages/git/src/browser/blame/blame-contribution.ts
@@ -165,9 +165,9 @@ export class BlameAnnotationsKeybindingContext extends EditorTextFocusContext {
     @inject(StrictEditorTextFocusContext)
     protected readonly base: StrictEditorTextFocusContext;
 
-    id = BlameAnnotationsKeybindingContext.showsBlameAnnotations;
+    override id = BlameAnnotationsKeybindingContext.showsBlameAnnotations;
 
-    protected canHandle(widget: EditorWidget): boolean {
+    protected override canHandle(widget: EditorWidget): boolean {
         return this.base.isEnabled() && this.blameContribution.showsBlameAnnotations(widget.editor.uri);
     }
 }

--- a/packages/git/src/browser/diff/git-diff-contribution.ts
+++ b/packages/git/src/browser/diff/git-diff-contribution.ts
@@ -94,7 +94,7 @@ export class GitDiffContribution extends AbstractViewContribution<GitDiffWidget>
 
     constructor(
         @inject(SelectionService) protected readonly selectionService: SelectionService,
-        @inject(WidgetManager) protected readonly widgetManager: WidgetManager,
+        @inject(WidgetManager) protected override readonly widgetManager: WidgetManager,
         @inject(FrontendApplication) protected readonly app: FrontendApplication,
         @inject(GitQuickOpenService) protected readonly quickOpenService: GitQuickOpenService,
         @inject(FileService) protected readonly fileService: FileService,
@@ -112,13 +112,13 @@ export class GitDiffContribution extends AbstractViewContribution<GitDiffWidget>
         });
     }
 
-    registerMenus(menus: MenuModelRegistry): void {
+    override registerMenus(menus: MenuModelRegistry): void {
         menus.registerMenuAction(NavigatorContextMenu.COMPARE, {
             commandId: GitDiffCommands.OPEN_FILE_DIFF.id
         });
     }
 
-    registerCommands(commands: CommandRegistry): void {
+    override registerCommands(commands: CommandRegistry): void {
         commands.registerCommand(GitDiffCommands.OPEN_FILE_DIFF, this.newWorkspaceRootUriAwareCommandHandler({
             isVisible: uri => !!this.findGitRepository(uri),
             isEnabled: uri => !!this.findGitRepository(uri),

--- a/packages/git/src/browser/diff/git-diff-tree-model.tsx
+++ b/packages/git/src/browser/diff/git-diff-tree-model.tsx
@@ -103,7 +103,7 @@ export class GitDiffTreeModel extends ScmTreeModel {
         await this.resourceOpener.open(uriToOpen);
     }
 
-    storeState(): GitDiffTreeModel.Options {
+    override storeState(): GitDiffTreeModel.Options {
         if (this.provider) {
             return {
                 ...super.storeState(),
@@ -115,7 +115,7 @@ export class GitDiffTreeModel extends ScmTreeModel {
         }
     }
 
-    restoreState(oldState: GitDiffTreeModel.Options): void {
+    override restoreState(oldState: GitDiffTreeModel.Options): void {
         super.restoreState(oldState);
         if (oldState.rootUri && oldState.diffOptions) {
             this.setContent(oldState);

--- a/packages/git/src/browser/diff/git-diff-widget.tsx
+++ b/packages/git/src/browser/diff/git-diff-widget.tsx
@@ -112,13 +112,13 @@ export class GitDiffWidget extends BaseWidget implements StatefulWidget {
         this.onUpdateRequest(Widget.Msg.UpdateRequest);
     }
 
-    protected onUpdateRequest(msg: Message): void {
+    protected override onUpdateRequest(msg: Message): void {
         MessageLoop.sendMessage(this.diffHeaderWidget, msg);
         MessageLoop.sendMessage(this.resourceWidget, msg);
         super.onUpdateRequest(msg);
     }
 
-    protected onAfterAttach(msg: Message): void {
+    protected override onAfterAttach(msg: Message): void {
         this.node.appendChild(this.diffHeaderWidget.node);
         this.node.appendChild(this.resourceWidget.node);
 

--- a/packages/git/src/browser/history/git-commit-detail-open-handler.ts
+++ b/packages/git/src/browser/history/git-commit-detail-open-handler.ts
@@ -46,7 +46,7 @@ export class GitCommitDetailOpenHandler extends WidgetOpenHandler<GitCommitDetai
         }
     }
 
-    protected async doOpen(widget: GitCommitDetailWidget, options: GitCommitDetailOpenerOptions): Promise<void> {
+    protected override async doOpen(widget: GitCommitDetailWidget, options: GitCommitDetailOpenerOptions): Promise<void> {
         await super.doOpen(widget, options);
     }
 

--- a/packages/git/src/browser/history/git-commit-detail-widget.tsx
+++ b/packages/git/src/browser/history/git-commit-detail-widget.tsx
@@ -107,13 +107,13 @@ export class GitCommitDetailWidget extends BaseWidget implements StatefulWidget 
         this.onUpdateRequest(Widget.Msg.UpdateRequest);
     }
 
-    protected onUpdateRequest(msg: Message): void {
+    protected override onUpdateRequest(msg: Message): void {
         MessageLoop.sendMessage(this.commitDetailHeaderWidget, msg);
         MessageLoop.sendMessage(this.resourceWidget, msg);
         super.onUpdateRequest(msg);
     }
 
-    protected onAfterAttach(msg: Message): void {
+    protected override onAfterAttach(msg: Message): void {
         this.node.appendChild(this.commitDetailHeaderWidget.node);
         this.node.appendChild(this.resourceWidget.node);
 

--- a/packages/git/src/electron-browser/prompt/git-quick-open-prompt.ts
+++ b/packages/git/src/electron-browser/prompt/git-quick-open-prompt.ts
@@ -27,7 +27,7 @@ export class GitQuickOpenPrompt extends GitPrompt {
 
     protected readonly queue = new PQueue({ autoStart: true, concurrency: 1 });
 
-    async ask(question: GitPrompt.Question): Promise<GitPrompt.Answer> {
+    override async ask(question: GitPrompt.Question): Promise<GitPrompt.Answer> {
         return this.queue.add(() => {
             const { details, text, password } = question;
             return new Promise<GitPrompt.Answer>(async resolve => {
@@ -40,7 +40,7 @@ export class GitQuickOpenPrompt extends GitPrompt {
             });
         });
     }
-    dispose(): void {
+    override dispose(): void {
         if (!this.queue.isPaused) {
             this.queue.pause();
         }

--- a/packages/git/src/electron-node/env/electron-git-env-provider.ts
+++ b/packages/git/src/electron-node/env/electron-git-env-provider.ts
@@ -32,12 +32,12 @@ export class ElectronGitEnvProvider extends DefaultGitEnvProvider {
     protected _env: Object | undefined;
 
     @postConstruct()
-    protected init(): void {
+    protected override init(): void {
         super.init();
         this.toDispose.push(this.askpass);
     }
 
-    async getEnv(): Promise<Object> {
+    override async getEnv(): Promise<Object> {
         if (!this._env) {
             this._env = this.askpass.getEnv();
         }

--- a/packages/git/src/node/test/no-sync-repository-manager.ts
+++ b/packages/git/src/node/test/no-sync-repository-manager.ts
@@ -24,7 +24,7 @@ import { GitRepositoryManager } from '../git-repository-manager';
 @injectable()
 export class NoSyncRepositoryManager extends GitRepositoryManager {
 
-    protected sync(repository: Repository): Promise<void> {
+    protected override sync(repository: Repository): Promise<void> {
         return Promise.resolve();
     }
 

--- a/packages/keymaps/src/browser/keybindings-widget.tsx
+++ b/packages/keymaps/src/browser/keybindings-widget.tsx
@@ -694,7 +694,7 @@ class EditKeybindingDialog extends SingleTextInputDialog {
     protected resetButton: HTMLButtonElement | undefined;
 
     constructor(
-        @inject(SingleTextInputDialogProps) protected override readonly props: SingleTextInputDialogProps,
+        @inject(SingleTextInputDialogProps) props: SingleTextInputDialogProps,
         @inject(KeymapsService) protected readonly keymapsService: KeymapsService,
         item: KeybindingItem
     ) {

--- a/packages/keymaps/src/browser/keybindings-widget.tsx
+++ b/packages/keymaps/src/browser/keybindings-widget.tsx
@@ -152,7 +152,7 @@ export class KeybindingWidget extends ReactWidget {
         }
     }
 
-    protected onActivateRequest(msg: Message): void {
+    protected override onActivateRequest(msg: Message): void {
         super.onActivateRequest(msg);
         this.focusInputField();
     }
@@ -694,7 +694,7 @@ class EditKeybindingDialog extends SingleTextInputDialog {
     protected resetButton: HTMLButtonElement | undefined;
 
     constructor(
-        @inject(SingleTextInputDialogProps) protected readonly props: SingleTextInputDialogProps,
+        @inject(SingleTextInputDialogProps) protected override readonly props: SingleTextInputDialogProps,
         @inject(KeymapsService) protected readonly keymapsService: KeymapsService,
         item: KeybindingItem
     ) {
@@ -706,7 +706,7 @@ class EditKeybindingDialog extends SingleTextInputDialog {
         }
     }
 
-    protected onAfterAttach(msg: Message): void {
+    protected override onAfterAttach(msg: Message): void {
         super.onAfterAttach(msg);
         if (this.resetButton) {
             this.addResetAction(this.resetButton, 'click');

--- a/packages/keymaps/src/browser/keymaps-frontend-contribution.ts
+++ b/packages/keymaps/src/browser/keymaps-frontend-contribution.ts
@@ -67,7 +67,7 @@ export class KeymapsFrontendContribution extends AbstractViewContribution<Keybin
         });
     }
 
-    registerCommands(commands: CommandRegistry): void {
+    override registerCommands(commands: CommandRegistry): void {
         commands.registerCommand(KeymapsCommands.OPEN_KEYMAPS, {
             isEnabled: () => true,
             execute: () => this.openView({ activate: true })
@@ -88,7 +88,7 @@ export class KeymapsFrontendContribution extends AbstractViewContribution<Keybin
         });
     }
 
-    registerMenus(menus: MenuModelRegistry): void {
+    override registerMenus(menus: MenuModelRegistry): void {
         menus.registerMenuAction(CommonMenus.FILE_SETTINGS_SUBMENU_OPEN, {
             commandId: KeymapsCommands.OPEN_KEYMAPS.id,
             order: 'a20'
@@ -99,7 +99,7 @@ export class KeymapsFrontendContribution extends AbstractViewContribution<Keybin
         });
     }
 
-    registerKeybindings(keybindings: KeybindingRegistry): void {
+    override registerKeybindings(keybindings: KeybindingRegistry): void {
         keybindings.registerKeybinding({
             command: KeymapsCommands.OPEN_KEYMAPS.id,
             keybinding: 'ctrl+alt+,'

--- a/packages/markers/src/browser/marker-tree-model.ts
+++ b/packages/markers/src/browser/marker-tree-model.ts
@@ -23,7 +23,7 @@ export class MarkerTreeModel extends TreeModelImpl {
 
     @inject(OpenerService) protected readonly openerService: OpenerService;
 
-    protected doOpenNode(node: TreeNode): void {
+    protected override doOpenNode(node: TreeNode): void {
         if (MarkerNode.is(node)) {
             open(this.openerService, node.uri, this.getOpenerOptionsByMarker(node));
         } else {

--- a/packages/markers/src/browser/marker-tree.ts
+++ b/packages/markers/src/browser/marker-tree.ts
@@ -72,7 +72,7 @@ export abstract class MarkerTree<T extends object> extends TreeImpl {
         this.setChildren(node, children);
     }
 
-    protected async resolveChildren(parent: CompositeTreeNode): Promise<TreeNode[]> {
+    protected override async resolveChildren(parent: CompositeTreeNode): Promise<TreeNode[]> {
         if (MarkerRootNode.is(parent)) {
             const nodes: MarkerInfoNode[] = [];
             for (const id of this.markerManager.getUris()) {

--- a/packages/markers/src/browser/problem/problem-contribution.ts
+++ b/packages/markers/src/browser/problem/problem-contribution.ts
@@ -127,7 +127,7 @@ export class ProblemContribution extends AbstractViewContribution<ProblemWidget>
 
     }
 
-    registerCommands(commands: CommandRegistry): void {
+    override registerCommands(commands: CommandRegistry): void {
         super.registerCommands(commands);
         commands.registerCommand(ProblemsCommands.COLLAPSE_ALL, {
             execute: () => this.collapseAllProblems()
@@ -160,7 +160,7 @@ export class ProblemContribution extends AbstractViewContribution<ProblemWidget>
         });
     }
 
-    registerMenus(menus: MenuModelRegistry): void {
+    override registerMenus(menus: MenuModelRegistry): void {
         super.registerMenus(menus);
         menus.registerMenuAction(ProblemsMenu.CLIPBOARD, {
             commandId: ProblemsCommands.COPY.id,

--- a/packages/markers/src/browser/problem/problem-selection.ts
+++ b/packages/markers/src/browser/problem/problem-selection.ts
@@ -30,8 +30,8 @@ export namespace ProblemSelection {
     export class CommandHandler extends SelectionCommandHandler<ProblemSelection> {
 
         constructor(
-            protected override readonly selectionService: SelectionService,
-            protected override readonly options: SelectionCommandHandler.Options<ProblemSelection>
+            selectionService: SelectionService,
+            options: SelectionCommandHandler.Options<ProblemSelection>
         ) {
             super(
                 selectionService,

--- a/packages/markers/src/browser/problem/problem-selection.ts
+++ b/packages/markers/src/browser/problem/problem-selection.ts
@@ -30,8 +30,8 @@ export namespace ProblemSelection {
     export class CommandHandler extends SelectionCommandHandler<ProblemSelection> {
 
         constructor(
-            protected readonly selectionService: SelectionService,
-            protected readonly options: SelectionCommandHandler.Options<ProblemSelection>
+            protected override readonly selectionService: SelectionService,
+            protected override readonly options: SelectionCommandHandler.Options<ProblemSelection>
         ) {
             super(
                 selectionService,

--- a/packages/markers/src/browser/problem/problem-tree-model.ts
+++ b/packages/markers/src/browser/problem/problem-tree-model.ts
@@ -29,9 +29,10 @@ import { ProblemUtils } from './problem-utils';
 export class ProblemTree extends MarkerTree<Diagnostic> {
 
     constructor(
-        @inject(ProblemManager) protected readonly problemManager: ProblemManager,
-        @inject(MarkerOptions) protected override readonly markerOptions: MarkerOptions) {
-        super(problemManager, markerOptions);
+        @inject(ProblemManager) markerManager: ProblemManager,
+        @inject(MarkerOptions) markerOptions: MarkerOptions
+    ) {
+        super(markerManager, markerOptions);
     }
 
     protected override getMarkerNodes(parent: MarkerInfoNode, markers: Marker<Diagnostic>[]): MarkerNode[] {

--- a/packages/markers/src/browser/problem/problem-tree-model.ts
+++ b/packages/markers/src/browser/problem/problem-tree-model.ts
@@ -30,11 +30,11 @@ export class ProblemTree extends MarkerTree<Diagnostic> {
 
     constructor(
         @inject(ProblemManager) protected readonly problemManager: ProblemManager,
-        @inject(MarkerOptions) protected readonly markerOptions: MarkerOptions) {
+        @inject(MarkerOptions) protected override readonly markerOptions: MarkerOptions) {
         super(problemManager, markerOptions);
     }
 
-    protected getMarkerNodes(parent: MarkerInfoNode, markers: Marker<Diagnostic>[]): MarkerNode[] {
+    protected override getMarkerNodes(parent: MarkerInfoNode, markers: Marker<Diagnostic>[]): MarkerNode[] {
         const nodes = super.getMarkerNodes(parent, markers);
         return nodes.sort((a, b) => this.sortMarkers(a, b));
     }
@@ -75,7 +75,7 @@ export class ProblemTree extends MarkerTree<Diagnostic> {
         return 0;
     }
 
-    protected insertNodeWithMarkers(node: MarkerInfoNode, markers: Marker<Diagnostic>[]): void {
+    protected override insertNodeWithMarkers(node: MarkerInfoNode, markers: Marker<Diagnostic>[]): void {
         ProblemCompositeTreeNode.addChild(node.parent, node, markers);
         const children = this.getMarkerNodes(node, markers);
         node.numberOfMarkers = markers.length;
@@ -89,7 +89,7 @@ export class ProblemTreeModel extends MarkerTreeModel {
 
     @inject(ProblemManager) protected readonly problemManager: ProblemManager;
 
-    protected getOpenerOptionsByMarker(node: MarkerNode): OpenerOptions | undefined {
+    protected override getOpenerOptionsByMarker(node: MarkerNode): OpenerOptions | undefined {
         if (ProblemMarker.is(node.marker)) {
             return {
                 selection: node.marker.data.range

--- a/packages/markers/src/browser/problem/problem-widget.tsx
+++ b/packages/markers/src/browser/problem/problem-widget.tsx
@@ -42,11 +42,13 @@ export class ProblemWidget extends TreeWidget {
     @inject(ApplicationShell)
     protected readonly shell: ApplicationShell;
 
+    @inject(ProblemManager)
+    protected readonly problemManager: ProblemManager;
+
     constructor(
-        @inject(ProblemManager) protected readonly problemManager: ProblemManager,
-        @inject(TreeProps) readonly treeProps: TreeProps,
+        @inject(TreeProps) treeProps: TreeProps,
         @inject(ProblemTreeModel) override readonly model: ProblemTreeModel,
-        @inject(ContextMenuRenderer) override readonly contextMenuRenderer: ContextMenuRenderer
+        @inject(ContextMenuRenderer) contextMenuRenderer: ContextMenuRenderer
     ) {
         super(treeProps, model, contextMenuRenderer);
 

--- a/packages/markers/src/browser/problem/problem-widget.tsx
+++ b/packages/markers/src/browser/problem/problem-widget.tsx
@@ -45,8 +45,8 @@ export class ProblemWidget extends TreeWidget {
     constructor(
         @inject(ProblemManager) protected readonly problemManager: ProblemManager,
         @inject(TreeProps) readonly treeProps: TreeProps,
-        @inject(ProblemTreeModel) readonly model: ProblemTreeModel,
-        @inject(ContextMenuRenderer) readonly contextMenuRenderer: ContextMenuRenderer
+        @inject(ProblemTreeModel) override readonly model: ProblemTreeModel,
+        @inject(ContextMenuRenderer) override readonly contextMenuRenderer: ContextMenuRenderer
     ) {
         super(treeProps, model, contextMenuRenderer);
 
@@ -61,7 +61,7 @@ export class ProblemWidget extends TreeWidget {
     }
 
     @postConstruct()
-    protected init(): void {
+    protected override init(): void {
         super.init();
         this.updateFollowActiveEditor();
         this.toDispose.push(this.preferences.onPreferenceChanged(e => {
@@ -96,14 +96,14 @@ export class ProblemWidget extends TreeWidget {
         }
     }
 
-    storeState(): object {
+    override storeState(): object {
         // no-op
         return {};
     }
     protected superStoreState(): object {
         return super.storeState();
     }
-    restoreState(state: object): void {
+    override restoreState(state: object): void {
         // no-op
     }
     protected superRestoreState(state: object): void {
@@ -111,7 +111,7 @@ export class ProblemWidget extends TreeWidget {
         return;
     }
 
-    protected handleClickEvent(node: TreeNode | undefined, event: React.MouseEvent<HTMLElement>): void {
+    protected override handleClickEvent(node: TreeNode | undefined, event: React.MouseEvent<HTMLElement>): void {
         super.handleClickEvent(node, event);
         if (MarkerNode.is(node)) {
             this.model.revealNode(node);
@@ -126,7 +126,7 @@ export class ProblemWidget extends TreeWidget {
         }
     }
 
-    protected handleDown(event: KeyboardEvent): void {
+    protected override handleDown(event: KeyboardEvent): void {
         const node = this.model.getNextSelectableNode();
         super.handleDown(event);
         if (MarkerNode.is(node)) {
@@ -134,7 +134,7 @@ export class ProblemWidget extends TreeWidget {
         }
     }
 
-    protected handleUp(event: KeyboardEvent): void {
+    protected override handleUp(event: KeyboardEvent): void {
         const node = this.model.getPrevSelectableNode();
         super.handleUp(event);
         if (MarkerNode.is(node)) {
@@ -142,14 +142,14 @@ export class ProblemWidget extends TreeWidget {
         }
     }
 
-    protected renderTree(model: TreeModel): React.ReactNode {
+    protected override renderTree(model: TreeModel): React.ReactNode {
         if (MarkerRootNode.is(model.root) && model.root.children.length > 0) {
             return super.renderTree(model);
         }
         return <div className='theia-widget-noInfo noMarkers'>No problems have been detected in the workspace so far.</div>;
     }
 
-    protected renderCaption(node: TreeNode, props: NodeProps): React.ReactNode {
+    protected override renderCaption(node: TreeNode, props: NodeProps): React.ReactNode {
         if (MarkerInfoNode.is(node)) {
             return this.decorateMarkerFileNode(node);
         } else if (MarkerNode.is(node)) {
@@ -158,7 +158,7 @@ export class ProblemWidget extends TreeWidget {
         return 'caption';
     }
 
-    protected renderTailDecorations(node: TreeNode, props: NodeProps): JSX.Element {
+    protected override renderTailDecorations(node: TreeNode, props: NodeProps): JSX.Element {
         return <div className='row-button-container'>
             {this.renderRemoveButton(node)}
         </div>;
@@ -224,7 +224,7 @@ export class ProblemWidget extends TreeWidget {
 
 export class ProblemMarkerRemoveButton extends React.Component<{ model: ProblemTreeModel, node: TreeNode }> {
 
-    render(): React.ReactNode {
+    override render(): React.ReactNode {
         return <span className={codicon('close')} onClick={this.remove}></span>;
     }
 

--- a/packages/messages/src/browser/notification-center-component.tsx
+++ b/packages/messages/src/browser/notification-center-component.tsx
@@ -41,7 +41,7 @@ export class NotificationCenterComponent extends React.Component<NotificationCen
 
     protected readonly toDisposeOnUnmount = new DisposableCollection();
 
-    async componentDidMount(): Promise<void> {
+    override async componentDidMount(): Promise<void> {
         this.toDisposeOnUnmount.push(
             this.props.manager.onUpdated(({ notifications, visibilityState }) => {
                 this.setState({
@@ -51,11 +51,11 @@ export class NotificationCenterComponent extends React.Component<NotificationCen
             })
         );
     }
-    componentWillUnmount(): void {
+    override componentWillUnmount(): void {
         this.toDisposeOnUnmount.dispose();
     }
 
-    render(): React.ReactNode {
+    override render(): React.ReactNode {
         const empty = this.state.notifications.length === 0;
         const title = empty
             ? nls.localizeByDefault('No New Notifications')

--- a/packages/messages/src/browser/notification-component.tsx
+++ b/packages/messages/src/browser/notification-component.tsx
@@ -69,7 +69,7 @@ export class NotificationComponent extends React.Component<NotificationComponent
         }
     };
 
-    render(): React.ReactNode {
+    override render(): React.ReactNode {
         const { messageId, message, type, progress, collapsed, expandable, source, actions } = this.props.notification;
         const isProgress = typeof progress === 'number';
         return (<div key={messageId} className='theia-notification-list-item'>

--- a/packages/messages/src/browser/notification-toasts-component.tsx
+++ b/packages/messages/src/browser/notification-toasts-component.tsx
@@ -39,7 +39,7 @@ export class NotificationToastsComponent extends React.Component<NotificationToa
 
     protected readonly toDisposeOnUnmount = new DisposableCollection();
 
-    async componentDidMount(): Promise<void> {
+    override async componentDidMount(): Promise<void> {
         this.toDisposeOnUnmount.push(
             this.props.manager.onUpdated(({ toasts, visibilityState }) => {
                 visibilityState = this.props.corePreferences['workbench.silentNotifications'] ? 'hidden' : visibilityState;
@@ -50,11 +50,11 @@ export class NotificationToastsComponent extends React.Component<NotificationToa
             })
         );
     }
-    componentWillUnmount(): void {
+    override componentWillUnmount(): void {
         this.toDisposeOnUnmount.dispose();
     }
 
-    render(): React.ReactNode {
+    override render(): React.ReactNode {
         return (
             <div className={`theia-notifications-container theia-notification-toasts ${this.state.visibilityState === 'toasts' ? 'open' : 'closed'}`}>
                 <div className='theia-notification-list'>

--- a/packages/messages/src/browser/notifications-manager.ts
+++ b/packages/messages/src/browser/notifications-manager.ts
@@ -169,7 +169,7 @@ export class NotificationManager extends MessageClient {
         this.fireUpdatedEvent();
     }
 
-    showMessage(plainMessage: PlainMessage): Promise<string | undefined> {
+    override showMessage(plainMessage: PlainMessage): Promise<string | undefined> {
         const messageId = this.getMessageId(plainMessage);
 
         let notification = this.notifications.get(messageId);
@@ -240,7 +240,7 @@ export class NotificationManager extends MessageClient {
         return String(Md5.hashStr(`[${m.type}] ${m.text} : ${(m.actions || []).join(' | ')};`));
     }
 
-    async showProgress(messageId: string, plainMessage: ProgressMessage, cancellationToken: CancellationToken): Promise<string | undefined> {
+    override async showProgress(messageId: string, plainMessage: ProgressMessage, cancellationToken: CancellationToken): Promise<string | undefined> {
         let notification = this.notifications.get(messageId);
         if (!notification) {
             const message = this.contentRenderer.renderMessage(plainMessage.text);
@@ -268,7 +268,7 @@ export class NotificationManager extends MessageClient {
         return result.promise;
     }
 
-    async reportProgress(messageId: string, update: ProgressUpdate, originalMessage: ProgressMessage, cancellationToken: CancellationToken): Promise<void> {
+    override async reportProgress(messageId: string, update: ProgressUpdate, originalMessage: ProgressMessage, cancellationToken: CancellationToken): Promise<void> {
         const notification = this.find(messageId);
         if (!notification) {
             return;

--- a/packages/mini-browser/src/browser/mini-browser-content.ts
+++ b/packages/mini-browser/src/browser/mini-browser-content.ts
@@ -240,7 +240,7 @@ export class MiniBrowserContent extends BaseWidget {
         }
     }
 
-    protected onActivateRequest(msg: Message): void {
+    protected override onActivateRequest(msg: Message): void {
         super.onActivateRequest(msg);
         if (this.getToolbarProps() !== 'hide') {
             this.input.focus();

--- a/packages/mini-browser/src/browser/mini-browser-open-handler.ts
+++ b/packages/mini-browser/src/browser/mini-browser-open-handler.ts
@@ -125,7 +125,7 @@ export class MiniBrowserOpenHandler extends NavigatableWidgetOpenHandler<MiniBro
         }
     }
 
-    async open(uri: URI, options?: MiniBrowserOpenerOptions): Promise<MiniBrowser> {
+    override async open(uri: URI, options?: MiniBrowserOpenerOptions): Promise<MiniBrowser> {
         const widget = await super.open(uri, options);
         const area = this.shell.getAreaFor(widget);
         if (area === 'right' || area === 'left') {
@@ -138,7 +138,7 @@ export class MiniBrowserOpenHandler extends NavigatableWidgetOpenHandler<MiniBro
         return widget;
     }
 
-    protected async getOrCreateWidget(uri: URI, options?: MiniBrowserOpenerOptions): Promise<MiniBrowser> {
+    protected override async getOrCreateWidget(uri: URI, options?: MiniBrowserOpenerOptions): Promise<MiniBrowser> {
         const props = await this.options(uri, options);
         const widget = await super.getOrCreateWidget(uri, props);
         widget.setProps(props);

--- a/packages/mini-browser/src/browser/mini-browser.ts
+++ b/packages/mini-browser/src/browser/mini-browser.ts
@@ -84,7 +84,7 @@ export class MiniBrowser extends BaseWidget implements NavigatableWidget, Statef
         this.toDisposeOnProps.push(content);
     }
 
-    protected onActivateRequest(msg: Message): void {
+    protected override onActivateRequest(msg: Message): void {
         super.onActivateRequest(msg);
         const widget = (this.layout as PanelLayout).widgets[0];
         if (widget) {

--- a/packages/mini-browser/src/electron-browser/environment/electron-mini-browser-environment.ts
+++ b/packages/mini-browser/src/electron-browser/environment/electron-mini-browser-environment.ts
@@ -26,7 +26,7 @@ export class ElectronMiniBrowserEnvironment extends MiniBrowserEnvironment {
     @inject(ElectronSecurityToken)
     protected readonly electronSecurityToken: ElectronSecurityToken;
 
-    getEndpoint(uuid: string, hostname?: string): Endpoint {
+    override getEndpoint(uuid: string, hostname?: string): Endpoint {
         const endpoint = super.getEndpoint(uuid, hostname);
         // Note: This call is async, but clients expect sync logic.
         electronRemote.session.defaultSession.cookies.set({
@@ -38,7 +38,7 @@ export class ElectronMiniBrowserEnvironment extends MiniBrowserEnvironment {
         return endpoint;
     }
 
-    protected getDefaultHostname(): string {
+    protected override getDefaultHostname(): string {
         const query = self.location.search
             .substr(1) // remove leading `?`
             .split('&')

--- a/packages/monaco/src/browser/monaco-color-registry.ts
+++ b/packages/monaco/src/browser/monaco-color-registry.ts
@@ -24,18 +24,18 @@ export class MonacoColorRegistry extends ColorRegistry {
     protected readonly monacoThemeService = monaco.services.StaticServices.standaloneThemeService.get();
     protected readonly monacoColorRegistry = monaco.color.getColorRegistry();
 
-    *getColors(): IterableIterator<string> {
+    override *getColors(): IterableIterator<string> {
         for (const { id } of this.monacoColorRegistry.getColors()) {
             yield id;
         }
     }
 
-    getCurrentColor(id: string): string | undefined {
+    override getCurrentColor(id: string): string | undefined {
         const color = this.monacoThemeService.getColorTheme().getColor(id);
         return color && color.toString();
     }
 
-    protected doRegister(definition: ColorDefinition): Disposable {
+    protected override doRegister(definition: ColorDefinition): Disposable {
         let defaults: monaco.color.ColorDefaults | undefined;
         if (definition.defaults) {
             defaults = {};

--- a/packages/monaco/src/browser/monaco-diff-editor.ts
+++ b/packages/monaco/src/browser/monaco-diff-editor.ts
@@ -37,8 +37,8 @@ export class MonacoDiffEditor extends MonacoEditor {
     protected _diffNavigator: DiffNavigator;
 
     constructor(
-        override readonly uri: URI,
-        override readonly node: HTMLElement,
+        uri: URI,
+        node: HTMLElement,
         readonly originalModel: MonacoEditorModel,
         readonly modifiedModel: MonacoEditorModel,
         services: MonacoEditorServices,

--- a/packages/monaco/src/browser/monaco-diff-editor.ts
+++ b/packages/monaco/src/browser/monaco-diff-editor.ts
@@ -37,8 +37,8 @@ export class MonacoDiffEditor extends MonacoEditor {
     protected _diffNavigator: DiffNavigator;
 
     constructor(
-        readonly uri: URI,
-        readonly node: HTMLElement,
+        override readonly uri: URI,
+        override readonly node: HTMLElement,
         readonly originalModel: MonacoEditorModel,
         readonly modifiedModel: MonacoEditorModel,
         services: MonacoEditorServices,
@@ -62,7 +62,7 @@ export class MonacoDiffEditor extends MonacoEditor {
         return this._diffNavigator;
     }
 
-    protected create(options?: IDiffEditorConstructionOptions, override?: monaco.editor.IEditorOverrideServices): Disposable {
+    protected override create(options?: IDiffEditorConstructionOptions, override?: monaco.editor.IEditorOverrideServices): Disposable {
         this._diffEditor = monaco.editor.createDiffEditor(this.node, <IDiffEditorConstructionOptions>{
             ...options,
             fixedOverflowWidgets: true
@@ -71,27 +71,27 @@ export class MonacoDiffEditor extends MonacoEditor {
         return this._diffEditor;
     }
 
-    protected resize(dimension: Dimension | null): void {
+    protected override resize(dimension: Dimension | null): void {
         if (this.node) {
             const layoutSize = this.computeLayoutSize(this.node, dimension);
             this._diffEditor.layout(layoutSize);
         }
     }
 
-    isActionSupported(id: string): boolean {
+    override isActionSupported(id: string): boolean {
         const action = this._diffEditor.getSupportedActions().find(a => a.id === id);
         return !!action && action.isSupported() && super.isActionSupported(id);
     }
 
-    deltaDecorations(params: DeltaDecorationParams): string[] {
+    override deltaDecorations(params: DeltaDecorationParams): string[] {
         console.warn('`deltaDecorations` should be called on either the original, or the modified editor.');
         return [];
     }
 
-    getResourceUri(): URI {
+    override getResourceUri(): URI {
         return new URI(this.originalModel.uri);
     }
-    createMoveToUri(resourceUri: URI): URI {
+    override createMoveToUri(resourceUri: URI): URI {
         const [left, right] = DiffUris.decode(this.uri);
         return DiffUris.encode(left.withPath(resourceUri.path), right.withPath(resourceUri.path));
     }

--- a/packages/monaco/src/browser/monaco-editor-service.ts
+++ b/packages/monaco/src/browser/monaco-editor-service.ts
@@ -55,7 +55,7 @@ export class MonacoEditorService extends monaco.services.CodeEditorServiceImpl {
     /**
      * Monaco active editor is either focused or last focused editor.
      */
-    getActiveCodeEditor(): monaco.editor.IStandaloneCodeEditor | undefined {
+    override getActiveCodeEditor(): monaco.editor.IStandaloneCodeEditor | undefined {
         let editor = MonacoEditor.getCurrent(this.editors);
         if (!editor && CustomEditorWidget.is(this.shell.activeWidget)) {
             const model = this.shell.activeWidget.modelRef.object;
@@ -66,7 +66,7 @@ export class MonacoEditorService extends monaco.services.CodeEditorServiceImpl {
         return editor && editor.getControl();
     }
 
-    async openCodeEditor(input: IResourceEditorInput, source?: ICodeEditor, sideBySide?: boolean): Promise<CommonCodeEditor | undefined> {
+    override async openCodeEditor(input: IResourceEditorInput, source?: ICodeEditor, sideBySide?: boolean): Promise<CommonCodeEditor | undefined> {
         const uri = new URI(input.resource.toString());
         const openerOptions = this.createEditorOpenerOptions(input, source, sideBySide);
         const widget = await open(this.openerService, uri, openerOptions);

--- a/packages/monaco/src/browser/monaco-gotoline-quick-access.ts
+++ b/packages/monaco/src/browser/monaco-gotoline-quick-access.ts
@@ -24,7 +24,7 @@ export class GotoLineQuickAccess extends monaco.quickInput.StandaloneGotoLineQui
         super(service);
     }
 
-    get activeTextEditorControl(): monaco.editor.ICodeEditor | undefined {
+    override get activeTextEditorControl(): monaco.editor.ICodeEditor | undefined {
         return this.service.getFocusedCodeEditor() || this.service.getActiveCodeEditor();
     }
 }

--- a/packages/monaco/src/browser/monaco-gotosymbol-quick-access.ts
+++ b/packages/monaco/src/browser/monaco-gotosymbol-quick-access.ts
@@ -24,7 +24,7 @@ export class GotoSymbolQuickAccess extends monaco.quickInput.StandaloneGotoSymbo
         super(service);
     }
 
-    get activeTextEditorControl(): monaco.editor.ICodeEditor | undefined {
+    override get activeTextEditorControl(): monaco.editor.ICodeEditor | undefined {
         return this.service.getFocusedCodeEditor() || this.service.getActiveCodeEditor();
     }
 }

--- a/packages/monaco/src/browser/monaco-indexed-db.ts
+++ b/packages/monaco/src/browser/monaco-indexed-db.ts
@@ -109,7 +109,7 @@ async function getThemeFromDB(id: string): Promise<Theme | undefined> {
 }
 
 export class ThemeServiceWithDB extends ThemeService {
-    static get(): ThemeService {
+    static override get(): ThemeService {
         const global = window as any; // eslint-disable-line @typescript-eslint/no-explicit-any
         if (!global[ThemeServiceSymbol]) {
             const themeService = new ThemeServiceWithDB();
@@ -120,7 +120,7 @@ export class ThemeServiceWithDB extends ThemeService {
         return global[ThemeServiceSymbol];
     }
 
-    loadUserTheme(): void {
+    override loadUserTheme(): void {
         this.loadUserThemeWithDB();
     }
 

--- a/packages/monaco/src/browser/monaco-keybinding-contexts.ts
+++ b/packages/monaco/src/browser/monaco-keybinding-contexts.ts
@@ -32,7 +32,7 @@ import { MonacoEditor } from './monaco-editor';
 @injectable()
 export class MonacoStrictEditorTextFocusContext extends StrictEditorTextFocusContext {
 
-    protected canHandle(widget: EditorWidget): boolean {
+    protected override canHandle(widget: EditorWidget): boolean {
         const { editor } = widget;
         if (editor instanceof MonacoEditor) {
             return editor.isFocused({ strict: true });

--- a/packages/monaco/src/browser/monaco-mime-service.ts
+++ b/packages/monaco/src/browser/monaco-mime-service.ts
@@ -34,7 +34,7 @@ export class MonacoMimeService extends MimeService {
         });
     }
 
-    setAssociations(associations: MimeAssociation[]): void {
+    override setAssociations(associations: MimeAssociation[]): void {
         this.associations = associations;
         this.updateAssociations();
     }

--- a/packages/monaco/src/browser/monaco-quick-access-registry.ts
+++ b/packages/monaco/src/browser/monaco-quick-access-registry.ts
@@ -65,8 +65,10 @@ export class MonacoQuickAccessRegistry implements QuickAccessRegistry {
                     super(descriptor.prefix);
                 }
 
-                // eslint-disable-next-line @typescript-eslint/no-explicit-any
-                getPicks(filter: string, disposables: any, token: CancellationToken): monaco.quickInput.Picks<QuickPickItem> | Promise<monaco.quickInput.Picks<QuickPickItem>> {
+                override getPicks(
+                    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                    filter: string, disposables: any, token: CancellationToken
+                ): monaco.quickInput.Picks<QuickPickItem> | Promise<monaco.quickInput.Picks<QuickPickItem>> {
                     const result = descriptor.getInstance().getPicks(filter, token);
                     if (result instanceof Promise) {
                         return result.then(picks => picks.map(toMonacoPick));

--- a/packages/monaco/src/browser/monaco-quick-input-service.ts
+++ b/packages/monaco/src/browser/monaco-quick-input-service.ts
@@ -379,7 +379,7 @@ class MonacoQuickInput {
 }
 
 class MonacoQuickPick<T extends QuickPickItem> extends MonacoQuickInput implements QuickPick<T> {
-    constructor(protected readonly wrapped: monaco.quickInput.IQuickPick<MonacoQuickPickItem<T>>, protected readonly keybindingRegistry: KeybindingRegistry) {
+    constructor(protected override readonly wrapped: monaco.quickInput.IQuickPick<MonacoQuickPickItem<T>>, protected readonly keybindingRegistry: KeybindingRegistry) {
         super(wrapped);
     }
 
@@ -494,4 +494,3 @@ export class MonacoQuickPickItem<T extends QuickPickItem> implements monaco.quic
         }
     }
 }
-

--- a/packages/navigator/src/browser/navigator-contribution.ts
+++ b/packages/navigator/src/browser/navigator-contribution.ts
@@ -266,7 +266,7 @@ export class FileNavigatorContribution extends AbstractViewContribution<FileNavi
         await this.openView();
     }
 
-    registerCommands(registry: CommandRegistry): void {
+    override registerCommands(registry: CommandRegistry): void {
         super.registerCommands(registry);
         registry.registerCommand(FileNavigatorCommands.FOCUS, {
             execute: () => this.openView({ activate: true })
@@ -399,7 +399,7 @@ export class FileNavigatorContribution extends AbstractViewContribution<FileNavi
         return false;
     }
 
-    registerMenus(registry: MenuModelRegistry): void {
+    override registerMenus(registry: MenuModelRegistry): void {
         super.registerMenus(registry);
         registry.registerMenuAction(SHELL_TABBAR_CONTEXT_REVEAL, {
             commandId: FileNavigatorCommands.REVEAL_IN_NAVIGATOR.id,
@@ -533,7 +533,7 @@ export class FileNavigatorContribution extends AbstractViewContribution<FileNavi
         });
     }
 
-    registerKeybindings(registry: KeybindingRegistry): void {
+    override registerKeybindings(registry: KeybindingRegistry): void {
         super.registerKeybindings(registry);
         registry.registerKeybinding({
             command: FileNavigatorCommands.REVEAL_IN_NAVIGATOR.id,

--- a/packages/navigator/src/browser/navigator-model.ts
+++ b/packages/navigator/src/browser/navigator-model.ts
@@ -29,7 +29,7 @@ import { Disposable } from '@theia/core/lib/common/disposable';
 export class FileNavigatorModel extends FileTreeModel {
 
     @inject(OpenerService) protected readonly openerService: OpenerService;
-    @inject(FileNavigatorTree) protected readonly tree: FileNavigatorTree;
+    @inject(FileNavigatorTree) protected override readonly tree: FileNavigatorTree;
     @inject(WorkspaceService) protected readonly workspaceService: WorkspaceService;
     @inject(FrontendApplicationStateService) protected readonly applicationState: FrontendApplicationStateService;
 
@@ -37,7 +37,7 @@ export class FileNavigatorModel extends FileTreeModel {
     protected readonly progressService: ProgressService;
 
     @postConstruct()
-    protected init(): void {
+    protected override init(): void {
         super.init();
         this.reportBusyProgress();
         this.initializeRoot();
@@ -98,7 +98,7 @@ export class FileNavigatorModel extends FileTreeModel {
         }
     }
 
-    protected doOpenNode(node: TreeNode): void {
+    protected override doOpenNode(node: TreeNode): void {
         if (node.visible === false) {
             return;
         } else if (FileNode.is(node)) {
@@ -108,7 +108,7 @@ export class FileNavigatorModel extends FileTreeModel {
         }
     }
 
-    *getNodesByUri(uri: URI): IterableIterator<TreeNode> {
+    override *getNodesByUri(uri: URI): IterableIterator<TreeNode> {
         const workspace = this.root;
         if (WorkspaceNode.is(workspace)) {
             for (const root of workspace.children) {
@@ -160,7 +160,7 @@ export class FileNavigatorModel extends FileTreeModel {
     /**
      * Move the given source file or directory to the given target directory.
      */
-    async move(source: TreeNode, target: TreeNode): Promise<URI | undefined> {
+    override async move(source: TreeNode, target: TreeNode): Promise<URI | undefined> {
         if (source.parent && WorkspaceRootNode.is(source)) {
             // do not support moving a root folder
             return undefined;

--- a/packages/navigator/src/browser/navigator-tree.ts
+++ b/packages/navigator/src/browser/navigator-tree.ts
@@ -47,14 +47,14 @@ export class FileNavigatorTree extends FileTree {
         this.refresh();
     }
 
-    async resolveChildren(parent: CompositeTreeNode): Promise<TreeNode[]> {
+    override async resolveChildren(parent: CompositeTreeNode): Promise<TreeNode[]> {
         if (WorkspaceNode.is(parent)) {
             return parent.children;
         }
         return this.filter.filter(super.resolveChildren(parent));
     }
 
-    protected toNodeId(uri: URI, parent: CompositeTreeNode): string {
+    protected override toNodeId(uri: URI, parent: CompositeTreeNode): string {
         const workspaceRootNode = WorkspaceRootNode.find(parent);
         if (workspaceRootNode) {
             return this.createId(workspaceRootNode, uri);

--- a/packages/navigator/src/browser/navigator-widget.tsx
+++ b/packages/navigator/src/browser/navigator-widget.tsx
@@ -17,9 +17,9 @@
 import { injectable, inject, postConstruct } from '@theia/core/shared/inversify';
 import { Message } from '@theia/core/shared/@phosphor/messaging';
 import URI from '@theia/core/lib/common/uri';
-import { CommandService, notEmpty, SelectionService } from '@theia/core/lib/common';
+import { CommandService, notEmpty } from '@theia/core/lib/common';
 import {
-    CorePreferences, Key, TreeModel, SelectableTreeNode, TREE_NODE_SEGMENT_CLASS, TREE_NODE_TAIL_CLASS,
+    Key, TreeModel, SelectableTreeNode, TREE_NODE_SEGMENT_CLASS, TREE_NODE_TAIL_CLASS,
     TreeDecoration, NodeProps, OpenerService, ContextMenuRenderer, ExpandableTreeNode, TreeProps, TreeNode
 } from '@theia/core/lib/browser';
 import { FileTreeWidget, FileNode, DirNode, FileStatNode } from '@theia/filesystem/lib/browser';
@@ -40,21 +40,16 @@ export const CLASS = 'theia-Files';
 @injectable()
 export class FileNavigatorWidget extends FileTreeWidget {
 
-    @inject(CorePreferences) protected override corePreferences: CorePreferences;
-
-    @inject(NavigatorContextKeyService)
-    protected readonly contextKeyService: NavigatorContextKeyService;
-
+    @inject(ApplicationShell) protected readonly shell: ApplicationShell;
+    @inject(CommandService) protected readonly commandService: CommandService;
+    @inject(NavigatorContextKeyService) protected readonly contextKeyService: NavigatorContextKeyService;
     @inject(OpenerService) protected readonly openerService: OpenerService;
+    @inject(WorkspaceService) protected readonly workspaceService: WorkspaceService;
 
     constructor(
-        @inject(TreeProps) override readonly props: TreeProps,
+        @inject(TreeProps) props: TreeProps,
         @inject(FileNavigatorModel) override readonly model: FileNavigatorModel,
         @inject(ContextMenuRenderer) contextMenuRenderer: ContextMenuRenderer,
-        @inject(CommandService) protected readonly commandService: CommandService,
-        @inject(SelectionService) protected override readonly selectionService: SelectionService,
-        @inject(WorkspaceService) protected readonly workspaceService: WorkspaceService,
-        @inject(ApplicationShell) protected readonly shell: ApplicationShell
     ) {
         super(props, model, contextMenuRenderer);
         this.id = FILE_NAVIGATOR_ID;

--- a/packages/navigator/src/browser/navigator-widget.tsx
+++ b/packages/navigator/src/browser/navigator-widget.tsx
@@ -40,7 +40,7 @@ export const CLASS = 'theia-Files';
 @injectable()
 export class FileNavigatorWidget extends FileTreeWidget {
 
-    @inject(CorePreferences) protected readonly corePreferences: CorePreferences;
+    @inject(CorePreferences) protected override corePreferences: CorePreferences;
 
     @inject(NavigatorContextKeyService)
     protected readonly contextKeyService: NavigatorContextKeyService;
@@ -48,11 +48,11 @@ export class FileNavigatorWidget extends FileTreeWidget {
     @inject(OpenerService) protected readonly openerService: OpenerService;
 
     constructor(
-        @inject(TreeProps) readonly props: TreeProps,
-        @inject(FileNavigatorModel) readonly model: FileNavigatorModel,
+        @inject(TreeProps) override readonly props: TreeProps,
+        @inject(FileNavigatorModel) override readonly model: FileNavigatorModel,
         @inject(ContextMenuRenderer) contextMenuRenderer: ContextMenuRenderer,
         @inject(CommandService) protected readonly commandService: CommandService,
-        @inject(SelectionService) protected readonly selectionService: SelectionService,
+        @inject(SelectionService) protected override readonly selectionService: SelectionService,
         @inject(WorkspaceService) protected readonly workspaceService: WorkspaceService,
         @inject(ApplicationShell) protected readonly shell: ApplicationShell
     ) {
@@ -62,7 +62,7 @@ export class FileNavigatorWidget extends FileTreeWidget {
     }
 
     @postConstruct()
-    protected init(): void {
+    protected override init(): void {
         super.init();
         // This ensures that the context menu command to hide this widget receives the label 'Folders'
         // regardless of the name of workspace. See ViewContainer.updateToolbarItems.
@@ -85,7 +85,7 @@ export class FileNavigatorWidget extends FileTreeWidget {
         ]);
     }
 
-    protected doUpdateRows(): void {
+    protected override doUpdateRows(): void {
         super.doUpdateRows();
         this.title.label = LABEL;
         if (WorkspaceNode.is(this.model.root)) {
@@ -134,7 +134,7 @@ export class FileNavigatorWidget extends FileTreeWidget {
         this.addEventListener(mainPanelNode, 'dragenter', handler);
     }
 
-    protected getContainerTreeNode(): TreeNode | undefined {
+    protected override getContainerTreeNode(): TreeNode | undefined {
         const root = this.model.root;
         if (this.workspaceService.isMultiRootWorkspaceOpened) {
             return root;
@@ -145,14 +145,14 @@ export class FileNavigatorWidget extends FileTreeWidget {
         return undefined;
     }
 
-    protected renderTree(model: TreeModel): React.ReactNode {
+    protected override renderTree(model: TreeModel): React.ReactNode {
         if (this.model.root && this.isEmptyMultiRootWorkspace(model)) {
             return this.renderEmptyMultiRootWorkspace();
         }
         return super.renderTree(model);
     }
 
-    protected renderTailDecorations(node: TreeNode, props: NodeProps): React.ReactNode {
+    protected override renderTailDecorations(node: TreeNode, props: NodeProps): React.ReactNode {
         const tailDecorations = this.getDecorationData(node, 'tailDecorations').filter(notEmpty).reduce((acc, current) => acc.concat(current), []);
 
         if (tailDecorations.length === 0) {
@@ -182,11 +182,11 @@ export class FileNavigatorWidget extends FileTreeWidget {
         </div>;
     }
 
-    protected shouldShowWelcomeView(): boolean {
+    protected override shouldShowWelcomeView(): boolean {
         return this.model.root === undefined;
     }
 
-    protected onAfterAttach(msg: Message): void {
+    protected override onAfterAttach(msg: Message): void {
         super.onAfterAttach(msg);
         this.addClipboardListener(this.node, 'copy', e => this.handleCopy(e));
         this.addClipboardListener(this.node, 'paste', e => this.handlePaste(e));
@@ -264,7 +264,7 @@ export class FileNavigatorWidget extends FileTreeWidget {
         return WorkspaceNode.is(model.root) && model.root.children.length === 0;
     }
 
-    protected handleClickEvent(node: TreeNode | undefined, event: React.MouseEvent<HTMLElement>): void {
+    protected override handleClickEvent(node: TreeNode | undefined, event: React.MouseEvent<HTMLElement>): void {
         const modifierKeyCombined: boolean = isOSX ? (event.shiftKey || event.metaKey) : (event.shiftKey || event.ctrlKey);
         if (!modifierKeyCombined && node && this.corePreferences['workbench.list.openMode'] === 'singleClick') {
             this.model.previewNode(node);
@@ -272,12 +272,12 @@ export class FileNavigatorWidget extends FileTreeWidget {
         super.handleClickEvent(node, event);
     }
 
-    protected onAfterShow(msg: Message): void {
+    protected override onAfterShow(msg: Message): void {
         super.onAfterShow(msg);
         this.contextKeyService.explorerViewletVisible.set(true);
     }
 
-    protected onAfterHide(msg: Message): void {
+    protected override onAfterHide(msg: Message): void {
         super.onAfterHide(msg);
         this.contextKeyService.explorerViewletVisible.set(false);
     }

--- a/packages/navigator/src/browser/open-editors-widget/navigator-open-editors-tree-model.ts
+++ b/packages/navigator/src/browser/open-editors-widget/navigator-open-editors-tree-model.ts
@@ -75,7 +75,7 @@ export class OpenEditorsModel extends FileTreeModel {
     }
 
     @postConstruct()
-    protected init(): void {
+    protected override init(): void {
         super.init();
         this.setupHandlers();
         this.initializeRoot();
@@ -245,7 +245,7 @@ export class OpenEditorsModel extends FileTreeModel {
         return rootNode;
     }
 
-    protected doOpenNode(node: TreeNode): void {
+    protected override doOpenNode(node: TreeNode): void {
         if (node.visible === false) {
             return;
         } else if (FileNode.is(node)) {

--- a/packages/navigator/src/browser/open-editors-widget/navigator-open-editors-widget.tsx
+++ b/packages/navigator/src/browser/open-editors-widget/navigator-open-editors-widget.tsx
@@ -79,9 +79,9 @@ export class OpenEditorsWidget extends FileTreeWidget {
     }
 
     constructor(
-        @inject(TreeProps) override readonly props: TreeProps,
+        @inject(TreeProps) props: TreeProps,
         @inject(OpenEditorsModel) override readonly model: OpenEditorsModel,
-        @inject(ContextMenuRenderer) protected override readonly contextMenuRenderer: ContextMenuRenderer
+        @inject(ContextMenuRenderer) contextMenuRenderer: ContextMenuRenderer
     ) {
         super(props, model, contextMenuRenderer);
     }

--- a/packages/navigator/src/browser/open-editors-widget/navigator-open-editors-widget.tsx
+++ b/packages/navigator/src/browser/open-editors-widget/navigator-open-editors-widget.tsx
@@ -79,15 +79,15 @@ export class OpenEditorsWidget extends FileTreeWidget {
     }
 
     constructor(
-        @inject(TreeProps) readonly props: TreeProps,
-        @inject(OpenEditorsModel) readonly model: OpenEditorsModel,
-        @inject(ContextMenuRenderer) protected readonly contextMenuRenderer: ContextMenuRenderer
+        @inject(TreeProps) override readonly props: TreeProps,
+        @inject(OpenEditorsModel) override readonly model: OpenEditorsModel,
+        @inject(ContextMenuRenderer) protected override readonly contextMenuRenderer: ContextMenuRenderer
     ) {
         super(props, model, contextMenuRenderer);
     }
 
     @postConstruct()
-    init(): void {
+    override init(): void {
         super.init();
         this.id = OpenEditorsWidget.ID;
         this.title.label = OpenEditorsWidget.LABEL;
@@ -102,7 +102,7 @@ export class OpenEditorsWidget extends FileTreeWidget {
     // eslint-disable-next-line no-null/no-null
     protected activeTreeNodePrefixElement: string | undefined | null;
 
-    protected renderNode(node: OpenEditorNode, props: NodeProps): React.ReactNode {
+    protected override renderNode(node: OpenEditorNode, props: NodeProps): React.ReactNode {
         if (!TreeNode.isVisible(node)) {
             return undefined;
         }
@@ -129,7 +129,7 @@ export class OpenEditorsWidget extends FileTreeWidget {
         return node.id.startsWith(OpenEditorsModel.AREA_NODE_ID_PREFIX);
     }
 
-    protected doRenderNodeRow({ node, depth }: OpenEditorsNodeRow): React.ReactNode {
+    protected override doRenderNodeRow({ node, depth }: OpenEditorsNodeRow): React.ReactNode {
         let groupClass = '';
         if (this.isGroupNode(node)) {
             groupClass = 'group-node';
@@ -221,7 +221,7 @@ export class OpenEditorsWidget extends FileTreeWidget {
         }
     }
 
-    protected handleClickEvent(node: OpenEditorNode | undefined, event: React.MouseEvent<HTMLElement>): void {
+    protected override handleClickEvent(node: OpenEditorNode | undefined, event: React.MouseEvent<HTMLElement>): void {
         if (OpenEditorNode.is(node)) {
             const { widget } = node;
             this.applicationShell.activateWidget(widget.id);
@@ -229,7 +229,7 @@ export class OpenEditorsWidget extends FileTreeWidget {
         super.handleClickEvent(node, event);
     }
 
-    protected handleContextMenuEvent(node: OpenEditorNode | undefined, event: React.MouseEvent<HTMLElement>): void {
+    protected override handleContextMenuEvent(node: OpenEditorNode | undefined, event: React.MouseEvent<HTMLElement>): void {
         super.handleContextMenuEvent(node, event);
         if (node) {
             // Since the CommonCommands used in the context menu act on the shell's activeWidget, this is necessary to ensure

--- a/packages/outline-view/src/browser/outline-breadcrumbs-contribution.tsx
+++ b/packages/outline-view/src/browser/outline-breadcrumbs-contribution.tsx
@@ -31,7 +31,7 @@ export interface BreadcrumbPopupOutlineViewFactory {
 export class BreadcrumbPopupOutlineView extends OutlineViewWidget {
     @inject(OpenerService) protected readonly openerService: OpenerService;
 
-    protected handleClickEvent(node: TreeNode | undefined, event: React.MouseEvent<HTMLElement>): void {
+    protected override handleClickEvent(node: TreeNode | undefined, event: React.MouseEvent<HTMLElement>): void {
         if (UriSelection.is(node) && OutlineSymbolInformationNode.hasRange(node)) {
             open(this.openerService, node.uri, { selection: node.range });
         } else {

--- a/packages/outline-view/src/browser/outline-view-contribution.ts
+++ b/packages/outline-view/src/browser/outline-view-contribution.ts
@@ -63,7 +63,7 @@ export class OutlineViewContribution extends AbstractViewContribution<OutlineVie
         await this.openView();
     }
 
-    registerCommands(commands: CommandRegistry): void {
+    override registerCommands(commands: CommandRegistry): void {
         super.registerCommands(commands);
         commands.registerCommand(OutlineViewCommands.COLLAPSE_ALL, {
             isEnabled: widget => this.withWidget(widget, () => true),

--- a/packages/outline-view/src/browser/outline-view-tree-model.ts
+++ b/packages/outline-view/src/browser/outline-view-tree-model.ts
@@ -20,7 +20,8 @@ import { CompositeTreeNode, TreeModelImpl, TreeExpansionService, ExpandableTreeN
 @injectable()
 export class OutlineViewTreeModel extends TreeModelImpl {
 
-    @inject(TreeExpansionService) protected readonly expansionService: TreeExpansionService;
+    @inject(TreeExpansionService)
+    protected override readonly expansionService: TreeExpansionService;
 
     /**
      * Handle the expansion of the tree node.
@@ -28,11 +29,11 @@ export class OutlineViewTreeModel extends TreeModelImpl {
      * after attempting to perform a `collapse-all`.
      * @param node the expandable tree node.
      */
-    protected handleExpansion(node: Readonly<ExpandableTreeNode>): void {
+    protected override handleExpansion(node: Readonly<ExpandableTreeNode>): void {
         // no-op
     }
 
-    async collapseAll(raw?: Readonly<CompositeTreeNode>): Promise<boolean> {
+    override async collapseAll(raw?: Readonly<CompositeTreeNode>): Promise<boolean> {
         const node = raw || this.selectedNodes[0];
         if (CompositeTreeNode.is(node)) {
             return this.expansionService.collapseAll(node);
@@ -45,7 +46,7 @@ export class OutlineViewTreeModel extends TreeModelImpl {
      * toggles the expansion of the node. Overriding to prevent expansion, but
      * allow for the `onOpenNode` event to still fire on a double-click event.
      */
-    openNode(raw?: TreeNode | undefined): void {
+    override openNode(raw?: TreeNode | undefined): void {
         const node = raw || this.selectedNodes[0];
         if (node) {
             this.onOpenNodeEmitter.fire(node);

--- a/packages/outline-view/src/browser/outline-view-tree-model.ts
+++ b/packages/outline-view/src/browser/outline-view-tree-model.ts
@@ -14,14 +14,11 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
-import { injectable, inject } from '@theia/core/shared/inversify';
-import { CompositeTreeNode, TreeModelImpl, TreeExpansionService, ExpandableTreeNode, TreeNode } from '@theia/core/lib/browser';
+import { injectable } from '@theia/core/shared/inversify';
+import { CompositeTreeNode, TreeModelImpl, ExpandableTreeNode, TreeNode } from '@theia/core/lib/browser';
 
 @injectable()
 export class OutlineViewTreeModel extends TreeModelImpl {
-
-    @inject(TreeExpansionService)
-    protected override readonly expansionService: TreeExpansionService;
 
     /**
      * Handle the expansion of the tree node.

--- a/packages/outline-view/src/browser/outline-view-widget.tsx
+++ b/packages/outline-view/src/browser/outline-view-widget.tsx
@@ -81,7 +81,7 @@ export class OutlineViewWidget extends TreeWidget {
     constructor(
         @inject(TreeProps) protected readonly treeProps: TreeProps,
         @inject(OutlineViewTreeModel) model: OutlineViewTreeModel,
-        @inject(ContextMenuRenderer) protected readonly contextMenuRenderer: ContextMenuRenderer
+        @inject(ContextMenuRenderer) protected override readonly contextMenuRenderer: ContextMenuRenderer
     ) {
         super(treeProps, model, contextMenuRenderer);
 
@@ -134,24 +134,24 @@ export class OutlineViewWidget extends TreeWidget {
         return nodes;
     }
 
-    protected onAfterHide(msg: Message): void {
+    protected override onAfterHide(msg: Message): void {
         super.onAfterHide(msg);
         this.onDidChangeOpenStateEmitter.fire(false);
     }
 
-    protected onAfterShow(msg: Message): void {
+    protected override onAfterShow(msg: Message): void {
         super.onAfterShow(msg);
         this.onDidChangeOpenStateEmitter.fire(true);
     }
 
-    renderIcon(node: TreeNode, props: NodeProps): React.ReactNode {
+    override renderIcon(node: TreeNode, props: NodeProps): React.ReactNode {
         if (OutlineSymbolInformationNode.is(node)) {
             return <div className={'symbol-icon symbol-icon-center ' + node.iconClass}></div>;
         }
         return undefined;
     }
 
-    protected createNodeAttributes(node: TreeNode, props: NodeProps): React.Attributes & React.HTMLAttributes<HTMLElement> {
+    protected override createNodeAttributes(node: TreeNode, props: NodeProps): React.Attributes & React.HTMLAttributes<HTMLElement> {
         const elementAttrs = super.createNodeAttributes(node, props);
         return {
             ...elementAttrs,
@@ -174,18 +174,18 @@ export class OutlineViewWidget extends TreeWidget {
         return undefined;
     }
 
-    protected isExpandable(node: TreeNode): node is ExpandableTreeNode {
+    protected override isExpandable(node: TreeNode): node is ExpandableTreeNode {
         return OutlineSymbolInformationNode.is(node) && node.children.length > 0;
     }
 
-    protected renderTree(model: TreeModel): React.ReactNode {
+    protected override renderTree(model: TreeModel): React.ReactNode {
         if (CompositeTreeNode.is(this.model.root) && !this.model.root.children.length) {
             return <div className='theia-widget-noInfo no-outline'>{nls.localizeByDefault('No outline information available.')}</div>;
         }
         return super.renderTree(model);
     }
 
-    protected deflateForStorage(node: TreeNode): object {
+    protected override deflateForStorage(node: TreeNode): object {
         const deflated = super.deflateForStorage(node) as { uri: string };
         if (UriSelection.is(node)) {
             deflated.uri = node.uri.toString();
@@ -193,7 +193,7 @@ export class OutlineViewWidget extends TreeWidget {
         return deflated;
     }
 
-    protected inflateFromStorage(node: any, parent?: TreeNode): TreeNode { /* eslint-disable-line @typescript-eslint/no-explicit-any */
+    protected override inflateFromStorage(node: any, parent?: TreeNode): TreeNode { /* eslint-disable-line @typescript-eslint/no-explicit-any */
         const inflated = super.inflateFromStorage(node, parent) as Mutable<TreeNode & UriSelection>;
         if (node && 'uri' in node && typeof node.uri === 'string') {
             inflated.uri = new URI(node.uri);

--- a/packages/outline-view/src/browser/outline-view-widget.tsx
+++ b/packages/outline-view/src/browser/outline-view-widget.tsx
@@ -79,9 +79,9 @@ export class OutlineViewWidget extends TreeWidget {
     readonly onDidChangeOpenStateEmitter = new Emitter<boolean>();
 
     constructor(
-        @inject(TreeProps) protected readonly treeProps: TreeProps,
-        @inject(OutlineViewTreeModel) model: OutlineViewTreeModel,
-        @inject(ContextMenuRenderer) protected override readonly contextMenuRenderer: ContextMenuRenderer
+        @inject(TreeProps) treeProps: TreeProps,
+        @inject(OutlineViewTreeModel) override readonly model: OutlineViewTreeModel,
+        @inject(ContextMenuRenderer) contextMenuRenderer: ContextMenuRenderer
     ) {
         super(treeProps, model, contextMenuRenderer);
 

--- a/packages/output/src/browser/output-context-menu.ts
+++ b/packages/output/src/browser/output-context-menu.ts
@@ -27,7 +27,7 @@ export namespace OutputContextMenu {
 @injectable()
 export class OutputContextMenuService extends MonacoContextMenuService {
 
-    protected menuPath(): MenuPath {
+    protected override menuPath(): MenuPath {
         return OutputContextMenu.MENU_PATH;
     }
 

--- a/packages/output/src/browser/output-contribution.ts
+++ b/packages/output/src/browser/output-contribution.ts
@@ -68,7 +68,7 @@ export class OutputContribution extends AbstractViewContribution<OutputWidget> i
             open(this.openerService, OutputUri.create(name), { activate: !preserveFocus, reveal: true }));
     }
 
-    registerCommands(registry: CommandRegistry): void {
+    override registerCommands(registry: CommandRegistry): void {
         super.registerCommands(registry);
         registry.registerCommand(OutputCommands.CLEAR__WIDGET, {
             isEnabled: arg => {
@@ -217,7 +217,7 @@ export class OutputContribution extends AbstractViewContribution<OutputWidget> i
         });
     }
 
-    registerMenus(registry: MenuModelRegistry): void {
+    override registerMenus(registry: MenuModelRegistry): void {
         super.registerMenus(registry);
         registry.registerMenuAction(OutputContextMenu.TEXT_EDIT_GROUP, {
             commandId: CommonCommands.COPY.id

--- a/packages/output/src/browser/output-editor-model-factory.ts
+++ b/packages/output/src/browser/output-editor-model-factory.ts
@@ -43,11 +43,11 @@ export class OutputEditorModelFactory implements MonacoEditorModelFactory {
 
 export class OutputEditorModel extends MonacoEditorModel {
 
-    get readOnly(): boolean {
+    override get readOnly(): boolean {
         return true;
     }
 
-    protected setDirty(dirty: boolean): void {
+    protected override setDirty(dirty: boolean): void {
         // NOOP
     }
 

--- a/packages/output/src/browser/output-widget.ts
+++ b/packages/output/src/browser/output-widget.ts
@@ -126,13 +126,13 @@ export class OutputWidget extends BaseWidget implements StatefulWidget {
         }
     }
 
-    protected onAfterAttach(message: Message): void {
+    protected override onAfterAttach(message: Message): void {
         super.onAfterAttach(message);
         Widget.attach(this.editorContainer, this.node);
         this.toDisposeOnDetach.push(Disposable.create(() => Widget.detach(this.editorContainer)));
     }
 
-    protected onActivateRequest(message: Message): void {
+    protected override onActivateRequest(message: Message): void {
         super.onActivateRequest(message);
         if (this.editor) {
             this.editor.focus();
@@ -141,7 +141,7 @@ export class OutputWidget extends BaseWidget implements StatefulWidget {
         }
     }
 
-    protected onResize(message: Widget.ResizeMessage): void {
+    protected override onResize(message: Widget.ResizeMessage): void {
         super.onResize(message);
         MessageLoop.sendMessage(this.editorContainer, Widget.ResizeMessage.UnknownSize);
         for (const widget of toArray(this.editorContainer.widgets())) {
@@ -149,7 +149,7 @@ export class OutputWidget extends BaseWidget implements StatefulWidget {
         }
     }
 
-    protected onAfterShow(msg: Message): void {
+    protected override onAfterShow(msg: Message): void {
         super.onAfterShow(msg);
         this.onResize(Widget.ResizeMessage.UnknownSize); // Triggers an editor widget resize. (#8361)
     }

--- a/packages/plugin-dev/src/node/hosted-instance-manager.ts
+++ b/packages/plugin-dev/src/node/hosted-instance-manager.ts
@@ -352,21 +352,21 @@ export class NodeHostedPluginRunner extends AbstractHostedInstanceManager {
     @inject(ContributionProvider) @named(Symbol.for(HostedPluginUriPostProcessorSymbolName))
     protected readonly uriPostProcessors: ContributionProvider<HostedPluginUriPostProcessor>;
 
-    protected async postProcessInstanceUri(uri: URI): Promise<URI> {
+    protected override async postProcessInstanceUri(uri: URI): Promise<URI> {
         for (const uriPostProcessor of this.uriPostProcessors.getContributions()) {
             uri = await uriPostProcessor.processUri(uri);
         }
         return uri;
     }
 
-    protected async postProcessInstanceOptions(options: object): Promise<object> {
+    protected override async postProcessInstanceOptions(options: object): Promise<object> {
         for (const uriPostProcessor of this.uriPostProcessors.getContributions()) {
             options = await uriPostProcessor.processOptions(options);
         }
         return options;
     }
 
-    protected async getStartCommand(port?: number, debugConfig?: DebugPluginConfiguration): Promise<string[]> {
+    protected override async getStartCommand(port?: number, debugConfig?: DebugPluginConfiguration): Promise<string[]> {
         if (!port) {
             port = process.env.HOSTED_PLUGIN_PORT ?
                 Number(process.env.HOSTED_PLUGIN_PORT) :

--- a/packages/plugin-ext-vscode/src/node/scanner-vscode.ts
+++ b/packages/plugin-ext-vscode/src/node/scanner-vscode.ts
@@ -25,11 +25,11 @@ export class VsCodePluginScanner extends TheiaPluginScanner implements PluginSca
     private readonly VSCODE_TYPE: PluginEngine = 'vscode';
     private readonly VSCODE_PREFIX: string = 'vscode:extension/';
 
-    get apiType(): PluginEngine {
+    override get apiType(): PluginEngine {
         return this.VSCODE_TYPE;
     }
 
-    getModel(plugin: PluginPackage): PluginModel {
+    override getModel(plugin: PluginPackage): PluginModel {
         // publisher can be empty on vscode extension development
         const publisher = plugin.publisher || '';
         const result: PluginModel = {
@@ -59,7 +59,7 @@ export class VsCodePluginScanner extends TheiaPluginScanner implements PluginSca
     /**
      * Maps extension dependencies to deployable extension dependencies.
      */
-    getDependencies(plugin: PluginPackage): Map<string, string> | undefined {
+    override getDependencies(plugin: PluginPackage): Map<string, string> | undefined {
         // Store the list of dependencies.
         const dependencies = new Map<string, string>();
         // Iterate through the list of dependencies from `extensionDependencies` and `extensionPack`.
@@ -76,7 +76,7 @@ export class VsCodePluginScanner extends TheiaPluginScanner implements PluginSca
         return dependencies.size > 0 ? dependencies : undefined;
     }
 
-    getLifecycle(plugin: PluginPackage): PluginLifecycle {
+    override getLifecycle(plugin: PluginPackage): PluginLifecycle {
         return {
             startMethod: 'activate',
             stopMethod: 'deactivate',

--- a/packages/plugin-ext/src/hosted/node-electron/scanner-theia-electron.ts
+++ b/packages/plugin-ext/src/hosted/node-electron/scanner-theia-electron.ts
@@ -21,7 +21,7 @@ import { PluginPackage, PluginModel } from '../../common/plugin-protocol';
 
 @injectable()
 export class TheiaPluginScannerElectron extends TheiaPluginScanner {
-    getModel(plugin: PluginPackage): PluginModel {
+    override getModel(plugin: PluginPackage): PluginModel {
         const result = super.getModel(plugin);
         if (result.entryPoint.frontend) {
             result.entryPoint.frontend = path.resolve(plugin.packagePath, result.entryPoint.frontend);

--- a/packages/plugin-ext/src/main/browser/comments/comment-thread-widget.tsx
+++ b/packages/plugin-ext/src/main/browser/comments/comment-thread-widget.tsx
@@ -114,7 +114,7 @@ export class CommentThreadWidget extends BaseWidget {
         this.commentService.disposeCommentThread(this.owner, this._commentThread.threadId);
     }
 
-    dispose(): void {
+    override dispose(): void {
         super.dispose();
         if (this.commentGlyphWidget) {
             this.commentGlyphWidget.dispose();
@@ -134,7 +134,7 @@ export class CommentThreadWidget extends BaseWidget {
         }
     }
 
-    hide(): void {
+    override hide(): void {
         this.zoneWidget.hide();
         this.isExpanded = false;
         super.hide();
@@ -231,7 +231,7 @@ export class CommentThreadWidget extends BaseWidget {
         return label;
     }
 
-    update(): void {
+    override update(): void {
         if (!this.isExpanded) {
             return;
         }
@@ -342,7 +342,7 @@ export class CommentForm<P extends CommentForm.Props = CommentForm.Props> extend
         }, 100);
     };
 
-    componentDidMount(): void {
+    override componentDidMount(): void {
         // Wait for the widget to be rendered.
         setTimeout(() => {
             this.inputRef.current?.focus();
@@ -377,7 +377,7 @@ export class CommentForm<P extends CommentForm.Props = CommentForm.Props> extend
         });
     }
 
-    render(): React.ReactNode {
+    override render(): React.ReactNode {
         const { commands, commentThread, contextKeyService } = this.props;
         const hasExistingComments = commentThread.comments && commentThread.comments.length > 0;
         return <div className={'comment-form' + (this.state.expanded || commentThread.comments && commentThread.comments.length === 0 ? ' expand' : '')}>
@@ -453,7 +453,7 @@ export class ReviewComment<P extends ReviewComment.Props = ReviewComment.Props> 
     protected showHover = () => this.setState({ hover: true });
     protected hideHover = () => this.setState({ hover: false });
 
-    render(): React.ReactNode {
+    override render(): React.ReactNode {
         const { comment, commentForm, contextKeyService, menus, commands, commentThread } = this.props;
         const commentUniqueId = comment.uniqueIdInThread;
         const { hover } = this.state;
@@ -499,7 +499,7 @@ namespace CommentBody {
 }
 
 export class CommentBody extends React.Component<CommentBody.Props> {
-    render(): React.ReactNode {
+    override render(): React.ReactNode {
         const { value, isVisible } = this.props;
         if (!isVisible) {
             return false;
@@ -528,7 +528,7 @@ export class CommentEditContainer extends React.Component<CommentEditContainer.P
     private dirtyCommentMode: CommentMode | undefined;
     private dirtyCommentFormState: boolean | undefined;
 
-    componentDidUpdate(prevProps: Readonly<CommentEditContainer.Props>, prevState: Readonly<{}>): void {
+    override componentDidUpdate(prevProps: Readonly<CommentEditContainer.Props>, prevState: Readonly<{}>): void {
         const commentFormState = this.props.commentForm.current?.state;
         const mode = this.props.comment.mode;
         if (this.dirtyCommentMode !== mode || (this.dirtyCommentFormState !== commentFormState?.expanded && !commentFormState?.expanded)) {
@@ -545,7 +545,7 @@ export class CommentEditContainer extends React.Component<CommentEditContainer.P
         this.dirtyCommentFormState = commentFormState?.expanded;
     }
 
-    render(): React.ReactNode {
+    override render(): React.ReactNode {
         const { menus, comment, commands, commentThread, contextKeyService } = this.props;
         if (!(comment.mode === CommentMode.Editing)) {
             return false;
@@ -588,7 +588,7 @@ namespace CommentsInlineAction {
 }
 
 export class CommentsInlineAction extends React.Component<CommentsInlineAction.Props> {
-    render(): React.ReactNode {
+    override render(): React.ReactNode {
         const { node, commands, contextKeyService, commentThread, commentUniqueId } = this.props;
         if (node.action.when && !contextKeyService.match(node.action.when)) {
             return false;
@@ -618,7 +618,7 @@ namespace CommentActions {
 }
 
 export class CommentActions extends React.Component<CommentActions.Props> {
-    render(): React.ReactNode {
+    override render(): React.ReactNode {
         const { contextKeyService, commands, menu, commentThread, getInput, clearInput } = this.props;
         return <div className={'form-actions'}>
             {menu.children.map((node, index) => node instanceof ActionMenuNode &&
@@ -647,7 +647,7 @@ namespace CommentAction {
 }
 
 export class CommentAction extends React.Component<CommentAction.Props> {
-    render(): React.ReactNode {
+    override render(): React.ReactNode {
         const classNames = ['comments-button', 'comments-text-button', 'theia-button'];
         const { node, commands, contextKeyService, onClick } = this.props;
         if (node.action.when && !contextKeyService.match(node.action.when)) {

--- a/packages/plugin-ext/src/main/browser/custom-editors/custom-editor-widget.ts
+++ b/packages/plugin-ext/src/main/browser/custom-editors/custom-editor-widget.ts
@@ -25,9 +25,9 @@ import { CustomEditorModel } from './custom-editors-main';
 
 @injectable()
 export class CustomEditorWidget extends WebviewWidget implements SaveableSource, NavigatableWidget {
-    static FACTORY_ID = 'plugin-custom-editor';
+    static override FACTORY_ID = 'plugin-custom-editor';
 
-    id: string;
+    override id: string;
     resource: URI;
 
     protected _modelRef: Reference<CustomEditorModel>;
@@ -47,7 +47,7 @@ export class CustomEditorWidget extends WebviewWidget implements SaveableSource,
     protected readonly undoRedoService: UndoRedoService;
 
     @postConstruct()
-    protected init(): void {
+    protected override init(): void {
         super.init();
         this.id = CustomEditorWidget.FACTORY_ID + ':' + this.identifier.id;
         this.toDispose.push(this.fileService.onDidRunOperation(e => {
@@ -83,14 +83,14 @@ export class CustomEditorWidget extends WebviewWidget implements SaveableSource,
         return this.resource.withPath(resourceUri.path);
     }
 
-    storeState(): CustomEditorWidget.State {
+    override storeState(): CustomEditorWidget.State {
         return {
             ...super.storeState(),
             strResource: this.resource.toString(),
         };
     }
 
-    restoreState(oldState: CustomEditorWidget.State): void {
+    override restoreState(oldState: CustomEditorWidget.State): void {
         const { strResource } = oldState;
         this.resource = new URI(strResource);
         super.restoreState(oldState);

--- a/packages/plugin-ext/src/main/browser/debug/plugin-debug-session-factory.ts
+++ b/packages/plugin-ext/src/main/browser/debug/plugin-debug-session-factory.ts
@@ -34,22 +34,22 @@ import { Channel } from '@theia/debug/lib/common/debug-service';
 
 export class PluginDebugSession extends DebugSession {
     constructor(
-        readonly id: string,
-        readonly options: DebugSessionOptions,
-        readonly parentSession: DebugSession | undefined,
-        protected readonly connection: DebugSessionConnection,
-        protected readonly terminalServer: TerminalService,
-        protected readonly editorManager: EditorManager,
-        protected readonly breakpoints: BreakpointManager,
-        protected readonly labelProvider: LabelProvider,
-        protected readonly messages: MessageClient,
-        protected readonly fileService: FileService,
+        override readonly id: string,
+        override readonly options: DebugSessionOptions,
+        override readonly parentSession: DebugSession | undefined,
+        protected override readonly connection: DebugSessionConnection,
+        protected override readonly terminalServer: TerminalService,
+        protected override readonly editorManager: EditorManager,
+        protected override readonly breakpoints: BreakpointManager,
+        protected override readonly labelProvider: LabelProvider,
+        protected override readonly messages: MessageClient,
+        protected override readonly fileService: FileService,
         protected readonly terminalOptionsExt: TerminalOptionsExt | undefined,
-        protected readonly debugContributionProvider: ContributionProvider<DebugContribution>) {
+        protected override readonly debugContributionProvider: ContributionProvider<DebugContribution>) {
         super(id, options, parentSession, connection, terminalServer, editorManager, breakpoints, labelProvider, messages, fileService, debugContributionProvider);
     }
 
-    protected async doCreateTerminal(terminalWidgetOptions: TerminalWidgetOptions): Promise<TerminalWidget> {
+    protected override async doCreateTerminal(terminalWidgetOptions: TerminalWidgetOptions): Promise<TerminalWidget> {
         terminalWidgetOptions = Object.assign({}, terminalWidgetOptions, this.terminalOptionsExt);
         return super.doCreateTerminal(terminalWidgetOptions);
     }
@@ -61,22 +61,22 @@ export class PluginDebugSession extends DebugSession {
  */
 export class PluginDebugSessionFactory extends DefaultDebugSessionFactory {
     constructor(
-        protected readonly terminalService: TerminalService,
-        protected readonly editorManager: EditorManager,
-        protected readonly breakpoints: BreakpointManager,
-        protected readonly labelProvider: LabelProvider,
-        protected readonly messages: MessageClient,
-        protected readonly outputChannelManager: OutputChannelManager,
-        protected readonly debugPreferences: DebugPreferences,
+        protected override readonly terminalService: TerminalService,
+        protected override readonly editorManager: EditorManager,
+        protected override readonly breakpoints: BreakpointManager,
+        protected override readonly labelProvider: LabelProvider,
+        protected override readonly messages: MessageClient,
+        protected override readonly outputChannelManager: OutputChannelManager,
+        protected override readonly debugPreferences: DebugPreferences,
         protected readonly connectionFactory: (sessionId: string) => Promise<Channel>,
-        protected readonly fileService: FileService,
+        protected override readonly fileService: FileService,
         protected readonly terminalOptionsExt: TerminalOptionsExt | undefined,
-        protected readonly debugContributionProvider: ContributionProvider<DebugContribution>
+        protected override readonly debugContributionProvider: ContributionProvider<DebugContribution>
     ) {
         super();
     }
 
-    get(sessionId: string, options: DebugSessionOptions, parentSession?: DebugSession): DebugSession {
+    override get(sessionId: string, options: DebugSessionOptions, parentSession?: DebugSession): DebugSession {
         const connection = new DebugSessionConnection(
             sessionId,
             this.connectionFactory,

--- a/packages/plugin-ext/src/main/browser/dialogs/modal-notification.ts
+++ b/packages/plugin-ext/src/main/browser/dialogs/modal-notification.ts
@@ -42,7 +42,7 @@ export class ModalNotification extends AbstractDialog<string | undefined> {
         super({ title: FrontendApplicationConfigProvider.get().applicationName });
     }
 
-    protected onCloseRequest(msg: Message): void {
+    protected override onCloseRequest(msg: Message): void {
         this.actionTitle = undefined;
         this.accept();
     }

--- a/packages/plugin-ext/src/main/browser/plugin-authentication-service.ts
+++ b/packages/plugin-ext/src/main/browser/plugin-authentication-service.ts
@@ -27,12 +27,12 @@ export function getAuthenticationProviderActivationEvent(id: string): string { r
 export class PluginAuthenticationServiceImpl extends AuthenticationServiceImpl implements AuthenticationService {
     @inject(HostedPluginSupport) protected readonly pluginService: HostedPluginSupport;
 
-    async getSessions(id: string, scopes?: string[]): Promise<ReadonlyArray<AuthenticationSession>> {
+    override async getSessions(id: string, scopes?: string[]): Promise<ReadonlyArray<AuthenticationSession>> {
         await this.tryActivateProvider(id);
         return super.getSessions(id, scopes);
     }
 
-    async login(id: string, scopes: string[]): Promise<AuthenticationSession> {
+    override async login(id: string, scopes: string[]): Promise<AuthenticationSession> {
         await this.tryActivateProvider(id);
         return super.login(id, scopes);
     }

--- a/packages/plugin-ext/src/main/browser/plugin-ext-widget.tsx
+++ b/packages/plugin-ext/src/main/browser/plugin-ext-widget.tsx
@@ -52,7 +52,7 @@ export class PluginWidget extends ReactWidget {
         this.toDispose.push(this.pluginService.onDidChangePlugins(() => this.update()));
     }
 
-    protected onActivateRequest(msg: Message): void {
+    protected override onActivateRequest(msg: Message): void {
         super.onActivateRequest(msg);
         this.node.focus();
     }

--- a/packages/plugin-ext/src/main/browser/view/plugin-view-widget.ts
+++ b/packages/plugin-ext/src/main/browser/view/plugin-view-widget.ts
@@ -66,7 +66,7 @@ export class PluginViewWidget extends Panel implements StatefulWidget, Descripti
         this.toDispose.push(localContext);
     }
 
-    protected onActivateRequest(msg: Message): void {
+    protected override onActivateRequest(msg: Message): void {
         super.onActivateRequest(msg);
         const widget = this.widgets[0];
         if (widget) {
@@ -144,17 +144,17 @@ export class PluginViewWidget extends Panel implements StatefulWidget, Descripti
         }
     }
 
-    addWidget(widget: Widget): void {
+    override addWidget(widget: Widget): void {
         super.addWidget(widget);
         this.updateWidgetMessage();
     }
 
-    insertWidget(index: number, widget: Widget): void {
+    override insertWidget(index: number, widget: Widget): void {
         super.insertWidget(index, widget);
         this.updateWidgetMessage();
     }
 
-    dispose(): void {
+    override dispose(): void {
         this.toDispose.dispose();
         super.dispose();
     }

--- a/packages/plugin-ext/src/main/browser/view/tree-view-widget.tsx
+++ b/packages/plugin-ext/src/main/browser/view/tree-view-widget.tsx
@@ -250,9 +250,6 @@ export class TreeViewWidget extends TreeViewWelcomeWidget {
     @inject(TooltipService)
     protected readonly tooltipService: TooltipService;
 
-    protected override readonly onDidChangeVisibilityEmitter = new Emitter<boolean>();
-    override readonly onDidChangeVisibility = this.onDidChangeVisibilityEmitter.event;
-
     @postConstruct()
     protected override init(): void {
         super.init();

--- a/packages/plugin-ext/src/main/browser/view/tree-view-widget.tsx
+++ b/packages/plugin-ext/src/main/browser/view/tree-view-widget.tsx
@@ -118,7 +118,7 @@ export class PluginTree extends TreeImpl {
         return this._isEmpty;
     }
 
-    protected async resolveChildren(parent: CompositeTreeNode): Promise<TreeNode[]> {
+    protected override async resolveChildren(parent: CompositeTreeNode): Promise<TreeNode[]> {
         if (!this._proxy) {
             return super.resolveChildren(parent);
         }
@@ -204,7 +204,7 @@ export class PluginTree extends TreeImpl {
 export class PluginTreeModel extends TreeModelImpl {
 
     @inject(PluginTree)
-    protected readonly tree: PluginTree;
+    protected override readonly tree: PluginTree;
 
     set proxy(proxy: TreeViewsExt | undefined) {
         this.tree.proxy = proxy;
@@ -242,7 +242,7 @@ export class TreeViewWidget extends TreeViewWelcomeWidget {
     readonly identifier: TreeViewWidgetIdentifier;
 
     @inject(PluginTreeModel)
-    readonly model: PluginTreeModel;
+    override readonly model: PluginTreeModel;
 
     @inject(ContextKeyService)
     protected readonly contextKeyService: ContextKeyService;
@@ -250,11 +250,11 @@ export class TreeViewWidget extends TreeViewWelcomeWidget {
     @inject(TooltipService)
     protected readonly tooltipService: TooltipService;
 
-    protected readonly onDidChangeVisibilityEmitter = new Emitter<boolean>();
-    readonly onDidChangeVisibility = this.onDidChangeVisibilityEmitter.event;
+    protected override readonly onDidChangeVisibilityEmitter = new Emitter<boolean>();
+    override readonly onDidChangeVisibility = this.onDidChangeVisibilityEmitter.event;
 
     @postConstruct()
-    protected init(): void {
+    protected override init(): void {
         super.init();
         this.id = this.identifier.id;
         this.addClass('theia-tree-view');
@@ -265,7 +265,7 @@ export class TreeViewWidget extends TreeViewWelcomeWidget {
         this.toDispose.push(this.onDidChangeVisibilityEmitter);
     }
 
-    protected renderIcon(node: TreeNode, props: NodeProps): React.ReactNode {
+    protected override renderIcon(node: TreeNode, props: NodeProps): React.ReactNode {
         const icon = this.toNodeIcon(node);
         if (icon) {
             return <div className={icon + ' theia-tree-view-icon'}></div>;
@@ -273,7 +273,7 @@ export class TreeViewWidget extends TreeViewWelcomeWidget {
         return undefined;
     }
 
-    protected renderCaption(node: TreeViewNode, props: NodeProps): React.ReactNode {
+    protected override renderCaption(node: TreeViewNode, props: NodeProps): React.ReactNode {
         const classes = [TREE_NODE_SEGMENT_CLASS];
         if (!this.hasTrailingSuffixes(node)) {
             classes.push(TREE_NODE_SEGMENT_GROW_CLASS);
@@ -325,7 +325,7 @@ export class TreeViewWidget extends TreeViewWelcomeWidget {
         return React.createElement('div', attrs, ...children);
     }
 
-    protected renderTailDecorations(node: TreeViewNode, props: NodeProps): React.ReactNode {
+    protected override renderTailDecorations(node: TreeViewNode, props: NodeProps): React.ReactNode {
         return this.contextKeys.with({ view: this.id, viewItem: node.contextValue }, () => {
             const menu = this.menus.getMenu(VIEW_ITEM_INLINE_MENU);
             const arg = this.toTreeViewSelection(node);
@@ -352,30 +352,30 @@ export class TreeViewWidget extends TreeViewWelcomeWidget {
         }} />;
     }
 
-    protected toContextMenuArgs(node: SelectableTreeNode): [TreeViewSelection] {
+    protected override toContextMenuArgs(node: SelectableTreeNode): [TreeViewSelection] {
         return [this.toTreeViewSelection(node)];
     }
 
-    setFlag(flag: Widget.Flag): void {
+    override setFlag(flag: Widget.Flag): void {
         super.setFlag(flag);
         if (flag === Widget.Flag.IsVisible) {
             this.onDidChangeVisibilityEmitter.fire(this.isVisible);
         }
     }
 
-    clearFlag(flag: Widget.Flag): void {
+    override clearFlag(flag: Widget.Flag): void {
         super.clearFlag(flag);
         if (flag === Widget.Flag.IsVisible) {
             this.onDidChangeVisibilityEmitter.fire(this.isVisible);
         }
     }
 
-    handleEnter(event: KeyboardEvent): void {
+    override handleEnter(event: KeyboardEvent): void {
         super.handleEnter(event);
         this.tryExecuteCommand();
     }
 
-    handleClickEvent(node: TreeNode, event: React.MouseEvent<HTMLElement>): void {
+    override handleClickEvent(node: TreeNode, event: React.MouseEvent<HTMLElement>): void {
         super.handleClickEvent(node, event);
         // If clicked on item (not collapsable icon) - execute command or toggle expansion if item has no command
         const commandMap = this.findCommands(node);
@@ -418,7 +418,7 @@ export class TreeViewWidget extends TreeViewWelcomeWidget {
         this.update();
     }
 
-    protected render(): React.ReactNode {
+    protected override render(): React.ReactNode {
         const node = React.createElement('div', this.createContainerAttributes(), this.renderSearchInfo(), this.renderTree(this.model));
         this.tooltipService.update();
         return node;
@@ -431,7 +431,7 @@ export class TreeViewWidget extends TreeViewWelcomeWidget {
         return undefined;
     }
 
-    shouldShowWelcomeView(): boolean {
+    override shouldShowWelcomeView(): boolean {
         return (this.model.proxy === undefined || this.model.isTreeEmpty) && this.message === undefined;
     }
 }

--- a/packages/plugin-ext/src/main/browser/webview/webview.ts
+++ b/packages/plugin-ext/src/main/browser/webview/webview.ts
@@ -198,14 +198,14 @@ export class WebviewWidget extends BaseWidget implements StatefulWidget {
         }));
     }
 
-    protected onBeforeAttach(msg: Message): void {
+    protected override onBeforeAttach(msg: Message): void {
         super.onBeforeAttach(msg);
         this.doShow();
         // iframe has to be reloaded when moved to another DOM element
         this.toDisposeOnDetach.push(Disposable.create(() => this.forceHide()));
     }
 
-    protected onAfterAttach(msg: Message): void {
+    protected override onAfterAttach(msg: Message): void {
         super.onAfterAttach(msg);
         this.addEventListener(this.node, 'focus', () => {
             if (this.element) {
@@ -214,12 +214,12 @@ export class WebviewWidget extends BaseWidget implements StatefulWidget {
         });
     }
 
-    protected onBeforeShow(msg: Message): void {
+    protected override onBeforeShow(msg: Message): void {
         super.onBeforeShow(msg);
         this.doShow();
     }
 
-    protected onAfterHide(msg: Message): void {
+    protected override onAfterHide(msg: Message): void {
         super.onAfterHide(msg);
         this.doHide();
     }
@@ -410,7 +410,7 @@ export class WebviewWidget extends BaseWidget implements StatefulWidget {
             });
     }
 
-    protected onActivateRequest(msg: Message): void {
+    protected override onActivateRequest(msg: Message): void {
         super.onActivateRequest(msg);
         this.node.focus();
     }

--- a/packages/plugin-ext/src/main/electron-browser/webview/electron-webview-widget-factory.ts
+++ b/packages/plugin-ext/src/main/electron-browser/webview/electron-webview-widget-factory.ts
@@ -23,7 +23,7 @@ import { CustomEditorWidget } from '../../browser/custom-editors/custom-editor-w
 
 export class ElectronWebviewWidgetFactory extends WebviewWidgetFactory {
 
-    async createWidget(identifier: WebviewWidgetIdentifier): Promise<WebviewWidget> {
+    override async createWidget(identifier: WebviewWidgetIdentifier): Promise<WebviewWidget> {
         const widget = await super.createWidget(identifier);
         await this.attachElectronSecurityCookie(widget.externalEndpoint);
         return widget;
@@ -47,7 +47,7 @@ export class ElectronWebviewWidgetFactory extends WebviewWidgetFactory {
 
 export class ElectronCustomEditorWidgetFactory extends CustomEditorWidgetFactory {
 
-    async createWidget(identifier: WebviewWidgetIdentifier): Promise<CustomEditorWidget> {
+    override async createWidget(identifier: WebviewWidgetIdentifier): Promise<CustomEditorWidget> {
         const widget = await super.createWidget(identifier);
         await this.attachElectronSecurityCookie(widget.externalEndpoint);
         return widget;

--- a/packages/plugin-ext/src/plugin/node/debug/plugin-debug-adapter-session.ts
+++ b/packages/plugin-ext/src/plugin/node/debug/plugin-debug-adapter-session.ts
@@ -30,7 +30,7 @@ export class PluginDebugAdapterSession extends DebugAdapterSessionImpl {
     readonly configuration: theia.DebugConfiguration;
 
     constructor(
-        readonly debugAdapter: DebugAdapter,
+        override readonly debugAdapter: DebugAdapter,
         protected readonly tracker: theia.DebugAdapterTracker,
         protected readonly theiaSession: theia.DebugSession) {
 
@@ -41,14 +41,14 @@ export class PluginDebugAdapterSession extends DebugAdapterSessionImpl {
         this.configuration = theiaSession.configuration;
     }
 
-    async start(channel: Channel): Promise<void> {
+    override async start(channel: Channel): Promise<void> {
         if (this.tracker.onWillStartSession) {
             this.tracker.onWillStartSession();
         }
         await super.start(channel);
     }
 
-    async stop(): Promise<void> {
+    override async stop(): Promise<void> {
         if (this.tracker.onWillStopSession) {
             this.tracker.onWillStopSession();
         }
@@ -59,14 +59,14 @@ export class PluginDebugAdapterSession extends DebugAdapterSessionImpl {
         return this.theiaSession.customRequest(command, args);
     }
 
-    protected onDebugAdapterError(error: Error): void {
+    protected override onDebugAdapterError(error: Error): void {
         if (this.tracker.onError) {
             this.tracker.onError(error);
         }
         super.onDebugAdapterError(error);
     }
 
-    protected send(message: string): void {
+    protected override send(message: string): void {
         try {
             super.send(message);
         } finally {
@@ -76,14 +76,14 @@ export class PluginDebugAdapterSession extends DebugAdapterSessionImpl {
         }
     }
 
-    protected write(message: string): void {
+    protected override write(message: string): void {
         if (this.tracker.onWillReceiveMessage) {
             this.tracker.onWillReceiveMessage(JSON.parse(message));
         }
         super.write(message);
     }
 
-    protected onDebugAdapterExit(): void {
+    protected override onDebugAdapterExit(): void {
         if (this.tracker.onExit) {
             this.tracker.onExit(undefined, undefined);
         }

--- a/packages/plugin-ext/src/plugin/node/env-node-ext.ts
+++ b/packages/plugin-ext/src/plugin/node/env-node-ext.ts
@@ -43,7 +43,7 @@ export class EnvNodeExtImpl extends EnvExtImpl {
     /**
      * override machineID
      */
-    get machineId(): string {
+    override get machineId(): string {
         return this.macMachineId;
     }
 

--- a/packages/plugin-ext/src/plugin/plugin-context.ts
+++ b/packages/plugin-ext/src/plugin/plugin-context.ts
@@ -1098,7 +1098,7 @@ export class PluginExt<T> extends Plugin<T> implements ExtensionPlugin<T> {
     extensionUri: theia.Uri;
     extensionKind: ExtensionKind;
 
-    constructor(protected readonly pluginManager: PluginManager, plugin: InternalPlugin) {
+    constructor(protected override readonly pluginManager: PluginManager, plugin: InternalPlugin) {
         super(pluginManager, plugin);
 
         this.extensionPath = this.pluginPath;
@@ -1106,15 +1106,15 @@ export class PluginExt<T> extends Plugin<T> implements ExtensionPlugin<T> {
         this.extensionKind = ExtensionKind.UI; // stub as a local extension (not running on a remote workspace)
     }
 
-    get isActive(): boolean {
+    override get isActive(): boolean {
         return this.pluginManager.isActive(this.id);
     }
 
-    get exports(): T {
+    override get exports(): T {
         return <T>this.pluginManager.getPluginExport(this.id);
     }
 
-    activate(): PromiseLike<T> {
+    override activate(): PromiseLike<T> {
         return this.pluginManager.activatePlugin(this.id).then(() => this.exports);
     }
 }

--- a/packages/plugin-ext/src/plugin/quick-open.ts
+++ b/packages/plugin-ext/src/plugin/quick-open.ts
@@ -492,11 +492,12 @@ export class InputBoxExt extends QuickInputExt implements InputBox {
     private _prompt: string | undefined;
     private _validationMessage: string | undefined;
 
-    constructor(readonly quickOpen: QuickOpenExtImpl,
-        readonly quickOpenMain: QuickOpenMain,
-        readonly plugin: Plugin,
-        onDispose: () => void) {
-
+    constructor(
+        override readonly quickOpen: QuickOpenExtImpl,
+        override readonly quickOpenMain: QuickOpenMain,
+        override readonly plugin: Plugin,
+        onDispose: () => void
+    ) {
         super(quickOpen, quickOpenMain, plugin, onDispose);
 
         this.buttons = [];
@@ -533,7 +534,7 @@ export class InputBoxExt extends QuickInputExt implements InputBox {
         }
     }
 
-    async show(): Promise<void> {
+    override async show(): Promise<void> {
         super.show();
 
         const update = (value: string) => {
@@ -584,11 +585,12 @@ export class QuickPickExt<T extends theia.QuickPickItem> extends QuickInputExt i
     private readonly _onDidChangeActiveEmitter = new Emitter<T[]>();
     private readonly _onDidChangeSelectionEmitter = new Emitter<T[]>();
 
-    constructor(readonly quickOpen: QuickOpenExtImpl,
-        readonly quickOpenMain: QuickOpenMain,
-        readonly plugin: Plugin,
-        onDispose: () => void) {
-
+    constructor(
+        override readonly quickOpen: QuickOpenExtImpl,
+        override readonly quickOpenMain: QuickOpenMain,
+        override readonly plugin: Plugin,
+        onDispose: () => void
+    ) {
         super(quickOpen, quickOpenMain, plugin, onDispose);
         this.buttons = [];
 

--- a/packages/plugin-ext/src/plugin/types-impl.ts
+++ b/packages/plugin-ext/src/plugin/types-impl.ts
@@ -68,7 +68,7 @@ export class URI extends CodeURI implements theia.Uri {
     /**
      * Override to create the correct class.
      */
-    with(change: {
+    override with(change: {
         scheme?: string;
         authority?: string | null;
         path?: string | null;
@@ -90,19 +90,19 @@ export class URI extends CodeURI implements theia.Uri {
      * Override to create the correct class.
      * @param data
      */
-    static revive(data: UriComponents | CodeURI): URI;
-    static revive(data: UriComponents | CodeURI | null): URI | null;
-    static revive(data: UriComponents | CodeURI | undefined): URI | undefined
-    static revive(data: UriComponents | CodeURI | undefined | null): URI | undefined | null {
+    static override revive(data: UriComponents | CodeURI): URI;
+    static override revive(data: UriComponents | CodeURI | null): URI | null;
+    static override revive(data: UriComponents | CodeURI | undefined): URI | undefined
+    static override revive(data: UriComponents | CodeURI | undefined | null): URI | undefined | null {
         const uri = CodeURI.revive(data);
         return uri ? new URI(uri) : undefined;
     }
 
-    static parse(value: string, _strict?: boolean): URI {
+    static override parse(value: string, _strict?: boolean): URI {
         return new URI(CodeURI.parse(value, _strict));
     }
 
-    static file(path: string): URI {
+    static override file(path: string): URI {
         return new URI(CodeURI.file(path));
     }
 
@@ -111,7 +111,7 @@ export class URI extends CodeURI implements theia.Uri {
      * transferring via JSON.stringify(). Making the CodeURI instance
      * makes sure we transfer this object as a vscode-uri URI.
      */
-    toJSON(): UriComponents {
+    override toJSON(): UriComponents {
         return CodeURI.from(this).toJSON();
     }
 }

--- a/packages/plugin-metrics/src/browser/plugin-metrics-languages-main.ts
+++ b/packages/plugin-metrics/src/browser/plugin-metrics-languages-main.ts
@@ -32,115 +32,115 @@ export class LanguagesMainPluginMetrics extends LanguagesMainImpl {
     // Map of handle to extension id
     protected readonly handleToExtensionID = new Map<number, string>();
 
-    $unregister(handle: number): void {
+    override $unregister(handle: number): void {
         this.handleToExtensionID.delete(handle);
         super.$unregister(handle);
     }
 
-    protected provideCompletionItems(handle: number, model: monaco.editor.ITextModel, position: monaco.Position,
+    protected override provideCompletionItems(handle: number, model: monaco.editor.ITextModel, position: monaco.Position,
         context: monaco.languages.CompletionContext, token: monaco.CancellationToken): monaco.languages.ProviderResult<monaco.languages.CompletionList> {
         return this.pluginMetricsResolver.resolveRequest(this.handleToExtensionName(handle),
             vst.CompletionRequest.type.method,
             super.provideCompletionItems(handle, model, position, context, token));
     }
 
-    protected resolveCompletionItem(handle: number,
+    protected override resolveCompletionItem(handle: number,
         item: monaco.languages.CompletionItem, token: monaco.CancellationToken): monaco.languages.ProviderResult<monaco.languages.CompletionItem> {
         return this.pluginMetricsResolver.resolveRequest(this.handleToExtensionName(handle),
             vst.CompletionRequest.type.method,
             super.resolveCompletionItem(handle, item, token));
     }
 
-    protected provideReferences(handle: number, model: monaco.editor.ITextModel, position: monaco.Position,
+    protected override provideReferences(handle: number, model: monaco.editor.ITextModel, position: monaco.Position,
         context: monaco.languages.ReferenceContext, token: monaco.CancellationToken): monaco.languages.ProviderResult<monaco.languages.Location[]> {
         return this.pluginMetricsResolver.resolveRequest(this.handleToExtensionName(handle),
             vst.ReferencesRequest.type.method,
             super.provideReferences(handle, model, position, context, token));
     }
 
-    protected provideImplementation(handle: number, model: monaco.editor.ITextModel,
+    protected override provideImplementation(handle: number, model: monaco.editor.ITextModel,
         position: monaco.Position, token: monaco.CancellationToken): monaco.languages.ProviderResult<monaco.languages.Definition> {
         return this.pluginMetricsResolver.resolveRequest(this.handleToExtensionName(handle),
             vst.ImplementationRequest.type.method,
             super.provideImplementation(handle, model, position, token));
     }
 
-    protected provideTypeDefinition(handle: number, model: monaco.editor.ITextModel,
+    protected override provideTypeDefinition(handle: number, model: monaco.editor.ITextModel,
         position: monaco.Position, token: monaco.CancellationToken): monaco.languages.ProviderResult<monaco.languages.Definition> {
         return this.pluginMetricsResolver.resolveRequest(this.handleToExtensionName(handle),
             vst.TypeDefinitionRequest.type.method,
             super.provideTypeDefinition(handle, model, position, token));
     }
 
-    protected provideHover(handle: number, model: monaco.editor.ITextModel, position: monaco.Position,
+    protected override provideHover(handle: number, model: monaco.editor.ITextModel, position: monaco.Position,
         token: monaco.CancellationToken): monaco.languages.ProviderResult<monaco.languages.Hover> {
         return this.pluginMetricsResolver.resolveRequest(this.handleToExtensionName(handle),
             vst.HoverRequest.type.method,
             super.provideHover(handle, model, position, token));
     }
 
-    protected provideDocumentHighlights(handle: number, model: monaco.editor.ITextModel, position: monaco.Position,
+    protected override provideDocumentHighlights(handle: number, model: monaco.editor.ITextModel, position: monaco.Position,
         token: monaco.CancellationToken): monaco.languages.ProviderResult<monaco.languages.DocumentHighlight[]> {
         return this.pluginMetricsResolver.resolveRequest(this.handleToExtensionName(handle),
             vst.DocumentHighlightRequest.type.method,
             super.provideDocumentHighlights(handle, model, position, token));
     }
 
-    protected provideWorkspaceSymbols(handle: number, params: WorkspaceSymbolParams, token: monaco.CancellationToken): Thenable<SymbolInformation[]> {
+    protected override provideWorkspaceSymbols(handle: number, params: WorkspaceSymbolParams, token: monaco.CancellationToken): Thenable<SymbolInformation[]> {
         return this.pluginMetricsResolver.resolveRequest(this.handleToExtensionName(handle),
             vst.WorkspaceSymbolRequest.type.method,
             super.provideWorkspaceSymbols(handle, params, token));
     }
 
-    protected resolveWorkspaceSymbol(handle: number, symbol: SymbolInformation, token: monaco.CancellationToken): Thenable<SymbolInformation> {
+    protected override resolveWorkspaceSymbol(handle: number, symbol: SymbolInformation, token: monaco.CancellationToken): Thenable<SymbolInformation> {
         return this.pluginMetricsResolver.resolveRequest(this.handleToExtensionName(handle),
             vst.WorkspaceSymbolRequest.type.method,
             super.resolveWorkspaceSymbol(handle, symbol, token));
     }
 
-    protected async provideLinks(handle: number, model: monaco.editor.ITextModel,
+    protected override async provideLinks(handle: number, model: monaco.editor.ITextModel,
         token: monaco.CancellationToken): Promise<monaco.languages.ProviderResult<monaco.languages.ILinksList>> {
         return this.pluginMetricsResolver.resolveRequest(this.handleToExtensionName(handle),
             vst.DocumentLinkRequest.type.method,
             super.provideLinks(handle, model, token));
     }
 
-    protected async resolveLink(handle: number, link: monaco.languages.ILink,
+    protected override async resolveLink(handle: number, link: monaco.languages.ILink,
         token: monaco.CancellationToken): Promise<monaco.languages.ProviderResult<monaco.languages.ILink>> {
         return this.pluginMetricsResolver.resolveRequest(this.handleToExtensionName(handle),
             vst.DocumentLinkRequest.type.method,
             super.resolveLink(handle, link, token));
     }
 
-    protected async provideCodeLenses(handle: number, model: monaco.editor.ITextModel,
+    protected override async provideCodeLenses(handle: number, model: monaco.editor.ITextModel,
         token: monaco.CancellationToken): Promise<monaco.languages.ProviderResult<monaco.languages.CodeLensList>> {
         return this.pluginMetricsResolver.resolveRequest(this.handleToExtensionName(handle),
             vst.CodeLensRequest.type.method,
             super.provideCodeLenses(handle, model, token));
     }
 
-    protected resolveCodeLens(handle: number, model: monaco.editor.ITextModel,
+    protected override resolveCodeLens(handle: number, model: monaco.editor.ITextModel,
         codeLens: monaco.languages.CodeLens, token: monaco.CancellationToken): monaco.languages.ProviderResult<monaco.languages.CodeLens> {
         return this.pluginMetricsResolver.resolveRequest(this.handleToExtensionName(handle),
             vst.CodeLensResolveRequest.type.method,
             super.resolveCodeLens(handle, model, codeLens, token));
     }
 
-    protected provideDocumentSymbols(handle: number, model: monaco.editor.ITextModel,
+    protected override provideDocumentSymbols(handle: number, model: monaco.editor.ITextModel,
         token: monaco.CancellationToken): monaco.languages.ProviderResult<monaco.languages.DocumentSymbol[]> {
         return this.pluginMetricsResolver.resolveRequest(this.handleToExtensionName(handle),
             vst.DocumentSymbolRequest.type.method,
             super.provideDocumentSymbols(handle, model, token));
     }
 
-    protected provideDefinition(handle: number, model: monaco.editor.ITextModel,
+    protected override provideDefinition(handle: number, model: monaco.editor.ITextModel,
         position: monaco.Position, token: monaco.CancellationToken): monaco.languages.ProviderResult<monaco.languages.Definition> {
         return this.pluginMetricsResolver.resolveRequest(this.handleToExtensionName(handle),
             vst.DefinitionRequest.type.method,
             super.provideDefinition(handle, model, position, token));
     }
 
-    protected async provideSignatureHelp(handle: number, model: monaco.editor.ITextModel,
+    protected override async provideSignatureHelp(handle: number, model: monaco.editor.ITextModel,
         position: monaco.Position, token: monaco.CancellationToken,
         context: monaco.languages.SignatureHelpContext): Promise<monaco.languages.ProviderResult<monaco.languages.SignatureHelpResult>> {
         return this.pluginMetricsResolver.resolveRequest(this.handleToExtensionName(handle),
@@ -148,49 +148,49 @@ export class LanguagesMainPluginMetrics extends LanguagesMainImpl {
             super.provideSignatureHelp(handle, model, position, token, context));
     }
 
-    protected provideDocumentFormattingEdits(handle: number, model: monaco.editor.ITextModel,
+    protected override provideDocumentFormattingEdits(handle: number, model: monaco.editor.ITextModel,
         options: monaco.languages.FormattingOptions, token: monaco.CancellationToken): monaco.languages.ProviderResult<monaco.languages.TextEdit[]> {
         return this.pluginMetricsResolver.resolveRequest(this.handleToExtensionName(handle),
             vst.DocumentFormattingRequest.type.method,
             super.provideDocumentFormattingEdits(handle, model, options, token));
     }
 
-    protected provideDocumentRangeFormattingEdits(handle: number, model: monaco.editor.ITextModel,
+    protected override provideDocumentRangeFormattingEdits(handle: number, model: monaco.editor.ITextModel,
         range: Range, options: monaco.languages.FormattingOptions, token: monaco.CancellationToken): monaco.languages.ProviderResult<monaco.languages.TextEdit[]> {
         return this.pluginMetricsResolver.resolveRequest(this.handleToExtensionName(handle),
             vst.DocumentRangeFormattingRequest.type.method,
             super.provideDocumentRangeFormattingEdits(handle, model, range, options, token));
     }
 
-    protected provideOnTypeFormattingEdits(handle: number, model: monaco.editor.ITextModel, position: monaco.Position,
+    protected override provideOnTypeFormattingEdits(handle: number, model: monaco.editor.ITextModel, position: monaco.Position,
         ch: string, options: monaco.languages.FormattingOptions, token: monaco.CancellationToken): monaco.languages.ProviderResult<monaco.languages.TextEdit[]> {
         return this.pluginMetricsResolver.resolveRequest(this.handleToExtensionName(handle),
             vst.DocumentOnTypeFormattingRequest.type.method,
             super.provideOnTypeFormattingEdits(handle, model, position, ch, options, token));
     }
 
-    protected provideFoldingRanges(handle: number, model: monaco.editor.ITextModel,
+    protected override provideFoldingRanges(handle: number, model: monaco.editor.ITextModel,
         context: monaco.languages.FoldingContext, token: monaco.CancellationToken): monaco.languages.ProviderResult<monaco.languages.FoldingRange[]> {
         return this.pluginMetricsResolver.resolveRequest(this.handleToExtensionName(handle),
             vst.FoldingRangeRequest.type.method,
             super.provideFoldingRanges(handle, model, context, token));
     }
 
-    protected provideDocumentColors(handle: number, model: monaco.editor.ITextModel,
+    protected override provideDocumentColors(handle: number, model: monaco.editor.ITextModel,
         token: monaco.CancellationToken): monaco.languages.ProviderResult<monaco.languages.IColorInformation[]> {
         return this.pluginMetricsResolver.resolveRequest(this.handleToExtensionName(handle),
             vst.DocumentColorRequest.type.method,
             super.provideDocumentColors(handle, model, token));
     }
 
-    protected provideColorPresentations(handle: number, model: monaco.editor.ITextModel,
+    protected override provideColorPresentations(handle: number, model: monaco.editor.ITextModel,
         colorInfo: monaco.languages.IColorInformation, token: monaco.CancellationToken): monaco.languages.ProviderResult<monaco.languages.IColorPresentation[]> {
         return this.pluginMetricsResolver.resolveRequest(this.handleToExtensionName(handle),
             vst.ColorPresentationRequest.type.method,
             super.provideColorPresentations(handle, model, colorInfo, token));
     }
 
-    protected async provideCodeActions(handle: number, model: monaco.editor.ITextModel,
+    protected override async provideCodeActions(handle: number, model: monaco.editor.ITextModel,
         rangeOrSelection: Range, context: monaco.languages.CodeActionContext,
         token: monaco.CancellationToken): Promise<monaco.languages.CodeActionList | monaco.languages.CodeActionList> {
         return this.pluginMetricsResolver.resolveRequest(this.handleToExtensionName(handle),
@@ -198,117 +198,117 @@ export class LanguagesMainPluginMetrics extends LanguagesMainImpl {
             super.provideCodeActions(handle, model, rangeOrSelection, context, token));
     }
 
-    protected provideRenameEdits(handle: number, model: monaco.editor.ITextModel,
+    protected override provideRenameEdits(handle: number, model: monaco.editor.ITextModel,
         position: monaco.Position, newName: string, token: monaco.CancellationToken): monaco.languages.ProviderResult<monaco.languages.WorkspaceEdit & monaco.languages.Rejection> {
         return this.pluginMetricsResolver.resolveRequest(this.handleToExtensionName(handle),
             vst.RenameRequest.type.method,
             super.provideRenameEdits(handle, model, position, newName, token));
     }
 
-    protected resolveRenameLocation(handle: number, model: monaco.editor.ITextModel,
+    protected override resolveRenameLocation(handle: number, model: monaco.editor.ITextModel,
         position: monaco.Position, token: monaco.CancellationToken): monaco.languages.ProviderResult<monaco.languages.RenameLocation> {
         return this.pluginMetricsResolver.resolveRequest(this.handleToExtensionName(handle),
             vst.RenameRequest.type.method,
             super.resolveRenameLocation(handle, model, position, token));
     }
 
-    $registerCompletionSupport(handle: number, pluginInfo: PluginInfo,
+    override $registerCompletionSupport(handle: number, pluginInfo: PluginInfo,
         selector: SerializedDocumentFilter[], triggerCharacters: string[], supportsResolveDetails: boolean): void {
         this.registerPluginWithFeatureHandle(handle, pluginInfo.id);
         super.$registerCompletionSupport(handle, pluginInfo, selector, triggerCharacters, supportsResolveDetails);
     }
 
-    $registerDefinitionProvider(handle: number, pluginInfo: PluginInfo, selector: SerializedDocumentFilter[]): void {
+    override $registerDefinitionProvider(handle: number, pluginInfo: PluginInfo, selector: SerializedDocumentFilter[]): void {
         this.registerPluginWithFeatureHandle(handle, pluginInfo.id);
         super.$registerDefinitionProvider(handle, pluginInfo, selector);
     }
 
-    $registerDeclarationProvider(handle: number, pluginInfo: PluginInfo, selector: SerializedDocumentFilter[]): void {
+    override $registerDeclarationProvider(handle: number, pluginInfo: PluginInfo, selector: SerializedDocumentFilter[]): void {
         this.registerPluginWithFeatureHandle(handle, pluginInfo.id);
         super.$registerDeclarationProvider(handle, pluginInfo, selector);
     }
 
-    $registerReferenceProvider(handle: number, pluginInfo: PluginInfo, selector: SerializedDocumentFilter[]): void {
+    override $registerReferenceProvider(handle: number, pluginInfo: PluginInfo, selector: SerializedDocumentFilter[]): void {
         this.registerPluginWithFeatureHandle(handle, pluginInfo.id);
         super.$registerReferenceProvider(handle, pluginInfo, selector);
     }
 
-    $registerSignatureHelpProvider(handle: number, pluginInfo: PluginInfo, selector: SerializedDocumentFilter[], metadata: theia.SignatureHelpProviderMetadata): void {
+    override $registerSignatureHelpProvider(handle: number, pluginInfo: PluginInfo, selector: SerializedDocumentFilter[], metadata: theia.SignatureHelpProviderMetadata): void {
         this.registerPluginWithFeatureHandle(handle, pluginInfo.id);
         super.$registerSignatureHelpProvider(handle, pluginInfo, selector, metadata);
     }
 
-    $registerImplementationProvider(handle: number, pluginInfo: PluginInfo, selector: SerializedDocumentFilter[]): void {
+    override $registerImplementationProvider(handle: number, pluginInfo: PluginInfo, selector: SerializedDocumentFilter[]): void {
         this.registerPluginWithFeatureHandle(handle, pluginInfo.id);
         super.$registerImplementationProvider(handle, pluginInfo, selector);
     }
 
-    $registerTypeDefinitionProvider(handle: number, pluginInfo: PluginInfo, selector: SerializedDocumentFilter[]): void {
+    override $registerTypeDefinitionProvider(handle: number, pluginInfo: PluginInfo, selector: SerializedDocumentFilter[]): void {
         this.registerPluginWithFeatureHandle(handle, pluginInfo.id);
         super.$registerTypeDefinitionProvider(handle, pluginInfo, selector);
     }
 
-    $registerHoverProvider(handle: number, pluginInfo: PluginInfo, selector: SerializedDocumentFilter[]): void {
+    override $registerHoverProvider(handle: number, pluginInfo: PluginInfo, selector: SerializedDocumentFilter[]): void {
         this.registerPluginWithFeatureHandle(handle, pluginInfo.id);
         super.$registerHoverProvider(handle, pluginInfo, selector);
     }
 
-    $registerDocumentHighlightProvider(handle: number, pluginInfo: PluginInfo, selector: SerializedDocumentFilter[]): void {
+    override $registerDocumentHighlightProvider(handle: number, pluginInfo: PluginInfo, selector: SerializedDocumentFilter[]): void {
         this.registerPluginWithFeatureHandle(handle, pluginInfo.id);
         super.$registerDocumentHighlightProvider(handle, pluginInfo, selector);
     }
 
-    $registerWorkspaceSymbolProvider(handle: number, pluginInfo: PluginInfo): void {
+    override $registerWorkspaceSymbolProvider(handle: number, pluginInfo: PluginInfo): void {
         this.registerPluginWithFeatureHandle(handle, pluginInfo.id);
         super.$registerWorkspaceSymbolProvider(handle, pluginInfo);
     }
 
-    $registerDocumentLinkProvider(handle: number, pluginInfo: PluginInfo, selector: SerializedDocumentFilter[]): void {
+    override $registerDocumentLinkProvider(handle: number, pluginInfo: PluginInfo, selector: SerializedDocumentFilter[]): void {
         this.registerPluginWithFeatureHandle(handle, pluginInfo.id);
         super.$registerDocumentLinkProvider(handle, pluginInfo, selector);
     }
 
-    $registerCodeLensSupport(handle: number, pluginInfo: PluginInfo, selector: SerializedDocumentFilter[], eventHandle: number): void {
+    override $registerCodeLensSupport(handle: number, pluginInfo: PluginInfo, selector: SerializedDocumentFilter[], eventHandle: number): void {
         this.registerPluginWithFeatureHandle(handle, pluginInfo.id);
         super.$registerCodeLensSupport(handle, pluginInfo, selector, eventHandle);
     }
 
-    $registerOutlineSupport(handle: number, pluginInfo: PluginInfo, selector: SerializedDocumentFilter[]): void {
+    override $registerOutlineSupport(handle: number, pluginInfo: PluginInfo, selector: SerializedDocumentFilter[]): void {
         this.registerPluginWithFeatureHandle(handle, pluginInfo.id);
         super.$registerOutlineSupport(handle, pluginInfo, selector);
     }
 
-    $registerDocumentFormattingSupport(handle: number, pluginInfo: PluginInfo, selector: SerializedDocumentFilter[]): void {
+    override $registerDocumentFormattingSupport(handle: number, pluginInfo: PluginInfo, selector: SerializedDocumentFilter[]): void {
         this.registerPluginWithFeatureHandle(handle, pluginInfo.id);
         super.$registerDocumentFormattingSupport(handle, pluginInfo, selector);
     }
 
-    $registerRangeFormattingSupport(handle: number, pluginInfo: PluginInfo, selector: SerializedDocumentFilter[]): void {
+    override $registerRangeFormattingSupport(handle: number, pluginInfo: PluginInfo, selector: SerializedDocumentFilter[]): void {
         this.registerPluginWithFeatureHandle(handle, pluginInfo.id);
         super.$registerRangeFormattingSupport(handle, pluginInfo, selector);
     }
 
-    $registerOnTypeFormattingProvider(handle: number, pluginInfo: PluginInfo, selector: SerializedDocumentFilter[], autoFormatTriggerCharacters: string[]): void {
+    override $registerOnTypeFormattingProvider(handle: number, pluginInfo: PluginInfo, selector: SerializedDocumentFilter[], autoFormatTriggerCharacters: string[]): void {
         this.registerPluginWithFeatureHandle(handle, pluginInfo.id);
         super.$registerOnTypeFormattingProvider(handle, pluginInfo, selector, autoFormatTriggerCharacters);
     }
 
-    $registerFoldingRangeProvider(handle: number, pluginInfo: PluginInfo, selector: SerializedDocumentFilter[]): void {
+    override $registerFoldingRangeProvider(handle: number, pluginInfo: PluginInfo, selector: SerializedDocumentFilter[]): void {
         this.registerPluginWithFeatureHandle(handle, pluginInfo.id);
         super.$registerFoldingRangeProvider(handle, pluginInfo, selector);
     }
 
-    $registerDocumentColorProvider(handle: number, pluginInfo: PluginInfo, selector: SerializedDocumentFilter[]): void {
+    override $registerDocumentColorProvider(handle: number, pluginInfo: PluginInfo, selector: SerializedDocumentFilter[]): void {
         this.registerPluginWithFeatureHandle(handle, pluginInfo.id);
         super.$registerDocumentColorProvider(handle, pluginInfo, selector);
     }
 
-    $registerQuickFixProvider(handle: number, pluginInfo: PluginInfo, selector: SerializedDocumentFilter[], codeActionKinds?: string[]): void {
+    override $registerQuickFixProvider(handle: number, pluginInfo: PluginInfo, selector: SerializedDocumentFilter[], codeActionKinds?: string[]): void {
         this.registerPluginWithFeatureHandle(handle, pluginInfo.id);
         super.$registerQuickFixProvider(handle, pluginInfo, selector);
     }
 
-    $registerRenameProvider(handle: number, pluginInfo: PluginInfo, selector: SerializedDocumentFilter[], supportsResolveLocation: boolean): void {
+    override $registerRenameProvider(handle: number, pluginInfo: PluginInfo, selector: SerializedDocumentFilter[], supportsResolveLocation: boolean): void {
         this.registerPluginWithFeatureHandle(handle, pluginInfo.id);
         super.$registerRenameProvider(handle, pluginInfo, selector, supportsResolveLocation);
     }

--- a/packages/plugin-metrics/src/browser/plugin-metrics-output-registry.ts
+++ b/packages/plugin-metrics/src/browser/plugin-metrics-output-registry.ts
@@ -26,7 +26,7 @@ export class PluginMetricsOutputChannelRegistry extends OutputChannelRegistryMai
     @inject(PluginMetricsCreator)
     protected readonly pluginMetricsCreator: PluginMetricsCreator;
 
-    $append(channelName: string, errorOrValue: string, pluginInfo: PluginInfo): PromiseLike<void> {
+    override $append(channelName: string, errorOrValue: string, pluginInfo: PluginInfo): PromiseLike<void> {
         if (errorOrValue.startsWith('[Error')) {
             const createdMetric = createDefaultRequestData(pluginInfo.id, errorOrValue);
             this.pluginMetricsCreator.createErrorMetric(createdMetric);

--- a/packages/preferences/src/browser/abstract-resource-preference-provider.ts
+++ b/packages/preferences/src/browser/abstract-resource-preference-provider.ts
@@ -78,9 +78,9 @@ export abstract class AbstractResourcePreferenceProvider extends PreferenceProvi
         return this._fileExists;
     }
 
-    getConfigUri(): URI;
-    getConfigUri(resourceUri: string | undefined): URI | undefined;
-    getConfigUri(resourceUri?: string): URI | undefined {
+    override getConfigUri(): URI;
+    override getConfigUri(resourceUri: string | undefined): URI | undefined;
+    override getConfigUri(resourceUri?: string): URI | undefined {
         if (!resourceUri) {
             return this.getUri();
         }

--- a/packages/preferences/src/browser/folder-preference-provider.ts
+++ b/packages/preferences/src/browser/folder-preference-provider.ts
@@ -18,7 +18,6 @@ import { inject, injectable } from '@theia/core/shared/inversify';
 import URI from '@theia/core/lib/common/uri';
 import { PreferenceScope } from '@theia/core/lib/browser';
 import { FileStat } from '@theia/filesystem/lib/common/files';
-import { WorkspaceService } from '@theia/workspace/lib/browser/workspace-service';
 import { SectionPreferenceProvider } from './section-preference-provider';
 
 export const FolderPreferenceProviderFactory = Symbol('FolderPreferenceProviderFactory');
@@ -35,7 +34,6 @@ export interface FolderPreferenceProviderOptions {
 @injectable()
 export class FolderPreferenceProvider extends SectionPreferenceProvider {
 
-    @inject(WorkspaceService) protected override readonly workspaceService: WorkspaceService;
     @inject(FolderPreferenceProviderFolder) protected readonly folder: FileStat;
 
     private _folderUri: URI;

--- a/packages/preferences/src/browser/folder-preference-provider.ts
+++ b/packages/preferences/src/browser/folder-preference-provider.ts
@@ -35,7 +35,7 @@ export interface FolderPreferenceProviderOptions {
 @injectable()
 export class FolderPreferenceProvider extends SectionPreferenceProvider {
 
-    @inject(WorkspaceService) protected readonly workspaceService: WorkspaceService;
+    @inject(WorkspaceService) protected override readonly workspaceService: WorkspaceService;
     @inject(FolderPreferenceProviderFolder) protected readonly folder: FileStat;
 
     private _folderUri: URI;
@@ -54,7 +54,7 @@ export class FolderPreferenceProvider extends SectionPreferenceProvider {
         return PreferenceScope.Folder;
     }
 
-    getDomain(): string[] {
+    override getDomain(): string[] {
         return [this.folderUri.toString()];
     }
 }

--- a/packages/preferences/src/browser/folders-preferences-provider.ts
+++ b/packages/preferences/src/browser/folders-preferences-provider.ts
@@ -77,7 +77,7 @@ export class FoldersPreferencesProvider extends PreferenceProvider {
         }
     }
 
-    getConfigUri(resourceUri?: string, sectionName: string = this.configurations.getConfigName()): URI | undefined {
+    override getConfigUri(resourceUri?: string, sectionName: string = this.configurations.getConfigName()): URI | undefined {
         for (const provider of this.getFolderProviders(resourceUri)) {
             const configUri = provider.getConfigUri(resourceUri);
             if (configUri && this.configurations.getName(configUri) === sectionName) {
@@ -87,7 +87,7 @@ export class FoldersPreferencesProvider extends PreferenceProvider {
         return undefined;
     }
 
-    getContainingConfigUri(resourceUri?: string, sectionName: string = this.configurations.getConfigName()): URI | undefined {
+    override getContainingConfigUri(resourceUri?: string, sectionName: string = this.configurations.getConfigName()): URI | undefined {
         for (const provider of this.getFolderProviders(resourceUri)) {
             const configUri = provider.getConfigUri();
             if (provider.contains(resourceUri) && this.configurations.getName(configUri) === sectionName) {
@@ -97,11 +97,11 @@ export class FoldersPreferencesProvider extends PreferenceProvider {
         return undefined;
     }
 
-    getDomain(): string[] {
+    override getDomain(): string[] {
         return this.workspaceService.tryGetRoots().map(root => root.resource.toString());
     }
 
-    resolve<T>(preferenceName: string, resourceUri?: string): PreferenceResolveResult<T> {
+    override resolve<T>(preferenceName: string, resourceUri?: string): PreferenceResolveResult<T> {
         const result: PreferenceResolveResult<T> = {};
         const groups = this.groupProvidersByConfigName(resourceUri);
         for (const group of groups.values()) {

--- a/packages/preferences/src/browser/preference-tree-model.ts
+++ b/packages/preferences/src/browser/preference-tree-model.ts
@@ -97,7 +97,7 @@ export class PreferenceTreeModel extends TreeModelImpl {
     }
 
     @postConstruct()
-    protected async init(): Promise<void> {
+    protected override async init(): Promise<void> {
         super.init();
         this.toDispose.pushAll([
             this.treeGenerator.onSchemaChanged(newTree => this.handleNewSchema(newTree)),
@@ -184,7 +184,7 @@ export class PreferenceTreeModel extends TreeModelImpl {
             || (node.preference.data.description ?? '').includes(this.lastSearchedLiteral);
     }
 
-    protected isVisibleSelectableNode(node: TreeNode): node is SelectableTreeNode {
+    protected override isVisibleSelectableNode(node: TreeNode): node is SelectableTreeNode {
         return CompositeTreeNode.is(node) && !!this._currentRows.get(node.id)?.visibleChildren;
     }
 

--- a/packages/preferences/src/browser/preferences-contribution.ts
+++ b/packages/preferences/src/browser/preferences-contribution.ts
@@ -63,7 +63,7 @@ export class PreferencesContribution extends AbstractViewContribution<Preference
         });
     }
 
-    registerCommands(commands: CommandRegistry): void {
+    override registerCommands(commands: CommandRegistry): void {
         commands.registerCommand(CommonCommands.OPEN_PREFERENCES, {
             execute: async (query?: string) => {
                 const widget = await this.openView({ activate: true });
@@ -138,7 +138,7 @@ export class PreferencesContribution extends AbstractViewContribution<Preference
         });
     }
 
-    registerMenus(menus: MenuModelRegistry): void {
+    override registerMenus(menus: MenuModelRegistry): void {
         menus.registerMenuAction(CommonMenus.FILE_SETTINGS_SUBMENU_OPEN, {
             commandId: CommonCommands.OPEN_PREFERENCES.id,
             label: CommonCommands.OPEN_PREFERENCES.label,
@@ -166,7 +166,7 @@ export class PreferencesContribution extends AbstractViewContribution<Preference
         });
     }
 
-    registerKeybindings(keybindings: KeybindingRegistry): void {
+    override registerKeybindings(keybindings: KeybindingRegistry): void {
         keybindings.registerKeybinding({
             command: CommonCommands.OPEN_PREFERENCES.id,
             keybinding: (isOSX && !isFirefox) ? 'cmd+,' : 'ctrl+,'

--- a/packages/preferences/src/browser/section-preference-provider.ts
+++ b/packages/preferences/src/browser/section-preference-provider.ts
@@ -52,7 +52,7 @@ export abstract class SectionPreferenceProvider extends AbstractResourcePreferen
         return this.uri;
     }
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    protected parse(content: string): any {
+    protected override parse(content: string): any {
         const prefs = super.parse(content);
         if (this.isSection) {
             if (prefs === undefined) {
@@ -68,7 +68,7 @@ export abstract class SectionPreferenceProvider extends AbstractResourcePreferen
         }
     }
 
-    protected getPath(preferenceName: string): string[] | undefined {
+    protected override getPath(preferenceName: string): string[] | undefined {
         if (!this.isSection) {
             return super.getPath(preferenceName);
         }

--- a/packages/preferences/src/browser/user-configs-preference-provider.ts
+++ b/packages/preferences/src/browser/user-configs-preference-provider.ts
@@ -59,7 +59,7 @@ export class UserConfigsPreferenceProvider extends PreferenceProvider {
         }
     }
 
-    getConfigUri(resourceUri?: string, sectionName: string = this.configurations.getConfigName()): URI | undefined {
+    override getConfigUri(resourceUri?: string, sectionName: string = this.configurations.getConfigName()): URI | undefined {
         for (const provider of this.providers.values()) {
             const configUri = provider.getConfigUri(resourceUri);
             if (configUri && this.configurations.getName(configUri) === sectionName) {
@@ -69,7 +69,7 @@ export class UserConfigsPreferenceProvider extends PreferenceProvider {
         return undefined;
     }
 
-    resolve<T>(preferenceName: string, resourceUri?: string): PreferenceResolveResult<T> {
+    override resolve<T>(preferenceName: string, resourceUri?: string): PreferenceResolveResult<T> {
         const result: PreferenceResolveResult<T> = {};
         for (const provider of this.providers.values()) {
             const { value, configUri } = provider.resolve<T>(preferenceName, resourceUri);

--- a/packages/preferences/src/browser/views/components/preference-array-input.ts
+++ b/packages/preferences/src/browser/views/components/preference-array-input.ts
@@ -149,7 +149,7 @@ export class PreferenceArrayInputRenderer extends PreferenceLeafNodeRenderer<str
             .map(([value]) => value);
     }
 
-    dispose(): void {
+    override dispose(): void {
         this.existingValues.clear();
         super.dispose();
     }

--- a/packages/preferences/src/browser/views/components/preference-node-renderer.ts
+++ b/packages/preferences/src/browser/views/components/preference-node-renderer.ts
@@ -152,7 +152,7 @@ export class PreferenceHeaderRenderer extends PreferenceNodeRenderer {
 export abstract class PreferenceLeafNodeRenderer<ValueType extends JSONValue, InteractableType extends HTMLElement>
     extends PreferenceNodeRenderer
     implements Required<GeneralPreferenceNodeRenderer> {
-    @inject(Preference.Node) protected readonly preferenceNode: Preference.LeafNode;
+    @inject(Preference.Node) protected override readonly preferenceNode: Preference.LeafNode;
     @inject(PreferenceService) protected readonly preferenceService: PreferenceService;
     @inject(ContextMenuRenderer) protected readonly menuRenderer: ContextMenuRenderer;
     @inject(PreferencesScopeTabBar) protected readonly scopeTracker: PreferencesScopeTabBar;
@@ -168,7 +168,7 @@ export abstract class PreferenceLeafNodeRenderer<ValueType extends JSONValue, In
     protected markdownRenderer: markdownit;
 
     @postConstruct()
-    protected init(): void {
+    protected override init(): void {
         this.setId();
         this.updateInspection();
         this.markdownRenderer = this.buildMarkdownRenderer();

--- a/packages/preferences/src/browser/views/preference-editor-widget.ts
+++ b/packages/preferences/src/browser/views/preference-editor-widget.ts
@@ -43,7 +43,7 @@ export class PreferencesEditorWidget extends BaseWidget implements StatefulWidge
     static readonly ID = 'settings.editor';
     static readonly LABEL = 'Settings Editor';
 
-    scrollOptions = DEFAULT_SCROLL_OPTIONS;
+    override scrollOptions = DEFAULT_SCROLL_OPTIONS;
 
     protected scrollContainer: HTMLDivElement;
     /**
@@ -307,7 +307,7 @@ export class PreferencesEditorWidget extends BaseWidget implements StatefulWidge
         return { id, group, collection };
     }
 
-    protected getScrollContainer(): HTMLElement {
+    protected override getScrollContainer(): HTMLElement {
         return this.scrollContainer;
     }
 

--- a/packages/preferences/src/browser/views/preference-scope-tabbar-widget.tsx
+++ b/packages/preferences/src/browser/views/preference-scope-tabbar-widget.tsx
@@ -133,7 +133,7 @@ export class PreferencesScopeTabBar extends TabBar<Widget> implements StatefulWi
         this.addOrUpdateFolderTab();
     }
 
-    protected onUpdateRequest(msg: Message): void {
+    protected override onUpdateRequest(msg: Message): void {
         super.onUpdateRequest(msg);
         this.addTabIndexToTabs();
     }
@@ -236,7 +236,7 @@ export class PreferencesScopeTabBar extends TabBar<Widget> implements StatefulWi
         this.preferencesMenuFactory.createFolderWorkspacesMenu(workspaceRoots, this.currentSelection.uri);
     }
 
-    handleEvent(): void {
+    override handleEvent(): void {
         // Don't - the handlers are defined in PreferenceScopeTabbarWidget.addTabIndexToTabs()
     }
 
@@ -337,7 +337,7 @@ export class PreferencesScopeTabBar extends TabBar<Widget> implements StatefulWi
         this.toggleClass(SHADOW_CLASSNAME, showShadow);
     }
 
-    dispose(): void {
+    override dispose(): void {
         super.dispose();
         this.toDispose.dispose();
     }

--- a/packages/preferences/src/browser/views/preference-tree-widget.tsx
+++ b/packages/preferences/src/browser/views/preference-tree-widget.tsx
@@ -33,12 +33,12 @@ export class PreferencesTreeWidget extends TreeWidget {
     protected shouldFireSelectionEvents: boolean = true;
     protected firstVisibleLeafNodeID: string;
 
-    @inject(PreferenceTreeModel) readonly model: PreferenceTreeModel;
+    @inject(PreferenceTreeModel) override readonly model: PreferenceTreeModel;
     @inject(TreeProps) protected readonly treeProps: TreeProps;
-    @inject(ContextMenuRenderer) protected readonly contextMenuRenderer: ContextMenuRenderer;
+    @inject(ContextMenuRenderer) protected override readonly contextMenuRenderer: ContextMenuRenderer;
 
     @postConstruct()
-    init(): void {
+    override init(): void {
         super.init();
         this.id = PreferencesTreeWidget.ID;
         this.toDispose.pushAll([
@@ -48,7 +48,7 @@ export class PreferencesTreeWidget extends TreeWidget {
         ]);
     }
 
-    doUpdateRows(): void {
+    override doUpdateRows(): void {
         this.rows = new Map();
         let index = 0;
         for (const [id, nodeRow] of this.model.currentRows.entries()) {
@@ -59,11 +59,11 @@ export class PreferencesTreeWidget extends TreeWidget {
         this.updateScrollToRow();
     }
 
-    protected doRenderNodeRow({ depth, visibleChildren, node, isExpansible }: PreferenceTreeNodeRow): React.ReactNode {
+    protected override doRenderNodeRow({ depth, visibleChildren, node, isExpansible }: PreferenceTreeNodeRow): React.ReactNode {
         return this.renderNode(node, { depth, visibleChildren, isExpansible });
     }
 
-    protected renderNode(node: TreeNode, props: PreferenceTreeNodeProps): React.ReactNode {
+    protected override renderNode(node: TreeNode, props: PreferenceTreeNodeProps): React.ReactNode {
         if (!TreeNode.isVisible(node)) {
             return undefined;
         }
@@ -77,14 +77,14 @@ export class PreferencesTreeWidget extends TreeWidget {
         return React.createElement('div', attributes, content);
     }
 
-    protected renderExpansionToggle(node: TreeNode, props: PreferenceTreeNodeProps): React.ReactNode {
+    protected override renderExpansionToggle(node: TreeNode, props: PreferenceTreeNodeProps): React.ReactNode {
         if (ExpandableTreeNode.is(node) && !props.isExpansible) {
             return <div className='preferences-tree-spacer' />;
         }
         return super.renderExpansionToggle(node, props);
     }
 
-    protected toNodeName(node: TreeNode): string {
+    protected override toNodeName(node: TreeNode): string {
         const visibleChildren = this.model.currentRows.get(node.id)?.visibleChildren;
         const baseName = this.labelProvider.getName(node);
         const printedNameWithVisibleChildren = this.model.isFiltered && visibleChildren !== undefined

--- a/packages/preferences/src/browser/views/preference-tree-widget.tsx
+++ b/packages/preferences/src/browser/views/preference-tree-widget.tsx
@@ -16,7 +16,6 @@
 
 import { inject, injectable, postConstruct } from '@theia/core/shared/inversify';
 import {
-    ContextMenuRenderer,
     ExpandableTreeNode,
     TreeNode,
     TreeProps,
@@ -35,7 +34,6 @@ export class PreferencesTreeWidget extends TreeWidget {
 
     @inject(PreferenceTreeModel) override readonly model: PreferenceTreeModel;
     @inject(TreeProps) protected readonly treeProps: TreeProps;
-    @inject(ContextMenuRenderer) protected override readonly contextMenuRenderer: ContextMenuRenderer;
 
     @postConstruct()
     override init(): void {

--- a/packages/preferences/src/browser/views/preference-widget.tsx
+++ b/packages/preferences/src/browser/views/preference-widget.tsx
@@ -58,7 +58,7 @@ export class PreferencesWidget extends Panel implements StatefulWidget {
         this.tabBarWidget.setScope(scope);
     }
 
-    protected onResize(msg: Widget.ResizeMessage): void {
+    protected override onResize(msg: Widget.ResizeMessage): void {
         super.onResize(msg);
         if (msg.width < 600 && this.treeWidget && !this.treeWidget.isHidden) {
             this.treeWidget.hide();
@@ -69,7 +69,7 @@ export class PreferencesWidget extends Panel implements StatefulWidget {
         }
     }
 
-    protected onActivateRequest(msg: Message): void {
+    protected override onActivateRequest(msg: Message): void {
         super.onActivateRequest(msg);
         this.searchbarWidget.focus();
     }

--- a/packages/preferences/src/browser/workspace-file-preference-provider.ts
+++ b/packages/preferences/src/browser/workspace-file-preference-provider.ts
@@ -44,7 +44,7 @@ export class WorkspaceFilePreferenceProvider extends AbstractResourcePreferenceP
     }
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    protected parse(content: string): any {
+    protected override parse(content: string): any {
         const data = super.parse(content);
         if (WorkspaceData.is(data)) {
             const settings = { ...data.settings };
@@ -64,7 +64,7 @@ export class WorkspaceFilePreferenceProvider extends AbstractResourcePreferenceP
         return {};
     }
 
-    protected getPath(preferenceName: string): string[] {
+    protected override getPath(preferenceName: string): string[] {
         const firstSegment = preferenceName.split('.', 1)[0];
         const remainder = preferenceName.slice(firstSegment.length + 1);
         if (this.belongsInSection(firstSegment, remainder)) {
@@ -93,7 +93,7 @@ export class WorkspaceFilePreferenceProvider extends AbstractResourcePreferenceP
         return PreferenceScope.Workspace;
     }
 
-    getDomain(): string[] {
+    override getDomain(): string[] {
         // workspace file is treated as part of the workspace
         return this.workspaceService.tryGetRoots().map(r => r.resource.toString()).concat([this.options.workspaceUri.toString()]);
     }

--- a/packages/preferences/src/browser/workspace-preference-provider.ts
+++ b/packages/preferences/src/browser/workspace-preference-provider.ts
@@ -50,11 +50,11 @@ export class WorkspacePreferenceProvider extends PreferenceProvider {
         this.workspaceService.onWorkspaceChanged(() => this.ensureDelegateUpToDate());
     }
 
-    getConfigUri(resourceUri: string | undefined = this.ensureResourceUri(), sectionName?: string): URI | undefined {
+    override getConfigUri(resourceUri: string | undefined = this.ensureResourceUri(), sectionName?: string): URI | undefined {
         return this.delegate?.getConfigUri(resourceUri, sectionName);
     }
 
-    getContainingConfigUri(resourceUri: string | undefined = this.ensureResourceUri(), sectionName?: string): URI | undefined {
+    override getContainingConfigUri(resourceUri: string | undefined = this.ensureResourceUri(), sectionName?: string): URI | undefined {
         return this.delegate?.getContainingConfigUri?.(resourceUri, sectionName);
     }
 
@@ -101,12 +101,12 @@ export class WorkspacePreferenceProvider extends PreferenceProvider {
         });
     }
 
-    get<T>(preferenceName: string, resourceUri: string | undefined = this.ensureResourceUri()): T | undefined {
+    override get<T>(preferenceName: string, resourceUri: string | undefined = this.ensureResourceUri()): T | undefined {
         const delegate = this.delegate;
         return delegate ? delegate.get<T>(preferenceName, resourceUri) : undefined;
     }
 
-    resolve<T>(preferenceName: string, resourceUri: string | undefined = this.ensureResourceUri()): { value?: T, configUri?: URI } {
+    override resolve<T>(preferenceName: string, resourceUri: string | undefined = this.ensureResourceUri()): { value?: T, configUri?: URI } {
         const delegate = this.delegate;
         return delegate ? delegate.resolve<T>(preferenceName, resourceUri) : {};
     }

--- a/packages/preview/src/browser/preview-contribution.ts
+++ b/packages/preview/src/browser/preview-contribution.ts
@@ -187,11 +187,11 @@ export class PreviewContribution extends NavigatableWidgetOpenHandler<PreviewWid
         return this.preferences['preview.openByDefault'];
     }
 
-    async open(uri: URI, options?: PreviewOpenerOptions): Promise<PreviewWidget> {
+    override async open(uri: URI, options?: PreviewOpenerOptions): Promise<PreviewWidget> {
         const resolvedOptions = await this.resolveOpenerOptions(options);
         return super.open(uri, resolvedOptions);
     }
-    protected serializeUri(uri: URI): string {
+    protected override serializeUri(uri: URI): string {
         return super.serializeUri(PreviewUri.decode(uri));
     }
 

--- a/packages/preview/src/browser/preview-widget.ts
+++ b/packages/preview/src/browser/preview-widget.ts
@@ -106,7 +106,7 @@ export class PreviewWidget extends BaseWidget implements Navigatable {
         this.update();
     }
 
-    protected onBeforeAttach(msg: Message): void {
+    protected override onBeforeAttach(msg: Message): void {
         super.onBeforeAttach(msg);
         this.toDispose.push(this.startScrollSync());
         this.toDispose.push(this.startDoubleClickListener());
@@ -153,13 +153,13 @@ export class PreviewWidget extends BaseWidget implements Navigatable {
         return this.uri.withPath(resourceUri.path);
     }
 
-    onActivateRequest(msg: Message): void {
+    override onActivateRequest(msg: Message): void {
         super.onActivateRequest(msg);
         this.node.focus();
         this.update();
     }
 
-    onUpdateRequest(msg: Message): void {
+    override onUpdateRequest(msg: Message): void {
         super.onUpdateRequest(msg);
         this.performUpdate();
     }

--- a/packages/process/src/node/dev-null-stream.ts
+++ b/packages/process/src/node/dev-null-stream.ts
@@ -36,11 +36,11 @@ export class DevNullStream extends stream.Duplex {
     }
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    _write(chunk: any, encoding: string, callback: (err?: Error) => void): void {
+    override _write(chunk: any, encoding: string, callback: (err?: Error) => void): void {
         callback();
     }
 
-    _read(size: number): void {
+    override _read(size: number): void {
         // eslint-disable-next-line no-null/no-null
         this.push(null);
     }

--- a/packages/process/src/node/multi-ring-buffer.ts
+++ b/packages/process/src/node/multi-ring-buffer.ts
@@ -39,12 +39,12 @@ export class MultiRingBufferReadableStream extends stream.Readable implements Di
         this.setEncoding(encoding);
     }
 
-    _read(size: number): void {
+    override _read(size: number): void {
         this.more = true;
         this.deq(size);
     }
 
-    _destroy(err: Error | null, callback: (err: Error | null) => void): void {
+    override _destroy(err: Error | null, callback: (err: Error | null) => void): void {
         this.ringBuffer.closeStream(this);
         this.ringBuffer.closeReader(this.reader);
         this.disposed = true;

--- a/packages/process/src/node/task-terminal-process.ts
+++ b/packages/process/src/node/task-terminal-process.ts
@@ -28,7 +28,7 @@ export class TaskTerminalProcess extends TerminalProcess {
     public exited = false;
     public attachmentAttempted = false;
 
-    protected onTerminalExit(code: number | undefined, signal: string | undefined): void {
+    protected override onTerminalExit(code: number | undefined, signal: string | undefined): void {
         this.emitOnExit(code, signal);
         this.exited = true;
         // Unregister process only if task terminal already attached (or failed attach),

--- a/packages/process/src/node/terminal-process.ts
+++ b/packages/process/src/node/terminal-process.ts
@@ -60,7 +60,7 @@ export class TerminalProcess extends Process {
     readonly inputStream: Writable;
 
     constructor( // eslint-disable-next-line @typescript-eslint/indent
-        @inject(TerminalProcessOptions) protected readonly options: TerminalProcessOptions,
+        @inject(TerminalProcessOptions) protected override readonly options: TerminalProcessOptions,
         @inject(ProcessManager) processManager: ProcessManager,
         @inject(MultiRingBuffer) protected readonly ringBuffer: MultiRingBuffer,
         @inject(ILogger) @named('process') logger: ILogger

--- a/packages/property-view/src/browser/empty-property-view-widget-provider.tsx
+++ b/packages/property-view/src/browser/empty-property-view-widget-provider.tsx
@@ -54,8 +54,8 @@ class EmptyPropertyViewWidget extends ReactWidget implements PropertyViewContent
 export class EmptyPropertyViewWidgetProvider extends DefaultPropertyViewWidgetProvider {
 
     static readonly ID = 'no-properties';
-    readonly id = EmptyPropertyViewWidgetProvider.ID;
-    readonly label = 'DefaultPropertyViewWidgetProvider';
+    override readonly id = EmptyPropertyViewWidgetProvider.ID;
+    override readonly label = 'DefaultPropertyViewWidgetProvider';
 
     private emptyWidget: EmptyPropertyViewWidget;
 
@@ -64,15 +64,15 @@ export class EmptyPropertyViewWidgetProvider extends DefaultPropertyViewWidgetPr
         this.emptyWidget = new EmptyPropertyViewWidget();
     }
 
-    canHandle(selection: Object | undefined): number {
+    override canHandle(selection: Object | undefined): number {
         return selection === undefined ? 1 : 0;
     }
 
-    provideWidget(selection: Object | undefined): Promise<EmptyPropertyViewWidget> {
+    override provideWidget(selection: Object | undefined): Promise<EmptyPropertyViewWidget> {
         return Promise.resolve(this.emptyWidget);
     }
 
-    updateContentWidget(selection: Object | undefined): void {
+    override updateContentWidget(selection: Object | undefined): void {
         this.emptyWidget.updatePropertyViewContent();
     }
 }

--- a/packages/property-view/src/browser/property-view-widget.tsx
+++ b/packages/property-view/src/browser/property-view-widget.tsx
@@ -31,7 +31,7 @@ export class PropertyViewWidget extends BaseWidget {
 
     protected contentWidget: PropertyViewContentWidget;
 
-    protected toDisposeOnDetach = new DisposableCollection();
+    protected override toDisposeOnDetach = new DisposableCollection();
 
     @inject(PropertyViewService) protected readonly propertyViewService: PropertyViewService;
     @inject(SelectionService) protected readonly selectionService: SelectionService;
@@ -91,12 +91,12 @@ export class PropertyViewWidget extends BaseWidget {
         this.update();
     }
 
-    protected onAfterAttach(msg: Message): void {
+    protected override onAfterAttach(msg: Message): void {
         super.onAfterAttach(msg);
         this.initializeContentWidget(this.selectionService.selection);
     }
 
-    protected onActivateRequest(msg: Message): void {
+    protected override onActivateRequest(msg: Message): void {
         super.onActivateRequest(msg);
         this.node.focus();
         if (this.contentWidget) {
@@ -104,7 +104,7 @@ export class PropertyViewWidget extends BaseWidget {
         }
     }
 
-    protected onResize(msg: Widget.ResizeMessage): void {
+    protected override onResize(msg: Widget.ResizeMessage): void {
         super.onResize(msg);
         if (this.contentWidget) {
             MessageLoop.sendMessage(this.contentWidget, msg);

--- a/packages/property-view/src/browser/resource-property-view/resource-property-view-tree-widget.tsx
+++ b/packages/property-view/src/browser/resource-property-view/resource-property-view-tree-widget.tsx
@@ -45,12 +45,12 @@ export class ResourcePropertyViewTreeWidget extends TreeWidget implements Proper
     protected propertiesTree: Map<string, ResourcePropertiesCategoryNode>;
     protected currentSelection: Object | undefined;
 
-    @inject(LabelProvider) protected readonly labelProvider: LabelProvider;
+    @inject(LabelProvider) protected override readonly labelProvider: LabelProvider;
 
     constructor(
-        @inject(TreeProps) readonly props: TreeProps,
+        @inject(TreeProps) override readonly props: TreeProps,
         @inject(TreeModel) model: TreeModel,
-        @inject(ContextMenuRenderer) protected readonly contextMenuRenderer: ContextMenuRenderer
+        @inject(ContextMenuRenderer) protected override readonly contextMenuRenderer: ContextMenuRenderer
     ) {
         super(props, model, contextMenuRenderer);
 
@@ -66,7 +66,7 @@ export class ResourcePropertyViewTreeWidget extends TreeWidget implements Proper
     }
 
     @postConstruct()
-    protected init(): void {
+    protected override init(): void {
         super.init();
 
         this.id = ResourcePropertyViewTreeWidget.ID + '-treeContainer';
@@ -174,7 +174,7 @@ export class ResourcePropertyViewTreeWidget extends TreeWidget implements Proper
         }
     }
 
-    protected renderCaption(node: TreeNode, props: NodeProps): React.ReactNode {
+    protected override renderCaption(node: TreeNode, props: NodeProps): React.ReactNode {
         if (ResourcePropertiesCategoryNode.is(node)) {
             return this.renderExpandableNode(node);
         } else if (ResourcePropertiesItemNode.is(node)) {
@@ -198,7 +198,7 @@ export class ResourcePropertyViewTreeWidget extends TreeWidget implements Proper
         </React.Fragment>;
     }
 
-    protected createNodeAttributes(node: TreeNode, props: NodeProps): React.Attributes & React.HTMLAttributes<HTMLElement> {
+    protected override createNodeAttributes(node: TreeNode, props: NodeProps): React.Attributes & React.HTMLAttributes<HTMLElement> {
         return {
             ...super.createNodeAttributes(node, props),
             title: this.getNodeTooltip(node)

--- a/packages/property-view/src/browser/resource-property-view/resource-property-view-tree-widget.tsx
+++ b/packages/property-view/src/browser/resource-property-view/resource-property-view-tree-widget.tsx
@@ -16,7 +16,6 @@
 
 import {
     ContextMenuRenderer,
-    LabelProvider,
     NodeProps,
     TreeModel,
     TreeNode,
@@ -45,12 +44,10 @@ export class ResourcePropertyViewTreeWidget extends TreeWidget implements Proper
     protected propertiesTree: Map<string, ResourcePropertiesCategoryNode>;
     protected currentSelection: Object | undefined;
 
-    @inject(LabelProvider) protected override readonly labelProvider: LabelProvider;
-
     constructor(
-        @inject(TreeProps) override readonly props: TreeProps,
+        @inject(TreeProps) props: TreeProps,
         @inject(TreeModel) model: TreeModel,
-        @inject(ContextMenuRenderer) protected override readonly contextMenuRenderer: ContextMenuRenderer
+        @inject(ContextMenuRenderer) contextMenuRenderer: ContextMenuRenderer
     ) {
         super(props, model, contextMenuRenderer);
 

--- a/packages/property-view/src/browser/resource-property-view/resource-property-view-widget-provider.ts
+++ b/packages/property-view/src/browser/resource-property-view/resource-property-view-widget-provider.ts
@@ -25,10 +25,10 @@ export class ResourcePropertyViewWidgetProvider extends DefaultPropertyViewWidge
 
     @inject(ResourcePropertyViewTreeWidget) protected treeWidget: ResourcePropertyViewTreeWidget;
 
-    readonly id = 'resources';
-    readonly label = 'ResourcePropertyViewWidgetProvider';
+    override readonly id = 'resources';
+    override readonly label = 'ResourcePropertyViewWidgetProvider';
 
-    canHandle(selection: Object | undefined): number {
+    override canHandle(selection: Object | undefined): number {
         return (this.isFileSelection(selection) || this.isNavigatableSelection(selection)) ? 1 : 0;
     }
 
@@ -40,11 +40,11 @@ export class ResourcePropertyViewWidgetProvider extends DefaultPropertyViewWidge
         return !!selection && Navigatable.is(selection);
     }
 
-    provideWidget(selection: Object | undefined): Promise<ResourcePropertyViewTreeWidget> {
+    override provideWidget(selection: Object | undefined): Promise<ResourcePropertyViewTreeWidget> {
         return Promise.resolve(this.treeWidget);
     }
 
-    updateContentWidget(selection: Object | undefined): void {
+    override updateContentWidget(selection: Object | undefined): void {
         this.getPropertyDataService(selection).then(service => this.treeWidget.updatePropertyViewContent(service, selection));
     }
 

--- a/packages/scm-extra/src/browser/history/scm-history-contribution.ts
+++ b/packages/scm-extra/src/browser/history/scm-history-contribution.ts
@@ -66,13 +66,13 @@ export class ScmHistoryContribution extends AbstractViewContribution<ScmHistoryW
         });
     }
 
-    async openView(args?: Partial<ScmHistoryOpenViewArguments>): Promise<ScmHistoryWidget> {
+    override async openView(args?: Partial<ScmHistoryOpenViewArguments>): Promise<ScmHistoryWidget> {
         const widget = await super.openView(args);
         this.refreshWidget(args!.uri);
         return widget;
     }
 
-    registerMenus(menus: MenuModelRegistry): void {
+    override registerMenus(menus: MenuModelRegistry): void {
         menus.registerMenuAction(NavigatorContextMenu.SEARCH, {
             commandId: ScmHistoryCommands.OPEN_FILE_HISTORY.id,
             label: SCM_HISTORY_LABEL
@@ -84,7 +84,7 @@ export class ScmHistoryContribution extends AbstractViewContribution<ScmHistoryW
         super.registerMenus(menus);
     }
 
-    registerCommands(commands: CommandRegistry): void {
+    override registerCommands(commands: CommandRegistry): void {
         commands.registerCommand(ScmHistoryCommands.OPEN_FILE_HISTORY, this.newUriAwareCommandHandler({
             isEnabled: (uri: URI) => !!this.scmService.findRepository(uri),
             isVisible: (uri: URI) => !!this.scmService.findRepository(uri),

--- a/packages/scm-extra/src/browser/history/scm-history-widget.tsx
+++ b/packages/scm-extra/src/browser/history/scm-history-widget.tsx
@@ -88,7 +88,7 @@ export class ScmHistoryWidget extends ScmNavigableListWidget<ScmHistoryListNode>
     protected historySupport: ScmHistorySupport | undefined;
 
     constructor(
-        @inject(ScmService) protected readonly scmService: ScmService,
+        @inject(ScmService) protected override readonly scmService: ScmService,
         @inject(OpenerService) protected readonly openerService: OpenerService,
         @inject(ApplicationShell) protected readonly shell: ApplicationShell,
         @inject(FileService) protected readonly fileService: FileService,
@@ -164,7 +164,7 @@ export class ScmHistoryWidget extends ScmNavigableListWidget<ScmHistoryListNode>
         }
     }
 
-    protected onAfterAttach(msg: Message): void {
+    protected override onAfterAttach(msg: Message): void {
         super.onAfterAttach(msg);
         this.addListNavigationKeyListeners(this.node);
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -176,7 +176,7 @@ export class ScmHistoryWidget extends ScmNavigableListWidget<ScmHistoryListNode>
         });
     }
 
-    update(): void {
+    override update(): void {
         if (this.listView && this.listView.list) {
             this.listView.list.forceUpdateGrid();
         }
@@ -495,7 +495,7 @@ export class ScmHistoryWidget extends ScmNavigableListWidget<ScmHistoryListNode>
         }} />;
     }
 
-    protected navigateLeft(): void {
+    protected override navigateLeft(): void {
         const selected = this.getSelected();
         if (selected && this.status.state === 'ready') {
             if (ScmCommitNode.is(selected)) {
@@ -515,7 +515,7 @@ export class ScmHistoryWidget extends ScmNavigableListWidget<ScmHistoryListNode>
         this.update();
     }
 
-    protected navigateRight(): void {
+    protected override navigateRight(): void {
         const selected = this.getSelected();
         if (selected) {
             if (ScmCommitNode.is(selected) && !selected.expanded && !this.singleFileMode) {
@@ -527,7 +527,7 @@ export class ScmHistoryWidget extends ScmNavigableListWidget<ScmHistoryListNode>
         this.update();
     }
 
-    protected handleListEnter(): void {
+    protected override handleListEnter(): void {
         const selected = this.getSelected();
         if (selected) {
             if (ScmCommitNode.is(selected)) {
@@ -570,7 +570,7 @@ export class ScmHistoryList extends React.Component<ScmHistoryList.Props> {
         return !!row;
     }
 
-    render(): React.ReactNode {
+    override render(): React.ReactNode {
         return <InfiniteLoader
             isRowLoaded={this.checkIfRowIsLoaded}
             loadMoreRows={this.props.loadMoreRows}
@@ -608,7 +608,7 @@ export class ScmHistoryList extends React.Component<ScmHistoryList.Props> {
         </InfiniteLoader>;
     }
 
-    componentWillUpdate(): void {
+    override componentWillUpdate(): void {
         this.measureCache.clearAll();
     }
 

--- a/packages/scm-extra/src/browser/history/scm-history-widget.tsx
+++ b/packages/scm-extra/src/browser/history/scm-history-widget.tsx
@@ -21,7 +21,6 @@ import { CancellationTokenSource } from '@theia/core/lib/common/cancellation';
 import { Message } from '@theia/core/shared/@phosphor/messaging';
 import { AutoSizer, List, ListRowRenderer, ListRowProps, InfiniteLoader, IndexRange, ScrollParams, CellMeasurerCache, CellMeasurer } from '@theia/core/shared/react-virtualized';
 import URI from '@theia/core/lib/common/uri';
-import { ScmService } from '@theia/scm/lib/browser/scm-service';
 import { ScmHistoryProvider } from '.';
 import { SCM_HISTORY_ID, SCM_HISTORY_MAX_COUNT, SCM_HISTORY_LABEL } from './scm-history-contribution';
 import { ScmHistoryCommit, ScmFileChange, ScmFileChangeNode } from '../scm-file-change-node';
@@ -88,7 +87,6 @@ export class ScmHistoryWidget extends ScmNavigableListWidget<ScmHistoryListNode>
     protected historySupport: ScmHistorySupport | undefined;
 
     constructor(
-        @inject(ScmService) protected override readonly scmService: ScmService,
         @inject(OpenerService) protected readonly openerService: OpenerService,
         @inject(ApplicationShell) protected readonly shell: ApplicationShell,
         @inject(FileService) protected readonly fileService: FileService,

--- a/packages/scm-extra/src/browser/scm-navigable-list-widget.tsx
+++ b/packages/scm-extra/src/browser/scm-navigable-list-widget.tsx
@@ -42,7 +42,7 @@ export abstract class ScmNavigableListWidget<T extends { selected?: boolean }> e
         this.node.tabIndex = 0;
     }
 
-    protected onActivateRequest(msg: Message): void {
+    protected override onActivateRequest(msg: Message): void {
         super.onActivateRequest(msg);
         this.update();
         this.node.focus();
@@ -56,7 +56,7 @@ export abstract class ScmNavigableListWidget<T extends { selected?: boolean }> e
         return this._scrollContainer;
     }
 
-    protected onUpdateRequest(msg: Message): void {
+    protected override onUpdateRequest(msg: Message): void {
         if (!this.isAttached || !this.isVisible) {
             return;
         }
@@ -72,7 +72,7 @@ export abstract class ScmNavigableListWidget<T extends { selected?: boolean }> e
         })();
     }
 
-    protected onResize(msg: Widget.ResizeMessage): void {
+    protected override onResize(msg: Widget.ResizeMessage): void {
         super.onResize(msg);
         this.update();
     }
@@ -170,7 +170,7 @@ export namespace ScmItemComponent {
 }
 export class ScmItemComponent extends React.Component<ScmItemComponent.Props> {
 
-    render(): JSX.Element {
+    override render(): JSX.Element {
         const { labelProvider, scmLabelProvider, change } = this.props;
         const icon = labelProvider.getIcon(change);
         const label = labelProvider.getName(change);

--- a/packages/scm-extra/src/browser/scm-navigable-list-widget.tsx
+++ b/packages/scm-extra/src/browser/scm-navigable-list-widget.tsx
@@ -34,8 +34,7 @@ export abstract class ScmNavigableListWidget<T extends { selected?: boolean }> e
 
     @inject(ScmService) protected readonly scmService: ScmService;
     @inject(LabelProvider) protected readonly labelProvider: LabelProvider;
-    @inject(ScmFileChangeLabelProvider)
-    protected readonly scmLabelProvider: ScmFileChangeLabelProvider;
+    @inject(ScmFileChangeLabelProvider) protected readonly scmLabelProvider: ScmFileChangeLabelProvider;
 
     constructor() {
         super();

--- a/packages/scm/src/browser/dirty-diff/diff-computer.ts
+++ b/packages/scm/src/browser/dirty-diff/diff-computer.ts
@@ -77,15 +77,15 @@ export class DiffComputer {
 
 class ArrayDiff extends jsdiff.Diff {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    tokenize(value: any): any {
+    override tokenize(value: any): any {
         return value;
     }
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    join(value: any): any {
+    override join(value: any): any {
         return value;
     }
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    removeEmpty(value: any): any {
+    override removeEmpty(value: any): any {
         return value;
     }
 }

--- a/packages/scm/src/browser/scm-amend-component.tsx
+++ b/packages/scm/src/browser/scm-amend-component.tsx
@@ -91,7 +91,7 @@ export class ScmAmendComponent extends React.Component<ScmAmendComponentProps, S
 
     protected readonly toDisposeOnUnmount = new DisposableCollection();
 
-    async componentDidMount(): Promise<void> {
+    override async componentDidMount(): Promise<void> {
         this.toDisposeOnUnmount.push(Disposable.create(() => { /* mark as mounted */ }));
 
         const lastCommit = await this.getLastCommit();
@@ -105,7 +105,7 @@ export class ScmAmendComponent extends React.Component<ScmAmendComponentProps, S
         );
     }
 
-    componentWillUnmount(): void {
+    override componentWillUnmount(): void {
         this.toDisposeOnUnmount.dispose();
     }
 
@@ -273,7 +273,7 @@ export class ScmAmendComponent extends React.Component<ScmAmendComponentProps, S
         this.props.setCommitMessage(message);
     }
 
-    render(): JSX.Element {
+    override render(): JSX.Element {
         const neverShrink = this.state.amendingCommits.length <= 3;
 
         const style: React.CSSProperties = neverShrink

--- a/packages/scm/src/browser/scm-commit-widget.tsx
+++ b/packages/scm/src/browser/scm-commit-widget.tsx
@@ -55,7 +55,7 @@ export class ScmCommitWidget extends ReactWidget implements StatefulWidget {
         this.id = ScmCommitWidget.ID;
     }
 
-    protected onAfterAttach(msg: Message): void {
+    protected override onAfterAttach(msg: Message): void {
         super.onAfterAttach(msg);
         this.refreshOnRepositoryChange();
         this.toDisposeOnDetach.push(this.scmService.onDidChangeSelectedRepository(() => {
@@ -77,7 +77,7 @@ export class ScmCommitWidget extends ReactWidget implements StatefulWidget {
         }
     }
 
-    protected onActivateRequest(msg: Message): void {
+    protected override onActivateRequest(msg: Message): void {
         super.onActivateRequest(msg);
         this.focus();
     }

--- a/packages/scm/src/browser/scm-contribution.ts
+++ b/packages/scm/src/browser/scm-contribution.ts
@@ -138,7 +138,7 @@ export class ScmContribution extends AbstractViewContribution<ScmWidget> impleme
         this.scmFocus.set(this.shell.currentWidget instanceof ScmWidget);
     }
 
-    registerCommands(commandRegistry: CommandRegistry): void {
+    override registerCommands(commandRegistry: CommandRegistry): void {
         super.registerCommands(commandRegistry);
         commandRegistry.registerCommand(SCM_COMMANDS.CHANGE_REPOSITORY, {
             execute: () => this.scmQuickOpenService.changeRepository(),
@@ -200,7 +200,7 @@ export class ScmContribution extends AbstractViewContribution<ScmWidget> impleme
         });
     }
 
-    registerKeybindings(keybindings: KeybindingRegistry): void {
+    override registerKeybindings(keybindings: KeybindingRegistry): void {
         super.registerKeybindings(keybindings);
         keybindings.registerKeybinding({
             command: SCM_COMMANDS.ACCEPT_INPUT.id,

--- a/packages/scm/src/browser/scm-groups-tree-model.ts
+++ b/packages/scm/src/browser/scm-groups-tree-model.ts
@@ -28,7 +28,7 @@ export class ScmGroupsTreeModel extends ScmTreeModel {
     protected readonly toDisposeOnRepositoryChange = new DisposableCollection();
 
     @postConstruct()
-    protected init(): void {
+    protected override init(): void {
         super.init();
         this.refreshOnRepositoryChange();
         this.toDispose.push(this.scmService.onDidChangeSelectedRepository(() => {

--- a/packages/scm/src/browser/scm-tree-model.ts
+++ b/packages/scm/src/browser/scm-tree-model.ts
@@ -389,7 +389,7 @@ export abstract class ScmTreeModel extends TreeModelImpl {
     }
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    storeState(): any {
+    override storeState(): any {
         return {
             ...super.storeState(),
             mode: this.viewMode,
@@ -397,7 +397,7 @@ export abstract class ScmTreeModel extends TreeModelImpl {
     }
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    restoreState(oldState: any): void {
+    override restoreState(oldState: any): void {
         super.restoreState(oldState);
         this.viewMode = oldState.mode === 'tree' ? 'tree' : 'list';
     }

--- a/packages/scm/src/browser/scm-tree-widget.tsx
+++ b/packages/scm/src/browser/scm-tree-widget.tsx
@@ -50,7 +50,6 @@ export class ScmTreeWidget extends TreeWidget {
 
     @inject(MenuModelRegistry) protected readonly menus: MenuModelRegistry;
     @inject(CommandRegistry) protected readonly commands: CommandRegistry;
-    @inject(CorePreferences) protected readonly corePreferences: CorePreferences;
     @inject(ScmContextKeyService) protected readonly contextKeys: ScmContextKeyService;
     @inject(EditorManager) protected readonly editorManager: EditorManager;
     @inject(DiffNavigatorProvider) protected readonly diffNavigatorProvider: DiffNavigatorProvider;
@@ -58,12 +57,12 @@ export class ScmTreeWidget extends TreeWidget {
     @inject(DecorationsService) protected readonly decorationsService: DecorationsService;
     @inject(ColorRegistry) protected readonly colors: ColorRegistry;
 
-    model: ScmTreeModel;
+    override model: ScmTreeModel;
 
     constructor(
-        @inject(TreeProps) readonly props: TreeProps,
+        @inject(TreeProps) override readonly props: TreeProps,
         @inject(TreeModel) readonly treeModel: TreeModel,
-        @inject(ContextMenuRenderer) protected readonly contextMenuRenderer: ContextMenuRenderer,
+        @inject(ContextMenuRenderer) protected override readonly contextMenuRenderer: ContextMenuRenderer,
     ) {
         super(props, treeModel, contextMenuRenderer);
         this.id = ScmTreeWidget.ID;
@@ -86,7 +85,7 @@ export class ScmTreeWidget extends TreeWidget {
      * @param node the tree node.
      * @param props the node properties.
      */
-    protected renderNode(node: TreeNode, props: NodeProps): React.ReactNode {
+    protected override renderNode(node: TreeNode, props: NodeProps): React.ReactNode {
         if (!TreeNode.isVisible(node)) {
             return undefined;
         }
@@ -163,7 +162,7 @@ export class ScmTreeWidget extends TreeWidget {
         return super.renderNode(node, props);
     }
 
-    protected createContainerAttributes(): React.HTMLAttributes<HTMLElement> {
+    protected override createContainerAttributes(): React.HTMLAttributes<HTMLElement> {
         if (this.model.canTabToWidget()) {
             return {
                 ...super.createContainerAttributes(),
@@ -192,7 +191,7 @@ export class ScmTreeWidget extends TreeWidget {
      * keys only, then they must press ARROW_UP repeatedly until the selected node is the folder
      * node and then press ARROW_LEFT.
      */
-    protected async handleLeft(event: KeyboardEvent): Promise<void> {
+    protected override async handleLeft(event: KeyboardEvent): Promise<void> {
         if (this.model.selectedNodes.length === 1) {
             const selectedNode = this.model.selectedNodes[0];
             if (ScmFileChangeNode.is(selectedNode)) {
@@ -236,7 +235,7 @@ export class ScmTreeWidget extends TreeWidget {
      * change chunks within each file.  If the selected chunk is the last chunk in the file
      * then the file selection is moved to the next file (no-op if no next file).
      */
-    protected async handleRight(event: KeyboardEvent): Promise<void> {
+    protected override async handleRight(event: KeyboardEvent): Promise<void> {
         if (this.model.selectedNodes.length === 0) {
             const firstNode = this.getFirstSelectableNode();
             // Selects the first visible resource as none are selected.
@@ -275,7 +274,7 @@ export class ScmTreeWidget extends TreeWidget {
         return super.handleRight(event);
     }
 
-    protected handleEnter(event: KeyboardEvent): void {
+    protected override handleEnter(event: KeyboardEvent): void {
         if (this.model.selectedNodes.length === 1) {
             const selectedNode = this.model.selectedNodes[0];
             if (ScmFileChangeNode.is(selectedNode)) {
@@ -417,7 +416,7 @@ export class ScmTreeWidget extends TreeWidget {
         return standaloneEditor;
     }
 
-    protected getPaddingLeft(node: TreeNode, props: NodeProps): number {
+    protected override getPaddingLeft(node: TreeNode, props: NodeProps): number {
         if (this.viewMode === 'list') {
             if (props.depth === 1) {
                 return this.props.expansionTogglePadding;
@@ -426,7 +425,7 @@ export class ScmTreeWidget extends TreeWidget {
         return super.getPaddingLeft(node, props);
     }
 
-    protected needsExpansionTogglePadding(node: TreeNode): boolean {
+    protected override needsExpansionTogglePadding(node: TreeNode): boolean {
         const theme = this.iconThemeService.getDefinition(this.iconThemeService.current);
         if (theme && (theme.hidesExplorerArrows || (theme.hasFileIcons && !theme.hasFolderIcons))) {
             return false;
@@ -471,10 +470,10 @@ export abstract class ScmElement<P extends ScmElement.Props = ScmElement.Props> 
     }
 
     protected readonly toDisposeOnUnmount = new DisposableCollection();
-    componentDidMount(): void {
+    override componentDidMount(): void {
         this.toDisposeOnUnmount.push(Disposable.create(() => { /* mark as mounted */ }));
     }
-    componentWillUnmount(): void {
+    override componentWillUnmount(): void {
         this.toDisposeOnUnmount.dispose();
     }
 
@@ -516,7 +515,7 @@ export namespace ScmElement {
 
 export class ScmResourceComponent extends ScmElement<ScmResourceComponent.Props> {
 
-    render(): JSX.Element | undefined {
+    override render(): JSX.Element | undefined {
         const { hover } = this.state;
         const { model, treeNode, colors, parentPath, sourceUri, decoration, labelProvider, commands, menus, contextKeys, caption } = this.props;
         const resourceUri = new URI(sourceUri);
@@ -630,7 +629,7 @@ export namespace ScmResourceComponent {
 
 export class ScmResourceGroupElement extends ScmElement<ScmResourceGroupComponent.Props> {
 
-    render(): JSX.Element {
+    override render(): JSX.Element {
         const { hover } = this.state;
         const { model, treeNode, menus, commands, contextKeys, caption } = this.props;
         return <div className={`theia-header scm-theia-header ${TREE_NODE_SEGMENT_GROW_CLASS}`}
@@ -680,7 +679,7 @@ export namespace ScmResourceGroupComponent {
 
 export class ScmResourceFolderElement extends ScmElement<ScmResourceFolderElement.Props> {
 
-    render(): JSX.Element {
+    override render(): JSX.Element {
         const { hover } = this.state;
         const { model, treeNode, sourceUri, labelProvider, commands, menus, contextKeys, caption } = this.props;
         const sourceFileStat: FileStat = { uri: sourceUri, isDirectory: true, lastModification: 0 };
@@ -737,7 +736,7 @@ export namespace ScmResourceFolderElement {
 }
 
 export class ScmInlineActions extends React.Component<ScmInlineActions.Props> {
-    render(): React.ReactNode {
+    override render(): React.ReactNode {
         const { hover, menu, args, commands, model, treeNode, contextKeys, children } = this.props;
         return <div className='theia-scm-inline-actions-container'>
             <div className='theia-scm-inline-actions'>
@@ -762,7 +761,7 @@ export namespace ScmInlineActions {
 }
 
 export class ScmInlineAction extends React.Component<ScmInlineAction.Props> {
-    render(): React.ReactNode {
+    override render(): React.ReactNode {
         const { node, model, treeNode, args, commands, contextKeys } = this.props;
 
         let isActive: boolean = false;

--- a/packages/scm/src/browser/scm-tree-widget.tsx
+++ b/packages/scm/src/browser/scm-tree-widget.tsx
@@ -57,17 +57,17 @@ export class ScmTreeWidget extends TreeWidget {
     @inject(DecorationsService) protected readonly decorationsService: DecorationsService;
     @inject(ColorRegistry) protected readonly colors: ColorRegistry;
 
-    override model: ScmTreeModel;
+    // TODO: Make TreeWidget generic to better type those fields.
+    override readonly model: ScmTreeModel;
 
     constructor(
-        @inject(TreeProps) override readonly props: TreeProps,
-        @inject(TreeModel) readonly treeModel: TreeModel,
-        @inject(ContextMenuRenderer) protected override readonly contextMenuRenderer: ContextMenuRenderer,
+        @inject(TreeProps) props: TreeProps,
+        @inject(TreeModel) treeModel: ScmTreeModel,
+        @inject(ContextMenuRenderer) contextMenuRenderer: ContextMenuRenderer,
     ) {
         super(props, treeModel, contextMenuRenderer);
         this.id = ScmTreeWidget.ID;
         this.addClass('groups-outer-container');
-        this.model = treeModel as ScmTreeModel;
     }
 
     set viewMode(id: 'tree' | 'list') {

--- a/packages/scm/src/browser/scm-widget.tsx
+++ b/packages/scm/src/browser/scm-widget.tsx
@@ -130,7 +130,7 @@ export class ScmWidget extends BaseWidget implements StatefulWidget {
         this.onUpdateRequest(Widget.Msg.UpdateRequest);
     }
 
-    protected onUpdateRequest(msg: Message): void {
+    protected override onUpdateRequest(msg: Message): void {
         MessageLoop.sendMessage(this.commitWidget, msg);
         MessageLoop.sendMessage(this.resourceWidget, msg);
         MessageLoop.sendMessage(this.amendWidget, msg);
@@ -138,7 +138,7 @@ export class ScmWidget extends BaseWidget implements StatefulWidget {
         super.onUpdateRequest(msg);
     }
 
-    protected onAfterAttach(msg: Message): void {
+    protected override onAfterAttach(msg: Message): void {
         this.node.appendChild(this.commitWidget.node);
         this.node.appendChild(this.resourceWidget.node);
         this.node.appendChild(this.amendWidget.node);
@@ -148,7 +148,7 @@ export class ScmWidget extends BaseWidget implements StatefulWidget {
         this.update();
     }
 
-    protected onActivateRequest(msg: Message): void {
+    protected override onActivateRequest(msg: Message): void {
         super.onActivateRequest(msg);
         this.refresh();
         if (this.commitWidget.isVisible) {

--- a/packages/search-in-workspace/src/browser/components/search-in-workspace-input.tsx
+++ b/packages/search-in-workspace/src/browser/components/search-in-workspace-input.tsx
@@ -128,7 +128,7 @@ export class SearchInWorkspaceInput extends React.Component<InputAttributes, His
         this.setIndex(history.length - 1);
     }
 
-    render(): React.ReactNode {
+    override render(): React.ReactNode {
         return (
             <input
                 {...this.props}

--- a/packages/search-in-workspace/src/browser/search-in-workspace-frontend-contribution.ts
+++ b/packages/search-in-workspace/src/browser/search-in-workspace-frontend-contribution.ts
@@ -140,7 +140,7 @@ export class SearchInWorkspaceFrontendContribution extends AbstractViewContribut
         await this.openView({ activate: false });
     }
 
-    async registerCommands(commands: CommandRegistry): Promise<void> {
+    override async registerCommands(commands: CommandRegistry): Promise<void> {
         super.registerCommands(commands);
         commands.registerCommand(SearchInWorkspaceCommands.OPEN_SIW_WIDGET, {
             isEnabled: () => this.workspaceService.tryGetRoots().length > 0,
@@ -287,7 +287,7 @@ export class SearchInWorkspaceFrontendContribution extends AbstractViewContribut
             : '';
     }
 
-    registerKeybindings(keybindings: KeybindingRegistry): void {
+    override registerKeybindings(keybindings: KeybindingRegistry): void {
         super.registerKeybindings(keybindings);
         keybindings.registerKeybinding({
             command: SearchInWorkspaceCommands.OPEN_SIW_WIDGET.id,
@@ -295,7 +295,7 @@ export class SearchInWorkspaceFrontendContribution extends AbstractViewContribut
         });
     }
 
-    registerMenus(menus: MenuModelRegistry): void {
+    override registerMenus(menus: MenuModelRegistry): void {
         super.registerMenus(menus);
         menus.registerMenuAction(NavigatorContextMenu.SEARCH, {
             commandId: SearchInWorkspaceCommands.FIND_IN_FOLDER.id

--- a/packages/search-in-workspace/src/browser/search-in-workspace-result-tree-widget.tsx
+++ b/packages/search-in-workspace/src/browser/search-in-workspace-result-tree-widget.tsx
@@ -153,9 +153,9 @@ export class SearchInWorkspaceResultTreeWidget extends TreeWidget {
     @inject(FileService) protected readonly fileService: FileService;
 
     constructor(
-        @inject(TreeProps) override readonly props: TreeProps,
-        @inject(TreeModel) override readonly model: TreeModel,
-        @inject(ContextMenuRenderer) protected override readonly contextMenuRenderer: ContextMenuRenderer
+        @inject(TreeProps) props: TreeProps,
+        @inject(TreeModel) model: TreeModel,
+        @inject(ContextMenuRenderer) contextMenuRenderer: ContextMenuRenderer
     ) {
         super(props, model, contextMenuRenderer);
 

--- a/packages/search-in-workspace/src/browser/search-in-workspace-result-tree-widget.tsx
+++ b/packages/search-in-workspace/src/browser/search-in-workspace-result-tree-widget.tsx
@@ -153,9 +153,9 @@ export class SearchInWorkspaceResultTreeWidget extends TreeWidget {
     @inject(FileService) protected readonly fileService: FileService;
 
     constructor(
-        @inject(TreeProps) readonly props: TreeProps,
-        @inject(TreeModel) readonly model: TreeModel,
-        @inject(ContextMenuRenderer) protected readonly contextMenuRenderer: ContextMenuRenderer
+        @inject(TreeProps) override readonly props: TreeProps,
+        @inject(TreeModel) override readonly model: TreeModel,
+        @inject(ContextMenuRenderer) protected override readonly contextMenuRenderer: ContextMenuRenderer
     ) {
         super(props, model, contextMenuRenderer);
 
@@ -178,7 +178,7 @@ export class SearchInWorkspaceResultTreeWidget extends TreeWidget {
     }
 
     @postConstruct()
-    protected init(): void {
+    protected override init(): void {
         super.init();
         this.addClass('resultContainer');
 
@@ -612,7 +612,7 @@ export class SearchInWorkspaceResultTreeWidget extends TreeWidget {
         }
     }
 
-    protected handleUp(event: KeyboardEvent): void {
+    protected override handleUp(event: KeyboardEvent): void {
         if (!this.model.getPrevSelectableNode(this.model.selectedNodes[0])) {
             this.focusInputEmitter.fire(true);
         } else {
@@ -717,7 +717,7 @@ export class SearchInWorkspaceResultTreeWidget extends TreeWidget {
         };
     }
 
-    protected renderCaption(node: TreeNode, props: NodeProps): React.ReactNode {
+    protected override renderCaption(node: TreeNode, props: NodeProps): React.ReactNode {
         if (SearchInWorkspaceRootFolderNode.is(node)) {
             return this.renderRootFolderNode(node);
         } else if (SearchInWorkspaceFileNode.is(node)) {
@@ -728,7 +728,7 @@ export class SearchInWorkspaceResultTreeWidget extends TreeWidget {
         return '';
     }
 
-    protected renderTailDecorations(node: TreeNode, props: NodeProps): React.ReactNode {
+    protected override renderTailDecorations(node: TreeNode, props: NodeProps): React.ReactNode {
         return <div className='result-node-buttons'>
             {this._showReplaceButtons && this.renderReplaceButton(node)}
             {this.renderRemoveButton(node)}

--- a/packages/search-in-workspace/src/browser/search-in-workspace-widget.tsx
+++ b/packages/search-in-workspace/src/browser/search-in-workspace-widget.tsx
@@ -300,7 +300,7 @@ export class SearchInWorkspaceWidget extends BaseWidget implements StatefulWidge
         this.update();
     }
 
-    protected onAfterAttach(msg: Message): void {
+    protected override onAfterAttach(msg: Message): void {
         super.onAfterAttach(msg);
         ReactDOM.render(<React.Fragment>{this.renderSearchHeader()}{this.renderSearchInfo()}</React.Fragment>, this.searchFormContainer);
         Widget.attach(this.resultTreeWidget, this.contentNode);
@@ -309,7 +309,7 @@ export class SearchInWorkspaceWidget extends BaseWidget implements StatefulWidge
         }));
     }
 
-    protected onUpdateRequest(msg: Message): void {
+    protected override onUpdateRequest(msg: Message): void {
         super.onUpdateRequest(msg);
         const searchInfo = this.renderSearchInfo();
         if (searchInfo) {
@@ -318,23 +318,23 @@ export class SearchInWorkspaceWidget extends BaseWidget implements StatefulWidge
         }
     }
 
-    protected onResize(msg: Widget.ResizeMessage): void {
+    protected override onResize(msg: Widget.ResizeMessage): void {
         super.onResize(msg);
         MessageLoop.sendMessage(this.resultTreeWidget, Widget.ResizeMessage.UnknownSize);
     }
 
-    protected onAfterShow(msg: Message): void {
+    protected override onAfterShow(msg: Message): void {
         super.onAfterShow(msg);
         this.focusInputField();
         this.contextKeyService.searchViewletVisible.set(true);
     }
 
-    protected onAfterHide(msg: Message): void {
+    protected override onAfterHide(msg: Message): void {
         super.onAfterHide(msg);
         this.contextKeyService.searchViewletVisible.set(false);
     }
 
-    protected onActivateRequest(msg: Message): void {
+    protected override onActivateRequest(msg: Message): void {
         super.onActivateRequest(msg);
         this.focusInputField();
     }

--- a/packages/task/src/browser/quick-open-task.ts
+++ b/packages/task/src/browser/quick-open-task.ts
@@ -383,15 +383,15 @@ export class QuickOpenTask implements QuickAccessProvider {
 
 export class TaskRunQuickOpenItem implements QuickPickItem {
     constructor(
-        public readonly token: number,
-        public readonly task: TaskConfiguration,
+        readonly token: number,
+        readonly task: TaskConfiguration,
         protected taskService: TaskService,
         protected isMulti: boolean,
         protected readonly taskDefinitionRegistry: TaskDefinitionRegistry,
         protected readonly taskNameResolver: TaskNameResolver,
         protected readonly taskSourceResolver: TaskSourceResolver,
         protected taskConfigurationManager: TaskConfigurationManager,
-        public readonly buttons?: Array<QuickInputButton>
+        readonly buttons?: Array<QuickInputButton>
     ) { }
 
     get label(): string {
@@ -423,15 +423,15 @@ export class TaskRunQuickOpenItem implements QuickPickItem {
 
 export class ConfigureBuildOrTestTaskQuickOpenItem extends TaskRunQuickOpenItem {
     constructor(
-        public override readonly token: number,
-        public override readonly task: TaskConfiguration,
-        protected override readonly taskService: TaskService,
-        protected override readonly isMulti: boolean,
-        protected override readonly taskNameResolver: TaskNameResolver,
+        token: number,
+        task: TaskConfiguration,
+        taskService: TaskService,
+        isMulti: boolean,
+        taskNameResolver: TaskNameResolver,
         protected readonly isBuildTask: boolean,
-        protected override readonly taskConfigurationManager: TaskConfigurationManager,
-        protected override readonly taskDefinitionRegistry: TaskDefinitionRegistry,
-        protected override readonly taskSourceResolver: TaskSourceResolver
+        taskConfigurationManager: TaskConfigurationManager,
+        taskDefinitionRegistry: TaskDefinitionRegistry,
+        taskSourceResolver: TaskSourceResolver
     ) {
         super(token, task, taskService, isMulti, taskDefinitionRegistry, taskNameResolver, taskSourceResolver, taskConfigurationManager);
     }

--- a/packages/task/src/browser/quick-open-task.ts
+++ b/packages/task/src/browser/quick-open-task.ts
@@ -423,20 +423,20 @@ export class TaskRunQuickOpenItem implements QuickPickItem {
 
 export class ConfigureBuildOrTestTaskQuickOpenItem extends TaskRunQuickOpenItem {
     constructor(
-        public readonly token: number,
-        public readonly task: TaskConfiguration,
-        protected taskService: TaskService,
-        protected isMulti: boolean,
-        protected readonly taskNameResolver: TaskNameResolver,
+        public override readonly token: number,
+        public override readonly task: TaskConfiguration,
+        protected override readonly taskService: TaskService,
+        protected override readonly isMulti: boolean,
+        protected override readonly taskNameResolver: TaskNameResolver,
         protected readonly isBuildTask: boolean,
-        protected taskConfigurationManager: TaskConfigurationManager,
-        protected readonly taskDefinitionRegistry: TaskDefinitionRegistry,
-        protected readonly taskSourceResolver: TaskSourceResolver
+        protected override readonly taskConfigurationManager: TaskConfigurationManager,
+        protected override readonly taskDefinitionRegistry: TaskDefinitionRegistry,
+        protected override readonly taskSourceResolver: TaskSourceResolver
     ) {
         super(token, task, taskService, isMulti, taskDefinitionRegistry, taskNameResolver, taskSourceResolver, taskConfigurationManager);
     }
 
-    execute(): void {
+    override execute(): void {
         this.taskService.updateTaskConfiguration(this.token, this.task, { group: { kind: this.isBuildTask ? 'build' : 'test', isDefault: true } })
             .then(() => {
                 if (this.task._scope) {
@@ -698,4 +698,3 @@ export class TaskRestartRunningQuickOpen {
         this.quickInputService?.showQuickPick(items, { placeholder: 'Select task to restart' });
     }
 }
-

--- a/packages/task/src/node/custom/custom-task.ts
+++ b/packages/task/src/node/custom/custom-task.ts
@@ -34,9 +34,9 @@ export type TaskFactory = (options: TaskCustomOptions) => CustomTask;
 export class CustomTask extends Task {
 
     constructor(
-        @inject(TaskManager) protected readonly taskManager: TaskManager,
-        @inject(ILogger) @named('task') protected readonly logger: ILogger,
-        @inject(TaskCustomOptions) protected readonly options: TaskCustomOptions
+        @inject(TaskManager) protected override readonly taskManager: TaskManager,
+        @inject(ILogger) @named('task') protected override readonly logger: ILogger,
+        @inject(TaskCustomOptions) protected override readonly options: TaskCustomOptions
     ) {
         super(taskManager, logger, options);
         this.logger.info(`Created new custom task, id: ${this.id}, context: ${this.context}`);

--- a/packages/task/src/node/custom/custom-task.ts
+++ b/packages/task/src/node/custom/custom-task.ts
@@ -34,8 +34,8 @@ export type TaskFactory = (options: TaskCustomOptions) => CustomTask;
 export class CustomTask extends Task {
 
     constructor(
-        @inject(TaskManager) protected override readonly taskManager: TaskManager,
-        @inject(ILogger) @named('task') protected override readonly logger: ILogger,
+        @inject(TaskManager) taskManager: TaskManager,
+        @inject(ILogger) @named('task') logger: ILogger,
         @inject(TaskCustomOptions) protected override readonly options: TaskCustomOptions
     ) {
         super(taskManager, logger, options);

--- a/packages/task/src/node/process/process-task.ts
+++ b/packages/task/src/node/process/process-task.ts
@@ -61,8 +61,8 @@ export class ProcessTask extends Task {
     protected command: string | undefined;
 
     constructor(
-        @inject(TaskManager) protected override readonly taskManager: TaskManager,
-        @inject(ILogger) @named('task') protected override readonly logger: ILogger,
+        @inject(TaskManager) taskManager: TaskManager,
+        @inject(ILogger) @named('task') logger: ILogger,
         @inject(TaskProcessOptions) protected override readonly options: TaskProcessOptions
     ) {
         super(taskManager, logger, options);

--- a/packages/task/src/node/process/process-task.ts
+++ b/packages/task/src/node/process/process-task.ts
@@ -61,9 +61,9 @@ export class ProcessTask extends Task {
     protected command: string | undefined;
 
     constructor(
-        @inject(TaskManager) protected readonly taskManager: TaskManager,
-        @inject(ILogger) @named('task') protected readonly logger: ILogger,
-        @inject(TaskProcessOptions) protected readonly options: TaskProcessOptions
+        @inject(TaskManager) protected override readonly taskManager: TaskManager,
+        @inject(ILogger) @named('task') protected override readonly logger: ILogger,
+        @inject(TaskProcessOptions) protected override readonly options: TaskProcessOptions
     ) {
         super(taskManager, logger, options);
 

--- a/packages/task/src/node/task-line-matchers.ts
+++ b/packages/task/src/node/task-line-matchers.ts
@@ -19,9 +19,7 @@ import { ProblemMatcher, ProblemMatch, WatchingPattern } from '../common/problem
 
 export class StartStopLineMatcher extends AbstractLineMatcher {
 
-    constructor(
-        protected override matcher: ProblemMatcher
-    ) {
+    constructor(matcher: ProblemMatcher) {
         super(matcher);
     }
 
@@ -69,9 +67,7 @@ export class WatchModeLineMatcher extends StartStopLineMatcher {
     private endsPattern: WatchingPattern;
     activeOnStart: boolean = false;
 
-    constructor(
-        protected override matcher: ProblemMatcher
-    ) {
+    constructor(matcher: ProblemMatcher) {
         super(matcher);
         this.beginsPattern = matcher.watching!.beginsPattern;
         this.endsPattern = matcher.watching!.endsPattern;

--- a/packages/task/src/node/task-line-matchers.ts
+++ b/packages/task/src/node/task-line-matchers.ts
@@ -20,7 +20,7 @@ import { ProblemMatcher, ProblemMatch, WatchingPattern } from '../common/problem
 export class StartStopLineMatcher extends AbstractLineMatcher {
 
     constructor(
-        protected matcher: ProblemMatcher
+        protected override matcher: ProblemMatcher
     ) {
         super(matcher);
     }
@@ -70,7 +70,7 @@ export class WatchModeLineMatcher extends StartStopLineMatcher {
     activeOnStart: boolean = false;
 
     constructor(
-        protected matcher: ProblemMatcher
+        protected override matcher: ProblemMatcher
     ) {
         super(matcher);
         this.beginsPattern = matcher.watching!.beginsPattern;
@@ -85,7 +85,7 @@ export class WatchModeLineMatcher extends StartStopLineMatcher {
      * @param line the line of text to find the problem from
      * @return the identified problem. If the problem is not found, `undefined` is returned.
      */
-    match(line: string): ProblemMatch | undefined {
+    override match(line: string): ProblemMatch | undefined {
         if (this.activeOnStart) {
             this.activeOnStart = false;
             this.resetActivePatternIndex(0);

--- a/packages/task/src/node/test/task-test-container.ts
+++ b/packages/task/src/node/test/task-test-container.ts
@@ -44,7 +44,7 @@ export function createTaskTestContainer(): Container {
     testContainer.rebind(TerminalProcess).to(TestTerminalProcess);
 
     testContainer.rebind(ProcessUtils).toConstantValue(new class extends ProcessUtils {
-        terminateProcessTree(): void { } // don't actually kill the tree, it breaks the tests.
+        override terminateProcessTree(): void { } // don't actually kill the tree, it breaks the tests.
     });
 
     return testContainer;
@@ -52,7 +52,7 @@ export function createTaskTestContainer(): Container {
 
 class TestTerminalProcess extends TerminalProcess {
 
-    protected emitOnStarted(): void {
+    protected override emitOnStarted(): void {
         if (process.env['THEIA_TASK_TEST_DEBUG']) {
             console.log(`START ${this.id} ${JSON.stringify([this.executable, this.options.commandLine, ...this.arguments])}`);
             this.outputStream.on('data', data => console.debug(`${this.id} OUTPUT: ${data.toString().trim()}`));

--- a/packages/terminal/src/browser/search/terminal-search-widget.tsx
+++ b/packages/terminal/src/browser/search/terminal-search-widget.tsx
@@ -149,11 +149,11 @@ export class TerminalSearchWidget extends ReactWidget {
         this.search(false, 'previous');
     };
 
-    onAfterHide(): void {
+    override onAfterHide(): void {
         this.terminal.focus();
     }
 
-    onAfterShow(): void {
+    override onAfterShow(): void {
         if (this.searchInput) {
             this.searchInput.select();
         }

--- a/packages/terminal/src/browser/terminal-linkmatcher-diff.ts
+++ b/packages/terminal/src/browser/terminal-linkmatcher-diff.ts
@@ -19,14 +19,14 @@ import { TerminalLinkmatcherFiles } from './terminal-linkmatcher-files';
 
 @injectable()
 export class TerminalLinkmatcherDiffPre extends TerminalLinkmatcherFiles {
-    async getRegExp(): Promise<RegExp> {
+    override async getRegExp(): Promise<RegExp> {
         return /^--- a\/(\S*)/;
     }
 }
 
 @injectable()
 export class TerminalLinkmatcherDiffPost extends TerminalLinkmatcherFiles {
-    async getRegExp(): Promise<RegExp> {
+    override async getRegExp(): Promise<RegExp> {
         return /^\+\+\+ b\/(\S*)/;
     }
 }

--- a/packages/terminal/src/browser/terminal-linkmatcher-files.ts
+++ b/packages/terminal/src/browser/terminal-linkmatcher-files.ts
@@ -45,7 +45,7 @@ export class TerminalLinkmatcherFiles extends AbstractCmdClickTerminalContributi
         return new RegExp(`${baseLocalLinkClause}(${lineAndColumnClause})`);
     }
 
-    getValidate(terminalWidget: TerminalWidgetImpl): (link: string) => Promise<boolean> {
+    override getValidate(terminalWidget: TerminalWidgetImpl): (link: string) => Promise<boolean> {
         return async match => {
             try {
                 const toOpen = await this.toURI(match, await terminalWidget.cwd);

--- a/packages/terminal/src/browser/terminal-widget-impl.ts
+++ b/packages/terminal/src/browser/terminal-widget-impl.ts
@@ -70,7 +70,7 @@ export class TerminalWidgetImpl extends TerminalWidget implements StatefulWidget
     @inject(ShellTerminalServerProxy) protected readonly shellTerminalServer: ShellTerminalServerProxy;
     @inject(TerminalWatcher) protected readonly terminalWatcher: TerminalWatcher;
     @inject(ILogger) @named('terminal') protected readonly logger: ILogger;
-    @inject('terminal-dom-id') public override readonly id: string;
+    @inject('terminal-dom-id') override readonly id: string;
     @inject(TerminalPreferences) protected readonly preferences: TerminalPreferences;
     @inject(ContributionProvider) @named(TerminalContribution) protected readonly terminalContributionProvider: ContributionProvider<TerminalContribution>;
     @inject(TerminalService) protected readonly terminalService: TerminalService;

--- a/packages/terminal/src/browser/terminal-widget-impl.ts
+++ b/packages/terminal/src/browser/terminal-widget-impl.ts
@@ -62,7 +62,7 @@ export class TerminalWidgetImpl extends TerminalWidget implements StatefulWidget
     protected hoverMessage: HTMLDivElement;
     protected lastTouchEnd: TouchEvent | undefined;
     protected isAttachedCloseListener: boolean = false;
-    lastCwd = new URI();
+    override lastCwd = new URI();
 
     @inject(WorkspaceService) protected readonly workspaceService: WorkspaceService;
     @inject(WebSocketConnectionProvider) protected readonly webSocketConnectionProvider: WebSocketConnectionProvider;
@@ -70,7 +70,7 @@ export class TerminalWidgetImpl extends TerminalWidget implements StatefulWidget
     @inject(ShellTerminalServerProxy) protected readonly shellTerminalServer: ShellTerminalServerProxy;
     @inject(TerminalWatcher) protected readonly terminalWatcher: TerminalWatcher;
     @inject(ILogger) @named('terminal') protected readonly logger: ILogger;
-    @inject('terminal-dom-id') public readonly id: string;
+    @inject('terminal-dom-id') public override readonly id: string;
     @inject(TerminalPreferences) protected readonly preferences: TerminalPreferences;
     @inject(ContributionProvider) @named(TerminalContribution) protected readonly terminalContributionProvider: ContributionProvider<TerminalContribution>;
     @inject(TerminalService) protected readonly terminalService: TerminalService;
@@ -441,7 +441,7 @@ export class TerminalWidgetImpl extends TerminalWidget implements StatefulWidget
         throw new Error('Error creating terminal widget, see the backend error log for more information.');
     }
 
-    processMessage(msg: Message): void {
+    override processMessage(msg: Message): void {
         super.processMessage(msg);
         switch (msg.type) {
             case 'fit-request':
@@ -451,35 +451,35 @@ export class TerminalWidgetImpl extends TerminalWidget implements StatefulWidget
                 break;
         }
     }
-    protected onFitRequest(msg: Message): void {
+    protected override onFitRequest(msg: Message): void {
         super.onFitRequest(msg);
         MessageLoop.sendMessage(this, Widget.ResizeMessage.UnknownSize);
     }
-    protected onActivateRequest(msg: Message): void {
+    protected override onActivateRequest(msg: Message): void {
         super.onActivateRequest(msg);
         this.term.focus();
     }
-    protected onAfterShow(msg: Message): void {
+    protected override onAfterShow(msg: Message): void {
         super.onAfterShow(msg);
         this.update();
     }
-    protected onAfterAttach(msg: Message): void {
+    protected override onAfterAttach(msg: Message): void {
         Widget.attach(this.searchBox, this.node);
         super.onAfterAttach(msg);
         this.update();
     }
-    protected onBeforeDetach(msg: Message): void {
+    protected override onBeforeDetach(msg: Message): void {
         Widget.detach(this.searchBox);
         super.onBeforeDetach(msg);
     }
-    protected onResize(msg: Widget.ResizeMessage): void {
+    protected override onResize(msg: Widget.ResizeMessage): void {
         super.onResize(msg);
         this.needsResize = true;
         this.update();
     }
 
     protected needsResize = true;
-    protected onUpdateRequest(msg: Message): void {
+    protected override onUpdateRequest(msg: Message): void {
         super.onUpdateRequest(msg);
         if (!this.isVisible || !this.isAttached) {
             return;
@@ -625,7 +625,7 @@ export class TerminalWidgetImpl extends TerminalWidget implements StatefulWidget
         return this.onTermDidClose.event;
     }
 
-    dispose(): void {
+    override dispose(): void {
         /* Close the backend terminal only when explicitly closing the terminal
          * a refresh for example won't close it.  */
         if (this.closeOnDispose === true && typeof this.terminalId === 'number') {

--- a/packages/terminal/src/node/terminal-server.ts
+++ b/packages/terminal/src/node/terminal-server.ts
@@ -28,8 +28,8 @@ export class TerminalServer extends BaseTerminalServer implements ITerminalServe
 
     constructor(
         @inject(TerminalProcessFactory) protected readonly terminalFactory: TerminalProcessFactory,
-        @inject(ProcessManager) protected readonly processManager: ProcessManager,
-        @inject(ILogger) @named('terminal') protected readonly logger: ILogger
+        @inject(ProcessManager) protected override readonly processManager: ProcessManager,
+        @inject(ILogger) @named('terminal') protected override readonly logger: ILogger
     ) {
         super(processManager, logger);
     }

--- a/packages/terminal/src/node/terminal-server.ts
+++ b/packages/terminal/src/node/terminal-server.ts
@@ -26,10 +26,11 @@ import { TerminalProcessFactory, ProcessManager } from '@theia/process/lib/node'
 @injectable()
 export class TerminalServer extends BaseTerminalServer implements ITerminalServer {
 
+    @inject(TerminalProcessFactory) protected readonly terminalFactory: TerminalProcessFactory;
+
     constructor(
-        @inject(TerminalProcessFactory) protected readonly terminalFactory: TerminalProcessFactory,
-        @inject(ProcessManager) protected override readonly processManager: ProcessManager,
-        @inject(ILogger) @named('terminal') protected override readonly logger: ILogger
+        @inject(ProcessManager) processManager: ProcessManager,
+        @inject(ILogger) @named('terminal') logger: ILogger,
     ) {
         super(processManager, logger);
     }

--- a/packages/terminal/src/node/test/terminal-test-container.ts
+++ b/packages/terminal/src/node/test/terminal-test-container.ts
@@ -28,7 +28,7 @@ export function createTerminalTestContainer(): Container {
     container.load(backendApplicationModule);
     container.rebind(ApplicationPackage).toConstantValue({} as ApplicationPackage);
     container.rebind(ProcessUtils).toConstantValue(new class extends ProcessUtils {
-        terminateProcessTree(): void { }
+        override terminateProcessTree(): void { }
     });
 
     bindLogger(container.bind.bind(container));

--- a/packages/timeline/src/browser/timeline-tree-widget.tsx
+++ b/packages/timeline/src/browser/timeline-tree-widget.tsx
@@ -34,13 +34,13 @@ export class TimelineTreeWidget extends TreeWidget {
 
     @inject(MenuModelRegistry) protected readonly menus: MenuModelRegistry;
     @inject(TimelineContextKeyService) protected readonly contextKeys: TimelineContextKeyService;
+    @inject(TimelineService) protected readonly timelineService: TimelineService;
+    @inject(CommandRegistry) protected readonly commandRegistry: CommandRegistry;
 
     constructor(
-        @inject(TreeProps) override readonly props: TreeProps,
-        @inject(TimelineService) protected readonly timelineService: TimelineService,
+        @inject(TreeProps) props: TreeProps,
         @inject(TimelineTreeModel) override readonly model: TimelineTreeModel,
-        @inject(ContextMenuRenderer) protected override readonly contextMenuRenderer: ContextMenuRenderer,
-        @inject(CommandRegistry) protected readonly commandRegistry: CommandRegistry
+        @inject(ContextMenuRenderer) contextMenuRenderer: ContextMenuRenderer,
     ) {
         super(props, model, contextMenuRenderer);
         this.id = TimelineTreeWidget.ID;

--- a/packages/timeline/src/browser/timeline-tree-widget.tsx
+++ b/packages/timeline/src/browser/timeline-tree-widget.tsx
@@ -36,10 +36,10 @@ export class TimelineTreeWidget extends TreeWidget {
     @inject(TimelineContextKeyService) protected readonly contextKeys: TimelineContextKeyService;
 
     constructor(
-        @inject(TreeProps) readonly props: TreeProps,
+        @inject(TreeProps) override readonly props: TreeProps,
         @inject(TimelineService) protected readonly timelineService: TimelineService,
-        @inject(TimelineTreeModel) readonly model: TimelineTreeModel,
-        @inject(ContextMenuRenderer) protected readonly contextMenuRenderer: ContextMenuRenderer,
+        @inject(TimelineTreeModel) override readonly model: TimelineTreeModel,
+        @inject(ContextMenuRenderer) protected override readonly contextMenuRenderer: ContextMenuRenderer,
         @inject(CommandRegistry) protected readonly commandRegistry: CommandRegistry
     ) {
         super(props, model, contextMenuRenderer);
@@ -47,7 +47,7 @@ export class TimelineTreeWidget extends TreeWidget {
         this.addClass('timeline-outer-container');
     }
 
-    protected renderNode(node: TimelineNode, props: NodeProps): React.ReactNode {
+    protected override renderNode(node: TimelineNode, props: NodeProps): React.ReactNode {
         const attributes = this.createNodeAttributes(node, props);
         const content = <TimelineItemNode
             timelineItem={node.timelineItem}
@@ -57,7 +57,7 @@ export class TimelineTreeWidget extends TreeWidget {
         return React.createElement('div', attributes, content);
     }
 
-    protected handleEnter(event: KeyboardEvent): void {
+    protected override handleEnter(event: KeyboardEvent): void {
         const node = this.model.selectedNodes[0] as TimelineNode;
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         const command: any = node.timelineItem.command;
@@ -66,7 +66,7 @@ export class TimelineTreeWidget extends TreeWidget {
         }
     }
 
-    protected async handleLeft(event: KeyboardEvent): Promise<void> {
+    protected override async handleLeft(event: KeyboardEvent): Promise<void> {
         this.model.selectPrevNode();
     }
 }
@@ -81,7 +81,7 @@ export namespace TimelineItemNode {
 }
 
 export class TimelineItemNode extends React.Component<TimelineItemNode.Props> {
-    render(): JSX.Element | undefined {
+    override render(): JSX.Element | undefined {
         const { label, description, detail } = this.props.timelineItem;
         return <div className='timeline-item'
                     title={detail}

--- a/packages/timeline/src/browser/timeline-widget.tsx
+++ b/packages/timeline/src/browser/timeline-widget.tsx
@@ -161,14 +161,14 @@ export class TimelineWidget extends BaseWidget {
         return this.panel.layout as PanelLayout;
     }
 
-    protected onUpdateRequest(msg: Message): void {
+    protected override onUpdateRequest(msg: Message): void {
         MessageLoop.sendMessage(this.resourceWidget, msg);
         MessageLoop.sendMessage(this.timelineEmptyWidget, msg);
         this.refresh();
         super.onUpdateRequest(msg);
     }
 
-    protected onAfterAttach(msg: Message): void {
+    protected override onAfterAttach(msg: Message): void {
         this.node.appendChild(this.resourceWidget.node);
         this.node.appendChild(this.timelineEmptyWidget.node);
         super.onAfterAttach(msg);

--- a/packages/typehierarchy/src/browser/tree/typehierarchy-tree-model.ts
+++ b/packages/typehierarchy/src/browser/tree/typehierarchy-tree-model.ts
@@ -26,7 +26,7 @@ export class TypeHierarchyTreeModel extends TreeModelImpl {
     @inject(TypeHierarchyRegistry)
     protected readonly registry: TypeHierarchyRegistry;
 
-    protected doOpenNode(node: TreeNode): void {
+    protected override doOpenNode(node: TreeNode): void {
         // do nothing (in particular do not expand the node)
     }
 

--- a/packages/typehierarchy/src/browser/tree/typehierarchy-tree-widget.tsx
+++ b/packages/typehierarchy/src/browser/tree/typehierarchy-tree-widget.tsx
@@ -35,9 +35,9 @@ export class TypeHierarchyTreeWidget extends TreeWidget {
     protected readonly icons = new Map(Array.from(Object.keys(SymbolKind)).map(key => [(SymbolKind as any)[key], key.toLocaleLowerCase()] as [number, string]));
 
     constructor(
-        @inject(TreeProps) readonly props: TreeProps,
-        @inject(TypeHierarchyTreeModel) readonly model: TypeHierarchyTreeModel,
-        @inject(ContextMenuRenderer) readonly contextMenuRenderer: ContextMenuRenderer,
+        @inject(TreeProps) override readonly props: TreeProps,
+        @inject(TypeHierarchyTreeModel) override readonly model: TypeHierarchyTreeModel,
+        @inject(ContextMenuRenderer) override readonly contextMenuRenderer: ContextMenuRenderer,
         @inject(EditorManager) readonly editorManager: EditorManager
     ) {
         super(props, model, contextMenuRenderer);
@@ -66,7 +66,7 @@ export class TypeHierarchyTreeWidget extends TreeWidget {
     /**
      * See: `TreeWidget#renderIcon`.
      */
-    protected renderIcon(node: TreeNode): React.ReactNode {
+    protected override renderIcon(node: TreeNode): React.ReactNode {
         if (TypeHierarchyTree.Node.is(node)) {
             return <div className={'symbol-icon ' + this.icons.get(node.item.kind) || 'unknown'}></div>;
         }

--- a/packages/typehierarchy/src/browser/tree/typehierarchy-tree-widget.tsx
+++ b/packages/typehierarchy/src/browser/tree/typehierarchy-tree-widget.tsx
@@ -34,11 +34,12 @@ export class TypeHierarchyTreeWidget extends TreeWidget {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     protected readonly icons = new Map(Array.from(Object.keys(SymbolKind)).map(key => [(SymbolKind as any)[key], key.toLocaleLowerCase()] as [number, string]));
 
+    @inject(EditorManager) readonly editorManager: EditorManager;
+
     constructor(
-        @inject(TreeProps) override readonly props: TreeProps,
+        @inject(TreeProps) props: TreeProps,
         @inject(TypeHierarchyTreeModel) override readonly model: TypeHierarchyTreeModel,
-        @inject(ContextMenuRenderer) override readonly contextMenuRenderer: ContextMenuRenderer,
-        @inject(EditorManager) readonly editorManager: EditorManager
+        @inject(ContextMenuRenderer) contextMenuRenderer: ContextMenuRenderer
     ) {
         super(props, model, contextMenuRenderer);
         this.id = TypeHierarchyTreeWidget.WIDGET_ID;

--- a/packages/typehierarchy/src/browser/tree/typehierarchy-tree.ts
+++ b/packages/typehierarchy/src/browser/tree/typehierarchy-tree.ts
@@ -29,7 +29,7 @@ export class TypeHierarchyTree extends TreeImpl {
 
     provider: TypeHierarchyProvider | undefined;
 
-    async resolveChildren(parent: CompositeTreeNode): Promise<TreeNode[]> {
+    override async resolveChildren(parent: CompositeTreeNode): Promise<TreeNode[]> {
         if (TypeHierarchyTree.Node.is(parent)) {
             await this.ensureResolved(parent);
             if (parent.children.length === 0) {

--- a/packages/typehierarchy/src/browser/typehierarchy-contribution.ts
+++ b/packages/typehierarchy/src/browser/typehierarchy-contribution.ts
@@ -34,7 +34,7 @@ export class TypeHierarchyContribution extends AbstractViewContribution<TypeHier
     protected readonly editorAccess: EditorAccess;
 
     @inject(ApplicationShell)
-    protected readonly shell: ApplicationShell;
+    protected override readonly shell: ApplicationShell;
 
     constructor() {
         super({
@@ -48,7 +48,7 @@ export class TypeHierarchyContribution extends AbstractViewContribution<TypeHier
         });
     }
 
-    async openView(args?: Partial<TypeHierarchyOpenViewArguments>): Promise<TypeHierarchyTreeWidget> {
+    override async openView(args?: Partial<TypeHierarchyOpenViewArguments>): Promise<TypeHierarchyTreeWidget> {
         const widget = await super.openView(args);
         const { selection, languageId } = this.editorAccess;
         const direction = this.getDirection(args);
@@ -56,7 +56,7 @@ export class TypeHierarchyContribution extends AbstractViewContribution<TypeHier
         return widget;
     }
 
-    registerCommands(commands: CommandRegistry): void {
+    override registerCommands(commands: CommandRegistry): void {
         super.registerCommands(commands);
         commands.registerCommand(TypeHierarchyCommands.OPEN_SUBTYPE, {
             execute: () => this.openViewOrFlipHierarchyDirection(TypeHierarchyDirection.Children),
@@ -68,7 +68,7 @@ export class TypeHierarchyContribution extends AbstractViewContribution<TypeHier
         });
     }
 
-    registerMenus(menus: MenuModelRegistry): void {
+    override registerMenus(menus: MenuModelRegistry): void {
         super.registerMenus(menus);
         const menuPath = [...EDITOR_CONTEXT_MENU, 'type-hierarchy'];
         menus.registerMenuAction(menuPath, {
@@ -79,7 +79,7 @@ export class TypeHierarchyContribution extends AbstractViewContribution<TypeHier
         });
     }
 
-    registerKeybindings(keybindings: KeybindingRegistry): void {
+    override registerKeybindings(keybindings: KeybindingRegistry): void {
         super.registerKeybindings(keybindings);
         keybindings.registerKeybinding({
             command: TypeHierarchyCommands.OPEN_SUBTYPE.id,

--- a/packages/vsx-registry/src/browser/recommended-extensions/preference-provider-overrides.ts
+++ b/packages/vsx-registry/src/browser/recommended-extensions/preference-provider-overrides.ts
@@ -38,7 +38,7 @@ import { SectionPreferenceProviderSection, SectionPreferenceProviderUri } from '
 
 @injectable()
 export class FolderPreferenceProviderWithExtensions extends FolderPreferenceProvider {
-    protected getPath(preferenceName: string): string[] | undefined {
+    protected override getPath(preferenceName: string): string[] | undefined {
         const path = super.getPath(preferenceName);
         if (this.section !== 'extensions' || !path?.length) {
             return path;
@@ -53,7 +53,7 @@ export class FolderPreferenceProviderWithExtensions extends FolderPreferenceProv
 
 @injectable()
 export class UserPreferenceProviderWithExtensions extends UserPreferenceProvider {
-    protected getPath(preferenceName: string): string[] | undefined {
+    protected override getPath(preferenceName: string): string[] | undefined {
         const path = super.getPath(preferenceName);
         if (this.section !== 'extensions' || !path?.length) {
             return path;
@@ -68,7 +68,7 @@ export class UserPreferenceProviderWithExtensions extends UserPreferenceProvider
 
 @injectable()
 export class WorkspaceFilePreferenceProviderWithExtensions extends WorkspaceFilePreferenceProvider {
-    protected belongsInSection(firstSegment: string, remainder: string): boolean {
+    protected override belongsInSection(firstSegment: string, remainder: string): boolean {
         if (firstSegment === 'extensions') {
             return remainder in extensionsConfigurationSchema.properties!;
         }

--- a/packages/vsx-registry/src/browser/vsx-extension-editor.tsx
+++ b/packages/vsx-registry/src/browser/vsx-extension-editor.tsx
@@ -46,21 +46,21 @@ export class VSXExtensionEditor extends ReactWidget {
         this.toDispose.push(this.model.onDidChange(() => this.update()));
     }
 
-    getScrollContainer(): Promise<HTMLElement> {
+    override getScrollContainer(): Promise<HTMLElement> {
         return this.deferredScrollContainer.promise;
     }
 
-    protected onActivateRequest(msg: Message): void {
+    protected override onActivateRequest(msg: Message): void {
         super.onActivateRequest(msg);
         this.node.focus();
     }
 
-    protected onUpdateRequest(msg: Message): void {
+    protected override onUpdateRequest(msg: Message): void {
         super.onUpdateRequest(msg);
         this.updateTitle();
     }
 
-    protected onAfterShow(msg: Message): void {
+    protected override onAfterShow(msg: Message): void {
         super.onAfterShow(msg);
         this.update();
     }
@@ -71,7 +71,7 @@ export class VSXExtensionEditor extends ReactWidget {
         this.title.caption = label;
     }
 
-    protected onResize(msg: Widget.ResizeMessage): void {
+    protected override onResize(msg: Widget.ResizeMessage): void {
         super.onResize(msg);
         this.update();
     };

--- a/packages/vsx-registry/src/browser/vsx-extension.tsx
+++ b/packages/vsx-registry/src/browser/vsx-extension.tsx
@@ -416,7 +416,7 @@ const downloadFormatter = new Intl.NumberFormat();
 const downloadCompactFormatter = new Intl.NumberFormat(undefined, { notation: 'compact', compactDisplay: 'short' } as any);
 
 export class VSXExtensionComponent extends AbstractVSXExtensionComponent {
-    render(): React.ReactNode {
+    override render(): React.ReactNode {
         const { iconUrl, publisher, displayName, description, version, downloadCount, averageRating, tooltipId, tooltip } = this.props.extension;
 
         return <div className='theia-vsx-extension noselect' data-for={tooltipId} data-tip={tooltip}>
@@ -452,7 +452,7 @@ export class VSXExtensionEditorComponent extends AbstractVSXExtensionComponent {
         return this._scrollContainer;
     }
 
-    render(): React.ReactNode {
+    override render(): React.ReactNode {
         const {
             builtin, preview, id, iconUrl, publisher, displayName, description, version,
             averageRating, downloadCount, repository, license, readme

--- a/packages/vsx-registry/src/browser/vsx-extensions-contribution.ts
+++ b/packages/vsx-registry/src/browser/vsx-extensions-contribution.ts
@@ -75,7 +75,7 @@ export class VSXExtensionsContribution extends AbstractViewContribution<VSXExten
         await this.openView({ activate: false });
     }
 
-    registerCommands(commands: CommandRegistry): void {
+    override registerCommands(commands: CommandRegistry): void {
         super.registerCommands(commands);
         commands.registerCommand(VSXExtensionsCommands.CLEAR_ALL, {
             execute: () => this.model.search.query = '',
@@ -108,7 +108,7 @@ export class VSXExtensionsContribution extends AbstractViewContribution<VSXExten
         });
     }
 
-    registerMenus(menus: MenuModelRegistry): void {
+    override registerMenus(menus: MenuModelRegistry): void {
         super.registerMenus(menus);
         menus.registerMenuAction(VSXExtensionsContextMenu.COPY, {
             commandId: VSXExtensionsCommands.COPY.id,

--- a/packages/vsx-registry/src/browser/vsx-extensions-search-bar.tsx
+++ b/packages/vsx-registry/src/browser/vsx-extensions-search-bar.tsx
@@ -53,14 +53,14 @@ export class VSXExtensionsSearchBar extends ReactWidget {
         }
     }
 
-    protected onActivateRequest(msg: Message): void {
+    protected override onActivateRequest(msg: Message): void {
         super.onActivateRequest(msg);
         if (this.input) {
             this.input.focus();
         }
     }
 
-    protected onAfterAttach(msg: Message): void {
+    protected override onAfterAttach(msg: Message): void {
         super.onAfterAttach(msg);
         this.update();
     }

--- a/packages/vsx-registry/src/browser/vsx-extensions-view-container.ts
+++ b/packages/vsx-registry/src/browser/vsx-extensions-view-container.ts
@@ -30,7 +30,7 @@ export class VSXExtensionsViewContainer extends ViewContainer {
     static ID = 'vsx-extensions-view-container';
     static LABEL = nls.localizeByDefault('Extensions');
 
-    disableDNDBetweenContainers = true;
+    override disableDNDBetweenContainers = true;
 
     @inject(VSXExtensionsSearchBar)
     protected readonly searchBar: VSXExtensionsSearchBar;
@@ -39,7 +39,7 @@ export class VSXExtensionsViewContainer extends ViewContainer {
     protected readonly model: VSXExtensionsModel;
 
     @postConstruct()
-    protected init(): void {
+    protected override init(): void {
         super.init();
         this.id = VSXExtensionsViewContainer.ID;
         this.addClass('theia-vsx-extensions-view-container');
@@ -51,17 +51,17 @@ export class VSXExtensionsViewContainer extends ViewContainer {
         });
     }
 
-    protected onActivateRequest(msg: Message): void {
+    protected override onActivateRequest(msg: Message): void {
         this.searchBar.activate();
     }
 
-    protected onAfterAttach(msg: Message): void {
+    protected override onAfterAttach(msg: Message): void {
         super.onBeforeAttach(msg);
         this.updateMode();
         this.toDisposeOnDetach.push(this.model.search.onDidChangeQuery(() => this.updateMode()));
     }
 
-    protected configureLayout(layout: PanelLayout): void {
+    protected override configureLayout(layout: PanelLayout): void {
         layout.addWidget(this.searchBar);
         super.configureLayout(layout);
     }
@@ -98,7 +98,7 @@ export class VSXExtensionsViewContainer extends ViewContainer {
         }
     }
 
-    protected registerPart(part: ViewContainerPart): void {
+    protected override registerPart(part: ViewContainerPart): void {
         super.registerPart(part);
         this.applyModeToPart(part);
     }
@@ -135,7 +135,7 @@ export class VSXExtensionsViewContainer extends ViewContainer {
     }
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    protected doStoreState(): any {
+    protected override doStoreState(): any {
         const modes: VSXExtensionsViewContainer.State['modes'] = {};
         for (const mode of this.lastModeState.keys()) {
             modes[mode] = this.lastModeState.get(mode);
@@ -147,7 +147,7 @@ export class VSXExtensionsViewContainer extends ViewContainer {
     }
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    protected doRestoreState(state: any): void {
+    protected override doRestoreState(state: any): void {
         // eslint-disable-next-line guard-for-in
         for (const key in state.modes) {
             const mode = Number(key) as VSXSearchMode;
@@ -159,13 +159,13 @@ export class VSXExtensionsViewContainer extends ViewContainer {
         this.model.search.query = state.query;
     }
 
-    protected updateToolbarItems(allParts: ViewContainerPart[]): void {
+    protected override updateToolbarItems(allParts: ViewContainerPart[]): void {
         super.updateToolbarItems(allParts);
         this.registerToolbarItem(VSXExtensionsCommands.INSTALL_FROM_VSIX.id, { tooltip: VSXExtensionsCommands.INSTALL_FROM_VSIX.label, group: 'other_1' });
         this.registerToolbarItem(VSXExtensionsCommands.CLEAR_ALL.id, { tooltip: VSXExtensionsCommands.CLEAR_ALL.label, priority: 1, onDidChange: this.model.onDidChange });
     }
 
-    protected getToggleVisibilityGroupLabel(): string {
+    protected override getToggleVisibilityGroupLabel(): string {
         return 'a/' + nls.localizeByDefault('Views');
     }
 }

--- a/packages/vsx-registry/src/browser/vsx-extensions-widget.ts
+++ b/packages/vsx-registry/src/browser/vsx-extensions-widget.ts
@@ -52,7 +52,7 @@ export class VSXExtensionsWidget extends SourceTreeWidget {
     protected readonly extensionsSource: VSXExtensionsSource;
 
     @postConstruct()
-    protected init(): void {
+    protected override init(): void {
         super.init();
         this.addClass('theia-vsx-extensions');
 
@@ -80,12 +80,12 @@ export class VSXExtensionsWidget extends SourceTreeWidget {
         }
     }
 
-    protected handleClickEvent(node: TreeNode | undefined, event: React.MouseEvent<HTMLElement>): void {
+    protected override handleClickEvent(node: TreeNode | undefined, event: React.MouseEvent<HTMLElement>): void {
         super.handleClickEvent(node, event);
         this.model.openNode(node); // Open the editor view on a single click.
     }
 
-    protected handleDblClickEvent(): void {
+    protected override handleDblClickEvent(): void {
         // Don't open the editor view on a double click.
     }
 }

--- a/packages/workspace/src/browser/untitled-workspace-exit-dialog.ts
+++ b/packages/workspace/src/browser/untitled-workspace-exit-dialog.ts
@@ -27,7 +27,7 @@ export class UntitledWorkspaceExitDialog extends AbstractDialog<UntitledWorkspac
     }
 
     constructor(
-        @inject(DialogProps) protected readonly props: DialogProps
+        @inject(DialogProps) protected override readonly props: DialogProps
     ) {
         super(props);
         const messageNode = document.createElement('div');
@@ -40,12 +40,12 @@ export class UntitledWorkspaceExitDialog extends AbstractDialog<UntitledWorkspac
         this.appendAcceptButton(nls.localizeByDefault(UntitledWorkspaceExitDialog.Values.Save));
     }
 
-    protected onAfterAttach(msg: Message): void {
+    protected override onAfterAttach(msg: Message): void {
         super.onAfterAttach(msg);
         this.addAction(this.dontSaveButton, () => this.dontSave(), 'click');
     }
 
-    protected addAcceptAction<K extends keyof HTMLElementEventMap>(element: HTMLElement, ...additionalEventTypes: K[]): void {
+    protected override addAcceptAction<K extends keyof HTMLElementEventMap>(element: HTMLElement, ...additionalEventTypes: K[]): void {
         this.addAction(element, () => this.doSave(), 'click');
     }
 

--- a/packages/workspace/src/browser/untitled-workspace-exit-dialog.ts
+++ b/packages/workspace/src/browser/untitled-workspace-exit-dialog.ts
@@ -27,7 +27,7 @@ export class UntitledWorkspaceExitDialog extends AbstractDialog<UntitledWorkspac
     }
 
     constructor(
-        @inject(DialogProps) protected override readonly props: DialogProps
+        @inject(DialogProps) props: DialogProps
     ) {
         super(props);
         const messageNode = document.createElement('div');

--- a/packages/workspace/src/browser/workspace-breadcrumbs-contribution.ts
+++ b/packages/workspace/src/browser/workspace-breadcrumbs-contribution.ts
@@ -26,7 +26,7 @@ export class WorkspaceBreadcrumbsContribution extends FilepathBreadcrumbsContrib
     @inject(WorkspaceService)
     protected readonly workspaceService: WorkspaceService;
 
-    getContainerClassCreator(fileURI: URI): FilepathBreadcrumbClassNameFactory {
+    override getContainerClassCreator(fileURI: URI): FilepathBreadcrumbClassNameFactory {
         const workspaceRoot = this.workspaceService.getWorkspaceRootUri(fileURI);
         return (location, index) => {
             if (location.isEqual(fileURI)) {
@@ -38,7 +38,7 @@ export class WorkspaceBreadcrumbsContribution extends FilepathBreadcrumbsContrib
         };
     }
 
-    getIconClassCreator(fileURI: URI): FilepathBreadcrumbClassNameFactory {
+    override getIconClassCreator(fileURI: URI): FilepathBreadcrumbClassNameFactory {
         const workspaceRoot = this.workspaceService.getWorkspaceRootUri(fileURI);
         return (location, index) => {
             if (location.isEqual(fileURI) || workspaceRoot?.isEqual(location)) {
@@ -48,7 +48,7 @@ export class WorkspaceBreadcrumbsContribution extends FilepathBreadcrumbsContrib
         };
     }
 
-    protected filterBreadcrumbs(uri: URI, breadcrumb: FilepathBreadcrumb): boolean {
+    protected override filterBreadcrumbs(uri: URI, breadcrumb: FilepathBreadcrumb): boolean {
         const workspaceRootUri = this.workspaceService.getWorkspaceRootUri(uri);
         const firstCrumbToHide = this.workspaceService.isMultiRootWorkspaceOpened ? workspaceRootUri?.parent : workspaceRootUri;
         return super.filterBreadcrumbs(uri, breadcrumb) && (!firstCrumbToHide || !breadcrumb.uri.isEqualOrParent(firstCrumbToHide));

--- a/packages/workspace/src/browser/workspace-commands.ts
+++ b/packages/workspace/src/browser/workspace-commands.ts
@@ -566,8 +566,8 @@ export class WorkspaceRootUriAwareCommandHandler extends UriAwareCommandHandler<
 
     constructor(
         protected readonly workspaceService: WorkspaceService,
-        protected override readonly selectionService: SelectionService,
-        protected override readonly handler: UriCommandHandler<URI>
+        selectionService: SelectionService,
+        handler: UriCommandHandler<URI>
     ) {
         super(selectionService, handler);
     }

--- a/packages/workspace/src/browser/workspace-commands.ts
+++ b/packages/workspace/src/browser/workspace-commands.ts
@@ -566,24 +566,24 @@ export class WorkspaceRootUriAwareCommandHandler extends UriAwareCommandHandler<
 
     constructor(
         protected readonly workspaceService: WorkspaceService,
-        protected readonly selectionService: SelectionService,
-        protected readonly handler: UriCommandHandler<URI>
+        protected override readonly selectionService: SelectionService,
+        protected override readonly handler: UriCommandHandler<URI>
     ) {
         super(selectionService, handler);
     }
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    public isEnabled(...args: any[]): boolean {
+    public override isEnabled(...args: any[]): boolean {
         return super.isEnabled(...args) && !!this.workspaceService.tryGetRoots().length;
     }
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    public isVisible(...args: any[]): boolean {
+    public override isVisible(...args: any[]): boolean {
         return super.isVisible(...args) && !!this.workspaceService.tryGetRoots().length;
     }
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    protected getUri(...args: any[]): URI | undefined {
+    protected override getUri(...args: any[]): URI | undefined {
         const uri = super.getUri(...args);
         // Return the `uri` immediately if the resource exists in any of the workspace roots and is of `file` scheme.
         if (uri && uri.scheme === 'file' && this.workspaceService.getWorkspaceRootUri(uri)) {

--- a/packages/workspace/src/browser/workspace-input-dialog.ts
+++ b/packages/workspace/src/browser/workspace-input-dialog.ts
@@ -30,7 +30,7 @@ export class WorkspaceInputDialogProps extends SingleTextInputDialogProps {
 export class WorkspaceInputDialog extends SingleTextInputDialog {
 
     constructor(
-        @inject(WorkspaceInputDialogProps) protected readonly props: WorkspaceInputDialogProps,
+        @inject(WorkspaceInputDialogProps) protected override readonly props: WorkspaceInputDialogProps,
         @inject(LabelProvider) protected readonly labelProvider: LabelProvider,
     ) {
         super(props);

--- a/packages/workspace/src/browser/workspace-uri-contribution.ts
+++ b/packages/workspace/src/browser/workspace-uri-contribution.ts
@@ -27,29 +27,29 @@ export class WorkspaceUriLabelProviderContribution extends DefaultUriLabelProvid
     protected readonly workspaceVariable: WorkspaceVariableContribution;
 
     @postConstruct()
-    async init(): Promise<void> {
+    override async init(): Promise<void> {
         // no-op, backward compatibility
     }
 
-    canHandle(element: object): number {
+    override canHandle(element: object): number {
         if ((element instanceof URI && element.scheme === 'file' || URIIconReference.is(element) || FileStat.is(element))) {
             return 10;
         }
         return 0;
     }
 
-    getIcon(element: URI | URIIconReference | FileStat): string {
+    override getIcon(element: URI | URIIconReference | FileStat): string {
         return super.getIcon(this.asURIIconReference(element));
     }
 
-    getName(element: URI | URIIconReference | FileStat): string | undefined {
+    override getName(element: URI | URIIconReference | FileStat): string | undefined {
         return super.getName(this.asURIIconReference(element));
     }
 
     /**
      * trims the workspace root from a file uri, if it is a child.
      */
-    getLongName(element: URI | URIIconReference | FileStat): string | undefined {
+    override getLongName(element: URI | URIIconReference | FileStat): string | undefined {
         const uri = this.getUri(element);
         if (uri) {
             const formatting = this.findFormatting(uri);
@@ -72,7 +72,7 @@ export class WorkspaceUriLabelProviderContribution extends DefaultUriLabelProvid
         return element;
     }
 
-    protected getUri(element: URI | URIIconReference | FileStat): URI | undefined {
+    protected override getUri(element: URI | URIIconReference | FileStat): URI | undefined {
         if (FileStat.is(element)) {
             return element.resource;
         }


### PR DESCRIPTION
This feature helps with quickly identifying overridden methods, as well
as notify us of potential breakage whenever APIs are removed and some
classes still try to override those missing methods.

It seems like this change wouldn't even force dependents to update their TS version as the `override` keyword doesn't make its way into the generated `.d.ts` files.

#### How to test

Try to remove one of the `override` and build: it should fail.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)