### PR TITLE
Use `OpenService` to handle preferences

### DIFF
--- a/packages/preferences/src/browser/preference-frontend-module.ts
+++ b/packages/preferences/src/browser/preference-frontend-module.ts
@@ -17,7 +17,7 @@
 import '../../src/browser/style/index.css';
 import './preferences-monaco-contribution';
 import { ContainerModule, interfaces } from '@theia/core/shared/inversify';
-import { bindViewContribution } from '@theia/core/lib/browser';
+import { bindViewContribution, OpenHandler } from '@theia/core/lib/browser';
 import { TabBarToolbarContribution } from '@theia/core/lib/browser/shell/tab-bar-toolbar';
 import { PreferenceTreeGenerator } from './util/preference-tree-generator';
 import { bindPreferenceProviders } from './preference-bindings';
@@ -28,6 +28,7 @@ import { JsonSchemaContribution } from '@theia/core/lib/browser/json-schema-stor
 import { PreferencesJsonSchemaContribution } from './preferences-json-schema-contribution';
 import { MonacoJSONCEditor } from './monaco-jsonc-editor';
 import { PreferenceContext, PreferenceTransaction, PreferenceTransactionFactory } from './preference-transaction-manager';
+import { PreferenceOpenHandler } from './preference-open-handler';
 
 export function bindPreferences(bind: interfaces.Bind, unbind: interfaces.Unbind): void {
     bindPreferenceProviders(bind, unbind);
@@ -36,6 +37,9 @@ export function bindPreferences(bind: interfaces.Bind, unbind: interfaces.Unbind
     bind(PreferenceTreeGenerator).toSelf().inSingletonScope();
 
     bindViewContribution(bind, PreferencesContribution);
+
+    bind(PreferenceOpenHandler).toSelf().inSingletonScope();
+    bind(OpenHandler).toService(PreferenceOpenHandler);
 
     bind(PreferenceScopeCommandManager).toSelf().inSingletonScope();
     bind(TabBarToolbarContribution).toService(PreferencesContribution);

--- a/packages/preferences/src/browser/preference-open-handler.ts
+++ b/packages/preferences/src/browser/preference-open-handler.ts
@@ -1,0 +1,53 @@
+// *****************************************************************************
+// Copyright (C) 2022 TypeFox and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { animationFrame, OpenHandler } from '@theia/core/lib/browser';
+import URI from '@theia/core/lib/common/uri';
+import { injectable, inject } from '@theia/core/shared/inversify';
+import { PreferencesContribution } from './preferences-contribution';
+
+@injectable()
+export class PreferenceOpenHandler implements OpenHandler {
+
+    readonly id = 'preference';
+
+    @inject(PreferencesContribution)
+    protected readonly preferencesContribution: PreferencesContribution;
+
+    canHandle(uri: URI): number {
+        return uri.scheme === this.id ? 500 : -1;
+    }
+
+    async open(uri: URI): Promise<boolean> {
+        const preferencesWidget = await this.preferencesContribution.openView();
+        const selector = `li[data-pref-id="${uri.path.toString()}"]:not([data-node-id^="commonly-used@"])`;
+        const element = document.querySelector(selector);
+        if (element instanceof HTMLElement) {
+            if (element.classList.contains('hidden')) {
+                // We clear the search term as we have clicked on a hidden preference
+                await preferencesWidget.setSearchTerm('');
+                await animationFrame();
+            }
+            element.scrollIntoView({
+                block: 'center'
+            });
+            element.focus();
+            return true;
+        }
+        return false;
+    }
+
+}

--- a/packages/preferences/src/browser/views/components/preference-node-renderer.ts
+++ b/packages/preferences/src/browser/views/components/preference-node-renderer.ts
@@ -17,7 +17,7 @@
 import { injectable, inject, postConstruct } from '@theia/core/shared/inversify';
 import {
     PreferenceService, ContextMenuRenderer, PreferenceInspection,
-    PreferenceScope, PreferenceProvider, codicon, animationFrame
+    PreferenceScope, PreferenceProvider, codicon, OpenerService, open
 } from '@theia/core/lib/browser';
 import { Preference, PreferenceMenus } from '../../util/preference-types';
 import { PreferenceTreeLabelProvider } from '../../util/preference-tree-label-provider';
@@ -27,7 +27,6 @@ import { JSONValue } from '@theia/core/shared/@phosphor/coreutils';
 import debounce = require('@theia/core/shared/lodash.debounce');
 import { PreferenceTreeModel } from '../../preference-tree-model';
 import { PreferencesSearchbarWidget } from '../preference-searchbar-widget';
-import { WindowService } from '@theia/core/lib/browser/window/window-service';
 import * as markdownit from '@theia/core/shared/markdown-it';
 import * as DOMPurify from '@theia/core/shared/dompurify';
 import URI from '@theia/core/lib/common/uri';
@@ -158,7 +157,7 @@ export abstract class PreferenceLeafNodeRenderer<ValueType extends JSONValue, In
     @inject(PreferencesScopeTabBar) protected readonly scopeTracker: PreferencesScopeTabBar;
     @inject(PreferenceTreeModel) protected readonly model: PreferenceTreeModel;
     @inject(PreferencesSearchbarWidget) protected readonly searchbar: PreferencesSearchbarWidget;
-    @inject(WindowService) protected readonly windowService: WindowService;
+    @inject(OpenerService) protected readonly openerService: OpenerService;
 
     protected headlineWrapper: HTMLDivElement;
     protected gutter: HTMLDivElement;
@@ -213,30 +212,8 @@ export abstract class PreferenceLeafNodeRenderer<ValueType extends JSONValue, In
             // Exclude right click
             if (event.button < 2) {
                 const uri = new URI(event.target.href);
-                if (uri.scheme === 'preference') {
-                    this.selectPreference(uri.path.toString());
-                } else {
-                    // Opens link in external browser
-                    this.windowService.openNewWindow(event.target.href, { external: true });
-                }
+                open(this.openerService, uri);
             }
-        }
-    }
-
-    protected async selectPreference(preferenceId: string): Promise<void> {
-        // Selects the rendered html preference node that does not belong to the commonly used group
-        const selector = `li[data-pref-id="${preferenceId}"]:not([data-node-id^="commonly-used@"])`;
-        const element = document.querySelector(selector);
-        if (element instanceof HTMLElement) {
-            if (element.classList.contains('hidden')) {
-                // We clear the search term as we have clicked on a hidden preference
-                await this.searchbar.updateSearchTerm('');
-                await animationFrame();
-            }
-            element.scrollIntoView({
-                block: 'center'
-            });
-            element.focus();
         }
     }
 

--- a/packages/preferences/src/browser/views/preference-widget.tsx
+++ b/packages/preferences/src/browser/views/preference-widget.tsx
@@ -50,8 +50,8 @@ export class PreferencesWidget extends Panel implements StatefulWidget {
         return this.tabBarWidget.currentScope;
     }
 
-    setSearchTerm(query: string): void {
-        this.searchbarWidget.updateSearchTerm(query);
+    setSearchTerm(query: string): Promise<void> {
+        return this.searchbarWidget.updateSearchTerm(query);
     }
 
     setScope(scope: PreferenceScope.User | PreferenceScope.Workspace | URI): void {


### PR DESCRIPTION
#### What it does

Closes https://github.com/eclipse-theia/theia/issues/10806

Refactors some code from `PreferenceNodeRenderer` into its own `OpenHandler`. This way we can target the `OpenService` purely instead of relying on some adhoc implementation. Also allows to open preferences from outside the preferences widget (VSCode does that a lot).

#### How to test

1. Confirm that links/references to other preferences still work as expected.
2. Download and install [this sample extension](https://github.com/eclipse-theia/theia/files/8153683/helloworld-sample.zip).
3. Search for `hello command` in the preference widget.
4. Click on the link, a notification with `Hello World!` should appear.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
