### PR TITLE
plugin: add `SourceFixAll` declaration to `CodeActionKind`

### DIFF
--- a/packages/plugin/src/theia.d.ts
+++ b/packages/plugin/src/theia.d.ts
@@ -8063,6 +8063,14 @@ export module '@theia/plugin' {
          */
         static readonly SourceOrganizeImports: CodeActionKind;
 
+        /**
+         * Base kind for auto-fix source actions: `source.fixAll`.
+         *
+         * Fix all actions automatically fix errors that have a clear fix that do not require user input.
+         * They should not suppress errors or perform unsafe fixes such as generating new types or classes.
+         */
+        static readonly SourceFixAll: CodeActionKind;
+
         private constructor(value: string);
 
         /**


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

Fixes: https://github.com/eclipse-theia/theia/issues/9991.

The pull-request adds the `SourceFillAll` declaration for `CodeActionKind`.

The action is already supported in our codebase, but was never added to our `theia.d.ts` file which meant it was marked as unsupported:

https://github.com/eclipse-theia/theia/blob/acd6f574ce9e620388376388ef32ca9d9845efca/packages/plugin-ext/src/plugin/types-impl.ts#L1204

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

There should not be a change in functionality, the build should successfully pass.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

Signed-off-by: vince-fugnitto <vincent.fugnitto@ericsson.com>