### PR TITLE
workspace: fix path alignment in dialogs

### DIFF
--- a/packages/workspace/src/browser/workspace-input-dialog.ts
+++ b/packages/workspace/src/browser/workspace-input-dialog.ts
@@ -49,6 +49,9 @@ export class WorkspaceInputDialog extends SingleTextInputDialog {
         const icon = document.createElement('i');
         icon.classList.add(...codiconArray('folder'));
         icon.style.marginRight = '0.5em';
+        icon.style.verticalAlign = 'middle';
+        element.style.verticalAlign = 'middle';
+        element.title = this.props.parentUri.path.toString();
         element.appendChild(icon);
         element.appendChild(document.createTextNode(label));
         // Add the path and icon div before the `inputField`.


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

Closes: https://github.com/eclipse-theia/theia/pull/10567.

The pull-request updates the path alignment for the workspace dialog (ex: `new file`, `new folder`) so that the content is properly aligned with the icon:

![image](https://user-images.githubusercontent.com/40359487/156030217-b6c77f05-d2c2-4011-aff8-3edb38a6d9ab.png)

The change also adds the folder path to the label's `title` (displayed when hovering).

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

1. start the application
2. confirm that the path alignment in `new file` and `new folder` are correct
3. repeat step 2 using different paths - root of the workspace, nested subdirectories

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

Signed-off-by: vince-fugnitto <vincent.fugnitto@ericsson.com>
Co-authored-by: shuyaqian <717749594@qq.com>
