### PR TITLE
Use correct colors for problem markers

### DIFF
--- a/packages/core/src/browser/common-frontend-contribution.ts
+++ b/packages/core/src/browser/common-frontend-contribution.ts
@@ -1313,14 +1313,15 @@ export class CommonFrontendContribution implements FrontendApplicationContributi
             // TODO: Following are not yet supported/no respective elements in theia:
             // list.focusBackground, list.focusForeground, list.inactiveFocusBackground, list.filterMatchBorder,
             // list.dropBackground, listFilterWidget.outline, listFilterWidget.noMatchesOutline
-            // list.invalidItemForeground,
-            // list.warningForeground, list.errorForeground => tree node needs an respective class
+            // list.invalidItemForeground => tree node needs an respective class
             { id: 'list.activeSelectionBackground', defaults: { dark: '#094771', light: '#0074E8' }, description: 'List/Tree background color for the selected item when the list/tree is active. An active list/tree has keyboard focus, an inactive does not.' },
             { id: 'list.activeSelectionForeground', defaults: { dark: '#FFF', light: '#FFF' }, description: 'List/Tree foreground color for the selected item when the list/tree is active. An active list/tree has keyboard focus, an inactive does not.' },
             { id: 'list.inactiveSelectionBackground', defaults: { dark: '#37373D', light: '#E4E6F1' }, description: 'List/Tree background color for the selected item when the list/tree is inactive. An active list/tree has keyboard focus, an inactive does not.' },
             { id: 'list.inactiveSelectionForeground', description: 'List/Tree foreground color for the selected item when the list/tree is inactive. An active list/tree has keyboard focus, an inactive does not.' },
             { id: 'list.hoverBackground', defaults: { dark: '#2A2D2E', light: '#F0F0F0' }, description: 'List/Tree background when hovering over items using the mouse.' },
             { id: 'list.hoverForeground', description: 'List/Tree foreground when hovering over items using the mouse.' },
+            { id: 'list.errorForeground', defaults: { dark: '#F88070', light: '#B01011' }, description: 'Foreground color of list items containing errors.' },
+            { id: 'list.warningForeground', defaults: { dark: '#CCA700', light: '#855F00' }, description: 'Foreground color of list items containing warnings.' },
             { id: 'list.filterMatchBackground', defaults: { dark: 'editor.findMatchHighlightBackground', light: 'editor.findMatchHighlightBackground' }, description: 'Background color of the filtered match.' },
             { id: 'list.highlightForeground', defaults: { dark: '#18A3FF', light: '#0066BF', hc: 'focusBorder' }, description: 'List/Tree foreground color of the match highlights when searching inside the list/tree.' },
             { id: 'list.focusHighlightForeground', defaults: { dark: 'list.highlightForeground', light: 'list.activeSelectionForeground', hc: 'list.highlightForeground' }, description: 'List/Tree foreground color of the match highlights on actively focused items when searching inside the list/tree.' },

--- a/packages/markers/src/browser/problem/problem-decorator.ts
+++ b/packages/markers/src/browser/problem/problem-decorator.ts
@@ -183,9 +183,8 @@ export class ProblemDecorator implements TreeDecorator {
     protected getColor(marker: Marker<Diagnostic>): TreeDecoration.Color {
         const { severity } = marker.data;
         switch (severity) {
-            case 1: return 'var(--theia-editorError-foreground)';
-            case 2: return 'var(--theia-editorWarning-foreground)';
-            case 3: return 'var(--theia-editorInfo-foreground)';
+            case 1: return 'var(--theia-list-errorForeground)';
+            case 2: return 'var(--theia-list-warningForeground)';
             default: return 'var(--theia-successBackground)';
         }
     }

--- a/packages/markers/src/browser/problem/problem-tabbar-decorator.ts
+++ b/packages/markers/src/browser/problem/problem-tabbar-decorator.ts
@@ -142,9 +142,8 @@ export class ProblemTabBarDecorator implements TabBarDecorator {
     protected getOverlayIconColor(marker: Marker<Diagnostic>): WidgetDecoration.Color {
         const { severity } = marker.data;
         switch (severity) {
-            case 1: return 'var(--theia-editorError-foreground)';
-            case 2: return 'var(--theia-editorWarning-foreground)';
-            case 3: return 'var(--theia-editorInfo-foreground)';
+            case 1: return 'var(--theia-list-errorForeground)';
+            case 2: return 'var(--theia-list-warningForeground)';
             default: return 'var(--theia-successBackground)';
         }
     }


### PR DESCRIPTION
#### What it does

Closes https://github.com/eclipse-theia/theia/issues/10949

#### How to test

1. Edit a file in your workspace so that it shows errors/warnings
2. Assert that the file node color in the navigator matches VSCode's color

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
