### PR TITLE
Revert "Use same tempdir for user and system compressed plugin files"

### DIFF
--- a/packages/plugin-ext-vscode/src/node/plugin-vscode-file-handler.ts
+++ b/packages/plugin-ext-vscode/src/node/plugin-vscode-file-handler.ts
@@ -54,7 +54,11 @@ export class PluginVsCodeFileHandler implements PluginDeployerFileHandler {
     }
 
     protected async getExtensionDir(context: PluginDeployerFileHandlerContext): Promise<string> {
-        return FileUri.fsPath(this.systemExtensionsDirUri.resolve(filenamify(context.pluginEntry().id(), { replacement: '_' })));
+        let extensionsDirUri = this.systemExtensionsDirUri;
+        if (context.pluginEntry().type === PluginType.User) {
+            extensionsDirUri = await this.environment.getExtensionsDirUri();
+        }
+        return FileUri.fsPath(extensionsDirUri.resolve(filenamify(context.pluginEntry().id(), { replacement: '_' })));
     }
 
     protected async decompress(extensionDir: string, context: PluginDeployerFileHandlerContext): Promise<void> {

--- a/packages/plugin-ext/src/main/node/handlers/plugin-theia-file-handler.ts
+++ b/packages/plugin-ext/src/main/node/handlers/plugin-theia-file-handler.ts
@@ -49,6 +49,10 @@ export class PluginTheiaFileHandler implements PluginDeployerFileHandler {
     }
 
     protected async getPluginDir(context: PluginDeployerFileHandlerContext): Promise<string> {
-        return FileUri.fsPath(this.systemPluginsDirUri.resolve(filenamify(context.pluginEntry().id(), { replacement: '_' })));
+        let pluginsDirUri = this.systemPluginsDirUri;
+        if (context.pluginEntry().type === PluginType.User) {
+            pluginsDirUri = await this.environment.getPluginsDirUri();
+        }
+        return FileUri.fsPath(pluginsDirUri.resolve(filenamify(context.pluginEntry().id(), { replacement: '_' })));
     }
 }


### PR DESCRIPTION
## What it does:

Reverts #10951, which modified the behavior of the `PluginVscodeFileHandler` and `PluginTheiaFileHandler`. It turns out that several different scenarios depended indirectly on the old behavior according to which user plugins were decompressed into the `~/.theia/extensions` folder, so these changes should be reverted, pending a new PR that implements better handling of those scenarios without an implicit dependency on the behavior of the `PluginFileHandlers`.

## How to test
1. Using the plugin view, download a plugin from Open VSX.
2. Observe that it is decompressed into your `<home>/.theia/extensions` directory.
3. Download a compressed plugin from `open-vsx.org` and Install it using the  'Install from VSX' command.
4. Observe that it is decompressed into your `<home>/.theia/extensions` directory.