### PR TITLE
preferences: fix tab styling for inactive scopes

### DIFF
--- a/packages/preferences/src/browser/style/index.css
+++ b/packages/preferences/src/browser/style/index.css
@@ -80,6 +80,7 @@
     background: var(--theia-editor-background);
     border-right: unset;
     border-bottom: var(--theia-border-width) solid var(--theia-tab-unfocusedInactiveForeground);
+    border-top: none;
 }
 
 #theia-main-content-panel .theia-settings-container .tabbar-underline {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

The pull-request fixes a minor regression (https://github.com/eclipse-theia/theia/pull/10822#issuecomment-1062986594) where a top-border existed for the preferences-view for inactive workspace scopes. The change adjusts the preferences-ui since it styles the tabs differently than the rest of the application.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

1. start the application
2. open the preferences-view (ensure that multiple scopes are visible)
3. confirm that the top border does not display
4. confirm with multiple different themes

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

Signed-off-by: vince-fugnitto <vincent.fugnitto@ericsson.com>

