### PR TITLE
Honor debug stop from configuration providers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,32 @@
 - [plugin] added support for `AccessibilityInformation` [#10961](https://github.com/eclipse-theia/theia/pull/10961) - Contributed on behalf of STMicroelectronics
 
 <a name="breaking_changes_1.25.0">[Breaking Changes:](#breaking_changes_1.25.0)</a>
+- [debug] 
+The following methods may now return `undefined | null` ([#10999](https://github.com/eclipse-theia/theia/pull/10999)):
+  - DebugSessionManager
+    - resolveConfiguration
+    - resolveDebugConfiguration
+    - resolveDebugConfigurationWithSubstitutedVariables
+  - DebugService
+    - resolveDebugConfiguration
+    - resolveDebugConfigurationWithSubstitutedVariables
+  - theia.d.ts ProviderResult
+      it's now aligned to vscode and can return `null`
+  - plugin-api-rpc.ts DebugConfigurationProvider
+    - resolveDebugConfiguration
+    - resolveDebugConfigurationWithSubstitutedVariables
+  - DebugExt
+    - $resolveDebugConfigurationByHandle
+    - $resolveDebugConfigurationWithSubstitutedVariablesByHandle
+  - DebugExtImpl
+    - $resolveDebugConfigurationByHandle
+    - $resolveDebugConfigurationWithSubstitutedVariablesByHandle
+  - PluginDebugConfigurationProvider
+    - resolveDebugConfiguration
+    - resolveDebugConfigurationWithSubstitutedVariables
+  - PluginDebugService
+    - resolveDebugConfiguration
+    - resolveDebugConfigurationWithSubstitutedVariables
 
 ## v1.24.0 - 3/31/2022
 

--- a/packages/debug/src/common/debug-service.ts
+++ b/packages/debug/src/common/debug-service.ts
@@ -79,17 +79,23 @@ export interface DebugService extends Disposable {
      * Resolves a [debug configuration](#DebugConfiguration) by filling in missing values
      * or by adding/changing/removing attributes before variable substitution.
      * @param debugConfiguration The [debug configuration](#DebugConfiguration) to resolve.
-     * @returns The resolved debug configuration.
+     * @returns The resolved debug configuration, undefined or null.
      */
-    resolveDebugConfiguration(config: DebugConfiguration, workspaceFolderUri: string | undefined): Promise<DebugConfiguration>;
+    resolveDebugConfiguration(
+        config: DebugConfiguration,
+        workspaceFolderUri: string | undefined
+    ): Promise<DebugConfiguration | undefined | null>;
 
     /**
      * Resolves a [debug configuration](#DebugConfiguration) by filling in missing values
      * or by adding/changing/removing attributes with substituted variables.
      * @param debugConfiguration The [debug configuration](#DebugConfiguration) to resolve.
-     * @returns The resolved debug configuration.
+     * @returns The resolved debug configuration, undefined or null.
      */
-    resolveDebugConfigurationWithSubstitutedVariables(config: DebugConfiguration, workspaceFolderUri: string | undefined): Promise<DebugConfiguration>;
+    resolveDebugConfigurationWithSubstitutedVariables(
+        config: DebugConfiguration,
+        workspaceFolderUri: string | undefined
+    ): Promise<DebugConfiguration | undefined | null>;
 
     /**
      * Creates a new [debug adapter session](#DebugAdapterSession).

--- a/packages/plugin-ext/src/common/plugin-api-rpc.ts
+++ b/packages/plugin-ext/src/common/plugin-api-rpc.ts
@@ -640,7 +640,7 @@ export interface WorkspaceMain {
 export interface WorkspaceExt {
     $onWorkspaceFoldersChanged(event: WorkspaceRootsChangeEvent): void;
     $onWorkspaceLocationChanged(event: files.FileStat | undefined): void;
-    $provideTextDocumentContent(uri: string): Promise<string | undefined>;
+    $provideTextDocumentContent(uri: string): Promise<string | undefined | null>;
     $onTextSearchResult(searchRequestId: number, done: boolean, result?: SearchInWorkspaceResult): void;
     $onWorkspaceTrustChanged(trust: boolean | undefined): void;
 }
@@ -1659,8 +1659,14 @@ export interface DebugConfigurationProvider {
     readonly type: string;
     readonly triggerKind: DebugConfigurationProviderTriggerKind;
     provideDebugConfigurations?(folder: string | undefined): Promise<theia.DebugConfiguration[]>;
-    resolveDebugConfiguration?(folder: string | undefined, debugConfiguration: theia.DebugConfiguration): Promise<theia.DebugConfiguration | undefined>;
-    resolveDebugConfigurationWithSubstitutedVariables?(folder: string | undefined, debugConfiguration: theia.DebugConfiguration): Promise<theia.DebugConfiguration | undefined>;
+    resolveDebugConfiguration?(
+        folder: string | undefined,
+        debugConfiguration: theia.DebugConfiguration
+    ): Promise<theia.DebugConfiguration | undefined | null>;
+    resolveDebugConfigurationWithSubstitutedVariables?(
+        folder: string | undefined,
+        debugConfiguration: theia.DebugConfiguration
+    ): Promise<theia.DebugConfiguration | undefined | null>;
 }
 
 export interface DebugConfigurationProviderDescriptor {
@@ -1678,25 +1684,17 @@ export interface DebugExt {
     $sessionDidCreate(sessionId: string): void;
     $sessionDidDestroy(sessionId: string): void;
     $sessionDidChange(sessionId: string | undefined): void;
-    /**
-     * @deprecated since 1.24.0. Use $registerDebugConfigurationProvider with $provideDebugConfigurationsByHandle instead.
-     */
-    $provideDebugConfigurations(debugType: string, workspaceFolder: string | undefined, dynamic?: boolean): Promise<theia.DebugConfiguration[]>;
-
-    /**
-     * @deprecated since 1.24.0. Use $registerDebugConfigurationProvider with $resolveDebugConfigurationByHandle instead.
-     */
-    $resolveDebugConfigurations(debugConfiguration: theia.DebugConfiguration, workspaceFolder: string | undefined): Promise<theia.DebugConfiguration | undefined>;
-
-    /**
-     * @deprecated since 1.24.0. Use $registerDebugConfigurationProvider with $resolveDebugConfigurationWithSubstitutedVariablesByHandle instead.
-     */
-    $resolveDebugConfigurationWithSubstitutedVariables(debugConfiguration: theia.DebugConfiguration, workspaceFolder: string | undefined):
-        Promise<theia.DebugConfiguration | undefined>;
-
     $provideDebugConfigurationsByHandle(handle: number, workspaceFolder: string | undefined): Promise<theia.DebugConfiguration[]>;
-    $resolveDebugConfigurationByHandle(handle: number, workspaceFolder: string | undefined, debugConfiguration: theia.DebugConfiguration): Promise<theia.DebugConfiguration | undefined>;
-    $resolveDebugConfigurationWithSubstitutedVariablesByHandle(handle: number, workspaceFolder: string | undefined, debugConfiguration: theia.DebugConfiguration): Promise<theia.DebugConfiguration | undefined>;
+    $resolveDebugConfigurationByHandle(
+        handle: number,
+        workspaceFolder: string | undefined,
+        debugConfiguration: theia.DebugConfiguration
+    ): Promise<theia.DebugConfiguration | undefined | null>;
+    $resolveDebugConfigurationWithSubstitutedVariablesByHandle(
+        handle: number,
+        workspaceFolder: string | undefined,
+        debugConfiguration: theia.DebugConfiguration
+    ): Promise<theia.DebugConfiguration | undefined | null>;
 
     $createDebugSession(debugConfiguration: theia.DebugConfiguration): Promise<string>;
     $terminateDebugSession(sessionId: string): Promise<void>;

--- a/packages/plugin-ext/src/main/browser/debug/plugin-debug-adapter-contribution.ts
+++ b/packages/plugin-ext/src/main/browser/debug/plugin-debug-adapter-contribution.ts
@@ -37,27 +37,6 @@ export class PluginDebugAdapterContribution {
         return this.description.label;
     }
 
-    /**
-     * @deprecated since 1.24.0, Use [PluginDebugConfigurationProvider](plugin-debug-configuration-provider.ts)
-     */
-    async provideDebugConfigurations(workspaceFolderUri: string | undefined, dynamic: boolean = false): Promise<DebugConfiguration[]> {
-        return this.debugExt.$provideDebugConfigurations(this.type, workspaceFolderUri, dynamic);
-    }
-
-    /**
-     * @deprecated since 1.24.0, Use [PluginDebugConfigurationProvider](plugin-debug-configuration-provider.ts)
-     */
-    async resolveDebugConfiguration(config: DebugConfiguration, workspaceFolderUri: string | undefined): Promise<DebugConfiguration | undefined> {
-        return this.debugExt.$resolveDebugConfigurations(config, workspaceFolderUri);
-    }
-
-    /**
-     * @deprecated since 1.24.0, Use [PluginDebugConfigurationProvider](plugin-debug-configuration-provider.ts)
-     */
-    async resolveDebugConfigurationWithSubstitutedVariables(config: DebugConfiguration, workspaceFolderUri: string | undefined): Promise<DebugConfiguration | undefined> {
-        return this.debugExt.$resolveDebugConfigurationWithSubstitutedVariables(config, workspaceFolderUri);
-    }
-
     async createDebugSession(config: DebugConfiguration): Promise<string> {
         await this.pluginService.activateByDebug('onDebugAdapterProtocolTracker', config.type);
         return this.debugExt.$createDebugSession(config);

--- a/packages/plugin-ext/src/main/browser/debug/plugin-debug-configuration-provider.ts
+++ b/packages/plugin-ext/src/main/browser/debug/plugin-debug-configuration-provider.ts
@@ -27,8 +27,14 @@ export class PluginDebugConfigurationProvider implements DebugConfigurationProvi
     public type: string;
     public triggerKind: DebugConfigurationProviderTriggerKind;
     provideDebugConfigurations: (folder: string | undefined) => Promise<DebugConfiguration[]>;
-    resolveDebugConfiguration: (folder: string | undefined, debugConfiguration: DebugConfiguration) => Promise<DebugConfiguration | undefined>;
-    resolveDebugConfigurationWithSubstitutedVariables: (folder: string | undefined, debugConfiguration: DebugConfiguration) => Promise<DebugConfiguration | undefined>;
+    resolveDebugConfiguration: (
+        folder: string | undefined,
+        debugConfiguration: DebugConfiguration
+    ) => Promise<DebugConfiguration | undefined | null>;
+    resolveDebugConfigurationWithSubstitutedVariables: (
+        folder: string | undefined,
+        debugConfiguration: DebugConfiguration
+    ) => Promise<DebugConfiguration | undefined | null>;
 
     constructor(
         description: DebugConfigurationProviderDescriptor,

--- a/packages/plugin-ext/src/plugin/comments.ts
+++ b/packages/plugin-ext/src/plugin/comments.ts
@@ -171,7 +171,7 @@ export class CommentsExtImpl implements CommentsExt {
 
         const documentData = this._documents.getDocumentData(URI.revive(uriComponents));
         if (documentData) {
-            const ranges: theia.Range[] | undefined = await commentController.commentingRangeProvider!.provideCommentingRanges(documentData.document, token);
+            const ranges: theia.Range[] | undefined | null = await commentController.commentingRangeProvider!.provideCommentingRanges(documentData.document, token);
             if (ranges) {
                 return ranges.map(x => fromRange(x));
             }

--- a/packages/plugin-ext/src/plugin/languages/lens.ts
+++ b/packages/plugin-ext/src/plugin/languages/lens.ts
@@ -71,7 +71,7 @@ export class CodeLensAdapter {
             return undefined;
         }
 
-        let newLens: theia.CodeLens | undefined;
+        let newLens: theia.CodeLens | undefined | null;
         if (typeof this.provider.resolveCodeLens === 'function' && !lens.isResolved) {
             newLens = await this.provider.resolveCodeLens(lens, token);
             if (token.isCancellationRequested) {

--- a/packages/plugin-ext/src/plugin/node/debug/debug.ts
+++ b/packages/plugin-ext/src/plugin/node/debug/debug.ts
@@ -346,12 +346,20 @@ export class DebugExtImpl implements DebugExt {
         return { provider, type };
     }
 
-    async $provideDebugConfigurationsByHandle(handle: number, workspaceFolderUri: string | undefined): Promise<theia.DebugConfiguration[]> {
+    async $provideDebugConfigurationsByHandle(
+        handle: number,
+        workspaceFolderUri: string | undefined
+    ): Promise<theia.DebugConfiguration[]> {
         const { provider, type } = this.getConfigurationProviderRecord(handle);
 
-        const configurations = await provider.provideDebugConfigurations?.(this.toWorkspaceFolder(workspaceFolderUri));
+        const configurations = await provider.provideDebugConfigurations?.(
+            this.toWorkspaceFolder(workspaceFolderUri)
+        );
+
         if (!configurations) {
-            throw new Error('nothing returned from DebugConfigurationProvider.provideDebugConfigurations, type: ' + type);
+            throw new Error(
+                'nothing returned from DebugConfigurationProvider.provideDebugConfigurations, type: ' + type
+            );
         }
 
         return configurations;
@@ -361,88 +369,24 @@ export class DebugExtImpl implements DebugExt {
         handle: number,
         workspaceFolderUri: string | undefined,
         debugConfiguration: theia.DebugConfiguration
-    ): Promise<theia.DebugConfiguration | undefined> {
-
+    ): Promise<theia.DebugConfiguration | undefined | null> {
         const { provider } = this.getConfigurationProviderRecord(handle);
-        return provider.resolveDebugConfiguration?.(this.toWorkspaceFolder(workspaceFolderUri), debugConfiguration);
+        return provider.resolveDebugConfiguration?.(
+            this.toWorkspaceFolder(workspaceFolderUri),
+            debugConfiguration
+        );
     }
 
     async $resolveDebugConfigurationWithSubstitutedVariablesByHandle(
         handle: number,
         workspaceFolderUri: string | undefined,
         debugConfiguration: theia.DebugConfiguration
-    ): Promise<theia.DebugConfiguration | undefined> {
-
+    ): Promise<theia.DebugConfiguration | undefined | null> {
         const { provider } = this.getConfigurationProviderRecord(handle);
-        return provider.resolveDebugConfigurationWithSubstitutedVariables?.(this.toWorkspaceFolder(workspaceFolderUri), debugConfiguration);
-    }
-
-    async $provideDebugConfigurations(debugType: string, workspaceFolderUri: string | undefined, dynamic: boolean = false): Promise<theia.DebugConfiguration[]> {
-        let result: theia.DebugConfiguration[] = [];
-
-        const trigger = dynamic ? DebugConfigurationProviderTriggerKind.Dynamic : DebugConfigurationProviderTriggerKind.Initial;
-        const providers = this.configurationProviders
-            .filter(p => p.type === debugType && p.trigger === trigger)
-            .map(p => p.provider);
-
-        for (const provider of providers) {
-            if (provider.provideDebugConfigurations) {
-                result = result.concat(await provider.provideDebugConfigurations(this.toWorkspaceFolder(workspaceFolderUri)) || []);
-            }
-        }
-
-        return result;
-    }
-
-    async $resolveDebugConfigurations(debugConfiguration: theia.DebugConfiguration, workspaceFolderUri: string | undefined): Promise<theia.DebugConfiguration | undefined> {
-        let current = debugConfiguration;
-
-        const providers = this.configurationProviders
-            .filter(p => p.type === debugConfiguration.type || p.type === '*')
-            .map(p => p.provider);
-
-        for (const provider of providers) {
-            if (provider.resolveDebugConfiguration) {
-                try {
-                    const next = await provider.resolveDebugConfiguration(this.toWorkspaceFolder(workspaceFolderUri), current);
-                    if (next) {
-                        current = next;
-                    } else {
-                        return current;
-                    }
-                } catch (e) {
-                    console.error(e);
-                }
-            }
-        }
-
-        return current;
-    }
-
-    async $resolveDebugConfigurationWithSubstitutedVariables(debugConfiguration: theia.DebugConfiguration, workspaceFolderUri: string | undefined):
-        Promise<theia.DebugConfiguration | undefined> {
-        let current = debugConfiguration;
-
-        const providers = this.configurationProviders
-            .filter(p => p.type === debugConfiguration.type || p.type === '*')
-            .map(p => p.provider);
-
-        for (const provider of providers) {
-            if (provider.resolveDebugConfigurationWithSubstitutedVariables) {
-                try {
-                    const next = await provider.resolveDebugConfigurationWithSubstitutedVariables(this.toWorkspaceFolder(workspaceFolderUri), current);
-                    if (next) {
-                        current = next;
-                    } else {
-                        return current;
-                    }
-                } catch (e) {
-                    console.error(e);
-                }
-            }
-        }
-
-        return current;
+        return provider.resolveDebugConfigurationWithSubstitutedVariables?.(
+            this.toWorkspaceFolder(workspaceFolderUri),
+            debugConfiguration
+        );
     }
 
     protected async createDebugAdapterTracker(session: theia.DebugSession): Promise<theia.DebugAdapterTracker> {

--- a/packages/plugin-ext/src/plugin/tree/tree-views.ts
+++ b/packages/plugin-ext/src/plugin/tree/tree-views.ts
@@ -262,7 +262,8 @@ class TreeViewExtImpl<T> implements Disposable {
             // root
             return [];
         }
-        const parent = this.treeDataProvider.getParent && await this.treeDataProvider.getParent(element);
+        const result = this.treeDataProvider.getParent && await this.treeDataProvider.getParent(element);
+        const parent = result ? result : undefined;
         const chain = await this.calculateRevealParentChain(parent);
         if (!chain) {
             // parents are inconsistent

--- a/packages/plugin-ext/src/plugin/workspace.ts
+++ b/packages/plugin-ext/src/plugin/workspace.ts
@@ -276,7 +276,7 @@ export class WorkspaceExtImpl implements WorkspaceExt {
         };
     }
 
-    async $provideTextDocumentContent(documentURI: string): Promise<string | undefined> {
+    async $provideTextDocumentContent(documentURI: string): Promise<string | undefined | null> {
         const uri = URI.parse(documentURI);
         const provider = this.documentContentProviders.get(uri.scheme);
         if (provider) {

--- a/packages/plugin/src/theia.d.ts
+++ b/packages/plugin/src/theia.d.ts
@@ -6879,8 +6879,7 @@ export module '@theia/plugin' {
      * thenable.
      *
      */
-    export type ProviderResult<T> = T | undefined | PromiseLike<T | undefined>;
-
+    export type ProviderResult<T> = T | undefined | null | Thenable<T | undefined | null>;
     /**
      * A symbol kind.
      */


### PR DESCRIPTION
#### What it does
<!-- Include relevant issues and describe how they are addressed. -->
Fixes: #10998 

Debug configuration providers can indicate to stop debugging by
returning `undefined` or `null` on either of the functions
- `resolveDebugConfiguration` or
- `resolveDebugConfigurationWithSubstitutedVariables`

The vscode API
https://code.visualstudio.com/api/references/vscode-api#DebugConfigurationProvider
specifies different handling for `undefined` and `null` as follows:

"Returning the value 'undefined' prevents the debug session from
starting. Returning the value 'null' prevents the debug session from
starting and opens the underlying debug configuration instead."

This implementation focuses on passing the `undefined` or `null`
response from the extension to the debug session manager where the
indication from the extension is handled.

Signed-off-by: Alvaro Sanchez-Leon <alvaro.sanchez-leon@ericsson.com>

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

1. Download the following extension and place it under your theia/plugins folder 
https://github.com/alvsan09/debug-activation-events/blob/master/on-debug-resolve-null.vsix
2. Start theia 
3. Testing behavior for an extension returning `undefined`: 
From the command palette (Ctrl + shft + P) , type `debug `, note trailing space is needed.
Select configuration named `Create JavaScript Debug Terminal`
Verify that no debug session is started and that a single `JavaScript Debug Terminal` instance is created.
This verifies the fix for issue: #10998
6. Testing behavior for an extension returning `null`:
From the command palette (Ctrl + shft + P) , type `debug `, note trailing space is needed.
Select configuration named `Resolve config to null` (this configuration is provided by the test extension loaded in step 1)
Verify that no debug session is started and that the `launch.json` file is opened.
 
![config_resolve_undefined_null](https://user-images.githubusercontent.com/76971376/162072780-025f80a2-1401-4358-a14a-5ca6f7008f57.gif)

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
