### PR TITLE
Update type check for `TreeContainerProps`

### DIFF
--- a/packages/core/src/browser/tree/tree-container.spec.ts
+++ b/packages/core/src/browser/tree/tree-container.spec.ts
@@ -13,6 +13,7 @@
 //
 // SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
 // *****************************************************************************
+
 import * as assert from 'assert';
 import { Container } from 'inversify';
 import { createTreeContainer, isTreeServices } from './tree-container';

--- a/packages/core/src/browser/tree/tree-container.spec.ts
+++ b/packages/core/src/browser/tree/tree-container.spec.ts
@@ -18,11 +18,15 @@ import { isTreeServices } from './tree-container';
 import { TreeSearch } from './tree-search';
 import { defaultTreeProps } from './tree-widget';
 
-describe('IsTreeServices should accurately distinguish TreeProps from TreeContainerProps', () => {
-    it('should not be confused by the fact that both have a `search` key', () => {
-        assert(isTreeServices({
-            ...defaultTreeProps, search: true, multiSelect: true, globalSelection: true, contextMenuPath: ['so-contextual']
-        }) === false, 'search:boolean -> false');
-        assert(isTreeServices({ search: TreeSearch }) === true, 'search:class -> true');
+describe('TreeContainer', () => {
+    describe('IsTreeServices should accurately distinguish TreeProps from TreeContainerProps', () => {
+        it('should assign search:boolean to TreeProps', () => {
+            assert(isTreeServices({
+                ...defaultTreeProps, search: true, multiSelect: true, globalSelection: true, contextMenuPath: ['so-contextual']
+            }) === false);
+        });
+        it('should assign search:not-a-boolean to TreeContainerProps', () => {
+            assert(isTreeServices({ search: TreeSearch }) === true);
+        });
     });
 });

--- a/packages/core/src/browser/tree/tree-container.spec.ts
+++ b/packages/core/src/browser/tree/tree-container.spec.ts
@@ -1,0 +1,28 @@
+// *****************************************************************************
+// Copyright (C) 2022 Ericsson and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+// *****************************************************************************
+import * as assert from 'assert';
+import { isTreeServices } from './tree-container';
+import { TreeSearch } from './tree-search';
+import { defaultTreeProps } from './tree-widget';
+
+describe('IsTreeServices should accurately distinguish TreeProps from TreeContainerProps', () => {
+    it('should not be confused by the fact that both have a `search` key', () => {
+        assert(isTreeServices({
+            ...defaultTreeProps, search: true, multiSelect: true, globalSelection: true, contextMenuPath: ['so-contextual']
+        }) === false, 'search:boolean -> false');
+        assert(isTreeServices({ search: TreeSearch }) === true, 'search:class -> true');
+    });
+});

--- a/packages/core/src/browser/tree/tree-container.spec.ts
+++ b/packages/core/src/browser/tree/tree-container.spec.ts
@@ -14,9 +14,10 @@
 // SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
 // *****************************************************************************
 import * as assert from 'assert';
-import { isTreeServices } from './tree-container';
+import { Container } from 'inversify';
+import { createTreeContainer, isTreeServices } from './tree-container';
 import { TreeSearch } from './tree-search';
-import { defaultTreeProps } from './tree-widget';
+import { defaultTreeProps, TreeProps } from './tree-widget';
 
 describe('TreeContainer', () => {
     describe('IsTreeServices should accurately distinguish TreeProps from TreeContainerProps', () => {
@@ -27,6 +28,17 @@ describe('TreeContainer', () => {
         });
         it('should assign search:not-a-boolean to TreeContainerProps', () => {
             assert(isTreeServices({ search: TreeSearch }) === true);
+        });
+        const nonDefault = { search: !defaultTreeProps.search, contextMenu: ['no-default-for-this'] };
+        it('should use props passed in as just props', () => {
+            const parent = new Container();
+            const child = createTreeContainer(parent, nonDefault);
+            assert.deepStrictEqual(child.get(TreeProps), { ...defaultTreeProps, ...nonDefault });
+        });
+        it('should use props passed in as part of TreeContainerProps', () => {
+            const parent = new Container();
+            const child = createTreeContainer(parent, { props: nonDefault });
+            assert.deepStrictEqual(child.get(TreeProps), { ...defaultTreeProps, ...nonDefault });
         });
     });
 });

--- a/packages/core/src/browser/tree/tree-container.ts
+++ b/packages/core/src/browser/tree/tree-container.ts
@@ -28,10 +28,14 @@ import { FuzzySearch } from './fuzzy-search';
 import { SearchBox, SearchBoxFactory } from './search-box';
 import { SearchBoxDebounce } from './search-box-debounce';
 
-function isTreeServices(candidate?: Partial<TreeProps> | Partial<TreeContainerProps>): candidate is TreeContainerProps {
+export function isTreeServices(candidate?: Partial<TreeProps> | Partial<TreeContainerProps>): candidate is TreeContainerProps {
     if (candidate) {
         const maybeServices = candidate as TreeContainerProps;
         for (const key of Object.keys(maybeServices)) {
+            // This key is in both TreeProps and TreeContainerProps, so we have to handle it separately
+            if (key === 'search' && typeof maybeServices[key] === 'boolean') {
+                return false;
+            }
             if (key in defaultImplementations) {
                 return true;
             }

--- a/packages/core/src/browser/tree/tree-container.ts
+++ b/packages/core/src/browser/tree/tree-container.ts
@@ -53,7 +53,7 @@ export function createTreeContainer(parent: interfaces.Container, props?: Partia
 export function createTreeContainer(parent: interfaces.Container, props?: Partial<TreeProps> | Partial<TreeContainerProps>): Container {
     const child = new Container({ defaultScope: 'Singleton' });
     child.parent = parent;
-    const overrideServices: Partial<TreeServiceProviders> = isTreeServices(props) ? props : {};
+    const overrideServices: Partial<TreeContainerProps> = isTreeServices(props) ? props : { props: props as Partial<TreeProps> | undefined };
     for (const key of Object.keys(serviceIdentifiers) as (keyof TreeIdentifiers)[]) {
         if (key === 'props') {
             const { service, identifier } = getServiceAndIdentifier(key, overrideServices);


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

The previous implementation of the check to distinguish `TreeProps` from `TreeContainerProps` could be confused by the fact that both had a `search` key. This PR introduces special handling of that field to ensure that the check returns the correct value.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
1. Assert that the new test introduced in this PR passes.
2. use `createTreeContainer` with `TreeProps` that include a `search` field. Observe that the tree view is successfully constructed and functions correctly.

e.g. in `outline-view-frontend-module.ts` replace this:

```typescript
    const child = createTreeContainer(parent, {
         props: { expandOnlyOnExpansionToggleClick: true, search: true },
         widget: OutlineViewWidget,
         model: OutlineViewTreeModel,
         decoratorService: OutlineDecoratorService,
     });
```

with this:
```typescript
    const child = createTreeContainer(parent, { ...defaultTreeProps, expandOnlyOnExpansionToggleClick: true, search: true });


     child.unbind(TreeWidget);
     child.bind(OutlineViewWidget).toSelf();

     child.unbind(TreeModelImpl);
     child.bind(OutlineViewTreeModel).toSelf();
     child.rebind(TreeModel).toService(OutlineViewTreeModel);

     child.bind(OutlineDecoratorService).toSelf().inSingletonScope();
     child.rebind(TreeDecoratorService).toDynamicValue(ctx => ctx.container.get(OutlineDecoratorService)).inSingletonScope();
```

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
