### PR TITLE
vsx-registry: prevent search with no query present

### DIFF
--- a/packages/vsx-registry/src/browser/vsx-extensions-model.ts
+++ b/packages/vsx-registry/src/browser/vsx-extensions-model.ts
@@ -166,12 +166,16 @@ export class VSXExtensionsModel {
     }, 500);
     protected doUpdateSearchResult(param: VSXSearchParam, token: CancellationToken): Promise<void> {
         return this.doChange(async () => {
+            const searchResult = new Set<string>();
+            if (!param.query) {
+                this._searchResult = searchResult;
+                return;
+            }
             const client = await this.clientProvider();
             const result = await client.search(param);
             if (token.isCancellationRequested) {
                 return;
             }
-            const searchResult = new Set<string>();
             for (const data of result.extensions) {
                 const id = data.namespace.toLowerCase() + '.' + data.name.toLowerCase();
                 const extension = client.getLatestCompatibleVersion(data);


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

The pull-request prevents a search from the vsx-registry view to open-vsx when no query is present.
Previously, a search would happen when no query is present which caused us to call the api and it would return the list of popular extensions. This change should effectively prevent extraneous searches from happening like an initial search when a user types, and when the search term is cleared.

https://user-images.githubusercontent.com/40359487/156428739-76f8f7ca-c006-4628-bfc5-f600c398d147.mp4

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

1. start the application, and open the extensions-view
2. perform searches - no intermediate results should appear unrelated to the query, listing the popular extensions
3. clearing the search should not cause an api call 

#### Review checklist



- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

Signed-off-by: vince-fugnitto <vincent.fugnitto@ericsson.com>