### PR TITLE
No validation warning for undefined preference value

### DIFF
--- a/packages/core/src/browser/preferences/preference-validation-service.ts
+++ b/packages/core/src/browser/preferences/preference-validation-service.ts
@@ -57,7 +57,8 @@ export class PreferenceValidationService {
 
     validateByName(preferenceName: string, value: JSONValue): JSONValue {
         const validValue = this.doValidateByName(preferenceName, value);
-        if (validValue !== value) {
+        // If value is undefined, it means the preference wasn't set, not that a bad value was set.
+        if (validValue !== value && value !== undefined) {
             console.warn(`While validating options, found impermissible value for ${preferenceName}. Using valid value`, validValue, 'instead of configured value', value);
         }
         return validValue;


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

Reduces the number of warnings logged during preference validation by not warning if the initial value is `undefined`. Since `undefined` is not a JSON value, it doesn't reflect a bad user setting, so the warning is unnecessary.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

1. Start the application, open an editor, and open the dev tools.
2. On master, you would see something like this:
![image](https://user-images.githubusercontent.com/62660806/158662596-95208414-5764-4f26-9d9d-d3cb40932473.png)

3. Observe that you do not see the warnings for `undefined` values.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
