### PR TITLE
Align tabbar styling to vscode

### DIFF
--- a/packages/core/src/browser/common-frontend-contribution.ts
+++ b/packages/core/src/browser/common-frontend-contribution.ts
@@ -1484,6 +1484,10 @@ export class CommonFrontendContribution implements FrontendApplicationContributi
             },
             {
                 id: 'tab.hoverBackground',
+                defaults: {
+                    dark: 'tab.inactiveBackground',
+                    light: 'tab.inactiveBackground'
+                },
                 description: 'Tab background color when hovering. Tabs are the containers for editors in the editor area. Multiple tabs can be opened in one editor group. There can be multiple editor groups.'
             },
             {

--- a/packages/core/src/browser/common-frontend-contribution.ts
+++ b/packages/core/src/browser/common-frontend-contribution.ts
@@ -1474,10 +1474,6 @@ export class CommonFrontendContribution implements FrontendApplicationContributi
             },
             {
                 id: 'tab.activeBorderTop',
-                defaults: {
-                    dark: 'focusBorder',
-                    light: 'focusBorder'
-                },
                 description: 'Border to the top of an active tab. Tabs are the containers for editors in the editor area. Multiple tabs can be opened in one editor group. There can be multiple editor groups.'
             },
             {

--- a/packages/core/src/browser/shell/application-shell.ts
+++ b/packages/core/src/browser/shell/application-shell.ts
@@ -690,6 +690,7 @@ export class ApplicationShell extends Widget {
                 this.collapseBottomPanel();
             }
             const widgets = toArray(this.bottomPanel.widgets());
+            this.bottomPanel.markActiveTabBar(widgets[0]?.title);
             if (bottomPanel.pinned && bottomPanel.pinned.length === widgets.length) {
                 widgets.forEach((a, i) => {
                     if (bottomPanel.pinned![i]) {
@@ -706,6 +707,9 @@ export class ApplicationShell extends Widget {
             this.mainPanel.restoreLayout(mainPanel);
             this.registerWithFocusTracker(mainPanel.main);
             const widgets = toArray(this.mainPanel.widgets());
+            // We don't store information about the last active tabbar
+            // So we simply mark the first as being active
+            this.mainPanel.markActiveTabBar(widgets[0]?.title);
             if (mainPanelPinned && mainPanelPinned.length === widgets.length) {
                 widgets.forEach((a, i) => {
                     if (mainPanelPinned[i]) {

--- a/packages/core/src/browser/style/sidepanel.css
+++ b/packages/core/src/browser/style/sidepanel.css
@@ -90,17 +90,9 @@
   border-top-color: transparent;
 }
 
-.p-TabBar.theia-app-left .p-TabBar-tab.p-mod-current.theia-mod-active {
-    border-left: var(--theia-panel-border-width) solid var(--theia-focusBorder);
-}
-
 .p-TabBar.theia-app-right .p-TabBar-tab.p-mod-current {
     border-right: var(--theia-panel-border-width) solid var(--theia-activityBar-activeBorder);
     border-top-color: transparent;
-}
-
-.p-TabBar.theia-app-right .p-TabBar-tab.p-mod-current.theia-mod-active {
-    border-right: var(--theia-panel-border-width) solid var(--theia-focusBorder);
 }
 
 .p-TabBar.theia-app-sides .p-TabBar-tabLabel,
@@ -285,16 +277,12 @@
 
 #theia-bottom-content-panel .p-TabBar-tab:not(.p-mod-current) {
     color: var(--theia-panelTitle-inactiveForeground);
-    border-top: var(--theia-border-width) solid  var(--theia-panel-background);
+    border-top: var(--theia-border-width) solid transparent;
 }
 
 #theia-bottom-content-panel .p-TabBar-tab.p-mod-current {
     color: var(--theia-panelTitle-activeForeground);
     border-top: var(--theia-border-width) solid var(--theia-panelTitle-activeBorder);
-}
-
-#theia-bottom-content-panel .p-TabBar-tab.p-mod-current.theia-mod-active {
-    border-top-color: var(--theia-focusBorder);
 }
 
 /*-----------------------------------------------------------------------------

--- a/packages/core/src/browser/style/sidepanel.css
+++ b/packages/core/src/browser/style/sidepanel.css
@@ -285,6 +285,14 @@
     border-top: var(--theia-border-width) solid var(--theia-panelTitle-activeBorder);
 }
 
+#theia-bottom-content-panel .p-TabBar:not(.theia-tabBar-active) .p-TabBar-tab .theia-tab-icon-label {
+    color: var(--theia-tab-unfocusedInactiveForeground);
+}
+
+#theia-bottom-content-panel .p-TabBar:not(.theia-tabBar-active) .p-TabBar-tab.p-mod-current .theia-tab-icon-label {
+    color: var(--theia-tab-unfocusedActiveForeground);
+}
+
 /*-----------------------------------------------------------------------------
 | Hidden tab bars used for rendering vertical side bars
 |----------------------------------------------------------------------------*/

--- a/packages/core/src/browser/style/sidepanel.css
+++ b/packages/core/src/browser/style/sidepanel.css
@@ -277,12 +277,11 @@
 
 #theia-bottom-content-panel .p-TabBar-tab:not(.p-mod-current) {
     color: var(--theia-panelTitle-inactiveForeground);
-    border-top: var(--theia-border-width) solid transparent;
 }
 
 #theia-bottom-content-panel .p-TabBar-tab.p-mod-current {
     color: var(--theia-panelTitle-activeForeground);
-    border-top: var(--theia-border-width) solid var(--theia-panelTitle-activeBorder);
+    box-shadow: 0 var(--theia-border-width) 0 var(--theia-panelTitle-activeBorder) inset;
 }
 
 #theia-bottom-content-panel .p-TabBar:not(.theia-tabBar-active) .p-TabBar-tab .theia-tab-icon-label {

--- a/packages/core/src/browser/style/tabs.css
+++ b/packages/core/src/browser/style/tabs.css
@@ -82,11 +82,13 @@
     border-right: 1px solid var(--theia-tab-border);
     background: var(--theia-tab-inactiveBackground);
     color: var(--theia-tab-inactiveForeground);
+    border-top: 1px solid transparent;
 }
 
 #theia-main-content-panel .p-TabBar .p-TabBar-tab.p-mod-current {
     background: var(--theia-tab-activeBackground);
     color: var(--theia-tab-activeForeground);
+    border-top: 1px solid var(--theia-tab-activeBorderTop);
 }
 
 .p-TabBar.theia-app-centers {

--- a/packages/core/src/browser/style/tabs.css
+++ b/packages/core/src/browser/style/tabs.css
@@ -80,65 +80,13 @@
 
 #theia-main-content-panel .p-TabBar .p-TabBar-tab {
     border-right: 1px solid var(--theia-tab-border);
+    background: var(--theia-tab-inactiveBackground);
+    color: var(--theia-tab-inactiveForeground);
 }
 
-#theia-main-content-panel .p-TabBar .p-TabBar-tab:hover.theia-mod-active {
-    background: var(--theia-tab-hoverBackground) !important;
-    box-shadow: var(--theia-tab-hoverBorder) 0 -1px inset !important;
-}
-
-#theia-main-content-panel .p-TabBar .p-TabBar-tab:hover:not(.theia-mod-active) {
-    background: var(--theia-tab-unfocusedHoverBackground) !important;
-    box-shadow: var(--theia-tab-unfocusedHoverBorder) 0 -1px inset !important;
-}
-
-/* active tab in an active group */
-body.theia-editor-highlightModifiedTabs
-#theia-main-content-panel .p-TabBar .p-TabBar-tab.p-mod-current.theia-mod-active.theia-mod-dirty {
-    border-top: 1px solid var(--theia-tab-activeModifiedBorder);
-}
-
-#theia-main-content-panel .p-TabBar .p-TabBar-tab.p-mod-current.theia-mod-active {
+#theia-main-content-panel .p-TabBar .p-TabBar-tab.p-mod-current {
     background: var(--theia-tab-activeBackground);
     color: var(--theia-tab-activeForeground);
-    border-top: 1px solid var(--theia-tab-activeBorderTop);
-    border-bottom: 1px solid var(--theia-tab-activeBorder);
-}
-
-/* inactive tab in an active group */
-body.theia-editor-highlightModifiedTabs
-#theia-main-content-panel .p-TabBar .p-TabBar-tab:not(.p-mod-current).theia-mod-active.theia-mod-dirty {
-    border-top: 1px solid var(--theia-tab-inactiveModifiedBorder);
-}
-
-#theia-main-content-panel .p-TabBar .p-TabBar-tab:not(.p-mod-current).theia-mod-active {
-    background: var(--theia-tab-inactiveBackground);
-    color: var(--theia-tab-inactiveForeground);
-}
-
-/* active tab in an unfocused group */
-body.theia-editor-highlightModifiedTabs
-#theia-main-content-panel .p-TabBar .p-TabBar-tab.p-mod-current:not(.theia-mod-active).theia-mod-dirty {
-    border-top: 1px solid var(--theia-tab-unfocusedActiveModifiedBorder);
-}
-
-#theia-main-content-panel .p-TabBar .p-TabBar-tab.p-mod-current:not(.theia-mod-active) {
-    background: var(--theia-tab-unfocusedActiveBackground);
-    color: var(--theia-tab-unfocusedActiveForeground);
-    border-top: 1px solid var(--theia-tab-unfocusedActiveBorderTop);
-    border-bottom: 1px solid var(--theia-tab-unfocusedActiveBorder);
-}
-
-/* inactive tab in an unfocused group */
-body.theia-editor-highlightModifiedTabs
-#theia-main-content-panel .p-TabBar .p-TabBar-tab:not(.p-mod-current):not(.theia-mod-active).theia-mod-dirty {
-    border-top: 1px solid var(--theia-tab-unfocusedInactiveModifiedBorder);
-}
-
-#theia-main-content-panel .p-TabBar .p-TabBar-tab:not(.p-mod-current):not(.theia-mod-active) {
-    background: var(--theia-tab-inactiveBackground);
-    color: var(--theia-tab-inactiveForeground);
-    border-top: 1px solid var(--theia-tab-inactiveBackground);
 }
 
 .p-TabBar.theia-app-centers {

--- a/packages/core/src/browser/style/tabs.css
+++ b/packages/core/src/browser/style/tabs.css
@@ -91,6 +91,14 @@
     border-top: 1px solid var(--theia-tab-activeBorderTop);
 }
 
+#theia-main-content-panel .p-TabBar:not(.theia-tabBar-active) .p-TabBar-tab .p-TabBar-tabLabel {
+    color: var(--theia-tab-unfocusedInactiveForeground);
+}
+
+#theia-main-content-panel .p-TabBar:not(.theia-tabBar-active) .p-TabBar-tab.p-mod-current .p-TabBar-tabLabel {
+    color: var(--theia-tab-unfocusedActiveForeground);
+}
+
 .p-TabBar.theia-app-centers {
     background: var(--theia-editorGroupHeader-tabsBackground);
 }

--- a/packages/core/src/browser/style/tabs.css
+++ b/packages/core/src/browser/style/tabs.css
@@ -90,12 +90,14 @@
     box-shadow: 0 1px 0 var(--theia-tab-activeBorderTop) inset, 0 -1px 0 var(--theia-tab-activeBorder) inset;
 }
 
-#theia-main-content-panel .p-TabBar:not(.theia-tabBar-active) .p-TabBar-tab .p-TabBar-tabLabel {
+#theia-main-content-panel .p-TabBar:not(.theia-tabBar-active) .p-TabBar-tab {
     color: var(--theia-tab-unfocusedInactiveForeground);
 }
 
-#theia-main-content-panel .p-TabBar:not(.theia-tabBar-active) .p-TabBar-tab.p-mod-current .p-TabBar-tabLabel {
+#theia-main-content-panel .p-TabBar:not(.theia-tabBar-active) .p-TabBar-tab.p-mod-current {
+    background: var(--theia-tab-unfocusedActiveBackground);
     color: var(--theia-tab-unfocusedActiveForeground);
+    box-shadow: 0 1px 0 var(--theia-tab-unfocusedActiveBorderTop) inset, 0 -1px 0 var(--theia-tab-unfocusedActiveBorder) inset;
 }
 
 .p-TabBar.theia-app-centers {

--- a/packages/core/src/browser/style/tabs.css
+++ b/packages/core/src/browser/style/tabs.css
@@ -84,6 +84,16 @@
     color: var(--theia-tab-inactiveForeground);
 }
 
+#theia-main-content-panel .p-TabBar .p-TabBar-tab:hover {
+    background: var(--theia-tab-hoverBackground);
+    box-shadow: 0 1px 0 var(--theia-tab-hoverBorder) inset;
+}
+
+#theia-main-content-panel .p-TabBar:not(.theia-tabBar-active) .p-TabBar-tab:hover {
+    background: var(--theia-tab-unfocusedHoverBackground);
+    box-shadow: 0 1px 0 var(--theia-tab-unfocusedHoverBorder) inset;
+}
+
 #theia-main-content-panel .p-TabBar .p-TabBar-tab.p-mod-current {
     background: var(--theia-tab-activeBackground);
     color: var(--theia-tab-activeForeground);

--- a/packages/core/src/browser/style/tabs.css
+++ b/packages/core/src/browser/style/tabs.css
@@ -82,13 +82,12 @@
     border-right: 1px solid var(--theia-tab-border);
     background: var(--theia-tab-inactiveBackground);
     color: var(--theia-tab-inactiveForeground);
-    border-top: 1px solid transparent;
 }
 
 #theia-main-content-panel .p-TabBar .p-TabBar-tab.p-mod-current {
     background: var(--theia-tab-activeBackground);
     color: var(--theia-tab-activeForeground);
-    border-top: 1px solid var(--theia-tab-activeBorderTop);
+    box-shadow: 0 1px 0 var(--theia-tab-activeBorderTop) inset, 0 -1px 0 var(--theia-tab-activeBorder) inset;
 }
 
 #theia-main-content-panel .p-TabBar:not(.theia-tabBar-active) .p-TabBar-tab .p-TabBar-tabLabel {


### PR DESCRIPTION

#### What it does

Closes https://github.com/eclipse-theia/theia/issues/10906

#### How to test

1. Open editors/widgets in the main area
2. While hovering over them, changing tabs, etc. they should behave as VSCode's main area tabs
3. The focus for bottom/side panel tabs now behaves a bit differently, there's no distinction between active and non-active tabs anymore.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
