### PR TITLE
#10696 Complete createStatusBarItem in window namespace from VSCode API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - [core] Removed method `attachGlobalShortcuts` from `ElectronMainApplication`. Attaching shortcuts in that way interfered with internal shortcuts. Use internal keybindings instead of global shortcuts. [#10704](https://github.com/eclipse-theia/theia/pull/10704)
 - [plugin-ext] function `logMeasurement` of `PluginDeployerImpl` class and browser class `HostedPluginSupport` is replaced by `measure` using the new `Stopwatch` API [#10407](https://github.com/eclipse-theia/theia/pull/10407)
 - [plugin-ext] the constructor of `BackendApplication` class no longer invokes the `initialize` method. Instead, the `@postConstruct configure` method now starts by calling `initialize` [#10407](https://github.com/eclipse-theia/theia/pull/10407)
+- [plugin] Added support for `vscode.window.createStatusBarItem` [#10754](https://github.com/eclipse-theia/theia/pull/10754) - Contributed on behalf of STMicroelectronics
 
 ## v1.22.0 - 1/27/2022
 

--- a/packages/plugin-ext/src/plugin/plugin-context.ts
+++ b/packages/plugin-ext/src/plugin/plugin-context.ts
@@ -413,8 +413,22 @@ export function createAPIFactory(
             showInputBox(options?: theia.InputBoxOptions, token?: theia.CancellationToken): PromiseLike<string | undefined> {
                 return quickOpenExt.showInput(options, token);
             },
-            createStatusBarItem(alignment?: theia.StatusBarAlignment, priority?: number): theia.StatusBarItem {
-                return statusBarMessageRegistryExt.createStatusBarItem(alignment, priority);
+            createStatusBarItem(alignmentOrId?: theia.StatusBarAlignment | string, priorityOrAlignment?: number | theia.StatusBarAlignment,
+                priorityArg?: number): theia.StatusBarItem {
+                let id: string | undefined;
+                let alignment: number | undefined;
+                let priority: number | undefined;
+
+                if (typeof alignmentOrId === 'string') {
+                    id = alignmentOrId;
+                    alignment = priorityOrAlignment;
+                    priority = priorityArg;
+                } else {
+                    alignment = alignmentOrId;
+                    priority = priorityOrAlignment;
+                }
+
+                return statusBarMessageRegistryExt.createStatusBarItem(alignment, priority, id);
             },
             createOutputChannel(name: string): theia.OutputChannel {
                 return outputChannelRegistryExt.createOutputChannel(name, pluginToPluginInfo(plugin));

--- a/packages/plugin-ext/src/plugin/status-bar-message-registry.ts
+++ b/packages/plugin-ext/src/plugin/status-bar-message-registry.ts
@@ -57,9 +57,10 @@ export class StatusBarMessageRegistryExt {
 
     }
 
-    createStatusBarItem(alignment?: StatusBarAlignment, priority?: number): StatusBarItem {
-        return new StatusBarItemImpl(this.proxy, alignment, priority);
+    createStatusBarItem(alignment?: StatusBarAlignment, priority?: number, id?: string): StatusBarItem {
+        return new StatusBarItemImpl(this.proxy, alignment, priority, id);
     }
+
 }
 
 // copied from https://github.com/Microsoft/vscode/blob/6c8f02b41db9ae5c4d15df767d47755e5c73b9d5/src/vs/workbench/api/node/extHostStatusBar.ts#L122

--- a/packages/plugin-ext/src/plugin/status-bar/status-bar-item.ts
+++ b/packages/plugin-ext/src/plugin/status-bar/status-bar-item.ts
@@ -20,7 +20,7 @@ import { UUID } from '@theia/core/shared/@phosphor/coreutils';
 
 export class StatusBarItemImpl implements theia.StatusBarItem {
 
-    private readonly id = StatusBarItemImpl.nextId();
+    private _id: string;
 
     private _alignment: StatusBarAlignment;
     private _priority: number;
@@ -37,10 +37,16 @@ export class StatusBarItemImpl implements theia.StatusBarItem {
 
     constructor(_proxy: StatusBarMessageRegistryMain,
         alignment: StatusBarAlignment = StatusBarAlignment.Left,
-        priority: number = 0) {
+        priority: number = 0,
+        id = StatusBarItemImpl.nextId()) {
         this._proxy = _proxy;
         this._alignment = alignment;
         this._priority = priority;
+        this._id = id;
+    }
+
+    public get id(): string {
+        return this._id;
     }
 
     public get alignment(): theia.StatusBarAlignment {

--- a/packages/plugin/src/theia.d.ts
+++ b/packages/plugin/src/theia.d.ts
@@ -4553,13 +4553,23 @@ export module '@theia/plugin' {
         export function setStatusBarMessage(text: string, hideWhenDone: PromiseLike<any>): Disposable;
 
         /**
-         * Creates a status bar [item](#StatusBarItem).
+         * Creates a status bar {@link StatusBarItem item}.
          *
          * @param alignment The alignment of the item.
          * @param priority The priority of the item. Higher values mean the item should be shown more to the left.
          * @return A new status bar item.
          */
         export function createStatusBarItem(alignment?: StatusBarAlignment, priority?: number): StatusBarItem;
+
+        /**
+         * Creates a status bar {@link StatusBarItem item}.
+         *
+         * @param id The unique identifier of the item.
+         * @param alignment The alignment of the item.
+         * @param priority The priority of the item. Higher values mean the item should be shown more to the left.
+         * @return A new status bar item.
+         */
+        export function createStatusBarItem(id: string, alignment?: StatusBarAlignment, priority?: number): StatusBarItem;
 
         /**
          * Create a new [output channel](#OutputChannel) with the given name.


### PR DESCRIPTION
#### What it does

This PR adds the missing createStatusBarItem overload in window namespace from VSCode API
- Add createStatusBarItem overload in theia.d.ts to allow an item id as argument
- Extend createStatusBarItem implementation in plugin-context
- Adapt createStatusBarItem in status-bar-message-registry
- Adapat StatusBarItemImpl to accept external ids

Contributed on behalf of STMicroelectronics

Signed-off-by: Nina Doschek <ndoschek@eclipsesource.com>

Fixes #10696

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

1. Start the Theia browser example (which includes the `vscode-builtin-json` extension)
2. Add a JSON file to your workspace that produces a schema resolution error. E.g. this snippet:
```json
{
    "$schema": "http://invalid-schema-url"
}
```
3. The extension should still add a status bar item (warning symbol) with the title `Unable to resolve schema. Click to retry.` on the right area of the Theia status bar.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
