### PR TITLE
Fix MacOS browser menu keybinding display

### DIFF
--- a/packages/core/src/browser/keybinding.ts
+++ b/packages/core/src/browser/keybinding.ts
@@ -314,9 +314,9 @@ export class KeybindingRegistry {
      * @param keybinding the keybinding
      * @param separator the separator to be used to stringify {@link KeyCode}s that are part of the {@link KeySequence}
      */
-    acceleratorFor(keybinding: common.Keybinding, separator: string = ' '): string[] {
+    acceleratorFor(keybinding: common.Keybinding, separator: string = ' ', asciiOnly = false): string[] {
         const bindingKeySequence = this.resolveKeybinding(keybinding);
-        return this.acceleratorForSequence(bindingKeySequence, separator);
+        return this.acceleratorForSequence(bindingKeySequence, separator, asciiOnly);
     }
 
     /**
@@ -325,8 +325,8 @@ export class KeybindingRegistry {
      * @param keySequence the keysequence
      * @param separator the separator to be used to stringify {@link KeyCode}s that are part of the {@link KeySequence}
      */
-    acceleratorForSequence(keySequence: KeySequence, separator: string = ' '): string[] {
-        return keySequence.map(keyCode => this.acceleratorForKeyCode(keyCode, separator));
+    acceleratorForSequence(keySequence: KeySequence, separator: string = ' ', asciiOnly = false): string[] {
+        return keySequence.map(keyCode => this.acceleratorForKeyCode(keyCode, separator, asciiOnly));
     }
 
     /**

--- a/packages/core/src/browser/menu/browser-menu-plugin.ts
+++ b/packages/core/src/browser/menu/browser-menu-plugin.ts
@@ -479,7 +479,7 @@ export class MenuCommandRegistry extends PhosphorCommandRegistry {
         // Only consider the first keybinding.
         if (bindings.length) {
             const binding = bindings[0];
-            const keys = keybindingRegistry.acceleratorFor(binding);
+            const keys = keybindingRegistry.acceleratorFor(binding, ' ', true);
             this.addKeyBinding({
                 command: id,
                 keys,


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->
Fixes #10931
On `master`, keybindings do not display correctly in menus in MacOS in the browser. This PR fixes that by ensuring that Phosphor receives ascii-only keybinding descriptions, which it then converts into the expected MacOS characers.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

0. On MacOS.
1. Start the browser application
3. Open the `File` menu.
4. You should see correctly rendered keyboard shortcuts.
5. Open the keybindings widget.
6. You should still see MacOS style characters in that widget.

![image](https://user-images.githubusercontent.com/62660806/165963799-9b445d1c-b4f6-49f5-a874-8938fff84f51.png)

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
