### PR TITLE
vscode: support `Terminal#exitStatus`

### DIFF
--- a/packages/plugin-ext/src/common/plugin-api-rpc.ts
+++ b/packages/plugin-ext/src/common/plugin-api-rpc.ts
@@ -260,7 +260,7 @@ export interface TerminalServiceExt {
     $terminalCreated(id: string, name: string): void;
     $terminalNameChanged(id: string, name: string): void;
     $terminalOpened(id: string, processId: number, terminalId: number, cols: number, rows: number): void;
-    $terminalClosed(id: string): void;
+    $terminalClosed(id: string, exitStatus: theia.TerminalExitStatus | undefined): void;
     $terminalOnInput(id: string, data: string): void;
     $terminalSizeChanged(id: string, cols: number, rows: number): void;
     $currentTerminalChanged(id: string | undefined): void;

--- a/packages/plugin-ext/src/main/browser/terminal-main.ts
+++ b/packages/plugin-ext/src/main/browser/terminal-main.ts
@@ -90,7 +90,7 @@ export class TerminalServiceMainImpl implements TerminalServiceMain, Disposable 
         );
         updateProcessId();
         this.toDispose.push(terminal.onDidOpen(() => updateProcessId()));
-        this.toDispose.push(terminal.onTerminalDidClose(() => this.extProxy.$terminalClosed(terminal.id)));
+        this.toDispose.push(terminal.onTerminalDidClose((term) => this.extProxy.$terminalClosed(term.id, term.exitStatus)));
         this.toDispose.push(terminal.onSizeChanged(({ cols, rows }) => {
             this.extProxy.$terminalSizeChanged(terminal.id, cols, rows);
         }));

--- a/packages/plugin-ext/src/main/browser/terminal-main.ts
+++ b/packages/plugin-ext/src/main/browser/terminal-main.ts
@@ -90,7 +90,7 @@ export class TerminalServiceMainImpl implements TerminalServiceMain, Disposable 
         );
         updateProcessId();
         this.toDispose.push(terminal.onDidOpen(() => updateProcessId()));
-        this.toDispose.push(terminal.onTerminalDidClose((term) => this.extProxy.$terminalClosed(term.id, term.exitStatus)));
+        this.toDispose.push(terminal.onTerminalDidClose(term => this.extProxy.$terminalClosed(term.id, term.exitStatus)));
         this.toDispose.push(terminal.onSizeChanged(({ cols, rows }) => {
             this.extProxy.$terminalSizeChanged(terminal.id, cols, rows);
         }));

--- a/packages/plugin-ext/src/plugin/terminal-ext.ts
+++ b/packages/plugin-ext/src/plugin/terminal-ext.ts
@@ -141,7 +141,7 @@ export class TerminalServiceExtImpl implements TerminalServiceExt {
     $terminalClosed(id: string, exitStatus: theia.TerminalExitStatus | undefined): void {
         const terminal = this._terminals.get(id);
         if (terminal) {
-            terminal.updateExitStatus(exitStatus);
+            terminal.exitStatus = exitStatus ?? { code: undefined };
             this.onDidCloseTerminalEmitter.fire(terminal);
             this._terminals.delete(id);
         }
@@ -271,14 +271,12 @@ export class TerminalExtImpl implements Terminal {
 
     readonly id = new Deferred<string>();
 
+    exitStatus: theia.TerminalExitStatus | undefined;
+
     deferredProcessId = new Deferred<number>();
+
     get processId(): Thenable<number> {
         return this.deferredProcessId.promise;
-    }
-
-    protected _exitStatus: theia.TerminalExitStatus | undefined;
-    get exitStatus(): theia.TerminalExitStatus | undefined {
-        return this._exitStatus;
     }
 
     constructor(private readonly proxy: TerminalServiceMain) { }
@@ -297,10 +295,6 @@ export class TerminalExtImpl implements Terminal {
 
     dispose(): void {
         this.id.promise.then(id => this.proxy.$dispose(id));
-    }
-
-    updateExitStatus(exitStatus: theia.TerminalExitStatus | undefined): void {
-        this._exitStatus = exitStatus;
     }
 }
 

--- a/packages/plugin-ext/src/plugin/terminal-ext.ts
+++ b/packages/plugin-ext/src/plugin/terminal-ext.ts
@@ -141,7 +141,7 @@ export class TerminalServiceExtImpl implements TerminalServiceExt {
     $terminalClosed(id: string, exitStatus: theia.TerminalExitStatus | undefined): void {
         const terminal = this._terminals.get(id);
         if (terminal) {
-            terminal.updateExitStatus(exitStatus)
+            terminal.updateExitStatus(exitStatus);
             this.onDidCloseTerminalEmitter.fire(terminal);
             this._terminals.delete(id);
         }
@@ -299,7 +299,7 @@ export class TerminalExtImpl implements Terminal {
         this.id.promise.then(id => this.proxy.$dispose(id));
     }
 
-    updateExitStatus(exitStatus: theia.TerminalExitStatus | undefined) {
+    updateExitStatus(exitStatus: theia.TerminalExitStatus | undefined): void {
         this._exitStatus = exitStatus;
     }
 }

--- a/packages/plugin-ext/src/plugin/terminal-ext.ts
+++ b/packages/plugin-ext/src/plugin/terminal-ext.ts
@@ -138,9 +138,10 @@ export class TerminalServiceExtImpl implements TerminalServiceExt {
         }
     }
 
-    $terminalClosed(id: string): void {
+    $terminalClosed(id: string, exitStatus: theia.TerminalExitStatus | undefined): void {
         const terminal = this._terminals.get(id);
         if (terminal) {
+            terminal.updateExitStatus(exitStatus)
             this.onDidCloseTerminalEmitter.fire(terminal);
             this._terminals.delete(id);
         }
@@ -275,6 +276,11 @@ export class TerminalExtImpl implements Terminal {
         return this.deferredProcessId.promise;
     }
 
+    protected _exitStatus: theia.TerminalExitStatus | undefined;
+    get exitStatus(): theia.TerminalExitStatus | undefined {
+        return this._exitStatus;
+    }
+
     constructor(private readonly proxy: TerminalServiceMain) { }
 
     sendText(text: string, addNewLine: boolean = true): void {
@@ -293,6 +299,9 @@ export class TerminalExtImpl implements Terminal {
         this.id.promise.then(id => this.proxy.$dispose(id));
     }
 
+    updateExitStatus(exitStatus: theia.TerminalExitStatus | undefined) {
+        this._exitStatus = exitStatus;
+    }
 }
 
 export class PseudoTerminal {

--- a/packages/plugin/src/theia.d.ts
+++ b/packages/plugin/src/theia.d.ts
@@ -2834,6 +2834,11 @@ export module '@theia/plugin' {
         readonly processId: PromiseLike<number>;
 
         /**
+         * The exit status of the terminal, this will be undefined while the terminal is active.
+         */
+        readonly exitStatus: TerminalExitStatus | undefined;
+
+        /**
          * Send text to the terminal.
          * @param text - text content.
          * @param addNewLine - in case true - apply new line after the text, otherwise don't apply new line. This defaults to `true`.
@@ -2905,6 +2910,20 @@ export module '@theia/plugin' {
          * The number of rows of the terminal.
          */
         readonly rows: number;
+    }
+
+    /**
+     * Represents how a terminal exited.
+     */
+    export interface TerminalExitStatus {
+        /**
+         * The exit code that a terminal exited with, it can have the following values:
+         * - Zero: the terminal process or custom execution succeeded.
+         * - Non-zero: the terminal process or custom execution failed.
+         * - `undefined`: the user forcibly closed the terminal or a custom execution exited
+         *   without providing an exit code.
+         */
+        readonly code: number | undefined;
     }
 
     /**

--- a/packages/plugin/src/theia.d.ts
+++ b/packages/plugin/src/theia.d.ts
@@ -2835,6 +2835,16 @@ export module '@theia/plugin' {
 
         /**
          * The exit status of the terminal, this will be undefined while the terminal is active.
+         *
+         * **Example:** Show a notification with the exit code when the terminal exits with a
+         * non-zero exit code.
+         * ```typescript
+         * window.onDidCloseTerminal(t => {
+         *   if (t.exitStatus && t.exitStatus.code) {
+         *     vscode.window.showInformationMessage(`Exit code: ${t.exitStatus.code}`);
+         *   }
+         * });
+         * ```
          */
         readonly exitStatus: TerminalExitStatus | undefined;
 

--- a/packages/terminal/src/browser/base/terminal-widget.ts
+++ b/packages/terminal/src/browser/base/terminal-widget.ts
@@ -26,6 +26,10 @@ export interface TerminalDimensions {
     rows: number;
 }
 
+export interface TerminalExitStatus {
+    readonly code: number | undefined;
+}
+
 /**
  * Terminal UI widget.
  */
@@ -44,6 +48,8 @@ export abstract class TerminalWidget extends BaseWidget {
     abstract readonly terminalId: number;
 
     abstract readonly dimensions: TerminalDimensions;
+
+    abstract readonly exitStatus: TerminalExitStatus | undefined;
 
     /** The last CWD assigned to the terminal, useful when attempting getCwdURI on a task terminal fails */
     lastCwd: URI;


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->
Fixes [#11139](https://github.com/eclipse-theia/theia/issues/11139) by adding support for `Terminal#exitStatus`. This field is set with the `TerminalExitStatus` object when the terminal it is referring to is closed, and contains the exit code of its process, if one was provided when terminating.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

@vince-fugnitto created a small extension to test this new feature : [term-exit-0.0.1.zip](https://github.com/eclipse-theia/theia/files/8720597/term-exit-0.0.1.zip)
You can fin the source code for this extension on [this repository](https://github.com/vince-fugnitto/term-exit)

1. download and include the [term-exit-0.0.1.zip](https://github.com/eclipse-theia/theia/files/8720597/term-exit-0.0.1.zip) test extension
2. build and start the application
3. open a terminal
4. run the command `exit <code>` in the open terminal. `<code>` must be an integer between 0 and 255, and will default to 0 if not provided.
5. terminal should close and extension will display its exit code, as shown in the picture below.

<details>
<summary>Test example</summary>

![image](https://user-images.githubusercontent.com/105316945/169146732-166e65d4-f80c-45d2-a520-facb88835b79.png)

</details>

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

Signed-off-by: Philippe Ducas <philippe.ducas@ericsson.com>
