### PR TITLE
Update windows-build-tools installation instructions

### DIFF
--- a/doc/Developing.md
+++ b/doc/Developing.md
@@ -512,7 +512,7 @@ etc.) by opening `packages/<package name>/coverage/index.html`.
  - Install [`nvm`](https://github.com/coreybutler/nvm-windows) with scoop: `scoop install nvm`.
  - Install Node.js with `nvm`: `nvm install 12.14.1`, then use it: `nvm use 12.14.1`. You can list all available Node.js versions with `nvm list available` if you want to pick another version.
  - Install `yarn`: `scoop install yarn`.
- - Install [`windows-build-tools`](https://github.com/felixrieseberg/windows-build-tools). Run `PowerShell` as _Administrator_ and copy paste the following: `npm --add-python-to-path install --global --production windows-build-tools`
+ - If you need to install `windows-build-tools`, see [`Installing Windows Build Tools`](#installing-windows-build-tools).
 
 Clone, build and run Theia.
 Using Git Bash as administrator:
@@ -524,8 +524,13 @@ git clone https://github.com/eclipse-theia/theia.git \
     && yarn browser build \
     && yarn browser start
 ```
-
 If you do not have Git Bash installed on your system, [get one](https://gitforwindows.org/), or use `scoop`: `scoop install git`.
+
+### Installing Windows Build Tools
+ - Previously, [`windows-build-tools`](https://github.com/felixrieseberg/windows-build-tools) is required to build 
+ Native Nodes modules on Windows. The npm package is now [`deprecated`](https://www.npmjs.com/package/windows-build-tools) because NodeJS installer can now install all the required tools that it needs, including Windows Build Tools. 
+ - In case you need to install the tool manually, after installing `yarn`, run `PowerShell` as _Administrator_ and 
+ copy paste the following: `npm --add-python-to-path install --global --production windows-build-tools`.
 
 ## Troubleshooting
 

--- a/doc/Developing.md
+++ b/doc/Developing.md
@@ -527,10 +527,9 @@ git clone https://github.com/eclipse-theia/theia.git \
 If you do not have Git Bash installed on your system, [get one](https://gitforwindows.org/), or use `scoop`: `scoop install git`.
 
 ### Installing Windows Build Tools
- - Previously, [`windows-build-tools`](https://github.com/felixrieseberg/windows-build-tools) is required to build 
- Native Nodes modules on Windows. The npm package is now [`deprecated`](https://www.npmjs.com/package/windows-build-tools) because NodeJS installer can now install all the required tools that it needs, including Windows Build Tools. 
- - In case you need to install the tool manually, after installing `yarn`, run `PowerShell` as _Administrator_ and 
- copy paste the following: `npm --add-python-to-path install --global --production windows-build-tools`.
+
+ - Previously, [`windows-build-tools`](https://github.com/felixrieseberg/windows-build-tools) is required to build Native Nodes modules on Windows. The npm package is now [`deprecated`](https://www.npmjs.com/package/windows-build-tools) because NodeJS installer can now install all the required tools that it needs, including Windows Build Tools.
+ - In case you need to install the tool manually, after installing `yarn`, run `PowerShell` as _Administrator_ and copy paste the following: `npm --add-python-to-path install --global --production windows-build-tools`.
 
 ## Troubleshooting
 


### PR DESCRIPTION
#### What it does
windows-build-tools is now deprecated since NodeJs installer can now install all of its required tools. This commit updates the instructions on how to build Theia on Windows to inform developers about the deprecation of windows-build-tools and mark the installation instruction of the tool as fallback.

This commit closes [Issue #10856](https://github.com/eclipse-theia/theia/issues/10856).

#### How to test
See [Issue #10856](https://github.com/eclipse-theia/theia/issues/10856).

#### Review checklist

- [X] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
