### PR TITLE
Support traversing the editor navigation history through mouse buttons

### DIFF
--- a/packages/core/src/browser/core-preferences.ts
+++ b/packages/core/src/browser/core-preferences.ts
@@ -97,6 +97,12 @@ export const corePreferenceSchema: PreferenceSchema = {
             'description': nls.localizeByDefault('Controls whether editors showing a file that was opened during the session should close automatically when getting deleted or renamed by some other process. Disabling this will keep the editor open  on such an event. Note that deleting from within the application will always close the editor and that dirty files will never close to preserve your data.'),
             'default': false
         },
+        'workbench.editor.mouseBackForwardToNavigate': {
+            'type': 'boolean',
+            // nls-todo: Will be available with newer VSCode API
+            'description': nls.localize('theia/core/mouseBackForwardToNavigate', "Enables the use of mouse buttons four and five for commands 'Go Back' and 'Go Forward'."),
+            'default': true
+        },
         'workbench.commandPalette.history': {
             type: 'number',
             default: 50,
@@ -166,6 +172,7 @@ export interface CoreConfiguration {
     'workbench.list.openMode': 'singleClick' | 'doubleClick';
     'workbench.commandPalette.history': number;
     'workbench.editor.highlightModifiedTabs': boolean;
+    'workbench.editor.mouseBackForwardToNavigate': boolean;
     'workbench.editor.closeOnFileDelete': boolean;
     'workbench.colorTheme': string;
     'workbench.iconTheme': string | null;

--- a/packages/editor/src/browser/editor-navigation-contribution.ts
+++ b/packages/editor/src/browser/editor-navigation-contribution.ts
@@ -26,13 +26,14 @@ import { EditorManager } from './editor-manager';
 import { TextEditor, Position, Range, TextDocumentChangeEvent } from './editor';
 import { NavigationLocation, RecentlyClosedEditor } from './navigation/navigation-location';
 import { NavigationLocationService } from './navigation/navigation-location-service';
-import { PreferenceService, PreferenceScope } from '@theia/core/lib/browser';
+import { PreferenceService, PreferenceScope, addEventListener } from '@theia/core/lib/browser';
 
 @injectable()
 export class EditorNavigationContribution implements Disposable, FrontendApplicationContribution {
 
     private static ID = 'editor-navigation-contribution';
     private static CLOSED_EDITORS_KEY = 'recently-closed-editors';
+    private static MOUSE_NAVIGATION_PREFERENCE = 'workbench.editor.mouseBackForwardToNavigate';
 
     protected readonly toDispose = new DisposableCollection();
     protected readonly toDisposePerCurrentEditor = new DisposableCollection();
@@ -102,6 +103,39 @@ export class EditorNavigationContribution implements Disposable, FrontendApplica
         this.commandRegistry.registerHandler(EditorCommands.REOPEN_CLOSED_EDITOR.id, {
             execute: () => this.reopenLastClosedEditor()
         });
+
+        this.installMouseNavigationSupport();
+    }
+
+    protected async installMouseNavigationSupport(): Promise<void> {
+        const mouseNavigationSupport = new DisposableCollection();
+        const updateMouseNavigationListener = () => {
+            mouseNavigationSupport.dispose();
+            if (this.shouldNavigateWithMouse()) {
+                mouseNavigationSupport.push(addEventListener(document.body, 'mousedown', event => this.onMouseDown(event), true));
+            }
+        };
+        this.toDispose.push(this.preferenceService.onPreferenceChanged(change => {
+            if (change.preferenceName === EditorNavigationContribution.MOUSE_NAVIGATION_PREFERENCE) {
+                updateMouseNavigationListener();
+            }
+        }));
+        updateMouseNavigationListener();
+        this.toDispose.push(mouseNavigationSupport);
+    }
+
+    protected async onMouseDown(event: MouseEvent): Promise<void> {
+        // Support to navigate in history when mouse buttons 4/5 are pressed
+        switch (event.button) {
+            case 3:
+                event.preventDefault();
+                this.locationStack.back();
+                break;
+            case 4:
+                event.preventDefault();
+                this.locationStack.forward();
+                break;
+        }
     }
 
     /**
@@ -272,6 +306,10 @@ export class EditorNavigationContribution implements Disposable, FrontendApplica
 
     private shouldStoreClosedEditors(): boolean {
         return !!this.preferenceService.get('editor.history.persistClosedEditors');
+    }
+
+    private shouldNavigateWithMouse(): boolean {
+        return !!this.preferenceService.get(EditorNavigationContribution.MOUSE_NAVIGATION_PREFERENCE);
     }
 
 }

--- a/packages/editor/src/browser/editor-navigation-contribution.ts
+++ b/packages/editor/src/browser/editor-navigation-contribution.ts
@@ -125,7 +125,7 @@ export class EditorNavigationContribution implements Disposable, FrontendApplica
     }
 
     protected async onMouseDown(event: MouseEvent): Promise<void> {
-        // Support to navigate in history when mouse buttons 4/5 are pressed
+        // Support navigation in history when mouse buttons 4/5 are pressed
         switch (event.button) {
             case 3:
                 event.preventDefault();


### PR DESCRIPTION
#### What it does
- Adds support for traversing the editor navigation history through mouse buttons 4 and 5, similar to the [VS Code History Service](https://github.dev/microsoft/vscode/blob/c23f0305dbf82b2319b198f4dbf3c5d5bc522f15/src/vs/workbench/services/history/browser/historyService.ts#L114).
- Fixes https://github.com/eclipse-theia/theia/issues/11158

#### How to test
- Open application in browser or electron. If you use the browser you can open your application through a link so you don't have any history to begin with, otherwise the window history navigation will navigate you away from your Theia app. This is also the behavior in the GitHub web editor.
- Navigate within a file or between files.
- Click your mouse button 4 and 5 to navigate between your previous navigations.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
