### PR TITLE
vscode: support generic `CodeActionProvider`

### DIFF
--- a/packages/plugin/src/theia.d.ts
+++ b/packages/plugin/src/theia.d.ts
@@ -7909,7 +7909,7 @@ export module '@theia/plugin' {
      *
      * A code action can be any command that is [known](#commands.getCommands) to the system.
      */
-    export interface CodeActionProvider {
+    export interface CodeActionProvider<T extends CodeAction = CodeAction> {
         /**
          * Provide commands for the given document and range.
          *
@@ -7921,12 +7921,7 @@ export module '@theia/plugin' {
          * @return An array of commands, quick fixes, or refactorings or a thenable of such. The lack of a result can be
          * signaled by returning `undefined`, `null`, or an empty array.
          */
-        provideCodeActions(
-            document: TextDocument,
-            range: Range | Selection,
-            context: CodeActionContext,
-            token: CancellationToken | undefined
-        ): ProviderResult<(Command | CodeAction)[]>;
+        provideCodeActions(document: TextDocument, range: Range | Selection, context: CodeActionContext, token: CancellationToken | undefined): ProviderResult<(Command | T)[]>;
 
         /**
          * Given a code action fill in its `edit`-property. Changes to
@@ -7942,7 +7937,7 @@ export module '@theia/plugin' {
          * @return The resolved code action or a thenable that resolves to such. It is OK to return the given
          * `item`. When no result is returned, the given `item` will be used.
          */
-        resolveCodeAction?(codeAction: CodeAction, token: CancellationToken | undefined): ProviderResult<CodeAction>;
+        resolveCodeAction?(codeAction: T, token: CancellationToken | undefined): ProviderResult<T>;
     }
 
     /**


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

The pull-request updates `CodeActionProvider` to accept the generic `CodeAction` type.
The change ultimately aligns the API with VS Code and will be marked as supported in the compatibility report.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

1. include the following test extension [code-actions-sample-0.0.2.zip](https://github.com/eclipse-theia/theia/files/8411640/code-actions-sample-0.0.2.zip)
2. start the application
3. open a **markdown** file
4. type `:)`
5. a code-action menu should appear where the entries should work

https://user-images.githubusercontent.com/40359487/161594210-8d52bca6-855f-4835-8e61-e456dd2c60df.mp4


#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

Signed-off-by: vince-fugnitto <vincent.fugnitto@ericsson.com>