### PR TITLE
Reenable Typescript codelens test

### DIFF
--- a/examples/api-tests/src/undo-redo-selectAll.spec.js
+++ b/examples/api-tests/src/undo-redo-selectAll.spec.js
@@ -32,6 +32,7 @@ describe('Undo, Redo and Select All', function () {
     const { MonacoEditor } = require('@theia/monaco/lib/browser/monaco-editor');
     const { ScmContribution } = require('@theia/scm/lib/browser/scm-contribution');
     const { Range } = require('@theia/monaco-editor-core/esm/vs/editor/common/core/range');
+    const { PreferenceService, PreferenceScope } = require('@theia/core/lib/browser');
 
     const container = window.theia.container;
     const editorManager = container.get(EditorManager);
@@ -41,6 +42,8 @@ describe('Undo, Redo and Select All', function () {
     const navigatorContribution = container.get(FileNavigatorContribution);
     const shell = container.get(ApplicationShell);
     const scmContribution = container.get(ScmContribution);
+    /** @type {PreferenceService} */
+    const preferenceService = container.get(PreferenceService)
 
     const rootUri = workspaceService.tryGetRoots()[0].resource;
     const fileUri = rootUri.resolve('webpack.config.js');
@@ -61,8 +64,10 @@ describe('Undo, Redo and Select All', function () {
             resolve(undefined);
         });
     }
-
-    before(() => {
+    let originalValue = undefined;
+    before(async () => {
+        originalValue = preferenceService.inspect('files.autoSave').globalValue;
+        await preferenceService.set('files.autoSave', false, PreferenceScope.User);
         shell.leftPanelHandler.collapse();
     });
 
@@ -79,7 +84,8 @@ describe('Undo, Redo and Select All', function () {
         await editorManager.closeAll({ save: false });
     });
 
-    after(() => {
+    after(async () => {
+        await preferenceService.set('files.autoSave', originalValue, PreferenceScope.User);
         shell.leftPanelHandler.collapse();
     });
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

Fixes #10689 by updating and reenabling the Typescript 'run reference codelens' test. I believe that the reason the test was previously timing out was that it involved an edit that then required a scan of the entire repo to detect references to the newly exported item. Following the changes in #11095, these tests are running on a much smaller scope, so the indexing required is trivial.

It also fixes a minor glitch in the tests where, because of the change in the default value of `files.autoSave` in the browser, running tests locally would result in a modified `webpack.config.js` file in the example browser application folder.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

1. Assert that the updated test passes.
2. Turn on the `typescript.referencesCodeLens.enabled` preference, and observe that code lenses appear promptly in your editors.

---

1. Build the application and run `yarn browser test` locally.
2. Assert that `examples/browser/webpack.config.js` is unchanged.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
