### PR TITLE
Use same tempdir for user and system compressed plugin files

### DIFF
--- a/packages/plugin-ext-vscode/src/node/plugin-vscode-file-handler.ts
+++ b/packages/plugin-ext-vscode/src/node/plugin-vscode-file-handler.ts
@@ -54,11 +54,7 @@ export class PluginVsCodeFileHandler implements PluginDeployerFileHandler {
     }
 
     protected async getExtensionDir(context: PluginDeployerFileHandlerContext): Promise<string> {
-        let extensionsDirUri = this.systemExtensionsDirUri;
-        if (context.pluginEntry().type === PluginType.User) {
-            extensionsDirUri = await this.environment.getExtensionsDirUri();
-        }
-        return FileUri.fsPath(extensionsDirUri.resolve(filenamify(context.pluginEntry().id(), { replacement: '_' })));
+        return FileUri.fsPath(this.systemExtensionsDirUri.resolve(filenamify(context.pluginEntry().id(), { replacement: '_' })));
     }
 
     protected async decompress(extensionDir: string, context: PluginDeployerFileHandlerContext): Promise<void> {

--- a/packages/plugin-ext/src/main/node/handlers/plugin-theia-file-handler.ts
+++ b/packages/plugin-ext/src/main/node/handlers/plugin-theia-file-handler.ts
@@ -49,10 +49,6 @@ export class PluginTheiaFileHandler implements PluginDeployerFileHandler {
     }
 
     protected async getPluginDir(context: PluginDeployerFileHandlerContext): Promise<string> {
-        let pluginsDirUri = this.systemPluginsDirUri;
-        if (context.pluginEntry().type === PluginType.User) {
-            pluginsDirUri = await this.environment.getPluginsDirUri();
-        }
-        return FileUri.fsPath(pluginsDirUri.resolve(filenamify(context.pluginEntry().id(), { replacement: '_' })));
+        return FileUri.fsPath(this.systemPluginsDirUri.resolve(filenamify(context.pluginEntry().id(), { replacement: '_' })));
     }
 }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

On present `master`, if you put a zipped `.vsix` file in your user plugin directory (`~/.theia/extensions`), that plugin will not be loaded successfully. This is due to the behavior of our `PluginDeployerFileHandler` implementations, which attempt to decompress into the user plugin folder for user plugins but back off when they find the existing (compressed) file. This PR modifies that behavior to use the same temporary folder for all plugin decompressions.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
1. Put a compressed `.vsix` file in the user plugin area. (e.g. [quick-pick-align-0.0.1.zip](https://github.com/eclipse-theia/theia/files/8365758/quick-pick-align-0.0.1.zip))
2. Start the application.
3. On `master`, you see messages like this and the plugin is not loaded (e.g. no `Show quick pick` command):
```
root ERROR Failed to load plugin dependencies from '.../.theia/extensions/quick-pick-align-0.0.1.vsix' path Error: ENOTDIR: not a directory, open '.../.theia/extensions/quick-pick-align-0.0.1.vsix/package.json'
```

4. With this code, you should eventually see a message like the one below and the plugin should work in the application
```
root INFO Resolved "<plugin-file-name>" to a VS Code extension "<plugin-id>@0.0.1" with engines: { vscode: '^1.65.0' }
```

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
