### PR TITLE
Fix frontend use of Uri.joinPath with path-browserify

### DIFF
--- a/dev-packages/application-manager/package.json
+++ b/dev-packages/application-manager/package.json
@@ -48,6 +48,7 @@
     "ignore-loader": "^0.1.2",
     "less": "^3.0.3",
     "node-abi": "*",
+    "path-browserify": "^1.0.1",
     "semver": "^7.3.5",
     "setimmediate": "^1.0.5",
     "source-map": "^0.6.1",

--- a/dev-packages/application-manager/src/generator/webpack-generator.ts
+++ b/dev-packages/application-manager/src/generator/webpack-generator.ts
@@ -195,7 +195,7 @@ module.exports = {
             'child_process': false,
             'crypto': false,
             'net': false,
-            'path': false,
+            'path': require.resolve('path-browserify'),
             'process': false,
             'os': false,
             'timers': false

--- a/yarn.lock
+++ b/yarn.lock
@@ -8846,6 +8846,11 @@ parseurl@~1.3.3:
   resolved "https://registry.yarnpkg.com/parseurl/-/parseurl-1.3.3.tgz#9da19e7bee8d12dff0513ed5b76957793bc2e8d4"
   integrity sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==
 
+path-browserify@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/path-browserify/-/path-browserify-1.0.1.tgz#d98454a9c3753d5790860f16f68867b9e46be1fd"
+  integrity sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==
+
 path-exists@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/path-exists/-/path-exists-3.0.0.tgz#ce0ebeaa5f78cb18925ea7d810d7b59b010fd515"


### PR DESCRIPTION
Signed-off-by: robmor01 <Rob.Moran@arm.com>

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

Using `vscode.Uri.joinPath()` or `theia.Uri.joinPath()` in frontend modules (Theia frontend plugins or VS Code Web Extensions) was failing because `path` was not found:

```
TypeError: Cannot read properties of undefined (reading 'join')
```

This PR adds the `path-browserify` polyfill to fix the issue.

Note, a new dependency has been added which uses the MIT license, does this need to be tracked or signed off?

[path-browserify](https://github.com/browserify/path-browserify)

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

Create a frontend module which calls `Uri.joinPath()`

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
