### PR TITLE
repo: fix typedoc config

### DIFF
--- a/configs/typedoc.json
+++ b/configs/typedoc.json
@@ -1,9 +1,9 @@
 {
   "emit": false,
   "exclude": [
-    "+(dev-packages|examples|typings|scripts)",
-    "packages/*/lib",
-    "**/node_modules",
+    "../+(dev-packages|examples|typings|scripts)/**",
+    "../packages/*/lib/**",
+    "**/node_modules/**",
     "**/*spec.ts"
   ],
   "excludeExternals": true,
@@ -11,6 +11,6 @@
   "hideGenerator": true,
   "name": "Theia TypeDoc",
   "out": "gh-pages/docs/next",
-  "readme": "README.md",
+  "readme": "../README.md",
   "entryPointStrategy": "expand"
 }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

Fixes: #10727

The pull-request fixes some breaking changes from typedoc in 0.22.0, namely how excluded paths should be resolved relative to the config file and not relative to the current  working directory.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

1 .perform yarn on the repo
2. increase the memory limit - `export NODE_OPTIONS=--max-old-space-size=8196`
3. execute the script - yarn docs
4. the script should no longer hang and terminate

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

Signed-off-by: vince-fugnitto <vincent.fugnitto@ericsson.com>