### PR TITLE
Console: Fixed issues involving Console History not being capped at specified limit, regarding Issue #10598

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,12 +5,10 @@
 - [Previous Changelogs](https://github.com/eclipse-theia/theia/tree/master/doc/changelogs/)
 
 
-## v.1.27.0
-- [console] fixed issue in Debug console where console history was not being trimmed in accordance with the maximum commands limit [#10598](https://github.com/eclipse-theia/theia/pull/10598)
-
 ## v.1.26.0
 
 - [plugin] Introduce `DebugSession#workspaceFolder` [#11090](https://github.com/eclipse-theia/theia/pull/11090) - Contributed on behalf of STMicroelectronics
+- [console] fixed issue in Debug console where console history was not being trimmed in accordance with the maximum commands limit [#10598](https://github.com/eclipse-theia/theia/pull/10598)
 
 ## v1.25.0 - 4/28/2022
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 - [Previous Changelogs](https://github.com/eclipse-theia/theia/tree/master/doc/changelogs/)
 
+
+## v.1.27.0
+- [console] fixed issue in Debug console where console history was not being trimmed in accordance with the maximum commands limit [#10598](https://github.com/eclipse-theia/theia/pull/10598)
+
 ## v.1.26.0
 
 - [plugin] Introduce `DebugSession#workspaceFolder` [#11090](https://github.com/eclipse-theia/theia/pull/11090) - Contributed on behalf of STMicroelectronics

--- a/examples/browser/webpack.config.js
+++ b/examples/browser/webpack.config.js
@@ -1,4 +1,4 @@
-AAAA/**
+/**
  * This file can be edited to customize webpack configuration.
  * To reset delete this file and rerun theia build again.
  */

--- a/examples/browser/webpack.config.js
+++ b/examples/browser/webpack.config.js
@@ -1,4 +1,4 @@
-/**
+AAAA/**
  * This file can be edited to customize webpack configuration.
  * To reset delete this file and rerun theia build again.
  */

--- a/packages/console/src/browser/console-history.ts
+++ b/packages/console/src/browser/console-history.ts
@@ -19,7 +19,7 @@ import { injectable } from '@theia/core/shared/inversify';
 @injectable()
 export class ConsoleHistory {
 
-    static limit = 3;
+    static limit = 50;
 
     protected values: string[] = [];
     protected index = -1;

--- a/packages/console/src/browser/console-history.ts
+++ b/packages/console/src/browser/console-history.ts
@@ -19,7 +19,7 @@ import { injectable } from '@theia/core/shared/inversify';
 @injectable()
 export class ConsoleHistory {
 
-    static limit = 50;
+    static limit = 3;
 
     protected values: string[] = [];
     protected index = -1;
@@ -39,7 +39,7 @@ export class ConsoleHistory {
     protected trim(): void {
         const index = this.values.length - ConsoleHistory.limit;
         if (index > 0) {
-            this.values.slice(index);
+            this.values = this.values.slice(index);
         }
     }
 


### PR DESCRIPTION

#### What it does
The history of commands typed in the Debug Console in the Debug view(access in the left sidebar of the browser version) was not adhering to the limit specified in the `limit` variable in the file: `theia/packages/console/src/browser/console-history.ts`. 

The main issue was that the newly sliced array(`this.values.slice(index)`) was not being assigned to the original array. 

Therefore, I replaced that line with the following: `this.values = this.values.slice(index);` in order to resolve this issue.

#### Fixes #10598 

#### How to test
1. Navigate to the file: `theia/packages/console/src/browser/console-history.ts`
2. Change the `limit` variable to a lower number such as `3` 
3. Build the browser version via `yarn build browser` then navigate to `/examples/browser` and run `yarn start`
4. Navigate to `http://localhost:3000` and open the `Debug` tab in the left sidebar
5. Enter many commands(at least over the number specified for the `limit` variable) in the debug console then press the up arrow to validate that the messages saved conforms to the number assigned to the `limit` variable(Ex: `limit = 3` should cap the maximum number of saved commands up to 3)

#### Review checklist

- [X] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
