### PR TITLE
plugin: align `Task.detail` declaration

### DIFF
--- a/packages/plugin-ext/src/plugin/type-converters.ts
+++ b/packages/plugin-ext/src/plugin/type-converters.ts
@@ -735,7 +735,7 @@ export function fromTask(task: theia.Task): TaskDto | undefined {
         taskDto.problemMatcher = task.problemMatchers;
     }
     if ('detail' in task) {
-        taskDto.detail = (task as theia.Task2).detail;
+        taskDto.detail = task.detail;
     }
     if (typeof task.scope === 'object') {
         taskDto.scope = task.scope.uri.toString();
@@ -797,7 +797,7 @@ export function toTask(taskDto: TaskDto): theia.Task {
     result.name = label;
     result.source = source;
     if (detail) {
-        (result as theia.Task2).detail = detail;
+        result.detail = detail;
     }
     if (typeof scope === 'string') {
         const uri = URI.parse(scope);

--- a/packages/plugin-ext/src/plugin/types-impl.ts
+++ b/packages/plugin-ext/src/plugin/types-impl.ts
@@ -2086,9 +2086,7 @@ export class Task {
 }
 
 @es5ClassCompat
-export class Task2 extends Task {
-    detail?: string;
-}
+export class Task2 extends Task { }
 
 @es5ClassCompat
 export class DebugAdapterExecutable {

--- a/packages/plugin/src/theia.d.ts
+++ b/packages/plugin/src/theia.d.ts
@@ -10454,6 +10454,13 @@ export module '@theia/plugin' {
         source?: string;
 
         /**
+         * A human-readable string which is rendered less prominently on a separate line in places
+         * where the task's name is displayed. Supports rendering of {@link ThemeIcon theme icons}
+         * via the `$(<name>)`-syntax.
+         */
+        detail?: string;
+
+        /**
          * The task group this tasks belongs to. See TaskGroup
          * for a predefined set of available groups.
          * Defaults to undefined meaning that the task doesn't
@@ -10471,9 +10478,10 @@ export module '@theia/plugin' {
         problemMatchers?: string[];
     }
 
-    export class Task2 extends Task {
-        detail?: string;
-    }
+    /**
+     * Task2 is kept for compatibility reasons.
+     */
+    export class Task2 extends Task { }
 
     export interface TaskProvider<T extends Task = Task> {
         /**


### PR DESCRIPTION



<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

The pull-request aligns the declaration for `Task.detail` which was moved in vscode from the proposed `Task2` to `Task`. The change aligns this behavior to produce the proper result in the compatibility report, while keeping backwards compatibility for `Task2` (used by the builtin-npm among other extensions).

![task-detail](https://user-images.githubusercontent.com/40359487/159493426-f6c2d218-ca55-49f3-8e2e-4b5f753712e0.gif)



#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
1. include the following task-provider extension [vscode-task-provider-example-0.0.1.zip](https://github.com/eclipse-theia/theia/files/8324659/vscode-task-provider-example-0.0.1.zip)
2. start the application with a workspace
3. execute the command `task: run task...`
4. the quick-open menu should work
5. the task should properly have a `detail` and support codicons in the form `$(name)` (which the extension uses) 

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

Signed-off-by: vince-fugnitto <vincent.fugnitto@ericsson.com>