### PR TITLE
Use correct path for call hierarchy

### DIFF
--- a/packages/plugin-ext-vscode/src/browser/plugin-vscode-commands-contribution.ts
+++ b/packages/plugin-ext-vscode/src/browser/plugin-vscode-commands-contribution.ts
@@ -599,7 +599,7 @@ export class PluginVscodeCommandsContribution implements CommandContribution {
                 execute: async (resource: URI, position: Position): Promise<CallHierarchyItem[]> => {
                     const provider = await this.getCallHierarchyServiceForUri(resource);
                     const definition = await provider?.getRootDefinition(
-                        resource.fsPath,
+                        resource.path,
                         toPosition(position),
                         new CancellationTokenSource().token
                     );


### PR DESCRIPTION
#### What it does

Fixes the call hierarchy view for Windows. See the discussion in https://github.com/eclipse-theia/theia/pull/11011 for more infos.

The culprit seems to be the `URI.fsPath` call. When calling it on Windows, we receive an invalid URI back (containing backslashes, etc.). Using the simple `path` variable enables correct revival of the URI on the plugin side.

#### How to test

Open the call hierarchy on different OS configurations:

| Backend | Frontend |
|---------|-----------|
| Linux/Mac | Windows |
| Linux/Mac | Linux/Mac |
| Windows  | Linux/Mac |
| Windows  | Windows |

It should open correctly without any errors.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
