### PR TITLE
Fix TypeDoc config for breaking changes in 0.22.0

### DIFF
--- a/configs/typedoc.json
+++ b/configs/typedoc.json
@@ -1,9 +1,9 @@
 {
   "emit": false,
   "exclude": [
-    "+(dev-packages|examples|typings|scripts)",
-    "packages/*/lib",
-    "**/node_modules",
+    "../+(dev-packages|examples|typings|scripts)/**",
+    "../packages/*/lib/**",
+    "**/node_modules/**",
     "**/*spec.ts"
   ],
   "excludeExternals": true,


### PR DESCRIPTION
Resolves TypeStrong/typedoc#1868

#### What it does

Corrects TypeDoc configuration 

#### How to test

Pull - run `yarn docs`, documentation will now work properly.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
