### PR TITLE
vscode: align signature of `showQuickPick`

### DIFF
--- a/packages/plugin/src/theia.d.ts
+++ b/packages/plugin/src/theia.d.ts
@@ -4211,36 +4211,43 @@ export module '@theia/plugin' {
 
         /**
          * Shows a selection list.
-         * @param items
-         * @param options
-         * @param token
+         *
+         * @param items An array of strings, or a promise that resolves to an array of strings.
+         * @param options Configures the behavior of the selection list.
+         * @param token A token that can be used to signal cancellation.
+         * @return A promise that resolves to the selection or `undefined`.
          */
-        export function showQuickPick(items: string[] | PromiseLike<string[]>, options: QuickPickOptions, token?: CancellationToken): PromiseLike<string | undefined>;
+        export function showQuickPick(readonly items: string[] | PromiseLike<readonly string[]>, options: QuickPickOptions, token?: CancellationToken): PromiseLike<string | undefined>;
 
         /**
-         * Shows a selection list with multiple selection allowed.
+         * Shows a selection list allowing multiple selections.
+         *
+         * @param items An array of strings, or a promise that resolves to an array of strings.
+         * @param options Configures the behavior of the selection list.
+         * @param token A token that can be used to signal cancellation.
+         * @return A promise that resolves to the selected items or `undefined`.
          */
-        export function showQuickPick(
-            items: string[] | PromiseLike<string[]>,
-            options: QuickPickOptions & { canPickMany: true },
-            token?: CancellationToken
-        ): PromiseLike<string[] | undefined>;
+        export function showQuickPick(readonly items: string[] | PromiseLike<readonly string[]>, options: QuickPickOptions & { canPickMany: true }, token?: CancellationToken): PromiseLike<string[] | undefined>;
 
         /**
          * Shows a selection list.
-         * @param items
-         * @param options
-         * @param token
+         *
+         * @param items An array of items, or a promise that resolves to an array of items.
+         * @param options Configures the behavior of the selection list.
+         * @param token A token that can be used to signal cancellation.
+         * @return A promise that resolves to the selected item or `undefined`.
          */
-        export function showQuickPick<T extends QuickPickItem>(items: T[] | PromiseLike<T[]>, options: QuickPickOptions, token?: CancellationToken): PromiseLike<T | undefined>;
+        export function showQuickPick<T extends QuickPickItem>(items: readonly T[] | PromiseLike<readonly T[]>, options: QuickPickOptions, token?: CancellationToken): PromiseLike<T | undefined>;
 
         /**
-         * Shows a selection list with multiple selection allowed.
+         * Shows a selection list allowing multiple selections.
+         *
+         * @param items An array of items, or a promise that resolves to an array of items.
+         * @param options Configures the behavior of the selection list.
+         * @param token A token that can be used to signal cancellation.
+         * @return A promise that resolves to the selected items or `undefined`.
          */
-        export function showQuickPick<T extends QuickPickItem>(items: T[] | PromiseLike<T[]>,
-            options: QuickPickOptions & { canPickMany: true },
-            token?: CancellationToken
-        ): PromiseLike<T[] | undefined>;
+        export function showQuickPick<T extends QuickPickItem>(items: readonly T[] | PromiseLike<readonly T[]>, options: QuickPickOptions & { canPickMany: true }, token?: CancellationToken): PromiseLike<T[] | undefined>;
 
         /**
          * Creates a [QuickPick](#QuickPick) to let the user pick an item from a list


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

Fixes: https://github.com/eclipse-theia/theia/issues/10968.

The pull-request aligns the signature of `showQuickPick` with the expectations from the VS Code API, and ultimately marks our compatibility report for the method as supported.


#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

1. include the following test extension [quick-pick-0.0.1.zip](https://github.com/eclipse-theia/theia/files/8397391/quick-pick-0.0.1.zip)
2. start the application
3. confirm the commands `Quick Pick: A`, `Quick Pick: B` and `Quick Pick: C` work as expected

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

Signed-off-by: vince-fugnitto <vincent.fugnitto@ericsson.com>