### PR TITLE
Resolve command variables contributed by debuggers

### DIFF
--- a/packages/debug/src/browser/debug-session-manager.ts
+++ b/packages/debug/src/browser/debug-session-manager.ts
@@ -244,15 +244,22 @@ export class DebugSessionManager {
         let configuration = await this.resolveDebugConfiguration(options.configuration, workspaceFolderUri);
 
         if (configuration) {
+            // Resolve command variables provided by the debugger
+            const commandIdVariables = await this.debug.provideDebuggerVariables(configuration.type);
             configuration = await this.variableResolver.resolve(configuration, {
                 context: options.workspaceFolderUri ? new URI(options.workspaceFolderUri) : undefined,
                 configurationSection: 'launch',
+                commandIdVariables,
+                configuration,
+                checkAllResolved: true
             });
 
-            configuration = await this.resolveDebugConfigurationWithSubstitutedVariables(
-                configuration,
-                workspaceFolderUri
-            );
+            if (configuration) {
+                configuration = await this.resolveDebugConfigurationWithSubstitutedVariables(
+                    configuration,
+                    workspaceFolderUri
+                );
+            }
         }
 
         if (!configuration) {

--- a/packages/debug/src/common/debug-service.ts
+++ b/packages/debug/src/common/debug-service.ts
@@ -19,6 +19,7 @@
 import { Disposable } from '@theia/core';
 import { ApplicationError } from '@theia/core/lib/common/application-error';
 import { IJSONSchema, IJSONSchemaSnippet } from '@theia/core/lib/common/json-schema';
+import { CommandIdVariables } from '@theia/variable-resolver/lib/browser';
 import { DebugConfiguration } from './debug-configuration';
 
 export interface DebuggerDescription {
@@ -53,6 +54,12 @@ export interface DebugService extends Disposable {
     debugTypes(): Promise<string[]>;
 
     getDebuggersForLanguage(language: string): Promise<DebuggerDescription[]>;
+
+    /**
+     * Provide debugger contributed variables
+     * see "variables" at https://code.visualstudio.com/api/references/contribution-points#contributes.debuggers
+     */
+    provideDebuggerVariables(debugType: string): Promise<CommandIdVariables>;
 
     /**
      * Provides the schema attributes.

--- a/packages/debug/src/node/debug-service-impl.ts
+++ b/packages/debug/src/node/debug-service-impl.ts
@@ -19,6 +19,7 @@ import { DebugConfiguration } from '../common/debug-configuration';
 import { DebugService, DebuggerDescription } from '../common/debug-service';
 
 import { IJSONSchema, IJSONSchemaSnippet } from '@theia/core/lib/common/json-schema';
+import { CommandIdVariables } from '@theia/variable-resolver/lib/browser';
 import { DebugAdapterSessionManager } from './debug-adapter-session-manager';
 import { DebugAdapterContributionRegistry } from './debug-adapter-contribution-registry';
 
@@ -52,6 +53,11 @@ export class DebugServiceImpl implements DebugService {
 
     getConfigurationSnippets(): Promise<IJSONSchemaSnippet[]> {
         return this.registry.getConfigurationSnippets();
+    }
+
+    async provideDebuggerVariables(debugType: string): Promise<CommandIdVariables> {
+        // TODO: Support resolution of variables map through Theia extensions?
+        return {};
     }
 
     async provideDebugConfigurations(debugType: string, workspaceFolderUri?: string): Promise<DebugConfiguration[]> {

--- a/packages/plugin-ext/package.json
+++ b/packages/plugin-ext/package.json
@@ -26,6 +26,7 @@
     "@theia/task": "1.25.0",
     "@theia/terminal": "1.25.0",
     "@theia/timeline": "1.25.0",
+    "@theia/variable-resolver": "1.25.0",
     "@theia/workspace": "1.25.0",
     "@types/mime": "^2.0.1",
     "decompress": "^4.2.1",

--- a/packages/plugin-ext/src/main/browser/debug/plugin-debug-service.ts
+++ b/packages/plugin-ext/src/main/browser/debug/plugin-debug-service.ts
@@ -23,6 +23,7 @@ import { PluginDebugConfigurationProvider } from './plugin-debug-configuration-p
 import { injectable, inject, postConstruct } from '@theia/core/shared/inversify';
 import { WebSocketConnectionProvider } from '@theia/core/lib/browser/messaging/ws-connection-provider';
 import { WorkspaceService } from '@theia/workspace/lib/browser';
+import { CommandIdVariables } from '@theia/variable-resolver/lib/browser';
 import { DebugConfigurationProviderTriggerKind } from '../../../common/plugin-api-rpc';
 import { DebuggerContribution } from '../../../common/plugin-protocol';
 import { DebugRequestTypes } from '@theia/debug/lib/browser/debug-session-connection';
@@ -225,6 +226,18 @@ export class PluginDebugService implements DebugService {
                 this.debuggers.splice(index, 1);
             }
         });
+    }
+
+    async provideDebuggerVariables(debugType: string): Promise<CommandIdVariables> {
+        for (const contribution of this.debuggers) {
+            if (contribution.type === debugType) {
+                const variables = contribution.variables;
+                if (variables && Object.keys(variables).length > 0) {
+                    return variables;
+                }
+            }
+        }
+        return {};
     }
 
     async getDebuggersForLanguage(language: string): Promise<DebuggerDescription[]> {

--- a/packages/plugin-ext/tsconfig.json
+++ b/packages/plugin-ext/tsconfig.json
@@ -75,6 +75,9 @@
       "path": "../timeline"
     },
     {
+      "path": "../variable-resolver"
+    },
+    {
       "path": "../workspace"
     }
   ]

--- a/packages/variable-resolver/src/browser/common-variable-contribution.ts
+++ b/packages/variable-resolver/src/browser/common-variable-contribution.ts
@@ -76,9 +76,15 @@ export class CommonVariableContribution implements VariableContribution {
         });
         variables.registerVariable({
             name: 'command',
-            resolve: async (_, command) =>
-                // eslint-disable-next-line no-return-await
-                command && await this.commands.executeCommand(command)
+            resolve: async (_, name, __, commandIdVariables, configuration) => {
+                let commandId = name;
+                if (name && commandIdVariables) {
+                    const mappedValue = commandIdVariables[name];
+                    commandId = mappedValue ? mappedValue : name;
+                }
+                const result = commandId && await this.commands.executeCommand(commandId, configuration);
+                return result ? result : undefined;
+            }
         });
         variables.registerVariable({
             name: 'input',

--- a/packages/variable-resolver/src/browser/variable-resolver-service.spec.ts
+++ b/packages/variable-resolver/src/browser/variable-resolver-service.spec.ts
@@ -71,7 +71,7 @@ describe('variable-resolver-service', () => {
 
     it('should resolve known variables in a string array', async () => {
         const resolved = await variableResolverService.resolveArray(['file: ${file}', 'line: ${lineNumber}']);
-        expect(resolved.length).to.be.equal(2);
+        expect(resolved!.length).to.be.equal(2);
         expect(resolved).to.contain('file: package.json');
         expect(resolved).to.contain('line: 6');
     });
@@ -79,5 +79,13 @@ describe('variable-resolver-service', () => {
     it('should skip unknown variables', async () => {
         const resolved = await variableResolverService.resolve('workspace: ${workspaceRoot}; file: ${file}; line: ${lineNumber}');
         expect(resolved).is.equal('workspace: ${workspaceRoot}; file: package.json; line: 6');
+    });
+
+    it('should check if all variables are resolved', async () => {
+        const options = {
+            checkAllResolved: true
+        };
+        const resolved = await variableResolverService.resolve('workspace: ${command:testCommand}; file: ${file}; line: ${lineNumber}', options);
+        expect(resolved).equal(undefined);
     });
 });

--- a/packages/variable-resolver/src/browser/variable.ts
+++ b/packages/variable-resolver/src/browser/variable.ts
@@ -17,6 +17,7 @@
 import { injectable } from '@theia/core/shared/inversify';
 import { Disposable, DisposableCollection, MaybePromise } from '@theia/core';
 import URI from '@theia/core/lib/common/uri';
+import { CommandIdVariables } from './variable-resolver-service';
 
 /**
  * Variable can be used inside of strings using ${variableName} syntax.
@@ -38,7 +39,13 @@ export interface Variable {
      * `undefined` if variable cannot be resolved.
      * Never reject.
      */
-    resolve(context?: URI, argument?: string, configurationSection?: string): MaybePromise<Object | undefined>;
+    resolve(
+        context?: URI,
+        argument?: string,
+        configurationSection?: string,
+        commandIdVariables?: CommandIdVariables,
+        configuration?: unknown
+    ): MaybePromise<Object | undefined>;
 }
 
 export const VariableContribution = Symbol('VariableContribution');


### PR DESCRIPTION
#### What it does
<!-- Include relevant issues and describe how they are addressed. -->
Fixes: #10710, Fixes: #2819

The debuggers contribution point provides the possibility to specify
command id variables which can therefore be referenced within debug
configurations.

This change reads these contributed variables and feeds them to the
variable resolver so they can be used just before resolving values
via commands.

See "variables" at:
https://code.visualstudio.com/api/references/contribution-points#contributes.debuggers

In addition, the 'VariableResolverOptions' includes an option to
indicate if all variables were successfully resolved, this enables
to stop the processing and prevent the possibility of error
notifications e.g. in case a user did not select a valid option.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
The following test uses the command "PickProcess" contributed by the `node-debug` extension.
We will need to start a `node` application that we can attach to i.e. using the `--inspect` option.

1. You can use the following test application, created for this purpose:
https://github.com/alvsan09/hello_express.git

2. Build the application by running
> yarn 
3. Run the application 
> node --inspect hello_express.js
4. Open a browser pointing to `localhost:3099`, make sure you see the `Hello world!` message and a counter incrementing every refresh.
5. Open the folder holding your application with `theia`
6. From the debug view, start the provided configuration i.e. `Attach to node process`,
NOTE: This configuration uses the following variable that needs to be resolved `"${command:PickProcess}"`
7. From the list of `node` processes select the one `hello_express.js`
NOTE: The fact that a list of node processes is presented for selection is an indication of the successful resolution of the command variable mentioned in the previous step.
8. Open the file `hello_express.js` in editor and place a break point inside the `get` block. The break point shall become active.
9. In the browser, Refresh the application and make sure the break point is hit.
10. Repeat steps 1-6 above but don't select any of the `node` processes e.g. pressing escape or clicking outside of the options area.
11. Note that no debug session is started and no errors are reported.

![pickProcess](https://user-images.githubusercontent.com/76971376/168896931-3ec0954a-573a-4c5b-8614-3a5c9f4833ba.gif)

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
