### PR TITLE
Add TailDecoration comma as content rather than CSS

### DIFF
--- a/packages/core/src/browser/style/tree.css
+++ b/packages/core/src/browser/style/tree.css
@@ -139,10 +139,6 @@
     text-align: center;
 }
 
-.theia-TreeNodeTail:not(:last-of-type)::after {
-    content: ',';
-}
-
 .theia-TreeNodeSegment mark {
     background-color: var(--theia-list-filterMatchBackground);
     color: var(--theia-list-inactiveSelectionForeground);

--- a/packages/core/src/browser/tree/tree-widget.tsx
+++ b/packages/core/src/browser/tree/tree-widget.tsx
@@ -818,7 +818,7 @@ export class TreeWidget extends ReactWidget implements StatefulWidget {
                 const icon = (decoration as TreeDecoration.TailDecorationIcon).icon || (decoration as TreeDecoration.TailDecorationIconClass).iconClass;
                 const content = data ? data : icon ? <span key={node.id + 'icon' + index} className={this.getIconClass(icon)}></span> : '';
                 return <div key={node.id + className + index} className={className} style={style} title={tooltip}>
-                    {content}
+                    {content}{index !== tailDecorations.length - 1 ? ',' : ''}
                 </div>;
             })}
         </React.Fragment>;


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->
Modifies the approach taken to adding a comma between tail decorations to put it in the HTML markup rather than the CSS.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

1. Open a file and create some problems, then save it.
2. See something like this in the navigator, with a comma:
![image](https://user-images.githubusercontent.com/62660806/158889858-e889c1e6-328f-4717-b52f-88307b8f41a3.png)
3. Install GitLens, open the `Branches` tree view, and select one of the branches.
4. See this:
![image](https://user-images.githubusercontent.com/62660806/158890008-d7ff135e-3e49-423e-a9f9-0e75007354cc.png)

Not this (note funny commas):

![image](https://user-images.githubusercontent.com/62660806/158890055-8e7d359f-0d06-4ae2-9135-4dd363265b14.png)

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
