### PR TITLE
[playwright] Start theia with THEIA_CONFIG_DIR

### DIFF
--- a/examples/playwright/.gitignore
+++ b/examples/playwright/.gitignore
@@ -1,2 +1,3 @@
 allure-results
 test-results
+.tmp.cfg

--- a/examples/playwright/package.json
+++ b/examples/playwright/package.json
@@ -15,7 +15,7 @@
     "prepare": "yarn clean && yarn build",
     "clean": "rimraf lib",
     "build": "tsc --incremental && yarn lint && npx playwright install chromium",
-    "theia:start": "yarn --cwd ../browser start",
+    "theia:start": "rimraf .tmp.cfg && THEIA_CONFIG_DIR=$PWD/.tmp.cfg yarn --cwd ../browser start",
     "lint": "eslint -c ./.eslintrc.js --ext .ts ./src ./tests",
     "lint:fix": "eslint -c ./.eslintrc.js --ext .ts ./src ./tests --fix",
     "ui-tests": "yarn && playwright test --config=./configs/playwright.config.ts",

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "rebuild:clean": "rimraf .browser_modules",
     "test": "yarn -s test:theia && yarn -s electron test && yarn -s browser test",
     "test:theia": "lerna run --scope \"@theia/!(example-)*\" test --stream --concurrency=1",
-    "test:playwright": "concurrently --success first -c gray,blue -k -n theia,playwright \"yarn browser start\" \"yarn -s --cwd examples/playwright ui-tests-ci\"",
+    "test:playwright": "concurrently --success first -c gray,blue -k -n theia,playwright \"yarn -s --cwd examples/playwright theia:start\" \"yarn -s --cwd examples/playwright ui-tests-ci\"",
     "watch": "concurrently --kill-others -n tsc,browser,electron -c red,yellow,blue \"tsc -b -w --preserveWatchOutput\" \"yarn -s --cwd examples/browser watch:bundle\" \"yarn -s --cwd examples/electron watch:bundle\"",
     "watch:compile": "concurrently --kill-others -n cleanup,tsc -c magenta,red \"ts-clean dev-packages/* packages/* -w\" \"tsc -b -w --preserveWatchOutput\"",
     "performance:startup": "yarn -s performance:startup:browser && yarn -s performance:startup:electron",


### PR DESCRIPTION
#### What it does
This change modifies the scripts so that theia as a system under test is started with a dedicated temporary `THEIA_CONFIG_DIR` for running the playwright tests.

Fixes https://github.com/eclipse-theia/theia/issues/10800

#### How to test
1. Check your local `.theia` folder
2. Run `yarn test:playwright`
3. Observe how this doesn't affect your local `.theia` folder
4. Observe how instead `examples/playwright/.tmp.cfg` is used instead

#### Review checklist

- [X] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
