### PR TITLE
Introduce DebugSession#workspaceFolder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 - [Previous Changelogs](https://github.com/eclipse-theia/theia/tree/master/doc/changelogs/)
 
+## v.1.26.0
+
+- [plugin] Introduce `DebugSession#workspaceFolder` [#11090](https://github.com/eclipse-theia/theia/pull/11090) - Contributed on behalf of STMicroelectronics
+
 ## v1.25.0 - 4/28/2022
 
 [1.25.0 Milestone](https://github.com/eclipse-theia/theia/milestone/35)

--- a/packages/debug/src/browser/debug-session-contribution.ts
+++ b/packages/debug/src/browser/debug-session-contribution.ts
@@ -30,6 +30,7 @@ import { Channel, DebugAdapterPath } from '../common/debug-service';
 import { ContributionProvider } from '@theia/core/lib/common/contribution-provider';
 import { FileService } from '@theia/filesystem/lib/browser/file-service';
 import { DebugContribution } from './debug-contribution';
+import { WorkspaceService } from '@theia/workspace/lib/browser';
 
 /**
  * DebugSessionContribution symbol for DI.
@@ -114,6 +115,8 @@ export class DefaultDebugSessionFactory implements DebugSessionFactory {
     protected readonly fileService: FileService;
     @inject(ContributionProvider) @named(DebugContribution)
     protected readonly debugContributionProvider: ContributionProvider<DebugContribution>;
+    @inject(WorkspaceService)
+    protected readonly workspaceService: WorkspaceService;
 
     get(sessionId: string, options: DebugSessionOptions, parentSession?: DebugSession): DebugSession {
         const connection = new DebugSessionConnection(
@@ -135,7 +138,8 @@ export class DefaultDebugSessionFactory implements DebugSessionFactory {
             this.labelProvider,
             this.messages,
             this.fileService,
-            this.debugContributionProvider);
+            this.debugContributionProvider,
+            this.workspaceService);
     }
 
     protected getTraceOutputChannel(): OutputChannel | undefined {

--- a/packages/debug/src/browser/debug-session-manager.ts
+++ b/packages/debug/src/browser/debug-session-manager.ts
@@ -214,7 +214,7 @@ export class DebugSessionManager {
                     }
                 }
 
-                const sessionId = await this.debug.createDebugSession(resolved.configuration);
+                const sessionId = await this.debug.createDebugSession(resolved.configuration, options.workspaceFolderUri);
                 return this.doStart(sessionId, resolved);
             } catch (e) {
                 if (DebugError.NotFound.is(e)) {

--- a/packages/debug/src/browser/debug-session.tsx
+++ b/packages/debug/src/browser/debug-session.tsx
@@ -749,19 +749,14 @@ export class DebugSession implements CompositeTreeElement {
     }
 
     get label(): string {
-        const showWSFolderInLabel = this.workspaceService.isMultiRootWorkspaceOpened && this.options.workspaceFolderUri;
-        if (showWSFolderInLabel) {
-            const wsFolder = this.labelProvider.getName(new URI(this.options.workspaceFolderUri));
-            if (InternalDebugSessionOptions.is(this.options) && this.options.id) {
-                return this.configuration.name + ' (' + (this.options.id + 1) + ' - ' + wsFolder + ')';
-            }
-            return this.configuration.name + ' (' + wsFolder + ')';
-        } else {
-            if (InternalDebugSessionOptions.is(this.options) && this.options.id) {
-                return this.configuration.name + ' (' + (this.options.id + 1) + ')';
-            }
-            return this.configuration.name;
+        const suffixes = [];
+        if (InternalDebugSessionOptions.is(this.options) && this.options.id) {
+            suffixes.push(String(this.options.id + 1));
         }
+        if (this.workspaceService.isMultiRootWorkspaceOpened && this.options.workspaceFolderUri) {
+            suffixes.push(this.labelProvider.getName(new URI(this.options.workspaceFolderUri)));
+        }
+        return suffixes.length === 0 ? this.configuration.name : this.configuration.name + ` (${suffixes.join(' - ')})`;
     }
 
     get visible(): boolean {

--- a/packages/debug/src/browser/debug-session.tsx
+++ b/packages/debug/src/browser/debug-session.tsx
@@ -41,6 +41,7 @@ import { DebugFunctionBreakpoint } from './model/debug-function-breakpoint';
 import { FileService } from '@theia/filesystem/lib/browser/file-service';
 import { DebugContribution } from './debug-contribution';
 import { waitForEvent } from '@theia/core/lib/common/promise-util';
+import { WorkspaceService } from '@theia/workspace/lib/browser';
 
 export enum DebugState {
     Inactive,
@@ -79,7 +80,8 @@ export class DebugSession implements CompositeTreeElement {
         protected readonly labelProvider: LabelProvider,
         protected readonly messages: MessageClient,
         protected readonly fileService: FileService,
-        protected readonly debugContributionProvider: ContributionProvider<DebugContribution>
+        protected readonly debugContributionProvider: ContributionProvider<DebugContribution>,
+        protected readonly workspaceService: WorkspaceService,
     ) {
         this.connection.onRequest('runInTerminal', (request: DebugProtocol.RunInTerminalRequest) => this.runInTerminal(request));
         this.connection.onDidClose(() => {
@@ -747,10 +749,19 @@ export class DebugSession implements CompositeTreeElement {
     }
 
     get label(): string {
-        if (InternalDebugSessionOptions.is(this.options) && this.options.id) {
-            return this.configuration.name + ' (' + (this.options.id + 1) + ')';
+        const showWSFolderInLabel = this.workspaceService.isMultiRootWorkspaceOpened && this.options.workspaceFolderUri;
+        if (showWSFolderInLabel) {
+            const wsFolder = this.labelProvider.getName(new URI(this.options.workspaceFolderUri));
+            if (InternalDebugSessionOptions.is(this.options) && this.options.id) {
+                return this.configuration.name + ' (' + (this.options.id + 1) + ' - ' + wsFolder + ')';
+            }
+            return this.configuration.name + ' (' + wsFolder + ')';
+        } else {
+            if (InternalDebugSessionOptions.is(this.options) && this.options.id) {
+                return this.configuration.name + ' (' + (this.options.id + 1) + ')';
+            }
+            return this.configuration.name;
         }
-        return this.configuration.name;
     }
 
     get visible(): boolean {

--- a/packages/debug/src/common/debug-configuration.ts
+++ b/packages/debug/src/common/debug-configuration.ts
@@ -77,9 +77,6 @@ export interface DebugConfiguration {
 
     /** Indicates if it's a dynamic debug configuration */
     dynamic?: boolean;
-
-    /** The worspace folder used for looking up tasks, resolving variables, etc. */
-    workspaceFolderUri?: string;
 }
 export namespace DebugConfiguration {
     export function is(arg: DebugConfiguration | any): arg is DebugConfiguration {

--- a/packages/debug/src/common/debug-configuration.ts
+++ b/packages/debug/src/common/debug-configuration.ts
@@ -77,6 +77,9 @@ export interface DebugConfiguration {
 
     /** Indicates if it's a dynamic debug configuration */
     dynamic?: boolean;
+
+    /** The worspace folder used for looking up tasks, resolving variables, etc. */
+    workspaceFolderUri?: string;
 }
 export namespace DebugConfiguration {
     export function is(arg: DebugConfiguration | any): arg is DebugConfiguration {

--- a/packages/debug/src/common/debug-service.ts
+++ b/packages/debug/src/common/debug-service.ts
@@ -100,9 +100,10 @@ export interface DebugService extends Disposable {
     /**
      * Creates a new [debug adapter session](#DebugAdapterSession).
      * @param config The resolved [debug configuration](#DebugConfiguration).
+     * @param workspaceFolderUri The worspace folder for this sessions or undefined when folderless
      * @returns The identifier of the created [debug adapter session](#DebugAdapterSession).
      */
-    createDebugSession(config: DebugConfiguration): Promise<string>;
+    createDebugSession(config: DebugConfiguration, workspaceFolderUri: string | undefined): Promise<string>;
 
     /**
      * Stop a running session for the given session id.

--- a/packages/debug/src/node/debug-service-impl.ts
+++ b/packages/debug/src/node/debug-service-impl.ts
@@ -65,7 +65,7 @@ export class DebugServiceImpl implements DebugService {
     }
 
     protected readonly sessions = new Set<string>();
-    async createDebugSession(config: DebugConfiguration): Promise<string> {
+    async createDebugSession(config: DebugConfiguration, _workspaceFolderUri?: string): Promise<string> {
         const session = await this.sessionManager.create(config, this.registry);
         this.sessions.add(session.id);
         return session.id;

--- a/packages/plugin-ext/src/common/plugin-api-rpc.ts
+++ b/packages/plugin-ext/src/common/plugin-api-rpc.ts
@@ -1701,7 +1701,7 @@ export interface DebugExt {
         debugConfiguration: theia.DebugConfiguration
     ): Promise<theia.DebugConfiguration | undefined | null>;
 
-    $createDebugSession(debugConfiguration: theia.DebugConfiguration): Promise<string>;
+    $createDebugSession(debugConfiguration: theia.DebugConfiguration, workspaceFolder: string | undefined): Promise<string>;
     $terminateDebugSession(sessionId: string): Promise<void>;
     $getTerminalCreationOptions(debugType: string): Promise<TerminalOptionsExt | undefined>;
 }

--- a/packages/plugin-ext/src/main/browser/debug/debug-main.ts
+++ b/packages/plugin-ext/src/main/browser/debug/debug-main.ts
@@ -54,6 +54,7 @@ import { DebugConsoleSession } from '@theia/debug/lib/browser/console/debug-cons
 import { ContributionProvider } from '@theia/core/lib/common';
 import { DebugContribution } from '@theia/debug/lib/browser/debug-contribution';
 import { ConnectionImpl } from '../../../common/connection';
+import { WorkspaceService } from '@theia/workspace/lib/browser';
 
 export class DebugMainImpl implements DebugMain, Disposable {
     private readonly debugExt: DebugExt;
@@ -73,6 +74,7 @@ export class DebugMainImpl implements DebugMain, Disposable {
     private readonly fileService: FileService;
     private readonly pluginService: HostedPluginSupport;
     private readonly debugContributionProvider: ContributionProvider<DebugContribution>;
+    private readonly workspaceService: WorkspaceService;
 
     private readonly debuggerContributions = new Map<string, DisposableCollection>();
     private readonly configurationProviders = new Map<number, DisposableCollection>();
@@ -95,6 +97,7 @@ export class DebugMainImpl implements DebugMain, Disposable {
         this.debugContributionProvider = container.getNamed(ContributionProvider, DebugContribution);
         this.fileService = container.get(FileService);
         this.pluginService = container.get(HostedPluginSupport);
+        this.workspaceService = container.get(WorkspaceService);
 
         const fireDidChangeBreakpoints = ({ added, removed, changed }: BreakpointsChangeEvent<SourceBreakpoint | FunctionBreakpoint>) => {
             this.debugExt.$breakpointsDidChange(
@@ -155,7 +158,8 @@ export class DebugMainImpl implements DebugMain, Disposable {
             },
             this.fileService,
             terminalOptionsExt,
-            this.debugContributionProvider
+            this.debugContributionProvider,
+            this.workspaceService,
         );
 
         const toDispose = new DisposableCollection(

--- a/packages/plugin-ext/src/main/browser/debug/plugin-debug-adapter-contribution.ts
+++ b/packages/plugin-ext/src/main/browser/debug/plugin-debug-adapter-contribution.ts
@@ -37,9 +37,9 @@ export class PluginDebugAdapterContribution {
         return this.description.label;
     }
 
-    async createDebugSession(config: DebugConfiguration): Promise<string> {
+    async createDebugSession(config: DebugConfiguration, workspaceFolder: string | undefined): Promise<string> {
         await this.pluginService.activateByDebug('onDebugAdapterProtocolTracker', config.type);
-        return this.debugExt.$createDebugSession(config);
+        return this.debugExt.$createDebugSession(config, workspaceFolder);
     }
 
     async terminateDebugSession(sessionId: string): Promise<void> {

--- a/packages/plugin-ext/src/main/browser/debug/plugin-debug-service.ts
+++ b/packages/plugin-ext/src/main/browser/debug/plugin-debug-service.ts
@@ -264,14 +264,14 @@ export class PluginDebugService implements DebugService {
         return snippets;
     }
 
-    async createDebugSession(config: DebugConfiguration): Promise<string> {
+    async createDebugSession(config: DebugConfiguration, workspaceFolder: string | undefined): Promise<string> {
         const contributor = this.contributors.get(config.type);
         if (contributor) {
-            const sessionId = await contributor.createDebugSession(config);
+            const sessionId = await contributor.createDebugSession(config, workspaceFolder);
             this.sessionId2contrib.set(sessionId, contributor);
             return sessionId;
         } else {
-            return this.delegated.createDebugSession(config);
+            return this.delegated.createDebugSession(config, workspaceFolder);
         }
     }
 

--- a/packages/plugin-ext/src/main/browser/debug/plugin-debug-session-factory.ts
+++ b/packages/plugin-ext/src/main/browser/debug/plugin-debug-session-factory.ts
@@ -31,6 +31,7 @@ import { FileService } from '@theia/filesystem/lib/browser/file-service';
 import { DebugContribution } from '@theia/debug/lib/browser/debug-contribution';
 import { ContributionProvider } from '@theia/core/lib/common/contribution-provider';
 import { Channel } from '@theia/debug/lib/common/debug-service';
+import { WorkspaceService } from '@theia/workspace/lib/browser';
 
 export class PluginDebugSession extends DebugSession {
     constructor(
@@ -45,8 +46,10 @@ export class PluginDebugSession extends DebugSession {
         protected override readonly messages: MessageClient,
         protected override readonly fileService: FileService,
         protected readonly terminalOptionsExt: TerminalOptionsExt | undefined,
-        protected override readonly debugContributionProvider: ContributionProvider<DebugContribution>) {
-        super(id, options, parentSession, connection, terminalServer, editorManager, breakpoints, labelProvider, messages, fileService, debugContributionProvider);
+        protected override readonly debugContributionProvider: ContributionProvider<DebugContribution>,
+        protected override readonly workspaceService: WorkspaceService) {
+        super(id, options, parentSession, connection, terminalServer, editorManager, breakpoints, labelProvider, messages, fileService, debugContributionProvider,
+            workspaceService);
     }
 
     protected override async doCreateTerminal(terminalWidgetOptions: TerminalWidgetOptions): Promise<TerminalWidget> {
@@ -71,7 +74,8 @@ export class PluginDebugSessionFactory extends DefaultDebugSessionFactory {
         protected readonly connectionFactory: (sessionId: string) => Promise<Channel>,
         protected override readonly fileService: FileService,
         protected readonly terminalOptionsExt: TerminalOptionsExt | undefined,
-        protected override readonly debugContributionProvider: ContributionProvider<DebugContribution>
+        protected override readonly debugContributionProvider: ContributionProvider<DebugContribution>,
+        protected override readonly workspaceService: WorkspaceService,
     ) {
         super();
     }
@@ -94,7 +98,8 @@ export class PluginDebugSessionFactory extends DefaultDebugSessionFactory {
             this.messages,
             this.fileService,
             this.terminalOptionsExt,
-            this.debugContributionProvider
+            this.debugContributionProvider,
+            this.workspaceService,
         );
     }
 }

--- a/packages/plugin-ext/src/plugin/node/debug/debug.ts
+++ b/packages/plugin-ext/src/plugin/node/debug/debug.ts
@@ -290,13 +290,14 @@ export class DebugExtImpl implements DebugExt {
         return undefined;
     }
 
-    async $createDebugSession(debugConfiguration: theia.DebugConfiguration): Promise<string> {
+    async $createDebugSession(debugConfiguration: theia.DebugConfiguration, workspaceFolderUri: string | undefined): Promise<string> {
         const sessionId = uuid.v4();
 
         const theiaSession: theia.DebugSession = {
             id: sessionId,
             type: debugConfiguration.type,
             name: debugConfiguration.name,
+            workspaceFolder: this.toWorkspaceFolder(workspaceFolderUri),
             configuration: debugConfiguration,
             customRequest: async (command: string, args?: any) => {
                 const response = await this.proxy.$customRequest(sessionId, command, args);

--- a/packages/plugin-ext/src/plugin/node/debug/plugin-debug-adapter-session.ts
+++ b/packages/plugin-ext/src/plugin/node/debug/plugin-debug-adapter-session.ts
@@ -27,6 +27,7 @@ import { Channel } from '@theia/debug/lib/common/debug-service';
 export class PluginDebugAdapterSession extends DebugAdapterSessionImpl {
     readonly type: string;
     readonly name: string;
+    readonly workspaceFolder: theia.WorkspaceFolder | undefined;
     readonly configuration: theia.DebugConfiguration;
 
     constructor(
@@ -38,6 +39,7 @@ export class PluginDebugAdapterSession extends DebugAdapterSessionImpl {
 
         this.type = theiaSession.type;
         this.name = theiaSession.name;
+        this.workspaceFolder = theiaSession.workspaceFolder;
         this.configuration = theiaSession.configuration;
     }
 

--- a/packages/plugin/src/theia.d.ts
+++ b/packages/plugin/src/theia.d.ts
@@ -9649,6 +9649,11 @@ export module '@theia/plugin' {
         readonly name: string;
 
         /**
+         * The workspace folder of this session or `undefined` for a folderless setup.
+         */
+        readonly workspaceFolder: WorkspaceFolder | undefined;
+
+        /**
          * The "resolved" [debug configuration](#DebugConfiguration) of this session.
          */
         readonly configuration: DebugConfiguration;


### PR DESCRIPTION
#### What it does
Fixes #10023

* Adds the missing `workspaceFolderUri` to the `DebugSession` API
* Adjust code to create the session including `workspaceFolderUri`
* The existing `DebugSessionManager` was already honoring the workspace folder as far as I could see (-> e.g. when executing pre launch tasks: https://github.com/eclipse-theia/theia/blob/7f5047fcb21c1415d4ecf9b5ba34f802615e1c05/packages/debug/src/browser/debug-session-manager.ts#L211) so only the session object creation itself was adjusted
* Adds the workspacefolder to the DebugSession's UI label, in case we have a multi-root workspace (and multiple running debug sessions, as otherwise the ui node is hidden)

_VS-Code UI (esm-i was the set workspace-folder. This is not shown in the Top, because this is a launch without a set ws folder):_
![ksnip_20220426-092056](https://user-images.githubusercontent.com/5889696/166423075-5242ee5b-1666-4ef3-bd04-e50efe4ed464.png)

_Theia UI (workspace folder was called java):_
![ksnip_20220503-101753](https://user-images.githubusercontent.com/5889696/166423019-eecef881-3011-47c7-b3e9-d997fa9de0a0.png)

Contributed on behalf of STMicroelectronics

Signed-off-by: Johannes Faltermeier <jfaltermeier@eclipsesource.com>

#### How to test
I've created a small VSCode extension that tracks the creation of debug sessions and logs the workspace folder of a session:
https://github.com/jfaltermeier/vscode-debug-playground
https://github.com/jfaltermeier/vscode-debug-playground/blob/main/src/extension.ts
You may get this test extension from https://github.com/jfaltermeier/vscode-debug-playground/releases/tag/0.0.1

* start Theia Browser Example with above extension
* debug any application (I was testing with a java application)

This should create a log message similar to this one:

```
root INFO [hosted-plugin: 67589] ES : DebugAdapterTracker: DebugSession created with workspaceFolder: file:///home/johannes/git/java-sample
```

Without the changes, the worspaceFolder was undefined all the time
```
root INFO [hosted-plugin: 70803] ES : DebugAdapterTracker: DebugSession created with workspaceFolder: undef
```


* For testing the UI label, create a multi root workspace and start multiple debug sessions that stop at a breakpoint. 
* The session label will show the wsfolder in brackets

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
