### PR TITLE
plugin: add `replace` method support for `OutputChannel`

### DIFF
--- a/packages/plugin-ext/src/plugin/output-channel/output-channel-item.ts
+++ b/packages/plugin-ext/src/plugin/output-channel/output-channel-item.ts
@@ -41,6 +41,12 @@ export class OutputChannelImpl implements theia.OutputChannel {
         this.append(value + '\n');
     }
 
+    replace(value: string): void {
+        this.validate();
+        this.clear();
+        this.append(value);
+    }
+
     clear(): void {
         this.validate();
         this.proxy.$clear(this.name);

--- a/packages/plugin/src/theia.d.ts
+++ b/packages/plugin/src/theia.d.ts
@@ -2543,6 +2543,13 @@ export module '@theia/plugin' {
         appendLine(value: string): void;
 
         /**
+         * Replaces all output from the channel with the given value.
+         *
+         * @param value A string, falsy values will not be printed.
+         */
+        replace(value: string): void;
+
+        /**
          * Removes all output from the channel.
          */
         clear(): void;


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

Fixes: https://github.com/eclipse-theia/theia/issues/10914.

The pull-request adds support for the `replace` method for the `OutputChannel` VS Code API which replaces all content in a given channel with the new value.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

1. include the following test plugin [vs-output-0.0.1.zip](https://github.com/eclipse-theia/theia/files/8334157/vs-output-0.0.1.zip)
2. start the application
3. execute the command `Output: Part 1`
4. open the output-view, and select the `vs-output` channel
5. confirm that the view has output
6. execute the command `Output: Part 2`
7. confirm that the content is replaced

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

Signed-off-by: vince-fugnitto <vincent.fugnitto@ericsson.com>

