### PR TITLE
[Decorations]: Emit old and new URI's to ensure ProvideWrapper.data correctly updated

### DIFF
--- a/packages/git/src/browser/git-decoration-provider.ts
+++ b/packages/git/src/browser/git-decoration-provider.ts
@@ -43,8 +43,9 @@ export class GitDecorationProvider implements DecorationsProvider {
         const newDecorations = new Map<string, Decoration>();
         this.collectDecorationData(event.status.changes, newDecorations);
 
+        const uris = new Set([...this.decorations.keys()].concat([...newDecorations.keys()]));
         this.decorations = newDecorations;
-        this.onDidChangeDecorationsEmitter.fire(Array.from(newDecorations.keys(), value => new URI(value)));
+        this.onDidChangeDecorationsEmitter.fire(Array.from(uris, value => new URI(value)));
     }
 
     private collectDecorationData(changes: GitFileChange[], bucket: Map<string, Decoration>): void {

--- a/packages/markers/src/browser/problem/problem-decorations-provider.ts
+++ b/packages/markers/src/browser/problem/problem-decorations-provider.ts
@@ -26,6 +26,8 @@ import { CancellationToken, Emitter, Event, nls } from '@theia/core';
 export class ProblemDecorationsProvider implements DecorationsProvider {
     @inject(ProblemManager) protected readonly problemManager: ProblemManager;
 
+    protected currentUris: URI[] = [];
+
     protected readonly onDidChangeEmitter = new Emitter<URI[]>();
     get onDidChange(): Event<URI[]> {
         return this.onDidChangeEmitter.event;
@@ -33,7 +35,11 @@ export class ProblemDecorationsProvider implements DecorationsProvider {
 
     @postConstruct()
     protected init(): void {
-        this.problemManager.onDidChangeMarkers(() => this.onDidChangeEmitter.fire(Array.from(this.problemManager.getUris(), stringified => new URI(stringified))));
+        this.problemManager.onDidChangeMarkers(() => {
+            const newUris = Array.from(this.problemManager.getUris(), stringified => new URI(stringified));
+            this.onDidChangeEmitter.fire(newUris.concat(this.currentUris));
+            this.currentUris = newUris;
+        });
     }
 
     provideDecorations(uri: URI, token: CancellationToken): Decoration | Promise<Decoration | undefined> | undefined {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

In #10846, I misunderstood the behavior of the [DecorationProviderWrapper](https://github.com/eclipse-theia/theia/blob/08abc2f830708e7a6acfe0e9fbcc8da7293321f9/packages/core/src/browser/decorations-service.ts#L61) class and believed that it would respond correctly to a `DecorationsProvider` emitting only the currently decorated URI's. In fact, it needs to receive a list of both removed and changed URIs. 

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

1. Open a file.
2. Create some problems.
3. Problem decorations should appear in the file tree.
4. Save the file.
5. Git decorations should appear in the file tree. (assuming you're in a tracked repository)
6. Revert the file to its old state.
7. The git decorations should disappear from the file tree, and if there are no problems left in the file, the problem decorations should disappear from the file tree.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
