### PR TITLE
Add fragment to scheme uris to align to vscode api

### DIFF
--- a/packages/plugin-ext/src/plugin/workspace.ts
+++ b/packages/plugin-ext/src/plugin/workspace.ts
@@ -277,7 +277,11 @@ export class WorkspaceExtImpl implements WorkspaceExt {
     }
 
     async $provideTextDocumentContent(documentURI: string): Promise<string | undefined> {
-        const uri = URI.parse(documentURI);
+        let uri = URI.parse(documentURI);
+        if (uri.scheme !== 'http' && uri.scheme !== 'https') {
+            const httpScheme = URI.parse(documentURI).with({ scheme: 'https' });
+            uri = uri.with({ fragment: httpScheme.toString() });
+        }
         const provider = this.documentContentProviders.get(uri.scheme);
         if (provider) {
             return provider.provideTextDocumentContent(uri, CancellationToken.None);


### PR DESCRIPTION
#### What it does
This PR fixes a problem where the codelens link for showing schema source does not show the schema. The problem is that the https URL of the schema is expected to be specified as the fragment of the schema uri. This change brings Theia into line with vscode and adds the fragment.

#### How to test
- Install a plugin with schema validation, for example Redhat's YAML plugin.
- Open a yml file and configure a schema.
- Click on the codelens link at the top of the yml file.
expected: the schema should open in an editor.
actual without this fix: an error is shown because an attempt is made to fetch the schema contents using json-schema rather than https.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
