### PR TITLE
core: update default loading animation

### DIFF
--- a/packages/core/src/browser/style/index.css
+++ b/packages/core/src/browser/style/index.css
@@ -99,12 +99,30 @@ blockquote {
   bottom: 0;
   z-index: 50000;
   background: var(--theia-editor-background);
-  background-image: var(--theia-preloader);
   background-size: 60px 60px;
   background-repeat: no-repeat;
   background-attachment: fixed;
   background-position: center;
   transition: opacity 0.8s;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
+.theia-preload::after {
+  animation: 1s theia-preload-rotate infinite;
+  color: #777; /* color works on both light and dark themes */
+  content: "\eb19"; /* codicon-load */
+  font: normal normal normal 72px/1 codicon;
+}
+
+@keyframes theia-preload-rotate {
+  0% {
+    transform: rotate(0deg);
+  }
+  100% {
+    transform: rotate(360deg);
+  }
 }
 
 .theia-preload.theia-hidden {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

Fixes: https://github.com/eclipse-theia/theia/issues/6463.
Closes: https://github.com/eclipse-theia/theia/pull/7513.

The pull-request updates the default loading animation on startup to instead use the existing `codicon` icon for consistency with the rest of the framework. 

The pull-request contains the minimal changes from #7513 without the need to replace the existing icon, or preload template not to break downstream applications.


https://user-images.githubusercontent.com/40359487/154357336-be912ec7-0e24-4013-a574-adde067a65ee.mov


#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

1. build the example-browser or example-electron application
2. start the application - the new codicon icon should be used
3. verify the changes with different themes - both light and dark

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)


Signed-off-by: vince-fugnitto <vincent.fugnitto@ericsson.com>
Co-authored-by: Dmitry Sharshakov <d3dx12.xx@gmail.com>