### PR TITLE
Fix preference and view container ui regressions

### DIFF
--- a/packages/core/src/browser/style/view-container.css
+++ b/packages/core/src/browser/style/view-container.css
@@ -75,11 +75,11 @@
 }
 
 .p-Widget > .theia-view-container-part-header {
-    border-top: 1px solid var(--theia-sideBarSectionHeader-border);
+    box-shadow: 0 1px 0 var(--theia-sideBarSectionHeader-border) inset;
 }
 
 .p-Widget.p-first-visible > .theia-view-container-part-header {
-    border-top: none;
+    box-shadow: none;
 }
 
 .theia-view-container-part-header .theia-ExpansionToggle {

--- a/packages/preferences/src/browser/style/index.css
+++ b/packages/preferences/src/browser/style/index.css
@@ -92,6 +92,14 @@
     z-index: -1;
 }
 
+#theia-main-content-panel .theia-settings-container #preferences-scope-tab-bar .preferences-scope-tab {
+    color: var(--theia-panelTitle-inactiveForeground);
+}
+
+#theia-main-content-panel .theia-settings-container #preferences-scope-tab-bar .preferences-scope-tab:hover {
+    color: var(--theia-panelTitle-activeForeground);
+}
+
 #theia-main-content-panel .theia-settings-container #preferences-scope-tab-bar .preferences-scope-tab.p-mod-current {
     color: var(--theia-panelTitle-activeForeground);
     border-bottom: var(--theia-border-width) solid var(--theia-panelTitle-activeBorder);


### PR DESCRIPTION
#### What it does

Closes https://github.com/eclipse-theia/theia/issues/11060
Closes https://github.com/eclipse-theia/theia/issues/11005

#### How to test

For https://github.com/eclipse-theia/theia/issues/11005

1. Select the `Dark+` theme
2. Focus a view container header
3. The outline should be visible completely

---

For https://github.com/eclipse-theia/theia/issues/11060

1. Open the preference widget
2. Assert that the tabs behave like VSCode in regard to inactive/hover coloring

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
