### PR TITLE
Fix undefined reference error when uninstalling extensions

### DIFF
--- a/packages/plugin-ext/src/hosted/node/hosted-plugin-deployer-handler.ts
+++ b/packages/plugin-ext/src/hosted/node/hosted-plugin-deployer-handler.ts
@@ -163,22 +163,14 @@ export class HostedPluginDeployerHandler implements PluginDeployerHandler {
 
         const undeployPlugin = this.stopwatch.start('undeployPlugin');
         this.deployedLocations.delete(pluginId);
-        let undeployError: unknown;
-        const failedLocations: string[] = [];
 
         for (const location of deployedLocations) {
             try {
                 await fs.remove(location);
+                undeployPlugin.log(`[${pluginId}]: undeployed from "${location}"`);
             } catch (e) {
-                failedLocations.push(location);
-                undeployError = undeployError ?? e;
+                undeployPlugin.error(`[${pluginId}]: failed to undeploy from location "${location}". reason:`, e);
             }
-        }
-
-        if (undeployError) {
-            undeployPlugin.error(`[${pluginId}]: failed to undeploy from locations "${failedLocations}". First reason:`, undeployError);
-        } else {
-            undeployPlugin.log(`[${pluginId}]: undeployed from "${location}"`);
         }
 
         return true;


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

Closes https://github.com/eclipse-theia/theia/issues/10828

The previous code referenced the global variable `location`, which was `undefined`. The new code references the loop variable.

#### How to test

1. Install an extension and uninstall it directly after that
2. The UI should refresh
3. The backend should have logged a message about the uninstalled location

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
