### PR TITLE
plugin: add support for `CompletionItemLabel`

### DIFF
--- a/packages/monaco/src/browser/style/index.css
+++ b/packages/monaco/src/browser/style/index.css
@@ -115,19 +115,6 @@
   box-shadow: rgb(0 0 0 / 36%) 0px 0px 8px 2px;
 }
 
-.monaco-icon-label,
-.monaco-icon-label-container,
-.monaco-icon-name-container,
-.monaco-highlighted-label,
-.quick-input-list-row {
-  line-height: var(--theia-content-line-height) !important;
-  height: var(--theia-content-line-height) !important;
-}
-
-.monaco-icon-label-container {
-  font-family: var(--theia-ui-font-family) !important;
-}
-
 .quick-input-list
   .quick-input-list-rows
   > .quick-input-list-row

--- a/packages/plugin-ext/src/common/plugin-api-rpc-model.ts
+++ b/packages/plugin-ext/src/common/plugin-api-rpc-model.ts
@@ -102,7 +102,7 @@ export enum CompletionItemInsertTextRule {
 }
 
 export interface Completion {
-    label: string;
+    label: string | theia.CompletionItemLabel;
     label2?: string;
     kind: CompletionItemKind;
     detail?: string;

--- a/packages/plugin-ext/src/plugin/languages/completion.ts
+++ b/packages/plugin-ext/src/plugin/languages/completion.ts
@@ -115,7 +115,9 @@ export class CompletionAdapter {
 
     private convertCompletionItem(item: theia.CompletionItem, id: number, parentId: number,
         defaultInserting?: theia.Range, defaultReplacing?: theia.Range): CompletionDto | undefined {
-        if (typeof item.label !== 'string' || item.label.length === 0) {
+
+        const itemLabel = typeof item.label === 'string' ? item.label : item.label.label;
+        if (itemLabel.length === 0) {
             console.warn('Invalid Completion Item -> must have at least a label');
             return undefined;
         }
@@ -125,7 +127,7 @@ export class CompletionAdapter {
             throw Error('DisposableCollection is missing...');
         }
 
-        let insertText = item.label;
+        let insertText = itemLabel;
         let insertTextRules = item.keepWhitespace ? CompletionItemInsertTextRule.KeepWhitespace : 0;
         if (item.textEdit) {
             insertText = item.textEdit.newText;

--- a/packages/plugin/src/theia.d.ts
+++ b/packages/plugin/src/theia.d.ts
@@ -7334,6 +7334,31 @@ export module '@theia/plugin' {
     }
 
     /**
+     * A structured label for a {@link CompletionItem completion item}.
+     */
+    export interface CompletionItemLabel {
+
+        /**
+         * The label of this completion item.
+         *
+         * By default this is also the text that is inserted when this completion is selected.
+         */
+        label: string;
+
+        /**
+         * An optional string which is rendered less prominently directly after {@link CompletionItemLabel.label label},
+         * without any spacing. Should be used for function signatures or type annotations.
+         */
+        detail?: string;
+
+        /**
+         * An optional string which is rendered less prominently after {@link CompletionItemLabel.detail}. Should be used
+         * for fully qualified names or file path.
+         */
+        description?: string;
+    }
+
+    /**
      * A completion item represents a text snippet that is proposed to complete text that is being typed.
      *
      * It is sufficient to create a completion item from just a [label](#CompletionItem.label). In that
@@ -7355,7 +7380,7 @@ export module '@theia/plugin' {
          * this is also the text that is inserted when selecting
          * this completion.
          */
-        label: string;
+        label: string | CompletionItemLabel;
 
         /**
          * The kind of this completion item. Based on the kind
@@ -7474,7 +7499,7 @@ export module '@theia/plugin' {
          * @param label The label of the completion.
          * @param kind The [kind](#CompletionItemKind) of the completion.
          */
-        constructor(label: string, kind?: CompletionItemKind);
+        constructor(label: string | CompletionItemLabel, kind?: CompletionItemKind);
     }
 
     /**


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

The commit adds support for `CompletionItemLabel` for `CompletionItem`. The change also adjusts the styling of monaco suggestions to more closely resemble vscode (using monospaced fonts) and fixing an issue when rendering the `detail` due to a superflous line-height.

![suggestions](https://user-images.githubusercontent.com/40359487/160173115-394489d5-8a48-429b-b52e-6b382ae151a6.gif)

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

1. include the following test extension [completions-sample-0.0.2.zip](https://github.com/eclipse-theia/theia/files/8352680/completions-sample-0.0.2.zip)
2. open a `.txt` file
3. execute the command `Trigger Suggest`
4. the quick-suggestion should appear (the detail and description)
5. the styling of the suggestion should be correct (monospaced font, alignment)

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

Signed-off-by: vince-fugnitto <vincent.fugnitto@ericsson.com>
