### PR TITLE
Normalize URI's before interacting with recentworkspaces.json

### DIFF
--- a/packages/workspace/src/node/default-workspace-server.spec.ts
+++ b/packages/workspace/src/node/default-workspace-server.spec.ts
@@ -78,7 +78,7 @@ describe('DefaultWorkspaceServer', function (): void {
 
             const recent = await workspaceServer.getRecentWorkspaces();
 
-            expect(recent).to.have.members([FileUri.fsPath(tmpConfigDir)]);
+            expect(recent).to.have.members([tmpConfigDir.toString()]);
         });
 
         it('should ignore non-string array entries but return remaining existing file paths', async function (): Promise<void> {
@@ -95,7 +95,7 @@ describe('DefaultWorkspaceServer', function (): void {
 
             const recent = await workspaceServer.getRecentWorkspaces();
 
-            expect(recent).to.have.members([FileUri.fsPath(tmpConfigDir)]);
+            expect(recent).to.have.members([tmpConfigDir.toString()]);
         });
     });
 });

--- a/packages/workspace/src/node/default-workspace-server.ts
+++ b/packages/workspace/src/node/default-workspace-server.ts
@@ -101,14 +101,16 @@ export class DefaultWorkspaceServer implements WorkspaceServer, BackendApplicati
         return this.root.promise;
     }
 
-    async setMostRecentlyUsedWorkspace(uri: string): Promise<void> {
+    async setMostRecentlyUsedWorkspace(rawUri: string): Promise<void> {
+        const uri = FileUri.fsPath(rawUri);
         this.root = new Deferred();
         this.root.resolve(uri);
         const recentRoots = Array.from(new Set([uri, ...await this.getRecentWorkspaces()]));
         this.writeToUserHome({ recentRoots });
     }
 
-    async removeRecentWorkspace(uri: string): Promise<void> {
+    async removeRecentWorkspace(rawUri: string): Promise<void> {
+        const uri = FileUri.fsPath(rawUri);
         const recentRoots = await this.getRecentWorkspaces();
         const index = recentRoots.indexOf(uri);
         if (index !== -1) {

--- a/packages/workspace/src/node/default-workspace-server.ts
+++ b/packages/workspace/src/node/default-workspace-server.ts
@@ -24,6 +24,7 @@ import { CliContribution } from '@theia/core/lib/node/cli';
 import { Deferred } from '@theia/core/lib/common/promise-util';
 import { WorkspaceServer, CommonWorkspaceUtils } from '../common';
 import { EnvVariablesServer } from '@theia/core/lib/common/env-variables';
+import URI from '@theia/core/lib/common/uri';
 
 @injectable()
 export class WorkspaceCliContribution implements CliContribution {
@@ -102,7 +103,7 @@ export class DefaultWorkspaceServer implements WorkspaceServer, BackendApplicati
     }
 
     async setMostRecentlyUsedWorkspace(rawUri: string): Promise<void> {
-        const uri = FileUri.fsPath(rawUri);
+        const uri = rawUri && new URI(rawUri).toString(); // the empty string is used as a signal from the frontend not to load a workspace.
         this.root = new Deferred();
         this.root.resolve(uri);
         const recentRoots = Array.from(new Set([uri, ...await this.getRecentWorkspaces()]));
@@ -110,7 +111,7 @@ export class DefaultWorkspaceServer implements WorkspaceServer, BackendApplicati
     }
 
     async removeRecentWorkspace(rawUri: string): Promise<void> {
-        const uri = FileUri.fsPath(rawUri);
+        const uri = rawUri && new URI(rawUri).toString(); // the empty string is used as a signal from the frontend not to load a workspace.
         const recentRoots = await this.getRecentWorkspaces();
         const index = recentRoots.indexOf(uri);
         if (index !== -1) {
@@ -128,7 +129,7 @@ export class DefaultWorkspaceServer implements WorkspaceServer, BackendApplicati
             data.recentRoots.forEach(element => {
                 if (element.length > 0) {
                     if (this.workspaceStillExist(element)) {
-                        listUri.push(FileUri.fsPath(element));
+                        listUri.push(element);
                     }
                 }
             });


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

Fixes #11013 by normalizing URI's before comparing them with the contents of the `recentworkspaces.json` file.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->


1. Open a few workspaces
2. Use the Open recent workspace command
3. Observe that the current workspace is _not_ listed twice

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
