### PR TITLE
Restore `detail` field of EditorMouseEvent

### DIFF
--- a/packages/monaco/src/browser/monaco-editor.ts
+++ b/packages/monaco/src/browser/monaco-editor.ts
@@ -186,7 +186,7 @@ export class MonacoEditor extends MonacoEditorServices implements TextEditor {
                     mouseColumn: this.m2p.asPosition(undefined, e.target.mouseColumn).character,
                     range: range && this.m2p.asRange(range) || undefined,
                     position: position && this.m2p.asPosition(position.lineNumber, position.column) || undefined,
-                    detail: (e.target as monaco.editor.IMouseTargetMargin).detail || undefined,
+                    detail: (e.target as monaco.editor.IMouseTargetMargin).detail || {},
                 },
                 event: e.event.browserEvent
             });

--- a/packages/monaco/src/browser/monaco-editor.ts
+++ b/packages/monaco/src/browser/monaco-editor.ts
@@ -186,7 +186,7 @@ export class MonacoEditor extends MonacoEditorServices implements TextEditor {
                     mouseColumn: this.m2p.asPosition(undefined, e.target.mouseColumn).character,
                     range: range && this.m2p.asRange(range) || undefined,
                     position: position && this.m2p.asPosition(position.lineNumber, position.column) || undefined,
-                    detail: undefined,
+                    detail: (e.target as monaco.editor.IMouseTargetMargin).detail || undefined,
                 },
                 event: e.event.browserEvent
             });


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

Fixes #11064 by restoring the details field of the `target` of the mouse event fired by the `MonacoEditor` class. The necessary data was written into a base interface in `monaco.d.ts`, but in fact came from an extension of that interface. Referring to that extended interface satisfies TypeScript and restores the data.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

1. Follow the steps in #11064 
2. Observe that no errors are logged and the comment input box appears.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
