### PR TITLE
Allow to configure default locale

### DIFF
--- a/dev-packages/application-package/src/application-props.ts
+++ b/dev-packages/application-package/src/application-props.ts
@@ -64,7 +64,8 @@ export namespace FrontendApplicationConfig {
         applicationName: 'Eclipse Theia',
         defaultTheme: 'dark',
         defaultIconTheme: 'none',
-        electron: ElectronFrontendApplicationConfig.DEFAULT
+        electron: ElectronFrontendApplicationConfig.DEFAULT,
+        defaultLocale: ''
     };
     export interface Partial extends ApplicationConfig {
 
@@ -95,6 +96,13 @@ export namespace FrontendApplicationConfig {
          * Defaults to `ElectronFrontendApplicationConfig.DEFAULT`.
          */
         readonly electron?: ElectronFrontendApplicationConfig.Partial;
+
+        /**
+         * The default locale for the application.
+         *
+         * Defaults to "".
+         */
+        readonly defaultLocale?: string;
     }
 }
 

--- a/packages/core/src/browser/nls-loader.ts
+++ b/packages/core/src/browser/nls-loader.ts
@@ -16,8 +16,15 @@
 
 import { nls } from '../common/nls';
 import { Endpoint } from './endpoint';
+import { FrontendApplicationConfigProvider } from './frontend-application-config-provider';
 
 export async function loadTranslations(): Promise<void> {
+    const defaultLocale = FrontendApplicationConfigProvider.get().defaultLocale;
+    if (defaultLocale && !nls.locale) {
+        Object.assign(nls, {
+            locale: defaultLocale
+        });
+    }
     if (nls.locale) {
         const endpoint = new Endpoint({ path: '/i18n/' + nls.locale }).getRestUrl().toString();
         const response = await fetch(endpoint);


### PR DESCRIPTION
#### What it does

I originally became aware of this due to [this community post](https://community.theia-ide.org/t/how-to-set-default-locale/2312).

Since we don't have access to the `FrontendApplicationConfigProvider` in the `nls.ts` file, we need to set the `nls.locale` during the `nls-loader` routine, which requires the `Object.assign` workaround.

#### How to test

0. Delete the `localeId` value from your local storage.
1. Download and install a language pack of your choice.
2. Set the `defaultLocale` of the frontend config to the language code of your language pack (i.e. `fr` for french)
3. Confirm that the application starts in the configured locale without having it selected beforehand using the `Configure Display Language` command.
4. Configuring the language manually (with another language pack) should override the default locale.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
