### PR TITLE
typedoc: fix `out` directory

### DIFF
--- a/configs/typedoc.json
+++ b/configs/typedoc.json
@@ -10,7 +10,7 @@
   "external-modulemap": ".*\/packages\/([\\w\\-_]+)\/",
   "hideGenerator": true,
   "name": "Theia TypeDoc",
-  "out": "gh-pages/docs/next",
+  "out": "../gh-pages/docs/next",
   "readme": "../README.md",
   "entryPointStrategy": "expand"
 }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

Fixes: #10758 

Due to typedoc `0.22.x` changes, the config `typedoc.json` configurations should be relative to the config and not the cwd anymore.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

- the generation of typedoc should have `gh-pages` under the root directory and not under `configs/` (same as for previous releases)

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

Signed-off-by: vince-fugnitto <vincent.fugnitto@ericsson.com>

