### PR TITLE
Fix starting pseudoterminal

### DIFF
--- a/packages/plugin-ext/src/plugin/terminal-ext.ts
+++ b/packages/plugin-ext/src/plugin/terminal-ext.ts
@@ -131,7 +131,8 @@ export class TerminalServiceExtImpl implements TerminalServiceExt {
             terminal.deferredProcessId = new Deferred<number>();
             terminal.deferredProcessId.resolve(processId);
         }
-        const pseudoTerminal = this._pseudoTerminals.get(terminalId.toString());
+        // Pseudoterminal is keyed on ID
+        const pseudoTerminal = this._pseudoTerminals.get(id);
         if (pseudoTerminal) {
             pseudoTerminal.emitOnOpen(cols, rows);
         }


### PR DESCRIPTION
Signed-off-by: robmor01 <Rob.Moran@arm.com>

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

When using a pseudoterminal, the `$terminalOpened()` function in `terminal-ext.ts` should signal the pseudoterminal to open.
This wasn't working because the wrong ID (`terminalID` - index of open terminal) was being used to find the pseudoterminal rather than the UUID it was keyed on.

This resulted in pseudoterminals not starting.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

Use an extension or plugin which implements a pseudoterminal for emitting data.
I could create an example project, but it would take some time...

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
