### PR TITLE
Add correct extension mode to plugin context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 ## History
 
 - [Previous Changelogs](https://github.com/eclipse-theia/theia/tree/master/doc/changelogs/)
+## v1.25.0 - 4/28/2022
+[1.25.0 Milestone](https://github.com/eclipse-theia/theia/milestone/33)
+
+- [plugin] added support for `ExtensionMode` [#10201](https://github.com/eclipse-theia/theia/pull/10201) - Contributed on behalf of STMicroelectronics
+
 
 
 ## v.1.26.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,17 +3,13 @@
 ## History
 
 - [Previous Changelogs](https://github.com/eclipse-theia/theia/tree/master/doc/changelogs/)
-## v1.25.0 - 4/28/2022
-[1.25.0 Milestone](https://github.com/eclipse-theia/theia/milestone/33)
-
-- [plugin] added support for `ExtensionMode` [#10201](https://github.com/eclipse-theia/theia/pull/10201) - Contributed on behalf of STMicroelectronics
-
 
 
 ## v.1.26.0
 
 - [plugin] Introduce `DebugSession#workspaceFolder` [#11090](https://github.com/eclipse-theia/theia/pull/11090) - Contributed on behalf of STMicroelectronics
 - [console] fixed issue in Debug console where console history was not being trimmed in accordance with the maximum commands limit [#10598](https://github.com/eclipse-theia/theia/pull/10598)
+- [plugin] added support for `ExtensionMode` [#10201](https://github.com/eclipse-theia/theia/pull/10201) - Contributed on behalf of STMicroelectronics
 
 <a name="breaking_changes_1.26.0">[Breaking Changes:](#breaking_changes_1.26.0)</a>
 

--- a/packages/plugin-dev/src/node/hosted-plugin-reader.ts
+++ b/packages/plugin-dev/src/node/hosted-plugin-reader.ts
@@ -40,6 +40,7 @@ export class HostedPluginReader implements BackendApplicationContribution {
         const pluginPath = process.env.HOSTED_PLUGIN;
         if (pluginPath) {
             const hostedPlugin = new PluginDeployerEntryImpl('Hosted Plugin', pluginPath!, pluginPath);
+            hostedPlugin.storeValue('isUnderDevelopment', true);
             const hostedMetadata = await this.hostedPlugin.promise;
             if (hostedMetadata!.model.entryPoint && hostedMetadata!.model.entryPoint.backend) {
                 this.deployerHandler.deployBackendPlugins([hostedPlugin]);

--- a/packages/plugin-dev/src/node/hosted-plugin-reader.ts
+++ b/packages/plugin-dev/src/node/hosted-plugin-reader.ts
@@ -42,11 +42,11 @@ export class HostedPluginReader implements BackendApplicationContribution {
             const hostedPlugin = new PluginDeployerEntryImpl('Hosted Plugin', pluginPath!, pluginPath);
             const hostedMetadata = await this.hostedPlugin.promise;
             if (hostedMetadata!.model.entryPoint && hostedMetadata!.model.entryPoint.backend) {
-                this.deployerHandler.deployBackendPlugins([hostedPlugin]);
+                this.deployerHandler.deployBackendPlugins([hostedPlugin], true);
             }
 
             if (hostedMetadata!.model.entryPoint && hostedMetadata!.model.entryPoint.frontend) {
-                this.deployerHandler.deployFrontendPlugins([hostedPlugin]);
+                this.deployerHandler.deployFrontendPlugins([hostedPlugin], true);
             }
         }
     }

--- a/packages/plugin-dev/src/node/hosted-plugin-reader.ts
+++ b/packages/plugin-dev/src/node/hosted-plugin-reader.ts
@@ -42,11 +42,11 @@ export class HostedPluginReader implements BackendApplicationContribution {
             const hostedPlugin = new PluginDeployerEntryImpl('Hosted Plugin', pluginPath!, pluginPath);
             const hostedMetadata = await this.hostedPlugin.promise;
             if (hostedMetadata!.model.entryPoint && hostedMetadata!.model.entryPoint.backend) {
-                this.deployerHandler.deployBackendPlugins([hostedPlugin], true);
+                this.deployerHandler.deployBackendPlugins([hostedPlugin]);
             }
 
             if (hostedMetadata!.model.entryPoint && hostedMetadata!.model.entryPoint.frontend) {
-                this.deployerHandler.deployFrontendPlugins([hostedPlugin], true);
+                this.deployerHandler.deployFrontendPlugins([hostedPlugin]);
             }
         }
     }

--- a/packages/plugin-ext/src/common/plugin-api-rpc.ts
+++ b/packages/plugin-ext/src/common/plugin-api-rpc.ts
@@ -114,6 +114,7 @@ export interface Plugin {
     model: PluginModel;
     rawModel: PluginPackage;
     lifecycle: PluginLifecycle;
+    isUnderDevelopment: boolean;
 }
 
 export interface ConfigStorage {
@@ -197,7 +198,8 @@ export const emptyPlugin: Plugin = {
             version: 'empty'
         },
         packagePath: 'empty'
-    }
+    },
+    isUnderDevelopment: false
 };
 
 export interface PluginManagerInitializeParams {

--- a/packages/plugin-ext/src/common/plugin-protocol.ts
+++ b/packages/plugin-ext/src/common/plugin-protocol.ts
@@ -795,6 +795,7 @@ export interface PluginMetadata {
     host: string;
     model: PluginModel;
     lifecycle: PluginLifecycle;
+    isUnderDevelopment?: boolean;
 }
 
 export const MetadataProcessor = Symbol('MetadataProcessor');
@@ -826,8 +827,8 @@ export interface PluginDependencies {
 
 export const PluginDeployerHandler = Symbol('PluginDeployerHandler');
 export interface PluginDeployerHandler {
-    deployFrontendPlugins(frontendPlugins: PluginDeployerEntry[]): Promise<void>;
-    deployBackendPlugins(backendPlugins: PluginDeployerEntry[]): Promise<void>;
+    deployFrontendPlugins(frontendPlugins: PluginDeployerEntry[], isUnderDevelopment?: boolean): Promise<void>;
+    deployBackendPlugins(backendPlugins: PluginDeployerEntry[], isUnderDevelopment?: boolean): Promise<void>;
 
     getDeployedPlugin(pluginId: string): DeployedPlugin | undefined;
     undeployPlugin(pluginId: string): Promise<boolean>;

--- a/packages/plugin-ext/src/common/plugin-protocol.ts
+++ b/packages/plugin-ext/src/common/plugin-protocol.ts
@@ -827,8 +827,8 @@ export interface PluginDependencies {
 
 export const PluginDeployerHandler = Symbol('PluginDeployerHandler');
 export interface PluginDeployerHandler {
-    deployFrontendPlugins(frontendPlugins: PluginDeployerEntry[], isUnderDevelopment?: boolean): Promise<void>;
-    deployBackendPlugins(backendPlugins: PluginDeployerEntry[], isUnderDevelopment?: boolean): Promise<void>;
+    deployFrontendPlugins(frontendPlugins: PluginDeployerEntry[]): Promise<void>;
+    deployBackendPlugins(backendPlugins: PluginDeployerEntry[]): Promise<void>;
 
     getDeployedPlugin(pluginId: string): DeployedPlugin | undefined;
     undeployPlugin(pluginId: string): Promise<boolean>;

--- a/packages/plugin-ext/src/hosted/browser/worker/worker-main.ts
+++ b/packages/plugin-ext/src/hosted/browser/worker/worker-main.ts
@@ -129,7 +129,8 @@ const pluginManager = new PluginManagerExtImpl({
                     pluginUri: pluginModel.packageUri,
                     model: pluginModel,
                     lifecycle: pluginLifecycle,
-                    rawModel
+                    rawModel,
+                    isUnderDevelopment: !!plg.isUnderDevelopment
                 };
                 const apiImpl = apiFactory(plugin);
                 pluginsApiImpl.set(plugin.model.id, apiImpl);
@@ -146,7 +147,8 @@ const pluginManager = new PluginManagerExtImpl({
                         lifecycle: pluginLifecycle,
                         get rawModel(): never {
                             throw new Error('not supported');
-                        }
+                        },
+                        isUnderDevelopment: !!plg.isUnderDevelopment
                     }
                 };
             }

--- a/packages/plugin-ext/src/hosted/node/hosted-plugin-deployer-handler.ts
+++ b/packages/plugin-ext/src/hosted/node/hosted-plugin-deployer-handler.ts
@@ -99,17 +99,17 @@ export class HostedPluginDeployerHandler implements PluginDeployerHandler {
         }
     }
 
-    async deployFrontendPlugins(frontendPlugins: PluginDeployerEntry[]): Promise<void> {
+    async deployFrontendPlugins(frontendPlugins: PluginDeployerEntry[], isUnderDevelopment?: boolean): Promise<void> {
         for (const plugin of frontendPlugins) {
-            await this.deployPlugin(plugin, 'frontend');
+            await this.deployPlugin(plugin, 'frontend', isUnderDevelopment);
         }
         // resolve on first deploy
         this.frontendPluginsMetadataDeferred.resolve(undefined);
     }
 
-    async deployBackendPlugins(backendPlugins: PluginDeployerEntry[]): Promise<void> {
+    async deployBackendPlugins(backendPlugins: PluginDeployerEntry[], isUnderDevelopment?: boolean): Promise<void> {
         for (const plugin of backendPlugins) {
-            await this.deployPlugin(plugin, 'backend');
+            await this.deployPlugin(plugin, 'backend', isUnderDevelopment);
         }
         // rebuild translation config after deployment
         this.localizationService.buildTranslationConfig([...this.deployedBackendPlugins.values()]);
@@ -120,7 +120,7 @@ export class HostedPluginDeployerHandler implements PluginDeployerHandler {
     /**
      * @throws never! in order to isolate plugin deployment
      */
-    protected async deployPlugin(entry: PluginDeployerEntry, entryPoint: keyof PluginEntryPoint): Promise<void> {
+    protected async deployPlugin(entry: PluginDeployerEntry, entryPoint: keyof PluginEntryPoint, isUnderDevelopment: boolean = false): Promise<void> {
         const pluginPath = entry.path();
         const deployPlugin = this.stopwatch.start('deployPlugin');
         try {
@@ -131,6 +131,7 @@ export class HostedPluginDeployerHandler implements PluginDeployerHandler {
             }
 
             const metadata = this.reader.readMetadata(manifest);
+            metadata.isUnderDevelopment = isUnderDevelopment;
 
             const deployedLocations = this.deployedLocations.get(metadata.model.id) || new Set<string>();
             deployedLocations.add(entry.rootPath);

--- a/packages/plugin-ext/src/hosted/node/hosted-plugin-deployer-handler.ts
+++ b/packages/plugin-ext/src/hosted/node/hosted-plugin-deployer-handler.ts
@@ -99,17 +99,17 @@ export class HostedPluginDeployerHandler implements PluginDeployerHandler {
         }
     }
 
-    async deployFrontendPlugins(frontendPlugins: PluginDeployerEntry[], isUnderDevelopment?: boolean): Promise<void> {
+    async deployFrontendPlugins(frontendPlugins: PluginDeployerEntry[]): Promise<void> {
         for (const plugin of frontendPlugins) {
-            await this.deployPlugin(plugin, 'frontend', isUnderDevelopment);
+            await this.deployPlugin(plugin, 'frontend');
         }
         // resolve on first deploy
         this.frontendPluginsMetadataDeferred.resolve(undefined);
     }
 
-    async deployBackendPlugins(backendPlugins: PluginDeployerEntry[], isUnderDevelopment?: boolean): Promise<void> {
+    async deployBackendPlugins(backendPlugins: PluginDeployerEntry[]): Promise<void> {
         for (const plugin of backendPlugins) {
-            await this.deployPlugin(plugin, 'backend', isUnderDevelopment);
+            await this.deployPlugin(plugin, 'backend');
         }
         // rebuild translation config after deployment
         this.localizationService.buildTranslationConfig([...this.deployedBackendPlugins.values()]);
@@ -120,7 +120,7 @@ export class HostedPluginDeployerHandler implements PluginDeployerHandler {
     /**
      * @throws never! in order to isolate plugin deployment
      */
-    protected async deployPlugin(entry: PluginDeployerEntry, entryPoint: keyof PluginEntryPoint, isUnderDevelopment: boolean = false): Promise<void> {
+    protected async deployPlugin(entry: PluginDeployerEntry, entryPoint: keyof PluginEntryPoint): Promise<void> {
         const pluginPath = entry.path();
         const deployPlugin = this.stopwatch.start('deployPlugin');
         try {
@@ -131,7 +131,7 @@ export class HostedPluginDeployerHandler implements PluginDeployerHandler {
             }
 
             const metadata = this.reader.readMetadata(manifest);
-            metadata.isUnderDevelopment = isUnderDevelopment;
+            metadata.isUnderDevelopment = entry.getValue('isUnderDevelopment') ?? false;
 
             const deployedLocations = this.deployedLocations.get(metadata.model.id) || new Set<string>();
             deployedLocations.add(entry.rootPath);

--- a/packages/plugin-ext/src/hosted/node/plugin-host-rpc.ts
+++ b/packages/plugin-ext/src/hosted/node/plugin-host-rpc.ts
@@ -167,7 +167,8 @@ export class PluginHostRPC {
                                 pluginUri: pluginModel.packageUri,
                                 model: pluginModel,
                                 lifecycle: pluginLifecycle,
-                                rawModel
+                                rawModel,
+                                isUnderDevelopment: !!plg.isUnderDevelopment
                             });
                         } else {
                             let backendInitPath = pluginLifecycle.backendInitPath;
@@ -182,7 +183,8 @@ export class PluginHostRPC {
                                 pluginUri: pluginModel.packageUri,
                                 model: pluginModel,
                                 lifecycle: pluginLifecycle,
-                                rawModel
+                                rawModel,
+                                isUnderDevelopment: !!plg.isUnderDevelopment
                             };
 
                             self.initContext(backendInitPath, plugin);

--- a/packages/plugin-ext/src/main/node/plugin-deployer-entry-impl.ts
+++ b/packages/plugin-ext/src/main/node/plugin-deployer-entry-impl.ts
@@ -47,7 +47,6 @@ export class PluginDeployerEntryImpl implements PluginDeployerEntry {
         } else {
             this.resolved = false;
         }
-        this.storeValue('isUnderDevelopment', originId === 'Hosted Plugin');
     }
 
     id(): string {

--- a/packages/plugin-ext/src/main/node/plugin-deployer-entry-impl.ts
+++ b/packages/plugin-ext/src/main/node/plugin-deployer-entry-impl.ts
@@ -47,6 +47,7 @@ export class PluginDeployerEntryImpl implements PluginDeployerEntry {
         } else {
             this.resolved = false;
         }
+        this.storeValue('isUnderDevelopment', originId === 'Hosted Plugin');
     }
 
     id(): string {

--- a/packages/plugin-ext/src/plugin/plugin-manager.ts
+++ b/packages/plugin-ext/src/plugin/plugin-manager.ts
@@ -30,6 +30,7 @@ import {
 } from '../common/plugin-api-rpc';
 import { PluginMetadata, PluginJsonValidationContribution } from '../common/plugin-protocol';
 import * as theia from '@theia/plugin';
+import * as types from './types-impl';
 import { join } from './path';
 import { EnvExtImpl } from './env';
 import { PreferenceRegistryExtImpl } from './preference-registry';
@@ -372,6 +373,7 @@ export class PluginManagerExtImpl implements PluginManagerExt, PluginManager {
         const secrets = new SecretStorageExt(plugin, this.secrets);
         const globalStoragePath = join(configStorage.hostGlobalStoragePath, plugin.model.id);
         const extension = new PluginExt(this, plugin);
+        const extensionModeValue = plugin.isUnderDevelopment ? types.ExtensionMode.Development : types.ExtensionMode.Production;
         const pluginContext: theia.PluginContext = {
             extensionPath: extension.extensionPath,
             extensionUri: extension.extensionUri,
@@ -386,7 +388,7 @@ export class PluginManagerExtImpl implements PluginManagerExt, PluginManager {
             globalStoragePath: globalStoragePath,
             globalStorageUri: Uri.file(globalStoragePath),
             environmentVariableCollection: this.terminalService.getEnvironmentVariableCollection(plugin.model.id),
-            extensionMode: 1, // @todo: implement proper `extensionMode`.
+            extensionMode: extensionModeValue,
             extension,
             logUri: Uri.file(logPath)
         };


### PR DESCRIPTION
Fix #10201

Contributed on behalf of STMicroelectronics
Signed-off-by: Eugen Neufeld <eneufeld@eclipsesource.com>

#### What it does
The plugin context was hardcoded to have the production extensionMode.
Now a flag is passed to mark a plugin as under development when
deploying it. This flag is stored in the plugin metadata and later set in
the plugin. When creating the context this flag is then converted to the
correct extensionMode.

#### How to test
Download this plugin project: [theia-hello-world-plugin.zip](https://github.com/eclipse-theia/theia/files/8407558/theia-hello-world-plugin.zip) .
It contains a built version of the plugin which you should add to your plugins folder. This add a new command which opens a message with `Hello World! Mode: ${mode}` where the mode is the extensionMode. For the deployed plugin the mode should be '1' (Production).
Also add the project to your workspace so that you can start the plugin in a hosted version, by calling `Hosted mode: start instance`. When you trigger the command now in the hosted mode, the message should be `Hello World! Mode: 2` (Development).

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)