### PR TITLE
Make preference node renderers more robust against `null` values

### DIFF
--- a/packages/preferences/src/browser/views/components/preference-array-input.ts
+++ b/packages/preferences/src/browser/views/components/preference-array-input.ts
@@ -95,7 +95,7 @@ export class PreferenceArrayInputRenderer extends PreferenceLeafNodeRenderer<str
 
     protected doHandleValueChange(): void {
         this.updateInspection();
-        const values = this.getValue();
+        const values = this.getValue() ?? [];
         const newValues = new Set(...values);
         for (const [value, row] of this.existingValues.entries()) {
             if (!newValues.has(value)) {

--- a/packages/preferences/src/browser/views/components/preference-boolean-input.ts
+++ b/packages/preferences/src/browser/views/components/preference-boolean-input.ts
@@ -26,7 +26,7 @@ export class PreferenceBooleanInputRenderer extends PreferenceLeafNodeRenderer<b
         this.interactable = interactable;
         interactable.type = 'checkbox';
         interactable.classList.add('theia-input');
-        interactable.defaultChecked = this.getValue();
+        interactable.defaultChecked = Boolean(this.getValue());
         interactable.onchange = this.handleUserInteraction.bind(this);
         parent.appendChild(interactable);
     }
@@ -46,7 +46,7 @@ export class PreferenceBooleanInputRenderer extends PreferenceLeafNodeRenderer<b
     protected doHandleValueChange(): void {
         const currentValue = this.interactable.checked;
         this.updateInspection();
-        const newValue = this.getValue();
+        const newValue = Boolean(this.getValue());
         this.updateModificationStatus(newValue);
         if (newValue !== currentValue && document.activeElement !== this.interactable) {
             this.interactable.checked = newValue;

--- a/packages/preferences/src/browser/views/components/preference-node-renderer.ts
+++ b/packages/preferences/src/browser/views/components/preference-node-renderer.ts
@@ -473,7 +473,8 @@ export abstract class PreferenceLeafNodeRenderer<ValueType extends JSONValue, In
         return modifiedScopes;
     }
 
-    protected getValue(): ValueType {
+    // Many preferences allow `null` and even use it as a default regardless of the declared type.
+    protected getValue(): ValueType | null {
         let currentValue = Preference.getValueInScope(this.inspection, this.scopeTracker.currentScope.scope);
         if (currentValue === undefined) {
             currentValue = this.inspection?.defaultValue;

--- a/packages/preferences/src/browser/views/components/preference-number-input.ts
+++ b/packages/preferences/src/browser/views/components/preference-number-input.ts
@@ -53,7 +53,7 @@ export class PreferenceNumberInputRenderer extends PreferenceLeafNodeRenderer<nu
         this.interactable = interactable;
         interactable.type = 'number';
         interactable.classList.add('theia-input');
-        interactable.defaultValue = this.getValue().toString();
+        interactable.defaultValue = this.getValue()?.toString() ?? '';
         interactable.oninput = this.handleUserInteraction.bind(this);
         interactable.onblur = this.handleBlur.bind(this);
         interactableWrapper.appendChild(interactable);
@@ -84,7 +84,7 @@ export class PreferenceNumberInputRenderer extends PreferenceLeafNodeRenderer<nu
         const { value } = this.interactable;
         const currentValue = value.length ? Number(value) : NaN;
         this.updateInspection();
-        const newValue = this.getValue();
+        const newValue = this.getValue() ?? '';
         this.updateModificationStatus(newValue);
         if (newValue !== currentValue) {
             if (document.activeElement !== this.interactable) {

--- a/packages/preferences/src/browser/views/components/preference-string-input.ts
+++ b/packages/preferences/src/browser/views/components/preference-string-input.ts
@@ -27,7 +27,7 @@ export class PreferenceStringInputRenderer extends PreferenceLeafNodeRenderer<st
         interactable.type = 'text';
         interactable.spellcheck = false;
         interactable.classList.add('theia-input');
-        interactable.defaultValue = this.getValue();
+        interactable.defaultValue = this.getValue() ?? '';
         interactable.oninput = this.handleUserInteraction.bind(this);
         interactable.onblur = this.handleBlur.bind(this);
         parent.appendChild(interactable);
@@ -40,7 +40,7 @@ export class PreferenceStringInputRenderer extends PreferenceLeafNodeRenderer<st
     protected doHandleValueChange(): void {
         const currentValue = this.interactable.value;
         this.updateInspection();
-        const newValue = this.getValue();
+        const newValue = this.getValue() ?? '';
         this.updateModificationStatus(newValue);
         if (newValue !== currentValue) {
             if (document.activeElement !== this.interactable) {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

A number of preferences use `null` as a default even if that is not among their declared values. As a consequence, it is possible for a preference renderer to encounter a null value when another value type is expected.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

1. Start the application.
2. Open the preferences UI
3. On `master`, you will see a message about inability to read `toString` of `null` and the layout may fail to be restored.
4. With this code, you will see no message about inability to read `toString` of `null` and the layout should successfully be restored. The preference `html.format.maxPreserveNewLines` should show an empty input box, unless you have set a numerical value for it.


#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
