### PR TITLE
Implement icon reference rendering for plugin tree view tooltips

### DIFF
--- a/packages/plugin-ext/src/main/browser/style/tree.css
+++ b/packages/plugin-ext/src/main/browser/style/tree.css
@@ -44,3 +44,7 @@
 .theia-tree-view .theia-TreeNode:not(:hover):not(.theia-mod-selected) .theia-tree-view-inline-action {
     display: none;
 }
+
+.codicon.icon-inline {
+    font-size: var(--theia-ui-font-size1);
+}


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

Fixes #10896 by implementing a small plugin for markdownit that adds a rule to replace icon references in plugin tree tooltips with icons.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

1. Open the application, install GitLens, open the `Branches` view and hover over a branch
2. See this:

![image](https://user-images.githubusercontent.com/62660806/158906954-bf1526bd-0013-4920-9882-d9644c9ad6e9.png)

Instead of this:

![image](https://user-images.githubusercontent.com/62660806/158847309-badb296c-94e5-4be0-b8b2-1e9ad1cda88f.png)

3. Perform the same check on other plugin icon references you're aware of.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
