### PR TITLE
[playwright] Add support for handling option preferences and reactivate skipped test

### DIFF
--- a/examples/playwright/src/tests/theia-preference-view.test.ts
+++ b/examples/playwright/src/tests/theia-preference-view.test.ts
@@ -38,14 +38,14 @@ test.describe('Preference View', () => {
         const preferences = await app.openPreferences(TheiaPreferenceView);
         const preferenceId = PreferenceIds.DiffEditor.MaxComputationTime;
 
-        await preferences.resetStringPreferenceById(preferenceId);
+        await preferences.resetPreferenceById(preferenceId);
         expect(await preferences.getStringPreferenceById(preferenceId)).toBe(DefaultPreferences.DiffEditor.MaxComputationTime);
 
         await preferences.setStringPreferenceById(preferenceId, '8000');
         await preferences.waitForModified(preferenceId);
         expect(await preferences.getStringPreferenceById(preferenceId)).toBe('8000');
 
-        await preferences.resetStringPreferenceById(preferenceId);
+        await preferences.resetPreferenceById(preferenceId);
         expect(await preferences.getStringPreferenceById(preferenceId)).toBe(DefaultPreferences.DiffEditor.MaxComputationTime);
     });
 
@@ -53,15 +53,30 @@ test.describe('Preference View', () => {
         const preferences = await app.openPreferences(TheiaPreferenceView);
         const preferenceId = PreferenceIds.Explorer.AutoReveal;
 
-        await preferences.resetBooleanPreferenceById(preferenceId);
+        await preferences.resetPreferenceById(preferenceId);
         expect(await preferences.getBooleanPreferenceById(preferenceId)).toBe(DefaultPreferences.Explorer.AutoReveal.Enabled);
 
         await preferences.setBooleanPreferenceById(preferenceId, false);
         await preferences.waitForModified(preferenceId);
         expect(await preferences.getBooleanPreferenceById(preferenceId)).toBe(false);
 
-        await preferences.resetBooleanPreferenceById(preferenceId);
+        await preferences.resetPreferenceById(preferenceId);
         expect(await preferences.getBooleanPreferenceById(preferenceId)).toBe(DefaultPreferences.Explorer.AutoReveal.Enabled);
+    });
+
+    test('should be able to read, set, and reset Options preferences', async () => {
+        const preferences = await app.openPreferences(TheiaPreferenceView);
+        const preferenceId = PreferenceIds.Editor.RenderWhitespace;
+
+        await preferences.resetPreferenceById(preferenceId);
+        expect(await preferences.getOptionsPreferenceById(preferenceId)).toBe(DefaultPreferences.Editor.RenderWhitespace.Selection);
+
+        await preferences.setOptionsPreferenceById(preferenceId, DefaultPreferences.Editor.RenderWhitespace.Boundary);
+        await preferences.waitForModified(preferenceId);
+        expect(await preferences.getOptionsPreferenceById(preferenceId)).toBe(DefaultPreferences.Editor.RenderWhitespace.Boundary);
+
+        await preferences.resetPreferenceById(preferenceId);
+        expect(await preferences.getOptionsPreferenceById(preferenceId)).toBe(DefaultPreferences.Editor.RenderWhitespace.Selection);
     });
 
     test('should throw an error if we try to read, set, or reset a non-existing preference', async () => {
@@ -69,13 +84,17 @@ test.describe('Preference View', () => {
 
         preferences.customTimeout = 500;
         try {
-            await expect(preferences.getBooleanPreferenceById('no.a.real.preference')).rejects.toThrowError();
-            await expect(preferences.setBooleanPreferenceById('no.a.real.preference', true)).rejects.toThrowError();
-            await expect(preferences.resetBooleanPreferenceById('no.a.real.preference')).rejects.toThrowError();
+            await expect(preferences.getBooleanPreferenceById('not.a.real.preference')).rejects.toThrowError();
+            await expect(preferences.setBooleanPreferenceById('not.a.real.preference', true)).rejects.toThrowError();
+            await expect(preferences.resetPreferenceById('not.a.real.preference')).rejects.toThrowError();
 
-            await expect(preferences.getStringPreferenceById('no.a.real.preference')).rejects.toThrowError();
-            await expect(preferences.setStringPreferenceById('no.a.real.preference', 'a')).rejects.toThrowError();
-            await expect(preferences.resetStringPreferenceById('no.a.real.preference')).rejects.toThrowError();
+            await expect(preferences.getStringPreferenceById('not.a.real.preference')).rejects.toThrowError();
+            await expect(preferences.setStringPreferenceById('not.a.real.preference', 'a')).rejects.toThrowError();
+            await expect(preferences.resetPreferenceById('not.a.real.preference')).rejects.toThrowError();
+
+            await expect(preferences.getOptionsPreferenceById('not.a.real.preference')).rejects.toThrowError();
+            await expect(preferences.setOptionsPreferenceById('not.a.real.preference', 'a')).rejects.toThrowError();
+            await expect(preferences.resetPreferenceById('not.a.real.preference')).rejects.toThrowError();
         } finally {
             preferences.customTimeout = undefined;
         }
@@ -86,8 +105,14 @@ test.describe('Preference View', () => {
         const stringPreference = PreferenceIds.DiffEditor.MaxComputationTime;
         const booleanPreference = PreferenceIds.Explorer.AutoReveal;
 
-        await expect(preferences.getBooleanPreferenceById(stringPreference)).rejects.toThrowError();
-        await expect(preferences.setBooleanPreferenceById(stringPreference, true)).rejects.toThrowError();
-        await expect(preferences.setStringPreferenceById(booleanPreference, 'true')).rejects.toThrowError();
+        preferences.customTimeout = 500;
+        try {
+            await expect(preferences.getBooleanPreferenceById(stringPreference)).rejects.toThrowError();
+            await expect(preferences.setBooleanPreferenceById(stringPreference, true)).rejects.toThrowError();
+            await expect(preferences.setStringPreferenceById(booleanPreference, 'true')).rejects.toThrowError();
+            await expect(preferences.setOptionsPreferenceById(booleanPreference, 'true')).rejects.toThrowError();
+        } finally {
+            preferences.customTimeout = undefined;
+        }
     });
 });

--- a/examples/playwright/src/tests/theia-text-editor.test.ts
+++ b/examples/playwright/src/tests/theia-text-editor.test.ts
@@ -15,6 +15,7 @@
 // *****************************************************************************
 
 import { expect } from '@playwright/test';
+import { DefaultPreferences, PreferenceIds, TheiaPreferenceView } from '../theia-preference-view';
 import { TheiaApp } from '../theia-app';
 import { TheiaTextEditor } from '../theia-text-editor';
 import { TheiaWorkspace } from '../theia-workspace';
@@ -27,6 +28,11 @@ test.describe('Theia Text Editor', () => {
     test.beforeAll(async () => {
         const ws = new TheiaWorkspace(['src/tests/resources/sample-files1']);
         app = await TheiaApp.load(page, ws);
+
+        // set auto-save preference to off
+        const preferenceView = await app.openPreferences(TheiaPreferenceView);
+        await preferenceView.setOptionsPreferenceById(PreferenceIds.Editor.AutoSave, DefaultPreferences.Editor.AutoSave.Off);
+        await preferenceView.close();
     });
 
     test('should be visible and active after opening "sample.txt"', async () => {
@@ -164,7 +170,7 @@ test.describe('Theia Text Editor', () => {
         await sampleTextEditor.saveAndClose();
     });
 
-    test.skip('should close without saving', async () => {
+    test('should close without saving', async () => {
         const sampleTextEditor = await app.openEditor('sample.txt', TheiaTextEditor);
         await sampleTextEditor.replaceLineWithLineNumber('change again', 1);
         expect(await sampleTextEditor.isDirty()).toBe(true);


### PR DESCRIPTION
#### What it does

Due to the Monaco uplift, we had to temporarily skip a test, because the Monaco change affected the default preference regarding auto-save.

To re-enable the skipped test, we now explicitly set the auto save preference to `off` before the test. This way the preference value is ensured to be consistent. In order to do that conveniently, this change adds general support for preferences that are set by HTML select/options. In the course of introducing support for select/option preferences, we harmonized the code for handling different types of preferences in the `TheiaPreferenceView` page object.

See also https://github.com/eclipse-theia/theia/pull/10736
Fixes https://github.com/eclipse-theia/theia/issues/10891

#### How to test
This change adds additional tests for the new support for option preferences and reactivates the test that had to be skipped in https://github.com/eclipse-theia/theia/pull/10736.

#### Review checklist

- [X] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
