### PR TITLE
Align plugin API getSession method signatures with VS Code API

### DIFF
--- a/packages/plugin/src/theia.d.ts
+++ b/packages/plugin/src/theia.d.ts
@@ -11388,7 +11388,7 @@ export module '@theia/plugin' {
          * @param options The [getSessionOptions](#GetSessionOptions) to use
          * @returns A thenable that resolves to an authentication session
          */
-        export function getSession(providerId: string, scopes: string[], options: AuthenticationGetSessionOptions & { createIfNone: true }): Thenable<AuthenticationSession>;
+        export function getSession(providerId: string, scopes: readonly string[], options: AuthenticationGetSessionOptions & { createIfNone: true }): Thenable<AuthenticationSession>;
 
         /**
          * Get an authentication session matching the desired scopes. Rejects if a provider with providerId is not
@@ -11416,7 +11416,7 @@ export module '@theia/plugin' {
          * @param options The [getSessionOptions](#GetSessionOptions) to use
          * @returns A thenable that resolves to an authentication session if available, or undefined if there are no sessions
          */
-        export function getSession(providerId: string, scopes: string[], options?: AuthenticationGetSessionOptions): Thenable<AuthenticationSession | undefined>;
+        export function getSession(providerId: string, scopes: readonly string[], options?: AuthenticationGetSessionOptions): Thenable<AuthenticationSession | undefined>;
 
         /**
          * An [event](#Event) which fires when the authentication sessions of an authentication provider have


### PR DESCRIPTION
#### What it does
Add missing readonly modifiers. This aligns the method signatures with https://github.com/microsoft/vscode/blob/1.64.2/src/vscode-dts/vscode.d.ts#L14290-L14320

Fixes #10836

Contributed on behalf of STMicroelectronics

Signed-off-by: Lucas Koehler <lkoehler@eclipsesource.com>

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
