### PR TITLE
Translate monaco using default keys

### DIFF
--- a/examples/api-samples/src/browser/monaco-editor-preferences/monaco-editor-preference-extractor.ts
+++ b/examples/api-samples/src/browser/monaco-editor-preferences/monaco-editor-preference-extractor.ts
@@ -64,15 +64,15 @@ export interface GeneratedEditorPreferences {
 }
 `;
 }
-const deQuoteMarker = '@#@';
+const dequoteMarker = '@#@';
 
 // From src/vs/editor/common/config/editorOptions.ts
 const DEFAULT_WINDOWS_FONT_FAMILY = "Consolas, \\'Courier New\\', monospace";
 const DEFAULT_MAC_FONT_FAMILY = "Menlo, Monaco, \\'Courier New\\', monospace";
 const DEFAULT_LINUX_FONT_FAMILY = "\\'Droid Sans Mono\\', \\'monospace\\', monospace";
 
-const fontFamilyText = `${deQuoteMarker}isOSX ? '${DEFAULT_MAC_FONT_FAMILY}' : isWindows ? '${DEFAULT_WINDOWS_FONT_FAMILY}' : '${DEFAULT_LINUX_FONT_FAMILY}'${deQuoteMarker}`;
-const fontSizeText = `${deQuoteMarker}isOSX ? 12 : 14${deQuoteMarker}`;
+const fontFamilyText = `${dequoteMarker}isOSX ? '${DEFAULT_MAC_FONT_FAMILY}' : isWindows ? '${DEFAULT_WINDOWS_FONT_FAMILY}' : '${DEFAULT_LINUX_FONT_FAMILY}'${dequoteMarker}`;
+const fontSizeText = `${dequoteMarker}isOSX ? 12 : 14${dequoteMarker}`;
 
 /**
  * This class is intended for use when uplifting Monaco.
@@ -82,8 +82,6 @@ export class MonacoEditorPreferenceSchemaExtractor implements CommandContributio
     @inject(WorkspaceService) protected readonly workspaceService: WorkspaceService;
     @inject(MessageService) protected readonly messageService: MessageService;
     @inject(FileService) protected readonly fileService: FileService;
-
-    protected lastPreferenceName: string;
 
     registerCommands(commands: CommandRegistry): void {
         commands.registerCommand({ id: 'extract-editor-preference-schema', label: 'Extract Editor preference schema from Monaco' }, {
@@ -113,12 +111,51 @@ export class MonacoEditorPreferenceSchemaExtractor implements CommandContributio
                     }
                     interfaceEntries.push(`'${name}': ${this.formatTypeForInterface(description.enum ?? description.type)};`);
                 }
-                const propertyList = this.deQuoteCodeSnippets(JSON.stringify(properties, (key, value) => this.withLocalization(key, value), 4));
+                const stringified = JSON.stringify(properties, this.codeSnippetReplacer(), 4);
+                const propertyList = this.dequoteCodeSnippets(stringified);
                 const content = generateContent(propertyList, interfaceEntries);
                 await this.fileService.write(fileToWrite, content);
             }
         });
     }
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    protected codeSnippetReplacer(): (key: string, value: any) => any {
+        // JSON.stringify doesn't give back the whole context when serializing so we use state...
+        let lastPreferenceName: string;
+        return (key, value) => {
+            if (key.startsWith('editor.') || key.startsWith('diffEditor.')) {
+                lastPreferenceName = key;
+            }
+            if ((key === 'description' || key === 'markdownDescription') && typeof value === 'string') {
+                if (value.length === 0) {
+                    return value;
+                }
+                const defaultKey = nls.getDefaultKey(value);
+                if (defaultKey) {
+                    return `${dequoteMarker}nls.localizeByDefault(${dequoteMarker}"${value}${dequoteMarker}")${dequoteMarker}`;
+                } else {
+                    const localizationKey = `${dequoteMarker}"theia/editor/${lastPreferenceName}${dequoteMarker}"`;
+                    return `${dequoteMarker}nls.localize(${localizationKey}, ${dequoteMarker}"${value}${dequoteMarker}")${dequoteMarker}`;
+                }
+            }
+            if ((key === 'enumDescriptions' || key === 'markdownEnumDescriptions') && Array.isArray(value)) {
+                return value.map((description, i) => {
+                    if (description.length === 0) {
+                        return description;
+                    }
+                    const defaultKey = nls.getDefaultKey(description);
+                    if (defaultKey) {
+                        return `${dequoteMarker}nls.localizeByDefault(${dequoteMarker}"${description}${dequoteMarker}")${dequoteMarker}`;
+                    } else {
+                        const localizationKey = `${dequoteMarker}"theia/editor/${lastPreferenceName}${i}${dequoteMarker}"`;
+                        return `${dequoteMarker}nls.localize(${localizationKey}, ${dequoteMarker}"${description}${dequoteMarker}")${dequoteMarker}`;
+                    }
+                });
+            }
+            return value;
+        };
+    };
 
     protected getScope(monacoScope: unknown): string | undefined {
         switch (monacoScope) {
@@ -158,43 +195,10 @@ export class MonacoEditorPreferenceSchemaExtractor implements CommandContributio
         return `'${jsonType}'`;
     }
 
-    protected withLocalization(key: string, value: unknown): unknown {
-        if (key.startsWith('editor.') || key.startsWith('diffEditor.')) {
-            this.lastPreferenceName = key;
-        }
-        if ((key === 'description' || key === 'markdownDescription') && typeof value === 'string') {
-            if (value.length === 0) {
-                return value;
-            }
-            const defaultKey = nls.getDefaultKey(value);
-            if (defaultKey) {
-                return `${deQuoteMarker}nls.localizeByDefault(${deQuoteMarker}"${value}${deQuoteMarker}")${deQuoteMarker}`;
-            } else {
-                const localizationKey = `${deQuoteMarker}"theia/editor/${this.lastPreferenceName}${deQuoteMarker}"`;
-                return `${deQuoteMarker}nls.localize(${localizationKey}, ${deQuoteMarker}"${value}${deQuoteMarker}")${deQuoteMarker}`;
-            }
-        }
-        if ((key === 'enumDescriptions' || key === 'markdownEnumDescriptions') && Array.isArray(value)) {
-            return value.map((description, i) => {
-                if (description.length === 0) {
-                    return description;
-                }
-                const defaultKey = nls.getDefaultKey(description);
-                if (defaultKey) {
-                    return `${deQuoteMarker}nls.localizeByDefault(${deQuoteMarker}"${description}${deQuoteMarker}")${deQuoteMarker}`;
-                } else {
-                    const localizationKey = `${deQuoteMarker}"theia/editor/${this.lastPreferenceName}${i}${deQuoteMarker}"`;
-                    return `${deQuoteMarker}nls.localize(${localizationKey}, ${deQuoteMarker}"${description}${deQuoteMarker}")${deQuoteMarker}`;
-                }
-            });
-        }
-        return value;
-    }
-
-    protected deQuoteCodeSnippets(stringification: string): string {
+    protected dequoteCodeSnippets(stringification: string): string {
         return stringification
-            .replace(new RegExp(`${deQuoteMarker}"|"${deQuoteMarker}|${deQuoteMarker}\\\\`, 'g'), '')
-            .replace(new RegExp(`\\\\"${deQuoteMarker}`, 'g'), '"')
+            .replace(new RegExp(`${dequoteMarker}"|"${dequoteMarker}|${dequoteMarker}\\\\`, 'g'), '')
+            .replace(new RegExp(`\\\\"${dequoteMarker}`, 'g'), '"')
             .replace(/\\\\'/g, "\\'");
     }
 
@@ -208,13 +212,13 @@ export class MonacoEditorPreferenceSchemaExtractor implements CommandContributio
                 type: 'boolean',
                 default: false,
                 description: 'Controls whether the Find Widget should read or modify the shared find clipboard on macOS.',
-                included: `${deQuoteMarker}isOSX${deQuoteMarker}`,
+                included: `${dequoteMarker}isOSX${dequoteMarker}`,
             },
             'editor.selectionClipboard': {
                 type: 'boolean',
                 default: true,
                 description: 'Controls whether the Linux primary clipboard should be supported.',
-                included: `${deQuoteMarker}!isOSX && !isWindows${deQuoteMarker}`
+                included: `${dequoteMarker}!isOSX && !isWindows${dequoteMarker}`
             }
         });
     }
@@ -223,5 +227,5 @@ export class MonacoEditorPreferenceSchemaExtractor implements CommandContributio
 // Utility to assist with Monaco uplifts to generate preference schema. Not for regular use in the application.
 export function bindMonacoPreferenceExtractor(bind: interfaces.Bind): void {
     // bind(MonacoEditorPreferenceSchemaExtractor).toSelf().inSingletonScope();
-    // bind(CommandContribution).to(MonacoEditorPreferenceSchemaExtractor);
+    // bind(CommandContribution).toService(MonacoEditorPreferenceSchemaExtractor);
 }

--- a/examples/api-samples/src/browser/monaco-editor-preferences/monaco-editor-preference-extractor.ts
+++ b/examples/api-samples/src/browser/monaco-editor-preferences/monaco-editor-preference-extractor.ts
@@ -49,7 +49,7 @@ function generateContent(properties: string, interfaceEntries: string[]): string
 import { isOSX, isWindows, nls } from '@theia/core';
 import { PreferenceSchema } from '@theia/core/lib/browser';
 
-/* eslint-disable @typescript-eslint/quotes,max-len,@theia/localization-check,no-null/no-null */
+/* eslint-disable @typescript-eslint/quotes,max-len,no-null/no-null */
 
 /**
  * Please do not modify this file by hand. It should be generated automatically

--- a/packages/core/src/common/nls.ts
+++ b/packages/core/src/common/nls.ts
@@ -30,9 +30,13 @@ export namespace nls {
      * Automatically localizes a text if that text also exists in the vscode repository.
      */
     export function localizeByDefault(defaultValue: string, ...args: FormatType[]): string {
-        const key = getDefaultKey(defaultValue);
-        if (key) {
-            return localize(key, defaultValue, ...args);
+        if (localization) {
+            const key = getDefaultKey(defaultValue);
+            if (key) {
+                return localize(key, defaultValue, ...args);
+            } else {
+                console.warn(`Could not find translation key for default value: "${defaultValue}"`);
+            }
         }
         return Localization.format(defaultValue, args);
     }
@@ -45,8 +49,6 @@ export namespace nls {
             const key = keyProvider.get(defaultValue);
             if (key) {
                 return key;
-            } else {
-                console.warn(`Could not find translation key for default value: "${defaultValue}"`);
             }
         }
         return '';
@@ -71,7 +73,7 @@ class LocalizationKeyProvider {
     private data = this.buildData();
 
     get(defaultValue: string): string | undefined {
-        return this.data.get(defaultValue);
+        return this.data.get(Localization.normalize(defaultValue.toLowerCase()));
     }
 
     /**
@@ -89,7 +91,7 @@ class LocalizationKeyProvider {
         for (const [fileKey, messageBundle] of Object.entries(messages)) {
             const keyBundle = keys[fileKey];
             for (let i = 0; i < messageBundle.length; i++) {
-                const message = Localization.normalize(messageBundle[i]);
+                const message = Localization.normalize(messageBundle[i]).toLowerCase();
                 const key = keyBundle[i];
                 const localizationKey = this.buildKey(typeof key === 'string' ? key : key.key, fileKey);
                 data.set(message, localizationKey);

--- a/packages/core/src/common/nls.ts
+++ b/packages/core/src/common/nls.ts
@@ -42,14 +42,12 @@ export namespace nls {
     }
 
     export function getDefaultKey(defaultValue: string): string {
-        if (localization) {
-            if (!keyProvider) {
-                keyProvider = new LocalizationKeyProvider();
-            }
-            const key = keyProvider.get(defaultValue);
-            if (key) {
-                return key;
-            }
+        if (!keyProvider) {
+            keyProvider = new LocalizationKeyProvider();
+        }
+        const key = keyProvider.get(defaultValue);
+        if (key) {
+            return key;
         }
         return '';
     }

--- a/packages/editor/src/browser/editor-generated-preference-schema.ts
+++ b/packages/editor/src/browser/editor-generated-preference-schema.ts
@@ -89,7 +89,7 @@ export const editorGeneratedPreferenceProperties: PreferenceSchema['properties']
             nls.localizeByDefault("Suggest words from all open documents of the same language."),
             nls.localizeByDefault("Suggest words from all open documents.")
         ],
-        "description": nls.localizeByDefault("Controls from which documents word based completions are computed."),
+        "description": nls.localize("theia/editor/editor.wordBasedSuggestionsMode", "Controls from which documents word based completions are computed."),
         "scope": "language-overridable",
         "restricted": false
     },
@@ -146,7 +146,7 @@ export const editorGeneratedPreferenceProperties: PreferenceSchema['properties']
     "editor.language.colorizedBracketPairs": {
         "type": "array",
         "default": false,
-        "description": nls.localizeByDefault("Defines the bracket pairs that are colorized by their nesting level if bracket pair colorization is enabled."),
+        "description": nls.localize("theia/editor/editor.language.colorizedBracketPairs", "Defines the bracket pairs that are colorized by their nesting level if bracket pair colorization is enabled."),
         "items": {
             "type": "array",
             "items": [
@@ -173,7 +173,7 @@ export const editorGeneratedPreferenceProperties: PreferenceSchema['properties']
     "diffEditor.maxFileSize": {
         "type": "number",
         "default": 50,
-        "description": nls.localizeByDefault("Maximum file size in MB for which to compute diffs. Use 0 for no limit."),
+        "description": nls.localize("theia/editor/diffEditor.maxFileSize", "Maximum file size in MB for which to compute diffs. Use 0 for no limit."),
         "scope": "language-overridable",
         "restricted": false
     },
@@ -230,9 +230,9 @@ export const editorGeneratedPreferenceProperties: PreferenceSchema['properties']
     },
     "editor.acceptSuggestionOnEnter": {
         "markdownEnumDescriptions": [
-            nls.localizeByDefault(""),
+            "",
             nls.localizeByDefault("Only accept a suggestion with `Enter` when it makes a textual change."),
-            nls.localizeByDefault("")
+            ""
         ],
         "markdownDescription": nls.localizeByDefault("Controls whether suggestions should be accepted on `Enter`, in addition to `Tab`. Helps to avoid ambiguity between inserting new lines or accepting suggestions."),
         "type": "string",
@@ -263,7 +263,7 @@ export const editorGeneratedPreferenceProperties: PreferenceSchema['properties']
         "restricted": false
     },
     "editor.accessibilityPageSize": {
-        "description": nls.localizeByDefault("Controls the number of lines in the editor that can be read out by a screen reader at once. When we detect a screen reader we automatically set the default to be 500. Warning: this has a performance implication for numbers larger than the default."),
+        "description": nls.localize("theia/editor/editor.accessibilityPageSize", "Controls the number of lines in the editor that can be read out by a screen reader at once. When we detect a screen reader we automatically set the default to be 500. Warning: this has a performance implication for numbers larger than the default."),
         "type": "integer",
         "default": 10,
         "minimum": 1,
@@ -273,10 +273,10 @@ export const editorGeneratedPreferenceProperties: PreferenceSchema['properties']
     },
     "editor.autoClosingBrackets": {
         "enumDescriptions": [
-            nls.localizeByDefault(""),
+            "",
             nls.localizeByDefault("Use language configurations to determine when to autoclose brackets."),
             nls.localizeByDefault("Autoclose brackets only when the cursor is to the left of whitespace."),
-            nls.localizeByDefault("")
+            ""
         ],
         "description": nls.localizeByDefault("Controls whether the editor should automatically close brackets after the user adds an opening bracket."),
         "type": "string",
@@ -292,11 +292,11 @@ export const editorGeneratedPreferenceProperties: PreferenceSchema['properties']
     },
     "editor.autoClosingDelete": {
         "enumDescriptions": [
-            nls.localizeByDefault(""),
-            nls.localizeByDefault("Remove adjacent closing quotes or brackets only if they were automatically inserted."),
-            nls.localizeByDefault("")
+            "",
+            nls.localize("theia/editor/editor.autoClosingDelete1", "Remove adjacent closing quotes or brackets only if they were automatically inserted."),
+            ""
         ],
-        "description": nls.localizeByDefault("Controls whether the editor should remove adjacent closing quotes or brackets when deleting."),
+        "description": nls.localize("theia/editor/editor.autoClosingDelete", "Controls whether the editor should remove adjacent closing quotes or brackets when deleting."),
         "type": "string",
         "enum": [
             "always",
@@ -309,9 +309,9 @@ export const editorGeneratedPreferenceProperties: PreferenceSchema['properties']
     },
     "editor.autoClosingOvertype": {
         "enumDescriptions": [
-            nls.localizeByDefault(""),
+            "",
             nls.localizeByDefault("Type over closing quotes or brackets only if they were automatically inserted."),
-            nls.localizeByDefault("")
+            ""
         ],
         "description": nls.localizeByDefault("Controls whether the editor should type over closing quotes or brackets."),
         "type": "string",
@@ -326,10 +326,10 @@ export const editorGeneratedPreferenceProperties: PreferenceSchema['properties']
     },
     "editor.autoClosingQuotes": {
         "enumDescriptions": [
-            nls.localizeByDefault(""),
+            "",
             nls.localizeByDefault("Use language configurations to determine when to autoclose quotes."),
             nls.localizeByDefault("Autoclose quotes only when the cursor is to the left of whitespace."),
-            nls.localizeByDefault("")
+            ""
         ],
         "description": nls.localizeByDefault("Controls whether the editor should automatically close quotes after the user adds an opening quote."),
         "type": "string",
@@ -369,7 +369,7 @@ export const editorGeneratedPreferenceProperties: PreferenceSchema['properties']
             nls.localizeByDefault("Use language configurations to determine when to automatically surround selections."),
             nls.localizeByDefault("Surround with quotes but not brackets."),
             nls.localizeByDefault("Surround with brackets but not quotes."),
-            nls.localizeByDefault("")
+            ""
         ],
         "description": nls.localizeByDefault("Controls whether the editor should automatically surround selections when typing quotes or brackets."),
         "type": "string",
@@ -386,7 +386,7 @@ export const editorGeneratedPreferenceProperties: PreferenceSchema['properties']
     "editor.bracketPairColorization.enabled": {
         "type": "boolean",
         "default": false,
-        "description": nls.localizeByDefault("Controls whether bracket pair colorization is enabled or not. Use 'workbench.colorCustomizations' to override the bracket highlight colors."),
+        "description": nls.localize("theia/editor/editor.bracketPairColorization.enabled", "Controls whether bracket pair colorization is enabled or not. Use 'workbench.colorCustomizations' to override the bracket highlight colors."),
         "scope": "language-overridable",
         "restricted": false
     },
@@ -401,12 +401,12 @@ export const editorGeneratedPreferenceProperties: PreferenceSchema['properties']
             false
         ],
         "enumDescriptions": [
-            nls.localizeByDefault("Enables bracket pair guides."),
-            nls.localizeByDefault("Enables bracket pair guides only for the active bracket pair."),
-            nls.localizeByDefault("Disables bracket pair guides.")
+            nls.localize("theia/editor/editor.guides.bracketPairs0", "Enables bracket pair guides."),
+            nls.localize("theia/editor/editor.guides.bracketPairs1", "Enables bracket pair guides only for the active bracket pair."),
+            nls.localize("theia/editor/editor.guides.bracketPairs2", "Disables bracket pair guides.")
         ],
         "default": false,
-        "description": nls.localizeByDefault("Controls whether bracket pair guides are enabled or not."),
+        "description": nls.localize("theia/editor/editor.guides.bracketPairs", "Controls whether bracket pair guides are enabled or not."),
         "scope": "language-overridable",
         "restricted": false
     },
@@ -421,19 +421,19 @@ export const editorGeneratedPreferenceProperties: PreferenceSchema['properties']
             false
         ],
         "enumDescriptions": [
-            nls.localizeByDefault("Enables horizontal guides as addition to vertical bracket pair guides."),
-            nls.localizeByDefault("Enables horizontal guides only for the active bracket pair."),
-            nls.localizeByDefault("Disables horizontal bracket pair guides.")
+            nls.localize("theia/editor/editor.guides.bracketPairsHorizontal0", "Enables horizontal guides as addition to vertical bracket pair guides."),
+            nls.localize("theia/editor/editor.guides.bracketPairsHorizontal1", "Enables horizontal guides only for the active bracket pair."),
+            nls.localize("theia/editor/editor.guides.bracketPairsHorizontal2", "Disables horizontal bracket pair guides.")
         ],
         "default": "active",
-        "description": nls.localizeByDefault("Controls whether horizontal bracket pair guides are enabled or not."),
+        "description": nls.localize("theia/editor/editor.guides.bracketPairsHorizontal", "Controls whether horizontal bracket pair guides are enabled or not."),
         "scope": "language-overridable",
         "restricted": false
     },
     "editor.guides.highlightActiveBracketPair": {
         "type": "boolean",
         "default": true,
-        "description": nls.localizeByDefault("Controls whether bracket pair guides are enabled or not."),
+        "description": nls.localize("theia/editor/editor.guides.highlightActiveBracketPair", "Controls whether the editor should highlight the active bracket pair."),
         "scope": "language-overridable",
         "restricted": false
     },
@@ -470,7 +470,7 @@ export const editorGeneratedPreferenceProperties: PreferenceSchema['properties']
         "default": 0,
         "minimum": 0,
         "maximum": 100,
-        "markdownDescription": nls.localizeByDefault("Controls the font size in pixels for CodeLens. When set to `0`, 90% of `#editor.fontSize#` is used."),
+        "markdownDescription": nls.localize("theia/editor/editor.codeLensFontSize", "Controls the font size in pixels for CodeLens. When set to `0`, 90% of `#editor.fontSize#` is used."),
         "scope": "language-overridable",
         "restricted": false
     },
@@ -615,9 +615,9 @@ export const editorGeneratedPreferenceProperties: PreferenceSchema['properties']
         ],
         "default": "always",
         "enumDescriptions": [
-            nls.localizeByDefault("Never seed search string from the editor selection."),
-            nls.localizeByDefault("Always seed search string from the editor selection, including word at cursor position."),
-            nls.localizeByDefault("Only seed search string from the editor selection.")
+            nls.localize("theia/editor/editor.find.seedSearchStringFromSelection0", "Never seed search string from the editor selection."),
+            nls.localize("theia/editor/editor.find.seedSearchStringFromSelection1", "Always seed search string from the editor selection, including word at cursor position."),
+            nls.localize("theia/editor/editor.find.seedSearchStringFromSelection2", "Only seed search string from the editor selection.")
         ],
         "description": nls.localizeByDefault("Controls whether the search string in the Find Widget is seeded from the editor selection."),
         "scope": "language-overridable",
@@ -632,19 +632,13 @@ export const editorGeneratedPreferenceProperties: PreferenceSchema['properties']
         ],
         "default": "never",
         "enumDescriptions": [
-            nls.localizeByDefault("Never turn on Find in Selection automatically (default)."),
-            nls.localizeByDefault("Always turn on Find in Selection automatically."),
+            nls.localize("theia/editor/editor.find.autoFindInSelection0", "Never turn on Find in Selection automatically (default)."),
+            nls.localize("theia/editor/editor.find.autoFindInSelection1", "Always turn on Find in Selection automatically."),
             nls.localizeByDefault("Turn on Find in Selection automatically when multiple lines of content are selected.")
         ],
         "description": nls.localizeByDefault("Controls the condition for turning on Find in Selection automatically."),
         "scope": "language-overridable",
         "restricted": false
-    },
-    "editor.find.globalFindClipboard": {
-        "type": "boolean",
-        "default": false,
-        "description": nls.localizeByDefault("Controls whether the Find Widget should read or modify the shared find clipboard on macOS."),
-        "included": isOSX
     },
     "editor.find.addExtraSpaceOnTop": {
         "type": "boolean",
@@ -690,14 +684,14 @@ export const editorGeneratedPreferenceProperties: PreferenceSchema['properties']
         "restricted": false
     },
     "editor.foldingImportsByDefault": {
-        "description": nls.localizeByDefault("Controls whether the editor automatically collapses import ranges."),
+        "description": nls.localize("theia/editor/editor.foldingImportsByDefault", "Controls whether the editor automatically collapses import ranges."),
         "type": "boolean",
         "default": false,
         "scope": "language-overridable",
         "restricted": false
     },
     "editor.foldingMaximumRegions": {
-        "description": nls.localizeByDefault("The maximum number of foldable regions. Increasing this value may result in the editor becoming less responsive when the current source has a large number of foldable regions."),
+        "description": nls.localize("theia/editor/editor.foldingMaximumRegions", "The maximum number of foldable regions. Increasing this value may result in the editor becoming less responsive when the current source has a large number of foldable regions."),
         "type": "integer",
         "default": 5000,
         "minimum": 10,
@@ -1027,14 +1021,14 @@ export const editorGeneratedPreferenceProperties: PreferenceSchema['properties']
     "editor.hover.above": {
         "type": "boolean",
         "default": true,
-        "description": nls.localizeByDefault("Prefer showing hovers above the line, if there's space."),
+        "description": nls.localize("theia/editor/editor.hover.above", "Prefer showing hovers above the line, if there's space."),
         "scope": "language-overridable",
         "restricted": false
     },
     "editor.inlineSuggest.enabled": {
         "type": "boolean",
         "default": true,
-        "description": nls.localizeByDefault("Controls whether to automatically show inline suggestions in the editor."),
+        "description": nls.localize("theia/editor/editor.inlineSuggest.enabled", "Controls whether to automatically show inline suggestions in the editor."),
         "scope": "language-overridable",
         "restricted": false
     },
@@ -1053,7 +1047,7 @@ export const editorGeneratedPreferenceProperties: PreferenceSchema['properties']
         "restricted": false
     },
     "editor.lineHeight": {
-        "markdownDescription": nls.localizeByDefault("Controls the line height. \n - Use 0 to automatically compute the line height from the font size.\n - Values between 0 and 8 will be used as a multiplier with the font size.\n - Values greater than or equal to 8 will be used as effective values."),
+        "markdownDescription": nls.localize("theia/editor/editor.lineHeight", "Controls the line height. \n - Use 0 to automatically compute the line height from the font size.\n - Values between 0 and 8 will be used as a multiplier with the font size.\n - Values greater than or equal to 8 will be used as effective values."),
         "type": "number",
         "default": 0,
         "scope": "language-overridable",
@@ -1366,9 +1360,9 @@ export const editorGeneratedPreferenceProperties: PreferenceSchema['properties']
     },
     "editor.renderLineHighlight": {
         "enumDescriptions": [
-            nls.localizeByDefault(""),
-            nls.localizeByDefault(""),
-            nls.localizeByDefault(""),
+            "",
+            "",
+            "",
             nls.localizeByDefault("Highlights both the gutter and the current line.")
         ],
         "description": nls.localizeByDefault("Controls how the editor should render the current line highlight."),
@@ -1384,7 +1378,7 @@ export const editorGeneratedPreferenceProperties: PreferenceSchema['properties']
         "restricted": false
     },
     "editor.renderLineHighlightOnlyWhenFocus": {
-        "description": nls.localizeByDefault("Controls if the editor should render the current line highlight only when the editor is focused."),
+        "description": nls.localize("theia/editor/editor.renderLineHighlightOnlyWhenFocus", "Controls if the editor should render the current line highlight only when the editor is focused."),
         "type": "boolean",
         "default": false,
         "scope": "language-overridable",
@@ -1392,11 +1386,11 @@ export const editorGeneratedPreferenceProperties: PreferenceSchema['properties']
     },
     "editor.renderWhitespace": {
         "enumDescriptions": [
-            nls.localizeByDefault(""),
+            "",
             nls.localizeByDefault("Render whitespace characters except for single spaces between words."),
             nls.localizeByDefault("Render whitespace characters only on selected text."),
-            nls.localizeByDefault("Render only trailing whitespace characters."),
-            nls.localizeByDefault("")
+            nls.localize("theia/editor/editor.renderWhitespace3", "Render only trailing whitespace characters."),
+            ""
         ],
         "description": nls.localizeByDefault("Controls how the editor should render whitespace characters."),
         "type": "string",
@@ -1457,12 +1451,12 @@ export const editorGeneratedPreferenceProperties: PreferenceSchema['properties']
             "hidden"
         ],
         "enumDescriptions": [
-            nls.localizeByDefault("The vertical scrollbar will be visible only when necessary."),
-            nls.localizeByDefault("The vertical scrollbar will always be visible."),
-            nls.localizeByDefault("The vertical scrollbar will always be hidden.")
+            nls.localize("theia/editor/editor.scrollbar.vertical0", "The vertical scrollbar will be visible only when necessary."),
+            nls.localize("theia/editor/editor.scrollbar.vertical1", "The vertical scrollbar will always be visible."),
+            nls.localize("theia/editor/editor.scrollbar.vertical2", "The vertical scrollbar will always be hidden.")
         ],
         "default": "auto",
-        "description": nls.localizeByDefault("Controls the visibility of the vertical scrollbar."),
+        "description": nls.localize("theia/editor/editor.scrollbar.vertical", "Controls the visibility of the vertical scrollbar."),
         "scope": "language-overridable",
         "restricted": false
     },
@@ -1474,33 +1468,33 @@ export const editorGeneratedPreferenceProperties: PreferenceSchema['properties']
             "hidden"
         ],
         "enumDescriptions": [
-            nls.localizeByDefault("The horizontal scrollbar will be visible only when necessary."),
-            nls.localizeByDefault("The horizontal scrollbar will always be visible."),
-            nls.localizeByDefault("The horizontal scrollbar will always be hidden.")
+            nls.localize("theia/editor/editor.scrollbar.horizontal0", "The horizontal scrollbar will be visible only when necessary."),
+            nls.localize("theia/editor/editor.scrollbar.horizontal1", "The horizontal scrollbar will always be visible."),
+            nls.localize("theia/editor/editor.scrollbar.horizontal2", "The horizontal scrollbar will always be hidden.")
         ],
         "default": "auto",
-        "description": nls.localizeByDefault("Controls the visibility of the horizontal scrollbar."),
+        "description": nls.localize("theia/editor/editor.scrollbar.horizontal", "Controls the visibility of the horizontal scrollbar."),
         "scope": "language-overridable",
         "restricted": false
     },
     "editor.scrollbar.verticalScrollbarSize": {
         "type": "number",
         "default": 14,
-        "description": nls.localizeByDefault("The width of the vertical scrollbar."),
+        "description": nls.localize("theia/editor/editor.scrollbar.verticalScrollbarSize", "The width of the vertical scrollbar."),
         "scope": "language-overridable",
         "restricted": false
     },
     "editor.scrollbar.horizontalScrollbarSize": {
         "type": "number",
         "default": 12,
-        "description": nls.localizeByDefault("The height of the horizontal scrollbar."),
+        "description": nls.localize("theia/editor/editor.scrollbar.horizontalScrollbarSize", "The height of the horizontal scrollbar."),
         "scope": "language-overridable",
         "restricted": false
     },
     "editor.scrollbar.scrollByPage": {
         "type": "boolean",
         "default": false,
-        "description": nls.localizeByDefault("Controls whether clicks scroll by page or jump to click position."),
+        "description": nls.localize("theia/editor/editor.scrollbar.scrollByPage", "Controls whether clicks scroll by page or jump to click position."),
         "scope": "language-overridable",
         "restricted": false
     },
@@ -1590,7 +1584,7 @@ export const editorGeneratedPreferenceProperties: PreferenceSchema['properties']
         "restricted": false
     },
     "editor.stickyTabStops": {
-        "description": nls.localizeByDefault("Emulate selection behavior of tab characters when using spaces for indentation. Selection will stick to tab stops."),
+        "description": nls.localize("theia/editor/editor.stickyTabStops", "Emulate selection behavior of tab characters when using spaces for indentation. Selection will stick to tab stops."),
         "type": "boolean",
         "default": false,
         "scope": "language-overridable",
@@ -1621,7 +1615,7 @@ export const editorGeneratedPreferenceProperties: PreferenceSchema['properties']
     "editor.suggest.localityBonus": {
         "type": "boolean",
         "default": false,
-        "description": nls.localizeByDefault("Controls whether sorting favors words that appear close to the cursor."),
+        "description": nls.localize("theia/editor/editor.suggest.localityBonus", "Controls whether sorting favors words that appear close to the cursor."),
         "scope": "language-overridable",
         "restricted": false
     },
@@ -1656,7 +1650,7 @@ export const editorGeneratedPreferenceProperties: PreferenceSchema['properties']
     "editor.suggest.preview": {
         "type": "boolean",
         "default": false,
-        "description": nls.localizeByDefault("Controls whether to preview the suggestion outcome in the editor."),
+        "description": nls.localize("theia/editor/editor.suggest.preview", "Controls whether to preview the suggestion outcome in the editor."),
         "scope": "language-overridable",
         "restricted": false
     },
@@ -1705,7 +1699,7 @@ export const editorGeneratedPreferenceProperties: PreferenceSchema['properties']
     "editor.suggest.showDeprecated": {
         "type": "boolean",
         "default": true,
-        "markdownDescription": nls.localizeByDefault("When enabled IntelliSense shows `deprecated`-suggestions."),
+        "markdownDescription": nls.localize("theia/editor/editor.suggest.showDeprecated", "When enabled IntelliSense shows `deprecated`-suggestions."),
         "scope": "language-overridable",
         "restricted": false
     },
@@ -1955,21 +1949,21 @@ export const editorGeneratedPreferenceProperties: PreferenceSchema['properties']
             "inUntrustedWorkspace"
         ],
         "default": "inUntrustedWorkspace",
-        "description": nls.localizeByDefault("Controls whether all non-basic ASCII characters are highlighted. Only characters between U+0020 and U+007E, tab, line-feed and carriage-return are considered basic ASCII."),
+        "description": nls.localize("theia/editor/editor.unicodeHighlight.nonBasicASCII", "Controls whether all non-basic ASCII characters are highlighted. Only characters between U+0020 and U+007E, tab, line-feed and carriage-return are considered basic ASCII."),
         "scope": "language-overridable"
     },
     "editor.unicodeHighlight.invisibleCharacters": {
         "restricted": true,
         "type": "boolean",
         "default": true,
-        "description": nls.localizeByDefault("Controls whether characters that just reserve space or have no width at all are highlighted."),
+        "description": nls.localize("theia/editor/editor.unicodeHighlight.invisibleCharacters", "Controls whether characters that just reserve space or have no width at all are highlighted."),
         "scope": "language-overridable"
     },
     "editor.unicodeHighlight.ambiguousCharacters": {
         "restricted": true,
         "type": "boolean",
         "default": true,
-        "description": nls.localizeByDefault("Controls whether characters are highlighted that can be confused with basic ASCII characters, except those that are common in the current user locale."),
+        "description": nls.localize("theia/editor/editor.unicodeHighlight.ambiguousCharacters", "Controls whether characters are highlighted that can be confused with basic ASCII characters, except those that are common in the current user locale."),
         "scope": "language-overridable"
     },
     "editor.unicodeHighlight.includeComments": {
@@ -1984,7 +1978,7 @@ export const editorGeneratedPreferenceProperties: PreferenceSchema['properties']
             "inUntrustedWorkspace"
         ],
         "default": "inUntrustedWorkspace",
-        "description": nls.localizeByDefault("Controls whether characters in comments should also be subject to unicode highlighting."),
+        "description": nls.localize("theia/editor/editor.unicodeHighlight.includeComments", "Controls whether characters in comments should also be subject to unicode highlighting."),
         "scope": "language-overridable"
     },
     "editor.unicodeHighlight.includeStrings": {
@@ -1999,14 +1993,14 @@ export const editorGeneratedPreferenceProperties: PreferenceSchema['properties']
             "inUntrustedWorkspace"
         ],
         "default": true,
-        "description": nls.localizeByDefault("Controls whether characters in strings should also be subject to unicode highlighting."),
+        "description": nls.localize("theia/editor/editor.unicodeHighlight.includeStrings", "Controls whether characters in strings should also be subject to unicode highlighting."),
         "scope": "language-overridable"
     },
     "editor.unicodeHighlight.allowedCharacters": {
         "restricted": true,
         "type": "object",
         "default": {},
-        "description": nls.localizeByDefault("Defines allowed characters that are not being highlighted."),
+        "description": nls.localize("theia/editor/editor.unicodeHighlight.allowedCharacters", "Defines allowed characters that are not being highlighted."),
         "additionalProperties": {
             "type": "boolean"
         },
@@ -2022,7 +2016,7 @@ export const editorGeneratedPreferenceProperties: PreferenceSchema['properties']
             "_os": true,
             "_vscode": true
         },
-        "description": nls.localizeByDefault("Unicode characters that are common in allowed locales are not being highlighted."),
+        "description": nls.localize("theia/editor/editor.unicodeHighlight.allowedLocales", "Unicode characters that are common in allowed locales are not being highlighted."),
         "scope": "language-overridable"
     },
     "editor.unusualLineTerminators": {
@@ -2128,23 +2122,29 @@ export const editorGeneratedPreferenceProperties: PreferenceSchema['properties']
     "editor.inlayHints.enabled": {
         "type": "boolean",
         "default": true,
-        "description": nls.localizeByDefault("Enables the inlay hints in the editor."),
+        "description": nls.localize("theia/editor/editor.inlayHints.enabled", "Enables the inlay hints in the editor."),
         "scope": "language-overridable",
         "restricted": false
     },
     "editor.inlayHints.fontSize": {
         "type": "number",
         "default": 0,
-        "markdownDescription": nls.localizeByDefault("Controls font size of inlay hints in the editor. A default of 90% of `#editor.fontSize#` is used when the configured value is less than `5` or greater than the editor font size."),
+        "markdownDescription": nls.localize("theia/editor/editor.inlayHints.fontSize", "Controls font size of inlay hints in the editor. A default of 90% of `#editor.fontSize#` is used when the configured value is less than `5` or greater than the editor font size."),
         "scope": "language-overridable",
         "restricted": false
     },
     "editor.inlayHints.fontFamily": {
         "type": "string",
         "default": "",
-        "markdownDescription": nls.localizeByDefault("Controls font family of inlay hints in the editor. When set to empty, the `#editor.fontFamily#` is used."),
+        "markdownDescription": nls.localize("theia/editor/editor.inlayHints.fontFamily", "Controls font family of inlay hints in the editor. When set to empty, the `#editor.fontFamily#` is used."),
         "scope": "language-overridable",
         "restricted": false
+    },
+    "editor.find.globalFindClipboard": {
+        "type": "boolean",
+        "default": false,
+        "description": nls.localizeByDefault("Controls whether the Find Widget should read or modify the shared find clipboard on macOS."),
+        "included": isOSX
     },
     "editor.selectionClipboard": {
         "type": "boolean",

--- a/packages/editor/src/browser/editor-generated-preference-schema.ts
+++ b/packages/editor/src/browser/editor-generated-preference-schema.ts
@@ -18,7 +18,7 @@ import { isOSX, isWindows, nls } from '@theia/core';
 import { PreferenceSchema } from '@theia/core/lib/browser';
 import { JSONObject } from '@theia/core/shared/@phosphor/coreutils';
 
-/* eslint-disable @typescript-eslint/quotes,max-len,@theia/localization-check,no-null/no-null */
+/* eslint-disable @typescript-eslint/quotes,max-len,no-null/no-null */
 
 /**
  * Please do not modify this file by hand. It should be generated automatically
@@ -634,9 +634,9 @@ export const editorGeneratedPreferenceProperties: PreferenceSchema['properties']
         "enumDescriptions": [
             nls.localize("theia/editor/editor.find.autoFindInSelection0", "Never turn on Find in Selection automatically (default)."),
             nls.localize("theia/editor/editor.find.autoFindInSelection1", "Always turn on Find in Selection automatically."),
-            nls.localizeByDefault("Turn on Find in Selection automatically when multiple lines of content are selected.")
+            nls.localizeByDefault('Turn on Find in selection automatically when multiple lines of content are selected.')
         ],
-        "description": nls.localizeByDefault("Controls the condition for turning on Find in Selection automatically."),
+        "description": nls.localizeByDefault('Controls the condition for turning on find in selection automatically.'),
         "scope": "language-overridable",
         "restricted": false
     },
@@ -1198,7 +1198,7 @@ export const editorGeneratedPreferenceProperties: PreferenceSchema['properties']
             nls.localizeByDefault("Maps to `Control` on Windows and Linux and to `Command` on macOS."),
             nls.localizeByDefault("Maps to `Alt` on Windows and Linux and to `Option` on macOS.")
         ],
-        "markdownDescription": nls.localizeByDefault("The modifier to be used to add multiple cursors with the mouse. The Go to Definition and Open Link mouse gestures will adapt such that they do not conflict with the multicursor modifier. [Read more](https://code.visualstudio.com/docs/editor/codebasics#_multicursor-modifier)."),
+        "markdownDescription": nls.localizeByDefault('The modifier to be used to add multiple cursors with the mouse. The Go To Definition and Open Link mouse gestures will adapt such that they do not conflict with the multicursor modifier. [Read more](https://code.visualstudio.com/docs/editor/codebasics#_multicursor-modifier).'),
         "type": "string",
         "enum": [
             "ctrlCmd",

--- a/packages/editor/src/browser/editor-preferences.ts
+++ b/packages/editor/src/browser/editor-preferences.ts
@@ -82,7 +82,7 @@ const fileContributionSchema: PreferenceSchema['properties'] = {
         'enumDescriptions': [
             nls.localizeByDefault('Format the whole file.'),
             nls.localizeByDefault('Format modifications (requires source control).'),
-            nls.localizeByDefault("Will attempt to format modifications only (requires source control). If source control can't be used, then the whole file will be formatted."),
+            nls.localize('theia/editor/editor.formatOnSaveMode.modificationsIfAvailable', "Will attempt to format modifications only (requires source control). If source control can't be used, then the whole file will be formatted."),
         ],
         'markdownDescription': nls.localizeByDefault('Controls if format on save formats the whole file or only modifications. Only applies when `#editor.formatOnSave#` is enabled.'),
         'scope': PreferenceScope.fromString('language-overridable'),
@@ -109,19 +109,19 @@ const fileContributionSchema: PreferenceSchema['properties'] = {
         'type': 'string',
         'enum': ['off', 'afterDelay', 'onFocusChange', 'onWindowChange'],
         'markdownEnumDescriptions': [
-            nls.localizeByDefault('An editor with changes is never automatically saved.'),
-            nls.localizeByDefault('An editor with changes is automatically saved after the configured `#files.autoSaveDelay#`.'),
-            nls.localizeByDefault('An editor with changes is automatically saved when the editor loses focus.'),
-            nls.localizeByDefault('An editor with changes is automatically saved when the window loses focus.')
+            nls.localize('theia/editor/files.autoSave.off', 'An editor with changes is never automatically saved.'),
+            nls.localize('theia/editor/files.autoSave.afterDelay', 'An editor with changes is automatically saved after the configured `#files.autoSaveDelay#`.'),
+            nls.localize('theia/editor/files.autoSave.onFocusChange', 'An editor with changes is automatically saved when the editor loses focus.'),
+            nls.localize('theia/editor/files.autoSave.onWindowChange', 'An editor with changes is automatically saved when the window loses focus.')
         ],
         'default': environment.electron.is() ? 'off' : 'afterDelay',
-        'markdownDescription': nls.localizeByDefault('Controls [auto save](https://code.visualstudio.com/docs/editor/codebasics#_save-auto-save) of editors that have unsaved changes.', 'off', 'afterDelay', 'onFocusChange', 'onWindowChange', 'afterDelay')
+        'markdownDescription': nls.localize('theia/editor/files.autoSave', 'Controls [auto save](https://code.visualstudio.com/docs/editor/codebasics#_save-auto-save) of editors that have unsaved changes.', 'off', 'afterDelay', 'onFocusChange', 'onWindowChange', 'afterDelay')
     },
     'files.autoSaveDelay': {
         'type': 'number',
         'default': 1000,
         'minimum': 0,
-        'markdownDescription': nls.localizeByDefault('Controls the delay in milliseconds after which an editor with unsaved changes is saved automatically. Only applies when `#files.autoSave#` is set to `{0}`.', 'afterDelay')
+        'markdownDescription': nls.localizeByDefault('Controls the delay in ms after which a dirty editor is saved automatically. Only applies when `#files.autoSave#` is set to `{0}`.', 'afterDelay')
     },
 };
 

--- a/packages/monaco/src/browser/monaco-frontend-module.ts
+++ b/packages/monaco/src/browser/monaco-frontend-module.ts
@@ -14,6 +14,20 @@
 // SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
 // *****************************************************************************
 
+import * as MonacoNls from '@theia/monaco-editor-core/esm/vs/nls';
+import { nls } from '@theia/core/lib/common/nls';
+import { FormatType, Localization } from '@theia/core/lib/common/i18n/localization';
+
+Object.assign(MonacoNls, {
+    localize(_key: string, label: string, ...args: FormatType[]): string {
+        const defaultKey = nls.getDefaultKey(label);
+        if (defaultKey) {
+            return nls.localize(defaultKey, label, ...args);
+        }
+        return Localization.format(label, args);
+    }
+});
+
 import '../../src/browser/style/index.css';
 import '../../src/browser/style/symbol-sprite.svg';
 import '../../src/browser/style/symbol-icons.css';

--- a/packages/monaco/src/browser/monaco-frontend-module.ts
+++ b/packages/monaco/src/browser/monaco-frontend-module.ts
@@ -20,9 +20,11 @@ import { FormatType, Localization } from '@theia/core/lib/common/i18n/localizati
 
 Object.assign(MonacoNls, {
     localize(_key: string, label: string, ...args: FormatType[]): string {
-        const defaultKey = nls.getDefaultKey(label);
-        if (defaultKey) {
-            return nls.localize(defaultKey, label, ...args);
+        if (nls.locale) {
+            const defaultKey = nls.getDefaultKey(label);
+            if (defaultKey) {
+                return nls.localize(defaultKey, label, ...args);
+            }
         }
         return Localization.format(label, args);
     }

--- a/packages/plugin-ext/src/hosted/browser/hosted-plugin.ts
+++ b/packages/plugin-ext/src/hosted/browser/hosted-plugin.ts
@@ -33,7 +33,7 @@ import { RPCProtocol, RPCProtocolImpl } from '../../common/rpc-protocol';
 import {
     Disposable, DisposableCollection, Emitter, isCancelled,
     ILogger, ContributionProvider, CommandRegistry, WillExecuteCommandEvent,
-    CancellationTokenSource, JsonRpcProxy, ProgressService
+    CancellationTokenSource, JsonRpcProxy, ProgressService, nls
 } from '@theia/core';
 import { PreferenceServiceImpl, PreferenceProviderProvider } from '@theia/core/lib/browser/preferences';
 import { WorkspaceService } from '@theia/workspace/lib/browser';
@@ -494,7 +494,7 @@ export class HostedPluginSupport {
                 workspaceState,
                 env: {
                     queryParams: getQueryParameters(),
-                    language: navigator.language,
+                    language: nls.locale || 'en',
                     shell: defaultShell,
                     uiKind: environment.electron.is() ? UIKind.Desktop : UIKind.Web,
                     appName: FrontendApplicationConfigProvider.get().applicationName


### PR DESCRIPTION
#### What it does

Now that https://github.com/eclipse-theia/theia/pull/10736 has been merged, our previous method of translating monaco doesn't work anymore. Instead it can be accomplished way easier :)

Before loading any monaco related code, we simply override the `localize` function to delegate to our `nls.localize` function. This doesn't work in all cases (210 of 4200 strings remain untranslated this way), but most of these aren't visible to users anyway. I've made the `getDefaultKey` function a bit more lenient to support labels which have only changed in their capitalization. For example VSCode changed from `Previous match` to `Previous Match`, which should still be translated correctly.

Also updates some generated `nls.localizeByDefault` calls which weren't working correctly. I updated the preference extractor for that. It seems like the eslint rule doesn't pick these up for some reason. Really weird :/

I will probably come back to this next month and translate the missing pieces as well.

#### How to test

0. Running Theia in English shouldn't affect any strings displayed by Monaco
1. Download and install a language pack of your choice
2. Open the editor and associated menus/widgets
3. Confirm that most of the user visible labels are translated.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
