### PR TITLE
Make preference node rendering customizable and provide file selection

### DIFF
--- a/packages/core/src/common/preferences/preference-schema.ts
+++ b/packages/core/src/common/preferences/preference-schema.ts
@@ -84,6 +84,7 @@ export interface PreferenceDataProperty extends PreferenceItem {
     description?: string;
     markdownDescription?: string;
     scope?: PreferenceScope;
+    typeDetails?: any;
 }
 export namespace PreferenceDataProperty {
     export function fromPreferenceSchemaProperty(schemaProps: PreferenceSchemaProperty, defaultScope: PreferenceScope = PreferenceScope.Workspace): PreferenceDataProperty {

--- a/packages/external-terminal/src/electron-browser/external-terminal-preference.ts
+++ b/packages/external-terminal/src/electron-browser/external-terminal-preference.ts
@@ -87,6 +87,7 @@ export async function getExternalTerminalSchema(externalTerminalService: Externa
         properties: {
             'terminal.external.windowsExec': {
                 type: 'string',
+                typeDetails: { isFilepath: true },
                 description: nls.localizeByDefault('Customizes which terminal to run on Windows.'),
                 default: `${isWindows ? hostExec : 'C:\\WINDOWS\\System32\\cmd.exe'}`
             },

--- a/packages/preferences/src/browser/style/index.css
+++ b/packages/preferences/src/browser/style/index.css
@@ -28,6 +28,7 @@
 
 @import url("./preference-context-menu.css");
 @import url("./preference-array.css");
+@import url("./preference-file.css");
 @import url("./preference-object.css");
 @import url("./search-input.css");
 

--- a/packages/preferences/src/browser/style/preference-file.css
+++ b/packages/preferences/src/browser/style/preference-file.css
@@ -1,0 +1,32 @@
+/********************************************************************************
+ * Copyright (C) 2022 EclipseSource and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+.theia-settings-container .preference-file-container {
+  position: relative;
+  display: flex;
+  align-items: center;
+}
+
+.theia-settings-container .preference-file-input {
+  flex: 1;
+  padding-right: 4px;
+}
+
+.theia-settings-container .preference-file-button {
+  position: absolute;
+  padding: 2px 9px;
+  right: 4px;
+}

--- a/packages/preferences/src/browser/util/preference-types.ts
+++ b/packages/preferences/src/browser/util/preference-types.ts
@@ -21,6 +21,7 @@ import {
     CompositeTreeNode as BaseCompositeTreeNode,
     PreferenceInspection,
     CommonCommands,
+    JsonType,
 } from '@theia/core/lib/browser';
 import { Command, MenuPath } from '@theia/core';
 import { JSONValue } from '@theia/core/shared/@phosphor/coreutils';
@@ -69,6 +70,10 @@ export namespace Preference {
 
     export namespace LeafNode {
         export const is = (node: BaseTreeNode | LeafNode): node is LeafNode => 'preference' in node && !!node.preference.data;
+
+        export const getType = (node: BaseTreeNode | LeafNode): JsonType | undefined => is(node)
+            ? Array.isArray(node.preference.data.type) ? node.preference.data.type[0] : node.preference.data.type
+            : undefined;
     }
 
     export const getValueInScope = <T extends JSONValue>(preferenceInfo: PreferenceInspection<T> | undefined, scope: number): T | undefined => {

--- a/packages/preferences/src/browser/views/components/preference-array-input.ts
+++ b/packages/preferences/src/browser/views/components/preference-array-input.ts
@@ -15,8 +15,11 @@
 // *****************************************************************************
 
 import { codiconArray } from '@theia/core/lib/browser';
-import { injectable } from '@theia/core/shared/inversify';
-import { PreferenceLeafNodeRenderer } from './preference-node-renderer';
+import { injectable, interfaces } from '@theia/core/shared/inversify';
+import { IJSONSchema } from '@theia/core/lib/common/json-schema';
+import { Preference } from '../../util/preference-types';
+import { PreferenceLeafNodeRenderer, PreferenceNodeRenderer } from './preference-node-renderer';
+import { PreferenceLeafNodeRendererContribution } from './preference-node-renderer-creator';
 
 @injectable()
 export class PreferenceArrayInputRenderer extends PreferenceLeafNodeRenderer<string[], HTMLInputElement> {
@@ -152,5 +155,20 @@ export class PreferenceArrayInputRenderer extends PreferenceLeafNodeRenderer<str
     override dispose(): void {
         this.existingValues.clear();
         super.dispose();
+    }
+}
+
+@injectable()
+export class PreferenceArrayInputRendererContribution extends PreferenceLeafNodeRendererContribution {
+    static ID = 'preference-array-input-renderer';
+    id = PreferenceArrayInputRendererContribution.ID;
+
+    canHandleLeafNode(node: Preference.LeafNode): number {
+        const type = Preference.LeafNode.getType(node);
+        return type === 'array' && (node.preference.data.items as IJSONSchema)?.type === 'string' ? 2 : 0;
+    }
+
+    createLeafNodeRenderer(container: interfaces.Container): PreferenceNodeRenderer {
+        return container.get(PreferenceArrayInputRenderer);
     }
 }

--- a/packages/preferences/src/browser/views/components/preference-boolean-input.ts
+++ b/packages/preferences/src/browser/views/components/preference-boolean-input.ts
@@ -14,8 +14,10 @@
 // SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
 // *****************************************************************************
 
-import { injectable } from '@theia/core/shared/inversify';
-import { PreferenceLeafNodeRenderer } from './preference-node-renderer';
+import { injectable, interfaces } from '@theia/core/shared/inversify';
+import { Preference } from '../../util/preference-types';
+import { PreferenceLeafNodeRenderer, PreferenceNodeRenderer } from './preference-node-renderer';
+import { PreferenceLeafNodeRendererContribution } from './preference-node-renderer-creator';
 
 @injectable()
 export class PreferenceBooleanInputRenderer extends PreferenceLeafNodeRenderer<boolean, HTMLInputElement> {
@@ -49,5 +51,19 @@ export class PreferenceBooleanInputRenderer extends PreferenceLeafNodeRenderer<b
         if (newValue !== currentValue && document.activeElement !== this.interactable) {
             this.interactable.checked = newValue;
         }
+    }
+}
+
+@injectable()
+export class PreferenceBooleanInputRendererContribution extends PreferenceLeafNodeRendererContribution {
+    static ID = 'preference-boolean-input-renderer';
+    id = PreferenceBooleanInputRendererContribution.ID;
+
+    canHandleLeafNode(node: Preference.LeafNode): number {
+        return Preference.LeafNode.getType(node) === 'boolean' ? 2 : 0;
+    }
+
+    createLeafNodeRenderer(container: interfaces.Container): PreferenceNodeRenderer {
+        return container.get(PreferenceBooleanInputRenderer);
     }
 }

--- a/packages/preferences/src/browser/views/components/preference-file-input.ts
+++ b/packages/preferences/src/browser/views/components/preference-file-input.ts
@@ -1,0 +1,104 @@
+// *****************************************************************************
+// Copyright (C) 2022 EclipseSource and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { nls } from '@theia/core/lib/common/nls';
+import { inject, injectable, interfaces } from '@theia/core/shared/inversify';
+import { OpenFileDialogProps } from '@theia/filesystem/lib/browser';
+import { FileDialogService } from '@theia/filesystem/lib/browser/file-dialog/file-dialog-service';
+import { WorkspaceCommands } from '@theia/workspace/lib/browser';
+import { Preference } from '../../util/preference-types';
+import { PreferenceNodeRenderer } from './preference-node-renderer';
+import { PreferenceLeafNodeRendererContribution } from './preference-node-renderer-creator';
+import { PreferenceStringInputRenderer } from './preference-string-input';
+
+export interface FileNodeTypeDetails {
+    isFilepath: boolean;
+    selectionProps?: Partial<OpenFileDialogProps>;
+}
+
+export namespace FileNodeTypeDetails {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    export function is(typeDetails?: any): typeDetails is FileNodeTypeDetails {
+        return !!typeDetails && !!typeDetails.isFilepath;
+    }
+}
+
+@injectable()
+export class PreferenceSingleFilePathInputRendererContribution extends PreferenceLeafNodeRendererContribution {
+    static ID = 'preference-single-file-path-input-renderer';
+    id = PreferenceSingleFilePathInputRendererContribution.ID;
+
+    canHandleLeafNode(node: Preference.LeafNode): number {
+        const typeDetails = node.preference.data.typeDetails;
+        return FileNodeTypeDetails.is(typeDetails) && !typeDetails.selectionProps?.canSelectMany ? 5 : 0;
+    }
+
+    createLeafNodeRenderer(container: interfaces.Container): PreferenceNodeRenderer {
+        return container.get(PreferenceSingleFilePathInputRenderer);
+    }
+}
+
+@injectable()
+export class PreferenceSingleFilePathInputRenderer extends PreferenceStringInputRenderer {
+    @inject(FileDialogService) fileDialogService: FileDialogService;
+
+    get typeDetails(): FileNodeTypeDetails {
+        return this.preferenceNode.preference.data.typeDetails as FileNodeTypeDetails;
+    }
+
+    protected createInputWrapper(): HTMLElement {
+        const inputWrapper = document.createElement('div');
+        inputWrapper.classList.add('preference-file-container');
+        return inputWrapper;
+    }
+
+    protected override createInteractable(parent: HTMLElement): void {
+        const inputWrapper = this.createInputWrapper();
+
+        super.createInteractable(inputWrapper);
+        this.interactable.classList.add('preference-file-input');
+
+        this.createBrowseButton(inputWrapper);
+
+        parent.appendChild(inputWrapper);
+    }
+
+    protected createBrowseButton(parent: HTMLElement): void {
+        const button = document.createElement('button');
+        button.classList.add('theia-button', 'main', 'preference-file-button');
+        button.textContent = nls.localize('theia/core/file/browse', 'Browse');
+        const handler = this.browse.bind(this);
+        button.onclick = handler;
+        button.onkeydown = handler;
+        button.tabIndex = 0;
+        button.setAttribute('aria-label', 'Submit Preference Input');
+        parent.appendChild(button);
+    }
+
+    protected async browse(): Promise<void> {
+        const selectionProps = this.typeDetails.selectionProps;
+        const title = selectionProps?.title ?? selectionProps?.canSelectFolders ? WorkspaceCommands.OPEN_FOLDER.dialogLabel : WorkspaceCommands.OPEN_FILE.dialogLabel;
+        const selection = await this.fileDialogService.showOpenDialog({ title, ...selectionProps });
+        if (selection) {
+            this.setPreferenceImmediately(selection.path.toString());
+        }
+    }
+
+    protected override setPreferenceImmediately(value: string): Promise<void> {
+        this.interactable.value = value;
+        return super.setPreferenceImmediately(value);
+    }
+}

--- a/packages/preferences/src/browser/views/components/preference-json-input.ts
+++ b/packages/preferences/src/browser/views/components/preference-json-input.ts
@@ -14,11 +14,12 @@
 // SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
 // *****************************************************************************
 
-import { PreferenceLeafNodeRenderer } from './preference-node-renderer';
-import { injectable, inject } from '@theia/core/shared/inversify';
+import { PreferenceLeafNodeRenderer, PreferenceNodeRenderer } from './preference-node-renderer';
+import { injectable, inject, interfaces } from '@theia/core/shared/inversify';
 import { CommandService, nls } from '@theia/core/lib/common';
-import { PreferencesCommands } from '../../util/preference-types';
+import { Preference, PreferencesCommands } from '../../util/preference-types';
 import { JSONValue } from '@theia/core/shared/@phosphor/coreutils';
+import { PreferenceLeafNodeRendererContribution } from './preference-node-renderer-creator';
 
 @injectable()
 export class PreferenceJSONLinkRenderer extends PreferenceLeafNodeRenderer<JSONValue, HTMLAnchorElement> {
@@ -59,5 +60,19 @@ export class PreferenceJSONLinkRenderer extends PreferenceLeafNodeRenderer<JSONV
 
     protected handleUserInteraction(): void {
         this.commandService.executeCommand(PreferencesCommands.OPEN_PREFERENCES_JSON_TOOLBAR.id, this.id);
+    }
+}
+
+@injectable()
+export class PreferenceJSONLinkRendererContribution extends PreferenceLeafNodeRendererContribution {
+    static ID = 'preference-json-link-renderer';
+    id = PreferenceJSONLinkRendererContribution.ID;
+
+    canHandleLeafNode(_node: Preference.LeafNode): number {
+        return 1;
+    }
+
+    createLeafNodeRenderer(container: interfaces.Container): PreferenceNodeRenderer {
+        return container.get(PreferenceJSONLinkRenderer);
     }
 }

--- a/packages/preferences/src/browser/views/components/preference-node-renderer-creator.ts
+++ b/packages/preferences/src/browser/views/components/preference-node-renderer-creator.ts
@@ -1,0 +1,121 @@
+// *****************************************************************************
+// Copyright (C) 2022 EclipseSource and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { ContributionProvider, Disposable, Emitter, Event, Prioritizeable } from '@theia/core';
+import { inject, injectable, interfaces, named } from '@theia/core/shared/inversify';
+import { Preference } from '../../util/preference-types';
+import { PreferenceNodeRenderer } from './preference-node-renderer';
+
+export const PreferenceNodeRendererCreatorRegistry = Symbol('PreferenceNodeRendererCreatorRegistry');
+export interface PreferenceNodeRendererCreatorRegistry {
+    registerPreferenceNodeRendererCreator(creator: PreferenceNodeRendererCreator): Disposable;
+    unregisterPreferenceNodeRendererCreator(creator: PreferenceNodeRendererCreator): void;
+    getPreferenceNodeRendererCreator(node: Preference.TreeNode): PreferenceNodeRendererCreator;
+    onDidChange: Event<void>;
+}
+
+export const PreferenceNodeRendererContribution = Symbol('PreferenceNodeRendererContribution');
+export interface PreferenceNodeRendererContribution {
+    registerPreferenceNodeRendererCreator(registry: PreferenceNodeRendererCreatorRegistry): void;
+}
+
+export const PreferenceNodeRendererCreator = Symbol('PreferenceNodeRendererCreator');
+export interface PreferenceNodeRendererCreator {
+    id: string;
+    canHandle(node: Preference.TreeNode): number;
+    createRenderer(node: Preference.TreeNode, container: interfaces.Container): PreferenceNodeRenderer;
+}
+
+@injectable()
+export class DefaultPreferenceNodeRendererCreatorRegistry implements PreferenceNodeRendererCreatorRegistry {
+    protected readonly _creators: Map<string, PreferenceNodeRendererCreator> = new Map<string, PreferenceNodeRendererCreator>();
+    protected readonly onDidChangeEmitter = new Emitter<void>();
+    readonly onDidChange = this.onDidChangeEmitter.event;
+
+    constructor(
+        @inject(ContributionProvider) @named(PreferenceNodeRendererContribution)
+        protected readonly contributionProvider: ContributionProvider<PreferenceNodeRendererContribution>
+    ) {
+        const contributions = this.contributionProvider.getContributions();
+        for (const contrib of contributions) {
+            contrib.registerPreferenceNodeRendererCreator(this);
+        }
+    }
+
+    registerPreferenceNodeRendererCreator(creator: PreferenceNodeRendererCreator): Disposable {
+        if (this._creators.has(creator.id)) {
+            console.warn(`A preference node renderer creator ${creator.id} is already registered.`);
+            return Disposable.NULL;
+        }
+        this._creators.set(creator.id, creator);
+        this.fireDidChange();
+        return Disposable.create(() => this._creators.delete(creator.id));
+    }
+
+    unregisterPreferenceNodeRendererCreator(creator: PreferenceNodeRendererCreator | string): void {
+        const id = typeof creator === 'string' ? creator : creator.id;
+        if (this._creators.delete(id)) {
+            this.fireDidChange();
+        }
+    }
+
+    getPreferenceNodeRendererCreator(node: Preference.TreeNode): PreferenceNodeRendererCreator {
+        const contributions = this.prioritize(node);
+        if (contributions.length >= 1) {
+            return contributions[0];
+        }
+        // we already bind a default creator contribution so if that happens it was deliberate
+        throw new Error(`There is no contribution for ${node.id}.`);
+    }
+
+    protected fireDidChange(): void {
+        this.onDidChangeEmitter.fire(undefined);
+    }
+
+    protected prioritize(node: Preference.TreeNode): PreferenceNodeRendererCreator[] {
+        const prioritized = Prioritizeable.prioritizeAllSync(Array.from(this._creators.values()), creator => {
+            try {
+                return creator.canHandle(node);
+            } catch {
+                return 0;
+            }
+        });
+        return prioritized.map(p => p.value);
+    }
+}
+
+@injectable()
+export abstract class PreferenceLeafNodeRendererContribution implements PreferenceNodeRendererCreator, PreferenceNodeRendererContribution {
+    abstract id: string;
+
+    canHandle(node: Preference.TreeNode): number {
+        return Preference.LeafNode.is(node) ? this.canHandleLeafNode(node) : 0;
+    }
+
+    registerPreferenceNodeRendererCreator(registry: PreferenceNodeRendererCreatorRegistry): void {
+        registry.registerPreferenceNodeRendererCreator(this);
+    }
+
+    abstract canHandleLeafNode(node: Preference.LeafNode): number;
+
+    createRenderer(node: Preference.TreeNode, container: interfaces.Container): PreferenceNodeRenderer {
+        const child = container.createChild();
+        child.bind(Preference.Node).toConstantValue(node);
+        return this.createLeafNodeRenderer(child);
+    }
+
+    abstract createLeafNodeRenderer(container: interfaces.Container): PreferenceNodeRenderer;
+}

--- a/packages/preferences/src/browser/views/components/preference-node-renderer.ts
+++ b/packages/preferences/src/browser/views/components/preference-node-renderer.ts
@@ -14,7 +14,7 @@
 // SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
 // *****************************************************************************
 
-import { injectable, inject, postConstruct } from '@theia/core/shared/inversify';
+import { injectable, inject, postConstruct, interfaces } from '@theia/core/shared/inversify';
 import {
     PreferenceService, ContextMenuRenderer, PreferenceInspection,
     PreferenceScope, PreferenceProvider, codicon, OpenerService, open
@@ -30,6 +30,7 @@ import { PreferencesSearchbarWidget } from '../preference-searchbar-widget';
 import * as markdownit from '@theia/core/shared/markdown-it';
 import * as DOMPurify from '@theia/core/shared/dompurify';
 import URI from '@theia/core/lib/common/uri';
+import { PreferenceNodeRendererContribution, PreferenceNodeRendererCreator, PreferenceNodeRendererCreatorRegistry } from './preference-node-renderer-creator';
 
 export const PreferenceNodeRendererFactory = Symbol('PreferenceNodeRendererFactory');
 export type PreferenceNodeRendererFactory = (node: Preference.TreeNode) => PreferenceNodeRenderer;
@@ -148,6 +149,26 @@ export class PreferenceHeaderRenderer extends PreferenceNodeRenderer {
         label.textContent = name;
         wrapper.appendChild(label);
         return wrapper;
+    }
+}
+
+@injectable()
+export class PreferenceHeaderRendererContribution implements PreferenceNodeRendererCreator, PreferenceNodeRendererContribution {
+    static ID = 'preference-header-renderer';
+    id = PreferenceHeaderRendererContribution.ID;
+
+    registerPreferenceNodeRendererCreator(registry: PreferenceNodeRendererCreatorRegistry): void {
+        registry.registerPreferenceNodeRendererCreator(this);
+    }
+
+    canHandle(node: Preference.TreeNode): number {
+        return !Preference.LeafNode.is(node) ? 1 : 0;
+    }
+
+    createRenderer(node: Preference.TreeNode, container: interfaces.Container): PreferenceNodeRenderer {
+        const grandchild = container.createChild();
+        grandchild.bind(Preference.Node).toConstantValue(node);
+        return grandchild.get(PreferenceHeaderRenderer);
     }
 }
 

--- a/packages/preferences/src/browser/views/components/preference-number-input.ts
+++ b/packages/preferences/src/browser/views/components/preference-number-input.ts
@@ -14,8 +14,10 @@
 // SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
 // *****************************************************************************
 
-import { injectable } from '@theia/core/shared/inversify';
-import { PreferenceLeafNodeRenderer } from './preference-node-renderer';
+import { injectable, interfaces } from '@theia/core/shared/inversify';
+import { Preference } from '../../util/preference-types';
+import { PreferenceLeafNodeRenderer, PreferenceNodeRenderer } from './preference-node-renderer';
+import { PreferenceLeafNodeRendererContribution } from './preference-node-renderer-creator';
 
 interface PreferenceNumberInputValidation {
     /**
@@ -124,5 +126,20 @@ export class PreferenceNumberInputRenderer extends PreferenceLeafNodeRenderer<nu
 
     protected hideErrorMessage(): void {
         this.errorMessage.remove();
+    }
+}
+
+@injectable()
+export class PreferenceNumberInputRendererContribution extends PreferenceLeafNodeRendererContribution {
+    static ID = 'preference-number-input-renderer';
+    id = PreferenceNumberInputRendererContribution.ID;
+
+    canHandleLeafNode(node: Preference.LeafNode): number {
+        const type = Preference.LeafNode.getType(node);
+        return type === 'integer' || type === 'number' ? 2 : 0;
+    }
+
+    createLeafNodeRenderer(container: interfaces.Container): PreferenceNodeRenderer {
+        return container.get(PreferenceNumberInputRenderer);
     }
 }

--- a/packages/preferences/src/browser/views/components/preference-select-input.ts
+++ b/packages/preferences/src/browser/views/components/preference-select-input.ts
@@ -14,9 +14,11 @@
 // SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
 // *****************************************************************************
 
-import { PreferenceLeafNodeRenderer } from './preference-node-renderer';
-import { injectable } from '@theia/core/shared/inversify';
+import { PreferenceLeafNodeRenderer, PreferenceNodeRenderer } from './preference-node-renderer';
+import { injectable, interfaces } from '@theia/core/shared/inversify';
 import { JSONValue } from '@theia/core/shared/@phosphor/coreutils';
+import { Preference } from '../../util/preference-types';
+import { PreferenceLeafNodeRendererContribution } from './preference-node-renderer-creator';
 
 @injectable()
 export class PreferenceSelectInputRenderer extends PreferenceLeafNodeRenderer<JSONValue, HTMLSelectElement> {
@@ -67,5 +69,19 @@ export class PreferenceSelectInputRenderer extends PreferenceLeafNodeRenderer<JS
     protected handleUserInteraction(): void {
         const value = this.enumValues[Number(this.interactable.value)];
         this.setPreferenceImmediately(value);
+    }
+}
+
+@injectable()
+export class PreferenceSelectInputRendererContribution extends PreferenceLeafNodeRendererContribution {
+    static ID = 'preference-select-input-renderer';
+    id = PreferenceSelectInputRendererContribution.ID;
+
+    canHandleLeafNode(node: Preference.LeafNode): number {
+        return node.preference.data.enum ? 3 : 0;
+    }
+
+    createLeafNodeRenderer(container: interfaces.Container): PreferenceNodeRenderer {
+        return container.get(PreferenceSelectInputRenderer);
     }
 }

--- a/packages/preferences/src/browser/views/components/preference-string-input.ts
+++ b/packages/preferences/src/browser/views/components/preference-string-input.ts
@@ -14,8 +14,10 @@
 // SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
 // *****************************************************************************
 
-import { injectable } from '@theia/core/shared/inversify';
-import { PreferenceLeafNodeRenderer } from './preference-node-renderer';
+import { injectable, interfaces } from '@theia/core/shared/inversify';
+import { Preference } from '../../util/preference-types';
+import { PreferenceLeafNodeRenderer, PreferenceNodeRenderer } from './preference-node-renderer';
+import { PreferenceLeafNodeRendererContribution } from './preference-node-renderer-creator';
 
 @injectable()
 export class PreferenceStringInputRenderer extends PreferenceLeafNodeRenderer<string, HTMLInputElement> {
@@ -56,5 +58,19 @@ export class PreferenceStringInputRenderer extends PreferenceLeafNodeRenderer<st
     protected async handleBlur(): Promise<void> {
         await this.setPreferenceWithDebounce.flush();
         this.handleValueChange();
+    }
+}
+
+@injectable()
+export class PreferenceStringInputRendererContribution extends PreferenceLeafNodeRendererContribution {
+    static ID = 'preference-string-input-renderer';
+    id = PreferenceStringInputRendererContribution.ID;
+
+    canHandleLeafNode(node: Preference.LeafNode): number {
+        return Preference.LeafNode.getType(node) === 'string' ? 2 : 0;
+    }
+
+    createLeafNodeRenderer(container: interfaces.Container): PreferenceNodeRenderer {
+        return container.get(PreferenceStringInputRenderer);
     }
 }

--- a/packages/terminal/src/browser/terminal-preferences.ts
+++ b/packages/terminal/src/browser/terminal-preferences.ts
@@ -111,6 +111,7 @@ export const TerminalConfigSchema: PreferenceSchema = {
         },
         'terminal.integrated.shell.windows': {
             type: ['string', 'null'],
+            typeDetails: { isFilepath: true },
             markdownDescription: nls.localize('theia/terminal/shellWindows', 'The path of the shell that the terminal uses on Windows. (default: \'{0}\').', 'C:\\Windows\\System32\\cmd.exe'),
             default: undefined
         },


### PR DESCRIPTION
#### What it does
Fixes #10765 

- Introduce preference node render service to support contributions
  - Convert previous renderer factory content to default contribution
  - Let new renderer factory implementation use service
  - Contributions are ranked similar to open handlers

- Provide base for leaf node contributions and render hints

- Implement concrete string renderer for single file selection

#### How to test
- Specify rendering hint in preferences
- Usage Example: Windows terminal (part of the commit but can be removed if unwanted)

![browse](https://user-images.githubusercontent.com/19170971/154459510-dfa63202-a6d8-4299-b00a-a2961102f452.png)

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
