### PR TITLE
Check application state before showing file resource dialog

### DIFF
--- a/packages/filesystem/src/browser/file-resource.ts
+++ b/packages/filesystem/src/browser/file-resource.ts
@@ -22,7 +22,7 @@ import { Readable, ReadableStream } from '@theia/core/lib/common/stream';
 import URI from '@theia/core/lib/common/uri';
 import { FileOperation, FileOperationError, FileOperationResult, ETAG_DISABLED, FileSystemProviderCapabilities, FileReadStreamOptions, BinarySize } from '../common/files';
 import { FileService, TextFileOperationError, TextFileOperationResult } from './file-service';
-import { ConfirmDialog } from '@theia/core/lib/browser/dialogs';
+import { ConfirmDialog, Dialog } from '@theia/core/lib/browser/dialogs';
 import { LabelProvider } from '@theia/core/lib/browser/label-provider';
 import { GENERAL_MAX_FILE_SIZE_MB } from './filesystem-preferences';
 import { FrontendApplicationStateService } from '@theia/core/lib/browser/frontend-application-state';
@@ -327,8 +327,8 @@ export class FileResourceResolver implements ResourceResolver {
             title: nls.localize('theia/filesystem/fileResource/overwriteTitle', "The file '{0}' has been changed on the file system.", this.labelProvider.getName(uri)),
             msg: nls.localize('theia/fileSystem/fileResource/overWriteBody',
                 "Do you want to overwrite the changes made to '{0}' on the file system?", this.labelProvider.getLongName(uri)),
-            ok: 'Yes',
-            cancel: 'No'
+            ok: Dialog.YES,
+            cancel: Dialog.NO,
         });
         return !!await dialog.open();
     }
@@ -345,8 +345,8 @@ export class FileResourceResolver implements ResourceResolver {
                     msg: nls.localize('theia/filesystem/fileResource/binaryFileQuery',
                         "Opening it might take some time and might make the IDE unresponsive. Do you want to open '{0}' anyway?", this.labelProvider.getLongName(uri)
                     ),
-                    ok: 'Yes',
-                    cancel: 'No'
+                    ok: Dialog.YES,
+                    cancel: Dialog.NO,
                 });
                 return !!await dialog.open();
             }

--- a/packages/filesystem/src/browser/file-resource.ts
+++ b/packages/filesystem/src/browser/file-resource.ts
@@ -26,6 +26,7 @@ import { ConfirmDialog } from '@theia/core/lib/browser/dialogs';
 import { LabelProvider } from '@theia/core/lib/browser/label-provider';
 import { GENERAL_MAX_FILE_SIZE_MB } from './filesystem-preferences';
 import { FrontendApplicationStateService } from '@theia/core/lib/browser/frontend-application-state';
+import { nls } from '@theia/core';
 
 export interface FileResourceVersion extends ResourceVersion {
     readonly encoding: string;
@@ -110,14 +111,15 @@ export class FileResource implements Resource {
             return stat.value;
         } catch (e) {
             if (e instanceof TextFileOperationError && e.textFileOperationResult === TextFileOperationResult.FILE_IS_BINARY) {
-                if (await this.shouldOpenAsText('The file is either binary or uses an unsupported text encoding.')) {
+                if (await this.shouldOpenAsText(nls.localize('theia/filesystem/fileResource/binaryTitle', 'The file is either binary or uses an unsupported text encoding.'))) {
                     this.acceptTextOnly = false;
                     return this.readContents(options);
                 }
             } else if (e instanceof FileOperationError && e.fileOperationResult === FileOperationResult.FILE_TOO_LARGE) {
                 const stat = await this.fileService.resolve(this.uri, { resolveMetadata: true });
                 const maxFileSize = GENERAL_MAX_FILE_SIZE_MB * 1024 * 1024;
-                if (this.limits?.size !== maxFileSize && await this.shouldOpenAsText(`The file is too large (${BinarySize.formatSize(stat.size)}).`)) {
+                if (this.limits?.size !== maxFileSize && await this.shouldOpenAsText(nls.localize(
+                    'theia/filesystem/fileResource/largeFileTitle', 'The file is too large ({0}).', BinarySize.formatSize(stat.size)))) {
                     this.limits = {
                         size: maxFileSize
                     };
@@ -154,14 +156,15 @@ export class FileResource implements Resource {
             return stat.value;
         } catch (e) {
             if (e instanceof TextFileOperationError && e.textFileOperationResult === TextFileOperationResult.FILE_IS_BINARY) {
-                if (await this.shouldOpenAsText('The file is either binary or uses an unsupported text encoding.')) {
+                if (await this.shouldOpenAsText(nls.localize('theia/filesystem/fileResource/binaryTitle', 'The file is either binary or uses an unsupported text encoding.'))) {
                     this.acceptTextOnly = false;
                     return this.readStream(options);
                 }
             } else if (e instanceof FileOperationError && e.fileOperationResult === FileOperationResult.FILE_TOO_LARGE) {
                 const stat = await this.fileService.resolve(this.uri, { resolveMetadata: true });
                 const maxFileSize = GENERAL_MAX_FILE_SIZE_MB * 1024 * 1024;
-                if (this.limits?.size !== maxFileSize && await this.shouldOpenAsText(`The file is too large (${BinarySize.formatSize(stat.size)}).`)) {
+                if (this.limits?.size !== maxFileSize && await this.shouldOpenAsText(nls.localize(
+                    'theia/filesystem/fileResource/largeFileTitle', 'The file is too large ({0}).', BinarySize.formatSize(stat.size)))) {
                     this.limits = {
                         size: maxFileSize
                     };
@@ -321,8 +324,9 @@ export class FileResourceResolver implements ResourceResolver {
 
     protected async shouldOverwrite(uri: URI): Promise<boolean> {
         const dialog = new ConfirmDialog({
-            title: `The file '${this.labelProvider.getName(uri)}' has been changed on the file system.`,
-            msg: `Do you want to overwrite the changes made to '${this.labelProvider.getLongName(uri)}' on the file system?`,
+            title: nls.localize('theia/filesystem/fileResource/overwriteTitle', "The file '{0}' has been changed on the file system.", this.labelProvider.getName(uri)),
+            msg: nls.localize('theia/fileSystem/fileResource/overWriteBody',
+                "Do you want to overwrite the changes made to '{0}' on the file system?", this.labelProvider.getLongName(uri)),
             ok: 'Yes',
             cancel: 'No'
         });
@@ -338,7 +342,9 @@ export class FileResourceResolver implements ResourceResolver {
             default: {
                 const dialog = new ConfirmDialog({
                     title: error,
-                    msg: `Opening it might take some time and might make the IDE unresponsive. Do you want to open '${this.labelProvider.getLongName(uri)}' anyway?`,
+                    msg: nls.localize('theia/filesystem/fileResource/binaryFileQuery',
+                        "Opening it might take some time and might make the IDE unresponsive. Do you want to open '{0}' anyway?", this.labelProvider.getLongName(uri)
+                    ),
                     ok: 'Yes',
                     cancel: 'No'
                 });


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

Fixes #9843 by checking application state before trying to show a file-resource-related dialog.

I think ideally, it wouldn't be the resource that was responsible for this dialog: different contexts should be allowed to handle it differently. But this fix does address the specific problem described in the bug with a minimum change in the architecture. I'm open to other suggestions (for example, maybe if we're running remotely, we should automatically reject rather than automatically approve the request?).

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

1. Open the application.
2. Open a binary file or large file of some kind.
3. Observe that you get a dialog requesting confirmation that you want to open the binary file as text.
4. Close and reopen the application.
5. The layout should be restored, and the file should be opened as text without a dialog prompt.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
