### PR TITLE
Keep current configuration when executing a dynamic configuration

### DIFF
--- a/packages/debug/src/browser/debug-prefix-configuration.ts
+++ b/packages/debug/src/browser/debug-prefix-configuration.ts
@@ -135,7 +135,7 @@ export class DebugPrefixConfiguration implements CommandContribution, CommandHan
             for (const configuration of dynamicConfigurations) {
                 items.push({
                     label: configuration.name,
-                    execute: () => this.runConfiguration({ configuration })
+                    execute: () => this.runDynamicConfiguration({ configuration })
                 });
             }
         }
@@ -151,6 +151,14 @@ export class DebugPrefixConfiguration implements CommandContribution, CommandHan
     protected runConfiguration(configuration: DebugSessionOptions): void {
         this.debugConfigurationManager.current = { ...configuration };
         this.commandRegistry.executeCommand(DebugCommands.START.id);
+    }
+
+    /**
+     * Execute the debug start command without affecting the current debug configuration
+     * @param configuration the `DebugSessionOptions`.
+     */
+    protected runDynamicConfiguration(configuration: DebugSessionOptions): void {
+        this.commandRegistry.executeCommand(DebugCommands.START.id, configuration);
     }
 
     /**


### PR DESCRIPTION
#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

Starting a session from a dynamic debug configuration left it selected as `current` in the `DebugConfigurationManager`, however this selection was not reflected in the debug view since dynamic configurations are not found under the `launch.json` file.

Therefore before this change, starting a debug session by clicking the `start` button under the debug view may start a previously run dynamic configuration instead of the one reflected in the GUI.

![debug_started_wrong_config](https://user-images.githubusercontent.com/76971376/159753366-beeeaba7-99d2-4905-9e63-febfec15d309.gif)

This change fixes the above problem by saving the `current` configuration before the start of a dynamic debug session and
restores it right after the session starts.

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

- Having two `.ts` program files e.g. A and B
  - Define a corresponding launch entry (under the `launch.json`) for each of them (the configurations are arbitrary as long as you have two file programs that are ready for debugging).
    - Example [launch.json](https://gist.github.com/alvsan09/a040d742c4fbf82e485328a87b140940)
  - Start B, make sure the debug session starts properly
  - Start A, make sure the debug session starts properly
  - Select the Editor for B
  - Using the command palette call the command `debug ', NOTE: The last space is important to trigger the command
  - Select the entry dynamic configuration entry: 'Run Current File' 
  - Make sure a debug session is started for B and then stop the session
  - The debug view shall still indicate A as the currently selected configuration
  - From the debug view click the `start` button and make sure that A is started (and not B as before the fix)
  

![debug_started_wrong_config_fix](https://user-images.githubusercontent.com/76971376/159753488-ee65d0df-0b72-4530-ab58-e50d65132a66.gif)

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
