### PR TITLE
[playwright] Improve getting started documentation

### DIFF
--- a/examples/playwright/README.md
+++ b/examples/playwright/README.md
@@ -33,6 +33,7 @@ It is [extensible](./docs/EXTENSIBILITY.md) so you can add dedicated page object
 
 - [Getting Started](./docs/GETTING_STARTED.md)
 - [Extensibility](./docs/EXTENSIBILITY.md)
+- [Theia 🎭 Playwright Template](https://github.com/eclipse-theia/theia-playwright-template)
 - [Building and Developing Theia 🎭 Playwright](./docs/DEVELOPING.md)
 
 ## Additional Information

--- a/examples/playwright/docs/GETTING_STARTED.md
+++ b/examples/playwright/docs/GETTING_STARTED.md
@@ -1,14 +1,34 @@
 # Getting Started
 
-This repository contains several tests based on Theia 🎭 Playwright in `examples/playwright/src/tests` that should help getting started quickly.
-You can also use this package as a template for your own tests.
+The fastest way to getting started is to clone the [theia-playwright-template](https://github.com/eclipse-theia/theia-playwright-template) and build the theia-playwright-template.
 
-Please note that Theia 🎭 Playwright is built to be extended with custom page objects.
-Please refer to the [extension guide](EXTENSIBILITY.md).
+```bash
+git clone git@github.com:eclipse-theia/theia-playwright-template.git
+cd theia-playwright-template
+yarn
+```
+
+The most important files in the theia-playwright-template are:
+
+* Example test in `tests/theia-app.test.ts`
+* Example page object in `test/page-objects/theia-app.ts`
+* Configuration files in `configs`, including the base playwright configuration at `configs/playwright.config.ts`
+* `package.json` with all required dependencies and scripts for running and debugging the tests
+
+Now, let's run the tests:
+
+1. Run your Theia application under test (not part of the theia-playwright-template)
+2. Run `yarn ui-tests` in the theia-playwright-template to run its tests in headless mode
+
+Please note that Theia 🎭 Playwright is built to be extended with custom page objects, such as the one in `test/page-objects/theia-app.ts` in the theia-playwright-template.
+We recommend to add further page objects for all custom views, editors, widgets, etc.
+Please refer to the [extension guide](EXTENSIBILITY.md) for more information.
+
+Moreover, this repository contains several tests based on Theia 🎭 Playwright in `examples/playwright/src/tests` that may serve as additional examples for writing tests.
 
 ## Adding further tests
 
-Let's write a system test for the Theia text editor as an example:
+Let's write add another system test for the Theia text editor as an example:
 
 1. Initialize a prepared workspace containing a file `sampleFolder/sample.txt` and open the workspace with the Theia application under test
 2. Open the Theia text editor


### PR DESCRIPTION
#### What it does
Improves the documentation for getting started with the theia-playwright page object library.

This change requires https://github.com/eclipse-theia/theia-playwright-template/pull/1
And fixes https://github.com/eclipse-theia/theia/issues/11015

#### How to test
Please read `examples/playwright/docs/GETTING_STARTED.md` and follow the steps in order to evaluate whether this guide will help newcomers to get started easily.

#### Review checklist

- [X] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
