### PR TITLE
Fix check for Cmd+Click on MacOS for Trees

### DIFF
--- a/packages/core/src/browser/tree/tree-widget.tsx
+++ b/packages/core/src/browser/tree/tree-widget.tsx
@@ -1270,8 +1270,7 @@ export class TreeWidget extends ReactWidget implements StatefulWidget {
      * @returns `true` if the tree modifier aware event contains the `ctrlcmd` mask.
      */
     protected hasCtrlCmdMask(event: TreeWidget.ModifierAwareEvent): boolean {
-        const { metaKey, ctrlKey } = event;
-        return (isOSX && metaKey) || ctrlKey;
+        return isOSX ? event.metaKey : event.ctrlKey;
     }
 
     /**


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

Fixes #10876 by ensuring that on MacOS, we check for meta and not ctrl when handling clicks in the tree widget.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

1. On MacOS
2. Open the navigator
3. Select a node
4. Cmd+click on another node
5. Observe that the second node is selected and the first remains selected.
6. Ctrl+click on a third node
7. Observe that the third node is selected, the first two nodes are not selected, and the context menu is displayed with a `rename` option. 

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
