### PR TITLE
Draft: Add a watermark widget

### DIFF
--- a/packages/core/src/browser/frontend-application-module.ts
+++ b/packages/core/src/browser/frontend-application-module.ts
@@ -122,6 +122,10 @@ import { TooltipService, TooltipServiceImpl } from './tooltip-service';
 import { bindFrontendStopwatch, bindBackendStopwatch } from './performance';
 import { SaveResourceService } from './save-resource-service';
 import { UserWorkingDirectoryProvider } from './user-working-directory-provider';
+import { WatermarkWidget } from './watermark/watermark-widget';
+import { WatermarkCommandRegistry } from './watermark/watermark-command-registry';
+import { KeybindingUtil } from './keybinding/keybinding-util';
+import { WatermarkCommandApplicationContribution, WatermarkCommandContribution } from './watermark';
 
 export { bindResourceProvider, bindMessageService, bindPreferenceService };
 
@@ -224,6 +228,7 @@ export const frontendApplicationModule = new ContainerModule((bind, unbind, isBo
     });
     bind(CommandService).toService(CommandRegistry);
     bindContributionProvider(bind, CommandContribution);
+    bind(KeybindingUtil).toSelf().inSingletonScope();
 
     bind(ContextKeyService).to(ContextKeyServiceDummyImpl).inSingletonScope();
 
@@ -253,7 +258,7 @@ export const frontendApplicationModule = new ContainerModule((bind, unbind, isBo
     );
 
     bind(QuickCommandFrontendContribution).toSelf().inSingletonScope();
-    [CommandContribution, KeybindingContribution, MenuContribution].forEach(serviceIdentifier =>
+    [CommandContribution, KeybindingContribution, MenuContribution, WatermarkCommandContribution].forEach(serviceIdentifier =>
         bind(serviceIdentifier).toService(QuickCommandFrontendContribution)
     );
     bind(QuickCommandService).toSelf().inSingletonScope();
@@ -400,4 +405,10 @@ export const frontendApplicationModule = new ContainerModule((bind, unbind, isBo
 
     bind(SaveResourceService).toSelf().inSingletonScope();
     bind(UserWorkingDirectoryProvider).toSelf().inSingletonScope();
+
+    bind(WatermarkWidget).toSelf().inSingletonScope();
+    bind(WatermarkCommandRegistry).toSelf().inSingletonScope();
+    bindContributionProvider(bind, WatermarkCommandContribution);
+    bind(WatermarkCommandApplicationContribution).toSelf().inSingletonScope();
+    bind(FrontendApplicationContribution).toService(WatermarkCommandApplicationContribution);
 });

--- a/packages/core/src/browser/index.ts
+++ b/packages/core/src/browser/index.ts
@@ -42,3 +42,5 @@ export * from './view-container';
 export * from './breadcrumbs';
 export * from './tooltip-service';
 export * from './decoration-style';
+export * from './keybinding';
+export * from './watermark';

--- a/packages/core/src/browser/keybinding/index.ts
+++ b/packages/core/src/browser/keybinding/index.ts
@@ -1,0 +1,18 @@
+// *****************************************************************************
+// Copyright (C) 2022 Alexander Flammer.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+// *****************************************************************************
+
+export * from './keybinding-util';
+export * from './keybinding-segments-widget';

--- a/packages/core/src/browser/keybinding/keybinding-segments-widget.tsx
+++ b/packages/core/src/browser/keybinding/keybinding-segments-widget.tsx
@@ -1,0 +1,45 @@
+// *****************************************************************************
+// Copyright (C) 2022 Ericsson and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import * as React from 'react';
+import { injectable } from 'inversify';
+import { RenderableKeybindingStringSegment } from './keybinding-util';
+
+export interface KeybindingProps {
+    segments: RenderableKeybindingStringSegment[];
+}
+
+/**
+ * A reusable widget to render keybindings
+ */
+@injectable()
+export class KeybindingSegmentsWidget extends React.Component<KeybindingProps> {
+
+    override render(): React.ReactNode {
+        return this.props.segments.map((segment, index) => {
+            if (segment.key) {
+                return <span key={index} className='monaco-keybinding-key'>
+                    <span>{segment.value}</span>
+                </span>;
+            } else {
+                return <span key={index} className='monaco-keybinding-separator'>
+                    {segment.value}
+                </span>;
+            }
+        });
+    }
+
+}

--- a/packages/core/src/browser/keybinding/keybinding-util.ts
+++ b/packages/core/src/browser/keybinding/keybinding-util.ts
@@ -1,0 +1,71 @@
+// *****************************************************************************
+// Copyright (C) 2022 Ericsson and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { inject, injectable } from 'inversify';
+import { KeybindingRegistry, ResolvedKeybinding } from '../keybinding';
+import { Command } from '../../common';
+
+export interface RenderableKeybindingStringSegment {
+    value: string;
+    key: boolean;
+}
+
+@injectable()
+export class KeybindingUtil {
+
+    @inject(KeybindingRegistry) protected readonly keybindingRegistry: KeybindingRegistry;
+
+    public getRenderableKeybindingSegments(item: ResolvedKeybinding): RenderableKeybindingStringSegment[] {
+        const segments = this.keybindingRegistry.resolveKeybinding(item).reduce<RenderableKeybindingStringSegment[]>((collection, code, codeIndex) => {
+            if (codeIndex !== 0) {
+                // Two non-breaking spaces.
+                collection.push({ value: '\u00a0\u00a0', key: false });
+            }
+            const displayChunks = this.keybindingRegistry.componentsForKeyCode(code);
+
+            displayChunks.forEach((chunk, chunkIndex) => {
+                if (chunkIndex !== 0) {
+                    collection.push({ value: '+', key: false });
+                }
+                collection.push({ value: chunk, key: true });
+            });
+            return collection;
+        }, []);
+        return segments;
+    }
+
+    /**
+     * Get the human-readable label for a given command.
+     * @param command the command.
+     *
+     * @returns a human-readable label for the given command.
+     */
+    public getCommandLabel(command: Command): string {
+        if (command.label) {
+            // Prefix the command label with the category if it exists, else return the simple label.
+            return command.category ? `${command.category}: ${command.label}` : command.label;
+        }
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        if ((command as any).dialogLabel) {
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            const label = (command as any).dialogLabel;
+            return command.category ? `${command.category}: ${label}` : label;
+        };
+
+        return command.id;
+    }
+
+}

--- a/packages/core/src/browser/quick-input/quick-command-frontend-contribution.ts
+++ b/packages/core/src/browser/quick-input/quick-command-frontend-contribution.ts
@@ -19,9 +19,10 @@ import { KeybindingRegistry, KeybindingContribution } from '../keybinding';
 import { CommonMenus } from '../common-frontend-contribution';
 import { CLEAR_COMMAND_HISTORY, quickCommand, QuickCommandService } from './quick-command-service';
 import { QuickInputService } from './quick-input-service';
+import { WatermarkCommandContribution, WatermarkCommandRegistry } from '../watermark';
 
 @injectable()
-export class QuickCommandFrontendContribution implements CommandContribution, KeybindingContribution, MenuContribution {
+export class QuickCommandFrontendContribution implements CommandContribution, KeybindingContribution, MenuContribution, WatermarkCommandContribution {
 
     @inject(QuickInputService) @optional()
     protected readonly quickInputService: QuickInputService;
@@ -38,6 +39,10 @@ export class QuickCommandFrontendContribution implements CommandContribution, Ke
         commands.registerCommand(CLEAR_COMMAND_HISTORY, {
             execute: () => commands.clearCommandHistory(),
         });
+    }
+
+    registerWatermarkCommands(registry: WatermarkCommandRegistry): void {
+        registry.registerWatermarkCommand(quickCommand.id);
     }
 
     registerMenus(menus: MenuModelRegistry): void {

--- a/packages/core/src/browser/quick-input/quick-command-service.ts
+++ b/packages/core/src/browser/quick-input/quick-command-service.ts
@@ -16,7 +16,7 @@
 
 import { inject, injectable } from 'inversify';
 import { KeybindingRegistry } from '../keybinding';
-import { Disposable, Command, CommandRegistry, CancellationToken } from '../../common';
+import { Disposable, Command, CommandRegistry, CancellationToken, nls } from '../../common';
 import { ContextKeyService } from '../context-key-service';
 import { CorePreferences } from '../core-preferences';
 import { QuickAccessContribution, QuickAccessProvider, QuickAccessRegistry } from './quick-access';
@@ -25,7 +25,8 @@ import { KeySequence } from '../keys';
 import { codiconArray } from '../widgets';
 
 export const quickCommand: Command = {
-    id: 'workbench.action.showCommands'
+    id: 'workbench.action.showCommands',
+    label: nls.localizeByDefault('Show All Commands')
 };
 
 export const CLEAR_COMMAND_HISTORY = Command.toDefaultLocalizedCommand({

--- a/packages/core/src/browser/shell/application-shell.ts
+++ b/packages/core/src/browser/shell/application-shell.ts
@@ -39,6 +39,7 @@ import { CorePreferences } from '../core-preferences';
 import { BreadcrumbsRendererFactory } from '../breadcrumbs/breadcrumbs-renderer';
 import { Deferred } from '../../common/promise-util';
 import { SaveResourceService } from '../save-resource-service';
+import { WatermarkWidget } from '../watermark/watermark-widget';
 
 /** The class name added to ApplicationShell instances. */
 const APPLICATION_SHELL_CLASS = 'theia-ApplicationShell';
@@ -207,6 +208,9 @@ export class ApplicationShell extends Widget {
     protected readonly onDidChangeCurrentWidgetEmitter = new Emitter<FocusTracker.IChangedArgs<Widget>>();
     readonly onDidChangeCurrentWidget = this.onDidChangeCurrentWidgetEmitter.event;
 
+    @inject(WatermarkWidget)
+    protected readonly watermarkWidget: WatermarkWidget;
+
     /**
      * Construct a new application shell.
      */
@@ -317,6 +321,10 @@ export class ApplicationShell extends Widget {
         document.addEventListener('p-dragover', this, true);
         document.addEventListener('p-dragleave', this, true);
         document.addEventListener('p-drop', this, true);
+    }
+
+    protected override onAfterAttach(msg: Message): void {
+        Widget.attach(this.watermarkWidget, this.mainPanel.node);
     }
 
     protected override onAfterDetach(msg: Message): void {

--- a/packages/core/src/browser/style/index.css
+++ b/packages/core/src/browser/style/index.css
@@ -282,3 +282,4 @@ button.secondary[disabled], .theia-button.secondary[disabled] {
 @import './progress-bar.css';
 @import './breadcrumbs.css';
 @import './tooltip.css';
+@import './watermark.css';

--- a/packages/core/src/browser/style/watermark.css
+++ b/packages/core/src/browser/style/watermark.css
@@ -1,0 +1,32 @@
+/********************************************************************************
+ * Copyright (C) 2022 Alexander Flammer.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+#theia-main-content-watermark {
+    margin-right: auto;
+    width: 100%;
+    display: flex;
+    justify-content: center;
+    top: calc(50% + 150px);
+    opacity: .8;
+}
+ 
+.watermark-keybinding {
+    padding: 2px 10px 5px 10px;
+}
+
+.watermark-keybinding-label {
+    text-align: right;
+}

--- a/packages/core/src/browser/watermark/index.ts
+++ b/packages/core/src/browser/watermark/index.ts
@@ -1,0 +1,18 @@
+// *****************************************************************************
+// Copyright (C) 2022 Alexander Flammer.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+// *****************************************************************************
+export * from './watermark-widget';
+export * from './watermark-command-registry';
+export * from './watermark-command-contribution';

--- a/packages/core/src/browser/watermark/watermark-command-contribution.ts
+++ b/packages/core/src/browser/watermark/watermark-command-contribution.ts
@@ -1,0 +1,48 @@
+// *****************************************************************************
+// Copyright (C) 2022 Alexander Flammer.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { injectable, inject, named } from 'inversify';
+import { ContributionProvider, MaybePromise } from '../../common';
+import { FrontendApplication, FrontendApplicationContribution } from '../frontend-application';
+import { WatermarkCommandRegistry } from './watermark-command-registry';
+
+export const WatermarkCommandContribution = Symbol('WatermarkCommandContribution');
+/**
+ * The watermark command contribution should be implemented to register custom watermark commands.
+ */
+export interface WatermarkCommandContribution {
+    /**
+     * Register watermark commands.
+     */
+    registerWatermarkCommands(registry: WatermarkCommandRegistry): void;
+}
+
+@injectable()
+export class WatermarkCommandApplicationContribution implements FrontendApplicationContribution {
+
+    @inject(ContributionProvider) @named(WatermarkCommandContribution)
+    protected readonly watermarkCommandContributions: ContributionProvider<WatermarkCommandContribution>;
+
+    @inject(WatermarkCommandRegistry)
+    protected readonly registry: WatermarkCommandRegistry;
+
+    onStart(app: FrontendApplication): MaybePromise<void> {
+        for (const contribution of this.watermarkCommandContributions.getContributions()) {
+            contribution.registerWatermarkCommands(this.registry);
+        }
+    }
+
+}

--- a/packages/core/src/browser/watermark/watermark-command-registry.spec.ts
+++ b/packages/core/src/browser/watermark/watermark-command-registry.spec.ts
@@ -1,0 +1,62 @@
+// *****************************************************************************
+// Copyright (C) 2022 Alexander Flammer.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import * as chai from 'chai';
+import { WatermarkCommandRegistry } from './watermark-command-registry';
+
+const expect = chai.expect;
+let commandRegistry: WatermarkCommandRegistry;
+const dummyCommandId = 'someCommand';
+
+describe('WatermarkCommand Registration', () => {
+
+    beforeEach(() => {
+        commandRegistry = new WatermarkCommandRegistry();
+    });
+
+    it('should register a command id', async () => {
+        commandRegistry.registerWatermarkCommand(dummyCommandId);
+        const result = commandRegistry.getAllEnabledWatermarkCommands();
+        expect(result).to.have.key(dummyCommandId);
+    });
+
+    it('should not add duplicate command ids', async () => {
+        commandRegistry.registerWatermarkCommand(dummyCommandId);
+        commandRegistry.registerWatermarkCommand(dummyCommandId);
+        const result = commandRegistry.getAllEnabledWatermarkCommands();
+        expect(result).to.have.key(dummyCommandId);
+    });
+
+    it('should remove registrations upon disposal', async () => {
+        const registration = commandRegistry.registerWatermarkCommand(dummyCommandId);
+        const result = commandRegistry.getAllEnabledWatermarkCommands();
+        expect(result).to.have.key(dummyCommandId);
+        registration.dispose();
+        const commandsAfterDisposal = commandRegistry.getAllEnabledWatermarkCommands();
+        // eslint-disable-next-line no-unused-expressions
+        expect(commandsAfterDisposal).to.be.empty;
+    });
+
+    it('should return only enabled commands', async () => {
+        const notVisibleCommandId = 'someNotVisibleCommandId';
+        commandRegistry.registerWatermarkCommand(dummyCommandId, { isVisible: () => true });
+        commandRegistry.registerWatermarkCommand(notVisibleCommandId, { isVisible: () => false });
+        const result = commandRegistry.getAllEnabledWatermarkCommands();
+        expect(result).to.have.key(dummyCommandId);
+        expect(result).to.not.have.key(notVisibleCommandId);
+    });
+
+});

--- a/packages/core/src/browser/watermark/watermark-command-registry.ts
+++ b/packages/core/src/browser/watermark/watermark-command-registry.ts
@@ -1,0 +1,75 @@
+// *****************************************************************************
+// Copyright (C) 2022 Alexander Flammer.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { injectable } from 'inversify';
+import { Disposable, DisposableCollection } from '../../common';
+
+export interface WatermarkCommandOptions {
+    /**
+     * Priority of the watermark command
+     */
+    rank?: number;
+    /**
+     * Test whether the watermark command should be shown
+     */
+    isVisible?(): boolean;
+}
+
+/**
+ * The watermark command registry manages commands to be shown in the watermark widget.
+ */
+@injectable()
+export class WatermarkCommandRegistry {
+
+    /**
+     * Registered commands to be shown in the watermark widget
+     */
+    protected readonly _commands: { [id: string]: WatermarkCommandOptions } = {};
+    protected readonly toUnregisterCommands = new Map<string, Disposable>();
+
+    registerWatermarkCommand(commandId: string, options?: WatermarkCommandOptions): Disposable {
+        if (this._commands[commandId]) {
+            console.warn(`Command ${commandId} is already registered as a watermark command.`);
+            return Disposable.NULL;
+        }
+        const toDispose = new DisposableCollection(this.doRegisterCommand(commandId, options ?? {}));
+        this.toUnregisterCommands.set(commandId, toDispose);
+        toDispose.push(Disposable.create(() => this.toUnregisterCommands.delete(commandId)));
+        return toDispose;
+    }
+
+    protected doRegisterCommand(commandId: string, options: WatermarkCommandOptions): Disposable {
+        this._commands[commandId] = options;
+        return {
+            dispose: () => {
+                delete this._commands[commandId];
+            }
+        };
+    }
+
+    getAllEnabledWatermarkCommands(): ReadonlyMap<string, WatermarkCommandOptions> {
+        const result = new Map<string, WatermarkCommandOptions>();
+
+        for (const [key, value] of Object.entries(this._commands)) {
+            if (!value.isVisible || value.isVisible()) {
+                result.set(key, value);
+            }
+        }
+
+        return result;
+    }
+
+}

--- a/packages/core/src/browser/watermark/watermark-widget.tsx
+++ b/packages/core/src/browser/watermark/watermark-widget.tsx
@@ -1,0 +1,121 @@
+// *****************************************************************************
+// Copyright (C) 2022 Alexander Flammer.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import * as React from 'react';
+import { ReactWidget } from '../widgets/react-widget';
+import { injectable, inject } from 'inversify';
+import { Message } from '../widgets';
+import { KeybindingUtil, RenderableKeybindingStringSegment } from '../keybinding/keybinding-util';
+import { Command, CommandRegistry } from '../../common';
+import { WatermarkCommandOptions, WatermarkCommandRegistry } from './watermark-command-registry';
+import { KeybindingSegmentsWidget } from '../keybinding/keybinding-segments-widget';
+import { KeybindingRegistry, ScopedKeybinding } from '../keybinding';
+
+export interface KeybindingRenderingItem {
+    command: Command
+    keybinding: ScopedKeybinding
+    keySegments: RenderableKeybindingStringSegment[]
+    commandLabel: string;
+}
+
+@injectable()
+export class WatermarkWidget extends ReactWidget {
+
+    @inject(CommandRegistry) protected readonly commandRegistry: CommandRegistry;
+    @inject(KeybindingUtil) protected readonly keybindingUtil: KeybindingUtil;
+    @inject(WatermarkCommandRegistry) protected readonly watermarkCommandRegistry: WatermarkCommandRegistry;
+    @inject(KeybindingRegistry) protected readonly keybindingRegistry: KeybindingRegistry;
+
+    constructor() {
+        super();
+        this.id = 'theia-main-content-watermark';
+    }
+
+    protected override onAfterAttach(msg: Message): void {
+        super.onAfterAttach(msg);
+        this.update();
+        const disposable = this.keybindingRegistry.onKeybindingsChanged(() => {
+            this.update();
+        });
+        this.toDispose.push(disposable);
+    }
+
+    protected override render(): React.ReactNode {
+        const watermarkCommandIds = this.watermarkCommandRegistry.getAllEnabledWatermarkCommands();
+        const enabledWatermarkCommandIds = this.filterCommands(watermarkCommandIds);
+
+        const items: KeybindingRenderingItem[] = [];
+
+        for (let i = 0; i < enabledWatermarkCommandIds.length; i++) {
+            const command = enabledWatermarkCommandIds[i];
+
+            const keybinding = this.keybindingRegistry.getKeybindingsForCommand(command.id)[0];
+            if (!keybinding) {
+                continue;
+            }
+
+            const keySegments = this.keybindingUtil.getRenderableKeybindingSegments(keybinding);
+            const commandLabel = this.keybindingUtil.getCommandLabel(command);
+
+            const item = {
+                command,
+                keybinding,
+                keySegments,
+                commandLabel
+            };
+
+            items.push(item);
+        }
+
+        const content = items.map((item, _) =>
+            this.renderKeybindings(item)
+        );
+
+        return <table>
+            <tbody>
+                {content}
+            </tbody>
+        </table>;
+    }
+
+    protected filterCommands(watermarkCommandIds: ReadonlyMap<string, WatermarkCommandOptions>): Command[] {
+        const commandsIds = Array.from(watermarkCommandIds.keys());
+
+        return commandsIds
+            .map(a => this.commandRegistry.commands.find(c => c.id === a))
+            .filter((a): a is Command => !!a)
+            .sort((a: Command, b: Command) => {
+                const firstRank = watermarkCommandIds.get(a.id)?.rank ?? 0;
+                const secondRank = watermarkCommandIds.get(b.id)?.rank ?? 0;
+                if (firstRank !== secondRank) {
+                    return firstRank - secondRank;
+                }
+                return Command.compareCommands(a, b);
+            });
+    }
+
+    protected renderKeybindings(item: KeybindingRenderingItem): React.ReactNode {
+        return <tr key={item.command.id}>
+            <td className='watermark-keybinding-label' title={item.commandLabel}>
+                {item.commandLabel}
+            </td>
+            <td title={item.keybinding.keybinding} className='watermark-keybinding monaco-keybinding'>
+                {<KeybindingSegmentsWidget segments={item.keySegments} />}
+            </td>
+        </tr>;
+    }
+
+}

--- a/packages/debug/src/browser/debug-frontend-application-contribution.ts
+++ b/packages/debug/src/browser/debug-frontend-application-contribution.ts
@@ -14,7 +14,10 @@
 // SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
 // *****************************************************************************
 
-import { AbstractViewContribution, ApplicationShell, KeybindingRegistry, Widget, CompositeTreeNode, LabelProvider, codicon } from '@theia/core/lib/browser';
+import {
+    AbstractViewContribution, ApplicationShell, KeybindingRegistry, Widget, CompositeTreeNode, LabelProvider, codicon, WatermarkCommandContribution,
+    WatermarkCommandRegistry
+} from '@theia/core/lib/browser';
 import { injectable, inject } from '@theia/core/shared/inversify';
 import * as monaco from '@theia/monaco-editor-core';
 import { MenuModelRegistry, CommandRegistry, MAIN_MENU_BAR, Command, Emitter, Mutable } from '@theia/core/lib/common';
@@ -52,6 +55,7 @@ import { ColorRegistry } from '@theia/core/lib/browser/color-registry';
 import { DebugFunctionBreakpoint } from './model/debug-function-breakpoint';
 import { DebugBreakpoint } from './model/debug-breakpoint';
 import { nls } from '@theia/core/lib/common/nls';
+import { WorkspaceService } from '@theia/workspace/lib/browser';
 
 export namespace DebugMenus {
     export const DEBUG = [...MAIN_MENU_BAR, '6_debug'];
@@ -389,7 +393,8 @@ export namespace DebugBreakpointWidgetCommands {
 }
 
 @injectable()
-export class DebugFrontendApplicationContribution extends AbstractViewContribution<DebugWidget> implements TabBarToolbarContribution, ColorContribution {
+export class DebugFrontendApplicationContribution extends AbstractViewContribution<DebugWidget> implements TabBarToolbarContribution, ColorContribution,
+    WatermarkCommandContribution {
 
     @inject(DebugService)
     protected readonly debug: DebugService;
@@ -426,6 +431,9 @@ export class DebugFrontendApplicationContribution extends AbstractViewContributi
 
     @inject(EditorManager)
     protected readonly editorManager: EditorManager;
+
+    @inject(WorkspaceService)
+    protected readonly workspaceService: WorkspaceService;
 
     constructor() {
         super({
@@ -1490,6 +1498,13 @@ export class DebugFrontendApplicationContribution extends AbstractViewContributi
         }
 
         return true;
+    }
+
+    registerWatermarkCommands(registry: WatermarkCommandRegistry): void {
+        registry.registerWatermarkCommand(DebugCommands.START.id, {
+            rank: 10,
+            isVisible: () => this.workspaceService.tryGetRoots().length > 0
+        });
     }
 
 }

--- a/packages/debug/src/browser/debug-frontend-module.ts
+++ b/packages/debug/src/browser/debug-frontend-module.ts
@@ -22,7 +22,7 @@ import { DebugWidget } from './view/debug-widget';
 import { DebugPath, DebugService } from '../common/debug-service';
 import {
     WidgetFactory, WebSocketConnectionProvider, FrontendApplicationContribution,
-    bindViewContribution, KeybindingContext
+    bindViewContribution, KeybindingContext, WatermarkCommandContribution
 } from '@theia/core/lib/browser';
 import { DebugSessionManager } from './debug-session-manager';
 import { DebugResourceResolver } from './debug-resource';
@@ -108,6 +108,7 @@ export default new ContainerModule((bind: interfaces.Bind) => {
     bind(FrontendApplicationContribution).toService(DebugFrontendApplicationContribution);
     bind(TabBarToolbarContribution).toService(DebugFrontendApplicationContribution);
     bind(ColorContribution).toService(DebugFrontendApplicationContribution);
+    bind(WatermarkCommandContribution).toService(DebugFrontendApplicationContribution);
 
     bind(DebugSessionContributionRegistryImpl).toSelf().inSingletonScope();
     bind(DebugSessionContributionRegistry).toService(DebugSessionContributionRegistryImpl);

--- a/packages/file-search/src/browser/file-search-frontend-module.ts
+++ b/packages/file-search/src/browser/file-search-frontend-module.ts
@@ -16,7 +16,7 @@
 
 import { ContainerModule, interfaces } from '@theia/core/shared/inversify';
 import { CommandContribution, MenuContribution } from '@theia/core/lib/common';
-import { WebSocketConnectionProvider, KeybindingContribution } from '@theia/core/lib/browser';
+import { WebSocketConnectionProvider, KeybindingContribution, WatermarkCommandContribution } from '@theia/core/lib/browser';
 import { QuickFileOpenFrontendContribution } from './quick-file-open-contribution';
 import { QuickFileOpenService } from './quick-file-open';
 import { fileSearchServicePath, FileSearchService } from '../common/file-search-service';
@@ -29,7 +29,7 @@ export default new ContainerModule((bind: interfaces.Bind) => {
     }).inSingletonScope();
 
     bind(QuickFileOpenFrontendContribution).toSelf().inSingletonScope();
-    [CommandContribution, KeybindingContribution, MenuContribution, QuickAccessContribution].forEach(serviceIdentifier =>
+    [CommandContribution, KeybindingContribution, MenuContribution, QuickAccessContribution, WatermarkCommandContribution].forEach(serviceIdentifier =>
         bind(serviceIdentifier).toService(QuickFileOpenFrontendContribution)
     );
 

--- a/packages/file-search/src/browser/quick-file-open-contribution.ts
+++ b/packages/file-search/src/browser/quick-file-open-contribution.ts
@@ -18,15 +18,18 @@ import { injectable, inject } from '@theia/core/shared/inversify';
 import URI from '@theia/core/lib/common/uri';
 import { QuickFileOpenService, quickFileOpen } from './quick-file-open';
 import { CommandRegistry, CommandContribution, MenuContribution, MenuModelRegistry } from '@theia/core/lib/common';
-import { KeybindingRegistry, KeybindingContribution, QuickAccessContribution } from '@theia/core/lib/browser';
+import { KeybindingRegistry, KeybindingContribution, QuickAccessContribution, WatermarkCommandRegistry, WatermarkCommandContribution } from '@theia/core/lib/browser';
 import { EditorMainMenu } from '@theia/editor/lib/browser';
 import { nls } from '@theia/core/lib/common/nls';
+import { WorkspaceService } from '@theia/workspace/lib/browser/workspace-service';
 
 @injectable()
-export class QuickFileOpenFrontendContribution implements QuickAccessContribution, CommandContribution, KeybindingContribution, MenuContribution {
+export class QuickFileOpenFrontendContribution implements QuickAccessContribution, CommandContribution, KeybindingContribution, MenuContribution, WatermarkCommandContribution {
 
     @inject(QuickFileOpenService)
     protected readonly quickFileOpenService: QuickFileOpenService;
+    @inject(WorkspaceService)
+    protected readonly workspaceService: WorkspaceService;
 
     registerCommands(commands: CommandRegistry): void {
         commands.registerCommand(quickFileOpen, {
@@ -62,5 +65,12 @@ export class QuickFileOpenFrontendContribution implements QuickAccessContributio
 
     registerQuickAccessProvider(): void {
         this.quickFileOpenService.registerQuickAccessProvider();
+    }
+
+    registerWatermarkCommands(registry: WatermarkCommandRegistry): void {
+        registry.registerWatermarkCommand(quickFileOpen.id, {
+            rank: 1,
+            isVisible: () => this.workspaceService.tryGetRoots().length > 0
+        });
     }
 }

--- a/packages/search-in-workspace/src/browser/search-in-workspace-frontend-contribution.ts
+++ b/packages/search-in-workspace/src/browser/search-in-workspace-frontend-contribution.ts
@@ -15,7 +15,8 @@
 // *****************************************************************************
 
 import {
-    AbstractViewContribution, KeybindingRegistry, LabelProvider, CommonMenus, FrontendApplication, FrontendApplicationContribution, CommonCommands
+    AbstractViewContribution, KeybindingRegistry, LabelProvider, CommonMenus, FrontendApplication, FrontendApplicationContribution, CommonCommands, WatermarkCommandRegistry,
+    WatermarkCommandContribution
 } from '@theia/core/lib/browser';
 import { SearchInWorkspaceWidget } from './search-in-workspace-widget';
 import { injectable, inject, postConstruct } from '@theia/core/shared/inversify';
@@ -103,7 +104,8 @@ export namespace SearchInWorkspaceCommands {
 }
 
 @injectable()
-export class SearchInWorkspaceFrontendContribution extends AbstractViewContribution<SearchInWorkspaceWidget> implements FrontendApplicationContribution, TabBarToolbarContribution {
+export class SearchInWorkspaceFrontendContribution extends AbstractViewContribution<SearchInWorkspaceWidget> implements FrontendApplicationContribution, TabBarToolbarContribution,
+    WatermarkCommandContribution {
 
     @inject(SelectionService) protected readonly selectionService: SelectionService;
     @inject(LabelProvider) protected readonly labelProvider: LabelProvider;
@@ -125,6 +127,13 @@ export class SearchInWorkspaceFrontendContribution extends AbstractViewContribut
                 rank: 200
             },
             toggleCommandId: SearchInWorkspaceCommands.TOGGLE_SIW_WIDGET.id
+        });
+    }
+
+    registerWatermarkCommands(registry: WatermarkCommandRegistry): void {
+        registry.registerWatermarkCommand(SearchInWorkspaceCommands.OPEN_SIW_WIDGET.id, {
+            rank: 2,
+            isVisible: () => this.workspaceService.tryGetRoots().length > 0
         });
     }
 

--- a/packages/search-in-workspace/src/browser/search-in-workspace-frontend-module.ts
+++ b/packages/search-in-workspace/src/browser/search-in-workspace-frontend-module.ts
@@ -21,7 +21,8 @@ import { SearchInWorkspaceService, SearchInWorkspaceClientImpl } from './search-
 import { SearchInWorkspaceServer, SIW_WS_PATH } from '../common/search-in-workspace-interface';
 import {
     WebSocketConnectionProvider, WidgetFactory, createTreeContainer, bindViewContribution, FrontendApplicationContribution, LabelProviderContribution,
-    ApplicationShellLayoutMigration
+    ApplicationShellLayoutMigration,
+    WatermarkCommandContribution
 } from '@theia/core/lib/browser';
 import { SearchInWorkspaceWidget } from './search-in-workspace-widget';
 import { SearchInWorkspaceResultTreeWidget } from './search-in-workspace-result-tree-widget';
@@ -49,6 +50,7 @@ export default new ContainerModule(bind => {
     bindViewContribution(bind, SearchInWorkspaceFrontendContribution);
     bind(FrontendApplicationContribution).toService(SearchInWorkspaceFrontendContribution);
     bind(TabBarToolbarContribution).toService(SearchInWorkspaceFrontendContribution);
+    bind(WatermarkCommandContribution).toService(SearchInWorkspaceFrontendContribution);
 
     // The object that gets notified of search results.
     bind(SearchInWorkspaceClientImpl).toSelf().inSingletonScope();

--- a/packages/workspace/src/browser/workspace-frontend-contribution.ts
+++ b/packages/workspace/src/browser/workspace-frontend-contribution.ts
@@ -19,7 +19,8 @@ import { CommandContribution, CommandRegistry, MenuContribution, MenuModelRegist
 import { isOSX, environment, OS } from '@theia/core';
 import {
     open, OpenerService, CommonMenus, ConfirmDialog, KeybindingRegistry, KeybindingContribution,
-    FrontendApplicationContribution, SHELL_TABBAR_CONTEXT_COPY, OnWillStopAction, Navigatable, SaveableSource, Widget
+    FrontendApplicationContribution, SaveableSource, Widget, Navigatable, SHELL_TABBAR_CONTEXT_COPY, OnWillStopAction,
+    WatermarkCommandRegistry, WatermarkCommandContribution
 } from '@theia/core/lib/browser';
 import { FileDialogService, OpenFileDialogProps, FileDialogTreeFilters } from '@theia/filesystem/lib/browser';
 import { ContextKeyService } from '@theia/core/lib/browser/context-key-service';
@@ -58,7 +59,7 @@ export type WorkspaceState = keyof typeof WorkspaceStates;
 export type WorkbenchState = keyof typeof WorkspaceStates;
 
 @injectable()
-export class WorkspaceFrontendContribution implements CommandContribution, KeybindingContribution, MenuContribution, FrontendApplicationContribution {
+export class WorkspaceFrontendContribution implements CommandContribution, KeybindingContribution, MenuContribution, FrontendApplicationContribution, WatermarkCommandContribution {
 
     @inject(MessageService) protected readonly messageService: MessageService;
     @inject(FileService) protected readonly fileService: FileService;
@@ -159,6 +160,21 @@ export class WorkspaceFrontendContribution implements CommandContribution, Keybi
                 }
             }
 
+        });
+    }
+
+    registerWatermarkCommands(registry: WatermarkCommandRegistry): void {
+        registry.registerWatermarkCommand(WorkspaceCommands.OPEN_FOLDER.id, {
+            isVisible: () => this.workspaceService.tryGetRoots().length === 0
+        });
+        registry.registerWatermarkCommand(WorkspaceCommands.OPEN_WORKSPACE.id, {
+            isVisible: () => this.workspaceService.tryGetRoots().length === 0
+        });
+        registry.registerWatermarkCommand(WorkspaceCommands.OPEN_RECENT_WORKSPACE.id, {
+            isVisible: () => this.workspaceService.tryGetRoots().length === 0
+        });
+        registry.registerWatermarkCommand(WorkspaceCommands.OPEN.id, {
+            isVisible: () => this.workspaceService.tryGetRoots().length === 0
         });
     }
 

--- a/packages/workspace/src/browser/workspace-frontend-module.ts
+++ b/packages/workspace/src/browser/workspace-frontend-module.ts
@@ -16,7 +16,7 @@
 
 import { ContainerModule, interfaces } from '@theia/core/shared/inversify';
 import { CommandContribution, MenuContribution } from '@theia/core/lib/common';
-import { WebSocketConnectionProvider, FrontendApplicationContribution, KeybindingContribution } from '@theia/core/lib/browser';
+import { WebSocketConnectionProvider, FrontendApplicationContribution, KeybindingContribution, WatermarkCommandContribution } from '@theia/core/lib/browser';
 import {
     OpenFileDialogFactory,
     SaveFileDialogFactory,
@@ -65,7 +65,7 @@ export default new ContainerModule((bind: interfaces.Bind, unbind: interfaces.Un
     }).inSingletonScope();
 
     bind(WorkspaceFrontendContribution).toSelf().inSingletonScope();
-    for (const identifier of [FrontendApplicationContribution, CommandContribution, KeybindingContribution, MenuContribution]) {
+    for (const identifier of [FrontendApplicationContribution, CommandContribution, KeybindingContribution, MenuContribution, WatermarkCommandContribution]) {
         bind(identifier).toService(WorkspaceFrontendContribution);
     }
 


### PR DESCRIPTION
#### What it does
Adds a watermark widget which, similar to the one in VSCode, displays useful commands and their keybindings.
Closes #10804.

Marked this as a draft for now due to some open topics:
- Is the implementation approach taken fine? (adding a new contribution point for watermark commands and moving existing keybinding rendering logic from the keymaps package into core to enable a watermark widget already in core instead of in a separate package - see #10804 for earlier discussion)
-  Which commands should be shown as watermarks? (for now, i only used a subset of the same commands VSCode shows for demonstration - i'd simply use the same commands VSCode displays)

![watermark](https://user-images.githubusercontent.com/23746778/159093033-189ac0b9-2566-48ed-a5b9-d278739dab4e.png)

#### How to test
- Verify watermark widget is shown when there's no open editor

#### Review checklist

- [X] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)


