### PR TITLE
Ensure that old values aren't cached inappropriately

### DIFF
--- a/packages/core/src/browser/preferences/preference-proxy.spec.ts
+++ b/packages/core/src/browser/preferences/preference-proxy.spec.ts
@@ -351,15 +351,29 @@ describe('Preference Proxy', () => {
                 it("Validated proxies don't retain old values for overrides after a change (with emitter)", async () => {
                     const { proxy, validationCallCounter } = await prepareValidationTest();
                     prefSchema.registerOverrideIdentifier('swift');
+                    const override = { preferenceName: 'my.pref', overrideIdentifier: 'swift' };
                     proxy.onPreferenceChanged; // Initialize the listeners.
-                    const initialValue = proxy.get({ preferenceName: 'my.pref', overrideIdentifier: 'swift' });
+                    const initialValue = proxy.get(override);
                     expect(initialValue).to.equal('foo', 'Proxy should start with default value.');
                     expect(validationCallCounter.calls).to.equal(1, 'Retrieval should validate.');
+
                     await prefService.set('my.pref', 'bar', PreferenceScope.User);
-                    expect(validationCallCounter.calls).to.equal(2, 'Event should trigger validation.');
+                    expect(validationCallCounter.calls).to.equal(2, 'Event should trigger validation (1).');
                     expect(proxy.get('my.pref')).to.equal('bar', 'The base should have been updated.');
-                    expect(proxy.get({ preferenceName: 'my.pref', overrideIdentifier: 'swift' })).to.equal('bar', 'Proxy should update empty overrides on change.');
-                    expect(validationCallCounter.calls).to.equal(2, 'Subsequent retrievals should not trigger validation.');
+                    expect(proxy.get(override)).to.equal('bar', 'Proxy should update empty overrides on change.');
+                    expect(validationCallCounter.calls).to.equal(2, 'Subsequent retrievals should not trigger validation. (1)');
+
+                    await prefService.set(prefService.overridePreferenceName(override), 'baz', PreferenceScope.User);
+                    expect(validationCallCounter.calls).to.equal(3, 'Event should trigger validation (2).');
+                    expect(proxy.get('my.pref')).to.equal('bar', 'Base should not have been updated.');
+                    expect(proxy.get(override)).to.equal('baz', 'Override should have been updated');
+                    expect(validationCallCounter.calls).to.equal(3, 'Subsequent retrievals should not trigger validation. (2)');
+
+                    await prefService.set('my.pref', 'boom', PreferenceScope.User);
+                    expect(validationCallCounter.calls).to.equal(4, 'Event should trigger validation (3).');
+                    expect(proxy.get('my.pref')).to.equal('boom', 'Base should have been updated.');
+                    expect(proxy.get(override)).to.equal('baz', 'Override should not have been updated');
+                    expect(validationCallCounter.calls).to.equal(4, 'Subsequent retrievals should not trigger validation. (3)');
                 });
             }
 

--- a/packages/core/src/browser/preferences/preference-proxy.spec.ts
+++ b/packages/core/src/browser/preferences/preference-proxy.spec.ts
@@ -333,6 +333,34 @@ describe('Preference Proxy', () => {
                     expect(events).to.have.length(3, 'One event for base, one for each override');
                     expect(events.every(event => event.newValue === 'foo'), 'Should have returned the default in case of garbage.');
                 });
+
+                it("Validated proxies don't retain old values for overrides after a change (no emitter).", async () => {
+                    const { proxy, validationCallCounter } = await prepareValidationTest();
+                    prefSchema.registerOverrideIdentifier('swift');
+                    const initialValue = proxy.get({ preferenceName: 'my.pref', overrideIdentifier: 'swift' });
+                    expect(initialValue).to.equal('foo', 'Proxy should start with default value.');
+                    expect(validationCallCounter.calls).to.equal(1, 'Retrieval should validate (1).');
+                    await prefService.set('my.pref', 'bar', PreferenceScope.User);
+                    expect(proxy.get('my.pref')).to.equal('bar', 'The base should have been updated.');
+                    expect(validationCallCounter.calls).to.equal(2, 'Retrieval should validate (2).');
+                    expect(proxy.get({ preferenceName: 'my.pref', overrideIdentifier: 'swift' })).to.equal('bar', 'Proxy should update empty overrides on change.');
+                    expect(validationCallCounter.calls).to.equal(3, 'Retrieval should validate (3).');
+                });
+
+                // The scenario with a listener differs because the proxy will start caching known valid values when a listener is attached.
+                it("Validated proxies don't retain old values for overrides after a change (with emitter)", async () => {
+                    const { proxy, validationCallCounter } = await prepareValidationTest();
+                    prefSchema.registerOverrideIdentifier('swift');
+                    proxy.onPreferenceChanged; // Initialize the listeners.
+                    const initialValue = proxy.get({ preferenceName: 'my.pref', overrideIdentifier: 'swift' });
+                    expect(initialValue).to.equal('foo', 'Proxy should start with default value.');
+                    expect(validationCallCounter.calls).to.equal(1, 'Retrieval should validate.');
+                    await prefService.set('my.pref', 'bar', PreferenceScope.User);
+                    expect(validationCallCounter.calls).to.equal(2, 'Event should trigger validation.');
+                    expect(proxy.get('my.pref')).to.equal('bar', 'The base should have been updated.');
+                    expect(proxy.get({ preferenceName: 'my.pref', overrideIdentifier: 'swift' })).to.equal('bar', 'Proxy should update empty overrides on change.');
+                    expect(validationCallCounter.calls).to.equal(2, 'Subsequent retrievals should not trigger validation.');
+                });
             }
 
             it('toJSON with deep', async () => {

--- a/packages/core/src/browser/preferences/validated-preference-proxy.ts
+++ b/packages/core/src/browser/preferences/validated-preference-proxy.ts
@@ -16,10 +16,11 @@
 
 import { JSONValue } from '@phosphor/coreutils';
 import { inject, injectable } from 'inversify';
-import { PreferenceValidationService } from '.';
 import { InjectablePreferenceProxy } from './injectable-preference-proxy';
 import { OverridePreferenceName } from './preference-language-override-service';
+import { PreferenceProvider } from './preference-provider';
 import { PreferenceChanges } from './preference-service';
+import { PreferenceValidationService } from './preference-validation-service';
 
 @injectable()
 export class ValidatedPreferenceProxy<T extends Record<string, JSONValue>> extends InjectablePreferenceProxy<T> {
@@ -33,18 +34,16 @@ export class ValidatedPreferenceProxy<T extends Record<string, JSONValue>> exten
 
     protected override handlePreferenceChanges(changes: PreferenceChanges): void {
         if (this.schema) {
-            interface TrackedOverrides { value?: JSONValue, overrides: OverridePreferenceName[] };
+            interface TrackedOverrides { overrides: OverridePreferenceName[] };
             const overrideTracker: Map<string, TrackedOverrides> = new Map();
             for (const change of Object.values(changes)) {
                 const overridden = this.preferences.overriddenPreferenceName(change.preferenceName);
                 if (this.isRelevantChange(change, overridden)) {
                     let doSet = false;
                     const baseName = overridden?.preferenceName ?? change.preferenceName;
-                    const tracker: TrackedOverrides = overrideTracker.get(baseName) ?? (doSet = true, { value: undefined, overrides: [] });
+                    const tracker: TrackedOverrides = overrideTracker.get(baseName) ?? (doSet = true, { overrides: [] });
                     if (overridden) {
                         tracker.overrides.push(overridden);
-                    } else {
-                        tracker.value = change.newValue;
                     }
                     if (doSet) {
                         overrideTracker.set(baseName, tracker);
@@ -52,18 +51,29 @@ export class ValidatedPreferenceProxy<T extends Record<string, JSONValue>> exten
                 }
             }
             for (const [baseName, tracker] of overrideTracker.entries()) {
-                const configuredValue = tracker.value as T[typeof baseName];
-                const validatedValue = this.ensureValid(baseName, () => configuredValue, true);
+                const validated: Array<[JSONValue, JSONValue]> = [];
+                // This could go wrong if someone sets a lot of different, complex values for different language overrides simultaneously.
+                // In the normal case, we'll just be doing strict equal checks on primitives.
+                const getValidValue = (name: string): JSONValue => {
+                    const configuredForCurrent = changes[name].newValue;
+                    const existingValue = validated.find(([configuredForValid]) => PreferenceProvider.deepEqual(configuredForValid, configuredForCurrent));
+                    if (existingValue) {
+                        this.validPreferences?.set(name, existingValue[1]);
+                        return existingValue[1];
+                    }
+                    const validValue = this.ensureValid(name, () => configuredForCurrent, true);
+                    validated.push([configuredForCurrent, validValue]);
+                    return validValue;
+                };
                 if (baseName in changes && this.isRelevantChange(changes[baseName])) {
+                    const newValue = getValidValue(baseName);
                     const { domain, oldValue, preferenceName, scope } = changes[baseName];
-                    this.fireChangeEvent(this.buildNewChangeEvent({ domain, oldValue, preferenceName, scope, newValue: validatedValue }));
+                    this.fireChangeEvent(this.buildNewChangeEvent({ domain, oldValue, preferenceName, scope, newValue }));
                 }
                 for (const override of tracker.overrides) {
                     const name = this.preferences.overridePreferenceName(override);
                     const { domain, oldValue, preferenceName, scope } = changes[name];
-                    const newValue = changes[name].newValue === configuredValue
-                        ? (this.validPreferences?.set(name, validatedValue), validatedValue)
-                        : this.ensureValid(name, () => changes[name].newValue, true);
+                    const newValue = getValidValue(name);
                     this.fireChangeEvent(this.buildNewChangeEvent({ domain, oldValue, preferenceName, scope, newValue }, override));
                 }
             }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

Fixes https://github.com/eclipse-theia/theia/issues/10959 
Fixes https://github.com/eclipse-theia/theia/issues/10865

Previously, the caching mechanism in `ValidatedPreferenceProxy` could mistakenly retain cached values for language overrides. This PR ensures that the cache is maintained only once the proxy subscribes to preference events and that it is updated for all overrides in case of a preference change.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
1. Activate and deactivate the `editor.minimap.enabled` preference. It should immediately take effect in open editors (in all languages) and apply correctly to new editors.
2. Assert that the new tests pass.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
