### PR TITLE
core: remove `maxListeners` property from `Event`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@
   - `TimelineTreeWidget`
   - `TypeHierarchyTreeWidget`
 - [core] Moved methods `attachReadyToShow`, `restoreMaximizedState`, `attachCloseListeners`, `handleStopRequest`, `checkSafeToStop`, `handleReload`, `reload` from `ElectronMainAPplication` into new class `TheiaElectronWindow`. [#10600](https://github.com/eclipse-theia/theia/pull/10600)
+- [core] Removed the `Event.maxListeners` field; The feature still exists but please use `Event.getMaxListeners(event)` and `Event.setMaxListeners(event, maxListeners)` instead.
+
 ## v1.22.0 - 1/27/2022
 
 [1.22.0 Milestone](https://github.com/eclipse-theia/theia/milestone/30)

--- a/packages/core/src/browser/authentication-service.ts
+++ b/packages/core/src/browser/authentication-service.ts
@@ -85,7 +85,7 @@ export interface AuthenticationProvider {
      * An [event](#Event) which fires when the array of sessions has changed, or data
      * within a session has changed.
      */
-    readonly onDidChangeSessions: Omit<Event<AuthenticationProviderAuthenticationSessionsChangeEvent>, 'maxListeners'>;
+    readonly onDidChangeSessions: Event<AuthenticationProviderAuthenticationSessionsChangeEvent>;
 
     /**
      * Get a list of sessions.

--- a/packages/core/src/common/cancellation.ts
+++ b/packages/core/src/common/cancellation.ts
@@ -33,7 +33,10 @@ export interface CancellationToken {
 const shortcutEvent: Event<void> = Object.freeze(Object.assign(function (callback: any, context?: any): any {
     const handle = setTimeout(callback.bind(context), 0);
     return { dispose(): void { clearTimeout(handle); } };
-}, { maxListeners: 0 }));
+}, {
+    get maxListeners(): number { return 0; },
+    set maxListeners(maxListeners: number) { }
+}));
 
 export namespace CancellationToken {
 

--- a/packages/plugin-ext/src/main/browser/menus/menus-contribution-handler.ts
+++ b/packages/plugin-ext/src/main/browser/menus/menus-contribution-handler.ts
@@ -21,7 +21,7 @@ import { injectable, inject, optional } from '@theia/core/shared/inversify';
 import { MenuPath, ILogger, CommandRegistry, Command, Mutable, MenuAction, SelectionService, CommandHandler, Disposable, DisposableCollection } from '@theia/core';
 import { EDITOR_CONTEXT_MENU, EditorWidget } from '@theia/editor/lib/browser';
 import { MenuModelRegistry } from '@theia/core/lib/common';
-import { Emitter } from '@theia/core/lib/common/event';
+import { Emitter, Event } from '@theia/core/lib/common/event';
 import { TabBarToolbarRegistry, TabBarToolbarItem } from '@theia/core/lib/browser/shell/tab-bar-toolbar';
 import { NAVIGATOR_CONTEXT_MENU } from '@theia/navigator/lib/browser/navigator-contribution';
 import { VIEW_ITEM_CONTEXT_MENU, TreeViewWidget, VIEW_ITEM_INLINE_MENU } from '../view/tree-view-widget';
@@ -359,19 +359,19 @@ export class MenusContributionPointHandler {
 
         const { when } = action;
         const whenKeys = when && this.contextKeyService.parseKeys(when);
-        let onDidChange;
+        let onDidChange: Event<void> | undefined;
         if (whenKeys && whenKeys.size) {
             const onDidChangeEmitter = new Emitter<void>();
             toDispose.push(onDidChangeEmitter);
             onDidChange = onDidChangeEmitter.event;
-            this.contextKeyService.onDidChange.maxListeners = this.contextKeyService.onDidChange.maxListeners + 1;
+            Event.addMaxListeners(this.contextKeyService.onDidChange, 1);
+            toDispose.push(Disposable.create(() => {
+                Event.addMaxListeners(this.contextKeyService.onDidChange, -1);
+            }));
             toDispose.push(this.contextKeyService.onDidChange(event => {
                 if (event.affects(whenKeys)) {
                     onDidChangeEmitter.fire(undefined);
                 }
-            }));
-            toDispose.push(Disposable.create(() => {
-                this.contextKeyService.onDidChange.maxListeners = this.contextKeyService.onDidChange.maxListeners - 1;
             }));
         }
 


### PR DESCRIPTION
Align our `Event` interface closer to VS Code's.

The main benefit is that things typed with `Event` will now be
semantically colored as functions, which they are meant to be.

Replaced the missing field with two functions:
`Event.getMaxListeners(event)` and `Event.setMaxListeners(event,
maxListeners)`.

See the way the field is colored with this PR, it would be blue on master:

![image](https://user-images.githubusercontent.com/14182238/154592022-9973747c-006c-4379-a21f-e5930424d92b.png)

#### How to test

Everything should work as before: building/running.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
