### PR TITLE
Separate debug configuration providers from debug adapter contributors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,4 @@ dev-packages/electron/compile_commands.json
 scripts/download
 license-check-summary.txt*
 *-trace.json
+.tours

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,15 @@
   - `commandService`, `instantiationService` removed from `MonacoEditor`. Use `StandaloneServices.get(IInstantationService / ICommandService)` instead.
   - `DecorationMiniMapOptions.position`, `DecorationOverviewRulerOptions.position` no longer optional.
   - Overrides used by `MonacoEditorFactory` accept the type `EditorServiceOverrides` rather than `{[key: string]: any}`.
+- [debug] The interface method `DebugService#provideDynamicDebugConfigurations` changes the return type to  `Record<string, DebugConfiguration[]>`.
+This impacts the corresponding return type for `DebugConfigurationManager#provideDynamicDebugConfigurations`.
+The following functions under `plugin-api-rpc.ts#DebugExt` and in the `PluginDebugAdapterContribution` are deprecated
+  * $provideDebugConfigurations
+  * $resolveDebugConfigurations
+  * $resolveDebugConfigurationWithSubstitutedVariablesByHandle
+
+  The `PluginDebugAdapterContributionRegistrator` interface has been removed
+
 
 ## v1.23.0 - 2/24/2022
 

--- a/packages/debug/src/browser/debug-configuration-manager.ts
+++ b/packages/debug/src/browser/debug-configuration-manager.ts
@@ -344,7 +344,7 @@ export class DebugConfigurationManager {
         await WaitUntilEvent.fire(this.onWillProvideDebugConfigurationEmitter, {});
     }
 
-    async provideDynamicDebugConfigurations(): Promise<{ type: string, configurations: DebugConfiguration[] }[]> {
+    async provideDynamicDebugConfigurations(): Promise<Record<string, DebugConfiguration[]>> {
         await this.fireWillProvideDynamicDebugConfiguration();
         return this.debug.provideDynamicDebugConfigurations!();
     }

--- a/packages/debug/src/browser/debug-prefix-configuration.ts
+++ b/packages/debug/src/browser/debug-prefix-configuration.ts
@@ -122,12 +122,11 @@ export class DebugPrefixConfiguration implements CommandContribution, CommandHan
         }
 
         // Resolve dynamic configurations from providers
-        const configurationsByType = await this.debugConfigurationManager.provideDynamicDebugConfigurations();
-        for (const typeConfigurations of configurationsByType) {
-            const dynamicConfigurations = typeConfigurations.configurations;
+        const record = await this.debugConfigurationManager.provideDynamicDebugConfigurations();
+        for (const [type, dynamicConfigurations] of Object.entries(record)) {
             if (dynamicConfigurations.length > 0) {
                 items.push({
-                    label: typeConfigurations.type,
+                    label: type,
                     type: 'separator'
                 });
             }

--- a/packages/debug/src/common/debug-service.ts
+++ b/packages/debug/src/common/debug-service.ts
@@ -71,10 +71,9 @@ export interface DebugService extends Disposable {
     provideDebugConfigurations(debugType: string, workspaceFolderUri: string | undefined): Promise<DebugConfiguration[]>;
 
     /**
-     * Provides dynamic debug configurations by a provider debug type
-     * @returns An Array of objects containing the debug type and corresponding dynamic debug configurations array
+     * @returns A Record of debug configuration provider types and a corresponding dynamic debug configurations array
      */
-    provideDynamicDebugConfigurations?(): Promise<{ type: string, configurations: DebugConfiguration[] }[]>;
+    provideDynamicDebugConfigurations?(): Promise<Record<string, DebugConfiguration[]>>;
 
     /**
      * Resolves a [debug configuration](#DebugConfiguration) by filling in missing values

--- a/packages/plugin-ext/src/common/plugin-api-rpc.ts
+++ b/packages/plugin-ext/src/common/plugin-api-rpc.ts
@@ -1651,16 +1651,50 @@ export enum DebugConfigurationProviderTriggerKind {
     Dynamic = 2
 }
 
+export interface DebugConfigurationProvider {
+    readonly handle: number;
+    readonly type: string;
+    readonly triggerKind: DebugConfigurationProviderTriggerKind;
+    provideDebugConfigurations?(folder: string | undefined): Promise<theia.DebugConfiguration[]>;
+    resolveDebugConfiguration?(folder: string | undefined, debugConfiguration: theia.DebugConfiguration): Promise<theia.DebugConfiguration | undefined>;
+    resolveDebugConfigurationWithSubstitutedVariables?(folder: string | undefined, debugConfiguration: theia.DebugConfiguration): Promise<theia.DebugConfiguration | undefined>;
+}
+
+export interface DebugConfigurationProviderDescriptor {
+    readonly handle: number,
+    readonly type: string,
+    readonly trigger: DebugConfigurationProviderTriggerKind,
+    readonly provideDebugConfiguration: boolean,
+    readonly resolveDebugConfigurations: boolean,
+    readonly resolveDebugConfigurationWithSubstitutedVariables: boolean
+}
+
 export interface DebugExt {
     $onSessionCustomEvent(sessionId: string, event: string, body?: any): void;
     $breakpointsDidChange(added: Breakpoint[], removed: string[], changed: Breakpoint[]): void;
     $sessionDidCreate(sessionId: string): void;
     $sessionDidDestroy(sessionId: string): void;
     $sessionDidChange(sessionId: string | undefined): void;
+    /**
+     * @deprecated since 1.24.0. Use $registerDebugConfigurationProvider with $provideDebugConfigurationsByHandle instead.
+     */
     $provideDebugConfigurations(debugType: string, workspaceFolder: string | undefined, dynamic?: boolean): Promise<theia.DebugConfiguration[]>;
+
+    /**
+     * @deprecated since 1.24.0. Use $registerDebugConfigurationProvider with $resolveDebugConfigurationByHandle instead.
+     */
     $resolveDebugConfigurations(debugConfiguration: theia.DebugConfiguration, workspaceFolder: string | undefined): Promise<theia.DebugConfiguration | undefined>;
+
+    /**
+     * @deprecated since 1.24.0. Use $registerDebugConfigurationProvider with $resolveDebugConfigurationWithSubstitutedVariablesByHandle instead.
+     */
     $resolveDebugConfigurationWithSubstitutedVariables(debugConfiguration: theia.DebugConfiguration, workspaceFolder: string | undefined):
         Promise<theia.DebugConfiguration | undefined>;
+
+    $provideDebugConfigurationsByHandle(handle: number, workspaceFolder: string | undefined): Promise<theia.DebugConfiguration[]>;
+    $resolveDebugConfigurationByHandle(handle: number, workspaceFolder: string | undefined, debugConfiguration: theia.DebugConfiguration): Promise<theia.DebugConfiguration | undefined>;
+    $resolveDebugConfigurationWithSubstitutedVariablesByHandle(handle: number, workspaceFolder: string | undefined, debugConfiguration: theia.DebugConfiguration): Promise<theia.DebugConfiguration | undefined>;
+
     $createDebugSession(debugConfiguration: theia.DebugConfiguration): Promise<string>;
     $terminateDebugSession(sessionId: string): Promise<void>;
     $getTerminalCreationOptions(debugType: string): Promise<TerminalOptionsExt | undefined>;
@@ -1671,6 +1705,8 @@ export interface DebugMain {
     $appendLineToDebugConsole(value: string): Promise<void>;
     $registerDebuggerContribution(description: DebuggerDescription): Promise<void>;
     $unregisterDebuggerConfiguration(debugType: string): Promise<void>;
+    $registerDebugConfigurationProvider(description: DebugConfigurationProviderDescriptor): void;
+    $unregisterDebugConfigurationProvider(handle: number): Promise<void>;
     $addBreakpoints(breakpoints: Breakpoint[]): Promise<void>;
     $removeBreakpoints(breakpoints: string[]): Promise<void>;
     $startDebugging(folder: theia.WorkspaceFolder | undefined, nameOrConfiguration: string | theia.DebugConfiguration, options: theia.DebugSessionOptions): Promise<boolean>;

--- a/packages/plugin-ext/src/main/browser/debug/plugin-debug-adapter-contribution.ts
+++ b/packages/plugin-ext/src/main/browser/debug/plugin-debug-adapter-contribution.ts
@@ -37,14 +37,23 @@ export class PluginDebugAdapterContribution {
         return this.description.label;
     }
 
+    /**
+     * @deprecated since 1.24.0, Use [PluginDebugConfigurationProvider](plugin-debug-configuration-provider.ts)
+     */
     async provideDebugConfigurations(workspaceFolderUri: string | undefined, dynamic: boolean = false): Promise<DebugConfiguration[]> {
         return this.debugExt.$provideDebugConfigurations(this.type, workspaceFolderUri, dynamic);
     }
 
+    /**
+     * @deprecated since 1.24.0, Use [PluginDebugConfigurationProvider](plugin-debug-configuration-provider.ts)
+     */
     async resolveDebugConfiguration(config: DebugConfiguration, workspaceFolderUri: string | undefined): Promise<DebugConfiguration | undefined> {
         return this.debugExt.$resolveDebugConfigurations(config, workspaceFolderUri);
     }
 
+    /**
+     * @deprecated since 1.24.0, Use [PluginDebugConfigurationProvider](plugin-debug-configuration-provider.ts)
+     */
     async resolveDebugConfigurationWithSubstitutedVariables(config: DebugConfiguration, workspaceFolderUri: string | undefined): Promise<DebugConfiguration | undefined> {
         return this.debugExt.$resolveDebugConfigurationWithSubstitutedVariables(config, workspaceFolderUri);
     }

--- a/packages/plugin-ext/src/main/browser/debug/plugin-debug-configuration-provider.ts
+++ b/packages/plugin-ext/src/main/browser/debug/plugin-debug-configuration-provider.ts
@@ -1,0 +1,57 @@
+// *****************************************************************************
+// Copyright (C) 2022 Ericsson and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import {
+    DebugConfigurationProvider,
+    DebugConfigurationProviderDescriptor,
+    DebugConfigurationProviderTriggerKind,
+    DebugExt
+} from '../../../common/plugin-api-rpc';
+import { DebugConfiguration } from '@theia/debug/lib/common/debug-configuration';
+
+export class PluginDebugConfigurationProvider implements DebugConfigurationProvider {
+    public handle: number;
+    public type: string;
+    public triggerKind: DebugConfigurationProviderTriggerKind;
+    provideDebugConfigurations: (folder: string | undefined) => Promise<DebugConfiguration[]>;
+    resolveDebugConfiguration: (folder: string | undefined, debugConfiguration: DebugConfiguration) => Promise<DebugConfiguration | undefined>;
+    resolveDebugConfigurationWithSubstitutedVariables: (folder: string | undefined, debugConfiguration: DebugConfiguration) => Promise<DebugConfiguration | undefined>;
+
+    constructor(
+        description: DebugConfigurationProviderDescriptor,
+        protected readonly debugExt: DebugExt
+    ) {
+        this.handle = description.handle;
+        this.type = description.type;
+        this.triggerKind = description.trigger;
+
+        if (description.provideDebugConfiguration) {
+            this.provideDebugConfigurations = async (folder: string | undefined) => this.debugExt.$provideDebugConfigurationsByHandle(this.handle, folder);
+        }
+
+        if (description.resolveDebugConfigurations) {
+            this.resolveDebugConfiguration =
+                async (folder: string | undefined, debugConfiguration: DebugConfiguration) =>
+                    this.debugExt.$resolveDebugConfigurationByHandle(this.handle, folder, debugConfiguration);
+        }
+
+        if (description.resolveDebugConfigurationWithSubstitutedVariables) {
+            this.resolveDebugConfigurationWithSubstitutedVariables =
+                async (folder: string | undefined, debugConfiguration: DebugConfiguration) =>
+                    this.debugExt.$resolveDebugConfigurationWithSubstitutedVariablesByHandle(this.handle, folder, debugConfiguration);
+        }
+    }
+}

--- a/packages/plugin-ext/src/plugin/node/debug/debug.ts
+++ b/packages/plugin-ext/src/plugin/node/debug/debug.ts
@@ -34,21 +34,23 @@ import { PluginDebugAdapterTracker } from './plugin-debug-adapter-tracker';
 import uuid = require('uuid');
 import { DebugAdapter } from '@theia/debug/lib/node/debug-model';
 
+interface ConfigurationProviderRecord {
+    handle: number;
+    type: string;
+    trigger: DebugConfigurationProviderTriggerKind,
+    provider: theia.DebugConfigurationProvider;
+}
+
 /* eslint-disable @typescript-eslint/no-explicit-any */
-
 // TODO: rename file to `debug-ext.ts`
-
 /**
  * It is supposed to work at node only.
  */
 export class DebugExtImpl implements DebugExt {
     // debug sessions by sessionId
     private sessions = new Map<string, PluginDebugAdapterSession>();
-
-    // providers by type (initial)
-    private configurationProviders = new Map<string, Set<theia.DebugConfigurationProvider>>();
-    // providers by type (dynamic)
-    private dynamicConfigurationProviders = new Map<string, Set<theia.DebugConfigurationProvider>>();
+    private configurationProviderHandleGenerator: number;
+    private configurationProviders: ConfigurationProviderRecord[];
 
     /**
      * Only use internally, don't send it to the frontend. It's expensive!
@@ -85,6 +87,8 @@ export class DebugExtImpl implements DebugExt {
             append: (value: string) => this.proxy.$appendToDebugConsole(value),
             appendLine: (value: string) => this.proxy.$appendLineToDebugConsole(value)
         };
+        this.configurationProviderHandleGenerator = 0;
+        this.configurationProviders = [];
     }
 
     /**
@@ -191,24 +195,23 @@ export class DebugExtImpl implements DebugExt {
         });
     }
 
-    registerDebugConfigurationProvider(debugType: string, provider: theia.DebugConfigurationProvider, trigger: theia.DebugConfigurationProviderTriggerKind): Disposable {
+    registerDebugConfigurationProvider(debugType: string, provider: theia.DebugConfigurationProvider, trigger: DebugConfigurationProviderTriggerKind): Disposable {
         console.log(`Debug configuration provider has been registered: ${debugType}, trigger: ${trigger}`);
-        const providersByTriggerKind = trigger === DebugConfigurationProviderTriggerKind.Initial ? this.configurationProviders : this.dynamicConfigurationProviders;
-        let providers = providersByTriggerKind.get(debugType);
-        if (!providers) {
-            providersByTriggerKind.set(debugType, providers = new Set());
-        }
-        providers.add(provider);
 
+        const handle = this.configurationProviderHandleGenerator++;
+        this.configurationProviders.push({ handle, type: debugType, trigger, provider });
+        const descriptor = {
+            handle,
+            type: debugType,
+            trigger,
+            provideDebugConfiguration: !!provider.provideDebugConfigurations,
+            resolveDebugConfigurations: !!provider.resolveDebugConfiguration,
+            resolveDebugConfigurationWithSubstitutedVariables: !!provider.resolveDebugConfigurationWithSubstitutedVariables
+        };
+        this.proxy.$registerDebugConfigurationProvider(descriptor);
         return Disposable.create(() => {
-            // eslint-disable-next-line @typescript-eslint/no-shadow
-            const providers = providersByTriggerKind.get(debugType);
-            if (providers) {
-                providers.delete(provider);
-                if (providers.size === 0) {
-                    providersByTriggerKind.delete(debugType);
-                }
-            }
+            this.configurationProviders = this.configurationProviders.filter(p => (p.handle !== handle));
+            this.proxy.$unregisterDebugConfigurationProvider(handle);
         });
     }
 
@@ -331,15 +334,60 @@ export class DebugExtImpl implements DebugExt {
         return undefined;
     }
 
+    private getConfigurationProviderRecord(handle: number): {
+        provider: theia.DebugConfigurationProvider
+        type: string
+    } {
+        const record = this.configurationProviders.find(p => p.handle === handle);
+        if (!record) {
+            throw new Error('No Debug configuration provider found with given handle number: ' + handle);
+        }
+        const { provider, type } = record;
+        return { provider, type };
+    }
+
+    async $provideDebugConfigurationsByHandle(handle: number, workspaceFolderUri: string | undefined): Promise<theia.DebugConfiguration[]> {
+        const { provider, type } = this.getConfigurationProviderRecord(handle);
+
+        const configurations = await provider.provideDebugConfigurations?.(this.toWorkspaceFolder(workspaceFolderUri));
+        if (!configurations) {
+            throw new Error('nothing returned from DebugConfigurationProvider.provideDebugConfigurations, type: ' + type);
+        }
+
+        return configurations;
+    }
+
+    async $resolveDebugConfigurationByHandle(
+        handle: number,
+        workspaceFolderUri: string | undefined,
+        debugConfiguration: theia.DebugConfiguration
+    ): Promise<theia.DebugConfiguration | undefined> {
+
+        const { provider } = this.getConfigurationProviderRecord(handle);
+        return provider.resolveDebugConfiguration?.(this.toWorkspaceFolder(workspaceFolderUri), debugConfiguration);
+    }
+
+    async $resolveDebugConfigurationWithSubstitutedVariablesByHandle(
+        handle: number,
+        workspaceFolderUri: string | undefined,
+        debugConfiguration: theia.DebugConfiguration
+    ): Promise<theia.DebugConfiguration | undefined> {
+
+        const { provider } = this.getConfigurationProviderRecord(handle);
+        return provider.resolveDebugConfigurationWithSubstitutedVariables?.(this.toWorkspaceFolder(workspaceFolderUri), debugConfiguration);
+    }
+
     async $provideDebugConfigurations(debugType: string, workspaceFolderUri: string | undefined, dynamic: boolean = false): Promise<theia.DebugConfiguration[]> {
         let result: theia.DebugConfiguration[] = [];
 
-        const providers = dynamic ? this.dynamicConfigurationProviders.get(debugType) : this.configurationProviders.get(debugType);
-        if (providers) {
-            for (const provider of providers) {
-                if (provider.provideDebugConfigurations) {
-                    result = result.concat(await provider.provideDebugConfigurations(this.toWorkspaceFolder(workspaceFolderUri)) || []);
-                }
+        const trigger = dynamic ? DebugConfigurationProviderTriggerKind.Dynamic : DebugConfigurationProviderTriggerKind.Initial;
+        const providers = this.configurationProviders
+            .filter(p => p.type === debugType && p.trigger === trigger)
+            .map(p => p.provider);
+
+        for (const provider of providers) {
+            if (provider.provideDebugConfigurations) {
+                result = result.concat(await provider.provideDebugConfigurations(this.toWorkspaceFolder(workspaceFolderUri)) || []);
             }
         }
 
@@ -349,25 +397,21 @@ export class DebugExtImpl implements DebugExt {
     async $resolveDebugConfigurations(debugConfiguration: theia.DebugConfiguration, workspaceFolderUri: string | undefined): Promise<theia.DebugConfiguration | undefined> {
         let current = debugConfiguration;
 
-        for (const providers of [
-            this.configurationProviders.get(debugConfiguration.type),
-            this.dynamicConfigurationProviders.get(debugConfiguration.type),
-            this.configurationProviders.get('*')
-        ]) {
-            if (providers) {
-                for (const provider of providers) {
-                    if (provider.resolveDebugConfiguration) {
-                        try {
-                            const next = await provider.resolveDebugConfiguration(this.toWorkspaceFolder(workspaceFolderUri), current);
-                            if (next) {
-                                current = next;
-                            } else {
-                                return current;
-                            }
-                        } catch (e) {
-                            console.error(e);
-                        }
+        const providers = this.configurationProviders
+            .filter(p => p.type === debugConfiguration.type || p.type === '*')
+            .map(p => p.provider);
+
+        for (const provider of providers) {
+            if (provider.resolveDebugConfiguration) {
+                try {
+                    const next = await provider.resolveDebugConfiguration(this.toWorkspaceFolder(workspaceFolderUri), current);
+                    if (next) {
+                        current = next;
+                    } else {
+                        return current;
                     }
+                } catch (e) {
+                    console.error(e);
                 }
             }
         }
@@ -379,25 +423,21 @@ export class DebugExtImpl implements DebugExt {
         Promise<theia.DebugConfiguration | undefined> {
         let current = debugConfiguration;
 
-        for (const providers of [
-            this.configurationProviders.get(debugConfiguration.type),
-            this.dynamicConfigurationProviders.get(debugConfiguration.type),
-            this.configurationProviders.get('*')
-        ]) {
-            if (providers) {
-                for (const provider of providers) {
-                    if (provider.resolveDebugConfigurationWithSubstitutedVariables) {
-                        try {
-                            const next = await provider.resolveDebugConfigurationWithSubstitutedVariables(this.toWorkspaceFolder(workspaceFolderUri), current);
-                            if (next) {
-                                current = next;
-                            } else {
-                                return current;
-                            }
-                        } catch (e) {
-                            console.error(e);
-                        }
+        const providers = this.configurationProviders
+            .filter(p => p.type === debugConfiguration.type || p.type === '*')
+            .map(p => p.provider);
+
+        for (const provider of providers) {
+            if (provider.resolveDebugConfigurationWithSubstitutedVariables) {
+                try {
+                    const next = await provider.resolveDebugConfigurationWithSubstitutedVariables(this.toWorkspaceFolder(workspaceFolderUri), current);
+                    if (next) {
+                        current = next;
+                    } else {
+                        return current;
                     }
+                } catch (e) {
+                    console.error(e);
                 }
             }
         }


### PR DESCRIPTION
#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

Fixes: #9978 

The implementation of the vscode API for the resolution of initial
debug configurations as well as the resolution of specific
configurations was relying on registered debug adapter
contributors rather than debug configuration providers,
this is causing issues e.g. #9978.

This implementation brings access to the debug configuration
providers all the way to the browser debug/plugin-debug-service,
where the providers can be filtered and then call its corresponding
API indirectly towards the extension host.

The former API is kept and marked deprecated.

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
Based on: https://github.com/eclipse-theia/theia/pull/5645
Use the test extension in the `tar` file as follows:
https://github.com/alvsan09/debug-activation-events/raw/master/plugins.tar

NOTE: It is recommended to install only the required test extension(s), otherwise not all notifications may appear (must likely due to a hard coded limit).

- test `onDebug`: install [on-debug-0.0.1.vsix](https://github.com/alvsan09/debug-activation-events/blob/master/on-debug-0.0.1.vsix) and check that `onDebug` notification appears on any debug activation event
- test `onDebugInitialConfigurations`:
  - install [on-debug-initial-configurations-0.0.1.vsix](https://github.com/alvsan09/debug-activation-events/blob/master/on-debug-initial-configurations-0.0.1.vsix)
  - delete launch.json file
  - try to add a new configuration with markdown file opened 
  - you should see `onDebugInitialConfigurations` and `provideDebugConfigurations` notifications plus mock debug configuration should be generated dynamically
- test `onDebugResolve`:
  - install [on-debug-resolve-0.0.1.vsix](https://github.com/alvsan09/debug-activation-events/blob/master/on-debug-resolve-0.0.1.vsix)
  - try to run any launch configuration
  - you should see `onDebugResolve` and `resolveDebugConfiguration(*)[0]` notifications
- test `onDebugResolve:<debug type>`:
  - install [on-debug-resolve-node-0.0.1.vsix](https://github.com/alvsan09/debug-activation-events/blob/master/on-debug-resolve-node-0.0.1.vsix)
  - try to run any node launch configuration
  - you should see `onDebugResolve:node` and `resolveDebugConfiguration:node` notifications
- test calling two different extension providers for debug type '*' supporting `onDebugResolve` :
  - install [on-debug-resolve-0.0.1.vsix](https://github.com/alvsan09/debug-activation-events/blob/master/on-debug-resolve-0.0.1.vsix)
  - install [on-debug-resolve-2.vsix](https://github.com/alvsan09/debug-activation-events/blob/master/on-debug-resolve-2.vsix)
  - try to run any node launch configuration
  - you should see `resolveDebugConfiguration(*)[0]` and `resolveDebugConfiguration(*)[1]` notifications, one for each of the installed `on-debug-resolve-*` extensions. ![config_providers_resolve](https://user-images.githubusercontent.com/76971376/159554236-f500838b-54e0-46f4-ae29-804768e0b667.png)
- test #9978, follow the instructions on the issue:
  - you should now see two terminals created one for the session and the other one triggered by the extension (there is still an issue here as the behavior does not match vscode (i.e. vscode does not mantain a session), however the original issue is resolved as we no longer create additional terminals i.e. one per registered debug adapter contributor).

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
