### PR TITLE
Use modified menuPath only for main action registration

### DIFF
--- a/packages/plugin-ext/src/main/browser/menus/menus-contribution-handler.ts
+++ b/packages/plugin-ext/src/main/browser/menus/menus-contribution-handler.ts
@@ -526,11 +526,9 @@ export class MenusContributionPointHandler {
         const command: Command = { id: commandId };
         const action: MenuAction = { commandId, alt: altId, order, when: menu.when };
 
-        menuPath = inline ? menuPath : [...menuPath, ...group.split('/')];
-
         toDispose.push(this.commands.registerCommand(command, handler(menu.command)));
         toDispose.push(this.quickCommandService?.pushCommandContext(commandId, 'false'));
-        toDispose.push(this.menuRegistry.registerMenuAction(menuPath, action));
+        toDispose.push(this.menuRegistry.registerMenuAction(inline ? menuPath : [...menuPath, ...group.split('/')], action));
         toDispose.push(this.onDidRegisterCommand(menu.command, pluginCommand => {
             command.category = pluginCommand.category;
             command.label = pluginCommand.label;


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

Fixes #10889 by removing the reassignment of the `menuPath` argument. #10863 moved the reassignment up in appropriately: the new value was only supposed to be used in one place. 

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

1. Install GitLens plugin in both VSCode and Theia
2. Open SCM panel
3. Open Branches tree view
4. Open context menu on any branch
5. Observe that the context menu includes submenus for `Copy As` rather than subsections:

![image](https://user-images.githubusercontent.com/62660806/158859723-36f108d2-3059-46ff-98f2-5a3e64cc9d61.png)


#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
