### PR TITLE
tree: ensure that decorations respect selection

### DIFF
--- a/packages/core/src/browser/style/tree.css
+++ b/packages/core/src/browser/style/tree.css
@@ -99,7 +99,8 @@
 .theia-Tree:focus .theia-TreeNode.theia-mod-selected .theia-caption-suffix,
 .theia-Tree .ReactVirtualized__List:focus .theia-TreeNode.theia-mod-selected .theia-caption-suffix,
 .theia-Tree:focus .theia-TreeNode.theia-mod-selected .theia-TreeNodeInfo,
-.theia-Tree .ReactVirtualized__List:focus .theia-TreeNode.theia-mod-selected .theia-TreeNodeInfo {
+.theia-Tree .ReactVirtualized__List:focus .theia-TreeNode.theia-mod-selected .theia-TreeNodeInfo,
+.theia-Tree .ReactVirtualized__List:focus .theia-TreeNode.theia-mod-selected .theia-TreeNodeSegment {
     color: var(--theia-list-activeSelectionForeground) !important;
 }
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

Fixes: https://github.com/eclipse-theia/theia/issues/11115.

The pull-request updates the `css` so that if a decoration node is selected it will properly apply the selected foreground instead of the decoration color.

![image](https://user-images.githubusercontent.com/40359487/167416569-7d9cab4f-c170-42fa-9d0f-34fd2229c049.png)

![image](https://user-images.githubusercontent.com/40359487/167416676-979186df-b393-4046-bd8d-52a57f75c86b.png)


#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

1. open a workspace under git version control
2. edit a few files, and produce errors
3. confirm with different themes that selecting nodes properly applies the foreground color for all decorations (regular and tail)

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

Signed-off-by: vince-fugnitto <vincent.fugnitto@ericsson.com>
