### PR TITLE
plugin: add `Uri.from` declaration

### DIFF
--- a/packages/plugin/src/theia.d.ts
+++ b/packages/plugin/src/theia.d.ts
@@ -1297,6 +1297,15 @@ export module '@theia/plugin' {
         static parse(value: string): Uri;
 
         /**
+         * Create an URI from its component parts
+         *
+         * @see {@link Uri.toString}
+         * @param components The component parts of an Uri.
+         * @return A new Uri instance.
+         */
+        static from(components: { readonly scheme: string; readonly authority?: string; readonly path?: string; readonly query?: string; readonly fragment?: string }): Uri;
+
+        /**
          * Use the `file` and `parse` factory functions to create new `Uri` objects.
          */
         private constructor(scheme: string, authority: string, path: string, query: string, fragment: string);


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

The commit adds the missing declaration for `Uri.from` in our `theia.d.ts` file (helps with the compatibility report). The static
method is already supported but now should officially be marked as such in our [report](https://eclipse-theia.github.io/vscode-theia-comparator/status.html).

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
1. add the following test plugin [uri-from-0.0.1.zip](https://github.com/eclipse-theia/theia/files/8317329/uri-from-0.0.1.zip)
2. start the application
3. execute the `hello world` command
4. the outputted uri should work

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

Signed-off-by: vince-fugnitto <vincent.fugnitto@ericsson.com>
