### PR TITLE
Update sash visibility based on check of all ViewContainerParts

### DIFF
--- a/packages/core/src/browser/view-container.ts
+++ b/packages/core/src/browser/view-container.ts
@@ -46,11 +46,6 @@ export interface ViewContainerTitleOptions {
     closeable?: boolean;
 }
 
-enum SashType {
-    TopSash = 'top-sash',
-    BottomSash = 'bottom-sash'
-}
-
 @injectable()
 export class ViewContainerIdentifier {
     id: string;
@@ -412,9 +407,11 @@ export class ViewContainer extends BaseWidget implements StatefulWidget, Applica
                 this.updateTitle();
                 this.updateCurrentPart();
                 this.updateSplitterVisibility();
+                this.containerLayout.updateSashes();
             }),
             newPart.onCollapsed(() => {
                 this.containerLayout.updateCollapsed(newPart, this.enableAnimation);
+                this.containerLayout.updateSashes();
                 this.updateCurrentPart();
             }),
             newPart.onContextMenu(event => {
@@ -598,9 +595,6 @@ export class ViewContainer extends BaseWidget implements StatefulWidget, Applica
         if (this.titleOptions) {
             this.menuRegistry.registerMenuAction([...SIDE_PANEL_TOOLBAR_CONTEXT_MENU, 'navigation'], action);
         }
-
-        ViewContainer.updateSashState(SashType.TopSash, part.node.previousElementSibling, part.collapsed);
-        ViewContainer.updateSashState(SashType.BottomSash, part.node.nextElementSibling, part.collapsed);
     }
 
     protected unregisterPart(part: ViewContainerPart): void {
@@ -906,27 +900,6 @@ export namespace ViewContainer {
         }
         return 'vertical';
     }
-
-    export function updateSashState(sashType: SashType, sashElement: Element | null, activeContainerCollapsed: boolean): void {
-        if (sashElement && sashElement.className.includes('p-SplitPanel-handle')) {
-            // Hide the sash when the active `horizontal` container in the left panel is collapsed
-            sashElement.classList.toggle('sash-hidden', activeContainerCollapsed);
-
-            let adjacentContainer: Element | null;
-            if (sashType === SashType.TopSash) {
-                adjacentContainer = sashElement.previousElementSibling;
-            } else {
-                adjacentContainer = sashElement.nextElementSibling;
-            }
-
-            // Sash should only appear when the following two conditions are met:
-            //    1.  the active `horizontal` container is expanded
-            //    2.  the container that is above/below the active `horizontal` container is also expanded
-            if (!activeContainerCollapsed && adjacentContainer) {
-                sashElement.classList.toggle('sash-hidden', adjacentContainer.className.includes('collapsed'));
-            }
-        }
-    }
 }
 
 /**
@@ -1041,10 +1014,6 @@ export class ViewContainerPart extends BaseWidget {
         }
         this._collapsed = collapsed;
         this.node.classList.toggle('collapsed', collapsed);
-
-        // Update the sashes for the active `horizontal` container when the container is collapsed/expanded
-        ViewContainer.updateSashState(SashType.TopSash, this.node.previousElementSibling, collapsed);
-        ViewContainer.updateSashState(SashType.BottomSash, this.node.nextElementSibling, collapsed);
 
         if (collapsed && this.wrapped.node.contains(document.activeElement)) {
             this.header.focus();
@@ -1465,7 +1434,6 @@ export class ViewContainerLayout extends SplitLayout {
         if (index < 0 || !this.parent || part.isHidden) {
             return;
         }
-
         // Do not store the height of the "stretched item". Otherwise, we mess up the "hint height".
         // Store the height only if there are other expanded items.
         const currentSize = this.orientation === 'horizontal' ? part.node.offsetWidth : part.node.offsetHeight;
@@ -1527,6 +1495,44 @@ export class ViewContainerLayout extends SplitLayout {
             MessageLoop.sendMessage(this.parent, Widget.Msg.FitRequest);
         };
         requestAnimationFrame(updateFunc);
+    }
+
+    updateSashes(): void {
+        const { widgets, handles } = this;
+        if (widgets.length !== handles.length) {
+            console.warn('Unexpected mismatch between number of widgets and number of handles.');
+            return;
+        }
+        const firstUncollapsed = this.getFirstUncollapsedWidgetIndex();
+        const lastUncollapsed = firstUncollapsed === undefined ? undefined : this.getLastUncollapsedWidgetIndex();
+        const allHidden = firstUncollapsed === lastUncollapsed;
+        for (const [index, handle] of this.handles.entries()) {
+            // The or clauses are added for type checking. If they're true, allHidden will also have been true.
+            if (allHidden || firstUncollapsed === undefined || lastUncollapsed === undefined) {
+                handle.classList.add('sash-hidden');
+                // Handle is at the bottom of an uncollapsed widget above the last uncollapsed.
+            } else if (index < lastUncollapsed && !this.widgets[index].collapsed && !this.widgets[index].isHidden) {
+                handle.classList.remove('sash-hidden');
+                // Handle is at the top of an uncollapsed widget below the first uncollapsed.
+            } else if (index > firstUncollapsed && this.widgets[index + 1]?.collapsed === false && !this.widgets[index + 1].isHidden) {
+                handle.classList.remove('sash-hidden');
+            } else {
+                handle.classList.add('sash-hidden');
+            }
+        }
+    }
+
+    protected getFirstUncollapsedWidgetIndex(): number | undefined {
+        const index = this.widgets.findIndex(widget => !widget.collapsed && !widget.isHidden);
+        return index === -1 ? undefined : index;
+    }
+
+    protected getLastUncollapsedWidgetIndex(): number | undefined {
+        for (let i = this.widgets.length - 1; i >= 0; i--) {
+            if (!this.widgets[i].collapsed && !this.widgets[i].isHidden) {
+                return i;
+            }
+        }
     }
 
     protected override onFitRequest(msg: Message): void {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->
Fixes #10894 by updating sash visibility for all ViewContainerParts when any ViewContainerPart is collapsed or uncollapsed.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
1. In a view container with many parts (e.g. SCM with GitLens installed)
2. Confirm that sashes are visible and can be used to resize parts _if_
    - The sash is at the _bottom_ of a visible, uncollapsed widget _above_ the last visible, uncollapsed part.
    - OR the sash is at the _top_ of a visible, uncollapsed widget _below_ the first visible, uncollapsed part.
3. Confirm that sashes are invisible otherwise. 
    
#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
