### PR TITLE
Ensure active element is preserved when opening context menu

### DIFF
--- a/packages/core/src/browser/menu/browser-menu-plugin.ts
+++ b/packages/core/src/browser/menu/browser-menu-plugin.ts
@@ -256,8 +256,6 @@ export class DynamicMenuWidget extends MenuWidget {
         this.updateSubMenus(this, this.menu, this.options.commands);
     }
 
-    // Hint: this is not called from the context menu use-case, but is not required.
-    // For the context menu the command registry state is calculated by the factory before `open`.
     public aboutToShow({ previousFocusedElement }: { previousFocusedElement: HTMLElement | undefined }): void {
         this.preserveFocusedElement(previousFocusedElement);
         this.clearItems();
@@ -273,6 +271,7 @@ export class DynamicMenuWidget extends MenuWidget {
             this.aboutToClose.disconnect(cb);
         };
         this.aboutToClose.connect(cb);
+        this.preserveFocusedElement();
         super.open(x, y, options);
     }
 


### PR DESCRIPTION
#### What it does
Fixes https://github.com/eclipse-theia/theia/issues/10851

This change ensures that the active element from the document is preserved when opening the menu. If there is already another element that is preserved, this fix simply does nothing as the previous preserved element is kept.

Please note that the top menu is not affected by this since the `aboutToShow` is called through the `DynamicMenuBarWidget`. 

#### How to test
1. Start Theia (I used the Electron app but it might occur also in the Browser app)
2. ensure that browser menus are used (`window.titleBarStyle: custom`)
3. Select any file and open the context menu and hit 'Copy'
4. Open the context menu and hit 'Paste'
5. See that the file is copied as expected

![copy-paste_after](https://user-images.githubusercontent.com/19170971/157047198-849b1a5d-fa1b-4657-97a0-fa03fd30ed45.gif)

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
