### PR TITLE
Fix more quick input styling issues

### DIFF
--- a/packages/monaco/src/browser/style/index.css
+++ b/packages/monaco/src/browser/style/index.css
@@ -197,6 +197,7 @@
   .monaco-icon-label
   .monaco-icon-description-container
   .label-description {
+    font-family: var(--theia-ui-font-family);
     font-size: calc(var(--theia-ui-font-size1) * 0.95) !important;
     color: var(--theia-foreground) !important;
 }

--- a/packages/monaco/src/browser/style/index.css
+++ b/packages/monaco/src/browser/style/index.css
@@ -158,7 +158,6 @@
 
 .quick-input-list .monaco-list-row .codicon {
   color: var(--theia-foreground) !important;
-  padding: 2px !important;
 }
 
 .quick-input-list .monaco-list-row.focused .codicon {
@@ -180,7 +179,7 @@
 
 .monaco-icon-label > .monaco-icon-label-container {
   flex: 1 !important;
-  align-items: end;
+  line-height: 22px;
 }
 
 .quick-input-list
@@ -215,7 +214,14 @@
 
 .quick-input-list .monaco-icon-label::before {
   transform: scale(0.8);
-  height: 16px;
+}
+
+.quick-input-list .monaco-icon-label.codicon::before {
+  padding-top: 3px;
+}
+
+.quick-input-list .monaco-icon-label.theia-file-icons-js {
+  line-height: inherit;
 }
 
 .quick-input-list .quick-input-list-label {


### PR DESCRIPTION
#### What it does

1. Closes https://github.com/eclipse-theia/theia/issues/10987 by fixing the actual source of the misalignment. A `codicon` css rule sets the `line-height` of the whole row to `13px` which messes up all of the sub-layouting
2. Fixes a minor font issue for `label-description` parts of the quick input row, which used a serif font. See also https://github.com/eclipse-theia/theia/pull/10962

#### How to test

1. Open the command palette and enter `view: toggle`
2. Assert that quick input items with checkmarks are correctly layouted
3. Run the `Open Recent Workspaces` command (The original issue only seems to appear on Windows+Electron, don't know why)
4. Assert that the `label-description` font is using the default app font

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
