### PR TITLE
Add method appendChoice to class SnippetString of VS Code API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 [1.25.0 Milestone](https://github.com/eclipse-theia/theia/milestone/33)
 
 - [core] Move code for untitled resources into `core` from `plugin-ext` and allow users to open untitled editors with `New File` command. [#10868](https://github.com/eclipse-theia/theia/pull/10868)
+- [plugin] added support for `SnippetString.appendChoice` [#10969](https://github.com/eclipse-theia/theia/pull/10969) - Contributed on behalf of STMicroelectronics
 
 <a name="breaking_changes_1.25.0">[Breaking Changes:](#breaking_changes_1.25.0)</a>
 

--- a/packages/plugin-ext/src/plugin/types-impl.ts
+++ b/packages/plugin-ext/src/plugin/types-impl.ts
@@ -679,6 +679,12 @@ export class SnippetString {
         return this;
     }
 
+    appendChoice(values: string[], number: number = this._tabstop++): SnippetString {
+        const value = values.map(s => s.replace(/\$|}|\\|,/g, '\\$&')).join(',');
+        this.value += `\$\{${number}|${value}|\}`;
+        return this;
+    }
+
     appendVariable(name: string, defaultValue?: string | ((snippet: SnippetString) => void)): SnippetString {
 
         if (typeof defaultValue === 'function') {

--- a/packages/plugin/src/theia.d.ts
+++ b/packages/plugin/src/theia.d.ts
@@ -497,6 +497,17 @@ export module '@theia/plugin' {
         appendPlaceholder(value: string | ((snippet: SnippetString) => any), number?: number): SnippetString;
 
         /**
+         * Builder-function that appends a choice (`${1|a,b,c|}`) to
+         * the {@linkcode SnippetString.value value} of this snippet string.
+         *
+         * @param values The values for choices - the array of strings
+         * @param number The number of this tabstop, defaults to an auto-increment
+         * value starting at 1.
+         * @return This snippet string.
+         */
+        appendChoice(values: string[], number?: number): SnippetString;
+
+        /**
          * Builder-function that appends a variable (`${VAR}`) to
          * the [`value`](#SnippetString.value) of this snippet string.
          *


### PR DESCRIPTION
Fixes #10967

Contributed on behalf of STMicroelectronics

Signed-off-by: Lucas Koehler <lkoehler@eclipsesource.com>

#### What it does
Adds missing method `appendChoice` to VS Code/plugin API class `SnippetString`.

#### How to test

- Download completions sample extension [here](https://github.com/lucas-koehler/vscode-extension-samples/releases/download/snippet-string-builder-0.0.2/completions-sample-0.0.2.vsix).
- Put it in the `plugins` folder in your theia repo and run one of the sample apps
- Open a text file and hit `ctrl+space` to trigger auto complete
- You should be offered a completion "Excellent part of the day`
![image](https://user-images.githubusercontent.com/6959840/161074980-fe0e35b9-45f8-4967-b61c-79713981537f.png)
- Hitting enter should give you the following completion options
![image](https://user-images.githubusercontent.com/6959840/161075125-4ca7c572-78bd-4ae7-a53e-4ed76957bf5a.png)

- See [here](https://github.com/lucas-koehler/vscode-extension-samples/blob/snippet-string-builder-0.0.2/completions-sample/src/extension.ts#L26-L30) for reference how the snippet was built with the new method.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
