### PR TITLE
Implement `disabled`, `isPreferred` and `documentation` fields for code actions

### DIFF
--- a/packages/plugin-ext/src/common/plugin-api-rpc-model.ts
+++ b/packages/plugin-ext/src/common/plugin-api-rpc-model.ts
@@ -344,6 +344,8 @@ export interface CodeAction {
     edit?: WorkspaceEdit;
     diagnostics?: MarkerData[];
     kind?: string;
+    disabled?: { reason: string };
+    isPreferred?: boolean;
 }
 
 export interface CodeActionContext {

--- a/packages/plugin-ext/src/common/plugin-api-rpc-model.ts
+++ b/packages/plugin-ext/src/common/plugin-api-rpc-model.ts
@@ -352,6 +352,8 @@ export interface CodeActionContext {
     only?: string;
 }
 
+export type CodeActionProviderDocumentation = ReadonlyArray<{ command: Command, kind: string }>;
+
 export interface CodeActionProvider {
     provideCodeActions(
         model: monaco.editor.ITextModel,

--- a/packages/plugin-ext/src/common/plugin-api-rpc.ts
+++ b/packages/plugin-ext/src/common/plugin-api-rpc.ts
@@ -69,7 +69,8 @@ import {
     CommentOptions,
     CommentThreadCollapsibleState,
     CommentThread,
-    CommentThreadChangedEvent
+    CommentThreadChangedEvent,
+    CodeActionProviderDocumentation
 } from './plugin-api-rpc-model';
 import { ExtPluginApi } from './plugin-ext-api-contribution';
 import { KeysToAnyValues, KeysToKeysToAnyValue } from './types';
@@ -1493,7 +1494,7 @@ export interface LanguagesMain {
     $registerSignatureHelpProvider(handle: number, pluginInfo: PluginInfo, selector: SerializedDocumentFilter[], metadata: theia.SignatureHelpProviderMetadata): void;
     $registerHoverProvider(handle: number, pluginInfo: PluginInfo, selector: SerializedDocumentFilter[]): void;
     $registerDocumentHighlightProvider(handle: number, pluginInfo: PluginInfo, selector: SerializedDocumentFilter[]): void;
-    $registerQuickFixProvider(handle: number, pluginInfo: PluginInfo, selector: SerializedDocumentFilter[], codeActionKinds?: string[]): void;
+    $registerQuickFixProvider(handle: number, pluginInfo: PluginInfo, selector: SerializedDocumentFilter[], codeActionKinds?: string[], documentation?: CodeActionProviderDocumentation): void;
     $clearDiagnostics(id: string): void;
     $changeDiagnostics(id: string, delta: [string, MarkerData[]][]): void;
     $registerDocumentFormattingSupport(handle: number, pluginInfo: PluginInfo, selector: SerializedDocumentFilter[]): void;

--- a/packages/plugin-ext/src/main/browser/languages-main.ts
+++ b/packages/plugin-ext/src/main/browser/languages-main.ts
@@ -37,7 +37,7 @@ import {
 import { injectable, inject } from '@theia/core/shared/inversify';
 import {
     SerializedDocumentFilter, MarkerData, Range, RelatedInformation,
-    MarkerSeverity, DocumentLink, WorkspaceSymbolParams, CodeAction, CompletionDto
+    MarkerSeverity, DocumentLink, WorkspaceSymbolParams, CodeAction, CompletionDto, CodeActionProviderDocumentation
 } from '../../common/plugin-api-rpc-model';
 import { RPCProtocol } from '../../common/rpc-protocol';
 import { MonacoLanguages, WorkspaceSymbolProvider } from '@theia/monaco/lib/browser/monaco-languages';
@@ -710,7 +710,9 @@ export class LanguagesMainImpl implements LanguagesMain, Disposable {
         }, token);
     }
 
-    $registerQuickFixProvider(handle: number, pluginInfo: PluginInfo, selector: SerializedDocumentFilter[], providedCodeActionKinds?: string[]): void {
+    $registerQuickFixProvider(handle: number, pluginInfo: PluginInfo, selector: SerializedDocumentFilter[], providedCodeActionKinds?: string[],
+        documentation?: CodeActionProviderDocumentation): void {
+
         const languageSelector = this.toLanguageSelector(selector);
         const quickFixProvider = {
             provideCodeActions: (model: monaco.editor.ITextModel, range: monaco.Range,
@@ -720,7 +722,8 @@ export class LanguagesMainImpl implements LanguagesMain, Disposable {
             },
             resolveCodeAction: (codeAction: monaco.languages.CodeAction, token: monaco.CancellationToken): Promise<monaco.languages.CodeAction> =>
                 this.resolveCodeAction(handle, codeAction, token),
-            providedCodeActionKinds
+            providedCodeActionKinds,
+            documentation
         };
         this.register(handle, monaco.modes.CodeActionProviderRegistry.register(languageSelector, quickFixProvider));
     }

--- a/packages/plugin-ext/src/main/browser/languages-main.ts
+++ b/packages/plugin-ext/src/main/browser/languages-main.ts
@@ -1022,6 +1022,7 @@ function toMonacoAction(action: CodeAction): monaco.languages.CodeAction {
     return {
         ...action,
         diagnostics: action.diagnostics ? action.diagnostics.map(m => toMonacoMarkerData(m)) : undefined,
+        disabled: action.disabled?.reason,
         edit: action.edit ? toMonacoWorkspaceEdit(action.edit) : undefined
     };
 }

--- a/packages/plugin-ext/src/plugin/languages.ts
+++ b/packages/plugin-ext/src/plugin/languages.ts
@@ -35,6 +35,7 @@ import { PluginModel } from '../common/plugin-protocol';
 import { Disposable, URI } from './types-impl';
 import { UriComponents } from '../common/uri-components';
 import {
+    CodeActionProviderDocumentation,
     CompletionContext,
     CompletionResultDto,
     Completion,
@@ -91,6 +92,7 @@ import { CallHierarchyAdapter } from './languages/call-hierarchy';
 import { BinaryBuffer } from '@theia/core/lib/common/buffer';
 import { DocumentSemanticTokensAdapter, DocumentRangeSemanticTokensAdapter } from './languages/semantic-highlighting';
 import { isReadonlyArray } from '../common/arrays';
+import { DisposableCollection } from '@theia/core/lib/common/disposable';
 
 type Adapter = CompletionAdapter |
     SignatureHelpAdapter |
@@ -179,10 +181,11 @@ export class LanguagesExtImpl implements LanguagesExt {
         return this.callId++;
     }
 
-    private createDisposable(callId: number): theia.Disposable {
+    private createDisposable(callId: number, onDispose?: () => void): theia.Disposable {
         return new Disposable(() => {
             this.adaptersMap.delete(callId);
             this.proxy.$unregister(callId);
+            onDispose?.();
         });
     }
 
@@ -446,13 +449,26 @@ export class LanguagesExtImpl implements LanguagesExt {
         metadata?: theia.CodeActionProviderMetadata
     ): theia.Disposable {
         const callId = this.addNewAdapter(new CodeActionAdapter(provider, this.documents, this.diagnostics, pluginModel ? pluginModel.id : '', this.commands));
+
+        let documentation: CodeActionProviderDocumentation | undefined;
+        let disposables: DisposableCollection | undefined;
+        if (metadata && metadata.documentation) {
+            disposables = new DisposableCollection();
+            documentation = metadata.documentation.map(doc => ({
+                kind: doc.kind.value!,
+                command: this.commands.converter.toSafeCommand(doc.command, disposables!)
+            }));
+        }
+
         this.proxy.$registerQuickFixProvider(
             callId,
             pluginInfo,
             this.transformDocumentSelector(selector),
-            metadata && metadata.providedCodeActionKinds ? metadata.providedCodeActionKinds.map(kind => kind.value!) : undefined
+            metadata && metadata.providedCodeActionKinds ? metadata.providedCodeActionKinds.map(kind => kind.value!) : undefined,
+            documentation
         );
-        return this.createDisposable(callId);
+
+        return this.createDisposable(callId, disposables?.dispose);
     }
 
     $provideCodeActions(handle: number,

--- a/packages/plugin-ext/src/plugin/languages.ts
+++ b/packages/plugin-ext/src/plugin/languages.ts
@@ -455,7 +455,7 @@ export class LanguagesExtImpl implements LanguagesExt {
         if (metadata && metadata.documentation) {
             disposables = new DisposableCollection();
             documentation = metadata.documentation.map(doc => ({
-                kind: doc.kind.value!,
+                kind: doc.kind.value,
                 command: this.commands.converter.toSafeCommand(doc.command, disposables!)
             }));
         }
@@ -464,7 +464,7 @@ export class LanguagesExtImpl implements LanguagesExt {
             callId,
             pluginInfo,
             this.transformDocumentSelector(selector),
-            metadata && metadata.providedCodeActionKinds ? metadata.providedCodeActionKinds.map(kind => kind.value!) : undefined,
+            metadata && metadata.providedCodeActionKinds ? metadata.providedCodeActionKinds.map(kind => kind.value) : undefined,
             documentation
         );
 

--- a/packages/plugin-ext/src/plugin/languages/code-action.ts
+++ b/packages/plugin-ext/src/plugin/languages/code-action.ts
@@ -104,7 +104,9 @@ export class CodeActionAdapter {
                     command: this.commands.converter.toSafeCommand(candidate.command, toDispose),
                     diagnostics: candidate.diagnostics && candidate.diagnostics.map(Converter.convertDiagnosticToMarkerData),
                     edit: candidate.edit && Converter.fromWorkspaceEdit(candidate.edit),
-                    kind: candidate.kind && candidate.kind.value
+                    kind: candidate.kind && candidate.kind.value,
+                    disabled: candidate.disabled,
+                    isPreferred: candidate.isPreferred
                 });
             }
         }

--- a/packages/plugin-ext/src/plugin/types-impl.ts
+++ b/packages/plugin-ext/src/plugin/types-impl.ts
@@ -1238,6 +1238,10 @@ export class CodeAction {
 
     kind?: CodeActionKind;
 
+    disabled?: { reason: string };
+
+    isPreferred?: boolean;
+
     constructor(title: string, kind?: CodeActionKind) {
         this.title = title;
         this.kind = kind;

--- a/packages/plugin-metrics/src/browser/plugin-metrics-languages-main.ts
+++ b/packages/plugin-metrics/src/browser/plugin-metrics-languages-main.ts
@@ -14,7 +14,7 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
-import { Range, SerializedDocumentFilter, WorkspaceSymbolParams } from '@theia/plugin-ext/lib/common/plugin-api-rpc-model';
+import { CodeActionProviderDocumentation, Range, SerializedDocumentFilter, WorkspaceSymbolParams } from '@theia/plugin-ext/lib/common/plugin-api-rpc-model';
 import { PluginMetricsResolver } from './plugin-metrics-resolver';
 import { LanguagesMainImpl } from '@theia/plugin-ext/lib/main/browser/languages-main';
 import { SymbolInformation } from '@theia/core/shared/vscode-languageserver-protocol';
@@ -303,9 +303,10 @@ export class LanguagesMainPluginMetrics extends LanguagesMainImpl {
         super.$registerDocumentColorProvider(handle, pluginInfo, selector);
     }
 
-    override $registerQuickFixProvider(handle: number, pluginInfo: PluginInfo, selector: SerializedDocumentFilter[], codeActionKinds?: string[]): void {
+    override $registerQuickFixProvider(handle: number, pluginInfo: PluginInfo, selector: SerializedDocumentFilter[], codeActionKinds?: string[],
+        documentation?: CodeActionProviderDocumentation): void {
         this.registerPluginWithFeatureHandle(handle, pluginInfo.id);
-        super.$registerQuickFixProvider(handle, pluginInfo, selector);
+        super.$registerQuickFixProvider(handle, pluginInfo, selector, codeActionKinds, documentation);
     }
 
     override $registerRenameProvider(handle: number, pluginInfo: PluginInfo, selector: SerializedDocumentFilter[], supportsResolveLocation: boolean): void {

--- a/packages/plugin/src/theia.d.ts
+++ b/packages/plugin/src/theia.d.ts
@@ -7801,6 +7801,16 @@ export module '@theia/plugin' {
         kind?: CodeActionKind;
 
         /**
+         * Marks that the code action cannot currently be applied.
+         */
+        disabled?: { reason: string };
+
+        /**
+         * Marks this as a preferred action.
+         */
+        isPreferred?: boolean;
+
+        /**
          * Creates a new code action.
          *
          * A code action must have at least a [title](#CodeAction.title) and [edits](#CodeAction.edit)
@@ -7865,6 +7875,13 @@ export module '@theia/plugin' {
          * may list our every specific kind they provide, such as `CodeActionKind.Refactor.Extract.append('function`)`
          */
         readonly providedCodeActionKinds?: ReadonlyArray<CodeActionKind>;
+
+        /**
+         * Documentation from the provider is shown in the code actions menu
+         *
+         * At most one documentation entry will be shown per provider.
+         */
+        documentation?: ReadonlyArray<{ command: Command, kind: CodeActionKind }>
     }
 
     /**

--- a/packages/plugin/src/theia.d.ts
+++ b/packages/plugin/src/theia.d.ts
@@ -8036,7 +8036,7 @@ export module '@theia/plugin' {
         /**
          * String value of the kind, e.g. `"refactor.extract.function"`.
          */
-        readonly value?: string;
+        readonly value: string;
 
         /**
          * Create a new kind by appending a more specific selector to the current kind.


### PR DESCRIPTION
Fixes #9989
Closes #10073 - this builds on #10073 but also hands in the documentation metadata into monaco.

Contributed on behalf of STMicroelectronics

Signed-off-by: Lucas Koehler <lkoehler@eclipsesource.com>
#### What it does
Fixes https://github.com/eclipse-theia/theia/issues/9989

* Adds support for the `disabled` and `isPreferred` fields to the `CodeAction` interface
* Adds support for the `documentation` field to `CodeActionProviderMetaData` interface.

#### How to test
* Include my [code actions test plugin](https://github.com/lucas-koehler/vscode-extension-samples/releases/download/code-actions-sample-0.0.3/code-actions-sample-0.0.3.vsix). For reference, it's code can be found [here](https://github.com/lucas-koehler/vscode-extension-samples/tree/code-actions-sample-0.0.3/code-actions-sample)
* Start the application and open a markdown file
* Type `:)`
* Lightbulb should be blue to indicate a preferred fix
* Open quick fix menu and look at the entries
  * The poop emoji entry is hidden (present on master).
  * There should be an entry `Learn more about Emojis...` which opens the emoji wikipedia page when selected. This is the documentation entry

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
