### PR TITLE
Fix debug session to be deleted in $sessionDidDestroy instead of $terminateDebugSession

### DIFF
--- a/packages/plugin-ext/src/plugin/node/debug/debug.ts
+++ b/packages/plugin-ext/src/plugin/node/debug/debug.ts
@@ -230,6 +230,7 @@ export class DebugExtImpl implements DebugExt {
         const session = this.sessions.get(sessionId);
         if (session) {
             this.onDidTerminateDebugSessionEmitter.fire(session);
+            this.sessions.delete(sessionId);
         }
     }
 
@@ -319,7 +320,6 @@ export class DebugExtImpl implements DebugExt {
         const debugAdapterSession = this.sessions.get(sessionId);
         if (debugAdapterSession) {
             await debugAdapterSession.stop();
-            this.sessions.delete(sessionId);
         }
     }
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

### What it does
<!-- Include relevant issues and describe how they are addressed. -->
Related to https://github.com/eclipse-theia/theia/issues/10953.

#### Cause
`$terminateDebugSession` always comes before `$sessionDidDestroy` and removes debug session from `sessions`.
As a result, `$sessionDidDestroy` never fires `onDidTerminateDebugSessionEmitter`, because there is no session at the moment of the execution.

#### Solution
`$terminateDebugSession` shouldn't delete debug session, it should only terminate (stop) it - it comes from the method name.
`$sessionDidDestroy` should delete debug session - it also comes from the method name.


### How to test
1. Create test plugin:
```ts
import * as vscode from "vscode";
import { ExtensionContext, window } from "vscode";

export async function activate(_: ExtensionContext) {
  vscode.debug.onDidStartDebugSession((session: vscode.DebugSession) => {
    window.showInformationMessage(`Started debug session: ${session.id}`);
  });

  vscode.debug.onDidTerminateDebugSession((session: vscode.DebugSession) => {
    window.showInformationMessage(`Terminated debug session: ${session.id}`);
  });
}
```
3. Run Theia with any language supported (tested with Python) with test plugin added.
4. Create any debug configuration.
![image](https://user-images.githubusercontent.com/20160689/160755422-42508613-5d38-46bb-a0be-5587a3ccd50f.png)
5. Run debug session.
![image](https://user-images.githubusercontent.com/20160689/160758208-fc610c54-e2f5-46b5-b4c6-c8b255a78c62.png)

#### Expected behavior
1. Information message 'Started debug session' is shown on execution start.
2. Information message 'Terminated debug session' is shown on execution end.

### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
