### PR TITLE
electron: Fix missing custom menu bug

### DIFF
--- a/packages/core/src/electron-browser/menu/electron-menu-contribution.ts
+++ b/packages/core/src/electron-browser/menu/electron-menu-contribution.ts
@@ -129,13 +129,13 @@ export class ElectronMenuContribution extends BrowserMenuBarContribution impleme
         this.hideTopPanel(app);
         electron.ipcRenderer.on(TitleBarStyleAtStartup, (_event, style: string) => {
             this.titleBarStyle = style;
+            this.setMenu(app);
             this.preferenceService.ready.then(() => {
                 this.preferenceService.set('window.titleBarStyle', this.titleBarStyle, PreferenceScope.User);
             });
         });
         electron.ipcRenderer.send(RequestTitleBarStyle);
         this.preferenceService.ready.then(() => {
-            this.setMenu(app);
             electronRemote.getCurrentWindow().setMenuBarVisibility(['classic', 'visible'].includes(this.preferenceService.get('window.menuBarVisibility', 'classic')));
         });
         this.preferenceService.onPreferenceChanged(change => {


### PR DESCRIPTION
#### What it does

Closes #10843 

Setting the app as soon as the `TitleBarStyleAtStartup` event is received fixes the bug. This should've been the intended behavior anyway.

I assume in some rare circumstances, the event is fired __after__ the `PreferenceService#ready` promise is resolved, therefore callling the `setMenu` method with an undefined `titleBarStyle`. Consequently, no custom menu is displayed.

#### How to test

1. Start the application on Linux/Windows
2. The custom menu should appear as indicated by the preference

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
