### PR TITLE
Copy/paste not working within folder in Explorer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 
 - [markers] `ProblemDecorator` reimplemented to reduce redundancy and align more closely with VSCode. `collectMarkers` now returns `Map<string, TreeDecoration.Data>`, `getOverlayIconColor` renamed to `getColor`, `getOverlayIcon` removed, `appendContainerMarkers` returns `void`.
 - [core] removed method `attachGlobalShortcuts` from `ElectronMainApplication`. Attaching shortcuts in that way interfered with internal shortcuts. Use internal keybindings instead of global shortcuts [#10869](https://github.com/eclipse-theia/theia/pull/10869)
+- [filesystem] The `generateUniqueResourceURI` method from the `FileSystemUtils` class has an updated signature. Additionally, the method now returns a generated Uri that uses spaces as separators. The naming scheme was also changed to match VSCode. [10767](https://github.com/eclipse-theia/theia/pull/10767)
 
 ## v1.23.0 - 2/24/2022
 

--- a/packages/filesystem/src/browser/file-service.ts
+++ b/packages/filesystem/src/browser/file-service.ts
@@ -1120,8 +1120,8 @@ export class FileService {
         // if target exists get valid target
         if (exists && !overwrite) {
             const parent = await this.resolve(target.parent);
-            const name = isSameResourceWithDifferentPathCase ? target.path.name : target.path.name + '_copy';
-            target = FileSystemUtils.generateUniqueResourceURI(target.parent, parent, name, target.path.ext);
+            const targetFileStat = await this.resolve(target);
+            target = FileSystemUtils.generateUniqueResourceURI(parent, target, targetFileStat.isDirectory, isSameResourceWithDifferentPathCase ? 'copy' : undefined);
         }
 
         // delete as needed (unless target is same resource with different path case)

--- a/packages/filesystem/src/common/filesystem-utils.spec.ts
+++ b/packages/filesystem/src/common/filesystem-utils.spec.ts
@@ -1,0 +1,411 @@
+// *****************************************************************************
+// Copyright (C) 2022 EclipseSource and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { FileSystemUtils } from '.';
+import { FileStat } from './files';
+import { expect } from 'chai';
+
+describe('generateUniqueResourceURI', () => {
+    describe('Target is file', () => {
+        describe('file without extension', () => {
+            it('appends index', () => {
+                const parent = FileStat.dir('parent');
+                const source = FileStat.file('source');
+                parent.children = [source];
+                const result = FileSystemUtils.generateUniqueResourceURI(parent, source.resource, source.isDirectory);
+                expect(result.path.base).to.eq('source 1');
+            });
+            it('appends first available index', () => {
+                const parent = FileStat.dir('parent');
+                const source = FileStat.file('source');
+                parent.children = [source, FileStat.file('source 1'), FileStat.file('source 3')];
+                const result = FileSystemUtils.generateUniqueResourceURI(parent, source.resource, source.isDirectory);
+                expect(result.path.base).to.eq('source 2');
+            });
+
+            it('appends suffix', () => {
+                const parent = FileStat.dir('parent');
+                const source = FileStat.file('source');
+                parent.children = [source];
+                const result = FileSystemUtils.generateUniqueResourceURI(parent, source.resource, source.isDirectory, 'copy');
+                expect(result.path.base).to.eq('source copy');
+            });
+
+            it('appends suffix and index', () => {
+                const parent = FileStat.dir('parent');
+                const source = FileStat.file('source');
+                parent.children = [source, FileStat.file('source copy')];
+                const result = FileSystemUtils.generateUniqueResourceURI(parent, source.resource, source.isDirectory, 'copy');
+                expect(result.path.base).to.eq('source copy 1');
+            });
+
+            it('appends suffix and first available index', () => {
+                const parent = FileStat.dir('parent');
+                const source = FileStat.file('source');
+                parent.children = [source, FileStat.file('source copy'), FileStat.file('source copy 1'), FileStat.file('source copy 3')];
+                const result = FileSystemUtils.generateUniqueResourceURI(parent, source.resource, source.isDirectory, 'copy');
+                expect(result.path.base).to.eq('source copy 2');
+            });
+
+            it('appends only index when source name already contains suffix', () => {
+                const parent = FileStat.dir('parent');
+                const source = FileStat.file('source copy 1');
+                parent.children = [FileStat.file('source'), source, FileStat.file('source copy 2'), FileStat.file('source copy 3')];
+                const result = FileSystemUtils.generateUniqueResourceURI(parent, source.resource, source.isDirectory, 'copy');
+                expect(result.path.base).to.eq('source copy 4');
+            });
+        });
+        describe('file with extension', () => {
+            it('appends index', () => {
+                const parent = FileStat.dir('parent');
+                const source = FileStat.file('source.txt');
+                parent.children = [source];
+                const result = FileSystemUtils.generateUniqueResourceURI(parent, source.resource, source.isDirectory);
+                expect(result.path.base).to.eq('source 1.txt');
+            });
+            it('appends first available index', () => {
+                const parent = FileStat.dir('parent');
+                const source = FileStat.file('source.txt');
+                parent.children = [source, FileStat.file('source 1.txt'), FileStat.file('source 3.txt')];
+                const result = FileSystemUtils.generateUniqueResourceURI(parent, source.resource, source.isDirectory);
+                expect(result.path.base).to.eq('source 2.txt');
+            });
+
+            it('appends suffix', () => {
+                const parent = FileStat.dir('parent');
+                const source = FileStat.file('source.txt');
+                parent.children = [source];
+                const result = FileSystemUtils.generateUniqueResourceURI(parent, source.resource, source.isDirectory, 'copy');
+                expect(result.path.base).to.eq('source copy.txt');
+            });
+
+            it('appends suffix and index', () => {
+                const parent = FileStat.dir('parent');
+                const source = FileStat.file('source.txt');
+                parent.children = [source, FileStat.file('source copy.txt')];
+                const result = FileSystemUtils.generateUniqueResourceURI(parent, source.resource, source.isDirectory, 'copy');
+                expect(result.path.base).to.eq('source copy 1.txt');
+            });
+
+            it('appends suffix and first available index', () => {
+                const parent = FileStat.dir('parent');
+                const source = FileStat.file('source.txt');
+                parent.children = [source, FileStat.file('source copy.txt'), FileStat.file('source copy 1.txt'), FileStat.file('source copy 3.txt')];
+                const result = FileSystemUtils.generateUniqueResourceURI(parent, source.resource, source.isDirectory, 'copy');
+                expect(result.path.base).to.eq('source copy 2.txt');
+            });
+
+            it('appends only index when source name already contains suffix', () => {
+                const parent = FileStat.dir('parent');
+                const source = FileStat.file('source copy 1.txt');
+                parent.children = [FileStat.file('source.txt'), source, FileStat.file('source copy 2.txt'), FileStat.file('source copy 3.txt')];
+                const result = FileSystemUtils.generateUniqueResourceURI(parent, source.resource, source.isDirectory, 'copy');
+                expect(result.path.base).to.eq('source copy 4.txt');
+            });
+        });
+        describe('dotfile without extension', () => {
+            it('appends index', () => {
+                const parent = FileStat.dir('parent');
+                const source = FileStat.file('.source');
+                parent.children = [source];
+                const result = FileSystemUtils.generateUniqueResourceURI(parent, source.resource, source.isDirectory);
+                expect(result.path.base).to.eq('.source 1');
+            });
+            it('appends first available index', () => {
+                const parent = FileStat.dir('parent');
+                const source = FileStat.file('.source');
+                parent.children = [source, FileStat.file('.source 1'), FileStat.file('.source 3')];
+                const result = FileSystemUtils.generateUniqueResourceURI(parent, source.resource, source.isDirectory);
+                expect(result.path.base).to.eq('.source 2');
+            });
+
+            it('appends suffix', () => {
+                const parent = FileStat.dir('parent');
+                const source = FileStat.file('.source');
+                parent.children = [source];
+                const result = FileSystemUtils.generateUniqueResourceURI(parent, source.resource, source.isDirectory, 'copy');
+                expect(result.path.base).to.eq('.source copy');
+            });
+
+            it('appends suffix and index', () => {
+                const parent = FileStat.dir('parent');
+                const source = FileStat.file('.source');
+                parent.children = [source, FileStat.file('.source copy')];
+                const result = FileSystemUtils.generateUniqueResourceURI(parent, source.resource, source.isDirectory, 'copy');
+                expect(result.path.base).to.eq('.source copy 1');
+            });
+
+            it('appends suffix and first available index', () => {
+                const parent = FileStat.dir('parent');
+                const source = FileStat.file('.source');
+                parent.children = [source, FileStat.file('.source copy'), FileStat.file('.source copy 1'), FileStat.file('.source copy 3')];
+                const result = FileSystemUtils.generateUniqueResourceURI(parent, source.resource, source.isDirectory, 'copy');
+                expect(result.path.base).to.eq('.source copy 2');
+            });
+
+            it('appends only index when source name already contains suffix', () => {
+                const parent = FileStat.dir('parent');
+                const source = FileStat.file('.source copy 1');
+                parent.children = [FileStat.file('.source'), source, FileStat.file('.source copy 2'), FileStat.file('.source copy 3')];
+                const result = FileSystemUtils.generateUniqueResourceURI(parent, source.resource, source.isDirectory, 'copy');
+                expect(result.path.base).to.eq('.source copy 4');
+            });
+        });
+        describe('dotfile with extension', () => {
+            it('appends index', () => {
+                const parent = FileStat.dir('parent');
+                const source = FileStat.file('.source.txt');
+                parent.children = [source];
+                const result = FileSystemUtils.generateUniqueResourceURI(parent, source.resource, source.isDirectory);
+                expect(result.path.base).to.eq('.source 1.txt');
+            });
+            it('appends first available index', () => {
+                const parent = FileStat.dir('parent');
+                const source = FileStat.file('.source.txt');
+                parent.children = [source, FileStat.file('.source 1.txt'), FileStat.file('.source 3.txt')];
+                const result = FileSystemUtils.generateUniqueResourceURI(parent, source.resource, source.isDirectory);
+                expect(result.path.base).to.eq('.source 2.txt');
+            });
+
+            it('appends suffix', () => {
+                const parent = FileStat.dir('parent');
+                const source = FileStat.file('.source.txt');
+                parent.children = [source];
+                const result = FileSystemUtils.generateUniqueResourceURI(parent, source.resource, source.isDirectory, 'copy');
+                expect(result.path.base).to.eq('.source copy.txt');
+            });
+
+            it('appends suffix and index', () => {
+                const parent = FileStat.dir('parent');
+                const source = FileStat.file('.source.txt');
+                parent.children = [source, FileStat.file('.source copy.txt')];
+                const result = FileSystemUtils.generateUniqueResourceURI(parent, source.resource, source.isDirectory, 'copy');
+                expect(result.path.base).to.eq('.source copy 1.txt');
+            });
+
+            it('appends suffix and first available index', () => {
+                const parent = FileStat.dir('parent');
+                const source = FileStat.file('.source.txt');
+                parent.children = [source, FileStat.file('.source copy.txt'), FileStat.file('.source copy 1.txt'), FileStat.file('.source copy 3.txt')];
+                const result = FileSystemUtils.generateUniqueResourceURI(parent, source.resource, source.isDirectory, 'copy');
+                expect(result.path.base).to.eq('.source copy 2.txt');
+            });
+
+            it('appends only index when source name already contains suffix', () => {
+                const parent = FileStat.dir('parent');
+                const source = FileStat.file('.source copy 1.txt');
+                parent.children = [FileStat.file('.source.txt'), source, FileStat.file('.source copy 2.txt'), FileStat.file('.source copy 3.txt')];
+                const result = FileSystemUtils.generateUniqueResourceURI(parent, source.resource, source.isDirectory, 'copy');
+                expect(result.path.base).to.eq('.source copy 4.txt');
+            });
+        });
+    });
+
+    describe('Target is directory', () => {
+        describe('directory with path without extension', () => {
+            it('appends index', () => {
+                const parent = FileStat.dir('parent');
+                const source = FileStat.dir('source');
+                parent.children = [source];
+                const result = FileSystemUtils.generateUniqueResourceURI(parent, source.resource, source.isDirectory);
+                expect(result.path.base).to.eq('source 1');
+            });
+            it('appends first available index', () => {
+                const parent = FileStat.dir('parent');
+                const source = FileStat.dir('source');
+                parent.children = [source, FileStat.dir('source 1'), FileStat.dir('source 3')];
+                const result = FileSystemUtils.generateUniqueResourceURI(parent, source.resource, source.isDirectory);
+                expect(result.path.base).to.eq('source 2');
+            });
+
+            it('appends suffix', () => {
+                const parent = FileStat.dir('parent');
+                const source = FileStat.dir('source');
+                parent.children = [source];
+                const result = FileSystemUtils.generateUniqueResourceURI(parent, source.resource, source.isDirectory, 'copy');
+                expect(result.path.base).to.eq('source copy');
+            });
+
+            it('appends suffix and index', () => {
+                const parent = FileStat.dir('parent');
+                const source = FileStat.dir('source');
+                parent.children = [source, FileStat.dir('source copy')];
+                const result = FileSystemUtils.generateUniqueResourceURI(parent, source.resource, source.isDirectory, 'copy');
+                expect(result.path.base).to.eq('source copy 1');
+            });
+
+            it('appends suffix and first available index', () => {
+                const parent = FileStat.dir('parent');
+                const source = FileStat.dir('source');
+                parent.children = [source, FileStat.dir('source copy'), FileStat.dir('source copy 1'), FileStat.dir('source copy 3')];
+                const result = FileSystemUtils.generateUniqueResourceURI(parent, source.resource, source.isDirectory, 'copy');
+                expect(result.path.base).to.eq('source copy 2');
+            });
+
+            it('appends only index when source name already contains suffix', () => {
+                const parent = FileStat.dir('parent');
+                const source = FileStat.dir('source copy 1');
+                parent.children = [FileStat.dir('source'), source, FileStat.dir('source copy 2'), FileStat.dir('source copy 3')];
+                const result = FileSystemUtils.generateUniqueResourceURI(parent, source.resource, source.isDirectory, 'copy');
+                expect(result.path.base).to.eq('source copy 4');
+            });
+        });
+        describe('directory with path with extension', () => {
+            it('appends index', () => {
+                const parent = FileStat.dir('parent');
+                const source = FileStat.dir('source.test');
+                parent.children = [source];
+                const result = FileSystemUtils.generateUniqueResourceURI(parent, source.resource, source.isDirectory);
+                expect(result.path.base).to.eq('source.test 1');
+            });
+            it('appends first available index', () => {
+                const parent = FileStat.dir('parent');
+                const source = FileStat.dir('source.test');
+                parent.children = [source, FileStat.dir('source.test 1'), FileStat.dir('source.test 3')];
+                const result = FileSystemUtils.generateUniqueResourceURI(parent, source.resource, source.isDirectory);
+                expect(result.path.base).to.eq('source.test 2');
+            });
+
+            it('appends suffix', () => {
+                const parent = FileStat.dir('parent');
+                const source = FileStat.dir('source.test');
+                parent.children = [source];
+                const result = FileSystemUtils.generateUniqueResourceURI(parent, source.resource, source.isDirectory, 'copy');
+                expect(result.path.base).to.eq('source.test copy');
+            });
+
+            it('appends suffix and index', () => {
+                const parent = FileStat.dir('parent');
+                const source = FileStat.dir('source.test');
+                parent.children = [source, FileStat.dir('source.test copy')];
+                const result = FileSystemUtils.generateUniqueResourceURI(parent, source.resource, source.isDirectory, 'copy');
+                expect(result.path.base).to.eq('source.test copy 1');
+            });
+
+            it('appends suffix and first available index', () => {
+                const parent = FileStat.dir('parent');
+                const source = FileStat.dir('source.test');
+                parent.children = [source, FileStat.dir('source.test copy'), FileStat.dir('source.test copy 1'), FileStat.dir('source.test copy 3')];
+                const result = FileSystemUtils.generateUniqueResourceURI(parent, source.resource, source.isDirectory, 'copy');
+                expect(result.path.base).to.eq('source.test copy 2');
+            });
+
+            it('appends only index when source name already contains suffix', () => {
+                const parent = FileStat.dir('parent');
+                const source = FileStat.dir('source.test copy 1');
+                parent.children = [FileStat.dir('source.test'), source, FileStat.dir('source.test copy 2'), FileStat.dir('source.test copy 3')];
+                const result = FileSystemUtils.generateUniqueResourceURI(parent, source.resource, source.isDirectory, 'copy');
+                expect(result.path.base).to.eq('source.test copy 4');
+            });
+        });
+        describe('name starts with . and has path without extension', () => {
+            it('appends index', () => {
+                const parent = FileStat.dir('parent');
+                const source = FileStat.dir('.source');
+                parent.children = [source];
+                const result = FileSystemUtils.generateUniqueResourceURI(parent, source.resource, source.isDirectory);
+                expect(result.path.base).to.eq('.source 1');
+            });
+            it('appends first available index', () => {
+                const parent = FileStat.dir('parent');
+                const source = FileStat.dir('.source');
+                parent.children = [source, FileStat.dir('.source 1'), FileStat.dir('.source 3')];
+                const result = FileSystemUtils.generateUniqueResourceURI(parent, source.resource, source.isDirectory);
+                expect(result.path.base).to.eq('.source 2');
+            });
+
+            it('appends suffix', () => {
+                const parent = FileStat.dir('parent');
+                const source = FileStat.dir('.source');
+                parent.children = [source];
+                const result = FileSystemUtils.generateUniqueResourceURI(parent, source.resource, source.isDirectory, 'copy');
+                expect(result.path.base).to.eq('.source copy');
+            });
+
+            it('appends suffix and index', () => {
+                const parent = FileStat.dir('parent');
+                const source = FileStat.dir('.source');
+                parent.children = [source, FileStat.dir('.source copy')];
+                const result = FileSystemUtils.generateUniqueResourceURI(parent, source.resource, source.isDirectory, 'copy');
+                expect(result.path.base).to.eq('.source copy 1');
+            });
+
+            it('appends suffix and first available index', () => {
+                const parent = FileStat.dir('parent');
+                const source = FileStat.dir('.source');
+                parent.children = [source, FileStat.dir('.source copy'), FileStat.dir('.source copy 1'), FileStat.dir('.source copy 3')];
+                const result = FileSystemUtils.generateUniqueResourceURI(parent, source.resource, source.isDirectory, 'copy');
+                expect(result.path.base).to.eq('.source copy 2');
+            });
+
+            it('appends only index when source name already contains suffix', () => {
+                const parent = FileStat.dir('parent');
+                const source = FileStat.dir('.source copy 1');
+                parent.children = [FileStat.dir('.source'), source, FileStat.dir('.source copy 2'), FileStat.dir('.source copy 3')];
+                const result = FileSystemUtils.generateUniqueResourceURI(parent, source.resource, source.isDirectory, 'copy');
+                expect(result.path.base).to.eq('.source copy 4');
+            });
+        });
+        describe('name starts with . and has path with extension', () => {
+            it('appends index', () => {
+                const parent = FileStat.dir('parent');
+                const source = FileStat.dir('.source.test');
+                parent.children = [source];
+                const result = FileSystemUtils.generateUniqueResourceURI(parent, source.resource, source.isDirectory);
+                expect(result.path.base).to.eq('.source.test 1');
+            });
+            it('appends first available index', () => {
+                const parent = FileStat.dir('parent');
+                const source = FileStat.dir('.source.test');
+                parent.children = [source, FileStat.dir('.source.test 1'), FileStat.dir('.source.test 3')];
+                const result = FileSystemUtils.generateUniqueResourceURI(parent, source.resource, source.isDirectory);
+                expect(result.path.base).to.eq('.source.test 2');
+            });
+
+            it('appends suffix', () => {
+                const parent = FileStat.dir('parent');
+                const source = FileStat.dir('.source.test');
+                parent.children = [source];
+                const result = FileSystemUtils.generateUniqueResourceURI(parent, source.resource, source.isDirectory, 'copy');
+                expect(result.path.base).to.eq('.source.test copy');
+            });
+
+            it('appends suffix and index', () => {
+                const parent = FileStat.dir('parent');
+                const source = FileStat.dir('.source.test');
+                parent.children = [source, FileStat.dir('.source.test copy')];
+                const result = FileSystemUtils.generateUniqueResourceURI(parent, source.resource, source.isDirectory, 'copy');
+                expect(result.path.base).to.eq('.source.test copy 1');
+            });
+
+            it('appends suffix and first available index', () => {
+                const parent = FileStat.dir('parent');
+                const source = FileStat.dir('.source.test');
+                parent.children = [source, FileStat.dir('.source.test copy'), FileStat.dir('.source.test copy 1'), FileStat.dir('.source.test copy 3')];
+                const result = FileSystemUtils.generateUniqueResourceURI(parent, source.resource, source.isDirectory, 'copy');
+                expect(result.path.base).to.eq('.source.test copy 2');
+            });
+
+            it('appends only index when source name already contains suffix', () => {
+                const parent = FileStat.dir('parent');
+                const source = FileStat.dir('.source.test copy 1');
+                parent.children = [FileStat.dir('.source.test'), source, FileStat.dir('.source.test copy 2'), FileStat.dir('.source.test copy 3')];
+                const result = FileSystemUtils.generateUniqueResourceURI(parent, source.resource, source.isDirectory, 'copy');
+                expect(result.path.base).to.eq('.source.test copy 4');
+            });
+        });
+    });
+});

--- a/packages/workspace/src/browser/workspace-commands.ts
+++ b/packages/workspace/src/browser/workspace-commands.ts
@@ -246,7 +246,8 @@ export class WorkspaceCommandContribution implements CommandContribution {
                 if (parent) {
                     const parentUri = parent.resource;
                     const { fileName, fileExtension } = this.getDefaultFileConfig();
-                    const vacantChildUri = FileSystemUtils.generateUniqueResourceURI(parentUri, parent, fileName, fileExtension);
+                    const targetUri = parentUri.resolve(fileName + fileExtension);
+                    const vacantChildUri = FileSystemUtils.generateUniqueResourceURI(parent, targetUri, false);
 
                     const dialog = new WorkspaceInputDialog({
                         title: nls.localizeByDefault('New File'),
@@ -270,7 +271,8 @@ export class WorkspaceCommandContribution implements CommandContribution {
             execute: uri => this.getDirectory(uri).then(parent => {
                 if (parent) {
                     const parentUri = parent.resource;
-                    const vacantChildUri = FileSystemUtils.generateUniqueResourceURI(parentUri, parent, 'Untitled');
+                    const targetUri = parentUri.resolve('Untitled');
+                    const vacantChildUri = FileSystemUtils.generateUniqueResourceURI(parent, targetUri, true);
                     const dialog = new WorkspaceInputDialog({
                         title: nls.localizeByDefault('New Folder'),
                         parentUri: parentUri,

--- a/packages/workspace/src/browser/workspace-duplicate-handler.ts
+++ b/packages/workspace/src/browser/workspace-duplicate-handler.ts
@@ -63,10 +63,8 @@ export class WorkspaceDuplicateHandler implements UriCommandHandler<URI[]> {
         await Promise.all(uris.map(async uri => {
             try {
                 const parent = await this.fileService.resolve(uri.parent);
-                const parentUri = parent.resource;
-                const name = uri.path.name + '_copy';
-                const ext = uri.path.ext;
-                const target = FileSystemUtils.generateUniqueResourceURI(parentUri, parent, name, ext);
+                const targetFileStat = await this.fileService.resolve(uri);
+                const target = FileSystemUtils.generateUniqueResourceURI(parent, uri, targetFileStat.isDirectory, 'copy');
                 await this.fileService.copy(uri, target);
             } catch (e) {
                 console.error(e);


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->
Fixes copy/pasting of a file or folder within the same parent folder in the Explorer, by renaming the target file if the source and target URIs are the same. 
Also changes the naming scheme to use spaces instead of underscores when creating a new file, to align with VS Code and user expectations (e.g. on macOS).

Fixes #9923 

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
##### Testing copy/paste in the same parent folder:
1. Copy a file/folder in the Explorer view
2. Paste in the same folder
3. A copy of the file/folder should be created (its name should be in the form `originalName copy.ext` or 
`originalName copy index.ext`)

##### Testing the name generation of new files:
Several commands were affected by the change in naming for new files/folders. New files/folders should now have spaces instead of underscores in the generated name portion:

1. the **New File** / **New Folder** commands: from the _File_ menu, select _New File_: the name suggestion in the dialog that opens should use spaces, e.g. `Untitled 2.txt`
2. the **Duplicate** command: select a file in the Explorer and select Duplicate from its context menu: a copy of the file is created and its name has ` copy <index>` appended to the original file name
3. copy a file in the Explorer view and paste in into a folder that already contains a file with the same name: a copy of the file is created and its name has ` copy <index>` appended to the original file name

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
