### PR TITLE
Ensure compression parent is also visible

### DIFF
--- a/packages/core/src/browser/tree/tree-compression/tree-compression-service.ts
+++ b/packages/core/src/browser/tree/tree-compression/tree-compression-service.ts
@@ -47,7 +47,11 @@ export class TreeCompressionService {
      * In that case, the child can be shown in the same row as the parent.
      */
     isCompressionParent(node?: unknown): node is CompressionParent {
-        return ExpandableTreeNode.is(node) && node.children.length === 1 && ExpandableTreeNode.is(node.children[0]);
+        return this.isVisibleExpandableNode(node) && node.children.length === 1 && this.isVisibleExpandableNode(node.children[0]);
+    }
+
+    protected isVisibleExpandableNode(node?: unknown): node is ExpandableTreeNode {
+        return ExpandableTreeNode.is(node) && TreeNode.isVisible(node);
     }
 
     /**


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

Fixes a bug in which folders could get compressed into an invisible workspace root.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

1. Create a directory that has a single, empty directory as its only child.
2. Open that directory as a workspace.
3. Observe that the child folder is visible under both settings of the `explorer.compactFolders` preference.
4. Use the `examples/compression-example` workspace to ensure that other compression features continue to work as usual.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
