### PR TITLE
debug: fix `debuggingForeground` theming

### DIFF
--- a/packages/debug/src/browser/style/index.css
+++ b/packages/debug/src/browser/style/index.css
@@ -421,8 +421,11 @@
 /* Status Bar */
 .theia-mod-debugging #theia-statusBar {
     background: var(--theia-statusBar-debuggingBackground);
-    color: var(--theia-statusBar-debuggingForeground);
     border-top: var(--theia-border-width) solid var(--theia-statusBar-debuggingBorder);
+}
+
+.theia-mod-debugging #theia-statusBar .area .element {
+    color: var(--theia-statusBar-debuggingForeground);
 }
 
 /** Exception Widget */


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

Closes: https://github.com/eclipse-theia/theia/pull/10430.

The pull-request fixes the `debuggingForeground` theming when a debug session is started and a theme defines a custom foreground color. Previously the custom color would not apply.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

1. consume https://github.com/vince-fugnitto/vscode-debug-theme/releases/download/v0.0.1/theme-debug-0.0.1.vsix in your application - the extension contributes a theme which sets the foreground color to blue when debugging
2. start the application
3. confirm that during a debug session the styling of the toolbar is correct
4. set the theme to `Theme: Debug Test`
5. confirm that during a debug session the foreground color of the statusbar is blue

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
