### PR TITLE
Align "Add Folder" visibility with VSCode

### DIFF
--- a/packages/core/src/browser/style/tree.css
+++ b/packages/core/src/browser/style/tree.css
@@ -42,6 +42,10 @@
     border: none;
 }
 
+.theia-TreeContainer .ReactVirtualized__Grid__innerScrollContainer {
+    margin-bottom: calc(var(--theia-ui-padding) * 3);
+}
+
 .theia-TreeContainer {
     height: 100%;
 }

--- a/packages/navigator/src/browser/navigator-contribution.ts
+++ b/packages/navigator/src/browser/navigator-contribution.ts
@@ -65,7 +65,6 @@ import {
 } from '@theia/core/lib/browser/shell/tab-bar-toolbar';
 import { FileSystemCommands } from '@theia/filesystem/lib/browser/filesystem-frontend-contribution';
 import { NavigatorDiff, NavigatorDiffCommands } from './navigator-diff';
-import { UriSelection } from '@theia/core/lib/common/selection';
 import { DirNode, FileNode } from '@theia/filesystem/lib/browser';
 import { FileNavigatorModel } from './navigator-model';
 import { ClipboardService } from '@theia/core/lib/browser/clipboard-service';
@@ -317,9 +316,10 @@ export class FileNavigatorContribution extends AbstractViewContribution<FileNavi
                     return false;
                 }
                 const navigator = this.tryGetWidget();
-                const model = navigator && navigator.model;
-                const uris = UriSelection.getUris(model && model.selectedNodes);
-                return this.workspaceService.areWorkspaceRoots(uris);
+                const selection = navigator?.model.selectedNodes[0];
+                // The node that is selected when the user clicks in empty space.
+                const root = navigator?.getContainerTreeNode();
+                return selection === root;
             }
         });
 

--- a/packages/navigator/src/browser/navigator-widget.tsx
+++ b/packages/navigator/src/browser/navigator-widget.tsx
@@ -129,7 +129,7 @@ export class FileNavigatorWidget extends FileTreeWidget {
         this.addEventListener(mainPanelNode, 'dragenter', handler);
     }
 
-    protected override getContainerTreeNode(): TreeNode | undefined {
+    override getContainerTreeNode(): TreeNode | undefined {
         const root = this.model.root;
         if (this.workspaceService.isMultiRootWorkspaceOpened) {
             return root;


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

This PR aligns the visibility of the context menu command to add a folder to a workspace with the corresponding command in VSCode.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

On `master`, the command is visible if:
 - You right-click in empty space in the Navigator widget in an unsaved single-root workspace.
 - You right-click in on an existing root in the Navigator widget in a saved or multi-root workspace.

With these changes the command is visible if:
 - You right-click in empty space in the navigator widget in any workspace.
> On `master`, there may not be any empty space in the Navigator widget. This PR adds a margin to a React virtualized scroll container to ensure that there is always some empty space at the bottom of the list, as there is in VSCode.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
