### PR TITLE
Execute app shutdown vetoes in sequence

### DIFF
--- a/packages/core/src/browser/frontend-application.ts
+++ b/packages/core/src/browser/frontend-application.ts
@@ -55,7 +55,7 @@ export interface FrontendApplicationContribution {
      * Return `true` or an OnWillStopAction in order to prevent exit.
      * Note: No async code allowed, this function has to run on one tick.
      */
-    onWillStop?(app: FrontendApplication): boolean | undefined | OnWillStopAction;
+    onWillStop?(app: FrontendApplication): boolean | undefined | OnWillStopAction<unknown>;
 
     /**
      * Called when an application is stopped or unloaded.
@@ -77,11 +77,15 @@ export interface FrontendApplicationContribution {
     onDidInitializeLayout?(app: FrontendApplication): MaybePromise<void>;
 }
 
-export interface OnWillStopAction {
+export interface OnWillStopAction<T = unknown> {
+    /**
+     * @resolves to a prepared value to be passed into the `action` function.
+     */
+    prepare?: () => MaybePromise<T>;
     /**
      * @resolves to `true` if it is safe to close the application; `false` otherwise.
      */
-    action: () => MaybePromise<boolean>;
+    action: (prepared: T) => MaybePromise<boolean>;
     /**
      * A descriptive string for the reason preventing close.
      */


### PR DESCRIPTION
#### What it does

Closes https://github.com/eclipse-theia/theia/issues/10860

Since we prioritize actions anyway, it didn't make a lot of sense to execute the actions in parallel. For example, if we have the following two `OnWillStop` results, the second one returns first, even though its priority is lower:

```ts
[{
  reason: 'a',
  priority: 10,
  action: async () => {
    await timeout(10);
    return ...;
  }
},{
  reason: 'b',
  priority: 0,
  action: async () => {
    return ...;
  }
}]
```

#### How to test

1. Create a new multi-root workspace and __don't save it__
2. Edit a file in your workspace and __don't save it__
3. Exit the app
4. Any shutdown action returning `false` will prevent execution of subsequent actions

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
