### PR TITLE
Prevent MonacoEditorService from instantiating ContextKeyService thro…

### DIFF
--- a/examples/api-tests/src/monaco-api.spec.js
+++ b/examples/api-tests/src/monaco-api.spec.js
@@ -29,10 +29,9 @@ describe('Monaco API', async function () {
     const { SimpleKeybinding } = require('@theia/monaco-editor-core/esm/vs/base/common/keybindings');
     const { IKeybindingService } = require('@theia/monaco-editor-core/esm/vs/platform/keybinding/common/keybinding');
     const { StandaloneServices } = require('@theia/monaco-editor-core/esm/vs/editor/standalone/browser/standaloneServices');
-    const { KeyCode } = require('@theia/monaco-editor-core/esm/vs/base/common/keyCodes');
     const { TokenizationRegistry } = require('@theia/monaco-editor-core/esm/vs/editor/common/languages');
     const { MonacoContextKeyService } = require('@theia/monaco/lib/browser/monaco-context-key-service');
-    const { Uri } = require('@theia/monaco-editor-core');
+    const { URI } = require('@theia/monaco-editor-core/esm/vs/base/common/uri');
 
     const container = window.theia.container;
     const editorManager = container.get(EditorManager);
@@ -59,7 +58,7 @@ describe('Monaco API', async function () {
     });
 
     it('KeybindingService.resolveKeybinding', () => {
-        const simpleKeybinding = new SimpleKeybinding(true, true, true, true, KeyCode.KeyK);
+        const simpleKeybinding = new SimpleKeybinding(true, true, true, true, 41 /* KeyCode.KeyK */);
         const chordKeybinding = simpleKeybinding.toChord();
         assert.equal(chordKeybinding.parts.length, 1);
         assert.equal(chordKeybinding.parts[0], simpleKeybinding);
@@ -167,7 +166,7 @@ describe('Monaco API', async function () {
             execute: arg => (console.log(arg), opened = arg === 'foo')
         });
         try {
-            await openerService.open(Uri.parse('command:' + id + '?"foo"'));
+            await openerService.open(URI.parse('command:' + id + '?"foo"'));
             assert.isTrue(opened);
         } finally {
             unregisterCommand.dispose();

--- a/examples/api-tests/src/monaco-api.spec.js
+++ b/examples/api-tests/src/monaco-api.spec.js
@@ -179,6 +179,7 @@ describe('Monaco API', async function () {
         const key = 'monaco-api-test-context';
         const firstValue = 'first setting';
         const secondValue = 'second setting';
+        assert.isFalse(contextKeys.match(`${key} == ${firstValue}`));
         await commands.executeCommand(setContext, key, firstValue);
         assert.isTrue(contextKeys.match(`${key} == ${firstValue}`));
         await commands.executeCommand(setContext, key, secondValue);

--- a/examples/api-tests/src/monaco-api.spec.js
+++ b/examples/api-tests/src/monaco-api.spec.js
@@ -31,13 +31,17 @@ describe('Monaco API', async function () {
     const { StandaloneServices } = require('@theia/monaco-editor-core/esm/vs/editor/standalone/browser/standaloneServices');
     const { KeyCode } = require('@theia/monaco-editor-core/esm/vs/base/common/keyCodes');
     const { TokenizationRegistry } = require('@theia/monaco-editor-core/esm/vs/editor/common/languages');
+    const { MonacoContextKeyService } = require('@theia/monaco/lib/browser/monaco-context-key-service');
     const { Uri } = require('@theia/monaco-editor-core');
 
     const container = window.theia.container;
     const editorManager = container.get(EditorManager);
     const workspaceService = container.get(WorkspaceService);
     const textmateService = container.get(MonacoTextmateService);
+    /** @type {import('@theia/core/src/common/command').CommandRegistry} */
     const commands = container.get(CommandRegistry);
+    /** @type {import('@theia/monaco/src/browser/monaco-context-key-service').MonacoContextKeyService} */
+    const contextKeys = container.get(MonacoContextKeyService);
 
     /** @type {MonacoEditor} */
     let monacoEditor;
@@ -168,6 +172,17 @@ describe('Monaco API', async function () {
         } finally {
             unregisterCommand.dispose();
         }
+    });
+
+    it('Supports setting contexts using the command registry', async () => {
+        const setContext = 'setContext';
+        const key = 'monaco-api-test-context';
+        const firstValue = 'first setting';
+        const secondValue = 'second setting';
+        await commands.executeCommand(setContext, key, firstValue);
+        assert.isTrue(contextKeys.match(`${key} == ${firstValue}`));
+        await commands.executeCommand(setContext, key, secondValue);
+        assert.isTrue(contextKeys.match(`${key} == ${secondValue}`));
     });
 
 });

--- a/examples/api-tests/src/saveable.spec.js
+++ b/examples/api-tests/src/saveable.spec.js
@@ -31,7 +31,7 @@ describe('Saveable', function () {
     const { MonacoEditor } = require('@theia/monaco/lib/browser/monaco-editor');
     const { Deferred } = require('@theia/core/lib/common/promise-util');
     const { Disposable, DisposableCollection } = require('@theia/core/lib/common/disposable');
-    const { Range } = require('@theia/monaco-editor-core');
+    const { Range } = require('@theia/monaco-editor-core/esm/vs/editor/common/core/range');
 
     const container = window.theia.container;
     /** @type {EditorManager} */

--- a/examples/api-tests/src/undo-redo-selectAll.spec.js
+++ b/examples/api-tests/src/undo-redo-selectAll.spec.js
@@ -31,7 +31,7 @@ describe('Undo, Redo and Select All', function () {
     const { ApplicationShell } = require('@theia/core/lib/browser/shell/application-shell');
     const { MonacoEditor } = require('@theia/monaco/lib/browser/monaco-editor');
     const { ScmContribution } = require('@theia/scm/lib/browser/scm-contribution');
-    const { Range } = require('@theia/monaco-editor-core');
+    const { Range } = require('@theia/monaco-editor-core/esm/vs/editor/common/core/range');
 
     const container = window.theia.container;
     const editorManager = container.get(EditorManager);

--- a/examples/api-tests/test-ts-workspace/demo-definitions-file.ts
+++ b/examples/api-tests/test-ts-workspace/demo-definitions-file.ts
@@ -1,0 +1,4 @@
+
+export interface DefinedInterface {
+    coolField: number[];
+}

--- a/examples/api-tests/test-ts-workspace/demo-file.ts
+++ b/examples/api-tests/test-ts-workspace/demo-file.ts
@@ -1,0 +1,32 @@
+
+interface DemoInterface {
+    stringField: string;
+    numberField: number;
+    doSomething(): number;
+}
+
+class DemoClass implements DemoInterface {
+    stringField: string;
+    numberField: number;
+    constructor(someString: string) {
+        this.stringField = someString;
+        this.numberField = this.stringField.length;
+    }
+    doSomething(): number {
+        let output = 0;
+        for (let i = 0; i < this.stringField.length; i++) {
+            output += this.stringField.charCodeAt(i);
+        }
+        return output;
+    }
+}
+
+const demoInstance = new DemoClass('demo');
+
+const demoVariable = demoInstance.stringField;
+
+demoVariable.concat('-string');
+
+import { DefinedInterface } from "./demo-definitions-file";
+
+const bar: DefinedInterface = { coolField: [] };

--- a/examples/api-tests/test-ts-workspace/tsconfig.json
+++ b/examples/api-tests/test-ts-workspace/tsconfig.json
@@ -1,0 +1,28 @@
+{
+  "$schema": "https://json.schemastore.org/tsconfig",
+  "compilerOptions": {
+    "skipLibCheck": true,
+    "declaration": true,
+    "declarationMap": true,
+    "noImplicitAny": true,
+    "noImplicitOverride": true,
+    "noEmitOnError": false,
+    "noImplicitThis": true,
+    "noUnusedLocals": true,
+    "strictNullChecks": true,
+    "experimentalDecorators": true,
+    "emitDecoratorMetadata": true,
+    "downlevelIteration": true,
+    "resolveJsonModule": true,
+    "module": "commonjs",
+    "moduleResolution": "node",
+    "target": "ES2017",
+    "jsx": "react",
+    "lib": [
+      "ES2017",
+      "ES2020.Promise",
+      "dom"
+    ],
+    "sourceMap": true
+  }
+}

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "all": "yarn -s install && yarn -s lint && yarn -s build",
     "browser": "yarn -s --cwd examples/browser",
     "build": "yarn -s compile && yarn -s build:examples",
+    "build-p": "yarn -s compile && lerna run --scope=\"@theia/example-*\" bundle --parallel",
     "build:examples": "yarn -s download:plugins && lerna run --scope=\"@theia/example-*\" bundle --parallel",
     "clean": "yarn -s rebuild:clean && yarn -s lint:clean && node scripts/run-reverse-topo.js yarn -s clean",
     "compile": "echo Compiling TypeScript sources... && yarn -s compile:clean && yarn -s compile:tsc",

--- a/packages/monaco/src/browser/monaco-editor-service.ts
+++ b/packages/monaco/src/browser/monaco-editor-service.ts
@@ -25,9 +25,9 @@ import { IResourceEditorInput, ITextResourceEditorInput } from '@theia/monaco-ed
 import { StandaloneServices } from '@theia/monaco-editor-core/esm/vs/editor/standalone/browser/standaloneServices';
 import { IStandaloneThemeService } from '@theia/monaco-editor-core/esm/vs/editor/standalone/common/standaloneTheme';
 import { StandaloneCodeEditorService } from '@theia/monaco-editor-core/esm/vs/editor/standalone/browser/standaloneCodeEditorService';
-import { IContextKeyService } from '@theia/monaco-editor-core/esm/vs/platform/contextkey/common/contextkey';
 import { StandaloneCodeEditor } from '@theia/monaco-editor-core/esm/vs/editor/standalone/browser/standaloneCodeEditor';
 import { ICodeEditor } from '@theia/monaco-editor-core/esm/vs/editor/browser/editorBrowser';
+import { ContextKeyService as VSCodeContextKeyService } from '@theia/monaco-editor-core/esm/vs/platform/contextkey/browser/contextKeyService';
 
 decorate(injectable(), StandaloneCodeEditorService);
 
@@ -51,8 +51,8 @@ export class MonacoEditorService extends StandaloneCodeEditorService {
     @inject(PreferenceService)
     protected readonly preferencesService: PreferenceService;
 
-    constructor() {
-        super(StandaloneServices.get(IContextKeyService), StandaloneServices.get(IStandaloneThemeService));
+    constructor(@inject(VSCodeContextKeyService) contextKeyService: VSCodeContextKeyService) {
+        super(contextKeyService, StandaloneServices.get(IStandaloneThemeService));
     }
 
     /**


### PR DESCRIPTION
…ugh Monaco

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

Fixes: https://github.com/eclipse-theia/theia/issues/11096.

If we wish to override Monaco services, we must do so before the same services are instantiated by Monaco by other means. At the moment, one of our desired overrides, the `MonacoEditorService` is instantiating a `ContextKeyService` using Monaco methods, but we want to override the `ContextKeyService` as well. This PR changes the way the `MonacoEditorService` accesses the `ContextKeyService` to allow the override to take effect.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

1. Install [this plugin](https://github.com/vince-fugnitto/enablement-test/releases/tag/0.0.1)
2. Use the command palette to run the `Enablement: Enable` and `Enablement: Disable` commands.
3. Observe that the `Show Enablement Issue` widget appears and disappears from its view container. (But due to https://github.com/eclipse-theia/theia/issues/10778 , the view container will not close)

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
