### PR TITLE
vscode: support `keepScrollPosition` for `QuickPick`

### DIFF
--- a/packages/core/src/common/quick-pick-service.ts
+++ b/packages/core/src/common/quick-pick-service.ts
@@ -201,6 +201,7 @@ export interface QuickPick<T extends QuickPickItemOrSeparator> extends QuickInpu
     canSelectMany: boolean;
     matchOnDescription: boolean;
     matchOnDetail: boolean;
+    keepScrollPosition: boolean;
     readonly onDidAccept: Event<{ inBackground: boolean } | undefined>;
     readonly onDidChangeValue: Event<string>;
     readonly onDidTriggerButton: Event<QuickInputButton>;
@@ -261,6 +262,7 @@ export interface QuickPickOptions<T extends QuickPickItemOrSeparator> {
     matchOnDetail?: boolean;
     matchOnLabel?: boolean;
     sortByLabel?: boolean;
+    keepScrollPosition?: boolean;
     autoFocusOnList?: boolean;
     ignoreFocusOut?: boolean;
     valueSelection?: Readonly<[number, number]>;

--- a/packages/monaco/src/browser/monaco-quick-input-service.ts
+++ b/packages/monaco/src/browser/monaco-quick-input-service.ts
@@ -259,6 +259,7 @@ export class MonacoQuickInputService implements QuickInputService {
                 wrapped.ignoreFocusOut = !!options.ignoreFocusOut;
                 wrapped.matchOnDescription = options.matchOnDescription ?? true;
                 wrapped.matchOnDetail = options.matchOnDetail ?? true;
+                wrapped.keepScrollPosition = options.keepScrollPosition ?? false;
                 wrapped.placeholder = options.placeholder;
                 wrapped.step = options.step;
                 wrapped.title = options.title;
@@ -468,6 +469,14 @@ class MonacoQuickPick<T extends QuickPickItem> extends MonacoQuickInput implemen
 
     set matchOnDetail(v: boolean) {
         this.wrapped.matchOnDetail = v;
+    }
+
+    get keepScrollPosition(): boolean {
+        return this.wrapped.keepScrollPosition;
+    }
+
+    set keepScrollPosition(v: boolean) {
+        this.wrapped.keepScrollPosition = v;
     }
 
     get items(): readonly (T | QuickPickSeparator)[] {

--- a/packages/plugin-ext/src/plugin/quick-open.ts
+++ b/packages/plugin-ext/src/plugin/quick-open.ts
@@ -580,6 +580,7 @@ export class QuickPickExt<T extends theia.QuickPickItem> extends QuickInputExt i
     private _matchOnDescription = true;
     private _matchOnDetail = true;
     private _sortByLabel = true;
+    private _keepScrollPosition = false;
     private _activeItems: T[] = [];
     private _selectedItems: T[] = [];
     private readonly _onDidChangeActiveEmitter = new Emitter<T[]>();
@@ -664,6 +665,15 @@ export class QuickPickExt<T extends theia.QuickPickItem> extends QuickInputExt i
     set sortByLabel(sortByLabel: boolean) {
         this._sortByLabel = sortByLabel;
         this.update({ sortByLabel });
+    }
+
+    get keepScrollPosition(): boolean {
+        return this._keepScrollPosition;
+    }
+
+    set keepScrollPosition(keepScrollPosition: boolean) {
+        this._keepScrollPosition = keepScrollPosition;
+        this.update({ keepScrollPosition });
     }
 
     get activeItems(): T[] {

--- a/packages/plugin/src/theia.d.ts
+++ b/packages/plugin/src/theia.d.ts
@@ -2191,6 +2191,11 @@ export module '@theia/plugin' {
          */
         matchOnDetail: boolean;
 
+        /*
+         * An optional flag to maintain the scroll position of the quick pick when the quick pick items are updated. Defaults to false.
+         */
+        keepScrollPosition?: boolean;
+
         /**
          * Active items. This can be read and updated by the extension.
          */


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

The pull-request adds support for `keepScrollPosition` when creating a `QuickPick`. The option is used to enforce that the menu does not scroll back to the top of the list when there is an update to the items in the list.

The updates should also help with our VS Code compatibility report.

<details>

<summary>Extension Videos</summary>

<br/>

_master_:

https://user-images.githubusercontent.com/40359487/162258397-09e90669-561f-406d-9a2e-32758f45e73a.mov

_pull-request_:

https://user-images.githubusercontent.com/40359487/162258430-167265a5-da97-4850-b22e-763e0bcc9cff.mov

</details>


#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

The following extension ([vscode-keep-scroll-position-0.0.1.vsix.zip](https://github.com/eclipse-theia/theia/files/8445131/vscode-keep-scroll-position-0.0.1.vsix.zip)) can be used to test the option when creating a quick-pick, the extension creates a quick-pick with `keepScrollPosition` set to `true`, and after some time it will update the list.

On master this would cause the list to jump to the top after the update.

<details>

<summary>Extension Code</summary>

<br/>

```ts
let disposable = vscode.commands.registerCommand('vscode-keep-scroll-position.show', async () => {

    // Create the quick pick.
    const pick = vscode.window.createQuickPick();

    // Set options for the quick pick.
    const initialItems = [...Array(50).keys()].map(i => <vscode.QuickPickItem>{ label: `Initial Item ${i.toFixed()}` });
    pick.items = initialItems;
    pick.keepScrollPosition = true;

    // Display the quick pick.
    pick.show();

    // Wait some time.
    await new Promise(resolve => setTimeout(resolve, 5000));

    // Update the items to test the update.
    const updatedItems = [...Array(20).keys()].map(i => <vscode.QuickPickItem>{ label: `Updated Item: ${i.toFixed()}` });
    pick.items = [...initialItems, ...updatedItems];
});
```

</details>

1. include [vscode-keep-scroll-position-0.0.1.vsix.zip](https://github.com/eclipse-theia/theia/files/8445131/vscode-keep-scroll-position-0.0.1.vsix.zip)
2. start the application
3. trigger the command `Quick Pick: Show`
4. scroll the quick pick menu to the end
5. confirm that after a few seconds the position is kept
6. scroll to the bottom - confirm the `updated items` exist

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

Signed-off-by: vince-fugnitto <vincent.fugnitto@ericsson.com>