### PR TITLE
Introduce custom select component

### DIFF
--- a/packages/core/src/browser/browser.ts
+++ b/packages/core/src/browser/browser.ts
@@ -156,3 +156,42 @@ export function preventNavigation(event: WheelEvent): void {
     event.preventDefault();
     event.stopPropagation();
 }
+
+export function measureTextWidth(text: string | string[]): number {
+    const measureElement = getMeasurementElement();
+    text = Array.isArray(text) ? text : [text];
+    let width = 0;
+    for (const item of text) {
+        measureElement.textContent = item;
+        width = Math.max(measureElement.getBoundingClientRect().width, width);
+    }
+    return width;
+}
+
+export function measureTextHeight(text: string | string[], maxWidth?: number): number {
+    const measureElement = getMeasurementElement();
+    if (maxWidth !== undefined) {
+        measureElement.style.maxWidth = `${Math.ceil(maxWidth)}px`;
+    }
+    text = Array.isArray(text) ? text : [text];
+    let height = 0;
+    for (const item of text) {
+        measureElement.textContent = item;
+        height = Math.max(measureElement.getBoundingClientRect().height, height);
+    }
+    measureElement.style.maxWidth = 'none';
+    return height;
+}
+
+function getMeasurementElement(): HTMLElement {
+    let measureElement = document.getElementById('measure');
+    if (!measureElement) {
+        measureElement = document.createElement('span');
+        measureElement.id = 'measure';
+        measureElement.style.fontFamily = 'var(--theia-ui-font-family)';
+        measureElement.style.fontSize = 'var(--theia-ui-font-size1)';
+        measureElement.style.visibility = 'hidden';
+        document.body.appendChild(measureElement);
+    }
+    return measureElement;
+}

--- a/packages/core/src/browser/common-frontend-contribution.ts
+++ b/packages/core/src/browser/common-frontend-contribution.ts
@@ -1765,6 +1765,34 @@ export class CommonFrontendContribution implements FrontendApplicationContributi
             { id: 'welcomePage.buttonHoverBackground', defaults: { dark: Color.rgba(200, 235, 255, .072), light: Color.rgba(0, 0, 0, .10) }, description: 'Hover background color for the buttons on the Welcome page.' },
             { id: 'walkThrough.embeddedEditorBackground', defaults: { dark: Color.rgba(0, 0, 0, .4), light: '#f4f4f4' }, description: 'Background color for the embedded editors on the Interactive Playground.' },
 
+            // Dropdown colors should be aligned with https://code.visualstudio.com/api/references/theme-color#dropdown-control
+
+            {
+                id: 'dropdown.background', defaults: {
+                    light: Color.white,
+                    dark: '#3C3C3C',
+                    hc: Color.black
+                }, description: 'Dropdown background.'
+            },
+            {
+                id: 'dropdown.listBackground', defaults: {
+                    hc: Color.black
+                }, description: 'Dropdown list background.'
+            },
+            {
+                id: 'dropdown.foreground', defaults: {
+                    dark: '#F0F0F0',
+                    hc: Color.white
+                }, description: 'Dropdown foreground.'
+            },
+            {
+                id: 'dropdown.border', defaults: {
+                    light: '#CECECE',
+                    dark: 'dropdown.background',
+                    hc: '#6FC3DF'
+                }, description: 'Dropdown border.'
+            },
+
             // Settings Editor colors should be aligned with https://code.visualstudio.com/api/references/theme-color#settings-editor-colors
             {
                 id: 'settings.headerForeground', defaults: {

--- a/packages/core/src/browser/style/select-component.css
+++ b/packages/core/src/browser/style/select-component.css
@@ -1,0 +1,79 @@
+/********************************************************************************
+ * Copyright (C) 2022 TypeFox and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+.theia-select-component {
+    background-color: var(--theia-dropdown-background);
+    outline: var(--theia-dropdown-border) solid 1px;
+    outline-offset: -1px;
+    height: 26px;
+    padding: 0px 8px;
+    width: 320px;
+    display: flex;
+    align-items: center;
+}
+
+.theia-select-component .theia-select-component-label {
+    width: 100%;
+    color: var(--theia-dropdown-foreground);
+}
+
+.theia-select-component:focus {
+    outline-color: var(--theia-focusBorder);
+}
+
+.theia-select-component-dropdown {
+    font-family: var(--theia-ui-font-family);
+    font-size: var(--theia-ui-font-size1);
+    color: var(--theia-foreground);
+    background-color: var(--theia-settings-dropdownBackground);
+    outline: var(--theia-focusBorder) solid 1px;
+    outline-offset: -1px;
+}
+
+.theia-select-component-dropdown .theia-select-component-option {
+    display: flex;
+    padding: 2px 5px;
+}
+
+.theia-select-component-dropdown .theia-select-component-description {
+    padding: 6px 5px;
+    border-top: 1px solid var(--theia-editorWidget-border);
+    margin-top: 2px;
+}
+
+.theia-select-component-dropdown .theia-select-component-option .theia-select-component-option-value {
+    width: 100%;
+}
+
+.theia-select-component-dropdown .theia-select-component-option:not(.selected) .theia-select-component-option-detail {
+    color: var(--theia-textLink-foreground);
+}
+
+.theia-select-component-dropdown .theia-select-component-option.selected {
+    color: var(--theia-dropdown-foreground);
+    background: var(--theia-list-activeSelectionBackground);
+    outline: var(--theia-focusBorder) solid 1px;
+    outline-offset: -1px;
+}
+
+.theia-select-component-dropdown .theia-select-component-separator {
+    width: 100%;
+    height: 2px;
+    padding: 5px 3px;
+    background: var(--theia-dropdown-foreground);
+}
+
+/** color: var(--theia-settings-headerForeground); */

--- a/packages/core/src/browser/style/select-component.css
+++ b/packages/core/src/browser/style/select-component.css
@@ -90,7 +90,7 @@
 
 .theia-select-component-dropdown .theia-select-component-separator {
     width: 84px;
-    height: 2px;
-    margin: 5px 3px;
+    height: 1px;
+    margin: 3px 3px;
     background: var(--theia-foreground);
 }

--- a/packages/core/src/browser/style/select-component.css
+++ b/packages/core/src/browser/style/select-component.css
@@ -49,6 +49,8 @@
 }
 
 .theia-select-component-dropdown .theia-select-component-option {
+    text-overflow: ellipsis;
+    overflow: hidden;
     display: flex;
     padding: 2px 5px;
 }
@@ -69,6 +71,10 @@
 
 .theia-select-component-dropdown .theia-select-component-option .theia-select-component-option-value {
     width: 100%;
+}
+
+.theia-select-component-dropdown .theia-select-component-option .theia-select-component-option-detail {
+    padding-left: 4px;
 }
 
 .theia-select-component-dropdown .theia-select-component-option:not(.selected) .theia-select-component-option-detail {

--- a/packages/core/src/browser/style/select-component.css
+++ b/packages/core/src/browser/style/select-component.css
@@ -18,16 +18,20 @@
     background-color: var(--theia-dropdown-background);
     outline: var(--theia-dropdown-border) solid 1px;
     outline-offset: -1px;
-    height: 26px;
+    min-height: 23px;
+    min-width: 90px;
     padding: 0px 8px;
-    width: 320px;
     display: flex;
     align-items: center;
+    user-select: none;
 }
 
 .theia-select-component .theia-select-component-label {
     width: 100%;
     color: var(--theia-dropdown-foreground);
+    white-space: nowrap;
+    text-overflow: ellipsis;
+    overflow: hidden;
 }
 
 .theia-select-component:focus {
@@ -41,6 +45,7 @@
     background-color: var(--theia-settings-dropdownBackground);
     outline: var(--theia-focusBorder) solid 1px;
     outline-offset: -1px;
+    user-select: none;
 }
 
 .theia-select-component-dropdown .theia-select-component-option {
@@ -50,6 +55,14 @@
 
 .theia-select-component-dropdown .theia-select-component-description {
     padding: 6px 5px;
+}
+
+.theia-select-component-dropdown .theia-select-component-description:first-child {
+    border-bottom: 1px solid var(--theia-editorWidget-border);
+    margin-bottom: 2px;
+}
+
+.theia-select-component-dropdown .theia-select-component-description:last-child {
     border-top: 1px solid var(--theia-editorWidget-border);
     margin-top: 2px;
 }
@@ -63,17 +76,15 @@
 }
 
 .theia-select-component-dropdown .theia-select-component-option.selected {
-    color: var(--theia-dropdown-foreground);
+    color: var(--theia-list-activeSelectionForeground);
     background: var(--theia-list-activeSelectionBackground);
     outline: var(--theia-focusBorder) solid 1px;
     outline-offset: -1px;
 }
 
 .theia-select-component-dropdown .theia-select-component-separator {
-    width: 100%;
+    width: 84px;
     height: 2px;
-    padding: 5px 3px;
-    background: var(--theia-dropdown-foreground);
+    margin: 5px 3px;
+    background: var(--theia-foreground);
 }
-
-/** color: var(--theia-settings-headerForeground); */

--- a/packages/core/src/browser/widgets/select-component.tsx
+++ b/packages/core/src/browser/widgets/select-component.tsx
@@ -17,13 +17,11 @@
 import * as React from 'react';
 import * as ReactDOM from 'react-dom';
 import * as DOMPurify from 'dompurify';
-import * as markdownit from 'markdown-it';
 import { Event as TheiaEvent } from '../../common/event';
 import { codicon } from './widget';
+import { measureTextHeight, measureTextWidth } from '../browser';
 
 import '../../../src/browser/style/select-component.css';
-
-const markdownRenderer = markdownit();
 
 export interface SelectOption {
     value?: string
@@ -32,26 +30,27 @@ export interface SelectOption {
     disabled?: boolean
     detail?: string
     description?: string
-    markdownDescription?: string
-    onSelected?: () => void
+    markdown?: boolean
 }
 
 export interface SelectComponentProps {
     options: SelectOption[]
     selected: number
-    onSelected?: (index: number, option: SelectOption) => void
-    onDidChange?: TheiaEvent<number>
+    onChange?: (option: SelectOption, index: number) => void
+    onDidSelectedChange?: TheiaEvent<number>
 }
 
-export type SelectComponentDropdownDimensions = {
+export interface SelectComponentDropdownDimensions {
     top: number
     left: number
     width: number
-} | 'hidden';
+    parentHeight: number
+};
 
 export interface SelectComponentState {
-    dimensions: SelectComponentDropdownDimensions
+    dimensions?: SelectComponentDropdownDimensions
     selected: number
+    original: number
 }
 
 export const SELECT_COMPONENT_CONTAINER = 'select-component-container';
@@ -59,13 +58,16 @@ export const SELECT_COMPONENT_CONTAINER = 'select-component-container';
 export class SelectComponent extends React.Component<SelectComponentProps, SelectComponentState> {
     protected dropdownElement: HTMLElement;
     protected fieldRef = React.createRef<HTMLDivElement>();
-    protected mountedListeners: Map<keyof DocumentEventMap, EventListenerOrEventListenerObject> = new Map();
+    protected mountedListeners: Map<string, EventListenerOrEventListenerObject> = new Map();
+    protected optimalWidth = 0;
+    protected optimalHeight = 0;
 
     constructor(props: SelectComponentProps) {
         super(props);
+        const selected = Math.max(props.selected, 0);
         this.state = {
-            dimensions: 'hidden',
-            selected: props.selected
+            selected,
+            original: selected
         };
 
         let list = document.getElementById(SELECT_COMPONENT_CONTAINER);
@@ -77,11 +79,41 @@ export class SelectComponent extends React.Component<SelectComponentProps, Selec
         this.dropdownElement = list;
     }
 
-    override componentDidMount(): void {
-        const hide = () => this.hide();
-        this.mountedListeners.set('click', hide);
+    getOptimalWidth(): number {
+        const textWidth = measureTextWidth(this.props.options.map(e => e.label || e.value || '' + (e.detail || '')));
+        return Math.ceil(textWidth + 16);
+    }
+
+    getOptimalHeight(maxWidth?: number): number {
+        const firstLine = this.props.options.find(e => e.label || e.value || e.detail);
+        if (!firstLine) {
+            return 0;
+        }
+        if (maxWidth) {
+            maxWidth -= 10; // Decrease width by 10 due to side padding
+        }
+        const descriptionHeight = measureTextHeight(this.props.options.map(e => e.description || ''), maxWidth) + 18;
+        const singleLineHeight = measureTextHeight(firstLine.label || firstLine.value || firstLine.detail || '') + 6;
+        const optimal = descriptionHeight + singleLineHeight * this.props.options.length;
+        return optimal + 20; // Just to be safe, add another 20 pixels here
+    }
+
+    attachListeners(): void {
+        const hide = () => {
+            this.hide(true);
+        };
         this.mountedListeners.set('scroll', hide);
         this.mountedListeners.set('wheel', hide);
+
+        let parent = this.fieldRef.current?.parentElement;
+        while (parent) {
+            // Workaround for perfect scrollbar, since using `overflow: hidden`
+            // neither triggers the `scroll`, `wheel` nor `blur` event
+            if (parent.classList.contains('ps')) {
+                parent.addEventListener('ps-scroll-y', hide);
+            }
+            parent = parent.parentElement;
+        }
 
         for (const [key, listener] of this.mountedListeners.entries()) {
             window.addEventListener(key, listener);
@@ -89,25 +121,38 @@ export class SelectComponent extends React.Component<SelectComponentProps, Selec
     }
 
     override componentWillUnmount(): void {
-        for (const [key, listener] of this.mountedListeners.entries()) {
-            window.removeEventListener(key, listener);
+        if (this.mountedListeners.size > 0) {
+            const eventListener = this.mountedListeners.get('scroll')!;
+            let parent = this.fieldRef.current?.parentElement;
+            while (parent) {
+                parent.removeEventListener('ps-scroll-y', eventListener);
+                parent = parent.parentElement;
+            }
+            for (const [key, listener] of this.mountedListeners.entries()) {
+                window.removeEventListener(key, listener);
+            }
         }
     }
 
     override render(): React.ReactNode {
         const { options } = this.props;
-        const { selected } = this.state;
+        let { selected } = this.state;
+        while (options[selected]?.separator) {
+            selected = (selected + 1) % this.props.options.length;
+        }
         const selectedItemLabel = options[selected].label ?? options[selected].value;
         return <>
             <div
+                key="select-component"
                 ref={this.fieldRef}
                 tabIndex={0}
                 className="theia-select-component"
                 onClick={e => this.handleClickEvent(e)}
+                onBlur={() => this.hide(true)}
                 onKeyDown={e => this.handleKeypress(e)}
             >
-                <div className="theia-select-component-label">{selectedItemLabel}</div>
-                <div className={`theia-select-component-chevron ${codicon('chevron-down')}`} />
+                <div key="label" className="theia-select-component-label">{selectedItemLabel}</div>
+                <div key="icon" className={`theia-select-component-chevron ${codicon('chevron-down')}`} />
             </div>
             {ReactDOM.createPortal(this.renderDropdown(), this.dropdownElement)}
         </>;
@@ -133,14 +178,14 @@ export class SelectComponent extends React.Component<SelectComponentProps, Selec
                 selected
             });
         } else if (ev.key === 'Enter') {
-            if (this.state.dimensions === 'hidden') {
+            if (!this.state.dimensions) {
                 this.toggleVisibility();
             } else {
                 const selected = this.state.selected;
                 this.selectOption(selected, this.props.options[selected]);
             }
-        } else if (ev.key === 'Escape') {
-            this.hide();
+        } else if (ev.key === 'Escape' || ev.key === 'Tab') {
+            this.hide(true);
         }
         ev.stopPropagation();
         ev.nativeEvent.stopImmediatePropagation();
@@ -156,80 +201,101 @@ export class SelectComponent extends React.Component<SelectComponentProps, Selec
         if (!this.fieldRef.current) {
             return;
         }
-        if (this.state.dimensions === 'hidden') {
+        if (!this.state.dimensions) {
             const rect = this.fieldRef.current.getBoundingClientRect();
             this.setState({
                 dimensions: {
                     top: rect.top + rect.height,
                     left: rect.left,
-                    width: rect.width
+                    width: rect.width,
+                    parentHeight: rect.height
                 },
             });
         } else {
-            this.hide();
+            this.hide(true);
         }
     }
 
-    protected hide(): void {
-        this.setState({ dimensions: 'hidden' });
+    protected hide(reset?: boolean): void {
+        this.setState({
+            dimensions: undefined,
+            selected: reset ? this.state.original : this.state.selected,
+            original: reset ? this.state.original : this.state.selected
+        });
     }
 
     protected renderDropdown(): React.ReactNode {
-        if (this.state.dimensions === 'hidden') {
+        if (!this.state.dimensions) {
             return;
         }
+        if (this.mountedListeners.size === 0) {
+            // Only attach our listeners once we render our dropdown menu
+            this.attachListeners();
+            // We can now also calculate the optimal width
+            this.optimalWidth = this.getOptimalWidth();
+            this.optimalHeight = this.getOptimalHeight(Math.max(this.state.dimensions.width, this.optimalWidth));
+        }
+        const clientHeight = document.getElementById('theia-app-shell')!.getBoundingClientRect().height;
+        const invert = this.optimalHeight > clientHeight - this.state.dimensions.top;
         const { options } = this.props;
         const { selected } = this.state;
         const description = selected !== undefined && options[selected].description;
-        const markdownDescription = selected !== undefined && options[selected].markdownDescription;
-        return <div className="theia-select-component-dropdown" style={{
-            top: this.state.dimensions.top,
+        const markdown = selected !== undefined && options[selected].markdown;
+        const items = options.map((item, i) => this.renderOption(i, item));
+        if (description) {
+            let descriptionNode: React.ReactNode | undefined;
+            const className = 'theia-select-component-description';
+            if (markdown) {
+                descriptionNode = <div key="description" className={className}
+                    dangerouslySetInnerHTML={{ __html: DOMPurify.sanitize(description) }} />; // eslint-disable-line react/no-danger
+            } else {
+                descriptionNode = <div key="description" className={className}>
+                    {description}
+                </div>;
+            }
+            if (invert) {
+                items.unshift(descriptionNode);
+            } else {
+                items.push(descriptionNode);
+            }
+        }
+        return <div key="dropdown" className="theia-select-component-dropdown" style={{
+            top: invert ? 'none' : this.state.dimensions.top,
+            bottom: invert ? clientHeight - this.state.dimensions.top + this.state.dimensions.parentHeight : 'none',
             left: this.state.dimensions.left,
-            width: this.state.dimensions.width,
+            width: Math.max(this.state.dimensions.width, this.optimalWidth),
             position: 'absolute'
         }}>
-            {
-                options.map((item, i) => this.renderOption(i, item))
-            }
-            {markdownDescription && (
-                <div className="theia-select-component-description"
-                    dangerouslySetInnerHTML={{ __html: DOMPurify.sanitize(markdownRenderer.renderInline(markdownDescription)) }} /> // eslint-disable-line react/no-danger
-            )}
-            {description && !markdownDescription && (
-                <div className="theia-select-component-description">
-                    {description}
-                </div>
-            )}
+            {items}
         </div>;
     }
 
     protected renderOption(index: number, option: SelectOption): React.ReactNode {
         if (option.separator) {
-            return <div className="theia-select-component-separator" />;
+            return <div key={index} className="theia-select-component-separator" />;
         }
         const selected = this.state.selected;
         return (
             <div
-                key={option.value}
+                key={index}
                 className={`theia-select-component-option${index === selected ? ' selected' : ''}`}
                 onMouseOver={() => {
                     this.setState({
                         selected: index
                     });
                 }}
-                onClick={() => {
+                onMouseDown={() => {
                     this.selectOption(index, option);
                 }}
             >
-                <div className="theia-select-component-option-value">{option.label ?? option.value}</div>
-                {option.detail && <div className="theia-select-component-option-detail">{option.detail}</div>}
+                <div key="value" className="theia-select-component-option-value">{option.label ?? option.value}</div>
+                {option.detail && <div key="detail" className="theia-select-component-option-detail">{option.detail}</div>}
             </div>
         );
     }
 
     protected selectOption(index: number, option: SelectOption): void {
-        option.onSelected?.();
-        this.props.onSelected?.(index, option);
+        this.props.onChange?.(option, index);
         this.hide();
     }
 }

--- a/packages/core/src/browser/widgets/select-component.tsx
+++ b/packages/core/src/browser/widgets/select-component.tsx
@@ -1,0 +1,235 @@
+// *****************************************************************************
+// Copyright (C) 2022 TypeFox and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import * as React from 'react';
+import * as ReactDOM from 'react-dom';
+import * as DOMPurify from 'dompurify';
+import * as markdownit from 'markdown-it';
+import { Event as TheiaEvent } from '../../common/event';
+import { codicon } from './widget';
+
+import '../../../src/browser/style/select-component.css';
+
+const markdownRenderer = markdownit();
+
+export interface SelectOption {
+    value?: string
+    label?: string
+    separator?: boolean
+    disabled?: boolean
+    detail?: string
+    description?: string
+    markdownDescription?: string
+    onSelected?: () => void
+}
+
+export interface SelectComponentProps {
+    options: SelectOption[]
+    selected: number
+    onSelected?: (index: number, option: SelectOption) => void
+    onDidChange?: TheiaEvent<number>
+}
+
+export type SelectComponentDropdownDimensions = {
+    top: number
+    left: number
+    width: number
+} | 'hidden';
+
+export interface SelectComponentState {
+    dimensions: SelectComponentDropdownDimensions
+    selected: number
+}
+
+export const SELECT_COMPONENT_CONTAINER = 'select-component-container';
+
+export class SelectComponent extends React.Component<SelectComponentProps, SelectComponentState> {
+    protected dropdownElement: HTMLElement;
+    protected fieldRef = React.createRef<HTMLDivElement>();
+    protected mountedListeners: Map<keyof DocumentEventMap, EventListenerOrEventListenerObject> = new Map();
+
+    constructor(props: SelectComponentProps) {
+        super(props);
+        this.state = {
+            dimensions: 'hidden',
+            selected: props.selected
+        };
+
+        let list = document.getElementById(SELECT_COMPONENT_CONTAINER);
+        if (!list) {
+            list = document.createElement('div');
+            list.id = SELECT_COMPONENT_CONTAINER;
+            document.body.appendChild(list);
+        }
+        this.dropdownElement = list;
+    }
+
+    override componentDidMount(): void {
+        const hide = () => this.hide();
+        this.mountedListeners.set('click', hide);
+        this.mountedListeners.set('scroll', hide);
+        this.mountedListeners.set('wheel', hide);
+
+        for (const [key, listener] of this.mountedListeners.entries()) {
+            window.addEventListener(key, listener);
+        }
+    }
+
+    override componentWillUnmount(): void {
+        for (const [key, listener] of this.mountedListeners.entries()) {
+            window.removeEventListener(key, listener);
+        }
+    }
+
+    override render(): React.ReactNode {
+        const { options } = this.props;
+        const { selected } = this.state;
+        const selectedItemLabel = options[selected].label ?? options[selected].value;
+        return <>
+            <div
+                ref={this.fieldRef}
+                tabIndex={0}
+                className="theia-select-component"
+                onClick={e => this.handleClickEvent(e)}
+                onKeyDown={e => this.handleKeypress(e)}
+            >
+                <div className="theia-select-component-label">{selectedItemLabel}</div>
+                <div className={`theia-select-component-chevron ${codicon('chevron-down')}`} />
+            </div>
+            {ReactDOM.createPortal(this.renderDropdown(), this.dropdownElement)}
+        </>;
+    }
+
+    protected handleKeypress(ev: React.KeyboardEvent<HTMLDivElement>): void {
+        if (!this.fieldRef.current) {
+            return;
+        }
+        if (ev.key === 'ArrowUp') {
+            let selected = this.state.selected;
+            if (selected <= 0) {
+                selected = this.props.options.length - 1;
+            } else {
+                selected--;
+            }
+            this.setState({
+                selected
+            });
+        } else if (ev.key === 'ArrowDown') {
+            const selected = (this.state.selected + 1) % this.props.options.length;
+            this.setState({
+                selected
+            });
+        } else if (ev.key === 'Enter') {
+            if (this.state.dimensions === 'hidden') {
+                this.toggleVisibility();
+            } else {
+                const selected = this.state.selected;
+                this.selectOption(selected, this.props.options[selected]);
+            }
+        } else if (ev.key === 'Escape') {
+            this.hide();
+        }
+        ev.stopPropagation();
+        ev.nativeEvent.stopImmediatePropagation();
+    }
+
+    protected handleClickEvent(event: React.MouseEvent<HTMLElement>): void {
+        this.toggleVisibility();
+        event.stopPropagation();
+        event.nativeEvent.stopImmediatePropagation();
+    }
+
+    protected toggleVisibility(): void {
+        if (!this.fieldRef.current) {
+            return;
+        }
+        if (this.state.dimensions === 'hidden') {
+            const rect = this.fieldRef.current.getBoundingClientRect();
+            this.setState({
+                dimensions: {
+                    top: rect.top + rect.height,
+                    left: rect.left,
+                    width: rect.width
+                },
+            });
+        } else {
+            this.hide();
+        }
+    }
+
+    protected hide(): void {
+        this.setState({ dimensions: 'hidden' });
+    }
+
+    protected renderDropdown(): React.ReactNode {
+        if (this.state.dimensions === 'hidden') {
+            return;
+        }
+        const { options } = this.props;
+        const { selected } = this.state;
+        const description = selected !== undefined && options[selected].description;
+        const markdownDescription = selected !== undefined && options[selected].markdownDescription;
+        return <div className="theia-select-component-dropdown" style={{
+            top: this.state.dimensions.top,
+            left: this.state.dimensions.left,
+            width: this.state.dimensions.width,
+            position: 'absolute'
+        }}>
+            {
+                options.map((item, i) => this.renderOption(i, item))
+            }
+            {markdownDescription && (
+                <div className="theia-select-component-description"
+                    dangerouslySetInnerHTML={{ __html: DOMPurify.sanitize(markdownRenderer.renderInline(markdownDescription)) }} /> // eslint-disable-line react/no-danger
+            )}
+            {description && !markdownDescription && (
+                <div className="theia-select-component-description">
+                    {description}
+                </div>
+            )}
+        </div>;
+    }
+
+    protected renderOption(index: number, option: SelectOption): React.ReactNode {
+        if (option.separator) {
+            return <div className="theia-select-component-separator" />;
+        }
+        const selected = this.state.selected;
+        return (
+            <div
+                key={option.value}
+                className={`theia-select-component-option${index === selected ? ' selected' : ''}`}
+                onMouseOver={() => {
+                    this.setState({
+                        selected: index
+                    });
+                }}
+                onClick={() => {
+                    this.selectOption(index, option);
+                }}
+            >
+                <div className="theia-select-component-option-value">{option.label ?? option.value}</div>
+                {option.detail && <div className="theia-select-component-option-detail">{option.detail}</div>}
+            </div>
+        );
+    }
+
+    protected selectOption(index: number, option: SelectOption): void {
+        option.onSelected?.();
+        this.props.onSelected?.(index, option);
+        this.hide();
+    }
+}

--- a/packages/debug/src/browser/console/debug-console-contribution.tsx
+++ b/packages/debug/src/browser/console/debug-console-contribution.tsx
@@ -24,6 +24,7 @@ import { Command, CommandRegistry } from '@theia/core/lib/common/command';
 import { Severity } from '@theia/core/lib/common/severity';
 import { inject, injectable, interfaces, postConstruct } from '@theia/core/shared/inversify';
 import * as React from '@theia/core/shared/react';
+import { SelectComponent, SelectOption } from '@theia/core/lib/browser/widgets/select-component';
 import { DebugSession } from '../debug-session';
 import { DebugSessionManager, DidChangeActiveDebugSession } from '../debug-session-manager';
 import { DebugConsoleSession, DebugConsoleSessionFactory } from './debug-console-session';
@@ -181,47 +182,43 @@ export class DebugConsoleContribution extends AbstractViewContribution<ConsoleWi
     }
 
     protected renderSeveritySelector(widget: Widget | undefined): React.ReactNode {
-        const severityElements: React.ReactNode[] = [];
-        Severity.toArray().forEach(s => severityElements.push(<option value={s} key={s}>{s}</option>));
-        const selectedValue = Severity.toString(this.consoleSessionManager.severity || Severity.Ignore);
+        const severityElements: SelectOption[] = Severity.toArray().map(e => ({
+            value: e
+        }));
 
-        return <select
-            className='theia-select'
-            id={'debugConsoleSeverity'}
-            key={'debugConsoleSeverity'}
-            value={selectedValue}
-            onChange={this.changeSeverity}
-        >
-            {severityElements}
-        </select>;
+        return <SelectComponent
+            key="debugConsoleSeverity"
+            options={severityElements}
+            selected={this.consoleSessionManager.severity || Severity.Ignore}
+            onChange={this.changeSeverity} />;
     }
 
     protected renderDebugConsoleSelector(widget: Widget | undefined): React.ReactNode {
-        const availableConsoles: React.ReactNode[] = [];
+        const availableConsoles: SelectOption[] = [];
         this.consoleSessionManager.all.forEach(e => {
             if (e instanceof DebugConsoleSession) {
-                availableConsoles.push(<option value={e.id} key={e.id}>{e.debugSession.label}</option>);
+                availableConsoles.push({
+                    value: e.id,
+                    label: e.debugSession.label
+                });
             }
         });
-        return <select
-            className='theia-select'
-            id='debugConsoleSelector'
-            key='debugConsoleSelector'
-            value={undefined}
-            onChange={this.changeDebugConsole}
-        >
-            {availableConsoles}
-        </select>;
+
+        return <SelectComponent
+            key="debugConsoleSelector"
+            options={availableConsoles}
+            selected={0}
+            onChange={this.changeDebugConsole} />;
     }
 
-    protected changeDebugConsole = (event: React.ChangeEvent<HTMLSelectElement>) => {
-        const id = event.target.value;
+    protected changeDebugConsole = (option: SelectOption) => {
+        const id = option.value!;
         const session = this.consoleSessionManager.get(id);
         this.consoleSessionManager.selectedSession = session;
     };
 
-    protected changeSeverity = (event: React.ChangeEvent<HTMLSelectElement>) => {
-        this.consoleSessionManager.severity = Severity.fromValue(event.target.value);
+    protected changeSeverity = (option: SelectOption) => {
+        this.consoleSessionManager.severity = Severity.fromValue(option.value);
     };
 
     protected withWidget<T>(widget: Widget | undefined = this.tryGetWidget(), fn: (widget: ConsoleWidget) => T): T | false {

--- a/packages/debug/src/browser/console/debug-console-contribution.tsx
+++ b/packages/debug/src/browser/console/debug-console-contribution.tsx
@@ -189,7 +189,7 @@ export class DebugConsoleContribution extends AbstractViewContribution<ConsoleWi
         return <SelectComponent
             key="debugConsoleSeverity"
             options={severityElements}
-            selected={this.consoleSessionManager.severity || Severity.Ignore}
+            value={this.consoleSessionManager.severity || Severity.Ignore}
             onChange={this.changeSeverity} />;
     }
 
@@ -207,7 +207,7 @@ export class DebugConsoleContribution extends AbstractViewContribution<ConsoleWi
         return <SelectComponent
             key="debugConsoleSelector"
             options={availableConsoles}
-            selected={0}
+            value={0}
             onChange={this.changeDebugConsole} />;
     }
 

--- a/packages/debug/src/browser/editor/debug-breakpoint-widget.tsx
+++ b/packages/debug/src/browser/editor/debug-breakpoint-widget.tsx
@@ -18,7 +18,7 @@ import * as React from '@theia/core/shared/react';
 import * as ReactDOM from '@theia/core/shared/react-dom';
 import { DebugProtocol } from 'vscode-debugprotocol';
 import { injectable, postConstruct, inject } from '@theia/core/shared/inversify';
-import { Disposable, DisposableCollection } from '@theia/core';
+import { Disposable, DisposableCollection, nls } from '@theia/core';
 import URI from '@theia/core/lib/common/uri';
 import { MonacoEditorProvider } from '@theia/monaco/lib/browser/monaco-editor-provider';
 import { MonacoEditorZoneWidget } from '@theia/monaco/lib/browser/monaco-editor-zone-widget';
@@ -35,6 +35,7 @@ import { CompletionItemKind, CompletionContext } from '@theia/monaco-editor-core
 import { ILanguageFeaturesService } from '@theia/monaco-editor-core/esm/vs/editor/common/services/languageFeatures';
 import { StandaloneServices } from '@theia/monaco-editor-core/esm/vs/editor/standalone/browser/standaloneServices';
 import { TextModel } from '@theia/monaco-editor-core/esm/vs/editor/common/model/textModel';
+import { SelectComponent, SelectOption } from '@theia/core/lib/browser/widgets/select-component';
 
 export type ShowDebugBreakpointOptions = DebugSourceBreakpoint | {
     position: monaco.Position,
@@ -212,23 +213,21 @@ export class DebugBreakpointWidget implements Disposable {
         if (this._input) {
             this._input.getControl().setValue(this._values[this.context] || '');
         }
-        ReactDOM.render(<select
-            className='theia-select'
-            value={this.context} onChange={this.updateInput}>
-            {this.renderOption('condition', 'Expression')}
-            {this.renderOption('hitCondition', 'Hit Count')}
-            {this.renderOption('logMessage', 'Log Message')}
-        </select>, this.selectNode);
+        ReactDOM.render(<SelectComponent
+            value={this.context} onChange={this.updateInput}
+            options={[
+                { value: 'condition', label: nls.localizeByDefault('Expression') },
+                { value: 'hitCondition', label: nls.localizeByDefault('Hit Count') },
+                { value: 'logMessage', label: nls.localizeByDefault('Log Message') },
+            ]}
+        />, this.selectNode);
     }
 
-    protected renderOption(context: DebugBreakpointWidget.Context, label: string): JSX.Element {
-        return <option value={context}>{label}</option>;
-    }
-    protected readonly updateInput = (e: React.ChangeEvent<HTMLSelectElement>) => {
+    protected readonly updateInput = (option: SelectOption) => {
         if (this._input) {
             this._values[this.context] = this._input.getControl().getValue();
         }
-        this.context = e.currentTarget.value as DebugBreakpointWidget.Context;
+        this.context = option.value as DebugBreakpointWidget.Context;
         this.render();
         if (this._input) {
             this._input.focus();
@@ -259,12 +258,12 @@ export class DebugBreakpointWidget implements Disposable {
     }
     protected get placeholder(): string {
         if (this.context === 'logMessage') {
-            return "Message to log when breakpoint is hit. Expressions within {} are interpolated. 'Enter' to accept, 'esc' to cancel.";
+            return nls.localizeByDefault("Message to log when breakpoint is hit. Expressions within {} are interpolated. 'Enter' to accept, 'esc' to cancel.");
         }
         if (this.context === 'hitCondition') {
-            return "Break when hit count condition is met. 'Enter' to accept, 'esc' to cancel.";
+            return nls.localizeByDefault("Break when hit count condition is met. 'Enter' to accept, 'esc' to cancel.");
         }
-        return "Break when expression evaluates to true. 'Enter' to accept, 'esc' to cancel.";
+        return nls.localizeByDefault("Break when expression evaluates to true. 'Enter' to accept, 'esc' to cancel.");
     }
 
 }

--- a/packages/debug/src/browser/style/index.css
+++ b/packages/debug/src/browser/style/index.css
@@ -125,9 +125,10 @@
     border-bottom: 1px solid var(--theia-sideBarSectionHeader-border);
 }
 
-.debug-toolbar .debug-configuration {
+.debug-toolbar .theia-select-component {
     width: 100%;
     min-width: 40px;
+    margin: 0px 4px;
 }
 
 .debug-toolbar .debug-action {

--- a/packages/debug/src/browser/view/debug-configuration-widget.tsx
+++ b/packages/debug/src/browser/view/debug-configuration-widget.tsx
@@ -17,6 +17,7 @@
 import * as React from '@theia/core/shared/react';
 import { injectable, inject, postConstruct } from '@theia/core/shared/inversify';
 import { CommandRegistry, Disposable } from '@theia/core/lib/common';
+import { SelectComponent, SelectOption } from '@theia/core/lib/browser/widgets/select-component';
 import URI from '@theia/core/lib/common/uri';
 import { ReactWidget } from '@theia/core/lib/browser';
 import { WorkspaceService } from '@theia/workspace/lib/browser';
@@ -78,13 +79,10 @@ export class DebugConfigurationWidget extends ReactWidget {
 
     render(): React.ReactNode {
         const { options } = this;
+        const currentIndex = options.findIndex(e => e.value === this.currentValue);
         return <React.Fragment>
             <DebugAction run={this.start} label={nls.localizeByDefault('Start Debugging')} iconClass='debug-start' ref={this.setStepRef} />
-            <select className='theia-select debug-configuration' value={this.currentValue} onChange={this.setCurrentConfiguration}>
-                {options.length ? options : <option value='__NO_CONF__'>{nls.localizeByDefault('No Configurations')}</option>}
-                <option disabled>{'Add Configuration...'.replace(/./g, '-')}</option>
-                <option value='__ADD_CONF__'>{nls.localizeByDefault('Add Configuration...')}</option>
-            </select>
+            <SelectComponent options={options} selected={currentIndex} onChange={option => this.setCurrentConfiguration(option)} />
             <DebugAction run={this.openConfiguration} label={nls.localizeByDefault('Open {0}', '"launch.json"')}
                 iconClass='settings-gear' />
             <DebugAction run={this.openConsole} label={nls.localizeByDefault('Debug Console')} iconClass='terminal' />
@@ -94,10 +92,25 @@ export class DebugConfigurationWidget extends ReactWidget {
         const { current } = this.manager;
         return current ? this.toValue(current) : '__NO_CONF__';
     }
-    protected get options(): React.ReactNode[] {
-        return Array.from(this.manager.all).map((options, index) =>
-            <option key={index} value={this.toValue(options)}>{this.toName(options)}</option>
-        );
+    protected get options(): SelectOption[] {
+        const items: SelectOption[] = Array.from(this.manager.all).map(option => ({
+            value: this.toValue(option),
+            label: this.toName(option)
+        }));
+        if (items.length === 0) {
+            items.push({
+                value: '__NO_CONF__',
+                label: nls.localizeByDefault('No Configurations')
+            });
+        }
+        items.push({
+            separator: true
+        });
+        items.push({
+            value: '__ADD_CONF__',
+            label: nls.localizeByDefault('Add Configuration...')
+        });
+        return items;
     }
     protected toValue({ configuration, workspaceFolderUri }: DebugSessionOptions): string {
         if (!workspaceFolderUri) {
@@ -112,8 +125,8 @@ export class DebugConfigurationWidget extends ReactWidget {
         return configuration.name + ' (' + new URI(workspaceFolderUri).path.base + ')';
     }
 
-    protected readonly setCurrentConfiguration = (event: React.ChangeEvent<HTMLSelectElement>) => {
-        const value = event.currentTarget.value;
+    protected readonly setCurrentConfiguration = (option: SelectOption) => {
+        const value = option.value!;
         if (value === '__ADD_CONF__') {
             this.manager.addConfiguration();
         } else {

--- a/packages/debug/src/browser/view/debug-configuration-widget.tsx
+++ b/packages/debug/src/browser/view/debug-configuration-widget.tsx
@@ -79,10 +79,9 @@ export class DebugConfigurationWidget extends ReactWidget {
 
     render(): React.ReactNode {
         const { options } = this;
-        const currentIndex = options.findIndex(e => e.value === this.currentValue);
         return <React.Fragment>
             <DebugAction run={this.start} label={nls.localizeByDefault('Start Debugging')} iconClass='debug-start' ref={this.setStepRef} />
-            <SelectComponent options={options} selected={currentIndex} onChange={option => this.setCurrentConfiguration(option)} />
+            <SelectComponent options={options} value={this.currentValue} onChange={option => this.setCurrentConfiguration(option)} />
             <DebugAction run={this.openConfiguration} label={nls.localizeByDefault('Open {0}', '"launch.json"')}
                 iconClass='settings-gear' />
             <DebugAction run={this.openConsole} label={nls.localizeByDefault('Debug Console')} iconClass='terminal' />

--- a/packages/output/src/browser/output-toolbar-contribution.tsx
+++ b/packages/output/src/browser/output-toolbar-contribution.tsx
@@ -18,6 +18,7 @@ import * as React from '@theia/core/shared/react';
 import { inject, injectable, postConstruct } from '@theia/core/shared/inversify';
 import { Emitter } from '@theia/core/lib/common/event';
 import { TabBarToolbarContribution, TabBarToolbarRegistry } from '@theia/core/lib/browser/shell/tab-bar-toolbar';
+import { SelectComponent, SelectOption } from '@theia/core/lib/browser/widgets/select-component';
 import { OutputWidget } from './output-widget';
 import { OutputCommands } from './output-commands';
 import { OutputContribution } from './output-contribution';
@@ -84,27 +85,29 @@ export class OutputToolbarContribution implements TabBarToolbarContribution {
     protected readonly NONE = '<no channels>';
 
     protected renderChannelSelector(): React.ReactNode {
-        const channelOptionElements: React.ReactNode[] = [];
-        this.outputChannelManager.getVisibleChannels().forEach(channel => {
-            channelOptionElements.push(<option value={channel.name} key={channel.name}>{channel.name}</option>);
+        const channelOptionElements: SelectOption[] = [];
+        let selected = 0;
+        this.outputChannelManager.getVisibleChannels().forEach((channel, i) => {
+            channelOptionElements.push({
+                value: channel.name
+            });
+            if (channel === this.outputChannelManager.selectedChannel) {
+                selected = i;
+            }
         });
         if (channelOptionElements.length === 0) {
-            channelOptionElements.push(<option key={this.NONE} value={this.NONE}>{this.NONE}</option>);
+            channelOptionElements.push({
+                value: this.NONE
+            });
         }
-        return <select
-            className='theia-select'
-            id='outputChannelList'
-            key='outputChannelList'
-            value={this.outputChannelManager.selectedChannel ? this.outputChannelManager.selectedChannel.name : this.NONE}
-            onChange={this.changeChannel}
-        >
-            {channelOptionElements}
-        </select>;
+        return <div id='outputChannelList'>
+            <SelectComponent options={channelOptionElements} selected={selected} onChange={option => this.changeChannel(option)} />
+        </div>;
     }
 
-    protected changeChannel = (event: React.ChangeEvent<HTMLSelectElement>) => {
-        const channelName = event.target.value;
-        if (channelName !== this.NONE) {
+    protected changeChannel = (option: SelectOption) => {
+        const channelName = option.value;
+        if (channelName !== this.NONE && channelName) {
             this.outputChannelManager.getChannel(channelName).show();
         }
     };

--- a/packages/output/src/browser/output-toolbar-contribution.tsx
+++ b/packages/output/src/browser/output-toolbar-contribution.tsx
@@ -86,14 +86,10 @@ export class OutputToolbarContribution implements TabBarToolbarContribution {
 
     protected renderChannelSelector(): React.ReactNode {
         const channelOptionElements: SelectOption[] = [];
-        let selected = 0;
         this.outputChannelManager.getVisibleChannels().forEach((channel, i) => {
             channelOptionElements.push({
                 value: channel.name
             });
-            if (channel === this.outputChannelManager.selectedChannel) {
-                selected = i;
-            }
         });
         if (channelOptionElements.length === 0) {
             channelOptionElements.push({
@@ -101,7 +97,7 @@ export class OutputToolbarContribution implements TabBarToolbarContribution {
             });
         }
         return <div id='outputChannelList'>
-            <SelectComponent options={channelOptionElements} selected={selected} onChange={option => this.changeChannel(option)} />
+            <SelectComponent options={channelOptionElements} value={this.outputChannelManager.selectedChannel?.name} onChange={option => this.changeChannel(option)} />
         </div>;
     }
 

--- a/packages/output/src/browser/style/output.css
+++ b/packages/output/src/browser/style/output.css
@@ -25,3 +25,7 @@
 .theia-output .theia-output-warning {
     color: var(--theia-editorWarning-foreground);
 }
+
+#outputChannelList .theia-select-component {
+    width: 170px;
+}

--- a/packages/preferences/src/browser/style/index.css
+++ b/packages/preferences/src/browser/style/index.css
@@ -434,3 +434,11 @@
 .theia-settings-container .preference-modified-scope-wrapper:not(:last-child)::after {
     content: ', ';
 }
+
+/** Select component */
+
+.theia-settings-container .theia-select-component {
+    height: 26px;
+    width: 100%;
+    max-width: 320px;
+}

--- a/packages/preferences/src/browser/views/components/preference-select-input.ts
+++ b/packages/preferences/src/browser/views/components/preference-select-input.ts
@@ -17,29 +17,56 @@
 import { PreferenceLeafNodeRenderer, PreferenceNodeRenderer } from './preference-node-renderer';
 import { injectable, interfaces } from '@theia/core/shared/inversify';
 import { JSONValue } from '@theia/core/shared/@phosphor/coreutils';
+import { Event, Emitter } from '@theia/core/lib/common/event';
+import { SelectComponent, SelectOption } from '@theia/core/lib/browser/widgets/select-component';
 import { Preference } from '../../util/preference-types';
 import { PreferenceLeafNodeRendererContribution } from './preference-node-renderer-creator';
+import * as React from '@theia/core/shared/react';
+import * as ReactDOM from '@theia/core/shared/react-dom';
 
 @injectable()
-export class PreferenceSelectInputRenderer extends PreferenceLeafNodeRenderer<JSONValue, HTMLSelectElement> {
+export class PreferenceSelectInputRenderer extends PreferenceLeafNodeRenderer<JSONValue, HTMLDivElement> {
+
+    protected readonly onDidChangeEmitter = new Emitter<number>();
+
+    protected get onDidChange(): Event<number> {
+        return this.onDidChangeEmitter.event;
+    }
 
     protected get enumValues(): JSONValue[] {
         return this.preferenceNode.preference.data.enum!;
     }
 
-    protected createInteractable(parent: HTMLElement): void {
-        const { enumValues } = this;
-        const interactable = document.createElement('select');
-        this.interactable = interactable;
-        interactable.classList.add('theia-select');
-        interactable.onchange = this.handleUserInteraction.bind(this);
-        for (const [index, value] of enumValues.entries()) {
-            const option = document.createElement('option');
-            option.value = index.toString();
-            option.textContent = `${value}`;
-            interactable.appendChild(option);
+    protected get selectComponentOptions(): SelectOption[] {
+        const items: SelectOption[] = [];
+        const values = this.enumValues;
+        const defaultValue = this.preferenceNode.preference.data.default;
+        for (let i = 0; i < values.length; i++) {
+            const index = i;
+            const value = `${values[i]}`;
+            const detail = defaultValue === value ? 'default' : undefined;
+            const enumDescription = this.preferenceNode.preference.data.enumDescriptions?.[i];
+            const markdownEnumDescription = this.preferenceNode.preference.data.markdownEnumDescriptions?.[i];
+            items.push({
+                value,
+                detail,
+                description: enumDescription,
+                markdownDescription: markdownEnumDescription,
+                onSelected: () => this.handleUserInteraction(index)
+            });
         }
-        interactable.value = this.getDataValue();
+        return items;
+    }
+
+    protected createInteractable(parent: HTMLElement): void {
+        const interactable = document.createElement('div');
+        const selectComponent = React.createElement(SelectComponent, {
+            options: this.selectComponentOptions,
+            selected: this.getDataValue(),
+            onDidChange: this.onDidChange
+        });
+        this.interactable = interactable;
+        ReactDOM.render(selectComponent, interactable);
         parent.appendChild(interactable);
     }
 
@@ -48,26 +75,25 @@ export class PreferenceSelectInputRenderer extends PreferenceLeafNodeRenderer<JS
     }
 
     protected doHandleValueChange(): void {
-        const currentValue = this.interactable.value || undefined;
         this.updateInspection();
         const newValue = this.getDataValue();
         this.updateModificationStatus(this.getValue());
-        if (newValue !== currentValue && document.activeElement !== this.interactable) {
-            this.interactable.value = newValue;
+        if (document.activeElement !== this.interactable) {
+            this.onDidChangeEmitter.fire(newValue);
         }
     }
 
     /**
      * Returns the stringified index corresponding to the currently selected value.
      */
-    protected getDataValue(): string {
+    protected getDataValue(): number {
         const currentValue = this.getValue();
         const selected = this.enumValues.findIndex(value => value === currentValue);
-        return selected > -1 ? selected.toString() : '0';
+        return selected > -1 ? selected : 0;
     }
 
-    protected handleUserInteraction(): void {
-        const value = this.enumValues[Number(this.interactable.value)];
+    protected handleUserInteraction(selected: number): void {
+        const value = this.enumValues[selected];
         this.setPreferenceImmediately(value);
     }
 }

--- a/packages/preferences/src/browser/views/components/preference-select-input.ts
+++ b/packages/preferences/src/browser/views/components/preference-select-input.ts
@@ -29,7 +29,7 @@ export class PreferenceSelectInputRenderer extends PreferenceLeafNodeRenderer<JS
 
     protected readonly onDidChangeEmitter = new Emitter<number>();
 
-    protected get onDidChange(): Event<number> {
+    protected get onDidSelectedChange(): Event<number> {
         return this.onDidChangeEmitter.event;
     }
 
@@ -42,17 +42,20 @@ export class PreferenceSelectInputRenderer extends PreferenceLeafNodeRenderer<JS
         const values = this.enumValues;
         const defaultValue = this.preferenceNode.preference.data.default;
         for (let i = 0; i < values.length; i++) {
-            const index = i;
             const value = `${values[i]}`;
             const detail = defaultValue === value ? 'default' : undefined;
-            const enumDescription = this.preferenceNode.preference.data.enumDescriptions?.[i];
+            let enumDescription = this.preferenceNode.preference.data.enumDescriptions?.[i];
+            let markdown = false;
             const markdownEnumDescription = this.preferenceNode.preference.data.markdownEnumDescriptions?.[i];
+            if (markdownEnumDescription) {
+                enumDescription = this.markdownRenderer.renderInline(markdownEnumDescription);
+                markdown = true;
+            }
             items.push({
                 value,
                 detail,
                 description: enumDescription,
-                markdownDescription: markdownEnumDescription,
-                onSelected: () => this.handleUserInteraction(index)
+                markdown
             });
         }
         return items;
@@ -63,7 +66,8 @@ export class PreferenceSelectInputRenderer extends PreferenceLeafNodeRenderer<JS
         const selectComponent = React.createElement(SelectComponent, {
             options: this.selectComponentOptions,
             selected: this.getDataValue(),
-            onDidChange: this.onDidChange
+            onDidSelectedChange: this.onDidSelectedChange,
+            onChange: (_, index) => this.handleUserInteraction(index)
         });
         this.interactable = interactable;
         ReactDOM.render(selectComponent, interactable);


### PR DESCRIPTION
#### What it does

Closes https://github.com/eclipse-theia/theia/issues/8153

Introduces a custom react component for rendering `select` elements. It mirrors mostly how a native html `select` element works and allows for some additional features like element descriptions, details, separators, etc.

Mostly get's used for preference enum rendering, but I've also replaced some other `select` elements throughout the app.

#### How to test

In general, test that the component works just like the VSCode select element for enum preferences, launch debug config selection, etc.

1. Open the preference widget and play around with the different enum preferences. Also try to open preferences which are near the bottom of the app and observe that the dropdown gets inverted.
2. The component should react as expected when clicking on other elements or scrolling
3. The debug toolbar also uses the component. Confirm that every option is always rendered on a single line, expanding the dropdown width as necessary.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
