### PR TITLE
vsx-registry: Increase query delay to 500ms

### DIFF
--- a/packages/vsx-registry/src/browser/vsx-extensions-model.ts
+++ b/packages/vsx-registry/src/browser/vsx-extensions-model.ts
@@ -163,7 +163,7 @@ export class VSXExtensionsModel {
         this.searchCancellationTokenSource = new CancellationTokenSource();
         const query = this.search.query;
         return this.doUpdateSearchResult({ query, includeAllVersions: true }, this.searchCancellationTokenSource.token);
-    }, 150);
+    }, 500);
     protected doUpdateSearchResult(param: VSXSearchParam, token: CancellationToken): Promise<void> {
         return this.doChange(async () => {
             const client = await this.clientProvider();


### PR DESCRIPTION
#### What it does

This is part of an ongoing effort to improve on the heavy load hitting the ovsx servers. See https://github.com/eclipse/openvsx/issues/379 for more info. VSCode uses a delay of `500ms` as well. Since OVSX servers usually take a few seconds to return a search response anyway, this delay shouldn't be noticeable.

#### How to test

1. Open the `Network` tab of your browser.
2. Search for an extension (like `typescript`).
3. Compare the amount of network requests to the `/search` endpoint with `master`.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
