### PR TITLE
core: fix `onclick` for statusbar items

### DIFF
--- a/packages/core/src/browser/status-bar/status-bar.tsx
+++ b/packages/core/src/browser/status-bar/status-bar.tsx
@@ -173,11 +173,7 @@ export class StatusBarImpl extends ReactWidget implements StatusBar {
             attrs.onClick = this.onclick(entry);
             attrs.className = 'element hasCommand';
         } else if (entry.onclick) {
-            attrs.onClick = e => {
-                if (entry.onclick && e instanceof MouseEvent) {
-                    entry.onclick(e);
-                }
-            };
+            attrs.onClick = e => entry.onclick?.(e.nativeEvent);
             attrs.className = 'element hasCommand';
         } else {
             attrs.className = 'element';


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

Fixes: https://github.com/eclipse-theia/theia/issues/11116.

The issue fixes an issue from https://github.com/eclipse-theia/theia/pull/10961, where the `onclick` callback did not pass the check we had causing the callback to never execute the `onclick` handler. 

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

You can use the test commit (which will be dropped prior to merge):

1. execute the `StatusBar Test` - a statusbar item should be contributed to the statusbar (commit https://github.com/eclipse-theia/theia/commit/c6dd3f5779278b26e70f059a8b93cbc4bae1c23b)
2. click the `StatusBar Test` statusbar entry
3. the `onclick` should work and display a message

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

Signed-off-by: vince-fugnitto <vincent.fugnitto@ericsson.com>