### PR TITLE
Check for locked after unlocked

### DIFF
--- a/examples/api-tests/src/preferences.spec.js
+++ b/examples/api-tests/src/preferences.spec.js
@@ -161,23 +161,23 @@ describe('Preferences', function () {
     it('Handles many synchronous settings of preferences gracefully', async function () {
         let settings = 0;
         const promises = [];
-        let fontSize;
-        let tabSize;
+        let searchDebounce;
+        let channelHistory;
         let hoverDelay;
         while (settings++ < 100) {
-            fontSize = 8 + Math.floor(Math.random() * 12);
-            tabSize = 1 + Math.floor(Math.random() * 12);
+            searchDebounce = 100 + Math.floor(Math.random() * 500);
+            channelHistory = 200 + Math.floor(Math.random() * 800);
             hoverDelay = 250 + Math.floor(Math.random() * 2_500);
             promises.push(
-                preferenceService.set('editor.fontSize', fontSize),
-                preferenceService.set('editor.tabSize', tabSize),
-                preferenceService.set('editor.hover.delay', hoverDelay)
+                preferenceService.set('search.searchOnTypeDebouncePeriod', searchDebounce),
+                preferenceService.set('output.maxChannelHistory', channelHistory),
+                preferenceService.set('workbench.hover.delay', hoverDelay)
             );
         }
         const results = await Promise.allSettled(promises);
         assert(results.every(setting => setting.status === 'fulfilled'), 'All promises should have resolved rather than rejected.');
-        assert.equal(fontSize, preferenceService.get('editor.fontSize'), 'The last font size setting should have taken effect.');
-        assert.equal(tabSize, preferenceService.get('editor.tabSize'), 'The last tab size setting should have taken effect.');
-        assert.equal(hoverDelay, preferenceService.get('editor.hover.delay'), 'The last hover delay setting should have taken effect');
+        assert.equal(searchDebounce, preferenceService.get('search.searchOnTypeDebouncePeriod'), 'The last debounce setting should have taken effect.');
+        assert.equal(channelHistory, preferenceService.get('output.maxChannelHistory'), 'The last channel setting should have taken effect.');
+        assert.equal(hoverDelay, preferenceService.get('workbench.hover.delay'), 'The last hover delay setting should have taken effect');
     });
 });

--- a/examples/api-tests/src/preferences.spec.js
+++ b/examples/api-tests/src/preferences.spec.js
@@ -157,4 +157,27 @@ describe('Preferences', function () {
         const prefs = await getPreferences();
         shouldBeUndefined(prefs[override], override);
     });
+
+    it('Handles many synchronous settings of preferences gracefully', async function () {
+        let settings = 0;
+        const promises = [];
+        let fontSize;
+        let tabSize;
+        let hoverDelay;
+        while (settings++ < 100) {
+            fontSize = 8 + Math.floor(Math.random() * 12);
+            tabSize = 1 + Math.floor(Math.random() * 12);
+            hoverDelay = 250 + Math.floor(Math.random() * 2_500);
+            promises.push(
+                preferenceService.set('editor.fontSize', fontSize),
+                preferenceService.set('editor.tabSize', tabSize),
+                preferenceService.set('editor.hover.delay', hoverDelay)
+            );
+        }
+        const results = await Promise.allSettled(promises);
+        assert(results.every(setting => setting.status === 'fulfilled'), 'All promises should have resolved rather than rejected.');
+        assert.equal(fontSize, preferenceService.get('editor.fontSize'), 'The last font size setting should have taken effect.');
+        assert.equal(tabSize, preferenceService.get('editor.tabSize'), 'The last tab size setting should have taken effect.');
+        assert.equal(hoverDelay, preferenceService.get('editor.hover.delay'), 'The last hover delay setting should have taken effect');
+    });
 });

--- a/packages/preferences/src/browser/abstract-resource-preference-provider.ts
+++ b/packages/preferences/src/browser/abstract-resource-preference-provider.ts
@@ -115,6 +115,7 @@ export abstract class AbstractResourcePreferenceProvider extends PreferenceProvi
         if (!this.transaction?.open) {
             const current = this.transaction;
             this.transaction = this.transactionFactory(this);
+            this.transaction.waitFor(current?.result);
             this.transaction.onWillConclude(({ status, waitUntil }) => {
                 if (status) {
                     waitUntil((async () => {
@@ -124,7 +125,6 @@ export abstract class AbstractResourcePreferenceProvider extends PreferenceProvi
                 }
             });
             this.toDispose.push(this.transaction);
-            await current?.result;
         }
         return this.transaction.enqueueAction(key, path, value);
     }

--- a/packages/preferences/src/browser/preference-transaction-manager.ts
+++ b/packages/preferences/src/browser/preference-transaction-manager.ts
@@ -82,6 +82,16 @@ export abstract class Transaction<Arguments extends unknown[], Result = unknown,
         }
     }
 
+    async waitFor(delay?: Promise<unknown>, disposeIfRejected?: boolean): Promise<void> {
+        try {
+            await this.queue.runExclusive(() => delay);
+        } catch {
+            if (disposeIfRejected) {
+                this.dispose();
+            }
+        }
+    }
+
     /**
      * @returns a promise reflecting the result of performing an action. Typically the promise will not resolve until the whole transaction is complete.
      */


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->
Fixes #10824 by checking whether the queue is in use before disposing of it. Apparently new actions could be enqueued between the resolution of the `watiForUnlock` promise and the actual running of the wait for unlick code.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

1. I have added a test that ensures that preference transactions can handle many synchronous settings: observe that that passes.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
