### PR TITLE
Restore `selection` in Monaco editor options

### DIFF
--- a/packages/monaco/src/browser/monaco-editor-service.ts
+++ b/packages/monaco/src/browser/monaco-editor-service.ts
@@ -21,7 +21,7 @@ import { EditorWidget, EditorOpenerOptions, EditorManager, CustomEditorWidget } 
 import { MonacoEditor } from './monaco-editor';
 import { MonacoToProtocolConverter } from './monaco-to-protocol-converter';
 import { MonacoEditorModel } from './monaco-editor-model';
-import { IResourceEditorInput } from '@theia/monaco-editor-core/esm/vs/platform/editor/common/editor';
+import { IResourceEditorInput, ITextResourceEditorInput } from '@theia/monaco-editor-core/esm/vs/platform/editor/common/editor';
 import { StandaloneServices } from '@theia/monaco-editor-core/esm/vs/editor/standalone/browser/standaloneServices';
 import { IStandaloneThemeService } from '@theia/monaco-editor-core/esm/vs/editor/standalone/common/standaloneTheme';
 import { StandaloneCodeEditorService } from '@theia/monaco-editor-core/esm/vs/editor/standalone/browser/standaloneCodeEditorService';
@@ -105,11 +105,18 @@ export class MonacoEditorService extends StandaloneCodeEditorService {
         return undefined;
     }
 
-    protected createEditorOpenerOptions(input: IResourceEditorInput, source: ICodeEditor | null, sideBySide?: boolean): EditorOpenerOptions {
+    protected createEditorOpenerOptions(input: IResourceEditorInput | ITextResourceEditorInput, source: ICodeEditor | null, sideBySide?: boolean): EditorOpenerOptions {
         const mode = this.getEditorOpenMode(input);
         const widgetOptions = this.getWidgetOptions(source, sideBySide);
+        const selection = this.getSelection(input);
         const preview = !!this.preferencesService.get<boolean>(MonacoEditorService.ENABLE_PREVIEW_PREFERENCE, false);
-        return { mode, widgetOptions, preview };
+        return { mode, widgetOptions, preview, selection };
+    }
+
+    protected getSelection(input: IResourceEditorInput | ITextResourceEditorInput): EditorOpenerOptions['selection'] {
+        if ('options' in input && input.options && 'selection' in input.options) {
+            return this.m2p.asRange(input.options.selection);
+        }
     }
 
     protected getEditorOpenMode(input: IResourceEditorInput): WidgetOpenMode {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

Fixes #11017 by restoring the logic to extract the selection from the options passed to the `MonacoEditorService`. Previously, the relevant fields had been added to the `IResourceEditorInput` declaration in our `monaco.d.ts`, but in fact they come from an extension of that interface, the `ITextResourceEditorInput`. The new code checks whether the input we're dealing with satisfies the latter and extracts the selection if possible.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

1. `ctrl+click` on variables / methods imported from / defined in other files.
2. Observe that the file opens and scrolls to the definition / declaration of the relevant method.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
