### PR TITLE
10002: Add canReply to CommentThread

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - [plugin] added support for `SnippetString.appendChoice` [#10969](https://github.com/eclipse-theia/theia/pull/10969) - Contributed on behalf of STMicroelectronics
 - [plugin] added support for `AccessibilityInformation` [#10961](https://github.com/eclipse-theia/theia/pull/10961) - Contributed on behalf of STMicroelectronics
 - [plugin] added missing properties `id`, `name` and `backgroundColor` to `StatusBarItem` [#11026](https://github.com/eclipse-theia/theia/pull/11026) - Contributed on behalf of STMicroelectronics
+- [plugin] Add `canReply` to `CommentThread` [#11062](https://github.com/eclipse-theia/theia/pull/11062) - Contributed on behalf of STMicroelectronics
 
 <a name="breaking_changes_1.25.0">[Breaking Changes:](#breaking_changes_1.25.0)</a>
 - [debug] 

--- a/packages/plugin-ext/src/common/plugin-api-rpc-model.ts
+++ b/packages/plugin-ext/src/common/plugin-api-rpc-model.ts
@@ -654,6 +654,8 @@ export interface CommentThread {
     onDidChangeLabel: TheiaEvent<string | undefined>;
     onDidChangeCollapsibleState: TheiaEvent<CommentThreadCollapsibleState | undefined>;
     isDisposed: boolean;
+    canReply: boolean;
+    onDidChangeCanReply: TheiaEvent<boolean>;
 }
 
 export interface CommentThreadChangedEventMain extends CommentThreadChangedEvent {

--- a/packages/plugin-ext/src/common/plugin-api-rpc.ts
+++ b/packages/plugin-ext/src/common/plugin-api-rpc.ts
@@ -1789,6 +1789,7 @@ export type CommentThreadChanges = Partial<{
     contextValue: string,
     comments: Comment[],
     collapseState: CommentThreadCollapsibleState;
+    canReply: boolean;
 }>;
 
 export interface CommentsMain {

--- a/packages/plugin-ext/src/main/browser/comments/comment-thread-widget.tsx
+++ b/packages/plugin-ext/src/main/browser/comments/comment-thread-widget.tsx
@@ -89,6 +89,12 @@ export class CommentThreadWidget extends BaseWidget {
                 commentForm.update();
             }
         }));
+        this.toDispose.push(this._commentThread.onDidChangeCanReply(_canReply => {
+            const commentForm = this.commentFormRef.current;
+            if (commentForm) {
+                commentForm.update();
+            }
+        }));
         this.contextMenu = this.menus.getMenu(COMMENT_THREAD_CONTEXT);
         this.contextMenu.children.map(node => node instanceof ActionMenuNode && node.action.when).forEach(exp => {
             if (typeof exp === 'string') {
@@ -381,7 +387,7 @@ export class CommentForm<P extends CommentForm.Props = CommentForm.Props> extend
     override render(): React.ReactNode {
         const { commands, commentThread, contextKeyService } = this.props;
         const hasExistingComments = commentThread.comments && commentThread.comments.length > 0;
-        return <div className={'comment-form' + (this.state.expanded || commentThread.comments && commentThread.comments.length === 0 ? ' expand' : '')}>
+        return commentThread.canReply ? <div className={'comment-form' + (this.state.expanded || commentThread.comments && commentThread.comments.length === 0 ? ' expand' : '')}>
             <div className={'theia-comments-input-message-container'}>
                 <textarea className={'theia-comments-input-message theia-input'}
                     spellCheck={false}
@@ -409,7 +415,7 @@ export class CommentForm<P extends CommentForm.Props = CommentForm.Props> extend
                 clearInput={this.clearInput}
             />
             <button className={'review-thread-reply-button'} title={'Reply...'} onClick={this.expand}>Reply...</button>
-        </div>;
+        </div> : null;
     }
 }
 

--- a/packages/plugin-ext/src/main/browser/comments/comments-main.ts
+++ b/packages/plugin-ext/src/main/browser/comments/comments-main.ts
@@ -124,10 +124,23 @@ export class CommentThreadImpl implements CommentThread, Disposable {
     private readonly onDidChangeCollapsibleStateEmitter = new Emitter<CommentThreadCollapsibleState | undefined>();
     readonly onDidChangeCollapsibleState = this.onDidChangeCollapsibleStateEmitter.event;
 
+    private readonly onDidChangeCanReplyEmitter = new Emitter<boolean>();
+    readonly onDidChangeCanReply = this.onDidChangeCanReplyEmitter.event;
+
     private _isDisposed: boolean;
 
     get isDisposed(): boolean {
         return this._isDisposed;
+    }
+
+    private _canReply: boolean = true;
+    get canReply(): boolean {
+        return this._canReply;
+    }
+
+    set canReply(canReply: boolean) {
+        this._canReply = canReply;
+        this.onDidChangeCanReplyEmitter.fire(this._canReply);
     }
 
     constructor(
@@ -150,6 +163,7 @@ export class CommentThreadImpl implements CommentThread, Disposable {
         if (modified('contextValue')) { this._contextValue = changes.contextValue; }
         if (modified('comments')) { this._comments = changes.comments; }
         if (modified('collapseState')) { this._collapsibleState = changes.collapseState; }
+        if (modified('canReply')) { this._canReply = changes.canReply!; }
     }
 
     dispose(): void {
@@ -159,6 +173,7 @@ export class CommentThreadImpl implements CommentThread, Disposable {
         this.onDidChangeInputEmitter.dispose();
         this.onDidChangeLabelEmitter.dispose();
         this.onDidChangeRangeEmitter.dispose();
+        this.onDidChangeCanReplyEmitter.dispose();
     }
 }
 

--- a/packages/plugin-ext/src/plugin/comments.ts
+++ b/packages/plugin-ext/src/plugin/comments.ts
@@ -185,6 +185,7 @@ type CommentThreadModification = Partial<{
     contextValue: string | undefined,
     comments: theia.Comment[],
     collapsibleState: theia.CommentThreadCollapsibleState
+    canReply: boolean;
 }>;
 
 export class ExtHostCommentThread implements theia.CommentThread, theia.Disposable {
@@ -283,6 +284,17 @@ export class ExtHostCommentThread implements theia.CommentThread, theia.Disposab
         return this._isDisposed;
     }
 
+    private _canReply: boolean = true;
+    get canReply(): boolean {
+        return this._canReply;
+    }
+
+    set canReply(canReply: boolean) {
+        this._canReply = canReply;
+        this.modifications.canReply = canReply;
+        this._onDidUpdateCommentThread.fire();
+    }
+
     private commentsMap: Map<theia.Comment, number> = new Map<theia.Comment, number>();
 
     private acceptInputDisposables = new DisposableCollection();
@@ -344,6 +356,9 @@ export class ExtHostCommentThread implements theia.CommentThread, theia.Disposab
         }
         if (modified('collapsibleState')) {
             formattedModifications.collapseState = convertToCollapsibleState(this.collapseState);
+        }
+        if (modified('canReply')) {
+            formattedModifications.canReply = this.canReply;
         }
         this.modifications = {};
 

--- a/packages/plugin/src/theia.d.ts
+++ b/packages/plugin/src/theia.d.ts
@@ -10941,6 +10941,11 @@ export module '@theia/plugin' {
          * Once disposed, this comment thread will be removed from visible editors and Comment Panel when appropriate.
          */
         dispose(): void;
+
+        /**
+         * Whether the thread supports reply. Defaults to true.
+         */
+        canReply: boolean;
     }
 
     /**


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
- Add canReply to the CommentThread API
- Show or Hide the Comment Reply widget based on the CommentThread.canReply value

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
- Use the test extension: https://github.com/CamilleLetavernier/vscode-comment-api-example/releases
- Select 2 files and use "Compare with each other" (Or open any DiffEditor)
- Use the gutter to create a new comment thread
- Use the "Toggle canReply" action to disable replies 

- Notes: 
  - It seems that not all menus options are supported. The "Toggle canReply" command is also enabled for the CommentThread, but isn't displayed; so it's currently not possible to turn replies back on.
  - ~~The PR is based on an older branch, because it seems that the upgrade for `Monaco to VSCode v. 1.65.2` broke CommentThreads (See detailed comment below)~~ Fixed in #11064 
  - ~~Because it is based on an older branch, I haven't push the Changelog (It would cause too much conflict at the moment)~~ Fixed

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

Fixes #10002

Contributed on behalf of STMicroelectronics

Signed-off-by: Camille Letavernier <cletavernier@eclipsesource.com>