### PR TITLE
For calls to vscode.tasks.executeTask that use shell tasks, treat command as we treat the arguments in terms of the use of ShellQuotedString.

### DIFF
--- a/packages/plugin-ext/src/plugin/type-converters.spec.ts
+++ b/packages/plugin-ext/src/plugin/type-converters.spec.ts
@@ -235,6 +235,19 @@ describe('Type converters:', () => {
             }
         };
 
+        const shellPluginTaskWithQuotedCommand: theia.Task = {
+            ...shellPluginTask, execution: {
+                command: {
+                    quoting: types.ShellQuoting.Strong,
+                    value: 'yarn'
+                },
+                args,
+                options: {
+                    cwd
+                }
+            }
+        };
+
         const pluginTaskWithCommandLine: theia.Task = {
             name: label,
             source,
@@ -278,9 +291,17 @@ describe('Type converters:', () => {
             }
         };
 
-        it('should convert to task dto', () => {
+        it('shell task with string command should convert to task dto', () => {
             // when
             const result: TaskDto | undefined = Converter.fromTask(shellPluginTask);
+
+            // then
+            assert.notStrictEqual(result, undefined);
+            assert.deepStrictEqual(result, shellTaskDto);
+        });
+
+        it('shell task with ShellStringQuoted command should convert to task dto', () => {
+            const result: TaskDto | undefined = Converter.fromTask(shellPluginTaskWithQuotedCommand);
 
             // then
             assert.notStrictEqual(result, undefined);

--- a/packages/plugin-ext/src/plugin/type-converters.spec.ts
+++ b/packages/plugin-ext/src/plugin/type-converters.spec.ts
@@ -291,7 +291,7 @@ describe('Type converters:', () => {
             }
         };
 
-        it('shell task with string command should convert to task dto', () => {
+        it('should convert to task dto with string command', () => {
             // when
             const result: TaskDto | undefined = Converter.fromTask(shellPluginTask);
 
@@ -300,7 +300,7 @@ describe('Type converters:', () => {
             assert.deepStrictEqual(result, shellTaskDto);
         });
 
-        it('shell task with ShellStringQuoted command should convert to task dto', () => {
+        it('should convert to task dto with ShellStringQuoted', () => {
             const result: TaskDto | undefined = Converter.fromTask(shellPluginTaskWithQuotedCommand);
 
             // then

--- a/packages/plugin-ext/src/plugin/type-converters.spec.ts
+++ b/packages/plugin-ext/src/plugin/type-converters.spec.ts
@@ -302,8 +302,6 @@ describe('Type converters:', () => {
 
         it('should convert to task dto with ShellStringQuoted', () => {
             const result: TaskDto | undefined = Converter.fromTask(shellPluginTaskWithQuotedCommand);
-
-            // then
             assert.notStrictEqual(result, undefined);
             assert.deepStrictEqual(result, shellTaskDto);
         });

--- a/packages/plugin-ext/src/plugin/type-converters.ts
+++ b/packages/plugin-ext/src/plugin/type-converters.ts
@@ -885,13 +885,12 @@ export function fromShellExecution(execution: theia.ShellExecution, taskDto: Tas
         return taskDto;
     }
 
-    const command = execution.command;
-    if (typeof command === 'string') {
-        taskDto.command = command;
+    if (execution.command) {
+        taskDto.command = getCommand(execution.command);
         taskDto.args = getShellArgs(execution.args);
         return taskDto;
     } else {
-        throw new Error('Converting ShellQuotedString command is not implemented');
+        throw new Error('Command is undefined');
     }
 }
 
@@ -947,6 +946,15 @@ export function getShellArgs(args: undefined | (string | theia.ShellQuotedString
     });
 
     return result;
+}
+
+function getCommand(command: string | theia.ShellQuotedString): string {
+    if (typeof command === 'string') {
+        return command;
+    }
+    const shellQuotedCommand = command as theia.ShellQuotedString;
+
+    return shellQuotedCommand.value;
 }
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/packages/plugin-ext/src/plugin/type-converters.ts
+++ b/packages/plugin-ext/src/plugin/type-converters.ts
@@ -949,12 +949,7 @@ export function getShellArgs(args: undefined | (string | theia.ShellQuotedString
 }
 
 function getCommand(command: string | theia.ShellQuotedString): string {
-    if (typeof command === 'string') {
-        return command;
-    }
-    const shellQuotedCommand = command as theia.ShellQuotedString;
-
-    return shellQuotedCommand.value;
+    return typeof command === 'string' ? command : command.value;
 }
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/packages/task/src/node/process/process-task-runner.ts
+++ b/packages/task/src/node/process/process-task-runner.ts
@@ -203,29 +203,23 @@ export class ProcessTaskRunner implements TaskRunner {
         return { command, args, commandLine, options };
     }
 
-    protected quoteShellCommandOrArg(commandOrArg: string | ShellQuotedString, quotingFunctions?: ShellQuotingFunctions): string | ShellQuotedString {
-        // We want to quote arguments only if needed.
-        if (quotingFunctions && typeof commandOrArg === 'string' && this.argumentNeedsQuotes(commandOrArg, quotingFunctions)) {
-            return {
-                quoting: ShellQuoting.Strong,
-                value: commandOrArg,
-            };
-        } else {
-            return commandOrArg;
-        }
-    }
     protected buildShellCommand(systemSpecificCommand: OsSpecificCommand, quotingFunctions?: ShellQuotingFunctions): string {
         if (Array.isArray(systemSpecificCommand.args)) {
-            const commandLineElements: Array<string | ShellQuotedString> =
-                [systemSpecificCommand.command, ...systemSpecificCommand.args].map(arg => this.quoteShellCommandOrArg(arg));
+            const commandLineElements: Array<string | ShellQuotedString> = [systemSpecificCommand.command, ...systemSpecificCommand.args].map(arg => {
+                // We want to quote arguments only if needed.
+                if (quotingFunctions && typeof arg === 'string' && this.argumentNeedsQuotes(arg, quotingFunctions)) {
+                    return {
+                        quoting: ShellQuoting.Strong,
+                        value: arg,
+                    };
+                } else {
+                    return arg;
+                }
+            });
             return createShellCommandLine(commandLineElements, quotingFunctions);
         } else {
             // No arguments are provided, so `command` is actually the full command line to execute.
-            if (systemSpecificCommand.command) {
-                return createShellCommandLine([this.quoteShellCommandOrArg(systemSpecificCommand.command, quotingFunctions)], quotingFunctions);
-            } else {
-                return '';
-            }
+            return systemSpecificCommand.command ?? '';
         }
     }
 


### PR DESCRIPTION
#### What it does
This pull request fixes #10805 

It basically removes the [limitation](https://github.com/eclipse-theia/theia/blob/master/packages/plugin-ext/src/plugin/type-converters.ts#L889) of a command having to be a string.
It does this by treating the command the same way as the arguments are currently treated: for `ShellQuotedString`s keep the value of the command, and then later on in the backend, quote strongly.

The reason for this fix is to allow the [ms-vscode.makefile-tools](https://marketplace.visualstudio.com/items?itemName=ms-vscode.makefile-tools) extension to work with Theia. This extension runs make and uses a `ShellQuotedString` as a command.

#### How to test
Try to use the ms-vscode.makefile-tools extension, it will not work. Apply the patch, it will start working.

Before the patch, any call to `vscode.tasks.executeTask` where a command is passed as a `ShellQuotedString` would fail. For example:

```ts
let myTaskOptions: vscode.ShellExecutionOptions = {env: process.env as { [key: string]: string }, cwd: "/home/jose/tmp/foo"};
const quotingStlye: vscode.ShellQuoting = vscode.ShellQuoting.Strong;
let myTaskCommand: vscode.ShellQuotedString = {value: "make with spaces", quoting: quotingStlye};
let shellExec: vscode.ShellExecution = new vscode.ShellExecution("make with spaces", myTaskOptions);
let myTask: vscode.Task = new vscode.Task({type: "shell", group: "build", label: "my label"},
vscode.TaskScope.Workspace, "makefileBuildTaskName", "makefile", shellExec);

myTask.problemMatchers = [];
myTask.presentationOptions.showReuseMessage = true;

await vscode.tasks.executeTask(myTask);
```

would fail with:

```
throw new Error('Converting ShellQuotedString command is not implemented');
```
#### Review checklist

- [X] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/eclipse-theia/theia/blob/master/doc/pull-requests.md#requesting-a-review)
Commands with spaces, for example, now can be passed to `executeTask` and they will work OK in windows or *nix.


