### PR TITLE
Preferences UI: Delegate Classnames to Type Renderers

### DIFF
--- a/packages/editor/src/browser/editor-preferences.ts
+++ b/packages/editor/src/browser/editor-preferences.ts
@@ -122,6 +122,7 @@ const codeEditorPreferenceProperties = {
         'description': nls.localizeByDefault('Controls form what documents word based completions are computed.')
     },
     'editor.semanticHighlighting.enabled': {
+        'type': ['boolean', 'string'],
         'enum': [true, false, 'configuredByTheme'],
         'markdownEnumDescriptions': [
             nls.localizeByDefault('Semantic highlighting enabled for all color themes.'),

--- a/packages/preferences/src/browser/views/components/preference-boolean-input.ts
+++ b/packages/preferences/src/browser/views/components/preference-boolean-input.ts
@@ -29,6 +29,10 @@ export class PreferenceBooleanInputRenderer extends PreferenceLeafNodeRenderer<b
         parent.appendChild(interactable);
     }
 
+    protected override getAdditionalNodeClassnames(): Iterable<string> {
+        return ['boolean'];
+    }
+
     protected getFallbackValue(): false {
         return false;
     }

--- a/packages/preferences/src/browser/views/components/preference-node-renderer.ts
+++ b/packages/preferences/src/browser/views/components/preference-node-renderer.ts
@@ -101,6 +101,10 @@ export abstract class PreferenceNodeRenderer implements Disposable, GeneralPrefe
 
     protected abstract createDomNode(): HTMLElement;
 
+    protected getAdditionalNodeClassnames(): Iterable<string> {
+        return [];
+    }
+
     insertBefore(nextSibling: HTMLElement): void {
         nextSibling.insertAdjacentElement('beforebegin', this.domNode);
         this.attached = true;
@@ -247,9 +251,8 @@ export abstract class PreferenceLeafNodeRenderer<ValueType extends JSONValue, In
         cog.title = nls.localizeByDefault('More Actions...');
         gutter.appendChild(cog);
 
-        const activeType = Array.isArray(this.preferenceNode.preference.data.type) ? this.preferenceNode.preference.data.type[0] : this.preferenceNode.preference.data.type;
         const contentWrapper = document.createElement('div');
-        contentWrapper.classList.add('pref-content-container', activeType ?? 'open-json');
+        contentWrapper.classList.add('pref-content-container', ...this.getAdditionalNodeClassnames());
         wrapper.appendChild(contentWrapper);
 
         const { description, markdownDescription } = this.preferenceNode.preference.data;


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

The Monaco uplift [exposed a bug](https://github.com/eclipse-theia/theia/pull/10736#pullrequestreview-904858883) in the preference node renderer system in which the base renderer was applying type-specific classnames. Since renderers are already selected on the basis of type, the application of type-specific classes has been delegated to the individual renderers.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

1. Open the Preferences UI
2. Search for `editor.semanticHighlighting.enabled`.
3. Observe that it is correctly rendered as a select input.
4. Check other preference nodes, especially booleans (checkmarks)
5. Observe that they are all rendered correctly.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
