### PR TITLE
fix files.eol preferences cannot display correctly

### DIFF
--- a/packages/preferences/src/browser/views/components/preference-select-input.ts
+++ b/packages/preferences/src/browser/views/components/preference-select-input.ts
@@ -23,6 +23,7 @@ import { Preference } from '../../util/preference-types';
 import { PreferenceLeafNodeRendererContribution } from './preference-node-renderer-creator';
 import * as React from '@theia/core/shared/react';
 import * as ReactDOM from '@theia/core/shared/react-dom';
+import { escapeInvisibleChars } from '@theia/core/lib/common/strings';
 
 @injectable()
 export class PreferenceSelectInputRenderer extends PreferenceLeafNodeRenderer<JSONValue, HTMLDivElement> {
@@ -38,7 +39,7 @@ export class PreferenceSelectInputRenderer extends PreferenceLeafNodeRenderer<JS
         const values = this.enumValues;
         const defaultValue = this.preferenceNode.preference.data.default;
         for (let i = 0; i < values.length; i++) {
-            const value = `${values[i]}`;
+            const value = escapeInvisibleChars(`${values[i]}`);
             const detail = PreferenceProvider.deepEqual(defaultValue, value) ? 'default' : undefined;
             let enumDescription = this.preferenceNode.preference.data.enumDescriptions?.[i];
             let markdown = false;


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->
https://github.com/eclipse-theia/theia/pull/4110
https://community.theia-ide.org/t/preference-files-eol-cannot-display-correctly/2368

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
click menu:  Preferences => Open Settings(UI) => Files Eol => edit & show options

#### Review checklist

- [ ] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
