### PR TITLE
Add a title for custom title bar style

### DIFF
--- a/packages/core/src/browser/core-preferences.ts
+++ b/packages/core/src/browser/core-preferences.ts
@@ -23,6 +23,24 @@ import { isOSX } from '../common/os';
 import { nls } from '../common/nls';
 import { DefaultTheme } from '@theia/application-package/lib/application-props';
 
+const windowTitleDescription = [
+    'Controls the window title based on the active editor. Variables are substituted based on the context:',
+    '`${activeEditorShort}`: the file name (e.g. myFile.txt).',
+    '`${activeEditorMedium}`: the path of the file relative to the workspace folder (e.g. myFolder/myFileFolder/myFile.txt).',
+    '`${activeEditorLong}`: the full path of the file (e.g. /Users/Development/myFolder/myFileFolder/myFile.txt).',
+    '`${activeFolderShort}`: the name of the folder the file is contained in (e.g. myFileFolder).',
+    '`${activeFolderMedium}`: the path of the folder the file is contained in, relative to the workspace folder (e.g. myFolder/myFileFolder).',
+    '`${activeFolderLong}`: the full path of the folder the file is contained in (e.g. /Users/Development/myFolder/myFileFolder).',
+    '`${folderName}`: name of the workspace folder the file is contained in (e.g. myFolder).',
+    '`${folderPath}`: file path of the workspace folder the file is contained in (e.g. /Users/Development/myFolder).',
+    '`${rootName}`: name of the opened workspace or folder (e.g. myFolder or myWorkspace).',
+    '`${rootPath}`: file path of the opened workspace or folder (e.g. /Users/Development/myWorkspace).',
+    '`${appName}`: e.g. VS Code.',
+    '`${remoteName}`: e.g. SSH',
+    '`${dirty}`: an indicator for when the active editor has unsaved changes.',
+    '`${separator}`: a conditional separator (" - ") that only shows when surrounded by variables with values or static text.'
+].map(e => nls.localizeByDefault(e)).join('\n- ');
+
 export const corePreferenceSchema: PreferenceSchema = {
     'type': 'object',
     properties: {
@@ -76,6 +94,20 @@ export const corePreferenceSchema: PreferenceSchema = {
             // eslint-disable-next-line max-len
             markdownDescription: nls.localizeByDefault("Control the visibility of the menu bar. A setting of 'toggle' means that the menu bar is hidden and a single press of the Alt key will show it. By default, the menu bar will be visible, unless the window is full screen."),
             included: !(isOSX && environment.electron.is())
+        },
+        'window.title': {
+            type: 'string',
+            default: isOSX
+                ? '${activeEditorShort}${separator}${rootName}'
+                : '${dirty} ${activeEditorShort}${separator}${rootName}${separator}${appName}',
+            scope: 'application',
+            markdownDescription: windowTitleDescription
+        },
+        'window.titleSeparator': {
+            type: 'string',
+            default: ' - ',
+            scope: 'application',
+            markdownDescription: nls.localizeByDefault('Separator used by `window.title`.')
         },
         'http.proxy': {
             type: 'string',
@@ -211,9 +243,11 @@ export const corePreferenceSchema: PreferenceSchema = {
 export interface CoreConfiguration {
     'application.confirmExit': 'never' | 'ifRequired' | 'always';
     'breadcrumbs.enabled': boolean;
-    'files.encoding': string
+    'files.encoding': string;
     'keyboard.dispatch': 'code' | 'keyCode';
     'window.menuBarVisibility': 'classic' | 'visible' | 'hidden' | 'compact';
+    'window.title': string;
+    'window.titleSeparator': string;
     'workbench.list.openMode': 'singleClick' | 'doubleClick';
     'workbench.commandPalette.history': number;
     'workbench.editor.highlightModifiedTabs': boolean;

--- a/packages/core/src/browser/frontend-application-module.ts
+++ b/packages/core/src/browser/frontend-application-module.ts
@@ -128,6 +128,8 @@ import { bindFrontendStopwatch, bindBackendStopwatch } from './performance';
 import { SaveResourceService } from './save-resource-service';
 import { SecondaryWindowHandler } from './secondary-window-handler';
 import { UserWorkingDirectoryProvider } from './user-working-directory-provider';
+import { WindowTitleService } from './window/window-title-service';
+import { WindowTitleUpdater } from './window/window-title-updater';
 import { TheiaDockPanel } from './shell/theia-dock-panel';
 import { bindStatusBar } from './status-bar';
 import { MarkdownRenderer, MarkdownRendererFactory, MarkdownRendererImpl } from './markdown-rendering/markdown-renderer';
@@ -399,6 +401,9 @@ export const frontendApplicationModule = new ContainerModule((bind, _unbind, _is
     for (const contribution of [CommandContribution, KeybindingContribution, MenuContribution]) {
         bind(contribution).toService(WindowContribution);
     }
+    bind(WindowTitleService).toSelf().inSingletonScope();
+    bind(WindowTitleUpdater).toSelf().inSingletonScope();
+    bind(FrontendApplicationContribution).toService(WindowTitleUpdater);
     bindContributionProvider(bind, BreadcrumbsContribution);
     bind(BreadcrumbsService).toSelf().inSingletonScope();
     bind(BreadcrumbsRenderer).toSelf();

--- a/packages/core/src/browser/shell/theia-dock-panel.ts
+++ b/packages/core/src/browser/shell/theia-dock-panel.ts
@@ -20,7 +20,7 @@ import { Signal } from '@phosphor/signaling';
 import { Disposable, DisposableCollection } from '../../common/disposable';
 import { UnsafeWidgetUtilities } from '../widgets';
 import { CorePreferences } from '../core-preferences';
-import { Emitter, environment } from '../../common';
+import { Emitter, Event, environment } from '../../common';
 
 export const MAXIMIZED_CLASS = 'theia-maximized';
 export const ACTIVE_TABBAR_CLASS = 'theia-tabBar-active';
@@ -50,6 +50,10 @@ export class TheiaDockPanel extends DockPanel {
 
     protected readonly onDidToggleMaximizedEmitter = new Emitter<Widget>();
     readonly onDidToggleMaximized = this.onDidToggleMaximizedEmitter.event;
+    protected readonly onDidChangeCurrentEmitter = new Emitter<Title<Widget> | undefined>();
+    get onDidChangeCurrent(): Event<Title<Widget> | undefined> {
+        return this.onDidChangeCurrentEmitter.event;
+    }
 
     constructor(options?: DockPanel.IOptions,
         protected readonly preferences?: CorePreferences
@@ -114,6 +118,7 @@ export class TheiaDockPanel extends DockPanel {
                 title.owner.disposed.disconnect(resetCurrent)
             ));
         }
+        this.onDidChangeCurrentEmitter.fire(title);
     }
 
     markActiveTabBar(title?: Title<Widget>): void {

--- a/packages/core/src/browser/window/window-title-service.ts
+++ b/packages/core/src/browser/window/window-title-service.ts
@@ -1,0 +1,107 @@
+// *****************************************************************************
+// Copyright (C) 2022 TypeFox and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { inject, injectable, postConstruct } from 'inversify';
+import { escapeRegExpCharacters } from '../../common/strings';
+import { Emitter, Event } from '../../common/event';
+import { CorePreferences } from '../core-preferences';
+import { FrontendApplicationConfigProvider } from '../frontend-application-config-provider';
+
+export const InitialWindowTitleParts = {
+    activeEditorShort: undefined,
+    activeEditorMedium: undefined,
+    activeEditorLong: undefined,
+    activeFolderShort: undefined,
+    activeFolderMedium: undefined,
+    activeFolderLong: undefined,
+    folderName: undefined,
+    folderPath: undefined,
+    rootName: undefined,
+    rootPath: undefined,
+    appName: FrontendApplicationConfigProvider.get().applicationName,
+    remoteName: undefined,
+    dirty: undefined,
+    developmentHost: undefined
+};
+
+@injectable()
+export class WindowTitleService {
+
+    @inject(CorePreferences)
+    protected readonly preferences: CorePreferences;
+
+    protected _title = '';
+    protected titleTemplate?: string;
+
+    protected onDidChangeTitleEmitter = new Emitter<string>();
+    protected titleParts = new Map<string, string | undefined>(Object.entries(InitialWindowTitleParts));
+    protected separator = ' - ';
+
+    @postConstruct()
+    protected init(): void {
+        this.titleTemplate = this.preferences['window.title'];
+        this.separator = this.preferences['window.titleSeparator'];
+        this.updateTitle();
+        this.preferences.onPreferenceChanged(e => {
+            if (e.preferenceName === 'window.title') {
+                this.titleTemplate = e.newValue;
+                this.updateTitle();
+            } else if (e.preferenceName === 'window.titleSeparator') {
+                this.separator = e.newValue;
+                this.updateTitle();
+            }
+        });
+    }
+
+    get onDidChangeTitle(): Event<string> {
+        return this.onDidChangeTitleEmitter.event;
+    }
+
+    get title(): string {
+        return this._title;
+    }
+
+    update(parts: Record<string, string | undefined>): void {
+        for (const [key, value] of Object.entries(parts)) {
+            this.titleParts.set(key, value);
+        }
+        this.updateTitle();
+    }
+
+    protected updateTitle(): void {
+        if (!this.titleTemplate) {
+            this._title = '';
+        } else {
+            let title = this.titleTemplate;
+            for (const [key, value] of this.titleParts.entries()) {
+                if (key !== 'developmentHost') {
+                    const label = `$\{${key}\}`;
+                    const regex = new RegExp(escapeRegExpCharacters(label), 'g');
+                    title = title.replace(regex, value ?? '');
+                }
+            }
+            const separatedTitle = title.split('${separator}').filter(e => e.length > 0);
+            this._title = separatedTitle.join(this.separator);
+        }
+        const developmentHost = this.titleParts.get('developmentHost');
+        if (developmentHost) {
+            this._title = developmentHost + this.separator + this._title;
+        }
+        document.title = this._title;
+        this.onDidChangeTitleEmitter.fire(this._title);
+    }
+
+}

--- a/packages/core/src/browser/window/window-title-service.ts
+++ b/packages/core/src/browser/window/window-title-service.ts
@@ -93,7 +93,7 @@ export class WindowTitleService {
                     title = title.replace(regex, value ?? '');
                 }
             }
-            const separatedTitle = title.split('${separator}').filter(e => e.length > 0);
+            const separatedTitle = title.split('${separator}').filter(e => e.trim().length > 0);
             this._title = separatedTitle.join(this.separator);
         }
         const developmentHost = this.titleParts.get('developmentHost');

--- a/packages/core/src/browser/window/window-title-updater.ts
+++ b/packages/core/src/browser/window/window-title-updater.ts
@@ -1,0 +1,76 @@
+// *****************************************************************************
+// Copyright (C) 2022 TypeFox and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { Widget } from '../widgets';
+import { FrontendApplication, FrontendApplicationContribution } from '../frontend-application';
+import { NavigatableWidget } from '../navigatable-types';
+import { inject, injectable } from 'inversify';
+import { WindowTitleService } from './window-title-service';
+import { LabelProvider } from '../label-provider';
+
+@injectable()
+export class WindowTitleUpdater implements FrontendApplicationContribution {
+
+    @inject(WindowTitleService)
+    protected readonly windowTitleService: WindowTitleService;
+
+    @inject(LabelProvider)
+    protected readonly labelProvider: LabelProvider;
+
+    onStart(app: FrontendApplication): void {
+        // Update the current title every 33 ms (30 times per second)
+        // This update is relatively cheap and work arounds a few issues in the application shell:
+        // 1. We can't easily identify when an editor becomes dirty/non-dirty, as there's no event for it
+        // 2. Adding a new widget might take a few frames for it to actually becomes the main widget, leaving the old widget in the title
+        // 3. Removing focus from the app messes with the active widget, leading to unexpected behavior
+        setInterval(() => {
+            this.updateTitleWidget(app.shell.getCurrentWidget('main'));
+        }, 33);
+    }
+
+    protected updateTitleWidget(widget?: Widget): void {
+        let activeEditorLong: string | undefined;
+        let activeEditorMedium: string | undefined;
+        let activeEditorShort: string | undefined;
+        let activeFolderLong: string | undefined;
+        let activeFolderMedium: string | undefined;
+        let activeFolderShort: string | undefined;
+        const uri = NavigatableWidget.getUri(widget);
+        if (uri) {
+            activeEditorLong = uri.path.toString();
+            activeEditorMedium = this.labelProvider.getLongName(uri);
+            activeEditorShort = this.labelProvider.getName(uri);
+            const parent = uri.parent;
+            activeFolderLong = parent.path.toString();
+            activeFolderMedium = this.labelProvider.getLongName(parent);
+            activeFolderShort = this.labelProvider.getName(parent);
+        } else if (widget) {
+            const widgetTitle = widget.title.label;
+            activeEditorLong = widgetTitle;
+            activeEditorMedium = widgetTitle;
+            activeEditorShort = widgetTitle;
+        }
+        this.windowTitleService.update({
+            activeEditorLong,
+            activeEditorMedium,
+            activeEditorShort,
+            activeFolderLong,
+            activeFolderMedium,
+            activeFolderShort
+        });
+    }
+
+}

--- a/packages/core/src/browser/window/window-title-updater.ts
+++ b/packages/core/src/browser/window/window-title-updater.ts
@@ -20,6 +20,7 @@ import { NavigatableWidget } from '../navigatable-types';
 import { inject, injectable } from 'inversify';
 import { WindowTitleService } from './window-title-service';
 import { LabelProvider } from '../label-provider';
+import { Saveable } from '../saveable';
 
 @injectable()
 export class WindowTitleUpdater implements FrontendApplicationContribution {
@@ -34,13 +35,18 @@ export class WindowTitleUpdater implements FrontendApplicationContribution {
         // Update the current title every 33 ms (30 times per second)
         // This update is relatively cheap and work arounds a few issues in the application shell:
         // 1. We can't easily identify when an editor becomes dirty/non-dirty, as there's no event for it
-        // 2. Adding a new widget might take a few frames for it to actually becomes the main widget, leaving the old widget in the title
+        // 2. Adding a new widget might take a few frames for it to actually become the main widget, leaving the old widget in the title
         // 3. Removing focus from the app messes with the active widget, leading to unexpected behavior
         setInterval(() => {
             this.updateTitleWidget(app.shell.getCurrentWidget('main'));
         }, 33);
     }
 
+    /**
+     * Updates the title of the application based on the currently opened widget.
+     * Note that this method is called in an interval of 33ms. Don't perform expensive operations on the widget.
+     * @param widget The current widget in the `main` application area. `undefined` if no widget is currently open in that area.
+     */
     protected updateTitleWidget(widget?: Widget): void {
         let activeEditorLong: string | undefined;
         let activeEditorMedium: string | undefined;
@@ -48,13 +54,14 @@ export class WindowTitleUpdater implements FrontendApplicationContribution {
         let activeFolderLong: string | undefined;
         let activeFolderMedium: string | undefined;
         let activeFolderShort: string | undefined;
+        let dirty: string | undefined;
         const uri = NavigatableWidget.getUri(widget);
         if (uri) {
-            activeEditorLong = uri.path.toString();
+            activeEditorLong = uri.path.fsPath();
             activeEditorMedium = this.labelProvider.getLongName(uri);
             activeEditorShort = this.labelProvider.getName(uri);
             const parent = uri.parent;
-            activeFolderLong = parent.path.toString();
+            activeFolderLong = parent.path.fsPath();
             activeFolderMedium = this.labelProvider.getLongName(parent);
             activeFolderShort = this.labelProvider.getName(parent);
         } else if (widget) {
@@ -63,13 +70,17 @@ export class WindowTitleUpdater implements FrontendApplicationContribution {
             activeEditorMedium = widgetTitle;
             activeEditorShort = widgetTitle;
         }
+        if (Saveable.isDirty(widget)) {
+            dirty = '●';
+        }
         this.windowTitleService.update({
             activeEditorLong,
             activeEditorMedium,
             activeEditorShort,
             activeFolderLong,
             activeFolderMedium,
-            activeFolderShort
+            activeFolderShort,
+            dirty
         });
     }
 

--- a/packages/core/src/electron-browser/menu/electron-menu-module.ts
+++ b/packages/core/src/electron-browser/menu/electron-menu-module.ts
@@ -19,7 +19,7 @@ import { CommandContribution, MenuContribution } from '../../common';
 import { FrontendApplicationContribution, ContextMenuRenderer, KeybindingContribution, KeybindingContext } from '../../browser';
 import { ElectronMainMenuFactory } from './electron-main-menu-factory';
 import { ElectronContextMenuRenderer, ElectronTextInputContextMenuContribution } from './electron-context-menu-renderer';
-import { ElectronMenuContribution } from './electron-menu-contribution';
+import { CustomTitleWidget, CustomTitleWidgetFactory, ElectronMenuContribution } from './electron-menu-contribution';
 
 export default new ContainerModule(bind => {
     bind(ElectronMainMenuFactory).toSelf().inSingletonScope();
@@ -33,6 +33,8 @@ export default new ContainerModule(bind => {
     for (const serviceIdentifier of [FrontendApplicationContribution, KeybindingContribution, CommandContribution, MenuContribution]) {
         bind(serviceIdentifier).toService(ElectronMenuContribution);
     }
+    bind(CustomTitleWidget).toSelf().inSingletonScope();
+    bind(CustomTitleWidgetFactory).toFactory(context => () => context.container.get(CustomTitleWidget));
     bind(FrontendApplicationContribution).to(ElectronTextInputContextMenuContribution).inSingletonScope();
     bind(MenuContribution).to(ElectronTextInputContextMenuContribution).inSingletonScope();
 });

--- a/packages/core/src/electron-browser/menu/electron-menu-style.css
+++ b/packages/core/src/electron-browser/menu/electron-menu-style.css
@@ -29,6 +29,31 @@
   -webkit-app-region: no-drag;
 }
 
+#theia-custom-title {
+  position: absolute;
+  left: 50%;
+  transform: translate(-50%, 0px);
+  line-height: 30px;
+  flex: 0 1 auto;
+  font-size: 12px;
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+  margin-top: 2px;
+  margin-left: auto;
+  margin-right: auto;
+  zoom: 1;
+  -webkit-app-region: drag !important;
+}
+
+#theia-custom-title.relative {
+  transform: none;
+}
+
+#theia-custom-title.hidden {
+  visibility: hidden;
+}
+
 #window-controls {
   display: grid;
   grid-template-columns: repeat(3, 48px);

--- a/packages/preferences/src/browser/style/index.css
+++ b/packages/preferences/src/browser/style/index.css
@@ -242,6 +242,10 @@
     position: relative;
 }
 
+.theia-settings-container li.single-pref p {
+    margin: 0;
+}
+
 .theia-settings-container li.single-pref:hover:not(:focus) {
     background-color: var(--theia-settings-rowHoverBackground);
 }

--- a/packages/preferences/src/browser/views/components/preference-node-renderer.ts
+++ b/packages/preferences/src/browser/views/components/preference-node-renderer.ts
@@ -281,7 +281,7 @@ export abstract class PreferenceLeafNodeRenderer<ValueType extends JSONValue, In
             const descriptionWrapper = document.createElement('div');
             descriptionWrapper.classList.add('pref-description');
             if (markdownDescription) {
-                const renderedDescription = this.markdownRenderer.renderInline(markdownDescription);
+                const renderedDescription = this.markdownRenderer.render(markdownDescription);
                 descriptionWrapper.onauxclick = this.openLink.bind(this);
                 descriptionWrapper.onclick = this.openLink.bind(this);
                 descriptionWrapper.oncontextmenu = () => false;

--- a/packages/workspace/src/browser/workspace-frontend-module.ts
+++ b/packages/workspace/src/browser/workspace-frontend-module.ts
@@ -52,6 +52,8 @@ import { WorkspaceTrustService } from './workspace-trust-service';
 import { bindWorkspaceTrustPreferences } from './workspace-trust-preferences';
 import { UserWorkingDirectoryProvider } from '@theia/core/lib/browser/user-working-directory-provider';
 import { WorkspaceUserWorkingDirectoryProvider } from './workspace-user-working-directory-provider';
+import { WindowTitleUpdater } from '@theia/core/lib/browser/window/window-title-updater';
+import { WorkspaceWindowTitleUpdater } from './workspace-window-title-updater';
 
 export default new ContainerModule((bind: interfaces.Bind, unbind: interfaces.Unbind, isBound: interfaces.IsBound, rebind: interfaces.Rebind) => {
     bindWorkspacePreferences(bind);
@@ -108,4 +110,6 @@ export default new ContainerModule((bind: interfaces.Bind, unbind: interfaces.Un
 
     bind(WorkspaceTrustService).toSelf().inSingletonScope();
     rebind(UserWorkingDirectoryProvider).to(WorkspaceUserWorkingDirectoryProvider).inSingletonScope();
+
+    rebind(WindowTitleUpdater).to(WorkspaceWindowTitleUpdater).inSingletonScope();
 });

--- a/packages/workspace/src/browser/workspace-service.ts
+++ b/packages/workspace/src/browser/workspace-service.ts
@@ -20,7 +20,7 @@ import { WorkspaceServer, CommonWorkspaceUtils } from '../common';
 import { WindowService } from '@theia/core/lib/browser/window/window-service';
 import { DEFAULT_WINDOW_HASH } from '@theia/core/lib/common/window';
 import {
-    FrontendApplicationContribution, PreferenceServiceImpl, PreferenceScope, PreferenceSchemaProvider, LabelProvider, Widget, Navigatable, FrontendApplication, Saveable
+    FrontendApplicationContribution, PreferenceServiceImpl, PreferenceScope, PreferenceSchemaProvider, LabelProvider
 } from '@theia/core/lib/browser';
 import { Deferred } from '@theia/core/lib/common/promise-util';
 import { EnvVariablesServer } from '@theia/core/lib/common/env-variables';
@@ -115,12 +115,6 @@ export class WorkspaceService implements FrontendApplicationContribution {
             }
         });
         this._ready.resolve();
-    }
-
-    onStart(app: FrontendApplication): void {
-        setInterval(() => {
-            this.updateTitleWidget(app.shell.getCurrentWidget('main'));
-        }, 33);
     }
 
     /**
@@ -287,27 +281,6 @@ export class WorkspaceService implements FrontendApplicationContribution {
                 this.logger.warn(`Not a valid workspace file: ${this.labelProvider.getLongName(this._workspace)}`);
             }
         }
-    }
-
-    protected updateTitleWidget(widget?: Widget): void {
-        let folderName: string | undefined;
-        let folderPath: string | undefined;
-        let dirty: string | undefined;
-        if (Navigatable.is(widget)) {
-            const folder = this.getWorkspaceRootUri(widget.getResourceUri());
-            if (folder) {
-                folderName = this.labelProvider.getName(folder);
-                folderPath = folder.path.toString();
-            }
-        }
-        if (Saveable.isDirty(widget)) {
-            dirty = '●';
-        }
-        this.windowTitleService.update({
-            folderName,
-            folderPath,
-            dirty
-        });
     }
 
     protected updateTitle(): void {

--- a/packages/workspace/src/browser/workspace-window-title-updater.ts
+++ b/packages/workspace/src/browser/workspace-window-title-updater.ts
@@ -1,0 +1,45 @@
+// *****************************************************************************
+// Copyright (C) 2022 TypeFox and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { WindowTitleUpdater } from '@theia/core/lib/browser/window/window-title-updater';
+import { inject, injectable } from '@theia/core/shared/inversify';
+import { Widget } from '@theia/core/lib/browser/widgets/widget';
+import { WorkspaceService } from './workspace-service';
+import { Navigatable } from '@theia/core/lib/browser/navigatable';
+
+@injectable()
+export class WorkspaceWindowTitleUpdater extends WindowTitleUpdater {
+
+    @inject(WorkspaceService) protected readonly workspaceService: WorkspaceService;
+
+    protected override updateTitleWidget(widget?: Widget): void {
+        super.updateTitleWidget(widget);
+        let folderName: string | undefined;
+        let folderPath: string | undefined;
+        if (Navigatable.is(widget)) {
+            const folder = this.workspaceService.getWorkspaceRootUri(widget.getResourceUri());
+            if (folder) {
+                folderName = this.labelProvider.getName(folder);
+                folderPath = folder.path.toString();
+            }
+        }
+        this.windowTitleService.update({
+            folderName,
+            folderPath
+        });
+    }
+
+}


### PR DESCRIPTION
#### What it does

Closes https://github.com/eclipse-theia/theia/issues/7076

When selecting the `custom` title bar style, the application currently shows no title. This change adresses the issue by trying to replicate what VSCode does with its title bars. Also aligns the title behavior of Theia to VSCode which shows the currently opened workspace and active main area widget in the title. For this, some more title-based infrastructure has been introduced to facilitate different contributions to the title.

#### How to test

1. Start the electron app on Windows or Linux and select the `custom` title bar style in the preferences
2. Assert that the title bar behaves like VSCode when resizing the window.
3. Open a workspace and start opening files or other widgets which appear in the main area. The currently opened workspace and the currently selected main area widget appear in the title bar.
4. Closing all workspaces/main area widgets removes these contributions from the title bar.
5. Assert that these changes also work correctly when using the `native` title bar style and in the browser.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
