### PR TITLE
electron: fix electron global shortcuts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,13 +10,10 @@
 
 - [plugin] added support for `DocumentSymbolProviderMetadata` [#10811](https://github.com/eclipse-theia/theia/pull/10811) - Contributed on behalf of STMicroelectronics
 
-## v1.24.0 - unreleased
-
-[1.24.0 Milestone](https://github.com/eclipse-theia/theia/milestone/32)
-
 <a name="breaking_changes_1.24.0">[Breaking Changes:](#breaking_changes_1.24.0)</a>
 
- - [markers] `ProblemDecorator` reimplemented to reduce redundancy and align more closely with VSCode. `collectMarkers` now returns `Map<string, TreeDecoration.Data>`, `getOverlayIconColor` renamed to `getColor`, `getOverlayIcon` removed, `appendContainerMarkers` returns `void`.
+- [markers] `ProblemDecorator` reimplemented to reduce redundancy and align more closely with VSCode. `collectMarkers` now returns `Map<string, TreeDecoration.Data>`, `getOverlayIconColor` renamed to `getColor`, `getOverlayIcon` removed, `appendContainerMarkers` returns `void`.
+- [core] removed method `attachGlobalShortcuts` from `ElectronMainApplication`. Attaching shortcuts in that way interfered with internal shortcuts. Use internal keybindings instead of global shortcuts [#10869](https://github.com/eclipse-theia/theia/pull/10869)
 
 ## v1.23.0 - 2/24/2022
 

--- a/packages/core/src/electron-main/theia-electron-window.ts
+++ b/packages/core/src/electron-main/theia-electron-window.ts
@@ -17,7 +17,7 @@
 import { FrontendApplicationConfig } from '@theia/application-package';
 import { FrontendApplicationState } from '../common/frontend-application-state';
 import { APPLICATION_STATE_CHANGE_SIGNAL, CLOSE_REQUESTED_SIGNAL, RELOAD_REQUESTED_SIGNAL, StopReason } from '../electron-common/messaging/electron-messages';
-import { BrowserWindow, BrowserWindowConstructorOptions, globalShortcut, ipcMain, IpcMainEvent } from '../../electron-shared/electron';
+import { BrowserWindow, BrowserWindowConstructorOptions, ipcMain, IpcMainEvent } from '../../electron-shared/electron';
 import { inject, injectable, postConstruct } from '../../shared/inversify';
 import { ElectronMainApplicationGlobals } from './electron-main-constants';
 import { DisposableCollection, Emitter, Event, isWindows } from '../common';
@@ -69,7 +69,6 @@ export class TheiaElectronWindow {
         this._window = new BrowserWindow(this.options);
         this._window.setMenuBarVisibility(false);
         this.attachReadyToShow();
-        this.attachGlobalShortcuts();
         this.restoreMaximizedState();
         this.attachCloseListeners();
         this.trackApplicationState();
@@ -101,26 +100,6 @@ export class TheiaElectronWindow {
     protected doCloseWindow(): void {
         this.closeIsConfirmed = true;
         this._window.close();
-    }
-
-    /**
-     * Catch certain keybindings to prevent reloading the window using keyboard shortcuts.
-     */
-    protected attachGlobalShortcuts(): void {
-        const handler = this.config.electron?.disallowReloadKeybinding
-            ? () => { }
-            : () => this.reload();
-        const accelerators = ['CmdOrCtrl+R', 'F5'];
-        createDisposableListener(this._window, 'focus', () => {
-            for (const accelerator of accelerators) {
-                globalShortcut.register(accelerator, handler);
-            }
-        }, this.toDispose);
-        createDisposableListener(this._window, 'blur', () => {
-            for (const accelerator of accelerators) {
-                globalShortcut.unregister(accelerator);
-            }
-        }, this.toDispose);
     }
 
     close(reason: StopReason = StopReason.Close): Promise<boolean> {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

The pull-request restores the change https://github.com/eclipse-theia/theia/pull/10704 which was re-introduced after #10600.

The goal of the pull-request is to remove the problematic `attachGlobalShortcuts` method which caused the application to always interpret <kbd>ctrl</kbd>+<kbd>r</kbd> as a hard reload of the application despite having either a different context (ex: terminals), or updating keybinding.

The change should now properly use the reload command which uses a proper context, and can be customized by end-users (`keymaps.json`).

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

Same as https://github.com/eclipse-theia/theia/pull/10704:

1. Run the Electron application
2. Open a bash terminal
3. Use the <kbd>ctrl</kbd>+<kbd>r</kbd> shortcut to access 'reverse-i-search'
4. Put focus on some element other than the terminal.
5. Use the  <kbd>ctrl</kbd>+<kbd>r</kbd>shortcut to refresh the window - it should refresh
6. Dirty an editor and use the <kbd>ctrl</kbd>+<kbd>r</kbd> shortcut - you should be prompted to confirm the refresh
7. If you'd like, rebind the Refresh Window command to some other keybinding and confirm that it behaves correctly.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

Signed-off-by: vince-fugnitto <vincent.fugnitto@ericsson.com>
Co-authored-by: Colin Grant <colin.grant@ericsson.com>