### PR TITLE
Use old header for CSS

### DIFF
--- a/.vscode/theia.code-snippets
+++ b/.vscode/theia.code-snippets
@@ -1,11 +1,20 @@
 {
-    "Copyright-JS/JSX/TS/TSX/CSS": {
+    "Copyright-JS/JSX/TS/TSX": {
         "prefix": [
             "header",
             "copyright"
         ],
         "body": "// *****************************************************************************\n// Copyright (C) $CURRENT_YEAR ${YourCompany} and others.\n//\n// This program and the accompanying materials are made available under the\n// terms of the Eclipse Public License v. 2.0 which is available at\n// http://www.eclipse.org/legal/epl-2.0.\n//\n// This Source Code may also be made available under the following Secondary\n// Licenses when the conditions for such availability set forth in the Eclipse\n// Public License v. 2.0 are satisfied: GNU General Public License, version 2\n// with the GNU Classpath Exception which is available at\n// https://www.gnu.org/software/classpath/license.html.\n//\n// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0\n// *****************************************************************************\n$0",
         "description": "Adds the copyright...",
-        "scope": "javascript,javascriptreact,typescript,typescriptreact,css"
+        "scope": "javascript,javascriptreact,typescript,typescriptreact"
+    },
+    "Copyright-CSS": {
+        "prefix": [
+            "header",
+            "copyright"
+        ],
+        "body": "/********************************************************************************\n * Copyright (C) $CURRENT_YEAR ${YourCompany} and others.\n *\n * This program and the accompanying materials are made available under the\n * terms of the Eclipse Public License v. 2.0 which is available at\n * http://www.eclipse.org/legal/epl-2.0.\n *\n * This Source Code may also be made available under the following Secondary\n * Licenses when the conditions for such availability set forth in the Eclipse\n * Public License v. 2.0 are satisfied: GNU General Public License, version 2\n * with the GNU Classpath Exception which is available at\n * https://www.gnu.org/software/classpath/license.html.\n *\n * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0\n ********************************************************************************/\n\n$0",
+        "description": "Adds the copyright...",
+        "scope": "css"
     }
 }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

This PR brings back the old snippet format for the header for CSS files. The form introduced by @paul-marechal doesn't work in CSS files because they don't use `//` as a comment marker.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

0. In the Theia repo...
1. Create a new TS/JS file.
2. Type `header`
3. Accept the snippet.
4. Observe that it has the new form from #10796.
5. Create a new CSS file
6. Type `header`
7. Accept the snippet.
8. Observe that it has the form from before #10796 and doesn't produce a bunch of CSS syntax errors.



#### Review checklist

- [X] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
