### PR TITLE
Ensure previous transaction has saved before checking for dirty

### DIFF
--- a/packages/preferences/src/browser/abstract-resource-preference-provider.ts
+++ b/packages/preferences/src/browser/abstract-resource-preference-provider.ts
@@ -115,8 +115,7 @@ export abstract class AbstractResourcePreferenceProvider extends PreferenceProvi
     protected async doSetPreference(key: string, path: string[], value: unknown): Promise<boolean> {
         if (!this.transaction?.open) {
             const current = this.transaction;
-            this.transaction = this.transactionFactory(this.toFileManager());
-            this.transaction.waitFor(current?.result);
+            this.transaction = this.transactionFactory(this.toFileManager(), current?.result);
             this.transaction.onWillConclude(({ status, waitUntil }) => {
                 if (status) {
                     waitUntil((async () => {

--- a/packages/preferences/src/browser/preference-frontend-module.ts
+++ b/packages/preferences/src/browser/preference-frontend-module.ts
@@ -27,7 +27,7 @@ import { PreferenceScopeCommandManager } from './util/preference-scope-command-m
 import { JsonSchemaContribution } from '@theia/core/lib/browser/json-schema-store';
 import { PreferencesJsonSchemaContribution } from './preferences-json-schema-contribution';
 import { MonacoJSONCEditor } from './monaco-jsonc-editor';
-import { PreferenceContext, PreferenceTransaction, PreferenceTransactionFactory } from './preference-transaction-manager';
+import { PreferenceTransaction, PreferenceTransactionFactory, preferenceTransactionFactoryCreator } from './preference-transaction-manager';
 import { PreferenceOpenHandler } from './preference-open-handler';
 
 export function bindPreferences(bind: interfaces.Bind, unbind: interfaces.Unbind): void {
@@ -49,11 +49,7 @@ export function bindPreferences(bind: interfaces.Bind, unbind: interfaces.Unbind
 
     bind(MonacoJSONCEditor).toSelf().inSingletonScope();
     bind(PreferenceTransaction).toSelf();
-    bind(PreferenceTransactionFactory).toFactory(({ container }) => (context: PreferenceContext) => {
-        const child = container.createChild();
-        child.bind(PreferenceContext).toConstantValue(context);
-        return child.get(PreferenceTransaction);
-    });
+    bind(PreferenceTransactionFactory).toFactory(preferenceTransactionFactoryCreator);
 }
 
 export default new ContainerModule((bind, unbind, isBound, rebind) => {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

Follows up on [this comment](https://github.com/eclipse-theia/theia/pull/10884#issuecomment-1072499108) by directly addressing the handling of the dirty file. Now the next transaction waits until the previous transaction has definitely concluded and saved its changes (ensuring the file is not dirty) before beginning its startup and checking whether the model is `dirty`.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
1. Rapidly change the `window.zoom` preference using <kbd>Ctrl / Cmd</kbd> + <kbd>+ / -</kbd>
2. Observe that there are _no_ toasts reporting that the preference file is dirty, and your changes to the preference take effect.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
