### PR TITLE
Fix `'.'` and `'..'` imports

### DIFF
--- a/configs/errors.eslintrc.json
+++ b/configs/errors.eslintrc.json
@@ -139,7 +139,14 @@
     "@theia/runtime-import-check": "error",
     "@theia/shared-dependencies": "error",
     "import/no-extraneous-dependencies": "error",
-    "import/no-dynamic-require": "error"
+    "import/no-dynamic-require": "error",
+    "no-restricted-imports": [
+      "error",
+      ".",
+      "./",
+      "..",
+      "../"
+    ]
   },
   "overrides": [
     {

--- a/dev-packages/localization-manager/src/localization-manager.ts
+++ b/dev-packages/localization-manager/src/localization-manager.ts
@@ -17,8 +17,7 @@
 import * as chalk from 'chalk';
 import * as fs from 'fs-extra';
 import * as path from 'path';
-import { sortLocalization } from '.';
-import { Localization } from './common';
+import { Localization, sortLocalization } from './common';
 import { deepl, DeeplLanguage, DeeplParameters, isSupportedLanguage, supportedLanguages } from './deepl-api';
 
 export interface LocalizationOptions {

--- a/dev-packages/private-re-exports/src/package-re-exports.ts
+++ b/dev-packages/private-re-exports/src/package-re-exports.ts
@@ -17,8 +17,7 @@
 import cp = require('child_process');
 import fs = require('fs');
 import path = require('path');
-import { parseModule } from '.';
-import { PackageJson, ReExportJson } from './utility';
+import { PackageJson, parseModule, ReExportJson } from './utility';
 
 export async function readJson<T = unknown>(jsonPath: string): Promise<T> {
     return JSON.parse(await fs.promises.readFile(jsonPath, 'utf8')) as T;

--- a/packages/core/src/browser/preferences/injectable-preference-proxy.ts
+++ b/packages/core/src/browser/preferences/injectable-preference-proxy.ts
@@ -17,10 +17,11 @@
 import { inject, injectable, postConstruct } from 'inversify';
 import { PreferenceSchema } from '../../common/preferences/preference-schema';
 import { Disposable, DisposableCollection, Emitter, Event, MaybePromise } from '../../common';
-import { PreferenceChangeEvent, PreferenceEventEmitter, PreferenceProxyOptions, PreferenceRetrieval } from './preference-proxy';
-import { PreferenceChange, PreferenceScope, PreferenceService } from './preference-service';
-import { OverridePreferenceName, PreferenceChangeImpl, PreferenceChanges, PreferenceProviderDataChange, PreferenceProxy } from '.';
+import { PreferenceChangeEvent, PreferenceEventEmitter, PreferenceProxy, PreferenceProxyOptions, PreferenceRetrieval } from './preference-proxy';
+import { PreferenceChange, PreferenceChangeImpl, PreferenceChanges, PreferenceScope, PreferenceService } from './preference-service';
 import { JSONValue } from '@phosphor/coreutils';
+import { PreferenceProviderDataChange } from './preference-provider';
+import { OverridePreferenceName } from './preference-language-override-service';
 
 export const PreferenceProxySchema = Symbol('PreferenceProxySchema');
 export interface PreferenceProxyFactory {

--- a/packages/core/src/browser/preferences/preference-proxy.spec.ts
+++ b/packages/core/src/browser/preferences/preference-proxy.spec.ts
@@ -43,7 +43,7 @@ process.on('unhandledRejection', (reason, promise) => {
 });
 
 import { expect } from 'chai';
-import { PreferenceValidationService } from '.';
+import { PreferenceValidationService } from './preference-validation-service';
 import { JSONValue } from '@phosphor/coreutils';
 let testContainer: Container;
 

--- a/packages/core/src/browser/preferences/test/mock-preference-provider.ts
+++ b/packages/core/src/browser/preferences/test/mock-preference-provider.ts
@@ -17,7 +17,7 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
 import { interfaces } from 'inversify';
-import { PreferenceProvider } from '../';
+import { PreferenceProvider } from '../preference-provider';
 import { PreferenceScope } from '../preference-scope';
 
 export class MockPreferenceProvider extends PreferenceProvider {

--- a/packages/core/src/browser/preferences/test/mock-preference-service.ts
+++ b/packages/core/src/browser/preferences/test/mock-preference-service.ts
@@ -15,11 +15,11 @@
 // *****************************************************************************
 
 import { injectable } from 'inversify';
-import { PreferenceService, PreferenceChange, OverridePreferenceName } from '../';
 import { Emitter, Event } from '../../../common';
 import URI from '../../../common/uri';
-import { PreferenceChanges, PreferenceInspection } from '../preference-service';
+import { PreferenceChange, PreferenceChanges, PreferenceInspection, PreferenceService } from '../preference-service';
 import { PreferenceScope } from '../preference-scope';
+import { OverridePreferenceName } from '../preference-language-override-service';
 
 @injectable()
 export class MockPreferenceService implements PreferenceService {

--- a/packages/core/src/browser/quick-input/quick-view-service.ts
+++ b/packages/core/src/browser/quick-input/quick-view-service.ts
@@ -15,10 +15,10 @@
 // *****************************************************************************
 
 import { inject, injectable } from 'inversify';
-import { filterItems, QuickPickItem, QuickPicks } from '..';
 import { CancellationToken, Disposable } from '../../common';
 import { ContextKeyService } from '../context-key-service';
 import { QuickAccessContribution, QuickAccessProvider, QuickAccessRegistry } from './quick-access';
+import { filterItems, QuickPickItem, QuickPicks } from './quick-input-service';
 
 export interface QuickViewItem {
     readonly label: string;

--- a/packages/core/src/common/uri-command-handler.spec.ts
+++ b/packages/core/src/common/uri-command-handler.spec.ts
@@ -15,7 +15,7 @@
 // *****************************************************************************
 
 import * as chai from 'chai';
-import { SelectionService } from '.';
+import { SelectionService } from './selection-service';
 import { MaybeArray } from './types';
 import URI from './uri';
 import { UriAwareCommandHandler, UriCommandHandler } from './uri-command-handler';

--- a/packages/core/src/common/uri-command-handler.ts
+++ b/packages/core/src/common/uri-command-handler.ts
@@ -19,8 +19,8 @@
 import { SelectionService } from '../common/selection-service';
 import { UriSelection } from '../common/selection';
 import { CommandHandler } from './command';
-import { MaybeArray } from '.';
 import URI from './uri';
+import { MaybeArray } from './types';
 
 export interface UriCommandHandler<T extends MaybeArray<URI>> extends CommandHandler {
 

--- a/packages/editor/src/browser/quick-editor-service.ts
+++ b/packages/editor/src/browser/quick-editor-service.ts
@@ -21,7 +21,8 @@ import { LabelProvider } from '@theia/core/lib/browser/label-provider';
 import { OpenerService } from '@theia/core/lib/browser/opener-service';
 import { QuickAccessProvider, QuickAccessRegistry, QuickAccessContribution } from '@theia/core/lib/browser/quick-input/quick-access';
 import { filterItems, QuickPickItem, QuickPickSeparator } from '@theia/core/lib/browser/quick-input/quick-input-service';
-import { EditorManager, EditorWidget } from '.';
+import { EditorManager } from './editor-manager';
+import { EditorWidget } from './editor-widget';
 
 @injectable()
 export class QuickEditorService implements QuickAccessContribution, QuickAccessProvider {

--- a/packages/filesystem/src/browser/breadcrumbs/filepath-breadcrumbs-container.ts
+++ b/packages/filesystem/src/browser/breadcrumbs/filepath-breadcrumbs-container.ts
@@ -16,8 +16,7 @@
 
 import { Container, interfaces, injectable, inject } from '@theia/core/shared/inversify';
 import { TreeProps, ContextMenuRenderer, TreeNode, OpenerService, open, NodeProps, defaultTreeProps } from '@theia/core/lib/browser';
-import { createFileTreeContainer, FileTreeWidget } from '../';
-import { FileTreeModel, FileStatNode } from '../file-tree';
+import { FileTreeModel, FileStatNode, createFileTreeContainer, FileTreeWidget } from '../file-tree';
 
 const BREADCRUMBS_FILETREE_CLASS = 'theia-FilepathBreadcrumbFileTree';
 

--- a/packages/filesystem/src/common/filesystem-utils.spec.ts
+++ b/packages/filesystem/src/common/filesystem-utils.spec.ts
@@ -14,9 +14,9 @@
 // SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
 // *****************************************************************************
 
-import { FileSystemUtils } from '.';
 import { FileStat } from './files';
 import { expect } from 'chai';
+import { FileSystemUtils } from './filesystem-utils';
 
 describe('generateUniqueResourceURI', () => {
     describe('Target is file', () => {

--- a/packages/scm-extra/src/browser/history/index.ts
+++ b/packages/scm-extra/src/browser/history/index.ts
@@ -14,16 +14,8 @@
 // SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
 // *****************************************************************************
 
-import { ScmProvider } from '@theia/scm/lib/browser/scm-provider';
+export * from './scm-history-provider';
 import { ScmHistorySupport } from './scm-history-widget';
 
 export { ScmHistorySupport };
 
-export interface ScmHistoryProvider extends ScmProvider {
-    historySupport?: ScmHistorySupport;
-}
-export namespace ScmHistoryProvider {
-    export function is(scmProvider: ScmProvider | undefined): scmProvider is ScmHistoryProvider {
-        return !!scmProvider && 'historySupport' in scmProvider;
-    }
-}

--- a/packages/scm-extra/src/browser/history/scm-history-provider.ts
+++ b/packages/scm-extra/src/browser/history/scm-history-provider.ts
@@ -1,5 +1,5 @@
 // *****************************************************************************
-// Copyright (C) 2018 Ericsson and others.
+// Copyright (C) 2020 Arm and others.
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License v. 2.0 which is available at
@@ -14,20 +14,14 @@
 // SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
 // *****************************************************************************
 
-import * as prom from 'prom-client';
-import { injectable } from '@theia/core/shared/inversify';
-import { MetricsContribution } from './metrics-contribution';
+import { ScmProvider } from '@theia/scm/lib/browser/scm-provider';
+import { ScmHistorySupport } from './scm-history-widget';
 
-@injectable()
-export class NodeMetricsContribution implements MetricsContribution {
-    getMetrics(): string {
-        return prom.register.metrics().toString();
-    }
-
-    startCollecting(): void {
-        const collectDefaultMetrics = prom.collectDefaultMetrics;
-
-        // Probe every 5th second.
-        collectDefaultMetrics({ timeout: 5000 });
+export interface ScmHistoryProvider extends ScmProvider {
+    historySupport?: ScmHistorySupport;
+}
+export namespace ScmHistoryProvider {
+    export function is(scmProvider: ScmProvider | undefined): scmProvider is ScmHistoryProvider {
+        return !!scmProvider && 'historySupport' in scmProvider;
     }
 }

--- a/packages/scm-extra/src/browser/history/scm-history-widget.tsx
+++ b/packages/scm-extra/src/browser/history/scm-history-widget.tsx
@@ -21,7 +21,6 @@ import { CancellationTokenSource } from '@theia/core/lib/common/cancellation';
 import { Message } from '@theia/core/shared/@phosphor/messaging';
 import { AutoSizer, List, ListRowRenderer, ListRowProps, InfiniteLoader, IndexRange, ScrollParams, CellMeasurerCache, CellMeasurer } from '@theia/core/shared/react-virtualized';
 import URI from '@theia/core/lib/common/uri';
-import { ScmHistoryProvider } from '.';
 import { SCM_HISTORY_ID, SCM_HISTORY_MAX_COUNT, SCM_HISTORY_LABEL } from './scm-history-contribution';
 import { ScmHistoryCommit, ScmFileChange, ScmFileChangeNode } from '../scm-file-change-node';
 import { ScmAvatarService } from '@theia/scm/lib/browser/scm-avatar-service';
@@ -30,6 +29,7 @@ import * as React from '@theia/core/shared/react';
 import { AlertMessage } from '@theia/core/lib/browser/widgets/alert-message';
 import { FileService } from '@theia/filesystem/lib/browser/file-service';
 import { nls } from '@theia/core/lib/common/nls';
+import { ScmHistoryProvider } from './scm-history-provider';
 
 export const ScmHistorySupport = Symbol('scm-history-support');
 export interface ScmHistorySupport {

--- a/packages/workspace/src/browser/workspace-trust-service.ts
+++ b/packages/workspace/src/browser/workspace-trust-service.ts
@@ -21,11 +21,11 @@ import { nls } from '@theia/core/lib/common/nls';
 import { Deferred } from '@theia/core/lib/common/promise-util';
 import { inject, injectable, postConstruct } from '@theia/core/shared/inversify';
 import { WindowService } from '@theia/core/lib/browser/window/window-service';
-import { WorkspaceService } from '.';
 import {
     WorkspaceTrustPreferences, WORKSPACE_TRUST_EMPTY_WINDOW, WORKSPACE_TRUST_ENABLED, WORKSPACE_TRUST_STARTUP_PROMPT, WorkspaceTrustPrompt
 } from './workspace-trust-preferences';
 import { FrontendApplicationConfigProvider } from '@theia/core/lib/browser/frontend-application-config-provider';
+import { WorkspaceService } from './workspace-service';
 
 const STORAGE_TRUSTED = 'trusted';
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

Imports from `index.ts` files in the same directory as a file or a higher level almost always entail circular dependencies. That doesn't have to be a catastrophe, but it's not a good idea. This PR adds a lint rule forbidding such imports and fixes those cases that currently exist. This reduces the number of warnings from `webpack` from 95 to 81.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
1. Assert that there are no more imports `from '.'` or `from '..'` in our code.
2. Add such an import to a file.
3. Observe that the import is treated as a lint error.
4. Check that the application builds and runs as expected.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
