### PR TITLE
electron: Open dialogs are not modal (#10768)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - [plugin-ext] add more detail to logging of backend and frontend start-up, especially in plugin management [#10407](https://github.com/eclipse-theia/theia/pull/10407) - Contributed on behalf of STMicroelectronics
 - [plugin] Added support for `vscode.CodeActionProvider.resolveCodeAction` [#10730](https://github.com/eclipse-theia/theia/pull/10730) - Contributed on behalf of STMicroelectronics
+- [electron] The Open and Save file dialogs are now modal by default [#10769](https://github.com/eclipse-theia/theia/pull/10769)
 
 <a name="breaking_changes_1.23.0">[Breaking Changes:](#breaking_changes_1.23.0)</a>
 

--- a/packages/filesystem/src/browser/file-dialog/file-dialog.ts
+++ b/packages/filesystem/src/browser/file-dialog/file-dialog.ts
@@ -70,6 +70,12 @@ export class FileDialogProps extends DialogProps {
      */
     filters?: FileDialogTreeFilters;
 
+    /**
+     * Determines if the dialog window should be modal.
+     * Defaults to `true`.
+     */
+    modal?: boolean;
+
 }
 
 @injectable()

--- a/packages/filesystem/src/electron-browser/file-dialog/electron-file-dialog-service.ts
+++ b/packages/filesystem/src/electron-browser/file-dialog/electron-file-dialog-service.ts
@@ -49,7 +49,9 @@ export class ElectronFileDialogService extends DefaultFileDialogService {
     override async showOpenDialog(props: OpenFileDialogProps, folder?: FileStat): Promise<MaybeArray<URI> | undefined> {
         const rootNode = await this.getRootNode(folder);
         if (rootNode) {
-            const { filePaths } = await electronRemote.dialog.showOpenDialog(this.toOpenDialogOptions(rootNode.uri, props));
+            const { filePaths } = props.modal !== false ?
+                await electronRemote.dialog.showOpenDialog(electronRemote.getCurrentWindow(), this.toOpenDialogOptions(rootNode.uri, props)) :
+                await electronRemote.dialog.showOpenDialog(this.toOpenDialogOptions(rootNode.uri, props));
             if (filePaths.length === 0) {
                 return undefined;
             }
@@ -65,7 +67,9 @@ export class ElectronFileDialogService extends DefaultFileDialogService {
     override async showSaveDialog(props: SaveFileDialogProps, folder?: FileStat): Promise<URI | undefined> {
         const rootNode = await this.getRootNode(folder);
         if (rootNode) {
-            const { filePath } = await electronRemote.dialog.showSaveDialog(this.toSaveDialogOptions(rootNode.uri, props));
+            const { filePath } = props.modal !== false ?
+                await electronRemote.dialog.showSaveDialog(electronRemote.getCurrentWindow(), this.toSaveDialogOptions(rootNode.uri, props)) :
+                await electronRemote.dialog.showSaveDialog(this.toSaveDialogOptions(rootNode.uri, props));
             if (!filePath) {
                 return undefined;
             }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->
The Open dialog in the electron application is not modal. Multiple ones can be opened at the same time. This affects the Open File, Open Folder, Open Workspace commands. 

Pass the electron BrowserWindow to the dialog.showOpenDialog command, to make the dialog modal.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
1. Start the electron example app
2. Go to the _File_ menu, select the _Open File..._ menu entry. A dialog to select the file should open.
3. Click outside the dialog, e.g. in the main window
4. Nothing should happen, as the dialog is modal.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
