### PR TITLE
Allow to override language metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@
 
 <a name="breaking_changes_1.25.0">[Breaking Changes:](#breaking_changes_1.25.0)</a>
 
+- [core] changed return type of `(Async)LocalizationProvider#getAvailableLanguages` from `string[]` to `LanguageInfo[]` [#11018](https://github.com/eclipse-theia/theia/pull/11018)
+
 ## v1.24.0 - 3/31/2022
 
 [1.24.0 Milestone](https://github.com/eclipse-theia/theia/milestone/32)

--- a/packages/core/src/browser/common-frontend-contribution.ts
+++ b/packages/core/src/browser/common-frontend-contribution.ts
@@ -1143,17 +1143,19 @@ export class CommonFrontendContribution implements FrontendApplicationContributi
     protected async configureDisplayLanguage(): Promise<void> {
         const availableLanguages = await this.localizationProvider.getAvailableLanguages();
         const items: QuickPickItem[] = [];
-        for (const additionalLanguage of ['en', ...availableLanguages.map(e => e.languageId)]) {
-            items.push({
-                label: additionalLanguage,
-                execute: async () => {
-                    if (additionalLanguage !== nls.locale && await this.confirmRestart()) {
-                        this.windowService.setSafeToShutDown();
-                        window.localStorage.setItem(nls.localeId, additionalLanguage);
-                        this.windowService.reload();
+        for (const languageId of ['en', ...availableLanguages.map(e => e.languageId)]) {
+            if (typeof languageId === 'string') {
+                items.push({
+                    label: languageId,
+                    execute: async () => {
+                        if (languageId !== nls.locale && await this.confirmRestart()) {
+                            this.windowService.setSafeToShutDown();
+                            window.localStorage.setItem(nls.localeId, languageId);
+                            this.windowService.reload();
+                        }
                     }
-                }
-            });
+                });
+            }
         }
         this.quickInputService?.showQuickPick(items,
             {

--- a/packages/core/src/browser/common-frontend-contribution.ts
+++ b/packages/core/src/browser/common-frontend-contribution.ts
@@ -1143,7 +1143,7 @@ export class CommonFrontendContribution implements FrontendApplicationContributi
     protected async configureDisplayLanguage(): Promise<void> {
         const availableLanguages = await this.localizationProvider.getAvailableLanguages();
         const items: QuickPickItem[] = [];
-        for (const additionalLanguage of ['en', ...availableLanguages]) {
+        for (const additionalLanguage of ['en', ...availableLanguages.map(e => e.languageId)]) {
             items.push({
                 label: additionalLanguage,
                 execute: async () => {

--- a/packages/core/src/common/i18n/localization.ts
+++ b/packages/core/src/common/i18n/localization.ts
@@ -20,16 +20,19 @@ export const AsyncLocalizationProvider = Symbol('AsyncLocalizationProvider');
 export interface AsyncLocalizationProvider {
     getCurrentLanguage(): Promise<string>
     setCurrentLanguage(languageId: string): Promise<void>
-    getAvailableLanguages(): Promise<string[]>
+    getAvailableLanguages(): Promise<LanguageInfo[]>
     loadLocalization(languageId: string): Promise<Localization>
 }
 
-export interface Localization {
+export interface Localization extends LanguageInfo {
+    translations: { [key: string]: string };
+}
+
+export interface LanguageInfo {
     languageId: string;
     languageName?: string;
     languagePack?: boolean;
     localizedLanguageName?: string;
-    translations: { [key: string]: string };
 }
 
 export type FormatType = string | number | boolean | undefined;

--- a/packages/core/src/node/i18n/localization-backend-contribution.ts
+++ b/packages/core/src/node/i18n/localization-backend-contribution.ts
@@ -36,7 +36,7 @@ export class LocalizationBackendContribution implements BackendApplicationContri
     configure(app: express.Application): void {
         app.get('/i18n/:locale', (req, res) => {
             let locale = req.params.locale;
-            locale = this.localizationProvider.getAvailableLanguages().includes(locale) && locale || 'en';
+            locale = this.localizationProvider.getAvailableLanguages().some(e => e.languageId === locale) ? locale : 'en';
             this.localizationProvider.setCurrentLanguage(locale);
             res.send(this.localizationProvider.loadLocalization(locale));
         });

--- a/packages/core/src/node/i18n/localization-provider.ts
+++ b/packages/core/src/node/i18n/localization-provider.ts
@@ -15,7 +15,7 @@
 // *****************************************************************************
 
 import { injectable } from 'inversify';
-import { Localization } from '../../common/i18n/localization';
+import { LanguageInfo, Localization } from '../../common/i18n/localization';
 
 @injectable()
 export class LocalizationProvider {
@@ -29,11 +29,11 @@ export class LocalizationProvider {
             if (!merged) {
                 this.localizations.set(localization.languageId, merged = {
                     languageId: localization.languageId,
-                    languageName: localization.languageName,
-                    localizedLanguageName: localization.localizedLanguageName,
                     translations: {}
                 });
             }
+            merged.languageName = merged.languageName || localization.languageName;
+            merged.localizedLanguageName = merged.localizedLanguageName || merged.localizedLanguageName;
             merged.languagePack = merged.languagePack || localization.languagePack;
             Object.assign(merged.translations, localization.translations);
         }
@@ -47,14 +47,19 @@ export class LocalizationProvider {
         return this.currentLanguage;
     }
 
-    getAvailableLanguages(all?: boolean): string[] {
-        const languageIds: string[] = [];
+    getAvailableLanguages(all?: boolean): LanguageInfo[] {
+        const languageIds: LanguageInfo[] = [];
         for (const localization of this.localizations.values()) {
             if (all || localization.languagePack) {
-                languageIds.push(localization.languageId);
+                languageIds.push({
+                    languageId: localization.languageId,
+                    languageName: localization.languageName,
+                    languagePack: localization.languagePack,
+                    localizedLanguageName: localization.localizedLanguageName
+                });
             }
         }
-        return languageIds.sort((a, b) => a.localeCompare(b));
+        return languageIds.sort((a, b) => a.languageId.localeCompare(b.languageId));
     }
 
     loadLocalization(languageId: string): Localization {

--- a/packages/core/src/node/i18n/localization-provider.ts
+++ b/packages/core/src/node/i18n/localization-provider.ts
@@ -33,7 +33,7 @@ export class LocalizationProvider {
                 });
             }
             merged.languageName = merged.languageName || localization.languageName;
-            merged.localizedLanguageName = merged.localizedLanguageName || merged.localizedLanguageName;
+            merged.localizedLanguageName = merged.localizedLanguageName || localization.localizedLanguageName;
             merged.languagePack = merged.languagePack || localization.languagePack;
             Object.assign(merged.translations, localization.translations);
         }


### PR DESCRIPTION
#### What it does

Closes #11010 

1. Fixes a bug in the `LocalizationProvider` which should've allowed to merge localization. It only merged the `translations` property and nothing else, leaving the `languageName` empty.
2. Returns a bit more metadata in the `getAvailableLanguages()` method.

#### How to test

1. Change the language and assert that the app works as expected.
2. Set a breakpoint in [this line](https://github.com/eclipse-theia/theia/blob/07dcfbd071c5a184a32efe72915e09506c927bdb/packages/core/src/browser/common-frontend-contribution.ts#L1145) and assert that the `languageName` and `localizedLanguageName` property is correctly set in the `availableLanguages` array (is `undefined` on `master`).

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
