### PR TITLE
Guarantee that `QuickPickService.showQuickPick` resolves on hide

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,7 +44,11 @@ The following methods may now return `undefined | null` ([#10999](https://github
 - [core] changed return type of `(Async)LocalizationProvider#getAvailableLanguages` from `string[]` to `LanguageInfo[]` [#11018](https://github.com/eclipse-theia/theia/pull/11018)
 - [core] changed return type of `Saveable.createSnapshot` from `object` to `{ value: string } | { read(): string | null }` [#11032](https://github.com/eclipse-theia/theia/pull/11032)
 - [markers, scm] deprecated `ProblemDecorator` and `SCMNavigatorDecorator` classes. They are no longer bound in the `inversify` container by default. [#10846](https://github.com/eclipse-theia/theia/pull/10846)
+<<<<<<< HEAD
 - [callhierarchy] types `Definition`, `Caller` and `Callee` removed and replaced with `CallHierarchyItem`, `CallHierarchyIncomingCall`, `CallHierarchyOutgoingCall`
+=======
+- [core] changed return type of `QuickInputService.showQuickPick` and its implementation in `MonacoQuickInputService` to `Promise<T | undefined>`. `undefined` will be returned if the user closes the quick pick without making a selection.
+>>>>>>> 2c30af31d63 (Resolve on hide)
 
 ## v1.24.0 - 3/31/2022
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,11 +44,8 @@ The following methods may now return `undefined | null` ([#10999](https://github
 - [core] changed return type of `(Async)LocalizationProvider#getAvailableLanguages` from `string[]` to `LanguageInfo[]` [#11018](https://github.com/eclipse-theia/theia/pull/11018)
 - [core] changed return type of `Saveable.createSnapshot` from `object` to `{ value: string } | { read(): string | null }` [#11032](https://github.com/eclipse-theia/theia/pull/11032)
 - [markers, scm] deprecated `ProblemDecorator` and `SCMNavigatorDecorator` classes. They are no longer bound in the `inversify` container by default. [#10846](https://github.com/eclipse-theia/theia/pull/10846)
-<<<<<<< HEAD
 - [callhierarchy] types `Definition`, `Caller` and `Callee` removed and replaced with `CallHierarchyItem`, `CallHierarchyIncomingCall`, `CallHierarchyOutgoingCall`
-=======
 - [core] changed return type of `QuickInputService.showQuickPick` and its implementation in `MonacoQuickInputService` to `Promise<T | undefined>`. `undefined` will be returned if the user closes the quick pick without making a selection.
->>>>>>> 2c30af31d63 (Resolve on hide)
 
 ## v1.24.0 - 3/31/2022
 

--- a/packages/core/src/browser/quick-input/quick-pick-service-impl.ts
+++ b/packages/core/src/browser/quick-input/quick-pick-service-impl.ts
@@ -46,7 +46,7 @@ export class QuickPickServiceImpl implements QuickPickService {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     private items: Array<any> = [];
 
-    async show<T extends QuickPickItem>(items: Array<T | QuickPickSeparator>, options?: QuickPickOptions<T>): Promise<T> {
+    async show<T extends QuickPickItem>(items: Array<T | QuickPickSeparator>, options?: QuickPickOptions<T>): Promise<T | undefined> {
         this.items = items;
         const opts = Object.assign({}, options, {
             onDidAccept: () => this.onDidAcceptEmitter.fire(),
@@ -56,7 +56,7 @@ export class QuickPickServiceImpl implements QuickPickService {
             onDidHide: () => this.onDidHideEmitter.fire(),
             onDidTriggerButton: (btn: QuickInputButtonHandle) => this.onDidTriggerButtonEmitter.fire(btn),
         });
-        return this.quickInputService?.showQuickPick(this.items, opts);
+        return this.quickInputService?.showQuickPick<T>(this.items, opts);
     }
 
     hide(): void {

--- a/packages/core/src/common/quick-pick-service.ts
+++ b/packages/core/src/common/quick-pick-service.ts
@@ -279,7 +279,7 @@ export interface QuickInputService {
     input(options?: InputOptions, token?: CancellationToken): Promise<string | undefined>;
     pick<T extends QuickPickItem, O extends PickOptions<T>>(picks: Promise<T[]> | T[], options?: O, token?: CancellationToken):
         Promise<(O extends { canPickMany: true } ? T[] : T) | undefined>;
-    showQuickPick<T extends QuickPickItem>(items: Array<T | QuickPickSeparator>, options?: QuickPickOptions<T>): Promise<T>;
+    showQuickPick<T extends QuickPickItem>(items: Array<T | QuickPickSeparator>, options?: QuickPickOptions<T>): Promise<T | undefined>;
     hide(): void;
     /**
      * Provides raw access to the quick pick controller.

--- a/packages/git/src/browser/git-sync-service.ts
+++ b/packages/git/src/browser/git-sync-service.ts
@@ -123,7 +123,7 @@ export class GitSyncService {
         }];
 
         const selectedCWD = await this.quickInputService?.showQuickPick(methods, { placeholder: 'Select current working directory for new terminal' });
-        if (await this.confirm('Synchronize Changes', methods.find(({ detail }) => detail === selectedCWD.detail)!.warning)) {
+        if (selectedCWD && await this.confirm('Synchronize Changes', methods.find(({ detail }) => detail === selectedCWD.detail)!.warning)) {
             return (selectedCWD.detail as GitSyncService.SyncMethod);
         } else {
             return (undefined);
@@ -165,7 +165,7 @@ export class GitSyncService {
 
         const selectedRemote = await this.quickInputService?.showQuickPick(remotes.map(remote => ({ label: remote })),
             { placeholder: `Pick a remote to publish the branch ${branch} to:` });
-        return selectedRemote.label;
+        return selectedRemote?.label;
     }
 
     protected shouldPush(status: WorkingDirectoryStatus): boolean {

--- a/packages/monaco/src/browser/monaco-formatting-conflicts.ts
+++ b/packages/monaco/src/browser/monaco-formatting-conflicts.ts
@@ -93,7 +93,7 @@ export class MonacoFormattingConflictsContribution implements FrontendApplicatio
             }
         }
 
-        return new Promise<T>(async (resolve, reject) => {
+        return new Promise<T | undefined>(async (resolve, reject) => {
             const items = formatters
                 .filter(formatter => formatter.displayName)
                 .map(formatter => ({
@@ -104,8 +104,12 @@ export class MonacoFormattingConflictsContribution implements FrontendApplicatio
                 .sort((a, b) => a.label!.localeCompare(b.label!));
 
             const selectedFormatter = await this.monacoQuickInputService.showQuickPick(items, { placeholder: 'Select formatter for the current document' });
-            this.setDefaultFormatter(languageId, selectedFormatter.detail ? selectedFormatter.detail : '');
-            resolve(selectedFormatter.value);
+            if (selectedFormatter) {
+                this.setDefaultFormatter(languageId, selectedFormatter.detail ? selectedFormatter.detail : '');
+                resolve(selectedFormatter.value);
+            } else {
+                resolve(undefined);
+            }
         });
     }
 }

--- a/packages/monaco/src/browser/monaco-quick-input-service.ts
+++ b/packages/monaco/src/browser/monaco-quick-input-service.ts
@@ -249,8 +249,8 @@ export class MonacoQuickInputService implements QuickInputService {
         return Array.isArray(picked) ? picked[0] : picked;
     }
 
-    showQuickPick<T extends QuickPickItem>(items: Array<T | QuickPickSeparator>, options?: QuickPickOptions<T>): Promise<T> {
-        return new Promise<T>((resolve, reject) => {
+    showQuickPick<T extends QuickPickItem>(items: Array<T | QuickPickSeparator>, options?: QuickPickOptions<T>): Promise<T | undefined> {
+        return new Promise<T | undefined>((resolve, reject) => {
             const quickPick = this.monacoService.createQuickPick<MonacoQuickPickItem<T>>();
             const wrapped = this.wrapQuickPick(quickPick);
 
@@ -285,6 +285,7 @@ export class MonacoQuickInputService implements QuickInputService {
                         options.onDidHide();
                     };
                     wrapped.dispose();
+                    setTimeout(() => resolve(undefined));
                 });
                 wrapped.onDidChangeValue((filter: string) => {
                     if (options.onDidChangeValue) {

--- a/packages/preferences/src/browser/preferences-contribution.ts
+++ b/packages/preferences/src/browser/preferences-contribution.ts
@@ -27,7 +27,8 @@ import {
     PreferenceService,
     QuickInputService,
     QuickPickItem,
-    isFirefox
+    isFirefox,
+    QuickPickService
 } from '@theia/core/lib/browser';
 import { isOSX } from '@theia/core/lib/common/os';
 import { TabBarToolbarRegistry } from '@theia/core/lib/browser/shell/tab-bar-toolbar';
@@ -52,6 +53,7 @@ export class PreferencesContribution extends AbstractViewContribution<Preference
     @inject(PreferencesWidget) protected readonly scopeTracker: PreferencesWidget;
     @inject(WorkspaceService) protected readonly workspaceService: WorkspaceService;
     @inject(QuickInputService) @optional() protected readonly quickInputService: QuickInputService;
+    @inject(QuickPickService) private readonly quickPickService: QuickPickService;
 
     constructor() {
         super({
@@ -135,6 +137,12 @@ export class PreferencesContribution extends AbstractViewContribution<Preference
             isEnabled: () => !!this.workspaceService.isMultiRootWorkspaceOpened && this.workspaceService.tryGetRoots().length > 0,
             isVisible: () => !!this.workspaceService.isMultiRootWorkspaceOpened && this.workspaceService.tryGetRoots().length > 0,
             execute: () => this.openFolderPreferences(root => this.openJson(PreferenceScope.Folder, root.resource.toString()))
+        });
+        commands.registerCommand({ id: 'quick-pick-test-command', 'label': 'Test QuickPickService.show' }, {
+            execute: async () => {
+                const quickPickValue = await this.quickPickService.show([{ label: 'First item!' }, { label: 'Second item!' }, { label: 'Third item?' }]);
+                console.log('SENTINEL FOR RESOLVING THE QUICKPICK PROMISE!', quickPickValue)
+            }
         });
     }
 

--- a/packages/preferences/src/browser/preferences-contribution.ts
+++ b/packages/preferences/src/browser/preferences-contribution.ts
@@ -28,7 +28,6 @@ import {
     QuickInputService,
     QuickPickItem,
     isFirefox,
-    QuickPickService
 } from '@theia/core/lib/browser';
 import { isOSX } from '@theia/core/lib/common/os';
 import { TabBarToolbarRegistry } from '@theia/core/lib/browser/shell/tab-bar-toolbar';
@@ -53,7 +52,6 @@ export class PreferencesContribution extends AbstractViewContribution<Preference
     @inject(PreferencesWidget) protected readonly scopeTracker: PreferencesWidget;
     @inject(WorkspaceService) protected readonly workspaceService: WorkspaceService;
     @inject(QuickInputService) @optional() protected readonly quickInputService: QuickInputService;
-    @inject(QuickPickService) private readonly quickPickService: QuickPickService;
 
     constructor() {
         super({
@@ -137,12 +135,6 @@ export class PreferencesContribution extends AbstractViewContribution<Preference
             isEnabled: () => !!this.workspaceService.isMultiRootWorkspaceOpened && this.workspaceService.tryGetRoots().length > 0,
             isVisible: () => !!this.workspaceService.isMultiRootWorkspaceOpened && this.workspaceService.tryGetRoots().length > 0,
             execute: () => this.openFolderPreferences(root => this.openJson(PreferenceScope.Folder, root.resource.toString()))
-        });
-        commands.registerCommand({ id: 'quick-pick-test-command', 'label': 'Test QuickPickService.show' }, {
-            execute: async () => {
-                const quickPickValue = await this.quickPickService.show([{ label: 'First item!' }, { label: 'Second item!' }, { label: 'Third item?' }]);
-                console.log('SENTINEL FOR RESOLVING THE QUICKPICK PROMISE!', quickPickValue)
-            }
         });
     }
 

--- a/packages/toolbar/src/browser/toolbar-command-quick-input-service.ts
+++ b/packages/toolbar/src/browser/toolbar-command-quick-input-service.ts
@@ -57,7 +57,7 @@ export class ToolbarCommandQuickInputService {
         });
     }
 
-    protected openColumnQP(): Promise<QuickPickItem> {
+    protected openColumnQP(): Promise<QuickPickItem | undefined> {
         return this.quickInputService.showQuickPick(this.columnQuickPickItems, {
             placeholder: nls.localize('theia/toolbar/toolbarLocationPlaceholder', 'Where would you like the command added?')
         });
@@ -74,7 +74,7 @@ export class ToolbarCommandQuickInputService {
                     const iconDialog = this.iconDialogFactory(command);
                     const iconClass = await iconDialog.open();
                     if (iconClass) {
-                        const { id } = await this.openColumnQP();
+                        const { id } = await this.openColumnQP() ?? {};
                         if (ToolbarAlignmentString.is(id)) {
                             this.model.addItem({ ...command, iconClass }, id);
                         }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

Fixes #11067 by ensuring that the promise returned by `QuickPickService.showQuickPick` will be resolved by modifying `MonacoQuickInputService` to resolve `undefined` after the quick pick is hidden. If the promise has already been resolved, the second resolution will have no effect, and if it hasn't, it will be resolved with `undefined`.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

1. There is an included test commit (with a lint error as a reminder to remove it). Run the command `Test QuickPickService.show`.
2. If you make a selection, you should see a log reflecting that selection.
3. If you close the quick pick without making a selection (e.g. hitting <kbd>Esc</kbd> or unfocusing the quick pick by clicking elsewhere), you should see a log reflecting a selection of `undefined`.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
