### PR TITLE
Attach Open Editors after Navigator

### DIFF
--- a/packages/core/src/browser/view-container.ts
+++ b/packages/core/src/browser/view-container.ts
@@ -1036,7 +1036,7 @@ export class ViewContainerPart extends BaseWidget {
     set collapsed(collapsed: boolean) {
         // Cannot collapse/expand if the orientation of the container is `horizontal`.
         const orientation = ViewContainer.getOrientation(this.node);
-        if (this._collapsed === collapsed || orientation === 'horizontal' && collapsed) {
+        if (this._collapsed === collapsed || (orientation === 'horizontal' && collapsed)) {
             return;
         }
         this._collapsed = collapsed;

--- a/packages/navigator/src/browser/navigator-widget-factory.ts
+++ b/packages/navigator/src/browser/navigator-widget-factory.ts
@@ -68,8 +68,8 @@ export class NavigatorWidgetFactory implements WidgetFactory {
         viewContainer.setTitleOptions(EXPLORER_VIEW_CONTAINER_TITLE_OPTIONS);
         const openEditorsWidget = await this.widgetManager.getOrCreateWidget(OpenEditorsWidget.ID);
         const navigatorWidget = await this.widgetManager.getOrCreateWidget(FILE_NAVIGATOR_ID);
-        viewContainer.addWidget(openEditorsWidget, this.openEditorsWidgetOptions);
         viewContainer.addWidget(navigatorWidget, this.fileNavigatorWidgetOptions);
+        viewContainer.addWidget(openEditorsWidget, this.openEditorsWidgetOptions);
         return viewContainer;
     }
 }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->
Fixes #10928 by adding the open editors widget after the navigator. The `order` field should ensure that the open editors widget appears before the navigator, and adding it second ensures that it is not automatically expanded as the sole child of the `ViewContainer`.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
1. Run `Reset Workbench Layout`
2. Open the Navigator view container
3. Observe that the open editors widget is collapsed and above the navigator tree.


#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
