### PR TITLE
Correctly expose extensionUri for frontend modules

### DIFF
--- a/packages/core/src/browser/endpoint.ts
+++ b/packages/core/src/browser/endpoint.ts
@@ -62,6 +62,10 @@ export class Endpoint {
         return 'localhost:' + this.port;
     }
 
+    get origin(): string {
+        return `${this.httpScheme}//${this.host}`;
+    }
+
     protected get port(): string {
         return this.getSearchParam('port', '3000');
     }

--- a/packages/plugin-ext/src/plugin/plugin-context.ts
+++ b/packages/plugin-ext/src/plugin/plugin-context.ts
@@ -174,6 +174,8 @@ import { ThemingExtImpl } from './theming';
 import { CommentsExtImpl } from './comments';
 import { CustomEditorsExtImpl } from './custom-editors';
 import { WebviewViewsExtImpl } from './webview-views';
+import { PluginPackage } from '../common';
+import { Endpoint } from '@theia/core/lib/browser/endpoint';
 
 export function createAPIFactory(
     rpc: RPCProtocol,
@@ -1040,9 +1042,15 @@ export class Plugin<T> implements theia.Plugin<T> {
     constructor(protected readonly pluginManager: PluginManager, plugin: InternalPlugin) {
         this.id = plugin.model.id;
         this.pluginPath = plugin.pluginFolder;
-        this.pluginUri = URI.parse(plugin.pluginUri);
         this.packageJSON = plugin.rawModel;
         this.pluginType = plugin.model.entryPoint.frontend ? 'frontend' : 'backend';
+
+        if (this.pluginType === 'frontend') {
+            const { origin } = new Endpoint();
+            this.pluginUri = URI.parse(origin + '/' + PluginPackage.toPluginUrl(plugin.model, ''));
+        } else {
+            this.pluginUri = URI.parse(plugin.pluginUri);
+        }
     }
 
     get isActive(): boolean {

--- a/packages/plugin-ext/src/plugin/plugin-manager.ts
+++ b/packages/plugin-ext/src/plugin/plugin-manager.ts
@@ -370,9 +370,10 @@ export class PluginManagerExtImpl implements PluginManagerExt, PluginManager {
         const storagePath = configStorage.hostStoragePath ? join(configStorage.hostStoragePath, plugin.model.id) : undefined;
         const secrets = new SecretStorageExt(plugin, this.secrets);
         const globalStoragePath = join(configStorage.hostGlobalStoragePath, plugin.model.id);
+        const extension = new PluginExt(this, plugin);
         const pluginContext: theia.PluginContext = {
-            extensionPath: plugin.pluginFolder,
-            extensionUri: Uri.file(plugin.pluginFolder),
+            extensionPath: extension.extensionPath,
+            extensionUri: extension.extensionUri,
             globalState: new GlobalState(plugin.model.id, true, this.storageProxy),
             workspaceState: new Memento(plugin.model.id, false, this.storageProxy),
             subscriptions: subscriptions,
@@ -385,7 +386,7 @@ export class PluginManagerExtImpl implements PluginManagerExt, PluginManager {
             globalStorageUri: Uri.file(globalStoragePath),
             environmentVariableCollection: this.terminalService.getEnvironmentVariableCollection(plugin.model.id),
             extensionMode: 1, // @todo: implement proper `extensionMode`.
-            extension: new PluginExt(this, plugin),
+            extension,
             logUri: Uri.file(logPath)
         };
         this.pluginContextsMap.set(plugin.model.id, pluginContext);


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

Depends on https://github.com/eclipse-theia/theia/pull/10721.

The `extensionContext.extensionUri` was incorrectly returning a `file` schemed Uri for frontend modules.
This meant loading assets based on `context.extensionUri` wasn't possible (and breaks some loading in VS Code web extensions)

This PR ensures `extensionUri` is correctly formed based on the type of module.

It also updates the `pluginContext` to use the underlying `plugin` `extensionPath` and `extensionUri` fields rather than recalculating them. 

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

Create a frontend module (VS Code web extension or Theia frontend plugin) and inspect the `context.extensionUri`;

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
