### PR TITLE
core: track `ApplicationError` codes

### DIFF
--- a/packages/core/src/common/application-error.spec.ts
+++ b/packages/core/src/common/application-error.spec.ts
@@ -1,0 +1,27 @@
+// *****************************************************************************
+// Copyright (C) 2022 Ericsson and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { ApplicationError } from './application-error';
+import { expect } from 'chai';
+
+describe('ApplicationError', () => {
+
+    it('should not be able to use the same code twice', () => {
+        const code = 12345;
+        ApplicationError.declare(code, (message, data) => ({ message, data }));
+        expect(() => ApplicationError.declare(code, (message, data) => ({ message, data }))).throw();
+    });
+});

--- a/packages/core/src/common/application-error.ts
+++ b/packages/core/src/common/application-error.ts
@@ -32,11 +32,12 @@ export namespace ApplicationError {
         code: C;
         is(arg: object | undefined): arg is ApplicationError<C, D>
     }
-    const codes: number[] = [];
+    const codes = new Set<number>();
     export function declare<C extends number, D>(code: C, factory: (...args: any[]) => Literal<D>): Constructor<C, D> {
-        if (codes.indexOf(code) !== -1) {
+        if (codes.has(code)) {
             throw new Error(`An application error for '${code}' code is already declared`);
         }
+        codes.add(code);
         const constructorOpt = Object.assign((...args: any[]) => new Impl(code, factory(...args), constructorOpt), {
             code,
             is(arg: object | undefined): arg is ApplicationError<C, D> {


### PR DESCRIPTION
We don't register new codes.

Properly track defined `ApplicationError` codes.

#### How to test

N/A: There is a new test case for it.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)