### PR TITLE
Add missing property to CustomDocumentOpenContext

### DIFF
--- a/packages/plugin-ext/src/common/plugin-api-rpc.ts
+++ b/packages/plugin-ext/src/common/plugin-api-rpc.ts
@@ -1586,7 +1586,7 @@ export interface CustomEditorsExt {
         widgetOpenerOptions: WidgetOpenerOptions | undefined,
         options: theia.WebviewPanelOptions,
         cancellation: CancellationToken): Promise<void>;
-    $createCustomDocument(resource: UriComponents, viewType: string, backupId: string | undefined, cancellation: CancellationToken): Promise<{ editable: boolean }>;
+    $createCustomDocument(resource: UriComponents, viewType: string, openContext: theia.CustomDocumentOpenContext, cancellation: CancellationToken): Promise<{ editable: boolean }>;
     $disposeCustomDocument(resource: UriComponents, viewType: string): Promise<void>;
     $undo(resource: UriComponents, viewType: string, editId: number, isDirty: boolean): Promise<void>;
     $redo(resource: UriComponents, viewType: string, editId: number, isDirty: boolean): Promise<void>;

--- a/packages/plugin-ext/src/main/browser/custom-editors/custom-editors-main.ts
+++ b/packages/plugin-ext/src/main/browser/custom-editors/custom-editors-main.ts
@@ -308,7 +308,7 @@ export class MainCustomEditorModel implements CustomEditorModel {
         editorPreferences: EditorPreferences,
         cancellation: CancellationToken,
     ): Promise<MainCustomEditorModel> {
-        const { editable } = await proxy.$createCustomDocument(URI.file(resource.path.toString()), viewType, undefined, cancellation);
+        const { editable } = await proxy.$createCustomDocument(URI.file(resource.path.toString()), viewType, {}, cancellation);
         return new MainCustomEditorModel(proxy, viewType, resource, editable, undoRedoService, fileService, editorPreferences);
     }
 

--- a/packages/plugin-ext/src/plugin/custom-editors.ts
+++ b/packages/plugin-ext/src/plugin/custom-editors.ts
@@ -81,7 +81,7 @@ export class CustomEditorsExtImpl implements CustomEditorsExt {
         );
     }
 
-    async $createCustomDocument(resource: UriComponents, viewType: string, backupId: string | undefined, cancellation: CancellationToken): Promise<{
+    async $createCustomDocument(resource: UriComponents, viewType: string, openContext: theia.CustomDocumentOpenContext, cancellation: CancellationToken): Promise<{
         editable: boolean;
     }> {
         const entry = this.editorProviders.get(viewType);
@@ -94,7 +94,7 @@ export class CustomEditorsExtImpl implements CustomEditorsExt {
         }
 
         const revivedResource = URI.revive(resource);
-        const document = await entry.provider.openCustomDocument(revivedResource, { backupId }, cancellation);
+        const document = await entry.provider.openCustomDocument(revivedResource, openContext, cancellation);
         this.documents.add(viewType, document);
 
         return { editable: this.supportEditing(entry.provider) };

--- a/packages/plugin/src/theia.d.ts
+++ b/packages/plugin/src/theia.d.ts
@@ -3791,6 +3791,12 @@ export module '@theia/plugin' {
          * from the user's workspace.
          */
         readonly backupId?: string;
+        /**
+         * If the URI is an untitled file, this will be populated with the byte data of that file.
+         *
+         * If this is provided, your extension should utilize this byte data rather than executing fs APIs on the URI passed in.
+         */
+        readonly untitledDocumentData?: Uint8Array;
     }
 
     /**


### PR DESCRIPTION
#### What it does

VSCode defines the optional property `untitledDocumentData` in `CustomDocumentOpenContext`. In `theia.d.ts`, this property is however missing. As it is optional and is not used from the plugin main implementation, this change is merely achieving source compatibility, but prepares its usage in the ext implementation of the plugin API.

Fixes https://github.com/eclipse-theia/theia/issues/10005

Contributed on behalf of STMicroelectronics

#### How to test
As this change doesn't introduce new functionality per se, we just need to make sure existing functionality, especially with respect to custom editors contributed by VS Code extensions still work. Therefore, I tested with `cat-customs.cat-customs` and `vscode.simple-browser`, which both seem to be still working fine.

![image](https://user-images.githubusercontent.com/588090/155154574-3b82334c-fdcb-4346-960e-549273f4f914.png)

#### Review checklist

- [X] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
