### PR TITLE
ui: improve tabbar styling

### DIFF
--- a/packages/core/src/browser/style/sidepanel.css
+++ b/packages/core/src/browser/style/sidepanel.css
@@ -285,6 +285,7 @@
 
 #theia-bottom-content-panel .p-TabBar-tab:not(.p-mod-current) {
     color: var(--theia-panelTitle-inactiveForeground);
+    border-top: var(--theia-border-width) solid  var(--theia-panel-background);
 }
 
 #theia-bottom-content-panel .p-TabBar-tab.p-mod-current {

--- a/packages/core/src/browser/style/tabs.css
+++ b/packages/core/src/browser/style/tabs.css
@@ -138,6 +138,7 @@ body.theia-editor-highlightModifiedTabs
 #theia-main-content-panel .p-TabBar .p-TabBar-tab:not(.p-mod-current):not(.theia-mod-active) {
     background: var(--theia-tab-inactiveBackground);
     color: var(--theia-tab-inactiveForeground);
+    border-top: 1px solid var(--theia-tab-inactiveBackground);
 }
 
 .p-TabBar.theia-app-centers {
@@ -145,14 +146,14 @@ body.theia-editor-highlightModifiedTabs
 }
 
 .p-TabBar.theia-app-centers::after {
-	content: '';
-	position: absolute;
-	bottom: 0;
-	left: 0;
-	pointer-events: none;
-	background-color: var(--theia-editorGroupHeader-tabsBorder);
-	width: 100%;
-	height: 1px;
+  content: '';
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  pointer-events: none;
+  background-color: var(--theia-editorGroupHeader-tabsBorder);
+  width: 100%;
+  height: 1px;
 }
 
 .p-TabBar.theia-app-centers .p-TabBar-tabIcon,
@@ -261,22 +262,14 @@ body.theia-editor-highlightModifiedTabs
   padding-right: 4px;
 }
 
-.p-TabBar.theia-app-centers .p-TabBar-tab.p-mod-current > .theia-tab-icon-label > .p-TabBar-tabIcon {
-  margin-top: -2px;
-}
-
-.p-TabBar.theia-app-centers .p-TabBar-tab.p-mod-current > .p-TabBar-tabCloseIcon {
-  margin-top: 0px;
-}
-
 .p-TabBar.theia-app-centers .p-TabBar-tab.p-mod-closable:not(.theia-mod-dirty):hover > .p-TabBar-tabCloseIcon:before,
 .p-TabBar.theia-app-centers .p-TabBar-tab.p-mod-closable:not(.theia-mod-dirty).p-TabBar-tab.p-mod-current > .p-TabBar-tabCloseIcon:before,
-.p-TabBar.theia-app-centers .p-TabBar-tab.p-mod-closable.theia-mod-dirty > .p-TabBar-tabCloseIcon:hover:before { 
-  content: "\ea76" 
+.p-TabBar.theia-app-centers .p-TabBar-tab.p-mod-closable.theia-mod-dirty > .p-TabBar-tabCloseIcon:hover:before {
+  content: "\ea76";
 }
 
-.p-TabBar.theia-app-centers .p-TabBar-tab.p-mod-closable.theia-mod-dirty > .p-TabBar-tabCloseIcon:before { 
-  content: "\ea71" 
+.p-TabBar.theia-app-centers .p-TabBar-tab.p-mod-closable.theia-mod-dirty > .p-TabBar-tabCloseIcon:before {
+  content: "\ea71";
 }
 
 .p-TabBar-tabIcon.no-icon {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

The pull-request fixes some user-experience issues related to the tabbar styling.
Previously, when cycling through the tabs a shift would occur with the tab, file-icons, and close icons.

The pull-request addresses these problems by:
- adding a "transparent" border for all incative tabs so when a tab is activated and an active border is shown they will not shift compared to inactive tabs.
- removes extraneous code which caused file-icons and the close icon to shift.

https://user-images.githubusercontent.com/40359487/156239318-be75b948-5365-498b-825d-85c399200853.mp4

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

1. start the application
2. open multiple editors
3. confirm that switching between editors yields a consistent experience (no shifting of elements) compared to master
4. confirm that tabs in the bottom area also behave well

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

Signed-off-by: vince-fugnitto <vincent.fugnitto@ericsson.com>