### PR TITLE
Update Monaco keybindings on keybinding change

### DIFF
--- a/packages/monaco/src/browser/monaco-context-key-service.ts
+++ b/packages/monaco/src/browser/monaco-context-key-service.ts
@@ -69,7 +69,7 @@ export class MonacoContextKeyService implements TheiaContextKeyService {
     }
 
     protected readonly expressions = new Map<string, ContextKeyExpression>();
-    protected parse(when: string): ContextKeyExpression | undefined {
+    parse(when: string): ContextKeyExpression | undefined {
         let expression = this.expressions.get(when);
         if (!expression) {
             expression = ContextKeyExpr.deserialize(when);

--- a/packages/monaco/src/browser/monaco-keybinding.ts
+++ b/packages/monaco/src/browser/monaco-keybinding.ts
@@ -14,19 +14,33 @@
 // SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
 // *****************************************************************************
 
-import { injectable, inject } from '@theia/core/shared/inversify';
-import { KeybindingContribution, KeybindingRegistry } from '@theia/core/lib/browser';
+import { injectable, inject, postConstruct } from '@theia/core/shared/inversify';
+import { KeybindingContribution, KeybindingRegistry, KeybindingScope, KeyCode } from '@theia/core/lib/browser';
 import { MonacoCommands } from './monaco-command';
 import { MonacoCommandRegistry } from './monaco-command-registry';
-import { environment } from '@theia/core';
+import { CommandRegistry, DisposableCollection, environment, isOSX } from '@theia/core';
 import { MonacoResolvedKeybinding } from './monaco-resolved-keybinding';
 import { KeybindingsRegistry } from '@theia/monaco-editor-core/esm/vs/platform/keybinding/common/keybindingsRegistry';
+import { StandaloneKeybindingService, StandaloneServices } from '@theia/monaco-editor-core/esm/vs/editor/standalone/browser/standaloneServices';
+import { IKeybindingService } from '@theia/monaco-editor-core/esm/vs/platform/keybinding/common/keybinding';
+import { MonacoContextKeyService } from './monaco-context-key-service';
+import { KEY_CODE_MAP } from './monaco-keycode-map';
+import * as monaco from '@theia/monaco-editor-core';
 
 @injectable()
 export class MonacoKeybindingContribution implements KeybindingContribution {
 
-    @inject(MonacoCommandRegistry)
-    protected readonly commands: MonacoCommandRegistry;
+    protected toDisposeOnKeybindingChange = new DisposableCollection();
+
+    @inject(MonacoCommandRegistry) protected readonly commands: MonacoCommandRegistry;
+    @inject(KeybindingRegistry) protected readonly keybindings: KeybindingRegistry;
+    @inject(CommandRegistry) protected readonly theiaCommandRegistry: CommandRegistry;
+    @inject(MonacoContextKeyService) protected readonly contextKeyService: MonacoContextKeyService;
+
+    @postConstruct()
+    protected init(): void {
+        this.keybindings.onKeybindingsChanged(() => this.updateMonacoKeybindings());
+    }
 
     registerKeybindings(registry: KeybindingRegistry): void {
         const defaultKeybindings = KeybindingsRegistry.getDefaultKeybindings();
@@ -43,5 +57,55 @@ export class MonacoKeybindingContribution implements KeybindingContribution {
                 registry.registerKeybinding({ command, keybinding, when });
             }
         }
+    }
+
+    protected updateMonacoKeybindings(): void {
+        const monacoKeybindingRegistry = StandaloneServices.get(IKeybindingService);
+        if (monacoKeybindingRegistry instanceof StandaloneKeybindingService) {
+            this.toDisposeOnKeybindingChange.dispose();
+            for (const binding of this.keybindings.getKeybindingsByScope(KeybindingScope.USER).concat(this.keybindings.getKeybindingsByScope(KeybindingScope.WORKSPACE))) {
+                const resolved = this.keybindings.resolveKeybinding(binding);
+                const command = binding.command;
+                const when = binding.when
+                    ? this.contextKeyService.parse(binding.when)
+                    : binding.context
+                        ? this.contextKeyService.parse(binding.context)
+                        : undefined;
+                this.toDisposeOnKeybindingChange.push(monacoKeybindingRegistry.addDynamicKeybinding(
+                    binding.command,
+                    this.toMonacoKeybindingNumber(resolved),
+                    (_, ...args) => this.theiaCommandRegistry.executeCommand(command, ...args),
+                    when,
+                ));
+            }
+        }
+    }
+
+    protected toMonacoKeybindingNumber(codes: KeyCode[]): number {
+        const [firstPart, secondPart] = codes;
+        if (codes.length > 2) {
+            console.warn('Key chords should not consist of more than two parts; got ', codes);
+        }
+        const encodedFirstPart = this.toSingleMonacoKeybindingNumber(firstPart);
+        const encodedSecondPart = secondPart ? this.toSingleMonacoKeybindingNumber(secondPart) << 16 : 0;
+        return monaco.KeyMod.chord(encodedFirstPart, encodedSecondPart);
+    }
+
+    protected toSingleMonacoKeybindingNumber(code: KeyCode): number {
+        const keyCode = code.key?.keyCode !== undefined ? KEY_CODE_MAP[code.key.keyCode] : 0;
+        let encoded = (keyCode >>> 0) & 0x000000FF;
+        if (code.alt) {
+            encoded |= monaco.KeyMod.Alt;
+        }
+        if (code.shift) {
+            encoded |= monaco.KeyMod.Shift;
+        }
+        if (code.ctrl) {
+            encoded |= monaco.KeyMod.WinCtrl;
+        }
+        if (code.meta && isOSX) {
+            encoded |= monaco.KeyMod.CtrlCmd;
+        }
+        return encoded;
     }
 }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

Fixes #8769, closes #8776

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

1. Change keybindings for commands relevant in Monaco. (e.g. for command `editor.action.deleteLines`).
2. Ensure that those keybindings take effect in an editor.
3. Change keybinding for `acceptRenameInput`.
4. Open an editor and start a `rename symbol` interaction.
5. Observe that the new `acceptRenameInput` shortcut is displayed as part of the input, and that that key sequence in fact accepts the rename.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
