### PR TITLE
monaco: fix styling of toggled commands

### DIFF
--- a/packages/monaco/src/browser/style/index.css
+++ b/packages/monaco/src/browser/style/index.css
@@ -206,8 +206,13 @@
   .monaco-icon-label-container
   .monaco-icon-name-container
   .label-name {
+    font-family: var(--theia-ui-font-family);
     font-size: var(--theia-ui-font-size1) !important;
     color: var(--theia-foreground) !important;
+}
+
+.quick-input-list .monaco-icon-label::before {
+  transform: scale(0.8);
 }
 
 .quick-input-list .quick-input-list-label {

--- a/packages/monaco/src/browser/style/index.css
+++ b/packages/monaco/src/browser/style/index.css
@@ -180,6 +180,7 @@
 
 .monaco-icon-label > .monaco-icon-label-container {
   flex: 1 !important;
+  align-items: end;
 }
 
 .quick-input-list
@@ -213,6 +214,7 @@
 
 .quick-input-list .monaco-icon-label::before {
   transform: scale(0.8);
+  height: 16px;
 }
 
 .quick-input-list .quick-input-list-label {


### PR DESCRIPTION



<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

Fixes: https://github.com/eclipse-theia/theia/issues/10960.

The commit fixes the styling of the toggled commands in the quick-command menu. Previously, the font-family was incorrect and led to an inconsistent styling with the rest of the commands.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

1. start the application
2. trigger the quick-command menu <kbd>F1</kbd>
3. confirm the styling of the commands are correct, and that toggle commands (with checkmarks) are correct

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

Signed-off-by: vince-fugnitto <vincent.fugnitto@ericsson.com>

