### PR TITLE
[MacOS] Remove window focus listener on unload

### DIFF
--- a/packages/core/src/electron-browser/menu/electron-menu-contribution.ts
+++ b/packages/core/src/electron-browser/menu/electron-menu-contribution.ts
@@ -101,10 +101,7 @@ export class ElectronMenuContribution extends BrowserMenuBarContribution impleme
     override onStart(app: FrontendApplication): void {
         this.handleTitleBarStyling(app);
         if (isOSX) {
-            // OSX: Recreate the menus when changing windows.
-            // OSX only has one menu bar for all windows, so we need to swap
-            // between them as the user switches windows.
-            electronRemote.getCurrentWindow().on('focus', () => this.setMenu(app));
+            this.attachWindowFocusListener(app);
         }
         // Make sure the application menu is complete, once the frontend application is ready.
         // https://github.com/theia-ide/theia/issues/5100
@@ -123,6 +120,16 @@ export class ElectronMenuContribution extends BrowserMenuBarContribution impleme
         this.shell.bottomPanel.onDidToggleMaximized(() => {
             this.handleToggleMaximized();
         });
+    }
+
+    protected attachWindowFocusListener(app: FrontendApplication): void {
+        // OSX: Recreate the menus when changing windows.
+        // OSX only has one menu bar for all windows, so we need to swap
+        // between them as the user switches windows.
+        const targetWindow = electronRemote.getCurrentWindow();
+        const callback = () => this.setMenu(app);
+        targetWindow.on('focus', callback);
+        window.addEventListener('unload', () => targetWindow.off('focus', callback));
     }
 
     handleTitleBarStyling(app: FrontendApplication): void {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

On `master` in Electron on MacOS, we attach a listener for window focus and never release it. As a consequence, if the user refreshes the Electron window, they will see logs indicating that a listener was called an a renderer that has been released. This PR removes that message by ensuring that we remove the listener when the window unloads.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

0. On MacOS
1. Start the Electron application
2. Confirm that the OSX top bar menu appears as expected and the menu items behave as they should.
3. Switch windows (on the same monitor, if you have more than one)
4. Observe that the OSX top bar menu is swapped out as expected and continues to work as expected.
5. Refresh the window one or more times. (Cmd+R)
6. Repeat steps 2-4
7. Observe additionally that your backend logs do not show any messages about callbacks in released renderers.


#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
