### PR TITLE
Add missing lib folder to package.json's files

### DIFF
--- a/examples/playwright/package.json
+++ b/examples/playwright/package.json
@@ -25,6 +25,7 @@
     "ui-tests-report": "yarn ui-tests-report-generate && allure open allure-results/allure-report"
   },
   "files": [
+    "lib",
     "src"
   ],
   "dependencies": {


### PR DESCRIPTION
Change-Id: Icdf84ef17c208bf90a77abf3ef71e9b474d4ec1c

#### What it does
Add the `lib` folder to the `files` property of the `package.json`.
Otherwise the compiled sources aren't included when the package is installed as a dependency.

#### How to test
Once published, the compiled dependenciesin `lib` should be published.

#### Review checklist

- [X] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
