### PR TITLE
Narrow typing of Saveable.createSnapshot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 <a name="breaking_changes_1.25.0">[Breaking Changes:](#breaking_changes_1.25.0)</a>
 
 - [core] changed return type of `(Async)LocalizationProvider#getAvailableLanguages` from `string[]` to `LanguageInfo[]` [#11018](https://github.com/eclipse-theia/theia/pull/11018)
+- [core] changed return type of `Saveable.createSnapshot` from `object` to `{ value: string } | { read(): string | null }` [#11032](https://github.com/eclipse-theia/theia/pull/11032)
 
 ## v1.24.0 - 3/31/2022
 

--- a/packages/core/src/browser/saveable.ts
+++ b/packages/core/src/browser/saveable.ts
@@ -37,7 +37,7 @@ export interface Saveable {
     /**
      * Creates a snapshot of the dirty state.
      */
-    createSnapshot?(): object;
+    createSnapshot?(): Saveable.Snapshot;
     /**
      * Applies the given snapshot to the dirty state.
      */
@@ -56,6 +56,8 @@ export namespace Saveable {
          */
         soft?: boolean
     }
+
+    export type Snapshot = { value: string } | { read(): string | null };
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     export function isSource(arg: any): arg is SaveableSource {
         return !!arg && ('saveable' in arg) && is(arg.saveable);

--- a/packages/monaco/src/browser/monaco-editor-model.ts
+++ b/packages/monaco/src/browser/monaco-editor-model.ts
@@ -650,8 +650,9 @@ export class MonacoEditorModel implements IResolvedTextEditorModel, TextEditorDo
         return this.model.createSnapshot(preserveBOM);
     }
 
-    applySnapshot(snapshot: { value: string }): void {
-        this.model.setValue(snapshot.value);
+    applySnapshot(snapshot: Saveable.Snapshot): void {
+        const value = 'value' in snapshot ? snapshot.value : snapshot.read() ?? '';
+        this.model.setValue(value);
     }
 
     protected trace(loggable: Loggable): void {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

Fixes: https://github.com/eclipse-theia/theia/issues/11031.

In the Monaco uplift, the return of `MonacoEditorModel.createSnapshot` was changed, but its effect on the `Saveable` system was not detected because the return of `Saveable.createSnapshot` was typed as `object`. This PR narrows that typing so that callers of the function have some idea what to expect, and deviations from those expectations can be caught.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

1. Open two editors, one with an existing file and one Untitled.
1. Use `Save as` on both editors
1. In both cases, the content should be copied and the old editor closed.
1. No errors should be logged about failures to create text buffers.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
