### PR TITLE
Fix localization for `threads` term

### DIFF
--- a/packages/core/i18n/nls.de.json
+++ b/packages/core/i18n/nls.de.json
@@ -51,7 +51,7 @@
       "openRight": "Rechts öffnen",
       "pauseAll": "Pause Alle",
       "reveal": "Enthüllen",
-      "threads": "Fäden",
+      "threads": "Threads",
       "toggleTracing": "Aktivieren/Deaktivieren der Verfolgung der Kommunikation mit Debug-Adaptern"
     },
     "editor": {

--- a/packages/core/i18n/nls.zh-cn.json
+++ b/packages/core/i18n/nls.zh-cn.json
@@ -51,7 +51,7 @@
       "openRight": "右边开放",
       "pauseAll": "暂停所有",
       "reveal": "揭秘",
-      "threads": "缝纫机",
+      "threads": "线程",
       "toggleTracing": "启用/禁用与调试适配器的跟踪通信"
     },
     "editor": {


### PR DESCRIPTION
#### What it does

Closes https://github.com/eclipse-theia/theia/issues/11104

Fixes the German and Chinese (simplified) translation of the word "Threads".

#### How to test

1. Install the Chinese/German language pack
2. Assert that the new value is visible in the "Threads" view container in the debug view.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
