### PR TITLE
application-manager: fix expose-loader

### DIFF
--- a/dev-packages/application-manager/src/expose-loader.ts
+++ b/dev-packages/application-manager/src/expose-loader.ts
@@ -40,7 +40,7 @@ function exposeModule(modulePackage: { dir: string, name?: string }, resourcePat
     if (path.sep !== '/') {
         moduleName = moduleName.split(path.sep).join('/');
     }
-    return source + `\nif (!global) global = {};\n(global['theia'] = global['theia'] || {})['${moduleName}'] = this;\n`;
+    return source + `\n;(globalThis['theia'] = globalThis['theia'] || {})['${moduleName}'] = this;\n`;
 }
 
 /**


### PR DESCRIPTION
For some reason the loader causes some applications to fail at runtime.

Use an alternative writing for one of the injected string of code.

#### How to test

Should fix the browser application start failure for this repository:

https://github.com/theia-ide/theia-trace-extension/tree/b4855ec742015d08bbec0d3d549b83eb61df8ec5

Linux-only:

- Clone the repo.
- Run `yarn`.
- Run `yarn download:server`
- Run `yarn --cwd examples/browser start`
- Open your browser at `localhost:3000`, it should fail because of some `ReferenceError: global`.
- Edit `node_modules/@theia/application-manager/lib/expose-loader.js` and replace the same string as this PR.
- Run `yarn --cwd examples/browser`
- Run `yarn --cwd examples/browser start`
- Open your browser at `localhost:3000`, it should work.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
