### PR TITLE
quality: remove duplicate header from a ts file

### DIFF
--- a/packages/core/src/common/quick-pick-service.ts
+++ b/packages/core/src/common/quick-pick-service.ts
@@ -14,22 +14,6 @@
 // SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
 // *****************************************************************************
 
-// *****************************************************************************
-// Copyright (C) 2021 SAP SE or an SAP affiliate company and others.
-//
-// This program and the accompanying materials are made available under the
-// terms of the Eclipse Public License v. 2.0 which is available at
-// http://www.eclipse.org/legal/epl-2.0.
-//
-// This Source Code may also be made available under the following Secondary
-// Licenses when the conditions for such availability set forth in the Eclipse
-// Public License v. 2.0 are satisfied: GNU General Public License, version 2
-// with the GNU Classpath Exception which is available at
-// https://www.gnu.org/software/classpath/license.html.
-//
-// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
-// *****************************************************************************
-
 import URI from './uri';
 import * as fuzzy from 'fuzzy';
 import { Event } from './event';


### PR DESCRIPTION
This PR addresses the issue  #11056 

Removed the duplicate header that was present in the packages/core/src/common/quick-pick-service.ts file.

Please tell me if there is anything I may need to change! Thank you and welcome the feedback.