### PR TITLE
fix quick-open: multi-step input (#8777)

### DIFF
--- a/packages/plugin-ext/src/plugin/quick-open.ts
+++ b/packages/plugin-ext/src/plugin/quick-open.ts
@@ -451,6 +451,7 @@ export class QuickInputExt implements QuickInput {
     }
 
     _fireChangedValue(changedValue: string): void {
+        this._value = changedValue;
         this._onDidChangeValueEmitter.fire(changedValue);
     }
 
@@ -532,39 +533,6 @@ export class InputBoxExt extends QuickInputExt implements InputBox {
             this._validationMessage = validationMessage;
             this.update({ validationMessage });
         }
-    }
-
-    override async show(): Promise<void> {
-        super.show();
-
-        const update = (value: string) => {
-            this.value = value;
-            if (this.validationMessage && this.validationMessage.length > 0) {
-                return this.validationMessage;
-            }
-        };
-
-        this.quickOpen.showInputBox({
-            id: this._id,
-            busy: this.busy,
-            buttons: this.buttons,
-            enabled: this.enabled,
-            ignoreFocusOut: this.ignoreFocusOut,
-            password: this.password,
-            placeholder: this.placeholder,
-            prompt: this.prompt,
-            step: this.step,
-            title: this.title,
-            totalSteps: this.totalSteps,
-            validationMessage: this.validationMessage,
-            value: this.value,
-            visible: this.visible,
-            validateInput(value: string): string | undefined {
-                if (value.length > 0) {
-                    return update(value);
-                }
-            }
-        });
     }
 }
 


### PR DESCRIPTION
#### What it does
Fixes #8777 multiStep quick input flows that call createInputBox 

Previously, when invoking show() a quick input box would be initially created by calling update({visible: true}) in super(), which in turn would invoke $createOrUpdate in quick-open-main and create an InputBox and corresponding session. After the session is created, show() then calls $showInputBox (An api method introduced by Theia, which is not supported by the VS Code API) which creates another InputBox, destroying the previously created session and returning no value to the caller. This leaves an orpaned InputBox on screen.

To correct this, we simply enable show to invoke $createOrUpdate which handles the quick input flow correctly, and set the proper value when received from the quick-open-main.

#### How to test
1. Validate existing multi-step work flows by using the [QuickInput](https://github.com/microsoft/vscode-extension-samples/tree/master/quickinput-sample) [sample](https://github.com/vince-fugnitto/quick-open-samples/releases/download/1.0.0/quickinput-sample-0.0.1.vsix)
2. Validate quick input works in multi-step flows used by [VS Code Solution Explorer](https://open-vsx.org/extension/fernandoescolar/vscode-solution-explorer) using the the [reproduction steps provided](https://github.com/eclipse-theia/theia/issues/8777#issuecomment-1045213722)

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/eclipse-theia/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
