### PR TITLE
Support indeterminate progress notifications

### DIFF
--- a/examples/api-samples/src/browser/menu/sample-menu-contribution.ts
+++ b/examples/api-samples/src/browser/menu/sample-menu-contribution.ts
@@ -29,6 +29,14 @@ const SampleCommand2: Command = {
     id: 'sample-command2',
     label: 'Sample Command2'
 };
+const SampleCommandWithProgressMessage: Command = {
+    id: 'sample-command-with-progress',
+    label: 'Sample Command With Progress Message'
+};
+const SampleCommandWithIndeterminateProgressMessage: Command = {
+    id: 'sample-command-with-indeterminate-progress',
+    label: 'Sample Command With Indeterminate Progress Message'
+};
 const SampleQuickInputCommand: Command = {
     id: 'sample-quick-input-command',
     category: 'Quick Input',
@@ -75,6 +83,61 @@ export class SampleCommandContribution implements CommandContribution {
                 if (result) {
                     this.messageService.info(`Positive Integer: ${result}`);
                 }
+            }
+        });
+        commands.registerCommand(SampleCommandWithProgressMessage, {
+            execute: () => {
+                this.messageService
+                    .showProgress({
+                        text: 'Starting to report progress',
+                    })
+                    .then(progress => {
+                        window.setTimeout(() => {
+                            progress.report({
+                                message: 'First step completed',
+                                work: { done: 25, total: 100 }
+                            });
+                        }, 2000);
+                        window.setTimeout(() => {
+                            progress.report({
+                                message: 'Next step completed',
+                                work: { done: 60, total: 100 }
+                            });
+                        }, 4000);
+                        window.setTimeout(() => {
+                            progress.report({
+                                message: 'Complete',
+                                work: { done: 100, total: 100 }
+                            });
+                        }, 6000);
+                        window.setTimeout(() => progress.cancel(), 7000);
+                    });
+            }
+        });
+        commands.registerCommand(SampleCommandWithIndeterminateProgressMessage, {
+            execute: () => {
+                this.messageService
+                    .showProgress({
+                        text: 'Starting to report indeterminate progress',
+                    })
+                    .then(progress => {
+                        window.setTimeout(() => {
+                            progress.report({
+                                message: 'First step completed',
+                            });
+                        }, 2000);
+                        window.setTimeout(() => {
+                            progress.report({
+                                message: 'Next step completed',
+                            });
+                        }, 4000);
+                        window.setTimeout(() => {
+                            progress.report({
+                                message: 'Complete',
+                            });
+                        }, 6000);
+                        window.setTimeout(() => progress.cancel(), 7000);
+                    });
             }
         });
     }

--- a/packages/core/src/common/message-service.ts
+++ b/packages/core/src/common/message-service.ts
@@ -195,12 +195,13 @@ export class MessageService {
         const report = (update: ProgressUpdate) => {
             this.client.reportProgress(id, update, message, cancellationSource.token);
         };
+        const type = message.type ?? MessageType.Progress;
         const actions = new Set<string>(message.actions);
         if (ProgressMessage.isCancelable(message)) {
             actions.delete(ProgressMessage.Cancel);
             actions.add(ProgressMessage.Cancel);
         }
-        const clientMessage = { ...message, actions: Array.from(actions) };
+        const clientMessage = { ...message, type, actions: Array.from(actions) };
         const result = this.client.showProgress(id, clientMessage, cancellationSource.token);
         if (ProgressMessage.isCancelable(message) && typeof onDidCancel === 'function') {
             result.then(value => {

--- a/packages/messages/src/browser/notification-component.tsx
+++ b/packages/messages/src/browser/notification-component.tsx
@@ -71,11 +71,12 @@ export class NotificationComponent extends React.Component<NotificationComponent
 
     override render(): React.ReactNode {
         const { messageId, message, type, progress, collapsed, expandable, source, actions } = this.props.notification;
-        const isProgress = typeof progress === 'number';
+        const isProgress = type === 'progress' || typeof progress === 'number';
+        const icon = type === 'progress' ? 'info' : type;
         return (<div key={messageId} className='theia-notification-list-item' tabIndex={0}>
             <div className={`theia-notification-list-item-content ${collapsed ? 'collapsed' : ''}`}>
                 <div className='theia-notification-list-item-content-main'>
-                    <div className={`theia-notification-icon ${codicon(type)} ${type}`} />
+                    <div className={`theia-notification-icon ${codicon(icon)} ${icon}`} />
                     <div className='theia-notification-message'>
                         <span
                             // eslint-disable-next-line react/no-danger
@@ -115,7 +116,8 @@ export class NotificationComponent extends React.Component<NotificationComponent
             </div>
             {isProgress && (
                 <div className='theia-notification-item-progress'>
-                    <div className='theia-notification-item-progressbar' style={{ width: `${progress}%` }} />
+                    <div className={`theia-notification-item-progressbar ${progress ? 'determinate' : 'indeterminate'}`}
+                        style={{ width: `${progress ?? '100'}%` }} />
                 </div>
             )}
         </div>);

--- a/packages/messages/src/browser/style/notifications.css
+++ b/packages/messages/src/browser/style/notifications.css
@@ -245,6 +245,25 @@
     width: 66%;
 }
 
+.theia-notification-item-progressbar.indeterminate {
+    animation: progress-animation 1.3s 0s infinite cubic-bezier(0.645, 0.045, 0.355, 1);
+}
+
+@keyframes progress-animation {
+    0% {
+        margin-left: 0%;
+        width: 3%;
+    }
+    60% {
+        margin-left: 45%;
+        width: 20%;
+    }
+    100% {
+        margin-left: 99%;
+        width: 1%;
+    }
+}
+
 /* Perfect scrollbar */
 
 .theia-notification-list-scroll-container .ps__rail-y {


### PR DESCRIPTION
#### What it does

  * Default to `progress` notification type if `showProgress()` is used instead of overwriting it with `info`
  * Pass `progress` notification type through to view to make it aware that this is a progress without having to specify a value for the progress
  * Show indeterminate progress animation if notification type is `progress` but no numeric `progress` value is specified
  * Use `info` icon by default in view for `progress` notifications (this was implicitly done before too because we overwrote the notification type with `info` if the client didn't specify one
  * Add sample menu contributions to document and test progress notifications with determinate and indeterminate progress

Fixes https://github.com/eclipse-theia/theia/issues/10944

#### How to test

Use the added sample commands "Sample Command With Indeterminate Progress Message" and "Sample Command With Progress Message". See also their handler implementation in `sample-menu-contribution.ts`, in particular how one reports no progress (indeterminate) and the other one does.

With progress reporting:
![Peek 2022-03-29 13-21](https://user-images.githubusercontent.com/588090/160604266-52acd92b-d0eb-4238-b399-86a662c20b94.gif)

Without progress reporting:
![Peek 2022-03-29 13-22](https://user-images.githubusercontent.com/588090/160604269-cfa2e499-904a-46f8-9cef-18aa914d73b2.gif)

#### Other Observations

  * Theoretically you can specify a message type with `messageService.showProgress({ type: MessageType.Error, ...})` even though the argument type `ProgressMessage` dictates the optional `type` parameter to be of type `MessageType.Progress`. If clients still set another type, such as `MessageType.Error` this would affect the icon being shown in the notification. This PR doesn't change that behavior, but we only show an indeterminate progress, if the message type is `MessageType.Progress`.
  * Reporting a progress `{ done: 0, total: 100 }` is equal to specifying no progress, which is after this PR `indeterminate`. This might be surprising, but I felt it is fine as no progress bar would otherwise be visible anyway. This is because of the way how a progress update is handled in `NotificationManager#toPlainProgress()`.
  * Clients can't switch for existing notifications from a determinate progress to an indeterminate progress, because `NotificationManager#reportProgress(...)` falls back to previous progress message, if the new one is undefined. I guess this behavior is fine, because otherwise clients would be forced to always provide a `work` in their update, even if they just want to set a new message.

#### Review checklist

- [X] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
