### PR TITLE
Add missing StatusBarItem fields of VS Code API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - [core] Move code for untitled resources into `core` from `plugin-ext` and allow users to open untitled editors with `New File` command. [#10868](https://github.com/eclipse-theia/theia/pull/10868)
 - [plugin] added support for `SnippetString.appendChoice` [#10969](https://github.com/eclipse-theia/theia/pull/10969) - Contributed on behalf of STMicroelectronics
 - [plugin] added support for `AccessibilityInformation` [#10961](https://github.com/eclipse-theia/theia/pull/10961) - Contributed on behalf of STMicroelectronics
+- [plugin] added missing properties `id`, `name` and `backgroundColor` to `StatusBarItem` [#11026](https://github.com/eclipse-theia/theia/pull/11026) - Contributed on behalf of STMicroelectronics
 
 <a name="breaking_changes_1.25.0">[Breaking Changes:](#breaking_changes_1.25.0)</a>
 

--- a/packages/core/src/browser/common-frontend-contribution.ts
+++ b/packages/core/src/browser/common-frontend-contribution.ts
@@ -1591,6 +1591,34 @@ export class CommonFrontendContribution implements FrontendApplicationContributi
                     hc: Color.rgba(255, 255, 255, 0.12)
                 }, description: 'Status bar item background color when hovering. The status bar is shown in the bottom of the window.'
             },
+            {
+                id: 'statusBarItem.errorBackground', defaults: {
+                    dark: Color.darken('errorBackground', 0.4),
+                    light: Color.darken('errorBackground', 0.4),
+                    hc: undefined,
+                }, description: 'Status bar error items background color. Error items stand out from other status bar entries to indicate error conditions. The status bar is shown in the bottom of the window.'
+            },
+            {
+                id: 'statusBarItem.errorForeground', defaults: {
+                    dark: Color.white,
+                    light: Color.white,
+                    hc: Color.white
+                }, description: 'Status bar error items foreground color. Error items stand out from other status bar entries to indicate error conditions. The status bar is shown in the bottom of the window.'
+            },
+            {
+                id: 'statusBarItem.warningBackground', defaults: {
+                    dark: Color.darken('warningBackground', 0.4),
+                    light:  Color.darken('warningBackground', 0.4),
+                    hc: undefined
+                }, description: 'Status bar warning items background color. Warning items stand out from other status bar entries to indicate warning conditions. The status bar is shown in the bottom of the window.'
+            },
+            {
+                id: 'statusBarItem.warningForeground', defaults: {
+                    dark: Color.white,
+                    light: Color.white,
+                    hc: Color.white
+                }, description: 'Status bar warning items foreground color. Warning items stand out from other status bar entries to indicate warning conditions. The status bar is shown in the bottom of the window.'
+            },
 
             // Quickinput colors should be aligned with https://code.visualstudio.com/api/references/theme-color#quick-picker
             // if not yet contributed by Monaco, check runtime css variables to learn.

--- a/packages/core/src/browser/shell/application-shell.ts
+++ b/packages/core/src/browser/shell/application-shell.ts
@@ -1418,6 +1418,7 @@ export class ApplicationShell extends Widget {
             this.statusBar.removeElement(BOTTOM_PANEL_TOGGLE_ID);
         } else {
             const element: StatusBarEntry = {
+                name: 'Toggle Bottom Panel',
                 text: '$(codicon-window)',
                 alignment: StatusBarAlignment.RIGHT,
                 tooltip: 'Toggle Bottom Panel',

--- a/packages/core/src/browser/status-bar/status-bar.tsx
+++ b/packages/core/src/browser/status-bar/status-bar.tsx
@@ -38,7 +38,9 @@ export interface StatusBarEntry {
      */
     text: string;
     alignment: StatusBarAlignment;
+    name?: string;
     color?: string;
+    backgroundColor?: string;
     className?: string;
     tooltip?: string;
     command?: string;
@@ -195,7 +197,8 @@ export class StatusBarImpl extends ReactWidget implements StatusBar {
         }
 
         attrs.style = {
-            color: entry.color || this.color
+            color: entry.color || this.color,
+            backgroundColor: entry.backgroundColor
         };
 
         return attrs;

--- a/packages/plugin-ext/src/common/plugin-api-rpc.ts
+++ b/packages/plugin-ext/src/common/plugin-api-rpc.ts
@@ -401,10 +401,12 @@ export interface MessageRegistryMain {
 
 export interface StatusBarMessageRegistryMain {
     $setMessage(id: string,
+        name: string | undefined,
         text: string | undefined,
         priority: number,
         alignment: theia.StatusBarAlignment,
         color: string | undefined,
+        backgroundColor: string | undefined,
         tooltip: string | undefined,
         command: string | undefined,
         accessibilityInformation: theia.AccessibilityInformation,

--- a/packages/plugin-ext/src/main/browser/status-bar-message-registry-main.ts
+++ b/packages/plugin-ext/src/main/browser/status-bar-message-registry-main.ts
@@ -39,10 +39,12 @@ export class StatusBarMessageRegistryMainImpl implements StatusBarMessageRegistr
     }
 
     async $setMessage(id: string,
+        name: string | undefined,
         text: string | undefined,
         priority: number,
         alignment: number,
         color: string | undefined,
+        backgroundColor: string | undefined,
         tooltip: string | undefined,
         command: string | undefined,
         accessibilityInformation: types.AccessibilityInformation,
@@ -52,12 +54,15 @@ export class StatusBarMessageRegistryMainImpl implements StatusBarMessageRegistr
         const role = accessibilityInformation?.role;
 
         const entry = {
+            name,
             text: text || '',
             ariaLabel,
             role,
             priority,
             alignment: alignment === types.StatusBarAlignment.Left ? StatusBarAlignment.LEFT : StatusBarAlignment.RIGHT,
             color: color && (this.colorRegistry.getCurrentColor(color) || color),
+            // In contrast to color, the backgroundColor must be a theme color. Thus, do not hand in the plain string if it cannot be resolved.
+            backgroundColor: backgroundColor && (this.colorRegistry.getCurrentColor(backgroundColor)),
             tooltip,
             command,
             accessibilityInformation,

--- a/packages/plugin/src/theia.d.ts
+++ b/packages/plugin/src/theia.d.ts
@@ -2482,6 +2482,14 @@ export module '@theia/plugin' {
     export interface StatusBarItem {
 
         /**
+         * The identifier of this item.
+         *
+         * *Note*: if no identifier was provided by the {@linkcode window.createStatusBarItem}
+         * method, the identifier will match the {@link Extension.id extension identifier}.
+         */
+        readonly id: string;
+
+        /**
          * The alignment of this item.
          */
         readonly alignment: StatusBarAlignment;
@@ -2491,6 +2499,13 @@ export module '@theia/plugin' {
          * be shown more to the left.
          */
         readonly priority: number;
+
+        /**
+         * The name of the entry, like 'Python Language Indicator', 'Git Status' etc.
+         * Try to keep the length of the name short, yet descriptive enough that
+         * users can understand what the status bar item is about.
+         */
+        name: string | undefined;
 
         /**
          * The text to show for the entry. To set a text with icon use the following pattern in text string:
@@ -2507,6 +2522,20 @@ export module '@theia/plugin' {
          * The foreground color for this entry.
          */
         color: string | ThemeColor | undefined;
+
+        /**
+         * The background color for this entry.
+         *
+         * *Note*: only the following colors are supported:
+         * * `new ThemeColor('statusBarItem.errorBackground')`
+         * * `new ThemeColor('statusBarItem.warningBackground')`
+         *
+         * More background colors may be supported in the future.
+         *
+         * *Note*: when a background color is set, the statusbar may override
+         * the `color` choice to ensure the entry is readable in all themes.
+         */
+        backgroundColor: ThemeColor | undefined;
 
         /**
          * The identifier of a command to run on click.


### PR DESCRIPTION
#### What it does

Fixes #11019

* Add missing properties `id`, `name`, `backgroundColor` to `StatusBarItem` API
* Handle properties in implementation and forward to frontend
* Add backgroundColor handling to `StatusBar`
* In the plugin context, if no status bar item id is given, do NOT  use the extension id as specified in the VS Code API.
  Instead, keep the current logic of generating a unique id.

Contributed on behalf of STMicroelectronics

Signed-off-by: Lucas Koehler <lkoehler@eclipsesource.com>

https://user-images.githubusercontent.com/6959840/163400055-d81914c8-3cb0-4000-9c97-6cd6f6e73052.mp4

#### How to test

- Download the test extension from [here](https://github.com/lucas-koehler/vscode-extension-samples/releases/download/status-bar-item-test-0.0.1/status-ts-0.0.1.vsix). The source is available [here](https://github.com/lucas-koehler/vscode-extension-samples/tree/status-bar-item-test-0.0.1/statusbar-sample) for reference.
- Select Theia Light theme
- Open a text file and select a few lines. For line count zero, the error colors should be used, for one or two the text should have color blue (`#0000FF`), for 3 or more lines the warning colors should be used
- Click on the status bar entry.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
